### PR TITLE
fix(graphql): fix introspection TypeError on JSON fields with default_factory=dict

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -396,7 +396,7 @@ input ChatCompletionOverDatasetInput {
   splitIds: [ID!] = null
   experimentName: String = null
   experimentDescription: String = null
-  experimentMetadata: JSON = {}
+  experimentMetadata: JSON = null
   promptName: Identifier = null
   evaluators: [PlaygroundEvaluatorInput!]! = []
 
@@ -445,7 +445,7 @@ input ChatPromptVersionInput {
   description: String = null
   templateFormat: PromptTemplateFormat!
   template: PromptChatTemplateInput!
-  invocationParameters: JSON! = {}
+  invocationParameters: JSON!
   tools: PromptToolsInput = null
   responseFormat: PromptResponseFormatJSONSchemaInput = null
   modelProvider: GenerativeProviderKey!
@@ -627,7 +627,7 @@ input CreateDocumentAnnotationInput {
   label: String = null
   score: Float = null
   explanation: String = null
-  metadata: JSON! = {}
+  metadata: JSON!
   source: AnnotationSource!
   identifier: String
 }
@@ -671,7 +671,7 @@ input CreateProjectSessionAnnotationInput {
   label: String = null
   score: Float = null
   explanation: String = null
-  metadata: JSON! = {}
+  metadata: JSON!
   source: AnnotationSource! = APP
   identifier: String
 }
@@ -701,7 +701,7 @@ input CreateSpanAnnotationInput {
   label: String = null
   score: Float = null
   explanation: String = null
-  metadata: JSON! = {}
+  metadata: JSON!
   source: AnnotationSource!
   identifier: String
 }
@@ -724,7 +724,7 @@ input CreateTraceAnnotationInput {
   label: String = null
   score: Float = null
   explanation: String = null
-  metadata: JSON! = {}
+  metadata: JSON!
   source: AnnotationSource!
   identifier: String
 }
@@ -1366,8 +1366,8 @@ type EvaluatorInputMapping {
 }
 
 input EvaluatorInputMappingInput {
-  literalMapping: JSON! = {}
-  pathMapping: JSON! = {}
+  literalMapping: JSON!
+  pathMapping: JSON!
 }
 
 enum EvaluatorKind {
@@ -1384,7 +1384,7 @@ input EvaluatorPreviewInput @oneOf {
 input EvaluatorPreviewItemInput {
   evaluator: EvaluatorPreviewInput!
   context: JSON!
-  inputMapping: EvaluatorInputMappingInput! = {}
+  inputMapping: EvaluatorInputMappingInput!
 }
 
 input EvaluatorPreviewsInput {
@@ -2344,7 +2344,7 @@ input PlaygroundEvaluatorInput {
   id: ID!
   name: Identifier!
   description: String = null
-  inputMapping: EvaluatorInputMappingInput! = {}
+  inputMapping: EvaluatorInputMappingInput!
   outputConfigs: [AnnotationConfigInput!] = null
 }
 
@@ -3742,7 +3742,7 @@ input UpdateAnnotationInput {
   label: String = null
   score: Float = null
   explanation: String = null
-  metadata: JSON! = {}
+  metadata: JSON!
   source: AnnotationSource! = APP
 }
 

--- a/app/src/components/dataset/__generated__/CreateBuiltInDatasetEvaluatorSlideover_CreateDatasetBuiltinEvaluatorMutation.graphql.ts
+++ b/app/src/components/dataset/__generated__/CreateBuiltInDatasetEvaluatorSlideover_CreateDatasetBuiltinEvaluatorMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<277f6308dd02505b61b5a1944d98652a>>
+ * @generated SignedSource<<392b747e81c158606a7ba6cf5c4b07c7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,8 +20,8 @@ export type CreateDatasetBuiltinEvaluatorInput = {
   outputConfigs?: ReadonlyArray<AnnotationConfigInput> | null;
 };
 export type EvaluatorInputMappingInput = {
-  literalMapping?: any;
-  pathMapping?: any;
+  literalMapping: any;
+  pathMapping: any;
 };
 export type AnnotationConfigInput = {
   categorical?: CategoricalAnnotationConfigInput | null;

--- a/app/src/components/dataset/__generated__/CreateLLMDatasetEvaluatorSlideover_createLLMEvaluatorMutation.graphql.ts
+++ b/app/src/components/dataset/__generated__/CreateLLMDatasetEvaluatorSlideover_createLLMEvaluatorMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<edbb96cd132a2060c2beb448abffbb1e>>
+ * @generated SignedSource<<5e948152e68d4bd49a29214a59fefb31>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,7 +26,7 @@ export type CreateDatasetLLMEvaluatorInput = {
 export type ChatPromptVersionInput = {
   customProviderId?: string | null;
   description?: string | null;
-  invocationParameters?: any;
+  invocationParameters: any;
   modelName: string;
   modelProvider: GenerativeProviderKey;
   responseFormat?: PromptResponseFormatJSONSchemaInput | null;
@@ -119,8 +119,8 @@ export type FreeformAnnotationConfigInput = {
   name: string;
 };
 export type EvaluatorInputMappingInput = {
-  literalMapping?: any;
-  pathMapping?: any;
+  literalMapping: any;
+  pathMapping: any;
 };
 export type CreateLLMDatasetEvaluatorSlideover_createLLMEvaluatorMutation$variables = {
   connectionIds: ReadonlyArray<string>;

--- a/app/src/components/dataset/__generated__/EditBuiltInDatasetEvaluatorSlideover_UpdateDatasetBuiltinEvaluatorMutation.graphql.ts
+++ b/app/src/components/dataset/__generated__/EditBuiltInDatasetEvaluatorSlideover_UpdateDatasetBuiltinEvaluatorMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4191c6621eef2ec314eab2021d56ecb6>>
+ * @generated SignedSource<<aa465c248d63fee326245be3985030c1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,8 +19,8 @@ export type UpdateDatasetBuiltinEvaluatorInput = {
   outputConfigs?: ReadonlyArray<AnnotationConfigInput> | null;
 };
 export type EvaluatorInputMappingInput = {
-  literalMapping?: any;
-  pathMapping?: any;
+  literalMapping: any;
+  pathMapping: any;
 };
 export type AnnotationConfigInput = {
   categorical?: CategoricalAnnotationConfigInput | null;

--- a/app/src/components/dataset/__generated__/EditLLMDatasetEvaluatorSlideover_updateLLMEvaluatorMutation.graphql.ts
+++ b/app/src/components/dataset/__generated__/EditLLMDatasetEvaluatorSlideover_updateLLMEvaluatorMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3df647261ea5623e068c2bb19e09e084>>
+ * @generated SignedSource<<b36c75c6d2ab74eb579d885ec1ea704e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -27,7 +27,7 @@ export type UpdateDatasetLLMEvaluatorInput = {
 export type ChatPromptVersionInput = {
   customProviderId?: string | null;
   description?: string | null;
-  invocationParameters?: any;
+  invocationParameters: any;
   modelName: string;
   modelProvider: GenerativeProviderKey;
   responseFormat?: PromptResponseFormatJSONSchemaInput | null;
@@ -120,8 +120,8 @@ export type FreeformAnnotationConfigInput = {
   name: string;
 };
 export type EvaluatorInputMappingInput = {
-  literalMapping?: any;
-  pathMapping?: any;
+  literalMapping: any;
+  pathMapping: any;
 };
 export type EditLLMDatasetEvaluatorSlideover_updateLLMEvaluatorMutation$variables = {
   connectionIds: ReadonlyArray<string>;

--- a/app/src/components/evaluators/__generated__/EvaluatorOutputPreviewMutation.graphql.ts
+++ b/app/src/components/evaluators/__generated__/EvaluatorOutputPreviewMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e36490a4fd929fd92f61b9eab2a4da03>>
+ * @generated SignedSource<<8efaf4dbadf9dd6c3effe8ebc2ce10f7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,7 +20,7 @@ export type EvaluatorPreviewsInput = {
 export type EvaluatorPreviewItemInput = {
   context: any;
   evaluator: EvaluatorPreviewInput;
-  inputMapping?: EvaluatorInputMappingInput;
+  inputMapping: EvaluatorInputMappingInput;
 };
 export type EvaluatorPreviewInput = {
   builtInEvaluatorId?: string | null;
@@ -35,7 +35,7 @@ export type InlineLLMEvaluatorInput = {
 export type ChatPromptVersionInput = {
   customProviderId?: string | null;
   description?: string | null;
-  invocationParameters?: any;
+  invocationParameters: any;
   modelName: string;
   modelProvider: GenerativeProviderKey;
   responseFormat?: PromptResponseFormatJSONSchemaInput | null;
@@ -128,8 +128,8 @@ export type FreeformAnnotationConfigInput = {
   name: string;
 };
 export type EvaluatorInputMappingInput = {
-  literalMapping?: any;
-  pathMapping?: any;
+  literalMapping: any;
+  pathMapping: any;
 };
 export type GenerativeCredentialInput = {
   envVarName: string;

--- a/app/src/components/evaluators/__generated__/EvaluatorPromptPreviewQuery.graphql.ts
+++ b/app/src/components/evaluators/__generated__/EvaluatorPromptPreviewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d5d09076b41bc105d44d37d42b393b01>>
+ * @generated SignedSource<<129e3a3551b9801480fbe6eb8eb48182>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -44,8 +44,8 @@ export type PromptTemplateOptions = {
   variables: any;
 };
 export type EvaluatorInputMappingInput = {
-  literalMapping?: any;
-  pathMapping?: any;
+  literalMapping: any;
+  pathMapping: any;
 };
 export type EvaluatorPromptPreviewQuery$variables = {
   inputMapping: EvaluatorInputMappingInput;

--- a/app/src/components/trace/SpanAnnotationsEditor.tsx
+++ b/app/src/components/trace/SpanAnnotationsEditor.tsx
@@ -640,6 +640,7 @@ function SpanAnnotationsList(props: {
               annotatorKind: "HUMAN",
               explanation: data.explanation || null,
               source: "APP",
+              metadata: {},
             },
             name: data.name,
             spanId: spanNodeId,

--- a/app/src/components/trace/__generated__/SpanAnnotationsEditorCreateAnnotationMutation.graphql.ts
+++ b/app/src/components/trace/__generated__/SpanAnnotationsEditorCreateAnnotationMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<331b2cf3b8343d26eb049d733cd3dd2c>>
+ * @generated SignedSource<<4c3d5177ab6ea794780409039163df35>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,7 +17,7 @@ export type CreateSpanAnnotationInput = {
   explanation?: string | null;
   identifier?: string | null;
   label?: string | null;
-  metadata?: any;
+  metadata: any;
   name: string;
   score?: number | null;
   source: AnnotationSource;

--- a/app/src/pages/playground/PlaygroundDatasetSection.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetSection.tsx
@@ -4,7 +4,7 @@ import { graphql, readInlineData, useLazyLoadQuery } from "react-relay";
 import { Flex } from "@phoenix/components";
 import type { EvaluatorItem } from "@phoenix/components/evaluators/EvaluatorSelectMenuItem";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
-import type { EvaluatorInputMappingInput } from "@phoenix/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql";
+import type { EvaluatorInputMappingInput } from "@phoenix/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql";
 import type {
   PlaygroundDatasetSection_evaluator$data,
   PlaygroundDatasetSection_evaluator$key,

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<92c5fe412a1db375fe6bb3d12ad99aae>>
+ * @generated SignedSource<<e302c7e5bba57171d950e9188f11c44e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -40,7 +40,7 @@ export type ChatCompletionOverDatasetInput = {
 export type ChatPromptVersionInput = {
   customProviderId?: string | null;
   description?: string | null;
-  invocationParameters?: any;
+  invocationParameters: any;
   modelName: string;
   modelProvider: GenerativeProviderKey;
   responseFormat?: PromptResponseFormatJSONSchemaInput | null;
@@ -122,13 +122,13 @@ export type GenerativeCredentialInput = {
 export type PlaygroundEvaluatorInput = {
   description?: string | null;
   id: string;
-  inputMapping?: EvaluatorInputMappingInput;
+  inputMapping: EvaluatorInputMappingInput;
   name: string;
   outputConfigs?: ReadonlyArray<AnnotationConfigInput> | null;
 };
 export type EvaluatorInputMappingInput = {
-  literalMapping?: any;
-  pathMapping?: any;
+  literalMapping: any;
+  pathMapping: any;
 };
 export type AnnotationConfigInput = {
   categorical?: CategoricalAnnotationConfigInput | null;

--- a/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<231010dbea5ea9d62621f5f701c3f450>>
+ * @generated SignedSource<<edff6cccfedde97d36129678c1dc0881>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -28,7 +28,7 @@ export type ChatCompletionInput = {
 export type ChatPromptVersionInput = {
   customProviderId?: string | null;
   description?: string | null;
-  invocationParameters?: any;
+  invocationParameters: any;
   modelName: string;
   modelProvider: GenerativeProviderKey;
   responseFormat?: PromptResponseFormatJSONSchemaInput | null;
@@ -114,13 +114,13 @@ export type PromptTemplateOptions = {
 export type PlaygroundEvaluatorInput = {
   description?: string | null;
   id: string;
-  inputMapping?: EvaluatorInputMappingInput;
+  inputMapping: EvaluatorInputMappingInput;
   name: string;
   outputConfigs?: ReadonlyArray<AnnotationConfigInput> | null;
 };
 export type EvaluatorInputMappingInput = {
-  literalMapping?: any;
-  pathMapping?: any;
+  literalMapping: any;
+  pathMapping: any;
 };
 export type AnnotationConfigInput = {
   categorical?: CategoricalAnnotationConfigInput | null;

--- a/app/src/pages/playground/__generated__/UpsertPromptFromTemplateDialogCreateMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/UpsertPromptFromTemplateDialogCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d951a7ab6d165eb90a4882b30c9cbf30>>
+ * @generated SignedSource<<4c4f7f270432bb3283b811e2eb189871>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -22,7 +22,7 @@ export type CreateChatPromptInput = {
 export type ChatPromptVersionInput = {
   customProviderId?: string | null;
   description?: string | null;
-  invocationParameters?: any;
+  invocationParameters: any;
   modelName: string;
   modelProvider: GenerativeProviderKey;
   responseFormat?: PromptResponseFormatJSONSchemaInput | null;

--- a/app/src/pages/playground/__generated__/UpsertPromptFromTemplateDialogUpdateMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/UpsertPromptFromTemplateDialogUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ccaf5668523fa847d24a4d5bdb6971a4>>
+ * @generated SignedSource<<687546604b0de6e69e49a4b6e31632ec>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,7 +20,7 @@ export type CreateChatPromptVersionInput = {
 export type ChatPromptVersionInput = {
   customProviderId?: string | null;
   description?: string | null;
-  invocationParameters?: any;
+  invocationParameters: any;
   modelName: string;
   modelProvider: GenerativeProviderKey;
   responseFormat?: PromptResponseFormatJSONSchemaInput | null;

--- a/app/src/pages/trace/__generated__/DocumentAnnotationFormCreateMutation.graphql.ts
+++ b/app/src/pages/trace/__generated__/DocumentAnnotationFormCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<52b23c8379666f0712da3b8cee95d0e4>>
+ * @generated SignedSource<<4bb0931f58e66ace642bae010a1a9984>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,7 +17,7 @@ export type CreateDocumentAnnotationInput = {
   explanation?: string | null;
   identifier?: string | null;
   label?: string | null;
-  metadata?: any;
+  metadata: any;
   name: string;
   score?: number | null;
   source: AnnotationSource;

--- a/src/phoenix/server/api/input_types/ChatCompletionInput.py
+++ b/src/phoenix/server/api/input_types/ChatCompletionInput.py
@@ -40,7 +40,7 @@ class ChatCompletionOverDatasetInput:
     split_ids: Optional[list[GlobalID]] = None
     experiment_name: Optional[str] = None
     experiment_description: Optional[str] = None
-    experiment_metadata: Optional[JSON] = strawberry.field(default_factory=dict)
+    experiment_metadata: Optional[JSON] = None
     prompt_name: Optional[Identifier] = None
     evaluators: list[PlaygroundEvaluatorInput] = strawberry.field(default_factory=list)
     appended_messages_path: Optional[str] = strawberry.field(

--- a/src/phoenix/server/api/input_types/CreateDocumentAnnotationInput.py
+++ b/src/phoenix/server/api/input_types/CreateDocumentAnnotationInput.py
@@ -17,6 +17,6 @@ class CreateDocumentAnnotationInput:
     label: Optional[str] = None
     score: Optional[float] = None
     explanation: Optional[str] = None
-    metadata: JSON = strawberry.field(default_factory=dict)
+    metadata: JSON
     source: AnnotationSource
     identifier: Optional[str] = strawberry.UNSET

--- a/src/phoenix/server/api/input_types/CreateProjectSessionAnnotationInput.py
+++ b/src/phoenix/server/api/input_types/CreateProjectSessionAnnotationInput.py
@@ -17,7 +17,7 @@ class CreateProjectSessionAnnotationInput:
     label: Optional[str] = None
     score: Optional[float] = None
     explanation: Optional[str] = None
-    metadata: JSON = strawberry.field(default_factory=dict)
+    metadata: JSON
     source: AnnotationSource = AnnotationSource.APP
     identifier: Optional[str] = strawberry.UNSET
 

--- a/src/phoenix/server/api/input_types/CreateSpanAnnotationInput.py
+++ b/src/phoenix/server/api/input_types/CreateSpanAnnotationInput.py
@@ -16,7 +16,7 @@ class CreateSpanAnnotationInput:
     label: Optional[str] = None
     score: Optional[float] = None
     explanation: Optional[str] = None
-    metadata: JSON = strawberry.field(default_factory=dict)
+    metadata: JSON
     source: AnnotationSource
     identifier: Optional[str] = strawberry.UNSET
 

--- a/src/phoenix/server/api/input_types/CreateTraceAnnotationInput.py
+++ b/src/phoenix/server/api/input_types/CreateTraceAnnotationInput.py
@@ -16,6 +16,6 @@ class CreateTraceAnnotationInput:
     label: Optional[str] = None
     score: Optional[float] = None
     explanation: Optional[str] = None
-    metadata: JSON = strawberry.field(default_factory=dict)
+    metadata: JSON
     source: AnnotationSource
     identifier: Optional[str] = strawberry.UNSET

--- a/src/phoenix/server/api/input_types/EvaluatorPreviewInput.py
+++ b/src/phoenix/server/api/input_types/EvaluatorPreviewInput.py
@@ -48,6 +48,4 @@ class EvaluatorPreviewItemInput:
 
     evaluator: EvaluatorPreviewInput
     context: JSON
-    input_mapping: EvaluatorInputMappingInput = strawberry.field(
-        default_factory=EvaluatorInputMappingInput
-    )
+    input_mapping: EvaluatorInputMappingInput

--- a/src/phoenix/server/api/input_types/PlaygroundEvaluatorInput.py
+++ b/src/phoenix/server/api/input_types/PlaygroundEvaluatorInput.py
@@ -14,9 +14,9 @@ from phoenix.server.api.types.Identifier import Identifier
 
 @strawberry.input
 class EvaluatorInputMappingInput:
-    literal_mapping: JSON = strawberry.field(default_factory=dict)
+    literal_mapping: JSON
     """Direct key-value mappings to evaluator inputs."""
-    path_mapping: JSON = strawberry.field(default_factory=dict)
+    path_mapping: JSON
     """JSONPath expressions to extract values from the evaluation context."""
 
     def __post_init__(self) -> None:
@@ -45,7 +45,5 @@ class PlaygroundEvaluatorInput:
     id: GlobalID
     name: Identifier
     description: Optional[str] = None
-    input_mapping: EvaluatorInputMappingInput = strawberry.field(
-        default_factory=EvaluatorInputMappingInput
-    )
+    input_mapping: EvaluatorInputMappingInput
     output_configs: Optional[list[AnnotationConfigInput]] = None

--- a/src/phoenix/server/api/input_types/PromptVersionInput.py
+++ b/src/phoenix/server/api/input_types/PromptVersionInput.py
@@ -242,7 +242,7 @@ class ChatPromptVersionInput:
     description: Optional[str] = None
     template_format: PromptTemplateFormat
     template: PromptChatTemplateInput
-    invocation_parameters: JSON = strawberry.field(default_factory=dict)
+    invocation_parameters: JSON
     tools: Optional[PromptToolsInput] = None
     response_format: Optional[PromptResponseFormatJSONSchemaInput] = None
     model_provider: GenerativeProviderKey

--- a/src/phoenix/server/api/input_types/UpdateAnnotationInput.py
+++ b/src/phoenix/server/api/input_types/UpdateAnnotationInput.py
@@ -17,7 +17,7 @@ class UpdateAnnotationInput:
     label: Optional[str] = None
     score: Optional[float] = None
     explanation: Optional[str] = None
-    metadata: JSON = strawberry.field(default_factory=dict)
+    metadata: JSON
     source: AnnotationSource = AnnotationSource.APP
 
     def __post_init__(self) -> None:

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
 from strawberry import UNSET
 from strawberry.relay import GlobalID
+from strawberry.scalars import JSON
 from strawberry.types import Info
 
 from phoenix.db import models
@@ -754,7 +755,9 @@ class EvaluatorMutationMixin:
             user_id = int(user.identity)
 
         input_mapping: EvaluatorInputMappingInput = (
-            input.input_mapping if input.input_mapping is not None else EvaluatorInputMappingInput()
+            input.input_mapping
+            if input.input_mapping is not None
+            else EvaluatorInputMappingInput(literal_mapping=JSON({}), path_mapping=JSON({}))
         )
 
         try:
@@ -840,7 +843,9 @@ class EvaluatorMutationMixin:
             raise BadRequest(f"Invalid dataset evaluator id: {input.dataset_evaluator_id}")
 
         input_mapping: EvaluatorInputMappingInput = (
-            input.input_mapping if input.input_mapping is not None else EvaluatorInputMappingInput()
+            input.input_mapping
+            if input.input_mapping is not None
+            else EvaluatorInputMappingInput(literal_mapping=JSON({}), path_mapping=JSON({}))
         )
 
         user_id: Optional[int] = None

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -51,9 +51,9 @@ class EvaluatorKind(Enum):
 
 @strawberry.type
 class EvaluatorInputMapping:
-    literal_mapping: JSON = strawberry.field(default_factory=dict)
+    literal_mapping: JSON
     """Direct key-value mappings to evaluator inputs."""
-    path_mapping: JSON = strawberry.field(default_factory=dict)
+    path_mapping: JSON
     """JSONPath expressions to extract values from the evaluation context."""
 
 

--- a/src/phoenix/server/api/types/ExperimentTaskConfig.py
+++ b/src/phoenix/server/api/types/ExperimentTaskConfig.py
@@ -161,7 +161,7 @@ class PromptConfig:
     template: PromptTemplate
     tools: Optional[PromptTools] = None
     response_format: Optional[PromptResponseFormatJSONSchema] = None
-    invocation_parameters: JSON = strawberry.field(default_factory=dict)
+    invocation_parameters: JSON
     model_provider: GenerativeProviderKey = strawberry.field(
         description="The model provider (OPENAI, ANTHROPIC, etc.)"
     )

--- a/tests/unit/server/api/mutations/test_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_evaluator_mutations.py
@@ -34,7 +34,6 @@ from phoenix.db.types.prompts import (
     TextContentPart,
     get_raw_invocation_parameters,
 )
-from phoenix.server.api.input_types.PlaygroundEvaluatorInput import EvaluatorInputMappingInput
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
 
@@ -2431,7 +2430,9 @@ class TestUpdateDatasetBuiltinEvaluatorMutation:
             assert db_dataset_evaluator is not None
             assert db_dataset_evaluator.name.root == "updated-name"
             # Input mapping should revert to default value when not provided
-            assert db_dataset_evaluator.input_mapping == EvaluatorInputMappingInput().to_orm()
+            assert db_dataset_evaluator.input_mapping == InputMapping(
+                literal_mapping={}, path_mapping={}
+            )
             # user_id is None when authentication is disabled
             assert db_dataset_evaluator.user_id is None
 

--- a/tests/unit/server/api/mutations/test_project_session_annotation_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_session_annotation_mutations.py
@@ -545,6 +545,7 @@ class TestProjectSessionAnnotationMutations:
                 "id": str(GlobalID("ProjectSessionAnnotation", "999999")),
                 "name": "should_fail",
                 "label": "DUMMY_LABEL",  # Provide label to satisfy validation
+                "metadata": {},
             }
         }
         nonexistent_patch_response = await gql_client.execute(
@@ -563,6 +564,7 @@ class TestProjectSessionAnnotationMutations:
                 "id": str(GlobalID("Span", "999")),
                 "name": "should_fail",
                 "label": "DUMMY_LABEL",  # Provide label to satisfy validation
+                "metadata": {},
             }
         }
         invalid_gid_patch_response = await gql_client.execute(
@@ -585,6 +587,7 @@ class TestProjectSessionAnnotationMutations:
                 "score": None,
                 "label": "NULL_SCORE_TEST",  # Provide label to satisfy validation
                 "explanation": "Testing score update to null",
+                "metadata": {},
             }
         }
         score_to_null_response = await gql_client.execute(
@@ -617,13 +620,14 @@ class TestProjectSessionAnnotationMutations:
             assert db_annotation.label == "NULL_SCORE_TEST"
 
         # B5. Update with score=null, label=null, explanation="" should fail validation
-        invalid_all_null_input = {
+        invalid_all_null_input: dict[str, Any] = {
             "input": {
                 "id": created_basic_annotation["id"],
                 "name": "should_fail_validation",
                 "score": None,
                 "label": None,
                 "explanation": "",
+                "metadata": {},
             }
         }
         invalid_all_null_response = await gql_client.execute(
@@ -644,6 +648,7 @@ class TestProjectSessionAnnotationMutations:
                 "id": created_first_metadata_annotation["id"],  # Use annotation with score=0.1
                 "name": created_first_metadata_annotation["name"],  # Keep same name
                 "score": 0.95,  # Change score from 0.1 to 0.95
+                "metadata": {},
             }
         }
         score_only_response = await gql_client.execute(
@@ -669,6 +674,7 @@ class TestProjectSessionAnnotationMutations:
                 "id": created_second_metadata_annotation["id"],  # Use annotation with label="B"
                 "name": created_second_metadata_annotation["name"],  # Keep same name
                 "label": "UPDATED_B_LABEL",  # Change label from "B" to "UPDATED_B_LABEL"
+                "metadata": {},
             }
         }
         label_only_response = await gql_client.execute(
@@ -694,6 +700,7 @@ class TestProjectSessionAnnotationMutations:
                 "id": created_basic_annotation["id"],  # Use basic annotation
                 "name": "explanation_only_test",  # Change name too
                 "explanation": "This is a completely new explanation",  # Change explanation
+                "metadata": {},
             }
         }
         explanation_only_response = await gql_client.execute(
@@ -722,6 +729,7 @@ class TestProjectSessionAnnotationMutations:
                 "name": "label_set_to_null",
                 "label": None,
                 "score": 0.75,  # Provide score to satisfy validation
+                "metadata": {},
             }
         }
         label_to_null_response = await gql_client.execute(
@@ -746,6 +754,7 @@ class TestProjectSessionAnnotationMutations:
                 "name": "explanation_set_to_null",
                 "explanation": None,
                 "label": "EXPLANATION_NULL_TEST",  # Provide label to satisfy validation
+                "metadata": {},
             }
         }
         explanation_to_null_response = await gql_client.execute(
@@ -770,6 +779,7 @@ class TestProjectSessionAnnotationMutations:
                 "name": "annotator_kind_test",
                 "annotatorKind": "LLM",  # Change from HUMAN to LLM
                 "label": "ANNOTATOR_KIND_TEST",  # Provide label to satisfy validation
+                "metadata": {},
             }
         }
         annotator_kind_response = await gql_client.execute(
@@ -796,6 +806,7 @@ class TestProjectSessionAnnotationMutations:
                 "name": "source_test",
                 "source": "API",  # Change from APP to API
                 "explanation": "Testing source update",  # Provide explanation to satisfy validation
+                "metadata": {},
             }
         }
         source_response = await gql_client.execute(
@@ -820,6 +831,7 @@ class TestProjectSessionAnnotationMutations:
                 "name": "code_annotator_test",
                 "annotatorKind": "CODE",  # Test the third enum value
                 "score": 0.88,  # Provide score to satisfy validation
+                "metadata": {},
             }
         }
         code_annotator_response = await gql_client.execute(

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -2198,6 +2198,7 @@ class TestApplyChatTemplate:
                 "variables": {"name": "Alice"},
             },
             "inputMapping": {
+                "literalMapping": {},
                 "pathMapping": {"name": "[[[invalid jsonpath"},
             },
         }

--- a/tests/unit/server/api/test_subscriptions.py
+++ b/tests/unit/server/api/test_subscriptions.py
@@ -2512,6 +2512,7 @@ class TestChatCompletionOverDatasetSubscription:
                         "id": evaluator_gid,
                         "name": "correctness",
                         "inputMapping": {
+                            "literalMapping": {},
                             "pathMapping": {
                                 "input": "$.input",
                                 "output": "$.output",


### PR DESCRIPTION
## Summary

- Fixes `TypeError: Cannot convert value to AST: {}` during GraphQL introspection
- Removes `default_factory=dict` from all Strawberry `JSON`-typed fields, making them explicitly required
- Updates frontend callers and tests to pass the now-required fields

## Root Cause

During GraphQL introspection, `graphql-core`'s `ast_from_value()` serializes each input field's `defaultValue` into a GraphQL AST node. When a Strawberry field uses `default_factory=dict`, the exposed default is `{}` (a Python `dict`). `ast_from_value()` cannot convert a raw dict into a GraphQL AST node, so it raises:

```
TypeError: Cannot convert value to AST: {}.
```