### PR TITLE
chore(deps): unpin aiosqlite to >=0.22.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,9 @@ dependencies = [
   "openinference-semantic-conventions>=0.1.26",
   "openinference-instrumentation>=0.1.44",
   "openinference-instrumentation-openai>=0.1.41",
-  "sqlalchemy[asyncio]>=2.0.4, <3",
+  "sqlalchemy[asyncio]>=2.0.46, <3",
   "alembic>=1.3.0, <2",
-  "aiosqlite",
+  "aiosqlite>=0.22.1",
   "aioitertools",
   "sqlean.py>=3.45.1; platform_system != 'Windows' and python_version < '3.14'",
   "sqlean.py>=3.50; platform_system != 'Windows' and python_version >= '3.14'",  # 3.49.1 has no cp314 wheels
@@ -84,7 +84,7 @@ dev = [
   "twine",
   "aiobotocore>=3.1.1",
   "aioboto3",
-  "aiosqlite<0.22.0",  # new version is causing tests to hang
+  "aiosqlite>=0.22.1",
   "anthropic>=0.79.0",
   "arize>=8.1.0",
   "asgi-lifespan",

--- a/requirements/unit-tests.txt
+++ b/requirements/unit-tests.txt
@@ -25,5 +25,5 @@ typing-extensions
 vcrpy
 pytest-smtpd
 freezegun
-aiosqlite<0.22.0  # new version is causing tests to hang
+aiosqlite>=0.22.1
 azure-identity>1.18.0

--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -124,7 +124,10 @@ def aio_sqlite_engine(
             lambda: sqlean.connect(f"file:{database}", uri=True),
             iter_chunk_size=64,
         )
-        conn.daemon = True
+        # aiosqlite>=0.22 moved the worker to Connection._thread; SQLAlchemy's
+        # aiosqlite dialect daemonizes it only when it creates the connection
+        # itself, not when an async_creator is used.
+        conn._thread.daemon = True
         return conn
 
     engine = create_async_engine(

--- a/tests/integration/db_migrations/conftest.py
+++ b/tests/integration/db_migrations/conftest.py
@@ -53,7 +53,10 @@ async def _engine(
                 lambda: sqlean.connect(f"file:{file}", uri=True),
                 iter_chunk_size=64,
             )
-            conn.daemon = True
+            # aiosqlite>=0.22 moved the worker to Connection._thread; SQLAlchemy's
+            # aiosqlite dialect daemonizes it only when it creates the connection
+            # itself, not when an async_creator is used.
+            conn._thread.daemon = True
             return conn
 
         engine = create_async_engine(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -209,7 +209,10 @@ async def sqlite_engine(
                 lambda: sqlean.connect(uri, uri=True),
                 iter_chunk_size=64,
             )
-            conn.daemon = True
+            # aiosqlite>=0.22 moved the worker to Connection._thread; SQLAlchemy's
+            # aiosqlite dialect daemonizes it only when it creates the connection
+            # itself, not when an async_creator is used.
+            conn._thread.daemon = True
             return conn
 
         engine = create_async_engine(

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-18T15:57:30.012751Z"
+exclude-newer = "2026-04-18T20:32:40.434496Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -247,14 +247,11 @@ wheels = [
 
 [[package]]
 name = "aiosqlite"
-version = "0.21.0"
+version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454, upload-time = "2025-02-03T07:30:16.235Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792, upload-time = "2025-02-03T07:30:13.6Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
 ]
 
 [[package]]
@@ -608,7 +605,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'azure'" },
     { name = "aiohttp", marker = "extra == 'container'" },
     { name = "aioitertools" },
-    { name = "aiosqlite" },
+    { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "alembic", specifier = ">=1.3.0,<2" },
     { name = "anthropic", marker = "extra == 'container'", specifier = ">=0.78.0" },
     { name = "arize-phoenix-client", editable = "packages/phoenix-client" },
@@ -662,7 +659,7 @@ requires-dist = [
     { name = "pyyaml" },
     { name = "scikit-learn" },
     { name = "scipy" },
-    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.4,<3" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.46,<3" },
     { name = "sqlean-py", marker = "sys_platform == 'win32'", specifier = ">=3.45.1,<3.50" },
     { name = "sqlean-py", marker = "python_full_version < '3.14' and sys_platform != 'win32'", specifier = ">=3.45.1" },
     { name = "sqlean-py", marker = "python_full_version >= '3.14' and sys_platform != 'win32'", specifier = ">=3.50" },
@@ -681,7 +678,7 @@ provides-extras = ["aws", "azure", "container", "evals", "experimental", "pg"]
 dev = [
     { name = "aioboto3" },
     { name = "aiobotocore", specifier = ">=3.1.1" },
-    { name = "aiosqlite", specifier = "<0.22.0" },
+    { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "anthropic", specifier = ">=0.79.0" },
     { name = "arize", specifier = ">=8.1.0" },
     { name = "asgi-lifespan" },


### PR DESCRIPTION
## Summary
- Removes the `aiosqlite<0.22.0` dev pin added in #10701. SQLAlchemy 2.0.46 ([sqlalchemy#13039](https://github.com/sqlalchemy/sqlalchemy/issues/13039)) fixes the daemon-thread issue that caused the original test-hang regression and wires the terminate path to aiosqlite 0.22.1's new sync `stop()` method. Phoenix is already on SQLAlchemy 2.0.49, so the pin is stale.
- Also resolves a `NotImplementedError: terminate_force_close() not implemented by this DBAPI shim` observed on cancelled requests — that error fires specifically because aiosqlite 0.21.0 lacks `stop()`.
- Updates both `pyproject.toml` and `requirements/unit-tests.txt`; `uv.lock` re-resolves aiosqlite to 0.22.1.

## Test plan
- [ ] `make test` / unit suite completes without the exit-time hang originally reported in #10701
- [ ] No new `NotImplementedError` during request-cancellation paths
- [ ] CI green