### PR TITLE
chore: add changesets for phoenix-client/cli span attribute filter

### DIFF
--- a/js/.changeset/phoenix-cli-span-attribute-filter.md
+++ b/js/.changeset/phoenix-cli-span-attribute-filter.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": minor
+---
+
+Add `--attribute` filter to `px span list` for filtering by attribute key/value pairs (e.g., `--attribute "llm.model_name:gpt-4"`). Split is on the first `:` only, so values may contain colons. Repeat the flag to AND multiple filters. JSON-quote a value to force string matching when it looks like a number or boolean (e.g., `'user.id:"12345"'`). Requires Phoenix server >= 14.9.0.

--- a/js/.changeset/phoenix-client-span-attribute-filter.md
+++ b/js/.changeset/phoenix-client-span-attribute-filter.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Add `attributes` filter to `getSpans()` for type-aware attribute matching. Pass a `Record<string, string | number | boolean>` to filter spans by attribute key/value pairs with AND semantics — the JS value type selects how the stored attribute is matched (e.g., `{ "user.id": 12345 }` matches a stored integer, `{ "user.id": "12345" }` matches a stored string). Requires Phoenix server >= 14.9.0.


### PR DESCRIPTION
## Summary
- Follow-up changesets for [#12524](https://github.com/Arize-ai/phoenix/pull/12524), which merged without changeset entries for the js packages.
- `@arizeai/phoenix-client` minor: new `attributes` filter on `getSpans()` (type-aware via JS value type).
- `@arizeai/phoenix-cli` minor: new `--attribute` flag on `px span list`.

Both require Phoenix server >= 14.9.0 when the feature is used.

## Test plan
- [ ] `pnpm changeset status` picks up both entries and proposes minor bumps for the two packages.