### PR TITLE
feat(datasets): backfill content_hash and make column non-nullable

### DIFF
--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -574,7 +574,7 @@ CREATE TABLE public.dataset_example_revisions (
     metadata JSONB NOT NULL,
     revision_kind VARCHAR NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-    content_hash BYTEA,
+    content_hash BYTEA NOT NULL,
     CONSTRAINT pk_dataset_example_revisions PRIMARY KEY (id),
     CONSTRAINT uq_dataset_example_revisions_dataset_example_id_dataset_bbf2
         UNIQUE (dataset_example_id, dataset_version_id),

--- a/src/phoenix/db/insertion/dataset.py
+++ b/src/phoenix/db/insertion/dataset.py
@@ -15,6 +15,11 @@ from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect, get_dataset_example_revisions
 from phoenix.db.insertion.helpers import DataManipulationEvent, OnConflict, insert_on_conflict
 from phoenix.server.api.types.node import from_global_id_with_expected_type
+from phoenix.utilities.content_hashing import compute_example_content_hash
+
+# Sentinel hash used for DELETE revisions, whose input/output/metadata are all empty dicts.
+# Content is unused for DELETEs (the matcher excludes them), but the column is NOT NULL.
+_EMPTY_CONTENT_HASH: bytes = compute_example_content_hash(input={}, output={}, metadata={})
 
 # Batch size for bulk inserts - tuned for good performance across SQLite and PostgreSQL
 DEFAULT_BATCH_SIZE = 1000
@@ -167,8 +172,8 @@ async def insert_dataset_example_revision(
     input: dict[str, Any],
     output: dict[str, Any],
     metadata: dict[str, Any],
+    content_hash: bytes,
     revision_kind: RevisionKind = RevisionKind.CREATE,
-    content_hash: Optional[bytes] = None,
     created_at: Optional[datetime] = None,
 ) -> DatasetExampleRevisionId:
     id_ = await session.scalar(
@@ -485,11 +490,9 @@ async def _get_external_ids_and_content_hashes_for_most_recent_version(
             revisions_subq.c.dataset_example_id,
             models.DatasetExample.external_id,
             revisions_subq.c.content_hash,
-        )
-        .join(
+        ).join(
             models.DatasetExample, models.DatasetExample.id == revisions_subq.c.dataset_example_id
         )
-        .where(revisions_subq.c.content_hash.isnot(None))
     )
 
     return [(row.dataset_example_id, row.external_id, row.content_hash) for row in result]
@@ -841,7 +844,7 @@ async def _upsert_dataset_examples(
                 output={},
                 metadata={},
                 revision_kind=RevisionKind.DELETE,
-                content_hash=None,
+                content_hash=_EMPTY_CONTENT_HASH,
                 created_at=created_at,
             )
 

--- a/src/phoenix/db/migrations/versions/575aa27302ee_dataset_upsert.py
+++ b/src/phoenix/db/migrations/versions/575aa27302ee_dataset_upsert.py
@@ -11,6 +11,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
+from phoenix.utilities.content_hashing import compute_example_content_hash
+
 # revision identifiers, used by Alembic.
 revision: str = "575aa27302ee"
 down_revision: Union[str, None] = "aba52fffe1a1"
@@ -29,6 +31,40 @@ def upgrade() -> None:
 
     with op.batch_alter_table("dataset_example_revisions") as batch_op:
         batch_op.add_column(sa.Column("content_hash", sa.LargeBinary(), nullable=True))
+
+    revisions = sa.Table(
+        "dataset_example_revisions",
+        sa.MetaData(),
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("input", sa.JSON),
+        sa.Column("output", sa.JSON),
+        sa.Column("metadata", sa.JSON),
+        sa.Column("content_hash", sa.LargeBinary),
+    )
+
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.select(revisions.c.id, revisions.c.input, revisions.c.output, revisions.c["metadata"])
+    ).fetchall()
+    updates = [
+        {
+            "row_id": row.id,
+            "content_hash": compute_example_content_hash(
+                input=row.input, output=row.output, metadata=row.metadata
+            ),
+        }
+        for row in rows
+    ]
+    if updates:
+        bind.execute(
+            revisions.update()
+            .where(revisions.c.id == sa.bindparam("row_id"))
+            .values(content_hash=sa.bindparam("content_hash")),
+            updates,
+        )
+
+    with op.batch_alter_table("dataset_example_revisions") as batch_op:
+        batch_op.alter_column("content_hash", existing_type=sa.LargeBinary(), nullable=False)
         batch_op.create_index("ix_dataset_example_revisions_content_hash", ["content_hash"])
 
 

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -1423,7 +1423,7 @@ class DatasetExampleRevision(HasId):
     input: Mapped[dict[str, Any]]
     output: Mapped[dict[str, Any]]
     metadata_: Mapped[dict[str, Any]] = mapped_column("metadata")
-    content_hash: Mapped[Optional[bytes]] = mapped_column(LargeBinary, nullable=True, index=True)
+    content_hash: Mapped[bytes] = mapped_column(LargeBinary, index=True)
     revision_kind: Mapped[str] = mapped_column(
         CheckConstraint(
             "revision_kind IN ('CREATE', 'PATCH', 'DELETE')", name="valid_revision_kind"

--- a/src/phoenix/server/api/mutations/dataset_mutations.py
+++ b/src/phoenix/server/api/mutations/dataset_mutations.py
@@ -43,6 +43,7 @@ from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.Span import Span
 from phoenix.server.api.utils import delete_projects, delete_traces
 from phoenix.server.dml_event import DatasetDeleteEvent, DatasetInsertEvent
+from phoenix.utilities.content_hashing import compute_example_content_hash
 
 _MAX_REPORTED_EXTERNAL_ID_CONFLICTS = 10
 
@@ -201,29 +202,30 @@ class DatasetMutationMixin:
                 k: v for k, v in all_span_attributes.items() if not k.startswith("_")
             }
 
-            await session.execute(
-                insert(DatasetExampleRevision),
-                [
+            span_revisions: list[dict[str, Any]] = []
+            for dataset_example_rowid, span in zip(dataset_example_rowids, spans):
+                span_input = get_dataset_example_input(span)
+                span_output = get_dataset_example_output(span)
+                span_metadata = {
+                    **(span.attributes.get(SpanAttributes.METADATA) or dict()),
+                    **{k: v for k, v in span.attributes.items() if k in nonprivate_span_attributes},
+                    "span_kind": span.span_kind,
+                    "annotations": _gather_span_annotations_by_name(span.span_annotations),
+                }
+                span_revisions.append(
                     {
                         DatasetExampleRevision.dataset_example_id.key: dataset_example_rowid,
                         DatasetExampleRevision.dataset_version_id.key: dataset_version.id,
-                        DatasetExampleRevision.input.key: get_dataset_example_input(span),
-                        DatasetExampleRevision.output.key: get_dataset_example_output(span),
-                        DatasetExampleRevision.metadata_.key: {
-                            **(span.attributes.get(SpanAttributes.METADATA) or dict()),
-                            **{
-                                k: v
-                                for k, v in span.attributes.items()
-                                if k in nonprivate_span_attributes
-                            },
-                            "span_kind": span.span_kind,
-                            "annotations": _gather_span_annotations_by_name(span.span_annotations),
-                        },
+                        DatasetExampleRevision.input.key: span_input,
+                        DatasetExampleRevision.output.key: span_output,
+                        DatasetExampleRevision.metadata_.key: span_metadata,
+                        DatasetExampleRevision.content_hash.key: compute_example_content_hash(
+                            input=span_input, output=span_output, metadata=span_metadata
+                        ),
                         DatasetExampleRevision.revision_kind.key: "CREATE",
                     }
-                    for dataset_example_rowid, span in zip(dataset_example_rowids, spans)
-                ],
-            )
+                )
+            await session.execute(insert(DatasetExampleRevision), span_revisions)
         info.context.event_queue.put(DatasetInsertEvent((dataset.id,)))
         return DatasetMutationPayload(dataset=Dataset(id=dataset.id, db_record=dataset))
 
@@ -371,16 +373,24 @@ class DatasetMutationMixin:
                         expected_type_name=Span.__name__,
                     )
                     span_annotation = span_annotations_by_span.get(span_id, {})
