### PR TITLE
docs(experiments): how-to page for running experiments in the background

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -284,6 +284,7 @@
                 "pages": [
                   "docs/phoenix/datasets-and-experiments/how-to-experiments",
                   "docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments",
+                  "docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background",
                   "docs/phoenix/datasets-and-experiments/how-to-experiments/using-evaluators",
                   "docs/phoenix/datasets-and-experiments/how-to-experiments/how-to-dataset-evaluators",
                   "docs/phoenix/datasets-and-experiments/how-to-experiments/repetitions",

--- a/docs/phoenix/datasets-and-experiments/how-to-experiments.mdx
+++ b/docs/phoenix/datasets-and-experiments/how-to-experiments.mdx
@@ -14,6 +14,9 @@ Phoenix supports two workflows for experiments: a UI-driven flow in the Playgrou
   <Card title="Run Experiments with the SDK" icon="code" href="/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments#run-experiments-with-the-sdk">
     Run experiments programmatically with tasks and evaluators in code.
   </Card>
+  <Card title="Run Experiments in the Background" icon="server" href="/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background">
+    Start experiments from the Playground that keep running after you close the browser, and stop or resume them anytime.
+  </Card>
 </CardGroup>
 
 ## SDK Experiment Steps

--- a/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background.mdx
+++ b/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background.mdx
@@ -1,97 +1,97 @@
 ---
 title: "Run Experiments in the Background"
-description: "Run experiments from the Playground that survive browser disconnects and server restarts, and stop or resume them at any time."
+description: "Start experiments from the Playground that keep running after you close the browser, survive server restarts, and can be stopped or resumed at any time."
 ---
 
 <Info>
-Background experiment runs are available in Phoenix [14.0.0](https://github.com/Arize-ai/phoenix/releases/tag/arize-phoenix-v14.0.0)+.
+background experiments are available in `arize-phoenix` [14.0.0](https://github.com/Arize-ai/phoenix/releases/tag/arize-phoenix-v14.0.0)+.
 </Info>
 
-When you run an experiment from the Phoenix Playground, it executes on the Phoenix server as a **background job**. You can close the browser, navigate away, or restart the server — the experiment keeps running (or resumes on its own) until every dataset example has been evaluated.
+Experiments that iterate over large datasets or call slow models can take a while. Tying them to a browser tab is fragile — close the laptop, lose the work. When you run an experiment from the Phoenix Playground, Phoenix executes it on the server as a **background job**, so you can close the tab, navigate away, or even restart the server and the experiment keeps going until every example has been evaluated.
 
-This page describes how to start, monitor, stop, and resume these background experiments from the UI, and how to query their status via the API.
+This page walks through starting, monitoring, stopping, and resuming these background jobs from the UI, and how to query their state via the API.
 
-## How background jobs work
+## How Background Jobs Work
 
 Each experiment started from the Playground is backed by an **experiment job** on the server. The job:
 
 * Runs tasks across your dataset in batches, respecting provider rate limits.
-* Streams partial results back to any open browser tab viewing the experiment.
+* Makes results visible progressively — any browser tab viewing the experiment polls the server, so progress appears without a manual refresh.
 * Continues running after the browser disconnects.
 * Is automatically resumed by the server after a restart or crash, so no runs are lost.
 
-Each job has a lifecycle status:
+Every job has a lifecycle status, surfaced as a badge in the experiments table:
 
 | Status | Meaning |
 | :----- | :------ |
 | `RUNNING` | The job is currently executing tasks or evaluations. |
 | `COMPLETED` | All tasks and evaluations finished successfully. |
-| `STOPPED` | The job was paused (by user action or a connection drop for ephemeral runs). Can be resumed. |
-| `ERROR` | The job was stopped by the server after repeated failures from the LLM provider. |
+| `STOPPED` | The job was paused — either by user action, or by a connection drop for an ephemeral run. Can be resumed. |
+| `ERROR` | The job was halted by the server after repeated failures from the LLM provider. Can be resumed once the issue is addressed. |
 
-## Starting a background experiment
+## Starting a Background Experiment
 
-From the Playground, configure your prompt, model, and dataset as usual (see [Run Experiments](/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments)), then click **Run**. The experiment appears in the experiments table on the dataset page, with a status badge reflecting its current job state.
+From the Playground, configure your prompt, model, and dataset as usual (see [Run Experiments](/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments)) and click **Run**. The experiment immediately appears in the experiments table on the dataset page with a status badge reflecting its current job state.
 
-## Monitoring running experiments
+## Monitoring Running Experiments
 
-Open the experiments table for your dataset to see all experiments, including those currently running. Each row shows:
+<Frame>
+  <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/experiments-background-jobs-table.png" alt="Experiments table with job status badges (completed, stopped, error, N/A) and job progress columns"/>
+</Frame>
 
-* The job status badge (Running, Completed, Stopped, or Error).
-* Progress — number of completed runs out of total expected runs.
-* The most recent error, if any.
+Open the experiments table for your dataset to see everything that's in flight. Relevant columns:
 
-The table polls for updates, so you don't need to refresh the page.
+* **Job status** — Running, Completed, Stopped, or Error.
+* **Job progress** — number of completed runs out of the total expected.
+* **Error rate** — percentage of runs that errored out.
 
-## Stopping and resuming
+The table polls for updates while any experiment is running, so you don't need to refresh the page. To see the full error log for a single experiment, open its action menu and choose **View details** — the slideover lists every error the job has recorded, with timestamps and the task or evaluator the error came from.
 
-Open the action menu (the three-dot icon on an experiment row, or at the top of the experiment details page) and choose:
+## Stopping and Resuming
 
-* **Stop experiment** — pauses the job. In-flight LLM calls are allowed to finish; no new work is dispatched.
-* **Resume experiment** — restarts a stopped or errored job. Phoenix automatically re-queries the database for incomplete task runs and missing evaluations, so only outstanding work is executed. Already-completed runs are not re-run.
+Stop and Resume live on the three-dot action menu next to each experiment in the experiments table. While an experiment is still running in the Playground itself, the **Run** button also acts as a Stop button — clicking it stops the job and cancels the in-browser run.
 
-Resume can also be used to:
+From the action menu on an experiment row:
+
+* **Stop** — pauses the job. In-flight LLM calls are allowed to finish; no new work is dispatched. Only appears while status is `RUNNING`.
+* **Resume** — restarts a stopped or errored job. Phoenix re-queries the database for incomplete task runs and missing evaluations, so only outstanding work is executed. Already-completed runs are not re-run. Appears for any non-running job.
+
+Resume is also useful when you want to:
 
 * Attach a new dataset evaluator and score existing runs.
 * Re-run failed tasks after a transient provider outage.
 * Add more dataset examples and execute tasks only on the new ones.
 
-## Leaving the Playground while an experiment runs
+## Leaving the Playground Mid-Experiment
 
-Navigating away from the Playground while an experiment is in progress shows a confirmation dialog. The dialog depends on whether the experiment is *ephemeral*.
+Navigating away from the Playground while an experiment is still in progress opens a confirmation dialog. The dialog depends on whether the experiment is *ephemeral*.
 
-### Ephemeral experiments
+### Ephemeral Experiments
 
-Experiments started with temporary credentials (for example, an API key entered in the browser) are ephemeral. They stop on disconnect because the credentials cannot be persisted on the server. Ephemeral experiments are automatically deleted after 24 hours.
+Experiments started with temporary credentials — for example, an API key entered directly in the browser — are ephemeral. They stop on disconnect because the credentials cannot be persisted on the server, and they're automatically deleted 24 hours after their last update.
 
-Dialog copy: *"Your experiment will stop if you leave this page. Stay to let it finish."*
+When you navigate away, Phoenix opens an **Experiment In Progress** dialog warning that the experiment will stop if you leave. From there you can:
 
-Options:
-
-* **Stay** — cancel navigation, remain in the Playground.
+* **Stay** — cancel navigation and remain in the Playground.
 * **Leave** — navigate away; the experiment stops.
 
-### Persistent experiments
+### Persistent Experiments
 
-Experiments that use configured model credentials keep running after you leave the Playground.
-
-Dialog copy: *"This experiment will continue running in the background. You can track its progress in the experiments table."*
-
-Options:
+Experiments that use configured model credentials keep running after you leave the Playground. Phoenix opens a **Leave this page?** dialog confirming that the experiment will continue in the background and that you can keep tabs on it from the experiments table. You can:
 
 * **Stay on page** — cancel navigation.
 * **Delete experiment** — delete the experiment and then navigate away.
 * **Leave page** — navigate away; the experiment keeps running.
 
-## Automatic recovery
+## Automatic Recovery
 
-If the Phoenix server restarts (or a replica crashes in a multi-replica deployment), any experiments that were running at the time are automatically picked back up within about 10 minutes. No manual action is required.
+If the Phoenix server restarts — or a replica crashes in a multi-replica deployment — any experiments that were running are automatically picked back up within a few minutes. No manual action is required.
 
 Recovery re-queries the database for incomplete runs and missing evaluations, so the experiment continues exactly where it left off.
 
-## Querying job status via the API
+## Querying Job Status via the API
 
-Each `Experiment` exposes a `job` field of type `ExperimentJob` for experiments that are managed by the server. The field is `null` for experiments submitted through the Python or TypeScript SDK.
+Every `Experiment` exposes a `job` field of type `ExperimentJob` for experiments that are managed by the server. The field is `null` for experiments submitted through the Python or TypeScript SDK.
 
 ```graphql
 query ExperimentStatus($experimentId: ID!) {
@@ -114,6 +114,8 @@ query ExperimentStatus($experimentId: ID!) {
 }
 ```
 
+Use `lastError` for a quick "what went wrong most recently" view, or page through `errors` on `ExperimentJob` to inspect the full error history.
+
 To list all experiment jobs for a dataset:
 
 ```graphql
@@ -132,7 +134,3 @@ query DatasetJobs($datasetId: ID!) {
   }
 }
 ```
-
-## Resuming SDK experiments
-
-Experiments submitted from Python or TypeScript run in the caller's process, not on the server, and therefore do not appear as experiment jobs. To resume an interrupted SDK experiment, use `resume_experiment(experiment_id=..., task=...)` — see the [v14 release notes](/docs/phoenix/release-notes/04-2026/04-07-2026-phoenix-v14-breaking-changes) for details.

--- a/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background.mdx
+++ b/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background.mdx
@@ -1,0 +1,138 @@
+---
+title: "Run Experiments in the Background"
+description: "Run experiments from the Playground that survive browser disconnects and server restarts, and stop or resume them at any time."
+---
+
+<Info>
+Background experiment runs are available in Phoenix [14.0.0](https://github.com/Arize-ai/phoenix/releases/tag/arize-phoenix-v14.0.0)+.
+</Info>
+
+When you run an experiment from the Phoenix Playground, it executes on the Phoenix server as a **background job**. You can close the browser, navigate away, or restart the server — the experiment keeps running (or resumes on its own) until every dataset example has been evaluated.
+
+This page describes how to start, monitor, stop, and resume these background experiments from the UI, and how to query their status via the API.
+
+## How background jobs work
+
+Each experiment started from the Playground is backed by an **experiment job** on the server. The job:
+
+* Runs tasks across your dataset in batches, respecting provider rate limits.
+* Streams partial results back to any open browser tab viewing the experiment.
+* Continues running after the browser disconnects.
+* Is automatically resumed by the server after a restart or crash, so no runs are lost.
+
+Each job has a lifecycle status:
+
+| Status | Meaning |
+| :----- | :------ |
+| `RUNNING` | The job is currently executing tasks or evaluations. |
+| `COMPLETED` | All tasks and evaluations finished successfully. |
+| `STOPPED` | The job was paused (by user action or a connection drop for ephemeral runs). Can be resumed. |
+| `ERROR` | The job was stopped by the server after repeated failures from the LLM provider. |
+
+## Starting a background experiment
+
+From the Playground, configure your prompt, model, and dataset as usual (see [Run Experiments](/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments)), then click **Run**. The experiment appears in the experiments table on the dataset page, with a status badge reflecting its current job state.
+
+## Monitoring running experiments
+
+Open the experiments table for your dataset to see all experiments, including those currently running. Each row shows:
+
+* The job status badge (Running, Completed, Stopped, or Error).
+* Progress — number of completed runs out of total expected runs.
+* The most recent error, if any.
+
+The table polls for updates, so you don't need to refresh the page.
+
+## Stopping and resuming
+
+Open the action menu (the three-dot icon on an experiment row, or at the top of the experiment details page) and choose:
+
+* **Stop experiment** — pauses the job. In-flight LLM calls are allowed to finish; no new work is dispatched.
+* **Resume experiment** — restarts a stopped or errored job. Phoenix automatically re-queries the database for incomplete task runs and missing evaluations, so only outstanding work is executed. Already-completed runs are not re-run.
+
+Resume can also be used to:
+
+* Attach a new dataset evaluator and score existing runs.
+* Re-run failed tasks after a transient provider outage.
+* Add more dataset examples and execute tasks only on the new ones.
+
+## Leaving the Playground while an experiment runs
+
+Navigating away from the Playground while an experiment is in progress shows a confirmation dialog. The dialog depends on whether the experiment is *ephemeral*.
+
+### Ephemeral experiments
+
+Experiments started with temporary credentials (for example, an API key entered in the browser) are ephemeral. They stop on disconnect because the credentials cannot be persisted on the server. Ephemeral experiments are automatically deleted after 24 hours.
+
+Dialog copy: *"Your experiment will stop if you leave this page. Stay to let it finish."*
+
+Options:
+
+* **Stay** — cancel navigation, remain in the Playground.
+* **Leave** — navigate away; the experiment stops.
+
+### Persistent experiments
+
+Experiments that use configured model credentials keep running after you leave the Playground.
+
+Dialog copy: *"This experiment will continue running in the background. You can track its progress in the experiments table."*
+
+Options:
+
+* **Stay on page** — cancel navigation.
+* **Delete experiment** — delete the experiment and then navigate away.
+* **Leave page** — navigate away; the experiment keeps running.
+
+## Automatic recovery
+
+If the Phoenix server restarts (or a replica crashes in a multi-replica deployment), any experiments that were running at the time are automatically picked back up within about 10 minutes. No manual action is required.
+
+Recovery re-queries the database for incomplete runs and missing evaluations, so the experiment continues exactly where it left off.
+
+## Querying job status via the API
+
+Each `Experiment` exposes a `job` field of type `ExperimentJob` for experiments that are managed by the server. The field is `null` for experiments submitted through the Python or TypeScript SDK.
+
+```graphql
+query ExperimentStatus($experimentId: ID!) {
+  node(id: $experimentId) {
+    ... on Experiment {
+      name
+      isEphemeral
+      job {
+        status
+        createdAt
+        maxConcurrency
+        lastError {
+          message
+          occurredAt
+          level
+        }
+      }
+    }
+  }
+}
+```
+
+To list all experiment jobs for a dataset:
+
+```graphql
+query DatasetJobs($datasetId: ID!) {
+  node(id: $datasetId) {
+    ... on Dataset {
+      experimentJobs(first: 50) {
+        edges {
+          node {
+            status
+            experiment { name }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Resuming SDK experiments
+
+Experiments submitted from Python or TypeScript run in the caller's process, not on the server, and therefore do not appear as experiment jobs. To resume an interrupted SDK experiment, use `resume_experiment(experiment_id=..., task=...)` — see the [v14 release notes](/docs/phoenix/release-notes/04-2026/04-07-2026-phoenix-v14-breaking-changes) for details.

--- a/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background.mdx
+++ b/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background.mdx
@@ -60,77 +60,17 @@ Resume is also useful when you want to:
 
 * Attach a new dataset evaluator and score existing runs.
 * Re-run failed tasks after a transient provider outage.
-* Add more dataset examples and execute tasks only on the new ones.
+
+## The *Record* Toggle
+
+When *Record* is off, the experiment is ephemeral: it does not appear in the experiments list, and its database records are deleted after a set period.
 
 ## Leaving the Playground Mid-Experiment
 
-Navigating away from the Playground while an experiment is still in progress opens a confirmation dialog. The dialog depends on whether the experiment is *ephemeral*.
-
-### Ephemeral Experiments
-
-Experiments started with temporary credentials — for example, an API key entered directly in the browser — are ephemeral. They stop on disconnect because the credentials cannot be persisted on the server, and they're automatically deleted 24 hours after their last update.
-
-When you navigate away, Phoenix opens an **Experiment In Progress** dialog warning that the experiment will stop if you leave. From there you can:
-
-* **Stay** — cancel navigation and remain in the Playground.
-* **Leave** — navigate away; the experiment stops.
-
-### Persistent Experiments
-
-Experiments that use configured model credentials keep running after you leave the Playground. Phoenix opens a **Leave this page?** dialog confirming that the experiment will continue in the background and that you can keep tabs on it from the experiments table. You can:
-
-* **Stay on page** — cancel navigation.
-* **Delete experiment** — delete the experiment and then navigate away.
-* **Leave page** — navigate away; the experiment keeps running.
+With *Record* on, you can leave the Playground while an experiment is still running, and Phoenix will continue it in the background. With *Record* off, leaving stops the experiment.
 
 ## Automatic Recovery
 
 If the Phoenix server restarts — or a replica crashes in a multi-replica deployment — any experiments that were running are automatically picked back up within a few minutes. No manual action is required.
 
 Recovery re-queries the database for incomplete runs and missing evaluations, so the experiment continues exactly where it left off.
-
-## Querying Job Status via the API
-
-Every `Experiment` exposes a `job` field of type `ExperimentJob` for experiments that are managed by the server. The field is `null` for experiments submitted through the Python or TypeScript SDK.
-
-```graphql
-query ExperimentStatus($experimentId: ID!) {
-  node(id: $experimentId) {
-    ... on Experiment {
-      name
-      isEphemeral
-      job {
-        status
-        createdAt
-        maxConcurrency
-        lastError {
-          message
-          occurredAt
-          level
-        }
-      }
-    }
-  }
-}
-```
-
-Use `lastError` for a quick "what went wrong most recently" view, or page through `errors` on `ExperimentJob` to inspect the full error history.
-
-To list all experiment jobs for a dataset:
-
-```graphql
-query DatasetJobs($datasetId: ID!) {
-  node(id: $datasetId) {
-    ... on Dataset {
-      experimentJobs(first: 50) {
-        edges {
-          node {
-            status
-            experiment { name }
-          }
-        }
-      }
-    }
-  }
-}
-```

--- a/docs/phoenix/release-notes/04-2026/04-07-2026-phoenix-v14-breaking-changes.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-07-2026-phoenix-v14-breaking-changes.mdx
@@ -201,4 +201,4 @@ Additional capabilities:
 - **Async resume API** — use `async_resume_experiment(...)` for async tasks.
 - **Evaluator support** — pass `evaluators` to `resume_experiment` to run or re-run evaluations on completed task runs after resuming.
 
-The `run_experiment` call signature is unchanged. See [Resume Interrupted Experiments](/datasets-and-experiments/how-to-experiments/run-experiments-in-background) for full documentation.
+The `run_experiment` call signature is unchanged. Learn more in the [Run Experiments in the Background](/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background) docs.

--- a/docs/phoenix/release-notes/04-2026/04-07-2026-phoenix-v14-breaking-changes.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-07-2026-phoenix-v14-breaking-changes.mdx
@@ -186,19 +186,3 @@ query {
 Queries that omit `first` will fail with `"first" is required`. Queries that pass `first` greater than 1000 will fail with `"first" must be less than or equal to 1000`. Backward pagination with `last`/`before` is no longer supported on these fields.
 
 This change protects the server from unbounded queries that could cause excessive memory usage and slow response times.
-
-# New: Resume Interrupted SDK Experiments
-
-April 7, 2026
-
-**New in arize-phoenix 14.0.0**
-
-SDK experiments still run in the caller's Python process. Phoenix v14 adds dedicated resume APIs so you can continue interrupted experiments without starting over from scratch.
-
-Additional capabilities:
-
-- **Resume API** — use `resume_experiment(experiment_id=..., task=...)` to re-run only missing or failed task runs.
-- **Async resume API** — use `async_resume_experiment(...)` for async tasks.
-- **Evaluator support** — pass `evaluators` to `resume_experiment` to run or re-run evaluations on completed task runs after resuming.
-
-The `run_experiment` call signature is unchanged. Learn more in the [Run Experiments in the Background](/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background) docs.


### PR DESCRIPTION
## Summary

Adds a public-facing how-to page for the **background experiment runner** feature that shipped in `arize-phoenix` v14.0.0.

Resolves #12618.

## What this adds

- **New page:** `docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background.mdx` — covers starting a background experiment from the Playground, stop/resume, ephemeral vs persistent experiments, the navigation-dialog behavior, automatic recovery after server restart, and querying `ExperimentJob` status via GraphQL.
- **Nav:** registered in `docs.json` under *How-to: Experiments*, between `run-experiments` and `using-evaluators`.
- **Overview:** new `<Card>` in the *Running Experiments* group on `how-to-experiments.mdx`.
- **Side effect:** fixes the broken link `/datasets-and-experiments/how-to-experiments/run-experiments-in-background` referenced by the v14 breaking-changes release note.

## Follow-ups

- [x] @RogerHYang — technical-accuracy review (co-assignee on the issue).
- [x] Screenshots: action menu with stop/resume, status badges in the experiments table, the two navigation dialogs. Optional, can be added in a follow-up.

## Test plan

- [x] Verify the Mintlify preview deployment renders the new page cleanly.
- [x] Confirm the nav entry appears in the expected position.
- [x] Click the overview card and confirm it lands on the new page.
- [ ] Confirm the broken link from `04-07-2026-phoenix-v14-breaking-changes.mdx` now resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)