### PR TITLE
chore: add changeset for phoenix-cli span notes

### DIFF
--- a/js/.changeset/phoenix-cli-span-notes.md
+++ b/js/.changeset/phoenix-cli-span-notes.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": minor
+---
+
+Add span note support to `px`. New `px span add-note <span-id>` command creates notes on spans, and `--include-notes` is now supported on `px span list`, `px trace get`, and `px trace list` to fetch and render notes alongside spans.


### PR DESCRIPTION
## Summary
- Add missing changeset for #12739 (`px span add-note` and `--include-notes` support) as a minor bump to `@arizeai/phoenix-cli`.

## Test plan
- [ ] Changesets bot picks up the new entry