### PR TITLE
fix(datasets): omit missing & empty keys from CSV/JSONL upsert buckets

### DIFF
--- a/app/src/pages/dataset/AddExampleFromScratchForm.tsx
+++ b/app/src/pages/dataset/AddExampleFromScratchForm.tsx
@@ -258,11 +258,12 @@ export function AddExampleFromScratchForm(
                 name={"externalId"}
                 render={({ field: { onChange, onBlur, value } }) => (
                   <TextField value={value} onChange={onChange} onBlur={onBlur}>
-                    <Label>Custom ID</Label>
+                    <Label>ID</Label>
                     <Input placeholder="e.g. example-001" />
                     <Text slot="description">
-                      An optional identifier for this example. Must be unique
-                      within the dataset.
+                      An optional ID for the example. If provided, it must be
+                      unique within the dataset. If not provided, an ID will be
+                      generated.
                     </Text>
                   </TextField>
                 )}

--- a/app/src/pages/datasets/ColumnAssigner/__tests__/collapseUtils.test.ts
+++ b/app/src/pages/datasets/ColumnAssigner/__tests__/collapseUtils.test.ts
@@ -81,5 +81,19 @@ describe("computeBucketCollapseConflicts", () => {
       expect(result.keysToCollapse).toEqual([]);
       expect(result.conflicts.size).toBe(0);
     });
+
+    it("tolerates rows where the parent key is missing", () => {
+      const result = computeBucketCollapseConflicts(
+        ["metadata"],
+        { input: [], output: [], metadata: ["metadata"] },
+        [
+          { metadata: { category: "math" } },
+          { metadata: { category: "geography" } },
+          {}, // row missing the metadata key
+        ]
+      );
+      expect(result.keysToCollapse).toContain("metadata");
+      expect(result.conflicts.size).toBe(0);
+    });
   });
 });

