### PR TITLE
feat(cli): add span note support to px

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires Node.js (for npx) or global install of @arizeai/phoenix-cli. Optionally requires jq for JSON processing.
 metadata:
   author: arize-ai
-  version: "3.1.0"
+  version: "3.2.0"
 ---
 
 # Phoenix CLI
@@ -25,6 +25,7 @@ px trace get <trace-id>
 px trace annotate <trace-id>
 px span list
 px span annotate <span-id>
+px span add-note <span-id>
 px dataset list
 px dataset get <name>
 px project list
@@ -63,8 +64,10 @@ px trace list --limit 20 --format raw --no-progress | jq .
 px trace list --last-n-minutes 60 --limit 20 --format raw --no-progress | jq '.[] | select(.status == "ERROR")'
 px trace list --since 2025-01-15T00:00:00Z --limit 50 --format raw --no-progress | jq .
 px trace list --format raw --no-progress | jq 'sort_by(-.duration) | .[0:5]'
+px trace list --include-notes --format raw --no-progress | jq '.[].spans[].notes'
 px trace get <trace-id> --format raw | jq .
 px trace get <trace-id> --format raw | jq '.spans[] | select(.status_code != "OK")'
+px trace get <trace-id> --include-notes --format raw | jq '.spans[].notes'
 px trace annotate <trace-id> --name reviewer --label pass
 px trace annotate <trace-id> --name reviewer --score 0.9 --format raw --no-progress
 ```
@@ -74,10 +77,14 @@ px trace annotate <trace-id> --name reviewer --score 0.9 --format raw --no-progr
 ```
 Trace
   traceId, status ("OK"|"ERROR"), duration (ms), startTime, endTime
+  annotations[] (with --include-annotations, excludes note)
+    name, result { score, label, explanation }
   rootSpan  — top-level span (parent_id: null)
   spans[]
     name, span_kind ("LLM"|"CHAIN"|"TOOL"|"RETRIEVER"|"EMBEDDING"|"AGENT"|"RERANKER"|"GUARDRAIL"|"EVALUATOR"|"UNKNOWN")
     status_code ("OK"|"ERROR"|"UNSET"), parent_id, context.span_id
+    notes[] (with --include-notes)
+      name="note", result { explanation }
     attributes
       input.value, output.value          — raw input/output
       llm.model_name, llm.provider
@@ -103,10 +110,12 @@ px span list --trace-id <id> --format raw --no-progress | jq .   # all spans for
 px span list --parent-id null --limit 10                   # only root spans
 px span list --parent-id <span-id> --limit 10              # only children of a span
 px span list --include-annotations --limit 10              # include annotation scores
+px span list --include-notes --limit 10                    # include span notes
 px span list output.json --limit 100                       # save to JSON file
 px span list --format raw --no-progress | jq '.[] | select(.status_code == "ERROR")'
 px span annotate <span-id> --name reviewer --label pass
 px span annotate <span-id> --name checker --score 1 --annotator-kind CODE
+px span add-note <span-id> --text "verified by agent"
 ```
 
 ### Span JSON shape
@@ -125,8 +134,10 @@ Span
     llm.output_messages.{N}.message.role/content
     llm.invocation_parameters          — JSON string (temperature, etc.)
     exception.message                  — set if span errored
-  annotations[] (with --include-annotations)
+  annotations[] (with --include-annotations, excludes note)
     name, result { score, label, explanation }
+  notes[] (with --include-notes)
+    name="note", result { explanation }
 ```
 
 ## Sessions

--- a/js/packages/phoenix-cli/.agents/skills/phoenix-cli-development/SKILL.md
+++ b/js/packages/phoenix-cli/.agents/skills/phoenix-cli-development/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: oss@arize.com
-  version: "2.0.0"
+  version: "2.1.0"
   internal: true
 ---
 
@@ -303,7 +303,9 @@ px project --endpoint http://my-server:6006 list
 10. Run `pnpm test` — fix any failures before proceeding
 11. Run `pnpm build` — fix any type errors before proceeding
 12. Update `README.md` with usage examples showing both human and agent-friendly invocations
-13. If the command prompts for input or confirmation, support `--no-input` (see `InteractiveCommandOptions`)
-14. Add at least one example to `--help` via `.addHelpText('after', ...)`
-15. Mutating commands return the affected resource on stdout (not just a success message)
-16. Run manually with `--format raw` and `--no-input` to verify agents get clean, parseable output
+13. Update the external Phoenix CLI skill at `.agents/skills/phoenix-cli/SKILL.md` when commands, flags, examples, or output shapes change
+14. Keep skill updates concise: document the new capability with the smallest useful examples and output-shape notes rather than repeating the full README
+15. If the command prompts for input or confirmation, support `--no-input` (see `InteractiveCommandOptions`)
+16. Add at least one example to `--help` via `.addHelpText('after', ...)`
+17. Mutating commands return the affected resource on stdout (not just a success message)
+18. Run manually with `--format raw` and `--no-input` to verify agents get clean, parseable output

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -91,6 +91,7 @@ px trace list --since 2026-01-13T10:00:00Z       # since ISO timestamp
 | `--format <format>`         | `pretty`, `json`, or `raw`             | `pretty` |
 | `--no-progress`             | Suppress progress output               | —        |
 | `--include-annotations`     | Include span annotations               | —        |
