### PR TITLE
feat: aggregate span info on traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 * **app:** show root span name in session turn list ([#12795](https://github.com/Arize-ai/phoenix/issues/12795)) ([c31fd97](https://github.com/Arize-ai/phoenix/commit/c31fd9783fbfe2340ae05ac383891b3079929278)), closes [#12792](https://github.com/Arize-ai/phoenix/issues/12792)
 * **secrets:** Add secrets settings page ([#12797](https://github.com/Arize-ai/phoenix/issues/12797)) ([f911992](https://github.com/Arize-ai/phoenix/commit/f9119922160aef450a0e4237cfcd31bdeb50acd9))
 * **ui:** add Show Table Aside toggle to project filter config (featureflagged) ([#12773](https://github.com/Arize-ai/phoenix/issues/12773)) ([81db7aa](https://github.com/Arize-ai/phoenix/commit/81db7aa7ee198adc1b7a285cc69d03880675b076))
-* **graphql:** aggregate per-trace span counts by kind and error counts on `Trace`; add `filterCondition` to `Trace.spans` ([#12815](https://github.com/Arize-ai/phoenix/issues/12815), [#12760](https://github.com/Arize-ai/phoenix/issues/12760), [#12761](https://github.com/Arize-ai/phoenix/issues/12761))
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * **app:** show root span name in session turn list ([#12795](https://github.com/Arize-ai/phoenix/issues/12795)) ([c31fd97](https://github.com/Arize-ai/phoenix/commit/c31fd9783fbfe2340ae05ac383891b3079929278)), closes [#12792](https://github.com/Arize-ai/phoenix/issues/12792)
 * **secrets:** Add secrets settings page ([#12797](https://github.com/Arize-ai/phoenix/issues/12797)) ([f911992](https://github.com/Arize-ai/phoenix/commit/f9119922160aef450a0e4237cfcd31bdeb50acd9))
 * **ui:** add Show Table Aside toggle to project filter config (featureflagged) ([#12773](https://github.com/Arize-ai/phoenix/issues/12773)) ([81db7aa](https://github.com/Arize-ai/phoenix/commit/81db7aa7ee198adc1b7a285cc69d03880675b076))
+* **graphql:** aggregate per-trace span counts by kind and error counts on `Trace`; add `filterCondition` to `Trace.spans` ([#12815](https://github.com/Arize-ai/phoenix/issues/12815), [#12760](https://github.com/Arize-ai/phoenix/issues/12760), [#12761](https://github.com/Arize-ai/phoenix/issues/12761))
 
 
 ### Bug Fixes

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3597,7 +3597,7 @@ type Trace implements Node {
   errorCount: Int!
 
   """
-  Breakdown of errored-span exception types under this trace. Each `exception` event on an errored span contributes a count; errored spans that carry no `exception` event contribute to the `null` bucket. Sorted by count descending, then exception type ascending.
+  Breakdown of errored-span exception types under this trace. Each `exception` event on an errored span contributes a count; errored spans that carry no `exception` event contribute to the `null` bucket.
   """
   errorsByType: [SpanErrorTypeCount!]!
   spans(first: Int!, last: Int, after: String, before: String, rootSpansOnly: Boolean, orphanSpanAsRootSpan: Boolean = true, filterCondition: String): SpanConnection!

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3336,6 +3336,14 @@ type SpanEdge {
   node: Span!
 }
 
+type SpanErrorTypeCount {
+  """
+  The `exception.type` attribute of the span event. `None` when an errored span has no accompanying `exception` event.
+  """
+  exceptionType: String
+  count: Int!
+}
+
 type SpanEvent {
   name: String!
   message: String!
@@ -3363,6 +3371,11 @@ enum SpanKind {
   evaluator
   guardrail
   unknown
+}
+
+type SpanKindCount {
+  spanKind: SpanKind!
+  count: Int!
 }
 
 """
@@ -3574,7 +3587,20 @@ type Trace implements Node {
   session: ProjectSession
   rootSpan: Span
   numSpans: Int!
-  spans(first: Int!, last: Int, after: String, before: String, rootSpansOnly: Boolean, orphanSpanAsRootSpan: Boolean = true): SpanConnection!
+
+  """
+  Count of each span kind present under this trace. Only kinds with count > 0 are returned.
+  """
+  spanCountsByKind: [SpanKindCount!]!
+
+  """Count of spans under this trace with `status_code == ERROR`."""
+  errorCount: Int!
+
+  """
+  Breakdown of errored-span exception types under this trace. Each `exception` event on an errored span contributes a count; errored spans that carry no `exception` event contribute to the `null` bucket. Sorted by count descending, then exception type ascending.
+  """
+  errorsByType: [SpanErrorTypeCount!]!
+  spans(first: Int!, last: Int, after: String, before: String, rootSpansOnly: Boolean, orphanSpanAsRootSpan: Boolean = true, filterCondition: String): SpanConnection!
 
   """Annotations associated with the trace."""
   traceAnnotations(sort: TraceAnnotationSort, filter: AnnotationFilter = null): [TraceAnnotation!]!

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3338,7 +3338,7 @@ type SpanEdge {
 
 type SpanErrorTypeCount {
   """
-  The `exception.type` attribute of the span event. `None` when an errored span has no accompanying `exception` event.
+  The `exception.type` attribute of the span event. `None` when no type could be determined — either the errored span has no accompanying `exception` event, or an `exception` event is present but its `exception.type` attribute is missing or malformed.
   """
   exceptionType: String
   count: Int!

--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -88,8 +88,11 @@ if TYPE_CHECKING:
         TokenPricesByModelDataLoader,
         TraceAnnotationsByTraceDataLoader,
         TraceByTraceIdsDataLoader,
+        TraceErrorCountDataLoader,
+        TraceErrorsByTypeDataLoader,
         TraceRetentionPolicyIdByProjectIdDataLoader,
         TraceRootSpansDataLoader,
+        TraceSpanCountsByKindDataLoader,
         UserRolesDataLoader,
         UsersDataLoader,
     )
@@ -219,9 +222,12 @@ class DataLoaders:
     trace_annotation_fields: TableFieldsDataLoader
     trace_annotations_by_trace: TraceAnnotationsByTraceDataLoader
     trace_by_trace_ids: TraceByTraceIdsDataLoader
+    trace_error_count: TraceErrorCountDataLoader
+    trace_errors_by_type: TraceErrorsByTypeDataLoader
     trace_fields: TableFieldsDataLoader
     trace_retention_policy_id_by_project_id: TraceRetentionPolicyIdByProjectIdDataLoader
     trace_root_spans: TraceRootSpansDataLoader
+    trace_span_counts_by_kind: TraceSpanCountsByKindDataLoader
     user_roles: UserRolesDataLoader
     user_api_key_fields: TableFieldsDataLoader
     user_fields: TableFieldsDataLoader

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -90,8 +90,11 @@ from .token_counts import TokenCountCache, TokenCountDataLoader
 from .token_prices_by_model import TokenPricesByModelDataLoader
 from .trace_annotations_by_trace import TraceAnnotationsByTraceDataLoader
 from .trace_by_trace_ids import TraceByTraceIdsDataLoader
+from .trace_error_count import TraceErrorCountDataLoader
+from .trace_errors_by_type import TraceErrorsByTypeDataLoader
 from .trace_retention_policy_id_by_project_id import TraceRetentionPolicyIdByProjectIdDataLoader
 from .trace_root_spans import TraceRootSpansDataLoader
+from .trace_span_counts_by_kind import TraceSpanCountsByKindDataLoader
 from .user_roles import UserRolesDataLoader
 from .users import UsersDataLoader
 
@@ -169,8 +172,11 @@ __all__ = [
     "TokenPricesByModelDataLoader",
     "TraceAnnotationsByTraceDataLoader",
     "TraceByTraceIdsDataLoader",
+    "TraceErrorCountDataLoader",
+    "TraceErrorsByTypeDataLoader",
     "TraceRetentionPolicyIdByProjectIdDataLoader",
     "TraceRootSpansDataLoader",
+    "TraceSpanCountsByKindDataLoader",
     "UserRolesDataLoader",
     "UsersDataLoader",
 ]

--- a/src/phoenix/server/api/dataloaders/trace_error_count.py
+++ b/src/phoenix/server/api/dataloaders/trace_error_count.py
@@ -1,0 +1,40 @@
+from typing import Iterable
+
+from sqlalchemy import func, select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db.models import Span
+from phoenix.server.types import DbSessionFactory
+
+TraceRowId: TypeAlias = int
+
+Key: TypeAlias = TraceRowId
+Result: TypeAlias = int
+
+_ERROR_STATUS = "ERROR"
+
+
+class TraceErrorCountDataLoader(DataLoader[Key, Result]):
+    """Counts spans under each trace with `status_code == 'ERROR'`.
+
+    Cheap, backed by a single `COUNT(*)`. Missing keys return 0.
+    """
+
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: Iterable[Key]) -> list[Result]:
+        keys = list(keys)
+        stmt = (
+            select(Span.trace_rowid, func.count())
+            .where(Span.trace_rowid.in_(keys))
+            .where(Span.status_code == _ERROR_STATUS)
+            .group_by(Span.trace_rowid)
+        )
+        async with self._db.read() as session:
+            result: dict[Key, Result] = {
+                trace_rowid: cnt async for trace_rowid, cnt in await session.stream(stmt)
+            }
+        return [result.get(key, 0) for key in keys]

--- a/src/phoenix/server/api/dataloaders/trace_error_count.py
+++ b/src/phoenix/server/api/dataloaders/trace_error_count.py
@@ -19,6 +19,14 @@ class TraceErrorCountDataLoader(DataLoader[Key, Result]):
     """Counts spans under each trace with `status_code == 'ERROR'`.
 
     Cheap, backed by a single `COUNT(*)`. Missing keys return 0.
+
+    We intentionally do not reuse the pre-aggregated `Span.cumulative_error_count`
+    column. That column stores the error count of the subtree rooted at each
+    span, so recovering the per-trace total would require either ``max()`` over
+    a well-defined root or a sum across orphan-root candidates — both of which
+    re-introduce the orphan-root handling complexity that `Trace.spans` already
+    encodes for pagination. A direct `COUNT(*)` over `status_code == 'ERROR'`
+    sidesteps that branch and is correct regardless of parent/child topology.
     """
 
     def __init__(self, db: DbSessionFactory) -> None:

--- a/src/phoenix/server/api/dataloaders/trace_errors_by_type.py
+++ b/src/phoenix/server/api/dataloaders/trace_errors_by_type.py
@@ -1,0 +1,87 @@
+from collections import Counter, defaultdict
+from typing import Any, Iterable, Mapping, Optional
+
+from sqlalchemy import select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db.models import Span
+from phoenix.server.types import DbSessionFactory
+from phoenix.trace.schemas import EXCEPTION_TYPE
+
+TraceRowId: TypeAlias = int
+ExceptionType: TypeAlias = Optional[str]
+
+Key: TypeAlias = TraceRowId
+Result: TypeAlias = list[tuple[ExceptionType, int]]
+
+_ERROR_STATUS = "ERROR"
+_EXCEPTION_EVENT_NAME = "exception"
+
+
+class TraceErrorsByTypeDataLoader(DataLoader[Key, Result]):
+    """Aggregates errored-span exception types per trace.
+
+    For every span in the trace with ``status_code == 'ERROR'``:
+
+    - Each ``exception`` event on the span contributes a count for its
+      ``exception.type`` attribute. Multiple exception events on the same
+      span each count.
+    - Errored spans that carry no ``exception`` event contribute a single
+      count to the ``None`` bucket (OTel permits ``ERROR`` without an
+      accompanying exception event).
+
+    Results are returned sorted by count descending, then exception type
+    ascending (``None`` sorts first), so snapshot tests are deterministic.
+
+    The JSON walk is done in Python rather than SQL to stay
+    dialect-agnostic (Postgres ``jsonb`` vs SQLite ``JSON``); error volumes
+    per trace are typically small. If this becomes hot we can push the
+    extraction into dialect-specific SQL later.
+    """
+
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: Iterable[Key]) -> list[Result]:
+        keys = list(keys)
+        stmt = (
+            select(Span.trace_rowid, Span.events)
+            .where(Span.trace_rowid.in_(keys))
+            .where(Span.status_code == _ERROR_STATUS)
+        )
+        counters: dict[Key, Counter[ExceptionType]] = defaultdict(Counter)
+        async with self._db.read() as session:
+            async for trace_rowid, events in await session.stream(stmt):
+                counters[trace_rowid].update(_exception_types_from_events(events))
+        return [_sorted_counts(counters[key]) for key in keys]
+
+
+def _exception_types_from_events(events: Any) -> list[ExceptionType]:
+    """Extract one ``exception.type`` entry per ``exception`` event.
+
+    If the span has no exception events at all, return ``[None]`` so the
+    errored span still contributes to the null bucket.
+    """
+    types: list[ExceptionType] = []
+    if isinstance(events, list):
+        for event in events:
+            if not isinstance(event, Mapping):
+                continue
+            if event.get("name") != _EXCEPTION_EVENT_NAME:
+                continue
+            attributes = event.get("attributes") or {}
+            exc_type = attributes.get(EXCEPTION_TYPE) if isinstance(attributes, Mapping) else None
+            types.append(exc_type if isinstance(exc_type, str) and exc_type else None)
+    if not types:
+        return [None]
+    return types
+
+
+def _sorted_counts(counter: Counter[ExceptionType]) -> list[tuple[ExceptionType, int]]:
+    # Sort by count desc, then exception type asc. ``None`` sorts before any string.
+    return sorted(
+        counter.items(),
+        key=lambda row: (-row[1], row[0] is not None, row[0] or ""),
+    )

--- a/src/phoenix/server/api/dataloaders/trace_span_counts_by_kind.py
+++ b/src/phoenix/server/api/dataloaders/trace_span_counts_by_kind.py
@@ -1,0 +1,44 @@
+from collections import defaultdict
+from typing import Iterable
+
+from sqlalchemy import func, select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db.models import Span
+from phoenix.server.types import DbSessionFactory
+
+TraceRowId: TypeAlias = int
+SpanKindStr: TypeAlias = str
+
+Key: TypeAlias = TraceRowId
+Result: TypeAlias = list[tuple[SpanKindStr, int]]
+
+
+class TraceSpanCountsByKindDataLoader(DataLoader[Key, Result]):
+    """Counts spans per `(trace_rowid, span_kind)` pair.
+
+    Returns, per trace, a list of `(span_kind, count)` pairs in deterministic
+    order (descending count, then ascending kind name). Absent kinds are
+    omitted — callers can treat a missing kind as zero.
+    """
+
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: Iterable[Key]) -> list[Result]:
+        keys = list(keys)
+        stmt = (
+            select(Span.trace_rowid, Span.span_kind, func.count().label("cnt"))
+            .where(Span.trace_rowid.in_(keys))
+            .group_by(Span.trace_rowid, Span.span_kind)
+        )
+        buckets: dict[Key, list[tuple[SpanKindStr, int]]] = defaultdict(list)
+        async with self._db.read() as session:
+            async for trace_rowid, span_kind, cnt in await session.stream(stmt):
+                buckets[trace_rowid].append((span_kind, cnt))
+        # Sort each bucket deterministically: count desc, then kind asc.
+        for trace_rowid in buckets:
+            buckets[trace_rowid].sort(key=lambda row: (-row[1], row[0]))
+        return [buckets.get(key, []) for key in keys]

--- a/src/phoenix/server/api/types/Trace.py
+++ b/src/phoenix/server/api/types/Trace.py
@@ -55,8 +55,10 @@ class SpanKindCount:
 class SpanErrorTypeCount:
     exception_type: Optional[str] = strawberry.field(
         description=(
-            "The `exception.type` attribute of the span event. `None` when an errored "
-            "span has no accompanying `exception` event."
+            "The `exception.type` attribute of the span event. `None` when no type "
+            "could be determined — either the errored span has no accompanying "
+            "`exception` event, or an `exception` event is present but its "
+            "`exception.type` attribute is missing or malformed."
         ),
     )
     count: int
@@ -221,7 +223,22 @@ class Trace(Node):
         info: Info[Context, None],
     ) -> list[SpanKindCount]:
         rows = await info.context.data_loaders.trace_span_counts_by_kind.load(self.id)
-        return [SpanKindCount(span_kind=SpanKind(kind), count=count) for kind, count in rows]
+        # The dataloader groups by the raw DB `span_kind` string. `SpanKind(kind)`
+        # collapses any non-canonical value (lowercase, legacy name, etc.) to
+        # `SpanKind.unknown` via the enum's `_missing_` hook, which can produce
+        # multiple rows that resolve to the same enum member. Coalesce here so
+        # the response contains exactly one entry per kind.
+        counts: dict[SpanKind, int] = {}
+        for kind, count in rows:
+            enum_kind = SpanKind(kind)
+            counts[enum_kind] = counts.get(enum_kind, 0) + count
+        # Re-sort after dedup: count desc, then kind name asc. Names are the
+        # lowercase form of values, so this preserves the dataloader's order
+        # when no collision occurred.
+        return [
+            SpanKindCount(span_kind=k, count=c)
+            for k, c in sorted(counts.items(), key=lambda row: (-row[1], row[0].name))
+        ]
 
     @strawberry.field(  # type: ignore[untyped-decorator]
         description="Count of spans under this trace with `status_code == ERROR`.",

--- a/src/phoenix/server/api/types/Trace.py
+++ b/src/phoenix/server/api/types/Trace.py
@@ -31,10 +31,11 @@ from phoenix.server.api.types.pagination import (
     connection_from_cursors_and_nodes,
 )
 from phoenix.server.api.types.SortDir import SortDir
-from phoenix.server.api.types.Span import Span
+from phoenix.server.api.types.Span import Span, SpanKind
 from phoenix.server.api.types.SpanCostDetailSummaryEntry import SpanCostDetailSummaryEntry
 from phoenix.server.api.types.SpanCostSummary import SpanCostSummary
 from phoenix.server.api.types.TraceAnnotation import TraceAnnotation
+from phoenix.trace.dsl import SpanFilter
 
 if TYPE_CHECKING:
     from phoenix.server.api.types.Project import Project
@@ -42,6 +43,23 @@ if TYPE_CHECKING:
 
 ProjectRowId: TypeAlias = int
 TraceRowId: TypeAlias = int
+
+
+@strawberry.type
+class SpanKindCount:
+    span_kind: SpanKind
+    count: int
+
+
+@strawberry.type
+class SpanErrorTypeCount:
+    exception_type: Optional[str] = strawberry.field(
+        description=(
+            "The `exception.type` attribute of the span event. `None` when an errored "
+            "span has no accompanying `exception` event."
+        ),
+    )
+    count: int
 
 
 @strawberry.type
@@ -192,6 +210,45 @@ class Trace(Node):
     ) -> int:
         return await info.context.data_loaders.num_spans_per_trace.load(self.id)
 
+    @strawberry.field(  # type: ignore[untyped-decorator]
+        description=(
+            "Count of each span kind present under this trace. Only kinds with "
+            "count > 0 are returned."
+        ),
+    )
+    async def span_counts_by_kind(
+        self,
+        info: Info[Context, None],
+    ) -> list[SpanKindCount]:
+        rows = await info.context.data_loaders.trace_span_counts_by_kind.load(self.id)
+        return [SpanKindCount(span_kind=SpanKind(kind), count=count) for kind, count in rows]
+
+    @strawberry.field(  # type: ignore[untyped-decorator]
+        description="Count of spans under this trace with `status_code == ERROR`.",
+    )
+    async def error_count(
+        self,
+        info: Info[Context, None],
+    ) -> int:
+        return await info.context.data_loaders.trace_error_count.load(self.id)
+
+    @strawberry.field(  # type: ignore[untyped-decorator]
+        description=(
+            "Breakdown of errored-span exception types under this trace. Each "
+            "`exception` event on an errored span contributes a count; errored spans "
+            "that carry no `exception` event contribute to the `null` bucket. Sorted "
+            "by count descending, then exception type ascending."
+        ),
+    )
+    async def errors_by_type(
+        self,
+        info: Info[Context, None],
+    ) -> list[SpanErrorTypeCount]:
+        rows = await info.context.data_loaders.trace_errors_by_type.load(self.id)
+        return [
+            SpanErrorTypeCount(exception_type=exc_type, count=count) for exc_type, count in rows
+        ]
+
     @strawberry.field(extensions=[RequireForwardPaginationExtension()])  # type: ignore[untyped-decorator]
     async def spans(
         self,
@@ -202,6 +259,7 @@ class Trace(Node):
         before: Optional[CursorString] = UNSET,
         root_spans_only: Optional[bool] = UNSET,
         orphan_span_as_root_span: Optional[bool] = True,
+        filter_condition: Optional[str] = UNSET,
     ) -> Connection[Span]:
         assert isinstance(first, int)
 
@@ -225,6 +283,11 @@ class Trace(Node):
             # For descending order, "after" means we want spans with smaller IDs
             # (going forward in descending order)
             base_query = base_query.where(models.Span.id < cursor.rowid)
+        # Narrow by SpanFilter DSL (e.g. `span_kind == 'LLM'`, `status_code == 'ERROR'`)
+        # before any root-span CTE wrapping, so the filter applies to the candidate set.
+        if filter_condition:
+            span_filter = SpanFilter(condition=filter_condition)
+            base_query = span_filter(base_query)
         # Build final query based on filtering requirements
         if root_spans_only:
             if orphan_span_as_root_span:

--- a/src/phoenix/server/api/types/Trace.py
+++ b/src/phoenix/server/api/types/Trace.py
@@ -253,8 +253,7 @@ class Trace(Node):
         description=(
             "Breakdown of errored-span exception types under this trace. Each "
             "`exception` event on an errored span contributes a count; errored spans "
-            "that carry no `exception` event contribute to the `null` bucket. Sorted "
-            "by count descending, then exception type ascending."
+            "that carry no `exception` event contribute to the `null` bucket."
         ),
     )
     async def errors_by_type(

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -153,8 +153,11 @@ from phoenix.server.api.dataloaders import (
     TokenPricesByModelDataLoader,
     TraceAnnotationsByTraceDataLoader,
     TraceByTraceIdsDataLoader,
+    TraceErrorCountDataLoader,
+    TraceErrorsByTypeDataLoader,
     TraceRetentionPolicyIdByProjectIdDataLoader,
     TraceRootSpansDataLoader,
+    TraceSpanCountsByKindDataLoader,
     UserRolesDataLoader,
     UsersDataLoader,
 )
@@ -917,7 +920,10 @@ def create_graphql_router(
                 trace_annotation_fields=TableFieldsDataLoader(db, models.TraceAnnotation),
                 trace_annotations_by_trace=TraceAnnotationsByTraceDataLoader(db),
                 trace_by_trace_ids=TraceByTraceIdsDataLoader(db),
+                trace_error_count=TraceErrorCountDataLoader(db),
+                trace_errors_by_type=TraceErrorsByTypeDataLoader(db),
                 trace_fields=TableFieldsDataLoader(db, models.Trace),
+                trace_span_counts_by_kind=TraceSpanCountsByKindDataLoader(db),
                 trace_retention_policy_id_by_project_id=TraceRetentionPolicyIdByProjectIdDataLoader(
                     db
                 ),

--- a/tests/unit/server/api/dataloaders/test_trace_error_count.py
+++ b/tests/unit/server/api/dataloaders/test_trace_error_count.py
@@ -1,0 +1,93 @@
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import insert
+
+from phoenix.db import models
+from phoenix.server.api.dataloaders.trace_error_count import TraceErrorCountDataLoader
+from phoenix.server.types import DbSessionFactory
+
+
+@pytest.fixture
+async def traces_with_errors(db: DbSessionFactory) -> tuple[int, int, int]:
+    """Three traces:
+
+    - trace A: 0 errored spans, 2 OK
+    - trace B: 1 errored span, 1 OK
+    - trace C: 3 errored spans
+    """
+    orig_time = datetime.fromisoformat("2021-01-01T00:00:00.000+00:00")
+    async with db() as session:
+        project_id = await session.scalar(
+            insert(models.Project).values(name="trace_errors").returning(models.Project.id)
+        )
+
+        trace_rowids: list[int] = []
+        for i in range(3):
+            trace_id = await session.scalar(
+                insert(models.Trace)
+                .values(
+                    trace_id=f"trace_{i}",
+                    project_rowid=project_id,
+                    start_time=orig_time,
+                    end_time=orig_time + timedelta(seconds=1),
+                )
+                .returning(models.Trace.id)
+            )
+            assert trace_id is not None
+            trace_rowids.append(trace_id)
+
+        statuses_per_trace: dict[int, list[str]] = {
+            trace_rowids[0]: ["OK", "OK"],
+            trace_rowids[1]: ["ERROR", "OK"],
+            trace_rowids[2]: ["ERROR", "ERROR", "ERROR"],
+        }
+        for trace_rowid, statuses in statuses_per_trace.items():
+            for j, status in enumerate(statuses):
+                await session.execute(
+                    insert(models.Span).values(
+                        trace_rowid=trace_rowid,
+                        span_id=f"trace{trace_rowid}_span{j}",
+                        parent_id=None,
+                        name=f"span{j}",
+                        span_kind="UNKNOWN",
+                        start_time=orig_time,
+                        end_time=orig_time + timedelta(seconds=1),
+                        attributes={},
+                        events=[],
+                        status_code=status,
+                        status_message="",
+                        cumulative_error_count=0,
+                        cumulative_llm_token_count_prompt=0,
+                        cumulative_llm_token_count_completion=0,
+                        llm_token_count_prompt=None,
+                        llm_token_count_completion=None,
+                    )
+                )
+        await session.commit()
+    return trace_rowids[0], trace_rowids[1], trace_rowids[2]
+
+
+async def test_counts_error_status_only(
+    db: DbSessionFactory,
+    traces_with_errors: tuple[int, int, int],
+) -> None:
+    trace_a, trace_b, trace_c = traces_with_errors
+    loader = TraceErrorCountDataLoader(db)
+
+    actual = await loader.load_many([trace_a, trace_b, trace_c])
+
+    assert actual == [0, 1, 3]
+
+
+async def test_missing_trace_id_returns_zero(
+    db: DbSessionFactory,
+    traces_with_errors: tuple[int, int, int],
+) -> None:
+    trace_a, _, trace_c = traces_with_errors
+    loader = TraceErrorCountDataLoader(db)
+
+    missing_key = trace_c + 10_000
+    actual = await loader.load_many([missing_key, trace_a, trace_c])
+
+    assert actual == [0, 0, 3]

--- a/tests/unit/server/api/dataloaders/test_trace_errors_by_type.py
+++ b/tests/unit/server/api/dataloaders/test_trace_errors_by_type.py
@@ -27,8 +27,9 @@ async def traces_with_exception_events(db: DbSessionFactory) -> tuple[int, int, 
     - trace A: no errored spans
     - trace B: one errored span with one ``ValueError`` exception event
     - trace C: one errored span with two exception events (``ValueError``,
-      ``KeyError``) + a second errored span with no exception events (bucketed
-      under ``None``).
+      ``KeyError``) + a second errored span with no exception events + a third
+      errored span whose ``exception`` event is missing the ``exception.type``
+      attribute; the latter two both bucket under ``None``.
     - trace D: mixed — two errored spans with ``ValueError`` and one with
       ``RuntimeError``; also one OK span with an exception event that should
       NOT be counted (status != ERROR).
@@ -97,6 +98,9 @@ async def traces_with_exception_events(db: DbSessionFactory) -> tuple[int, int, 
             [_exception_event("ValueError"), _exception_event("KeyError")],
         )
         await _insert_span(trace_c, "c1", "ERROR", [])
+        # Errored span with an exception event whose `exception.type` attribute
+        # is absent — the extraction helper returns None for this case.
+        await _insert_span(trace_c, "c2", "ERROR", [_exception_event(None)])
 
         # trace D
         await _insert_span(trace_d, "d0", "ERROR", [_exception_event("ValueError")])
@@ -124,10 +128,12 @@ async def test_aggregates_and_sort_order(
     # One errored span with one exception event.
     assert actual[1] == [("ValueError", 1)]
 
-    # trace C: ValueError x1 and KeyError x1 from the same span (multi-event),
-    # plus a `None` bucket from the errored span with no exception events.
-    # All tie at count=1 so sort falls back to exception type asc with None first.
-    assert actual[2] == [(None, 1), ("KeyError", 1), ("ValueError", 1)]
+    # trace C: ValueError x1 and KeyError x1 from the same multi-event span,
+    # plus two contributions to the `None` bucket — one from the errored span
+    # with no exception events, and one from the errored span whose exception
+    # event lacks an `exception.type` attribute. None leads on count desc;
+    # the remaining ties fall back to exception type asc.
+    assert actual[2] == [(None, 2), ("KeyError", 1), ("ValueError", 1)]
 
     # trace D: ValueError x2 (highest), RuntimeError x1; the OK span is
     # ignored despite having an exception event.

--- a/tests/unit/server/api/dataloaders/test_trace_errors_by_type.py
+++ b/tests/unit/server/api/dataloaders/test_trace_errors_by_type.py
@@ -1,0 +1,148 @@
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+from sqlalchemy import insert
+
+from phoenix.db import models
+from phoenix.server.api.dataloaders.trace_errors_by_type import TraceErrorsByTypeDataLoader
+from phoenix.server.types import DbSessionFactory
+
+
+def _exception_event(exception_type: str | None) -> dict[str, Any]:
+    attributes: dict[str, Any] = {}
+    if exception_type is not None:
+        attributes["exception.type"] = exception_type
+    return {
+        "name": "exception",
+        "timestamp": "2021-01-01T00:00:00.000+00:00",
+        "attributes": attributes,
+    }
+
+
+@pytest.fixture
+async def traces_with_exception_events(db: DbSessionFactory) -> tuple[int, int, int, int]:
+    """Four traces covering the relevant cases:
+
+    - trace A: no errored spans
+    - trace B: one errored span with one ``ValueError`` exception event
+    - trace C: one errored span with two exception events (``ValueError``,
+      ``KeyError``) + a second errored span with no exception events (bucketed
+      under ``None``).
+    - trace D: mixed — two errored spans with ``ValueError`` and one with
+      ``RuntimeError``; also one OK span with an exception event that should
+      NOT be counted (status != ERROR).
+    """
+    orig_time = datetime.fromisoformat("2021-01-01T00:00:00.000+00:00")
+    async with db() as session:
+        project_id = await session.scalar(
+            insert(models.Project).values(name="trace_errors_by_type").returning(models.Project.id)
+        )
+
+        trace_rowids: list[int] = []
+        for i in range(4):
+            trace_id = await session.scalar(
+                insert(models.Trace)
+                .values(
+                    trace_id=f"trace_{i}",
+                    project_rowid=project_id,
+                    start_time=orig_time,
+                    end_time=orig_time + timedelta(seconds=1),
+                )
+                .returning(models.Trace.id)
+            )
+            assert trace_id is not None
+            trace_rowids.append(trace_id)
+
+        trace_a, trace_b, trace_c, trace_d = trace_rowids
+
+        async def _insert_span(
+            trace_rowid: int,
+            span_id: str,
+            status: str,
+            events: list[dict[str, Any]],
+        ) -> None:
+            await session.execute(
+                insert(models.Span).values(
+                    trace_rowid=trace_rowid,
+                    span_id=span_id,
+                    parent_id=None,
+                    name=span_id,
+                    span_kind="UNKNOWN",
+                    start_time=orig_time,
+                    end_time=orig_time + timedelta(seconds=1),
+                    attributes={},
+                    events=events,
+                    status_code=status,
+                    status_message="",
+                    cumulative_error_count=0,
+                    cumulative_llm_token_count_prompt=0,
+                    cumulative_llm_token_count_completion=0,
+                    llm_token_count_prompt=None,
+                    llm_token_count_completion=None,
+                )
+            )
+
+        # trace A: only OK spans
+        await _insert_span(trace_a, "a0", "OK", [])
+
+        # trace B
+        await _insert_span(trace_b, "b0", "ERROR", [_exception_event("ValueError")])
+
+        # trace C
+        await _insert_span(
+            trace_c,
+            "c0",
+            "ERROR",
+            [_exception_event("ValueError"), _exception_event("KeyError")],
+        )
+        await _insert_span(trace_c, "c1", "ERROR", [])
+
+        # trace D
+        await _insert_span(trace_d, "d0", "ERROR", [_exception_event("ValueError")])
+        await _insert_span(trace_d, "d1", "ERROR", [_exception_event("ValueError")])
+        await _insert_span(trace_d, "d2", "ERROR", [_exception_event("RuntimeError")])
+        # OK span with an exception event must NOT be counted.
+        await _insert_span(trace_d, "d3", "OK", [_exception_event("Ignored")])
+
+        await session.commit()
+    return trace_a, trace_b, trace_c, trace_d
+
+
+async def test_aggregates_and_sort_order(
+    db: DbSessionFactory,
+    traces_with_exception_events: tuple[int, int, int, int],
+) -> None:
+    trace_a, trace_b, trace_c, trace_d = traces_with_exception_events
+    loader = TraceErrorsByTypeDataLoader(db)
+
+    actual = await loader.load_many([trace_a, trace_b, trace_c, trace_d])
+
+    # No errored spans -> empty list.
+    assert actual[0] == []
+
+    # One errored span with one exception event.
+    assert actual[1] == [("ValueError", 1)]
+
+    # trace C: ValueError x1 and KeyError x1 from the same span (multi-event),
+    # plus a `None` bucket from the errored span with no exception events.
+    # All tie at count=1 so sort falls back to exception type asc with None first.
+    assert actual[2] == [(None, 1), ("KeyError", 1), ("ValueError", 1)]
+
+    # trace D: ValueError x2 (highest), RuntimeError x1; the OK span is
+    # ignored despite having an exception event.
+    assert actual[3] == [("ValueError", 2), ("RuntimeError", 1)]
+
+
+async def test_missing_trace_id_returns_empty_list(
+    db: DbSessionFactory,
+    traces_with_exception_events: tuple[int, int, int, int],
+) -> None:
+    _, trace_b, _, trace_d = traces_with_exception_events
+    loader = TraceErrorsByTypeDataLoader(db)
+
+    missing_key = trace_d + 10_000
+    actual = await loader.load_many([missing_key, trace_b])
+
+    assert actual[0] == []
+    assert actual[1] == [("ValueError", 1)]

--- a/tests/unit/server/api/dataloaders/test_trace_span_counts_by_kind.py
+++ b/tests/unit/server/api/dataloaders/test_trace_span_counts_by_kind.py
@@ -1,0 +1,100 @@
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import insert
+
+from phoenix.db import models
+from phoenix.server.api.dataloaders.trace_span_counts_by_kind import (
+    TraceSpanCountsByKindDataLoader,
+)
+from phoenix.server.types import DbSessionFactory
+
+
+@pytest.fixture
+async def traces_with_span_kinds(db: DbSessionFactory) -> tuple[int, int, int]:
+    """Three traces:
+
+    - trace A: 2 LLM, 1 TOOL, 1 CHAIN
+    - trace B: 3 CHAIN
+    - trace C: no spans
+    """
+    orig_time = datetime.fromisoformat("2021-01-01T00:00:00.000+00:00")
+    async with db() as session:
+        project_id = await session.scalar(
+            insert(models.Project).values(name="trace_span_kinds").returning(models.Project.id)
+        )
+
+        trace_rowids: list[int] = []
+        for i in range(3):
+            trace_id = await session.scalar(
+                insert(models.Trace)
+                .values(
+                    trace_id=f"trace_{i}",
+                    project_rowid=project_id,
+                    start_time=orig_time,
+                    end_time=orig_time + timedelta(seconds=1),
+                )
+                .returning(models.Trace.id)
+            )
+            assert trace_id is not None
+            trace_rowids.append(trace_id)
+
+        kinds_per_trace = {
+            trace_rowids[0]: ["LLM", "LLM", "TOOL", "CHAIN"],
+            trace_rowids[1]: ["CHAIN", "CHAIN", "CHAIN"],
+            trace_rowids[2]: [],
+        }
+        for trace_rowid, kinds in kinds_per_trace.items():
+            for j, kind in enumerate(kinds):
+                await session.execute(
+                    insert(models.Span).values(
+                        trace_rowid=trace_rowid,
+                        span_id=f"trace{trace_rowid}_span{j}",
+                        parent_id=None,
+                        name=f"span{j}",
+                        span_kind=kind,
+                        start_time=orig_time,
+                        end_time=orig_time + timedelta(seconds=1),
+                        attributes={},
+                        events=[],
+                        status_code="OK",
+                        status_message="",
+                        cumulative_error_count=0,
+                        cumulative_llm_token_count_prompt=0,
+                        cumulative_llm_token_count_completion=0,
+                        llm_token_count_prompt=None,
+                        llm_token_count_completion=None,
+                    )
+                )
+        await session.commit()
+    return trace_rowids[0], trace_rowids[1], trace_rowids[2]
+
+
+async def test_counts_are_grouped_per_trace_and_deterministic(
+    db: DbSessionFactory,
+    traces_with_span_kinds: tuple[int, int, int],
+) -> None:
+    trace_a, trace_b, trace_c = traces_with_span_kinds
+    loader = TraceSpanCountsByKindDataLoader(db)
+
+    actual = await loader.load_many([trace_a, trace_b, trace_c])
+
+    # trace A: LLM (2) is most common, then CHAIN (1) and TOOL (1) broken by
+    # alphabetical order on the kind string.
+    assert actual[0] == [("LLM", 2), ("CHAIN", 1), ("TOOL", 1)]
+    assert actual[1] == [("CHAIN", 3)]
+    assert actual[2] == []
+
+
+async def test_missing_trace_id_returns_empty_list(
+    db: DbSessionFactory,
+    traces_with_span_kinds: tuple[int, int, int],
+) -> None:
+    trace_a, _, _ = traces_with_span_kinds
+    loader = TraceSpanCountsByKindDataLoader(db)
+
+    missing_key = trace_a + 10_000
+    actual = await loader.load_many([missing_key, trace_a])
+
+    assert actual[0] == []
+    assert actual[1] == [("LLM", 2), ("CHAIN", 1), ("TOOL", 1)]

--- a/tests/unit/server/api/types/test_Trace_span_aggregates.py
+++ b/tests/unit/server/api/types/test_Trace_span_aggregates.py
@@ -1,0 +1,248 @@
+"""GraphQL integration tests for per-trace span aggregate fields on `Trace`.
+
+Covers ``spanCountsByKind``, ``errorCount``, ``errorsByType`` and the new
+``filterCondition`` argument on ``Trace.spans``.
+"""
+
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+from sqlalchemy import insert
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.server.api.types.Trace import Trace
+from phoenix.server.types import DbSessionFactory
+from tests.unit.graphql import AsyncGraphQLClient
+
+
+def _exception_event(exception_type: str) -> dict[str, Any]:
+    return {
+        "name": "exception",
+        "timestamp": "2021-01-01T00:00:00.000+00:00",
+        "attributes": {"exception.type": exception_type},
+    }
+
+
+@pytest.fixture
+async def trace_with_mixed_spans(db: DbSessionFactory) -> int:
+    """A trace with a mix of span kinds and statuses:
+
+    - 2 LLM (1 OK, 1 ERROR with ``ValueError``)
+    - 1 TOOL (ERROR with ``KeyError``)
+    - 1 CHAIN (OK)
+    - 1 CHAIN (ERROR, no exception event) → contributes to the `None` bucket
+    """
+    orig_time = datetime.fromisoformat("2021-01-01T00:00:00.000+00:00")
+    async with db() as session:
+        project_id = await session.scalar(
+            insert(models.Project).values(name="trace_aggregates").returning(models.Project.id)
+        )
+        trace_rowid = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="trace_aggregates",
+                project_rowid=project_id,
+                start_time=orig_time,
+                end_time=orig_time + timedelta(seconds=1),
+            )
+            .returning(models.Trace.id)
+        )
+        assert trace_rowid is not None
+
+        spans = [
+            # (span_id, kind, status, events)
+            ("s_llm_ok", "LLM", "OK", []),
+            ("s_llm_err", "LLM", "ERROR", [_exception_event("ValueError")]),
+            ("s_tool_err", "TOOL", "ERROR", [_exception_event("KeyError")]),
+            ("s_chain_ok", "CHAIN", "OK", []),
+            ("s_chain_err_no_event", "CHAIN", "ERROR", []),
+        ]
+        for span_id, kind, status, events in spans:
+            await session.execute(
+                insert(models.Span).values(
+                    trace_rowid=trace_rowid,
+                    span_id=span_id,
+                    parent_id=None,
+                    name=span_id,
+                    span_kind=kind,
+                    start_time=orig_time,
+                    end_time=orig_time + timedelta(seconds=1),
+                    attributes={},
+                    events=events,
+                    status_code=status,
+                    status_message="",
+                    cumulative_error_count=0,
+                    cumulative_llm_token_count_prompt=0,
+                    cumulative_llm_token_count_completion=0,
+                    llm_token_count_prompt=None,
+                    llm_token_count_completion=None,
+                )
+            )
+        await session.commit()
+    return trace_rowid
+
+
+async def test_span_counts_by_kind(
+    trace_with_mixed_spans: int,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    trace_gid = str(GlobalID(Trace.__name__, str(trace_with_mixed_spans)))
+    query = """
+        query ($traceId: ID!) {
+            node(id: $traceId) {
+                ... on Trace {
+                    spanCountsByKind { spanKind count }
+                }
+            }
+        }
+    """
+    response = await gql_client.execute(query=query, variables={"traceId": trace_gid})
+    assert not response.errors
+    assert (data := response.data) is not None
+
+    # Sort deterministically: CHAIN=2, LLM=2, TOOL=1 -> sorted by count desc,
+    # then span kind ascending (by string value). The GraphQL `SpanKind` enum
+    # serializes to its Python member name (lowercase), not the storage value.
+    assert data["node"]["spanCountsByKind"] == [
+        {"spanKind": "chain", "count": 2},
+        {"spanKind": "llm", "count": 2},
+        {"spanKind": "tool", "count": 1},
+    ]
+
+
+async def test_error_count(
+    trace_with_mixed_spans: int,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    trace_gid = str(GlobalID(Trace.__name__, str(trace_with_mixed_spans)))
+    query = """
+        query ($traceId: ID!) {
+            node(id: $traceId) {
+                ... on Trace {
+                    errorCount
+                }
+            }
+        }
+    """
+    response = await gql_client.execute(query=query, variables={"traceId": trace_gid})
+    assert not response.errors
+    assert (data := response.data) is not None
+    assert data["node"]["errorCount"] == 3
+
+
+async def test_errors_by_type(
+    trace_with_mixed_spans: int,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    trace_gid = str(GlobalID(Trace.__name__, str(trace_with_mixed_spans)))
+    query = """
+        query ($traceId: ID!) {
+            node(id: $traceId) {
+                ... on Trace {
+                    errorsByType { exceptionType count }
+                }
+            }
+        }
+    """
+    response = await gql_client.execute(query=query, variables={"traceId": trace_gid})
+    assert not response.errors
+    assert (data := response.data) is not None
+    # All three errored spans contribute one count each:
+    # ValueError (from LLM), KeyError (from TOOL), and `None`
+    # (from the errored CHAIN with no exception event). All tie at count=1,
+    # sorted with None first, then exception type ascending.
+    assert data["node"]["errorsByType"] == [
+        {"exceptionType": None, "count": 1},
+        {"exceptionType": "KeyError", "count": 1},
+        {"exceptionType": "ValueError", "count": 1},
+    ]
+
+
+async def test_spans_filter_condition_narrows_results(
+    trace_with_mixed_spans: int,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    trace_gid = str(GlobalID(Trace.__name__, str(trace_with_mixed_spans)))
+    query = """
+        query ($traceId: ID!, $first: Int!, $filter: String) {
+            node(id: $traceId) {
+                ... on Trace {
+                    spans(first: $first, filterCondition: $filter) {
+                        edges { node { name } }
+                    }
+                }
+            }
+        }
+    """
+    response = await gql_client.execute(
+        query=query,
+        variables={"traceId": trace_gid, "first": 10, "filter": "span_kind == 'LLM'"},
+    )
+    assert not response.errors
+    assert (data := response.data) is not None
+    edges = data["node"]["spans"]["edges"]
+    names = {edge["node"]["name"] for edge in edges}
+    assert names == {"s_llm_ok", "s_llm_err"}
+
+
+async def test_spans_filter_condition_on_status_code(
+    trace_with_mixed_spans: int,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    trace_gid = str(GlobalID(Trace.__name__, str(trace_with_mixed_spans)))
+    query = """
+        query ($traceId: ID!, $first: Int!, $filter: String) {
+            node(id: $traceId) {
+                ... on Trace {
+                    spans(first: $first, filterCondition: $filter) {
+                        edges { node { name } }
+                    }
+                }
+            }
+        }
+    """
+    response = await gql_client.execute(
+        query=query,
+        variables={
+            "traceId": trace_gid,
+            "first": 10,
+            "filter": "status_code == 'ERROR'",
+        },
+    )
+    assert not response.errors
+    assert (data := response.data) is not None
+    edges = data["node"]["spans"]["edges"]
+    names = {edge["node"]["name"] for edge in edges}
+    assert names == {"s_llm_err", "s_tool_err", "s_chain_err_no_event"}
+
+
+async def test_spans_invalid_filter_condition_raises(
+    trace_with_mixed_spans: int,
+    monkeypatch: pytest.MonkeyPatch,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    monkeypatch.setenv("PHOENIX_MASK_INTERNAL_SERVER_ERRORS", "false")
+    trace_gid = str(GlobalID(Trace.__name__, str(trace_with_mixed_spans)))
+    query = """
+        query ($traceId: ID!, $first: Int!, $filter: String) {
+            node(id: $traceId) {
+                ... on Trace {
+                    spans(first: $first, filterCondition: $filter) {
+                        edges { node { name } }
+                    }
+                }
+            }
+        }
+    """
+    response = await gql_client.execute(
+        query=query,
+        variables={
+            "traceId": trace_gid,
+            "first": 10,
+            # Bare identifier — not a valid SpanFilter expression.
+            "filter": "span_kind",
+        },
+    )
+    assert response.errors

--- a/tests/unit/server/api/types/test_Trace_span_aggregates.py
+++ b/tests/unit/server/api/types/test_Trace_span_aggregates.py
@@ -5,7 +5,7 @@ Covers ``spanCountsByKind``, ``errorCount``, ``errorsByType`` and the new
 """
 
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 from sqlalchemy import insert
@@ -246,3 +246,221 @@ async def test_spans_invalid_filter_condition_raises(
         },
     )
     assert response.errors
+
+
+@pytest.fixture
+async def trace_with_non_canonical_kinds(db: DbSessionFactory) -> int:
+    """A trace with two spans whose ``span_kind`` values both collapse to
+    ``SpanKind.unknown`` via the enum's ``_missing_`` hook.
+
+    Exercises the resolver-side dedup that protects the GraphQL response
+    from emitting multiple entries keyed by the same enum member when the
+    DB contains non-canonical values.
+    """
+    orig_time = datetime.fromisoformat("2021-01-01T00:00:00.000+00:00")
+    async with db() as session:
+        project_id = await session.scalar(
+            insert(models.Project)
+            .values(name="trace_non_canonical_kinds")
+            .returning(models.Project.id)
+        )
+        trace_rowid = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="trace_non_canonical",
+                project_rowid=project_id,
+                start_time=orig_time,
+                end_time=orig_time + timedelta(seconds=1),
+            )
+            .returning(models.Trace.id)
+        )
+        assert trace_rowid is not None
+
+        # Both kinds resolve to SpanKind.unknown: the first directly, the
+        # second via the enum's `_missing_` fallback for unrecognized strings.
+        for span_id, kind in [("s_canonical_unknown", "UNKNOWN"), ("s_legacy_kind", "CUSTOM")]:
+            await session.execute(
+                insert(models.Span).values(
+                    trace_rowid=trace_rowid,
+                    span_id=span_id,
+                    parent_id=None,
+                    name=span_id,
+                    span_kind=kind,
+                    start_time=orig_time,
+                    end_time=orig_time + timedelta(seconds=1),
+                    attributes={},
+                    events=[],
+                    status_code="OK",
+                    status_message="",
+                    cumulative_error_count=0,
+                    cumulative_llm_token_count_prompt=0,
+                    cumulative_llm_token_count_completion=0,
+                    llm_token_count_prompt=None,
+                    llm_token_count_completion=None,
+                )
+            )
+        await session.commit()
+    return trace_rowid
+
+
+async def test_span_counts_by_kind_dedupes_non_canonical(
+    trace_with_non_canonical_kinds: int,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    """Two DB rows that both collapse to ``SpanKind.unknown`` must produce a
+    single ``unknown`` bucket summing both counts, not two separate entries.
+    """
+    trace_gid = str(GlobalID(Trace.__name__, str(trace_with_non_canonical_kinds)))
+    query = """
+        query ($traceId: ID!) {
+            node(id: $traceId) {
+                ... on Trace {
+                    spanCountsByKind { spanKind count }
+                }
+            }
+        }
+    """
+    response = await gql_client.execute(query=query, variables={"traceId": trace_gid})
+    assert not response.errors
+    assert (data := response.data) is not None
+    assert data["node"]["spanCountsByKind"] == [{"spanKind": "unknown", "count": 2}]
+
+
+@pytest.fixture
+async def trace_with_hierarchy(db: DbSessionFactory) -> int:
+    """A trace with parent/child structure so root-span filtering is meaningful.
+
+    - ``s_root_llm_ok``: LLM, no parent (root), OK
+    - ``s_child_llm_err``: LLM, child of ``s_root_llm_ok``, ERROR
+    - ``s_root_tool_err``: TOOL, no parent (root), ERROR
+    - ``s_root_tool_err_2``: TOOL, no parent (root), ERROR (second root for pagination)
+    """
+    orig_time = datetime.fromisoformat("2021-01-01T00:00:00.000+00:00")
+    async with db() as session:
+        project_id = await session.scalar(
+            insert(models.Project).values(name="trace_hierarchy").returning(models.Project.id)
+        )
+        trace_rowid = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="trace_hierarchy",
+                project_rowid=project_id,
+                start_time=orig_time,
+                end_time=orig_time + timedelta(seconds=1),
+            )
+            .returning(models.Trace.id)
+        )
+        assert trace_rowid is not None
+
+        spans = [
+            # (span_id, parent_id, kind, status)
+            ("s_root_llm_ok", None, "LLM", "OK"),
+            ("s_child_llm_err", "s_root_llm_ok", "LLM", "ERROR"),
+            ("s_root_tool_err", None, "TOOL", "ERROR"),
+            ("s_root_tool_err_2", None, "TOOL", "ERROR"),
+        ]
+        for span_id, parent_id, kind, status in spans:
+            await session.execute(
+                insert(models.Span).values(
+                    trace_rowid=trace_rowid,
+                    span_id=span_id,
+                    parent_id=parent_id,
+                    name=span_id,
+                    span_kind=kind,
+                    start_time=orig_time,
+                    end_time=orig_time + timedelta(seconds=1),
+                    attributes={},
+                    events=[],
+                    status_code=status,
+                    status_message="",
+                    cumulative_error_count=0,
+                    cumulative_llm_token_count_prompt=0,
+                    cumulative_llm_token_count_completion=0,
+                    llm_token_count_prompt=None,
+                    llm_token_count_completion=None,
+                )
+            )
+        await session.commit()
+    return trace_rowid
+
+
+async def test_spans_filter_with_root_spans_only(
+    trace_with_hierarchy: int,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    """Filter must apply to the candidate set before root-span narrowing.
+
+    With ``span_kind == 'LLM'`` + ``rootSpansOnly: true`` we expect only
+    the LLM root span — the LLM child should be excluded by the root
+    narrowing, and the TOOL roots should be excluded by the kind filter.
+    """
+    trace_gid = str(GlobalID(Trace.__name__, str(trace_with_hierarchy)))
+    query = """
+        query ($traceId: ID!, $first: Int!, $filter: String) {
+            node(id: $traceId) {
+                ... on Trace {
+                    spans(first: $first, rootSpansOnly: true, filterCondition: $filter) {
+                        edges { node { name } }
+                    }
+                }
+            }
+        }
+    """
+    response = await gql_client.execute(
+        query=query,
+        variables={"traceId": trace_gid, "first": 10, "filter": "span_kind == 'LLM'"},
+    )
+    assert not response.errors
+    assert (data := response.data) is not None
+    names = {edge["node"]["name"] for edge in data["node"]["spans"]["edges"]}
+    assert names == {"s_root_llm_ok"}
+
+
+async def test_spans_filter_paginates(
+    trace_with_hierarchy: int,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    """Filter must compose with forward-cursor pagination.
+
+    Three errored spans exist in the trace. Asking for one at a time with an
+    ``after`` cursor must return all three across two pages without skipping
+    or duplicating.
+    """
+    trace_gid = str(GlobalID(Trace.__name__, str(trace_with_hierarchy)))
+    query = """
+        query ($traceId: ID!, $first: Int!, $after: String, $filter: String) {
+            node(id: $traceId) {
+                ... on Trace {
+                    spans(first: $first, after: $after, filterCondition: $filter) {
+                        edges { cursor node { name } }
+                        pageInfo { hasNextPage endCursor }
+                    }
+                }
+            }
+        }
+    """
+    seen: set[str] = set()
+    after: Optional[str] = None
+    # Two pages of 2 spans each is enough to exhaust three matches and observe
+    # `hasNextPage` flipping to false. Guard against infinite loops.
+    for _ in range(4):
+        response = await gql_client.execute(
+            query=query,
+            variables={
+                "traceId": trace_gid,
+                "first": 2,
+                "after": after,
+                "filter": "status_code == 'ERROR'",
+            },
+        )
+        assert not response.errors
+        assert (data := response.data) is not None
+        conn = data["node"]["spans"]
+        for edge in conn["edges"]:
+            name = edge["node"]["name"]
+            assert name not in seen, f"duplicate span across pages: {name}"
+            seen.add(name)
+        if not conn["pageInfo"]["hasNextPage"]:
+            break
+        after = conn["pageInfo"]["endCursor"]
+    assert seen == {"s_child_llm_err", "s_root_tool_err", "s_root_tool_err_2"}


### PR DESCRIPTION
## Summary
- Add `errorCount`, `errorsByType`, and `spanCountsByKind` aggregate fields to the `Trace` GraphQL type for per-trace span rollups.
- Introduce three new dataloaders (`trace_error_count`, `trace_errors_by_type`, `trace_span_counts_by_kind`) to batch aggregate queries by trace rowid and avoid N+1 loads.
- Wire the new dataloaders through `context.py` and `app.py` so they're available on the GraphQL request context.
- Extend the `Trace.spans` resolver with filter support consistent with the new aggregate fields.


Closes #12815, #12760