### PR TITLE
feat(app): show root span name in session turn list

### DIFF
--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -23,6 +23,7 @@ import {
   ListBoxItem,
   Loading,
   Text,
+  Truncate,
   View,
 } from "@phoenix/components";
 import { AnnotationSummaryGroupTokens } from "@phoenix/components/annotation/AnnotationSummaryGroup";
@@ -256,36 +257,55 @@ function SessionTurnList({
       }}
       css={turnListCSS}
     >
-      {(row) => (
-        <ListBoxItem id={row.traceId} textValue={`Turn ${row.index + 1}`}>
-          <Flex direction="column" gap="size-100">
-            <Flex
-              direction="row"
-              justifyContent="space-between"
-              alignItems="center"
-              gap="size-100"
-            >
-              <Text weight="heavy">Turn {row.index + 1}</Text>
-              <Text color="text-700" size="XS">
-                {fullTimeFormatter(new Date(row.rootSpan.startTime))}
-              </Text>
+      {(row) => {
+        const paddedIndex = String(row.index + 1).padStart(2, "0");
+        const turnLabel = `${paddedIndex} | ${row.rootSpan.name}`;
+        return (
+          <ListBoxItem id={row.traceId} textValue={turnLabel}>
+            <Flex direction="column" gap="size-100">
+              <Flex
+                direction="row"
+                justifyContent="space-between"
+                alignItems="center"
+                gap="size-100"
+              >
+                <Flex
+                  direction="row"
+                  gap="size-50"
+                  alignItems="center"
+                  flex={1}
+                  minWidth={0}
+                >
+                  <Text fontFamily="mono" color="text-500">
+                    {paddedIndex}
+                  </Text>
+                  <Flex flex={1} minWidth={0}>
+                    <Truncate maxWidth="100%" title={row.rootSpan.name}>
+                      <Text weight="heavy">{row.rootSpan.name}</Text>
+                    </Truncate>
+                  </Flex>
+                </Flex>
+                <Text color="text-700" size="XS">
+                  {fullTimeFormatter(new Date(row.rootSpan.startTime))}
+                </Text>
+              </Flex>
+              <Flex direction="row" gap="size-100" alignItems="center" wrap>
+                <TokenCount size="S">
+                  {row.rootSpan.cumulativeTokenCountTotal ?? 0}
+                </TokenCount>
+                {row.rootSpan.trace.costSummary?.total?.cost != null ? (
+                  <TokenCosts size="S">
+                    {row.rootSpan.trace.costSummary.total.cost}
+                  </TokenCosts>
+                ) : null}
+                {row.rootSpan.latencyMs != null ? (
+                  <LatencyText latencyMs={row.rootSpan.latencyMs} size="S" />
+                ) : null}
+              </Flex>
             </Flex>
-            <Flex direction="row" gap="size-100" alignItems="center" wrap>
-              <TokenCount size="S">
-                {row.rootSpan.cumulativeTokenCountTotal ?? 0}
-              </TokenCount>
-              {row.rootSpan.trace.costSummary?.total?.cost != null ? (
-                <TokenCosts size="S">
-                  {row.rootSpan.trace.costSummary.total.cost}
-                </TokenCosts>
-              ) : null}
-              {row.rootSpan.latencyMs != null ? (
-                <LatencyText latencyMs={row.rootSpan.latencyMs} size="S" />
-              ) : null}
-            </Flex>
-          </Flex>
-        </ListBoxItem>
-      )}
+          </ListBoxItem>
+        );
+      }}
     </ListBox>
   );
 }
@@ -325,6 +345,7 @@ export function SessionDetailsTraceList({
                   }
                 }
                 id