+                example_input = cast(dict[str, Any], example.input)
+                example_output = cast(dict[str, Any], example.output)
+                example_metadata = {
+                    **cast(dict[str, Any], example.metadata or {}),
+                    "annotations": span_annotation,
+                }
                 dataset_example_revisions.append(
                     {
                         DatasetExampleRevision.dataset_example_id.key: dataset_example_rowid,
                         DatasetExampleRevision.dataset_version_id.key: dataset_version_rowid,
-                        DatasetExampleRevision.input.key: example.input,
-                        DatasetExampleRevision.output.key: example.output,
-                        DatasetExampleRevision.metadata_.key: {
-                            **cast(dict[str, Any], example.metadata or {}),
-                            "annotations": span_annotation,
-                        },
+                        DatasetExampleRevision.input.key: example_input,
+                        DatasetExampleRevision.output.key: example_output,
+                        DatasetExampleRevision.metadata_.key: example_metadata,
+                        DatasetExampleRevision.content_hash.key: compute_example_content_hash(
+                            input=example_input,
+                            output=example_output,
+                            metadata=example_metadata,
+                        ),
                         DatasetExampleRevision.revision_kind.key: "CREATE",
                     }
                 )
@@ -581,6 +591,7 @@ class DatasetMutationMixin:
                 )
 
             DatasetExampleRevision = models.DatasetExampleRevision
+            empty_content_hash = compute_example_content_hash(input={}, output={}, metadata={})
             await session.execute(
                 insert(DatasetExampleRevision),
                 [
@@ -590,6 +601,7 @@ class DatasetMutationMixin:
                         DatasetExampleRevision.input.key: {},
                         DatasetExampleRevision.output.key: {},
                         DatasetExampleRevision.metadata_.key: {},
+                        DatasetExampleRevision.content_hash.key: empty_content_hash,
                         DatasetExampleRevision.revision_kind.key: "DELETE",
                         DatasetExampleRevision.created_at.key: timestamp,
                     }
@@ -638,6 +650,10 @@ def _to_orm_revision(
             (db_rev.input, input),
             (db_rev.output, output),
             (db_rev.metadata_, metadata),
+            (
+                db_rev.content_hash,
+                compute_example_content_hash(input=input, output=output, metadata=metadata),
+            ),
             (db_rev.revision_kind, "PATCH"),
         )
     }

