### PR TITLE
feat(agent): empty-state screen for PXI chat

### DIFF
--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -44,14 +44,14 @@ const DEFAULT_EMPTY_STATE_QUICK_ACTIONS: EmptyStateQuickAction[] = [
     prompt: "How do I use Phoenix?",
   },
   {
-    icon: <Icons.SearchOutline />,
+    icon: <Icons.BookOutline />,
     label: "Explain a concept",
     prompt: "Explain a Phoenix concept to me.",
   },
   {
-    icon: <Icons.MessageSquareOutline />,
-    label: "Help me debug",
-    prompt: "Help me debug an issue in my LLM application.",
+    icon: <Icons.Trace />,
+    label: "Find critical issues",
+    prompt: "Find critical issues in my traces.",
   },
 ];
 

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import type { ChatStatus } from "ai";
-import { useEffect, useRef } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import type {
@@ -24,7 +24,36 @@ import type { ModelMenuValue } from "@phoenix/components/generative/ModelMenu";
 import { AgentDebugMenu } from "./AgentDebugMenu";
 import { AgentModelMenu } from "./AgentModelMenu";
 import { AssistantMessage, UserMessage } from "./ChatMessage";
+import { PxiGlyph } from "./PxiGlyph";
 import { useAgentChat } from "./useAgentChat";
+
+export type EmptyStateQuickAction = {
+  icon: ReactNode;
+  label: string;
+  /** Prompt text sent to the chat when the action is pressed. */
+  prompt: string;
+};
+
+const DEFAULT_EMPTY_STATE_SUBTEXT =
+  "Ask questions about Phoenix, get help with tracing, datasets, evaluations, and more.";
+
+const DEFAULT_EMPTY_STATE_QUICK_ACTIONS: EmptyStateQuickAction[] = [
+  {
+    icon: <Icons.BulbOutline />,
+    label: "How do I use Phoenix?",
+    prompt: "How do I use Phoenix?",
+  },
+  {
+    icon: <Icons.SearchOutline />,
+    label: "Explain a concept",
+    prompt: "Explain a Phoenix concept to me.",
+  },
+  {
+    icon: <Icons.MessageSquareOutline />,
+    label: "Help me debug",
+    prompt: "Help me debug an issue in my LLM application.",
+  },
+];
 
 const chatCSS = css`
   display: flex;
@@ -65,9 +94,82 @@ const chatCSS = css`
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--global-dimension-size-100);
-    margin-top: var(--global-dimension-size-400);
+    gap: var(--global-dimension-size-200);
+    margin-top: var(--global-dimension-size-600);
+    padding: 0 var(--global-dimension-size-200);
     color: var(--global-text-color-300);
