### PR TITLE
fix: Offload tracer.shutdown() to a thread in /chat cleanup

### DIFF
--- a/src/phoenix/server/api/routers/data_stream_protocol.py
+++ b/src/phoenix/server/api/routers/data_stream_protocol.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from collections.abc import AsyncIterator, Sequence
@@ -704,7 +705,11 @@ async def stream_text(
                 )
             finally:
                 try:
-                    tracer.shutdown()
+                    # BatchSpanProcessor.shutdown() blocks on _worker_thread.join()
+                    # for up to the SDK default of 30 seconds.  Running it inline
+                    # in this async generator's finally stalls the whole uvicorn
+                    # worker event loop when the span exporter is slow.
+                    await asyncio.to_thread(tracer.shutdown)
                 except Exception:
                     logger.debug("Failed to shut down tracer", exc_info=True)
 


### PR DESCRIPTION
`tracer.shutdown()` runs `BatchSpanProcessor.shutdown()`, which blocks on `_worker_thread.join()` for up to the SDK default of 30 seconds. Called synchronously in the `/chat` async generator's `finally`, this stalls the whole uvicorn worker event loop — not just the current request — when the exporter is slow or unresponsive.

Wrap the call in `asyncio.to_thread` so the blocking join runs on a worker thread and other requests keep making progress.

Fixes #12744