+| `--include-notes`           | Include span notes                     | —        |
 
 ```bash
 # Find ERROR traces
@@ -114,6 +115,7 @@ Fetch a single trace by ID.
 px trace get abc123def456
 px trace get abc123def456 --format raw | jq '.spans[] | select(.status_code != "OK")'
 px trace get abc123def456 --file trace.json
+px trace get abc123def456 --include-notes --format raw | jq '.spans[].notes'
 ```
 
 ---
@@ -157,6 +159,7 @@ px span list --last-n-minutes 30 --span-kind TOOL RETRIEVER # multiple span kind
 | `--trace-id <ids...>`       | Filter by trace ID(s)                                                                                                            | —        |
 | `--parent-id <id>`          | Filter by parent span ID (use `"null"` for root spans only)                                                                      | —        |
 | `--include-annotations`     | Include span annotations in the output                                                                                           | —        |
+| `--include-notes`           | Include span notes in the output                                                                                                 | —        |
 | `--format <format>`         | `pretty`, `json`, or `raw`                                                                                                       | `pretty` |
 | `--no-progress`             | Suppress progress output                                                                                                         | —        |
 
@@ -183,6 +186,17 @@ px span annotate 7e2f08cb43bbf521 --name reviewer --label pass
 px span annotate 7e2f08cb43bbf521 --name reviewer --score 0.9 --format raw --no-progress
 px span annotate 7e2f08cb43bbf521 --name checker --score 1 --annotator-kind CODE
 px span annotate 7e2f08cb43bbf521 --name reviewer --explanation "looks good"
