### PR TITLE
fix: retain authenticated root Relay query data

### DIFF
--- a/.agents/skills/phoenix-frontend/rules/relay.md
+++ b/.agents/skills/phoenix-frontend/rules/relay.md
@@ -6,8 +6,29 @@ Declarative Relay hooks (`usePreloadedQuery`, `useLazyLoadQuery`) retain their q
 
 `fetchQuery` does **not** have this retention guarantee. Data fetched via `fetchQuery` can be evicted from the Relay store after enough subsequent requests (e.g., requests triggered by pagination). This means using `fetchQuery` to hydrate data that is rendered on a page is dangerous — the data may silently disappear from the store while the component is still mounted.
 
+Query refs returned by `loadQuery` are retained until they are disposed. Use `useQueryLoader` when the component owns loading. When a route loader or other external owner returns a `loadQuery` ref directly to a component, that component must dispose the ref when it stops owning it.
+
+## Owned preloaded queries
+
+Phoenix provides `app/src/hooks/useOwnedPreloadedQuery.ts` for the common route-loader pattern:
+
+- Loader uses `loadQuery(...)` and returns a query ref.
+- Component reads the ref with `useOwnedPreloadedQuery(...)`.
+- The hook disposes the ref on replacement or unmount.
+
+Use this hook only when the current component owns the lifecycle of an externally created query ref, such as `useLoaderData()` returning a `loadQuery` result.
+
+Do **not** use this hook when:
+
+- the query ref is already managed by `useQueryLoader`
+- the ref is shared and another component owns disposal
+- the ref is passed through context or props for multiple readers without clear single-owner semantics
+
 ## Rules
 
 - **Prefer declarative hooks.** Use hooks such as `usePreloadedQuery` or `useLazyLoadQuery` to fetch data that will be rendered on a page.
 - **Avoid `fetchQuery` for page-rendered data.** Do not use `fetchQuery` to hydrate data that a mounted component depends on for rendering.
 - **Limited safe uses of `fetchQuery`.** `fetchQuery` is acceptable when the result is consumed immediately and not held in the store for rendering, such as fetching data for a redirect or a one-shot action.
+- **Prefer `useQueryLoader` for component-owned query refs.** It handles retaining and disposal for refs the component loads itself.
+- **Use `useOwnedPreloadedQuery` for loader-owned query refs.** If a route loader returns a `loadQuery` ref that this component owns directly, read it with `useOwnedPreloadedQuery` instead of `usePreloadedQuery`.
+- **Treat disposal as an ownership decision.** Only the owner should dispose a query ref. Disposing a shared ref too early can make still-mounted readers hit missing-data or GC-related crashes later.

--- a/.agents/skills/phoenix-frontend/rules/relay.md
+++ b/.agents/skills/phoenix-frontend/rules/relay.md
@@ -14,7 +14,7 @@ Phoenix provides `app/src/hooks/useOwnedPreloadedQuery.ts` for the common route-
 
 - Loader uses `loadQuery(...)` and returns a query ref.
 - Component reads the ref with `useOwnedPreloadedQuery(...)`.
-- The hook disposes the ref on replacement or unmount.
+- The hook hands the ref to `useQueryLoader`, so Relay disposes it on replacement or unmount.
 
 Use this hook only when the current component owns the lifecycle of an externally created query ref, such as `useLoaderData()` returning a `loadQuery` result.
 