--- a/tests/integration/db_migrations/test_data_migration_575aa27302ee_dataset_upsert.py
+++ b/tests/integration/db_migrations/test_data_migration_575aa27302ee_dataset_upsert.py
@@ -1,0 +1,235 @@
+"""
+Test for the dataset_upsert migration's content_hash backfill.
+
+Verifies that migration 575aa27302ee:
+1. Backfills content_hash for existing dataset_example_revisions rows.
+2. Makes the content_hash column NOT NULL after backfill.
+3. Creates the content_hash index.
+4. Produces hashes that match compute_example_content_hash applied to the
+   row's stored (input, output, metadata), including for DELETE revisions
+   whose content fields are empty dicts.
+"""
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import Connection, text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from phoenix.utilities.content_hashing import compute_example_content_hash
+
+from . import _down, _get_table_schema_info, _run_async, _up, _version_num
+
+_PRE_REVISION = "aba52fffe1a1"
+_TARGET_REVISION = "575aa27302ee"
+
+
+async def test_content_hash_backfill_migration(
+    _engine: AsyncEngine,
+    _alembic_config: Config,
+    _db_backend: Literal["sqlite", "postgresql"],
+    _schema: str,
+) -> None:
+    with pytest.raises(BaseException, match="alembic_version"):
+        await _version_num(_engine, _schema)
+
+    await _up(_engine, _alembic_config, _PRE_REVISION, _schema)
+
+    seeded = await _seed_revisions(_engine)
+
+    await _verify_pre_migration_schema(_engine, _db_backend, _schema)
+
+    await _up(_engine, _alembic_config, _TARGET_REVISION, _schema)
+
+    await _verify_post_migration_schema(_engine, _db_backend, _schema)
+    await _verify_backfill(_engine, seeded)
+
+    await _down(_engine, _alembic_config, _PRE_REVISION, _schema)
+    await _verify_downgrade_schema(_engine, _db_backend, _schema)
+
+
+_REVISIONS: list[dict[str, Any]] = [
+    {
+        "tag": "create_rich",
+        "kind": "CREATE",
+        "input": {"question": "what is 2+2?", "ctx": {"lang": "en", "turns": [1, 2]}},
+        "output": {"answer": "4", "score": 0.99},
+        "metadata": {"source": "unit-test", "tags": ["math", "easy"]},
+    },
+    {
+        "tag": "patch_rich",
+        "kind": "PATCH",
+        "input": {"question": "what is 2+2?", "ctx": {"lang": "en", "turns": [1, 2, 3]}},
+        "output": {"answer": "four", "score": 0.95},
+        "metadata": {"source": "unit-test", "tags": ["math"]},
+    },
+    {
+        "tag": "delete_empty",
+        "kind": "DELETE",
+        "input": {},
+        "output": {},
+        "metadata": {},
+    },
+    {
+        "tag": "dup_a",
+        "kind": "CREATE",
+        "input": {"q": "same"},
+        "output": {"a": "same"},
+        "metadata": {"k": "v"},
+    },
+    {
+        "tag": "dup_b",
+        "kind": "CREATE",
+        "input": {"q": "same"},
+        "output": {"a": "same"},
+        "metadata": {"k": "v"},
+    },
+]
+
+
+async def _seed_revisions(engine: AsyncEngine) -> dict[str, int]:
+    """Insert a dataset, versions, examples, and revisions. Return a map from tag to revision id."""
+    now = datetime.now(timezone.utc)
+
+    def _do(conn: Connection) -> dict[str, int]:
+        dataset_id = conn.execute(
+            text(
+                "INSERT INTO datasets (name, description, metadata, created_at, updated_at)"
+                " VALUES ('ds_backfill', 'backfill test', '{}', :now, :now) RETURNING id"
+            ),
+            {"now": now},
+        ).scalar()
+
+        # One version per revision so the unique (example_id, version_id) constraint is satisfied.
+        version_ids = [
+            conn.execute(
+                text(
+                    "INSERT INTO dataset_versions (dataset_id, description, metadata, created_at)"
+                    " VALUES (:dataset_id, :desc, '{}', :now) RETURNING id"
+                ),
+                {"dataset_id": dataset_id, "desc": f"v{i}", "now": now},
+            ).scalar()
+            for i in range(len(_REVISIONS))
+        ]
+
+        # One example per revision keeps setup straightforward.
+        example_ids = [
+            conn.execute(
+                text(
+                    "INSERT INTO dataset_examples (dataset_id, created_at)"
+                    " VALUES (:dataset_id, :now) RETURNING id"
+                ),
+                {"dataset_id": dataset_id, "now": now},
+            ).scalar()
+            for _ in _REVISIONS
+        ]
+
+        tag_to_revision_id: dict[str, int] = {}
+        for rev, example_id, version_id in zip(_REVISIONS, example_ids, version_ids):
+            revision_id = conn.execute(
+                text(
+                    "INSERT INTO dataset_example_revisions"
+                    " (dataset_example_id, dataset_version_id, input, output, metadata,"
+                    "  revision_kind, created_at)"
+                    " VALUES (:example_id, :version_id, :input, :output, :metadata,"
+                    "  :kind, :now) RETURNING id"
+                ),
+                {
+                    "example_id": example_id,
+                    "version_id": version_id,
+                    "input": json.dumps(rev["input"]),
+                    "output": json.dumps(rev["output"]),
+                    "metadata": json.dumps(rev["metadata"]),
+                    "kind": rev["kind"],
+                    "now": now,
+                },
+            ).scalar()
+            assert revision_id is not None
+            tag_to_revision_id[rev["tag"]] = revision_id
+
+        conn.commit()
+        return tag_to_revision_id
+
+    return await _run_async(engine, _do)
+
+
+async def _verify_pre_migration_schema(
+    engine: AsyncEngine,
+    db_backend: Literal["sqlite", "postgresql"],
+    schema: str,
+) -> None:
+    def _do(conn: Connection) -> None:
+        info = _get_table_schema_info(conn, "dataset_example_revisions", db_backend, schema)
+        assert info is not None
+        assert "content_hash" not in info["column_names"], (
+            "content_hash should not exist before migration"
+        )
+
+    await _run_async(engine, _do)
+
+
+async def _verify_post_migration_schema(
+    engine: AsyncEngine,
+    db_backend: Literal["sqlite", "postgresql"],
+    schema: str,
+) -> None:
+    def _do(conn: Connection) -> None:
+        info = _get_table_schema_info(conn, "dataset_example_revisions", db_backend, schema)
+        assert info is not None
+        assert "content_hash" in info["column_names"]
+        assert "content_hash" not in info["nullable_column_names"], (
+            "content_hash should be NOT NULL after backfill"
+        )
+        assert "ix_dataset_example_revisions_content_hash" in info["index_names"]
+
+    await _run_async(engine, _do)
+
+
+async def _verify_backfill(engine: AsyncEngine, seeded: dict[str, int]) -> None:
+    def _do(conn: Connection) -> None:
+        for rev in _REVISIONS:
+            revision_id = seeded[rev["tag"]]
+            content_hash = conn.execute(
+                text("SELECT content_hash FROM dataset_example_revisions WHERE id = :id"),
+                {"id": revision_id},
+            ).scalar()
+            assert content_hash is not None, f"{rev['tag']} has NULL content_hash after backfill"
+            expected = compute_example_content_hash(
+                input=rev["input"], output=rev["output"], metadata=rev["metadata"]
+            )
+            assert bytes(content_hash) == expected, (
+                f"{rev['tag']} hash mismatch: got {bytes(content_hash)!r}, expected {expected!r}"
+            )
+
+        # Two revisions with identical content must produce identical hashes.
+        dup_a = conn.execute(
+            text("SELECT content_hash FROM dataset_example_revisions WHERE id = :id"),
+            {"id": seeded["dup_a"]},
+        ).scalar()
+        dup_b = conn.execute(
+            text("SELECT content_hash FROM dataset_example_revisions WHERE id = :id"),
+            {"id": seeded["dup_b"]},
+        ).scalar()
+        assert dup_a is not None and dup_b is not None
+        assert bytes(dup_a) == bytes(dup_b), "identical content must hash identically"
+
+    await _run_async(engine, _do)
+
+
+async def _verify_downgrade_schema(
+    engine: AsyncEngine,
+    db_backend: Literal["sqlite", "postgresql"],
+    schema: str,
+) -> None:
+    def _do(conn: Connection) -> None:
+        info = _get_table_schema_info(conn, "dataset_example_revisions", db_backend, schema)
+        assert info is not None
+        assert "content_hash" not in info["column_names"], (
+            "content_hash should be dropped after downgrade"
+        )
+        assert "ix_dataset_example_revisions_content_hash" not in info["index_names"]
+
+    await _run_async(engine, _do)

--- a/tests/unit/datasets/conftest.py
+++ b/tests/unit/datasets/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from phoenix.db import models
 from phoenix.db.models import ExperimentRunOutput
 from phoenix.server.types import DbSessionFactory
+from phoenix.utilities.content_hashing import compute_example_content_hash
 
 
 @pytest.fixture
@@ -48,6 +49,11 @@ async def simple_dataset(
             input={"in": "foo"},
             output={"out": "bar"},
             metadata_={"info": "the first reivision"},
+            content_hash=compute_example_content_hash(
+                input={"in": "foo"},
+                output={"out": "bar"},
+                metadata={"info": "the first reivision"},
+            ),
             revision_kind="CREATE",
         )
         session.add(example_0_revision_0)

--- a/tests/unit/db/test_helpers.py
+++ b/tests/unit/db/test_helpers.py
@@ -20,6 +20,7 @@ from phoenix.db.helpers import (
     get_dataset_example_revisions,
 )
 from phoenix.server.types import DbSessionFactory
+from phoenix.utilities.content_hashing import compute_example_content_hash
 
 fake = Faker()
 
@@ -509,6 +510,11 @@ class TestGetDatasetExampleRevisions:
                 input={"test": "basic1_v1"},
                 output={"result": "basic1_v1"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "basic1_v1"},
+                    output={"result": "basic1_v1"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
             basic1_v2_revision = models.DatasetExampleRevision(
@@ -517,6 +523,11 @@ class TestGetDatasetExampleRevisions:
                 input={"test": "basic1_v2"},
                 output={"result": "basic1_v2"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "basic1_v2"},
+                    output={"result": "basic1_v2"},
+                    metadata={},
+                ),
                 revision_kind="PATCH",
             )
             basic1_v3_revision = models.DatasetExampleRevision(
@@ -525,6 +536,11 @@ class TestGetDatasetExampleRevisions:
                 input={"test": "basic1_v3"},
                 output={"result": "basic1_v3"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "basic1_v3"},
+                    output={"result": "basic1_v3"},
+                    metadata={},
+                ),
                 revision_kind="PATCH",
             )
 
@@ -535,6 +551,11 @@ class TestGetDatasetExampleRevisions:
                 input={"test": "basic2_create"},
                 output={"result": "basic2_create"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "basic2_create"},
+                    output={"result": "basic2_create"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
             basic2_delete_revision = models.DatasetExampleRevision(
@@ -543,6 +564,11 @@ class TestGetDatasetExampleRevisions:
                 input={"test": "basic2_deleted"},
                 output={"result": "basic2_deleted"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "basic2_deleted"},
+                    output={"result": "basic2_deleted"},
+                    metadata={},
+                ),
                 revision_kind="DELETE",
             )
 
@@ -553,6 +579,11 @@ class TestGetDatasetExampleRevisions:
                 input={"test": "basic3_late"},
                 output={"result": "basic3_late"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "basic3_late"},
