### PR TITLE
feat(app): add tracing_ux feature flag

### DIFF
--- a/app/src/contexts/FeatureFlagsContext.tsx
+++ b/app/src/contexts/FeatureFlagsContext.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
 
-type FeatureFlag = "agents";
+type FeatureFlag = "agents" | "tracing_ux";
 export type FeatureFlagsContextType = {
   featureFlags: Record<FeatureFlag, boolean>;
   setFeatureFlags: (featureFlags: Record<FeatureFlag, boolean>) => void;
@@ -22,6 +22,7 @@ export const LOCAL_STORAGE_FEATURE_FLAGS_KEY = "arize-phoenix-feature-flags";
 const DEFAULT_FEATURE_FLAGS: Record<FeatureFlag, boolean> = {
   // TODO: when this flag is removed, update agentStore.ts by resetting / removing the persistence migration
   agents: false,
+  tracing_ux: false,
 };
 
 function getFeatureFlags(): Record<FeatureFlag, boolean> {


### PR DESCRIPTION
## Summary
- Adds a new `tracing_ux` feature flag (defaults to off) for gating upcoming tracing UX changes.

## Test plan
- [ ] Open the feature flags dialog (ctrl+shift+f) and verify `tracing_ux` appears and toggles.