--- a/app/src/hooks/__tests__/useOwnedPreloadedQuery.test.tsx
+++ b/app/src/hooks/__tests__/useOwnedPreloadedQuery.test.tsx
@@ -1,0 +1,172 @@
+import { act, Suspense } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { RelayEnvironmentProvider, loadQuery } from "react-relay";
+import {
+  Environment,
+  Network,
+  Observable,
+  RecordSource,
+  Store,
+} from "relay-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { datasetStore_latestVersionQuery } from "../../store/__generated__/datasetStore_latestVersionQuery.graphql";
+import datasetStoreLatestVersionQueryNode from "../../store/__generated__/datasetStore_latestVersionQuery.graphql";
+import {
+  useOwnedPreloadedQuery,
+  type OwnedPreloadedQueryRef,
+} from "../useOwnedPreloadedQuery";
+
+function createTestEnvironment() {
+  return new Environment({
+    network: Network.create((_operation, variables) => {
+      const { datasetId } = variables as { datasetId: string };
+
+      return Observable.create((sink) => {
+        // Return a distinct payload per query ref so the test can prove that
+        // rerendering with a new externally owned ref updates the UI.
+        sink.next({
+          data: {
+            dataset: {
+              __typename: "Dataset",
+              id: datasetId,
+              latestVersions: {
+                edges: [
+                  {
+                    version: {
+                      id: `version-${datasetId}`,
+                      description: `Description for ${datasetId}`,
+                      createdAt: "2026-01-01T00:00:00Z",
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        });
+        sink.complete();
+      });
+    }),
+    store: new Store(new RecordSource()),
+  });
+}
+
+function loadDatasetQueryRef({
+  environment,
+  datasetId,
+}: {
+  environment: Environment;
+  datasetId: string;
+}) {
+  return loadQuery<datasetStore_latestVersionQuery>(
+    environment,
+    datasetStoreLatestVersionQueryNode,
+    { datasetId },
+    { fetchPolicy: "network-only" }
+  );
+}
+
+function QueryReader({
+  queryRef,
+}: {
+  queryRef: OwnedPreloadedQueryRef<datasetStore_latestVersionQuery>;
+}) {
+  // This mirrors the real route-loader pattern we care about: the component
+  // receives a preloaded query ref it did not create, then assumes ownership
+  // through useOwnedPreloadedQuery.
+  const data = useOwnedPreloadedQuery<datasetStore_latestVersionQuery>({
+    query: datasetStoreLatestVersionQueryNode,
+    queryRef,
+  });
+
+  const latestVersionId =
+    data.dataset.latestVersions?.edges[0]?.version.id ?? "no-version";
+
+  return (
+    <div data-testid="result">
+      {data.dataset.id}:{latestVersionId}
+    </div>
+  );
+}
+
+describe("useOwnedPreloadedQuery", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let isUnmounted: boolean;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    isUnmounted = false;
+  });
+
+  afterEach(() => {
+    if (!isUnmounted) {
+      act(() => {
+        root.unmount();
+      });
+    }
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("updates when the owned query ref changes and disposes replaced refs", async () => {
+    const environment = createTestEnvironment();
+    // We intentionally create two refs for the same query with different
+    // variables. The regression we want to catch is "initial ref works, but a
+    // later ref passed on rerender is ignored or the old ref is leaked".
+    const firstQueryRef = loadDatasetQueryRef({
+      environment,
+      datasetId: "dataset-1",
+    });
+    const secondQueryRef = loadDatasetQueryRef({
+      environment,
+      datasetId: "dataset-2",
+    });
+
+    const firstDisposeSpy = vi.spyOn(firstQueryRef, "dispose");
+    const secondDisposeSpy = vi.spyOn(secondQueryRef, "dispose");
+
+    await act(async () => {
+      root.render(
+        <RelayEnvironmentProvider environment={environment}>
+          <Suspense fallback={<div>Loading...</div>}>
+            <QueryReader queryRef={firstQueryRef} />
+          </Suspense>
+        </RelayEnvironmentProvider>
+      );
+    });
+
+    expect(container.textContent).toBe("dataset-1:version-dataset-1");
+    expect(firstDisposeSpy).not.toHaveBeenCalled();
+    expect(secondDisposeSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root.render(
+        <RelayEnvironmentProvider environment={environment}>
+          <Suspense fallback={<div>Loading...</div>}>
+            <QueryReader queryRef={secondQueryRef} />
+          </Suspense>
+        </RelayEnvironmentProvider>
+      );
+    });
+
+    // If this ever stops updating, it means our hook is no longer adopting a
+    // replacement query ref from the caller.
+    expect(container.textContent).toBe("dataset-2:version-dataset-2");
+    // When ownership moves to the new ref, the old one must be disposed to
+    // avoid retaining unused data indefinitely.
+    expect(firstDisposeSpy).toHaveBeenCalledTimes(1);
+    expect(secondDisposeSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
+    isUnmounted = true;
+
+    // The currently owned ref should also be released when the component
+    // unmounts, matching the manual ownership contract this hook exists for.
+    expect(secondDisposeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -11,3 +11,4 @@ export * from "./useTimeFormatters";
 export * from "./useCurrentTime";
 export * from "./useUnnestedValue";
 export * from "./usePersistedState";
+export * from "./useOwnedPreloadedQuery";

--- a/app/src/hooks/useOwnedPreloadedQuery.ts
+++ b/app/src/hooks/useOwnedPreloadedQuery.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import type { PreloadedQuery } from "react-relay";
+import { usePreloadedQuery } from "react-relay";
+import type { GraphQLTaggedNode, OperationType } from "relay-runtime";
+
+export type OwnedPreloadedQueryRef<TQuery extends OperationType> =
+  PreloadedQuery<TQuery> & {
+    dispose?: () => void;
+  };
+
+/**
+ * Reads a preloaded query and disposes the query reference when this component
+ * no longer owns it.
+ *
+ * Use this only for query refs whose lifecycle is owned by the current
+ * component, such as refs returned from a route loader via `loadQuery`.
+ */
+export function useOwnedPreloadedQuery<TQuery extends OperationType>({
+  query,
+  queryRef,
+}: {
+  query: GraphQLTaggedNode;
+  queryRef: OwnedPreloadedQueryRef<TQuery>;
+}) {
+  const data = usePreloadedQuery<TQuery>(query, queryRef);
+
+  useEffect(() => {
+    return () => {
+      queryRef.dispose?.();
+    };
+  }, [queryRef]);
+
+  return data;
+}

--- a/app/src/hooks/useOwnedPreloadedQuery.ts
+++ b/app/src/hooks/useOwnedPreloadedQuery.ts
@@ -1,7 +1,7 @@
-import { useEffect } from "react";
 import type { PreloadedQuery } from "react-relay";
-import { usePreloadedQuery } from "react-relay";
+import { usePreloadedQuery, useQueryLoader } from "react-relay";
 import type { GraphQLTaggedNode, OperationType } from "relay-runtime";
+import invariant from "tiny-invariant";
 
 export type OwnedPreloadedQueryRef<TQuery extends OperationType> =
   PreloadedQuery<TQuery> & {
@@ -22,13 +22,10 @@ export function useOwnedPreloadedQuery<TQuery extends OperationType>({
   query: GraphQLTaggedNode;
   queryRef: OwnedPreloadedQueryRef<TQuery>;
 }) {
-  const data = usePreloadedQuery<TQuery>(query, queryRef);
-
-  useEffect(() => {
-    return () => {
-      queryRef.dispose?.();
-    };
-  }, [queryRef]);
-
-  return data;
+  const [ownedQueryRef] = useQueryLoader<TQuery>(query, queryRef);
+  invariant(
+    ownedQueryRef,
+    "ownedQueryRef is required when initialized from queryRef"
+  );
+  return usePreloadedQuery<TQuery>(query, ownedQueryRef);
 }

--- a/app/src/pages/AuthenticatedRoot.tsx
+++ b/app/src/pages/AuthenticatedRoot.tsx
@@ -1,4 +1,6 @@
 import { useEffect } from "react";
+import type { PreloadedQuery } from "react-relay";
+import { usePreloadedQuery } from "react-relay";
 import { Outlet, useLoaderData } from "react-router";
 import invariant from "tiny-invariant";
 
@@ -7,7 +9,11 @@ import { AgentChatWidget } from "@phoenix/components/agent";
 import { AgentChatRuntimeProvider } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { AgentProvider } from "@phoenix/contexts/AgentContext";
 import { ViewerProvider } from "@phoenix/contexts/ViewerContext";
-import type { authenticatedRootLoader } from "@phoenix/pages/authenticatedRootLoader";
+import type { authenticatedRootLoaderQuery } from "@phoenix/pages/__generated__/authenticatedRootLoaderQuery.graphql";
+import {
+  authenticatedRootLoaderQueryNode,
+  type AuthenticatedRootLoaderData,
+} from "@phoenix/pages/authenticatedRootLoader";
 
 import { AppAlerts } from "./AppAlerts";
 
@@ -15,24 +21,34 @@ import { AppAlerts } from "./AppAlerts";
  * The root of the authenticated application. Note that authentication might be entirely disabled
  */
 export function AuthenticatedRoot() {
-  const loaderData = useLoaderData<typeof authenticatedRootLoader>();
+  const loaderData = useLoaderData<AuthenticatedRootLoaderData>();
   invariant(loaderData, "loaderData is required");
+  const data = usePreloadedQuery<authenticatedRootLoaderQuery>(
+    authenticatedRootLoaderQueryNode,
+    loaderData.queryRef as PreloadedQuery<authenticatedRootLoaderQuery>
+  );
+
+  useEffect(() => {
+    return () => {
+      loaderData.queryRef.dispose?.();
+    };
+  }, [loaderData.queryRef]);
 
   // Set analytics if enabled
   useEffect(() => {
     // Double check that there is a viewer and that FullStory is enabled
-    if (isFullStoryEnabled() && loaderData.viewer) {
+    if (isFullStoryEnabled() && data.viewer) {
       setIdentity({
-        uid: loaderData.viewer.id,
-        displayName: loaderData.viewer.username,
-        email: loaderData.viewer.email,
+        uid: data.viewer.id,
+        displayName: data.viewer.username,
+        email: data.viewer.email,
       });
     }
-  }, [loaderData]);
+  }, [data.viewer]);
 
   return (
-    <ViewerProvider query={loaderData}>
-      <AgentProvider agentsConfig={loaderData.agentsConfig}>
+    <ViewerProvider query={data}>
+      <AgentProvider agentsConfig={data.agentsConfig}>
         <AgentChatRuntimeProvider>
           <AgentChatWidget />
           <AppAlerts />

--- a/app/src/pages/AuthenticatedRoot.tsx
+++ b/app/src/pages/AuthenticatedRoot.tsx
@@ -1,6 +1,4 @@
 import { useEffect } from "react";
-import type { PreloadedQuery } from "react-relay";
-import { usePreloadedQuery } from "react-relay";
 import { Outlet, useLoaderData } from "react-router";
 import invariant from "tiny-invariant";
 
@@ -9,6 +7,7 @@ import { AgentChatWidget } from "@phoenix/components/agent";
 import { AgentChatRuntimeProvider } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { AgentProvider } from "@phoenix/contexts/AgentContext";
 import { ViewerProvider } from "@phoenix/contexts/ViewerContext";
+import { useOwnedPreloadedQuery } from "@phoenix/hooks";
 import type { authenticatedRootLoaderQuery } from "@phoenix/pages/__generated__/authenticatedRootLoaderQuery.graphql";
 import {
   authenticatedRootLoaderQueryNode,
@@ -23,16 +22,10 @@ import { AppAlerts } from "./AppAlerts";
 export function AuthenticatedRoot() {
   const loaderData = useLoaderData<AuthenticatedRootLoaderData>();
   invariant(loaderData, "loaderData is required");
-  const data = usePreloadedQuery<authenticatedRootLoaderQuery>(
-    authenticatedRootLoaderQueryNode,
-    loaderData.queryRef as PreloadedQuery<authenticatedRootLoaderQuery>
-  );
-
-  useEffect(() => {
-    return () => {
-      loaderData.queryRef.dispose?.();
-    };
-  }, [loaderData.queryRef]);
+  const data = useOwnedPreloadedQuery<authenticatedRootLoaderQuery>({
+    query: authenticatedRootLoaderQueryNode,
+    queryRef: loaderData.queryRef,
+  });
 
   // Set analytics if enabled
   useEffect(() => {

--- a/app/src/pages/authenticatedRootLoader.ts
+++ b/app/src/pages/authenticatedRootLoader.ts
@@ -1,4 +1,4 @@
-import { fetchQuery, graphql } from "react-relay";
+import { fetchQuery, graphql, loadQuery } from "react-relay";
 import { redirect } from "react-router";
 
 import RelayEnvironment from "@phoenix/RelayEnvironment";
@@ -6,27 +6,29 @@ import { createRedirectUrlWithReturn } from "@phoenix/utils/routingUtils";
 
 import type { authenticatedRootLoaderQuery } from "./__generated__/authenticatedRootLoaderQuery.graphql";
 
+export const authenticatedRootLoaderQueryNode = graphql`
+  query authenticatedRootLoaderQuery {
+    ...ViewerContext_viewer
+    agentsConfig {
+      collectorEndpoint
+      assistantProjectName
+    }
+    viewer {
+      id
+      username
+      email
+      passwordNeedsReset
+    }
+  }
+`;
+
 /**
  * Loads in the necessary data at the root of the authenticated application
  */
 export async function authenticatedRootLoader() {
   const loaderData = await fetchQuery<authenticatedRootLoaderQuery>(
     RelayEnvironment,
-    graphql`
-      query authenticatedRootLoaderQuery {
-        ...ViewerContext_viewer
-        agentsConfig {
-          collectorEndpoint
-          assistantProjectName
-        }
-        viewer {
-          id
-          username
-          email
-          passwordNeedsReset
-        }
-      }
-    `,
+    authenticatedRootLoaderQueryNode,
     {}
   ).toPromise();
 
@@ -37,5 +39,18 @@ export async function authenticatedRootLoader() {
     return redirect(redirectUrl);
   }
 
-  return loaderData;
+  const queryRef = loadQuery<authenticatedRootLoaderQuery>(
+    RelayEnvironment,
+    authenticatedRootLoaderQueryNode,
+    {},
+    {
+      fetchPolicy: "store-or-network",
+    }
+  );
+
+  return { queryRef };
 }
+
+export type AuthenticatedRootLoaderData = {
+  queryRef: ReturnType<typeof loadQuery<authenticatedRootLoaderQuery>>;
+};


### PR DESCRIPTION
## Summary

This PR fixes a Relay data-retention bug in the authenticated app shell and codifies the ownership pattern we landed on for loader-owned `loadQuery` refs.

### What changed

- update `authenticatedRootLoader` to keep `fetchQuery` only for the password-reset redirect decision
- return a retained root query ref via `loadQuery(...)` for the mounted authenticated shell
- render `AuthenticatedRoot` from that retained query instead of from a `fetchQuery` snapshot
- add `useOwnedPreloadedQuery` for components that directly own an externally created `loadQuery` ref
- back `useOwnedPreloadedQuery` with Relay's `useQueryLoader` ownership/disposal behavior
- add a regression test that verifies the hook adopts a replacement query ref on rerender and disposes the old ref
- document the pattern in the `phoenix-frontend` Relay skill guidance

### Why

The previous root flow passed a `fetchQuery` result into `ViewerProvider`, which then called `useRefetchableFragment` on data whose owner query was not retained. With aggressive GC settings, the root viewer data could be collected while the authenticated shell was still mounted, causing crashes during navigation.

This change keeps redirect-only control flow on `fetchQuery`, but moves mounted UI data onto a retained query ref with explicit ownership and disposal.

## Verification

- `pnpm typecheck` in `app/`
- `pnpm test -- --run app/src/hooks/__tests__/useOwnedPreloadedQuery.test.tsx` in `app/`

## Notes

- local `app/src/RelayEnvironment.ts` changes used for reproduction are not included in this PR
- the regression test uses a fully local Relay test environment and does not make real network requests
