### PR TITLE
fix(app): use Empty component for project annotations empty state

### DIFF
--- a/app/src/pages/project/ProjectAnnotationConfigCard.tsx
+++ b/app/src/pages/project/ProjectAnnotationConfigCard.tsx
@@ -23,6 +23,7 @@ import {
   Alert,
   Card,
   ContentSkeleton,
+  Empty,
   Flex,
   Link,
   Text,
@@ -338,9 +339,9 @@ const ProjectAnnotationConfigCardContent = (
 
   if (allAnnotationConfigs.edges.length === 0) {
     return (
-      <Flex direction="row" justifyContent="center">
-        <Text>No annotation configurations available.</Text>
-      </Flex>
+      <View paddingY="size-400">
+        <Empty message="No annotation configurations available." />
+      </View>
     );
   }
 


### PR DESCRIPTION
## Summary
- Replace the plain "No annotation configurations available." text in the Project Annotations card with the shared `Empty` component
- Wrap it in a `View` with `size-400` vertical padding so the empty state has enough breathing room

## Test plan
- [ ] Navigate to a project's config page with no annotation configs and confirm the empty state renders with padding
- [ ] Verify the card still shows the configs table when annotation configs exist