### PR TITLE
fix(app): update secrets list synchronously on mutation

### DIFF
--- a/app/src/pages/settings/secrets/DeleteSecretButton.tsx
+++ b/app/src/pages/settings/secrets/DeleteSecretButton.tsx
@@ -10,13 +10,13 @@ import {
   DialogTitle,
   DialogTitleExtra,
   DialogTrigger,
+  Flex,
   Icon,
   Icons,
   Modal,
   ModalOverlay,
   Text,
   View,
-  Flex,
 } from "@phoenix/components";
 import { useNotifySuccess } from "@phoenix/contexts";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
@@ -25,10 +25,10 @@ import { useSecretMutation } from "./SecretsMutation";
 
 export function DeleteSecretButton({
   secretKey,
-  onComplete,
+  connectionId,
 }: {
   secretKey: string;
-  onComplete: () => void;
+  connectionId: string;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -96,10 +96,10 @@ export function DeleteSecretButton({
                           input: {
                             secrets: [{ key: secretKey, value: null }],
                           },
+                          connections: [connectionId],
                         },
                         onCompleted: () => {
                           setIsOpen(false);
-                          onComplete();
                           notifySuccess({
                             title: "Secret deleted",
                             message: `${secretKey} has been removed.`,

--- a/app/src/pages/settings/secrets/NewSecretButton.tsx
+++ b/app/src/pages/settings/secrets/NewSecretButton.tsx
@@ -21,7 +21,7 @@ import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtil
 import { SecretMutationForm } from "./SecretMutationForm";
 import { useSecretMutation } from "./SecretsMutation";
 
-export function NewSecretButton({ onComplete }: { onComplete: () => void }) {
+export function NewSecretButton({ connectionId }: { connectionId: string }) {
   const [isOpen, setIsOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const notifySuccess = useNotifySuccess();
@@ -67,10 +67,10 @@ export function NewSecretButton({ onComplete }: { onComplete: () => void }) {
                       input: {
                         secrets: [{ key: key.trim(), value: value.trim() }],
                       },
+                      connections: [connectionId],
                     },
                     onCompleted: () => {
                       setIsOpen(false);
-                      onComplete();
                       notifySuccess({
                         title: "Secret created",
                         message: `${key.trim()} is now stored on the server.`,

--- a/app/src/pages/settings/secrets/ReplaceSecretButton.tsx
+++ b/app/src/pages/settings/secrets/ReplaceSecretButton.tsx
@@ -23,10 +23,10 @@ import { useSecretMutation } from "./SecretsMutation";
 
 export function ReplaceSecretButton({
   secretKey,
-  onComplete,
+  connectionId,
 }: {
   secretKey: string;
-  onComplete: () => void;
+  connectionId: string;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -75,10 +75,10 @@ export function ReplaceSecretButton({
                       input: {
                         secrets: [{ key: secretKey, value: value.trim() }],
                       },
+                      connections: [connectionId],
                     },
                     onCompleted: () => {
                       setIsOpen(false);
-                      onComplete();
                       notifySuccess({
                         title: "Secret updated",
                         message: `${secretKey} has been replaced.`,

--- a/app/src/pages/settings/secrets/SecretsMutation.ts
+++ b/app/src/pages/settings/secrets/SecretsMutation.ts
@@ -4,9 +4,24 @@ import type { SecretsMutationMutation } from "./__generated__/SecretsMutationMut
 
 export function useSecretMutation() {
   return useMutation<SecretsMutationMutation>(graphql`
-    mutation SecretsMutationMutation($input: UpsertOrDeleteSecretsMutationInput!) {
+    mutation SecretsMutationMutation(
+      $input: UpsertOrDeleteSecretsMutationInput!
+      $connections: [ID!]!
+    ) {
       upsertOrDeleteSecrets(input: $input) {
-        __typename
+        upsertedSecrets
+          @deleteEdge(connections: $connections)
+          @appendNode(connections: $connections, edgeTypeName: "SecretEdge") {
+          id
+          key
+          updatedAt
+          user {
+            id
+            username
+            profilePictureUrl
+          }
+        }
+        deletedIds @deleteEdge(connections: $connections)
       }
     }
   `);

--- a/app/src/pages/settings/secrets/SecretsTable.tsx
+++ b/app/src/pages/settings/secrets/SecretsTable.tsx
@@ -26,12 +26,12 @@ export function SecretsTable({
   data,
   authenticationEnabled,
   search,
-  onComplete,
+  connectionId,
 }: {
   data: SecretRow[];
   authenticationEnabled: boolean;
   search: string;
-  onComplete: () => void;
+  connectionId: string;
 }) {
   const [sorting, setSorting] = useState<SortingState>([
     { id: "updatedAt", desc: true },
@@ -81,11 +81,11 @@ export function SecretsTable({
           <Flex direction="row" gap="size-50" width="100%" justifyContent="end">
             <ReplaceSecretButton
               secretKey={row.original.key}
-              onComplete={onComplete}
+              connectionId={connectionId}
             />
             <DeleteSecretButton
               secretKey={row.original.key}
-              onComplete={onComplete}
+              connectionId={connectionId}
             />
           </Flex>
         );
@@ -96,7 +96,7 @@ export function SecretsTable({
     });
 
     return cols;
-  }, [authenticationEnabled, onComplete]);
+  }, [authenticationEnabled, connectionId]);
 
   // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable<SecretRow>({
@@ -125,7 +125,10 @@ export function SecretsTable({
   const isEmpty = rows.length === 0;
 
   return (
-    <Card title="Secrets" extra={<NewSecretButton onComplete={onComplete} />}>
+    <Card
+      title="Secrets"
+      extra={<NewSecretButton connectionId={connectionId} />}
+    >
       <table css={tableCSS}>
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (

--- a/app/src/pages/settings/secrets/SettingsSecretsPage.tsx
+++ b/app/src/pages/settings/secrets/SettingsSecretsPage.tsx
@@ -1,12 +1,12 @@
 import {
   startTransition,
-  useCallback,
   useEffect,
   useEffectEvent,
   useMemo,
   useState,
 } from "react";
 import {
+  ConnectionHandler,
   graphql,
   usePreloadedQuery,
   useRefetchableFragment,
@@ -36,6 +36,8 @@ import { SecretsTable } from "./SecretsTable";
 import type { SettingsSecretsPageLoaderType } from "./settingsSecretsPageLoader";
 import { settingsSecretsPageLoaderGql } from "./settingsSecretsPageLoader";
 import type { SecretOwnerFilter } from "./types";
+
+export const SECRETS_CONNECTION_KEY = "SettingsSecretsPage_secrets";
 
 export function SettingsSecretsPage() {
   const { viewer } = useViewer();
@@ -67,8 +69,13 @@ function SettingsSecretsPageContent({
   >(
     graphql`
       fragment SettingsSecretsPageFragment on Query
-      @refetchable(queryName: "SettingsSecretsPageRefetchQuery") {
-        secrets(first: 100) {
+      @refetchable(queryName: "SettingsSecretsPageRefetchQuery")
+      @argumentDefinitions(
+        count: { type: "Int", defaultValue: 100 }
+        cursor: { type: "String" }
+      ) {
+        secrets(first: $count, after: $cursor)
+          @connection(key: "SettingsSecretsPage_secrets") {
           edges {
             node {
               id
@@ -90,15 +97,19 @@ function SettingsSecretsPageContent({
   const [search, setSearch] = useState("");
   const [ownerFilter, setOwnerFilter] = useState<SecretOwnerFilter>("ALL");
 
-  const refresh = useCallback(() => {
-    refetch({}, { fetchPolicy: "store-and-network" });
-  }, [refetch]);
+  const connectionId = useMemo(
+    () =>
+      ConnectionHandler.getConnectionID("client:root", SECRETS_CONNECTION_KEY),
+    []
+  );
 
-  const refreshOnMount = useEffectEvent(refresh);
+  const refreshOnMount = useEffectEvent(() => {
+    refetch({}, { fetchPolicy: "store-and-network" });
+  });
 
   useEffect(() => {
-    // Mutations that modify secrets around the app do not support query-level
-    // fragment returns, so refetch secrets in the background on page mount.
+    // Secrets can be mutated outside this page (other surfaces don't yet
+    // update the connection), so refetch once on mount to get fresh data.
     refreshOnMount();
   }, []);
 
@@ -154,7 +165,7 @@ function SettingsSecretsPageContent({
         data={filteredTableData}
         authenticationEnabled={authenticationEnabled}
         search={search}
-        onComplete={refresh}
+        connectionId={connectionId}
       />
     </Flex>
   );

--- a/app/src/pages/settings/secrets/__generated__/SecretsMutationMutation.graphql.ts
+++ b/app/src/pages/settings/secrets/__generated__/SecretsMutationMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2534d595c3e9b65466373e66650fdfc7>>
+ * @generated SignedSource<<8f77657804562f568c57c86d54352a3b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,11 +17,22 @@ export type SecretKeyValueInput = {
   value?: string | null;
 };
 export type SecretsMutationMutation$variables = {
+  connections: ReadonlyArray<string>;
   input: UpsertOrDeleteSecretsMutationInput;
 };
 export type SecretsMutationMutation$data = {
   readonly upsertOrDeleteSecrets: {
-    readonly __typename: "UpsertOrDeleteSecretsMutationPayload";
+    readonly deletedIds: ReadonlyArray<string>;
+    readonly upsertedSecrets: ReadonlyArray<{
+      readonly id: string;
+      readonly key: string;
+      readonly updatedAt: string;
+      readonly user: {
+        readonly id: string;
+        readonly profilePictureUrl: string | null;
+        readonly username: string;
+      } | null;
+    }>;
   };
 };
 export type SecretsMutationMutation = {
@@ -30,67 +41,185 @@ export type SecretsMutationMutation = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = [
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
   {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "input"
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
 ],
-v1 = [
-  {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
-    ],
-    "concreteType": "UpsertOrDeleteSecretsMutationPayload",
-    "kind": "LinkedField",
-    "name": "upsertOrDeleteSecrets",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "__typename",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  }
-];
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Secret",
+  "kind": "LinkedField",
+  "name": "upsertedSecrets",
+  "plural": true,
+  "selections": [
+    (v3/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "key",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "updatedAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "User",
+      "kind": "LinkedField",
+      "name": "user",
+      "plural": false,
+      "selections": [
+        (v3/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "username",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "profilePictureUrl",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedIds",
+  "storageKey": null
+},
+v6 = {
+  "kind": "Variable",
+  "name": "connections",
+  "variableName": "connections"
+};
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
     "kind": "Fragment",
     "metadata": null,
     "name": "SecretsMutationMutation",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "UpsertOrDeleteSecretsMutationPayload",
+        "kind": "LinkedField",
+        "name": "upsertOrDeleteSecrets",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Mutation",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
     "kind": "Operation",
     "name": "SecretsMutationMutation",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "UpsertOrDeleteSecretsMutationPayload",
+        "kind": "LinkedField",
+        "name": "upsertOrDeleteSecrets",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "appendNode",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "upsertedSecrets",
+            "handleArgs": [
+              (v6/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "edgeTypeName",
+                "value": "SecretEdge"
+              }
+            ]
+          },
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "deleteEdge",
+            "key": "",
+            "kind": "ScalarHandle",
+            "name": "deletedIds",
+            "handleArgs": [
+              (v6/*: any*/)
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "188290e4d91908596225d3ddd39e7f64",
+    "cacheID": "78687ca4cb391bedea4d4cffe9d0484a",
     "id": null,
     "metadata": {},
     "name": "SecretsMutationMutation",
     "operationKind": "mutation",
-    "text": "mutation SecretsMutationMutation(\n  $input: UpsertOrDeleteSecretsMutationInput!\n) {\n  upsertOrDeleteSecrets(input: $input) {\n    __typename\n  }\n}\n"
+    "text": "mutation SecretsMutationMutation(\n  $input: UpsertOrDeleteSecretsMutationInput!\n) {\n  upsertOrDeleteSecrets(input: $input) {\n    upsertedSecrets {\n      id\n      key\n      updatedAt\n      user {\n        id\n        username\n        profilePictureUrl\n      }\n    }\n    deletedIds\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "860d8a43efd1c77441679a28b8b3f1c1";
+(node as any).hash = "ac158c2cca394523ea36111a27ad7cff";
 
 export default node;

--- a/app/src/pages/settings/secrets/__generated__/SettingsSecretsPageFragment.graphql.ts
+++ b/app/src/pages/settings/secrets/__generated__/SettingsSecretsPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b1b902827b2fc8bc459878aaa0cf15a8>>
+ * @generated SignedSource<<bdfc2cfb2c7fdd5e34bc5dd5748461db>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -35,7 +35,10 @@ export type SettingsSecretsPageFragment$key = {
 import SettingsSecretsPageRefetchQuery_graphql from './SettingsSecretsPageRefetchQuery.graphql';
 
 const node: ReaderFragment = (function(){
-var v0 = {
+var v0 = [
+  "secrets"
+],
+v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -43,11 +46,37 @@ var v0 = {
   "storageKey": null
 };
 return {
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "defaultValue": 100,
+      "kind": "LocalArgument",
+      "name": "count"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "cursor"
+    }
+  ],
   "kind": "Fragment",
   "metadata": {
+    "connection": [
+      {
+        "count": "count",
+        "cursor": "cursor",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
+    ],
     "refetch": {
-      "connection": null,
+      "connection": {
+        "forward": {
+          "count": "count",
+          "cursor": "cursor"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
       "fragmentPathInResult": [],
       "operation": SettingsSecretsPageRefetchQuery_graphql
     }
@@ -55,17 +84,11 @@ return {
   "name": "SettingsSecretsPageFragment",
   "selections": [
     {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "first",
-          "value": 100
-        }
-      ],
+      "alias": "secrets",
+      "args": null,
       "concreteType": "SecretConnection",
       "kind": "LinkedField",
-      "name": "secrets",
+      "name": "__SettingsSecretsPage_secrets_connection",
       "plural": false,
       "selections": [
         {
@@ -84,7 +107,7 @@ return {
               "name": "node",
               "plural": false,
               "selections": [
-                (v0/*: any*/),
+                (v1/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -107,7 +130,7 @@ return {
                   "name": "user",
                   "plural": false,
                   "selections": [
-                    (v0/*: any*/),
+                    (v1/*: any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -124,15 +147,54 @@ return {
                     }
                   ],
                   "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
                 }
               ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
               "storageKey": null
             }
           ],
           "storageKey": null
         }
       ],
-      "storageKey": "secrets(first:100)"
+      "storageKey": null
     }
   ],
   "type": "Query",
@@ -140,6 +202,6 @@ return {
 };
 })();
 
-(node as any).hash = "f693b67c9e54bcd6885167d74099636c";
+(node as any).hash = "9458ee6e39a893b28d61dc76c23e2639";
 
 export default node;

--- a/app/src/pages/settings/secrets/__generated__/SettingsSecretsPageRefetchQuery.graphql.ts
+++ b/app/src/pages/settings/secrets/__generated__/SettingsSecretsPageRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<267d9e71b89b93f8543c58e1470aeedd>>
+ * @generated SignedSource<<ef3769a4cbd462cccbfa71c5a348fba0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,10 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type SettingsSecretsPageRefetchQuery$variables = Record<PropertyKey, never>;
+export type SettingsSecretsPageRefetchQuery$variables = {
+  count?: number | null;
+  cursor?: string | null;
+};
 export type SettingsSecretsPageRefetchQuery$data = {
   readonly " $fragmentSpreads": FragmentRefs<"SettingsSecretsPageFragment">;
 };
@@ -20,7 +23,31 @@ export type SettingsSecretsPageRefetchQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = {
+var v0 = [
+  {
+    "defaultValue": 100,
+    "kind": "LocalArgument",
+    "name": "count"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "cursor"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "cursor"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "count"
+  }
+],
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -29,13 +56,24 @@ var v0 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "SettingsSecretsPageRefetchQuery",
     "selections": [
       {
-        "args": null,
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "count",
+            "variableName": "count"
+          },
+          {
+            "kind": "Variable",
+            "name": "cursor",
+            "variableName": "cursor"
+          }
+        ],
         "kind": "FragmentSpread",
         "name": "SettingsSecretsPageFragment"
       }
@@ -45,19 +83,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "SettingsSecretsPageRefetchQuery",
     "selections": [
       {
         "alias": null,
-        "args": [
-          {
-            "kind": "Literal",
-            "name": "first",
-            "value": 100
-          }
-        ],
+        "args": (v1/*: any*/),
         "concreteType": "SecretConnection",
         "kind": "LinkedField",
         "name": "secrets",
@@ -79,7 +111,7 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v0/*: any*/),
+                  (v2/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -102,7 +134,7 @@ return {
                     "name": "user",
                     "plural": false,
                     "selections": [
-                      (v0/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -119,29 +151,77 @@ return {
                       }
                     ],
                     "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
                   }
                 ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cursor",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PageInfo",
+            "kind": "LinkedField",
+            "name": "pageInfo",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endCursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hasNextPage",
                 "storageKey": null
               }
             ],
             "storageKey": null
           }
         ],
-        "storageKey": "secrets(first:100)"
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "filters": null,
+        "handle": "connection",
+        "key": "SettingsSecretsPage_secrets",
+        "kind": "LinkedHandle",
+        "name": "secrets"
       }
     ]
   },
   "params": {
-    "cacheID": "ba78c830e8d2ac5e295edc43e7dae12e",
+    "cacheID": "9d72ead7340f856693f6637dab2351f5",
     "id": null,
     "metadata": {},
     "name": "SettingsSecretsPageRefetchQuery",
     "operationKind": "query",
-    "text": "query SettingsSecretsPageRefetchQuery {\n  ...SettingsSecretsPageFragment\n}\n\nfragment SettingsSecretsPageFragment on Query {\n  secrets(first: 100) {\n    edges {\n      node {\n        id\n        key\n        updatedAt\n        user {\n          id\n          username\n          profilePictureUrl\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query SettingsSecretsPageRefetchQuery(\n  $count: Int = 100\n  $cursor: String\n) {\n  ...SettingsSecretsPageFragment_1G22uz\n}\n\nfragment SettingsSecretsPageFragment_1G22uz on Query {\n  secrets(first: $count, after: $cursor) {\n    edges {\n      node {\n        id\n        key\n        updatedAt\n        user {\n          id\n          username\n          profilePictureUrl\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f693b67c9e54bcd6885167d74099636c";
+(node as any).hash = "9458ee6e39a893b28d61dc76c23e2639";
 
 export default node;

--- a/app/src/pages/settings/secrets/__generated__/settingsSecretsPageLoaderQuery.graphql.ts
+++ b/app/src/pages/settings/secrets/__generated__/settingsSecretsPageLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<991d9e9a5f8f70f157d73b2c99e10733>>
+ * @generated SignedSource<<f7344fa6e24c88d4c0c8b66066ff5403>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,7 +20,14 @@ export type settingsSecretsPageLoaderQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = {
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  }
+],
+v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -51,13 +58,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": [
-          {
-            "kind": "Literal",
-            "name": "first",
-            "value": 100
-          }
-        ],
+        "args": (v0/*: any*/),
         "concreteType": "SecretConnection",
         "kind": "LinkedField",
         "name": "secrets",
@@ -79,7 +80,7 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v0/*: any*/),
+                  (v1/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -102,7 +103,7 @@ return {
                     "name": "user",
                     "plural": false,
                     "selections": [
-                      (v0/*: any*/),
+                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -119,8 +120,47 @@ return {
                       }
                     ],
                     "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
                   }
                 ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cursor",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PageInfo",
+            "kind": "LinkedField",
+            "name": "pageInfo",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endCursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hasNextPage",
                 "storageKey": null
               }
             ],
@@ -128,16 +168,25 @@ return {
           }
         ],
         "storageKey": "secrets(first:100)"
+      },
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "filters": null,
+        "handle": "connection",
+        "key": "SettingsSecretsPage_secrets",
+        "kind": "LinkedHandle",
+        "name": "secrets"
       }
     ]
   },
   "params": {
-    "cacheID": "6a0bb21095b0b47b03502ed476909d25",
+    "cacheID": "df03cb0f0d66ff1df685f5d212efc3be",
     "id": null,
     "metadata": {},
     "name": "settingsSecretsPageLoaderQuery",
     "operationKind": "query",
-    "text": "query settingsSecretsPageLoaderQuery {\n  ...SettingsSecretsPageFragment\n}\n\nfragment SettingsSecretsPageFragment on Query {\n  secrets(first: 100) {\n    edges {\n      node {\n        id\n        key\n        updatedAt\n        user {\n          id\n          username\n          profilePictureUrl\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query settingsSecretsPageLoaderQuery {\n  ...SettingsSecretsPageFragment\n}\n\nfragment SettingsSecretsPageFragment on Query {\n  secrets(first: 100) {\n    edges {\n      node {\n        id\n        key\n        updatedAt\n        user {\n          id\n          username\n          profilePictureUrl\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
## Summary

- The Secrets page fired `refetch({}, { fetchPolicy: "store-and-network" })` in the mutation's `onCompleted` but never awaited it, so the UI had a visible gap after create/replace/delete while the follow-up list query was in flight. Under CI pressure this was long enough to make the Playwright `settings-secrets` tests flake.
- Name the connection (`@connection(key: "SettingsSecretsPage_secrets")`) and drive the list synchronously off the mutation response: `@deleteEdge` + `@appendNode` on `upsertedSecrets`, and `@deleteEdge` on `deletedIds`. On replace, the old edge is deleted and the new edge re-appended with the same node ID (the record update propagates the new `updatedAt`) — no second round trip. On delete, the edge is removed as the mutation response commits.
- Keep the mount-time refetch as a safety net for surfaces elsewhere that mutate secrets without updating this connection.

## Context

Observed as flaky failures on two unrelated Playwright runs:
- https://github.com/Arize-ai/phoenix/actions/runs/24760263831/job/72442181300 — `settings-secrets.spec.ts:35 › can create, replace, and delete a secret` (row still visible after delete) and `settings-secrets.spec.ts:155 › does not leak secret values` (row not yet visible after create).
- https://github.com/Arize-ai/phoenix/actions/runs/24756966678/job/72432938975 — `settings-secrets.spec.ts:84 › supports search, owner filter, and sorting` (sorted-first-row assertion races the sort + refetch).