### PR TITLE
feat(auth): downgrade admins to effective member for PXI-marked GraphQL

### DIFF
--- a/app/src/agent/tools/bash/context/__tests__/refreshAgentContext.test.ts
+++ b/app/src/agent/tools/bash/context/__tests__/refreshAgentContext.test.ts
@@ -293,6 +293,17 @@ EOF`
     expect(inlineResult.stdout).toContain("Project Alpha");
     expect(fileResult.stdout).toContain("Dataset A");
     expect(spillResult.stdout).toContain("/home/user/workspace/result.json");
+
+    const phoenixGqlFetchCalls = mockedAuthFetch.mock.calls.filter(
+      ([input, init]) => {
+        if (!String(input).includes("/graphql")) {
+          return false;
+        }
+        const headers = (init?.headers ?? {}) as Record<string, string>;
+        return headers["X-Phoenix-Request-Source"] === "pxi";
+      }
+    );
+    expect(phoenixGqlFetchCalls.length).toBeGreaterThan(0);
     expect(blockedMutation.exitCode).toBe(1);
     expect(blockedMutation.stderr.length).toBeGreaterThan(0);
     expect(mockedAuthFetch.mock.calls.length).toBe(

--- a/app/src/agent/tools/bash/phoenixGqlCommand.ts
+++ b/app/src/agent/tools/bash/phoenixGqlCommand.ts
@@ -8,6 +8,9 @@ import type { BashCustomCommandPolicy } from "./customCommandPolicy";
 
 const DEFAULT_SPILL_THRESHOLD_BYTES = 128 * 1024;
 
+const PHOENIX_REQUEST_SOURCE_HEADER = "X-Phoenix-Request-Source";
+const PXI_REQUEST_SOURCE = "pxi";
+
 function getHelpText(mutationsEnabled: boolean) {
   const permissionsLine = mutationsEnabled
     ? "Permissions: queries and mutations are ENABLED."
@@ -266,6 +269,7 @@ export const createPhoenixGqlCommand = ({
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          [PHOENIX_REQUEST_SOURCE_HEADER]: PXI_REQUEST_SOURCE,
         },
         body: JSON.stringify({ query, variables }),
       });

--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -12,6 +12,7 @@ from strawberry.fastapi import BaseContext
 
 from phoenix.auth import compute_password_hash
 from phoenix.server.bearer_auth import PhoenixUser
+from phoenix.server.pxi_auth import downgrade_if_pxi
 from phoenix.server.types import UserId
 
 if TYPE_CHECKING:
@@ -299,7 +300,8 @@ class Context(BaseContext):
 
     @cached_property
     def user(self) -> PhoenixUser:
-        return cast(PhoenixUser, self.get_request().user)
+        request = self.get_request()
+        return downgrade_if_pxi(cast(PhoenixUser, request.user), request=request)
 
     @cached_property
     def user_id(self) -> Optional[int]:

--- a/src/phoenix/server/api/mutations/api_key_mutations.py
+++ b/src/phoenix/server/api/mutations/api_key_mutations.py
@@ -102,7 +102,7 @@ class ApiKeyMutationMixin:
     ) -> CreateUserApiKeyMutationPayload:
         assert (token_store := info.context.token_store) is not None
         try:
-            user = info.context.request.user  # type: ignore
+            user = info.context.user
             assert isinstance(user, PhoenixUser)
         except AttributeError:
             raise ValueError("User not found")

--- a/src/phoenix/server/pxi_auth.py
+++ b/src/phoenix/server/pxi_auth.py
@@ -1,0 +1,58 @@
+from typing import Optional
+
+from starlette.requests import Request as StarletteRequest
+
+from phoenix.server.bearer_auth import PhoenixSystemUser, PhoenixUser
+
+PHOENIX_REQUEST_SOURCE_HEADER = "X-Phoenix-Request-Source"
+PXI_REQUEST_SOURCE = "pxi"
+
+
+def get_request_source(request: Optional[StarletteRequest]) -> Optional[str]:
+    if request is None:
+        return None
+    value = request.headers.get(PHOENIX_REQUEST_SOURCE_HEADER)
+    if not value:
+        return None
+    return value.strip().lower() or None
+
+
+def is_pxi_request(request: Optional[StarletteRequest]) -> bool:
+    return get_request_source(request) == PXI_REQUEST_SOURCE
+
+
+class PxiDowngradedPhoenixUser(PhoenixUser):
+    """
+    A PhoenixUser wrapper used when a GraphQL request self-identifies as PXI.
+
+    Downgrades admin to effective member (is_admin=False, is_viewer=False),
+    preserves viewer status, and leaves member unchanged. Not applied to
+    PhoenixSystemUser (callers should check before wrapping).
+    """
+
+    def __init__(self, base: PhoenixUser) -> None:
+        # Intentionally does not call super().__init__: PhoenixUser.__init__
+        # re-derives _is_admin/_is_viewer from claims, which would undo the
+        # downgrade.
+        self._user_id = base._user_id
+        self.claims = base.claims
+        self._is_admin = False
+        self._is_viewer = base._is_viewer
+
+
+def downgrade_if_pxi(
+    user: PhoenixUser,
+    *,
+    request: Optional[StarletteRequest],
+) -> PhoenixUser:
+    """
+    Return a PXI-downgraded wrapper for the given user when the request is
+    PXI-marked. System users, non-`PhoenixUser` principals (e.g. the
+    unauthenticated user when auth is disabled), and unmarked requests are
+    passed through unchanged.
+    """
+    if not isinstance(user, PhoenixUser) or isinstance(user, PhoenixSystemUser):
+        return user
+    if not is_pxi_request(request):
+        return user
+    return PxiDowngradedPhoenixUser(user)

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -843,9 +843,14 @@ def _gql(
     query: str,
     variables: Optional[Mapping[str, Any]] = None,
     operation_name: Optional[str] = None,
+    headers: Optional[Mapping[str, str]] = None,
 ) -> tuple[dict[str, Any], Headers]:
     json_ = dict(query=query, variables=dict(variables or {}), operationName=operation_name)
-    resp = _httpx_client(app, auth).post("graphql", json=json_)
+    resp = _httpx_client(
+        app,
+        auth,
+        headers=dict(headers) if headers else None,
+    ).post("graphql", json=json_)
     return _json(resp), resp.headers
 
 

--- a/tests/integration/auth/test_pxi_auth.py
+++ b/tests/integration/auth/test_pxi_auth.py
@@ -1,0 +1,262 @@
+"""Integration tests for the PXI request-source header and admin downgrade."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from secrets import token_hex
+
+import pytest
+
+from phoenix.server.api.input_types.UserRoleInput import UserRoleInput
+
+from .._helpers import (
+    _ADMIN,
+    _DENIED,
+    _MEMBER,
+    _VIEWER,
+    _AppInfo,
+    _GetUser,
+    _gql,
+    _LoggedInUser,
+    _Profile,
+)
+
+_PXI_HEADERS = {"X-Phoenix-Request-Source": "pxi"}
+
+_CREATE_SYSTEM_API_KEY = """
+mutation ($name: String!) {
+  createSystemApiKey(input: { name: $name }) {
+    apiKey { id name }
+  }
+}
+"""
+
+_CREATE_USER_API_KEY = """
+mutation ($name: String!) {
+  createUserApiKey(input: { name: $name }) {
+    jwt
+    apiKey { id name }
+  }
+}
+"""
+
+_DELETE_USER_API_KEY = """
+mutation ($id: ID!) {
+  deleteUserApiKey(input: { id: $id }) {
+    apiKeyId
+  }
+}
+"""
+
+_UPSERT_SECRETS = """
+mutation ($key: String!, $value: String) {
+  upsertOrDeleteSecrets(input: { secrets: [{ key: $key, value: $value }] }) {
+    upsertedSecrets { id }
+  }
+}
+"""
+
+_READ_SECRET_VALUE = """
+query ($keys: [String!]) {
+  secrets(keys: $keys) {
+    edges {
+      node {
+        id
+        value {
+          ... on DecryptedSecret { value }
+          ... on UnparsableSecret { parseError }
+        }
+      }
+    }
+  }
+}
+"""
+
+_CREATE_USER = """
+mutation ($email: String!, $username: String!, $password: String!, $role: UserRoleInput!) {
+  createUser(input: {
+    email: $email, username: $username, password: $password, role: $role
+  }) {
+    user { id }
+  }
+}
+"""
+
+_CREATE_PROJECT_TRACE_RETENTION_POLICY = """
+mutation ($name: String!) {
+  createProjectTraceRetentionPolicy(input: {
+    name: $name,
+    cronExpression: "0 0 * * 0",
+    rule: { maxDays: { maxDays: 30 } }
+  }) {
+    node { id }
+  }
+}
+"""
+
+_CREATE_ANNOTATION_CONFIG = """
+mutation ($name: String!) {
+  createAnnotationConfig(input: {
+    annotationConfig: { freeform: { name: $name } }
+  }) {
+    annotationConfig { ... on FreeformAnnotationConfig { id } }
+  }
+}
+"""
+
+_LIST_USERS = "query { users { edges { node { id } } } }"
+_LIST_USER_API_KEYS = "query { userApiKeys { id } }"
+_LIST_SYSTEM_API_KEYS = "query { systemApiKeys { id } }"
+
+
+class TestPxiAdminDowngrade:
+    @pytest.fixture
+    def _admin(self, _get_user: _GetUser, _app: _AppInfo) -> _LoggedInUser:
+        return _get_user(_app, _ADMIN).log_in(_app)
+
+    @pytest.fixture
+    def _member(self, _get_user: _GetUser, _app: _AppInfo) -> _LoggedInUser:
+        return _get_user(_app, _MEMBER).log_in(_app)
+
+    @pytest.fixture
+    def _viewer(self, _get_user: _GetUser, _app: _AppInfo) -> _LoggedInUser:
+        return _get_user(_app, _VIEWER).log_in(_app)
+
+    def test_admin_under_pxi_marker_denied_from_admin_operations(
+        self,
+        _admin: _LoggedInUser,
+        _member: _LoggedInUser,
+        _app: _AppInfo,
+        _profiles: Iterator[_Profile],
+    ) -> None:
+        """All admin-gated GraphQL surfaces (IsAdmin / IsAdminIfAuthEnabled on
+        mutations, fields, and resolver-internal `user.is_admin` branches)
+        must deny an admin whose request carries the PXI marker."""
+        # Top-level IsAdmin query fields.
+        for query in (_LIST_USERS, _LIST_USER_API_KEYS, _LIST_SYSTEM_API_KEYS):
+            with _DENIED:
+                _gql(_app, _admin, query=query, headers=_PXI_HEADERS)
+
+        # IsAdmin mutation.
+        with _DENIED:
+            _gql(
+                _app,
+                _admin,
+                query=_CREATE_SYSTEM_API_KEY,
+                variables={"name": f"pxi-sys-key-{token_hex(4)}"},
+                headers=_PXI_HEADERS,
+            )
+
+        # IsAdminIfAuthEnabled mutation.
+        with _DENIED:
+            _gql(
+                _app,
+                _admin,
+                query=_CREATE_PROJECT_TRACE_RETENTION_POLICY,
+                variables={"name": f"pxi-policy-{token_hex(4)}"},
+                headers=_PXI_HEADERS,
+            )
+
+        # IsAdmin mutation (user management).
+        profile = next(_profiles)
+        with _DENIED:
+            _gql(
+                _app,
+                _admin,
+                query=_CREATE_USER,
+                variables={
+                    "email": profile.email,
+                    "username": profile.username,
+                    "password": profile.password,
+                    "role": UserRoleInput.MEMBER.value,
+                },
+                headers=_PXI_HEADERS,
+            )
+
+        # IsAdminIfAuthEnabled mutation + field-level guard on Secret.value.
+        # Seed a secret as admin (no marker) so the read path has a
+        # `Secret.value` to resolve — otherwise an empty edges list would
+        # skip the IsAdminIfAuthEnabled check entirely.
+        key = f"PXI_TEST_SECRET_{token_hex(4).upper()}"
+        _gql(
+            _app,
+            _admin,
+            query=_UPSERT_SECRETS,
+            variables={"key": key, "value": token_hex(8)},
+        )
+        with _DENIED:
+            _gql(
+                _app,
+                _admin,
+                query=_UPSERT_SECRETS,
+                variables={"key": key, "value": token_hex(8)},
+                headers=_PXI_HEADERS,
+            )
+        with _DENIED:
+            _gql(
+                _app,
+                _admin,
+                query=_READ_SECRET_VALUE,
+                variables={"keys": [key]},
+                headers=_PXI_HEADERS,
+            )
+
+        # Resolver-internal `user.is_admin` branch in deleteUserApiKey.
+        create_body, _ = _gql(
+            _app,
+            _member,
+            query=_CREATE_USER_API_KEY,
+            variables={"name": f"victim-{token_hex(4)}"},
+        )
+        victim_key_id = create_body["data"]["createUserApiKey"]["apiKey"]["id"]
+        with _DENIED:
+            _gql(
+                _app,
+                _admin,
+                query=_DELETE_USER_API_KEY,
+                variables={"id": victim_key_id},
+                headers=_PXI_HEADERS,
+            )
+
+    def test_pxi_marker_does_not_escalate_member(
+        self,
+        _member: _LoggedInUser,
+        _app: _AppInfo,
+    ) -> None:
+        """A member sending the PXI marker must not gain admin privileges.
+        Guards against a wrapper bug that flips `is_admin=True`."""
+        with _DENIED:
+            _gql(
+                _app,
+                _member,
+                query=_CREATE_SYSTEM_API_KEY,
+                variables={"name": f"member-pxi-{token_hex(4)}"},
+                headers=_PXI_HEADERS,
+            )
+
+    def test_pxi_marker_does_not_escalate_viewer(
+        self,
+        _viewer: _LoggedInUser,
+        _app: _AppInfo,
+    ) -> None:
+        """A viewer sending the PXI marker must not gain member or admin
+        privileges. Guards against a wrapper bug that flips `is_viewer=False`
+        or `is_admin=True` for viewers."""
+        # Not promoted to member: still denied from an IsNotViewer-gated op.
+        with _DENIED:
+            _gql(
+                _app,
+                _viewer,
+                query=_CREATE_ANNOTATION_CONFIG,
+                variables={"name": f"viewer-pxi-{token_hex(4)}"},
+                headers=_PXI_HEADERS,
+            )
+        # Not promoted two levels to admin either.
+        with _DENIED:
+            _gql(
+                _app,
+                _viewer,
+                query=_CREATE_SYSTEM_API_KEY,
+                variables={"name": f"viewer-pxi-admin-{token_hex(4)}"},
+                headers=_PXI_HEADERS,
+            )


### PR DESCRIPTION
## Summary

- PXI (the in-app agent's `phoenix-gql` bash tool) shares the user's session cookies with the main Relay client, so an admin running the agent can drive admin-only GraphQL from the LLM as easily as from the UI. This PR caps the blast radius.
- The PXI client now labels its requests with `X-Phoenix-Request-Source: pxi`. Server-side, a new `PxiDowngradedPhoenixUser` wraps the authenticated `PhoenixUser` when the marker is present and the user is admin — admins become effective MEMBER (`is_admin=False, is_viewer=False`), viewers stay viewers, `PhoenixSystemUser` is passed through unchanged.
- Fixes a straggler in `api_key_mutations.create_user_api_key` that read `info.context.request.user` (raw principal), bypassing the downgrade — now reads `info.context.user`.

## Trust model

The marker is **self-reported**. The only known caller of `phoenix-gql` is the in-app agent running inside the user's own session, so the threat model is "protect admin users from their own LLM agent," not "block an attacker with a valid admin session." Omitting the header keeps today's behavior unchanged. An attacker already in possession of admin credentials can still act as admin via Relay or unmarked curl — that is out of scope.

## Scope

- **In scope:** GraphQL (`/graphql`). The marker is applied in `Context.user` so every resolver / permission class that honors `info.context.user` gets the downgrade for free. `IsAdmin`, `IsAdminIfAuthEnabled`, field-level guards, and resolver-internal `user.is_admin` branching are all covered.
- **Out of scope:** REST (`routers/v1/`) and gRPC ingest. If PXI ever expands to hit REST for admin-adjacent actions, the marker must be extended there as a follow-up. GraphiQL/playground is unmarked (same as Relay).