### PR TITLE
fix(db): wrap Azure AsyncEngine with ObjectProxy instead of patching dispose

### DIFF
--- a/src/phoenix/db/azure_auth.py
+++ b/src/phoenix/db/azure_auth.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+import wrapt
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from phoenix.config import get_env_postgres_azure_scope
@@ -12,6 +13,29 @@ if TYPE_CHECKING:
     from sqlalchemy import URL
 
 logger = logging.getLogger(__name__)
+
+
+class _AzureCredentialEngineProxy(wrapt.ObjectProxy):  # type: ignore[misc]
+    """Transparent proxy around an `AsyncEngine` whose `dispose()` also
+    closes the associated Azure credential.
+
+    `dispose` is overridden at the class level; all other attributes
+    forward to the wrapped engine, and `isinstance(proxy, AsyncEngine)`
+    holds. Instance-level method assignment is not possible because
+    `AsyncEngine` defines `__slots__`.
+    """
+
+    def __init__(self, wrapped: AsyncEngine, credential: Any) -> None:
+        super().__init__(wrapped)
+        # `ObjectProxy` routes `_self_*` attributes to the proxy itself
+        # rather than forwarding them to the wrapped object.
+        self._self_credential = credential
+
+    async def dispose(self, *args: Any, **kwargs: Any) -> Any:
+        try:
+            return await self.__wrapped__.dispose(*args, **kwargs)
+        finally:
+            await self._self_credential.close()
 
 
 def create_azure_engine(
@@ -88,18 +112,7 @@ def create_azure_engine(
 
     engine = create_async_engine(url=url, async_creator=async_creator, **engine_kwargs)
 
-    # Patch `dispose` on this instance so shutting down the engine also
-    # closes the credential on the loop that awaited dispose. Relies on
-    # callers invoking `engine.dispose(...)` (instance attribute lookup)
-    # rather than `type(engine).dispose(engine)` (class lookup).
-    original_dispose = engine.dispose
-
-    async def dispose_and_close_credential(*args: Any, **kwargs: Any) -> Any:
-        try:
-            return await original_dispose(*args, **kwargs)
-        finally:
-            await credential.close()
-
-    engine.dispose = dispose_and_close_credential  # type: ignore[method-assign]
-
-    return engine
+    # Wrap the engine so `dispose()` also closes the credential on the loop
+    # that awaited it. The proxy forwards all other attribute access to the
+    # wrapped engine and satisfies `isinstance(_, AsyncEngine)`.
+    return _AzureCredentialEngineProxy(engine, credential)

--- a/tests/unit/db/test_azure_auth.py
+++ b/tests/unit/db/test_azure_auth.py
@@ -1,8 +1,10 @@
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import URL
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from phoenix.db.azure_auth import create_azure_engine
 
@@ -30,13 +32,17 @@ def _make_token_response(token: str = "test_token_jwt") -> MagicMock:
     return mock
 
 
-def _make_mock_engine() -> MagicMock:
-    """Build a MagicMock that stands in for the AsyncEngine returned by
-    `sqlalchemy.ext.asyncio.create_async_engine`. `dispose` is an AsyncMock so
-    the credential-lifecycle patching in `create_azure_engine` can wrap it."""
-    engine = MagicMock()
-    engine.dispose = AsyncMock()
-    return engine
+def _make_real_engine() -> AsyncEngine:
+    """Return a real PostgreSQL/asyncpg `AsyncEngine` to stand in for the
+    value returned by the patched `create_async_engine`. No connection is
+    made — SQLAlchemy's engine construction is lazy, and `dispose()` on
+    an engine that never connected tears down the (empty) pool.
+
+    Using a real engine rather than a `MagicMock` ensures the
+    credential-lifecycle wrapper is exercised against the same
+    `__slots__`-bound class used in production. Any approach that
+    attempts instance-level assignment to `engine.dispose` fails here."""
+    return create_async_engine("postgresql+asyncpg://u:p@localhost/db")
 
 
 class TestCreateAzureEngineValidation:
@@ -65,7 +71,7 @@ class TestEngineWiring:
     async def test_engine_kwargs_forwarded_to_create_async_engine(self) -> None:
         mock_credential = AsyncMock()
         mock_credential.get_token = AsyncMock(return_value=_make_token_response())
-        mock_cae = MagicMock(return_value=_make_mock_engine())
+        mock_cae = MagicMock(return_value=_make_real_engine())
 
         with (
             patch("azure.identity.aio.DefaultAzureCredential", return_value=mock_credential),
@@ -83,14 +89,15 @@ class TestEngineWiring:
         assert cae_kwargs["echo"] is True
         assert cae_kwargs["pool_pre_ping"] is True
         assert cae_kwargs["pool_recycle"] == 3300
-        # async_creator is supplied by create_azure_engine itself.
-        assert callable(cae_kwargs["async_creator"])
+        # async_creator is supplied by create_azure_engine itself — and must
+        # actually be an `async def`, since SQLAlchemy will `await` it.
+        assert asyncio.iscoroutinefunction(cae_kwargs["async_creator"])
 
     async def test_connect_args_forwarded_to_asyncpg(self) -> None:
         mock_credential = AsyncMock()
         mock_credential.get_token = AsyncMock(return_value=_make_token_response())
         mock_connect = AsyncMock(return_value=MagicMock())
-        mock_cae = MagicMock(return_value=_make_mock_engine())
+        mock_cae = MagicMock(return_value=_make_real_engine())
 
         with (
             patch("azure.identity.aio.DefaultAzureCredential", return_value=mock_credential),
@@ -104,6 +111,8 @@ class TestEngineWiring:
         asyncpg_kwargs = mock_connect.call_args.kwargs
         assert asyncpg_kwargs["ssl"] == "require"
         assert asyncpg_kwargs["timeout"] == 30
+        # The username from `url.username` must reach asyncpg unchanged.
+        assert asyncpg_kwargs["user"] == "mi-user"
 
 
 class TestTokenFetchingBehavior:
@@ -116,7 +125,7 @@ class TestTokenFetchingBehavior:
             side_effect=[_make_token_response("token_1"), _make_token_response("token_2")]
         )
         mock_connect = AsyncMock(return_value=MagicMock())
-        mock_cae = MagicMock(return_value=_make_mock_engine())
+        mock_cae = MagicMock(return_value=_make_real_engine())
 
         with (
             patch("azure.identity.aio.DefaultAzureCredential", return_value=mock_credential),
@@ -134,38 +143,75 @@ class TestTokenFetchingBehavior:
 
 
 class TestCredentialLifecycle:
-    """`create_azure_engine` patches `engine.dispose` so it also closes the
-    underlying `DefaultAzureCredential`. This is load-bearing for the Azure
-    migration-engine path, which must close its credential on the migration
-    event loop before `asyncio.run` tears the loop down. See
-    internal_docs/specs/postgres-cloud-auth-pooling.md, section
-    'Event-loop affinity of azure.identity.aio credentials'."""
+    """`create_azure_engine` returns a wrapper around the `AsyncEngine` whose
+    `dispose()` also closes the underlying `DefaultAzureCredential`. This is
+    required for the Azure migration-engine path, which must close its
+    credential on the migration event loop before `asyncio.run` tears the
+    loop down. See internal_docs/specs/postgres-cloud-auth-pooling.md,
+    section 'Event-loop affinity of azure.identity.aio credentials'.
+
+    These tests use a real `AsyncEngine` (not `MagicMock`) so that
+    engine-shape regressions — e.g., instance-level assignment to a method
+    on a `__slots__`-bound class — are caught by the test suite."""
+
+    async def test_returned_object_behaves_as_async_engine(self) -> None:
+        """The wrapper must satisfy `isinstance(_, AsyncEngine)` and forward
+        attribute access to the wrapped engine so that callers which
+        type-check or read ordinary engine attributes continue to work.
+        A change that replaces the transparent proxy with, e.g., a direct
+        `AsyncEngine` subclass would fail this test."""
+        mock_credential = AsyncMock()
+        mock_credential.close = AsyncMock()
+        mock_credential.get_token = AsyncMock(return_value=_make_token_response())
+
+        real_engine = _make_real_engine()
+        with (
+            patch("azure.identity.aio.DefaultAzureCredential", return_value=mock_credential),
+            patch("phoenix.db.azure_auth.create_async_engine", return_value=real_engine),
+        ):
+            engine = create_azure_engine(_make_url(), {})
+
+        assert isinstance(engine, AsyncEngine)
+        # Transparent forwarding: attributes of the underlying engine must be
+        # reachable through the wrapper without special-casing.
+        assert engine.url is real_engine.url
+        assert engine.pool is real_engine.pool
+        assert engine.sync_engine is real_engine.sync_engine
+        await engine.dispose()
 
     async def test_dispose_also_closes_credential(self) -> None:
         mock_credential = AsyncMock()
         mock_credential.close = AsyncMock()
-        mock_engine = _make_mock_engine()
-        original_dispose = mock_engine.dispose
+        mock_credential.get_token = AsyncMock(return_value=_make_token_response())
 
         with (
             patch("azure.identity.aio.DefaultAzureCredential", return_value=mock_credential),
-            patch("phoenix.db.azure_auth.create_async_engine", return_value=mock_engine),
+            patch("phoenix.db.azure_auth.create_async_engine", return_value=_make_real_engine()),
         ):
             engine = create_azure_engine(_make_url(), {})
             await engine.dispose()
 
-        original_dispose.assert_awaited_once()
         mock_credential.close.assert_awaited_once()
 
     async def test_credential_closed_even_if_dispose_raises(self) -> None:
+        """If the underlying engine's `dispose` raises, the credential must
+        still be closed so the Azure SDK's aiohttp session doesn't leak."""
         mock_credential = AsyncMock()
         mock_credential.close = AsyncMock()
-        mock_engine = _make_mock_engine()
-        mock_engine.dispose = AsyncMock(side_effect=RuntimeError("boom"))
+
+        real_engine = _make_real_engine()
+
+        # Drive the except-branch by substituting `dispose` with a raising
+        # async function. Instance-level assignment is forbidden by
+        # `AsyncEngine.__slots__`, so patch the class attribute for the
+        # duration of this test.
+        async def _boom(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("boom")
 
         with (
             patch("azure.identity.aio.DefaultAzureCredential", return_value=mock_credential),
-            patch("phoenix.db.azure_auth.create_async_engine", return_value=mock_engine),
+            patch("phoenix.db.azure_auth.create_async_engine", return_value=real_engine),
+            patch.object(AsyncEngine, "dispose", _boom),
         ):
             engine = create_azure_engine(_make_url(), {})
             with pytest.raises(RuntimeError, match="boom"):
@@ -188,9 +234,9 @@ class TestCredentialLifecycle:
             credentials.append(cred)
             return cred
 
-        mock_engine_a = _make_mock_engine()
-        mock_engine_b = _make_mock_engine()
-        mock_cae = MagicMock(side_effect=[mock_engine_a, mock_engine_b])
+        real_engine_a = _make_real_engine()
+        real_engine_b = _make_real_engine()
+        mock_cae = MagicMock(side_effect=[real_engine_a, real_engine_b])
 
         with (
             patch(
@@ -224,7 +270,7 @@ class TestScopeConfiguration:
         mock_credential = AsyncMock()
         mock_credential.get_token = AsyncMock(return_value=_make_token_response())
         mock_connect = AsyncMock(return_value=MagicMock())
-        mock_cae = MagicMock(return_value=_make_mock_engine())
+        mock_cae = MagicMock(return_value=_make_real_engine())
 
         with (
             patch("azure.identity.aio.DefaultAzureCredential", return_value=mock_credential),


### PR DESCRIPTION
Resolves #12776

## Summary
- Replace the instance-level `engine.dispose = ...` monkey-patch in `create_azure_engine` with a `wrapt.ObjectProxy` subclass. `AsyncEngine` defines `__slots__`, so the old assignment raised `AttributeError: 'AsyncEngine' object attribute 'dispose' is read-only` at startup whenever Azure managed-identity auth was enabled. The proxy overrides `dispose` at the class level, forwards everything else to the wrapped engine, and still satisfies `isinstance(_, AsyncEngine)`.