--- a/app/src/pages/datasets/ColumnAssigner/collapseUtils.ts
+++ b/app/src/pages/datasets/ColumnAssigner/collapseUtils.ts
@@ -55,6 +55,7 @@ export function computeBucketCollapseConflicts(
   for (const parentKey of collapsibleKeys) {
     const childKeys = new Set<string>();
     for (const row of previewRows) {
+      if (!(parentKey in row)) continue;
       const value = row[parentKey];
       if (!isPlainObject(value)) {
         conflicts.set(parentKey, [NON_OBJECT_CONFLICT_MARKER]);

--- a/app/src/pages/datasets/DatasetPreview/DatasetPreviewTable.tsx
+++ b/app/src/pages/datasets/DatasetPreview/DatasetPreviewTable.tsx
@@ -193,6 +193,18 @@ export function DatasetPreviewTable({
       }
     };
 
+    // Empty CSV cells (missing or whitespace-only) are omitted from buckets
+    // so the preview only reflects columns with real values for the row.
+    const isEmptyCsvCell = (raw: unknown): boolean => {
+      if (raw == null) {
+        return true;
+      }
+      if (typeof raw === "string" && !raw.trim()) {
+        return true;
+      }
+      return false;
+    };
+
     return rows.map((row): DatasetPreviewRow => {
       const input: Record<string, unknown> = {};
       const output: Record<string, unknown> = {};
@@ -203,7 +215,17 @@ export function DatasetPreviewTable({
       if (Array.isArray(row)) {
         // CSV row - array of strings
         columns.forEach((col, idx) => {
-          let value: unknown = row[idx] ?? "";
+          const raw = row[idx];
+          if (splitColumn && col === splitColumn) {
+            splits = parseSplitValue(raw);
+          }
+          if (exampleIdColumn && col === exampleIdColumn) {
+            exampleId = raw ? String(raw) : null;
+          }
+          if (isEmptyCsvCell(raw)) {
+            return;
+          }
+          let value: unknown = raw;
           // For CSV, try to parse JSON strings so they render as objects
           // instead of escaped JSON with backslashes
           if (typeof value === "string") {
@@ -211,13 +233,6 @@ export function DatasetPreviewTable({
             if (parsed !== undefined) {
               value = parsed;
             }
-          }
-          if (splitColumn && col === splitColumn) {
-            splits = parseSplitValue(row[idx]);
-          }
-          if (exampleIdColumn && col === exampleIdColumn) {
-            const raw = row[idx];
-            exampleId = raw ? String(raw) : null;
           }
           if (inputColumns.includes(col)) {
             addToBucket(input, getBucketKey(col, "input"), value);

--- a/app/src/utils/__tests__/jsonlUtils.test.ts
+++ b/app/src/utils/__tests__/jsonlUtils.test.ts
@@ -310,10 +310,22 @@ describe("parseJSONLFile collapsibleKeys", () => {
     }
   });
 
-  it("does not mark key as collapsible if missing in any row", async () => {
-    // "input" missing in second row
+  it("marks key as collapsible even if missing in some rows", async () => {
     const file = createFile(
       '{"input": {"question": "Hi"}, "id": 1}\n' + '{"id": 2}'
+    );
+    const result = await parseJSONLFile(file);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.collapsibleKeys).toContain("input");
+    }
+  });
+
+  it("does not mark key as collapsible if present only as missing", async () => {
+    // Defensive: a key that exists in the key set but is never actually
+    // present as an object in any row should not be collapsible.
+    const file = createFile(
+      '{"input": "string", "id": 1}\n' + '{"id": 2, "input": 5}'
     );
     const result = await parseJSONLFile(file);
     expect(result.success).toBe(true);

--- a/app/src/utils/jsonlUtils.ts
+++ b/app/src/utils/jsonlUtils.ts
@@ -210,11 +210,19 @@ export async function parseJSONLFile(
       };
     }
 
-    // Compute collapsible keys: keys that have plain object values in ALL preview rows
+    // A key is collapsible if it is a plain object in every preview row where
+    // it is present. Missing rows are tolerated (the backend drops missing
+    // parents when flattening). Null, arrays, and primitives still disqualify.
     const keys = Array.from(allKeys);
-    const collapsibleKeys = keys.filter((key) =>
-      previewRows.every((row) => key in row && isPlainObject(row[key]))
-    );
+    const collapsibleKeys = keys.filter((key) => {
+      let seenObject = false;
+      for (const row of previewRows) {
+        if (!(key in row)) continue;
+        if (!isPlainObject(row[key])) return false;
+        seenObject = true;
+      }
+      return seenObject;
+    });
 
     return {
       success: true,

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -798,13 +798,20 @@ class BucketPlan:
 
         return cls(direct_keys=direct_keys, flatten_map=flatten_map)
 
-    def project(self, row: Mapping[str, Any]) -> dict[str, Any]:
-        result = {k: row.get(k) for k in self.direct_keys}
+    def project(self, row: Mapping[str, Any], *, skip_missing: bool = False) -> dict[str, Any]:
+        if skip_missing:
+            result = {k: row[k] for k in self.direct_keys if k in row}
+        else:
+            result = {k: row.get(k) for k in self.direct_keys}
         for parent, children in self.flatten_map.items():
+            if skip_missing and parent not in row:
+                continue
             value = row.get(parent)
             if not isinstance(value, Mapping):
                 raise ValueError(f"Cannot flatten '{parent}': expected object")
             for child in children:
+                if skip_missing and child not in value:
+                    continue
                 result[child] = value.get(child)
         return result
 
@@ -1130,9 +1137,9 @@ async def _process_jsonl(
         examples: list[ExampleContent] = []
         for obj in rows:
             example = ExampleContent(
-                input=input_plan.project(obj),
-                output=output_plan.project(obj),
-                metadata=metadata_plan.project(obj),
+                input=input_plan.project(obj, skip_missing=True),
+                output=output_plan.project(obj, skip_missing=True),
+                metadata=metadata_plan.project(obj, skip_missing=True),
                 splits=_get_splits(row=obj, split_key=split_key, split_keys=split_keys),
                 span_id=_get_span_id(obj, span_id_key),
                 external_id=_get_example_id(obj, example_id_key),

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -723,6 +723,20 @@ def _maybe_parse_json_value(value: Any) -> Any:
     return value
 
 
+def _is_empty_csv_cell(value: Any) -> bool:
+    """Return True if a CSV cell has no meaningful entry (None or blank string)."""
+    if value is None:
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    return False
+
+
+def _drop_empty_csv_entries(bucket: Mapping[str, Any]) -> dict[str, Any]:
+    """Drop keys from a CSV-derived bucket whose source cells had no entry."""
+    return {k: v for k, v in bucket.items() if not _is_empty_csv_cell(v)}
+
+
 def _build_bucket_from_dotted_keys(
     row: Mapping[str, Any],
     keys: frozenset[str],
@@ -732,13 +746,16 @@ def _build_bucket_from_dotted_keys(
 
     Keys starting with ``{bucket_prefix}.`` have the prefix stripped and the
     remaining dot-separated path is unflattened into nested dicts.  Plain keys
-    are included directly.
+    are included directly.  Columns with no entry for the given row are omitted.
     """
     prefix_dot = f"{bucket_prefix}."
     plain: dict[str, Any] = {}
     dotted: list[tuple[str, Any]] = []
     for key in keys:
-        value = _maybe_parse_json_value(row.get(key))
+        raw = row.get(key)
+        if _is_empty_csv_cell(raw):
+            continue
+        value = _maybe_parse_json_value(raw)
         if key.startswith(prefix_dot):
             remainder = key[len(prefix_dot) :]
             dotted.append((remainder, value))
@@ -1025,9 +1042,9 @@ async def _process_csv(
         for row in parsed_rows:
             examples.append(
                 ExampleContent(
-                    input=input_plan.project(row),
-                    output=output_plan.project(row),
-                    metadata=metadata_plan.project(row),
+                    input=_drop_empty_csv_entries(input_plan.project(row)),
+                    output=_drop_empty_csv_entries(output_plan.project(row)),
+                    metadata=_drop_empty_csv_entries(metadata_plan.project(row)),
                     splits=_get_splits(row=row, split_key=split_key, split_keys=split_keys),
                     span_id=_get_span_id(row, span_id_key),
                     external_id=_get_example_id(row, example_id_key),

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -2813,6 +2813,84 @@ async def test_post_dataset_upload_flatten_keys_partial(
     assert revisions[0].metadata_ == {"metadata": {"source": "test"}}
 
 
+async def test_post_dataset_upload_jsonl_flatten_metadata_missing_in_some_rows(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Flattening a metadata parent unwraps it even when some rows omit the key.
+
+    When "metadata" is in both metadata_keys and flatten_keys, the resulting
+    bucket should contain the object's children directly, not be wrapped as
+    {"metadata": {...}}. Rows missing the key produce an empty bucket.
+    """
+    name = inspect.stack()[0][3]
+    jsonl_content = (
+        b'{"input": {"question": "What is 2+2?"}, "output": {"answer": "4"}, '
+        b'"metadata": {"category": "math", "difficulty": "easy"}}\n'
+        b'{"input": {"question": "Capital of France?"}, "output": {"answer": "Paris"}, '
+        b'"metadata": {"category": "geography"}}\n'
+        b'{"input": {"question": "Describe photosynthesis"}, '
+        b'"output": {"answer": "Plants convert light to energy"}, '
+        b'"metadata": {"difficulty": null}}\n'
+        b'{"input": {"prompt": "Write a haiku"}, '
+        b'"output": {"response": "Cherry blossoms fall"}, '
+        b'"metadata": {"category": "creative"}}\n'
+        b'{"input": {"question": "Largest ocean?"}, "output": {"answer": "Pacific"}}\n'
+    )
+    file = gzip.compress(jsonl_content)
+    response = await httpx_client.post(
+        url="v1/datasets/upload?sync=true",
+        files={"file": (" ", file, "application/jsonl", {"Content-Encoding": "gzip"})},
+        data={
+            "action": "create",
+            "name": name,
+            "input_keys[]": ["input"],
+            "output_keys[]": ["output"],
+            "metadata_keys[]": ["metadata"],
+            "flatten_keys[]": ["input", "output", "metadata"],
+        },
+    )
+    assert response.status_code == 200
+    assert (data := response.json().get("data"))
+    assert (dataset_id := data.get("dataset_id"))
+
+    async with db() as session:
+        dataset_db_id = int(GlobalID.from_id(dataset_id).node_id)
+        revisions = list(
+            await session.scalars(
+                select(models.DatasetExampleRevision)
+                .join(models.DatasetExample)
+                .where(models.DatasetExample.dataset_id == dataset_db_id)
+                .order_by(models.DatasetExample.id)
+            )
+        )
+    assert len(revisions) == 5
+
+    assert revisions[0].input == {"question": "What is 2+2?"}
+    assert revisions[0].output == {"answer": "4"}
+    assert revisions[0].metadata_ == {"category": "math", "difficulty": "easy"}
+
+    assert revisions[1].input == {"question": "Capital of France?"}
+    assert revisions[1].output == {"answer": "Paris"}
+    assert revisions[1].metadata_ == {"category": "geography"}
+
+    assert revisions[2].input == {"question": "Describe photosynthesis"}
+    assert revisions[2].output == {"answer": "Plants convert light to energy"}
+    # Explicit nulls inside metadata are preserved.
+    assert revisions[2].metadata_ == {"difficulty": None}
+
+    # Row 4 uses a different input/output shape; only the keys present in this
+    # row are emitted into the respective buckets.
+    assert revisions[3].input == {"prompt": "Write a haiku"}
+    assert revisions[3].output == {"response": "Cherry blossoms fall"}
+    assert revisions[3].metadata_ == {"category": "creative"}
+
+    # Row 5 has no metadata key; the bucket is empty rather than double-wrapped.
+    assert revisions[4].input == {"question": "Largest ocean?"}
+    assert revisions[4].output == {"answer": "Pacific"}
+    assert revisions[4].metadata_ == {}
+
+
 @pytest.mark.parametrize("sync", [True, False])
 @pytest.mark.parametrize("action", ["create", "append"])
 @pytest.mark.parametrize(

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -814,6 +814,81 @@ async def test_post_dataset_upload_jsonl_create_then_append(
     assert db_dataset_version.dataset_id == int(GlobalID.from_id(dataset_id).node_id)
 
 
+async def test_post_dataset_upload_jsonl_preserves_per_row_keys(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Each JSONL example should retain only the keys present in its source row.
+
+    Regression: when rows have disjoint top-level keys, the backend was filling
+    missing keys with None, producing the union of keys across every example.
+    """
+    name = inspect.stack()[0][3]
+    jsonl_content = b'{"a": "foo", "x": "m"}\n{"b": "bar", "y": "n"}\n'
+    file = gzip.compress(jsonl_content)
+    response = await httpx_client.post(
+        url="v1/datasets/upload?sync=true",
+        files={"file": (" ", file, "application/jsonl", {"Content-Encoding": "gzip"})},
+        data={
+            "action": "create",
+            "name": name,
+            "input_keys[]": ["a", "b"],
+            "output_keys[]": ["x", "y"],
+        },
+    )
+    assert response.status_code == 200
+    async with db() as session:
+        revisions = list(
+            await session.scalars(
+                select(models.DatasetExampleRevision)
+                .join(models.DatasetExample)
+                .join_from(models.DatasetExample, models.Dataset)
+                .where(models.Dataset.name == name)
+                .order_by(models.DatasetExample.id)
+            )
+        )
+    assert len(revisions) == 2
+    assert revisions[0].input == {"a": "foo"}
+    assert revisions[0].output == {"x": "m"}
+    assert revisions[1].input == {"b": "bar"}
+    assert revisions[1].output == {"y": "n"}
+
+
+async def test_post_dataset_upload_jsonl_preserves_explicit_null(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """An explicit null in a JSONL row must be preserved, distinct from a missing key."""
+    name = inspect.stack()[0][3]
+    jsonl_content = b'{"a": null, "b": "x"}\n{"b": "y"}\n'
+    file = gzip.compress(jsonl_content)
+    response = await httpx_client.post(
+        url="v1/datasets/upload?sync=true",
+        files={"file": (" ", file, "application/jsonl", {"Content-Encoding": "gzip"})},
+        data={
+            "action": "create",
+            "name": name,
+            "input_keys[]": ["a", "b"],
+        },
+    )
+    assert response.status_code == 200
+    async with db() as session:
+        revisions = list(
+            await session.scalars(
+                select(models.DatasetExampleRevision)
+                .join(models.DatasetExample)
+                .join_from(models.DatasetExample, models.Dataset)
+                .where(models.Dataset.name == name)
+                .order_by(models.DatasetExample.id)
+            )
+        )
+    assert len(revisions) == 2
+    # Row 1: explicit null must be preserved as None.
+    assert revisions[0].input == {"a": None, "b": "x"}
+    # Row 2: `a` was absent from the source row — it must stay absent, not be filled with None.
+    assert revisions[1].input == {"b": "y"}
+
+
 async def test_post_dataset_upload_pyarrow_create_then_append(
     httpx_client: httpx.AsyncClient,
     db: DbSessionFactory,
@@ -2610,11 +2685,11 @@ async def test_post_dataset_upload_jsonl_with_flatten_keys(
     }
     assert revisions[0].output == {"answer": "4"}
 
-    # Second row: difficulty is missing from input, so it will be None
+    # Second row's source `input` has no "difficulty" key, so it is omitted
+    # from the flattened bucket rather than filled with None.
     assert revisions[1].input == {
         "question": "Capital of France?",
         "context": "geography",
-        "difficulty": None,
     }
     assert revisions[1].output == {"answer": "Paris"}
 

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -2362,6 +2362,198 @@ async def test_post_dataset_upload_csv_with_dotted_keys(
     assert revisions[1].metadata_ == {"info": "test2"}
 
 
+async def test_post_dataset_upload_csv_omits_empty_cells(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Empty CSV cells should be dropped rather than stored as empty strings."""
+    name = inspect.stack()[0][3]
+    file = gzip.compress(b"a,b,c\n1,,3\n")
+    response = await httpx_client.post(
+        url="v1/datasets/upload?sync=true",
+        files={"file": (" ", file, "text/csv", {"Content-Encoding": "gzip"})},
+        data={
+            "action": "create",
+            "name": name,
+            "input_keys[]": ["a", "b", "c"],
+            "output_keys[]": ["a", "b", "c"],
+            "metadata_keys[]": ["a", "b", "c"],
+        },
+    )
+    assert response.status_code == 200
+
+    async with db() as session:
+        revisions = list(
+            await session.scalars(
+                select(models.DatasetExampleRevision)
+                .join(models.DatasetExample)
+                .join_from(models.DatasetExample, models.Dataset)
+                .where(models.Dataset.name == name)
+            )
+        )
+    assert len(revisions) == 1
+    assert revisions[0].input == {"a": "1", "c": "3"}
+    assert revisions[0].output == {"a": "1", "c": "3"}
+    assert revisions[0].metadata_ == {"a": "1", "c": "3"}
+
+
+async def test_post_dataset_upload_csv_omits_missing_trailing_cells(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Rows shorter than the header (DictReader restval=None) drop the missing keys."""
+    name = inspect.stack()[0][3]
+    file = gzip.compress(b"a,b,c\n1,2\n")
+    response = await httpx_client.post(
+        url="v1/datasets/upload?sync=true",
+        files={"file": (" ", file, "text/csv", {"Content-Encoding": "gzip"})},
+        data={
+            "action": "create",
+            "name": name,
+            "input_keys[]": ["a", "b", "c"],
+        },
+    )
+    assert response.status_code == 200
+
+    async with db() as session:
+        revisions = list(
+            await session.scalars(
+                select(models.DatasetExampleRevision)
+                .join(models.DatasetExample)
+                .join_from(models.DatasetExample, models.Dataset)
+                .where(models.Dataset.name == name)
+            )
+        )
+    assert len(revisions) == 1
+    assert revisions[0].input == {"a": "1", "b": "2"}
+
+
+async def test_post_dataset_upload_csv_omits_whitespace_only_cells(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Whitespace-only CSV cells should be treated as missing and dropped."""
+    name = inspect.stack()[0][3]
+    file = gzip.compress(b"a,b\n1,   \n")
+    response = await httpx_client.post(
+        url="v1/datasets/upload?sync=true",
+        files={"file": (" ", file, "text/csv", {"Content-Encoding": "gzip"})},
+        data={
+            "action": "create",
+            "name": name,
+            "input_keys[]": ["a", "b"],
+        },
+    )
+    assert response.status_code == 200
+
+    async with db() as session:
+        revisions = list(
+            await session.scalars(
+                select(models.DatasetExampleRevision)
+                .join(models.DatasetExample)
+                .join_from(models.DatasetExample, models.Dataset)
+                .where(models.Dataset.name == name)
+            )
+        )
+    assert len(revisions) == 1
+    assert revisions[0].input == {"a": "1"}
+
+
+async def test_post_dataset_upload_csv_with_dotted_keys_omits_empty_leaf(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Dotted-key columns whose row cell is empty are omitted from the bucket."""
+    name = inspect.stack()[0][3]
+    file = gzip.compress(b"input.x,input.y\n1,\n")
+    response = await httpx_client.post(
+        url="v1/datasets/upload?sync=true",
+        files={"file": (" ", file, "text/csv", {"Content-Encoding": "gzip"})},
+        data={
+            "action": "create",
+            "name": name,
+            "input_keys[]": ["input.x", "input.y"],
+        },
+    )
+    assert response.status_code == 200
+
+    async with db() as session:
+        revisions = list(
+            await session.scalars(
+                select(models.DatasetExampleRevision)
+                .join(models.DatasetExample)
+                .join_from(models.DatasetExample, models.Dataset)
+                .where(models.Dataset.name == name)
+            )
+        )
+    assert len(revisions) == 1
+    assert revisions[0].input == {"x": "1"}
+
+
+async def test_post_dataset_upload_csv_with_dotted_keys_omits_empty_nested_leaf(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Empty nested dotted-key cells do not leave a stub entry under the parent."""
+    name = inspect.stack()[0][3]
+    file = gzip.compress(b"input.a.b,input.a.c\n1,\n")
+    response = await httpx_client.post(
+        url="v1/datasets/upload?sync=true",
+        files={"file": (" ", file, "text/csv", {"Content-Encoding": "gzip"})},
+        data={
+            "action": "create",
+            "name": name,
+            "input_keys[]": ["input.a.b", "input.a.c"],
+        },
+    )
+    assert response.status_code == 200
+
+    async with db() as session:
+        revisions = list(
+            await session.scalars(
+                select(models.DatasetExampleRevision)
+                .join(models.DatasetExample)
+                .join_from(models.DatasetExample, models.Dataset)
+                .where(models.Dataset.name == name)
+            )
+        )
+    assert len(revisions) == 1
+    assert revisions[0].input == {"a": {"b": "1"}}
+
+
+async def test_post_dataset_upload_csv_allows_fully_empty_bucket(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """A bucket whose columns are all empty for a row is stored as an empty dict."""
+    name = inspect.stack()[0][3]
+    file = gzip.compress(b"a,b,c\n1,,\n")
+    response = await httpx_client.post(
+        url="v1/datasets/upload?sync=true",
+        files={"file": (" ", file, "text/csv", {"Content-Encoding": "gzip"})},
+        data={
+            "action": "create",
+            "name": name,
+            "input_keys[]": ["a"],
+            "output_keys[]": ["b", "c"],
+        },
+    )
+    assert response.status_code == 200
+
+    async with db() as session:
+        revisions = list(
+            await session.scalars(
+                select(models.DatasetExampleRevision)
+                .join(models.DatasetExample)
+                .join_from(models.DatasetExample, models.Dataset)
+                .where(models.Dataset.name == name)
+            )
+        )
+    assert len(revisions) == 1
+    assert revisions[0].input == {"a": "1"}
+    assert revisions[0].output == {}
+
+
 async def test_post_dataset_upload_jsonl_with_flatten_keys(
     httpx_client: httpx.AsyncClient,
     db: DbSessionFactory,
@@ -2425,6 +2617,38 @@ async def test_post_dataset_upload_jsonl_with_flatten_keys(
         "difficulty": None,
     }
     assert revisions[1].output == {"answer": "Paris"}
+
+
+async def test_post_dataset_upload_jsonl_preserves_null_values(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Explicit JSON nulls in JSONL are preserved as None (unlike CSV empty cells, which are dropped)."""
+    name = inspect.stack()[0][3]
+    jsonl_content = b'{"a": null, "b": 2}\n'
+    file = gzip.compress(jsonl_content)
+    response = await httpx_client.post(
+        url="v1/datasets/upload?sync=true",
+        files={"file": (" ", file, "application/jsonl", {"Content-Encoding": "gzip"})},
+        data={
+            "action": "create",
+            "name": name,
+            "input_keys[]": ["a", "b"],
+        },
+    )
+    assert response.status_code == 200
+
+    async with db() as session:
+        revisions = list(
+            await session.scalars(
+                select(models.DatasetExampleRevision)
+                .join(models.DatasetExample)
+                .join_from(models.DatasetExample, models.Dataset)
+                .where(models.Dataset.name == name)
+            )
+        )
+    assert len(revisions) == 1
+    assert revisions[0].input == {"a": None, "b": 2}
 
 
 async def test_post_dataset_upload_flatten_keys_no_effect_when_empty(


### PR DESCRIPTION
## Summary
Tighten how dataset upsert builds `input`/`output`/`metadata` buckets so each example only contains keys with real values, and so the preview matches what the backend persists.

**Backend ([src/phoenix/server/api/routers/v1/datasets.py](src/phoenix/server/api/routers/v1/datasets.py))**
- CSV: drop keys whose cells are missing (short rows), empty strings, or whitespace-only from flat-key and dotted-key paths (no stub empty parent dicts).
- JSONL: thread a `skip_missing` flag through `BucketPlan.project` / `_process_jsonl` so keys absent from a source row are not projected as `None` via `row.get(k)`. Explicit `null` is still preserved and remains distinct from "missing".
- JSONL metadata: unwrap a top-level `metadata` object into the bucket even when some rows omit the key, matching the UI's `flatten_keys[]` submission.

**Frontend**
- [DatasetPreviewTable.tsx](app/src/pages/datasets/DatasetPreview/DatasetPreviewTable.tsx): mirror the backend CSV rule so the preview omits empty cells from buckets rather than storing them as `""`.
- [jsonlUtils.ts](app/src/utils/jsonlUtils.ts) and [collapseUtils.ts](app/src/pages/datasets/ColumnAssigner/collapseUtils.ts): a key is collapsible when it is a plain object in every row where it's present (missing rows are tolerated); `null`, arrays, and primitives still disqualify.

## Test plan
- [x] `pytest tests/unit/server/api/routers/v1/test_datasets.py` — new and existing tests pass, including:
  - CSV empty/missing/whitespace cells (flat and dotted keys), fully-empty bucket allowed
  - JSONL missing keys omitted per-row, explicit `null` preserved (regression guard)
  - JSONL metadata unwrapped when some rows omit the key
- [x] `pnpm test` for `jsonlUtils` and `collapseUtils` — updated collapsibility tests pass
- [ ] Manual: upload a CSV with empty cells and a JSONL with sparse keys through the UI; confirm preview and persisted examples only contain populated keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)