### PR TITLE
docs: add version notes for self-hosting configuration

### DIFF
--- a/docs/phoenix/self-hosting/configuration.mdx
+++ b/docs/phoenix/self-hosting/configuration.mdx
@@ -43,7 +43,7 @@ The following environment variables will control how your phoenix server runs.
 
   * SQLite, e.g. `sqlite:///path/to/database.db`
 
-* **PHOENIX\_SQL\_DATABASE\_READ\_REPLICA\_URL:** Optional PostgreSQL read replica URL used for read-only queries. Writes continue to use your primary database connection. This setting is ignored for SQLite deployments. Example: `postgresql://user:password@replica-host:5432/phoenix`.
+* **PHOENIX\_SQL\_DATABASE\_READ\_REPLICA\_URL:** Optional PostgreSQL read replica URL used for read-only queries. Writes continue to use your primary database connection. This setting is ignored for SQLite deployments. Example: `postgresql://user:password@replica-host:5432/phoenix`. Available since version 14.0.0.
 
 * **PHOENIX\_POSTGRES\_HOST:** As an alternative to setting **PHOENIX\_SQL\_DATABASE\_URL**, you can set the following environment variables to connect to a PostgreSQL database:
 
@@ -79,7 +79,7 @@ The following environment variables will control how your phoenix server runs.
 
 * **PHOENIX\_DEFAULT\_ADMIN\_INITIAL\_PASSWORD:** Sets the initial password for the built-in admin user (email `admin@localhost`) when that account is created on first startup. Defaults to `admin`. Changing this after the default admin already exists has no effect—update the password via the UI or an admin reset instead.
 
-* **PHOENIX\_ENABLE\_STRONG\_PASSWORD\_POLICY:** Enables a stronger password policy. When set to `True`, passwords must meet the following requirements: at least 12 characters, at least one uppercase letter, at least one lowercase letter, at least one number, and at least one special character. Defaults to `False` (minimum 4 characters).
+* **PHOENIX\_ENABLE\_STRONG\_PASSWORD\_POLICY:** Enables a stronger password policy. When set to `True`, passwords must meet the following requirements: at least 12 characters, at least one uppercase letter, at least one lowercase letter, at least one number, and at least one special character. Defaults to `False` (minimum 4 characters). Available since version 13.5.0.
 
 * **PHOENIX\_TELEMETRY\_ENABLED:** Toggle for telemetry (enabled by default). Set to `false` if you want to disable all analytics tracking. Only basic web analytics are collected (e.g., page views, UI interactions). No trace data or sensitive information is ever collected.
 
@@ -87,4 +87,4 @@ The following environment variables will control how your phoenix server runs.
 
 ### Logging
 
-* **PHOENIX\_LOG\_SQL:** Whether to log all SQL statements to stdout. Useful for debugging database queries. Defaults to `false`.
+* **PHOENIX\_LOG\_SQL:** Whether to log all SQL statements to stdout. Useful for debugging database queries. Defaults to `false`. Available since version 13.4.0.

--- a/docs/phoenix/self-hosting/configuration/using-amazon-aurora.mdx
+++ b/docs/phoenix/self-hosting/configuration/using-amazon-aurora.mdx
@@ -3,6 +3,10 @@ title: "Using Amazon Aurora"
 description: "Phoenix supports IAM database authentication for PostgreSQL connections to Amazon Aurora/RDS."
 ---
 
+<Info>
+IAM database authentication for PostgreSQL (Aurora/RDS) is available since Phoenix **12.9.0**. Use that version or newer before following this guide.
+</Info>
+
 First, ensure that Phoenix runs with valid AWS credentials, either by using an IAM role attached to the instance (EC2/ECS/EKS), or by configuring `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. Configuring `AWS_DEFAULT_REGION` is required.
 
 The IAM role will need a `rds-db:connect` policy associated with it.

--- a/docs/phoenix/self-hosting/configuration/using-azure-managed-identity.mdx
+++ b/docs/phoenix/self-hosting/configuration/using-azure-managed-identity.mdx
@@ -3,6 +3,10 @@ title: "Using Azure Database for PostgreSQL"
 description: "Phoenix supports Microsoft Entra managed-identity authentication for Azure Database for PostgreSQL."
 ---
 
+<Info>
+Azure managed-identity authentication for PostgreSQL is available since Phoenix **14.8.0**. Use that version or newer before following this guide.
+</Info>
+
 First, ensure Phoenix runs in an environment where a managed identity is available (for example AKS, App Service, or an Azure VM). Azure PostgreSQL must have Microsoft Entra authentication enabled, and the managed identity must be created as a PostgreSQL principal.
 
 Azure managed-identity auth in Phoenix requires `azure-identity` (for custom Python installs, install with `pip install 'arize-phoenix[azure]'`).


### PR DESCRIPTION
- Flag PHOENIX_SQL_DATABASE_READ_REPLICA_URL (14.0.0), strong password policy (13.5.0), and PHOENIX_LOG_SQL (13.4.0) on the env overview.
- Add minimum Phoenix versions to Aurora IAM (12.9.0) and Azure managed identity (14.8.0) guides.