### PR TITLE
feat(app): portal page controls into top nav

### DIFF
--- a/app/src/components/nav/TopNavActions.tsx
+++ b/app/src/components/nav/TopNavActions.tsx
@@ -1,0 +1,61 @@
+import { css } from "@emotion/react";
+import { createContext, type ReactNode, useContext, useState } from "react";
+import { createPortal } from "react-dom";
+
+type TopNavActionsContextValue = {
+  target: HTMLDivElement | null;
+  setTarget: (el: HTMLDivElement | null) => void;
+};
+
+const TopNavActionsContext = createContext<TopNavActionsContextValue | null>(
+  null
+);
+
+export function TopNavActionsProvider({ children }: { children: ReactNode }) {
+  const [target, setTarget] = useState<HTMLDivElement | null>(null);
+  return (
+    <TopNavActionsContext.Provider value={{ target, setTarget }}>
+      {children}
+    </TopNavActionsContext.Provider>
+  );
+}
+
+const slotCSS = css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--global-dimension-static-size-100);
+  margin-inline-start: auto;
+`;
+
+/**
+ * Portal target rendered inside TopNavbar. Pages declare content via
+ * <TopNavActions> and it lands here.
+ */
+export function TopNavActionsSlot() {
+  const ctx = useContext(TopNavActionsContext);
+  if (!ctx) {
+    throw new Error(
+      "TopNavActionsSlot must be rendered inside a TopNavActionsProvider"
+    );
+  }
+  return (
+    <div ref={ctx.setTarget} css={slotCSS} data-testid="top-nav-actions" />
+  );
+}
+
+/**
+ * Declares content to be rendered in the top nav's right-side action area.
+ * Children render in the declarer's React tree (inheriting its contexts) but
+ * are portaled into the TopNavbar's slot via createPortal.
+ */
+export function TopNavActions({ children }: { children: ReactNode }) {
+  const ctx = useContext(TopNavActionsContext);
+  if (!ctx) {
+    throw new Error(
+      "TopNavActions must be rendered inside a TopNavActionsProvider"
+    );
+  }
+  if (!ctx.target) return null;
+  return createPortal(children, ctx.target);
+}

--- a/app/src/components/nav/TopNavActions.tsx
+++ b/app/src/components/nav/TopNavActions.tsx
@@ -20,11 +20,15 @@ export function TopNavActionsProvider({ children }: { children: ReactNode }) {
   );
 }
 
-const slotCSS = css`
+const flexRowCSS = css`
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: var(--global-dimension-static-size-100);
+`;
+
+const slotCSS = css`
+  ${flexRowCSS};
   margin-inline-start: auto;
 `;
 
@@ -44,22 +48,14 @@ export function TopNavActionsSlot() {
   );
 }
 