+```
+
+---
+
+### `px span add-note <span-id>`
+
+Add a note to a span by OpenTelemetry span ID.
+
+```bash
+px span add-note 7e2f08cb43bbf521 --text "double-check tool output"
+px span add-note 7e2f08cb43bbf521 --text "verified by agent" --format raw --no-progress
 ```
 
 ---

--- a/js/packages/phoenix-cli/src/commands/formatNoteMutation.ts
+++ b/js/packages/phoenix-cli/src/commands/formatNoteMutation.ts
@@ -1,0 +1,32 @@
+import type { NoteMutationResult } from "./noteMutationUtils";
+
+export type OutputFormat = "pretty" | "json" | "raw";
+
+export interface FormatNoteMutationOutputOptions {
+  note: NoteMutationResult;
+  format?: OutputFormat;
+}
+
+export function formatNoteMutationOutput({
+  note,
+  format,
+}: FormatNoteMutationOutputOptions): string {
+  const selectedFormat = format || "pretty";
+  if (selectedFormat === "raw") {
+    return JSON.stringify(note);
+  }
+  if (selectedFormat === "json") {
+    return JSON.stringify(note, null, 2);
+  }
+  return formatNoteMutationPretty(note);
+}
+
+function formatNoteMutationPretty(note: NoteMutationResult): string {
+  return [
+    "Note added",
+    `  ID: ${note.id}`,
+    `  Target: ${note.targetType} ${note.targetId}`,
+    `  Text: ${note.text}`,
+    `  Annotator: ${note.annotatorKind}`,
+  ].join("\n");
+}

--- a/js/packages/phoenix-cli/src/commands/formatSpans.ts
+++ b/js/packages/phoenix-cli/src/commands/formatSpans.ts
@@ -29,6 +29,7 @@ function formatSpansPretty(spans: SpanWithAnnotations[]): string {
   const hasAnnotations = spans.some(
     (s) => s.annotations && s.annotations.length > 0
   );
+  const hasNotes = spans.some((s) => s.notes && s.notes.length > 0);
 
   const rows = spans.map((span) => {
     const statusCode = span.status_code || "UNSET";
@@ -45,6 +46,9 @@ function formatSpansPretty(spans: SpanWithAnnotations[]): string {
 
     if (hasAnnotations) {
       row.annotations = formatAnnotations(span.annotations);
+    }
+    if (hasNotes) {
+      row.notes = formatNotes(span.notes);
     }
 
     return row;
@@ -83,4 +87,12 @@ function formatAnnotations(annotations: SpanAnnotation[] | undefined): string {
       return pieces.join("");
     })
     .join(", ");
+}
+
+function formatNotes(notes: SpanAnnotation[] | undefined): string {
+  if (!notes || notes.length === 0) return "";
+  return notes
+    .map((note) => note.result?.explanation?.replace(/\s+/g, " ").trim() || "")
+    .filter((noteText) => noteText.length > 0)
+    .join(" | ");
 }

--- a/js/packages/phoenix-cli/src/commands/formatTraces.ts
+++ b/js/packages/phoenix-cli/src/commands/formatTraces.ts
@@ -210,6 +210,7 @@ function renderSpanNode(
 
   const nextAncestors = [...opts.ancestors, opts.isLast];
   renderSpanAnnotations(lines, span, nextAncestors);
+  renderSpanNotes(lines, span, nextAncestors);
   for (let i = 0; i < children.length; i++) {
     renderSpanNode(lines, children[i]!, {
       ancestors: nextAncestors,
@@ -251,6 +252,28 @@ function renderSpanAnnotations(
       ...formatAnnotationResultParts(annotation.result),
     ];
     lines.push(`${detailPrefix}- ${parts.join(" ")}`);
+  }
+}
+
+function renderSpanNotes(
+  lines: string[],
+  span: Span,
+  ancestors: boolean[]
+): void {
+  const notes = span.notes;
+  if (!notes?.length) {
+    return;
+  }
+
+  const detailPrefix =
+    "│  " +
+    ancestors
+      .map((ancestorIsLast) => (ancestorIsLast ? "   " : "│  "))
+      .join("");
+
+  lines.push(`${detailPrefix}notes:`);
+  for (const note of notes) {
+    lines.push(`${detailPrefix}- ${formatNoteText(note.result?.explanation)}`);
   }
 }
 
@@ -315,4 +338,17 @@ function truncateValue(value: string): string {
     return value;
   }
   return value.slice(0, VALUE_PREVIEW_MAX_CHARS) + "…";
+}
+
+function formatNoteText(text: string | null | undefined): string {
+  if (!text) {
+    return "(empty)";
+  }
+
+  const normalizedText = text.replace(/\s+/g, " ").trim();
+  if (!normalizedText) {
+    return "(empty)";
+  }
+
+  return truncateValue(normalizedText);
 }

--- a/js/packages/phoenix-cli/src/commands/noteMutationUtils.ts
+++ b/js/packages/phoenix-cli/src/commands/noteMutationUtils.ts
@@ -1,0 +1,76 @@
+import { InvalidArgumentError } from "../exitCodes";
+import { trimToUndefined } from "../normalize";
+import type { AnnotatorKind } from "./annotationMutationUtils";
+
+export type NoteTargetType = "span" | "trace";
+export const NOTE_ANNOTATION_NAME = "note";
+
+export interface NoteMutationResult {
+  id: string;
+  targetType: NoteTargetType;
+  targetId: string;
+  text: string;
+  annotatorKind: AnnotatorKind;
+}
+
+function getTargetIdPlaceholder({
+  targetType,
+}: {
+  targetType: NoteTargetType;
+}): string {
+  return targetType === "span" ? "<span-id>" : "<trace-id>";
+}
+
+function getAddNoteUsage({
+  targetType,
+}: {
+  targetType: NoteTargetType;
+}): string {
+  const targetIdPlaceholder = getTargetIdPlaceholder({ targetType });
+  return `px ${targetType} add-note ${targetIdPlaceholder} --text <text>`;
+}
+
+export function normalizeNoteText({
+  targetType,
+  text,
+}: {
+  targetType: NoteTargetType;
+  text?: string;
+}): string {
+  if (text === undefined) {
+    throw new InvalidArgumentError(
+      `Missing required flag --text.\n  ${getAddNoteUsage({ targetType })}`
+    );
+  }
+
+  const normalizedText = trimToUndefined({ value: text });
+  if (!normalizedText) {
+    throw new InvalidArgumentError(
+      `Invalid value for --text: <empty>. Expected non-empty text.\n  ${getAddNoteUsage({ targetType })}`
+    );
+  }
+
+  return normalizedText;
+}
+
+export function buildNoteMutationResult({
+  id,
+  targetType,
+  targetId,
+  text,
+  annotatorKind,
+}: {
+  id: string;
+  targetType: NoteTargetType;
+  targetId: string;
+  text: string;
+  annotatorKind?: AnnotatorKind;
+}): NoteMutationResult {
+  return {
+    id,
+    targetType,
+    targetId,
+    text,
+    annotatorKind: annotatorKind ?? "HUMAN",
+  };
+}

--- a/js/packages/phoenix-cli/src/commands/span.ts
+++ b/js/packages/phoenix-cli/src/commands/span.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import type { componentsV1, PhoenixClient } from "@arizeai/phoenix-client";
+import { addSpanNote } from "@arizeai/phoenix-client/spans";
 import { Command } from "commander";
 
 import { createPhoenixClient, resolveProjectId } from "../client";
@@ -23,9 +24,18 @@ import {
   type OutputFormat as AnnotationMutationOutputFormat,
 } from "./formatAnnotationMutation";
 import {
+  formatNoteMutationOutput,
+  type OutputFormat as NoteMutationOutputFormat,
+} from "./formatNoteMutation";
+import {
   formatSpansOutput,
   type OutputFormat as SpanOutputFormat,
 } from "./formatSpans";
+import {
+  buildNoteMutationResult,
+  NOTE_ANNOTATION_NAME,
+  normalizeNoteText,
+} from "./noteMutationUtils";
 import { fetchSpanAnnotations, type SpanAnnotation } from "./spanAnnotations";
 
 type Span = componentsV1["schemas"]["Span"];
@@ -45,6 +55,7 @@ interface SpanListOptions {
   traceId?: string[];
   parentId?: string;
   includeAnnotations?: boolean;
+  includeNotes?: boolean;
 }
 
 interface SpanAnnotateOptions {
@@ -57,6 +68,14 @@ interface SpanAnnotateOptions {
   score?: string;
   explanation?: string;
   annotatorKind?: string;
+}
+
+interface SpanAddNoteOptions {
+  endpoint?: string;
+  apiKey?: string;
+  format?: NoteMutationOutputFormat;
+  progress?: boolean;
+  text?: string;
 }
 
 /**
@@ -228,6 +247,7 @@ async function spanListHandler(
         client,
         projectIdentifier: projectId,
         spanIds,
+        excludeAnnotationNames: [NOTE_ANNOTATION_NAME],
       });
 
       const annotationsBySpanId = new Map<string, SpanAnnotation[]>();
@@ -245,6 +265,41 @@ async function spanListHandler(
         const spanAnnotations = annotationsBySpanId.get(spanId);
         if (spanAnnotations) {
           span.annotations = spanAnnotations;
+        }
+      }
+    }
+    if (options.includeNotes) {
+      writeProgress({
+        message: "Fetching span notes...",
+        noProgress: !options.progress,
+      });
+
+      const spanIds = spans
+        .map((span) => span.context?.span_id)
+        .filter((spanId): spanId is string => Boolean(spanId));
+
+      const notes = await fetchSpanAnnotations({
+        client,
+        projectIdentifier: projectId,
+        spanIds,
+        includeAnnotationNames: [NOTE_ANNOTATION_NAME],
+      });
+
+      const notesBySpanId = new Map<string, SpanAnnotation[]>();
+      for (const note of notes) {
+        const spanId = note.span_id;
+        if (!notesBySpanId.has(spanId)) {
+          notesBySpanId.set(spanId, []);
+        }
+        notesBySpanId.get(spanId)!.push(note);
+      }
+
+      for (const span of spans) {
+        const spanId = span.context?.span_id;
+        if (!spanId) continue;
+        const spanNotes = notesBySpanId.get(spanId);
+        if (spanNotes) {
+          span.notes = spanNotes;
         }
       }
     }
@@ -319,6 +374,7 @@ export function createSpanListCommand(): Command {
       'Filter by parent span ID (use "null" for root spans only)'
     )
     .option("--include-annotations", "Include span annotations in the output")
+    .option("--include-notes", "Include span notes in the output")
     .action(spanListHandler);
 }
 
@@ -432,6 +488,82 @@ export function createSpanAnnotateCommand(): Command {
     .action(spanAnnotateHandler);
 }
 
+async function spanAddNoteHandler(
+  spanId: string,
+  options: SpanAddNoteOptions
+): Promise<void> {
+  try {
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    const validation = validateConfig({ config, projectRequired: false });
+    if (!validation.valid) {
+      writeError({
+        message: getConfigErrorMessage({ errors: validation.errors }),
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+
+    const noteText = normalizeNoteText({
+      targetType: "span",
+      text: options.text,
+    });
+    const client = createPhoenixClient({ config });
+
+    writeProgress({
+      message: `Adding note to span ${spanId}...`,
+      noProgress: !options.progress,
+    });
+
+    const result = await addSpanNote({
+      client,
+      spanNote: {
+        spanId,
+        note: noteText,
+      },
+    });
+
+    const note = buildNoteMutationResult({
+      id: result.id,
+      targetType: "span",
+      targetId: spanId,
+      text: noteText,
+    });
+
+    writeOutput({
+      message: formatNoteMutationOutput({
+        note,
+        format: options.format,
+      }),
+    });
+  } catch (error) {
+    writeError({
+      message: `Error adding span note: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(getExitCodeForError(error));
+  }
+}
+
+export function createSpanAddNoteCommand(): Command {
+  return new Command("add-note")
+    .description("Add a note to a span by OpenTelemetry span ID")
+    .argument("<span-id>", "OpenTelemetry span ID")
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option("--text <text>", "Note text")
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .action(spanAddNoteHandler);
+}
+
 interface SpanDeleteOptions {
   endpoint?: string;
   apiKey?: string;
@@ -519,6 +651,7 @@ export function createSpanCommand(): Command {
   command.description("Manage Phoenix spans");
   command.addCommand(createSpanListCommand());
   command.addCommand(createSpanAnnotateCommand());
+  command.addCommand(createSpanAddNoteCommand());
   command.addCommand(createSpanDeleteCommand());
   return command;
 }

--- a/js/packages/phoenix-cli/src/commands/trace.ts
+++ b/js/packages/phoenix-cli/src/commands/trace.ts
@@ -33,6 +33,7 @@ import {
   formatTracesOutput,
   type OutputFormat as TraceOutputFormat,
 } from "./formatTraces";
+import { NOTE_ANNOTATION_NAME } from "./noteMutationUtils";
 import { fetchSpanAnnotations, type SpanAnnotation } from "./spanAnnotations";
 import {
   fetchTraceAnnotations,
@@ -85,6 +86,29 @@ function attachTraceAnnotationsToTraces(
   }
 }
 
+function attachSpanNotesToSpans(
+  spans: SpanWithAnnotations[],
+  notes: SpanAnnotation[]
+): void {
+  const notesBySpanId = new Map<string, SpanAnnotation[]>();
+  for (const note of notes) {
+    const spanId = note.span_id;
+    if (!notesBySpanId.has(spanId)) {
+      notesBySpanId.set(spanId, []);
+    }
+    notesBySpanId.get(spanId)!.push(note);
+  }
+
+  for (const span of spans) {
+    const spanId = span.context?.span_id;
+    if (!spanId) continue;
+    const spanNotes = notesBySpanId.get(spanId);
+    if (spanNotes) {
+      span.notes = spanNotes;
+    }
+  }
+}
+
 function getResolvedTraceId(spans: Span[]): string | undefined {
   return spans[0]?.context?.trace_id;
 }
@@ -97,6 +121,7 @@ interface TraceGetOptions {
   progress?: boolean;
   file?: string;
   includeAnnotations?: boolean;
+  includeNotes?: boolean;
 }
 
 interface TraceListOptions {
@@ -110,6 +135,7 @@ interface TraceListOptions {
   since?: string;
   maxConcurrent?: number;
   includeAnnotations?: boolean;
+  includeNotes?: boolean;
 }
 
 interface TraceAnnotateOptions {
@@ -411,6 +437,7 @@ async function traceGetHandler(
         client,
         projectIdentifier: projectId,
         traceIds: resolvedTraceId ? [resolvedTraceId] : [traceId],
+        excludeAnnotationNames: [NOTE_ANNOTATION_NAME],
       });
 
       const spanIds = traceSpans
@@ -420,8 +447,26 @@ async function traceGetHandler(
         client,
         projectIdentifier: projectId,
         spanIds,
+        excludeAnnotationNames: [NOTE_ANNOTATION_NAME],
       });
       attachSpanAnnotationsToSpans(traceSpans, spanAnnotations);
+    }
+    if (options.includeNotes) {
+      writeProgress({
+        message: "Fetching span notes...",
+        noProgress: !options.progress,
+      });
+
+      const spanIds = traceSpans
+        .map((span) => span.context?.span_id)
+        .filter((spanId): spanId is string => Boolean(spanId));
+      const spanNotes = await fetchSpanAnnotations({
+        client,
+        projectIdentifier: projectId,
+        spanIds,
+        includeAnnotationNames: [NOTE_ANNOTATION_NAME],
+      });
+      attachSpanNotesToSpans(traceSpans, spanNotes);
     }
 
     // Build trace
