### PR TITLE
fix(deps): migrate authlib.jose to joserfc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,8 @@ dependencies = [
   "fastapi>=0.135.2",  # older versions raise AssertionError on 204 routes, see https://github.com/Arize-ai/phoenix/issues/12384
   "pydantic>=2.1.0", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
   "pydantic-ai>=1.62.0",
-  "authlib<1.7.0",  # 1.7.0 migrated internals to joserfc; raises joserfc errors that bypass our authlib.jose.JoseError handlers
+  "authlib>=1.7.0",
+  "joserfc",
   "arize-phoenix-client>=2.1.0",
   "email-validator",
   "python-dateutil",

--- a/src/phoenix/server/api/routers/oauth2.py
+++ b/src/phoenix/server/api/routers/oauth2.py
@@ -9,9 +9,10 @@ from urllib.parse import unquote, urlparse
 import jmespath
 from authlib.common.security import generate_token
 from authlib.integrations.starlette_client import OAuthError
-from authlib.jose import jwt
-from authlib.jose.errors import JoseError
 from fastapi import APIRouter, Cookie, Depends, Path, Query, Request
+from joserfc import jwt
+from joserfc.errors import JoseError
+from joserfc.jwk import OctKey
 from sqlalchemy import Boolean, and_, case, cast, func, insert, or_, select
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -894,8 +895,7 @@ def _generate_state_for_oauth2_authorization_code_flow(
     )
     if return_url is not None:
         payload["return_url"] = return_url
-    jwt_bytes: bytes = jwt.encode(header=header, payload=payload, key=str(secret))
-    return jwt_bytes.decode()
+    return jwt.encode(header, dict(payload), OctKey.import_key(str(secret)))
 
 
 class _OAuth2StatePayload(TypedDict):
@@ -912,9 +912,9 @@ def _parse_state_payload(*, secret: Secret, state: str) -> _OAuth2StatePayload:
     """
     Validates the JWT signature and parses the return URL from the OAuth2 state.
     """
-    payload = jwt.decode(s=state, key=str(secret))
-    if _is_oauth2_state_payload(payload):
-        return payload
+    claims = jwt.decode(state, OctKey.import_key(str(secret))).claims
+    if _is_oauth2_state_payload(claims):
+        return claims
     raise ValueError("Invalid OAuth2 state payload.")
 
 

--- a/src/phoenix/server/jwt_store.py
+++ b/src/phoenix/server/jwt_store.py
@@ -8,8 +8,9 @@ from datetime import datetime, timezone
 from functools import cached_property, singledispatchmethod
 from typing import Any, Generic, Optional, TypeVar
 
-from authlib.jose import jwt
-from authlib.jose.errors import JoseError
+from joserfc import jwt
+from joserfc.errors import JoseError
+from joserfc.jwk import OctKey
 from sqlalchemy import Select, delete, select
 from starlette.datastructures import Secret
 
@@ -78,13 +79,10 @@ class JwtStore:
 
     async def read(self, token: Token) -> Optional[ClaimSet]:
         try:
-            payload = jwt.decode(
-                s=token,
-                key=str(self._secret),
-            )
+            decoded = jwt.decode(str(token), OctKey.import_key(str(self._secret)))
         except JoseError:
             return None
-        if (jti := payload.get("jti")) is None:
+        if (jti := decoded.claims.get("jti")) is None:
             return None
         if (token_id := TokenId.parse(jti)) is None:
             return None
@@ -248,8 +246,7 @@ class _Store(DaemonTask, Generic[_ClaimSetT, _TokenT, _TokenIdT, _RecordT], ABC)
     def _encode(self, claim: ClaimSet) -> str:
         payload: dict[str, Any] = dict(jti=claim.token_id)
         header = {"alg": self._algorithm}
-        jwt_bytes: bytes = jwt.encode(header=header, payload=payload, key=str(self._secret))
-        return jwt_bytes.decode()
+        return jwt.encode(header, payload, OctKey.import_key(str(self._secret)))
 
     async def get(self, token_id: _TokenIdT) -> Optional[_ClaimSetT]:
         if claims := self._claims.get(token_id):

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-18T15:06:01.17441Z"
+exclude-newer = "2026-04-18T15:57:30.012751Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -437,6 +437,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "jmespath" },
+    { name = "joserfc" },
     { name = "jsonpath-ng" },
     { name = "jsonschema" },
     { name = "ldap3" },
@@ -614,7 +615,7 @@ requires-dist = [
     { name = "arize-phoenix-evals", editable = "packages/phoenix-evals" },
     { name = "arize-phoenix-otel", editable = "packages/phoenix-otel" },
     { name = "asyncpg", marker = "extra == 'pg'" },
-    { name = "authlib", specifier = "<1.7.0" },
+    { name = "authlib", specifier = ">=1.7.0" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.18.0" },
     { name = "azure-identity", marker = "extra == 'container'", specifier = ">=1.18.0" },
     { name = "cachetools" },
@@ -627,6 +628,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "jmespath" },
+    { name = "joserfc" },
     { name = "jsonpath-ng" },
     { name = "jsonschema" },
     { name = "ldap3" },
@@ -1044,14 +1046,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.11"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/10/b325d58ffe86815b399334a101e63bc6fa4e1953921cb23703b48a0a0220/authlib-1.6.11.tar.gz", hash = "sha256:64db35b9b01aeccb4715a6c9a6613a06f2bd7be2ab9d2eb89edd1dfc7580a38f", size = 165359, upload-time = "2026-04-16T07:22:50.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/2f/55fca558f925a51db046e5b929deb317ddb05afed74b22d89f4eca578980/authlib-1.6.11-py2.py3-none-any.whl", hash = "sha256:c8687a9a26451c51a34a06fa17bb97cb15bba46a6a626755e2d7f50da8bff3e3", size = 244469, upload-time = "2026-04-16T07:22:48.413Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
 ]
 
 [[package]]
@@ -3162,6 +3165,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Follow the [authlib → joserfc migration guide](https://jose.authlib.org/en/dev/migrations/authlib/) to move our own JWT usage off the deprecated `authlib.jose` module, and unpin `authlib` now that 1.7.0+ is compatible.

Changes:
- `authlib.jose.jwt` → `joserfc.jwt` (keys wrapped with `OctKey.import_key(...)`; encode now returns `str`; decode now returns a `Token` with `.claims`)
- `authlib.jose.errors.JoseError` → `joserfc.errors.JoseError`
- `pyproject.toml`: unpin `authlib` (set `>=1.7.0`), add `joserfc` as a direct dependency

## Why

`authlib` 1.7.0 (released 2026-04-18) migrated its internals to `joserfc`. `parse_id_token` now raises `joserfc.errors.InvalidClaimError` on nonce/claim validation failures — our old `authlib.jose.errors.JoseError` handlers didn't catch it, so a tampered-nonce request returned a 500 instead of redirecting to `/login` (broke `tests/integration/auth/test_oidc.py::TestBasicFlow::test_nonce_mismatch_is_rejected`). #12783 pinned `authlib<1.7.0` as a stop-gap; this PR is the proper fix so we can track authlib's stable releases.