-const itemCSS = css`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: var(--global-dimension-static-size-100);
-`;
-
 /**
  * Declares content to be rendered in the top nav's right-side action area.
  * Children render in the declarer's React tree (inheriting its contexts) but
  * are portaled into the TopNavbar's slot via createPortal.
  *
- * `order` maps to the CSS `order` property on the portaled wrapper so a
- * caller can control visual position independent of React commit order —
- * useful when one contributor lives inside a Suspense boundary and another
- * does not.
+ * `order` maps to the CSS `order` property on a wrapper so a caller can
+ * control visual position independent of React commit order — useful when
+ * one contributor lives inside a Suspense boundary and another does not.
  */
 export function TopNavActions({
   children,
@@ -75,8 +71,11 @@ export function TopNavActions({
     );
   }
   if (!ctx.target) return null;
+  if (order === undefined) {
+    return createPortal(children, ctx.target);
+  }
   return createPortal(
-    <div css={itemCSS} style={order !== undefined ? { order } : undefined}>
+    <div css={flexRowCSS} style={{ order }}>
       {children}
     </div>,
     ctx.target

--- a/app/src/components/nav/TopNavActions.tsx
+++ b/app/src/components/nav/TopNavActions.tsx
@@ -44,12 +44,30 @@ export function TopNavActionsSlot() {
   );
 }
 
+const itemCSS = css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--global-dimension-static-size-100);
+`;
+
 /**
  * Declares content to be rendered in the top nav's right-side action area.
  * Children render in the declarer's React tree (inheriting its contexts) but
  * are portaled into the TopNavbar's slot via createPortal.
+ *
+ * `order` maps to the CSS `order` property on the portaled wrapper so a
+ * caller can control visual position independent of React commit order —
+ * useful when one contributor lives inside a Suspense boundary and another
+ * does not.
  */
-export function TopNavActions({ children }: { children: ReactNode }) {
+export function TopNavActions({
+  children,
+  order,
+}: {
+  children: ReactNode;
+  order?: number;
+}) {
   const ctx = useContext(TopNavActionsContext);
   if (!ctx) {
     throw new Error(
@@ -57,5 +75,10 @@ export function TopNavActions({ children }: { children: ReactNode }) {
     );
   }
   if (!ctx.target) return null;
-  return createPortal(children, ctx.target);
+  return createPortal(
+    <div css={itemCSS} style={order !== undefined ? { order } : undefined}>
+      {children}
+    </div>,
+    ctx.target
+  );
 }

--- a/app/src/components/nav/index.tsx
+++ b/app/src/components/nav/index.tsx
@@ -2,3 +2,4 @@ export * from "./Navbar";
 export * from "./NavBreadcrumb";
 export * from "./SideNavToggleButton";
 export * from "./NavTitle";
+export * from "./TopNavActions";

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -17,6 +17,8 @@ import {
   SideNavbar,
   SideNavToggleButton,
   ThemeSelector,
+  TopNavActionsProvider,
+  TopNavActionsSlot,
   TopNavbar,
 } from "@phoenix/components/nav";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
@@ -88,31 +90,34 @@ export function Layout() {
   });
 
   return (
-    <div css={layoutCSS} data-testid="layout">
-      <NavTitle />
-      <SideNav />
-      <div css={mainViewCSS}>
-        <TopNavbar>
-          <SideNavToggleButton />
-          <NavBreadcrumb />
-        </TopNavbar>
-        <Group
-          id="layout-panels"
-          orientation="horizontal"
-          defaultLayout={defaultLayout}
-          onLayoutChanged={onLayoutChanged}
-        >
-          <Panel id="layout-content">
-            <div data-testid="content" css={contentCSS}>
-              <Suspense fallback={<Loading />}>
-                <Outlet />
-              </Suspense>
-            </div>
-          </Panel>
-          {shouldShowDockedAgentPanel ? <AgentChatPanel /> : null}
-        </Group>
+    <TopNavActionsProvider>
+      <div css={layoutCSS} data-testid="layout">
+        <NavTitle />
+        <SideNav />
+        <div css={mainViewCSS}>
+          <TopNavbar>
+            <SideNavToggleButton />
+            <NavBreadcrumb />
+            <TopNavActionsSlot />
+          </TopNavbar>
+          <Group
+            id="layout-panels"
+            orientation="horizontal"
+            defaultLayout={defaultLayout}
+            onLayoutChanged={onLayoutChanged}
+          >
+            <Panel id="layout-content">
+              <div data-testid="content" css={contentCSS}>
+                <Suspense fallback={<Loading />}>
+                  <Outlet />
+                </Suspense>
+              </div>
+            </Panel>
+            {shouldShowDockedAgentPanel ? <AgentChatPanel /> : null}
+          </Group>
+        </div>
       </div>
-    </div>
+    </TopNavActionsProvider>
   );
 }
 

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -66,12 +66,17 @@ export function ProjectPage() {
   const { projectId } = useParams();
   const { timeRange } = useTimeRange();
   return (
-    <Suspense fallback={<Loading />}>
-      <ProjectPageContent
-        projectId={projectId as string}
-        timeRange={timeRange}
-      />
-    </Suspense>
+    <>
+      <TopNavActions>
+        <ConnectedTimeRangeSelector size="S" />
+      </TopNavActions>
+      <Suspense fallback={<Loading />}>
+        <ProjectPageContent
+          projectId={projectId as string}
+          timeRange={timeRange}
+        />
+      </Suspense>
+    </>
   );
 }
 
@@ -230,9 +235,8 @@ function ProjectPageContentBody({
 
   return (
     <main css={mainCSS}>
-      <TopNavActions>
+      <TopNavActions order={-1}>
         <StreamToggle project={data.project} />
-        <ConnectedTimeRangeSelector size="S" />
       </TopNavActions>
       <ProjectPageHeader project={data.project} />
       <ProjectPageQueryReferenceContext.Provider

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -9,18 +9,12 @@ import {
 import { graphql, useLazyLoadQuery, useQueryLoader } from "react-relay";
 import { Outlet, useNavigate, useParams } from "react-router";
 
-import {
-  Flex,
-  LazyTabPanel,
-  Loading,
-  Tab,
-  TabList,
-  Tabs,
-} from "@phoenix/components";
+import { LazyTabPanel, Loading, Tab, TabList, Tabs } from "@phoenix/components";
 import {
   ConnectedTimeRangeSelector,
   useTimeRange,
 } from "@phoenix/components/datetime";
+import { TopNavActions } from "@phoenix/components/nav";
 import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 import { StreamStateProvider } from "@phoenix/contexts/StreamStateContext";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
@@ -236,15 +230,11 @@ function ProjectPageContentBody({
 
   return (
     <main css={mainCSS}>
-      <ProjectPageHeader
-        project={data.project}
-        extra={
-          <Flex direction="row" alignItems="center" gap="size-100">
-            <StreamToggle project={data.project} />
-            <ConnectedTimeRangeSelector />
-          </Flex>
-        }
-      />
+      <TopNavActions>
+        <StreamToggle project={data.project} />
+        <ConnectedTimeRangeSelector size="S" />
+      </TopNavActions>
+      <ProjectPageHeader project={data.project} />
       <ProjectPageQueryReferenceContext.Provider
         value={{
           spansQueryReference: spansQueryReference ?? null,

--- a/app/src/pages/project/ProjectPageHeader.tsx
+++ b/app/src/pages/project/ProjectPageHeader.tsx
@@ -8,10 +8,19 @@ import type { ProjectStats_project$key } from "./__generated__/ProjectStats_proj
 import { ProjectStats } from "./ProjectStats";
 import { ProjectTraceCountSparkline } from "./ProjectTraceCountSparkline";
 
-export function ProjectPageHeader(props: {
+type ProjectPageHeaderProps = {
   project: ProjectStats_project$key;
-}) {
+};
+
+export function ProjectPageHeader(props: ProjectPageHeaderProps) {
   const isTracingUxEnabled = useFeatureFlag("tracing_ux");
+  if (isTracingUxEnabled) {
+    return <TracingUxProjectPageHeader />;
+  }
+  return <LegacyProjectPageHeader {...props} />;
+}
+
+function TracingUxProjectPageHeader() {
   return (
     <View
       paddingStart="size-200"
@@ -21,15 +30,26 @@ export function ProjectPageHeader(props: {
       flex="none"
       overflow="visible"
     >
-      {isTracingUxEnabled ? (
-        <Suspense fallback={<Loading size="S" />}>
-          <ProjectTraceCountSparkline />
-        </Suspense>
-      ) : (
-        <div css={statsScrollCSS}>
-          <ProjectStats project={props.project} />
-        </div>
-      )}
+      <Suspense fallback={<Loading size="S" />}>
+        <ProjectTraceCountSparkline />
+      </Suspense>
+    </View>
+  );
+}
+
+function LegacyProjectPageHeader({ project }: ProjectPageHeaderProps) {
+  return (
+    <View
+      paddingStart="size-200"
+      paddingEnd="size-200"
+      paddingTop="size-200"
+      paddingBottom="size-50"
+      flex="none"
+      overflow="visible"
+    >
+      <div css={statsScrollCSS}>
+        <ProjectStats project={project} />
+      </div>
     </View>
   );
 }

--- a/app/src/pages/project/ProjectPageHeader.tsx
+++ b/app/src/pages/project/ProjectPageHeader.tsx
@@ -12,6 +12,15 @@ type ProjectPageHeaderProps = {
   project: ProjectStats_project$key;
 };
 
+const headerViewProps = {
+  paddingStart: "size-200",
+  paddingEnd: "size-200",
+  paddingTop: "size-200",
+  paddingBottom: "size-50",
+  flex: "none",
+  overflow: "visible",
+} as const;
+
 export function ProjectPageHeader(props: ProjectPageHeaderProps) {
   const isTracingUxEnabled = useFeatureFlag("tracing_ux");
   if (isTracingUxEnabled) {
@@ -22,14 +31,7 @@ export function ProjectPageHeader(props: ProjectPageHeaderProps) {
 
 function TracingUxProjectPageHeader() {
   return (
-    <View
-      paddingStart="size-200"
-      paddingEnd="size-200"
-      paddingTop="size-200"
-      paddingBottom="size-50"
-      flex="none"
-      overflow="visible"
-    >
+    <View {...headerViewProps}>
       <Suspense fallback={<Loading size="S" />}>
         <ProjectTraceCountSparkline />
       </Suspense>
@@ -39,14 +41,7 @@ function TracingUxProjectPageHeader() {
 
 function LegacyProjectPageHeader({ project }: ProjectPageHeaderProps) {
   return (
-    <View
-      paddingStart="size-200"
-      paddingEnd="size-200"
-      paddingTop="size-200"
-      paddingBottom="size-50"
-      flex="none"
-      overflow="visible"
-    >
+    <View {...headerViewProps}>
       <div css={statsScrollCSS}>
         <ProjectStats project={project} />
       </div>

--- a/app/src/pages/project/ProjectPageHeader.tsx
+++ b/app/src/pages/project/ProjectPageHeader.tsx
@@ -1,8 +1,7 @@
 import { css } from "@emotion/react";
-import type { ReactNode } from "react";
 import { Suspense } from "react";
 
-import { Flex, Loading, View } from "@phoenix/components";
+import { Loading, View } from "@phoenix/components";
 import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 
 import type { ProjectStats_project$key } from "./__generated__/ProjectStats_project.graphql";
@@ -11,12 +10,7 @@ import { ProjectTraceCountSparkline } from "./ProjectTraceCountSparkline";
 
 export function ProjectPageHeader(props: {
   project: ProjectStats_project$key;
-  /**
-   * the extra component displayed on the right side of the header
-   */
-  extra: ReactNode;
 }) {
-  const { extra } = props;
   const isTracingUxEnabled = useFeatureFlag("tracing_ux");
   return (
     <View
@@ -27,20 +21,15 @@ export function ProjectPageHeader(props: {
       flex="none"
       overflow="visible"
     >
-      <Flex direction="row" justifyContent="space-between" alignItems="center">
-        {isTracingUxEnabled ? (
-          <Suspense fallback={<Loading size="S" />}>
-            <ProjectTraceCountSparkline />
-          </Suspense>
-        ) : (
-          <div css={statsScrollCSS}>
-            <ProjectStats project={props.project} />
-          </div>
-        )}
-        <View flex="none" paddingStart="size-100">
-          {extra}
-        </View>
-      </Flex>
+      {isTracingUxEnabled ? (
+        <Suspense fallback={<Loading size="S" />}>
+          <ProjectTraceCountSparkline />
+        </Suspense>
+      ) : (
+        <div css={statsScrollCSS}>
+          <ProjectStats project={props.project} />
+        </div>
+      )}
     </View>
   );
 }

--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -50,6 +50,7 @@ import {
   ConnectedTimeRangeSelector,
   useTimeRange,
 } from "@phoenix/components/datetime";
+import { TopNavActions } from "@phoenix/components/nav";
 import { GradientCircle } from "@phoenix/components/project/GradientCircle";
 import { tableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
@@ -312,104 +313,108 @@ export function ProjectsPageContent({
   }, [loadNext, queryArgs]);
 
   return (
-    <div
-      css={css`
-        display: flex;
-        flex-direction: column;
-        overflow: auto;
-      `}
-      onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
-      ref={projectsContainerRef}
-    >
-      <View
-        padding="size-200"
-        width="100%"
-        borderBottomColor="default"
-        borderBottomWidth="thin"
-        flex="none"
+    <>
+      <TopNavActions>
+        <ConnectedTimeRangeSelector size="S" />
+      </TopNavActions>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          overflow: auto;
+        `}
+        onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
+        ref={projectsContainerRef}
       >
