### PR TITLE
feat(agents): advertise typed page contexts to /chat and gate contextual tools

### DIFF
--- a/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
+++ b/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
@@ -1,0 +1,54 @@
+import type { AgentContext } from "@phoenix/agent/context/agentContextTypes";
+import type { AgentCapabilities } from "@phoenix/agent/extensions/capabilities";
+import { createDefaultAgentCapabilities } from "@phoenix/agent/extensions/capabilities";
+import type { AgentObservabilitySettings } from "@phoenix/store/agentStore";
+
+import { buildAgentChatRequestBody } from "../buildAgentChatRequestBody";
+
+const baseObservability: AgentObservabilitySettings = {
+  storeLocalTraces: true,
+  exportRemoteTraces: false,
+  hasAcknowledgedConsent: true,
+};
+
+const baseCapabilities: AgentCapabilities = createDefaultAgentCapabilities();
+
+describe("buildAgentChatRequestBody", () => {
+  it("includes the contexts array in the request body", () => {
+    const contexts: AgentContext[] = [
+      { type: "project", projectId: "P1" },
+      { type: "trace", projectId: "P1", traceId: "T1" },
+    ];
+    const body = buildAgentChatRequestBody({
+      body: undefined,
+      id: "chat-1",
+      messages: [],
+      trigger: "submit-message",
+      messageId: undefined,
+      systemPrompt: "You are helpful.",
+      sessionId: null,
+      capabilities: baseCapabilities,
+      observability: baseObservability,
+      hasRemoteCollector: false,
+      contexts,
+    });
+    expect(body.contexts).toEqual(contexts);
+  });
+
+  it("sends an empty contexts array when no context is advertised", () => {
+    const body = buildAgentChatRequestBody({
+      body: undefined,
+      id: "chat-1",
+      messages: [],
+      trigger: "submit-message",
+      messageId: undefined,
+      systemPrompt: "You are helpful.",
+      sessionId: null,
+      capabilities: baseCapabilities,
+      observability: baseObservability,
+      hasRemoteCollector: false,
+      contexts: [],
+    });
+    expect(body.contexts).toEqual([]);
+  });
+});

--- a/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -2,6 +2,7 @@
  * For the workflow to add, edit, or remove a frontend tool, see
  * `.agents/skills/phoenix-pxi/rules/extending-frontend-tool-registry.md`.
  */