@@ -541,6 +586,7 @@ async function traceListHandler(
         client,
         projectIdentifier: projectId,
         traceIds: traces.map((trace) => trace.traceId),
+        excludeAnnotationNames: [NOTE_ANNOTATION_NAME],
         maxConcurrent: options.maxConcurrent,
       });
       attachTraceAnnotationsToTraces(traces, traceAnnotations);
@@ -554,10 +600,33 @@ async function traceListHandler(
         client,
         projectIdentifier: projectId,
         spanIds,
+        excludeAnnotationNames: [NOTE_ANNOTATION_NAME],
         maxConcurrent: options.maxConcurrent,
       });
       for (const trace of traces) {
         attachSpanAnnotationsToSpans(trace.spans, spanAnnotations);
+      }
+    }
+    if (options.includeNotes) {
+      writeProgress({
+        message: "Fetching span notes...",
+        noProgress: !options.progress,
+      });
+
+      const spanIds = traces
+        .flatMap((trace) => trace.spans)
+        .map((span) => span.context?.span_id)
+        .filter((spanId): spanId is string => Boolean(spanId));
+
+      const spanNotes = await fetchSpanAnnotations({
+        client,
+        projectIdentifier: projectId,
+        spanIds,
+        includeAnnotationNames: [NOTE_ANNOTATION_NAME],
+        maxConcurrent: options.maxConcurrent,
+      });
+      for (const trace of traces) {
+        attachSpanNotesToSpans(trace.spans, spanNotes);
       }
     }
 