-        <Flex
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-          gap="size-100"
+        <View
+          padding="size-200"
+          width="100%"
+          borderBottomColor="default"
+          borderBottomWidth="thin"
+          flex="none"
         >
-          <DebouncedSearch
-            aria-label="Search projects by name"
-            placeholder="Search projects by name"
-            onChange={(newSearch) => {
-              setFilter(newSearch);
-              refetch({
-                vars: {
-                  filter: { value: newSearch, col: "name" },
-                },
-              });
-            }}
-          />
           <Flex
             direction="row"
-            justifyContent="end"
+            justifyContent="space-between"
             alignItems="center"
             gap="size-100"
+          >
+            <DebouncedSearch
+              aria-label="Search projects by name"
+              placeholder="Search projects by name"
+              onChange={(newSearch) => {
+                setFilter(newSearch);
+                refetch({
+                  vars: {
+                    filter: { value: newSearch, col: "name" },
+                  },
+                });
+              }}
+            />
+            <Flex
+              direction="row"
+              justifyContent="end"
+              alignItems="center"
+              gap="size-100"
+              css={css`
+                button {
+                  text-wrap: nowrap;
+                }
+              `}
+            >
+              <ProjectViewModeToggle />
+              <CanModify>
+                <NewProjectButton
+                  variant="primary"
+                  onProjectCreated={() => refetch({})}
+                />
+              </CanModify>
+            </Flex>
+          </Flex>
+        </View>
+        {projectViewMode === "grid" ? (
+          <div
             css={css`
-              button {
-                text-wrap: nowrap;
-              }
+              display: flex;
+              flex-direction: column;
+              flex: 1 1 auto;
             `}
           >
-            <ProjectViewModeToggle />
-            <ConnectedTimeRangeSelector size="M" />
-            <CanModify>
-              <NewProjectButton
-                variant="primary"
-                onProjectCreated={() => refetch({})}
-              />
-            </CanModify>
-          </Flex>
-        </Flex>
-      </View>
-      {projectViewMode === "grid" ? (
-        <div
-          css={css`
-            display: flex;
-            flex-direction: column;
-            flex: 1 1 auto;
-          `}
-        >
-          <ProjectsGrid
-            projects={projects}
-            onDelete={onDelete}
-            onClear={onClear}
-            onRemove={onRemove}
-            timeRangeVariable={timeRangeVariable}
-            hasNext={hasNext}
-            loadNext={loadNextWithArgs}
-            isLoadingNext={isLoadingNext}
-            onSort={onSort}
-          />
-        </div>
-      ) : (
-        <div
-          css={css`
-            display: flex;
-            flex-direction: column;
-            flex: 1 1 auto;
-          `}
-        >
-          <ProjectsTable
-            projects={projects}
-            onDelete={onDelete}
-            onClear={onClear}
-            onRemove={onRemove}
-            timeRangeVariable={timeRangeVariable}
-            hasNext={hasNext}
-            loadNext={loadNextWithArgs}
-            isLoadingNext={isLoadingNext}
-            onSort={onSort}
-          />
-        </div>
-      )}
-    </div>
+            <ProjectsGrid
+              projects={projects}
+              onDelete={onDelete}
+              onClear={onClear}
+              onRemove={onRemove}
+              timeRangeVariable={timeRangeVariable}
+              hasNext={hasNext}
+              loadNext={loadNextWithArgs}
+              isLoadingNext={isLoadingNext}
+              onSort={onSort}
+            />
+          </div>
+        ) : (
+          <div
+            css={css`
+              display: flex;
+              flex-direction: column;
+              flex: 1 1 auto;
+            `}
+          >
+            <ProjectsTable
+              projects={projects}
+              onDelete={onDelete}
+              onClear={onClear}
+              onRemove={onRemove}
+              timeRangeVariable={timeRangeVariable}
+              hasNext={hasNext}
+              loadNext={loadNextWithArgs}
+              isLoadingNext={isLoadingNext}
+              onSort={onSort}
+            />
+          </div>
+        )}
+      </div>
+    </>
   );
 }
 