+                    output={"result": "basic3_late"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
 
@@ -563,6 +594,11 @@ class TestGetDatasetExampleRevisions:
                 input={"split": "example1_train"},
                 output={"result": "split1"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"split": "example1_train"},
+                    output={"result": "split1"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
             split2_revision = models.DatasetExampleRevision(
@@ -571,6 +607,11 @@ class TestGetDatasetExampleRevisions:
                 input={"split": "example2_train_val"},
                 output={"result": "split2"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"split": "example2_train_val"},
+                    output={"result": "split2"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
             # Delete split_example2 in version 2 to test DELETE handling with splits
@@ -580,6 +621,11 @@ class TestGetDatasetExampleRevisions:
                 input={},
                 output={},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={},
+                    output={},
+                    metadata={},
+                ),
                 revision_kind="DELETE",
             )
             split3_revision = models.DatasetExampleRevision(
@@ -588,6 +634,11 @@ class TestGetDatasetExampleRevisions:
                 input={"split": "example3_val_test_extra"},
                 output={"result": "split3"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"split": "example3_val_test_extra"},
+                    output={"result": "split3"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
             split4_revision = models.DatasetExampleRevision(
@@ -596,6 +647,11 @@ class TestGetDatasetExampleRevisions:
                 input={"split": "example4_all_splits"},
                 output={"result": "split4_max_overlap"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"split": "example4_all_splits"},
+                    output={"result": "split4_max_overlap"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
             split5_revision = models.DatasetExampleRevision(
@@ -604,6 +660,11 @@ class TestGetDatasetExampleRevisions:
                 input={"split": "example5_no_splits"},
                 output={"result": "split5_control"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"split": "example5_no_splits"},
+                    output={"result": "split5_control"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
 
@@ -614,6 +675,11 @@ class TestGetDatasetExampleRevisions:
                 input={"test": "isolated"},
                 output={"result": "isolated"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "isolated"},
+                    output={"result": "isolated"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
 
@@ -1137,6 +1203,11 @@ class TestCreateExperimentExamplesSnapshotInsert:
                 input={"test": "example1_v1"},
                 output={"result": "example1_v1"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "example1_v1"},
+                    output={"result": "example1_v1"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
             # Example 1: PATCH in version 2
@@ -1146,6 +1217,11 @@ class TestCreateExperimentExamplesSnapshotInsert:
                 input={"test": "example1_v2"},
                 output={"result": "example1_v2"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "example1_v2"},
+                    output={"result": "example1_v2"},
+                    metadata={},
+                ),
                 revision_kind="PATCH",
             )
             # Example 2: CREATE in version 1
@@ -1155,6 +1231,11 @@ class TestCreateExperimentExamplesSnapshotInsert:
                 input={"test": "example2_v1"},
                 output={"result": "example2_v1"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "example2_v1"},
+                    output={"result": "example2_v1"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
             # Example 2: DELETE in version 2
@@ -1164,6 +1245,11 @@ class TestCreateExperimentExamplesSnapshotInsert:
                 input={"test": "deleted"},
                 output={"result": "deleted"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "deleted"},
+                    output={"result": "deleted"},
+                    metadata={},
+                ),
                 revision_kind="DELETE",
             )
             # Example 3: CREATE in version 2
@@ -1173,6 +1259,11 @@ class TestCreateExperimentExamplesSnapshotInsert:
                 input={"test": "example3_v2"},
                 output={"result": "example3_v2"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "example3_v2"},
+                    output={"result": "example3_v2"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
 
@@ -1183,6 +1274,11 @@ class TestCreateExperimentExamplesSnapshotInsert:
                 input={"test": "delete_example1"},
                 output={"result": "delete_example1"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "delete_example1"},
+                    output={"result": "delete_example1"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
             delete2_create_revision = models.DatasetExampleRevision(
@@ -1191,6 +1287,11 @@ class TestCreateExperimentExamplesSnapshotInsert:
                 input={"test": "delete_example2"},
                 output={"result": "delete_example2"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "delete_example2"},
+                    output={"result": "delete_example2"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
             delete3_create_revision = models.DatasetExampleRevision(
@@ -1199,6 +1300,11 @@ class TestCreateExperimentExamplesSnapshotInsert:
                 input={"test": "delete_example3"},
                 output={"result": "delete_example3"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"test": "delete_example3"},
+                    output={"result": "delete_example3"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
 
@@ -1209,6 +1315,11 @@ class TestCreateExperimentExamplesSnapshotInsert:
                 input={},
                 output={},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={},
+                    output={},
+                    metadata={},
+                ),
                 revision_kind="DELETE",
             )
             delete2_delete_revision = models.DatasetExampleRevision(
@@ -1217,6 +1328,11 @@ class TestCreateExperimentExamplesSnapshotInsert:
                 input={},
                 output={},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={},
+                    output={},
+                    metadata={},
+                ),
                 revision_kind="DELETE",
             )
             delete3_delete_revision = models.DatasetExampleRevision(
@@ -1225,6 +1341,11 @@ class TestCreateExperimentExamplesSnapshotInsert:
                 input={},
                 output={},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={},
+                    output={},
+                    metadata={},
+                ),
                 revision_kind="DELETE",
             )
 

--- a/tests/unit/server/api/conftest.py
+++ b/tests/unit/server/api/conftest.py
@@ -27,6 +27,7 @@ from phoenix.db.types.prompts import (
     PromptTools,
 )
 from phoenix.server.types import DbSessionFactory
+from phoenix.utilities.content_hashing import compute_example_content_hash
 
 
 @pytest.fixture
@@ -115,6 +116,11 @@ async def simple_dataset(db: DbSessionFactory) -> None:
             input={"in": "foo"},
             output={"out": "bar"},
             metadata_={"info": "the first reivision"},
+            content_hash=compute_example_content_hash(
+                input={"in": "foo"},
+                output={"out": "bar"},
+                metadata={"info": "the first reivision"},
+            ),
             revision_kind="CREATE",
         )
         session.add(example_0_revision_0)
@@ -166,6 +172,11 @@ async def empty_dataset(db: DbSessionFactory) -> None:
             input={"in": "foo"},
             output={"out": "bar"},
             metadata_={"info": "first revision"},
+            content_hash=compute_example_content_hash(
+                input={"in": "foo"},
+                output={"out": "bar"},
+                metadata={"info": "first revision"},
+            ),
             revision_kind="CREATE",
         )
         session.add(example_1_revision_1)
@@ -178,6 +189,11 @@ async def empty_dataset(db: DbSessionFactory) -> None:
             input={"in": "foofoo"},
             output={"out": "barbar"},
             metadata_={"info": "first revision"},
+            content_hash=compute_example_content_hash(
+                input={"in": "foofoo"},
+                output={"out": "barbar"},
+                metadata={"info": "first revision"},
+            ),
             revision_kind="CREATE",
         )
         session.add(example_2_revision_1)
@@ -199,6 +215,11 @@ async def empty_dataset(db: DbSessionFactory) -> None:
             input={"in": "FOO"},
             output={"out": "BAR"},
             metadata_={"info": "all caps revision"},
+            content_hash=compute_example_content_hash(
+                input={"in": "FOO"},
+                output={"out": "BAR"},
+                metadata={"info": "all caps revision"},
+            ),
             revision_kind="PATCH",
         )
         session.add(example_1_revision_2)
@@ -211,6 +232,11 @@ async def empty_dataset(db: DbSessionFactory) -> None:
             input={"in": "FOOFOO"},
             output={"out": "BARBAR"},
             metadata_={"info": "all caps revision"},
+            content_hash=compute_example_content_hash(
+                input={"in": "FOOFOO"},
+                output={"out": "BARBAR"},
+                metadata={"info": "all caps revision"},
+            ),
             revision_kind="PATCH",
         )
         session.add(example_2_revision_2)
@@ -232,6 +258,11 @@ async def empty_dataset(db: DbSessionFactory) -> None:
             input={},
             output={},
             metadata_={"info": "all caps revision"},
+            content_hash=compute_example_content_hash(
+                input={},
+                output={},
+                metadata={"info": "all caps revision"},
+            ),
             revision_kind="DELETE",
         )
         session.add(example_1_revision_3)
@@ -244,6 +275,11 @@ async def empty_dataset(db: DbSessionFactory) -> None:
             input={},
             output={},
             metadata_={"info": "all caps revision"},
+            content_hash=compute_example_content_hash(
+                input={},
+                output={},
+                metadata={"info": "all caps revision"},
+            ),
             revision_kind="DELETE",
         )
         session.add(example_2_revision_3)
@@ -299,6 +335,11 @@ async def dataset_with_revisions(db: DbSessionFactory) -> None:
             input={"in": "foo"},
             output={"out": "bar"},
             metadata_={"info": "first revision"},
+            content_hash=compute_example_content_hash(
+                input={"in": "foo"},
+                output={"out": "bar"},
+                metadata={"info": "first revision"},
+            ),
             revision_kind="CREATE",
         )
         session.add(example_3_revision_4)
@@ -311,6 +352,11 @@ async def dataset_with_revisions(db: DbSessionFactory) -> None:
             input={"in": "foofoo"},
             output={"out": "barbar"},
             metadata_={"info": "first revision"},
+            content_hash=compute_example_content_hash(
+                input={"in": "foofoo"},
+                output={"out": "barbar"},
+                metadata={"info": "first revision"},
+            ),
             revision_kind="CREATE",
         )
         session.add(example_4_revision_4)