+  }
+
+  .chat__empty-glyph {
+    width: 80px;
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--global-color-primary);
+    background: radial-gradient(
+      circle at center,
+      var(--global-color-primary-100) 0%,
+      transparent 65%
+    );
+  }
+
+  .chat__empty-title {
+    margin: 0;
+    font-size: var(--global-font-size-l);
+    font-weight: var(--px-font-weight-heavy, 600);
+    color: var(--global-text-color-900);
+    text-align: center;
+  }
+
+  .chat__empty-subtext {
+    margin: 0;
+    text-align: center;
+    color: var(--global-text-color-500);
+    line-height: var(--global-line-height-m);
+  }
+
+  .chat__empty-actions {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: var(--global-dimension-size-100);
+    margin-top: var(--global-dimension-size-100);
+  }
+
+  .chat__empty-action {
+    display: flex;
+    align-items: center;
+    gap: var(--global-dimension-size-150);
+    width: 100%;
+    padding: var(--global-dimension-size-150) var(--global-dimension-size-200);
+    background: transparent;
+    border: 1px solid var(--global-border-color-default);
+    border-radius: var(--global-rounding-medium);
+    color: var(--global-text-color-500);
+    font-size: var(--global-font-size-s);
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition:
+      background-color 0.15s ease,
+      color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .chat__empty-action:hover {
+    background: var(--global-color-gray-100);
+    border-color: var(--global-border-color-hover, var(--global-color-gray-300));
+    color: var(--global-text-color-900);
+  }
+
+  .chat__empty-action-icon {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--global-text-color-500);
+    font-size: 16px;
   }
 
   .chat__loading {
@@ -87,11 +189,15 @@ export function Chat({
   chatApiUrl,
   modelMenuValue,
   onModelChange,
+  emptyStateSubtext,
+  emptyStateQuickActions,
 }: {
   sessionId: string | null;
   chatApiUrl: string;
   modelMenuValue: ModelMenuValue;
   onModelChange: (model: ModelMenuValue) => void;
+  emptyStateSubtext?: ReactNode;
+  emptyStateQuickActions?: EmptyStateQuickAction[];
 }) {
   const {
     messages,
@@ -116,6 +222,8 @@ export function Chat({
       handleElicitationCancel={handleElicitationCancel}
       modelMenuValue={modelMenuValue}
       onModelChange={onModelChange}
+      emptyStateSubtext={emptyStateSubtext}
+      emptyStateQuickActions={emptyStateQuickActions}
     />
   );
 }
@@ -135,6 +243,8 @@ export function ChatView({
   handleElicitationCancel,
   modelMenuValue,
   onModelChange,
+  emptyStateSubtext = DEFAULT_EMPTY_STATE_SUBTEXT,
+  emptyStateQuickActions = DEFAULT_EMPTY_STATE_QUICK_ACTIONS,
 }: {
   messages: AgentUIMessage[];
   sendMessage: (message: { text: string }) => void;
@@ -146,9 +256,18 @@ export function ChatView({
   handleElicitationCancel: () => void;
   modelMenuValue: ModelMenuValue;
   onModelChange: (model: ModelMenuValue) => void;
+  emptyStateSubtext?: ReactNode;
+  emptyStateQuickActions?: EmptyStateQuickAction[];
 }) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRequestAnimationFrameRef = useRef<number>(0);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [inputValue, setInputValue] = useState("");
+
+  const handleQuickAction = (prompt: string) => {
+    setInputValue(prompt);
+    textareaRef.current?.focus();
+  };
 
   // Coalesce rapid message/status updates into a single smooth scroll.
   useEffect(() => {
@@ -166,7 +285,13 @@ export function ChatView({
     <div css={chatCSS}>
       <div className="chat__scroll">
         <div className="chat__messages">
-          {messages.length === 0 && <EmptyState />}
+          {messages.length === 0 && (
+            <EmptyState
+              subtext={emptyStateSubtext}
+              quickActions={emptyStateQuickActions}
+              onQuickAction={handleQuickAction}
+            />
+          )}
           {messages.map((message, index) => {
             if (message.role === "user") {
               return <UserMessage key={message.id} parts={message.parts} />;
@@ -202,9 +327,14 @@ export function ChatView({
             <PromptInput
               onSubmit={(text) => sendMessage({ text })}
               status={status}
+              value={inputValue}
+              onValueChange={setInputValue}
             >
               <PromptInputBody>
-                <PromptInputTextarea placeholder="Send a message..." />
+                <PromptInputTextarea
+                  ref={textareaRef}
+                  placeholder="Send a message..."
+                />
               </PromptInputBody>
               <PromptInputFooter>
                 <PromptInputTools>
@@ -234,16 +364,46 @@ export function ChatView({
 }
 
 /** Empty-state shown before the first user message in a session. */
-function EmptyState() {
+function EmptyState({
+  subtext,
+  quickActions,
+  onQuickAction,
+}: {
+  subtext: ReactNode;
+  quickActions: EmptyStateQuickAction[];
+  onQuickAction: (prompt: string) => void;
+}) {
   return (
     <div className="chat__empty">
-      <Icon
-        svg={<Icons.Robot />}
-        css={css`
-          font-size: 48px;
-        `}
-      />
-      <p>Send a message to chat with PXI</p>
+      <div className="chat__empty-glyph">
+        <PxiGlyph
+          fill="currentColor"
+          css={css`
+            transform: scale(1.8);
+          `}
+        />
+      </div>
+      <h2 className="chat__empty-title">
+        I&apos;m PXI, your Phoenix assistant
+      </h2>
+      <p className="chat__empty-subtext">{subtext}</p>
+      {quickActions.length > 0 && (
+        <div className="chat__empty-actions">
+          {quickActions.map((action) => (
+            <button
+              key={action.label}
+              type="button"
+              className="chat__empty-action"
+              onClick={() => onQuickAction(action.prompt)}
+            >
+              <span className="chat__empty-action-icon">
+                <Icon svg={action.icon} />
+              </span>
+              <span>{action.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/components/ai/prompt-input/PromptInput.tsx
+++ b/app/src/components/ai/prompt-input/PromptInput.tsx
@@ -39,6 +39,14 @@ export function PromptInput({
   onValueChange,
   ...restProps
 }: PromptInputProps) {
+  // Dual-mode value handling:
+  //   - Controlled (parent passes `value`): rendered value comes from
+  //     `controlledValue`. `internalValue` is unused. Writes are forwarded
+  //     to `onValueChange` only — the parent must update its own state for
+  //     the new value to appear on screen.
+  //   - Uncontrolled (no `value`): we own the state in `internalValue` and
+  //     update it on every write. `onValueChange` still fires as an optional
+  //     change observer for the parent.
   const [internalValue, setInternalValue] = useState("");
   const isControlled = controlledValue !== undefined;
   const value = isControlled ? controlledValue : internalValue;

--- a/app/src/components/ai/prompt-input/PromptInput.tsx
+++ b/app/src/components/ai/prompt-input/PromptInput.tsx
@@ -35,9 +35,19 @@ export function PromptInput({
   status = "ready",
   isDisabled = false,
   mode = "prompt",
+  value: controlledValue,
+  onValueChange,
   ...restProps
 }: PromptInputProps) {
-  const [value, setValue] = useState("");
+  const [internalValue, setInternalValue] = useState("");
+  const isControlled = controlledValue !== undefined;
+  const value = isControlled ? controlledValue : internalValue;
+  const setValue = (next: string) => {
+    if (!isControlled) {
+      setInternalValue(next);
+    }
+    onValueChange?.(next);
+  };
   const valueRef = useRef(value);
   valueRef.current = value;
 

--- a/app/src/components/ai/prompt-input/types.ts
+++ b/app/src/components/ai/prompt-input/types.ts
@@ -94,6 +94,17 @@ export interface PromptInputProps
    * @default "prompt"
    */
   mode?: PromptInputMode;
+  /**
+   * Controlled text value. When provided, makes the prompt input a controlled
+   * component — the parent owns the value and must pair this with
+   * `onValueChange`. When omitted, the prompt input manages its own state
+   * internally.
+   */
+  value?: string;
+  /**
+   * Called when the text content changes. Required when `value` is provided.
+   */
+  onValueChange?: (value: string) => void;
 }
 
 /**


### PR DESCRIPTION

<img width="650" height="1175" alt="Screenshot 2026-04-16 at 6 48 01 PM" src="https://github.com/user-attachments/assets/79a41d59-364b-4eb3-9e1e-237eb662a4fd" />

- New empty state for the PXI chat: `PxiGlyph` inside a subtle theme-adaptive radial glow, "I'm PXI, your Phoenix assistant" title, and prop-driven subtext + quick actions (defaults hardcoded for now; structured so they can be passed per-surface later).
- Clicking a quick action populates the prompt textarea and focuses it — users can edit before sending instead of the prompt being fired immediately.
- Adds optional controlled `value` / `onValueChange` props to `PromptInput` so consumers (here, `ChatView`) can drive the input value externally.