+                name
                 attributes
                 project {
                   id

--- a/app/src/pages/trace/__generated__/SessionDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c4a4b4c27272c8658203191645c75273>>
+ * @generated SignedSource<<f9a720bd9a855e170377557094127567>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -368,6 +368,7 @@ return {
                                 "storageKey": null
                               },
                               (v12/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -689,12 +690,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bb9746e11c3749f9e14870d6c73b21a5",
+    "cacheID": "a31e943dfb62bed890a6bd66985cb939",
     "id": null,
     "metadata": {},
     "name": "SessionDetailsQuery",
     "operationKind": "query",
-    "text": "query SessionDetailsQuery(\n  $id: ID!\n  $first: Int!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      numTraces\n      tokenUsage {\n        total\n      }\n      costSummary {\n        total {\n          cost\n          tokens\n        }\n        prompt {\n          cost\n          tokens\n        }\n        completion {\n          cost\n          tokens\n        }\n      }\n      sessionId\n      latencyP50: traceLatencyMsQuantile(probability: 0.5)\n      ...SessionDetailsTraceList_traces_3ASum4\n    }\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_3ASum4 on ProjectSession {\n  traces(first: $first) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          trace {\n            id\n            costSummary {\n              total {\n                cost\n              }\n            }\n          }\n          id\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            mimeType\n          }\n          output {\n            value\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query SessionDetailsQuery(\n  $id: ID!\n  $first: Int!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      numTraces\n      tokenUsage {\n        total\n      }\n      costSummary {\n        total {\n          cost\n          tokens\n        }\n        prompt {\n          cost\n          tokens\n        }\n        completion {\n          cost\n          tokens\n        }\n      }\n      sessionId\n      latencyP50: traceLatencyMsQuantile(probability: 0.5)\n      ...SessionDetailsTraceList_traces_3ASum4\n    }\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_3ASum4 on ProjectSession {\n  traces(first: $first) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          trace {\n            id\n            costSummary {\n              total {\n                cost\n              }\n            }\n          }\n          id\n          name\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            mimeType\n          }\n          output {\n            value\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/app/src/pages/trace/__generated__/SessionDetailsTraceListRefetchQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsTraceListRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cbc7167bca3e36d22b877b4c1ba4104c>>
+ * @generated SignedSource<<afe0f37a946b424b221c3794c7c1bd7d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -241,6 +241,7 @@ return {
                                 "storageKey": null
                               },
                               (v4/*: any*/),
+                              (v5/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -562,16 +563,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "550751bcd714574722b837b722d9e91f",
+    "cacheID": "66f4d1a1729ae0dfe6dd0d6070cb09e6",
     "id": null,
     "metadata": {},
     "name": "SessionDetailsTraceListRefetchQuery",
     "operationKind": "query",
-    "text": "query SessionDetailsTraceListRefetchQuery(\n  $after: String = null\n  $first: Int = 50\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionDetailsTraceList_traces_2HEEH6\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_2HEEH6 on ProjectSession {\n  traces(first: $first, after: $after) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          trace {\n            id\n            costSummary {\n              total {\n                cost\n              }\n            }\n          }\n          id\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            mimeType\n          }\n          output {\n            value\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query SessionDetailsTraceListRefetchQuery(\n  $after: String = null\n  $first: Int = 50\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionDetailsTraceList_traces_2HEEH6\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_2HEEH6 on ProjectSession {\n  traces(first: $first, after: $after) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          trace {\n            id\n            costSummary {\n              total {\n                cost\n              }\n            }\n          }\n          id\n          name\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            mimeType\n          }\n          output {\n            value\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d93b35659e600ca4438d4c1da87a24d5";
+(node as any).hash = "69c2f49d3ae386d40225d46433a66fc5";
 
 export default node;

--- a/app/src/pages/trace/__generated__/SessionDetailsTraceList_traces.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsTraceList_traces.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a6a24145cb81285e517caf0b79641b2d>>
+ * @generated SignedSource<<efbfc3ec19d66519c45b3b0ee83043ab>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,6 +26,7 @@ export type SessionDetailsTraceList_traces$data = {
             readonly value: string;
           } | null;
           readonly latencyMs: number | null;
+          readonly name: string;
           readonly output: {
             readonly mimeType: MimeType;
             readonly value: string;
@@ -215,6 +216,13 @@ return {
                       "alias": null,
                       "args": null,
                       "kind": "ScalarField",
+                      "name": "name",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
                       "name": "attributes",
                       "storageKey": null
                     },
@@ -352,6 +360,6 @@ return {
 };
 })();
 
-(node as any).hash = "d93b35659e600ca4438d4c1da87a24d5";
+(node as any).hash = "69c2f49d3ae386d40225d46433a66fc5";
 
 export default node;


### PR DESCRIPTION

<img width="1228" height="641" alt="Screenshot 2026-04-21 at 12 37 31 PM" src="https://github.com/user-attachments/assets/1687b621-4668-4e13-9731-f8dca737042f" />

- Displays the root span name alongside the turn index in the session details turn list, so turns are identifiable by their semantic name rather than just `Turn N`.
- Turn labels now render as a zero-padded index (e.g. `01`) plus the truncated root span name, with the hover title showing the full name.
- Adds `name` to the `rootSpan` selection in the session traces fragment (regenerated Relay artifacts).

Closes #12792