@@ -394,6 +440,11 @@ async def dataset_with_revisions(db: DbSessionFactory) -> None:
             input={"in": "updated foofoo"},
             output={"out": "updated barbar"},
             metadata_={"info": "updating revision"},
+            content_hash=compute_example_content_hash(
+                input={"in": "updated foofoo"},
+                output={"out": "updated barbar"},
+                metadata={"info": "updating revision"},
+            ),
             revision_kind="PATCH",
         )
         session.add(example_4_revision_5)
@@ -406,6 +457,11 @@ async def dataset_with_revisions(db: DbSessionFactory) -> None:
             input={"in": "look at me"},
             output={"out": "i have all the answers"},
             metadata_={"info": "a new example"},
+            content_hash=compute_example_content_hash(
+                input={"in": "look at me"},
+                output={"out": "i have all the answers"},
+                metadata={"info": "a new example"},
+            ),
             revision_kind="CREATE",
         )
         session.add(example_5_revision_5)
@@ -418,6 +474,11 @@ async def dataset_with_revisions(db: DbSessionFactory) -> None:
             input={"in": "look at us"},
             output={"out": "we have all the answers"},
             metadata_={"info": "a new example"},
+            content_hash=compute_example_content_hash(
+                input={"in": "look at us"},
+                output={"out": "we have all the answers"},
+                metadata={"info": "a new example"},
+            ),
             revision_kind="CREATE",
         )
         session.add(example_6_revision_6)
@@ -430,6 +491,11 @@ async def dataset_with_revisions(db: DbSessionFactory) -> None:
             input={"in": "look at us"},
             output={"out": "we have all the answers"},
             metadata_={"info": "a new example"},
+            content_hash=compute_example_content_hash(
+                input={"in": "look at us"},
+                output={"out": "we have all the answers"},
+                metadata={"info": "a new example"},
+            ),
             revision_kind="DELETE",
         )
         session.add(example_6_revision_7)
@@ -442,6 +508,11 @@ async def dataset_with_revisions(db: DbSessionFactory) -> None:
             input={"in": "look at me"},
             output={"out": "i have all the answers"},
             metadata_={"info": "a newer example"},
+            content_hash=compute_example_content_hash(
+                input={"in": "look at me"},
+                output={"out": "i have all the answers"},
+                metadata={"info": "a newer example"},
+            ),
             revision_kind="CREATE",
         )
         session.add(example_7_revision_8)
@@ -454,6 +525,11 @@ async def dataset_with_revisions(db: DbSessionFactory) -> None:
             input={"in": "look at me"},
             output={"out": "i have all the answers"},
             metadata_={"info": "a newer example"},
+            content_hash=compute_example_content_hash(
+                input={"in": "look at me"},
+                output={"out": "i have all the answers"},
+                metadata={"info": "a newer example"},
+            ),
             revision_kind="DELETE",
         )
         session.add(example_7_revision_9)
@@ -659,6 +735,20 @@ async def dataset_with_messages(
                         ]
                     },
                     "metadata_": {},
+                    "content_hash": compute_example_content_hash(
+                        input={
+                            "messages": [
+                                {"role": "system", "content": "x"},
+                                {"role": "user", "content": "y"},
+                            ]
+                        },
+                        output={
+                            "messages": [
+                                {"role": "assistant", "content": "z"},
+                            ]
+                        },
+                        metadata={},
+                    ),
                 },
                 {
                     "revision_kind": "CREATE",
@@ -676,6 +766,20 @@ async def dataset_with_messages(
                         ]
                     },
                     "metadata_": {},
+                    "content_hash": compute_example_content_hash(
+                        input={
+                            "messages": [
+                                {"role": "system", "content": "xx"},
+                                {"role": "user", "content": "yy"},
+                            ]
+                        },
+                        output={
+                            "messages": [
+                                {"role": "assistant", "content": "zz"},
+                            ]
+                        },
+                        metadata={},
+                    ),
                 },
             ],
         )
@@ -721,6 +825,11 @@ async def dataset_with_splits(
                     "input": {"question": "hello"},
                     "output": {"answer": "world"},
                     "metadata_": {"source": "test"},
+                    "content_hash": compute_example_content_hash(
+                        input={"question": "hello"},
+                        output={"answer": "world"},
+                        metadata={"source": "test"},
+                    ),
                 },
                 {
                     "revision_kind": "CREATE",
@@ -729,6 +838,11 @@ async def dataset_with_splits(
                     "input": {"question": "foo"},
                     "output": {"answer": "bar"},
                     "metadata_": {},
+                    "content_hash": compute_example_content_hash(
+                        input={"question": "foo"},
+                        output={"answer": "bar"},
+                        metadata={},
+                    ),
                 },
                 {
                     "revision_kind": "CREATE",
@@ -737,6 +851,11 @@ async def dataset_with_splits(
                     "input": {"question": "baz"},
                     "output": {"answer": "qux"},
                     "metadata_": {"note": "no splits"},
+                    "content_hash": compute_example_content_hash(
+                        input={"question": "baz"},
+                        output={"answer": "qux"},
+                        metadata={"note": "no splits"},
+                    ),
                 },
             ],
         )
@@ -809,6 +928,11 @@ async def playground_dataset_with_patch_revision(db: DbSessionFactory) -> None:
             input={"city": "Paris"},
             output={},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"city": "Paris"},