@@ -612,6 +681,7 @@ export function createTraceGetCommand(): Command {
       "--include-annotations",
       "Include trace and span annotations in the trace export"
     )
+    .option("--include-notes", "Include span notes in the trace export")
     .action(traceGetHandler);
 }
 
@@ -650,6 +720,7 @@ export function createTraceListCommand(): Command {
       "--include-annotations",
       "Include trace and span annotations in the trace export"
     )
+    .option("--include-notes", "Include span notes in the trace export")
     .action(traceListHandler);
 }
 

--- a/js/packages/phoenix-cli/src/trace.ts
+++ b/js/packages/phoenix-cli/src/trace.ts
@@ -3,7 +3,10 @@ import type { componentsV1 } from "@arizeai/phoenix-client";
 export type Span = componentsV1["schemas"]["Span"];
 export type SpanAnnotation = componentsV1["schemas"]["SpanAnnotation"];
 export type TraceAnnotation = componentsV1["schemas"]["TraceAnnotation"];
-export type SpanWithAnnotations = Span & { annotations?: SpanAnnotation[] };
+export type SpanWithAnnotations = Span & {
+  annotations?: SpanAnnotation[];
+  notes?: SpanAnnotation[];
+};
 
 /**
  * Represents a trace with its spans organized hierarchically

--- a/js/packages/phoenix-cli/test/cli.test.ts
+++ b/js/packages/phoenix-cli/test/cli.test.ts
@@ -74,6 +74,9 @@ describe("Phoenix CLI", () => {
     expect(spanCommand?.commands.map((command) => command.name())).toContain(
       "annotate"
     );
+    expect(spanCommand?.commands.map((command) => command.name())).toContain(
+      "add-note"
+    );
     expect(
       program.commands.find((command) => command.name() === "spans")
     ).toBeUndefined();

--- a/js/packages/phoenix-cli/test/notes.test.ts
+++ b/js/packages/phoenix-cli/test/notes.test.ts
@@ -1,0 +1,454 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createSpanCommand } from "../src/commands/span";
+import { createTraceCommand } from "../src/commands/trace";
+import { ExitCode } from "../src/exitCodes";
+
+function makeFetchMock(
+  responses: Array<
+    { ok: boolean; status?: number; body?: unknown } | { error: Error }
+  >
+) {
+  let callIndex = 0;
+  return vi.fn().mockImplementation((requestOrUrl: Request | string) => {
+    const response = responses[callIndex++] ?? responses[responses.length - 1];
+    if ("error" in response) {
+      return Promise.reject(response.error);
+    }
+    const status = response.status ?? (response.ok ? 200 : 500);
+    const url =
+      requestOrUrl instanceof Request ? requestOrUrl.url : requestOrUrl;
+    return Promise.resolve({
+      ok: response.ok,
+      status,
+      statusText: response.ok ? "OK" : "Error",
+      url,
+      headers: new Headers(),
+      json: () => Promise.resolve(response.body ?? {}),
+      text: () => Promise.resolve(""),
+    });
+  });
+}
+
+function getFetchUrl(arg: unknown): string {
+  if (arg instanceof Request) return arg.url;
+  return String(arg);
+}
+
+async function getFetchBody(
+  arg: unknown,
+  init?: RequestInit
+): Promise<unknown> {
+  if (arg instanceof Request) {
+    const text = await arg.clone().text();
+    return text ? JSON.parse(text) : undefined;
+  }
+  if (typeof init?.body === "string") {
+    return JSON.parse(init.body);
+  }
+  return undefined;
+}
+
+function makeProjectResponse() {
+  return {
+    ok: true,
+    body: {
+      data: {
+        id: "project-default",
+      },
+    },
+  } as const;
+}
+
+function makeSpanPageResponse() {
+  return {
+    ok: true,
+    body: {
+      data: [
+        {
+          name: "root",
+          span_kind: "CHAIN",
+          parent_id: null,
+          status_code: "OK",
+          status_message: "",
+          start_time: "2026-01-13T10:00:00.000Z",
+          end_time: "2026-01-13T10:00:01.000Z",
+          attributes: {
+            "input.value": "hello",
+            "output.value": "world",
+          },
+          events: [],
+          context: {
+            trace_id: "trace-123",
+            span_id: "span-123",
+          },
+        },
+      ],
+      next_cursor: null,
+    },
+  } as const;
+}
+
+function makeSpanNoteResponse() {
+  return {
+    ok: true,
+    body: {
+      data: [
+        {
+          id: "span-note-1",
+          created_at: "2026-01-13T10:00:00.750Z",
+          updated_at: "2026-01-13T10:00:00.750Z",
+          source: "API",
+          user_id: null,
+          name: "note",
+          annotator_kind: "HUMAN",
+          result: {
+            explanation: "span note text",
+          },
+          metadata: null,
+          identifier: "px-span-note:1",
+          span_id: "span-123",
+        },
+      ],
+      next_cursor: null,
+    },
+  } as const;
+}
+
+function makeTraceAnnotationResponse() {
+  return {
+    ok: true,
+    body: {
+      data: [],
+      next_cursor: null,
+    },
+  } as const;
+}
+
+const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("span add-note", () => {
+  it("posts a span note and returns raw output", async () => {
+    const fetchMock = makeFetchMock([
+      {
+        ok: true,
+        body: { data: { id: "span-note-1" } },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSpanCommand().parseAsync(
+      [
+        "add-note",
+        "span-123",
+        "--text",
+        "  needs review  ",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain("/v1/span_notes");
+    await expect(
+      getFetchBody(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
+    ).resolves.toEqual({
+      data: {
+        span_id: "span-123",
+        note: "needs review",
+      },
+    });
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        id: "span-note-1",
+        targetType: "span",
+        targetId: "span-123",
+        text: "needs review",
+        annotatorKind: "HUMAN",
+      })
+    );
+  });
+
+  it("fails with INVALID_ARGUMENT when --text is missing", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSpanCommand().parseAsync(["add-note", "span-123", ...BASE_ARGS], {
+        from: "user",
+      })
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails with INVALID_ARGUMENT when --text is blank", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSpanCommand().parseAsync(
+        ["add-note", "span-123", "--text", "   ", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid value for --text: <empty>. Expected non-empty text."
+      )
+    );
+  });
+});
+
+describe("span note readback", () => {
+  it("includes notes in span list raw output when requested", async () => {
+    const fetchMock = makeFetchMock([
+      makeProjectResponse(),
+      makeSpanPageResponse(),
+      makeSpanNoteResponse(),
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSpanCommand().parseAsync(
+      [
+        "list",
+        "--project",
+        "default",
+        "--include-notes",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
+      "/v1/projects/project-default/span_annotations"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
+      "include_annotation_names=note"
+    );
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const parsedOutput = JSON.parse(String(output));
+    expect(parsedOutput[0].notes).toEqual([
+      expect.objectContaining({ id: "span-note-1", name: "note" }),
+    ]);
+  });
+
+  it("keeps note names out of annotations when both note flags are used", async () => {
+    const fetchMock = makeFetchMock([
+      makeProjectResponse(),
+      makeSpanPageResponse(),
+      {
+        ok: true,
+        body: {
+          data: [
+            {
+              id: "annotation-1",
+              created_at: "2026-01-13T10:00:00.250Z",
+              updated_at: "2026-01-13T10:00:00.250Z",
+              source: "API",
+              user_id: null,
+              name: "correctness",
+              annotator_kind: "HUMAN",
+              result: {
+                label: "correct",
+              },
+              metadata: null,
+              identifier: "annotation:1",
+              span_id: "span-123",
+            },
+          ],
+          next_cursor: null,
+        },
+      },
+      makeSpanNoteResponse(),
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSpanCommand().parseAsync(
+      [
+        "list",
+        "--project",
+        "default",
+        "--include-annotations",
+        "--include-notes",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
+      "exclude_annotation_names=note"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
+      "include_annotation_names=note"
+    );
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const parsedOutput = JSON.parse(String(output));
+    expect(parsedOutput[0].annotations).toEqual([
+      expect.objectContaining({ id: "annotation-1", name: "correctness" }),
+    ]);
+    expect(parsedOutput[0].annotations).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "note" })])
+    );
+    expect(parsedOutput[0].notes).toEqual([
+      expect.objectContaining({ id: "span-note-1", name: "note" }),
+    ]);
+  });
+});
+
+describe("trace span-note readback", () => {
+  it("includes span notes in trace get raw output when requested", async () => {
+    const fetchMock = makeFetchMock([
+      makeProjectResponse(),
+      makeSpanPageResponse(),
+      makeSpanNoteResponse(),
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createTraceCommand().parseAsync(
+      [
+        "get",
+        "trace-123",
+        "--project",
+        "default",
+        "--include-notes",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
+      "/v1/projects/project-default/span_annotations"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
+      "include_annotation_names=note"
+    );
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const parsedOutput = JSON.parse(String(output));
+    expect(parsedOutput.notes).toBeUndefined();
+    expect(parsedOutput.spans[0].notes).toEqual([
+      expect.objectContaining({ id: "span-note-1", name: "note" }),
+    ]);
+  });
+
+  it("keeps notes excluded when only --include-annotations is used", async () => {
+    const fetchMock = makeFetchMock([
+      makeProjectResponse(),
+      makeSpanPageResponse(),
+      makeTraceAnnotationResponse(),
+      {
+        ok: true,
+        body: {
+          data: [],
+          next_cursor: null,
+        },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createTraceCommand().parseAsync(
+      [
+        "get",
+        "trace-123",
+        "--project",
+        "default",
+        "--include-annotations",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
+      "exclude_annotation_names=note"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
+      "exclude_annotation_names=note"
+    );
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const parsedOutput = JSON.parse(String(output));
+    expect(parsedOutput.notes).toBeUndefined();
+    expect(parsedOutput.spans[0].notes).toBeUndefined();
+  });
+
+  it("includes span notes in trace list raw output when requested", async () => {
+    const fetchMock = makeFetchMock([
+      makeProjectResponse(),
+      makeSpanPageResponse(),
+      makeSpanNoteResponse(),
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createTraceCommand().parseAsync(
+      [
+        "list",
+        "--project",
+        "default",
+        "--include-notes",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
+      "include_annotation_names=note"
+    );
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const parsedOutput = JSON.parse(String(output));
+    expect(parsedOutput[0].notes).toBeUndefined();
+    expect(parsedOutput[0].spans[0].notes).toEqual([
+      expect.objectContaining({ id: "span-note-1", name: "note" }),
+    ]);
+  });
+});

--- a/js/packages/phoenix-cli/test/output.test.ts
+++ b/js/packages/phoenix-cli/test/output.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { formatProjectsOutput } from "../src/commands/formatProjects";
+import { formatSpansOutput } from "../src/commands/formatSpans";
 import {
   formatTraceOutput,
   formatTracesOutput,
@@ -129,6 +130,36 @@ const mockTraceWithAnnotations: Trace = {
   ],
 };
 
+const mockTraceWithSpanNotes: Trace = {
+  traceId: "noted123",
+  spans: [
+    {
+      ...mockSpan1,
+      context: {
+        ...mockSpan1.context,
+        trace_id: "noted123",
+      },
+      notes: [
+        {
+          id: "span-note-1",
+          created_at: "2026-01-13T10:00:01.000Z",
+          updated_at: "2026-01-13T10:00:01.000Z",
+          source: "API",
+          user_id: null,
+          name: "note",
+          annotator_kind: "HUMAN",
+          identifier: "px-span-note:1",
+          metadata: null,
+          span_id: "span1",
+          result: {
+            explanation: "Span note content",
+          },
+        },
+      ],
+    } as unknown as MockSpan,
+  ],
+};
+
 describe("Output Formatting", () => {
   describe("trace output - raw", () => {
     it("should format as compact JSON", () => {
@@ -216,6 +247,16 @@ describe("Output Formatting", () => {
       );
     });
 
+    it("should render span notes when present", () => {
+      const output = formatTraceOutput({
+        trace: mockTraceWithSpanNotes,
+        format: "pretty",
+      });
+
+      expect(output).toContain("notes:");
+      expect(output).toContain("- Span note content");
+    });
+
     it("should format array of traces", () => {
       const output = formatTracesOutput({
         traces: [mockTraceReflection, mockTraceWithError],
@@ -268,6 +309,18 @@ describe("Output Formatting", () => {
       expect(output).toContain("SESSIONS-DEMO");
       expect(output).toContain("UHJvamVjdDo1");
       expect(output).not.toContain("{");
+    });
+  });
+
+  describe("span output - pretty", () => {
+    it("should include a notes column when notes are present", () => {
+      const output = formatSpansOutput({
+        spans: mockTraceWithSpanNotes.spans,
+        format: "pretty",
+      });
+
+      expect(output).toContain("notes");
+      expect(output).toContain("Span note content");
     });
   });
 });


### PR DESCRIPTION
## Summary
- add `px span add-note <span-id>` with shared note text normalization and mutation output formatting
- add `--include-notes` support for `px span list`, `px trace get`, and `px trace list` so span notes can be fetched and rendered alongside spans
- keep note entries separate from annotations by excluding `name=note` from annotation fetches when `--include-annotations` is used, and sync the README plus Phoenix CLI skill docs with the new behavior

## Testing
- `pnpm --dir js --filter @arizeai/phoenix-cli exec vitest run test/cli.test.ts test/output.test.ts test/notes.test.ts`
- `pnpm --dir js --filter @arizeai/phoenix-cli typecheck`