### PR TITLE
fix(playground): align connectionConfig keys with GraphQL schema

### DIFF
--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -1432,14 +1432,15 @@ const getBaseChatCompletionInput = ({
   const azureModelParams =
     instance.model.provider === "AZURE_OPENAI"
       ? {
-          endpoint: instance.model.endpoint,
+          azureEndpoint: instance.model.endpoint ?? null,
         }
       : {};
 
   const awsModelParams =
     instance.model.provider === "AWS"
       ? {
-          region: instance.model.region,
+          regionName: instance.model.region ?? null,
+          endpointUrl: instance.model.endpoint ?? null,
         }
       : {};
 


### PR DESCRIPTION
resolves #12782

## Summary
- Use GraphQL `ConnectionConfigInput` field names when building Playground chat completion variables.
- Map Azure and AWS routing fields to `azureEndpoint`, `regionName`, and `endpointUrl` to avoid runtime variable validation failures.
- Preserve existing model state shape while translating to schema-compatible request payloads.