+                output={},
+                metadata={},
+            ),
             revision_kind="CREATE",
         ),
         models.DatasetExampleRevision(
@@ -817,6 +941,11 @@ async def playground_dataset_with_patch_revision(db: DbSessionFactory) -> None:
             input={"city": "Tokyo"},
             output={},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"city": "Tokyo"},
+                output={},
+                metadata={},
+            ),
             revision_kind="CREATE",
         ),
         models.DatasetExampleRevision(
@@ -825,6 +954,11 @@ async def playground_dataset_with_patch_revision(db: DbSessionFactory) -> None:
             input={"city": "Cairo"},
             output={},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"city": "Cairo"},
+                output={},
+                metadata={},
+            ),
             revision_kind="CREATE",
         ),
         models.DatasetExampleRevision(
@@ -833,6 +967,11 @@ async def playground_dataset_with_patch_revision(db: DbSessionFactory) -> None:
             input={"cities": "Madrid"},
             output={},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"cities": "Madrid"},
+                output={},
+                metadata={},
+            ),
             revision_kind="PATCH",
         ),
     ]
@@ -890,6 +1029,11 @@ async def playground_city_and_country_dataset(
             input={"city": city},
             output={"country": country},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"city": city},
+                output={"country": country},
+                metadata={},
+            ),
             revision_kind="CREATE",
         )
         for example, (city, country) in zip(examples, cities_and_countries)
@@ -1109,6 +1253,11 @@ async def single_example_dataset(db: DbSessionFactory) -> models.Dataset:
             input={"city": "Paris"},
             output={"country": "France"},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"city": "Paris"},
+                output={"country": "France"},
+                metadata={},
+            ),
             revision_kind="CREATE",
         )
         session.add(revision)
@@ -1157,6 +1306,11 @@ async def playground_dataset_with_splits(db: DbSessionFactory) -> None:
             input={"city": city},
             output={},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"city": city},
+                output={},
+                metadata={},
+            ),
             revision_kind="CREATE",
         )
         for example, city in zip(examples, cities)
@@ -1294,6 +1448,11 @@ async def experiments_with_incomplete_runs(db: DbSessionFactory) -> ExperimentsW
                 input={"query": f"ex{i}-v1"},
                 output={"response": f"expected-{i}-v1"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"query": f"ex{i}-v1"},
+                    output={"response": f"expected-{i}-v1"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
             session.add(revision)
@@ -1330,6 +1489,11 @@ async def experiments_with_incomplete_runs(db: DbSessionFactory) -> ExperimentsW
             input={"query": "ex0-v1"},  # same as v1
             output={"response": "expected-0-v1"},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"query": "ex0-v1"},
+                output={"response": "expected-0-v1"},
+                metadata={},
+            ),
             revision_kind="CREATE",
         )
         session.add(rev)
@@ -1344,6 +1508,11 @@ async def experiments_with_incomplete_runs(db: DbSessionFactory) -> ExperimentsW
             input={"query": "ex1-v1"},
             output={"response": "expected-1-v1"},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"query": "ex1-v1"},
+                output={"response": "expected-1-v1"},
+                metadata={},
+            ),
             revision_kind="CREATE",
         )
         session.add(rev)
@@ -1358,6 +1527,11 @@ async def experiments_with_incomplete_runs(db: DbSessionFactory) -> ExperimentsW
             input={},
             output={},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={},
+                output={},
+                metadata={},
+            ),
             revision_kind="DELETE",
         )
         session.add(rev_deleted)
@@ -1371,6 +1545,11 @@ async def experiments_with_incomplete_runs(db: DbSessionFactory) -> ExperimentsW
             input={"query": "ex3-v2-patched"},  # changed
             output={"response": "expected-3-v2-patched"},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"query": "ex3-v2-patched"},
+                output={"response": "expected-3-v2-patched"},
+                metadata={},
+            ),
             revision_kind="PATCH",
         )
         session.add(rev)
@@ -1385,6 +1564,11 @@ async def experiments_with_incomplete_runs(db: DbSessionFactory) -> ExperimentsW
             input={"query": "ex4-v1"},
             output={"response": "expected-4-v1"},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"query": "ex4-v1"},
+                output={"response": "expected-4-v1"},
+                metadata={},
+            ),
             revision_kind="CREATE",
         )
         session.add(rev)
@@ -1399,6 +1583,11 @@ async def experiments_with_incomplete_runs(db: DbSessionFactory) -> ExperimentsW
             input={"query": "ex5-v2-new"},
             output={"response": "expected-5-v2-new"},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"query": "ex5-v2-new"},
+                output={"response": "expected-5-v2-new"},
+                metadata={},
+            ),
             revision_kind="CREATE",
         )
         session.add(rev_new)

--- a/tests/unit/server/api/mutations/test_dataset_mutations.py
+++ b/tests/unit/server/api/mutations/test_dataset_mutations.py
@@ -10,6 +10,7 @@ from phoenix.config import DEFAULT_PROJECT_NAME
 from phoenix.db import models
 from phoenix.server.api.types.DatasetExample import DatasetExample
 from phoenix.server.types import DbSessionFactory
+from phoenix.utilities.content_hashing import compute_example_content_hash
 from tests.unit.graphql import AsyncGraphQLClient
 
 
@@ -797,6 +798,11 @@ async def dataset_with_a_single_version(
                 input={"input": "first-input"},
                 output={"output": "first-output"},
                 metadata_={"metadata": "first-metadata"},
+                content_hash=compute_example_content_hash(
+                    input={"input": "first-input"},
+                    output={"output": "first-output"},
+                    metadata={"metadata": "first-metadata"},
+                ),
                 revision_kind="CREATE",
             )
         )
@@ -858,6 +864,11 @@ async def dataset_with_revisions(db: DbSessionFactory) -> None:
                 input={"input": "original-example-1-version-1-input"},
                 output={"output": "original-example-1-version-1-output"},
                 metadata_={"metadata": "original-example-1-version-1-metadata"},
+                content_hash=compute_example_content_hash(
+                    input={"input": "original-example-1-version-1-input"},
+                    output={"output": "original-example-1-version-1-output"},
+                    metadata={"metadata": "original-example-1-version-1-metadata"},
+                ),
                 revision_kind="CREATE",
             )
         )
@@ -868,6 +879,11 @@ async def dataset_with_revisions(db: DbSessionFactory) -> None:
                 input={"input": "original-example-2-version-1-input"},
                 output={"output": "original-example-2-version-1-output"},
                 metadata_={"metadata": "original-example-2-version-1-metadata"},
+                content_hash=compute_example_content_hash(
+                    input={"input": "original-example-2-version-1-input"},
+                    output={"output": "original-example-2-version-1-output"},
+                    metadata={"metadata": "original-example-2-version-1-metadata"},
+                ),
                 revision_kind="CREATE",
             )
         )
@@ -878,6 +894,11 @@ async def dataset_with_revisions(db: DbSessionFactory) -> None:
                 input={"input": "original-example-3-version-1-input"},
                 output={"output": "original-example-3-version-1-output"},
                 metadata_={"metadata": "original-example-3-version-1-metadata"},
+                content_hash=compute_example_content_hash(
+                    input={"input": "original-example-3-version-1-input"},
+                    output={"output": "original-example-3-version-1-output"},
+                    metadata={"metadata": "original-example-3-version-1-metadata"},
+                ),
                 revision_kind="CREATE",
             )
         )