--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -128,9 +128,14 @@ export function ProjectsPage() {
   );
 
   return (
-    <Suspense fallback={<Loading />}>
-      <ProjectsPageContent timeRange={timeRange} query={data} />
-    </Suspense>
+    <>
+      <TopNavActions>
+        <ConnectedTimeRangeSelector size="S" />
+      </TopNavActions>
+      <Suspense fallback={<Loading />}>
+        <ProjectsPageContent timeRange={timeRange} query={data} />
+      </Suspense>
+    </>
   );
 }
 
@@ -313,108 +318,103 @@ export function ProjectsPageContent({
   }, [loadNext, queryArgs]);
 
   return (
-    <>
-      <TopNavActions>
-        <ConnectedTimeRangeSelector size="S" />
-      </TopNavActions>
-      <div
-        css={css`
-          display: flex;
-          flex-direction: column;
-          overflow: auto;
-        `}
-        onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
-        ref={projectsContainerRef}
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        overflow: auto;
+      `}
+      onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
+      ref={projectsContainerRef}
+    >
+      <View
+        padding="size-200"
+        width="100%"
+        borderBottomColor="default"
+        borderBottomWidth="thin"
+        flex="none"
       >
-        <View
-          padding="size-200"
-          width="100%"
-          borderBottomColor="default"
-          borderBottomWidth="thin"
-          flex="none"
+        <Flex
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          gap="size-100"
         >
+          <DebouncedSearch
+            aria-label="Search projects by name"
+            placeholder="Search projects by name"
+            onChange={(newSearch) => {
+              setFilter(newSearch);
+              refetch({
+                vars: {
+                  filter: { value: newSearch, col: "name" },
+                },
+              });
+            }}
+          />
           <Flex
             direction="row"
-            justifyContent="space-between"
+            justifyContent="end"
             alignItems="center"
             gap="size-100"
+            css={css`
+              button {
+                text-wrap: nowrap;
+              }
+            `}
           >
-            <DebouncedSearch
-              aria-label="Search projects by name"
-              placeholder="Search projects by name"
-              onChange={(newSearch) => {
-                setFilter(newSearch);
-                refetch({
-                  vars: {
-                    filter: { value: newSearch, col: "name" },
-                  },
-                });
-              }}
-            />
-            <Flex
-              direction="row"
-              justifyContent="end"
-              alignItems="center"
-              gap="size-100"
-              css={css`
-                button {
-                  text-wrap: nowrap;
-                }
-              `}
-            >
-              <ProjectViewModeToggle />
-              <CanModify>
-                <NewProjectButton
-                  variant="primary"
-                  onProjectCreated={() => refetch({})}
-                />
-              </CanModify>
-            </Flex>
+            <ProjectViewModeToggle />
+            <CanModify>
+              <NewProjectButton
+                variant="primary"
+                onProjectCreated={() => refetch({})}
+              />
+            </CanModify>
           </Flex>
-        </View>
-        {projectViewMode === "grid" ? (
-          <div
-            css={css`
-              display: flex;
-              flex-direction: column;
-              flex: 1 1 auto;
-            `}
-          >
-            <ProjectsGrid
-              projects={projects}
-              onDelete={onDelete}
-              onClear={onClear}
-              onRemove={onRemove}
-              timeRangeVariable={timeRangeVariable}
-              hasNext={hasNext}
-              loadNext={loadNextWithArgs}
-              isLoadingNext={isLoadingNext}
-              onSort={onSort}
-            />
-          </div>
-        ) : (
-          <div
-            css={css`
-              display: flex;
-              flex-direction: column;
-              flex: 1 1 auto;
-            `}
-          >
-            <ProjectsTable
-              projects={projects}
-              onDelete={onDelete}
-              onClear={onClear}
-              onRemove={onRemove}
-              timeRangeVariable={timeRangeVariable}
-              hasNext={hasNext}
-              loadNext={loadNextWithArgs}
-              isLoadingNext={isLoadingNext}
-              onSort={onSort}
-            />
-          </div>
-        )}
-      </div>
-    </>
+        </Flex>
+      </View>
+      {projectViewMode === "grid" ? (
+        <div
+          css={css`
+            display: flex;
+            flex-direction: column;
+            flex: 1 1 auto;
+          `}
+        >
+          <ProjectsGrid
+            projects={projects}
+            onDelete={onDelete}
+            onClear={onClear}
+            onRemove={onRemove}
+            timeRangeVariable={timeRangeVariable}
+            hasNext={hasNext}
+            loadNext={loadNextWithArgs}
+            isLoadingNext={isLoadingNext}
+            onSort={onSort}
+          />
+        </div>
+      ) : (
+        <div
+          css={css`
+            display: flex;
+            flex-direction: column;
+            flex: 1 1 auto;
+          `}
+        >
+          <ProjectsTable
+            projects={projects}
+            onDelete={onDelete}
+            onClear={onClear}
+            onRemove={onRemove}
+            timeRangeVariable={timeRangeVariable}
+            hasNext={hasNext}
+            loadNext={loadNextWithArgs}
+            isLoadingNext={isLoadingNext}
+            onSort={onSort}
+          />
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/app/stories/TopNavActions.stories.tsx
+++ b/app/stories/TopNavActions.stories.tsx
@@ -1,0 +1,78 @@
+import { css } from "@emotion/react";
+import type { Meta, StoryFn } from "@storybook/react";
+
+import { Button, Flex, Text } from "@phoenix/components";
+import {
+  TopNavActions,
+  TopNavActionsProvider,
+  TopNavActionsSlot,
+} from "@phoenix/components/nav";
+
+const navPreviewCSS = css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--global-dimension-static-size-100);
+  padding: var(--global-dimension-static-size-100);
+  background-color: var(--global-color-gray-100);
+  border: 1px solid var(--global-border-color-default);
+  border-radius: var(--global-rounding-medium);
+  min-width: 480px;
+`;
+
+const pageBodyCSS = css`
+  margin-top: var(--global-dimension-static-size-200);
+  padding: var(--global-dimension-static-size-200);
+  border: 1px dashed var(--global-border-color-default);
+  border-radius: var(--global-rounding-medium);
+`;
+
+export default {
+  title: "Nav/TopNavActions",
+  component: TopNavActions,
+  parameters: {
+    layout: "centered",
+  },
+} as Meta<typeof TopNavActions>;
+
+const Shell = ({ children }: { children: React.ReactNode }) => (
+  <TopNavActionsProvider>
+    <Flex direction="column">
+      <nav css={navPreviewCSS}>
+        <Text weight="heavy">Breadcrumbs</Text>
+        <TopNavActionsSlot />
+      </nav>
+      <div css={pageBodyCSS}>{children}</div>
+    </Flex>
+  </TopNavActionsProvider>
+);
+
+export const Empty: StoryFn = () => (
+  <Shell>
+    <Text>No page-declared actions. Slot renders nothing.</Text>
+  </Shell>
+);
+
+export const SingleAction: StoryFn = () => (
+  <Shell>
+    <Text>Page body declares one action (rendered top-right).</Text>
+    <TopNavActions>
+      <Button variant="primary">Time Range</Button>
+    </TopNavActions>
+  </Shell>
+);
+
+export const MultipleContributors: StoryFn = () => (
+  <Shell>
+    <Text>
+      Two components each declare actions — both render side-by-side in the nav
+      slot.
+    </Text>
+    <TopNavActions>
+      <Button>Filter</Button>
+    </TopNavActions>
+    <TopNavActions>
+      <Button variant="primary">Time Range</Button>
+    </TopNavActions>
+  </Shell>
+);


### PR DESCRIPTION

<img width="2553" height="334" alt="Screenshot 2026-04-21 at 7 35 24 PM" src="https://github.com/user-attachments/assets/715eb5ad-2569-43bd-afe6-587ec9080d8b" />


Introduces a `TopNavActions` portal so pages can declare controls — time range filters, streaming toggles, etc. — that render in the top-right of the global nav. The control renders in the page's React tree (so page-level contexts like `TimeRangeContext` and `ProjectContext` still apply) but is portaled into the nav slot via `createPortal`.

### API

```tsx
// In any page under Layout:
<TopNavActions>
  <ConnectedTimeRangeSelector size="S" />
</TopNavActions>
```

### Changes

- New `TopNavActionsProvider` / `TopNavActionsSlot` / `TopNavActions` in `app/src/components/nav/TopNavActions.tsx`.
- `Layout.tsx` wraps in the provider and mounts the slot at the right side of `TopNavbar`.
- Projects page and Project page migrated: time range selector (and stream toggle on the project page) now render in the top nav.
- `ProjectPageHeader` loses its `extra` prop (only consumer used it for these controls).
- Storybook story with empty / single-action / multi-contributor variants.
