### PR TITLE
docs: Add Phoenix release notes for 04-16-2026 through 04-22-2026

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1155,6 +1155,9 @@
               {
                 "group": "04.2026",
                 "pages": [
+                  "docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id",
+                  "docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7",
+                  "docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres",
                   "docs/phoenix/release-notes/04-2026/04-14-2026-cli-annotation-commands",
                   "docs/phoenix/release-notes/04-2026/04-13-2026-phoenix-otel-ts-1-0",
                   "docs/phoenix/release-notes/04-2026/04-10-2026-shareable-url-redirects",

--- a/docs/phoenix.mdx
+++ b/docs/phoenix.mdx
@@ -103,7 +103,7 @@ The best next step is to start using Phoenix. Start with a quickstart to send da
   <Card title="Cookbooks" icon="book-open" href="/docs/phoenix/cookbook">
     Example notebooks for tracing, evals, RAG analysis, and more
   </Card>
-  <Card title="Community" icon="users" href="https://join.slack.com/t/arize-ai/shared_invite/zt-3lqwr2oc3-7rhdyYEh82zJL_UhPKrb0A">
+  <Card title="Community" icon="users" href="https://join.slack.com/t/arize-ai/shared_invite/zt-3r07iavnk-ammtATWSlF0pSrd1DsMW7g">
     Join the Phoenix Slack to ask questions and connect with developers
   </Card>
 </CardGroup>

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -7,6 +7,57 @@ description: The latest from the Phoenix team.
 GitHub
 </Card>
 
+<Update label="04.22.2026">
+## [04.22.2026: Secrets Settings Page](/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id)
+**Available in arize-phoenix 14.11.0+**
+
+A new **Settings → Secrets** page lets admins add, replace, and delete encrypted LLM provider credentials (e.g. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) directly in the Phoenix UI — no REST API calls required.
+
+- **Add / Replace / Delete** secrets from the browser
+- **Search and filter** the secrets list by key name or owner
+- **Admin-only** — all mutations require admin access
+</Update>
+
+<Update label="04.22.2026">
+## [04.22.2026: `trace_id` in Experiment Evaluators](/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id)
+**Available in arize-phoenix-client 2.4.0+**
+
+Evaluator functions now receive the originating trace ID for each experiment run. Add a `trace_id` keyword argument to any evaluator function or `Evaluator` class method to access it.
+
+- **Optional** — evaluators without `trace_id` are unaffected
+- **Works sync and async** — supported on both function-based and protocol-based evaluators
+</Update>
+
+<Update label="04.20.2026">
+## [04.20.2026: Span Attribute Filtering](/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7)
+**Available in arize-phoenix 14.9.0+ (server), arize-phoenix-client 2.4.0+ (Python), @arizeai/phoenix-client 6.7.0+ (TypeScript)**
+
+Filter spans by stored attribute values using the Python client, TypeScript client, REST API, or CLI. Multiple filters are AND-ed together; the value's JS/Python type selects which storage type is matched.
+
+- **Python** — `client.spans.get_spans(..., attributes={"llm.model_name": "gpt-4o"})`
+- **TypeScript** — `getSpans({ ..., attributes: { "llm.model_name": "gpt-4o" } })`
+- **CLI** — `px span list --attribute "llm.model_name:gpt-4o"`
+- **Type-aware** — `int`, `float`, `bool`, and `str` values each match their corresponding stored type
+</Update>
+
+<Update label="04.20.2026">
+## [04.20.2026: CLI Span Notes](/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7)
+**Available in @arizeai/phoenix-cli 1.1.0+**
+
+`px span add-note <span-id> --text "..."` attaches a free-text note to any span. Pass `--include-notes` to `px span list` or `px trace get` to read notes back alongside span data.
+</Update>
+
+<Update label="04.16.2026">
+## [04.16.2026: Azure Managed Identity for PostgreSQL](/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres)
+**Available in arize-phoenix 14.8.0+**
+
+Connect Phoenix to Azure Database for PostgreSQL using Microsoft Entra managed identity — no static database password required. Install the `azure` extra and set `PHOENIX_POSTGRES_USE_AZURE_MANAGED_IDENTITY=true`.
+
+- **Zero-credential setup** — tokens are fetched and refreshed automatically on each connection
+- **New `[azure]` extra** — `pip install 'arize-phoenix[azure]'` pulls in `azure-identity` and `aiohttp`
+- **`PHOENIX_POSTGRES_AWS_IAM_TOKEN_LIFETIME_SECONDS` deprecated** — silently ignored with a startup warning
+</Update>
+
 <Update label="04.14.2026">
 ## [04.14.2026: CLI Annotation Commands](/docs/phoenix/release-notes/04-2026/04-14-2026-cli-annotation-commands)
 **Available in @arizeai/phoenix-cli 1.0.4+**

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -47,6 +47,13 @@ Filter spans by stored attribute values using the Python client, TypeScript clie
 `px span add-note <span-id> --text "..."` attaches a free-text note to any span. Pass `--include-notes` to `px span list` or `px trace get` to read notes back alongside span data.
 </Update>
 
+<Update label="04.20.2026">
+## [04.20.2026: Claude Opus 4.7 in the Playground](/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7)
+**Available in arize-phoenix 14.9.0+**
+
+Claude Opus 4.7 is now available as a model option in the Phoenix Playground. Select it from the model picker to compare outputs against other Anthropic and cross-provider models.
+</Update>
+
 <Update label="04.16.2026">
 ## [04.16.2026: Azure Managed Identity for PostgreSQL](/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres)
 **Available in arize-phoenix 14.8.0+**

--- a/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres.mdx
@@ -25,7 +25,7 @@ PHOENIX_SQL_DATABASE_URL=postgresql+asyncpg://<user>@<host>/<db>
 `PHOENIX_POSTGRES_AZURE_SCOPE` defaults to `https://ossrdbms-aad.database.windows.net/.default`. Override it only if you are running in a sovereign cloud such as Azure US Government:
 
 ```bash
-PHOENIX_POSTGRES_AZURE_SCOPE=https://ossrdbms-aad.database.windows.net/.default
+PHOENIX_POSTGRES_AZURE_SCOPE=https://ossrdbms-aad.database.usgovcloudapi.net/.default
 ```
 
 ## Notes

--- a/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres.mdx
@@ -1,0 +1,43 @@
+---
+title: "04.16.2026 Azure Managed Identity for PostgreSQL"
+description: "Connect Phoenix to Azure Database for PostgreSQL using managed identity — no static passwords required."
+---
+
+**Available in arize-phoenix 14.8.0+**
+
+Phoenix now supports Microsoft Entra managed-identity authentication when connecting to Azure Database for PostgreSQL (Flexible Server). Set two environment variables and install the `azure` extra — Phoenix handles token acquisition and refresh automatically on every new database connection.
+
+## Setup
+
+Install the `azure` extra to pull in `azure-identity` and `aiohttp`:
+
+```bash
+pip install 'arize-phoenix[azure]'
+```
+
+Set the required environment variables:
+
+```bash
+PHOENIX_POSTGRES_USE_AZURE_MANAGED_IDENTITY=true
+PHOENIX_SQL_DATABASE_URL=postgresql+asyncpg://<user>@<host>/<db>
+```
+
+`PHOENIX_POSTGRES_AZURE_SCOPE` defaults to `https://ossrdbms-aad.database.windows.net/.default`. Override it only if you are running in a sovereign cloud such as Azure US Government:
+
+```bash
+PHOENIX_POSTGRES_AZURE_SCOPE=https://ossrdbms-aad.database.windows.net/.default
+```
+
+## Notes
+
+- **Mutual exclusion** — `PHOENIX_POSTGRES_USE_AZURE_MANAGED_IDENTITY` and `PHOENIX_POSTGRES_USE_AWS_IAM_AUTH` cannot both be `true`; Phoenix raises a `ValueError` at startup if both are set.
+- **`PHOENIX_POSTGRES_AWS_IAM_TOKEN_LIFETIME_SECONDS` is deprecated** — the env var is now silently ignored with a startup warning. Connection pool hygiene is managed internally.
+
+<CardGroup cols={2}>
+  <Card title="Using Azure Managed Identity" icon="microsoft" href="/docs/phoenix/self-hosting/configuration/using-azure-managed-identity">
+    Full setup guide for Azure managed-identity PostgreSQL connections.
+  </Card>
+  <Card title="Amazon Aurora (AWS IAM)" icon="aws" href="/docs/phoenix/self-hosting/configuration/using-amazon-aurora">
+    Configure AWS RDS IAM authentication for PostgreSQL.
+  </Card>
+</CardGroup>

--- a/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7.mdx
@@ -1,0 +1,91 @@
+---
+title: "Release Notes"
+---
+
+# Span Attribute Filtering
+
+April 20, 2026
+
+**Available in arize-phoenix 14.9.0+ (server), arize-phoenix-client 2.4.0+ (Python), @arizeai/phoenix-client 6.7.0+ (TypeScript)**
+
+Filter spans by stored attribute values when calling `GET /v1/spans`. Multiple `attribute=key:value` pairs are AND-ed together. The value's type determines how the stored attribute is matched — passing an integer matches a stored integer; passing a string matches a stored string — so `user.id: 12345` (int) and `user.id: "12345"` (string) are distinct filters.
+
+**Python**
+
+```python
+from phoenix.client import Client
+
+client = Client()
+spans = client.spans.get_spans(
+    project_identifier="my-project",
+    attributes={
+        "llm.model_name": "gpt-4o",
+        "metadata.tier": "premium",
+    },
+)
+```
+
+**TypeScript**
+
+```typescript
+import { createClient } from "@arizeai/phoenix-client";
+import { getSpans } from "@arizeai/phoenix-client/spans";
+
+const client = createClient();
+const result = await getSpans({
+  client,
+  project: { projectName: "my-project" },
+  attributes: {
+    "llm.model_name": "gpt-4o",
+    "metadata.tier": "premium",
+  },
+});
+```
+
+**REST**
+
+```http
+GET /v1/projects/my-project/spans?attribute=llm.model_name:gpt-4o&attribute=metadata.tier:premium
+```
+
+**CLI**
+
+```bash
+px span list --project my-project \
+  --attribute "llm.model_name:gpt-4o" \
+  --attribute "metadata.tier:premium"
+```
+
+- **Type-aware matching** — `str`, `int`, `float`, and `bool` values each select a distinct storage type; a whole-number float (`1.0`) also matches the integer `1`
+- **Forced-string matching** — wrap a numeric-looking string in quotes: `user.id:"12345"` (URL-encoded `%2212345%22`); the Python and TypeScript clients handle this automatically
+- **Colon-in-value** is supported — split is on the first `:` only, so `session.id:sess:abc:123` works without escaping
+- **AND semantics** — repeat the parameter or add multiple entries to the map to require all conditions
+
+# CLI Span Notes
+
+April 20, 2026
+
+**Available in @arizeai/phoenix-cli 1.1.0+**
+
+Add free-text notes to spans from the terminal with `px span add-note`. Pass `--include-notes` to `px span list` or `px trace get` to read notes back alongside span data.
+
+```bash
+# Attach a note to a span
+px span add-note <span-id> --text "Reviewed manually — output looks correct."
+
+# List spans with their notes
+px span list --include-notes
+
+# Fetch a trace with span notes
+px trace get <trace-id> --include-notes
+```
+
+Notes are stored separately from annotations. When you pass `--include-annotations`, note entries are excluded from that output — use `--include-notes` to fetch them explicitly.
+
+# Claude Opus 4.7 in the Playground
+
+April 20, 2026
+
+**Available in arize-phoenix 14.9.0+**
+
+Claude Opus 4.7 is now available as a model option in the Phoenix Playground. Select it from the model picker to compare outputs against other Anthropic and cross-provider models.

--- a/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Release Notes"
+title: "04.20.2026 Span Attribute Filtering, CLI Notes, and Claude Opus 4.7"
+description: "Filter spans by attributes across Python, TypeScript, REST, and CLI; add notes to spans via `px span add-note`; use Claude Opus 4.7 in the Playground."
 ---
 
 # Span Attribute Filtering

--- a/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7.mdx
@@ -8,7 +8,7 @@ April 20, 2026
 
 **Available in arize-phoenix 14.9.0+ (server), arize-phoenix-client 2.4.0+ (Python), @arizeai/phoenix-client 6.7.0+ (TypeScript)**
 
-Filter spans by stored attribute values when calling `GET /v1/spans`. Multiple `attribute=key:value` pairs are AND-ed together. The value's type determines how the stored attribute is matched — passing an integer matches a stored integer; passing a string matches a stored string — so `user.id: 12345` (int) and `user.id: "12345"` (string) are distinct filters.
+Filter spans by stored attribute values when calling `GET /v1/projects/{project_identifier}/spans`. Multiple `attribute=key:value` pairs are AND-ed together. The value's type determines how the stored attribute is matched — passing an integer matches a stored integer; passing a string matches a stored string — so `user.id: 12345` (int) and `user.id: "12345"` (string) are distinct filters.
 
 **Python**
 

--- a/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7.mdx
@@ -57,7 +57,7 @@ px span list --project my-project \
   --attribute "metadata.tier:premium"
 ```
 
-- **Type-aware matching** — `str`, `int`, `float`, and `bool` values each select a distinct storage type; a whole-number float (`1.0`) also matches the integer `1`
+- **Type-aware matching** — `str`, `int`, `float`, and `bool` values each select a distinct storage type; an integer query (`1`) also matches whole-number floats in storage (`1.0`)
 - **Forced-string matching** — wrap a numeric-looking string in quotes: `user.id:"12345"` (URL-encoded `%2212345%22`); the Python and TypeScript clients handle this automatically
 - **Colon-in-value** is supported — split is on the first `:` only, so `session.id:sess:abc:123` works without escaping
 - **AND semantics** — repeat the parameter or add multiple entries to the map to require all conditions

--- a/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id.mdx
@@ -47,7 +47,7 @@ client.experiments.run_experiment(
 - **Custom `Evaluator` classes** — add `trace_id` to the `evaluate` or `async_evaluate` method signature
 
 <CardGroup cols={2}>
-  <Card title="Run Experiments" icon="flask" href="/docs/phoenix/evaluation/run-experiments">
+  <Card title="Run Experiments" icon="flask" href="/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments">
     Learn how to define tasks and evaluators for experiment runs.
   </Card>
 </CardGroup>

--- a/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id.mdx
@@ -1,0 +1,53 @@
+---
+title: "Release Notes"
+---
+
+# Secrets Settings Page
+
+April 22, 2026
+
+**Available in arize-phoenix 14.11.0+**
+
+Phoenix now includes a dedicated **Settings → Secrets** page for managing encrypted LLM provider credentials in the UI. Previously, secrets could only be managed via the `PUT /v1/secrets` REST API. The new page lets admins add, replace, and delete secrets — such as `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` — without writing any API calls.
+
+- **Add** a new secret by entering its key name and value
+- **Replace** an existing secret's value in place
+- **Delete** secrets individually
+- **Search and filter** the secrets list by owner or key name
+- **Admin-only** — the page and all mutations require admin access
+
+# `trace_id` in Experiment Evaluators
+
+April 22, 2026
+
+**Available in arize-phoenix-client 2.4.0+**
+
+Experiment evaluator functions can now accept a `trace_id` parameter. Phoenix passes the originating trace ID for each experiment run, so your evaluator can fetch the corresponding trace or use the ID for correlation.
+
+```python
+from phoenix.client import Client
+from phoenix.client.types import EvaluationResult
+
+client = Client()
+
+def my_evaluator(output, expected, trace_id=None):
+    # Use trace_id to fetch the originating trace if needed
+    score = 1.0 if output == expected else 0.0
+    return EvaluationResult(score=score, label="correct" if score else "incorrect")
+
+client.experiments.run_experiment(
+    dataset="my-dataset",
+    task=lambda example: example.input["question"],
+    evaluators=[my_evaluator],
+)
+```
+
+- **Optional parameter** — add `trace_id` to your evaluator's keyword arguments; runs that produce a trace pass the ID automatically
+- **Works with sync and async evaluators** — both function-based and `Evaluator` protocol implementations support `trace_id`
+- **Custom `Evaluator` classes** — add `trace_id` to the `evaluate` or `async_evaluate` method signature
+
+<CardGroup cols={2}>
+  <Card title="Run Experiments" icon="flask" href="/docs/phoenix/evaluation/run-experiments">
+    Learn how to define tasks and evaluators for experiment runs.
+  </Card>
+</CardGroup>

--- a/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Release Notes"
+title: "04.22.2026 Secrets Settings Page and Evaluator Trace ID"
+description: "Manage LLM provider secrets in the UI; pass trace IDs to experiment evaluators for correlation and debugging."
 ---
 
 # Secrets Settings Page

--- a/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id.mdx
@@ -27,14 +27,13 @@ Experiment evaluator functions can now accept a `trace_id` parameter. Phoenix pa
 
 ```python
 from phoenix.client import Client
-from phoenix.client.types import EvaluationResult
 
 client = Client()
 
 def my_evaluator(output, expected, trace_id=None):
     # Use trace_id to fetch the originating trace if needed
     score = 1.0 if output == expected else 0.0
-    return EvaluationResult(score=score, label="correct" if score else "incorrect")
+    return {"score": score, "label": "correct" if score else "incorrect"}
 
 client.experiments.run_experiment(
     dataset="my-dataset",

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,9 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id" arrow="true" title="04.22.2026" icon="calendar" description="Secrets settings page in Phoenix UI; trace_id parameter in experiment evaluators"/>
+    <Card href="/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7" arrow="true" title="04.20.2026" icon="calendar" description="Span attribute filtering (Python, TypeScript, REST, CLI); px span add-note; Claude Opus 4.7 in playground"/>
+    <Card href="/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres" arrow="true" title="04.16.2026" icon="calendar" description="Azure managed identity authentication for PostgreSQL; arize-phoenix[azure] extra"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-14-2026-cli-annotation-commands" arrow="true" title="04.14.2026" icon="calendar" description="CLI annotation commands: px span annotate, px trace annotate, --include-annotations flag"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-13-2026-phoenix-otel-ts-1-0" arrow="true" title="04.13.2026" icon="calendar" description="@arizeai/phoenix-otel 1.0 — tracing helpers, observe decorator, context setters, and OpenInference semantic conventions"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-10-2026-shareable-url-redirects" arrow="true" title="04.10.2026" icon="calendar" description="Shareable project URLs: /redirects/projects/{name} resolves to the project page by name"/>


### PR DESCRIPTION
## Summary

- **04.16.2026** — Azure managed identity authentication for PostgreSQL (`arize-phoenix[azure]` extra, `PHOENIX_POSTGRES_USE_AZURE_MANAGED_IDENTITY` env var)
- **04.20.2026** — Span attribute filtering across Python client, TypeScript client, REST API, and CLI; `px span add-note` and `--include-notes` flag; Claude Opus 4.7 in playground
- **04.22.2026** — Secrets settings page in the Phoenix UI; `trace_id` parameter in experiment evaluators

## Test plan

- [ ] Verify MDX files render correctly in Mintlify preview
- [ ] Confirm all internal links resolve (no `.mdx` extensions, paths match files)
- [ ] Check reverse-chronological order in aggregate file and year overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)