@@ -902,6 +923,11 @@ async def dataset_with_revisions(db: DbSessionFactory) -> None:
                 input={"input": "original-example-3-version-1-input"},
                 output={"output": "original-example-3-version-1-output"},
                 metadata_={"metadata": "original-example-3-version-1-metadata"},
+                content_hash=compute_example_content_hash(
+                    input={"input": "original-example-3-version-1-input"},
+                    output={"output": "original-example-3-version-1-output"},
+                    metadata={"metadata": "original-example-3-version-1-metadata"},
+                ),
                 revision_kind="DELETE",
             )
         )

--- a/tests/unit/server/api/mutations/test_experiment_mutations.py
+++ b/tests/unit/server/api/mutations/test_experiment_mutations.py
@@ -6,6 +6,7 @@ from strawberry.relay import GlobalID
 
 from phoenix.db import models
 from phoenix.server.types import DbSessionFactory
+from phoenix.utilities.content_hashing import compute_example_content_hash
 from tests.unit.graphql import AsyncGraphQLClient
 
 
@@ -136,6 +137,11 @@ async def simple_experiments(db: DbSessionFactory) -> None:
                 input={"input": "first-input"},
                 output={"output": "first-output"},
                 metadata_={"metadata": "first-metadata"},
+                content_hash=compute_example_content_hash(
+                    input={"input": "first-input"},
+                    output={"output": "first-output"},
+                    metadata={"metadata": "first-metadata"},
+                ),
                 revision_kind="CREATE",
             )
         )

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -25,6 +25,7 @@ from phoenix.db.types.prompts import (
 )
 from phoenix.server.encryption import EncryptionService
 from phoenix.server.types import DbSessionFactory
+from phoenix.utilities.content_hashing import compute_example_content_hash
 from tests.unit.graphql import AsyncGraphQLClient
 
 
@@ -890,6 +891,11 @@ async def experiment_run_metric_comparison_experiments(
                 input={f"example-{i}-input-key": f"example-{i}-input-value"},
                 output={f"example-{i}-output-key": f"example-{i}-output-value"},
                 metadata_={f"example-{i}-metadata-key": f"example-{i}-metadata-value"},
+                content_hash=compute_example_content_hash(
+                    input={f"example-{i}-input-key": f"example-{i}-input-value"},
+                    output={f"example-{i}-output-key": f"example-{i}-output-value"},
+                    metadata={f"example-{i}-metadata-key": f"example-{i}-metadata-value"},
+                ),
                 revision_kind="CREATE",
             )
             session.add(revision)
@@ -1354,6 +1360,17 @@ async def comparison_experiments(db: DbSessionFactory) -> None:
                         "metadata_": {
                             f"revision-{revision_index + 1}-metadata-key": f"revision-{revision_index + 1}-metadata-value"
                         },
+                        "content_hash": compute_example_content_hash(
+                            input={
+                                f"revision-{revision_index + 1}-input-key": f"revision-{revision_index + 1}-input-value"
+                            },
+                            output={
+                                f"revision-{revision_index + 1}-output-key": f"revision-{revision_index + 1}-output-value"
+                            },
+                            metadata={
+                                f"revision-{revision_index + 1}-metadata-key": f"revision-{revision_index + 1}-metadata-value"
+                            },
+                        ),
                     }
                     for revision_index, revision in enumerate(
                         [

--- a/tests/unit/server/api/types/test_Dataset.py
+++ b/tests/unit/server/api/types/test_Dataset.py
@@ -25,6 +25,7 @@ from phoenix.db.types.prompts import (
 )
 from phoenix.server.api.types.Experiment import Experiment
 from phoenix.server.types import DbSessionFactory
+from phoenix.utilities.content_hashing import compute_example_content_hash
 from tests.unit.graphql import AsyncGraphQLClient
 
 
@@ -1181,6 +1182,11 @@ async def dataset_with_patch_revision(db: DbSessionFactory) -> None:
                     "input": {"input": "first-input"},
                     "output": {"output": "first-output"},
                     "metadata_": {},
+                    "content_hash": compute_example_content_hash(
+                        input={"input": "first-input"},
+                        output={"output": "first-output"},
+                        metadata={},
+                    ),
                     "revision_kind": "CREATE",
                 },
                 {
@@ -1189,6 +1195,11 @@ async def dataset_with_patch_revision(db: DbSessionFactory) -> None:
                     "input": {"input": "first-input"},
                     "output": {"output": "first-output"},
                     "metadata_": {},
+                    "content_hash": compute_example_content_hash(
+                        input={"input": "first-input"},
+                        output={"output": "first-output"},
+                        metadata={},
+                    ),
                     "revision_kind": "CREATE",
                 },
                 {
@@ -1197,6 +1208,11 @@ async def dataset_with_patch_revision(db: DbSessionFactory) -> None:
                     "input": {"input": "second-input"},
                     "output": {"output": "second-output"},
                     "metadata_": {},
+                    "content_hash": compute_example_content_hash(
+                        input={"input": "second-input"},
+                        output={"output": "second-output"},
+                        metadata={},
+                    ),
                     "revision_kind": "PATCH",
                 },
                 {
@@ -1205,6 +1221,11 @@ async def dataset_with_patch_revision(db: DbSessionFactory) -> None:
                     "input": {"input": "second-input"},
                     "output": {"output": "second-output"},
                     "metadata_": {},
+                    "content_hash": compute_example_content_hash(
+                        input={"input": "second-input"},
+                        output={"output": "second-output"},
+                        metadata={},
+                    ),
                     "revision_kind": "PATCH",
                 },
             ],
@@ -1253,6 +1274,11 @@ async def dataset_with_three_versions(db: DbSessionFactory) -> None:
             input={"input": "first-input"},
             output={"output": "first-output"},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"input": "first-input"},
+                output={"output": "first-output"},
+                metadata={},
+            ),
             revision_kind="CREATE",
         )
         session.add(dataset_example_revision_1)
@@ -1289,6 +1315,11 @@ async def dataset_with_three_versions(db: DbSessionFactory) -> None:
             input={"input": "third-input"},
             output={"output": "third-output"},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"input": "third-input"},
+                output={"output": "third-output"},
+                metadata={},
+            ),
             revision_kind="PATCH",
         )
         session.add(dataset_example_revision_3)
@@ -1337,6 +1368,11 @@ async def dataset_with_deletion(db: DbSessionFactory) -> None:
             input={"input": "first-input"},
             output={"output": "first-output"},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={"input": "first-input"},
+                output={"output": "first-output"},
+                metadata={},
+            ),
             revision_kind="CREATE",
         )
         session.add(dataset_example_revision_1)
@@ -1358,6 +1394,11 @@ async def dataset_with_deletion(db: DbSessionFactory) -> None:
             input={},
             output={},
             metadata_={},
+            content_hash=compute_example_content_hash(
+                input={},
+                output={},
+                metadata={},
+            ),
             revision_kind="DELETE",
         )
         session.add(dataset_example_revision_2)

--- a/tests/unit/server/api/types/test_DatasetExample.py
+++ b/tests/unit/server/api/types/test_DatasetExample.py
@@ -9,6 +9,7 @@ from strawberry.relay import GlobalID
 from phoenix.config import DEFAULT_PROJECT_NAME
 from phoenix.db import models
 from phoenix.server.types import DbSessionFactory