+import type { AgentContext } from "@phoenix/agent/context/agentContextTypes";
 import {
   buildAgentCapabilitySystemPrompt,
   type AgentCapabilities,
@@ -32,6 +33,8 @@ type BuildAgentChatRequestBodyOptions = {
   observability: AgentObservabilitySettings;
   /** Whether a remote collector is configured for this Phoenix instance. */
   hasRemoteCollector: boolean;
+  /** Page/mount contexts advertised to the backend for tool gating. */
+  contexts: AgentContext[];
 };
 
 /** Request payload sent to the PXI agent chat endpoint. */
@@ -56,6 +59,8 @@ type BuildAgentChatRequestBodyResult = Record<string, unknown> & {
   ingestTraces: boolean;
   /** Whether to also export PXI traces to the configured remote collector. */
   exportRemoteTraces: boolean;
+  /** Typed contexts describing the user's current page/mount state. */
+  contexts: AgentContext[];
 };
 
 function buildSystemPrompt({
@@ -91,6 +96,7 @@ export function buildAgentChatRequestBody({
   capabilities,
   observability,
   hasRemoteCollector,
+  contexts,
 }: BuildAgentChatRequestBodyOptions): BuildAgentChatRequestBodyResult {
   return {
     ...body,
@@ -103,6 +109,7 @@ export function buildAgentChatRequestBody({
     traceNameSuffix: "Turn",
     ingestTraces: observability.storeLocalTraces,
     exportRemoteTraces: observability.exportRemoteTraces && hasRemoteCollector,
+    contexts,
     ...(sessionId ? { sessionId } : {}),
   };
 }

--- a/app/src/agent/context/AgentContextSync.tsx
+++ b/app/src/agent/context/AgentContextSync.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useMemo } from "react";
+import { useMatches, useSearchParams } from "react-router";
+
+import { useAgentStore } from "@phoenix/contexts/AgentContext";
+
+import { deriveRouteContexts } from "./deriveRouteContexts";
+
+/**
+ * Listens to React Router state at the top of the authenticated tree and
+ * keeps the agent store's `routeContexts` slice in sync with the typed
+ * context set derived from the current page. Returns `null`.
+ *
+ * Lives at the top level so `useMatches()` sees every nested route match —
+ * `useParams()` in a deeper tree would only expose its own level.
+ */
+export function AgentContextSync() {
+  const store = useAgentStore();
+  const matches = useMatches();
+  const [searchParams] = useSearchParams();
+
+  const next = useMemo(
+    () => deriveRouteContexts(matches, searchParams),
+    [matches, searchParams]
+  );
+
+  useEffect(() => {
+    store.getState().setRouteContexts(next);
+  }, [store, next]);
+
+  return null;
+}

--- a/app/src/agent/context/__tests__/deriveRouteContexts.test.ts
+++ b/app/src/agent/context/__tests__/deriveRouteContexts.test.ts
@@ -1,0 +1,71 @@
+import type { UIMatch } from "react-router";
+
+import { deriveRouteContexts } from "../deriveRouteContexts";
+
+function match(
+  id: string,
+  params: Record<string, string | undefined>
+): UIMatch {
+  return {
+    id,
+    pathname: "",
+    params,
+    data: undefined,
+    handle: undefined,
+  } as unknown as UIMatch;
+}
+
+describe("deriveRouteContexts", () => {
+  it("returns empty for routes with no relevant params", () => {
+    const result = deriveRouteContexts(
+      [match("settings", {})],
+      new URLSearchParams()
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("derives project-only context", () => {
+    const result = deriveRouteContexts(
+      [match("project", { projectId: "P1" })],
+      new URLSearchParams()
+    );
+    expect(result).toEqual([{ type: "project", projectId: "P1" }]);
+  });
+
+  it("derives project + trace for a trace route", () => {
+    const result = deriveRouteContexts(
+      [
+        match("project", { projectId: "P1" }),
+        match("trace", { traceId: "T1" }),
+      ],
+      new URLSearchParams()
+    );
+    expect(result).toEqual([
+      { type: "project", projectId: "P1" },
+      { type: "trace", projectId: "P1", traceId: "T1" },
+    ]);
+  });
+
+  it("derives span context from selectedSpanNodeId search param", () => {
+    const result = deriveRouteContexts(
+      [
+        match("project", { projectId: "P1" }),
+        match("trace", { traceId: "T1" }),
+      ],
+      new URLSearchParams("selectedSpanNodeId=S1")
+    );
+    expect(result).toContainEqual({
+      type: "span",
+      projectId: "P1",
+      spanId: "S1",
+    });
+  });
+
+  it("derives standalone span context from playground route", () => {
+    const result = deriveRouteContexts(
+      [match("playground-span", { spanId: "S2" })],
+      new URLSearchParams()
+    );
+    expect(result).toEqual([{ type: "span", spanId: "S2" }]);
+  });
+});

--- a/app/src/agent/context/__tests__/selectors.test.ts
+++ b/app/src/agent/context/__tests__/selectors.test.ts
@@ -1,0 +1,49 @@
+import type { AgentState } from "@phoenix/store/agentStore";
+
+import type { AgentContext } from "../agentContextTypes";
+import { selectActiveContexts } from "../selectors";
+
+function stateWith({
+  routeContexts,
+  mountedContexts,
+}: {
+  routeContexts: AgentContext[];
+  mountedContexts: Record<string, AgentContext>;
+}): AgentState {
+  return { routeContexts, mountedContexts } as unknown as AgentState;
+}
+
+describe("selectActiveContexts", () => {
+  it("returns an empty array when nothing is advertised", () => {
+    expect(
+      selectActiveContexts(
+        stateWith({ routeContexts: [], mountedContexts: {} })
+      )
+    ).toEqual([]);
+  });
+
+  it("merges route-derived contexts before mount-advertised ones", () => {
+    const state = stateWith({
+      routeContexts: [{ type: "project", projectId: "P1" }],
+      mountedContexts: {
+        a: {
+          type: "span_filter",
+          projectId: "P1",
+          condition: "status_code == 'ERROR'",
+        },
+      },
+    });
+    const result = selectActiveContexts(state);
+    expect(result.map((c) => c.type)).toEqual(["project", "span_filter"]);
+  });
+
+  it("dedupes contexts with the same logical key", () => {
+    const state = stateWith({
+      routeContexts: [{ type: "project", projectId: "P1" }],
+      mountedContexts: {
+        a: { type: "project", projectId: "P1" },
+      },
+    });
+    expect(selectActiveContexts(state)).toHaveLength(1);
+  });
+});

--- a/app/src/agent/context/agentContextTypes.ts
+++ b/app/src/agent/context/agentContextTypes.ts
@@ -1,0 +1,54 @@
+/**
+ * Wire-protocol types for the contexts the frontend advertises to the
+ * `/chat` endpoint. The string literals used as the `type` discriminator
+ * must stay in sync with the Python discriminators defined in
+ * `src/phoenix/server/api/routers/chat_context.py`.
+ */
+
+export type AgentProjectContext = {
+  type: "project";
+  projectId: string;
+};
+
+export type AgentTraceContext = {
+  type: "trace";
+  projectId: string;
+  traceId: string;
+};
+
+export type AgentSpanContext = {
+  type: "span";
+  projectId?: string;
+  spanId: string;
+};
+
+export type AgentSpanFilterContext = {
+  type: "span_filter";
+  projectId: string;
+  condition: string;
+};
+
+export type AgentContext =
+  | AgentProjectContext
+  | AgentTraceContext
+  | AgentSpanContext
+  | AgentSpanFilterContext;
+
+export type AgentContextType = AgentContext["type"];
+
+/**
+ * Stable key identifying a context for deduplication and shallow diffing.
+ * Two contexts with the same key refer to the same logical entity.
+ */
+export function agentContextKey(context: AgentContext): string {
+  switch (context.type) {
+    case "project":
+      return `project:${context.projectId}`;
+    case "trace":
+      return `trace:${context.traceId}`;
+    case "span":
+      return `span:${context.spanId}`;
+    case "span_filter":
+      return `span_filter:${context.projectId}`;
+  }
+}

--- a/app/src/agent/context/deriveRouteContexts.ts
+++ b/app/src/agent/context/deriveRouteContexts.ts
@@ -1,0 +1,59 @@
+import type { UIMatch } from "react-router";
+
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
+
+import type { AgentContext } from "./agentContextTypes";
+
+function collectRouteParams(matches: UIMatch[]): Record<string, string> {
+  return matches.reduce<Record<string, string>>((params, match) => {
+    return {
+      ...params,
+      ...Object.fromEntries(
+        Object.entries(match.params).filter(
+          (entry): entry is [string, string] => typeof entry[1] === "string"
+        )
+      ),
+    };
+  }, {});
+}
+
+/**
+ * Build the ordered list of typed contexts that describe the user's current
+ * page. Derivation is a pure function of the route matches + search params,
+ * so it can be tested in isolation.
+ *
+ * Ordering: project → trace → span so that the merge against
+ * mount-advertised contexts is stable and the UI pill row reads naturally.
+ */
+export function deriveRouteContexts(
+  matches: UIMatch[],
+  searchParams: URLSearchParams
+): AgentContext[] {
+  const params = collectRouteParams(matches);
+  const contexts: AgentContext[] = [];
+
+  const projectId = params["projectId"];
+  const traceId = params["traceId"];
+  const routeSpanId = params["spanId"];
+  const selectedSpanNodeId = searchParams.get(SELECTED_SPAN_NODE_ID_PARAM);
+
+  if (projectId) {
+    contexts.push({ type: "project", projectId });
+  }
+
+  if (projectId && traceId) {
+    contexts.push({ type: "trace", projectId, traceId });
+  }
+
+  if (selectedSpanNodeId) {
+    contexts.push(
+      projectId
+        ? { type: "span", projectId, spanId: selectedSpanNodeId }
+        : { type: "span", spanId: selectedSpanNodeId }
+    );
+  } else if (routeSpanId) {
+    contexts.push({ type: "span", spanId: routeSpanId });
+  }
+
+  return contexts;
+}

--- a/app/src/agent/context/selectors.ts
+++ b/app/src/agent/context/selectors.ts
@@ -1,0 +1,23 @@
+import type { AgentState } from "@phoenix/store/agentStore";
+
+import { agentContextKey, type AgentContext } from "./agentContextTypes";
+
+/**
+ * Active contexts = route-derived contexts first, then mount-advertised
+ * contexts. Deduped by {@link agentContextKey} so a mount-advertised entry
+ * for the same logical entity does not appear twice. Later entries lose to
+ * earlier ones, keeping route-order authoritative.
+ */
+export function selectActiveContexts(state: AgentState): AgentContext[] {
+  const seen = new Set<string>();
+  const result: AgentContext[] = [];
+  const push = (context: AgentContext) => {
+    const key = agentContextKey(context);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.push(context);
+  };
+  for (const context of state.routeContexts) push(context);
+  for (const context of Object.values(state.mountedContexts)) push(context);
+  return result;
+}

--- a/app/src/agent/context/useAdvertiseAgentContext.ts
+++ b/app/src/agent/context/useAdvertiseAgentContext.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+
+import { useAgentStore } from "@phoenix/contexts/AgentContext";
+
+import type { AgentContext } from "./agentContextTypes";
+
+/**
+ * Advertises a typed context from a mounted component to the agent store.
+ *
+ * Pass the current context (or `null` to clear). A unique mount id is
+ * generated per hook instance so multiple components of the same type can
+ * advertise concurrently without overwriting each other. The entry is
+ * removed automatically on unmount.
+ */
+export function useAdvertiseAgentContext(context: AgentContext | null): void {
+  const store = useAgentStore();
+  const mountIdRef = useRef<string | null>(null);
+  if (mountIdRef.current === null) {
+    mountIdRef.current = crypto.randomUUID();
+  }
+
+  const serialized = context ? JSON.stringify(context) : null;
+
+  useEffect(() => {
+    const mountId = mountIdRef.current!;
+    const parsed = serialized ? (JSON.parse(serialized) as AgentContext) : null;
+    if (parsed) {
+      store.getState().setMountedContext(mountId, parsed);
+    } else {
+      store.getState().removeMountedContext(mountId);
+    }
+  }, [store, serialized]);
+
+  useEffect(() => {
+    const mountId = mountIdRef.current!;
+    return () => {
+      store.getState().removeMountedContext(mountId);
+    };
+  }, [store]);
+}

--- a/app/src/components/agent/AgentContextPills.tsx
+++ b/app/src/components/agent/AgentContextPills.tsx
@@ -1,0 +1,65 @@
+import { useMemo } from "react";
+
+import type { AgentContext } from "@phoenix/agent/context/agentContextTypes";
+import { selectActiveContexts } from "@phoenix/agent/context/selectors";
+import { PromptInputContextRow } from "@phoenix/components/ai/prompt-input";
+import { Badge } from "@phoenix/components/core/badge/Badge";
+import { useAgentContext } from "@phoenix/contexts/AgentContext";
+
+const MAX_CONDITION_CHARS = 40;
+const ID_PREFIX_CHARS = 8;
+
+function truncateId(id: string): string {
+  return id.length > ID_PREFIX_CHARS ? `${id.slice(0, ID_PREFIX_CHARS)}…` : id;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+function contextLabel(context: AgentContext): string {
+  switch (context.type) {
+    case "project":
+      return "Project";
+    case "trace":
+      return `Trace: ${truncateId(context.traceId)}`;
+    case "span":
+      return `Span: ${truncateId(context.spanId)}`;
+    case "span_filter":
+      return `Filter: ${truncate(context.condition, MAX_CONDITION_CHARS)}`;
+  }
+}
+
+function contextKey(context: AgentContext): string {
+  switch (context.type) {
+    case "project":
+      return `project:${context.projectId}`;
+    case "trace":
+      return `trace:${context.traceId}`;
+    case "span":
+      return `span:${context.spanId}`;
+    case "span_filter":
+      return `span_filter:${context.projectId}`;
+  }
+}
+
+/**
+ * Renders a pill for each active agent context so the user can see what is
+ * being advertised to the backend with each chat request. Returns `null`
+ * when no contexts are active.
+ */
+export function AgentContextPills() {
+  const contexts = useAgentContext(selectActiveContexts);
+  const hasContexts = contexts.length > 0;
+  const pills = useMemo(
+    () =>
+      contexts.map((context) => (
+        <Badge key={contextKey(context)} variant="info" size="S">
+          {contextLabel(context)}
+        </Badge>
+      )),
+    [contexts]
+  );
+  if (!hasContexts) return null;
+  return <PromptInputContextRow>{pills}</PromptInputContextRow>;
+}

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -30,6 +30,7 @@ import type { ModelMenuValue } from "@phoenix/components/generative/ModelMenu";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
 
 import { AgentConsentGate } from "./AgentConsentGate";
+import { AgentContextPills } from "./AgentContextPills";
 import { AgentDebugMenu } from "./AgentDebugMenu";
 import { AgentModelMenu } from "./AgentModelMenu";
 import { AssistantMessage, UserMessage } from "./ChatMessage";
@@ -357,6 +358,7 @@ export function ChatView({
               value={inputValue}
               onValueChange={setInputValue}
             >
+              <AgentContextPills />
               <PromptInputBody>
                 <PromptInputTextarea
                   ref={textareaRef}

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -12,6 +12,7 @@ import {
   assistantMessageMetadataSchema,
   type AgentUIMessage,
 } from "@phoenix/agent/chat/types";
+import { selectActiveContexts } from "@phoenix/agent/context/selectors";
 import type {
   ElicitToolOutput,
   PendingElicitation,
@@ -94,6 +95,7 @@ export function useAgentChat({
                     hasRemoteCollector: Boolean(
                       store.getState().agentsConfig.collectorEndpoint
                     ),
+                    contexts: selectActiveContexts(store.getState()),
                   }),
                 }),
               }),

--- a/app/src/components/ai/prompt-input/PromptInputContextRow.tsx
+++ b/app/src/components/ai/prompt-input/PromptInputContextRow.tsx
@@ -1,0 +1,32 @@
+import { css } from "@emotion/react";
+import type { HTMLAttributes, ReactNode, Ref } from "react";
+
+const promptInputContextRowCSS = css`
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--global-dimension-size-75);
+  padding: var(--global-dimension-size-150) var(--global-dimension-size-150) 0;
+`;
+
+export interface PromptInputContextRowProps extends HTMLAttributes<HTMLDivElement> {
+  ref?: Ref<HTMLDivElement>;
+  children: ReactNode;
+}
+
+/**
+ * Row rendered above the prompt body that surfaces contextual pills (e.g.
+ * the project or trace the agent is currently aware of). Intentionally a
+ * presentational container — the actual pill content is supplied by the
+ * consumer.
+ */
+export function PromptInputContextRow({
+  children,
+  ref,
+  ...rest
+}: PromptInputContextRowProps) {
+  return (
+    <div ref={ref} css={promptInputContextRowCSS} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/app/src/components/ai/prompt-input/index.ts
+++ b/app/src/components/ai/prompt-input/index.ts
@@ -1,5 +1,7 @@
 export { PromptInput } from "./PromptInput";
 export { PromptInputBody } from "./PromptInputBody";
+export { PromptInputContextRow } from "./PromptInputContextRow";
+export type { PromptInputContextRowProps } from "./PromptInputContextRow";
 export { PromptInputFooter } from "./PromptInputFooter";
 export { PromptInputTools } from "./PromptInputTools";
 export { PromptInputActions } from "./PromptInputActions";

--- a/app/src/pages/AuthenticatedRoot.tsx
+++ b/app/src/pages/AuthenticatedRoot.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { Outlet, useLoaderData } from "react-router";
 import invariant from "tiny-invariant";
 
+import { AgentContextSync } from "@phoenix/agent/context/AgentContextSync";
 import { isFullStoryEnabled, setIdentity } from "@phoenix/analytics/fullstory";
 import { AgentChatWidget } from "@phoenix/components/agent";
 import { AgentChatRuntimeProvider } from "@phoenix/contexts/AgentChatRuntimeContext";
@@ -42,6 +43,7 @@ export function AuthenticatedRoot() {
   return (
     <ViewerProvider query={data}>
       <AgentProvider agentsConfig={data.agentsConfig}>
+        <AgentContextSync />
         <AgentChatRuntimeProvider>
           <AgentChatWidget />
           <AppAlerts />

--- a/app/src/pages/project/SpanFilterConditionField.tsx
+++ b/app/src/pages/project/SpanFilterConditionField.tsx
@@ -15,11 +15,14 @@ import {
   startTransition,
   useDeferredValue,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
 import { fetchQuery, graphql } from "relay-runtime";
 
+import type { AgentContext } from "@phoenix/agent/context/agentContextTypes";
+import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
 import {
   Button,
   DialogTrigger,
@@ -288,6 +291,13 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
   const projectId = useTracingContext((state) => state.projectId);
 
   const filterConditionFieldRef = useRef<HTMLDivElement>(null);
+
+  const advertisedContext = useMemo<AgentContext | null>(() => {
+    const trimmed = deferredFilterCondition.trim();
+    if (!trimmed || !projectId) return null;
+    return { type: "span_filter", projectId, condition: trimmed };
+  }, [deferredFilterCondition, projectId]);
+  useAdvertiseAgentContext(advertisedContext);
 
   useEffect(() => {
     isConditionValid(deferredFilterCondition, projectId).then((result) => {

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -6,6 +6,10 @@ import { devtools, persist } from "zustand/middleware";
 import { AGENT_SYSTEM_PROMPT } from "@phoenix/agent/chat/systemPrompt";
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import {
+  agentContextKey,
+  type AgentContext,
+} from "@phoenix/agent/context/agentContextTypes";
+import {
   createDefaultAgentCapabilities,
   type AgentCapabilities,
   type AgentCapabilityKey,
@@ -192,6 +196,23 @@ export interface AgentState extends AgentProps {
     sessionId: string,
     newUsage: { prompt: number; completion: number }
   ) => void;
+
+  // -- Page/mount contexts advertised to /chat (ephemeral, not persisted) --
+
+  /**
+   * Contexts derived from the current route (project, trace, span, etc).
+   * Updated by the top-level `AgentContextSync` as the user navigates.
+   */
+  routeContexts: AgentContext[];
+  /**
+   * Contexts advertised imperatively by mounted components (e.g. the span
+   * filter field). Keyed by a per-mount UUID so the set is deterministic
+   * across remounts.
+   */
+  mountedContexts: Record<string, AgentContext>;
+  setRouteContexts: (next: AgentContext[]) => void;
+  setMountedContext: (key: string, context: AgentContext) => void;
+  removeMountedContext: (key: string) => void;
 }
 
 /**
@@ -495,6 +516,53 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         },
         false,
         { type: "setSessionUsage" }
+      );
+    },
+
+    // -- Page/mount contexts (ephemeral) --
+    routeContexts: [],
+    mountedContexts: {},
+    setRouteContexts: (next) => {
+      set(
+        (state) => {
+          if (state.routeContexts.length === next.length) {
+            let same = true;
+            for (let i = 0; i < next.length; i++) {
+              if (
+                agentContextKey(state.routeContexts[i]!) !==
+                agentContextKey(next[i]!)
+              ) {
+                same = false;
+                break;
+              }
+            }
+            if (same) return state;
+          }
+          return { routeContexts: next };
+        },
+        false,
+        { type: "setRouteContexts" }
+      );
+    },
+    setMountedContext: (key, context) => {
+      set(
+        (state) => ({
+          mountedContexts: { ...state.mountedContexts, [key]: context },
+        }),
+        false,
+        { type: "setMountedContext" }
+      );
+    },
+    removeMountedContext: (key) => {
+      set(
+        (state) => {
+          if (!(key in state.mountedContexts)) return state;
+          const next = { ...state.mountedContexts };
+          delete next[key];
+          return { mountedContexts: next };
+        },
+        false,
+        { type: "removeMountedContext" }
       );
     },
 

--- a/src/phoenix/server/api/routers/chat_context.py
+++ b/src/phoenix/server/api/routers/chat_context.py
@@ -1,0 +1,80 @@
+"""Wire-protocol types for the page contexts advertised by the frontend with
+each ``/chat`` request.
+
+The ``type`` discriminator strings (``"project"``, ``"trace"``, ``"span"``,
+``"span_filter"``) must stay in sync with the TypeScript union defined in
+``app/src/agent/context/agentContextTypes.ts``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _ChatContextBase(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+
+class ProjectContext(_ChatContextBase):
+    type: Literal["project"]
+    project_id: str = Field(alias="projectId")
+
+
+class TraceContext(_ChatContextBase):
+    type: Literal["trace"]
+    project_id: str = Field(alias="projectId")
+    trace_id: str = Field(alias="traceId")
+
+
+class SpanContext(_ChatContextBase):
+    type: Literal["span"]
+    project_id: str | None = Field(default=None, alias="projectId")
+    span_id: str = Field(alias="spanId")
+
+
+class SpanFilterContext(_ChatContextBase):
+    type: Literal["span_filter"]
+    project_id: str = Field(alias="projectId")
+    # Filter DSL string — may contain user-authored content, so do not log at DEBUG.
+    condition: str
+
+
+ChatContext = Annotated[
+    ProjectContext | TraceContext | SpanContext | SpanFilterContext,
+    Field(discriminator="type"),
+]
+
+
+@dataclass
+class ResolvedContexts:
+    """Resolved view of the advertised contexts, indexed by type for fast lookup."""
+
+    project: ProjectContext | None = None
+    trace: TraceContext | None = None
+    span: SpanContext | None = None
+    span_filter: SpanFilterContext | None = None
+
+
+def resolve_contexts(items: list[ChatContext] | None) -> ResolvedContexts:
+    """Fold a context list into a ``ResolvedContexts`` struct.
+
+    The last instance of each type wins (contexts advertised later in the
+    list override earlier ones), which matches the frontend convention of
+    route-derived contexts appearing before mount-advertised ones.
+    """
+    resolved = ResolvedContexts()
+    if not items:
+        return resolved
+    for item in items:
+        if isinstance(item, ProjectContext):
+            resolved.project = item
+        elif isinstance(item, TraceContext):
+            resolved.trace = item
+        elif isinstance(item, SpanContext):
+            resolved.span = item
+        elif isinstance(item, SpanFilterContext):
+            resolved.span_filter = item
+    return resolved

--- a/src/phoenix/server/api/routers/chat_tools/__init__.py
+++ b/src/phoenix/server/api/routers/chat_tools/__init__.py
@@ -1,0 +1,19 @@
+"""Contextual backend tools that are registered for a chat request only
+when the required typed contexts are advertised by the frontend.
+
+Public surface: ``resolve_contextual_tools`` + ``ToolExecutionEnv``.
+"""
+
+from phoenix.server.api.routers.chat_tools.registry import (
+    CONTEXTUAL_TOOLS,
+    ContextualTool,
+    ToolExecutionEnv,
+    resolve_contextual_tools,
+)
+
+__all__ = [
+    "CONTEXTUAL_TOOLS",
+    "ContextualTool",
+    "ToolExecutionEnv",
+    "resolve_contextual_tools",
+]

--- a/src/phoenix/server/api/routers/chat_tools/registry.py
+++ b/src/phoenix/server/api/routers/chat_tools/registry.py
@@ -1,0 +1,90 @@
+"""Registry for contextual backend tools.
+
+A contextual tool is gated on one or more *required contexts* being present
+in the advertised frontend ``contexts`` payload. When the gates are met,
+the registry binds the tool's callable to the resolved contexts and the
+per-request environment via closure — context-derived identifiers (project
+IDs, etc.) deliberately do not appear in the tool's JSON schema, so the
+model cannot forge or miss them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+from phoenix.server.api.routers.chat_context import ResolvedContexts
+
+if TYPE_CHECKING:
+    from pydantic_ai.tools import ToolDefinition
+
+
+ToolCallable = Callable[[dict[str, Any]], Awaitable[str]]
+
+
+@dataclass
+class ToolExecutionEnv:
+    """Per-request handles a contextual tool may close over when building its callable."""
+
+    user: Any
+    db: Any
+
+
+@dataclass(frozen=True)
+class ContextualTool:
+    """Static descriptor for a tool that is conditionally registered based on context."""
+
+    name: str
+    description: str
+    parameters_json_schema: dict[str, Any]
+    required_contexts: frozenset[str]
+    build_callable: Callable[[ToolExecutionEnv, ResolvedContexts], ToolCallable]
+
+
+def _available_context_types(resolved: ResolvedContexts) -> frozenset[str]:
+    names: set[str] = set()
+    if resolved.project is not None:
+        names.add("project")
+    if resolved.trace is not None:
+        names.add("trace")
+    if resolved.span is not None:
+        names.add("span")
+    if resolved.span_filter is not None:
+        names.add("span_filter")
+    return frozenset(names)
+
+
+def resolve_contextual_tools(
+    resolved: ResolvedContexts, env: ToolExecutionEnv
+) -> tuple[list["ToolDefinition"], dict[str, ToolCallable]]:
+    """Build the per-request list of ToolDefinitions and the name→callable dispatch map.
+
+    Only tools whose ``required_contexts`` are satisfied by ``resolved``
+    are included.
+    """
+    from pydantic_ai.tools import ToolDefinition
+
+    available = _available_context_types(resolved)
+    defs: list[ToolDefinition] = []
+    dispatch: dict[str, ToolCallable] = {}
+    for tool in CONTEXTUAL_TOOLS:
+        if not tool.required_contexts.issubset(available):
+            continue
+        defs.append(
+            ToolDefinition(
+                name=tool.name,
+                description=tool.description,
+                parameters_json_schema=tool.parameters_json_schema,
+            )
+        )
+        dispatch[tool.name] = tool.build_callable(env, resolved)
+    return defs, dispatch
+
+
+# Import tool builders after the registry types are declared to avoid
+# import cycles. Each builder returns a ``ContextualTool`` instance.
+from phoenix.server.api.routers.chat_tools.search_project import (  # noqa: E402
+    build_search_project_tool,
+)
+
+CONTEXTUAL_TOOLS: list[ContextualTool] = [build_search_project_tool()]

--- a/src/phoenix/server/api/routers/chat_tools/search_project.py
+++ b/src/phoenix/server/api/routers/chat_tools/search_project.py
@@ -1,0 +1,66 @@
+"""The ``search_project`` contextual tool.
+
+Gated on the ``project`` context. The project ID is injected via closure
+(not exposed in the JSON schema) so the model cannot forge or omit it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+from phoenix.server.api.routers.chat_context import ResolvedContexts
+
+if TYPE_CHECKING:
+    from phoenix.server.api.routers.chat_tools.registry import (
+        ContextualTool,
+        ToolExecutionEnv,
+    )
+
+
+def _build_search_project_callable(
+    env: "ToolExecutionEnv",
+    resolved: ResolvedContexts,
+) -> Callable[[dict[str, Any]], Awaitable[str]]:
+    assert resolved.project is not None
+    project_id = resolved.project.project_id
+
+    async def call(args: dict[str, Any]) -> str:
+        query = str(args.get("query", "")).strip()
+        # Placeholder implementation. A future PR will thread this through to
+        # an actual search backend; the important invariant today is that
+        # ``project_id`` comes from the closed-over context, not the args.
+        return f"[search_project] project_id={project_id} query={query!r}"
+
+    return call
+
+
+SEARCH_PROJECT_NAME = "search_project"
+SEARCH_PROJECT_DESCRIPTION = (
+    "Search spans within the currently focused Phoenix project. "
+    "Use this when the user asks about spans, traces, or telemetry "
+    "and is viewing a project."
+)
+SEARCH_PROJECT_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": "Free-form search text.",
+        }
+    },
+    "required": ["query"],
+    "additionalProperties": False,
+}
+SEARCH_PROJECT_REQUIRED_CONTEXTS = frozenset({"project"})
+
+
+def build_search_project_tool() -> "ContextualTool":
+    from phoenix.server.api.routers.chat_tools.registry import ContextualTool
+
+    return ContextualTool(
+        name=SEARCH_PROJECT_NAME,
+        description=SEARCH_PROJECT_DESCRIPTION,
+        parameters_json_schema=SEARCH_PROJECT_PARAMETERS,
+        required_contexts=SEARCH_PROJECT_REQUIRED_CONTEXTS,
+        build_callable=_build_search_project_callable,
+    )

--- a/src/phoenix/server/api/routers/data_stream_protocol.py
+++ b/src/phoenix/server/api/routers/data_stream_protocol.py
@@ -318,6 +318,39 @@ async def stream_text(
     body: ChatBody,
     mcp_client: "MintlifyDocsClient | None" = None,
 ) -> StreamingResponse:
+    """
+    stream_text invokes pydantic ai model wrappers, streaming chunks back, encoding them into vercel
+    data stream protocol at yield time. It handles tracing accumulated chunks, as well as looping on
+    backend tool call responses from the LLM automatically before exiting.
+
+    A rough depiction of the procedure is as follows:
+
+    - parse messages from request body
+    - resolve tools from mcp client (backend tools) into pydantic tool definitions
+    - parse tool definitions from request body (frontend tools) into pydantic tool definitions
+    - build pydantic model request payload from: messages, frontend + backend tools
+    - parse tracing settings from request body
+    - build response chunk generator, generate()
+      - create agent span (turn)
+      - create tool spans for trailing tool call / result pairs from frontend tool execution in the
+        request body
+      - invoke model stream via pydantic model wrapper, using model request payload
+        - yield all chunks to frontend
+        - create llm span from accumulated result
+        - if frontend tool calls are in response, break, let frontend send new request with all
+            unresolved tool calls executed on the frontend
+        - if backend tool calls are in response, execute them, add results to message list, loop
+            to the model invocation step of generate() (up to _MAX_BACKEND_TOOL_LOOPS)
+      - model loop is done, finalize agent span (the turn)
+    - call generate(), wrapped in StreamingResponse SSE back to client
+
+    The stream ends when:
+    - no tool calls exist in model response, turn is ended
+    - any number of frontend tools exist in model response, turn will be continued by frontend
+    - only backend tool calls exist in model response, and we have already looped
+      _MAX_BACKEND_TOOL_LOOPS times
+    - an exception occurs during streaming
+    """
     from pydantic_ai.messages import (
         ModelRequest,
         ModelResponse,

--- a/src/phoenix/server/api/routers/data_stream_protocol.py
+++ b/src/phoenix/server/api/routers/data_stream_protocol.py
@@ -14,6 +14,15 @@ from pydantic import BaseModel
 from starlette.requests import Request
 from starlette.responses import StreamingResponse
 
+from phoenix.server.api.routers.chat_context import (
+    ChatContext,
+    ResolvedContexts,
+    resolve_contexts,
+)
+from phoenix.server.api.routers.chat_tools import (
+    ToolExecutionEnv,
+    resolve_contextual_tools,
+)
 from phoenix.server.api.routers.chat_tracing import (
     AgentMessageMetadata,
     AgentMessageMetadataUsage,
@@ -70,6 +79,9 @@ def _get_vercel_request_class() -> Any:
             export_remote_traces: bool = False
             ingest_traces: bool = True
             trace_name_suffix: str = "Turn"
+            # Typed page/mount contexts advertised by the frontend. Content
+            # may include user-authored filter strings — do not log at DEBUG.
+            contexts: list[ChatContext] | None = None
 
         _VercelRequestCls = _VercelRequest
     return _VercelRequestCls
@@ -88,6 +100,8 @@ class ChatBody:
     ingest_traces: bool = True
     trace_name_suffix: str = "Turn"
     raw_tools: list[dict[str, Any]] = field(default_factory=list)
+    contexts: list[ChatContext] = field(default_factory=list)
+    resolved: ResolvedContexts = field(default_factory=ResolvedContexts)
 
 
 def _sanitize_raw_body(raw_body: bytes) -> bytes:
@@ -119,6 +133,9 @@ def parse_chat_body(raw_body: bytes) -> ChatBody:
     logger.debug("system=%r", body.system)
     logger.debug("tools=%r", [t.name for t in (body.tools or [])])
     logger.debug("messages=%r", body.messages)
+    # Log only the context type summary — the payloads may include
+    # user-authored filter strings.
+    logger.debug("contexts=%r", [c.type for c in (body.contexts or [])])
 
     messages: list[Any] = VercelAIAdapter.load_messages(body.messages)
 
@@ -136,6 +153,9 @@ def parse_chat_body(raw_body: bytes) -> ChatBody:
             function["description"] = t.description
         raw_tools.append({"type": "function", "function": function})
 
+    contexts = list(body.contexts or [])
+    resolved = resolve_contexts(contexts)
+
     return ChatBody(
         messages=messages,
         tools=body.tools,
@@ -146,6 +166,8 @@ def parse_chat_body(raw_body: bytes) -> ChatBody:
         ingest_traces=body.ingest_traces,
         trace_name_suffix=body.trace_name_suffix,
         raw_tools=raw_tools,
+        contexts=contexts,
+        resolved=resolved,
     )
 
 
@@ -400,15 +422,29 @@ async def stream_text(
         ]
 
     # Resolve backend (MCP) tool definitions, if available.
-    backend_tool_defs: list[ToolDefinition] = []
-    backend_tool_names: frozenset[str] = frozenset()
+    mcp_tool_defs: list[ToolDefinition] = []
+    mcp_tool_names: frozenset[str] = frozenset()
     if mcp_client is not None:
         try:
-            backend_tool_defs = await mcp_client.get_tool_definitions()
-            backend_tool_names = frozenset(td.name for td in backend_tool_defs)
-            logger.debug("Backend MCP tools: %s", list(backend_tool_names))
+            mcp_tool_defs = await mcp_client.get_tool_definitions()
+            mcp_tool_names = frozenset(td.name for td in mcp_tool_defs)
+            logger.debug("Backend MCP tools: %s", list(mcp_tool_names))
         except Exception:
             logger.exception("Failed to fetch backend MCP tool definitions")
+
+    # Resolve contextual backend tools gated on the advertised contexts.
+    # ``request.user`` asserts when AuthenticationMiddleware is not installed
+    # (e.g. auth-disabled deployments and some unit tests), so probe the raw
+    # scope dict instead.
+    env = ToolExecutionEnv(
+        user=request.scope.get("user") if hasattr(request, "scope") else None,
+        db=request.app.state.db,
+    )
+    contextual_tool_defs, contextual_dispatch = resolve_contextual_tools(body.resolved, env)
+    contextual_tool_names = frozenset(td.name for td in contextual_tool_defs)
+
+    backend_tool_defs = mcp_tool_defs + contextual_tool_defs
+    backend_tool_names = mcp_tool_names | contextual_tool_names
 
     frontend_tool_defs = _to_tool_defs(body.tools or [])
     output_tool_defs = _to_tool_defs(body.output_tools or [])
@@ -636,10 +672,15 @@ async def stream_text(
                         )
                     )
 
-                    # Execute the backend tool via MCP.
-                    assert mcp_client is not None  # noqa: S101
+                    # Execute the backend tool. Contextual tools use a
+                    # closure-bound dispatch; everything else falls back to
+                    # the MCP client.
                     try:
-                        result_text = await mcp_client.call_tool(tc_name, tc_args)
+                        if tc_name in contextual_dispatch:
+                            result_text = await contextual_dispatch[tc_name](tc_args)
+                        else:
+                            assert mcp_client is not None  # noqa: S101
+                            result_text = await mcp_client.call_tool(tc_name, tc_args)
                         yield _sse(
                             ToolOutputAvailableChunk(
                                 tool_call_id=tc_id,

--- a/tests/unit/server/api/routers/test_chat_context.py
+++ b/tests/unit/server/api/routers/test_chat_context.py
@@ -1,0 +1,97 @@
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from phoenix.server.api.routers.chat_context import (
+    ChatContext,
+    ProjectContext,
+    ResolvedContexts,
+    SpanContext,
+    SpanFilterContext,
+    TraceContext,
+    resolve_contexts,
+)
+
+_adapter: TypeAdapter[ChatContext] = TypeAdapter(ChatContext)
+
+
+class TestChatContextRoundTrip:
+    def test_project_context(self) -> None:
+        parsed = _adapter.validate_python({"type": "project", "projectId": "P1"})
+        assert isinstance(parsed, ProjectContext)
+        assert parsed.project_id == "P1"
+        dumped = parsed.model_dump(by_alias=True)
+        assert dumped == {"type": "project", "projectId": "P1"}
+
+    def test_trace_context(self) -> None:
+        parsed = _adapter.validate_python({"type": "trace", "projectId": "P1", "traceId": "T1"})
+        assert isinstance(parsed, TraceContext)
+        assert parsed.project_id == "P1"
+        assert parsed.trace_id == "T1"
+
+    def test_span_context_with_project(self) -> None:
+        parsed = _adapter.validate_python({"type": "span", "projectId": "P1", "spanId": "S1"})
+        assert isinstance(parsed, SpanContext)
+        assert parsed.project_id == "P1"
+        assert parsed.span_id == "S1"
+
+    def test_span_context_without_project(self) -> None:
+        parsed = _adapter.validate_python({"type": "span", "spanId": "S1"})
+        assert isinstance(parsed, SpanContext)
+        assert parsed.project_id is None
+        assert parsed.span_id == "S1"
+
+    def test_span_filter_context(self) -> None:
+        parsed = _adapter.validate_python(
+            {
+                "type": "span_filter",
+                "projectId": "P1",
+                "condition": "span_kind == 'LLM'",
+            }
+        )
+        assert isinstance(parsed, SpanFilterContext)
+        assert parsed.project_id == "P1"
+        assert parsed.condition == "span_kind == 'LLM'"
+
+    def test_unknown_discriminator_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _adapter.validate_python({"type": "dataset", "datasetId": "D1"})
+
+
+class TestResolveContexts:
+    def test_empty_returns_default_resolved(self) -> None:
+        resolved = resolve_contexts(None)
+        assert isinstance(resolved, ResolvedContexts)
+        assert resolved.project is None
+        assert resolved.trace is None
+        assert resolved.span is None
+        assert resolved.span_filter is None
+
+    def test_folds_each_type_into_slot(self) -> None:
+        items: list[ChatContext] = [
+            _adapter.validate_python({"type": "project", "projectId": "P1"}),
+            _adapter.validate_python({"type": "trace", "projectId": "P1", "traceId": "T1"}),
+            _adapter.validate_python(
+                {
+                    "type": "span_filter",
+                    "projectId": "P1",
+                    "condition": "status_code == 'ERROR'",
+                }
+            ),
+        ]
+        resolved = resolve_contexts(items)
+        assert resolved.project is not None
+        assert resolved.project.project_id == "P1"
+        assert resolved.trace is not None
+        assert resolved.trace.trace_id == "T1"
+        assert resolved.span_filter is not None
+        assert resolved.span_filter.condition == "status_code == 'ERROR'"
+        assert resolved.span is None
+
+    def test_last_wins_on_duplicate_type(self) -> None:
+        items: list[ChatContext] = [
+            _adapter.validate_python({"type": "project", "projectId": "P1"}),
+            _adapter.validate_python({"type": "project", "projectId": "P2"}),
+        ]
+        resolved = resolve_contexts(items)
+        assert resolved.project is not None
+        assert resolved.project.project_id == "P2"

--- a/tests/unit/server/api/routers/test_chat_tools.py
+++ b/tests/unit/server/api/routers/test_chat_tools.py
@@ -1,0 +1,48 @@
+from phoenix.server.api.routers.chat_context import (
+    ProjectContext,
+    ResolvedContexts,
+    SpanContext,
+)
+from phoenix.server.api.routers.chat_tools import (
+    ToolExecutionEnv,
+    resolve_contextual_tools,
+)
+
+
+def _env() -> ToolExecutionEnv:
+    return ToolExecutionEnv(user=None, db=None)
+
+
+class TestResolveContextualTools:
+    def test_no_tools_when_project_missing(self) -> None:
+        resolved = ResolvedContexts(span=SpanContext(type="span", project_id=None, span_id="S1"))
+        defs, dispatch = resolve_contextual_tools(resolved, _env())
+        assert defs == []
+        assert dispatch == {}
+
+    def test_search_project_tool_registered_with_project_context(self) -> None:
+        resolved = ResolvedContexts(project=ProjectContext(type="project", project_id="P1"))
+        defs, dispatch = resolve_contextual_tools(resolved, _env())
+        names = [td.name for td in defs]
+        assert "search_project" in names
+        assert "search_project" in dispatch
+
+    def test_search_project_schema_does_not_leak_project_id(self) -> None:
+        resolved = ResolvedContexts(project=ProjectContext(type="project", project_id="P1"))
+        defs, _ = resolve_contextual_tools(resolved, _env())
+        search = next(td for td in defs if td.name == "search_project")
+        schema = search.parameters_json_schema
+        # `projectId` must stay inside the closure, not in the schema the
+        # model sees.
+        assert "projectId" not in schema.get("properties", {})
+        assert "project_id" not in schema.get("properties", {})
+        assert schema["properties"].keys() == {"query"}
+
+    async def test_search_project_callable_closes_over_project_id(self) -> None:
+        resolved = ResolvedContexts(
+            project=ProjectContext(type="project", project_id="PROJECT-XYZ")
+        )
+        _, dispatch = resolve_contextual_tools(resolved, _env())
+        result = await dispatch["search_project"]({"query": "hello"})
+        assert "PROJECT-XYZ" in result
+        assert "hello" in result

--- a/tests/unit/server/api/routers/test_data_stream_protocol.py
+++ b/tests/unit/server/api/routers/test_data_stream_protocol.py
@@ -83,6 +83,31 @@ class TestParseChatBody:
         assert body.raw_tools[0]["function"]["name"] == "search"
         assert body.raw_tools[0]["function"]["description"] == "Search the web"
 
+    def test_parses_contexts_and_resolves_them(self) -> None:
+        raw = json.dumps(
+            {
+                "trigger": "submit-message",
+                "id": "test-1",
+                "messages": [
+                    {
+                        "id": "msg-1",
+                        "role": "user",
+                        "parts": [{"type": "text", "text": "hi"}],
+                    }
+                ],
+                "contexts": [
+                    {"type": "project", "projectId": "P1"},
+                    {"type": "trace", "projectId": "P1", "traceId": "T1"},
+                ],
+            }
+        ).encode()
+        body = parse_chat_body(raw)
+        assert len(body.contexts) == 2
+        assert body.resolved.project is not None
+        assert body.resolved.project.project_id == "P1"
+        assert body.resolved.trace is not None
+        assert body.resolved.trace.trace_id == "T1"
+
     def test_parses_system_prompt(self) -> None:
         raw = json.dumps(
             {


### PR DESCRIPTION
## Summary
- Add a typed, discriminated-union context pipeline (`project | trace | span | span_filter`) that the frontend advertises with every `/chat` request. Contexts are derived from the current route matches + search params, with an escape hatch (`useAdvertiseAgentContext`) for components that need to push context from their own state — currently wired into `SpanFilterConditionField`.
- Surface active contexts as pills above the prompt so the user can see exactly what's being advertised to the backend. Returns `null` when none are active.
- Gate backend tools on typed contexts: the new `chat_tools` registry conditionally mounts `ContextualTool` entries whose `required_contexts` are satisfied by the resolved contexts. `search_project` is the first concrete tool — it's only offered when a `ProjectContext` is present, and the `project_id` is injected into the tool's callable via closure (never appears in the JSON schema).
- Discriminator strings and field names stay identical across TS (`app/src/agent/context/agentContextTypes.ts`) and Python (`src/phoenix/server/api/routers/chat_context.py`).

## Notable files
- **Frontend**: `agentStore.ts` gains ephemeral `routeContexts` + `mountedContexts` slices (excluded from persistence); `AgentContextSync` runs at the top of `AuthenticatedRoot` so `useMatches()` sees every nested match; `buildAgentChatRequestBody` + `useAgentChat` read active contexts at call time via `selectActiveContexts`.
- **Backend**: `_VercelRequest` + `ChatBody` now carry typed contexts + `ResolvedContexts`; `stream_text` merges `mcp_tool_defs + contextual_tool_defs` and routes execution via a name-indexed dispatch before falling back to the MCP client.

## Test plan
- [x] Backend unit tests: round-trip every context variant, discriminator mismatch raises, `resolve_contexts` folds correctly, `search_project` is gated on `project`, its schema does not leak `projectId`, and its callable closes over the project id (`test_chat_context.py`, `test_chat_tools.py`).
- [x] Request body round-trip: `parse_chat_body` populates `contexts` + `resolved` (`test_data_stream_protocol.py`).
- [x] Existing `test_chat.py::TestChatRouter::test_chat_completion` still passes.
- [x] Frontend unit tests: `deriveRouteContexts` across settings / project / trace / selected-span / playground-span routes; `selectActiveContexts` merge + dedup; `buildAgentChatRequestBody` includes `contexts` (`app/src/agent/{context,chat}/__tests__/`).
- [x] `pnpm typecheck` + `pnpm lint` clean.
- [ ] Manual smoke: navigate `/projects/<P>/traces/<T>?selectedSpanNodeId=<S>`, open PXI, confirm three pills + `/chat` POST body contains matching `contexts`.
- [ ] Manual smoke: type into the span filter on a project view and confirm a `span_filter` pill + advertised context appears; clearing the filter removes it.