+from phoenix.utilities.content_hashing import compute_example_content_hash
 from tests.unit.graphql import AsyncGraphQLClient
 
 
@@ -283,6 +284,11 @@ async def dataset_with_span_and_nonspan_examples(
                 input={"input": "example-1-version-1-input"},
                 output={"output": "example-1-version-1-output"},
                 metadata_={"metadata": "example-1-version-1-metadata"},
+                content_hash=compute_example_content_hash(
+                    input={"input": "example-1-version-1-input"},
+                    output={"output": "example-1-version-1-output"},
+                    metadata={"metadata": "example-1-version-1-metadata"},
+                ),
                 revision_kind="CREATE",
             )
         )
@@ -293,6 +299,11 @@ async def dataset_with_span_and_nonspan_examples(
                 input={"input": "example-2-version-1-input"},
                 output={"output": "example-2-version-1-output"},
                 metadata_={"metadata": "example-2-version-1-metadata"},
+                content_hash=compute_example_content_hash(
+                    input={"input": "example-2-version-1-input"},
+                    output={"output": "example-2-version-1-output"},
+                    metadata={"metadata": "example-2-version-1-metadata"},
+                ),
                 revision_kind="CREATE",
             )
         )
@@ -346,6 +357,11 @@ async def example_with_experiment_runs(db: DbSessionFactory) -> None:
                 input={"input": "first-input"},
                 output={"output": "first-output"},
                 metadata_={"metadata": "first-metadata"},
+                content_hash=compute_example_content_hash(
+                    input={"input": "first-input"},
+                    output={"output": "first-output"},
+                    metadata={"metadata": "first-metadata"},
+                ),
                 revision_kind="CREATE",
             )
         )

--- a/tests/unit/server/api/types/test_Experiment.py
+++ b/tests/unit/server/api/types/test_Experiment.py
@@ -9,6 +9,7 @@ from phoenix.db import models
 from phoenix.server.api.types.Experiment import Experiment
 from phoenix.server.api.types.pagination import Cursor, CursorSortColumn, CursorSortColumnDataType
 from phoenix.server.types import DbSessionFactory
+from phoenix.utilities.content_hashing import compute_example_content_hash
 from tests.unit.graphql import AsyncGraphQLClient
 
 
@@ -485,6 +486,11 @@ async def experiment_with_expected_run_count(db: DbSessionFactory) -> int:
                 input={"input": "input"},
                 output={"output": "output"},
                 metadata_={},
+                content_hash=compute_example_content_hash(
+                    input={"input": "input"},
+                    output={"output": "output"},
+                    metadata={},
+                ),
                 revision_kind="CREATE",
             )
             for example in examples
@@ -848,6 +854,11 @@ async def dataset_with_experiment_runs(db: DbSessionFactory) -> None:
             input={"input": "first-input"},
             output={"output": "first-output"},
             metadata_={"metadata": "first-metadata"},
+            content_hash=compute_example_content_hash(
+                input={"input": "first-input"},
+                output={"output": "first-output"},
+                metadata={"metadata": "first-metadata"},
+            ),
             revision_kind="CREATE",
         )
         session.add(revision)
@@ -1022,6 +1033,11 @@ async def experiments_with_runs_and_annotations(
                 input={"input": "input"},
                 output={"output": "output"},
                 metadata_={"metadata": "metadata"},
+                content_hash=compute_example_content_hash(
+                    input={"input": "input"},
+                    output={"output": "output"},
+                    metadata={"metadata": "metadata"},
+                ),
                 revision_kind="CREATE",
             )
             for example in examples
@@ -1249,6 +1265,11 @@ async def experiments_with_runs(db: DbSessionFactory) -> None:
                 input={"input": "input"},
                 output={"output": "output"},
                 metadata_={"metadata": "metadata"},
+                content_hash=compute_example_content_hash(
+                    input={"input": "input"},
+                    output={"output": "output"},
+                    metadata={"metadata": "metadata"},
+                ),
                 revision_kind="CREATE",
             )
             for example in examples

--- a/tests/unit/server/api/types/test_Span.py
+++ b/tests/unit/server/api/types/test_Span.py
@@ -19,6 +19,7 @@ from phoenix.server.api.types.Span import Span
 from phoenix.server.api.types.Trace import Trace
 from phoenix.server.types import DbSessionFactory
 from phoenix.trace.attributes import get_attribute_value
+from phoenix.utilities.content_hashing import compute_example_content_hash
 from tests.unit.graphql import AsyncGraphQLClient
 
 _TraceRowId: TypeAlias = int
@@ -546,6 +547,11 @@ async def simple_dataset(
             input={"in": "foo"},
             output={"out": "bar"},
             metadata_={"info": "the first reivision"},
+            content_hash=compute_example_content_hash(
+                input={"in": "foo"},
+                output={"out": "bar"},
+                metadata={"info": "the first reivision"},
+            ),
             revision_kind="CREATE",
         )
         session.add(example_0_revision_0)


### PR DESCRIPTION
## Summary

Strengthens the unshipped `content_hash` column on `dataset_example_revisions` so every row is guaranteed to have a hash:

- Rewrites migration `575aa27302ee` to add the column as nullable, **backfill** hashes for existing rows in Python via `compute_example_content_hash`, then `ALTER COLUMN ... NOT NULL` and create the index.
- Updates the ORM model to `Mapped[bytes]` (non-optional).
- Makes `insert_dataset_example_revision`'s `content_hash` required; `DELETE` revisions now use a module-level `_EMPTY_CONTENT_HASH` sentinel (the hash of `{}, {}, {}`). Drops the now-redundant `content_hash IS NOT NULL` filter in the upsert matcher.
- Fixes four raw-`insert()` call sites in `dataset_mutations.py` (`add_spans_to_dataset`, `add_examples_to_dataset`, `patch_dataset_examples` via `_to_orm_revision`, `delete_dataset_examples`) to populate `content_hash`.
- Adds a migration integration test that seeds CREATE/PATCH/DELETE + duplicate-content revisions at the pre-revision, runs the upgrade, and asserts hashes match `compute_example_content_hash(input, output, metadata)`, the NOT NULL constraint is enforced, and the index exists. Also verifies the downgrade drops the column.
- Updates test fixtures (ORM constructor + bulk `insert()` forms) across the unit test suite to supply `content_hash`.

DELETE revisions get the hash of their empty `input`/`output`/`metadata_` (a fixed sentinel). This is harmless because `get_dataset_example_revisions` already excludes DELETEs from the upsert matcher.

## Test plan

- [x] `uv run pytest tests/integration/db_migrations/test_data_migration_575aa27302ee_dataset_upsert.py` (SQLite + Postgres)
- [x] `uv run pytest tests/integration/db_migrations/test_up_and_down_migrations.py` (SQLite + Postgres)
- [x] Full unit sweep: `tests/unit/server/api/types/test_Dataset.py`, `test_DatasetExample.py`, `test_queries.py`, `routers/v1/test_datasets.py`, `mutations/test_experiment_mutations.py`, `mutations/test_dataset_mutations.py`, `tests/unit/datasets/`, `tests/unit/db/insertion/test_dataset.py`, `tests/unit/db/test_helpers.py`, `tests/unit/utilities/test_content_hashing.py` — 294 passed, 0 failures
- [ ] Manual smoke: start Phoenix on a fresh DB, run the dataset upsert UI flow, confirm new revisions have non-null `content_hash`; delete an example, confirm the DELETE row also has a hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)