### PR TITLE
feat(sandbox): Wire up sandbox provider capabilities

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -365,6 +365,7 @@ type CategoricalAnnotationConfig implements Node & AnnotationConfigBase {
   annotationType: AnnotationType!
   optimizationDirection: OptimizationDirection!
   values: [CategoricalAnnotationValue!]!
+  shapeExamples(language: ShapeExamplesLanguage! = PYTHON, mode: ShapeExamplesMode! = FULL): [String!]!
 }
 
 input CategoricalAnnotationConfigInput {
@@ -550,6 +551,7 @@ type ContinuousAnnotationConfig implements Node & AnnotationConfigBase {
   optimizationDirection: OptimizationDirection!
   lowerBound: Float
   upperBound: Float
+  shapeExamples(language: ShapeExamplesLanguage! = PYTHON, mode: ShapeExamplesMode! = FULL): [String!]!
 }
 
 input ContinuousAnnotationConfigInput {
@@ -3143,6 +3145,10 @@ type SandboxConfig implements Node {
   name: String!
   description: String
   config: JSON!
+
+  """
+  Execution timeout in seconds (includes package install on ephemeral calls).
+  """
   timeout: Int!
   enabled: Boolean!
   provider: SandboxProvider!
@@ -3238,6 +3244,16 @@ type SetSandboxCredentialPayload {
   backendType: String!
   key: String!
   query: Query!
+}
+
+enum ShapeExamplesLanguage {
+  PYTHON
+  TYPESCRIPT
+}
+
+enum ShapeExamplesMode {
+  FULL
+  CURATED
 }
 
 enum SortDir {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3126,6 +3126,7 @@ type SandboxBackendInfo {
   displayName: String!
   supportedLanguages: [Language!]!
   status: SandboxBackendStatus!
+  statusDetail: String
   dependencyHints: [String!]!
   configFieldSpecs: [ConfigFieldSpecType!]!
   supportsEnvVars: Boolean!
@@ -3135,6 +3136,7 @@ type SandboxBackendInfo {
 
 enum SandboxBackendStatus {
   AVAILABLE
+  MISSING_CREDENTIALS
   UNAVAILABLE
   NOT_INSTALLED
 }

--- a/app/src/components/dataset/CreateCodeDatasetEvaluatorSlideover.tsx
+++ b/app/src/components/dataset/CreateCodeDatasetEvaluatorSlideover.tsx
@@ -10,7 +10,7 @@ import type { CreateCodeDatasetEvaluatorSlideover_createCodeEvaluatorMutation } 
 import type { CreateCodeDatasetEvaluatorSlideover_createDatasetCodeEvaluatorMutation } from "@phoenix/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideover_createDatasetCodeEvaluatorMutation.graphql";
 import type { CreateCodeDatasetEvaluatorSlideoverQuery } from "@phoenix/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideoverQuery.graphql";
 import { mapSandboxConfigOptions } from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
-import { DEFAULT_CODE_EVALUATOR_SOURCE } from "@phoenix/components/evaluators/codeEvaluatorUtils";
+import { getDefaultCodeEvaluatorSource } from "@phoenix/components/evaluators/codeEvaluatorUtils";
 import {
   createDefaultContinuousOutputConfig,
   EditCodeEvaluatorDialogContent,
@@ -264,7 +264,11 @@ const CreateCodeEvaluatorDialog = ({
           mode="create"
           error={error}
           initialLanguage="PYTHON"
-          initialSourceCode={DEFAULT_CODE_EVALUATOR_SOURCE.PYTHON}
+          initialSourceCode={getDefaultCodeEvaluatorSource(
+            "PYTHON",
+            "continuous",
+            createDefaultContinuousOutputConfig("")
+          )}
           sandboxConfigs={sandboxConfigs}
           initialSandboxConfigId={null}
         />

--- a/app/src/components/dataset/CreateCodeDatasetEvaluatorSlideover.tsx
+++ b/app/src/components/dataset/CreateCodeDatasetEvaluatorSlideover.tsx
@@ -110,11 +110,16 @@ const CreateCodeEvaluatorDialog = ({
             id
             name
             description
+            timeout
+            config
           }
         }
         sandboxBackends {
           backendType
           status
+          supportsEnvVars
+          internetAccess
+          dependenciesLanguage
         }
       }
     `,

--- a/app/src/components/dataset/EditCodeDatasetEvaluatorSlideover.tsx
+++ b/app/src/components/dataset/EditCodeDatasetEvaluatorSlideover.tsx
@@ -196,11 +196,16 @@ function EditCodeDatasetEvaluatorSlideoverContent({
               id
               name
               description
+              timeout
+              config
             }
           }
           sandboxBackends {
             backendType
             status
+            supportsEnvVars
+            internetAccess
+            dependenciesLanguage
           }
         }
       `,

--- a/app/src/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideoverQuery.graphql.ts
+++ b/app/src/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideoverQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5e569775dd6d69ca1c8f074190c66e94>>
+ * @generated SignedSource<<cfcf992839d7669d41bb44982fc47656>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,20 +9,26 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type SandboxBackendStatus = "AVAILABLE" | "NOT_INSTALLED" | "UNAVAILABLE";
 export type CreateCodeDatasetEvaluatorSlideoverQuery$variables = Record<PropertyKey, never>;
 export type CreateCodeDatasetEvaluatorSlideoverQuery$data = {
   readonly sandboxBackends: ReadonlyArray<{
     readonly backendType: string;
+    readonly dependenciesLanguage: Language | null;
+    readonly internetAccess: InternetAccessMode;
     readonly status: SandboxBackendStatus;
+    readonly supportsEnvVars: boolean;
   }>;
   readonly sandboxProviders: ReadonlyArray<{
     readonly backendType: string;
     readonly configs: ReadonlyArray<{
+      readonly config: any;
       readonly description: string | null;
       readonly id: string;
       readonly name: string;
+      readonly timeout: number;
     }>;
     readonly enabled: boolean;
     readonly language: Language;
@@ -84,6 +90,20 @@ v4 = {
       "kind": "ScalarField",
       "name": "description",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "timeout",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "config",
+      "storageKey": null
     }
   ],
   "storageKey": null
@@ -102,6 +122,27 @@ v5 = {
       "args": null,
       "kind": "ScalarField",
       "name": "status",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "supportsEnvVars",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internetAccess",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "dependenciesLanguage",
       "storageKey": null
     }
   ],
@@ -160,16 +201,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a0ca8e56dc9f78382ace98a30550e113",
+    "cacheID": "829630d1a89eebd47463937078c1212c",
     "id": null,
     "metadata": {},
     "name": "CreateCodeDatasetEvaluatorSlideoverQuery",
     "operationKind": "query",
-    "text": "query CreateCodeDatasetEvaluatorSlideoverQuery {\n  sandboxProviders {\n    backendType\n    language\n    enabled\n    configs {\n      id\n      name\n      description\n    }\n    id\n  }\n  sandboxBackends {\n    backendType\n    status\n  }\n}\n"
+    "text": "query CreateCodeDatasetEvaluatorSlideoverQuery {\n  sandboxProviders {\n    backendType\n    language\n    enabled\n    configs {\n      id\n      name\n      description\n      timeout\n      config\n    }\n    id\n  }\n  sandboxBackends {\n    backendType\n    status\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "6dc158e2f8dcebc2e068c3d0edcb4060";
+(node as any).hash = "07b3d83efa8b385d187c54ab77bf6108";
 
 export default node;

--- a/app/src/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideoverQuery.graphql.ts
+++ b/app/src/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideoverQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cfcf992839d7669d41bb44982fc47656>>
+ * @generated SignedSource<<5e7217b521d69f64a137190e14bd60a0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
-export type SandboxBackendStatus = "AVAILABLE" | "NOT_INSTALLED" | "UNAVAILABLE";
+export type SandboxBackendStatus = "AVAILABLE" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
 export type CreateCodeDatasetEvaluatorSlideoverQuery$variables = Record<PropertyKey, never>;
 export type CreateCodeDatasetEvaluatorSlideoverQuery$data = {
   readonly sandboxBackends: ReadonlyArray<{

--- a/app/src/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery.graphql.ts
+++ b/app/src/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1d0a16e5296b8abba920428753786658>>
+ * @generated SignedSource<<fe6e5c2285fbbb703b2d6de39673e389>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
+export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
 export type SandboxBackendStatus = "AVAILABLE" | "NOT_INSTALLED" | "UNAVAILABLE";
@@ -63,14 +64,19 @@ export type EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery$data = {
   };
   readonly sandboxBackends: ReadonlyArray<{
     readonly backendType: string;
+    readonly dependenciesLanguage: Language | null;
+    readonly internetAccess: InternetAccessMode;
     readonly status: SandboxBackendStatus;
+    readonly supportsEnvVars: boolean;
   }>;
   readonly sandboxProviders: ReadonlyArray<{
     readonly backendType: string;
     readonly configs: ReadonlyArray<{
+      readonly config: any;
       readonly description: string | null;
       readonly id: string;
       readonly name: string;
+      readonly timeout: number;
     }>;
     readonly enabled: boolean;
     readonly language: Language;
@@ -289,7 +295,21 @@ v18 = {
   "selections": [
     (v2/*: any*/),
     (v4/*: any*/),
-    (v5/*: any*/)
+    (v5/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "timeout",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "config",
+      "storageKey": null
+    }
   ],
   "storageKey": null
 },
@@ -307,6 +327,27 @@ v19 = {
       "args": null,
       "kind": "ScalarField",
       "name": "status",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "supportsEnvVars",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internetAccess",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "dependenciesLanguage",
       "storageKey": null
     }
   ],
@@ -516,16 +557,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "82065e93bd959f33205eb3f97e84170e",
+    "cacheID": "6aa8bd78d2e14fc42e5035c52aa4d3b8",
     "id": null,
     "metadata": {},
     "name": "EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery",
     "operationKind": "query",
-    "text": "query EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery(\n  $datasetEvaluatorId: ID!\n  $datasetId: ID!\n) {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      datasetEvaluator(datasetEvaluatorId: $datasetEvaluatorId) {\n        id\n        name\n        description\n        inputMapping {\n          literalMapping\n          pathMapping\n        }\n        outputConfigs {\n          __typename\n          ... on CategoricalAnnotationConfig {\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on ContinuousAnnotationConfig {\n            name\n            optimizationDirection\n            lowerBound\n            upperBound\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        evaluator {\n          __typename\n          id\n          kind\n          ... on CodeEvaluator {\n            name\n            description\n            sourceCode\n            language\n            sandboxConfig {\n              id\n            }\n            outputConfigs {\n              __typename\n              ... on CategoricalAnnotationConfig {\n                name\n                optimizationDirection\n                values {\n                  label\n                  score\n                }\n              }\n              ... on ContinuousAnnotationConfig {\n                name\n                optimizationDirection\n                lowerBound\n                upperBound\n              }\n              ... on Node {\n                __isNode: __typename\n                id\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n  sandboxProviders {\n    backendType\n    language\n    enabled\n    configs {\n      id\n      name\n      description\n    }\n    id\n  }\n  sandboxBackends {\n    backendType\n    status\n  }\n}\n"
+    "text": "query EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery(\n  $datasetEvaluatorId: ID!\n  $datasetId: ID!\n) {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      datasetEvaluator(datasetEvaluatorId: $datasetEvaluatorId) {\n        id\n        name\n        description\n        inputMapping {\n          literalMapping\n          pathMapping\n        }\n        outputConfigs {\n          __typename\n          ... on CategoricalAnnotationConfig {\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on ContinuousAnnotationConfig {\n            name\n            optimizationDirection\n            lowerBound\n            upperBound\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        evaluator {\n          __typename\n          id\n          kind\n          ... on CodeEvaluator {\n            name\n            description\n            sourceCode\n            language\n            sandboxConfig {\n              id\n            }\n            outputConfigs {\n              __typename\n              ... on CategoricalAnnotationConfig {\n                name\n                optimizationDirection\n                values {\n                  label\n                  score\n                }\n              }\n              ... on ContinuousAnnotationConfig {\n                name\n                optimizationDirection\n                lowerBound\n                upperBound\n              }\n              ... on Node {\n                __isNode: __typename\n                id\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n  sandboxProviders {\n    backendType\n    language\n    enabled\n    configs {\n      id\n      name\n      description\n      timeout\n      config\n    }\n    id\n  }\n  sandboxBackends {\n    backendType\n    status\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "210eabeeb373d8a2c919d19fc5042c34";
+(node as any).hash = "86a9451d4f662101ee1a0978aa834f0f";
 
 export default node;

--- a/app/src/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery.graphql.ts
+++ b/app/src/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fe6e5c2285fbbb703b2d6de39673e389>>
+ * @generated SignedSource<<ed3a776c45e35c2b916631abe67ccf05>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,7 @@ export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
 export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
-export type SandboxBackendStatus = "AVAILABLE" | "NOT_INSTALLED" | "UNAVAILABLE";
+export type SandboxBackendStatus = "AVAILABLE" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
 export type EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery$variables = {
   datasetEvaluatorId: string;
   datasetId: string;

--- a/app/src/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_updateDatasetCodeEvaluatorMutation.graphql.ts
+++ b/app/src/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_updateDatasetCodeEvaluatorMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<55032df165c1872b200d6bdd6d48323a>>
+ * @generated SignedSource<<4c5276b320442d6f957d6c70175183ae>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -272,6 +272,13 @@ v19 = {
 v20 = {
   "alias": null,
   "args": null,
+  "kind": "ScalarField",
+  "name": "language",
+  "storageKey": null
+},
+v21 = {
+  "alias": null,
+  "args": null,
   "concreteType": null,
   "kind": "LinkedField",
   "name": "outputConfigs",
@@ -542,13 +549,7 @@ return {
                     "kind": "InlineFragment",
                     "selections": [
                       (v5/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "language",
-                        "storageKey": null
-                      },
+                      (v20/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -556,7 +557,55 @@ return {
                         "name": "sourceCode",
                         "storageKey": null
                       },
-                      (v20/*: any*/)
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SandboxConfig",
+                        "kind": "LinkedField",
+                        "name": "sandboxConfig",
+                        "plural": false,
+                        "selections": [
+                          (v3/*: any*/),
+                          (v4/*: any*/),
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "config",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "timeout",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SandboxProvider",
+                            "kind": "LinkedField",
+                            "name": "provider",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "backendType",
+                                "storageKey": null
+                              },
+                              (v20/*: any*/),
+                              (v3/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v21/*: any*/)
                     ],
                     "type": "CodeEvaluator",
                     "abstractKey": null
@@ -565,7 +614,7 @@ return {
                 "storageKey": null
               },
               (v14/*: any*/),
-              (v20/*: any*/)
+              (v21/*: any*/)
             ],
             "storageKey": null
           },
@@ -596,12 +645,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "eb1b757d88de895f4d596b9c5c6ee95e",
+    "cacheID": "d9f0a128fe75a5737b7eaf47adb35731",
     "id": null,
     "metadata": {},
     "name": "EditCodeDatasetEvaluatorSlideover_updateDatasetCodeEvaluatorMutation",
     "operationKind": "mutation",
-    "text": "mutation EditCodeDatasetEvaluatorSlideover_updateDatasetCodeEvaluatorMutation(\n  $input: UpdateDatasetCodeEvaluatorInput!\n) {\n  updateDatasetCodeEvaluator(input: $input) {\n    evaluator {\n      ...DatasetEvaluatorsTable_row\n      ...PlaygroundDatasetSection_evaluator\n      ...CodeDatasetEvaluatorDetails_datasetEvaluator\n      id\n    }\n  }\n}\n\nfragment CodeDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    ... on CodeEvaluator {\n      id\n      name\n      description\n      language\n      sourceCode\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment DatasetEvaluatorsTable_row on DatasetEvaluator {\n  id\n  name\n  description\n  updatedAt\n  user {\n    username\n    profilePictureUrl\n    id\n  }\n  evaluator {\n    __typename\n    id\n    name\n    kind\n    createdAt\n    updatedAt\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n  }\n}\n\nfragment PlaygroundDatasetSection_evaluator on DatasetEvaluator {\n  id\n  name\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  evaluator {\n    __typename\n    id\n    kind\n    isBuiltin\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n"
+    "text": "mutation EditCodeDatasetEvaluatorSlideover_updateDatasetCodeEvaluatorMutation(\n  $input: UpdateDatasetCodeEvaluatorInput!\n) {\n  updateDatasetCodeEvaluator(input: $input) {\n    evaluator {\n      ...DatasetEvaluatorsTable_row\n      ...PlaygroundDatasetSection_evaluator\n      ...CodeDatasetEvaluatorDetails_datasetEvaluator\n      id\n    }\n  }\n}\n\nfragment CodeDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    ... on CodeEvaluator {\n      id\n      name\n      description\n      language\n      sourceCode\n      sandboxConfig {\n        id\n        name\n        description\n        config\n        timeout\n        provider {\n          backendType\n          language\n          id\n        }\n      }\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment DatasetEvaluatorsTable_row on DatasetEvaluator {\n  id\n  name\n  description\n  updatedAt\n  user {\n    username\n    profilePictureUrl\n    id\n  }\n  evaluator {\n    __typename\n    id\n    name\n    kind\n    createdAt\n    updatedAt\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n  }\n}\n\nfragment PlaygroundDatasetSection_evaluator on DatasetEvaluator {\n  id\n  name\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  evaluator {\n    __typename\n    id\n    kind\n    isBuiltin\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
+++ b/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
@@ -77,8 +77,6 @@ export type CodeEvaluatorSandboxFieldProps = {
   size?: "M" | "L";
   /** Whether to show the helper text below the field */
   showHelperText?: boolean;
-  /** Optional warning shown when a saved selection is no longer available */
-  unavailableSelectionMessage?: string;
 };
 
 /**
@@ -92,7 +90,6 @@ export const CodeEvaluatorSandboxField = ({
   onSelectionChange,
   size = "L",
   showHelperText = false,
-  unavailableSelectionMessage,
 }: CodeEvaluatorSandboxFieldProps) => {
   // Filter configs to only show those matching the current language
   const compatibleConfigs = useMemo(
@@ -174,11 +171,6 @@ export const CodeEvaluatorSandboxField = ({
           in Settings if none are available here.
         </Text>
       )}
-      {unavailableSelectionMessage ? (
-        <Text color="danger" size="S">
-          {unavailableSelectionMessage}
-        </Text>
-      ) : null}
     </View>
   );
 };

--- a/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
+++ b/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
@@ -23,6 +23,11 @@ export type SandboxConfigOption = {
   description?: string | null;
   providerLabel: string;
   providerLanguage: CodeEvaluatorLanguage;
+  timeout?: number | null;
+  config?: unknown;
+  supportsEnvVars?: boolean;
+  internetAccess?: string;
+  dependenciesLanguage?: CodeEvaluatorLanguage | null;
 };
 
 export type CodeEvaluatorLanguageFieldProps = {
@@ -204,32 +209,42 @@ export const mapSandboxConfigOptions = (
       id: string;
       name: string;
       description?: string | null;
+      timeout?: number | null;
+      config?: unknown;
     }>;
   }>,
   sandboxBackends: ReadonlyArray<{
     backendType: string;
     status: string;
+    supportsEnvVars?: boolean;
+    internetAccess?: string;
+    dependenciesLanguage?: CodeEvaluatorLanguage | null;
   }>
 ): SandboxConfigOption[] => {
-  // Build a set of available backend types
-  const availableBackendTypes = new Set(
+  const availableBackendsByType = new Map(
     sandboxBackends
       .filter((backend) => backend.status === "AVAILABLE")
-      .map((backend) => backend.backendType)
+      .map((backend) => [backend.backendType, backend])
   );
 
   return sandboxProviders
     .filter(
       (provider) =>
-        provider.enabled && availableBackendTypes.has(provider.backendType)
+        provider.enabled && availableBackendsByType.has(provider.backendType)
     )
-    .flatMap((provider) =>
-      provider.configs.map((config) => ({
+    .flatMap((provider) => {
+      const backend = availableBackendsByType.get(provider.backendType);
+      return provider.configs.map((config) => ({
         id: config.id,
         name: config.name,
         description: config.description,
         providerLanguage: provider.language,
         providerLabel: backendTypeLabel(provider.backendType),
-      }))
-    );
+        timeout: config.timeout,
+        config: config.config,
+        supportsEnvVars: backend?.supportsEnvVars,
+        internetAccess: backend?.internetAccess,
+        dependenciesLanguage: backend?.dependenciesLanguage,
+      }));
+    });
 };

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -45,8 +45,10 @@ import {
 import { CodeEvaluatorTestSection } from "@phoenix/components/evaluators/CodeEvaluatorTestSection";
 import { generateEvaluatorTypes } from "@phoenix/components/evaluators/codeEvaluatorTypeGeneration";
 import {
-  DEFAULT_CODE_EVALUATOR_SOURCE,
   extractCodeEvaluatorVariables,
+  getAllGeneratedSources,
+  getDefaultCodeEvaluatorSource,
+  type EvaluatorOutputShape,
 } from "@phoenix/components/evaluators/codeEvaluatorUtils";
 import { EvaluatorDescriptionInput } from "@phoenix/components/evaluators/EvaluatorDescriptionInput";
 import { EvaluatorExampleDataset } from "@phoenix/components/evaluators/EvaluatorExampleDataset";
@@ -117,10 +119,15 @@ export const EditCodeEvaluatorDialogContent = ({
   initialSandboxConfigId?: string | null;
 }) => {
   const store = useEvaluatorStoreInstance();
+  const outputConfig = useEvaluatorStore((state) => state.outputConfigs[0]);
+  const outputShape: EvaluatorOutputShape =
+    outputConfig && "values" in outputConfig ? "categorical" : "continuous";
   const [showValidationError, setShowValidationError] = useState(false);
   const [sourceCode, setSourceCode] = useState(initialSourceCode);
   const [language, setLanguage] =
     useState<CodeEvaluatorLanguage>(initialLanguage);
+  // Track the shape from the previous render so the shape-change guard can compare.
+  const prevShapeRef = useRef<EvaluatorOutputShape>(outputShape);
   const [sandboxConfigId, setSandboxConfigId] = useState<string | null>(
     initialSandboxConfigId ?? null
   );
@@ -193,6 +200,25 @@ export const EditCodeEvaluatorDialogContent = ({
       checkForDirtyChanges();
     });
   }, [store]);
+
+  // Output-shape-change guard: when outputShape changes and sourceCode is still
+  // a generated default for the previous {language, shape}, replace it with the
+  // generated default for the new shape. Preserves user-edited source.
+  useEffect(() => {
+    const prevShape = prevShapeRef.current;
+    if (prevShape !== outputShape) {
+      const prevDefaults = getAllGeneratedSources(language, outputConfig);
+      if (prevDefaults.includes(sourceCode)) {
+        setSourceCode(
+          getDefaultCodeEvaluatorSource(language, outputShape, outputConfig)
+        );
+      }
+      prevShapeRef.current = outputShape;
+    }
+    // outputConfig intentionally excluded: shape change is what drives the swap,
+    // not every config field edit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [outputShape]);
 
   const handleCancel = () => {
     onCancel?.();
@@ -317,10 +343,20 @@ export const EditCodeEvaluatorDialogContent = ({
           language={language}
           onLanguageChange={(nextLanguage) => {
             setLanguage((currentLanguage) => {
-              if (
-                sourceCode === DEFAULT_CODE_EVALUATOR_SOURCE[currentLanguage]
-              ) {
-                setSourceCode(DEFAULT_CODE_EVALUATOR_SOURCE[nextLanguage]);
+              // Auto-swap if sourceCode matches any generated default for the
+              // current language (substituted or fallback, across all shapes).
+              const currentDefaults = getAllGeneratedSources(
+                currentLanguage,
+                outputConfig
+              );
+              if (currentDefaults.includes(sourceCode)) {
+                setSourceCode(
+                  getDefaultCodeEvaluatorSource(
+                    nextLanguage,
+                    outputShape,
+                    outputConfig
+                  )
+                );
               }
               return nextLanguage;
             });
@@ -339,6 +375,8 @@ export const EditCodeEvaluatorDialogContent = ({
               <div css={editorPanelCSS}>
                 <CodeEditorSection
                   language={language}
+                  outputShape={outputShape}
+                  outputConfig={outputConfig}
                   sourceCode={sourceCode}
                   onChange={setSourceCode}
                 />
@@ -498,10 +536,14 @@ const CompactHeaderBar = ({
  */
 const CodeEditorSection = ({
   language,
+  outputShape,
+  outputConfig,
   sourceCode,
   onChange,
 }: {
   language: CodeEvaluatorLanguage;
+  outputShape: EvaluatorOutputShape;
+  outputConfig: AnnotationConfig | undefined;
   sourceCode: string;
   onChange: (value: string) => void;
 }) => {
@@ -527,6 +569,11 @@ const CodeEditorSection = ({
     [language, evaluatorMappingSource]
   );
 
+  const descriptionText =
+    outputShape === "categorical"
+      ? "Define an evaluate function that returns a string label."
+      : "Define an evaluate function that returns a numerical score.";
+
   return (
     <div css={editorSectionCSS}>
       {/* Editor header with reset button */}
@@ -537,13 +584,16 @@ const CodeEditorSection = ({
         flex="none"
       >
         <Text color="text-500" size="XS">
-          Define an <code>evaluate</code> function that returns a score or
-          label.
+          {descriptionText}
         </Text>
         <Button
           size="S"
           variant="quiet"
-          onPress={() => onChange(DEFAULT_CODE_EVALUATOR_SOURCE[language])}
+          onPress={() =>
+            onChange(
+              getDefaultCodeEvaluatorSource(language, outputShape, outputConfig)
+            )
+          }
         >
           <Icon svg={<Icons.Refresh />} />
           Reset

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -370,9 +370,13 @@ export const EditCodeEvaluatorDialogContent = ({
           sandboxConfigs={sandboxConfigs}
           selectedSandboxConfigId={selectedSandboxConfigId}
           onSandboxChange={setSandboxConfigId}
-          unavailableSelectionMessage={unavailableSandboxSelectionMessage}
           showSandboxHelperText={hasNoSandboxConfigs}
         />
+        {unavailableSandboxSelectionMessage ? (
+          <Alert variant="warning" title="Sandbox unavailable">
+            {unavailableSandboxSelectionMessage}
+          </Alert>
+        ) : null}
 
         <CodeEvaluatorInputVariablesProvider variables={variables}>
           <Group orientation="horizontal" style={{ flex: 1, minHeight: 0 }}>
@@ -418,7 +422,6 @@ const CompactHeaderBar = ({
   sandboxConfigs,
   selectedSandboxConfigId,
   onSandboxChange,
-  unavailableSelectionMessage,
   showSandboxHelperText,
 }: {
   language: CodeEvaluatorLanguage;
@@ -426,7 +429,6 @@ const CompactHeaderBar = ({
   sandboxConfigs: SandboxConfigOption[];
   selectedSandboxConfigId: string | null;
   onSandboxChange: (sandboxConfigId: string | null) => void;
-  unavailableSelectionMessage?: string;
   showSandboxHelperText?: boolean;
 }) => {
   return (
@@ -461,7 +463,6 @@ const CompactHeaderBar = ({
             selectedSandboxConfigId={selectedSandboxConfigId}
             onSelectionChange={onSandboxChange}
             showHelperText={showSandboxHelperText}
-            unavailableSelectionMessage={unavailableSelectionMessage}
           />
         </div>
       </div>
@@ -777,7 +778,7 @@ const CodeEditorSection = ({
             <div
               css={editorWrapCSS}
               onKeyDown={(e) => {
-                if (e.key === "Escape") {
+                if (e.key === "Escape" || e.key === "Tab") {
                   e.stopPropagation();
                 }
               }}
@@ -798,6 +799,7 @@ const CodeEditorSection = ({
                   syntaxHighlighting: true,
                   highlightActiveLine: false,
                   highlightActiveLineGutter: false,
+                  tabSize: language === "PYTHON" ? 4 : 2,
                 }}
               />
             </div>

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -790,6 +790,7 @@ const CodeEditorSection = ({
                 theme={codeMirrorTheme}
                 extensions={extensions}
                 height="100%"
+                indentWithTab
                 basicSetup={{
                   lineNumbers: true,
                   foldGutter: true,

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -14,6 +14,8 @@ import {
   Icons,
   Input,
   Label,
+  List,
+  ListItem,
   ListBox,
   Popover,
   Select,
@@ -248,6 +250,10 @@ export const EditCodeEvaluatorDialogContent = ({
     ? "The previously selected sandbox is no longer available. Save to keep the existing sandbox, or choose a new one to update it."
     : undefined;
   const hasNoSandboxConfigs = sandboxConfigs.length === 0;
+  const selectedSandboxConfig =
+    sandboxConfigs.find(
+      (sandboxConfig) => sandboxConfig.id === selectedSandboxConfigId
+    ) ?? null;
 
   const handleSubmit = async () => {
     const isValid = await store.getState().validateAll();
@@ -388,79 +394,12 @@ export const EditCodeEvaluatorDialogContent = ({
             {/* Right panel: Collapsible Sidebar (40%) */}
             <Panel defaultSize="40%" minSize="25%" style={panelStyle}>
               <div css={sidebarPanelCSS}>
-                <DisclosureGroup
-                  defaultExpandedKeys={["output-config", "input-mapping"]}
-                >
-                  {/* Test Section */}
-                  <Disclosure id="test-section" defaultExpanded={false}>
-                    <DisclosureTrigger arrowPosition="start">
-                      <Text weight="heavy" size="S">
-                        Test Evaluator
-                      </Text>
-                    </DisclosureTrigger>
-                    <DisclosurePanel>
-                      <div css={accordionContentCSS}>
-                        <View marginY="size-100" paddingX="size-200">
-                          <CodeEvaluatorTestSection
-                            sourceCode={sourceCode}
-                            language={language}
-                            sandboxConfigId={selectedSandboxConfigId}
-                          />
-                        </View>
-                        <View paddingX="size-200" paddingTop="size-50">
-                          <EvaluatorExampleDataset />
-                        </View>
-                        <View marginTop="size-100">
-                          <EvaluatorInputPreview />
-                        </View>
-                      </div>
-                    </DisclosurePanel>
-                  </Disclosure>
-
-                  {/* Output Configuration Section */}
-                  <Disclosure id="output-config">
-                    <DisclosureTrigger arrowPosition="start">
-                      <Text weight="heavy" size="S">
-                        Output Configuration
-                      </Text>
-                    </DisclosureTrigger>
-                    <DisclosurePanel>
-                      <div css={accordionContentCSS}>
-                        <View paddingX="size-200" paddingTop="size-100">
-                          <Text color="text-500" size="XS">
-                            Define the output type and optimization direction
-                            for your evaluator.
-                          </Text>
-                          <View marginTop="size-100">
-                            <OutputConfigSection />
-                          </View>
-                        </View>
-                      </div>
-                    </DisclosurePanel>
-                  </Disclosure>
-
-                  {/* Input Mapping Section */}
-                  <Disclosure id="input-mapping">
-                    <DisclosureTrigger arrowPosition="start">
-                      <Text weight="heavy" size="S">
-                        Input Mapping
-                      </Text>
-                    </DisclosureTrigger>
-                    <DisclosurePanel>
-                      <div css={accordionContentCSS}>
-                        <View paddingX="size-200" paddingTop="size-100">
-                          <Text color="text-500" size="XS">
-                            Map evaluator arguments to dataset fields. Arguments
-                            are auto-detected from your code.
-                          </Text>
-                          <View marginTop="size-100">
-                            <EvaluatorInputMapping />
-                          </View>
-                        </View>
-                      </div>
-                    </DisclosurePanel>
-                  </Disclosure>
-                </DisclosureGroup>
+                <ConfiguratorSidebar
+                  selectedSandboxConfig={selectedSandboxConfig}
+                  selectedSandboxConfigId={selectedSandboxConfigId}
+                  sourceCode={sourceCode}
+                  language={language}
+                />
               </div>
             </Panel>
           </Group>
@@ -529,6 +468,236 @@ const CompactHeaderBar = ({
     </Flex>
   );
 };
+
+const ConfiguratorSidebar = ({
+  selectedSandboxConfig,
+  selectedSandboxConfigId,
+  sourceCode,
+  language,
+}: {
+  selectedSandboxConfig: SandboxConfigOption | null;
+  selectedSandboxConfigId: string | null;
+  sourceCode: string;
+  language: CodeEvaluatorLanguage;
+}) => {
+  return (
+    <DisclosureGroup defaultExpandedKeys={["output-config", "input-mapping"]}>
+      <Disclosure id="sandbox-runtime" defaultExpanded={false}>
+        <DisclosureTrigger arrowPosition="start">
+          <Text weight="heavy" size="S">
+            Sandbox Runtime
+          </Text>
+        </DisclosureTrigger>
+        <DisclosurePanel>
+          <div css={accordionContentCSS}>
+            <View paddingTop="size-100">
+              <SandboxCapabilitySummaryCard
+                selectedSandboxConfig={selectedSandboxConfig}
+                description="Review the selected runtime before testing execution behavior or saving this evaluator."
+              />
+            </View>
+          </div>
+        </DisclosurePanel>
+      </Disclosure>
+
+      <Disclosure id="test-section" defaultExpanded={false}>
+        <DisclosureTrigger arrowPosition="start">
+          <Text weight="heavy" size="S">
+            Test Evaluator
+          </Text>
+        </DisclosureTrigger>
+        <DisclosurePanel>
+          <div css={accordionContentCSS}>
+            <View marginY="size-100" paddingX="size-200">
+              <CodeEvaluatorTestSection
+                sourceCode={sourceCode}
+                language={language}
+                sandboxConfigId={selectedSandboxConfigId}
+              />
+            </View>
+            <View paddingX="size-200" paddingTop="size-50">
+              <EvaluatorExampleDataset />
+            </View>
+            <View marginTop="size-100">
+              <EvaluatorInputPreview />
+            </View>
+          </div>
+        </DisclosurePanel>
+      </Disclosure>
+
+      <Disclosure id="output-config">
+        <DisclosureTrigger arrowPosition="start">
+          <Text weight="heavy" size="S">
+            Output Configuration
+          </Text>
+        </DisclosureTrigger>
+        <DisclosurePanel>
+          <div css={accordionContentCSS}>
+            <View paddingX="size-200" paddingTop="size-100">
+              <Text color="text-500" size="XS">
+                Define the output type and optimization direction for your
+                evaluator.
+              </Text>
+              <View marginTop="size-100">
+                <OutputConfigSection />
+              </View>
+            </View>
+          </div>
+        </DisclosurePanel>
+      </Disclosure>
+
+      <Disclosure id="input-mapping">
+        <DisclosureTrigger arrowPosition="start">
+          <Text weight="heavy" size="S">
+            Input Mapping
+          </Text>
+        </DisclosureTrigger>
+        <DisclosurePanel>
+          <div css={accordionContentCSS}>
+            <View paddingX="size-200" paddingTop="size-100">
+              <Text color="text-500" size="XS">
+                Map evaluator arguments to dataset fields. Arguments are
+                auto-detected from your code.
+              </Text>
+              <View marginTop="size-100">
+                <EvaluatorInputMapping />
+              </View>
+            </View>
+          </div>
+        </DisclosurePanel>
+      </Disclosure>
+    </DisclosureGroup>
+  );
+};
+
+const SandboxCapabilitySummaryCard = ({
+  selectedSandboxConfig,
+  description,
+}: {
+  selectedSandboxConfig: SandboxConfigOption | null;
+  description: string;
+}) => {
+  return (
+    <Flex direction="column" gap="size-100">
+      <Flex direction="column" gap="size-25">
+        <View paddingX="size-200">
+          <Text color="text-500" size="XS">
+            {description}
+          </Text>
+        </View>
+      </Flex>
+      {selectedSandboxConfig == null ? (
+        <View paddingX="size-200">
+          <Text color="text-500" size="XS">
+            Choose a sandbox to review its configured execution settings.
+          </Text>
+        </View>
+      ) : (
+        <List size="S">
+          <SandboxCapabilityRow
+            label="config"
+            value={selectedSandboxConfig.name}
+          />
+          {selectedSandboxConfig.timeout != null ? (
+            <SandboxCapabilityRow
+              label="timeout"
+              value={`${selectedSandboxConfig.timeout} seconds`}
+            />
+          ) : null}
+          <SandboxCapabilityRow
+            label="env_vars"
+            value={getSandboxEnvVarsLabel(selectedSandboxConfig.config)}
+          />
+          <SandboxCapabilityRow
+            label="internet_access"
+            value={getSandboxInternetAccessConfigLabel(
+              selectedSandboxConfig.config
+            )}
+          />
+          <SandboxCapabilityRow
+            label="dependencies"
+            value={getSandboxDependenciesConfigLabel(
+              selectedSandboxConfig.config
+            )}
+          />
+        </List>
+      )}
+    </Flex>
+  );
+};
+
+const SandboxCapabilityRow = ({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) => {
+  return (
+    <ListItem>
+      <View paddingStart="size-100" paddingEnd="size-100">
+        <Flex direction="row" justifyContent="space-between">
+          <Text size="XS" color="text-700">
+            {label}
+          </Text>
+          <Text size="XS">{value}</Text>
+        </Flex>
+      </View>
+    </ListItem>
+  );
+};
+
+function getSandboxEnvVarsLabel(config: unknown) {
+  const sandboxConfig = getSandboxConfigRecord(config);
+  const envVars = Array.isArray(sandboxConfig?.env_vars)
+    ? sandboxConfig.env_vars
+    : [];
+  const envVarNames = envVars
+    .map((entry) => {
+      if (entry != null && typeof entry === "object" && "name" in entry) {
+        return String((entry as Record<string, unknown>).name ?? "");
+      }
+      return "";
+    })
+    .filter(Boolean);
+
+  return envVarNames.length > 0 ? envVarNames.join(", ") : "none";
+}
+
+function getSandboxInternetAccessConfigLabel(config: unknown) {
+  const sandboxConfig = getSandboxConfigRecord(config);
+  const internetAccess = sandboxConfig?.internet_access;
+  if (internetAccess == null || typeof internetAccess !== "object") {
+    return "not configured";
+  }
+
+  const mode = (internetAccess as Record<string, unknown>).mode;
+  return typeof mode === "string" ? mode : "not configured";
+}
+
+function getSandboxDependenciesConfigLabel(config: unknown) {
+  const sandboxConfig = getSandboxConfigRecord(config);
+  const dependencies = sandboxConfig?.dependencies;
+  if (dependencies == null || typeof dependencies !== "object") {
+    return "none";
+  }
+
+  const packages = Array.isArray(
+    (dependencies as Record<string, unknown>).packages
+  )
+    ? ((dependencies as Record<string, unknown>).packages as unknown[])
+        .map((pkg) => String(pkg))
+        .filter(Boolean)
+    : [];
+
+  return packages.length > 0 ? packages.join(", ") : "none";
+}
+
+function getSandboxConfigRecord(config: unknown) {
+  return config != null && typeof config === "object"
+    ? (config as Record<string, unknown>)
+    : null;
+}
 
 /**
  * Code editor section - full height, primary element

--- a/app/src/components/evaluators/EvaluatorInputMapping.tsx
+++ b/app/src/components/evaluators/EvaluatorInputMapping.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from "react";
-import { Suspense, useEffect, useMemo } from "react";
+import { Suspense, useEffect, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 
 import { Loading, Text } from "@phoenix/components";
@@ -61,9 +61,12 @@ const EvaluatorInputMappingTitle = ({ children }: PropsWithChildren) => {
 
 const useEvaluatorInputMappingControlsForm = () => {
   const store = useEvaluatorStoreInstance();
-  const { pathMapping, literalMapping } = useEvaluatorStore(
-    (state) => state.evaluator.inputMapping
+  // Initialize RHF from the store once. Subscribing this component to the same
+  // mapping values it writes causes controlled input focus/caret churn.
+  const initialInputMappingRef = useRef(
+    store.getState().evaluator.inputMapping
   );
+  const { pathMapping, literalMapping } = initialInputMappingRef.current;
   // Escape keys for react-hook-form to prevent dots from being interpreted as nested paths
   const escapedPathMapping = useMemo(
     () => escapeMapping(pathMapping),
@@ -105,9 +108,6 @@ const EvaluatorInputMappingControls = () => {
     (state) => state.evaluatorMappingSource
   );
   const allExampleKeys = useFlattenedEvaluatorInputKeys(evaluatorMappingSource);
-  const inputValues = useEvaluatorStore(
-    (state) => state.evaluator.inputMapping.pathMapping
-  );
   // iterate over all keys in the control
   // each row should have a variable, an arrow pointing to the example field, and a select field
   // the variable should be the key, the select field should have all flattened example keys as options
@@ -128,10 +128,6 @@ const EvaluatorInputMappingControls = () => {
             pathOptions={allExampleKeys}
             pathPlaceholder={variable}
             literalPlaceholder="Enter a value"
-            pathInputValue={inputValues[variable] ?? ""}
-            onPathInputChange={(val) =>
-              setValue(`pathMapping.${escapedVariable}`, val)
-            }
           />
         );
       })}

--- a/app/src/components/evaluators/SwitchableEvaluatorInput.tsx
+++ b/app/src/components/evaluators/SwitchableEvaluatorInput.tsx
@@ -224,58 +224,69 @@ export function SwitchableEvaluatorInput<TFieldValues extends FieldValues>({
               name={pathFieldName}
               control={control}
               rules={requiredRules}
-              render={({ field, fieldState: { error } }) => (
-                <ComboBox
-                  isInvalid={!!error}
-                  errorMessage={error?.message}
-                  aria-label={`${label} path mapping`}
-                  placeholder={pathPlaceholder}
-                  defaultItems={pathOptionsWithUnset}
-                  selectedKey={field.value ?? ""}
-                  // for some reason combobox sizing is out of sync with everything else
-                  size={size === "M" ? "L" : size === "S" ? "M" : size}
-                  id={`${fieldName}-${mode}`}
-                  allowsCustomValue
-                  onSelectionChange={(key) => {
-                    if (!key) {
-                      return;
+              render={({ field, fieldState: { error } }) => {
+                const pathValue =
+                  pathInputValue ?? (field.value as string | undefined) ?? "";
+                // Custom typed paths are valid input values, but only real
+                // options should become selected keys for React Aria ComboBox.
+                const selectedKey = pathOptionsWithUnset.some(
+                  (item) => item.id === pathValue
+                )
+                  ? pathValue
+                  : null;
+                return (
+                  <ComboBox
+                    isInvalid={!!error}
+                    errorMessage={error?.message}
+                    aria-label={`${label} path mapping`}
+                    placeholder={pathPlaceholder}
+                    defaultItems={pathOptionsWithUnset}
+                    selectedKey={selectedKey}
+                    // for some reason combobox sizing is out of sync with everything else
+                    size={size === "M" ? "L" : size === "S" ? "M" : size}
+                    id={`${fieldName}-${mode}`}
+                    allowsCustomValue
+                    onSelectionChange={(key) => {
+                      if (!key) {
+                        return;
+                      }
+                      // Toggle: if selecting the same value, clear it
+                      if (key === "__unset__") {
+                        onPathInputChange?.("");
+                        field.onChange(undefined);
+                      } else {
+                        onPathInputChange?.(key as string);
+                        field.onChange(key as string);
+                      }
+                    }}
+                    onInputChange={(value) => {
+                      field.onChange(value);
+                      onPathInputChange?.(value);
+                    }}
+                    inputValue={pathValue}
+                  >
+                    {(item) =>
+                      item.id !== "__unset__" ? (
+                        <ComboBoxItem
+                          key={item.id}
+                          id={item.id}
+                          textValue={item.id}
+                        >
+                          {item.label}
+                        </ComboBoxItem>
+                      ) : (
+                        <ComboBoxItem
+                          key={item.id}
+                          id={item.id}
+                          textValue={item.id}
+                        >
+                          <Text fontStyle="italic">{item.label}</Text>
+                        </ComboBoxItem>
+                      )
                     }
-                    // Toggle: if selecting the same value, clear it
-                    if (key === "__unset__") {
-                      onPathInputChange?.("");
-                      field.onChange(undefined);
-                    } else {
-                      onPathInputChange?.(key as string);
-                      field.onChange(key);
-                    }
-                  }}
-                  onInputChange={(value) => {
-                    field.onChange(value);
-                    onPathInputChange?.(value);
-                  }}
-                  inputValue={pathInputValue ?? (field.value as string) ?? ""}
-                >
-                  {(item) =>
-                    item.id !== "__unset__" ? (
-                      <ComboBoxItem
-                        key={item.id}
-                        id={item.id}
-                        textValue={item.id}
-                      >
-                        {item.label}
-                      </ComboBoxItem>
-                    ) : (
-                      <ComboBoxItem
-                        key={item.id}
-                        id={item.id}
-                        textValue={item.id}
-                      >
-                        <Text fontStyle="italic">{item.label}</Text>
-                      </ComboBoxItem>
-                    )
-                  }
-                </ComboBox>
-              )}
+                  </ComboBox>
+                );
+              }}
             />
           ) : (
             <Controller

--- a/app/src/components/evaluators/__tests__/codeEvaluatorUtils.test.ts
+++ b/app/src/components/evaluators/__tests__/codeEvaluatorUtils.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import type { ClassificationEvaluatorAnnotationConfig } from "@phoenix/types";
+
+import { getDefaultCodeEvaluatorSource } from "../codeEvaluatorUtils";
+
+function _catConfig(label: string): ClassificationEvaluatorAnnotationConfig {
+  return {
+    type: "CATEGORICAL",
+    name: "score",
+    optimizationDirection: "MAXIMIZE",
+    description: "",
+    values: [{ label, score: 1 }],
+  } as unknown as ClassificationEvaluatorAnnotationConfig;
+}
+
+describe("getDefaultCodeEvaluatorSource — label escaping", () => {
+  it("escapes embedded double-quotes in Python output", () => {
+    const source = getDefaultCodeEvaluatorSource(
+      "PYTHON",
+      "categorical",
+      _catConfig('say "hi"')
+    );
+    // The escaped form must appear; the raw unescaped form must not.
+    expect(source).toContain('"say \\"hi\\""');
+    expect(source).not.toMatch(/return "say "hi""/);
+  });
+
+  it("escapes embedded double-quotes in TypeScript output", () => {
+    const source = getDefaultCodeEvaluatorSource(
+      "TYPESCRIPT",
+      "categorical",
+      _catConfig('say "hi"')
+    );
+    expect(source).toContain('"say \\"hi\\""');
+    expect(source).not.toMatch(/return "say "hi"";/);
+  });
+
+  it("escapes backslashes so they don't form unintended escape sequences", () => {
+    const source = getDefaultCodeEvaluatorSource(
+      "PYTHON",
+      "categorical",
+      _catConfig("a\\b")
+    );
+    // JSON.stringify renders \ as \\ (two characters), so the source contains
+    // four characters: \ \ \ \  (each \\ represents a single backslash in
+    // the source string).
+    expect(source).toContain('"a\\\\b"');
+  });
+
+  it("escapes newlines so the literal stays on one line", () => {
+    const source = getDefaultCodeEvaluatorSource(
+      "PYTHON",
+      "categorical",
+      _catConfig("line1\nline2")
+    );
+    // Newline must be escaped to \n inside the literal — not pass through raw
+    // and split the return statement across two physical lines.
+    expect(source).toContain('"line1\\nline2"');
+    // The bare-return line should be one line, not two.
+    const returnLines = source
+      .split("\n")
+      .filter((line) => line.includes("return "));
+    for (const line of returnLines) {
+      expect(line).toContain("line1\\nline2");
+    }
+  });
+});

--- a/app/src/components/evaluators/codeEvaluatorUtils.ts
+++ b/app/src/components/evaluators/codeEvaluatorUtils.ts
@@ -10,6 +10,9 @@ type OutputConfig =
   | ClassificationEvaluatorAnnotationConfig
   | ContinuousEvaluatorAnnotationConfig;
 
+const PYTHON_INDENT = "    ";
+const TYPESCRIPT_INDENT = "  ";
+
 /**
  * Returns hardcoded two-shape templates (bare return + dict-form comment) with
  * static fallback values ("pass" for categorical, 0.5 for continuous).
@@ -21,28 +24,28 @@ export function getStaticFallbackSource(
   if (language === "PYTHON") {
     if (shape === "categorical") {
       return `def evaluate(output, reference=None, input=None, metadata=None):
-    # return {"label": "pass", "score": 1, "explanation": "..."}  # also set score and explanation
-    return "pass"  # label only
+${PYTHON_INDENT}# return {"label": "pass", "score": 1, "explanation": "..."}  # also set score and explanation
+${PYTHON_INDENT}return "pass"  # label only
 `;
     }
     // continuous
     return `def evaluate(output, reference=None, input=None, metadata=None):
-    # return {"score": 0.5, "explanation": "..."}  # also set explanation
-    return 0.5  # score only
+${PYTHON_INDENT}# return {"score": 0.5, "explanation": "..."}  # also set explanation
+${PYTHON_INDENT}return 0.5  # score only
 `;
   }
   // TYPESCRIPT
   if (shape === "categorical") {
     return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-  // return { label: "pass", score: 1, explanation: "..." };  // also set score and explanation
-  return "pass";  // label only
+${TYPESCRIPT_INDENT}// return { label: "pass", score: 1, explanation: "..." };  // also set score and explanation
+${TYPESCRIPT_INDENT}return "pass";  // label only
 }
 `;
   }
   // continuous
   return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-  // return { score: 0.5, explanation: "..." };  // also set explanation
-  return 0.5;  // score only
+${TYPESCRIPT_INDENT}// return { score: 0.5, explanation: "..." };  // also set explanation
+${TYPESCRIPT_INDENT}return 0.5;  // score only
 }
 `;
 }
@@ -85,14 +88,14 @@ export function getDefaultCodeEvaluatorSource(
       const label = catConfig.values[0].label;
       if (language === "PYTHON") {
         return `def evaluate(output, reference=None, input=None, metadata=None):
-    # return {"label": "${label}", "score": 1, "explanation": "..."}  # also set score and explanation
-    return "${label}"  # label only
+${PYTHON_INDENT}# return {"label": "${label}", "score": 1, "explanation": "..."}  # also set score and explanation
+${PYTHON_INDENT}return "${label}"  # label only
 `;
       }
       // TYPESCRIPT
       return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-  // return { label: "${label}", score: 1, explanation: "..." };  // also set score and explanation
-  return "${label}";  // label only
+${TYPESCRIPT_INDENT}// return { label: "${label}", score: 1, explanation: "..." };  // also set score and explanation
+${TYPESCRIPT_INDENT}return "${label}";  // label only
 }
 `;
     }
@@ -115,14 +118,14 @@ export function getDefaultCodeEvaluatorSource(
       const rangeComment = `${lower.toFixed(1)} - ${upper.toFixed(1)}`;
       if (language === "PYTHON") {
         return `def evaluate(output, reference=None, input=None, metadata=None):
-    # return {"score": ${midpoint.toFixed(1)}, "explanation": "..."}  # also set explanation
-    return ${midpoint.toFixed(1)}  # score only (expected range: ${rangeComment})
+${PYTHON_INDENT}# return {"score": ${midpoint.toFixed(1)}, "explanation": "..."}  # also set explanation
+${PYTHON_INDENT}return ${midpoint.toFixed(1)}  # score only (expected range: ${rangeComment})
 `;
       }
       // TYPESCRIPT
       return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-  // return { score: ${midpoint.toFixed(1)}, explanation: "..." };  // also set explanation
-  return ${midpoint.toFixed(1)};  // score only (expected range: ${rangeComment})
+${TYPESCRIPT_INDENT}// return { score: ${midpoint.toFixed(1)}, explanation: "..." };  // also set explanation
+${TYPESCRIPT_INDENT}return ${midpoint.toFixed(1)};  // score only (expected range: ${rangeComment})
 }
 `;
     }

--- a/app/src/components/evaluators/codeEvaluatorUtils.ts
+++ b/app/src/components/evaluators/codeEvaluatorUtils.ts
@@ -1,25 +1,178 @@
-import type { CodeEvaluatorLanguage } from "@phoenix/types";
+import type {
+  ClassificationEvaluatorAnnotationConfig,
+  CodeEvaluatorLanguage,
+  ContinuousEvaluatorAnnotationConfig,
+} from "@phoenix/types";
+
+export type EvaluatorOutputShape = "categorical" | "continuous";
+
+type OutputConfig =
+  | ClassificationEvaluatorAnnotationConfig
+  | ContinuousEvaluatorAnnotationConfig;
+
+/**
+ * Returns hardcoded two-shape templates (bare return + dict-form comment) with
+ * static fallback values ("pass" for categorical, 0.5 for continuous).
+ */
+export function getStaticFallbackSource(
+  language: CodeEvaluatorLanguage,
+  shape: EvaluatorOutputShape
+): string {
+  if (language === "PYTHON") {
+    if (shape === "categorical") {
+      return `def evaluate(output, reference=None, input=None, metadata=None):
+    # Full dict form: return {"label": "pass", "score": 1, "explanation": "..."}
+    return "pass"
+`;
+    }
+    // continuous
+    return `def evaluate(output, reference=None, input=None, metadata=None):
+    # Full dict form: return {"score": 0.5, "explanation": "..."}
+    return 0.5
+`;
+  }
+  // TYPESCRIPT
+  if (shape === "categorical") {
+    return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
+  // Full dict form: return { label: "pass", score: 1, explanation: "..." };
+  return "pass";
+}
+`;
+  }
+  // continuous
+  return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
+  // Full dict form: return { score: 0.5, explanation: "..." };
+  return 0.5;
+}
+`;
+}
+
+/**
+ * Returns a config-aware two-shape template. Substitutes the first label
+ * (categorical) or the midpoint of bounds (continuous) into the template.
+ * Falls back to getStaticFallbackSource on any error or incomplete config and
+ * emits a structured console.warn describing the reason.
+ */
+export function getDefaultCodeEvaluatorSource(
+  language: CodeEvaluatorLanguage,
+  shape: EvaluatorOutputShape,
+  config?: OutputConfig
+): string {
+  try {
+    if (!config) {
+      // eslint-disable-next-line no-console
+      console.warn({
+        component: "getDefaultCodeEvaluatorSource",
+        shape,
+        language,
+        reason: "missing_config",
+      });
+      return getStaticFallbackSource(language, shape);
+    }
+
+    if (shape === "categorical") {
+      const catConfig = config as ClassificationEvaluatorAnnotationConfig;
+      if (!catConfig.values || catConfig.values.length === 0) {
+        // eslint-disable-next-line no-console
+        console.warn({
+          component: "getDefaultCodeEvaluatorSource",
+          shape,
+          language,
+          reason: "empty_values",
+        });
+        return getStaticFallbackSource(language, shape);
+      }
+      const label = catConfig.values[0].label;
+      if (language === "PYTHON") {
+        return `def evaluate(output, reference=None, input=None, metadata=None):
+    # Full dict form: return {"label": "${label}", "score": 1, "explanation": "..."}
+    return "${label}"
+`;
+      }
+      // TYPESCRIPT
+      return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
+  // Full dict form: return { label: "${label}", score: 1, explanation: "..." };
+  return "${label}";
+}
+`;
+    }
+
+    if (shape === "continuous") {
+      const contConfig = config as ContinuousEvaluatorAnnotationConfig;
+      const lower = contConfig.lowerBound;
+      const upper = contConfig.upperBound;
+      if (lower == null || upper == null) {
+        // eslint-disable-next-line no-console
+        console.warn({
+          component: "getDefaultCodeEvaluatorSource",
+          shape,
+          language,
+          reason: "missing_bounds",
+        });
+        return getStaticFallbackSource(language, shape);
+      }
+      const midpoint = (lower + upper) / 2;
+      const rangeComment = `${lower.toFixed(1)} - ${upper.toFixed(1)}`;
+      if (language === "PYTHON") {
+        return `def evaluate(output, reference=None, input=None, metadata=None):
+    # Full dict form: return {"score": ${midpoint.toFixed(1)}, "explanation": "..."}  # expected range: ${rangeComment}
+    return ${midpoint.toFixed(1)}
+`;
+      }
+      // TYPESCRIPT
+      return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
+  // Full dict form: return { score: ${midpoint.toFixed(1)}, explanation: "..." };  // expected range: ${rangeComment}
+  return ${midpoint.toFixed(1)};
+}
+`;
+    }
+
+    // unexpected shape
+    // eslint-disable-next-line no-console
+    console.warn({
+      component: "getDefaultCodeEvaluatorSource",
+      shape,
+      language,
+      reason: "unexpected_shape",
+    });
+    return getStaticFallbackSource(language, shape);
+  } catch {
+    // eslint-disable-next-line no-console
+    console.warn({
+      component: "getDefaultCodeEvaluatorSource",
+      shape,
+      language,
+      reason: "substitution_threw",
+    });
+    return getStaticFallbackSource(language, shape);
+  }
+}
+
+/**
+ * Returns all possible generated source strings for a given language across
+ * both shapes, including both substituted and static-fallback variants for
+ * any config. Used by guards to detect whether the current editor content
+ * is a generated default (vs. user-edited).
+ */
+export function getAllGeneratedSources(
+  language: CodeEvaluatorLanguage,
+  config?: OutputConfig
+): string[] {
+  const shapes: EvaluatorOutputShape[] = ["categorical", "continuous"];
+  const sources: string[] = [];
+  for (const shape of shapes) {
+    sources.push(getStaticFallbackSource(language, shape));
+    sources.push(getDefaultCodeEvaluatorSource(language, shape, config));
+  }
+  return [...new Set(sources)];
+}
 
 export const DEFAULT_CODE_EVALUATOR_SOURCE: Record<
   CodeEvaluatorLanguage,
   string
 > = {
-  PYTHON: `def evaluate(output, reference=None, input=None, metadata=None):
-    """
-    Evaluate the output against the reference.
-    See the auto-generated type information below for the structure of each parameter.
-    """
-    candidate = output.get("answer", "") if isinstance(output, dict) else ""
-    expected = reference.get("answer", "") if isinstance(reference, dict) else ""
-    return 1 if candidate == expected else 0
-`,
-  TYPESCRIPT: `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-  // See the auto-generated type definitions below for the structure of each parameter.
-  const candidate = typeof output?.answer === "string" ? output.answer : "";
-  const expected = typeof reference?.answer === "string" ? reference.answer : "";
-  return candidate === expected ? 1 : 0;
-}
-`,
+  PYTHON: getStaticFallbackSource("PYTHON", "continuous"),
+  TYPESCRIPT: getStaticFallbackSource("TYPESCRIPT", "continuous"),
 };
 
 export const extractCodeEvaluatorVariables = ({

--- a/app/src/components/evaluators/codeEvaluatorUtils.ts
+++ b/app/src/components/evaluators/codeEvaluatorUtils.ts
@@ -86,16 +86,21 @@ export function getDefaultCodeEvaluatorSource(
         return getStaticFallbackSource(language, shape);
       }
       const label = catConfig.values[0].label;
+      // JSON.stringify wraps the label in quotes and escapes ", \, and
+      // newlines. Output is valid string-literal syntax for both Python and
+      // TypeScript, so a label like `say "hi"` produces well-formed code in
+      // either target rather than a SyntaxError.
+      const labelLiteral = JSON.stringify(label);
       if (language === "PYTHON") {
         return `def evaluate(output, reference=None, input=None, metadata=None):
-${PYTHON_INDENT}# return {"label": "${label}", "score": 1, "explanation": "..."}  # also set score and explanation
-${PYTHON_INDENT}return "${label}"  # label only
+${PYTHON_INDENT}# return {"label": ${labelLiteral}, "score": 1, "explanation": "..."}  # also set score and explanation
+${PYTHON_INDENT}return ${labelLiteral}  # label only
 `;
       }
       // TYPESCRIPT
       return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-${TYPESCRIPT_INDENT}// return { label: "${label}", score: 1, explanation: "..." };  // also set score and explanation
-${TYPESCRIPT_INDENT}return "${label}";  // label only
+${TYPESCRIPT_INDENT}// return { label: ${labelLiteral}, score: 1, explanation: "..." };  // also set score and explanation
+${TYPESCRIPT_INDENT}return ${labelLiteral};  // label only
 }
 `;
     }

--- a/app/src/components/evaluators/codeEvaluatorUtils.ts
+++ b/app/src/components/evaluators/codeEvaluatorUtils.ts
@@ -21,28 +21,28 @@ export function getStaticFallbackSource(
   if (language === "PYTHON") {
     if (shape === "categorical") {
       return `def evaluate(output, reference=None, input=None, metadata=None):
-    # Full dict form: return {"label": "pass", "score": 1, "explanation": "..."}
-    return "pass"
+    # return {"label": "pass", "score": 1, "explanation": "..."}  # also set score and explanation
+    return "pass"  # label only
 `;
     }
     // continuous
     return `def evaluate(output, reference=None, input=None, metadata=None):
-    # Full dict form: return {"score": 0.5, "explanation": "..."}
-    return 0.5
+    # return {"score": 0.5, "explanation": "..."}  # also set explanation
+    return 0.5  # score only
 `;
   }
   // TYPESCRIPT
   if (shape === "categorical") {
     return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-  // Full dict form: return { label: "pass", score: 1, explanation: "..." };
-  return "pass";
+  // return { label: "pass", score: 1, explanation: "..." };  // also set score and explanation
+  return "pass";  // label only
 }
 `;
   }
   // continuous
   return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-  // Full dict form: return { score: 0.5, explanation: "..." };
-  return 0.5;
+  // return { score: 0.5, explanation: "..." };  // also set explanation
+  return 0.5;  // score only
 }
 `;
 }
@@ -85,14 +85,14 @@ export function getDefaultCodeEvaluatorSource(
       const label = catConfig.values[0].label;
       if (language === "PYTHON") {
         return `def evaluate(output, reference=None, input=None, metadata=None):
-    # Full dict form: return {"label": "${label}", "score": 1, "explanation": "..."}
-    return "${label}"
+    # return {"label": "${label}", "score": 1, "explanation": "..."}  # also set score and explanation
+    return "${label}"  # label only
 `;
       }
       // TYPESCRIPT
       return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-  // Full dict form: return { label: "${label}", score: 1, explanation: "..." };
-  return "${label}";
+  // return { label: "${label}", score: 1, explanation: "..." };  // also set score and explanation
+  return "${label}";  // label only
 }
 `;
     }
@@ -115,14 +115,14 @@ export function getDefaultCodeEvaluatorSource(
       const rangeComment = `${lower.toFixed(1)} - ${upper.toFixed(1)}`;
       if (language === "PYTHON") {
         return `def evaluate(output, reference=None, input=None, metadata=None):
-    # Full dict form: return {"score": ${midpoint.toFixed(1)}, "explanation": "..."}  # expected range: ${rangeComment}
-    return ${midpoint.toFixed(1)}
+    # return {"score": ${midpoint.toFixed(1)}, "explanation": "..."}  # also set explanation
+    return ${midpoint.toFixed(1)}  # score only (expected range: ${rangeComment})
 `;
       }
       // TYPESCRIPT
       return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-  // Full dict form: return { score: ${midpoint.toFixed(1)}, explanation: "..." };  // expected range: ${rangeComment}
-  return ${midpoint.toFixed(1)};
+  // return { score: ${midpoint.toFixed(1)}, explanation: "..." };  // also set explanation
+  return ${midpoint.toFixed(1)};  // score only (expected range: ${rangeComment})
 }
 `;
     }

--- a/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorDetails.tsx
+++ b/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorDetails.tsx
@@ -1,40 +1,112 @@
 import { css } from "@emotion/react";
 import type { ReactNode } from "react";
+import { useMemo } from "react";
 import { useFragment } from "react-relay";
 import { useRevalidator } from "react-router";
 import { graphql } from "relay-runtime";
 
-import { Flex, Heading, Text } from "@phoenix/components";
+import { Flex, Heading, List, ListItem, Text, View } from "@phoenix/components";
 import { JSONBlock } from "@phoenix/components/code";
 import { EditCodeDatasetEvaluatorSlideover } from "@phoenix/components/dataset/EditCodeDatasetEvaluatorSlideover";
 import { CodeEvaluatorSourceCodeBlock } from "@phoenix/components/evaluators/CodeEvaluatorSourceCodeBlock";
 import type { CodeDatasetEvaluatorDetails_datasetEvaluator$key } from "@phoenix/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorDetails_datasetEvaluator.graphql";
+import type { datasetEvaluatorDetailsLoaderQuery } from "@phoenix/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql";
+import {
+  getBackendDescription,
+  languageLabel,
+  summarizeConfig,
+} from "@phoenix/pages/settings/sandboxes/utils";
 
-const boxCSS = css`
-  border-radius: var(--global-rounding-medium);
-  padding: var(--global-dimension-static-size-200);
-  margin-top: var(--global-dimension-static-size-50);
-  border: 1px solid var(--global-border-color-default);
-  overflow: hidden;
+type SandboxBackendInfo =
+  datasetEvaluatorDetailsLoaderQuery["response"]["sandboxBackends"][number];
+
+const splitLayoutCSS = css`
+  display: grid;
+  gap: var(--global-dimension-size-200);
+  grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr);
+
+  @media (max-width: 1100px) {
+    grid-template-columns: minmax(0, 1fr);
+  }
 `;
 
 function Section({ title, children }: { title: string; children: ReactNode }) {
   return (
     <Flex direction="column" gap="size-100">
       <Heading level={2}>{title}</Heading>
-      <div css={boxCSS}>{children}</div>
+      <View
+        padding="size-200"
+        borderWidth="thin"
+        borderColor="default"
+        borderRadius="medium"
+      >
+        <Flex direction="column" gap="size-150">
+          {children}
+        </Flex>
+      </View>
     </Flex>
   );
+}
+
+function DetailRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <Flex direction="column" gap="size-25">
+      <Text weight="heavy" size="S">
+        {label}
+      </Text>
+      {typeof value === "string" ? <Text>{value}</Text> : value}
+    </Flex>
+  );
+}
+
+function DetailListItem({ label, value }: { label: string; value: string }) {
+  return (
+    <ListItem>
+      <View paddingStart="size-100" paddingEnd="size-100">
+        <Flex direction="row" justifyContent="space-between">
+          <Text size="XS" color="text-700">
+            {label}
+          </Text>
+          <Text size="XS">{value}</Text>
+        </Flex>
+      </View>
+    </ListItem>
+  );
+}
+
+function getInternetAccessLabel(
+  internetAccess: SandboxBackendInfo["internetAccess"]
+) {
+  switch (internetAccess) {
+    case "BOOLEAN":
+      return "Configurable";
+    case "ALLOWLIST":
+      return "Allowlist";
+    case "NONE":
+      return "Not supported";
+    default:
+      return internetAccess;
+  }
+}
+
+function getDependenciesLabel(
+  dependenciesLanguage: SandboxBackendInfo["dependenciesLanguage"]
+) {
+  return dependenciesLanguage == null
+    ? "Not supported"
+    : languageLabel(dependenciesLanguage);
 }
 
 export function CodeDatasetEvaluatorDetails({
   datasetEvaluatorRef,
   datasetId,
+  sandboxBackends,
   isEditSlideoverOpen,
   onEditSlideoverOpenChange,
 }: {
   datasetEvaluatorRef: CodeDatasetEvaluatorDetails_datasetEvaluator$key;
   datasetId: string;
+  sandboxBackends: ReadonlyArray<SandboxBackendInfo>;
   isEditSlideoverOpen: boolean;
   onEditSlideoverOpenChange: (isOpen: boolean) => void;
 }) {
@@ -71,6 +143,17 @@ export function CodeDatasetEvaluatorDetails({
             description
             language
             sourceCode
+            sandboxConfig {
+              id
+              name
+              description
+              config
+              timeout
+              provider {
+                backendType
+                language
+              }
+            }
             outputConfigs {
               ... on CategoricalAnnotationConfig {
                 name
@@ -106,49 +189,144 @@ export function CodeDatasetEvaluatorDetails({
     datasetEvaluator.outputConfigs.length > 0
       ? datasetEvaluator.outputConfigs
       : evaluator.outputConfigs;
+  const sandboxConfig = evaluator.sandboxConfig;
+  const sandboxBackendByType = useMemo(
+    () =>
+      new Map(
+        sandboxBackends.map((sandboxBackend) => [
+          sandboxBackend.backendType,
+          sandboxBackend,
+        ])
+      ),
+    [sandboxBackends]
+  );
+  const sandboxBackend =
+    sandboxConfig != null
+      ? sandboxBackendByType.get(sandboxConfig.provider.backendType)
+      : undefined;
 
   return (
     <>
-      <Flex direction="column" gap="size-200">
-        <Section title="Language">
-          <Text>
-            {evaluator.language === "PYTHON" ? "Python" : "TypeScript"}
-          </Text>
-        </Section>
-        <Section title="Input Mapping">
-          <Flex direction="column" gap="size-100">
-            <Text weight="heavy" size="S">
-              Path mapping
-            </Text>
-            <JSONBlock
-              value={JSON.stringify(
-                datasetEvaluator.inputMapping.pathMapping,
-                null,
-                2
-              )}
+      <div css={splitLayoutCSS}>
+        <Flex direction="column" gap="size-200" flex="2 1 0" minWidth={0}>
+          <Section title="Source Code">
+            <CodeEvaluatorSourceCodeBlock
+              language={evaluator.language}
+              sourceCode={evaluator.sourceCode}
             />
-            <Text weight="heavy" size="S">
-              Literal mapping
+          </Section>
+          <Section title="Input Mapping">
+            <Flex direction="column" gap="size-100">
+              <Text weight="heavy" size="S">
+                Path mapping
+              </Text>
+              <JSONBlock
+                value={JSON.stringify(
+                  datasetEvaluator.inputMapping.pathMapping,
+                  null,
+                  2
+                )}
+              />
+              <Text weight="heavy" size="S">
+                Literal mapping
+              </Text>
+              <JSONBlock
+                value={JSON.stringify(
+                  datasetEvaluator.inputMapping.literalMapping,
+                  null,
+                  2
+                )}
+              />
+            </Flex>
+          </Section>
+          <Section title="Evaluator Annotation">
+            <JSONBlock value={JSON.stringify(outputConfigs, null, 2)} />
+          </Section>
+        </Flex>
+        <Flex direction="column" gap="size-200" flex="1 1 0" minWidth={0}>
+          <Section title="Language">
+            <Text>
+              {evaluator.language === "PYTHON" ? "Python" : "TypeScript"}
             </Text>
-            <JSONBlock
-              value={JSON.stringify(
-                datasetEvaluator.inputMapping.literalMapping,
-                null,
-                2
-              )}
-            />
-          </Flex>
-        </Section>
-        <Section title="Evaluator Annotation">
-          <JSONBlock value={JSON.stringify(outputConfigs, null, 2)} />
-        </Section>
-        <Section title="Source Code">
-          <CodeEvaluatorSourceCodeBlock
-            language={evaluator.language}
-            sourceCode={evaluator.sourceCode}
-          />
-        </Section>
-      </Flex>
+          </Section>
+          <Section title="Sandbox">
+            {sandboxConfig == null ? (
+              <Text color="text-700">No sandbox configuration selected.</Text>
+            ) : (
+              <Flex direction="column" gap="size-150">
+                <DetailRow label="Config" value={sandboxConfig.name} />
+                {sandboxConfig.description ? (
+                  <DetailRow
+                    label="Description"
+                    value={sandboxConfig.description}
+                  />
+                ) : null}
+                <DetailRow
+                  label="Provider"
+                  value={
+                    sandboxBackend?.displayName ??
+                    sandboxConfig.provider.backendType
+                  }
+                />
+                <DetailRow
+                  label="Runtime"
+                  value={getBackendDescription(
+                    sandboxConfig.provider.backendType
+                  )}
+                />
+                <DetailRow
+                  label="Language"
+                  value={languageLabel(sandboxConfig.provider.language)}
+                />
+                <DetailRow
+                  label="Timeout"
+                  value={`${sandboxConfig.timeout} seconds`}
+                />
+                <Flex direction="column" gap="size-50">
+                  <Text weight="heavy" size="S">
+                    Capabilities
+                  </Text>
+                  <List size="S">
+                    <DetailListItem
+                      label="env_vars"
+                      value={
+                        sandboxBackend?.supportsEnvVars
+                          ? "supported"
+                          : "not supported"
+                      }
+                    />
+                    <DetailListItem
+                      label="internet_access"
+                      value={getInternetAccessLabel(
+                        sandboxBackend?.internetAccess ?? "NONE"
+                      )}
+                    />
+                    <DetailListItem
+                      label="dependencies"
+                      value={getDependenciesLabel(
+                        sandboxBackend?.dependenciesLanguage ?? null
+                      )}
+                    />
+                  </List>
+                </Flex>
+                <Flex direction="column" gap="size-50">
+                  <Text weight="heavy" size="S">
+                    Custom Settings
+                  </Text>
+                  {summarizeConfig(sandboxConfig.config) ===
+                  "No custom settings" ? (
+                    <Text color="text-700">No custom settings</Text>
+                  ) : (
+                    <JSONBlock
+                      value={JSON.stringify(sandboxConfig.config, null, 2)}
+                    />
+                  )}
+                </Flex>
+              </Flex>
+            )}
+          </Section>
+        </Flex>
+      </div>
       <EditCodeDatasetEvaluatorSlideover
         datasetEvaluatorId={datasetEvaluator.id}
         datasetId={datasetId}

--- a/app/src/pages/dataset/evaluators/DatasetEvaluatorDetailsPage.tsx
+++ b/app/src/pages/dataset/evaluators/DatasetEvaluatorDetailsPage.tsx
@@ -131,6 +131,7 @@ function DatasetEvaluatorDetailsPageContent({
                   <CodeDatasetEvaluatorDetails
                     datasetEvaluatorRef={datasetEvaluator}
                     datasetId={datasetId}
+                    sandboxBackends={data.sandboxBackends}
                     isEditSlideoverOpen={isEditSlideoverOpen}
                     onEditSlideoverOpenChange={setIsEditSlideoverOpen}
                   />

--- a/app/src/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorDetails_datasetEvaluator.graphql.ts
+++ b/app/src/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorDetails_datasetEvaluator.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<706fe9847aee0a328c978ae0dc511fc7>>
+ * @generated SignedSource<<5874c2192c0296501acfe449f2a10b6e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,6 +30,17 @@ export type CodeDatasetEvaluatorDetails_datasetEvaluator$data = {
         readonly score: number | null;
       }>;
     }>;
+    readonly sandboxConfig?: {
+      readonly config: any;
+      readonly description: string | null;
+      readonly id: string;
+      readonly name: string;
+      readonly provider: {
+        readonly backendType: string;
+        readonly language: Language;
+      };
+      readonly timeout: number;
+    } | null;
     readonly sourceCode?: string;
   };
   readonly id: string;
@@ -143,6 +154,20 @@ v3 = {
     }
   ],
   "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "language",
+  "storageKey": null
 };
 return {
   "argumentDefinitions": [],
@@ -197,25 +222,60 @@ return {
           "selections": [
             (v0/*: any*/),
             (v1/*: any*/),
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "description",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "language",
-              "storageKey": null
-            },
+            (v4/*: any*/),
+            (v5/*: any*/),
             {
               "alias": null,
               "args": null,
               "kind": "ScalarField",
               "name": "sourceCode",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "SandboxConfig",
+              "kind": "LinkedField",
+              "name": "sandboxConfig",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/),
+                (v1/*: any*/),
+                (v4/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "config",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "timeout",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "SandboxProvider",
+                  "kind": "LinkedField",
+                  "name": "provider",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "backendType",
+                      "storageKey": null
+                    },
+                    (v5/*: any*/)
+                  ],
+                  "storageKey": null
+                }
+              ],
               "storageKey": null
             },
             (v3/*: any*/)
@@ -232,6 +292,6 @@ return {
 };
 })();
 
-(node as any).hash = "16b385d6bfcbbd872f72f1c6a4827eb9";
+(node as any).hash = "88fd86cc602541670d30c2d0f1a2c25b";
 
 export default node;

--- a/app/src/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql.ts
+++ b/app/src/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2f8f00ed6f4fe4ab026cf29f55ae2abc>>
+ * @generated SignedSource<<9e9da7b7b91dc293e0379269b4b6b672>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,8 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
+export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
+export type Language = "PYTHON" | "TYPESCRIPT";
 export type TimeRange = {
   end?: string | null;
   start?: string | null;
@@ -40,6 +42,13 @@ export type datasetEvaluatorDetailsLoaderQuery$data = {
     };
     readonly id: string;
   };
+  readonly sandboxBackends: ReadonlyArray<{
+    readonly backendType: string;
+    readonly dependenciesLanguage: Language | null;
+    readonly displayName: string;
+    readonly internetAccess: InternetAccessMode;
+    readonly supportsEnvVars: boolean;
+  }>;
 };
 export type datasetEvaluatorDetailsLoaderQuery = {
   response: datasetEvaluatorDetailsLoaderQuery$data;
@@ -120,24 +129,71 @@ v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "optimizationDirection",
+  "name": "backendType",
   "storageKey": null
 },
 v12 = {
   "alias": null,
   "args": null,
-  "kind": "ScalarField",
-  "name": "label",
+  "concreteType": "SandboxBackendInfo",
+  "kind": "LinkedField",
+  "name": "sandboxBackends",
+  "plural": true,
+  "selections": [
+    (v11/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "displayName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "supportsEnvVars",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internetAccess",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "dependenciesLanguage",
+      "storageKey": null
+    }
+  ],
   "storageKey": null
 },
 v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "score",
+  "name": "optimizationDirection",
   "storageKey": null
 },
 v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "score",
+  "storageKey": null
+},
+v16 = {
   "alias": null,
   "args": null,
   "concreteType": "CategoricalAnnotationValue",
@@ -145,12 +201,12 @@ v14 = {
   "name": "values",
   "plural": true,
   "selections": [
-    (v12/*: any*/),
-    (v13/*: any*/)
+    (v14/*: any*/),
+    (v15/*: any*/)
   ],
   "storageKey": null
 },
-v15 = {
+v17 = {
   "kind": "InlineFragment",
   "selections": [
     (v5/*: any*/)
@@ -158,7 +214,7 @@ v15 = {
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v16 = {
+v18 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -171,8 +227,8 @@ v16 = {
       "kind": "InlineFragment",
       "selections": [
         (v7/*: any*/),
-        (v11/*: any*/),
-        (v14/*: any*/)
+        (v13/*: any*/),
+        (v16/*: any*/)
       ],
       "type": "CategoricalAnnotationConfig",
       "abstractKey": null
@@ -181,7 +237,7 @@ v16 = {
       "kind": "InlineFragment",
       "selections": [
         (v7/*: any*/),
-        (v11/*: any*/),
+        (v13/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -200,29 +256,36 @@ v16 = {
       "type": "ContinuousAnnotationConfig",
       "abstractKey": null
     },
-    (v15/*: any*/)
+    (v17/*: any*/)
   ],
-  "storageKey": null
-},
-v17 = [
-  (v5/*: any*/),
-  (v7/*: any*/)
-],
-v18 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "strict",
   "storageKey": null
 },
 v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "toolCallId",
+  "name": "language",
   "storageKey": null
 },
 v20 = [
+  (v5/*: any*/),
+  (v7/*: any*/)
+],
+v21 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "strict",
+  "storageKey": null
+},
+v22 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "toolCallId",
+  "storageKey": null
+},
+v23 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -252,7 +315,7 @@ v20 = [
     "variableName": "timeRange"
   }
 ],
-v21 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "LabelFraction",
@@ -267,18 +330,18 @@ v21 = {
       "name": "fraction",
       "storageKey": null
     },
-    (v12/*: any*/)
+    (v14/*: any*/)
   ],
   "storageKey": null
 },
-v22 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "meanScore",
   "storageKey": null
 },
-v23 = {
+v26 = {
   "alias": null,
   "args": null,
   "concreteType": "Project",
@@ -331,13 +394,13 @@ v23 = {
                   "selections": [
                     (v5/*: any*/),
                     (v7/*: any*/),
-                    (v11/*: any*/),
-                    (v14/*: any*/)
+                    (v13/*: any*/),
+                    (v16/*: any*/)
                   ],
                   "type": "CategoricalAnnotationConfig",
                   "abstractKey": null
                 },
-                (v15/*: any*/)
+                (v17/*: any*/)
               ],
               "storageKey": null
             }
@@ -350,11 +413,11 @@ v23 = {
   ],
   "storageKey": null
 },
-v24 = [
+v27 = [
   (v5/*: any*/),
   (v7/*: any*/),
-  (v12/*: any*/),
-  (v13/*: any*/),
+  (v14/*: any*/),
+  (v15/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -396,7 +459,7 @@ v24 = [
     "storageKey": null
   }
 ],
-v25 = [
+v28 = [
   {
     "alias": "value",
     "args": null,
@@ -495,7 +558,8 @@ return {
           }
         ],
         "storageKey": null
-      }
+      },
+      (v12/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -551,7 +615,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v16/*: any*/)
+                          (v18/*: any*/)
                         ],
                         "type": "BuiltInEvaluator",
                         "abstractKey": null
@@ -559,13 +623,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "language",
-                            "storageKey": null
-                          },
+                          (v19/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -573,7 +631,49 @@ return {
                             "name": "sourceCode",
                             "storageKey": null
                           },
-                          (v16/*: any*/)
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SandboxConfig",
+                            "kind": "LinkedField",
+                            "name": "sandboxConfig",
+                            "plural": false,
+                            "selections": [
+                              (v5/*: any*/),
+                              (v7/*: any*/),
+                              (v8/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "config",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "timeout",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "SandboxProvider",
+                                "kind": "LinkedField",
+                                "name": "provider",
+                                "plural": false,
+                                "selections": [
+                                  (v11/*: any*/),
+                                  (v19/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          (v18/*: any*/)
                         ],
                         "type": "CodeEvaluator",
                         "abstractKey": null
@@ -588,7 +688,7 @@ return {
                             "kind": "LinkedField",
                             "name": "prompt",
                             "plural": false,
-                            "selections": (v17/*: any*/),
+                            "selections": (v20/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -646,7 +746,7 @@ return {
                                           },
                                           (v7/*: any*/),
                                           (v8/*: any*/),
-                                          (v18/*: any*/)
+                                          (v21/*: any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -703,7 +803,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "customProvider",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v20/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -731,7 +831,7 @@ return {
                                         "name": "schema",
                                         "storageKey": null
                                       },
-                                      (v18/*: any*/)
+                                      (v21/*: any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -810,7 +910,7 @@ return {
                                                     "name": "toolCall",
                                                     "plural": false,
                                                     "selections": [
-                                                      (v19/*: any*/),
+                                                      (v22/*: any*/),
                                                       {
                                                         "alias": null,
                                                         "args": null,
@@ -848,7 +948,7 @@ return {
                                                     "name": "toolResult",
                                                     "plural": false,
                                                     "selections": [
-                                                      (v19/*: any*/),
+                                                      (v22/*: any*/),
                                                       {
                                                         "alias": null,
                                                         "args": null,
@@ -960,7 +1060,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v20/*: any*/),
+                        "args": (v23/*: any*/),
                         "concreteType": "SpanConnection",
                         "kind": "LinkedField",
                         "name": "spans",
@@ -1086,7 +1186,7 @@ return {
                                         "name": "traceAnnotationSummaries",
                                         "plural": true,
                                         "selections": [
-                                          (v21/*: any*/),
+                                          (v24/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -1094,12 +1194,12 @@ return {
                                             "name": "count",
                                             "storageKey": null
                                           },
-                                          (v22/*: any*/),
+                                          (v25/*: any*/),
                                           (v7/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
-                                      (v23/*: any*/),
+                                      (v26/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -1107,7 +1207,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "traceAnnotations",
                                         "plural": true,
-                                        "selections": (v24/*: any*/),
+                                        "selections": (v27/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
@@ -1120,7 +1220,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "input",
                                     "plural": false,
-                                    "selections": (v25/*: any*/),
+                                    "selections": (v28/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -1130,7 +1230,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "output",
                                     "plural": false,
-                                    "selections": (v25/*: any*/),
+                                    "selections": (v28/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -1140,7 +1240,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "spanAnnotations",
                                     "plural": true,
-                                    "selections": (v24/*: any*/),
+                                    "selections": (v27/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -1151,8 +1251,8 @@ return {
                                     "name": "spanAnnotationSummaries",
                                     "plural": true,
                                     "selections": [
-                                      (v21/*: any*/),
-                                      (v22/*: any*/),
+                                      (v24/*: any*/),
+                                      (v25/*: any*/),
                                       (v7/*: any*/)
                                     ],
                                     "storageKey": null
@@ -1196,7 +1296,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v23/*: any*/)
+                                  (v26/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -1253,7 +1353,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v20/*: any*/),
+                        "args": (v23/*: any*/),
                         "filters": [
                           "sort",
                           "rootSpansOnly",
@@ -1294,7 +1394,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v16/*: any*/)
+                  (v18/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1304,20 +1404,21 @@ return {
           }
         ],
         "storageKey": null
-      }
+      },
+      (v12/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "7f20ee3c69d0add53aba3603ebfaf112",
+    "cacheID": "15bf94d3d43ad35176f441a397d85f51",
     "id": null,
     "metadata": {},
     "name": "datasetEvaluatorDetailsLoaderQuery",
     "operationKind": "query",
-    "text": "query datasetEvaluatorDetailsLoaderQuery(\n  $datasetId: ID!\n  $datasetEvaluatorId: ID!\n  $timeRange: TimeRange\n  $orphanSpanAsRootSpan: Boolean!\n) {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      id\n      datasetEvaluator(datasetEvaluatorId: $datasetEvaluatorId) {\n        id\n        name\n        description\n        evaluator {\n          __typename\n          kind\n          description\n          id\n        }\n        project {\n          id\n          ...DatasetEvaluatorSpans_project\n        }\n        ...BuiltInDatasetEvaluatorDetails_datasetEvaluator\n        ...CodeDatasetEvaluatorDetails_datasetEvaluator\n        ...LLMDatasetEvaluatorDetails_datasetEvaluator\n      }\n    }\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment BuiltInDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    name\n    ... on BuiltInEvaluator {\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment CodeDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    ... on CodeEvaluator {\n      id\n      name\n      description\n      language\n      sourceCode\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment DatasetEvaluatorSpans_project on Project {\n  id\n  ...SpansTable_spans\n}\n\nfragment LLMDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        tools {\n          tools {\n            function {\n              parameters\n            }\n          }\n        }\n        ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n        ...PromptChatMessagesCard__main\n        id\n      }\n      promptVersionTag {\n        name\n        id\n      }\n    }\n    id\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment PromptChatMessagesCard__main on PromptVersion {\n  provider: modelProvider\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                arguments\n                name\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpanColumnSelector_traceAnnotations on Project {\n  traceAnnotationsNames\n}\n\nfragment SpansTable_spans on Project {\n  name\n  spanAnnotationNames\n  ...SpanColumnSelector_annotations\n  ...SpanColumnSelector_traceAnnotations\n  spans(first: 30, sort: {col: startTime, dir: desc}, rootSpansOnly: true, orphanSpanAsRootSpan: $orphanSpanAsRootSpan, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        spanId\n        trace {\n          id\n          traceId\n          costSummary {\n            total {\n              cost\n            }\n          }\n          traceAnnotationSummaries {\n            labelFractions {\n              fraction\n              label\n            }\n            count\n            meanScore\n            name\n          }\n          ...TraceAnnotationSummaryGroup\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n          createdAt\n        }\n        spanAnnotationSummaries {\n          labelFractions {\n            fraction\n            label\n          }\n          meanScore\n          name\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        ...AnnotationSummaryGroup\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment TraceAnnotationSummaryGroup on Trace {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  traceAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  traceAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  customProvider {\n    id\n    name\n  }\n  responseFormat {\n    jsonSchema {\n      name\n      description\n      schema\n      strict\n    }\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    tools {\n      function {\n        name\n        description\n        parameters\n        strict\n      }\n    }\n    toolChoice {\n      type\n      functionName\n    }\n    disableParallelToolCalls\n  }\n}\n"
+    "text": "query datasetEvaluatorDetailsLoaderQuery(\n  $datasetId: ID!\n  $datasetEvaluatorId: ID!\n  $timeRange: TimeRange\n  $orphanSpanAsRootSpan: Boolean!\n) {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      id\n      datasetEvaluator(datasetEvaluatorId: $datasetEvaluatorId) {\n        id\n        name\n        description\n        evaluator {\n          __typename\n          kind\n          description\n          id\n        }\n        project {\n          id\n          ...DatasetEvaluatorSpans_project\n        }\n        ...BuiltInDatasetEvaluatorDetails_datasetEvaluator\n        ...CodeDatasetEvaluatorDetails_datasetEvaluator\n        ...LLMDatasetEvaluatorDetails_datasetEvaluator\n      }\n    }\n  }\n  sandboxBackends {\n    backendType\n    displayName\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment BuiltInDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    name\n    ... on BuiltInEvaluator {\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment CodeDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    ... on CodeEvaluator {\n      id\n      name\n      description\n      language\n      sourceCode\n      sandboxConfig {\n        id\n        name\n        description\n        config\n        timeout\n        provider {\n          backendType\n          language\n          id\n        }\n      }\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment DatasetEvaluatorSpans_project on Project {\n  id\n  ...SpansTable_spans\n}\n\nfragment LLMDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        tools {\n          tools {\n            function {\n              parameters\n            }\n          }\n        }\n        ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n        ...PromptChatMessagesCard__main\n        id\n      }\n      promptVersionTag {\n        name\n        id\n      }\n    }\n    id\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment PromptChatMessagesCard__main on PromptVersion {\n  provider: modelProvider\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                arguments\n                name\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpanColumnSelector_traceAnnotations on Project {\n  traceAnnotationsNames\n}\n\nfragment SpansTable_spans on Project {\n  name\n  spanAnnotationNames\n  ...SpanColumnSelector_annotations\n  ...SpanColumnSelector_traceAnnotations\n  spans(first: 30, sort: {col: startTime, dir: desc}, rootSpansOnly: true, orphanSpanAsRootSpan: $orphanSpanAsRootSpan, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        spanId\n        trace {\n          id\n          traceId\n          costSummary {\n            total {\n              cost\n            }\n          }\n          traceAnnotationSummaries {\n            labelFractions {\n              fraction\n              label\n            }\n            count\n            meanScore\n            name\n          }\n          ...TraceAnnotationSummaryGroup\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n          createdAt\n        }\n        spanAnnotationSummaries {\n          labelFractions {\n            fraction\n            label\n          }\n          meanScore\n          name\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        ...AnnotationSummaryGroup\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment TraceAnnotationSummaryGroup on Trace {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  traceAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  traceAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  customProvider {\n    id\n    name\n  }\n  responseFormat {\n    jsonSchema {\n      name\n      description\n      schema\n      strict\n    }\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    tools {\n      function {\n        name\n        description\n        parameters\n        strict\n      }\n    }\n    toolChoice {\n      type\n      functionName\n    }\n    disableParallelToolCalls\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "faf73baa503be620a53f194a53a6af2e";
+(node as any).hash = "f1d5c0973d0b857860202056b87fb6d0";
 
 export default node;

--- a/app/src/pages/dataset/evaluators/datasetEvaluatorDetailsLoader.ts
+++ b/app/src/pages/dataset/evaluators/datasetEvaluatorDetailsLoader.ts
@@ -36,6 +36,13 @@ export const datasetEvaluatorDetailsLoaderGQL = graphql`
         }
       }
     }
+    sandboxBackends {
+      backendType
+      displayName
+      supportsEnvVars
+      internetAccess
+      dependenciesLanguage
+    }
   }
 `;
 

--- a/app/src/pages/settings/__generated__/settingsSandboxesPageLoaderQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/settingsSandboxesPageLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8e8502363924049f07a49b787a343bbb>>
+ * @generated SignedSource<<96306407a918ae2f00dfde9f207aa9c7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -118,6 +118,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "statusDetail",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "supportsEnvVars",
             "storageKey": null
           },
@@ -200,12 +207,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0d4bc9439f9c5fb3e72eb7e18d944250",
+    "cacheID": "362899792e1515262703a30b94bdb0d2",
     "id": null,
     "metadata": {},
     "name": "settingsSandboxesPageLoaderQuery",
     "operationKind": "query",
-    "text": "query settingsSandboxesPageLoaderQuery {\n  ...SettingsSandboxesPageFragment\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "query settingsSandboxesPageLoaderQuery {\n  ...SettingsSandboxesPageFragment\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -135,6 +135,13 @@ type SandboxConfigDialogContentProps = (
 
 const NOT_SUPPORTED_COPY = "Not supported by the selected backend.";
 
+function shouldShowLocalDenoTrustWarning() {
+  // Heuristic: managed Phoenix deployments inject managementUrl and users do
+  // not control the host runtime directly. Prefer a server-provided deployment
+  // capability flag if one becomes available.
+  return !window.Config.managementUrl;
+}
+
 function defaultConfigName(provider: ProviderRow): string {
   return `${provider.backend.displayName}`;
 }
@@ -341,6 +348,14 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
       <form onSubmit={handleSubmit}>
         <View padding="size-200">
           <Flex direction="column" gap="size-200">
+            {activeBackend?.backendType === "DENO" &&
+            shouldShowLocalDenoTrustWarning() ? (
+              <Alert variant="warning">
+                Deno runs locally on the Phoenix server and relies on Deno's
+                permission system for isolation. Only enable it for trusted code
+                execution.
+              </Alert>
+            ) : null}
             {mode === "create" ? (
               <Controller
                 name="sandboxProviderId"

--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -37,7 +37,6 @@ import {
   TextField,
   View,
 } from "@phoenix/components";
-import { CodeEditorFieldWrapper, JSONEditor } from "@phoenix/components/code";
 import { useNotifySuccess } from "@phoenix/contexts";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
@@ -52,12 +51,7 @@ import type {
   SandboxConfigFormValues,
   SandboxProvider,
 } from "./types";
-import {
-  formValuesToConfigPatch,
-  languageLabel,
-  parseConfigText,
-  toPrettyJSONObject,
-} from "./utils";
+import { formValuesToConfigPatch, languageLabel } from "./utils";
 
 type SandboxConfigDialogTriggerProps =
   | { mode: "create"; providers: ProviderRow[]; defaultProvider?: ProviderRow }
@@ -148,6 +142,7 @@ function configToFormValues(config: SandboxConfig["config"]): {
   envVars: EnvVarFormEntry[];
   internetAccessEnabled: boolean;
   dependenciesText: string;
+  dependenciesLockfile: string | null;
 } {
   const raw = (config as Record<string, unknown>) ?? {};
   const rawEnvVars = Array.isArray(raw["env_vars"]) ? raw["env_vars"] : [];
@@ -182,8 +177,15 @@ function configToFormValues(config: SandboxConfig["config"]): {
   const packages = Array.isArray(deps?.["packages"])
     ? (deps!["packages"] as string[]).join("\n")
     : "";
+  const dependenciesLockfile =
+    typeof deps?.["lockfile"] === "string" ? deps["lockfile"] : null;
 
-  return { envVars, internetAccessEnabled, dependenciesText: packages };
+  return {
+    envVars,
+    internetAccessEnabled,
+    dependenciesText: packages,
+    dependenciesLockfile,
+  };
 }
 
 function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
@@ -199,9 +201,15 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
     envVars: initEnvVars,
     internetAccessEnabled: initInternetAccess,
     dependenciesText: initDepsText,
+    dependenciesLockfile: initDepsLockfile,
   } = existingConfig != null
     ? configToFormValues(existingConfig.config)
-    : { envVars: [], internetAccessEnabled: false, dependenciesText: "" };
+    : {
+        envVars: [],
+        internetAccessEnabled: false,
+        dependenciesText: "",
+        dependenciesLockfile: null,
+      };
 
   const form = useForm<SandboxConfigFormValues>({
     defaultValues:
@@ -211,30 +219,20 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
             name: props.config.name,
             description: props.config.description ?? "",
             timeout: props.config.timeout,
-            configText: toPrettyJSONObject(
-              (() => {
-                const raw = {
-                  ...((props.config.config as Record<string, unknown>) ?? {}),
-                };
-                delete raw["env_vars"];
-                delete raw["internet_access"];
-                delete raw["dependencies"];
-                return raw;
-              })()
-            ),
             envVars: initEnvVars,
             internetAccessEnabled: initInternetAccess,
             dependenciesText: initDepsText,
+            dependenciesLockfile: initDepsLockfile,
           }
         : {
             sandboxProviderId: defaultProvider?.provider.id ?? "",
             name: defaultProvider ? defaultConfigName(defaultProvider) : "",
             description: "",
             timeout: 30,
-            configText: toPrettyJSONObject({}),
             envVars: [],
             internetAccessEnabled: false,
             dependenciesText: "",
+            dependenciesLockfile: null,
           },
   });
 
@@ -282,17 +280,7 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
 
   const handleSubmit = form.handleSubmit((values) => {
     setError(null);
-    const parsedConfig = parseConfigText(values.configText);
-    if (parsedConfig.error) {
-      setError(parsedConfig.error);
-      return;
-    }
-
-    const finalConfig = formValuesToConfigPatch(
-      values,
-      activeBackend,
-      (existingConfig?.config as Record<string, unknown>) ?? {}
-    );
+    const finalConfig = formValuesToConfigPatch(values, activeBackend);
 
     const onCompleted = () => {
       onClose();
@@ -548,26 +536,6 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
                 </Text>
               </Flex>
             ) : null}
-            <Controller
-              name="configText"
-              control={form.control}
-              rules={{
-                validate: (value) => parseConfigText(value).error ?? true,
-              }}
-              render={({ field, fieldState }) => (
-                <CodeEditorFieldWrapper
-                  label="Advanced Config JSON"
-                  errorMessage={fieldState.error?.message}
-                  description="Use this for backend-specific settings like templates, credentials, or runtime options."
-                >
-                  <JSONEditor
-                    value={field.value}
-                    onChange={field.onChange}
-                    optionalLint
-                  />
-                </CodeEditorFieldWrapper>
-              )}
-            />
           </Flex>
         </View>
         <DialogFooter>

--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -51,6 +51,7 @@ import type {
   SandboxConfigFormValues,
   SandboxProvider,
 } from "./types";
+import { DEFAULT_SANDBOX_TIMEOUT_SECONDS } from "./types";
 import { formValuesToConfigPatch, languageLabel } from "./utils";
 
 type SandboxConfigDialogTriggerProps =
@@ -228,7 +229,7 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
             sandboxProviderId: defaultProvider?.provider.id ?? "",
             name: defaultProvider ? defaultConfigName(defaultProvider) : "",
             description: "",
-            timeout: 30,
+            timeout: DEFAULT_SANDBOX_TIMEOUT_SECONDS,
             envVars: [],
             internetAccessEnabled: false,
             dependenciesText: "",

--- a/app/src/pages/settings/sandboxes/SandboxConfigsCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigsCard.tsx
@@ -94,7 +94,7 @@ export function SandboxConfigsCard({
                       >
                         {hasConfig(config.config)
                           ? summarizeConfig(config.config)
-                          : "No advanced settings"}
+                          : "No custom settings"}
                       </Text>
                     </Flex>
                   </td>

--- a/app/src/pages/settings/sandboxes/SandboxConfigsCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigsCard.tsx
@@ -81,7 +81,11 @@ export function SandboxConfigsCard({
                   </td>
                   <td>
                     <div css={inlineTokenRowCSS}>
-                      <StatusText status={backend.status} />
+                      <StatusText
+                        status={backend.status}
+                        detail={backend.statusDetail}
+                        dependencyHints={backend.dependencyHints}
+                      />
                     </div>
                   </td>
                   <td>

--- a/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
@@ -1,27 +1,17 @@
-import { css } from "@emotion/react";
 import { useState } from "react";
 import { graphql, useMutation } from "react-relay";
 
-import {
-  Card,
-  Flex,
-  Label,
-  RichTooltip,
-  Switch,
-  Text,
-  TooltipTrigger,
-  TriggerWrap,
-} from "@phoenix/components";
+import { Card, Flex, Label, Switch, Text } from "@phoenix/components";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import type { SandboxProvidersCardProviderEnabledSwitchMutation } from "./__generated__/SandboxProvidersCardProviderEnabledSwitchMutation.graphql";
 import { cardIntroCSS, sandboxesTableCSS } from "./styles";
-import type { BackendInfo, ProviderRow, SandboxProvider } from "./types";
+import type { ProviderRow, SandboxProvider } from "./types";
 import {
   formatTimestamp,
   getBackendDescription,
   languageLabel,
-  statusLabel,
+  StatusText,
 } from "./utils";
 
 export function SandboxProvidersCard({
@@ -64,7 +54,11 @@ export function SandboxProvidersCard({
                   <Text>{getBackendDescription(backend.backendType)}</Text>
                 </td>
                 <td>
-                  <ProviderStatusText backend={backend} />
+                  <StatusText
+                    status={backend.status}
+                    detail={backend.statusDetail}
+                    dependencyHints={backend.dependencyHints}
+                  />
                 </td>
 
                 <td>{formatTimestamp(provider.updatedAt)}</td>
@@ -86,42 +80,6 @@ export function SandboxProvidersCard({
         </tbody>
       </table>
     </Card>
-  );
-}
-
-function ProviderStatusText({ backend }: { backend: BackendInfo }) {
-  const label = statusLabel(backend.status);
-
-  if (backend.status === "AVAILABLE") {
-    return <Text color="success">{label}</Text>;
-  }
-
-  if (backend.dependencyHints.length === 0) {
-    return <Text color="text-700">{label}</Text>;
-  }
-
-  return (
-    <TooltipTrigger delay={100}>
-      <TriggerWrap>
-        <Text
-          color="text-700"
-          css={css`
-            text-decoration: underline dotted;
-            text-underline-offset: 2px;
-            cursor: help;
-          `}
-        >
-          {label}
-        </Text>
-      </TriggerWrap>
-      <RichTooltip width={320}>
-        <Flex direction="column" gap="size-50">
-          {backend.dependencyHints.map((hint: string) => (
-            <Text key={hint}>{hint}</Text>
-          ))}
-        </Flex>
-      </RichTooltip>
-    </TooltipTrigger>
   );
 }
 

--- a/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
@@ -1,55 +1,27 @@
 import { css } from "@emotion/react";
 import { useState } from "react";
-import { Controller, useForm } from "react-hook-form";
 import { graphql, useMutation } from "react-relay";
 
 import {
-  Alert,
-  Button,
   Card,
-  Dialog,
-  DialogCloseButton,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTitleExtra,
-  DialogTrigger,
   Flex,
-  Icon,
-  Icons,
   Label,
-  Modal,
-  ModalOverlay,
   RichTooltip,
   Switch,
   Text,
   TooltipTrigger,
   TriggerWrap,
-  View,
 } from "@phoenix/components";
-import { CodeEditorFieldWrapper, JSONEditor } from "@phoenix/components/code";
-import { useNotifySuccess } from "@phoenix/contexts";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import type { SandboxProvidersCardProviderEnabledSwitchMutation } from "./__generated__/SandboxProvidersCardProviderEnabledSwitchMutation.graphql";
-import type { SandboxProvidersCardUpdateSandboxProviderMutation } from "./__generated__/SandboxProvidersCardUpdateSandboxProviderMutation.graphql";
 import { cardIntroCSS, sandboxesTableCSS } from "./styles";
-import type {
-  BackendInfo,
-  ProviderRow,
-  ProviderSettingsFormValues,
-  SandboxProvider,
-} from "./types";
+import type { BackendInfo, ProviderRow, SandboxProvider } from "./types";
 import {
   formatTimestamp,
   getBackendDescription,
-  hasConfig,
   languageLabel,
-  parseConfigText,
   statusLabel,
-  summarizeConfig,
-  toPrettyJSONObject,
 } from "./utils";
 
 export function SandboxProvidersCard({
@@ -71,7 +43,6 @@ export function SandboxProvidersCard({
             <th>Provider</th>
             <th>Runtime</th>
             <th>Status</th>
-            <th>Shared Settings</th>
             <th>Updated</th>
             <th />
           </tr>
@@ -96,39 +67,18 @@ export function SandboxProvidersCard({
                   <ProviderStatusText backend={backend} />
                 </td>
 
-                <td>
-                  <Text
-                    color={hasConfig(provider.config) ? undefined : "text-700"}
-                  >
-                    {hasConfig(provider.config)
-                      ? summarizeConfig(provider.config)
-                      : "No shared settings"}
-                  </Text>
-                </td>
                 <td>{formatTimestamp(provider.updatedAt)}</td>
                 <td>
-                  <Flex
-                    gap="size-100"
-                    alignItems="center"
-                    justifyContent="space-between"
-                  >
-                    {canEnable ? (
-                      <ProviderEnabledSwitch
-                        provider={provider}
-                        canEnable={canEnable}
-                      />
-                    ) : (
-                      <Text color="text-700" size="S">
-                        Unavailable
-                      </Text>
-                    )}
-                    <Flex justifyContent="end">
-                      <EditSandboxProviderButton
-                        backend={backend}
-                        provider={provider}
-                      />
-                    </Flex>
-                  </Flex>
+                  {canEnable ? (
+                    <ProviderEnabledSwitch
+                      provider={provider}
+                      canEnable={canEnable}
+                    />
+                  ) : (
+                    <Text color="text-700" size="S">
+                      Unavailable
+                    </Text>
+                  )}
                 </td>
               </tr>
             );
@@ -227,149 +177,5 @@ function ProviderEnabledSwitch({
         </Text>
       ) : null}
     </Flex>
-  );
-}
-
-export function EditSandboxProviderButton({
-  backend,
-  provider,
-}: {
-  backend: BackendInfo;
-  provider: SandboxProvider;
-}) {
-  const [isOpen, setIsOpen] = useState(false);
-
-  return (
-    <DialogTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
-      <Button size="S" leadingVisual={<Icon svg={<Icons.EditOutline />} />} />
-      <ModalOverlay>
-        <Modal size="L">
-          <Dialog>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>
-                  {backend.displayName} {languageLabel(provider.language)}{" "}
-                  Provider
-                </DialogTitle>
-                <DialogTitleExtra>
-                  <DialogCloseButton slot="close" />
-                </DialogTitleExtra>
-              </DialogHeader>
-              <ProviderSettingsDialogContent
-                provider={provider}
-                onClose={() => setIsOpen(false)}
-              />
-            </DialogContent>
-          </Dialog>
-        </Modal>
-      </ModalOverlay>
-    </DialogTrigger>
-  );
-}
-
-function ProviderSettingsDialogContent({
-  provider,
-  onClose,
-}: {
-  provider: SandboxProvider;
-  onClose: () => void;
-}) {
-  const notifySuccess = useNotifySuccess();
-  const [error, setError] = useState<string | null>(null);
-  const form = useForm<ProviderSettingsFormValues>({
-    defaultValues: {
-      configText: toPrettyJSONObject(provider.config),
-    },
-  });
-  const [commitUpdate, isSubmitting] =
-    useMutation<SandboxProvidersCardUpdateSandboxProviderMutation>(graphql`
-      mutation SandboxProvidersCardUpdateSandboxProviderMutation(
-        $input: UpdateSandboxProviderInput!
-      ) {
-        updateSandboxProvider(input: $input) {
-          query {
-            ...SettingsSandboxesPageFragment
-          }
-        }
-      }
-    `);
-
-  const handleSubmit = form.handleSubmit((values) => {
-    setError(null);
-    const parsedConfig = parseConfigText(values.configText);
-    if (parsedConfig.error) {
-      setError(parsedConfig.error);
-      return;
-    }
-    commitUpdate({
-      variables: {
-        input: {
-          id: provider.id,
-          config: parsedConfig.config,
-        },
-      },
-      onCompleted: () => {
-        onClose();
-        notifySuccess({
-          title: "Provider updated",
-          message: `${languageLabel(provider.language)} provider settings saved.`,
-        });
-      },
-      onError: (mutationError) => {
-        setError(
-          getErrorMessagesFromRelayMutationError(mutationError)?.[0] ??
-            "Failed to update provider settings"
-        );
-      },
-    });
-  });
-
-  return (
-    <>
-      {error ? (
-        <Alert variant="danger" banner>
-          {error}
-        </Alert>
-      ) : null}
-      <form onSubmit={handleSubmit}>
-        <View padding="size-200">
-          <Flex direction="column" gap="size-200">
-            <Controller
-              name="configText"
-              control={form.control}
-              rules={{
-                validate: (value) => parseConfigText(value).error ?? true,
-              }}
-              render={({ field, fieldState }) => (
-                <CodeEditorFieldWrapper
-                  label="Shared Provider Settings"
-                  errorMessage={fieldState.error?.message}
-                  description="These settings are shared across every config under this provider."
-                >
-                  <JSONEditor
-                    value={field.value}
-                    onChange={field.onChange}
-                    optionalLint
-                  />
-                </CodeEditorFieldWrapper>
-              )}
-            />
-          </Flex>
-        </View>
-        <DialogFooter>
-          <Button variant="default" onPress={onClose} size="S">
-            Cancel
-          </Button>
-          <Button
-            type="submit"
-            variant="primary"
-            isDisabled={isSubmitting}
-            size="S"
-          >
-            Save Provider
-          </Button>
-        </DialogFooter>
-      </form>
-    </>
   );
 }

--- a/app/src/pages/settings/sandboxes/SettingsSandboxesPage.tsx
+++ b/app/src/pages/settings/sandboxes/SettingsSandboxesPage.tsx
@@ -47,6 +47,7 @@ function SettingsSandboxesPageContent({
           dependencyHints
           supportedLanguages
           status
+          statusDetail
           supportsEnvVars
           internetAccess
           dependenciesLanguage

--- a/app/src/pages/settings/sandboxes/__generated__/DeleteSandboxConfigButtonDeleteSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/DeleteSandboxConfigButtonDeleteSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0eadfba2dde1275f8eb32c44d273ff18>>
+ * @generated SignedSource<<a6b3d670fa7cfbced0aeac60e60cd4a2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -186,6 +186,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "statusDetail",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "supportsEnvVars",
                     "storageKey": null
                   },
@@ -274,12 +281,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3a434f83343028f39744f0d11c2f78fb",
+    "cacheID": "63768ec92cb19d23d3d2ca6ad9e02b21",
     "id": null,
     "metadata": {},
     "name": "DeleteSandboxConfigButtonDeleteSandboxConfigMutation",
     "operationKind": "mutation",
-    "text": "mutation DeleteSandboxConfigButtonDeleteSandboxConfigMutation(\n  $id: ID!\n) {\n  deleteSandboxConfig(id: $id) {\n    deletedId\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation DeleteSandboxConfigButtonDeleteSandboxConfigMutation(\n  $id: ID!\n) {\n  deleteSandboxConfig(id: $id) {\n    deletedId\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogCreateSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogCreateSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<39bccf4c2aaf56ccad12535f3d0ab030>>
+ * @generated SignedSource<<13fddc04769582c60b8757f179488fdd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -184,6 +184,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "statusDetail",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "supportsEnvVars",
                     "storageKey": null
                   },
@@ -272,12 +279,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c408b5c7969a3524b94197fc3988bd01",
+    "cacheID": "b57abfb530dda8f153202bcea1e2d907",
     "id": null,
     "metadata": {},
     "name": "SandboxConfigDialogCreateSandboxConfigMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxConfigDialogCreateSandboxConfigMutation(\n  $input: CreateSandboxConfigInput!\n) {\n  createSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxConfigDialogCreateSandboxConfigMutation(\n  $input: CreateSandboxConfigInput!\n) {\n  createSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c79e412ac3d120292cde5f95bc0a77a8>>
+ * @generated SignedSource<<277599302bd0f3a2ee6abfecbd3e6459>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -183,6 +183,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "statusDetail",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "supportsEnvVars",
                     "storageKey": null
                   },
@@ -271,12 +278,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "60850d8e16d23db006a428c3aada8bdc",
+    "cacheID": "406bd380df0c43502c0364b3ad39dba3",
     "id": null,
     "metadata": {},
     "name": "SandboxConfigDialogUpdateSandboxConfigMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxConfigDialogUpdateSandboxConfigMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxConfigDialogUpdateSandboxConfigMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<771aa85640a24e129a1f7464d93b0f0d>>
+ * @generated SignedSource<<66b2ba6804072366561474d441e0b77b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -183,6 +183,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "statusDetail",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "supportsEnvVars",
                     "storageKey": null
                   },
@@ -271,12 +278,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "92dabb3e8d056c3fbe541c60ea49ab97",
+    "cacheID": "1fabd9a2d9bb3f1f7552ab52144f8f53",
     "id": null,
     "metadata": {},
     "name": "SandboxConfigsCardConfigEnabledSwitchMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxConfigsCardConfigEnabledSwitchMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxConfigsCardConfigEnabledSwitchMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxProvidersCardProviderEnabledSwitchMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxProvidersCardProviderEnabledSwitchMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f1555fa6001c1b7a590a984a686b9227>>
+ * @generated SignedSource<<a2b2ec5e6486a8903a7de258e416e1fc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -181,6 +181,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "statusDetail",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "supportsEnvVars",
                     "storageKey": null
                   },
@@ -269,12 +276,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b101f285caef8a7c7081bdee796299ce",
+    "cacheID": "f66b48ce2c240d4889c8d1e352c3fcc5",
     "id": null,
     "metadata": {},
     "name": "SandboxProvidersCardProviderEnabledSwitchMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxProvidersCardProviderEnabledSwitchMutation(\n  $input: UpdateSandboxProviderInput!\n) {\n  updateSandboxProvider(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxProvidersCardProviderEnabledSwitchMutation(\n  $input: UpdateSandboxProviderInput!\n) {\n  updateSandboxProvider(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<398bee3fa30ed41d73ec0a21889eb907>>
+ * @generated SignedSource<<0f6f6a12695141fa562ec06945810b44>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ReaderFragment } from 'relay-runtime';
 export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
-export type SandboxBackendStatus = "AVAILABLE" | "NOT_INSTALLED" | "UNAVAILABLE";
+export type SandboxBackendStatus = "AVAILABLE" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
 import { FragmentRefs } from "relay-runtime";
 export type SettingsSandboxesPageFragment$data = {
   readonly sandboxBackends: ReadonlyArray<{
@@ -21,6 +21,7 @@ export type SettingsSandboxesPageFragment$data = {
     readonly displayName: string;
     readonly internetAccess: InternetAccessMode;
     readonly status: SandboxBackendStatus;
+    readonly statusDetail: string | null;
     readonly supportedLanguages: ReadonlyArray<Language>;
     readonly supportsEnvVars: boolean;
   }>;
@@ -131,6 +132,13 @@ return {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
+          "name": "statusDetail",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
           "name": "supportsEnvVars",
           "storageKey": null
         },
@@ -216,6 +224,6 @@ return {
 };
 })();
 
-(node as any).hash = "d448f7540d4e14bd05d86a348411cf36";
+(node as any).hash = "fbfdf2c6bcd4f7119c65cc9dbcf52876";
 
 export default node;

--- a/app/src/pages/settings/sandboxes/__tests__/formValuesToConfigPatch.test.ts
+++ b/app/src/pages/settings/sandboxes/__tests__/formValuesToConfigPatch.test.ts
@@ -13,10 +13,10 @@ const emptyValues: SandboxConfigFormValues = {
   name: "",
   description: "",
   timeout: 600,
-  configText: "{}",
   envVars: [],
   internetAccessEnabled: false,
   dependenciesText: "",
+  dependenciesLockfile: null,
 };
 
 const noCapabilityBackend: PartialBackend = {
@@ -31,111 +31,27 @@ const fullCapabilityBackend: PartialBackend = {
   dependenciesLanguage: "PYTHON",
 };
 
-describe("formValuesToConfigPatch — preserve-on-save", () => {
-  it("(a) flag flip False→True→False: stored capability-gated key survives a round-trip through unsupported state", () => {
-    const storedConfig: Record<string, unknown> = {
-      env_vars: [{ kind: "literal", name: "X", value: "1" }],
-      some_setting: "abc",
-    };
-
-    // Flag flipped to False (supportsEnvVars=false) — env_vars should be preserved from storedConfig
+describe("formValuesToConfigPatch — capability-only output", () => {
+  it("(a) no capabilities supported: result is empty", () => {
     const result = formValuesToConfigPatch(
       emptyValues,
-      noCapabilityBackend as BackendInfo,
-      storedConfig
-    );
-
-    expect(result["env_vars"]).toEqual(storedConfig["env_vars"]);
-    expect(result["some_setting"]).toBe("abc");
-  });
-
-  it("(b) activeBackend undefined: capability-gated keys preserved from storedConfig when no backend selected", () => {
-    const storedConfig: Record<string, unknown> = {
-      env_vars: [{ kind: "literal", name: "KEY", value: "val" }],
-      internet_access: { mode: "allow" },
-      dependencies: { packages: ["numpy"] },
-      extra_key: "preserved",
-    };
-
-    const result = formValuesToConfigPatch(
-      emptyValues,
-      undefined,
-      storedConfig
-    );
-
-    expect(result["env_vars"]).toEqual(storedConfig["env_vars"]);
-    expect(result["internet_access"]).toEqual(storedConfig["internet_access"]);
-    expect(result["dependencies"]).toEqual(storedConfig["dependencies"]);
-    expect(result["extra_key"]).toBe("preserved");
-  });
-
-  it("(c) non-UI-path stored data survives a UI-side save round-trip unchanged", () => {
-    // Data written via API (not the UI) — e.g., a lockfile field not exposed in the form
-    const storedConfig: Record<string, unknown> = {
-      dependencies: { packages: ["pandas"], lockfile: "pandas==2.2.0\n" },
-      custom_field: "api-written",
-    };
-
-    // Backend does not support dependencies — stored value is preserved verbatim
-    const result = formValuesToConfigPatch(
-      emptyValues,
-      noCapabilityBackend as BackendInfo,
-      storedConfig
-    );
-
-    expect(result["dependencies"]).toEqual(storedConfig["dependencies"]);
-    expect(result["custom_field"]).toBe("api-written");
-  });
-
-  it("(d) lockfile preserved when dependenciesLanguage is set and packages edited", () => {
-    const storedConfig: Record<string, unknown> = {
-      dependencies: { packages: ["old-pkg"], lockfile: "old-pkg==1.0.0\n" },
-    };
-    const values: SandboxConfigFormValues = {
-      ...emptyValues,
-      dependenciesText: "new-pkg",
-    };
-
-    const result = formValuesToConfigPatch(
-      values,
-      fullCapabilityBackend as BackendInfo,
-      storedConfig
-    );
-
-    expect(result["dependencies"]).toEqual({
-      packages: ["new-pkg"],
-      lockfile: "old-pkg==1.0.0\n",
-    });
-  });
-
-  it("JSON editor cannot inject env_vars, internet_access, or dependencies via configText", () => {
-    const storedConfig: Record<string, unknown> = {};
-    const valuesWithInjectedKeys: SandboxConfigFormValues = {
-      ...emptyValues,
-      configText: JSON.stringify({
-        env_vars: [{ kind: "literal", name: "INJECTED", value: "bad" }],
-        internet_access: { mode: "allow" },
-        dependencies: { packages: ["malicious"] },
-        safe_key: "allowed",
-      }),
-    };
-
-    const result = formValuesToConfigPatch(
-      valuesWithInjectedKeys,
-      noCapabilityBackend as BackendInfo,
-      storedConfig
+      noCapabilityBackend as BackendInfo
     );
 
     expect(result["env_vars"]).toBeUndefined();
     expect(result["internet_access"]).toBeUndefined();
     expect(result["dependencies"]).toBeUndefined();
-    expect(result["safe_key"]).toBe("allowed");
   });
 
-  it("capability flag True: form values are authoritative for env_vars", () => {
-    const storedConfig: Record<string, unknown> = {
-      env_vars: [{ kind: "literal", name: "OLD", value: "old" }],
-    };
+  it("(b) backend undefined: result is empty", () => {
+    const result = formValuesToConfigPatch(emptyValues, undefined);
+
+    expect(result["env_vars"]).toBeUndefined();
+    expect(result["internet_access"]).toBeUndefined();
+    expect(result["dependencies"]).toBeUndefined();
+  });
+
+  it("(f) capability flag True: form values are authoritative for env_vars", () => {
     const values: SandboxConfigFormValues = {
       ...emptyValues,
       envVars: [{ kind: "literal", name: "NEW", value: "new" }],
@@ -143,12 +59,62 @@ describe("formValuesToConfigPatch — preserve-on-save", () => {
 
     const result = formValuesToConfigPatch(
       values,
-      fullCapabilityBackend as BackendInfo,
-      storedConfig
+      fullCapabilityBackend as BackendInfo
     );
 
     expect(result["env_vars"]).toEqual([
       { kind: "literal", name: "NEW", value: "new" },
     ]);
+  });
+
+  it("(positive) all capabilities set: result contains exactly the three capability keys", () => {
+    const values: SandboxConfigFormValues = {
+      ...emptyValues,
+      envVars: [{ kind: "literal", name: "KEY", value: "val" }],
+      internetAccessEnabled: true,
+      dependenciesText: "numpy\npandas",
+      dependenciesLockfile: "numpy==1.26.0\npandas==2.0.0",
+    };
+
+    const result = formValuesToConfigPatch(
+      values,
+      fullCapabilityBackend as BackendInfo
+    );
+
+    expect(result).toEqual({
+      env_vars: [{ kind: "literal", name: "KEY", value: "val" }],
+      internet_access: { mode: "allow" },
+      dependencies: {
+        packages: ["numpy", "pandas"],
+        lockfile: "numpy==1.26.0\npandas==2.0.0",
+      },
+    });
+  });
+
+  it("(negative) env_vars absent when supportsEnvVars but envVars is empty", () => {
+    const result = formValuesToConfigPatch(
+      emptyValues,
+      fullCapabilityBackend as BackendInfo
+    );
+
+    expect(result).not.toHaveProperty("env_vars");
+  });
+
+  it("(negative) dependencies absent when dependenciesLanguage set but dependenciesText is empty", () => {
+    const result = formValuesToConfigPatch(
+      { ...emptyValues, dependenciesText: "" },
+      fullCapabilityBackend as BackendInfo
+    );
+
+    expect(result).not.toHaveProperty("dependencies");
+  });
+
+  it("(negative) internet_access absent when internetAccess is NONE", () => {
+    const result = formValuesToConfigPatch(
+      { ...emptyValues, internetAccessEnabled: true },
+      noCapabilityBackend as BackendInfo
+    );
+
+    expect(result).not.toHaveProperty("internet_access");
   });
 });

--- a/app/src/pages/settings/sandboxes/types.ts
+++ b/app/src/pages/settings/sandboxes/types.ts
@@ -22,10 +22,6 @@ export type ConfigRow = {
   config: SandboxConfig;
 };
 
-export type ProviderSettingsFormValues = {
-  configText: string;
-};
-
 export type EnvVarFormEntry =
   | { kind: "literal"; name: string; value: string }
   | { kind: "secret_ref"; name: string; secret_key: string };
@@ -35,8 +31,8 @@ export type SandboxConfigFormValues = {
   name: string;
   description: string;
   timeout: number;
-  configText: string;
   envVars: EnvVarFormEntry[];
   internetAccessEnabled: boolean;
   dependenciesText: string;
+  dependenciesLockfile: string | null;
 };

--- a/app/src/pages/settings/sandboxes/types.ts
+++ b/app/src/pages/settings/sandboxes/types.ts
@@ -36,3 +36,8 @@ export type SandboxConfigFormValues = {
   dependenciesText: string;
   dependenciesLockfile: string | null;
 };
+
+// Must stay aligned with the backend column server_default in
+// src/phoenix/db/models.py and the mutation fallback in
+// src/phoenix/server/api/mutations/sandbox_config_mutations.py.
+export const DEFAULT_SANDBOX_TIMEOUT_SECONDS = 300;

--- a/app/src/pages/settings/sandboxes/utils.tsx
+++ b/app/src/pages/settings/sandboxes/utils.tsx
@@ -1,9 +1,5 @@
 import { assertUnreachable } from "@phoenix/typeUtils";
-import {
-  isPlainObject,
-  safelyParseJSON,
-  safelyStringifyJSON,
-} from "@phoenix/utils/jsonUtils";
+import { isPlainObject } from "@phoenix/utils/jsonUtils";
 
 import type {
   BackendInfo,
@@ -69,7 +65,7 @@ export function getBackendDescription(backendType: BackendInfo["backendType"]) {
 
 export function summarizeConfig(config: unknown) {
   if (!isPlainObject(config) || Object.keys(config).length === 0) {
-    return "No advanced settings";
+    return "No custom settings";
   }
   const keys = Object.keys(config);
   if (keys.length === 1) {
@@ -82,99 +78,44 @@ export function hasConfig(config: unknown) {
   return isPlainObject(config) && Object.keys(config).length > 0;
 }
 
-export function toPrettyJSONObject(value: unknown) {
-  return safelyStringifyJSON(value ?? {}, null, 2).json ?? "{}";
-}
-
-export function parseConfigText(
-  value: string
-):
-  | { config: Record<string, unknown>; error?: undefined }
-  | { config?: undefined; error: string } {
-  const trimmed = value.trim();
-  if (trimmed.length === 0) {
-    return { config: {} };
-  }
-  const { json, parseError } = safelyParseJSON(trimmed);
-  if (parseError) {
-    return { error: "Config must be valid JSON." };
-  }
-  if (!isPlainObject(json)) {
-    return { error: "Config must be a JSON object." };
-  }
-  return { config: json };
-}
-
 export function formValuesToConfigPatch(
   values: SandboxConfigFormValues,
-  backend: BackendInfo | undefined,
-  storedConfig: Record<string, unknown>
+  backend: BackendInfo | undefined
 ): Record<string, unknown> {
-  // Start from a clone of the stored config so keys not visible in the current
-  // UI (capability flag is false, or activeBackend is undefined) are preserved.
-  const base: Record<string, unknown> = { ...storedConfig };
+  const result: Record<string, unknown> = {};
 
-  // Remove the three capability-gated keys; they are re-applied below from
-  // either form state (when the UI is visible) or left from storedConfig.
-  delete base["env_vars"];
-  delete base["internet_access"];
-  delete base["dependencies"];
-
-  // Merge flat configText keys on top (non-capability-gated backend settings).
-  // Strip capability-gated keys the user may have typed into the editor — only
-  // the structured editors may author env_vars, internet_access, dependencies.
-  const flatConfig = parseConfigText(values.configText).config ?? {};
-  delete flatConfig["env_vars"];
-  delete flatConfig["internet_access"];
-  delete flatConfig["dependencies"];
-  Object.assign(base, flatConfig);
-
-  // env_vars: authoritative from form when visible; preserve stored when hidden.
-  if (backend?.supportsEnvVars) {
-    if (values.envVars.length > 0) {
-      base["env_vars"] = values.envVars.map((entry) => {
-        if (entry.kind === "secret_ref") {
-          return {
-            kind: "secret_ref",
-            name: entry.name,
-            secret_key: entry.secret_key,
-          };
-        }
-        return { kind: "literal", name: entry.name, value: entry.value };
-      });
-    }
-    // Empty envVars list means the user cleared it intentionally — omit the key.
-  } else if (storedConfig["env_vars"] !== undefined) {
-    base["env_vars"] = storedConfig["env_vars"];
+  if (backend?.supportsEnvVars && values.envVars.length > 0) {
+    result["env_vars"] = values.envVars.map((entry) => {
+      if (entry.kind === "secret_ref") {
+        return {
+          kind: "secret_ref",
+          name: entry.name,
+          secret_key: entry.secret_key,
+        };
+      }
+      return { kind: "literal", name: entry.name, value: entry.value };
+    });
   }
 
-  // internet_access: authoritative from form when visible; preserve stored when hidden.
   if (backend?.internetAccess === "BOOLEAN") {
-    base["internet_access"] = {
+    result["internet_access"] = {
       mode: values.internetAccessEnabled ? "allow" : "deny",
     };
-  } else if (storedConfig["internet_access"] !== undefined) {
-    base["internet_access"] = storedConfig["internet_access"];
   }
 
-  // dependencies: authoritative from form when visible; preserve stored when hidden.
   if (backend?.dependenciesLanguage != null) {
     const packages = values.dependenciesText
       .split("\n")
       .map((s) => s.trim())
       .filter(Boolean);
     if (packages.length > 0) {
-      base["dependencies"] = {
-        ...(storedConfig["dependencies"] as
-          | Record<string, unknown>
-          | undefined),
-        packages,
-      };
+      const dep: Record<string, unknown> = { packages };
+      if (values.dependenciesLockfile != null) {
+        dep["lockfile"] = values.dependenciesLockfile;
+      }
+      result["dependencies"] = dep;
     }
-    // Empty packages means the user cleared it intentionally — omit the key.
-  } else if (storedConfig["dependencies"] !== undefined) {
-    base["dependencies"] = storedConfig["dependencies"];
   }
 
-  return base;
+  return result;
 }

--- a/app/src/pages/settings/sandboxes/utils.tsx
+++ b/app/src/pages/settings/sandboxes/utils.tsx
@@ -1,3 +1,12 @@
+import { css } from "@emotion/react";
+
+import {
+  Flex,
+  RichTooltip,
+  Text,
+  TooltipTrigger,
+  TriggerWrap,
+} from "@phoenix/components";
 import { assertUnreachable } from "@phoenix/typeUtils";
 import { isPlainObject } from "@phoenix/utils/jsonUtils";
 
@@ -7,14 +16,51 @@ import type {
   SandboxProvider,
 } from "./types";
 
-export function StatusText({ status }: { status: BackendInfo["status"] }) {
+export function StatusText({
+  status,
+  detail,
+  dependencyHints = [],
+}: {
+  status: BackendInfo["status"];
+  detail?: BackendInfo["statusDetail"];
+  dependencyHints?: BackendInfo["dependencyHints"];
+}) {
   const color =
     status === "AVAILABLE"
       ? "var(--global-color-success)"
-      : status === "UNAVAILABLE"
+      : status === "UNAVAILABLE" || status === "MISSING_CREDENTIALS"
         ? "var(--global-color-warning)"
         : "var(--ac-global-text-color-700)";
-  return <span style={{ color }}>{statusLabel(status)}</span>;
+  const label = statusLabel(status);
+  const tooltipLines = detail ? [detail] : dependencyHints;
+
+  if (status === "AVAILABLE" || tooltipLines.length === 0) {
+    return <span style={{ color }}>{label}</span>;
+  }
+
+  return (
+    <TooltipTrigger delay={100}>
+      <TriggerWrap>
+        <Text
+          color={status === "NOT_INSTALLED" ? "text-700" : "warning"}
+          css={css`
+            text-decoration: underline dotted;
+            text-underline-offset: 2px;
+            cursor: help;
+          `}
+        >
+          {label}
+        </Text>
+      </TriggerWrap>
+      <RichTooltip width={320}>
+        <Flex direction="column" gap="size-50">
+          {tooltipLines.map((line) => (
+            <Text key={line}>{line}</Text>
+          ))}
+        </Flex>
+      </RichTooltip>
+    </TooltipTrigger>
+  );
 }
 
 export function formatTimestamp(value: string) {
@@ -25,6 +71,8 @@ export function statusLabel(status: BackendInfo["status"]) {
   switch (status) {
     case "AVAILABLE":
       return "Available";
+    case "MISSING_CREDENTIALS":
+      return "Authentication required";
     case "UNAVAILABLE":
       return "Unavailable";
     case "NOT_INSTALLED":

--- a/app/tests/code-evaluators.spec.ts
+++ b/app/tests/code-evaluators.spec.ts
@@ -574,4 +574,256 @@ test.describe.serial("Code Evaluators", () => {
     await page.getByRole("button", { name: "Cancel" }).click();
     await expect(page.getByTestId("dialog")).not.toBeVisible();
   });
+
+  // Phase 4: Config-aware placeholder assertions
+
+  const placeholderCategoricalName = `placeholder-cat-${randomUUID().slice(0, 8)}`;
+  const placeholderContinuousName = `placeholder-cont-${randomUUID().slice(0, 8)}`;
+
+  async function getEditorContent(page: Page): Promise<string> {
+    // The editable CodeMirror panel is the first .cm-content in the dialog
+    return (
+      (await page
+        .getByRole("dialog")
+        .locator(".cm-content")
+        .first()
+        .textContent()) ?? ""
+    );
+  }
+
+  async function openOutputConfig(page: Page): Promise<void> {
+    const dialog = page.getByRole("dialog");
+    const panel = dialog.getByText(
+      "Define the output type and optimization direction"
+    );
+    if (!(await panel.isVisible())) {
+      await dialog
+        .getByRole("button", { name: "Output Configuration" })
+        .click();
+    }
+    await expect(panel).toBeVisible();
+  }
+
+  test("categorical placeholder shows substituted label from config", async ({
+    page,
+  }) => {
+    await gotoDatasetEvaluators(page, datasetName);
+
+    await page.getByRole("button", { name: "Add evaluator" }).click();
+    await page
+      .getByRole("menuitem", { name: "Create new code evaluator" })
+      .click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(
+      page.getByRole("heading", { name: "Create Evaluator" })
+    ).toBeVisible();
+
+    await dialog
+      .getByRole("textbox", { name: "Name", exact: true })
+      .fill(placeholderCategoricalName);
+
+    await selectComboboxOption(page, "Sandbox", pythonSandboxName, dialog);
+    await openOutputConfig(page);
+
+    // Switch to categorical
+    const outputTypeSelect = dialog.getByRole("button", {
+      name: /Continuous score|Categorical label/,
+    });
+    await outputTypeSelect.click();
+    await page
+      .getByRole("option", { name: "Categorical label", exact: true })
+      .click();
+
+    // Fill first choice label
+    const choiceInputs = dialog.locator('input[placeholder^="Choice"]');
+    await choiceInputs.first().fill("excellent");
+    await choiceInputs.nth(1).fill("poor");
+
+    // Allow store to sync and editor to re-render, then check placeholder
+    await page.waitForTimeout(200);
+    const content = await getEditorContent(page);
+
+    // Substituted label "excellent" should appear in return statement
+    expect(content).toContain('"excellent"');
+    // Static fallback "pass" should NOT appear as the return value
+    expect(content).not.toMatch(/return "pass"/);
+    // Dict-form comment with explanation key must be present
+    expect(content).toContain("explanation");
+
+    await page.getByRole("button", { name: "Create" }).click();
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
+    await expect(
+      page.getByRole("cell", { name: placeholderCategoricalName, exact: true })
+    ).toBeVisible();
+  });
+
+  test("continuous placeholder shows midpoint and bounds-range comment", async ({
+    page,
+  }) => {
+    await gotoDatasetEvaluators(page, datasetName);
+
+    await page.getByRole("button", { name: "Add evaluator" }).click();
+    await page
+      .getByRole("menuitem", { name: "Create new code evaluator" })
+      .click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(
+      page.getByRole("heading", { name: "Create Evaluator" })
+    ).toBeVisible();
+
+    await dialog
+      .getByRole("textbox", { name: "Name", exact: true })
+      .fill(placeholderContinuousName);
+
+    await selectComboboxOption(page, "Sandbox", pythonSandboxName, dialog);
+    await openOutputConfig(page);
+
+    // Ensure continuous is selected and set bounds
+    const contConfig = dialog.locator('input[type="number"]');
+    // Lower bound (first number input) = 0, upper bound = 10
+    await contConfig.first().fill("0");
+    await contConfig.last().fill("10");
+
+    await page.waitForTimeout(200);
+    const content = await getEditorContent(page);
+
+    // Midpoint of 0..10 is 5.0
+    expect(content).toContain("5.0");
+    // Bounds range comment
+    expect(content).toContain("0.0 - 10.0");
+    // Dict-form comment with explanation key
+    expect(content).toContain("explanation");
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
+  });
+
+  test("categorical with empty values falls back to static placeholder", async ({
+    page,
+  }) => {
+    // Open the existing categorical evaluator which has "Good"/"Bad" labels
+    await gotoDatasetEvaluators(page, datasetName);
+    await openEvaluatorEditor(page, categoricalEvaluatorName);
+
+    const dialog = page.getByRole("dialog");
+    await openOutputConfig(page);
+
+    // Clear all choice labels to trigger the empty-values fallback
+    const choiceInputs = dialog.locator('input[placeholder^="Choice"]');
+    await choiceInputs.first().fill("");
+    await choiceInputs.last().fill("");
+
+    await page.waitForTimeout(200);
+
+    // Press Reset — with empty values config, should produce static fallback "pass"
+    await dialog.getByRole("button", { name: "Reset" }).click();
+    await page.waitForTimeout(200);
+
+    const content = await getEditorContent(page);
+    expect(content).toContain('"pass"');
+    // Dict form comment must still be present
+    expect(content).toContain("explanation");
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
+  });
+
+  test("Reset on complete categorical config produces substituted placeholder", async ({
+    page,
+  }) => {
+    await gotoDatasetEvaluators(page, datasetName);
+    await openEvaluatorEditor(page, categoricalEvaluatorName);
+
+    const dialog = page.getByRole("dialog");
+
+    // Overwrite the editor with custom code
+    const editor = dialog.locator(".cm-content").first();
+    await editor.click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.insertText("# custom user code");
+
+    // Reset should restore the substituted placeholder for "Good"/"Bad"
+    await dialog.getByRole("button", { name: "Reset" }).click();
+    await page.waitForTimeout(200);
+
+    const content = await getEditorContent(page);
+    // "Good" is the first label in the categorical config
+    expect(content).toContain('"Good"');
+    expect(content).not.toMatch(/return "pass"/);
+    expect(content).toContain("explanation");
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
+  });
+
+  test("language switch on categorical preserves substituted placeholder", async ({
+    page,
+  }) => {
+    await gotoDatasetEvaluators(page, datasetName);
+    await openEvaluatorEditor(page, categoricalEvaluatorName);
+
+    const dialog = page.getByRole("dialog");
+
+    // Editor starts with Python substituted placeholder containing "Good"
+    let content = await getEditorContent(page);
+    expect(content).toContain('"Good"');
+
+    // Switch to TypeScript — guard should recognize default and auto-swap
+    await selectLanguage(page, dialog, "TypeScript");
+    await page.waitForTimeout(200);
+
+    content = await getEditorContent(page);
+    // TypeScript substituted placeholder still uses "Good"
+    expect(content).toContain('"Good"');
+    // TypeScript syntax: function keyword
+    expect(content).toContain("function evaluate");
+    expect(content).toContain("explanation");
+
+    // Switch back to Python — guard still recognizes it as a generated default
+    await selectLanguage(page, dialog, "Python");
+    await page.waitForTimeout(200);
+
+    content = await getEditorContent(page);
+    expect(content).toContain('"Good"');
+    expect(content).toContain("def evaluate");
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
+  });
+
+  test("shape change from continuous to categorical auto-swaps placeholder", async ({
+    page,
+  }) => {
+    await gotoDatasetEvaluators(page, datasetName);
+
+    // Open the continuous evaluator for editing
+    await openEvaluatorEditor(page, placeholderContinuousName);
+
+    const dialog = page.getByRole("dialog");
+    await openOutputConfig(page);
+
+    // Verify the editor shows a continuous placeholder (contains numeric return)
+    let content = await getEditorContent(page);
+    expect(content).toContain("5.0");
+
+    // Switch output type to categorical
+    const outputTypeSelect = dialog.getByRole("button", {
+      name: /Continuous score|Categorical label/,
+    });
+    await outputTypeSelect.click();
+    await page
+      .getByRole("option", { name: "Categorical label", exact: true })
+      .click();
+    await page.waitForTimeout(200);
+
+    content = await getEditorContent(page);
+    // Categorical fallback (default labels are "pass"/"fail" since no saved labels)
+    expect(content).toContain('"pass"');
+    expect(content).toContain("explanation");
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
+  });
 });

--- a/docs.json
+++ b/docs.json
@@ -190,6 +190,7 @@
                     ]
                   },
                   "docs/phoenix/evaluation/how-to-evals/code-evaluators",
+                  "docs/phoenix/evaluation/how-to-evals/code-evaluator-output-shapes",
                   "docs/phoenix/evaluation/how-to-evals/batch-evaluations",
                   "docs/phoenix/evaluation/how-to-evals/using-evals-with-phoenix",
                   {

--- a/docs/phoenix/evaluation/how-to-evals/code-evaluator-output-shapes.mdx
+++ b/docs/phoenix/evaluation/how-to-evals/code-evaluator-output-shapes.mdx
@@ -1,0 +1,226 @@
+---
+title: "Code Evaluator Output Shapes"
+---
+
+This page documents every return shape a code evaluator can produce and how Phoenix maps each one to an `EvaluationResult` with `label`, `score`, and `explanation` fields.
+
+<Info>
+This page covers the **server-side code evaluators** that run in the Phoenix UI (Sandbox evaluators). For client-side `create_evaluator` / `createEvaluator` SDK evaluators, see [Code Evaluators](/docs/phoenix/evaluation/how-to-evals/code-evaluators).
+</Info>
+
+## The Triple-Collapse Model
+
+Every return value from a code evaluator is normalized to a **triple**: `(label, score, explanation)`. Phoenix applies this in two stages:
+
+1. **Stage 1 — Extract**: The raw return value is mapped to a `Triple` based on its shape (bare scalar or dict-by-key).
+2. **Stage 2 — Validate**: The triple is checked against the evaluator's output config (categorical, continuous, or none).
+
+Any value that cannot be cleanly mapped raises a `ValueError` whose message enumerates all accepted shapes for the configured output type.
+
+## Accepted Shapes by Output Config
+
+### Categorical Output Config
+
+A categorical config defines a fixed set of `{label, score}` pairs. The evaluator must return one of the configured labels; Phoenix looks up the associated score automatically.
+
+**Bare string (recommended):**
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+return "pass"
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+return "pass";
+```
+</Tab>
+</Tabs>
+
+**Dict with label and optional explanation:**
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+return {"label": "pass", "explanation": "The output matched the expected format."}
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+return {"label": "pass", "explanation": "The output matched the expected format."};
+```
+</Tab>
+</Tabs>
+
+Notes:
+- The label must exactly match one of the configured values; unrecognized labels raise `ValueError`.
+- Including a `score` key in the dict that conflicts with the config's lookup value raises `ValueError`.
+- Free-form `explanation` strings are always accepted and passed through to `EvaluationResult.explanation`.
+- Tuple shorthand (`return ("pass", 1.0)`) is **not** accepted; use the dict form if you need to supply additional fields.
+
+### Continuous Output Config
+
+A continuous config validates that the returned value is a finite number within optional `lower_bound` / `upper_bound` bounds. Labels are optional and free-form.
+
+**Bare number (recommended):**
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+return 0.85
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+return 0.85;
+```
+</Tab>
+</Tabs>
+
+**Dict with score and optional explanation:**
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+# score in range 0.0 - 1.0
+return {"score": 0.85, "explanation": "High confidence based on keyword match."}
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+// score in range 0.0 - 1.0
+return {"score": 0.85, "explanation": "High confidence based on keyword match."};
+```
+</Tab>
+</Tabs>
+
+Notes:
+- `bool` values are **not** treated as numeric and raise `ValueError`.
+- `NaN` and `Infinity` are rejected.
+- Free-form string labels are allowed in the dict form alongside a numeric score.
+- Tuple shorthand is **not** accepted.
+
+### No Output Config
+
+When no output config is specified, Phoenix applies a permissive bare passthrough:
+
+| Return value | Result |
+|---|---|
+| `str` | `label=<value>` |
+| `int` or `float` | `score=<value>` |
+| `bool` | `label="True"` or `label="False"` (not numeric) |
+| `None` | `(label=None, score=None)` |
+| `{"label": ..., "score": ..., "explanation": ...}` | triple by key |
+
+**Lists and arbitrary nested objects are rejected** — they previously silently stringified into labels, which masked misconfiguration. Return a recognized shape instead.
+
+## The `explanation` Field
+
+Any accepted shape may include an `explanation` string. Phoenix passes it through to `EvaluationResult.explanation` unchanged:
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+return {"label": "fail", "explanation": "Response contained prohibited content."}
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+return {"label": "fail", "explanation": "Response contained prohibited content."};
+```
+</Tab>
+</Tabs>
+
+The explanation appears in the Phoenix UI alongside the label and score and is available in the evaluation results API.
+
+## Multi-Output Evaluators
+
+When an evaluator has **multiple output configs** (e.g., one for toxicity and one for safety), Phoenix supports two routing modes:
+
+### Shared value (default)
+
+Return a single value — Phoenix applies the same return value to each output config independently:
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+return "pass"  # applied to every output config
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+return "pass";  // applied to every output config
+```
+</Tab>
+</Tabs>
+
+### Per-config routing dict
+
+Return a dict whose keys match every output config name. Phoenix routes each value to the corresponding config:
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+return {
+    "toxicity": 0.1,
+    "safety": "pass",
+    "explanation": "Content appears safe.",  # shared fallback
+}
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+return {
+    "toxicity": 0.1,
+    "safety": "pass",
+    "explanation": "Content appears safe.",  // shared fallback
+};
+```
+</Tab>
+</Tabs>
+
+Routing rules:
+- The dict must contain a key for **every** output config name; a partial match is treated as a shared value, not a routing dict.
+- A top-level `"explanation"` key acts as a **shared fallback**: if a per-config sub-value omits explanation, the top-level value fills it in.
+- Per-config sub-values may themselves be dicts with their own `"explanation"` key — per-config explanation takes precedence over the shared fallback.
+
+**Per-config explanation example:**
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+return {
+    "toxicity": {"score": 0.9, "explanation": "Contains slurs."},
+    "safety": "fail",
+    "explanation": "Overall content is unsafe.",  # only used for safety
+}
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+return {
+    "toxicity": {"score": 0.9, "explanation": "Contains slurs."},
+    "safety": "fail",
+    "explanation": "Overall content is unsafe.",  // only used for safety
+};
+```
+</Tab>
+</Tabs>
+
+### Multi-output naming convention
+
+Each output config produces a separate `EvaluationResult` named `{evaluator_name}.{config_name}`. For example, an evaluator named `content-check` with configs `toxicity` and `safety` produces two results: `content-check.toxicity` and `content-check.safety`.
+
+## Error Messages
+
+When a return value does not match the accepted shapes, the `ValueError` message enumerates all valid shapes for the configured output type in the evaluator's language. For example, a categorical config with values `["pass", "fail"]` in Python would produce:
+
+```
+Label 'unknown' not in categorical output config values ['pass', 'fail'].
+Valid shapes:
+  return "pass"
+  return {"label": "pass", "explanation": "..."}
+```
+
+This makes it straightforward to identify and fix mismatches without consulting documentation.

--- a/docs/phoenix/evaluation/how-to-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/how-to-evals/code-evaluators.mdx
@@ -8,6 +8,8 @@ These evaluations that don't use an LLM are indicated by a `kind="code"` flag on
 
 <Info>
 This page covers **programmatic code evaluators** — functions you write in Python or TypeScript and run via the `arize-phoenix-evals` SDK. If you want deterministic checks that run automatically in the Phoenix UI without any code, see [Server Evals](/docs/phoenix/evaluation/server-evals/overview).
+
+For the full catalog of return shapes accepted by Phoenix UI code evaluators (categorical, continuous, multi-output routing, and the `explanation` field), see [Code Evaluator Output Shapes](/docs/phoenix/evaluation/how-to-evals/code-evaluator-output-shapes).
 </Info>
 
 ### Using `create_evaluator`

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -98,6 +98,7 @@
 - [Configuring the LLM](https://arize.com/docs/phoenix/evaluation/how-to-evals/configuring-the-llm): Set up LLM providers for evaluations
 - [Prompt Formats](https://arize.com/docs/phoenix/evaluation/how-to-evals/prompt-formats): Customize evaluator prompt structures
 - [Code Evaluators](https://arize.com/docs/phoenix/evaluation/how-to-evals/code-evaluators): Deterministic evaluation with Python or TypeScript
+- [Code Evaluator Output Shapes](https://arize.com/docs/phoenix/evaluation/how-to-evals/code-evaluator-output-shapes): All accepted return shapes, multi-output routing, and explanation field semantics
 - [Batch Evaluations](https://arize.com/docs/phoenix/evaluation/how-to-evals/batch-evaluations): Run evaluations at scale with automatic concurrency
 - [Using Evals with Phoenix](https://arize.com/docs/phoenix/evaluation/how-to-evals/using-evals-with-phoenix): Run evals on traces, datasets, or custom data sources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,14 +182,14 @@ e2b = [
   "e2b-code-interpreter>=0.0.12",
 ]
 daytona = [
-  "daytona>=0.140.0",
+  "daytona-sdk>=0.140.0",
 ]
 vercel = [
   "vercel>=0.5.1",
   "websockets>=14.0",
 ]
 modal = [
-  "modal>=0.70.0",
+  "modal>=1.2.0",
 ]
 pg = [
   "asyncpg",

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -227,7 +227,7 @@ CREATE TABLE public.sandbox_configs (
     name VARCHAR NOT NULL,
     description VARCHAR,
     config JSONB NOT NULL DEFAULT '{}'::jsonb,
-    timeout INTEGER NOT NULL DEFAULT 30,
+    timeout INTEGER NOT NULL DEFAULT 300,
     enabled BOOLEAN NOT NULL DEFAULT true,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -779,18 +779,6 @@ Accepted values: WASM, E2B, DAYTONA_PYTHON, VERCEL_PYTHON, VERCEL_TYPESCRIPT, DE
 When not set, the WASM (local WebAssembly) backend is used.
 """
 
-ENV_PHOENIX_SANDBOX_API_KEY = "PHOENIX_SANDBOX_API_KEY"
-"""
-API key credential for the configured sandbox provider (e.g. E2B API key).
-Used by sandbox backends that require an API key for authentication.
-"""
-
-ENV_PHOENIX_SANDBOX_TOKEN = "PHOENIX_SANDBOX_TOKEN"
-"""
-Token credential for the configured sandbox provider (e.g. Daytona API token).
-Used by sandbox backends that require a bearer token for authentication.
-"""
-
 
 @dataclass(frozen=True)
 class TLSConfig:

--- a/src/phoenix/db/migrations/versions/9a7a47b0dc5c_increase_sandbox_config_timeout_default.py
+++ b/src/phoenix/db/migrations/versions/9a7a47b0dc5c_increase_sandbox_config_timeout_default.py
@@ -1,0 +1,38 @@
+"""increase sandbox_configs timeout server_default from 30 to 300
+
+Revision ID: 9a7a47b0dc5c
+Revises: 0ff41b5b118f
+Create Date: 2026-04-23 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "9a7a47b0dc5c"
+down_revision: Union[str, None] = "0ff41b5b118f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("sandbox_configs") as batch_op:
+        batch_op.alter_column(
+            "timeout",
+            server_default=sa.text("300"),
+            existing_type=sa.Integer(),
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("sandbox_configs") as batch_op:
+        batch_op.alter_column(
+            "timeout",
+            server_default=sa.text("30"),
+            existing_type=sa.Integer(),
+            existing_nullable=False,
+        )

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -2770,7 +2770,7 @@ class SandboxConfig(HasId):
     name: Mapped[str] = mapped_column(nullable=False)
     description: Mapped[Optional[str]] = mapped_column(nullable=True)
     config: Mapped[dict[str, Any]] = mapped_column(JSON_, nullable=False, server_default="{}")
-    timeout: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("30"))
+    timeout: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("300"))
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(

--- a/src/phoenix/db/types/annotation_configs.py
+++ b/src/phoenix/db/types/annotation_configs.py
@@ -1,3 +1,4 @@
+import json
 from enum import Enum
 from typing import Annotated, Literal, Optional, Union
 
@@ -122,8 +123,13 @@ class CategoricalOutputConfig(CategoricalAnnotationConfig):
         Tuples are NOT included per D5 deferral.
         """
         example_label = self.values[0].label if self.values else "pass"
-        bare = _return_stmt(f'"{example_label}"', language)
-        dict_form = _return_stmt(f'{{"label": "{example_label}", "explanation": "..."}}', language)
+        # json.dumps wraps the label in double quotes and escapes ", \, and
+        # newlines. JSON string literals are valid in both Python and TS source,
+        # so a label like `say "hi"` produces well-formed code in either target
+        # rather than a SyntaxError.
+        label_literal = json.dumps(example_label)
+        bare = _return_stmt(label_literal, language)
+        dict_form = _return_stmt(f'{{"label": {label_literal}, "explanation": "..."}}', language)
         return [bare, dict_form]
 
 
@@ -192,7 +198,10 @@ def bare_shape_examples(language: str = _PYTHON, mode: str = "full") -> list[str
 def _config_bare_value(config: "CategoricalOutputConfig | ContinuousOutputConfig") -> str:
     if isinstance(config, CategoricalOutputConfig):
         label = config.values[0].label if config.values else "pass"
-        return f'"{label}"'
+        # json.dumps escapes ", \, and newlines so the result is valid string
+        # literal syntax for both Python and TS (see CategoricalOutputConfig
+        # .shape_examples for the same rationale).
+        return json.dumps(label)
     # ContinuousOutputConfig
     if config.lower_bound is not None and config.upper_bound is not None:
         score = (config.lower_bound + config.upper_bound) / 2

--- a/src/phoenix/db/types/annotation_configs.py
+++ b/src/phoenix/db/types/annotation_configs.py
@@ -6,6 +6,19 @@ from typing_extensions import Self, TypeAlias
 
 from .db_helper_types import DBBaseModel
 
+_PYTHON = "PYTHON"
+_TYPESCRIPT = "TYPESCRIPT"
+
+
+def _return_stmt(value: str, language: str) -> str:
+    if language == _TYPESCRIPT:
+        return f"return {value};"
+    return f"return {value}"
+
+
+def _comment(text: str, language: str) -> str:
+    return f"// {text}" if language == _TYPESCRIPT else f"# {text}"
+
 
 class AnnotationType(Enum):
     CATEGORICAL = "CATEGORICAL"
@@ -101,9 +114,54 @@ class AnnotationConfig(RootModel[AnnotationConfigType]):
 class CategoricalOutputConfig(CategoricalAnnotationConfig):
     name: str
 
+    def shape_examples(self, language: str = _PYTHON, mode: str = "full") -> list[str]:
+        """Return code snippet strings illustrating valid return shapes for this config.
+
+        mode='full'    — all valid shapes (bare label + dict-by-key)
+        mode='curated' — same for categorical (bare + dict-with-explanation)
+        Tuples are NOT included per D5 deferral.
+        """
+        example_label = self.values[0].label if self.values else "pass"
+        bare = _return_stmt(f'"{example_label}"', language)
+        dict_form = _return_stmt(f'{{"label": "{example_label}", "explanation": "..."}}', language)
+        return [bare, dict_form]
+
 
 class ContinuousOutputConfig(ContinuousAnnotationConfig):
     name: str
+
+    def shape_examples(self, language: str = _PYTHON, mode: str = "full") -> list[str]:
+        """Return code snippet strings illustrating valid return shapes for this config.
+
+        mode='full'    — all valid shapes (bare score + dict-by-key)
+        mode='curated' — same for continuous (bare + dict-with-explanation)
+        Tuples are NOT included per D5 deferral.
+        """
+        if self.lower_bound is not None and self.upper_bound is not None:
+            example_score = (self.lower_bound + self.upper_bound) / 2
+            bounds_hint = f"{self.lower_bound} - {self.upper_bound}"
+        elif self.lower_bound is not None:
+            example_score = self.lower_bound
+            bounds_hint = f">= {self.lower_bound}"
+        elif self.upper_bound is not None:
+            example_score = self.upper_bound
+            bounds_hint = f"<= {self.upper_bound}"
+        else:
+            example_score = 0.5
+            bounds_hint = None
+
+        score_str = f"{example_score}"
+        bare = _return_stmt(score_str, language)
+        if bounds_hint:
+            range_comment = _comment(f"score in range {bounds_hint}", language)
+            dict_form = (
+                range_comment
+                + "\n"
+                + _return_stmt(f'{{"score": {score_str}, "explanation": "..."}}', language)
+            )
+        else:
+            dict_form = _return_stmt(f'{{"score": {score_str}, "explanation": "..."}}', language)
+        return [bare, dict_form]
 
 
 OutputConfigType: TypeAlias = Annotated[
@@ -114,3 +172,55 @@ OutputConfigType: TypeAlias = Annotated[
 
 class OutputConfig(RootModel[OutputConfigType]):
     root: OutputConfigType
+
+
+def bare_shape_examples(language: str = _PYTHON, mode: str = "full") -> list[str]:
+    """Return code snippet strings illustrating valid return shapes when no output config exists.
+
+    Accepts bare scalars (str → label, numeric → score) and recognized dict-by-key shapes.
+    Lists and nested objects are rejected.
+    """
+    bare_str = _return_stmt('"pass"', language)
+    bare_num = _return_stmt("0.5", language)
+    dict_form = _return_stmt('{"label": "pass", "explanation": "..."}', language)
+    dict_score_form = _return_stmt('{"score": 0.5, "explanation": "..."}', language)
+    if mode == "curated":
+        return [bare_str, dict_form]
+    return [bare_str, bare_num, dict_form, dict_score_form]
+
+
+def _config_bare_value(config: "CategoricalOutputConfig | ContinuousOutputConfig") -> str:
+    if isinstance(config, CategoricalOutputConfig):
+        label = config.values[0].label if config.values else "pass"
+        return f'"{label}"'
+    # ContinuousOutputConfig
+    if config.lower_bound is not None and config.upper_bound is not None:
+        score = (config.lower_bound + config.upper_bound) / 2
+    elif config.lower_bound is not None:
+        score = config.lower_bound
+    elif config.upper_bound is not None:
+        score = config.upper_bound
+    else:
+        score = 0.5
+    return str(score)
+
+
+def multi_output_shape_examples(
+    configs: "list[CategoricalOutputConfig | ContinuousOutputConfig]",
+    language: str = _PYTHON,
+    mode: str = "curated",
+) -> list[str]:
+    """Return code snippet strings for multi-output routing dicts.
+
+    Renders a routing dict where each key is a config name and the value is
+    the curated bare shape for that config. A top-level 'explanation' key is
+    shown as a shared fallback.
+    """
+    lines: list[str] = []
+    for config in configs:
+        bare_value = _config_bare_value(config)
+        lines.append(f'    "{config.name}": {bare_value},')
+    lines.append('    "explanation": "...",')
+    inner = "\n".join(lines)
+    routing_dict = "{\n" + inner + "\n}"
+    return [_return_stmt(routing_dict, language)]

--- a/src/phoenix/server/api/coerce_output.py
+++ b/src/phoenix/server/api/coerce_output.py
@@ -2,19 +2,37 @@
 Output coercion for code evaluator results.
 
 _coerce_output maps a raw Python/TypeScript return value from sandbox
-execution to a (label, score) pair suitable for EvaluationResult.
+execution to a (label, score, explanation) triple suitable for EvaluationResult.
 
-Three modes:
-1. No output_configs — bare value passthrough (score if numeric, label if str).
-2. CategoricalOutputConfig — label validation + score lookup from values list.
-3. ContinuousOutputConfig — numeric extraction + bounds validation.
+User-facing spec: docs/phoenix/evaluation/how-to-evals/code-evaluator-output-shapes.mdx
+
+Triple-collapse model (two-stage):
+  Stage 1 — _extract_triple: parse any accepted raw_value shape into a Triple.
+    Accepted shapes:
+      - Bare scalar (str, int, float, bool, None) → bare triple
+      - Dict with any subset of {label, score, explanation} keys → triple by key
+    Not accepted:
+      - Tuples (deferred per D5)
+      - Multi-output routing dicts (handled by the runner, not this function)
+
+  Stage 2 — per-config validators: check the triple against config requirements.
+    - CategoricalOutputConfig: label required, must be in config.values, score
+      looked up from config (user-supplied score must match lookup or is rejected).
+    - ContinuousOutputConfig: score required, must be finite numeric (not bool),
+      must be within optional bounds; free-form label accepted.
+    - No config: bare passthrough; lists/nested objects rejected.
 
 Bool exclusion: bool is NOT treated as numeric in any mode.
+NaN/Infinity: rejected as continuous score.
+
+The 'language' keyword in _coerce_output is forwarded only to error-message
+rendering via shape_examples; it has no effect on accepted shapes.
 """
 
 from __future__ import annotations
 
-from typing import Any, Optional
+import math
+from typing import Any, NamedTuple, Optional
 
 from phoenix.db.types.annotation_configs import (
     CategoricalOutputConfig,
@@ -22,93 +40,235 @@ from phoenix.db.types.annotation_configs import (
     OutputConfigType,
 )
 
+_DICT_KEYS = frozenset({"label", "score", "explanation"})
 
-def _coerce_output(
-    value: Any,
-    output_config: Optional[OutputConfigType],
-) -> tuple[Optional[str], Optional[float]]:
+
+class Triple(NamedTuple):
+    label: Optional[str]
+    score: Optional[float]
+    explanation: Optional[str]
+
+
+def _extract_triple(value: Any) -> Triple:
+    """Stage 1: parse any accepted raw_value shape into a Triple.
+
+    Only bare scalars and recognized dict-by-key shapes are handled here.
+    Multi-output routing dicts (keyed by config.name) are handled by the runner.
     """
-    Coerce a raw sandbox return value to (label, score).
+    if isinstance(value, dict):
+        unknown = set(value.keys()) - _DICT_KEYS
+        if unknown:
+            raise ValueError(
+                f"Unrecognized keys in output dict: {sorted(unknown)!r}. "
+                f"Accepted dict keys are: {sorted(_DICT_KEYS)!r}"
+            )
+        raw_label = value.get("label")
+        raw_score = value.get("score")
+        raw_explanation = value.get("explanation")
+        return Triple(
+            label=raw_label,
+            score=raw_score,
+            explanation=raw_explanation,
+        )
 
-    Args:
-        value: Raw return value from sandbox execution.
-        output_config: Output config to validate/coerce against, or None for
-            bare passthrough.
-
-    Returns:
-        (label, score) tuple. Either or both may be None.
-
-    Raises:
-        ValueError: If the value is incompatible with the output_config
-            (e.g. label not in categorical values, numeric out of bounds).
-    """
-    if output_config is None:
-        return _coerce_bare(value)
-
-    if isinstance(output_config, CategoricalOutputConfig):
-        return _coerce_categorical(value, output_config)
-
-    if isinstance(output_config, ContinuousOutputConfig):
-        return _coerce_continuous(value, output_config)
-
-    # Should never reach here with a well-typed OutputConfigType
-    return _coerce_bare(value)
-
-
-def _coerce_bare(value: Any) -> tuple[Optional[str], Optional[float]]:
-    """No output_config: passthrough — numeric → score, str → label."""
+    # Bare scalar dispatch
     if isinstance(value, bool):
-        # Bool exclusion (D6): bool is not treated as numeric.
-        return (str(value), None)
+        return Triple(label=str(value), score=None, explanation=None)
     if isinstance(value, (int, float)):
-        return (None, float(value))
+        return Triple(label=None, score=float(value), explanation=None)
     if isinstance(value, str):
-        return (value, None)
+        return Triple(label=value, score=None, explanation=None)
     if value is None:
-        return (None, None)
-    # Complex types: stringify as label
-    return (str(value), None)
+        return Triple(label=None, score=None, explanation=None)
+
+    # Lists and complex objects: rejected here; _validate_triple_bare gives the error.
+    return Triple(label=None, score=None, explanation=None)
 
 
-def _coerce_categorical(
-    value: Any,
-    config: CategoricalOutputConfig,
-) -> tuple[Optional[str], Optional[float]]:
-    """Validate label against config.values; look up associated score."""
-    if isinstance(value, bool):
-        # Bool exclusion: stringify, then validate as label
-        label = str(value)
-    elif isinstance(value, str):
-        label = value
-    else:
+def _validate_field_types(triple: Triple) -> None:
+    """Validate that label, explanation are str|None.
+
+    Score type-checking is deferred to the per-config Stage 2 validators because
+    the bare passthrough path allows score to come from bare int/float without a
+    config, and continuous config does its own numeric validation.
+    """
+    if triple.label is not None and not isinstance(triple.label, str):
         raise ValueError(
-            f"Expected a string label for categorical output, got {type(value).__name__!r}: "
-            f"{value!r}"
+            f"'label' must be a string or None, got {type(triple.label).__name__!r}: "
+            f"{triple.label!r}"
+        )
+    if triple.explanation is not None and not isinstance(triple.explanation, str):
+        raise ValueError(
+            f"'explanation' must be a string or None, got "
+            f"{type(triple.explanation).__name__!r}: {triple.explanation!r}"
+        )
+
+
+def _validate_triple_bare(value: Any, triple: Triple) -> Triple:
+    """No config: passthrough for bare scalars and recognized dicts.
+
+    Lists and nested objects are rejected with a clear error pointing at the
+    shape catalog.
+    """
+    if isinstance(value, (list, tuple)) or (
+        isinstance(value, dict) and set(value.keys()) - _DICT_KEYS
+    ):
+        raise ValueError(
+            f"Unsupported output type {type(value).__name__!r}: {value!r}. "
+            f"Without an output config, accepted shapes are: bare scalar "
+            f"(str, int, float, bool, None) or a dict with keys from "
+            f"{sorted(_DICT_KEYS)!r}."
+        )
+    # Recognized dict-by-key or bare scalar: passthrough
+    return triple
+
+
+def _validate_triple_categorical(
+    triple: Triple,
+    config: CategoricalOutputConfig,
+    language: str = "PYTHON",
+) -> Triple:
+    """Stage 2: validate triple against categorical config.
+
+    - label is required
+    - label must be in config.values
+    - if score is present, it must match the config lookup
+    - explanation passes through verbatim
+    """
+    shapes = "\n".join(f"  {s}" for s in config.shape_examples(language=language, mode="full"))
+
+    label = triple.label
+    if label is None:
+        raise ValueError(
+            f"Categorical output requires a label. Got label=None. "
+            f"Return a string from {[v.label for v in config.values]!r} "
+            f"or a dict with a 'label' key.\nValid shapes:\n{shapes}"
+        )
+    if not isinstance(label, str):
+        raise ValueError(
+            f"Expected a string label for categorical output, got "
+            f"{type(label).__name__!r}: {label!r}\nValid shapes:\n{shapes}"
         )
 
     label_to_score: dict[str, Optional[float]] = {v.label: v.score for v in config.values}
     if label not in label_to_score:
         valid = ", ".join(repr(v.label) for v in config.values)
-        raise ValueError(f"Label {label!r} not in categorical output config values [{valid}]")
-    return (label, label_to_score[label])
+        raise ValueError(
+            f"Label {label!r} not in categorical output config values [{valid}].\n"
+            f"Valid shapes:\n{shapes}"
+        )
+
+    looked_up_score = label_to_score[label]
+
+    # If the user explicitly supplied a score, it must match the canonical lookup.
+    if triple.score is not None:
+        if isinstance(triple.score, bool):
+            raise ValueError(
+                f"'score' must not be bool; got {triple.score!r}. "
+                f"Categorical score is determined by the config lookup for label {label!r}."
+            )
+        user_score = float(triple.score)
+        if looked_up_score is not None and user_score != looked_up_score:
+            raise ValueError(
+                f"Score {user_score!r} does not match the configured score "
+                f"{looked_up_score!r} for label {label!r}. "
+                f"Remove the 'score' key or use the canonical value {looked_up_score!r}."
+            )
+
+    return Triple(label=label, score=looked_up_score, explanation=triple.explanation)
 
 
-def _coerce_continuous(
-    value: Any,
+def _validate_triple_continuous(
+    triple: Triple,
     config: ContinuousOutputConfig,
-) -> tuple[Optional[str], Optional[float]]:
-    """Extract numeric value; validate against optional bounds."""
-    if isinstance(value, bool):
-        # Bool exclusion (D6): bool is not numeric.
-        raise ValueError(f"Expected a numeric value for continuous output, got bool: {value!r}")
-    if not isinstance(value, (int, float)):
+    language: str = "PYTHON",
+) -> Triple:
+    """Stage 2: validate triple against continuous config.
+
+    - score is required
+    - score must be a finite numeric value (not bool, not NaN, not Infinity)
+    - score must be within optional bounds
+    - free-form label is accepted as-is
+    """
+    shapes = "\n".join(f"  {s}" for s in config.shape_examples(language=language, mode="full"))
+
+    score = triple.score
+    if score is None:
+        raise ValueError(
+            f"Continuous output requires a numeric score. Got score=None. "
+            f"Return a number or a dict with a 'score' key.\nValid shapes:\n{shapes}"
+        )
+    if isinstance(score, bool):
+        raise ValueError(f"Expected a numeric value for continuous output, got bool: {score!r}")
+    if not isinstance(score, (int, float)):
         raise ValueError(
             f"Expected a numeric value for continuous output, got "
-            f"{type(value).__name__!r}: {value!r}"
+            f"{type(score).__name__!r}: {score!r}\nValid shapes:\n{shapes}"
         )
-    score = float(value)
-    if config.lower_bound is not None and score < config.lower_bound:
-        raise ValueError(f"Score {score} is below lower_bound {config.lower_bound}")
-    if config.upper_bound is not None and score > config.upper_bound:
-        raise ValueError(f"Score {score} is above upper_bound {config.upper_bound}")
-    return (None, score)
+    score_f = float(score)
+    if math.isnan(score_f) or math.isinf(score_f):
+        raise ValueError(f"Score must be a finite number; got {score!r}")
+    if config.lower_bound is not None and score_f < config.lower_bound:
+        raise ValueError(f"Score {score_f} is below lower_bound {config.lower_bound}")
+    if config.upper_bound is not None and score_f > config.upper_bound:
+        raise ValueError(f"Score {score_f} is above upper_bound {config.upper_bound}")
+    # Free-form label accepted verbatim
+    return Triple(label=triple.label, score=score_f, explanation=triple.explanation)
+
+
+def _coerce_output(
+    value: Any,
+    output_config: Optional[OutputConfigType],
+    *,
+    language: str = "PYTHON",
+) -> tuple[Optional[str], Optional[float], Optional[str]]:
+    """
+    Coerce a raw sandbox return value to (label, score, explanation).
+
+    Args:
+        value: Raw return value from sandbox execution. Multi-output routing
+            (a dict keyed by config.name) must be resolved by the caller before
+            passing here; this function handles single-config coercion only.
+        output_config: Output config to validate/coerce against, or None for
+            bare passthrough.
+        language: Evaluator language ("PYTHON" or "TYPESCRIPT"). Used only for
+            rendering language-appropriate code examples in ValueError messages;
+            has no effect on accepted shapes.
+
+    Returns:
+        (label, score, explanation) triple. Any element may be None.
+
+    Raises:
+        ValueError: If the value is incompatible with the output_config
+            (e.g. label not in categorical values, numeric out of bounds).
+    """
+    # Stage 1: extract triple from value shape
+    if isinstance(value, (list, tuple)) and output_config is None:
+        # Early path for lists/tuples under no-config (gives better error message)
+        raise ValueError(
+            f"Unsupported output type {type(value).__name__!r}: {value!r}. "
+            f"Without an output config, accepted shapes are: bare scalar "
+            f"(str, int, float, bool, None) or a dict with keys from "
+            f"{sorted(_DICT_KEYS)!r}."
+        )
+
+    # Bool under continuous config must be caught before _extract_triple converts
+    # bool to label="True", which would then incorrectly raise "requires a numeric
+    # score" instead of the expected "got bool" message.
+    if isinstance(output_config, ContinuousOutputConfig) and isinstance(value, bool):
+        raise ValueError(f"Expected a numeric value for continuous output, got bool: {value!r}")
+
+    triple = _extract_triple(value)
+    _validate_field_types(triple)
+
+    # Stage 2: per-config validation
+    if output_config is None:
+        validated = _validate_triple_bare(value, triple)
+    elif isinstance(output_config, CategoricalOutputConfig):
+        validated = _validate_triple_categorical(triple, output_config, language)
+    elif isinstance(output_config, ContinuousOutputConfig):
+        validated = _validate_triple_continuous(triple, output_config, language)
+    else:
+        validated = _validate_triple_bare(value, triple)
+
+    return (validated.label, validated.score, validated.explanation)

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -1,4 +1,5 @@
 import ast
+import asyncio
 import json
 import logging
 import re
@@ -57,7 +58,7 @@ from phoenix.server.api.input_types.PromptVersionInput import (
 from phoenix.server.api.types.ChatCompletionMessageRole import ChatCompletionMessageRole
 from phoenix.server.api.types.ChatCompletionSubscriptionPayload import ToolCallChunk
 from phoenix.server.sandbox import MissingSecretError  # noqa: E402
-from phoenix.server.sandbox.types import SandboxBackend, UnsupportedOperation
+from phoenix.server.sandbox.types import ExecutionResult, SandboxBackend, UnsupportedOperation
 
 logger = logging.getLogger(__name__)
 
@@ -2494,6 +2495,15 @@ def _infer_typescript_evaluate_input_schema(
     return (_make_object_input_schema(parameter_names, required_names), None)
 
 
+async def _stop_session_quietly(
+    backend: SandboxBackend, session_key: str, log: logging.Logger
+) -> None:
+    try:
+        await backend.stop_session(session_key)
+    except Exception as exc:
+        log.warning("stop_session failed during timeout teardown: %s", exc)
+
+
 class CodeEvaluatorRunner(BaseEvaluator):
     """
     Evaluator that executes user-provided source code in a sandbox.
@@ -2629,11 +2639,21 @@ class CodeEvaluatorRunner(BaseEvaluator):
             code = self._build_typescript_harness(mapped_inputs)
 
         try:
-            execution = await self._sandbox_backend.execute(
-                code,
-                session_key=session_key or self._name,
+            execution = await asyncio.wait_for(
+                self._sandbox_backend.execute(
+                    code,
+                    session_key=session_key or self._name,
+                    timeout=self._timeout,
+                ),
                 timeout=self._timeout,
             )
+        except asyncio.TimeoutError:
+            asyncio.create_task(
+                _stop_session_quietly(
+                    self._sandbox_backend, session_key or self._name, logger
+                )
+            )
+            execution = ExecutionResult(stdout="", stderr="", error="timeout")
         except UnsupportedOperation as exc:
             err = f"Sandbox backend does not support this operation: {exc}"
             return [

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -858,6 +858,7 @@ async def get_evaluators(
                             MissingSecretError,
                             UnsupportedOperation,
                             PydanticValidationError,
+                            ValueError,
                         ) as exc:
                             raise BadRequest(str(exc))
 
@@ -2649,9 +2650,7 @@ class CodeEvaluatorRunner(BaseEvaluator):
             )
         except asyncio.TimeoutError:
             asyncio.create_task(
-                _stop_session_quietly(
-                    self._sandbox_backend, session_key or self._name, logger
-                )
+                _stop_session_quietly(self._sandbox_backend, session_key or self._name, logger)
             )
             execution = ExecutionResult(stdout="", stderr="", error="timeout")
         except UnsupportedOperation as exc:

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -2577,8 +2577,11 @@ class CodeEvaluatorRunner(BaseEvaluator):
         return (
             f"{self._source_code}\n\n"
             f"const _inputs = {inputs_json};\n"
-            f"const _result = evaluate(_inputs);\n"
-            f"console.log(JSON.stringify(_result));\n"
+            f"const _run = async () => {{\n"
+            f"  const _result = await evaluate(_inputs);\n"
+            f"  console.log(JSON.stringify(_result));\n"
+            f"}};\n"
+            f"await _run();\n"
         )
 
     def _make_error_result(

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -903,11 +903,12 @@ async def get_evaluators(
         elif isinstance(ev, models.CodeEvaluator):
             code_runner = code_evaluators_by_id.get(ev.id)
             if code_runner is None:
+                ev_name = ev.name.root if ev.name else str(ev.id)
                 evaluator_lang = code_evaluator_languages_by_id.get(ev.id, "")
                 lang_hint = f" for language '{evaluator_lang}'" if evaluator_lang else ""
                 raise NotFound(
-                    f"CODE evaluator with ID '{ev.id}' could not be resolved{lang_hint}. "
-                    "Please configure a sandbox provider for this evaluator."
+                    f"Code evaluator '{ev_name}' could not be resolved{lang_hint}. "
+                    "Please configure a sandbox provider at /settings/sandboxes."
                 )
             evaluators.append(code_runner)
         else:
@@ -2682,21 +2683,45 @@ class CodeEvaluatorRunner(BaseEvaluator):
                 raw_value = stdout
 
         multi_output = len(output_configs) > 1
+
+        # Multi-output routing: when raw_value is a dict whose keys cover every
+        # config.name, dispatch each named sub-value to _coerce_output individually.
+        # Top-level "explanation" acts as a shared fallback when a per-config
+        # sub-value omits its own explanation.
+        routed = (
+            multi_output
+            and isinstance(raw_value, dict)
+            and all(c.name in raw_value for c in output_configs)
+        )
+        shared_explanation: Optional[str] = None
+        if routed and isinstance(raw_value, dict):
+            top_level_explanation = raw_value.get("explanation")
+            if isinstance(top_level_explanation, str):
+                shared_explanation = top_level_explanation
+
         results: list[EvaluationResult] = []
         for config in output_configs:
             annotation_name = f"{name}.{config.name}" if multi_output else name
+            coerce_value = (
+                raw_value[config.name] if routed and isinstance(raw_value, dict) else raw_value
+            )
             try:
-                label, score = _coerce_output(raw_value, config)
+                label, score, explanation = _coerce_output(
+                    coerce_value, config, language=self._language
+                )
             except ValueError as exc:
                 results.append(self._make_error_result(annotation_name, str(exc), start_time))
                 continue
+            # Per-config explanation wins; fall back to shared top-level explanation.
+            if explanation is None:
+                explanation = shared_explanation
             results.append(
                 EvaluationResult(
                     name=annotation_name,
                     annotator_kind="CODE",
                     label=label,
                     score=score,
-                    explanation=None,
+                    explanation=explanation,
                     metadata={},
                     error=None,
                     trace_id=None,

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -163,6 +163,7 @@ async def _resolve_inline_code_evaluator_backend(
             MissingSecretError,
             UnsupportedOperation,
             ValidationError,
+            ValueError,
         ) as exc:
             raise BadRequest(str(exc))
 
@@ -351,6 +352,7 @@ class ChatCompletionMutationMixin:
                             MissingSecretError,
                             UnsupportedOperation,
                             ValidationError,
+                            ValueError,
                         ) as exc:
                             raise BadRequest(str(exc))
                 if sandbox_backend is None:

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -331,7 +331,7 @@ class ChatCompletionMutationMixin:
                                 }
 
                     # Eagerly capture scalar fields before session closes
-                    evaluator_name = str(code_evaluator_record.name)
+                    evaluator_name = code_evaluator_record.name.root
                     evaluator_description = code_evaluator_record.description
                     evaluator_source_code = code_evaluator_record.source_code
                     output_configs = [
@@ -357,8 +357,9 @@ class ChatCompletionMutationMixin:
                             raise BadRequest(str(exc))
                 if sandbox_backend is None:
                     raise BadRequest(
-                        f"No sandbox backend configured for language '{language}'. "
-                        "Please configure a sandbox provider for this evaluator."
+                        f"Code evaluator '{evaluator_name}' has no sandbox backend configured"
+                        f" for language '{language}'. "
+                        "Please configure a sandbox provider at /settings/sandboxes."
                     )
 
                 runner = CodeEvaluatorRunner(

--- a/src/phoenix/server/api/mutations/sandbox_config_mutations.py
+++ b/src/phoenix/server/api/mutations/sandbox_config_mutations.py
@@ -264,7 +264,7 @@ class SandboxConfigMutationMixin:
                             raise BadRequest(str(exc))
                 row.config = config_dict
             if input.timeout is not strawberry.UNSET:
-                row.timeout = input.timeout if input.timeout is not None else 30
+                row.timeout = input.timeout if input.timeout is not None else 300
             if input.enabled is not strawberry.UNSET and input.enabled is not None:
                 row.enabled = input.enabled
 

--- a/src/phoenix/server/api/mutations/sandbox_config_mutations.py
+++ b/src/phoenix/server/api/mutations/sandbox_config_mutations.py
@@ -366,8 +366,9 @@ class SandboxConfigMutationMixin:
                     on_conflict=OnConflict.DO_UPDATE,
                 )
             )
-        # Key-level fan-out covers shared credential_specs (e.g., VERCEL_TOKEN
-        # shared between VERCEL_PYTHON and VERCEL_TYPESCRIPT). Per-backend_type
+        # Key-level fan-out covers shared credential_specs (e.g.,
+        # PHOENIX_SANDBOX_VERCEL_TOKEN shared between VERCEL_PYTHON and
+        # VERCEL_TYPESCRIPT). Per-backend_type
         # invalidation remains as a defense-in-depth backstop.
         await invalidate_backend_cache_for_key(key)
         await invalidate_backend_cache(backend_type)

--- a/src/phoenix/server/api/mutations/sandbox_config_mutations.py
+++ b/src/phoenix/server/api/mutations/sandbox_config_mutations.py
@@ -320,6 +320,12 @@ class SandboxConfigMutationMixin:
                     dict(cast(dict[str, Any], input.config)) if input.config is not None else {}
                 )
                 _check_reserved_top_level_keys(provider_config, row.backend_type)
+                adapter = _SANDBOX_ADAPTERS.get(row.backend_type)
+                if adapter is not None:
+                    try:
+                        provider_config = adapter.validate_config(provider_config)
+                    except (ValueError, ValidationError) as exc:
+                        raise BadRequest(str(exc))
                 row.config = provider_config
             if input.enabled is not strawberry.UNSET and input.enabled is not None:
                 row.enabled = input.enabled

--- a/src/phoenix/server/api/types/AnnotationConfig.py
+++ b/src/phoenix/server/api/types/AnnotationConfig.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Annotated, Optional, Union
 
 import strawberry
@@ -13,11 +14,32 @@ from phoenix.db.types.annotation_configs import (
     CategoricalAnnotationConfig as CategoricalAnnotationConfigModel,
 )
 from phoenix.db.types.annotation_configs import (
+    CategoricalAnnotationValue as CategoricalAnnotationValueModel,
+)
+from phoenix.db.types.annotation_configs import (
+    CategoricalOutputConfig as CategoricalOutputConfigModel,
+)
+from phoenix.db.types.annotation_configs import (
     ContinuousAnnotationConfig as ContinuousAnnotationConfigModel,
+)
+from phoenix.db.types.annotation_configs import (
+    ContinuousOutputConfig as ContinuousOutputConfigModel,
 )
 from phoenix.db.types.annotation_configs import (
     FreeformAnnotationConfig as FreeformAnnotationConfigModel,
 )
+
+
+@strawberry.enum
+class ShapeExamplesLanguage(Enum):
+    PYTHON = "PYTHON"
+    TYPESCRIPT = "TYPESCRIPT"
+
+
+@strawberry.enum
+class ShapeExamplesMode(Enum):
+    FULL = "full"
+    CURATED = "curated"
 
 
 @strawberry.interface
@@ -39,6 +61,22 @@ class CategoricalAnnotationConfig(Node, AnnotationConfigBase):
     optimization_direction: OptimizationDirection
     values: list[CategoricalAnnotationValue]
 
+    @strawberry.field
+    def shape_examples(
+        self,
+        language: ShapeExamplesLanguage = ShapeExamplesLanguage.PYTHON,
+        mode: ShapeExamplesMode = ShapeExamplesMode.FULL,
+    ) -> list[str]:
+        config = CategoricalOutputConfigModel(
+            type="CATEGORICAL",
+            name=self.name,
+            optimization_direction=self.optimization_direction,
+            values=[
+                CategoricalAnnotationValueModel(label=v.label, score=v.score) for v in self.values
+            ],
+        )
+        return config.shape_examples(language=language.value, mode=mode.value)
+
 
 @strawberry.type
 class ContinuousAnnotationConfig(Node, AnnotationConfigBase):
@@ -46,6 +84,21 @@ class ContinuousAnnotationConfig(Node, AnnotationConfigBase):
     optimization_direction: OptimizationDirection
     lower_bound: Optional[float]
     upper_bound: Optional[float]
+
+    @strawberry.field
+    def shape_examples(
+        self,
+        language: ShapeExamplesLanguage = ShapeExamplesLanguage.PYTHON,
+        mode: ShapeExamplesMode = ShapeExamplesMode.FULL,
+    ) -> list[str]:
+        config = ContinuousOutputConfigModel(
+            type="CONTINUOUS",
+            name=self.name,
+            optimization_direction=self.optimization_direction,
+            lower_bound=self.lower_bound,
+            upper_bound=self.upper_bound,
+        )
+        return config.shape_examples(language=language.value, mode=mode.value)
 
 
 @strawberry.type

--- a/src/phoenix/server/api/types/SandboxConfig.py
+++ b/src/phoenix/server/api/types/SandboxConfig.py
@@ -192,7 +192,9 @@ class SandboxConfig(Node):
         record = await self._get_record(info)
         return cast(JSON, record.config)
 
-    @strawberry.field
+    @strawberry.field(  # type: ignore
+        description="Execution timeout in seconds (includes package install on ephemeral calls)."
+    )
     async def timeout(self, info: Info[Context, None]) -> int:
         record = await self._get_record(info)
         return record.timeout

--- a/src/phoenix/server/api/types/SandboxConfig.py
+++ b/src/phoenix/server/api/types/SandboxConfig.py
@@ -23,6 +23,7 @@ from phoenix.server.api.context import Context
 from phoenix.server.sandbox import (
     SANDBOX_ADAPTER_METADATA,
     MissingSecretError,
+    get_missing_sandbox_auth_detail,
     get_or_create_backend,
 )
 from phoenix.server.sandbox.types import UnsupportedOperation
@@ -56,6 +57,8 @@ class SandboxBackendStatus(Enum):
 
     AVAILABLE = "AVAILABLE"
     """Adapter is installed and the backend was created successfully."""
+    MISSING_CREDENTIALS = "MISSING_CREDENTIALS"
+    """Adapter is installed, but required auth credentials are not configured."""
     UNAVAILABLE = "UNAVAILABLE"
     """Adapter is installed but backend creation failed (e.g. bad credentials)."""
     NOT_INSTALLED = "NOT_INSTALLED"
@@ -82,6 +85,7 @@ class SandboxBackendInfo:
     display_name: str
     supported_languages: list[Language]
     status: SandboxBackendStatus
+    status_detail: Optional[str]
     dependency_hints: list[str]
     config_field_specs: list[ConfigFieldSpecType]
     supports_env_vars: bool
@@ -311,33 +315,44 @@ async def _get_sandbox_backend_info_with_session(
 
     infos: list[SandboxBackendInfo] = []
     for backend_type, meta in SANDBOX_ADAPTER_METADATA.items():
+        status_detail: Optional[str] = None
         if backend_type not in _SANDBOX_ADAPTERS:
             status = SandboxBackendStatus.NOT_INSTALLED
         else:
-            # TODO: Add backend-specific dependency validation here where possible.
-            # Adapter registration and backend construction can still over-report
-            # availability when runtime prerequisites are only checked later
-            # (for example, missing binaries, API keys, or first-use downloads).
-            try:
-                backend = await get_or_create_backend(
-                    backend_type, session=session, decrypt=decrypt
-                )
-                status = (
-                    SandboxBackendStatus.AVAILABLE
-                    if backend is not None
-                    else SandboxBackendStatus.UNAVAILABLE
-                )
-            except (ValueError, MissingSecretError, UnsupportedOperation) as exc:
-                # Adapter is registered but construction failed because a
-                # runtime precondition is not met (auth not configured,
-                # missing user secret, capability mismatch). Surface as
-                # UNAVAILABLE instead of 500ing the whole query — capability
-                # advertisement must continue to work for adapters the admin
-                # hasn't configured yet.
-                logger.debug(
-                    f"sandboxBackends: {backend_type!r} unavailable: {exc}",
-                )
-                status = SandboxBackendStatus.UNAVAILABLE
+            missing_auth_detail = await get_missing_sandbox_auth_detail(
+                backend_type,
+                session=session,
+                decrypt=decrypt,
+            )
+            if missing_auth_detail is not None:
+                status = SandboxBackendStatus.MISSING_CREDENTIALS
+                status_detail = missing_auth_detail
+            else:
+                # TODO: Add backend-specific dependency validation here where possible.
+                # Adapter registration and backend construction can still over-report
+                # availability when runtime prerequisites are only checked later
+                # (for example, missing binaries, API keys, or first-use downloads).
+                try:
+                    backend = await get_or_create_backend(
+                        backend_type, session=session, decrypt=decrypt
+                    )
+                    status = (
+                        SandboxBackendStatus.AVAILABLE
+                        if backend is not None
+                        else SandboxBackendStatus.UNAVAILABLE
+                    )
+                except (ValueError, MissingSecretError, UnsupportedOperation) as exc:
+                    # Adapter is registered but construction failed because a
+                    # runtime precondition is not met (auth not configured,
+                    # missing user secret, capability mismatch). Surface as
+                    # UNAVAILABLE instead of 500ing the whole query — capability
+                    # advertisement must continue to work for adapters the admin
+                    # hasn't configured yet.
+                    logger.debug(
+                        f"sandboxBackends: {backend_type!r} unavailable: {exc}",
+                    )
+                    status = SandboxBackendStatus.UNAVAILABLE
+                    status_detail = str(exc)
         raw_specs = getattr(meta, "config_field_specs", [])
         infos.append(
             SandboxBackendInfo(
@@ -345,6 +360,7 @@ async def _get_sandbox_backend_info_with_session(
                 display_name=meta.display_name,
                 supported_languages=[Language(meta.language)] if meta.language else [],
                 status=status,
+                status_detail=status_detail,
                 dependency_hints=meta.dependency_hints,
                 config_field_specs=[
                     ConfigFieldSpecType(

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -210,8 +210,8 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
             "Provide `PHOENIX_SANDBOX_E2B_API_KEY` or `PHOENIX_SANDBOX_API_KEY`.",
         ],
         supports_env_vars=True,
-        internet_access_capability="none",
-        dependencies_language=None,
+        internet_access_capability="boolean",
+        dependencies_language="PYTHON",
     ),
     "DAYTONA_PYTHON": AdapterMetadata(
         display_name="Daytona (Python)",
@@ -221,13 +221,15 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
             "Provide `PHOENIX_SANDBOX_DAYTONA_API_KEY` or `PHOENIX_SANDBOX_TOKEN`.",
         ],
         supports_env_vars=True,
-        internet_access_capability="none",
+        internet_access_capability="boolean",
         dependencies_language="PYTHON",
     ),
-    # internet_access_capability for both Vercel adapters is shipped as scaffolding
-    # only — the flag and UI wiring are in place but runtime enforcement through
-    # build_backend is not yet wired. Do not flip to 'boolean' until the Vercel
-    # backend honours the internet_access.mode from the stored config.
+    # Vercel Python SDK checked: pyproject minimum vercel>=0.5.1; uv.lock resolves
+    # vercel==0.5.7. AsyncSandbox.create() in 0.5.7 does not accept `env` or
+    # `network_policy` kwargs — the TypeScript Vercel SDK exposes both, but the
+    # Python SDK has not yet ported them. Re-evaluate when Python SDK >=0.5.8
+    # ships; flip internet_access_capability to "boolean" and wire network_policy
+    # then. Until that lands, both Vercel adapters remain internet_access="none".
     "VERCEL_PYTHON": AdapterMetadata(
         display_name="Vercel Sandbox (Python)",
         language="PYTHON",
@@ -270,8 +272,8 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
             "Provide `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` environment variables.",
         ],
         supports_env_vars=True,
-        internet_access_capability="none",
-        dependencies_language=None,
+        internet_access_capability="boolean",
+        dependencies_language="PYTHON",
     ),
 }
 

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -207,7 +207,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         language="PYTHON",
         dependency_hints=[
             "Install Phoenix with the `e2b` extra.",
-            "Provide `PHOENIX_SANDBOX_E2B_API_KEY` or `PHOENIX_SANDBOX_API_KEY`.",
+            "Provide `PHOENIX_SANDBOX_E2B_API_KEY`.",
         ],
         supports_env_vars=True,
         internet_access_capability="boolean",
@@ -218,7 +218,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         language="PYTHON",
         dependency_hints=[
             "Install Phoenix with the `daytona` extra.",
-            "Provide `PHOENIX_SANDBOX_DAYTONA_API_KEY` or `PHOENIX_SANDBOX_TOKEN`.",
+            "Provide `PHOENIX_SANDBOX_DAYTONA_API_KEY`.",
         ],
         supports_env_vars=True,
         internet_access_capability="boolean",
@@ -235,8 +235,12 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         language="PYTHON",
         dependency_hints=[
             "Install Phoenix with the `vercel` extra.",
-            "Set `VERCEL_OIDC_TOKEN`, or all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and "
-            "`VERCEL_TEAM_ID`.",
+            (
+                "Set `PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`, or all of "
+                "`PHOENIX_SANDBOX_VERCEL_TOKEN`, "
+                "`PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and "
+                "`PHOENIX_SANDBOX_VERCEL_TEAM_ID`."
+            ),
         ],
         supports_env_vars=True,
         internet_access_capability="none",
@@ -247,8 +251,12 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         language="TYPESCRIPT",
         dependency_hints=[
             "Install Phoenix with the `vercel` extra.",
-            "Set `VERCEL_OIDC_TOKEN`, or all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and "
-            "`VERCEL_TEAM_ID`.",
+            (
+                "Set `PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`, or all of "
+                "`PHOENIX_SANDBOX_VERCEL_TOKEN`, "
+                "`PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and "
+                "`PHOENIX_SANDBOX_VERCEL_TEAM_ID`."
+            ),
         ],
         supports_env_vars=True,
         internet_access_capability="none",
@@ -269,7 +277,10 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         language="PYTHON",
         dependency_hints=[
             "Install Phoenix with the `modal` extra.",
-            "Provide `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` environment variables.",
+            (
+                "Provide `PHOENIX_SANDBOX_MODAL_TOKEN_ID` and "
+                "`PHOENIX_SANDBOX_MODAL_TOKEN_SECRET` environment variables."
+            ),
         ],
         supports_env_vars=True,
         internet_access_capability="boolean",
@@ -346,8 +357,9 @@ async def invalidate_backend_cache_for_key(key: str) -> None:
     of each `ProviderCredentialSpec`.
 
     Broader than `invalidate_backend_cache` because one credential key may be
-    shared by multiple backend_types (e.g. VERCEL_TOKEN across VERCEL_PYTHON
-    and VERCEL_TYPESCRIPT). A per-adapter eviction failure logs and continues —
+    shared by multiple backend_types (e.g.
+    PHOENIX_SANDBOX_VERCEL_TOKEN across VERCEL_PYTHON and VERCEL_TYPESCRIPT).
+    A per-adapter eviction failure logs and continues —
     a rotation must not stall because one backend failed to close.
     """
     matched = 0
@@ -454,6 +466,125 @@ async def _resolve_user_env(
     return user_env
 
 
+async def _resolve_named_credentials(
+    session: Optional[AsyncSession],
+    decrypt: Optional[Callable[[bytes], bytes]],
+    keys: list[str],
+) -> dict[str, str]:
+    """Resolve arbitrary credential keys via DB secret lookup + env fallback."""
+    if not keys:
+        return {}
+
+    deduped_keys = list(dict.fromkeys(keys))
+    db_secrets: dict[str, str] = {}
+
+    if session is not None and decrypt is not None:
+        import sqlalchemy as sa
+
+        from phoenix.db import models
+
+        rows = (
+            await session.scalars(
+                sa.select(models.Secret).where(models.Secret.key.in_(deduped_keys))
+            )
+        ).all()
+        for row in rows:
+            try:
+                db_secrets[row.key] = decrypt(row.value).decode("utf-8")
+            except Exception:
+                logger.warning(f"Failed to decrypt sandbox credential {row.key!r}", exc_info=True)
+
+    result: dict[str, str] = {}
+    for key in deduped_keys:
+        if key in db_secrets:
+            result[key] = db_secrets[key]
+        else:
+            env_val = os.getenv(key)
+            if env_val:
+                result[key] = env_val
+    return result
+
+
+def _format_required_keys(keys: list[str]) -> str:
+    quoted = [f"`{key}`" for key in keys]
+    if len(quoted) == 1:
+        return quoted[0]
+    if len(quoted) == 2:
+        return f"{quoted[0]} and {quoted[1]}"
+    return f"{', '.join(quoted[:-1])}, and {quoted[-1]}"
+
+
+async def get_missing_sandbox_auth_detail(
+    backend_type: str,
+    session: Optional[AsyncSession] = None,
+    decrypt: Optional[Callable[[bytes], bytes]] = None,
+) -> Optional[str]:
+    """Return a user-facing auth requirement message when backend credentials are missing."""
+    adapter = _SANDBOX_ADAPTERS.get(backend_type)
+    if adapter is None:
+        return None
+
+    if backend_type == "E2B":
+        resolved = await _resolve_named_credentials(
+            session, decrypt, ["PHOENIX_SANDBOX_E2B_API_KEY"]
+        )
+        if "PHOENIX_SANDBOX_E2B_API_KEY" in resolved:
+            return None
+        return "Set `PHOENIX_SANDBOX_E2B_API_KEY`."
+
+    if backend_type == "DAYTONA_PYTHON":
+        resolved = await _resolve_named_credentials(
+            session, decrypt, ["PHOENIX_SANDBOX_DAYTONA_API_KEY"]
+        )
+        if "PHOENIX_SANDBOX_DAYTONA_API_KEY" in resolved:
+            return None
+        return "Set `PHOENIX_SANDBOX_DAYTONA_API_KEY`."
+
+    if backend_type in {"VERCEL_PYTHON", "VERCEL_TYPESCRIPT"}:
+        oidc_key = "PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN"
+        access_keys = [
+            "PHOENIX_SANDBOX_VERCEL_TOKEN",
+            "PHOENIX_SANDBOX_VERCEL_PROJECT_ID",
+            "PHOENIX_SANDBOX_VERCEL_TEAM_ID",
+        ]
+        resolved = await _resolve_named_credentials(session, decrypt, [oidc_key, *access_keys])
+        if oidc_key in resolved or all(key in resolved for key in access_keys):
+            return None
+        missing_access_keys = [key for key in access_keys if key not in resolved]
+        if len(missing_access_keys) < len(access_keys):
+            return (
+                "Set `PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`, or add "
+                f"{_format_required_keys(missing_access_keys)} to complete "
+                "the Vercel access token configuration."
+            )
+        return (
+            "Set `PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`, or all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, "
+            "`PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and `PHOENIX_SANDBOX_VERCEL_TEAM_ID`."
+        )
+
+    if backend_type == "MODAL":
+        missing_modal_keys = [
+            key
+            for key in (
+                "PHOENIX_SANDBOX_MODAL_TOKEN_ID",
+                "PHOENIX_SANDBOX_MODAL_TOKEN_SECRET",
+            )
+            if not os.getenv(key)
+        ]
+        if not missing_modal_keys:
+            return None
+        return f"Set {_format_required_keys(missing_modal_keys)}."
+
+    if not adapter.credential_specs:
+        return None
+
+    resolved = await _resolve_sandbox_credentials(session, decrypt, adapter.credential_specs)
+    missing_keys = [spec.key for spec in adapter.credential_specs if spec.key not in resolved]
+    if not missing_keys:
+        return None
+    return f"Set {_format_required_keys(missing_keys)}."
+
+
 async def _resolve_sandbox_credentials(
     session: Optional[AsyncSession],
     decrypt: Optional[Callable[[bytes], bytes]],
@@ -465,35 +596,11 @@ async def _resolve_sandbox_credentials(
     to os.getenv(). Keys absent from both tiers are omitted from the result.
     Safe when session or decrypt are None (returns env-only resolution).
     """
-    if not credential_specs:
-        return {}
-
-    keys = [spec.key for spec in credential_specs]
-    db_secrets: dict[str, str] = {}
-
-    if session is not None and decrypt is not None:
-        import sqlalchemy as sa
-
-        from phoenix.db import models
-
-        rows = (
-            await session.scalars(sa.select(models.Secret).where(models.Secret.key.in_(keys)))
-        ).all()
-        for row in rows:
-            try:
-                db_secrets[row.key] = decrypt(row.value).decode("utf-8")
-            except Exception:
-                logger.warning(f"Failed to decrypt sandbox credential {row.key!r}", exc_info=True)
-
-    result: dict[str, str] = {}
-    for key in keys:
-        if key in db_secrets:
-            result[key] = db_secrets[key]
-        else:
-            env_val = os.getenv(key)
-            if env_val:
-                result[key] = env_val
-    return result
+    return await _resolve_named_credentials(
+        session=session,
+        decrypt=decrypt,
+        keys=[spec.key for spec in credential_specs],
+    )
 
 
 async def get_or_create_backend(
@@ -628,10 +735,9 @@ except ImportError:
 # matching any of these (case-insensitive) are rejected at mutation time so
 # they cannot shadow resolved credentials in the factory merge.
 #
-# Derived from every registered adapter's credential_specs, unioned with the
-# Phoenix-level fallback env vars that adapters consult before env lookup.
-# Includes the fallbacks explicitly so missing optional extras (e.g. the
-# e2b adapter not registered) cannot narrow the reserved set.
+# Derived from every registered adapter's credential_specs, unioned with
+# reservation-only names for env-var-only backends so missing optional extras
+# cannot narrow the reserved set.
 # ---------------------------------------------------------------------------
 
 _PHOENIX_RESERVED_CREDENTIAL_ONLY_KEYS: frozenset[str] = frozenset(
@@ -639,12 +745,9 @@ _PHOENIX_RESERVED_CREDENTIAL_ONLY_KEYS: frozenset[str] = frozenset(
         # Reservation-only names: NOT settable via setSandboxCredential mutation.
         # Contrast with SandboxAdapter.credential_specs (adapter-declared, settable
         # via mutation). RESERVED_CREDENTIAL_NAMES is the derived union of both.
-        "PHOENIX_SANDBOX_TOKEN",
-        "PHOENIX_SANDBOX_API_KEY",
-        # Modal tokens — added here so dropping credential_specs from ModalAdapter
-        # (task 3) does not silently narrow the reserved set.
-        "MODAL_TOKEN_ID",
-        "MODAL_TOKEN_SECRET",
+        # Modal remains env-var-only, so reserve its names explicitly.
+        "PHOENIX_SANDBOX_MODAL_TOKEN_ID",
+        "PHOENIX_SANDBOX_MODAL_TOKEN_SECRET",
     }
 )
 
@@ -663,7 +766,8 @@ RESERVED_CREDENTIAL_NAMES: frozenset[str] = _build_reserved_credential_names()
 def is_reserved_credential_name(name: str) -> bool:
     """Return True if `name` collides with a reserved provider-credential key.
 
-    Comparison is case-insensitive: `VERCEL_TOKEN`, `Vercel_Token`, and
-    `vercel_token` are all reserved.
+    Comparison is case-insensitive: `PHOENIX_SANDBOX_VERCEL_TOKEN`,
+    `Phoenix_Sandbox_Vercel_Token`, and `phoenix_sandbox_vercel_token` are all
+    reserved.
     """
     return name.lower() in RESERVED_CREDENTIAL_NAMES

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -531,7 +531,10 @@ async def get_or_create_backend(
     # overridden here. Reserved-name rejection at the mutation boundary is the
     # primary defense; this factory-level override is defense-in-depth.
     provider_creds = await _resolve_sandbox_credentials(session, decrypt, adapter.credential_specs)
-    effective_config: dict[str, Any] = {**(config or {}), **provider_creds}
+    cred_keys = {spec.key for spec in adapter.credential_specs}
+    user_config = {k: v for k, v in (config or {}).items() if k not in cred_keys}
+    validated_config = adapter.validate_config(user_config)
+    effective_config: dict[str, Any] = {**validated_config, **provider_creds}
 
     cache_key = (backend_type, _config_hash(effective_config))
     if cache_key in _BACKEND_CACHE:

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -236,7 +236,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         dependency_hints=[
             "Install Phoenix with the `vercel` extra.",
             (
-                "Set `PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`, or all of "
+                "Set `VERCEL_OIDC_TOKEN`, or all of "
                 "`PHOENIX_SANDBOX_VERCEL_TOKEN`, "
                 "`PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and "
                 "`PHOENIX_SANDBOX_VERCEL_TEAM_ID`."
@@ -252,7 +252,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         dependency_hints=[
             "Install Phoenix with the `vercel` extra.",
             (
-                "Set `PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`, or all of "
+                "Set `VERCEL_OIDC_TOKEN`, or all of "
                 "`PHOENIX_SANDBOX_VERCEL_TOKEN`, "
                 "`PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and "
                 "`PHOENIX_SANDBOX_VERCEL_TEAM_ID`."
@@ -277,10 +277,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         language="PYTHON",
         dependency_hints=[
             "Install Phoenix with the `modal` extra.",
-            (
-                "Provide `PHOENIX_SANDBOX_MODAL_TOKEN_ID` and "
-                "`PHOENIX_SANDBOX_MODAL_TOKEN_SECRET` environment variables."
-            ),
+            "Provide `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` environment variables.",
         ],
         supports_env_vars=True,
         internet_access_capability="boolean",
@@ -541,7 +538,7 @@ async def get_missing_sandbox_auth_detail(
         return "Set `PHOENIX_SANDBOX_DAYTONA_API_KEY`."
 
     if backend_type in {"VERCEL_PYTHON", "VERCEL_TYPESCRIPT"}:
-        oidc_key = "PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN"
+        oidc_key = "VERCEL_OIDC_TOKEN"
         access_keys = [
             "PHOENIX_SANDBOX_VERCEL_TOKEN",
             "PHOENIX_SANDBOX_VERCEL_PROJECT_ID",
@@ -553,23 +550,18 @@ async def get_missing_sandbox_auth_detail(
         missing_access_keys = [key for key in access_keys if key not in resolved]
         if len(missing_access_keys) < len(access_keys):
             return (
-                "Set `PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`, or add "
+                "Set `VERCEL_OIDC_TOKEN`, or add "
                 f"{_format_required_keys(missing_access_keys)} to complete "
                 "the Vercel access token configuration."
             )
         return (
-            "Set `PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`, or all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, "
+            "Set `VERCEL_OIDC_TOKEN`, or all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, "
             "`PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and `PHOENIX_SANDBOX_VERCEL_TEAM_ID`."
         )
 
     if backend_type == "MODAL":
         missing_modal_keys = [
-            key
-            for key in (
-                "PHOENIX_SANDBOX_MODAL_TOKEN_ID",
-                "PHOENIX_SANDBOX_MODAL_TOKEN_SECRET",
-            )
-            if not os.getenv(key)
+            key for key in ("MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET") if not os.getenv(key)
         ]
         if not missing_modal_keys:
             return None
@@ -746,8 +738,8 @@ _PHOENIX_RESERVED_CREDENTIAL_ONLY_KEYS: frozenset[str] = frozenset(
         # Contrast with SandboxAdapter.credential_specs (adapter-declared, settable
         # via mutation). RESERVED_CREDENTIAL_NAMES is the derived union of both.
         # Modal remains env-var-only, so reserve its names explicitly.
-        "PHOENIX_SANDBOX_MODAL_TOKEN_ID",
-        "PHOENIX_SANDBOX_MODAL_TOKEN_SECRET",
+        "MODAL_TOKEN_ID",
+        "MODAL_TOKEN_SECRET",
     }
 )
 

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -181,6 +181,18 @@ class AdapterMetadata:
     # editor scoped to the appropriate package ecosystem.
     dependencies_language: Optional[Literal["PYTHON", "TYPESCRIPT"]] = None
 
+    # Distinguishes WHEN package install runs relative to the sandbox network
+    # policy. ``True`` → install runs INSIDE the created sandbox via run_code
+    # (e.g. E2B, Daytona). If the sandbox is created with internet denied, pip
+    # cannot reach PyPI and the install fails silently — so the combination
+    # ``internet_access.mode == "deny"`` + non-empty ``dependencies.packages``
+    # MUST be rejected at validate_config time. ``False`` → install runs at
+    # image-build time, before the sandbox (and any network policy) exists
+    # (e.g. Modal's ``image.pip_install``); the combo is safe. Adapters that
+    # don't support dependencies at all (``dependencies_language is None``)
+    # ignore this flag because the no-deps gate already rejects packages.
+    installs_packages_at_runtime: bool = False
+
 
 # ---------------------------------------------------------------------------
 # Static metadata — always present regardless of installed extras.
@@ -212,6 +224,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         supports_env_vars=True,
         internet_access_capability="boolean",
         dependencies_language="PYTHON",
+        installs_packages_at_runtime=True,
     ),
     "DAYTONA_PYTHON": AdapterMetadata(
         display_name="Daytona",
@@ -223,6 +236,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         supports_env_vars=True,
         internet_access_capability="boolean",
         dependencies_language="PYTHON",
+        installs_packages_at_runtime=True,
     ),
     # Vercel Python SDK checked: pyproject minimum vercel>=0.5.1; uv.lock resolves
     # vercel==0.5.7. AsyncSandbox.create() in 0.5.7 does not accept `env` or
@@ -745,14 +759,20 @@ _PHOENIX_RESERVED_CREDENTIAL_ONLY_KEYS: frozenset[str] = frozenset(
 
 
 def _build_reserved_credential_names() -> frozenset[str]:
+    """Compute the current set of reserved credential names (case-insensitive).
+
+    Resolved on every call because ``_SANDBOX_ADAPTERS`` is populated lazily
+    by ``register_sandbox_adapter`` as optional extras import. Caching the
+    result at module load would freeze a snapshot taken before any adapter
+    registers — leaving every adapter-declared key (e.g.
+    ``PHOENIX_SANDBOX_VERCEL_TOKEN``) absent from the reserved set and
+    silently accepted as a user-supplied env_var or secret_ref.
+    """
     names: set[str] = {key.lower() for key in _PHOENIX_RESERVED_CREDENTIAL_ONLY_KEYS}
     for adapter in _SANDBOX_ADAPTERS.values():
         for spec in adapter.credential_specs:
             names.add(spec.key.lower())
     return frozenset(names)
-
-
-RESERVED_CREDENTIAL_NAMES: frozenset[str] = _build_reserved_credential_names()
 
 
 def is_reserved_credential_name(name: str) -> bool:
@@ -762,4 +782,4 @@ def is_reserved_credential_name(name: str) -> bool:
     `Phoenix_Sandbox_Vercel_Token`, and `phoenix_sandbox_vercel_token` are all
     reserved.
     """
-    return name.lower() in RESERVED_CREDENTIAL_NAMES
+    return name.lower() in _build_reserved_credential_names()

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -214,7 +214,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         dependencies_language="PYTHON",
     ),
     "DAYTONA_PYTHON": AdapterMetadata(
-        display_name="Daytona (Python)",
+        display_name="Daytona",
         language="PYTHON",
         dependency_hints=[
             "Install Phoenix with the `daytona` extra.",
@@ -231,7 +231,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
     # ships; flip internet_access_capability to "boolean" and wire network_policy
     # then. Until that lands, both Vercel adapters remain internet_access="none".
     "VERCEL_PYTHON": AdapterMetadata(
-        display_name="Vercel Sandbox (Python)",
+        display_name="Vercel Sandbox",
         language="PYTHON",
         dependency_hints=[
             "Install Phoenix with the `vercel` extra.",
@@ -243,7 +243,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         dependencies_language=None,
     ),
     "VERCEL_TYPESCRIPT": AdapterMetadata(
-        display_name="Vercel Sandbox (TypeScript)",
+        display_name="Vercel Sandbox",
         language="TYPESCRIPT",
         dependency_hints=[
             "Install Phoenix with the `vercel` extra.",

--- a/src/phoenix/server/sandbox/daytona_backend.py
+++ b/src/phoenix/server/sandbox/daytona_backend.py
@@ -33,11 +33,13 @@ class DaytonaSandboxBackend(SandboxBackend):
         server_url: str = "",
         user_env: Optional[dict[str, str]] = None,
         packages: Optional[list[str]] = None,
+        network_block_all: bool = False,
     ) -> None:
         self._api_key = api_key
         self._server_url = server_url
         self._user_env: dict[str, str] = user_env or {}
         self._packages: list[str] = packages or []
+        self._network_block_all = network_block_all
         self._sessions: dict[str, Any] = {}
 
     def _get_client(self) -> Any:
@@ -65,12 +67,18 @@ class DaytonaSandboxBackend(SandboxBackend):
                 f"pip install {pkg_args!r} failed (exit {result.exit_code}): {result.stderr}"
             )
 
+    def _create_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {}
+        if self._network_block_all:
+            kwargs["network_block_all"] = True
+        return kwargs
+
     async def start_session(self, session_key: str) -> None:
         if session_key in self._sessions:
             logger.debug(f"Daytona session '{session_key}' already exists; reusing")
             return
         client = self._get_client()
-        workspace = await client.create()
+        workspace = await client.create(**self._create_kwargs())
         await self._install_packages(workspace)
         self._sessions[session_key] = workspace
         logger.debug(f"Started Daytona session '{session_key}'")
@@ -97,9 +105,13 @@ class DaytonaSandboxBackend(SandboxBackend):
             workspace = self._sessions.get(session_key)
             if workspace is None:
                 client = self._get_client()
-                workspace = await client.create()
+                workspace = await client.create(**self._create_kwargs())
                 await self._install_packages(workspace)
-            result = await workspace.process.code_run(code, envs=self._user_env)
+            from daytona_sdk.common.process import CodeRunParams  # type: ignore[import-not-found]
+
+            result = await workspace.process.code_run(
+                code, params=CodeRunParams(env=self._user_env or None)
+            )
             return ExecutionResult(
                 stdout=result.stdout or "",
                 stderr=result.stderr or "",
@@ -139,6 +151,13 @@ class DaytonaPythonAdapter(SandboxAdapter):
         server_url: str = config.get("server_url", "")
         deps = config.get("dependencies") or {}
         packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []
+        internet_access = config.get("internet_access") or {}
+        mode: str = internet_access.get("mode", "") if isinstance(internet_access, dict) else ""
+        network_block_all = mode == "deny"
         return DaytonaSandboxBackend(
-            api_key=api_key, server_url=server_url, user_env=user_env, packages=packages
+            api_key=api_key,
+            server_url=server_url,
+            user_env=user_env,
+            packages=packages,
+            network_block_all=network_block_all,
         )

--- a/src/phoenix/server/sandbox/daytona_backend.py
+++ b/src/phoenix/server/sandbox/daytona_backend.py
@@ -96,27 +96,39 @@ class DaytonaSandboxBackend(SandboxBackend):
         session_key: str,
         timeout: Optional[int] = None,
     ) -> ExecutionResult:
-        if timeout is not None:
-            logger.warning(
-                "DaytonaSandboxBackend does not support per-call timeout; ignoring timeout=%d",
-                timeout,
-            )
         try:
-            workspace = self._sessions.get(session_key)
-            if workspace is None:
-                client = self._get_client()
-                workspace = await client.create(**self._create_kwargs())
-                await self._install_packages(workspace)
             from daytona_sdk.common.process import CodeRunParams  # type: ignore[import-not-found]
 
-            result = await workspace.process.code_run(
-                code, params=CodeRunParams(env=self._user_env or None)
-            )
-            return ExecutionResult(
-                stdout=result.stdout or "",
-                stderr=result.stderr or "",
-                error=result.exit_code != 0 and result.stderr or None,
-            )
+            workspace = self._sessions.get(session_key)
+            if workspace is not None:
+                result = await workspace.process.code_run(
+                    code, params=CodeRunParams(env=self._user_env or None)
+                )
+                return ExecutionResult(
+                    stdout=result.stdout or "",
+                    stderr=result.stderr or "",
+                    error=result.exit_code != 0 and result.stderr or None,
+                )
+            else:
+                client = self._get_client()
+                workspace = await client.create(**self._create_kwargs())
+                try:
+                    await self._install_packages(workspace)
+                    result = await workspace.process.code_run(
+                        code, params=CodeRunParams(env=self._user_env or None)
+                    )
+                    return ExecutionResult(
+                        stdout=result.stdout or "",
+                        stderr=result.stderr or "",
+                        error=result.exit_code != 0 and result.stderr or None,
+                    )
+                finally:
+                    try:
+                        await client.remove(workspace)
+                    except Exception:
+                        logger.warning(
+                            "Failed to remove ephemeral Daytona workspace", exc_info=True
+                        )
         except Exception as exc:
             return ExecutionResult(stdout="", stderr=str(exc), error=str(exc))
 

--- a/src/phoenix/server/sandbox/daytona_backend.py
+++ b/src/phoenix/server/sandbox/daytona_backend.py
@@ -8,10 +8,7 @@ Import is deferred to avoid top-level failures when the extra is absent.
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any, Optional
-
-from phoenix.config import ENV_PHOENIX_SANDBOX_TOKEN
 
 from .types import (
     DaytonaPythonConfig,
@@ -154,12 +151,7 @@ class DaytonaPythonAdapter(SandboxAdapter):
         self, config: dict[str, Any], user_env: Optional[dict[str, str]] = None
     ) -> SandboxBackend:
         self._enforce_capabilities(config, user_env)
-        api_key: str = (
-            config.get("PHOENIX_SANDBOX_DAYTONA_API_KEY")
-            or os.environ.get("PHOENIX_SANDBOX_DAYTONA_API_KEY")
-            or os.environ.get(ENV_PHOENIX_SANDBOX_TOKEN)
-            or ""
-        )
+        api_key: str = config.get("PHOENIX_SANDBOX_DAYTONA_API_KEY") or ""
         deps = config.get("dependencies") or {}
         packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []
         internet_access = config.get("internet_access") or {}

--- a/src/phoenix/server/sandbox/daytona_backend.py
+++ b/src/phoenix/server/sandbox/daytona_backend.py
@@ -160,7 +160,6 @@ class DaytonaPythonAdapter(SandboxAdapter):
             or os.environ.get(ENV_PHOENIX_SANDBOX_TOKEN)
             or ""
         )
-        server_url: str = config.get("server_url", "")
         deps = config.get("dependencies") or {}
         packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []
         internet_access = config.get("internet_access") or {}
@@ -168,7 +167,7 @@ class DaytonaPythonAdapter(SandboxAdapter):
         network_block_all = mode == "deny"
         return DaytonaSandboxBackend(
             api_key=api_key,
-            server_url=server_url,
+            server_url="",
             user_env=user_env,
             packages=packages,
             network_block_all=network_block_all,

--- a/src/phoenix/server/sandbox/daytona_backend.py
+++ b/src/phoenix/server/sandbox/daytona_backend.py
@@ -139,7 +139,7 @@ class DaytonaSandboxBackend(SandboxBackend):
 
 class DaytonaPythonAdapter(SandboxAdapter):
     key = "DAYTONA_PYTHON"
-    display_name = "Daytona (Python)"
+    display_name = "Daytona"
     language = "PYTHON"
     config_model = DaytonaPythonConfig
     credential_specs = [

--- a/src/phoenix/server/sandbox/deno_backend.py
+++ b/src/phoenix/server/sandbox/deno_backend.py
@@ -2,13 +2,16 @@
 Local Deno sandbox backend.
 
 Stateless (BaseNoSessionBackend) — each execute() call is independent.
-Requires the ``deno_sandbox`` package (optional extra).
-Import is deferred to avoid top-level failures when the extra is absent.
+Executes code through the local ``deno`` CLI with a default-deny permission
+model, granting only exact env-var access for server-injected variables.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import re
+import shutil
 from typing import Any, Optional
 
 from .types import (
@@ -21,17 +24,49 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
+_ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_ESCAPE_RE.sub("", text)
+
 
 class DenoSandboxBackend(BaseNoSessionBackend):
     """Sandbox backend executing TypeScript code in a local Deno runtime."""
 
-    def __init__(self, user_env: Optional[dict[str, str]] = None) -> None:
+    def __init__(
+        self,
+        deno_executable: str,
+        user_env: Optional[dict[str, str]] = None,
+    ) -> None:
+        self._deno_executable = deno_executable
         self._user_env: dict[str, str] = user_env or {}
 
-    def _get_client(self) -> Any:
-        from deno_sandbox import DenoSandbox  # type: ignore[import-not-found]
+    def _build_command(self) -> list[str]:
+        # Deno security docs: permissions are denied by default, but config
+        # files can also supply permissions and module loading from remote/npm
+        # can still occur unless explicitly disabled.
+        # Docs:
+        # - https://docs.deno.com/runtime/fundamentals/security/
+        # - https://docs.deno.com/runtime/reference/cli/run/
+        cmd = [
+            self._deno_executable,
+            "run",
+            "--no-prompt",
+            "--no-config",
+            "--no-remote",
+            "--no-npm",
+        ]
+        if self._user_env:
+            allowed_env_names = ",".join(sorted(self._user_env))
+            cmd.append(f"--allow-env={allowed_env_names}")
+        cmd.append("-")
+        return cmd
 
-        return DenoSandbox()
+    def _build_subprocess_env(self) -> dict[str, str]:
+        # Pass only caller-resolved variables through to the child so Deno code
+        # cannot observe the Phoenix server's ambient environment.
+        return dict(self._user_env)
 
     async def execute(
         self,
@@ -39,17 +74,46 @@ class DenoSandboxBackend(BaseNoSessionBackend):
         session_key: str,
         timeout: Optional[int] = None,
     ) -> ExecutionResult:
+        proc: asyncio.subprocess.Process | None = None
+        cmd = self._build_command()
+        exec_timeout = timeout if timeout is not None else 30
+
         try:
-            client = self._get_client()
-            run_kwargs: dict[str, Any] = {"env": self._user_env}
-            if timeout is not None:
-                run_kwargs["timeout"] = timeout
-            result = await client.run(code, **run_kwargs)
-            return ExecutionResult(
-                stdout=result.stdout or "",
-                stderr=result.stderr or "",
-                error=result.error or None,
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=self._build_subprocess_env(),
             )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(code.encode("utf-8")),
+                timeout=exec_timeout,
+            )
+            stdout = _strip_ansi(stdout_bytes.decode("utf-8", errors="replace"))
+            stderr = _strip_ansi(stderr_bytes.decode("utf-8", errors="replace"))
+            if proc.returncode == 0:
+                return ExecutionResult(stdout=stdout, stderr=stderr)
+            error = stderr or f"Deno process exited with code {proc.returncode}"
+            return ExecutionResult(
+                stdout=stdout,
+                stderr=stderr,
+                error=error,
+            )
+        except asyncio.TimeoutError:
+            if proc is not None:
+                proc.kill()
+                try:
+                    await proc.wait()
+                except Exception:
+                    logger.debug("Timed-out Deno process failed to exit cleanly", exc_info=True)
+            message = f"Execution timed out after {exec_timeout}s"
+            return ExecutionResult(stdout="", stderr=message, error=message)
+        except FileNotFoundError:
+            message = (
+                "Deno executable not found. Install Deno and ensure the `deno` binary is on PATH."
+            )
+            return ExecutionResult(stdout="", stderr=message, error=message)
         except Exception as exc:
             return ExecutionResult(stdout="", stderr=str(exc), error=str(exc))
 
@@ -67,4 +131,9 @@ class DenoAdapter(SandboxAdapter):
         self, config: dict[str, Any], user_env: Optional[dict[str, str]] = None
     ) -> SandboxBackend:
         self._enforce_capabilities(config, user_env)
-        return DenoSandboxBackend(user_env=user_env)
+        deno_executable = shutil.which("deno")
+        if deno_executable is None:
+            raise ValueError(
+                "Deno is not installed. Install Deno and ensure the `deno` binary is on PATH."
+            )
+        return DenoSandboxBackend(deno_executable=deno_executable, user_env=user_env)

--- a/src/phoenix/server/sandbox/e2b_backend.py
+++ b/src/phoenix/server/sandbox/e2b_backend.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shlex
 from typing import Any, Optional
 
 from phoenix.config import ENV_PHOENIX_SANDBOX_API_KEY
@@ -39,12 +40,16 @@ class E2BSandboxBackend(SandboxBackend):
         cwd: Optional[str] = None,
         metadata: Optional[str] = None,
         user_env: Optional[dict[str, str]] = None,
+        allow_internet_access: bool = True,
+        packages: Optional[list[str]] = None,
     ) -> None:
         self._api_key = api_key
         self._template = template
         self._cwd = cwd
         self._metadata = metadata
         self._user_env: dict[str, str] = user_env or {}
+        self._allow_internet_access = allow_internet_access
+        self._packages: list[str] = packages or []
         self._sessions: dict[str, Any] = {}
 
     def _get_sandbox_cls(self) -> Any:
@@ -59,10 +64,32 @@ class E2BSandboxBackend(SandboxBackend):
         the config is passed under the key ``"info"``, so the sandbox is
         tagged with ``{"info": "<value>"}``.
         """
-        kwargs: dict[str, Any] = {"api_key": self._api_key, "template": self._template}
+        kwargs: dict[str, Any] = {
+            "api_key": self._api_key,
+            "template": self._template,
+            "allow_internet_access": self._allow_internet_access,
+        }
         if self._metadata is not None:
             kwargs["metadata"] = {"info": self._metadata}
         return kwargs
+
+    async def _install_packages(self, sandbox: Any) -> None:
+        """pip-install configured packages via run_code using argv-safe quoting."""
+        if not self._packages:
+            return
+        quoted = [shlex.quote(p) for p in self._packages]
+        install_code = (
+            "import subprocess, sys\n"
+            "r = subprocess.run(\n"
+            f"    [sys.executable, '-m', 'pip', 'install', *{quoted!r}],\n"
+            "    capture_output=True, text=True\n"
+            ")\n"
+            "if r.returncode != 0:\n"
+            "    raise RuntimeError(r.stderr)\n"
+        )
+        execution = await sandbox.run_code(install_code)
+        if execution.error:
+            raise RuntimeError(f"pip install failed for {self._packages!r}: {execution.error}")
 
     async def start_session(self, session_key: str) -> None:
         if session_key in self._sessions:
@@ -70,6 +97,7 @@ class E2BSandboxBackend(SandboxBackend):
             return
         AsyncSandbox = self._get_sandbox_cls()
         sandbox = await AsyncSandbox.create(**self._create_kwargs())
+        await self._install_packages(sandbox)
         self._sessions[session_key] = sandbox
         logger.debug(f"Started E2B session '{session_key}'")
 
@@ -149,6 +177,24 @@ class E2BAdapter(SandboxAdapter):
         template: str = config.get("template", "base")
         cwd: Optional[str] = config.get("cwd") or None
         metadata: Optional[str] = config.get("metadata") or None
+        internet_access = config.get("internet_access")
+        if internet_access is not None:
+            mode = (
+                internet_access.get("mode")
+                if isinstance(internet_access, dict)
+                else getattr(internet_access, "mode", None)
+            )
+            allow_internet_access = mode != "deny"
+        else:
+            allow_internet_access = True
+        deps = config.get("dependencies") or {}
+        packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []
         return E2BSandboxBackend(
-            api_key=api_key, template=template, cwd=cwd, metadata=metadata, user_env=user_env
+            api_key=api_key,
+            template=template,
+            cwd=cwd,
+            metadata=metadata,
+            user_env=user_env,
+            allow_internet_access=allow_internet_access,
+            packages=packages or None,
         )

--- a/src/phoenix/server/sandbox/e2b_backend.py
+++ b/src/phoenix/server/sandbox/e2b_backend.py
@@ -174,9 +174,6 @@ class E2BAdapter(SandboxAdapter):
             or os.environ.get(ENV_PHOENIX_SANDBOX_API_KEY)
             or ""
         )
-        template: str = config.get("template", "base")
-        cwd: Optional[str] = config.get("cwd") or None
-        metadata: Optional[str] = config.get("metadata") or None
         internet_access = config.get("internet_access")
         if internet_access is not None:
             mode = (
@@ -191,9 +188,9 @@ class E2BAdapter(SandboxAdapter):
         packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []
         return E2BSandboxBackend(
             api_key=api_key,
-            template=template,
-            cwd=cwd,
-            metadata=metadata,
+            template="base",
+            cwd=None,
+            metadata=None,
             user_env=user_env,
             allow_internet_access=allow_internet_access,
             packages=packages or None,

--- a/src/phoenix/server/sandbox/e2b_backend.py
+++ b/src/phoenix/server/sandbox/e2b_backend.py
@@ -8,11 +8,8 @@ Import is deferred to avoid top-level failures when the extra is absent.
 from __future__ import annotations
 
 import logging
-import os
 import shlex
 from typing import Any, Optional
-
-from phoenix.config import ENV_PHOENIX_SANDBOX_API_KEY
 
 from .types import (
     E2BConfig,
@@ -168,12 +165,7 @@ class E2BAdapter(SandboxAdapter):
         user_env: Optional[dict[str, str]] = None,
     ) -> SandboxBackend:
         self._enforce_capabilities(config, user_env)
-        api_key: str = (
-            config.get("PHOENIX_SANDBOX_E2B_API_KEY")
-            or os.environ.get("PHOENIX_SANDBOX_E2B_API_KEY")
-            or os.environ.get(ENV_PHOENIX_SANDBOX_API_KEY)
-            or ""
-        )
+        api_key: str = config.get("PHOENIX_SANDBOX_E2B_API_KEY") or ""
         internet_access = config.get("internet_access")
         if internet_access is not None:
             mode = (

--- a/src/phoenix/server/sandbox/e2b_backend.py
+++ b/src/phoenix/server/sandbox/e2b_backend.py
@@ -8,7 +8,6 @@ Import is deferred to avoid top-level failures when the extra is absent.
 from __future__ import annotations
 
 import logging
-import shlex
 from typing import Any, Optional
 
 from .types import (
@@ -71,14 +70,20 @@ class E2BSandboxBackend(SandboxBackend):
         return kwargs
 
     async def _install_packages(self, sandbox: Any) -> None:
-        """pip-install configured packages via run_code using argv-safe quoting."""
+        """pip-install configured packages via run_code.
+
+        ``{self._packages!r}`` serializes the list as a Python list literal
+        with each spec wrapped in correctly escaped string quotes. ``shlex.quote``
+        must NOT be used here: the generated code calls ``subprocess.run`` with
+        a list (no shell), so any shell-style quoting becomes part of the argv
+        element and pip rejects e.g. ``'numpy>=1.0'`` as an invalid name.
+        """
         if not self._packages:
             return
-        quoted = [shlex.quote(p) for p in self._packages]
         install_code = (
             "import subprocess, sys\n"
             "r = subprocess.run(\n"
-            f"    [sys.executable, '-m', 'pip', 'install', *{quoted!r}],\n"
+            f"    [sys.executable, '-m', 'pip', 'install', *{self._packages!r}],\n"
             "    capture_output=True, text=True\n"
             ")\n"
             "if r.returncode != 0:\n"
@@ -121,8 +126,14 @@ class E2BSandboxBackend(SandboxBackend):
                 execution = await sandbox.run_code(code, **run_kwargs)
             else:
                 # Ephemeral: spin up a fresh sandbox, run, then close.
+                # The evaluator path enters via execute() without ever calling
+                # start_session(), so configured dependencies.packages must be
+                # installed here too — otherwise they're silently dropped (the
+                # only other install site is start_session). Mirrors the
+                # Daytona ephemeral branch.
                 AsyncSandbox = self._get_sandbox_cls()
                 async with await AsyncSandbox.create(**self._create_kwargs()) as sb:
+                    await self._install_packages(sb)
                     execution = await sb.run_code(code, **run_kwargs)
 
             stdout = "\n".join(execution.logs.stdout) if execution.logs.stdout else ""

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -52,16 +52,20 @@ class ModalSandboxBackend(SandboxBackend):
         idle_timeout: int = _DEFAULT_IDLE_TIMEOUT,
         app_name: str = "phoenix-sandbox",
         user_env: Optional[dict[str, str]] = None,
+        packages: Optional[list[str]] = None,
+        block_network: bool = False,
     ) -> None:
         import modal  # type: ignore[import-not-found]
 
         self._timeout = timeout
         self._idle_timeout = idle_timeout
         self._user_env: dict[str, str] = user_env or {}
+        self._block_network = block_network
         self._sessions: dict[str, Any] = {}
         self._session_locks: dict[str, asyncio.Lock] = {}
         self._app = modal.App.lookup(app_name, create_if_missing=True)
-        self._image = modal.Image.debian_slim()
+        base_image = modal.Image.debian_slim()
+        self._image = base_image.pip_install(packages) if packages else base_image
 
     async def _create_sandbox(self) -> Any:
         import modal
@@ -73,7 +77,9 @@ class ModalSandboxBackend(SandboxBackend):
             "idle_timeout": self._idle_timeout,
         }
         if self._user_env:
-            kwargs["env_dict"] = self._user_env
+            kwargs["env"] = self._user_env
+        if self._block_network:
+            kwargs["block_network"] = True
         sandbox = await modal.Sandbox.create.aio(**kwargs)
         return sandbox
 
@@ -154,6 +160,16 @@ class ModalAdapter(SandboxAdapter):
         timeout: int = int(config.get("timeout", _DEFAULT_TIMEOUT))
         idle_timeout: int = int(config.get("idle_timeout", _DEFAULT_IDLE_TIMEOUT))
         app_name: str = config.get("app_name", "phoenix-sandbox")
+        deps = config.get("dependencies") or {}
+        packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []
+        ia = config.get("internet_access") or {}
+        mode = ia.get("mode") if isinstance(ia, dict) else getattr(ia, "mode", None)
+        block_network: bool = mode == "deny"
         return ModalSandboxBackend(
-            timeout=timeout, idle_timeout=idle_timeout, app_name=app_name, user_env=user_env
+            timeout=timeout,
+            idle_timeout=idle_timeout,
+            app_name=app_name,
+            user_env=user_env,
+            packages=packages or None,
+            block_network=block_network,
         )

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -122,10 +122,6 @@ class ModalSandboxBackend(SandboxBackend):
         session_key: str,
         timeout: Optional[int] = None,
     ) -> ExecutionResult:
-        if timeout is not None:
-            logger.warning(
-                "ModalSandboxBackend: per-call timeout not supported; using sandbox-level timeout"
-            )
         try:
             sandbox = self._sessions.get(session_key)
             if sandbox is not None:

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -4,9 +4,8 @@ Modal sandbox backend.
 Requires the ``modal`` package (optional extra).
 Import is deferred to avoid top-level failures when the extra is absent.
 
-Authentication is env-var-only: Modal picks up
-PHOENIX_SANDBOX_MODAL_TOKEN_ID and PHOENIX_SANDBOX_MODAL_TOKEN_SECRET
-automatically from the environment (D6 design decision —
+Authentication is env-var-only: Modal picks up MODAL_TOKEN_ID and
+MODAL_TOKEN_SECRET automatically from the environment (D6 design decision —
 no credentials stored in DB config).
 
 Session lifecycle

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -4,8 +4,9 @@ Modal sandbox backend.
 Requires the ``modal`` package (optional extra).
 Import is deferred to avoid top-level failures when the extra is absent.
 
-Authentication is env-var-only: Modal picks up MODAL_TOKEN_ID and
-MODAL_TOKEN_SECRET automatically from the environment (D6 design decision —
+Authentication is env-var-only: Modal picks up
+PHOENIX_SANDBOX_MODAL_TOKEN_ID and PHOENIX_SANDBOX_MODAL_TOKEN_SECRET
+automatically from the environment (D6 design decision —
 no credentials stored in DB config).
 
 Session lifecycle

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -153,18 +153,15 @@ class ModalAdapter(SandboxAdapter):
         user_env: Optional[dict[str, str]] = None,
     ) -> SandboxBackend:
         self._enforce_capabilities(config, user_env)
-        timeout: int = int(config.get("timeout", _DEFAULT_TIMEOUT))
-        idle_timeout: int = int(config.get("idle_timeout", _DEFAULT_IDLE_TIMEOUT))
-        app_name: str = config.get("app_name", "phoenix-sandbox")
         deps = config.get("dependencies") or {}
         packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []
         ia = config.get("internet_access") or {}
         mode = ia.get("mode") if isinstance(ia, dict) else getattr(ia, "mode", None)
         block_network: bool = mode == "deny"
         return ModalSandboxBackend(
-            timeout=timeout,
-            idle_timeout=idle_timeout,
-            app_name=app_name,
+            timeout=_DEFAULT_TIMEOUT,
+            idle_timeout=_DEFAULT_IDLE_TIMEOUT,
+            app_name="phoenix-sandbox",
             user_env=user_env,
             packages=packages or None,
             block_network=block_network,

--- a/src/phoenix/server/sandbox/types.py
+++ b/src/phoenix/server/sandbox/types.py
@@ -124,7 +124,7 @@ class E2BConfig(BaseModel):
     env_vars: list[EnvVarEntry] = Field(
         default_factory=list,
         title="Environment Variables",
-        description="User-defined environment variables injected at execution time.",
+        description="Environment variables set at build time; not overridable per call.",
     )
     internet_access: Optional[InternetAccessConfig] = Field(
         default=None,
@@ -149,7 +149,7 @@ class DaytonaPythonConfig(BaseModel):
     env_vars: list[EnvVarEntry] = Field(
         default_factory=list,
         title="Environment Variables",
-        description="User-defined environment variables injected at execution time.",
+        description="Environment variables set at build time; not overridable per call.",
     )
     internet_access: Optional[InternetAccessConfig] = Field(
         default=None,
@@ -169,7 +169,7 @@ class DenoConfig(BaseModel):
     env_vars: list[EnvVarEntry] = Field(
         default_factory=list,
         title="Environment Variables",
-        description="User-defined environment variables injected at execution time.",
+        description="Environment variables set at build time; not overridable per call.",
     )
     internet_access: Optional[InternetAccessConfig] = Field(
         default=None,
@@ -184,7 +184,7 @@ class _VercelConfigBase(BaseModel):
     env_vars: list[EnvVarEntry] = Field(
         default_factory=list,
         title="Environment Variables",
-        description="User-defined environment variables injected at execution time.",
+        description="Environment variables set at build time; not overridable per call.",
     )
     internet_access: Optional[InternetAccessConfig] = Field(
         default=None,
@@ -234,7 +234,7 @@ class ModalConfig(BaseModel):
     env_vars: list[EnvVarEntry] = Field(
         default_factory=list,
         title="Environment Variables",
-        description="User-defined environment variables injected at execution time.",
+        description="Environment variables set at build time; not overridable per call.",
     )
     internet_access: Optional[InternetAccessConfig] = Field(
         default=None,

--- a/src/phoenix/server/sandbox/types.py
+++ b/src/phoenix/server/sandbox/types.py
@@ -97,30 +97,15 @@ class ProviderCredentialSpec:
 
 # ---------------------------------------------------------------------------
 # Per-adapter pydantic config models.
-# extra="allow" preserves unknown keys (D9 contract).
+# extra="forbid" rejects unknown keys at validate_config (D7 contract).
 # All config fields are optional — adapters use defaults for missing keys.
 # Field(title=...) drives ConfigFieldSpec.display_name derivation.
 # ---------------------------------------------------------------------------
 
 
 class E2BConfig(BaseModel):
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
-    template: str = Field(
-        default="base",
-        title="Template",
-        description="E2B sandbox template ID. Defaults to 'base'.",
-    )
-    cwd: Optional[str] = Field(
-        default=None,
-        title="Working Directory",
-        description="Working directory for code execution inside the sandbox.",
-    )
-    metadata: Optional[str] = Field(
-        default=None,
-        title="Metadata",
-        description="Metadata string attached to the sandbox at creation time.",
-    )
     env_vars: list[EnvVarEntry] = Field(
         default_factory=list,
         title="Environment Variables",
@@ -139,13 +124,8 @@ class E2BConfig(BaseModel):
 
 
 class DaytonaPythonConfig(BaseModel):
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
-    server_url: str = Field(
-        default="",
-        title="Server URL",
-        description="Daytona server URL. Leave empty to use the default.",
-    )
     env_vars: list[EnvVarEntry] = Field(
         default_factory=list,
         title="Environment Variables",
@@ -164,7 +144,7 @@ class DaytonaPythonConfig(BaseModel):
 
 
 class DenoConfig(BaseModel):
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
     env_vars: list[EnvVarEntry] = Field(
         default_factory=list,
@@ -179,7 +159,7 @@ class DenoConfig(BaseModel):
 
 
 class _VercelConfigBase(BaseModel):
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
     env_vars: list[EnvVarEntry] = Field(
         default_factory=list,
@@ -210,27 +190,12 @@ class VercelTypescriptConfig(_VercelConfigBase):
 
 
 class WASMConfig(BaseModel):
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class ModalConfig(BaseModel):
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
-    app_name: str = Field(
-        default="phoenix-sandbox",
-        title="App Name",
-        description="Modal app name. Created on first use if it does not exist.",
-    )
-    timeout: int = Field(
-        default=600,
-        title="Timeout (seconds)",
-        description="Hard sandbox timeout in seconds.",
-    )
-    idle_timeout: int = Field(
-        default=300,
-        title="Idle Timeout (seconds)",
-        description="Duration of idleness before a sandbox is terminated.",
-    )
     env_vars: list[EnvVarEntry] = Field(
         default_factory=list,
         title="Environment Variables",

--- a/src/phoenix/server/sandbox/types.py
+++ b/src/phoenix/server/sandbox/types.py
@@ -602,6 +602,43 @@ class SandboxAdapter(ABC):
                         )
                     )
 
+        # Runtime-install adapters install packages INSIDE the sandbox via
+        # run_code, so a sandbox created with the network already denied has no
+        # PyPI access and the install silently fails. Reject the combination
+        # eagerly. No stored_config bypass: the combo never works, so
+        # round-tripping a stored config that's already in this state should
+        # also fail loudly rather than persisting a broken configuration.
+        if metadata.installs_packages_at_runtime and metadata.dependencies_language is not None:
+            ia_mode: Optional[str] = None
+            if isinstance(internet_access, dict):
+                ia_mode = internet_access.get("mode")
+            elif internet_access is not None:
+                ia_mode = getattr(internet_access, "mode", None)
+            packages_list: list[Any] = []
+            if isinstance(dependencies, dict):
+                packages_list = dependencies.get("packages") or []
+            elif dependencies is not None:
+                packages_list = getattr(dependencies, "packages", None) or []
+            if ia_mode == "deny" and packages_list:
+                errors.append(
+                    InitErrorDetails(
+                        type=PydanticCustomError(
+                            "capability_violation",
+                            (
+                                "{adapter} adapter installs packages inside the "
+                                "sandbox at runtime, so internet_access.mode='deny' "
+                                "is incompatible with non-empty "
+                                "dependencies.packages: pip cannot reach PyPI from "
+                                "a network-denied sandbox. Set internet_access.mode "
+                                "to 'allow' or remove dependencies.packages."
+                            ),
+                            {"adapter": self.key},
+                        ),
+                        loc=("dependencies", "packages"),
+                        input=packages_list,
+                    )
+                )
+
         if errors:
             raise ValidationError.from_exception_data(
                 type(self).__name__,
@@ -689,3 +726,29 @@ class SandboxAdapter(ABC):
                         "dependency installation. Remove `dependencies.packages` "
                         "or switch to a backend that supports dependencies."
                     )
+
+        # Runtime-install combo guard (mirrors _enforce_capability_gates).
+        # Defense-in-depth: validate_config already rejects this at write time,
+        # but a misconfigured stored config reaching build_backend (e.g. via a
+        # path that bypassed validate_config) must still fail loudly rather
+        # than silently producing a sandbox where pip install fails.
+        if metadata.installs_packages_at_runtime and metadata.dependencies_language is not None:
+            internet_access = config.get("internet_access")
+            ia_mode: Optional[str] = None
+            if isinstance(internet_access, dict):
+                ia_mode = internet_access.get("mode")
+            elif internet_access is not None:
+                ia_mode = getattr(internet_access, "mode", None)
+            deps = config.get("dependencies")
+            packages_list: list[Any] = []
+            if isinstance(deps, dict):
+                packages_list = deps.get("packages") or []
+            elif deps is not None:
+                packages_list = getattr(deps, "packages", None) or []
+            if ia_mode == "deny" and packages_list:
+                raise UnsupportedOperation(
+                    f"{self.display_name} backend installs packages inside the "
+                    "sandbox at runtime; internet_access.mode='deny' blocks pip "
+                    "from reaching PyPI. Set internet_access.mode to 'allow' or "
+                    "remove dependencies.packages."
+                )

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -162,11 +162,6 @@ class VercelSandboxBackend(SandboxBackend):
         session_key: str,
         timeout: Optional[int] = None,
     ) -> ExecutionResult:
-        if timeout is not None:
-            logger.debug(
-                "VercelSandboxBackend: per-call timeout not supported for session reuse; "
-                "set timeout at sandbox creation time via start_session"
-            )
         try:
             session_env: Optional[dict[str, str]] = self._user_env or None
             sandbox = self._sessions.get(session_key)

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -8,9 +8,11 @@ otherwise spins up an ephemeral sandbox (create → run_command → stop).
 Requires the ``vercel`` extra (``vercel>=0.5.1``).
 Import is deferred to avoid top-level failures when the extra is absent.
 
-Authentication follows the Vercel Sandbox SDK: either ``VERCEL_OIDC_TOKEN`` (for
-local ``vercel env pull`` or deployments on Vercel), or the access-token
-triple ``VERCEL_TOKEN``, ``VERCEL_PROJECT_ID``, and ``VERCEL_TEAM_ID``. See
+Authentication follows the Vercel Sandbox SDK: either
+``PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`` (for local ``vercel env pull`` or
+deployments on Vercel), or the access-token triple
+``PHOENIX_SANDBOX_VERCEL_TOKEN``, ``PHOENIX_SANDBOX_VERCEL_PROJECT_ID``, and
+``PHOENIX_SANDBOX_VERCEL_TEAM_ID``. See
 https://vercel.com/docs/vercel-sandbox/concepts/authentication
 
 Language routing
@@ -35,11 +37,11 @@ from .types import (
     VercelTypescriptConfig,
 )
 
-# Vercel SDK env (https://vercel.com/docs/vercel-sandbox/concepts/authentication)
-ENV_VERCEL_OIDC_TOKEN = "VERCEL_OIDC_TOKEN"
-ENV_VERCEL_TOKEN = "VERCEL_TOKEN"
-ENV_VERCEL_PROJECT_ID = "VERCEL_PROJECT_ID"
-ENV_VERCEL_TEAM_ID = "VERCEL_TEAM_ID"
+# Phoenix-scoped Vercel credentials.
+ENV_PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN = "PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN"
+ENV_PHOENIX_SANDBOX_VERCEL_TOKEN = "PHOENIX_SANDBOX_VERCEL_TOKEN"
+ENV_PHOENIX_SANDBOX_VERCEL_PROJECT_ID = "PHOENIX_SANDBOX_VERCEL_PROJECT_ID"
+ENV_PHOENIX_SANDBOX_VERCEL_TEAM_ID = "PHOENIX_SANDBOX_VERCEL_TEAM_ID"
 
 logger = logging.getLogger(__name__)
 
@@ -69,9 +71,9 @@ class VercelSandboxBackend(SandboxBackend):
     across multiple execute() calls, or ephemeral execution (no session) which
     spins up a fresh sandbox per call.
 
-    Credentials: either rely on ``VERCEL_OIDC_TOKEN`` in the process environment
-    (``use_oidc_env=True``), or pass an access-token triple ``token``,
-    ``project_id``, and ``team_id`` for ``AsyncSandbox.create``.
+    Credentials: either rely on ``PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`` in the
+    process environment (``use_oidc_env=True``), or pass an access-token triple
+    ``token``, ``project_id``, and ``team_id`` for ``AsyncSandbox.create``.
     """
 
     def __init__(
@@ -187,37 +189,55 @@ class VercelSandboxBackend(SandboxBackend):
 
 
 def _resolve_vercel_access_token(config: dict[str, Any]) -> str:
-    return str(config.get(ENV_VERCEL_TOKEN) or "") or os.environ.get(ENV_VERCEL_TOKEN, "")
+    return str(config.get(ENV_PHOENIX_SANDBOX_VERCEL_TOKEN) or "") or os.environ.get(
+        ENV_PHOENIX_SANDBOX_VERCEL_TOKEN, ""
+    )
 
 
 def _resolve_vercel_project_id(config: dict[str, Any]) -> str:
-    return str(config.get(ENV_VERCEL_PROJECT_ID) or "") or os.environ.get(ENV_VERCEL_PROJECT_ID, "")
+    return str(config.get(ENV_PHOENIX_SANDBOX_VERCEL_PROJECT_ID) or "") or os.environ.get(
+        ENV_PHOENIX_SANDBOX_VERCEL_PROJECT_ID, ""
+    )
 
 
 def _resolve_vercel_team_id(config: dict[str, Any]) -> str:
-    return str(config.get(ENV_VERCEL_TEAM_ID) or "") or os.environ.get(ENV_VERCEL_TEAM_ID, "")
+    return str(config.get(ENV_PHOENIX_SANDBOX_VERCEL_TEAM_ID) or "") or os.environ.get(
+        ENV_PHOENIX_SANDBOX_VERCEL_TEAM_ID, ""
+    )
+
+
+def _resolve_vercel_oidc_token(config: dict[str, Any]) -> str:
+    return str(config.get(ENV_PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN) or "") or os.environ.get(
+        ENV_PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN, ""
+    )
 
 
 _VERCEL_ENV_VAR_SPECS = [
     ProviderCredentialSpec(
-        key="VERCEL_OIDC_TOKEN",
+        key="PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN",
         display_name="Vercel OIDC Token",
         description="OIDC token for Vercel sandbox (e.g. from `vercel env pull`).",
     ),
     ProviderCredentialSpec(
-        key="VERCEL_TOKEN",
+        key="PHOENIX_SANDBOX_VERCEL_TOKEN",
         display_name="Vercel Access Token",
-        description="Vercel personal access token (used with VERCEL_PROJECT_ID and VERCEL_TEAM_ID).",  # noqa: E501
+        description="Vercel personal access token (used with PHOENIX_SANDBOX_VERCEL_PROJECT_ID and PHOENIX_SANDBOX_VERCEL_TEAM_ID).",  # noqa: E501
     ),
     ProviderCredentialSpec(
-        key="VERCEL_PROJECT_ID",
+        key="PHOENIX_SANDBOX_VERCEL_PROJECT_ID",
         display_name="Vercel Project ID",
-        description="Vercel project ID (used with VERCEL_TOKEN and VERCEL_TEAM_ID).",
+        description=(
+            "Vercel project ID (used with PHOENIX_SANDBOX_VERCEL_TOKEN and "
+            "PHOENIX_SANDBOX_VERCEL_TEAM_ID)."
+        ),
     ),
     ProviderCredentialSpec(
-        key="VERCEL_TEAM_ID",
+        key="PHOENIX_SANDBOX_VERCEL_TEAM_ID",
         display_name="Vercel Team ID",
-        description="Vercel team ID (used with VERCEL_TOKEN and VERCEL_PROJECT_ID).",
+        description=(
+            "Vercel team ID (used with PHOENIX_SANDBOX_VERCEL_TOKEN and "
+            "PHOENIX_SANDBOX_VERCEL_PROJECT_ID)."
+        ),
     ),
 ]
 
@@ -235,7 +255,7 @@ class VercelPythonAdapter(SandboxAdapter):
         user_env: Optional[dict[str, str]] = None,
     ) -> SandboxBackend:
         self._enforce_capabilities(config, user_env)
-        if os.environ.get(ENV_VERCEL_OIDC_TOKEN):
+        if _resolve_vercel_oidc_token(config):
             return VercelSandboxBackend(use_oidc_env=True, language="PYTHON", user_env=user_env)
 
         token = _resolve_vercel_access_token(config)
@@ -250,9 +270,10 @@ class VercelPythonAdapter(SandboxAdapter):
                 user_env=user_env,
             )
         raise ValueError(
-            "Vercel sandbox authentication is not configured. Set VERCEL_OIDC_TOKEN "
-            "(e.g. from `vercel env pull`), or set all of VERCEL_TOKEN, "
-            "VERCEL_PROJECT_ID, and VERCEL_TEAM_ID. See "
+            "Vercel sandbox authentication is not configured. Set "
+            "PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN (e.g. from `vercel env pull`), "
+            "or set all of PHOENIX_SANDBOX_VERCEL_TOKEN, "
+            "PHOENIX_SANDBOX_VERCEL_PROJECT_ID, and PHOENIX_SANDBOX_VERCEL_TEAM_ID. See "
             "https://vercel.com/docs/vercel-sandbox/concepts/authentication"
         )
 
@@ -270,7 +291,7 @@ class VercelTypescriptAdapter(SandboxAdapter):
         user_env: Optional[dict[str, str]] = None,
     ) -> SandboxBackend:
         self._enforce_capabilities(config, user_env)
-        if os.environ.get(ENV_VERCEL_OIDC_TOKEN):
+        if _resolve_vercel_oidc_token(config):
             return VercelSandboxBackend(use_oidc_env=True, language="TYPESCRIPT", user_env=user_env)
 
         token = _resolve_vercel_access_token(config)
@@ -285,8 +306,9 @@ class VercelTypescriptAdapter(SandboxAdapter):
                 user_env=user_env,
             )
         raise ValueError(
-            "Vercel sandbox authentication is not configured. Set VERCEL_OIDC_TOKEN "
-            "(e.g. from `vercel env pull`), or set all of VERCEL_TOKEN, "
-            "VERCEL_PROJECT_ID, and VERCEL_TEAM_ID. See "
+            "Vercel sandbox authentication is not configured. Set "
+            "PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN (e.g. from `vercel env pull`), "
+            "or set all of PHOENIX_SANDBOX_VERCEL_TOKEN, "
+            "PHOENIX_SANDBOX_VERCEL_PROJECT_ID, and PHOENIX_SANDBOX_VERCEL_TEAM_ID. See "
             "https://vercel.com/docs/vercel-sandbox/concepts/authentication"
         )

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -8,9 +8,9 @@ otherwise spins up an ephemeral sandbox (create → run_command → stop).
 Requires the ``vercel`` extra (``vercel>=0.5.1``).
 Import is deferred to avoid top-level failures when the extra is absent.
 
-Authentication follows the Vercel Sandbox SDK: either
-``PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`` (for local ``vercel env pull`` or
-deployments on Vercel), or the access-token triple
+Authentication follows the Vercel Sandbox SDK: either ``VERCEL_OIDC_TOKEN``
+(for local ``vercel env pull`` or deployments on Vercel — read directly from
+the process environment by the SDK), or the Phoenix-scoped access-token triple
 ``PHOENIX_SANDBOX_VERCEL_TOKEN``, ``PHOENIX_SANDBOX_VERCEL_PROJECT_ID``, and
 ``PHOENIX_SANDBOX_VERCEL_TEAM_ID``. See
 https://vercel.com/docs/vercel-sandbox/concepts/authentication
@@ -37,8 +37,12 @@ from .types import (
     VercelTypescriptConfig,
 )
 
-# Phoenix-scoped Vercel credentials.
-ENV_PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN = "PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN"
+# OIDC token is read directly from the SDK-native env var because
+# AsyncSandbox.create() with no token kwargs reads VERCEL_OIDC_TOKEN from
+# os.environ — renaming this would silently break authentication.
+ENV_VERCEL_OIDC_TOKEN = "VERCEL_OIDC_TOKEN"
+# Phoenix-scoped Vercel access-token credentials. These flow through
+# AsyncSandbox.create() as kwargs, so the rename is purely Phoenix-internal.
 ENV_PHOENIX_SANDBOX_VERCEL_TOKEN = "PHOENIX_SANDBOX_VERCEL_TOKEN"
 ENV_PHOENIX_SANDBOX_VERCEL_PROJECT_ID = "PHOENIX_SANDBOX_VERCEL_PROJECT_ID"
 ENV_PHOENIX_SANDBOX_VERCEL_TEAM_ID = "PHOENIX_SANDBOX_VERCEL_TEAM_ID"
@@ -71,9 +75,10 @@ class VercelSandboxBackend(SandboxBackend):
     across multiple execute() calls, or ephemeral execution (no session) which
     spins up a fresh sandbox per call.
 
-    Credentials: either rely on ``PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`` in the
-    process environment (``use_oidc_env=True``), or pass an access-token triple
-    ``token``, ``project_id``, and ``team_id`` for ``AsyncSandbox.create``.
+    Credentials: either rely on ``VERCEL_OIDC_TOKEN`` in the process environment
+    (``use_oidc_env=True`` — the SDK reads this env var directly), or pass an
+    access-token triple ``token``, ``project_id``, and ``team_id`` for
+    ``AsyncSandbox.create``.
     """
 
     def __init__(
@@ -207,14 +212,12 @@ def _resolve_vercel_team_id(config: dict[str, Any]) -> str:
 
 
 def _resolve_vercel_oidc_token(config: dict[str, Any]) -> str:
-    return str(config.get(ENV_PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN) or "") or os.environ.get(
-        ENV_PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN, ""
-    )
+    return str(config.get(ENV_VERCEL_OIDC_TOKEN) or "") or os.environ.get(ENV_VERCEL_OIDC_TOKEN, "")
 
 
 _VERCEL_ENV_VAR_SPECS = [
     ProviderCredentialSpec(
-        key="PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN",
+        key="VERCEL_OIDC_TOKEN",
         display_name="Vercel OIDC Token",
         description="OIDC token for Vercel sandbox (e.g. from `vercel env pull`).",
     ),
@@ -271,7 +274,7 @@ class VercelPythonAdapter(SandboxAdapter):
             )
         raise ValueError(
             "Vercel sandbox authentication is not configured. Set "
-            "PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN (e.g. from `vercel env pull`), "
+            "VERCEL_OIDC_TOKEN (e.g. from `vercel env pull`), "
             "or set all of PHOENIX_SANDBOX_VERCEL_TOKEN, "
             "PHOENIX_SANDBOX_VERCEL_PROJECT_ID, and PHOENIX_SANDBOX_VERCEL_TEAM_ID. See "
             "https://vercel.com/docs/vercel-sandbox/concepts/authentication"
@@ -307,7 +310,7 @@ class VercelTypescriptAdapter(SandboxAdapter):
             )
         raise ValueError(
             "Vercel sandbox authentication is not configured. Set "
-            "PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN (e.g. from `vercel env pull`), "
+            "VERCEL_OIDC_TOKEN (e.g. from `vercel env pull`), "
             "or set all of PHOENIX_SANDBOX_VERCEL_TOKEN, "
             "PHOENIX_SANDBOX_VERCEL_PROJECT_ID, and PHOENIX_SANDBOX_VERCEL_TEAM_ID. See "
             "https://vercel.com/docs/vercel-sandbox/concepts/authentication"

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -67,6 +67,15 @@ _LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
 }
 _DEFAULT_LANGUAGE = "TYPESCRIPT"
 
+# Vercel SDK 0.5.7's get_credentials() (vercel/oidc/credentials.py) only reads
+# the OIDC token from os.environ — there is no oidc_token= kwarg on
+# AsyncSandbox.create(). When Phoenix sources VERCEL_OIDC_TOKEN from a DB
+# secret rather than the process env, we must inject it into os.environ
+# briefly around AsyncSandbox.create(). The lock serializes those env
+# mutations process-wide so concurrent creates with different resolved tokens
+# cannot leak each other's value into the env.
+_VERCEL_OIDC_ENV_LOCK = asyncio.Lock()
+
 
 class VercelSandboxBackend(SandboxBackend):
     """Sandbox backend executing code via Vercel Sandbox (vercel >= 0.5.1).
@@ -75,30 +84,30 @@ class VercelSandboxBackend(SandboxBackend):
     across multiple execute() calls, or ephemeral execution (no session) which
     spins up a fresh sandbox per call.
 
-    Credentials: either rely on ``VERCEL_OIDC_TOKEN`` in the process environment
-    (``use_oidc_env=True`` — the SDK reads this env var directly), or pass an
-    access-token triple ``token``, ``project_id``, and ``team_id`` for
-    ``AsyncSandbox.create``.
+    Credentials: pass either ``oidc_token`` (the resolved OIDC token; injected
+    into ``os.environ[VERCEL_OIDC_TOKEN]`` around ``AsyncSandbox.create`` since
+    the SDK only autodiscovers OIDC from env), or the access-token triple
+    ``token``/``project_id``/``team_id`` (forwarded directly to
+    ``AsyncSandbox.create`` as kwargs).
     """
 
     def __init__(
         self,
         *,
-        use_oidc_env: bool = False,
+        oidc_token: Optional[str] = None,
         token: Optional[str] = None,
         project_id: Optional[str] = None,
         team_id: Optional[str] = None,
         language: str = _DEFAULT_LANGUAGE,
         user_env: Optional[dict[str, str]] = None,
     ) -> None:
-        self._use_oidc_env = use_oidc_env
+        self._oidc_token = oidc_token
         self._token = token
         self._project_id = project_id
         self._team_id = team_id
-        if not use_oidc_env and not (token and project_id and team_id):
+        if not oidc_token and not (token and project_id and team_id):
             raise ValueError(
-                "VercelSandboxBackend requires use_oidc_env=True, or "
-                "token, project_id, and team_id."
+                "VercelSandboxBackend requires oidc_token, or token, project_id, and team_id."
             )
         self._language = language.upper() if language else _DEFAULT_LANGUAGE
         self._user_env: dict[str, str] = user_env or {}
@@ -113,10 +122,26 @@ class VercelSandboxBackend(SandboxBackend):
 
         runtime: str = self._lang_cfg()["runtime"]
         create_kwargs: dict[str, Any] = {"runtime": runtime}
-        if not self._use_oidc_env:
-            create_kwargs["token"] = self._token
-            create_kwargs["project_id"] = self._project_id
-            create_kwargs["team_id"] = self._team_id
+        if self._oidc_token:
+            # SDK reads VERCEL_OIDC_TOKEN from os.environ synchronously at the
+            # top of AsyncSandbox.create() (before any await), then captures
+            # the value into a Credentials object. Injecting via env is safe
+            # under that synchronous read; the lock serializes the env-mutation
+            # window across concurrent VercelSandboxBackend instances so a
+            # second backend's env-set cannot clobber the first's restore.
+            async with _VERCEL_OIDC_ENV_LOCK:
+                original = os.environ.get(ENV_VERCEL_OIDC_TOKEN)
+                os.environ[ENV_VERCEL_OIDC_TOKEN] = self._oidc_token
+                try:
+                    return await AsyncSandbox.create(**create_kwargs)
+                finally:
+                    if original is None:
+                        os.environ.pop(ENV_VERCEL_OIDC_TOKEN, None)
+                    else:
+                        os.environ[ENV_VERCEL_OIDC_TOKEN] = original
+        create_kwargs["token"] = self._token
+        create_kwargs["project_id"] = self._project_id
+        create_kwargs["team_id"] = self._team_id
         return await AsyncSandbox.create(**create_kwargs)
 
     async def start_session(self, session_key: str) -> None:
@@ -258,8 +283,9 @@ class VercelPythonAdapter(SandboxAdapter):
         user_env: Optional[dict[str, str]] = None,
     ) -> SandboxBackend:
         self._enforce_capabilities(config, user_env)
-        if _resolve_vercel_oidc_token(config):
-            return VercelSandboxBackend(use_oidc_env=True, language="PYTHON", user_env=user_env)
+        oidc_token = _resolve_vercel_oidc_token(config)
+        if oidc_token:
+            return VercelSandboxBackend(oidc_token=oidc_token, language="PYTHON", user_env=user_env)
 
         token = _resolve_vercel_access_token(config)
         project_id = _resolve_vercel_project_id(config)
@@ -294,8 +320,11 @@ class VercelTypescriptAdapter(SandboxAdapter):
         user_env: Optional[dict[str, str]] = None,
     ) -> SandboxBackend:
         self._enforce_capabilities(config, user_env)
-        if _resolve_vercel_oidc_token(config):
-            return VercelSandboxBackend(use_oidc_env=True, language="TYPESCRIPT", user_env=user_env)
+        oidc_token = _resolve_vercel_oidc_token(config)
+        if oidc_token:
+            return VercelSandboxBackend(
+                oidc_token=oidc_token, language="TYPESCRIPT", user_env=user_env
+            )
 
         token = _resolve_vercel_access_token(config)
         project_id = _resolve_vercel_project_id(config)

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -224,7 +224,7 @@ _VERCEL_ENV_VAR_SPECS = [
 
 class VercelPythonAdapter(SandboxAdapter):
     key = "VERCEL_PYTHON"
-    display_name = "Vercel Sandbox (Python)"
+    display_name = "Vercel Sandbox"
     language = "PYTHON"
     config_model = VercelPythonConfig
     credential_specs = _VERCEL_ENV_VAR_SPECS
@@ -259,7 +259,7 @@ class VercelPythonAdapter(SandboxAdapter):
 
 class VercelTypescriptAdapter(SandboxAdapter):
     key = "VERCEL_TYPESCRIPT"
-    display_name = "Vercel Sandbox (TypeScript)"
+    display_name = "Vercel Sandbox"
     language = "TYPESCRIPT"
     config_model = VercelTypescriptConfig
     credential_specs = _VERCEL_ENV_VAR_SPECS

--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -13,7 +13,6 @@ Requires the ``wasmtime`` package (optional extra).
 from __future__ import annotations
 
 import asyncio
-import io
 import logging
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
@@ -61,8 +60,8 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
     """Execute *code* in a wasmtime WASI context. Runs in a thread."""
     import wasmtime as _wasm
 
-    stdout_buf = io.StringIO()
-    stderr_buf = io.StringIO()
+    stdout_chunks: list[bytes] = []
+    stderr_chunks: list[bytes] = []
     stdin_path: str | None = None
 
     try:
@@ -72,14 +71,14 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
         linker.define_wasi()
 
         wasi = _wasm.WasiConfig()
-        wasi.stdout_custom(stdout_buf)
-        wasi.stderr_custom(stderr_buf)
+        wasi.stdout_custom = lambda data: stdout_chunks.append(data)
+        wasi.stderr_custom = lambda data: stderr_chunks.append(data)
 
         # Inject code via a temp stdin file
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
             f.write(code)
             stdin_path = f.name
-        wasi.stdin_file(stdin_path)
+        wasi.stdin_file = stdin_path
 
         store = _wasm.Store(engine)
         store.set_wasi(wasi)
@@ -91,11 +90,14 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
         if isinstance(start, _wasm.Func):
             start(store)
 
-        return ExecutionResult(stdout=stdout_buf.getvalue(), stderr=stderr_buf.getvalue())
+        return ExecutionResult(
+            stdout=b"".join(stdout_chunks).decode("utf-8", errors="replace"),
+            stderr=b"".join(stderr_chunks).decode("utf-8", errors="replace"),
+        )
     except Exception as exc:
         return ExecutionResult(
-            stdout=stdout_buf.getvalue(),
-            stderr=stderr_buf.getvalue(),
+            stdout=b"".join(stdout_chunks).decode("utf-8", errors="replace"),
+            stderr=b"".join(stderr_chunks).decode("utf-8", errors="replace"),
             error=str(exc),
         )
     finally:

--- a/tests/unit/server/api/helpers/test_evaluators.py
+++ b/tests/unit/server/api/helpers/test_evaluators.py
@@ -3654,6 +3654,47 @@ class TestGetEvaluators:
 
         assert evaluators == []
 
+    async def test_code_evaluator_not_found_message_contains_name_and_settings_hint(
+        self,
+        db: Any,
+    ) -> None:
+        """NotFound raised for a CodeEvaluator with no sandbox must name the evaluator."""
+        async with db() as session:
+            dataset = models.Dataset(name="test-dataset-code-no-sandbox", metadata_={})
+            session.add(dataset)
+            await session.flush()
+
+            code_eval = models.CodeEvaluator(
+                name=Identifier("my-code-eval"),
+                source_code="def evaluate(output): return 1.0",
+                input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
+                output_configs=[],
+                sandbox_config_id=None,
+            )
+            session.add(code_eval)
+            await session.flush()
+
+            de_code = models.DatasetEvaluators(
+                dataset_id=dataset.id,
+                evaluator_id=code_eval.id,
+                name=Identifier("my-code-eval"),
+                input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
+                project=models.Project(name="code-eval-no-sandbox-project", description=""),
+            )
+            session.add(de_code)
+            await session.flush()
+
+            with pytest.raises(NotFound) as exc_info:
+                await get_evaluators(
+                    dataset_evaluator_ids=[de_code.id],
+                    session=session,
+                    decrypt=lambda x: x,
+                    credentials=None,
+                )
+
+        assert "my-code-eval" in str(exc_info.value)
+        assert "/settings/sandboxes" in str(exc_info.value)
+
     async def test_preserves_order_with_only_builtin_evaluators(
         self,
         db: Any,

--- a/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
+++ b/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
@@ -946,8 +946,8 @@ class TestConfigValidationPath:
         db: DbSessionFactory,
         seed_sandbox_providers: None,
     ) -> None:
-        """Non-PHOENIX_SANDBOX reserved names (adapter-owned credentials like
-        VERCEL_TOKEN) must also be rejected at createSandboxConfig time —
+        """Prefixed adapter-owned credentials like PHOENIX_SANDBOX_VERCEL_TOKEN
+        must also be rejected at createSandboxConfig time —
         reserved-name coverage is derived from every adapter's credential_specs,
         not just the PHOENIX_SANDBOX_ prefix."""
         async with db() as session:
@@ -968,7 +968,7 @@ class TestConfigValidationPath:
                             "env_vars": [
                                 {
                                     "kind": "secret_ref",
-                                    "name": "VERCEL_TOKEN",
+                                    "name": "PHOENIX_SANDBOX_VERCEL_TOKEN",
                                     "secret_key": "anything",
                                 }
                             ]
@@ -983,16 +983,16 @@ class TestConfigValidationPath:
                     "input": {
                         "sandboxProviderId": _provider_global_id(provider.id),
                         "name": "e2b-vercel-token-top",
-                        "config": {"VERCEL_TOKEN": "attacker-value"},
+                        "config": {"PHOENIX_SANDBOX_VERCEL_TOKEN": "attacker-value"},
                     }
                 },
             )
         assert env_var_result.errors, (
-            "Expected BadRequest for VERCEL_TOKEN in env_vars; "
+            "Expected BadRequest for PHOENIX_SANDBOX_VERCEL_TOKEN in env_vars; "
             "reserved-name enforcement may not cover adapter-owned credentials"
         )
         assert top_level_result.errors, (
-            "Expected BadRequest for VERCEL_TOKEN as top-level config key; "
+            "Expected BadRequest for PHOENIX_SANDBOX_VERCEL_TOKEN as top-level config key; "
             "reserved-name enforcement may not cover top-level SandboxConfig.config"
         )
 
@@ -1029,7 +1029,7 @@ class TestConfigValidationPath:
                             "env_vars": [
                                 {
                                     "kind": "secret_ref",
-                                    "name": "PHOENIX_SANDBOX_TOKEN",
+                                    "name": "PHOENIX_SANDBOX_VERCEL_TOKEN",
                                     "secret_key": "my-secret",
                                 }
                             ]

--- a/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
+++ b/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
@@ -302,24 +302,28 @@ class TestUpdateSandboxProvider:
     ) -> None:
         async with db() as session:
             provider = await session.scalar(
-                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "WASM")
+                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "E2B")
             )
         assert provider is not None
 
-        result = await gql_client.execute(
-            _UPDATE_PROVIDER,
-            variables={
-                "input": {
-                    "id": _provider_global_id(provider.id),
-                    "enabled": False,
-                    "config": {"template": "custom-template"},
-                }
-            },
-        )
+        new_config = {
+            "env_vars": [{"kind": "literal", "name": "FOO", "value": "bar"}],
+        }
+        with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"E2B": _e2b_adapter}):
+            result = await gql_client.execute(
+                _UPDATE_PROVIDER,
+                variables={
+                    "input": {
+                        "id": _provider_global_id(provider.id),
+                        "enabled": False,
+                        "config": new_config,
+                    }
+                },
+            )
         assert result.data and not result.errors
         sandbox_provider = result.data["updateSandboxProvider"]["sandboxProvider"]
         assert sandbox_provider["enabled"] is False
-        assert sandbox_provider["config"] == {"template": "custom-template"}
+        assert sandbox_provider["config"]["env_vars"] == new_config["env_vars"]
 
     async def test_update_provider_only_enabled_leaves_config_unchanged(
         self,
@@ -356,23 +360,27 @@ class TestUpdateSandboxProvider:
     ) -> None:
         async with db() as session:
             provider = await session.scalar(
-                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "WASM")
+                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "E2B")
             )
         assert provider is not None
         original_enabled = provider.enabled
 
-        result = await gql_client.execute(
-            _UPDATE_PROVIDER,
-            variables={
-                "input": {
-                    "id": _provider_global_id(provider.id),
-                    "config": {"new_key": "new_value"},
-                }
-            },
-        )
+        new_config = {
+            "env_vars": [{"kind": "literal", "name": "BAZ", "value": "qux"}],
+        }
+        with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"E2B": _e2b_adapter}):
+            result = await gql_client.execute(
+                _UPDATE_PROVIDER,
+                variables={
+                    "input": {
+                        "id": _provider_global_id(provider.id),
+                        "config": new_config,
+                    }
+                },
+            )
         assert result.data and not result.errors
         sp = result.data["updateSandboxProvider"]["sandboxProvider"]
-        assert sp["config"] == {"new_key": "new_value"}
+        assert sp["config"]["env_vars"] == new_config["env_vars"]
         assert sp["enabled"] is original_enabled
 
     async def test_update_provider_no_fields_is_noop(
@@ -748,19 +756,27 @@ class TestConfigValidationPath:
                     "input": {
                         "sandboxProviderId": _provider_global_id(provider.id),
                         "name": "e2b-valid",
-                        "config": {"template": "custom-tmpl", "cwd": "/workspace"},
+                        "config": {
+                            "env_vars": [{"kind": "literal", "name": "FOO", "value": "bar"}],
+                        },
                     }
                 },
             )
         assert result.data and not result.errors
 
-    async def test_create_preserves_unknown_keys(
+    async def test_create_rejects_unknown_keys(
         self,
         gql_client: AsyncGraphQLClient,
         db: DbSessionFactory,
         seed_sandbox_providers: None,
     ) -> None:
-        """extra="allow" means unknown keys survive validation and are persisted."""
+        """extra="forbid" means unknown keys must be rejected at the mutation boundary.
+
+        Canonical config shape per adapter is the closed set declared on the
+        per-adapter pydantic model (env_vars / internet_access / dependencies).
+        Anything outside that set is a stale or attacker-supplied key and must
+        surface as a BadRequest rather than silently persisting.
+        """
         async with db() as session:
             provider = await session.scalar(
                 select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "E2B")
@@ -774,22 +790,11 @@ class TestConfigValidationPath:
                     "input": {
                         "sandboxProviderId": _provider_global_id(provider.id),
                         "name": "e2b-extra-keys",
-                        "config": {"template": "base", "custom_key": "preserved"},
+                        "config": {"custom_key": "preserved"},
                     }
                 },
             )
-        assert result.data and not result.errors
-        cfg_id = result.data["createSandboxConfig"]["sandboxConfig"]["id"]
-
-        # Verify persisted config includes the unknown key
-        async with db() as session:
-            from strawberry.relay import GlobalID as GID
-
-            gid = GID.from_id(cfg_id)
-            row_id = int(gid.node_id)
-            row = await session.get(models.SandboxConfig, row_id)
-        assert row is not None
-        assert row.config.get("custom_key") == "preserved"
+        assert result.errors
 
     async def test_update_valid_config_succeeds(
         self,
@@ -820,7 +825,9 @@ class TestConfigValidationPath:
                 variables={
                     "input": {
                         "id": _config_global_id(config_id),
-                        "config": {"template": "new-template", "metadata": "my-label"},
+                        "config": {
+                            "env_vars": [{"kind": "literal", "name": "FOO", "value": "bar"}],
+                        },
                     }
                 },
             )
@@ -849,13 +856,14 @@ class TestConfigValidationPath:
             await session.flush()
             config_id = config.id
 
+        new_env_vars = [{"kind": "literal", "name": "FOO", "value": "bar"}]
         with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"E2B": _e2b_adapter}):
             result = await gql_client.execute(
                 _UPDATE,
                 variables={
                     "input": {
                         "id": _config_global_id(config_id),
-                        "config": {"template": "saved-tmpl"},
+                        "config": {"env_vars": new_env_vars},
                     }
                 },
             )
@@ -864,8 +872,8 @@ class TestConfigValidationPath:
         async with db() as session:
             row = await session.get(models.SandboxConfig, config_id)
         assert row is not None
-        # template was provided — must be persisted
-        assert row.config.get("template") == "saved-tmpl"
+        # env_vars was provided — must be persisted
+        assert row.config.get("env_vars") == new_env_vars
 
     async def test_create_env_var_round_trip(
         self,
@@ -888,7 +896,6 @@ class TestConfigValidationPath:
                         "sandboxProviderId": _provider_global_id(provider.id),
                         "name": "e2b-env-vars",
                         "config": {
-                            "template": "base",
                             "env_vars": [{"kind": "literal", "name": "FOO", "value": "bar"}],
                         },
                     }

--- a/tests/unit/server/api/mutations/test_evaluator_preview_mutation.py
+++ b/tests/unit/server/api/mutations/test_evaluator_preview_mutation.py
@@ -319,3 +319,58 @@ class TestInlineCodeEvaluatorPreviewMutation:
         assert results[0]["evaluatorName"] == "inline_code_eval"
         assert results[0]["error"] is None
         assert results[0]["annotation"]["score"] == 1.0
+
+
+class TestCodeEvaluatorPreviewNoSandbox:
+    """BadRequest raised when a code evaluator has no sandbox configured must name the evaluator."""
+
+    _MUTATION = TestEvaluatorPreviewMutation._MUTATION
+
+    async def test_bad_request_message_contains_name_and_settings_hint(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_languages: None,
+    ) -> None:
+        from sqlalchemy import select
+
+        from phoenix.db.types.evaluators import InputMapping
+        from phoenix.db.types.identifier import Identifier
+
+        async with db() as session:
+            python_lang = await session.scalar(
+                select(models.Language).where(models.Language.name == "PYTHON")
+            )
+            assert python_lang is not None
+
+            code_eval = models.CodeEvaluator(
+                name=Identifier("no-sandbox-eval"),
+                source_code="def evaluate(output): return 1.0",
+                input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
+                output_configs=[],
+                language_id=python_lang.id,
+                sandbox_config_id=None,
+            )
+            session.add(code_eval)
+            await session.flush()
+            code_eval_id = code_eval.id
+
+        gid = str(GlobalID("CodeEvaluator", str(code_eval_id)))
+        result = await gql_client.execute(
+            self._MUTATION,
+            {
+                "input": {
+                    "previews": [
+                        {
+                            "evaluator": {"codeEvaluatorId": gid},
+                            "context": {"output": "test"},
+                            "inputMapping": {"literalMapping": {}, "pathMapping": {}},
+                        }
+                    ]
+                }
+            },
+        )
+
+        assert result.errors is not None
+        assert "no-sandbox-eval" in result.errors[0].message
+        assert "/settings/sandboxes" in result.errors[0].message

--- a/tests/unit/server/api/mutations/test_reserved_credential_names.py
+++ b/tests/unit/server/api/mutations/test_reserved_credential_names.py
@@ -31,10 +31,10 @@ _e2b_adapter = E2BAdapter()
 # Reserved names exposed by the MODAL and VERCEL adapters (case-preserved for
 # readability; the mutation check is case-insensitive).
 _RESERVED_NAMES = [
-    "MODAL_TOKEN_SECRET",
-    "MODAL_TOKEN_ID",
-    "VERCEL_TOKEN",
-    "VERCEL_OIDC_TOKEN",
+    "PHOENIX_SANDBOX_MODAL_TOKEN_SECRET",
+    "PHOENIX_SANDBOX_MODAL_TOKEN_ID",
+    "PHOENIX_SANDBOX_VERCEL_TOKEN",
+    "PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN",
 ]
 
 

--- a/tests/unit/server/api/mutations/test_reserved_credential_names.py
+++ b/tests/unit/server/api/mutations/test_reserved_credential_names.py
@@ -190,7 +190,7 @@ class TestReservedCredentialNamesCaseInsensitive:
                             "env_vars": [
                                 {
                                     "kind": "literal",
-                                    "name": "vercel_token",
+                                    "name": "phoenix_sandbox_vercel_token",
                                     "value": "shadow-attempt",
                                 }
                             ]

--- a/tests/unit/server/api/mutations/test_reserved_credential_names.py
+++ b/tests/unit/server/api/mutations/test_reserved_credential_names.py
@@ -31,10 +31,10 @@ _e2b_adapter = E2BAdapter()
 # Reserved names exposed by the MODAL and VERCEL adapters (case-preserved for
 # readability; the mutation check is case-insensitive).
 _RESERVED_NAMES = [
-    "PHOENIX_SANDBOX_MODAL_TOKEN_SECRET",
-    "PHOENIX_SANDBOX_MODAL_TOKEN_ID",
+    "MODAL_TOKEN_SECRET",
+    "MODAL_TOKEN_ID",
     "PHOENIX_SANDBOX_VERCEL_TOKEN",
-    "PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN",
+    "VERCEL_OIDC_TOKEN",
 ]
 
 

--- a/tests/unit/server/api/mutations/test_sandbox_cache_invalidation.py
+++ b/tests/unit/server/api/mutations/test_sandbox_cache_invalidation.py
@@ -8,7 +8,8 @@ Three scenarios covered:
 1. Rebuild-with-new-value via setSandboxCredential — backend rebuilt with v2
    plaintext after rotation.
 2. Shared-spec invalidation — VERCEL_PYTHON and VERCEL_TYPESCRIPT share
-   `credential_specs` referencing VERCEL_TOKEN; rotating via either backend_type
+   `credential_specs` referencing PHOENIX_SANDBOX_VERCEL_TOKEN; rotating via
+   either backend_type
    evicts BOTH cache entries.
 3. upsertOrDeleteSecrets + SandboxConfig.secret_ref — rotating a user Secret
    referenced by `secret_ref` evicts the cache so the rebuilt backend sees
@@ -161,7 +162,8 @@ class TestRebuildWithNewValue:
 
 
 class TestSharedSpecInvalidation:
-    """Scenario 2: VERCEL_TOKEN is shared by VERCEL_PYTHON and VERCEL_TYPESCRIPT.
+    """Scenario 2: PHOENIX_SANDBOX_VERCEL_TOKEN is shared by VERCEL_PYTHON and
+    VERCEL_TYPESCRIPT.
 
     Rotating via either backend_type must evict BOTH cache entries.
     """

--- a/tests/unit/server/api/mutations/test_sandbox_cache_invalidation.py
+++ b/tests/unit/server/api/mutations/test_sandbox_cache_invalidation.py
@@ -24,6 +24,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import sqlalchemy as sa
+from pydantic import BaseModel, ConfigDict
 
 from phoenix.db import models
 from phoenix.server.encryption import EncryptionService
@@ -39,6 +40,19 @@ from phoenix.server.sandbox.types import (
 )
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
+
+
+class _PermissiveTestConfig(BaseModel):
+    """Permissive config model for cache-invalidation test adapters.
+
+    SandboxAdapter.config_model defaults to BaseModel itself, which Pydantic
+    refuses to instantiate (PydanticUserError). These tests exercise cache
+    eviction wiring (not config validation), so we accept any shape — env_vars
+    with secret_ref, empty dicts, etc. — without forbidding extras.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
 
 _SET_CRED_MUTATION = """
   mutation SetSandboxCredential(
@@ -65,6 +79,8 @@ _UPSERT_SECRETS_MUTATION = """
 
 class _CapturingAdapter(SandboxAdapter):
     """Test adapter that records each build_backend invocation for later assertions."""
+
+    config_model = _PermissiveTestConfig
 
     def __init__(
         self,

--- a/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
+++ b/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
@@ -41,11 +41,33 @@ mutation CreateSandboxConfig($input: CreateSandboxConfigInput!) {
 }
 """
 
+_CREATE_WITH_TIMEOUT = """
+mutation CreateSandboxConfig($input: CreateSandboxConfigInput!) {
+    createSandboxConfig(input: $input) {
+        sandboxConfig {
+            id
+            timeout
+        }
+    }
+}
+"""
+
 _UPDATE = """
 mutation UpdateSandboxConfig($input: UpdateSandboxConfigInput!) {
     updateSandboxConfig(input: $input) {
         sandboxConfig {
             id
+        }
+    }
+}
+"""
+
+_UPDATE_WITH_TIMEOUT = """
+mutation UpdateSandboxConfig($input: UpdateSandboxConfigInput!) {
+    updateSandboxConfig(input: $input) {
+        sandboxConfig {
+            id
+            timeout
         }
     }
 }
@@ -477,3 +499,115 @@ class TestReservedSecretKeyRejected:
                 },
             )
         assert result.data and not result.errors
+
+
+class TestSandboxConfigTimeoutDefault:
+    """The default timeout is 300s at both the DB and application layers."""
+
+    async def test_create_without_timeout_persists_300(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        """Creating a config without an explicit timeout must default to 300."""
+        provider = await _get_provider(db, "E2B")
+
+        with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"E2B": _e2b_adapter}):
+            result = await gql_client.execute(
+                _CREATE_WITH_TIMEOUT,
+                variables={
+                    "input": {
+                        "sandboxProviderId": _provider_global_id(provider.id),
+                        "name": "e2b-default-timeout",
+                    }
+                },
+            )
+        assert result.data and not result.errors
+        assert result.data["createSandboxConfig"]["sandboxConfig"]["timeout"] == 300
+
+    async def test_create_with_explicit_timeout_persists_given_value(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        """Creating a config with an explicit timeout must persist that value."""
+        provider = await _get_provider(db, "E2B")
+
+        for timeout_value in (30, 60, 120):
+            with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"E2B": _e2b_adapter}):
+                result = await gql_client.execute(
+                    _CREATE_WITH_TIMEOUT,
+                    variables={
+                        "input": {
+                            "sandboxProviderId": _provider_global_id(provider.id),
+                            "name": f"e2b-explicit-timeout-{timeout_value}",
+                            "timeout": timeout_value,
+                        }
+                    },
+                )
+            assert result.data and not result.errors
+            assert result.data["createSandboxConfig"]["sandboxConfig"]["timeout"] == timeout_value
+
+    async def test_update_timeout_to_null_resets_to_300(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        """Setting timeout=null via update resets to the default of 300."""
+        provider = await _get_provider(db, "E2B")
+        async with db() as session:
+            config = models.SandboxConfig(
+                sandbox_provider_id=provider.id,
+                name="e2b-reset-timeout",
+                config={},
+                timeout=60,
+            )
+            session.add(config)
+            await session.flush()
+
+        with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"E2B": _e2b_adapter}):
+            result = await gql_client.execute(
+                _UPDATE_WITH_TIMEOUT,
+                variables={
+                    "input": {
+                        "id": _config_global_id(config.id),
+                        "timeout": None,
+                    }
+                },
+            )
+        assert result.data and not result.errors
+        assert result.data["updateSandboxConfig"]["sandboxConfig"]["timeout"] == 300
+
+    async def test_existing_explicit_timeout_preserved_when_not_updated(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        """Updating an unrelated field leaves an explicitly-stored timeout untouched."""
+        provider = await _get_provider(db, "E2B")
+        async with db() as session:
+            config = models.SandboxConfig(
+                sandbox_provider_id=provider.id,
+                name="e2b-preserve-timeout",
+                config={},
+                timeout=30,
+            )
+            session.add(config)
+            await session.flush()
+
+        with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"E2B": _e2b_adapter}):
+            result = await gql_client.execute(
+                _UPDATE_WITH_TIMEOUT,
+                variables={
+                    "input": {
+                        "id": _config_global_id(config.id),
+                        "description": "updated description only",
+                    }
+                },
+            )
+        assert result.data and not result.errors
+        assert result.data["updateSandboxConfig"]["sandboxConfig"]["timeout"] == 30

--- a/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
+++ b/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
@@ -440,7 +440,7 @@ class TestReservedSecretKeyRejected:
                                 {
                                     "kind": "secret_ref",
                                     "name": "MY_TOKEN",
-                                    "secret_key": "vercel_token",
+                                    "secret_key": "phoenix_sandbox_vercel_token",
                                 }
                             ]
                         },

--- a/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
+++ b/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
@@ -21,6 +21,7 @@ from strawberry.relay import GlobalID
 
 from phoenix.db import models
 from phoenix.server import sandbox as sandbox_module
+from phoenix.server.sandbox.daytona_backend import DaytonaPythonAdapter
 from phoenix.server.sandbox.deno_backend import DenoAdapter
 from phoenix.server.sandbox.e2b_backend import E2BAdapter
 from phoenix.server.sandbox.wasm_backend import WASMAdapter
@@ -30,6 +31,7 @@ from tests.unit.graphql import AsyncGraphQLClient
 _e2b_adapter = E2BAdapter()
 _deno_adapter = DenoAdapter()
 _wasm_adapter = WASMAdapter()
+_daytona_adapter = DaytonaPythonAdapter()
 
 _CREATE = """
 mutation CreateSandboxConfig($input: CreateSandboxConfigInput!) {
@@ -68,6 +70,16 @@ mutation UpdateSandboxConfig($input: UpdateSandboxConfigInput!) {
         sandboxConfig {
             id
             timeout
+        }
+    }
+}
+"""
+
+_UPDATE_PROVIDER = """
+mutation UpdateSandboxProvider($input: UpdateSandboxProviderInput!) {
+    updateSandboxProvider(input: $input) {
+        sandboxProvider {
+            id
         }
     }
 }
@@ -307,39 +319,6 @@ class TestStoredBaselinePassthrough:
                 },
             )
         assert result.errors
-
-    async def test_update_preserved_dependencies_packages_passes(
-        self,
-        gql_client: AsyncGraphQLClient,
-        db: DbSessionFactory,
-        seed_sandbox_providers: None,
-    ) -> None:
-        """Stored config already has dependencies.packages; round-tripping the
-        same packages must succeed on a null-dependencies-language adapter."""
-        provider = await _get_provider(db, "WASM")
-        async with db() as session:
-            config = models.SandboxConfig(
-                sandbox_provider_id=provider.id,
-                name="wasm-preserved-deps",
-                description="Pre-existing config with dependencies",
-                config={"dependencies": {"packages": ["requests", "numpy"]}},
-                timeout=30,
-            )
-            session.add(config)
-            await session.flush()
-
-        with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"WASM": _wasm_adapter}):
-            result = await gql_client.execute(
-                _UPDATE,
-                variables={
-                    "input": {
-                        "id": _config_global_id(config.id),
-                        # Order-independent: same packages in different order
-                        "config": {"dependencies": {"packages": ["numpy", "requests"]}},
-                    }
-                },
-            )
-        assert result.data and not result.errors
 
     async def test_update_adding_new_dependency_rejected(
         self,
@@ -611,3 +590,73 @@ class TestSandboxConfigTimeoutDefault:
             )
         assert result.data and not result.errors
         assert result.data["updateSandboxConfig"]["sandboxConfig"]["timeout"] == 30
+
+
+class TestCreateSandboxConfigNonCapabilityKeyRejected:
+    """createSandboxConfig must reject non-capability keys in config.
+
+    After Phase 5, adapter config models use extra="forbid". Unknown keys in a
+    create payload must surface as BadRequest, not silently persist.
+    """
+
+    async def test_template_key_returns_bad_request(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        """Posting template to createSandboxConfig must be rejected.
+
+        template was an E2BConfig field passed to AsyncSandbox.create; it is
+        now stripped. validate_config raises ValueError (extra=forbid), which
+        the create mutation converts to BadRequest.
+        """
+        provider = await _get_provider(db, "E2B")
+
+        with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"E2B": _e2b_adapter}):
+            result = await gql_client.execute(
+                _CREATE,
+                variables={
+                    "input": {
+                        "sandboxProviderId": _provider_global_id(provider.id),
+                        "name": "e2b-template-rejected",
+                        "config": {"template": "python-3.11"},
+                    }
+                },
+            )
+        assert result.errors
+
+
+class TestUpdateSandboxProviderNonCapabilityKeyRejected:
+    """update_sandbox_provider must reject non-capability keys in config.
+
+    After Phase 5, adapter config models use extra="forbid". validate_config
+    is called at the mutation boundary (task-30), so unknown keys must surface
+    as BadRequest rather than silently persisting.
+    """
+
+    async def test_server_url_returns_bad_request(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        """Posting server_url to update_sandbox_provider must be rejected.
+
+        server_url is the Daytona SSRF footgun: it was previously consumed by
+        Daytona(server_url=...) but is now stripped. validate_config raises
+        ValueError (extra=forbid), which the mutation converts to BadRequest.
+        """
+        provider = await _get_provider(db, "DAYTONA_PYTHON")
+
+        with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"DAYTONA_PYTHON": _daytona_adapter}):
+            result = await gql_client.execute(
+                _UPDATE_PROVIDER,
+                variables={
+                    "input": {
+                        "id": _provider_global_id(provider.id),
+                        "config": {"server_url": "https://attacker.example.com"},
+                    }
+                },
+            )
+        assert result.errors

--- a/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
+++ b/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
@@ -379,7 +379,7 @@ class TestReservedSecretKeyRejected:
                                 {
                                     "kind": "secret_ref",
                                     "name": "MY_TOKEN",
-                                    "secret_key": "VERCEL_TOKEN",
+                                    "secret_key": "PHOENIX_SANDBOX_VERCEL_TOKEN",
                                 }
                             ]
                         },
@@ -410,7 +410,7 @@ class TestReservedSecretKeyRejected:
                                 {
                                     "kind": "secret_ref",
                                     "name": "MY_TOKEN",
-                                    "secret_key": "VERCEL_TOKEN",
+                                    "secret_key": "PHOENIX_SANDBOX_VERCEL_TOKEN",
                                 }
                             ]
                         },

--- a/tests/unit/server/api/test_capability_advertisement.py
+++ b/tests/unit/server/api/test_capability_advertisement.py
@@ -172,22 +172,34 @@ async def test_sandbox_config_secret_ref_env_var_round_trips(
         assert "value" not in entry or entry.get("kind") != "literal"
 
 
-async def test_internet_access_advertised_as_none_for_all_adapters(
+async def test_internet_access_advertisement_matches_adapter_capability(
     gql_client: AsyncGraphQLClient,
     seed_sandbox_providers: None,
 ) -> None:
-    """All adapters advertise internetAccess=NONE — no SDK exposes a network-policy API.
+    """Each adapter's advertised internetAccess matches its declared capability.
 
-    The frontend should hide the internet-access editor for every adapter until a
-    future phase ships a verifiable deny/allow control.
+    E2B / Daytona / Modal SDKs expose a deny-network knob, so those adapters
+    advertise BOOLEAN. WASM / Vercel / Deno do not (yet) expose a verifiable
+    network-policy API, so they advertise NONE and the frontend hides the
+    internet-access editor for them. The source of truth is
+    ``AdapterMetadata.internet_access_capability`` in
+    ``phoenix.server.sandbox.SANDBOX_ADAPTER_METADATA``.
     """
     response = await gql_client.execute(query=_SANDBOX_BACKENDS_QUERY)
     assert not response.errors
     assert response.data is not None
-    for backend in response.data["sandboxBackends"]:
-        assert backend["internetAccess"] == "NONE", (
-            f"{backend['backendType']} unexpectedly advertises internet_access != NONE"
-        )
+    expected = {
+        backend_type: meta.internet_access_capability.upper()
+        for backend_type, meta in SANDBOX_ADAPTER_METADATA.items()
+    }
+    advertised = {
+        backend["backendType"]: backend["internetAccess"]
+        for backend in response.data["sandboxBackends"]
+    }
+    assert advertised == expected, (
+        f"Advertised internet_access does not match adapter capability metadata. "
+        f"Expected {expected}, got {advertised}"
+    )
 
 
 async def test_dependencies_language_only_set_for_daytona(

--- a/tests/unit/server/api/test_code_evaluator_runner.py
+++ b/tests/unit/server/api/test_code_evaluator_runner.py
@@ -503,3 +503,95 @@ class TestMultiOutputEvaluate:
             output_configs=[_categorical_config("score")],
         )
         assert results[0]["name"] == "myeval"
+
+    async def test_multi_output_naming_convention(self) -> None:
+        """Verify {evaluator_name}.{config.name} convention for multi-output evaluators."""
+        runner, _ = _make_runner(backend_stdout='"pass"')
+        configs = [_categorical_config("toxicity"), _categorical_config("safety")]
+        results = await runner.evaluate(
+            context={},
+            input_mapping=_EMPTY_MAPPING,
+            name="content-check",
+            output_configs=configs,
+        )
+        names = {r["name"] for r in results}
+        assert "content-check.toxicity" in names
+        assert "content-check.safety" in names
+
+
+class TestExplanationPlumbing:
+    async def test_explanation_from_dict_label_is_plumbed_through(self) -> None:
+        payload = json.dumps({"label": "pass", "explanation": "matched keywords"})
+        runner, _ = _make_runner(backend_stdout=payload)
+        results = await runner.evaluate(
+            context={},
+            input_mapping=_EMPTY_MAPPING,
+            name="test",
+            output_configs=[_categorical_config()],
+        )
+        assert results[0]["label"] == "pass"
+        assert results[0]["explanation"] == "matched keywords"
+
+    async def test_explanation_from_dict_score_is_plumbed_through(self) -> None:
+        payload = json.dumps({"score": 0.75, "explanation": "moderate confidence"})
+        runner, _ = _make_runner(backend_stdout=payload)
+        results = await runner.evaluate(
+            context={},
+            input_mapping=_EMPTY_MAPPING,
+            name="test",
+            output_configs=[_continuous_config()],
+        )
+        assert results[0]["score"] == pytest.approx(0.75)
+        assert results[0]["explanation"] == "moderate confidence"
+
+    async def test_bare_return_has_no_explanation(self) -> None:
+        runner, _ = _make_runner(backend_stdout='"pass"')
+        results = await runner.evaluate(
+            context={},
+            input_mapping=_EMPTY_MAPPING,
+            name="test",
+            output_configs=[_categorical_config()],
+        )
+        assert results[0]["explanation"] is None
+
+    async def test_shared_explanation_fallback_in_multi_output_routing(self) -> None:
+        """Top-level explanation in routing dict is used as shared fallback."""
+        payload = json.dumps(
+            {
+                "a": "pass",
+                "b": "fail",
+                "explanation": "shared rationale",
+            }
+        )
+        runner, _ = _make_runner(backend_stdout=payload)
+        configs = [_categorical_config("a"), _categorical_config("b")]
+        results = await runner.evaluate(
+            context={},
+            input_mapping=_EMPTY_MAPPING,
+            name="eval",
+            output_configs=configs,
+        )
+        assert len(results) == 2
+        for r in results:
+            assert r["explanation"] == "shared rationale"
+
+    async def test_per_config_explanation_wins_over_shared_fallback(self) -> None:
+        """Per-config sub-value explanation takes precedence over top-level fallback."""
+        payload = json.dumps(
+            {
+                "a": {"label": "pass", "explanation": "config-specific"},
+                "b": "fail",
+                "explanation": "shared fallback",
+            }
+        )
+        runner, _ = _make_runner(backend_stdout=payload)
+        configs = [_categorical_config("a"), _categorical_config("b")]
+        results = await runner.evaluate(
+            context={},
+            input_mapping=_EMPTY_MAPPING,
+            name="eval",
+            output_configs=configs,
+        )
+        results_by_name = {r["name"]: r for r in results}
+        assert results_by_name["eval.a"]["explanation"] == "config-specific"
+        assert results_by_name["eval.b"]["explanation"] == "shared fallback"

--- a/tests/unit/server/api/test_code_evaluator_runner.py
+++ b/tests/unit/server/api/test_code_evaluator_runner.py
@@ -110,6 +110,13 @@ class TestHarnessGeneration:
         harness = runner._build_typescript_harness({"k": "v"})
         assert "JSON.stringify" in harness
 
+    def test_typescript_harness_awaits_evaluate_result(self) -> None:
+        runner, _ = _make_runner(language="TYPESCRIPT")
+        harness = runner._build_typescript_harness({"k": "v"})
+        assert "const _run = async () => {" in harness
+        assert "await evaluate(_inputs)" in harness
+        assert "await _run();" in harness
+
 
 class TestInputSchemaInference:
     def test_python_input_schema_infers_top_level_parameters(self) -> None:
@@ -447,6 +454,28 @@ class TestBackendConfiguration:
         # TypeScript harness uses console.log and JSON.stringify
         assert "JSON.stringify" in code_arg
         assert "console.log" in code_arg
+        assert "await evaluate(_inputs)" in code_arg
+
+    async def test_async_typescript_evaluator_source_is_wrapped_correctly(self) -> None:
+        runner, backend = _make_runner(
+            source_code=(
+                "async function evaluate({ output }: EvaluatorParams) { return output ? 1 : 0; }"
+            ),
+            language="TYPESCRIPT",
+            backend_stdout="1",
+        )
+        await runner.evaluate(
+            context={"output": {"answer": "a"}},
+            input_mapping=_EMPTY_MAPPING,
+            name="test",
+            output_configs=[_continuous_config()],
+        )
+        call_args = backend.execute.call_args
+        code_arg = call_args.args[0] if call_args.args else call_args.kwargs.get("code", "")
+        assert "async function evaluate" in code_arg
+        assert "const _run = async () => {" in code_arg
+        assert "await evaluate(_inputs)" in code_arg
+        assert "await _run();" in code_arg
 
     async def test_python_language_uses_python_harness(self) -> None:
         """Runner selects Python harness when language is PYTHON."""

--- a/tests/unit/server/api/test_coerce_output.py
+++ b/tests/unit/server/api/test_coerce_output.py
@@ -312,6 +312,51 @@ class TestShapeExamples:
         examples = config.shape_examples(language="PYTHON", mode="full")
         assert any("0.5" in ex for ex in examples)
 
+    def test_categorical_shape_examples_escapes_label_with_double_quote(self) -> None:
+        """A label containing `"` must produce well-formed Python source.
+
+        Naively interpolating ``f'"{label}"'`` for a label like ``pass"fail``
+        yields ``return "pass"fail"`` — a SyntaxError. json.dumps escapes the
+        embedded quote so the generated literal is valid Python (and TS).
+        """
+        config = _cat([('pass"fail', 1.0)])
+        examples = config.shape_examples(language="PYTHON", mode="full")
+        # Each example must be syntactically valid Python.
+        import ast
+
+        for ex in examples:
+            ast.parse(ex)
+        # And the bare-return example must contain the escaped form, not the
+        # raw unescaped quote.
+        bare = next(ex for ex in examples if ex.startswith("return "))
+        assert '"pass\\"fail"' in bare, f"Expected escaped quote in {bare!r}"
+
+    def test_categorical_shape_examples_escapes_label_with_backslash(self) -> None:
+        """A label containing `\\` must not introduce an unintended escape sequence."""
+        config = _cat([("a\\b", 1.0)])
+        examples = config.shape_examples(language="PYTHON", mode="full")
+        import ast
+
+        for ex in examples:
+            ast.parse(ex)
+        # The literal value the generated Python returns must round-trip back
+        # to the original label string.
+        bare = next(ex for ex in examples if ex.startswith("return "))
+        # Strip the "return " prefix and eval the literal.
+        import ast as _ast
+
+        returned = _ast.literal_eval(bare[len("return ") :].strip())
+        assert returned == "a\\b"
+
+    def test_categorical_shape_examples_typescript_escapes_label(self) -> None:
+        """TypeScript variant must also produce a valid string literal."""
+        config = _cat([('say "hi"', 1.0)])
+        examples = config.shape_examples(language="TYPESCRIPT", mode="full")
+        # JSON string literal syntax is valid TS string literal syntax, so
+        # the escaped form must appear and the raw unescaped quote must not.
+        bare = next(ex for ex in examples if ex.startswith("return "))
+        assert '"say \\"hi\\""' in bare, f"Expected escaped quotes in {bare!r}"
+
     def test_categorical_shape_examples_curated_subset_of_full(self) -> None:
         config = _cat()
         full = config.shape_examples(mode="full")

--- a/tests/unit/server/api/test_coerce_output.py
+++ b/tests/unit/server/api/test_coerce_output.py
@@ -5,10 +5,14 @@ Covers all three modes:
 2. CategoricalOutputConfig — label validation + score lookup
 3. ContinuousOutputConfig — numeric extraction + bounds validation
 
-Also covers the D6 bool-exclusion rule throughout.
+Also covers the D6 bool-exclusion rule throughout, triple-collapse dict
+acceptance, explanation passthrough, multi-output routing, and the new
+no-config rejection of arbitrary dicts/lists.
 """
 
 from __future__ import annotations
+
+import math
 
 import pytest
 
@@ -51,48 +55,79 @@ def _cont(
 
 class TestBarePassthrough:
     def test_int_returns_score(self) -> None:
-        label, score = _coerce_output(42, None)
+        label, score, explanation = _coerce_output(42, None)
         assert label is None
         assert score == pytest.approx(42.0)
+        assert explanation is None
 
     def test_float_returns_score(self) -> None:
-        label, score = _coerce_output(0.5, None)
+        label, score, explanation = _coerce_output(0.5, None)
         assert score == pytest.approx(0.5)
+        assert explanation is None
 
     def test_str_returns_label(self) -> None:
-        label, score = _coerce_output("pass", None)
+        label, score, explanation = _coerce_output("pass", None)
         assert label == "pass"
         assert score is None
+        assert explanation is None
 
     def test_none_returns_none_none(self) -> None:
-        label, score = _coerce_output(None, None)
+        label, score, explanation = _coerce_output(None, None)
         assert label is None
         assert score is None
+        assert explanation is None
 
     def test_bool_is_not_numeric_returns_label(self) -> None:
-        label, score = _coerce_output(True, None)
+        label, score, explanation = _coerce_output(True, None)
         assert label == "True"
         assert score is None
 
     def test_bool_false_returns_label(self) -> None:
-        label, score = _coerce_output(False, None)
+        label, score, explanation = _coerce_output(False, None)
         assert label == "False"
         assert score is None
 
-    def test_dict_returns_stringified_label(self) -> None:
-        label, score = _coerce_output({"x": 1}, None)
-        assert label is not None
+    def test_arbitrary_dict_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unrecognized keys"):
+            _coerce_output({"x": 1}, None)
+
+    def test_list_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported output type"):
+            _coerce_output([1, 2, 3], None)
+
+    def test_recognized_dict_label_key(self) -> None:
+        label, score, explanation = _coerce_output({"label": "pass"}, None)
+        assert label == "pass"
         assert score is None
+        assert explanation is None
+
+    def test_recognized_dict_score_key(self) -> None:
+        label, score, explanation = _coerce_output({"score": 0.5}, None)
+        assert label is None
+        assert score == pytest.approx(0.5)
+
+    def test_recognized_dict_explanation_key(self) -> None:
+        label, score, explanation = _coerce_output({"explanation": "ok"}, None)
+        assert explanation == "ok"
+
+    def test_recognized_dict_all_keys(self) -> None:
+        label, score, explanation = _coerce_output(
+            {"label": "pass", "score": 0.5, "explanation": "good"}, None
+        )
+        assert label == "pass"
+        assert score == pytest.approx(0.5)
+        assert explanation == "good"
 
 
 class TestCategoricalCoerce:
     def test_valid_label_returns_label_and_score(self) -> None:
-        label, score = _coerce_output("pass", _cat())
+        label, score, explanation = _coerce_output("pass", _cat())
         assert label == "pass"
         assert score == pytest.approx(1.0)
+        assert explanation is None
 
     def test_valid_label_fail_returns_score_zero(self) -> None:
-        label, score = _coerce_output("fail", _cat())
+        label, score, explanation = _coerce_output("fail", _cat())
         assert label == "fail"
         assert score == pytest.approx(0.0)
 
@@ -100,52 +135,84 @@ class TestCategoricalCoerce:
         with pytest.raises(ValueError, match="not in categorical"):
             _coerce_output("unknown", _cat())
 
-    def test_numeric_value_raises(self) -> None:
-        with pytest.raises(ValueError, match="Expected a string label"):
+    def test_numeric_value_raises_label_required(self) -> None:
+        with pytest.raises(ValueError, match="requires a label"):
             _coerce_output(1, _cat())
 
-    def test_none_raises(self) -> None:
-        with pytest.raises(ValueError, match="Expected a string label"):
+    def test_none_raises_label_required(self) -> None:
+        with pytest.raises(ValueError, match="requires a label"):
             _coerce_output(None, _cat())
 
     def test_bool_exclusion_stringified_and_validated(self) -> None:
-        # True → "True"; only valid if "True" is a configured label
         cat_with_true = _cat([("True", 1.0), ("False", 0.0)])
-        label, score = _coerce_output(True, cat_with_true)
+        label, score, explanation = _coerce_output(True, cat_with_true)
         assert label == "True"
 
     def test_bool_exclusion_invalid_label_raises(self) -> None:
-        # True → "True" but "True" is not in pass/fail config
         with pytest.raises(ValueError, match="not in categorical"):
             _coerce_output(True, _cat())
 
     def test_label_score_can_be_none(self) -> None:
         cat = _cat([("maybe", None)])  # type: ignore[list-item]
-        label, score = _coerce_output("maybe", cat)
+        label, score, explanation = _coerce_output("maybe", cat)
         assert label == "maybe"
         assert score is None
+
+    def test_dict_with_label_key_accepted(self) -> None:
+        label, score, explanation = _coerce_output({"label": "pass"}, _cat())
+        assert label == "pass"
+        assert score == pytest.approx(1.0)
+        assert explanation is None
+
+    def test_dict_with_label_and_explanation(self) -> None:
+        label, score, explanation = _coerce_output(
+            {"label": "pass", "explanation": "matched"}, _cat()
+        )
+        assert label == "pass"
+        assert score == pytest.approx(1.0)
+        assert explanation == "matched"
+
+    def test_dict_score_matches_lookup_accepted(self) -> None:
+        label, score, explanation = _coerce_output({"label": "pass", "score": 1.0}, _cat())
+        assert label == "pass"
+        assert score == pytest.approx(1.0)
+
+    def test_dict_score_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="does not match the configured score"):
+            _coerce_output({"label": "pass", "score": 0.99}, _cat())
+
+    def test_arbitrary_dict_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unrecognized keys"):
+            _coerce_output({"x": 1}, _cat())
+
+    def test_explanation_passthrough(self) -> None:
+        label, score, explanation = _coerce_output(
+            {"label": "fail", "explanation": "low confidence"}, _cat()
+        )
+        assert explanation == "low confidence"
 
 
 class TestContinuousCoerce:
     def test_int_returns_score(self) -> None:
-        label, score = _coerce_output(1, _cont())
+        label, score, explanation = _coerce_output(1, _cont())
         assert label is None
         assert score == pytest.approx(1.0)
+        assert explanation is None
 
     def test_float_returns_score(self) -> None:
-        label, score = _coerce_output(0.75, _cont())
+        label, score, explanation = _coerce_output(0.75, _cont())
         assert score == pytest.approx(0.75)
 
     def test_bool_raises(self) -> None:
         with pytest.raises(ValueError, match="got bool"):
             _coerce_output(True, _cont())
 
-    def test_str_raises(self) -> None:
-        with pytest.raises(ValueError, match="Expected a numeric value"):
+    def test_str_raises_score_required(self) -> None:
+        with pytest.raises(ValueError, match="requires a numeric score"):
             _coerce_output("0.5", _cont())
 
-    def test_none_raises(self) -> None:
-        with pytest.raises(ValueError, match="Expected a numeric value"):
+    def test_none_raises_score_required(self) -> None:
+        with pytest.raises(ValueError, match="requires a numeric score"):
             _coerce_output(None, _cont())
 
     def test_below_lower_bound_raises(self) -> None:
@@ -157,13 +224,105 @@ class TestContinuousCoerce:
             _coerce_output(1.1, _cont(upper_bound=1.0))
 
     def test_at_lower_bound_is_valid(self) -> None:
-        _, score = _coerce_output(0.0, _cont(lower_bound=0.0))
+        _, score, _ = _coerce_output(0.0, _cont(lower_bound=0.0))
         assert score == pytest.approx(0.0)
 
     def test_at_upper_bound_is_valid(self) -> None:
-        _, score = _coerce_output(1.0, _cont(upper_bound=1.0))
+        _, score, _ = _coerce_output(1.0, _cont(upper_bound=1.0))
         assert score == pytest.approx(1.0)
 
     def test_no_bounds_accepts_any_numeric(self) -> None:
-        _, score = _coerce_output(-999.0, _cont())
+        _, score, _ = _coerce_output(-999.0, _cont())
         assert score == pytest.approx(-999.0)
+
+    def test_nan_raises(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            _coerce_output(math.nan, _cont())
+
+    def test_infinity_raises(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            _coerce_output(math.inf, _cont())
+
+    def test_dict_with_score_key_accepted(self) -> None:
+        label, score, explanation = _coerce_output({"score": 0.5}, _cont())
+        assert label is None
+        assert score == pytest.approx(0.5)
+        assert explanation is None
+
+    def test_dict_with_score_and_explanation(self) -> None:
+        label, score, explanation = _coerce_output(
+            {"score": 0.5, "explanation": "moderate confidence"}, _cont()
+        )
+        assert score == pytest.approx(0.5)
+        assert explanation == "moderate confidence"
+
+    def test_free_form_label_accepted(self) -> None:
+        label, score, explanation = _coerce_output({"label": "high", "score": 0.9}, _cont())
+        assert label == "high"
+        assert score == pytest.approx(0.9)
+
+    def test_arbitrary_dict_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unrecognized keys"):
+            _coerce_output({"toxicity": 0.9}, _cont())
+
+    def test_explanation_passthrough(self) -> None:
+        _, _, explanation = _coerce_output({"score": 0.7, "explanation": "seems ok"}, _cont())
+        assert explanation == "seems ok"
+
+
+class TestShapeExamples:
+    def test_categorical_shape_examples_contains_bare_label(self) -> None:
+        config = _cat([("good", 1.0), ("bad", 0.0)])
+        examples = config.shape_examples(language="PYTHON", mode="full")
+        assert any("good" in ex for ex in examples)
+
+    def test_categorical_shape_examples_no_tuples(self) -> None:
+        config = _cat()
+        examples = config.shape_examples(language="PYTHON", mode="full")
+        assert not any("(" in ex and ")" in ex for ex in examples), (
+            "Tuples must not appear in shape_examples per D5 deferral"
+        )
+
+    def test_categorical_shape_examples_typescript(self) -> None:
+        config = _cat([("pass", 1.0), ("fail", 0.0)])
+        examples = config.shape_examples(language="TYPESCRIPT", mode="full")
+        assert all(ex.endswith(";") for ex in examples)
+
+    def test_continuous_shape_examples_uses_midpoint(self) -> None:
+        config = _cont(lower_bound=0.0, upper_bound=1.0)
+        examples = config.shape_examples(language="PYTHON", mode="full")
+        assert any("0.5" in ex for ex in examples)
+
+    def test_continuous_shape_examples_no_tuples(self) -> None:
+        config = _cont(lower_bound=0.0, upper_bound=10.0)
+        examples = config.shape_examples(language="PYTHON", mode="full")
+        assert not any("(" in ex and ")" in ex for ex in examples), (
+            "Tuples must not appear in shape_examples per D5 deferral"
+        )
+
+    def test_continuous_shape_examples_includes_bounds_hint(self) -> None:
+        config = _cont(lower_bound=0.0, upper_bound=10.0)
+        examples = config.shape_examples(language="PYTHON", mode="full")
+        # The dict form should include a bounds range comment
+        full_text = "\n".join(examples)
+        assert "0.0" in full_text and "10.0" in full_text
+
+    def test_continuous_shape_examples_no_bounds_uses_fallback(self) -> None:
+        config = _cont()
+        examples = config.shape_examples(language="PYTHON", mode="full")
+        assert any("0.5" in ex for ex in examples)
+
+    def test_categorical_shape_examples_curated_subset_of_full(self) -> None:
+        config = _cat()
+        full = config.shape_examples(mode="full")
+        curated = config.shape_examples(mode="curated")
+        # curated should not have more examples than full
+        assert len(curated) <= len(full)
+
+    def test_shape_examples_in_error_message(self) -> None:
+        config = _cat([("pass", 1.0), ("fail", 0.0)])
+        with pytest.raises(ValueError) as exc_info:
+            _coerce_output("unknown", config)
+        msg = str(exc_info.value)
+        assert "Valid shapes" in msg
+        assert "pass" in msg

--- a/tests/unit/server/api/test_evaluators_timeout.py
+++ b/tests/unit/server/api/test_evaluators_timeout.py
@@ -1,0 +1,181 @@
+"""Tests for the asyncio.wait_for timeout wrapper in CodeEvaluatorRunner.evaluate."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from phoenix.db.types.annotation_configs import (
+    CategoricalAnnotationValue,
+    CategoricalOutputConfig,
+    OptimizationDirection,
+)
+from phoenix.db.types.evaluators import InputMapping
+from phoenix.server.api.evaluators import CodeEvaluatorRunner
+from phoenix.server.sandbox.types import ExecutionResult, SandboxBackend
+
+
+def _categorical_config() -> CategoricalOutputConfig:
+    return CategoricalOutputConfig(
+        type="CATEGORICAL",
+        name="score",
+        optimization_direction=OptimizationDirection.MAXIMIZE,
+        description="",
+        values=[
+            CategoricalAnnotationValue(label="pass", score=1.0),
+            CategoricalAnnotationValue(label="fail", score=0.0),
+        ],
+    )
+
+
+def _make_runner(backend: SandboxBackend, timeout: int = 1) -> CodeEvaluatorRunner:
+    return CodeEvaluatorRunner(
+        name="test-runner",
+        description=None,
+        source_code='def evaluate(**kw): return "pass"',
+        stored_output_configs=[_categorical_config()],
+        sandbox_backend=backend,
+        language="PYTHON",
+        timeout=timeout,
+    )
+
+
+_EMPTY_MAPPING = InputMapping(literal_mapping={}, path_mapping={})
+
+
+class _SlowBackend(SandboxBackend):
+    """Backend whose execute sleeps indefinitely; stop_session is tracked."""
+
+    def __init__(self, stop_raises: Exception | None = None) -> None:
+        self.stop_session_calls: list[str] = []
+        self._stop_raises = stop_raises
+
+    async def start_session(self, session_key: str) -> None:
+        pass
+
+    async def stop_session(self, session_key: str) -> None:
+        self.stop_session_calls.append(session_key)
+        if self._stop_raises is not None:
+            raise self._stop_raises
+
+    async def execute(
+        self,
+        code: str,
+        session_key: str = "",
+        timeout: int | None = None,
+    ) -> ExecutionResult:
+        await asyncio.sleep(60)
+        return ExecutionResult(stdout='"pass"', stderr="", error=None)
+
+    async def close(self) -> None:
+        pass
+
+
+class _FastBackend(SandboxBackend):
+    """Backend that returns immediately with a configurable result."""
+
+    def __init__(self, result: ExecutionResult) -> None:
+        self._result = result
+        self.stop_session_calls: list[str] = []
+
+    async def start_session(self, session_key: str) -> None:
+        pass
+
+    async def stop_session(self, session_key: str) -> None:
+        self.stop_session_calls.append(session_key)
+
+    async def execute(
+        self,
+        code: str,
+        session_key: str = "",
+        timeout: int | None = None,
+    ) -> ExecutionResult:
+        return self._result
+
+    async def close(self) -> None:
+        pass
+
+
+class TestTimeoutWrapper:
+    @pytest.mark.asyncio
+    async def test_slow_backend_returns_timeout_execution_result(self) -> None:
+        backend = _SlowBackend()
+        runner = _make_runner(backend, timeout=1)
+        results = await runner.evaluate(
+            context={},
+            input_mapping=_EMPTY_MAPPING,
+            name="test",
+            output_configs=[_categorical_config()],
+        )
+
+        assert len(results) == 1
+        assert results[0]["error"] == "timeout"
+
+    @pytest.mark.asyncio
+    async def test_slow_backend_schedules_stop_session(self) -> None:
+        backend = _SlowBackend()
+        runner = _make_runner(backend, timeout=1)
+        await runner.evaluate(
+            context={},
+            input_mapping=_EMPTY_MAPPING,
+            name="test",
+            output_configs=[_categorical_config()],
+        )
+
+        # Allow the fire-and-forget task to run
+        await asyncio.sleep(0)
+        assert len(backend.stop_session_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_stop_session_exception_during_timeout_does_not_propagate(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        backend = _SlowBackend(stop_raises=RuntimeError("stop failed"))
+        runner = _make_runner(backend, timeout=1)
+
+        with caplog.at_level(logging.WARNING):
+            results = await runner.evaluate(
+                context={},
+                input_mapping=_EMPTY_MAPPING,
+                name="test",
+                output_configs=[_categorical_config()],
+            )
+            # Let the fire-and-forget task run and log
+            await asyncio.sleep(0)
+
+        assert len(results) == 1
+        assert results[0]["error"] == "timeout"
+        assert any("stop_session" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_fast_backend_result_passes_through_unchanged(self) -> None:
+        backend = _FastBackend(ExecutionResult(stdout='"pass"', stderr="", error=None))
+        runner = _make_runner(backend, timeout=30)
+        results = await runner.evaluate(
+            context={},
+            input_mapping=_EMPTY_MAPPING,
+            name="test",
+            output_configs=[_categorical_config()],
+        )
+
+        assert len(results) == 1
+        assert results[0]["error"] is None
+        assert results[0]["label"] == "pass"
+        assert len(backend.stop_session_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_fast_backend_with_error_field_passes_through_unchanged(self) -> None:
+        backend = _FastBackend(ExecutionResult(stdout="", stderr="", error="runtime error"))
+        runner = _make_runner(backend, timeout=30)
+        results = await runner.evaluate(
+            context={},
+            input_mapping=_EMPTY_MAPPING,
+            name="test",
+            output_configs=[_categorical_config()],
+        )
+
+        assert len(results) == 1
+        assert results[0]["error"] == "runtime error"
+        assert len(backend.stop_session_calls) == 0

--- a/tests/unit/server/api/test_sandbox_queries.py
+++ b/tests/unit/server/api/test_sandbox_queries.py
@@ -1,12 +1,7 @@
-from typing import Any
-
-import pytest
 from sqlalchemy import func, select
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
-from phoenix.server.sandbox import SANDBOX_ADAPTER_METADATA, register_sandbox_adapter
-from phoenix.server.sandbox.types import E2BConfig, SandboxAdapter, SandboxBackend
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
 
@@ -119,33 +114,12 @@ async def test_sandbox_backends_and_providers_can_be_loaded_together(
     assert len(response.data["sandboxProviders"]) == provider_count
 
 
-@pytest.fixture
-def register_e2b_adapter() -> Any:
-    """Register a minimal E2BAdapter so config_field_specs are derived from E2BConfig."""
-
-    class _FakeE2BAdapter(SandboxAdapter):
-        key = "E2B"
-        display_name = "E2B"
-        language = "PYTHON"
-        config_model = E2BConfig
-
-        def build_backend(
-            self, config: dict[str, Any], user_env: dict[str, str] | None = None
-        ) -> SandboxBackend:
-            raise ValueError("fake adapter — not constructible")
-
-    original_specs = list(SANDBOX_ADAPTER_METADATA["E2B"].config_field_specs)
-    register_sandbox_adapter(_FakeE2BAdapter())
-    yield
-    SANDBOX_ADAPTER_METADATA["E2B"].config_field_specs = original_specs
-
-
 async def test_sandbox_backends_config_field_specs(
     gql_client: AsyncGraphQLClient,
     seed_sandbox_providers: None,
-    register_e2b_adapter: Any,
 ) -> None:
-    """configFieldSpecs for E2B derives 3 fields from E2BConfig; others have none."""
+    """configFieldSpecs for all adapters: after removing non-capability scalar fields,
+    E2B/Daytona/Modal emit zero specs alongside other capability-only adapters."""
     query = """
       query {
         sandboxBackends {
@@ -167,35 +141,16 @@ async def test_sandbox_backends_config_field_specs(
     assert response.data is not None
     backends = {b["backendType"]: b for b in response.data["sandboxBackends"]}
 
-    # E2B derives 3 specs from E2BConfig (template, cwd, metadata)
-    e2b_specs = backends["E2B"]["configFieldSpecs"]
-    assert len(e2b_specs) == 3
-    spec_by_key = {s["key"]: s for s in e2b_specs}
-    assert spec_by_key["template"] == {
-        "key": "template",
-        "displayName": "Template",
-        "fieldType": "string",
-        "required": False,
-        "description": "E2B sandbox template ID. Defaults to 'base'.",
-        "choices": None,
-    }
-    assert spec_by_key["cwd"] == {
-        "key": "cwd",
-        "displayName": "Working Directory",
-        "fieldType": "string",
-        "required": False,
-        "description": "Working directory for code execution inside the sandbox.",
-        "choices": None,
-    }
-    assert spec_by_key["metadata"] == {
-        "key": "metadata",
-        "displayName": "Metadata",
-        "fieldType": "string",
-        "required": False,
-        "description": "Metadata string attached to the sandbox at creation time.",
-        "choices": None,
-    }
-
-    # Adapters with empty config models have no specs
-    for backend_type in ("WASM", "VERCEL_PYTHON", "VERCEL_TYPESCRIPT", "DENO"):
-        assert backends[backend_type]["configFieldSpecs"] == [], backend_type
+    # All adapters now expose only capability fields (internet_access, dependencies,
+    # env_vars) which are not surfaced as configFieldSpecs — so all emit zero scalar specs.
+    for backend_type in (
+        "E2B",
+        "DAYTONA_PYTHON",
+        "MODAL",
+        "WASM",
+        "VERCEL_PYTHON",
+        "VERCEL_TYPESCRIPT",
+        "DENO",
+    ):
+        if backend_type in backends:
+            assert backends[backend_type]["configFieldSpecs"] == [], backend_type

--- a/tests/unit/server/api/test_sandbox_queries.py
+++ b/tests/unit/server/api/test_sandbox_queries.py
@@ -143,7 +143,7 @@ async def test_sandbox_backends_and_providers_can_be_loaded_together(
     ]
     assert backends["VERCEL_PYTHON"]["dependencyHints"] == [
         "Install Phoenix with the `vercel` extra.",
-        "Set `PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`, or all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, `PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and `PHOENIX_SANDBOX_VERCEL_TEAM_ID`.",
+        "Set `VERCEL_OIDC_TOKEN`, or all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, `PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and `PHOENIX_SANDBOX_VERCEL_TEAM_ID`.",
     ]
     assert backends["DENO"]["dependencyHints"] == [
         "Install the Deno runtime and ensure the `deno` binary is available on PATH.",

--- a/tests/unit/server/api/test_sandbox_queries.py
+++ b/tests/unit/server/api/test_sandbox_queries.py
@@ -1,9 +1,46 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
 from sqlalchemy import func, select
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
+from phoenix.server.sandbox import (
+    _BACKEND_CACHE,
+    _SANDBOX_ADAPTERS,
+    SANDBOX_ADAPTER_METADATA,
+    AdapterMetadata,
+)
+from phoenix.server.sandbox.types import ProviderCredentialSpec, SandboxAdapter, SandboxBackend
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
+
+_TEST_AUTH_BACKEND = "TEST_AUTH_BACKEND"
+_TEST_AUTH_KEY = "TEST_AUTH_KEY"
+
+
+class _TestAuthAdapter(SandboxAdapter):
+    key = _TEST_AUTH_BACKEND
+    display_name = "Test Auth Backend"
+    language = "PYTHON"
+    credential_specs = [ProviderCredentialSpec(key=_TEST_AUTH_KEY, display_name="Test Auth Key")]
+
+    def build_backend(
+        self,
+        config: dict,  # type: ignore[type-arg]
+        user_env: dict | None = None,  # type: ignore[type-arg]
+    ) -> SandboxBackend:
+        return MagicMock(spec=SandboxBackend)
+
+
+@pytest.fixture(autouse=True)
+def _clean_test_auth_backend() -> Any:
+    yield
+    SANDBOX_ADAPTER_METADATA.pop(_TEST_AUTH_BACKEND, None)
+    _SANDBOX_ADAPTERS.pop(_TEST_AUTH_BACKEND, None)
+    for key in [key for key in _BACKEND_CACHE if key[0] == _TEST_AUTH_BACKEND]:
+        _BACKEND_CACHE.pop(key, None)
 
 
 async def test_sandbox_providers_returns_nested_configs(
@@ -75,6 +112,7 @@ async def test_sandbox_backends_and_providers_can_be_loaded_together(
           displayName
           supportedLanguages
           status
+          statusDetail
           dependencyHints
         }
         sandboxProviders {
@@ -97,21 +135,50 @@ async def test_sandbox_backends_and_providers_can_be_loaded_together(
     ]
     assert backends["E2B"]["dependencyHints"] == [
         "Install Phoenix with the `e2b` extra.",
-        "Provide `PHOENIX_SANDBOX_E2B_API_KEY` or `PHOENIX_SANDBOX_API_KEY`.",
+        "Provide `PHOENIX_SANDBOX_E2B_API_KEY`.",
     ]
     assert backends["DAYTONA_PYTHON"]["dependencyHints"] == [
         "Install Phoenix with the `daytona` extra.",
-        "Provide `PHOENIX_SANDBOX_DAYTONA_API_KEY` or `PHOENIX_SANDBOX_TOKEN`.",
+        "Provide `PHOENIX_SANDBOX_DAYTONA_API_KEY`.",
     ]
     assert backends["VERCEL_PYTHON"]["dependencyHints"] == [
         "Install Phoenix with the `vercel` extra.",
-        "Set `VERCEL_OIDC_TOKEN`, or all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and "
-        "`VERCEL_TEAM_ID`.",
+        "Set `PHOENIX_SANDBOX_VERCEL_OIDC_TOKEN`, or all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, `PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and `PHOENIX_SANDBOX_VERCEL_TEAM_ID`.",
     ]
     assert backends["DENO"]["dependencyHints"] == [
         "Install the Deno runtime and ensure the `deno` binary is available on PATH.",
     ]
     assert len(response.data["sandboxProviders"]) == provider_count
+
+
+async def test_sandbox_backends_reports_missing_credentials_status(
+    gql_client: AsyncGraphQLClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(_TEST_AUTH_KEY, raising=False)
+    SANDBOX_ADAPTER_METADATA[_TEST_AUTH_BACKEND] = AdapterMetadata(
+        display_name="Test Auth Backend",
+        language="PYTHON",
+    )
+    _SANDBOX_ADAPTERS[_TEST_AUTH_BACKEND] = _TestAuthAdapter()
+
+    query = """
+      query {
+        sandboxBackends {
+          backendType
+          status
+          statusDetail
+        }
+      }
+    """
+
+    response = await gql_client.execute(query=query)
+    assert not response.errors
+    assert response.data is not None
+
+    backends = {backend["backendType"]: backend for backend in response.data["sandboxBackends"]}
+    assert backends[_TEST_AUTH_BACKEND]["status"] == "MISSING_CREDENTIALS"
+    assert backends[_TEST_AUTH_BACKEND]["statusDetail"] == f"Set `{_TEST_AUTH_KEY}`."
 
 
 async def test_sandbox_backends_config_field_specs(

--- a/tests/unit/server/api/test_wasm_backend.py
+++ b/tests/unit/server/api/test_wasm_backend.py
@@ -11,7 +11,8 @@ metadata, build_backend config plumbing).
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from typing import Any  # noqa: F401
+from unittest.mock import MagicMock, patch  # noqa: F401
 
 import pytest
 
@@ -141,6 +142,219 @@ class TestEngineCaching:
         assert engine_a is not engine_b
         _MODULE_CACHE.pop(str(path_a), None)
         _MODULE_CACHE.pop(str(path_b), None)
+
+
+class TestRunWasmStdoutCapture:
+    """_run_wasm captures stdout/stderr via WasiConfig setter-property assignment.
+
+    Patches _get_engine_and_module and Linker.instantiate to exercise the real
+    WasiConfig setter-property code path without a WASM binary.  A real
+    wasmtime.Func is used for _start so isinstance(start, wasmtime.Func) passes;
+    its callback invokes the captured stdout callback, proving bytes flow through
+    the accumulator and are decoded into result.stdout.
+    """
+
+    def test_stdout_captured_via_setter_property(self) -> None:
+        import wasmtime
+
+        # Captures the stdout/stderr callbacks registered via setter assignment
+        stdout_cb_holder: list[Any] = []
+        stderr_cb_holder: list[Any] = []
+
+        class _CapturingWasiConfig:
+            @property
+            def stdout_custom(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stdout_custom.setter
+            def stdout_custom(self, cb: object) -> None:
+                stdout_cb_holder.append(cb)
+
+            @property
+            def stderr_custom(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stderr_custom.setter
+            def stderr_custom(self, cb: object) -> None:
+                stderr_cb_holder.append(cb)
+
+            @property
+            def stdin_file(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stdin_file.setter
+            def stdin_file(self, path: object) -> None:
+                pass
+
+            def inherit_env(self) -> None:
+                pass
+
+        # Real Store needed to construct a real wasmtime.Func
+        store = wasmtime.Store()
+        ft = wasmtime.FuncType([], [])
+
+        def _start_impl(caller: object) -> None:
+            if stdout_cb_holder:
+                stdout_cb_holder[0](b"hello from wasm\n")
+
+        start_func = wasmtime.Func(store, ft, _start_impl, access_caller=True)
+
+        mock_exports = MagicMock()
+        mock_exports.get.return_value = start_func
+
+        mock_instance = MagicMock()
+        mock_instance.exports.return_value = mock_exports
+
+        fake_engine = wasmtime.Engine()
+
+        with patch(
+            "phoenix.server.sandbox.wasm_backend._get_engine_and_module",
+            return_value=(fake_engine, MagicMock()),
+        ):
+            with patch("wasmtime.WasiConfig", _CapturingWasiConfig):
+                with patch("wasmtime.Linker") as mock_linker_cls:
+                    mock_linker = MagicMock()
+                    mock_linker_cls.return_value = mock_linker
+                    mock_linker.instantiate.return_value = mock_instance
+                    with patch("wasmtime.Store", return_value=store):
+                        result = _run_wasm(Path("/fake/cpython.wasm"), "x=1", timeout=5)
+
+        assert result.error is None
+        assert result.stdout == "hello from wasm\n"
+
+    def test_stderr_captured_via_setter_property(self) -> None:
+        import wasmtime
+
+        stderr_cb_holder: list[Any] = []
+
+        class _CapturingWasiConfig:
+            @property
+            def stdout_custom(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stdout_custom.setter
+            def stdout_custom(self, cb: object) -> None:
+                pass
+
+            @property
+            def stderr_custom(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stderr_custom.setter
+            def stderr_custom(self, cb: object) -> None:
+                stderr_cb_holder.append(cb)
+
+            @property
+            def stdin_file(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stdin_file.setter
+            def stdin_file(self, path: object) -> None:
+                pass
+
+            def inherit_env(self) -> None:
+                pass
+
+        store = wasmtime.Store()
+        ft = wasmtime.FuncType([], [])
+
+        def _start_impl(caller: object) -> None:
+            if stderr_cb_holder:
+                stderr_cb_holder[0](b"error output\n")
+
+        start_func = wasmtime.Func(store, ft, _start_impl, access_caller=True)
+
+        mock_exports = MagicMock()
+        mock_exports.get.return_value = start_func
+
+        mock_instance = MagicMock()
+        mock_instance.exports.return_value = mock_exports
+
+        fake_engine = wasmtime.Engine()
+
+        with patch(
+            "phoenix.server.sandbox.wasm_backend._get_engine_and_module",
+            return_value=(fake_engine, MagicMock()),
+        ):
+            with patch("wasmtime.WasiConfig", _CapturingWasiConfig):
+                with patch("wasmtime.Linker") as mock_linker_cls:
+                    mock_linker = MagicMock()
+                    mock_linker_cls.return_value = mock_linker
+                    mock_linker.instantiate.return_value = mock_instance
+                    with patch("wasmtime.Store", return_value=store):
+                        result = _run_wasm(Path("/fake/cpython.wasm"), "x=1", timeout=5)
+
+        assert result.error is None
+        assert result.stderr == "error output\n"
+
+    def test_wasi_config_setter_raises_on_read(self) -> None:
+        """WasiConfig.stdout_custom is set-only — reading it raises AttributeError."""
+        import wasmtime
+
+        wasi = wasmtime.WasiConfig()
+        with pytest.raises(AttributeError):
+            _ = wasi.stdout_custom
+
+    def test_stdin_assigned_via_setter_property(self) -> None:
+        """wasi.stdin_file assignment (not method call) is the correct API."""
+        import wasmtime
+
+        stdin_path_holder: list[Any] = []
+
+        class _CapturingWasiConfig:
+            @property
+            def stdout_custom(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stdout_custom.setter
+            def stdout_custom(self, cb: object) -> None:
+                pass
+
+            @property
+            def stderr_custom(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stderr_custom.setter
+            def stderr_custom(self, cb: object) -> None:
+                pass
+
+            @property
+            def stdin_file(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stdin_file.setter
+            def stdin_file(self, path: object) -> None:
+                stdin_path_holder.append(path)
+
+            def inherit_env(self) -> None:
+                pass
+
+        store = wasmtime.Store()
+        ft = wasmtime.FuncType([], [])
+        start_func = wasmtime.Func(store, ft, lambda c: None, access_caller=True)
+
+        mock_exports = MagicMock()
+        mock_exports.get.return_value = start_func
+        mock_instance = MagicMock()
+        mock_instance.exports.return_value = mock_exports
+
+        fake_engine = wasmtime.Engine()
+
+        with patch(
+            "phoenix.server.sandbox.wasm_backend._get_engine_and_module",
+            return_value=(fake_engine, MagicMock()),
+        ):
+            with patch("wasmtime.WasiConfig", _CapturingWasiConfig):
+                with patch("wasmtime.Linker") as mock_linker_cls:
+                    mock_linker = MagicMock()
+                    mock_linker_cls.return_value = mock_linker
+                    mock_linker.instantiate.return_value = mock_instance
+                    with patch("wasmtime.Store", return_value=store):
+                        result = _run_wasm(Path("/fake/cpython.wasm"), "print(1)", timeout=5)
+
+        assert result.error is None
+        assert len(stdin_path_holder) == 1
+        assert stdin_path_holder[0].endswith(".py")
 
 
 class TestTempFileCleanup:

--- a/tests/unit/server/sandbox/test_capability_matrix.py
+++ b/tests/unit/server/sandbox/test_capability_matrix.py
@@ -1,0 +1,401 @@
+"""Parameterized capability-matrix tests across all 7 sandbox adapters.
+
+Coverage:
+  (a) validate_config rejects unsupported capability sections at create time.
+  (b) validate_config(..., stored_config=...) permits semantically unchanged
+      sections to round-trip (bypass-for-unchanged-sections path).
+  (c) build_backend raises UnsupportedOperation for unsupported sections
+      (double-guard runtime gate).
+  (d) Per-wired-capability positive reach-through tests (mock-verified).
+
+Tests assert against SANDBOX_ADAPTER_METADATA, not prose descriptions, so they
+remain correct as flag values evolve across Phases 2-4.
+
+SDK mocking strategy:
+- Modal: sys.modules["modal"] must be patched before ModalSandboxBackend.__init__
+- Vercel: unsupported-capability guard fires before credential access; no env
+  patching needed for rejection tests.
+- E2B / Daytona / Deno / WASM: no SDK import at build_backend time.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from phoenix.server.sandbox import SANDBOX_ADAPTER_METADATA
+from phoenix.server.sandbox.types import UnsupportedOperation
+
+# ---------------------------------------------------------------------------
+# Adapter instantiation helpers
+# ---------------------------------------------------------------------------
+
+_ADAPTER_MODULES = {
+    "WASM": ("phoenix.server.sandbox.wasm_backend", "WASMAdapter"),
+    "E2B": ("phoenix.server.sandbox.e2b_backend", "E2BAdapter"),
+    "DAYTONA_PYTHON": ("phoenix.server.sandbox.daytona_backend", "DaytonaPythonAdapter"),
+    "VERCEL_PYTHON": ("phoenix.server.sandbox.vercel_backend", "VercelPythonAdapter"),
+    "VERCEL_TYPESCRIPT": ("phoenix.server.sandbox.vercel_backend", "VercelTypescriptAdapter"),
+    "DENO": ("phoenix.server.sandbox.deno_backend", "DenoAdapter"),
+    "MODAL": ("phoenix.server.sandbox.modal_backend", "ModalAdapter"),
+}
+
+
+def _modal_mock() -> MagicMock:
+    modal = MagicMock()
+    modal.App.lookup.return_value = MagicMock()
+    modal.Image.debian_slim.return_value = MagicMock()
+    modal.Sandbox.create = MagicMock()
+    modal.Sandbox.create.aio = MagicMock()
+    return modal
+
+
+def _get_adapter(key: str) -> Any:
+    module_path, cls_name = _ADAPTER_MODULES[key]
+    mod = importlib.import_module(module_path)
+    return getattr(mod, cls_name)()
+
+
+def _build_backend_for(adapter_key: str, config: dict[str, Any], **kwargs: Any) -> Any:
+    """Call build_backend, patching modal if needed."""
+    if adapter_key == "MODAL":
+        modal_mock = _modal_mock()
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            adapter = _get_adapter(adapter_key)
+            return adapter.build_backend(config, **kwargs)
+    adapter = _get_adapter(adapter_key)
+    return adapter.build_backend(config, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# (a) validate_config — reject unsupported capability sections at create time
+# ---------------------------------------------------------------------------
+
+_ADAPTERS_WITHOUT_ENV_VARS = [
+    key for key, meta in SANDBOX_ADAPTER_METADATA.items() if not meta.supports_env_vars
+]
+_ADAPTERS_WITHOUT_INTERNET_ACCESS = [
+    key
+    for key, meta in SANDBOX_ADAPTER_METADATA.items()
+    if meta.internet_access_capability == "none"
+]
+_ADAPTERS_WITHOUT_DEPENDENCIES = [
+    key for key, meta in SANDBOX_ADAPTER_METADATA.items() if meta.dependencies_language is None
+]
+
+
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITHOUT_ENV_VARS)
+def test_validate_config_rejects_env_vars_when_unsupported(adapter_key: str) -> None:
+    """validate_config raises ValidationError for env_vars on adapters that don't support them."""
+    adapter = _get_adapter(adapter_key)
+    config = {"env_vars": [{"kind": "literal", "name": "X", "value": "1"}]}
+    with pytest.raises(ValidationError, match="capability_violation"):
+        adapter.validate_config(config)
+
+
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITHOUT_INTERNET_ACCESS)
+def test_validate_config_rejects_internet_access_when_unsupported(adapter_key: str) -> None:
+    """validate_config raises ValidationError for internet_access on adapters with capability=none."""
+    adapter = _get_adapter(adapter_key)
+    config = {"internet_access": {"mode": "allow"}}
+    with pytest.raises(ValidationError, match="capability_violation"):
+        adapter.validate_config(config)
+
+
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITHOUT_DEPENDENCIES)
+def test_validate_config_rejects_dependencies_when_unsupported(adapter_key: str) -> None:
+    """validate_config raises ValidationError for non-empty packages on adapters with no dep support."""
+    adapter = _get_adapter(adapter_key)
+    config = {"dependencies": {"packages": ["numpy"]}}
+    with pytest.raises(ValidationError, match="capability_violation"):
+        adapter.validate_config(config)
+
+
+# ---------------------------------------------------------------------------
+# (b) validate_config — stored-config round-trip bypass for unchanged sections
+# ---------------------------------------------------------------------------
+
+_ADAPTERS_WITH_INTERNET_ACCESS_NONE = _ADAPTERS_WITHOUT_INTERNET_ACCESS
+_ADAPTERS_WITHOUT_DEPENDENCIES_SUPPORT = _ADAPTERS_WITHOUT_DEPENDENCIES
+
+
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITH_INTERNET_ACCESS_NONE)
+def test_validate_config_stored_config_roundtrip_internet_access(adapter_key: str) -> None:
+    """Unchanged internet_access from stored_config is permitted to round-trip even when capability=none."""
+    adapter = _get_adapter(adapter_key)
+    ia_section = {"mode": "allow"}
+    config = {"internet_access": ia_section}
+    # Round-trip: same value in stored_config → no capability_violation raised
+    result = adapter.validate_config(config, stored_config={"internet_access": ia_section})
+    assert result.get("internet_access") is not None
+
+
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITHOUT_DEPENDENCIES_SUPPORT)
+def test_validate_config_stored_config_roundtrip_dependencies(adapter_key: str) -> None:
+    """Unchanged dependencies from stored_config are permitted to round-trip even when dep support is None."""
+    adapter = _get_adapter(adapter_key)
+    deps_section = {"packages": ["requests"], "lockfile": None}
+    config = {"dependencies": deps_section}
+    result = adapter.validate_config(config, stored_config={"dependencies": deps_section})
+    assert result.get("dependencies") is not None
+
+
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITH_INTERNET_ACCESS_NONE)
+def test_validate_config_changed_internet_access_still_rejected(adapter_key: str) -> None:
+    """A changed internet_access section is NOT permitted even with stored_config present."""
+    adapter = _get_adapter(adapter_key)
+    stored_config = {"internet_access": {"mode": "deny"}}
+    new_config = {"internet_access": {"mode": "allow"}}
+    with pytest.raises(ValidationError, match="capability_violation"):
+        adapter.validate_config(new_config, stored_config=stored_config)
+
+
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITHOUT_DEPENDENCIES_SUPPORT)
+def test_validate_config_changed_dependencies_still_rejected(adapter_key: str) -> None:
+    """Changed packages are NOT permitted even with stored_config present."""
+    adapter = _get_adapter(adapter_key)
+    stored_config = {"dependencies": {"packages": ["requests"], "lockfile": None}}
+    new_config = {"dependencies": {"packages": ["numpy"], "lockfile": None}}
+    with pytest.raises(ValidationError, match="capability_violation"):
+        adapter.validate_config(new_config, stored_config=stored_config)
+
+
+# ---------------------------------------------------------------------------
+# (c) build_backend — double-guard runtime gate (UnsupportedOperation)
+# ---------------------------------------------------------------------------
+
+_INTERNET_ACCESS_CONFIG = {"internet_access": {"mode": "allow"}}
+_DEPENDENCIES_CONFIG = {"dependencies": {"packages": ["numpy"]}}
+
+
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITHOUT_ENV_VARS)
+def test_build_backend_raises_for_non_empty_user_env(adapter_key: str) -> None:
+    """build_backend raises UnsupportedOperation when user_env non-empty and supports_env_vars=False."""
+    with pytest.raises(UnsupportedOperation):
+        _build_backend_for(adapter_key, {}, user_env={"SECRET": "value"})
+
+
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITHOUT_INTERNET_ACCESS)
+def test_build_backend_raises_for_internet_access_config(adapter_key: str) -> None:
+    """build_backend raises UnsupportedOperation for internet_access config when capability=none."""
+    with pytest.raises(UnsupportedOperation):
+        _build_backend_for(adapter_key, _INTERNET_ACCESS_CONFIG)
+
+
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITHOUT_DEPENDENCIES)
+def test_build_backend_raises_for_non_empty_packages(adapter_key: str) -> None:
+    """build_backend raises UnsupportedOperation for non-empty packages when dependencies_language=None."""
+    with pytest.raises(UnsupportedOperation):
+        _build_backend_for(adapter_key, _DEPENDENCIES_CONFIG)
+
+
+# ---------------------------------------------------------------------------
+# (d) Positive wiring tests — newly-wired capabilities reach SDK kwargs
+# ---------------------------------------------------------------------------
+
+# --- E2B: internet_access_capability="boolean" (wired in Phase 2) ---
+# When internet_access_capability="boolean", the metadata flag is non-"none"
+# so build_backend must NOT raise for a config with internet_access.
+# (Actual SDK forwarding verified in a separate targeted test below.)
+
+
+def test_e2b_build_backend_permits_internet_access_config() -> None:
+    """E2B with internet_access_capability='boolean' accepts internet_access config in build_backend."""
+    meta = SANDBOX_ADAPTER_METADATA["E2B"]
+    assert meta.internet_access_capability == "boolean", (
+        "E2B internet_access_capability must be 'boolean' for this test to be valid; "
+        "check that task #7 has been completed."
+    )
+    adapter = _get_adapter("E2B")
+    # Should not raise UnsupportedOperation (no SDK import in build_backend itself)
+    backend = adapter.build_backend(
+        {"internet_access": {"mode": "allow"}},
+        user_env=None,
+    )
+    assert backend is not None
+
+
+def test_e2b_validate_config_permits_internet_access_when_boolean() -> None:
+    """E2B validate_config does not raise for internet_access when capability='boolean'."""
+    meta = SANDBOX_ADAPTER_METADATA["E2B"]
+    assert meta.internet_access_capability == "boolean"
+    adapter = _get_adapter("E2B")
+    result = adapter.validate_config({"internet_access": {"mode": "allow"}})
+    assert result.get("internet_access") == {"mode": "allow"}
+
+
+def test_e2b_validate_config_permits_internet_access_deny() -> None:
+    """E2B validate_config allows mode='deny' (blocking internet)."""
+    adapter = _get_adapter("E2B")
+    result = adapter.validate_config({"internet_access": {"mode": "deny"}})
+    assert result["internet_access"]["mode"] == "deny"
+
+
+# --- E2B: dependencies_language=PYTHON (wired in Phase 3, task #8) ---
+
+
+def test_e2b_validate_config_permits_dependencies_when_python() -> None:
+    """When E2B dependencies_language='PYTHON', validate_config accepts non-empty packages."""
+    meta = SANDBOX_ADAPTER_METADATA["E2B"]
+    if meta.dependencies_language is None:
+        pytest.skip("E2B dependencies_language not yet wired (task #8 pending)")
+    assert meta.dependencies_language == "PYTHON"
+    adapter = _get_adapter("E2B")
+    result = adapter.validate_config({"dependencies": {"packages": ["requests"]}})
+    assert "requests" in result["dependencies"]["packages"]
+
+
+def test_e2b_build_backend_permits_dependencies_when_python() -> None:
+    """When E2B dependencies_language='PYTHON', build_backend does not raise for packages."""
+    meta = SANDBOX_ADAPTER_METADATA["E2B"]
+    if meta.dependencies_language is None:
+        pytest.skip("E2B dependencies_language not yet wired (task #8 pending)")
+    adapter = _get_adapter("E2B")
+    backend = adapter.build_backend({"dependencies": {"packages": ["requests"]}})
+    assert backend is not None
+
+
+# --- DAYTONA_PYTHON: dependencies_language=PYTHON (already wired) ---
+
+
+def test_daytona_build_backend_wires_packages_to_backend() -> None:
+    """DAYTONA_PYTHON build_backend forwards packages list to DaytonaSandboxBackend._packages."""
+    meta = SANDBOX_ADAPTER_METADATA["DAYTONA_PYTHON"]
+    assert meta.dependencies_language == "PYTHON"
+    adapter = _get_adapter("DAYTONA_PYTHON")
+    packages = ["requests", "numpy"]
+    backend = adapter.build_backend({"dependencies": {"packages": packages}})
+    assert backend._packages == packages
+
+
+def test_daytona_validate_config_permits_dependencies() -> None:
+    """DAYTONA_PYTHON validate_config accepts non-empty packages (dependencies_language=PYTHON)."""
+    adapter = _get_adapter("DAYTONA_PYTHON")
+    result = adapter.validate_config({"dependencies": {"packages": ["boto3"]}})
+    assert "boto3" in result["dependencies"]["packages"]
+
+
+# --- MODAL: internet_access_capability wiring (task #9) ---
+
+
+def test_modal_validate_config_internet_access_when_boolean() -> None:
+    """When MODAL internet_access_capability='boolean', validate_config accepts internet_access."""
+    meta = SANDBOX_ADAPTER_METADATA["MODAL"]
+    if meta.internet_access_capability == "none":
+        pytest.skip("MODAL internet_access_capability not yet wired (task #9 pending)")
+    adapter = _get_adapter("MODAL")
+    result = adapter.validate_config({"internet_access": {"mode": "deny"}})
+    assert result["internet_access"]["mode"] == "deny"
+
+
+def test_modal_build_backend_permits_internet_access_when_boolean() -> None:
+    """When MODAL internet_access_capability='boolean', build_backend does not raise for internet_access."""
+    meta = SANDBOX_ADAPTER_METADATA["MODAL"]
+    if meta.internet_access_capability == "none":
+        pytest.skip("MODAL internet_access_capability not yet wired (task #9 pending)")
+    modal_mock = _modal_mock()
+    with patch.dict(sys.modules, {"modal": modal_mock}):
+        adapter = _get_adapter("MODAL")
+        backend = adapter.build_backend({"internet_access": {"mode": "deny"}})
+    assert backend is not None
+
+
+# --- MODAL: dependencies_language=PYTHON (task #10) ---
+
+
+def test_modal_validate_config_dependencies_when_python() -> None:
+    """When MODAL dependencies_language='PYTHON', validate_config accepts non-empty packages."""
+    meta = SANDBOX_ADAPTER_METADATA["MODAL"]
+    if meta.dependencies_language is None:
+        pytest.skip("MODAL dependencies_language not yet wired (task #10 pending)")
+    assert meta.dependencies_language == "PYTHON"
+    adapter = _get_adapter("MODAL")
+    result = adapter.validate_config({"dependencies": {"packages": ["pandas"]}})
+    assert "pandas" in result["dependencies"]["packages"]
+
+
+def test_modal_build_backend_wires_packages_to_image() -> None:
+    """When MODAL dependencies_language='PYTHON', build_backend calls Image.pip_install with packages."""
+    meta = SANDBOX_ADAPTER_METADATA["MODAL"]
+    if meta.dependencies_language is None:
+        pytest.skip("MODAL dependencies_language not yet wired (task #10 pending)")
+    modal_mock = _modal_mock()
+    pip_image = MagicMock()
+    modal_mock.Image.debian_slim.return_value.pip_install.return_value = pip_image
+    packages = ["pandas", "scikit-learn"]
+    with patch.dict(sys.modules, {"modal": modal_mock}):
+        adapter = _get_adapter("MODAL")
+        backend = adapter.build_backend({"dependencies": {"packages": packages}})
+    modal_mock.Image.debian_slim.return_value.pip_install.assert_called_once_with(packages)
+    assert backend._image is pip_image
+
+
+# --- DAYTONA_PYTHON: internet_access_capability wiring (task #5/#6) ---
+
+
+def test_daytona_validate_config_internet_access_when_boolean() -> None:
+    """When DAYTONA_PYTHON internet_access_capability='boolean', validate_config accepts internet_access."""
+    meta = SANDBOX_ADAPTER_METADATA["DAYTONA_PYTHON"]
+    if meta.internet_access_capability == "none":
+        pytest.skip("DAYTONA_PYTHON internet_access_capability not yet wired (tasks #5/#6 pending)")
+    adapter = _get_adapter("DAYTONA_PYTHON")
+    result = adapter.validate_config({"internet_access": {"mode": "deny"}})
+    assert result["internet_access"]["mode"] == "deny"
+
+
+# --- WASM: env_vars=False — always rejected at both gates ---
+
+
+def test_wasm_validate_config_rejects_env_vars() -> None:
+    """WASM validate_config rejects env_vars (supports_env_vars=False)."""
+    adapter = _get_adapter("WASM")
+    with pytest.raises(ValidationError, match="capability_violation"):
+        adapter.validate_config({"env_vars": [{"kind": "literal", "name": "X", "value": "v"}]})
+
+
+def test_wasm_validate_config_rejects_internet_access() -> None:
+    """WASM validate_config rejects internet_access (capability=none)."""
+    adapter = _get_adapter("WASM")
+    with pytest.raises(ValidationError, match="capability_violation"):
+        adapter.validate_config({"internet_access": {"mode": "allow"}})
+
+
+def test_wasm_validate_config_rejects_dependencies() -> None:
+    """WASM validate_config rejects non-empty packages (dependencies_language=None)."""
+    adapter = _get_adapter("WASM")
+    with pytest.raises(ValidationError, match="capability_violation"):
+        adapter.validate_config({"dependencies": {"packages": ["numpy"]}})
+
+
+# ---------------------------------------------------------------------------
+# Extra keys (extra="allow") round-trip through validate_config
+# ---------------------------------------------------------------------------
+
+_ALL_ADAPTER_KEYS = list(SANDBOX_ADAPTER_METADATA.keys())
+
+
+@pytest.mark.parametrize("adapter_key", _ALL_ADAPTER_KEYS)
+def test_extra_keys_preserved_in_validate_config(adapter_key: str) -> None:
+    """validate_config preserves unknown keys (extra='allow' D9 contract)."""
+    adapter = _get_adapter(adapter_key)
+    config = {"_legacy_field": "some_value"}
+    result = adapter.validate_config(config)
+    assert result.get("_legacy_field") == "some_value"
+
+
+# ---------------------------------------------------------------------------
+# Metadata structural guard — all 7 adapters covered in _ADAPTER_MODULES
+# ---------------------------------------------------------------------------
+
+
+def test_all_metadata_keys_covered_by_adapter_modules() -> None:
+    missing = set(SANDBOX_ADAPTER_METADATA.keys()) - set(_ADAPTER_MODULES.keys())
+    assert not missing, (
+        f"Adapters in SANDBOX_ADAPTER_METADATA are missing from _ADAPTER_MODULES: {missing}. "
+        "Add entries to _ADAPTER_MODULES in this test file."
+    )

--- a/tests/unit/server/sandbox/test_capability_matrix.py
+++ b/tests/unit/server/sandbox/test_capability_matrix.py
@@ -89,30 +89,46 @@ _ADAPTERS_WITHOUT_DEPENDENCIES = [
 ]
 
 
+def _adapter_declares(adapter_key: str, field: str) -> bool:
+    """Return True if the adapter's config_model declares `field` as a pydantic field.
+
+    Under D7 (extra="forbid"), undeclared fields are rejected by pydantic struct
+    validation (surfaced as ValueError by validate_config). Declared-but-unsupported
+    fields are rejected by _enforce_capability_gates (pydantic ValidationError).
+    Tests that want to isolate the gate path must filter to declared-field adapters.
+    """
+    return field in _get_adapter(adapter_key).config_model.model_fields
+
+
 @pytest.mark.parametrize("adapter_key", _ADAPTERS_WITHOUT_ENV_VARS)
 def test_validate_config_rejects_env_vars_when_unsupported(adapter_key: str) -> None:
-    """validate_config raises ValidationError for env_vars on adapters that don't support them."""
+    """validate_config rejects env_vars on adapters that don't support them.
+
+    Two rejection paths are acceptable per D7:
+    - Adapter declares the field but capability=false → gate raises ValidationError
+    - Adapter doesn't declare the field → pydantic extra="forbid" raises, wrapped as ValueError
+    """
     adapter = _get_adapter(adapter_key)
     config = {"env_vars": [{"kind": "literal", "name": "X", "value": "1"}]}
-    with pytest.raises(ValidationError, match="capability_violation"):
+    with pytest.raises((ValidationError, ValueError)):
         adapter.validate_config(config)
 
 
 @pytest.mark.parametrize("adapter_key", _ADAPTERS_WITHOUT_INTERNET_ACCESS)
 def test_validate_config_rejects_internet_access_when_unsupported(adapter_key: str) -> None:
-    """validate_config raises ValidationError for internet_access on adapters with capability=none."""
+    """validate_config rejects internet_access on adapters with capability=none."""
     adapter = _get_adapter(adapter_key)
     config = {"internet_access": {"mode": "allow"}}
-    with pytest.raises(ValidationError, match="capability_violation"):
+    with pytest.raises((ValidationError, ValueError)):
         adapter.validate_config(config)
 
 
 @pytest.mark.parametrize("adapter_key", _ADAPTERS_WITHOUT_DEPENDENCIES)
 def test_validate_config_rejects_dependencies_when_unsupported(adapter_key: str) -> None:
-    """validate_config raises ValidationError for non-empty packages on adapters with no dep support."""
+    """validate_config rejects non-empty packages on adapters with no dep support."""
     adapter = _get_adapter(adapter_key)
     config = {"dependencies": {"packages": ["numpy"]}}
-    with pytest.raises(ValidationError, match="capability_violation"):
+    with pytest.raises((ValidationError, ValueError)):
         adapter.validate_config(config)
 
 
@@ -120,24 +136,32 @@ def test_validate_config_rejects_dependencies_when_unsupported(adapter_key: str)
 # (b) validate_config — stored-config round-trip bypass for unchanged sections
 # ---------------------------------------------------------------------------
 
-_ADAPTERS_WITH_INTERNET_ACCESS_NONE = _ADAPTERS_WITHOUT_INTERNET_ACCESS
-_ADAPTERS_WITHOUT_DEPENDENCIES_SUPPORT = _ADAPTERS_WITHOUT_DEPENDENCIES
+# Stored-config bypass only applies when the adapter actually declares the field
+# on its pydantic config model. For adapters that don't declare a field (WASM for
+# all three; DENO for dependencies), pydantic extra="forbid" rejects the key
+# before _enforce_capability_gates can consult stored_config. Those cases are
+# covered by the undeclared-field rejection tests above, not by bypass tests.
+_ADAPTERS_INTERNET_ACCESS_GATE_PATH = [
+    key for key in _ADAPTERS_WITHOUT_INTERNET_ACCESS if _adapter_declares(key, "internet_access")
+]
+_ADAPTERS_DEPENDENCIES_GATE_PATH = [
+    key for key in _ADAPTERS_WITHOUT_DEPENDENCIES if _adapter_declares(key, "dependencies")
+]
 
 
-@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITH_INTERNET_ACCESS_NONE)
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_INTERNET_ACCESS_GATE_PATH)
 def test_validate_config_stored_config_roundtrip_internet_access(adapter_key: str) -> None:
-    """Unchanged internet_access from stored_config is permitted to round-trip even when capability=none."""
+    """Unchanged internet_access from stored_config round-trips when capability=none and field is declared."""
     adapter = _get_adapter(adapter_key)
     ia_section = {"mode": "allow"}
     config = {"internet_access": ia_section}
-    # Round-trip: same value in stored_config → no capability_violation raised
     result = adapter.validate_config(config, stored_config={"internet_access": ia_section})
     assert result.get("internet_access") is not None
 
 
-@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITHOUT_DEPENDENCIES_SUPPORT)
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_DEPENDENCIES_GATE_PATH)
 def test_validate_config_stored_config_roundtrip_dependencies(adapter_key: str) -> None:
-    """Unchanged dependencies from stored_config are permitted to round-trip even when dep support is None."""
+    """Unchanged dependencies from stored_config round-trip when dep support=None and field is declared."""
     adapter = _get_adapter(adapter_key)
     deps_section = {"packages": ["requests"], "lockfile": None}
     config = {"dependencies": deps_section}
@@ -145,7 +169,7 @@ def test_validate_config_stored_config_roundtrip_dependencies(adapter_key: str) 
     assert result.get("dependencies") is not None
 
 
-@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITH_INTERNET_ACCESS_NONE)
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_INTERNET_ACCESS_GATE_PATH)
 def test_validate_config_changed_internet_access_still_rejected(adapter_key: str) -> None:
     """A changed internet_access section is NOT permitted even with stored_config present."""
     adapter = _get_adapter(adapter_key)
@@ -155,7 +179,7 @@ def test_validate_config_changed_internet_access_still_rejected(adapter_key: str
         adapter.validate_config(new_config, stored_config=stored_config)
 
 
-@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITHOUT_DEPENDENCIES_SUPPORT)
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_DEPENDENCIES_GATE_PATH)
 def test_validate_config_changed_dependencies_still_rejected(adapter_key: str) -> None:
     """Changed packages are NOT permitted even with stored_config present."""
     adapter = _get_adapter(adapter_key)
@@ -195,135 +219,46 @@ def test_build_backend_raises_for_non_empty_packages(adapter_key: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# (d) Positive wiring tests — newly-wired capabilities reach SDK kwargs
+# (d) Positive: supported capabilities validate + build without raising
 # ---------------------------------------------------------------------------
 
-# --- E2B: internet_access_capability="boolean" (wired in Phase 2) ---
-# When internet_access_capability="boolean", the metadata flag is non-"none"
-# so build_backend must NOT raise for a config with internet_access.
-# (Actual SDK forwarding verified in a separate targeted test below.)
+_ADAPTERS_WITH_INTERNET_ACCESS = [
+    key
+    for key, meta in SANDBOX_ADAPTER_METADATA.items()
+    if meta.internet_access_capability != "none"
+]
+_ADAPTERS_WITH_DEPENDENCIES = [
+    key for key, meta in SANDBOX_ADAPTER_METADATA.items() if meta.dependencies_language is not None
+]
 
 
-def test_e2b_build_backend_permits_internet_access_config() -> None:
-    """E2B with internet_access_capability='boolean' accepts internet_access config in build_backend."""
-    meta = SANDBOX_ADAPTER_METADATA["E2B"]
-    assert meta.internet_access_capability == "boolean", (
-        "E2B internet_access_capability must be 'boolean' for this test to be valid; "
-        "check that task #7 has been completed."
-    )
-    adapter = _get_adapter("E2B")
-    # Should not raise UnsupportedOperation (no SDK import in build_backend itself)
-    backend = adapter.build_backend(
-        {"internet_access": {"mode": "allow"}},
-        user_env=None,
-    )
-    assert backend is not None
-
-
-def test_e2b_validate_config_permits_internet_access_when_boolean() -> None:
-    """E2B validate_config does not raise for internet_access when capability='boolean'."""
-    meta = SANDBOX_ADAPTER_METADATA["E2B"]
-    assert meta.internet_access_capability == "boolean"
-    adapter = _get_adapter("E2B")
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITH_INTERNET_ACCESS)
+def test_validate_config_permits_internet_access_when_supported(adapter_key: str) -> None:
+    adapter = _get_adapter(adapter_key)
     result = adapter.validate_config({"internet_access": {"mode": "allow"}})
-    assert result.get("internet_access") == {"mode": "allow"}
+    assert result["internet_access"]["mode"] == "allow"
 
 
-def test_e2b_validate_config_permits_internet_access_deny() -> None:
-    """E2B validate_config allows mode='deny' (blocking internet)."""
-    adapter = _get_adapter("E2B")
-    result = adapter.validate_config({"internet_access": {"mode": "deny"}})
-    assert result["internet_access"]["mode"] == "deny"
-
-
-# --- E2B: dependencies_language=PYTHON (wired in Phase 3, task #8) ---
-
-
-def test_e2b_validate_config_permits_dependencies_when_python() -> None:
-    """When E2B dependencies_language='PYTHON', validate_config accepts non-empty packages."""
-    meta = SANDBOX_ADAPTER_METADATA["E2B"]
-    if meta.dependencies_language is None:
-        pytest.skip("E2B dependencies_language not yet wired (task #8 pending)")
-    assert meta.dependencies_language == "PYTHON"
-    adapter = _get_adapter("E2B")
+@pytest.mark.parametrize("adapter_key", _ADAPTERS_WITH_DEPENDENCIES)
+def test_validate_config_permits_dependencies_when_supported(adapter_key: str) -> None:
+    adapter = _get_adapter(adapter_key)
     result = adapter.validate_config({"dependencies": {"packages": ["requests"]}})
     assert "requests" in result["dependencies"]["packages"]
 
 
-def test_e2b_build_backend_permits_dependencies_when_python() -> None:
-    """When E2B dependencies_language='PYTHON', build_backend does not raise for packages."""
-    meta = SANDBOX_ADAPTER_METADATA["E2B"]
-    if meta.dependencies_language is None:
-        pytest.skip("E2B dependencies_language not yet wired (task #8 pending)")
-    adapter = _get_adapter("E2B")
-    backend = adapter.build_backend({"dependencies": {"packages": ["requests"]}})
-    assert backend is not None
-
-
-# --- DAYTONA_PYTHON: dependencies_language=PYTHON (already wired) ---
+# --- SDK-wiring assertions (irreducible — each SDK has different kwarg names) ---
 
 
 def test_daytona_build_backend_wires_packages_to_backend() -> None:
     """DAYTONA_PYTHON build_backend forwards packages list to DaytonaSandboxBackend._packages."""
-    meta = SANDBOX_ADAPTER_METADATA["DAYTONA_PYTHON"]
-    assert meta.dependencies_language == "PYTHON"
     adapter = _get_adapter("DAYTONA_PYTHON")
     packages = ["requests", "numpy"]
     backend = adapter.build_backend({"dependencies": {"packages": packages}})
     assert backend._packages == packages
 
 
-def test_daytona_validate_config_permits_dependencies() -> None:
-    """DAYTONA_PYTHON validate_config accepts non-empty packages (dependencies_language=PYTHON)."""
-    adapter = _get_adapter("DAYTONA_PYTHON")
-    result = adapter.validate_config({"dependencies": {"packages": ["boto3"]}})
-    assert "boto3" in result["dependencies"]["packages"]
-
-
-# --- MODAL: internet_access_capability wiring (task #9) ---
-
-
-def test_modal_validate_config_internet_access_when_boolean() -> None:
-    """When MODAL internet_access_capability='boolean', validate_config accepts internet_access."""
-    meta = SANDBOX_ADAPTER_METADATA["MODAL"]
-    if meta.internet_access_capability == "none":
-        pytest.skip("MODAL internet_access_capability not yet wired (task #9 pending)")
-    adapter = _get_adapter("MODAL")
-    result = adapter.validate_config({"internet_access": {"mode": "deny"}})
-    assert result["internet_access"]["mode"] == "deny"
-
-
-def test_modal_build_backend_permits_internet_access_when_boolean() -> None:
-    """When MODAL internet_access_capability='boolean', build_backend does not raise for internet_access."""
-    meta = SANDBOX_ADAPTER_METADATA["MODAL"]
-    if meta.internet_access_capability == "none":
-        pytest.skip("MODAL internet_access_capability not yet wired (task #9 pending)")
-    modal_mock = _modal_mock()
-    with patch.dict(sys.modules, {"modal": modal_mock}):
-        adapter = _get_adapter("MODAL")
-        backend = adapter.build_backend({"internet_access": {"mode": "deny"}})
-    assert backend is not None
-
-
-# --- MODAL: dependencies_language=PYTHON (task #10) ---
-
-
-def test_modal_validate_config_dependencies_when_python() -> None:
-    """When MODAL dependencies_language='PYTHON', validate_config accepts non-empty packages."""
-    meta = SANDBOX_ADAPTER_METADATA["MODAL"]
-    if meta.dependencies_language is None:
-        pytest.skip("MODAL dependencies_language not yet wired (task #10 pending)")
-    assert meta.dependencies_language == "PYTHON"
-    adapter = _get_adapter("MODAL")
-    result = adapter.validate_config({"dependencies": {"packages": ["pandas"]}})
-    assert "pandas" in result["dependencies"]["packages"]
-
-
 def test_modal_build_backend_wires_packages_to_image() -> None:
-    """When MODAL dependencies_language='PYTHON', build_backend calls Image.pip_install with packages."""
-    meta = SANDBOX_ADAPTER_METADATA["MODAL"]
-    if meta.dependencies_language is None:
-        pytest.skip("MODAL dependencies_language not yet wired (task #10 pending)")
+    """MODAL build_backend calls Image.pip_install with packages."""
     modal_mock = _modal_mock()
     pip_image = MagicMock()
     modal_mock.Image.debian_slim.return_value.pip_install.return_value = pip_image
@@ -335,57 +270,20 @@ def test_modal_build_backend_wires_packages_to_image() -> None:
     assert backend._image is pip_image
 
 
-# --- DAYTONA_PYTHON: internet_access_capability wiring (task #5/#6) ---
-
-
-def test_daytona_validate_config_internet_access_when_boolean() -> None:
-    """When DAYTONA_PYTHON internet_access_capability='boolean', validate_config accepts internet_access."""
-    meta = SANDBOX_ADAPTER_METADATA["DAYTONA_PYTHON"]
-    if meta.internet_access_capability == "none":
-        pytest.skip("DAYTONA_PYTHON internet_access_capability not yet wired (tasks #5/#6 pending)")
-    adapter = _get_adapter("DAYTONA_PYTHON")
-    result = adapter.validate_config({"internet_access": {"mode": "deny"}})
-    assert result["internet_access"]["mode"] == "deny"
-
-
-# --- WASM: env_vars=False — always rejected at both gates ---
-
-
-def test_wasm_validate_config_rejects_env_vars() -> None:
-    """WASM validate_config rejects env_vars (supports_env_vars=False)."""
-    adapter = _get_adapter("WASM")
-    with pytest.raises(ValidationError, match="capability_violation"):
-        adapter.validate_config({"env_vars": [{"kind": "literal", "name": "X", "value": "v"}]})
-
-
-def test_wasm_validate_config_rejects_internet_access() -> None:
-    """WASM validate_config rejects internet_access (capability=none)."""
-    adapter = _get_adapter("WASM")
-    with pytest.raises(ValidationError, match="capability_violation"):
-        adapter.validate_config({"internet_access": {"mode": "allow"}})
-
-
-def test_wasm_validate_config_rejects_dependencies() -> None:
-    """WASM validate_config rejects non-empty packages (dependencies_language=None)."""
-    adapter = _get_adapter("WASM")
-    with pytest.raises(ValidationError, match="capability_violation"):
-        adapter.validate_config({"dependencies": {"packages": ["numpy"]}})
-
-
 # ---------------------------------------------------------------------------
-# Extra keys (extra="allow") round-trip through validate_config
+# Extra keys (extra="forbid") rejected by validate_config
 # ---------------------------------------------------------------------------
 
 _ALL_ADAPTER_KEYS = list(SANDBOX_ADAPTER_METADATA.keys())
 
 
 @pytest.mark.parametrize("adapter_key", _ALL_ADAPTER_KEYS)
-def test_extra_keys_preserved_in_validate_config(adapter_key: str) -> None:
-    """validate_config preserves unknown keys (extra='allow' D9 contract)."""
+def test_extra_keys_rejected_in_validate_config(adapter_key: str) -> None:
+    """validate_config rejects unknown keys (extra='forbid' D10 contract)."""
     adapter = _get_adapter(adapter_key)
-    config = {"_legacy_field": "some_value"}
-    result = adapter.validate_config(config)
-    assert result.get("_legacy_field") == "some_value"
+    config = {"_unknown_field": "some_value"}
+    with pytest.raises(ValueError):
+        adapter.validate_config(config)
 
 
 # ---------------------------------------------------------------------------
@@ -399,3 +297,28 @@ def test_all_metadata_keys_covered_by_adapter_modules() -> None:
         f"Adapters in SANDBOX_ADAPTER_METADATA are missing from _ADAPTER_MODULES: {missing}. "
         "Add entries to _ADAPTER_MODULES in this test file."
     )
+
+
+# ---------------------------------------------------------------------------
+# Removed scalar fields rejected by validate_config (extra="forbid" D10)
+# ---------------------------------------------------------------------------
+
+_REMOVED_FIELD_CASES = [
+    ("E2B", "template", "custom-template"),
+    ("E2B", "cwd", "/workspace"),
+    ("E2B", "metadata", "some-metadata"),
+    ("DAYTONA_PYTHON", "server_url", "https://example.com"),
+    ("MODAL", "app_name", "my-app"),
+    ("MODAL", "timeout", 300),
+    ("MODAL", "idle_timeout", 120),
+]
+
+
+@pytest.mark.parametrize("adapter_key,field,value", _REMOVED_FIELD_CASES)
+def test_removed_scalar_fields_rejected_by_validate_config(
+    adapter_key: str, field: str, value: object
+) -> None:
+    """Removed non-capability fields are no longer accepted by validate_config."""
+    adapter = _get_adapter(adapter_key)
+    with pytest.raises(ValueError):
+        adapter.validate_config({field: value})

--- a/tests/unit/server/sandbox/test_daytona_backend.py
+++ b/tests/unit/server/sandbox/test_daytona_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -30,7 +31,9 @@ def _make_daytona_mocks() -> tuple[MagicMock, MagicMock]:
     workspace.process.code_run = AsyncMock(
         return_value=MagicMock(stdout="ok", stderr="", exit_code=0)
     )
-    daytona_mod.Daytona.return_value.create = AsyncMock(return_value=workspace)
+    client = daytona_mod.Daytona.return_value
+    client.create = AsyncMock(return_value=workspace)
+    client.remove = AsyncMock()
 
     return daytona_mod, process_mod
 
@@ -158,3 +161,60 @@ class TestNetworkBlockAll:
         assert create_call.kwargs.get("network_block_all") is True, (
             f"Expected network_block_all=True in start_session path; got {create_call.kwargs}"
         )
+
+
+class TestEphemeralTeardown:
+    """Verify that ephemeral execute() always removes the workspace, even on failure or cancel."""
+
+    @pytest.mark.asyncio
+    async def test_remove_called_when_code_run_raises(self) -> None:
+        """client.remove() is called exactly once when code_run raises."""
+        daytona_mod, process_mod = _make_daytona_mocks()
+        client = daytona_mod.Daytona.return_value
+        client.create.return_value.process.code_run = AsyncMock(
+            side_effect=RuntimeError("code_run failed")
+        )
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            backend = DaytonaSandboxBackend(api_key="test-key")
+            result = await backend.execute("raise RuntimeError()", session_key="ephemeral")
+
+        assert result.error is not None
+        assert client.create.call_count == 1
+        assert client.remove.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_remove_called_on_cancellation(self) -> None:
+        """client.remove() is called when the coroutine is cancelled via asyncio.wait_for."""
+        daytona_mod, process_mod = _make_daytona_mocks()
+        client = daytona_mod.Daytona.return_value
+
+        async def _slow_code_run(*args: object, **kwargs: object) -> None:
+            await asyncio.sleep(10)
+
+        client.create.return_value.process.code_run = AsyncMock(side_effect=_slow_code_run)
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            backend = DaytonaSandboxBackend(api_key="test-key")
+            with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+                await asyncio.wait_for(
+                    backend.execute("sleep(10)", session_key="ephemeral"),
+                    timeout=0.05,
+                )
+
+        assert client.create.call_count == 1
+        assert client.remove.call_count == 1

--- a/tests/unit/server/sandbox/test_daytona_backend.py
+++ b/tests/unit/server/sandbox/test_daytona_backend.py
@@ -1,0 +1,160 @@
+"""Unit tests for DaytonaSandboxBackend code_run kwarg correctness."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class _CodeRunParams:
+    """Minimal stand-in for daytona_sdk.common.process.CodeRunParams."""
+
+    def __init__(
+        self,
+        argv: list[str] | None = None,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        self.argv = argv
+        self.env = env
+
+
+def _make_daytona_mocks() -> tuple[MagicMock, MagicMock]:
+    """Return (daytona_sdk mock, daytona_sdk.common.process mock)."""
+    process_mod = MagicMock()
+    process_mod.CodeRunParams = _CodeRunParams
+
+    daytona_mod = MagicMock()
+    workspace = MagicMock()
+    workspace.process.code_run = AsyncMock(
+        return_value=MagicMock(stdout="ok", stderr="", exit_code=0)
+    )
+    daytona_mod.Daytona.return_value.create = AsyncMock(return_value=workspace)
+
+    return daytona_mod, process_mod
+
+
+class TestCodeRunParamsKwarg:
+    @pytest.mark.asyncio
+    async def test_execute_passes_params_not_envs(self) -> None:
+        """code_run must receive params=CodeRunParams(env=...) instead of envs=."""
+        daytona_mod, process_mod = _make_daytona_mocks()
+        user_env = {"MY_KEY": "my_val"}
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            backend = DaytonaSandboxBackend(api_key="test-key", user_env=user_env)
+            await backend.execute("print('hi')", session_key="s1")
+
+        workspace = daytona_mod.Daytona.return_value.create.return_value
+        call_args = workspace.process.code_run.call_args
+        assert call_args is not None, "code_run was never called"
+
+        assert "envs" not in call_args.kwargs, (
+            f"code_run received deprecated 'envs' kwarg: {call_args.kwargs}"
+        )
+        assert "params" in call_args.kwargs, (
+            f"code_run missing 'params' kwarg; got: {call_args.kwargs}"
+        )
+        params = call_args.kwargs["params"]
+        assert isinstance(params, _CodeRunParams), (
+            f"params is {type(params)}, expected _CodeRunParams"
+        )
+        assert params.env == user_env, f"params.env={params.env!r}, expected {user_env!r}"
+
+    @pytest.mark.asyncio
+    async def test_execute_empty_user_env_passes_none_env(self) -> None:
+        """Empty user_env must produce params.env=None, not an empty dict."""
+        daytona_mod, process_mod = _make_daytona_mocks()
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            backend = DaytonaSandboxBackend(api_key="test-key", user_env={})
+            await backend.execute("1+1", session_key="s1")
+
+        workspace = daytona_mod.Daytona.return_value.create.return_value
+        call_args = workspace.process.code_run.call_args
+        params = call_args.kwargs["params"]
+        assert isinstance(params, _CodeRunParams)
+        assert params.env is None, (
+            f"Expected params.env=None for empty user_env, got {params.env!r}"
+        )
+
+
+class TestNetworkBlockAll:
+    @pytest.mark.asyncio
+    async def test_deny_mode_passes_network_block_all_true(self) -> None:
+        """internet_access.mode='deny' → client.create() receives network_block_all=True."""
+        daytona_mod, process_mod = _make_daytona_mocks()
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            backend = DaytonaSandboxBackend(api_key="key", network_block_all=True)
+            await backend.execute("1", session_key="s1")
+
+        create_call = daytona_mod.Daytona.return_value.create.call_args
+        assert create_call is not None, "client.create() was never called"
+        assert create_call.kwargs.get("network_block_all") is True, (
+            f"Expected network_block_all=True; got {create_call.kwargs}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_allow_mode_omits_network_block_all(self) -> None:
+        """internet_access.mode='allow' → network_block_all NOT passed to client.create()."""
+        daytona_mod, process_mod = _make_daytona_mocks()
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            backend = DaytonaSandboxBackend(api_key="key", network_block_all=False)
+            await backend.execute("1", session_key="s1")
+
+        create_call = daytona_mod.Daytona.return_value.create.call_args
+        assert "network_block_all" not in create_call.kwargs, (
+            f"network_block_all should be absent when mode != 'deny'; got {create_call.kwargs}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_session_deny_passes_network_block_all(self) -> None:
+        """start_session also passes network_block_all=True to client.create() when deny mode."""
+        daytona_mod, process_mod = _make_daytona_mocks()
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            backend = DaytonaSandboxBackend(api_key="key", network_block_all=True)
+            await backend.start_session("sess")
+
+        create_call = daytona_mod.Daytona.return_value.create.call_args
+        assert create_call.kwargs.get("network_block_all") is True, (
+            f"Expected network_block_all=True in start_session path; got {create_call.kwargs}"
+        )

--- a/tests/unit/server/sandbox/test_deno_backend.py
+++ b/tests/unit/server/sandbox/test_deno_backend.py
@@ -98,6 +98,7 @@ class TestDenoSandboxBackend:
         assert result.stderr == ""
         assert result.error is None
         proc.communicate.assert_awaited_once_with(b"console.log('ok')")
+        assert create_subprocess_exec.await_args is not None
         assert create_subprocess_exec.await_args.kwargs["env"] == {
             "TOKEN": "secret",
             "FOO": "bar",
@@ -174,4 +175,5 @@ class TestDenoSandboxBackend:
 
         assert result.stdout == ""
         assert "Deno executable not found" in result.stderr
+        assert result.error is not None
         assert "Deno executable not found" in result.error

--- a/tests/unit/server/sandbox/test_deno_backend.py
+++ b/tests/unit/server/sandbox/test_deno_backend.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from phoenix.server.sandbox.deno_backend import DenoAdapter, DenoSandboxBackend
+
+
+class _StubProcess:
+    def __init__(
+        self,
+        *,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+        returncode: int = 0,
+    ) -> None:
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+        self.communicate = AsyncMock(return_value=(stdout, stderr))
+        self.kill = MagicMock()
+        self.wait = AsyncMock()
+
+
+class TestDenoAdapter:
+    def test_build_backend_requires_deno_on_path(self) -> None:
+        adapter = DenoAdapter()
+
+        with patch("phoenix.server.sandbox.deno_backend.shutil.which", return_value=None):
+            with pytest.raises(ValueError, match="Deno is not installed"):
+                adapter.build_backend({})
+
+    def test_build_backend_uses_resolved_deno_path(self) -> None:
+        adapter = DenoAdapter()
+
+        with patch(
+            "phoenix.server.sandbox.deno_backend.shutil.which",
+            return_value="/opt/homebrew/bin/deno",
+        ):
+            backend = adapter.build_backend({}, user_env={"TOKEN": "value"})
+
+        assert isinstance(backend, DenoSandboxBackend)
+        assert backend._build_command() == [
+            "/opt/homebrew/bin/deno",
+            "run",
+            "--no-prompt",
+            "--no-config",
+            "--no-remote",
+            "--no-npm",
+            "--allow-env=TOKEN",
+            "-",
+        ]
+
+
+class TestDenoSandboxBackend:
+    def test_build_command_scopes_env_permissions_exactly(self) -> None:
+        backend = DenoSandboxBackend(
+            deno_executable="/usr/local/bin/deno",
+            user_env={"B": "2", "A": "1"},
+        )
+
+        assert backend._build_command() == [
+            "/usr/local/bin/deno",
+            "run",
+            "--no-prompt",
+            "--no-config",
+            "--no-remote",
+            "--no-npm",
+            "--allow-env=A,B",
+            "-",
+        ]
+
+    def test_build_subprocess_env_includes_only_user_env(self) -> None:
+        backend = DenoSandboxBackend(
+            deno_executable="/usr/local/bin/deno",
+            user_env={"SECRET": "value"},
+        )
+
+        assert backend._build_subprocess_env() == {"SECRET": "value"}
+
+    @pytest.mark.asyncio
+    async def test_execute_successfully_runs_deno_process(self) -> None:
+        backend = DenoSandboxBackend(
+            deno_executable="/usr/local/bin/deno",
+            user_env={"TOKEN": "secret", "FOO": "bar"},
+        )
+        proc = _StubProcess(stdout=b"ok\n", stderr=b"", returncode=0)
+
+        with patch(
+            "phoenix.server.sandbox.deno_backend.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ) as create_subprocess_exec:
+            result = await backend.execute("console.log('ok')", session_key="test", timeout=5)
+
+        assert result.stdout == "ok\n"
+        assert result.stderr == ""
+        assert result.error is None
+        proc.communicate.assert_awaited_once_with(b"console.log('ok')")
+        assert create_subprocess_exec.await_args.kwargs["env"] == {
+            "TOKEN": "secret",
+            "FOO": "bar",
+        }
+        assert create_subprocess_exec.await_args.args == (
+            "/usr/local/bin/deno",
+            "run",
+            "--no-prompt",
+            "--no-config",
+            "--no-remote",
+            "--no-npm",
+            "--allow-env=FOO,TOKEN",
+            "-",
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_nonzero_exit_returns_error(self) -> None:
+        backend = DenoSandboxBackend(deno_executable="/usr/local/bin/deno")
+        proc = _StubProcess(stderr=b"permission denied\n", returncode=1)
+
+        with patch(
+            "phoenix.server.sandbox.deno_backend.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ):
+            result = await backend.execute("console.log('x')", session_key="test", timeout=5)
+
+        assert result.stdout == ""
+        assert result.stderr == "permission denied\n"
+        assert result.error == "permission denied\n"
+
+    @pytest.mark.asyncio
+    async def test_execute_strips_ansi_sequences_from_stderr(self) -> None:
+        backend = DenoSandboxBackend(deno_executable="/usr/local/bin/deno")
+        proc = _StubProcess(
+            stderr=(b"\x1b[0m\x1b[1m\x1b[31merror\x1b[0m: Uncaught (in promise) NotCapable\n"),
+            returncode=1,
+        )
+
+        with patch(
+            "phoenix.server.sandbox.deno_backend.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ):
+            result = await backend.execute("console.log('x')", session_key="test", timeout=5)
+
+        assert result.stderr == "error: Uncaught (in promise) NotCapable\n"
+        assert result.error == "error: Uncaught (in promise) NotCapable\n"
+
+    @pytest.mark.asyncio
+    async def test_execute_timeout_kills_process_and_returns_error(self) -> None:
+        backend = DenoSandboxBackend(deno_executable="/usr/local/bin/deno")
+        proc = _StubProcess()
+        proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+
+        with patch(
+            "phoenix.server.sandbox.deno_backend.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ):
+            result = await backend.execute("console.log('x')", session_key="test", timeout=7)
+
+        proc.kill.assert_called_once_with()
+        proc.wait.assert_awaited_once()
+        assert result.error == "Execution timed out after 7s"
+        assert result.stderr == "Execution timed out after 7s"
+
+    @pytest.mark.asyncio
+    async def test_execute_missing_binary_returns_error(self) -> None:
+        backend = DenoSandboxBackend(deno_executable="/missing/deno")
+
+        with patch(
+            "phoenix.server.sandbox.deno_backend.asyncio.create_subprocess_exec",
+            AsyncMock(side_effect=FileNotFoundError),
+        ):
+            result = await backend.execute("console.log('x')", session_key="test", timeout=5)
+
+        assert result.stdout == ""
+        assert "Deno executable not found" in result.stderr
+        assert "Deno executable not found" in result.error

--- a/tests/unit/server/sandbox/test_e2b_backend.py
+++ b/tests/unit/server/sandbox/test_e2b_backend.py
@@ -1,0 +1,201 @@
+"""Unit tests for E2BSandboxBackend and E2BAdapter."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from phoenix.server.sandbox import SANDBOX_ADAPTER_METADATA
+from phoenix.server.sandbox.e2b_backend import E2BAdapter, E2BSandboxBackend
+
+
+def _make_mock_sandbox_cls(create_result: Any = None) -> MagicMock:
+    """Return a mock AsyncSandbox class with a tracked create() coroutine."""
+    sandbox_instance = MagicMock()
+    sandbox_instance.run_code = AsyncMock(
+        return_value=MagicMock(
+            logs=MagicMock(stdout=[], stderr=[]),
+            error=None,
+        )
+    )
+    sandbox_instance.close = AsyncMock()
+    sandbox_cls = MagicMock()
+    sandbox_cls.create = AsyncMock(return_value=create_result or sandbox_instance)
+    return sandbox_cls
+
+
+# ---------------------------------------------------------------------------
+# Metadata contract
+# ---------------------------------------------------------------------------
+
+
+def test_e2b_internet_access_capability_is_boolean() -> None:
+    assert SANDBOX_ADAPTER_METADATA["E2B"].internet_access_capability == "boolean"
+
+
+# ---------------------------------------------------------------------------
+# _create_kwargs / allow_internet_access
+# ---------------------------------------------------------------------------
+
+
+def test_create_kwargs_allow_internet_access_default_true() -> None:
+    backend = E2BSandboxBackend(api_key="k", template="base")
+    kwargs = backend._create_kwargs()
+    assert kwargs["allow_internet_access"] is True
+
+
+def test_create_kwargs_allow_internet_access_false_when_set() -> None:
+    backend = E2BSandboxBackend(api_key="k", template="base", allow_internet_access=False)
+    kwargs = backend._create_kwargs()
+    assert kwargs["allow_internet_access"] is False
+
+
+# ---------------------------------------------------------------------------
+# build_backend → AsyncSandbox.create receives correct allow_internet_access
+# ---------------------------------------------------------------------------
+
+
+def _build_and_get_create_kwargs(config: dict[str, Any]) -> dict[str, Any]:
+    """Build a backend from config and return the kwargs passed to AsyncSandbox.create()."""
+    adapter = E2BAdapter()
+    backend: E2BSandboxBackend = adapter.build_backend(config)  # type: ignore[assignment]
+    return backend._create_kwargs()
+
+
+def test_build_backend_deny_mode_passes_allow_internet_access_false() -> None:
+    config = {
+        "PHOENIX_SANDBOX_E2B_API_KEY": "test-key",
+        "internet_access": {"mode": "deny"},
+    }
+    kwargs = _build_and_get_create_kwargs(config)
+    assert kwargs["allow_internet_access"] is False
+
+
+def test_build_backend_allow_mode_passes_allow_internet_access_true() -> None:
+    config = {
+        "PHOENIX_SANDBOX_E2B_API_KEY": "test-key",
+        "internet_access": {"mode": "allow"},
+    }
+    kwargs = _build_and_get_create_kwargs(config)
+    assert kwargs["allow_internet_access"] is True
+
+
+def test_build_backend_no_internet_access_block_defaults_to_true() -> None:
+    config = {"PHOENIX_SANDBOX_E2B_API_KEY": "test-key"}
+    kwargs = _build_and_get_create_kwargs(config)
+    assert kwargs["allow_internet_access"] is True
+
+
+# ---------------------------------------------------------------------------
+# start_session forwards allow_internet_access to AsyncSandbox.create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_session_deny_passes_allow_internet_access_false() -> None:
+    mock_cls = _make_mock_sandbox_cls()
+    backend = E2BSandboxBackend(api_key="k", template="base", allow_internet_access=False)
+    with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
+        await backend.start_session("s1")
+    call_kwargs = mock_cls.create.call_args.kwargs
+    assert call_kwargs["allow_internet_access"] is False
+
+
+@pytest.mark.asyncio
+async def test_start_session_allow_passes_allow_internet_access_true() -> None:
+    mock_cls = _make_mock_sandbox_cls()
+    backend = E2BSandboxBackend(api_key="k", template="base", allow_internet_access=True)
+    with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
+        await backend.start_session("s1")
+    call_kwargs = mock_cls.create.call_args.kwargs
+    assert call_kwargs["allow_internet_access"] is True
+
+
+# ---------------------------------------------------------------------------
+# dependencies_language metadata
+# ---------------------------------------------------------------------------
+
+
+def test_e2b_dependencies_language_is_python() -> None:
+    assert SANDBOX_ADAPTER_METADATA["E2B"].dependencies_language == "PYTHON"
+
+
+# ---------------------------------------------------------------------------
+# _install_packages / packages wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_session_with_packages_calls_run_code() -> None:
+    """packages=["cowsay"] must trigger a run_code pip install call."""
+    mock_cls = _make_mock_sandbox_cls()
+    backend = E2BSandboxBackend(api_key="k", template="base", packages=["cowsay"])
+    with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
+        await backend.start_session("s1")
+    sandbox_instance = mock_cls.create.return_value
+    sandbox_instance.run_code.assert_called_once()
+    code_arg = sandbox_instance.run_code.call_args.args[0]
+    assert "pip" in code_arg
+    assert "cowsay" in code_arg
+
+
+@pytest.mark.asyncio
+async def test_start_session_no_packages_skips_run_code() -> None:
+    """No packages → run_code must NOT be called during start_session."""
+    mock_cls = _make_mock_sandbox_cls()
+    backend = E2BSandboxBackend(api_key="k", template="base", packages=None)
+    with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
+        await backend.start_session("s1")
+    sandbox_instance = mock_cls.create.return_value
+    sandbox_instance.run_code.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_start_session_install_failure_propagates_and_session_absent() -> None:
+    """If run_code returns an error, start_session must raise and not cache the session."""
+    error_result = MagicMock(
+        logs=MagicMock(stdout=[], stderr=[]),
+        error="ModuleNotFoundError: No module named pip",
+    )
+    mock_cls = _make_mock_sandbox_cls()
+    mock_cls.create.return_value.run_code = AsyncMock(return_value=error_result)
+
+    backend = E2BSandboxBackend(api_key="k", template="base", packages=["bad-pkg"])
+    with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
+        with pytest.raises(RuntimeError):
+            await backend.start_session("s1")
+    assert "s1" not in backend._sessions
+
+
+@pytest.mark.asyncio
+async def test_package_with_shell_metachar_is_quoted() -> None:
+    """A package name containing shell metacharacters must be shlex-quoted, not raw-interpolated."""
+    # This would be dangerous if passed as raw shell: "evil; rm -rf /"
+    # shlex.quote produces "'evil; rm -rf /'" — harmless as a Python string literal
+    mock_cls = _make_mock_sandbox_cls()
+    backend = E2BSandboxBackend(api_key="k", template="base", packages=["evil; rm -rf /"])
+    with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
+        await backend.start_session("s1")
+    sandbox_instance = mock_cls.create.return_value
+    code_arg = sandbox_instance.run_code.call_args.args[0]
+    # The metachar must appear only inside a quoted form, not raw
+    assert "rm -rf /" not in code_arg or "'evil; rm -rf /'" in code_arg
+
+
+def test_build_backend_with_packages_wires_to_backend() -> None:
+    """build_backend with dependencies.packages passes them to E2BSandboxBackend._packages."""
+    adapter = E2BAdapter()
+    backend: E2BSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
+        {"PHOENIX_SANDBOX_E2B_API_KEY": "k", "dependencies": {"packages": ["cowsay"]}}
+    )
+    assert backend._packages == ["cowsay"]
+
+
+def test_build_backend_without_packages_empty_packages() -> None:
+    adapter = E2BAdapter()
+    backend: E2BSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
+        {"PHOENIX_SANDBOX_E2B_API_KEY": "k"}
+    )
+    assert backend._packages == []

--- a/tests/unit/server/sandbox/test_e2b_backend.py
+++ b/tests/unit/server/sandbox/test_e2b_backend.py
@@ -1,4 +1,8 @@
-"""Unit tests for E2BSandboxBackend and E2BAdapter."""
+"""Unit tests for E2BSandboxBackend and E2BAdapter.
+
+Scope: E2B-specific SDK kwarg shapes and pip-install-via-run_code wiring.
+Metadata and cross-adapter rejection coverage lives in test_capability_matrix.py.
+"""
 
 from __future__ import annotations
 
@@ -7,18 +11,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from phoenix.server.sandbox import SANDBOX_ADAPTER_METADATA
 from phoenix.server.sandbox.e2b_backend import E2BAdapter, E2BSandboxBackend
 
 
 def _make_mock_sandbox_cls(create_result: Any = None) -> MagicMock:
-    """Return a mock AsyncSandbox class with a tracked create() coroutine."""
     sandbox_instance = MagicMock()
     sandbox_instance.run_code = AsyncMock(
-        return_value=MagicMock(
-            logs=MagicMock(stdout=[], stderr=[]),
-            error=None,
-        )
+        return_value=MagicMock(logs=MagicMock(stdout=[], stderr=[]), error=None)
     )
     sandbox_instance.close = AsyncMock()
     sandbox_cls = MagicMock()
@@ -26,110 +25,50 @@ def _make_mock_sandbox_cls(create_result: Any = None) -> MagicMock:
     return sandbox_cls
 
 
-# ---------------------------------------------------------------------------
-# Metadata contract
-# ---------------------------------------------------------------------------
-
-
-def test_e2b_internet_access_capability_is_boolean() -> None:
-    assert SANDBOX_ADAPTER_METADATA["E2B"].internet_access_capability == "boolean"
-
-
-# ---------------------------------------------------------------------------
-# _create_kwargs / allow_internet_access
-# ---------------------------------------------------------------------------
-
-
-def test_create_kwargs_allow_internet_access_default_true() -> None:
+def test_create_kwargs_defaults_to_allow_true() -> None:
+    """Default allow_internet_access must be True when not specified."""
     backend = E2BSandboxBackend(api_key="k", template="base")
-    kwargs = backend._create_kwargs()
-    assert kwargs["allow_internet_access"] is True
+    assert backend._create_kwargs()["allow_internet_access"] is True
 
 
-def test_create_kwargs_allow_internet_access_false_when_set() -> None:
-    backend = E2BSandboxBackend(api_key="k", template="base", allow_internet_access=False)
-    kwargs = backend._create_kwargs()
-    assert kwargs["allow_internet_access"] is False
+@pytest.mark.parametrize("allow", [True, False])
+def test_create_kwargs_forwards_allow_internet_access(allow: bool) -> None:
+    backend = E2BSandboxBackend(api_key="k", template="base", allow_internet_access=allow)
+    assert backend._create_kwargs()["allow_internet_access"] is allow
 
 
-# ---------------------------------------------------------------------------
-# build_backend → AsyncSandbox.create receives correct allow_internet_access
-# ---------------------------------------------------------------------------
-
-
-def _build_and_get_create_kwargs(config: dict[str, Any]) -> dict[str, Any]:
-    """Build a backend from config and return the kwargs passed to AsyncSandbox.create()."""
+@pytest.mark.parametrize(
+    "config,expected",
+    [
+        ({"internet_access": {"mode": "deny"}}, False),
+        ({"internet_access": {"mode": "allow"}}, True),
+        ({}, True),  # no internet_access → default permissive
+    ],
+)
+def test_build_backend_translates_internet_access_to_allow_flag(
+    config: dict[str, Any], expected: bool
+) -> None:
+    """E2BAdapter.build_backend translates internet_access.mode → allow_internet_access kwarg."""
     adapter = E2BAdapter()
-    backend: E2BSandboxBackend = adapter.build_backend(config)  # type: ignore[assignment]
-    return backend._create_kwargs()
-
-
-def test_build_backend_deny_mode_passes_allow_internet_access_false() -> None:
-    config = {
-        "PHOENIX_SANDBOX_E2B_API_KEY": "test-key",
-        "internet_access": {"mode": "deny"},
-    }
-    kwargs = _build_and_get_create_kwargs(config)
-    assert kwargs["allow_internet_access"] is False
-
-
-def test_build_backend_allow_mode_passes_allow_internet_access_true() -> None:
-    config = {
-        "PHOENIX_SANDBOX_E2B_API_KEY": "test-key",
-        "internet_access": {"mode": "allow"},
-    }
-    kwargs = _build_and_get_create_kwargs(config)
-    assert kwargs["allow_internet_access"] is True
-
-
-def test_build_backend_no_internet_access_block_defaults_to_true() -> None:
-    config = {"PHOENIX_SANDBOX_E2B_API_KEY": "test-key"}
-    kwargs = _build_and_get_create_kwargs(config)
-    assert kwargs["allow_internet_access"] is True
-
-
-# ---------------------------------------------------------------------------
-# start_session forwards allow_internet_access to AsyncSandbox.create
-# ---------------------------------------------------------------------------
+    backend: E2BSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
+        {"PHOENIX_SANDBOX_E2B_API_KEY": "k", **config}
+    )
+    assert backend._create_kwargs()["allow_internet_access"] is expected
 
 
 @pytest.mark.asyncio
-async def test_start_session_deny_passes_allow_internet_access_false() -> None:
+@pytest.mark.parametrize("allow", [True, False])
+async def test_start_session_forwards_allow_internet_access(allow: bool) -> None:
     mock_cls = _make_mock_sandbox_cls()
-    backend = E2BSandboxBackend(api_key="k", template="base", allow_internet_access=False)
+    backend = E2BSandboxBackend(api_key="k", template="base", allow_internet_access=allow)
     with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
         await backend.start_session("s1")
-    call_kwargs = mock_cls.create.call_args.kwargs
-    assert call_kwargs["allow_internet_access"] is False
+    assert mock_cls.create.call_args.kwargs["allow_internet_access"] is allow
 
 
 @pytest.mark.asyncio
-async def test_start_session_allow_passes_allow_internet_access_true() -> None:
-    mock_cls = _make_mock_sandbox_cls()
-    backend = E2BSandboxBackend(api_key="k", template="base", allow_internet_access=True)
-    with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
-        await backend.start_session("s1")
-    call_kwargs = mock_cls.create.call_args.kwargs
-    assert call_kwargs["allow_internet_access"] is True
-
-
-# ---------------------------------------------------------------------------
-# dependencies_language metadata
-# ---------------------------------------------------------------------------
-
-
-def test_e2b_dependencies_language_is_python() -> None:
-    assert SANDBOX_ADAPTER_METADATA["E2B"].dependencies_language == "PYTHON"
-
-
-# ---------------------------------------------------------------------------
-# _install_packages / packages wiring
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_start_session_with_packages_calls_run_code() -> None:
-    """packages=["cowsay"] must trigger a run_code pip install call."""
+async def test_start_session_installs_packages_via_run_code() -> None:
+    """Non-empty packages trigger a pip install run_code; absent otherwise."""
     mock_cls = _make_mock_sandbox_cls()
     backend = E2BSandboxBackend(api_key="k", template="base", packages=["cowsay"])
     with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
@@ -137,31 +76,27 @@ async def test_start_session_with_packages_calls_run_code() -> None:
     sandbox_instance = mock_cls.create.return_value
     sandbox_instance.run_code.assert_called_once()
     code_arg = sandbox_instance.run_code.call_args.args[0]
-    assert "pip" in code_arg
-    assert "cowsay" in code_arg
+    assert "pip" in code_arg and "cowsay" in code_arg
 
 
 @pytest.mark.asyncio
-async def test_start_session_no_packages_skips_run_code() -> None:
-    """No packages → run_code must NOT be called during start_session."""
+async def test_start_session_without_packages_skips_run_code() -> None:
     mock_cls = _make_mock_sandbox_cls()
     backend = E2BSandboxBackend(api_key="k", template="base", packages=None)
     with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
         await backend.start_session("s1")
-    sandbox_instance = mock_cls.create.return_value
-    sandbox_instance.run_code.assert_not_called()
+    mock_cls.create.return_value.run_code.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_start_session_install_failure_propagates_and_session_absent() -> None:
-    """If run_code returns an error, start_session must raise and not cache the session."""
-    error_result = MagicMock(
-        logs=MagicMock(stdout=[], stderr=[]),
-        error="ModuleNotFoundError: No module named pip",
-    )
+async def test_pip_install_failure_raises_and_leaves_no_cached_session() -> None:
     mock_cls = _make_mock_sandbox_cls()
-    mock_cls.create.return_value.run_code = AsyncMock(return_value=error_result)
-
+    mock_cls.create.return_value.run_code = AsyncMock(
+        return_value=MagicMock(
+            logs=MagicMock(stdout=[], stderr=[]),
+            error="ModuleNotFoundError: No module named pip",
+        )
+    )
     backend = E2BSandboxBackend(api_key="k", template="base", packages=["bad-pkg"])
     with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
         with pytest.raises(RuntimeError):
@@ -170,32 +105,27 @@ async def test_start_session_install_failure_propagates_and_session_absent() -> 
 
 
 @pytest.mark.asyncio
-async def test_package_with_shell_metachar_is_quoted() -> None:
-    """A package name containing shell metacharacters must be shlex-quoted, not raw-interpolated."""
-    # This would be dangerous if passed as raw shell: "evil; rm -rf /"
-    # shlex.quote produces "'evil; rm -rf /'" — harmless as a Python string literal
+async def test_package_names_with_shell_metachars_are_quoted() -> None:
+    """Shell injection guard: a package name with metachars must not be interpolated raw."""
     mock_cls = _make_mock_sandbox_cls()
     backend = E2BSandboxBackend(api_key="k", template="base", packages=["evil; rm -rf /"])
     with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
         await backend.start_session("s1")
-    sandbox_instance = mock_cls.create.return_value
-    code_arg = sandbox_instance.run_code.call_args.args[0]
-    # The metachar must appear only inside a quoted form, not raw
+    code_arg = mock_cls.create.return_value.run_code.call_args.args[0]
+    # metacharacters may only appear inside a shell-quoted form
     assert "rm -rf /" not in code_arg or "'evil; rm -rf /'" in code_arg
 
 
-def test_build_backend_with_packages_wires_to_backend() -> None:
-    """build_backend with dependencies.packages passes them to E2BSandboxBackend._packages."""
+@pytest.mark.parametrize(
+    "config,expected_packages",
+    [
+        ({"dependencies": {"packages": ["cowsay"]}}, ["cowsay"]),
+        ({}, []),
+    ],
+)
+def test_build_backend_wires_packages(config: dict[str, Any], expected_packages: list[str]) -> None:
     adapter = E2BAdapter()
     backend: E2BSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
-        {"PHOENIX_SANDBOX_E2B_API_KEY": "k", "dependencies": {"packages": ["cowsay"]}}
+        {"PHOENIX_SANDBOX_E2B_API_KEY": "k", **config}
     )
-    assert backend._packages == ["cowsay"]
-
-
-def test_build_backend_without_packages_empty_packages() -> None:
-    adapter = E2BAdapter()
-    backend: E2BSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
-        {"PHOENIX_SANDBOX_E2B_API_KEY": "k"}
-    )
-    assert backend._packages == []
+    assert backend._packages == expected_packages

--- a/tests/unit/server/sandbox/test_e2b_backend.py
+++ b/tests/unit/server/sandbox/test_e2b_backend.py
@@ -105,15 +105,56 @@ async def test_pip_install_failure_raises_and_leaves_no_cached_session() -> None
 
 
 @pytest.mark.asyncio
-async def test_package_names_with_shell_metachars_are_quoted() -> None:
-    """Shell injection guard: a package name with metachars must not be interpolated raw."""
+async def test_package_specs_pass_through_to_subprocess_unmodified() -> None:
+    """Version specifiers and extras must reach pip exactly as configured.
+
+    The generated code calls ``subprocess.run`` with a list (no shell), so each
+    package spec is passed as a single argv element with no shell interpretation.
+    Earlier versions of this helper used ``shlex.quote`` which corrupted any
+    spec containing shell metacharacters (``>=``, ``[extras]``, whitespace) by
+    baking literal single-quote characters into the argv element — pip then
+    rejected ``'numpy>=1.0'`` as an invalid package name.
+    """
     mock_cls = _make_mock_sandbox_cls()
-    backend = E2BSandboxBackend(api_key="k", template="base", packages=["evil; rm -rf /"])
+    specs = ["numpy>=1.0", "requests[security]", "pandas==2.1.0"]
+    backend = E2BSandboxBackend(api_key="k", template="base", packages=specs)
     with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
         await backend.start_session("s1")
     code_arg = mock_cls.create.return_value.run_code.call_args.args[0]
-    # metacharacters may only appear inside a shell-quoted form
-    assert "rm -rf /" not in code_arg or "'evil; rm -rf /'" in code_arg
+    # The list literal embedded in the generated code must be repr(specs),
+    # i.e. each spec wrapped in Python string quotes — never wrapped a second
+    # time in literal single-quote characters.
+    for spec in specs:
+        assert repr(spec) in code_arg, (
+            f"Expected {spec!r} (Python repr) in generated code; got: {code_arg}"
+        )
+        assert f"'{spec}'" not in code_arg.replace(repr(spec), ""), (
+            f"Found double-quoted form of {spec!r} — shlex.quote regression"
+        )
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_execute_installs_packages_before_run_code() -> None:
+    """Ephemeral execute() must install configured packages before user code.
+
+    The evaluator path enters via execute() without ever calling start_session(),
+    so a missing _install_packages call here means dependencies.packages is
+    silently dropped for every E2B evaluation. Regression guard for that bug.
+    """
+    mock_cls = _make_mock_sandbox_cls()
+    sandbox_instance = mock_cls.create.return_value
+    # Make the context-manager protocol work for `async with await create(...)`.
+    sandbox_instance.__aenter__ = AsyncMock(return_value=sandbox_instance)
+    sandbox_instance.__aexit__ = AsyncMock(return_value=None)
+    backend = E2BSandboxBackend(api_key="k", template="base", packages=["cowsay"])
+    with patch.object(backend, "_get_sandbox_cls", return_value=mock_cls):
+        await backend.execute("print('hi')", session_key="s1")
+    # Two run_code calls are expected: pip install (first), then user code.
+    assert sandbox_instance.run_code.await_count == 2
+    install_code = sandbox_instance.run_code.call_args_list[0].args[0]
+    user_code = sandbox_instance.run_code.call_args_list[1].args[0]
+    assert "pip" in install_code and "cowsay" in install_code
+    assert user_code == "print('hi')"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/server/sandbox/test_env_var_resolution.py
+++ b/tests/unit/server/sandbox/test_env_var_resolution.py
@@ -115,10 +115,10 @@ class TestReservedCredentialNameHelper:
     @pytest.mark.parametrize(
         "name",
         [
-            "PHOENIX_SANDBOX_MODAL_TOKEN_ID",
-            "PHOENIX_SANDBOX_MODAL_TOKEN_SECRET",
-            "phoenix_sandbox_modal_token_id",
-            "phoenix_sandbox_modal_token_secret",
+            "MODAL_TOKEN_ID",
+            "MODAL_TOKEN_SECRET",
+            "modal_token_id",
+            "modal_token_secret",
         ],
     )
     def test_modal_token_keys_are_reserved(self, name: str) -> None:
@@ -128,6 +128,7 @@ class TestReservedCredentialNameHelper:
         assert is_reserved_credential_name("PHOENIX_SANDBOX_E2B_API_KEY")
         assert is_reserved_credential_name("PHOENIX_SANDBOX_VERCEL_TOKEN")
         assert is_reserved_credential_name("phoenix_sandbox_vercel_token")
+        assert is_reserved_credential_name("VERCEL_OIDC_TOKEN")
 
 
 class TestValidateConfigRejectsDuplicateEnvVarNames:

--- a/tests/unit/server/sandbox/test_env_var_resolution.py
+++ b/tests/unit/server/sandbox/test_env_var_resolution.py
@@ -69,9 +69,11 @@ class TestResolveUserEnvReservedSecretKey:
         """secret_ref whose `secret_key` matches a reserved provider-credential
         name raises MissingSecretError before any DB query — fail-closed
         defense-in-depth for rows persisted before the mutation-layer guard."""
-        raw = [{"kind": "secret_ref", "name": "MY_TOKEN", "secret_key": "VERCEL_TOKEN"}]
-        session = _make_session({"VERCEL_TOKEN": b"should-not-reach-here"})
-        with pytest.raises(MissingSecretError, match="VERCEL_TOKEN"):
+        raw = [
+            {"kind": "secret_ref", "name": "MY_TOKEN", "secret_key": "PHOENIX_SANDBOX_VERCEL_TOKEN"}
+        ]
+        session = _make_session({"PHOENIX_SANDBOX_VERCEL_TOKEN": b"should-not-reach-here"})
+        with pytest.raises(MissingSecretError, match="PHOENIX_SANDBOX_VERCEL_TOKEN"):
             await _resolve_user_env(raw, session, _identity_decrypt)
         session.scalars.assert_not_called()
 
@@ -80,17 +82,19 @@ class TestResolveUserEnvReservedSecretKey:
         """An EnvVarLiteral whose `name` matches a reserved provider-credential name
         raises MissingSecretError — pre-mutation-guard rows with reserved literal
         names must not pass resolution at runtime (asymmetry-bug closure)."""
-        raw = [{"kind": "literal", "name": "VERCEL_TOKEN", "value": "x"}]
+        raw = [{"kind": "literal", "name": "PHOENIX_SANDBOX_VERCEL_TOKEN", "value": "x"}]
         session = _make_session({})
-        with pytest.raises(MissingSecretError, match="VERCEL_TOKEN"):
+        with pytest.raises(MissingSecretError, match="PHOENIX_SANDBOX_VERCEL_TOKEN"):
             await _resolve_user_env(raw, session, _identity_decrypt)
         session.scalars.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_reserved_check_is_case_insensitive(self) -> None:
         """Reserved-name comparison is case-insensitive in both positions."""
-        raw = [{"kind": "secret_ref", "name": "MY_TOKEN", "secret_key": "vercel_token"}]
-        session = _make_session({"vercel_token": b"should-not-reach-here"})
+        raw = [
+            {"kind": "secret_ref", "name": "MY_TOKEN", "secret_key": "phoenix_sandbox_vercel_token"}
+        ]
+        session = _make_session({"phoenix_sandbox_vercel_token": b"should-not-reach-here"})
         with pytest.raises(MissingSecretError):
             await _resolve_user_env(raw, session, _identity_decrypt)
         session.scalars.assert_not_called()
@@ -111,19 +115,19 @@ class TestReservedCredentialNameHelper:
     @pytest.mark.parametrize(
         "name",
         [
-            "MODAL_TOKEN_ID",
-            "MODAL_TOKEN_SECRET",
-            "modal_token_id",
-            "modal_token_secret",
+            "PHOENIX_SANDBOX_MODAL_TOKEN_ID",
+            "PHOENIX_SANDBOX_MODAL_TOKEN_SECRET",
+            "phoenix_sandbox_modal_token_id",
+            "phoenix_sandbox_modal_token_secret",
         ],
     )
     def test_modal_token_keys_are_reserved(self, name: str) -> None:
         assert is_reserved_credential_name(name)
 
     def test_non_modal_reserved_names_still_reserved(self) -> None:
-        assert is_reserved_credential_name("PHOENIX_SANDBOX_TOKEN")
-        assert is_reserved_credential_name("PHOENIX_SANDBOX_API_KEY")
-        assert is_reserved_credential_name("phoenix_sandbox_token")
+        assert is_reserved_credential_name("PHOENIX_SANDBOX_E2B_API_KEY")
+        assert is_reserved_credential_name("PHOENIX_SANDBOX_VERCEL_TOKEN")
+        assert is_reserved_credential_name("phoenix_sandbox_vercel_token")
 
 
 class TestValidateConfigRejectsDuplicateEnvVarNames:

--- a/tests/unit/server/sandbox/test_get_or_create_backend.py
+++ b/tests/unit/server/sandbox/test_get_or_create_backend.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import BaseModel, ConfigDict
 
 from phoenix.server.sandbox import (
     _BACKEND_CACHE,
@@ -13,7 +14,12 @@ from phoenix.server.sandbox import (
     get_or_create_backend,
     invalidate_backend_cache,
 )
+from phoenix.server.sandbox.daytona_backend import DaytonaPythonAdapter
 from phoenix.server.sandbox.types import ProviderCredentialSpec, SandboxAdapter, SandboxBackend
+
+
+class _StubConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
 
 
 def _make_session(secrets: dict[str, bytes]) -> Any:
@@ -39,6 +45,7 @@ def _make_adapter(received: dict[str, Any], cred_key: str = "CRED_X") -> Sandbox
         key = "STUB"
         display_name = "Stub"
         language = "PYTHON"
+        config_model = _StubConfig
         credential_specs = [ProviderCredentialSpec(key=cred_key, display_name="Cred X")]
 
         def build_backend(
@@ -136,7 +143,9 @@ class TestGetOrCreateBackendCredentialMerge:
     async def test_user_config_preserved_when_key_unresolved(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Non-credential user config keys pass through untouched."""
+        """Non-credential user config keys pass through untouched.
+        Credential keys supplied by the user are stripped before validate_config
+        and replaced only by the resolved value (empty string when unresolved)."""
         received: dict[str, Any] = {}
         adapter = _make_adapter(received, "CRED_X")
         monkeypatch.delenv("CRED_X", raising=False)
@@ -145,16 +154,16 @@ class TestGetOrCreateBackendCredentialMerge:
         with patch.dict(_SANDBOX_ADAPTERS, {"STUB": adapter}):
             await get_or_create_backend(
                 "STUB",
-                config={"template": "python", "CRED_X": "user-fallback"},
+                config={"custom_key": "some-value", "CRED_X": "user-fallback"},
                 session=session,
                 decrypt=_identity_decrypt,
             )
 
-        # When no DB/env value resolves, user-supplied key remains.
-        # (Reserved-name enforcement at mutation time prevents this for
-        # actual reserved credential keys; this is just shape-agnostic behavior.)
-        assert received["config"].get("template") == "python"
-        assert received["config"].get("CRED_X") == "user-fallback"
+        # Non-credential key passes through from user config untouched.
+        assert received["config"].get("custom_key") == "some-value"
+        # Credential key is stripped from user config before validate_config;
+        # when neither DB nor env resolves it, it is absent from effective_config.
+        assert "CRED_X" not in received["config"]
 
     @pytest.mark.asyncio
     async def test_no_session_resolves_from_env_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -211,10 +220,10 @@ class TestGetOrCreateBackendCache:
 
         with patch.dict(_SANDBOX_ADAPTERS, {"STUB": adapter}):
             b1 = await get_or_create_backend(
-                "STUB", config={"template": "a"}, session=session, decrypt=_identity_decrypt
+                "STUB", config={"region": "us-east-1"}, session=session, decrypt=_identity_decrypt
             )
             b2 = await get_or_create_backend(
-                "STUB", config={"template": "b"}, session=session, decrypt=_identity_decrypt
+                "STUB", config={"region": "eu-west-1"}, session=session, decrypt=_identity_decrypt
             )
 
         assert b1 is not b2
@@ -223,3 +232,44 @@ class TestGetOrCreateBackendCache:
     async def test_unregistered_backend_returns_none(self) -> None:
         result = await get_or_create_backend("NONEXISTENT", config={}, session=None, decrypt=None)
         assert result is None
+
+
+class TestProviderMergeSSRFBlocked:
+    """Provider-level non-capability keys must be rejected by validate_config
+    inside get_or_create_backend, blocking the SSRF vector.
+
+    The evaluators.py merge shape is:
+        merged = {**sandbox_config.config, **sandbox_provider.config}
+        get_or_create_backend(backend_type, config=merged, ...)
+
+    Provider config wins on key collision (admin-authored). Before Phase 5,
+    a poisoned provider config with server_url would flow into
+    Daytona(server_url=...) unchecked. After Phase 5, validate_config raises
+    ValueError (extra=forbid) before any Daytona client is constructed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_daytona_provider_server_url_raises_before_build_backend(self) -> None:
+        """A sandbox_provider.config with server_url must not reach build_backend.
+
+        Simulates the evaluators.py merge where provider config wins over user
+        config. validate_config (called at line 536 of sandbox/__init__.py) must
+        raise ValueError so the evaluator layer converts it to BadRequest.
+        """
+        adapter = DaytonaPythonAdapter()
+        session = _make_session({})
+
+        merged_config = {
+            "server_url": "https://attacker.example.com",
+        }
+
+        with (
+            patch.dict(_SANDBOX_ADAPTERS, {"DAYTONA_PYTHON": adapter}),
+            pytest.raises(ValueError, match="Extra inputs are not permitted"),
+        ):
+            await get_or_create_backend(
+                "DAYTONA_PYTHON",
+                config=merged_config,
+                session=session,
+                decrypt=_identity_decrypt,
+            )

--- a/tests/unit/server/sandbox/test_modal_backend.py
+++ b/tests/unit/server/sandbox/test_modal_backend.py
@@ -1,0 +1,245 @@
+"""Unit tests for ModalSandboxBackend focusing on kwarg forwarding invariants.
+
+Tests that env vars passed through user_env reach Modal.Sandbox.create.aio()
+via the `env` kwarg (not the legacy `env_dict` kwarg which was never a valid
+Sandbox.create argument).
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_modal_mock() -> MagicMock:
+    """Build a Modal SDK mock sufficient to instantiate ModalSandboxBackend."""
+    modal = MagicMock()
+    modal.App.lookup.return_value = MagicMock()
+    modal.Image.debian_slim.return_value = MagicMock()
+    sandbox_mock = MagicMock()
+    modal.Sandbox.create = MagicMock()
+    modal.Sandbox.create.aio = AsyncMock(return_value=sandbox_mock)
+    return modal
+
+
+class TestCreateSandboxEnvKwarg:
+    @pytest.mark.asyncio
+    async def test_user_env_forwarded_as_env_kwarg(self) -> None:
+        """user_env dict must reach Sandbox.create.aio() as `env`, not `env_dict`."""
+        modal_mock = _make_modal_mock()
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+            backend = ModalSandboxBackend(user_env={"KEY": "value"})
+            await backend._create_sandbox()
+
+        _, kwargs = modal_mock.Sandbox.create.aio.call_args
+        assert kwargs.get("env") == {"KEY": "value"}, f"Expected env={{KEY: value}}, got {kwargs}"
+        assert "env_dict" not in kwargs, (
+            f"env_dict should not appear in Sandbox.create.aio kwargs; got {kwargs}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_user_env_omits_env_kwarg(self) -> None:
+        """When user_env is empty, `env` kwarg must NOT be passed to Sandbox.create.aio()."""
+        modal_mock = _make_modal_mock()
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+            backend = ModalSandboxBackend(user_env={})
+            await backend._create_sandbox()
+
+        _, kwargs = modal_mock.Sandbox.create.aio.call_args
+        assert "env" not in kwargs, f"env kwarg should be absent for empty user_env; got {kwargs}"
+        assert "env_dict" not in kwargs, (
+            f"env_dict should never appear in Sandbox.create.aio kwargs; got {kwargs}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_none_user_env_omits_env_kwarg(self) -> None:
+        """When user_env is None, `env` kwarg must NOT be passed to Sandbox.create.aio()."""
+        modal_mock = _make_modal_mock()
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+            backend = ModalSandboxBackend(user_env=None)
+            await backend._create_sandbox()
+
+        _, kwargs = modal_mock.Sandbox.create.aio.call_args
+        assert "env" not in kwargs, f"env kwarg should be absent for None user_env; got {kwargs}"
+
+
+# ---------------------------------------------------------------------------
+# Image.pip_install wiring
+# ---------------------------------------------------------------------------
+
+
+def _make_modal_mock_with_image_tracking() -> tuple[MagicMock, MagicMock]:
+    """Return (modal_mock, slim_image_mock) so callers can assert on pip_install."""
+    modal = MagicMock()
+    modal.App.lookup.return_value = MagicMock()
+    slim_image = MagicMock()
+    modal.Image.debian_slim.return_value = slim_image
+    modal.Sandbox.create = MagicMock()
+    modal.Sandbox.create.aio = AsyncMock(return_value=MagicMock())
+    return modal, slim_image
+
+
+class TestPipInstallWiring:
+    def test_modal_dependencies_language_is_python(self) -> None:
+        from phoenix.server.sandbox import SANDBOX_ADAPTER_METADATA
+
+        assert SANDBOX_ADAPTER_METADATA["MODAL"].dependencies_language == "PYTHON"
+
+    def test_no_packages_uses_debian_slim_only(self) -> None:
+        modal_mock, slim_image = _make_modal_mock_with_image_tracking()
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+            backend = ModalSandboxBackend(packages=None)
+
+        slim_image.pip_install.assert_not_called()
+        assert backend._image is slim_image
+
+    def test_packages_calls_pip_install(self) -> None:
+        modal_mock, slim_image = _make_modal_mock_with_image_tracking()
+        installed_image = MagicMock()
+        slim_image.pip_install.return_value = installed_image
+
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+            backend = ModalSandboxBackend(packages=["cowsay"])
+
+        slim_image.pip_install.assert_called_once_with(["cowsay"])
+        assert backend._image is installed_image
+
+    def test_build_backend_with_packages_wires_pip_install(self) -> None:
+        modal_mock, slim_image = _make_modal_mock_with_image_tracking()
+        installed_image = MagicMock()
+        slim_image.pip_install.return_value = installed_image
+
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalAdapter, ModalSandboxBackend
+
+            adapter = ModalAdapter()
+            backend: ModalSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
+                {"dependencies": {"packages": ["cowsay"]}}
+            )
+            slim_image.pip_install.assert_called_once_with(["cowsay"])
+            assert backend._image is installed_image
+
+    def test_build_backend_without_packages_no_pip_install(self) -> None:
+        modal_mock, slim_image = _make_modal_mock_with_image_tracking()
+
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalAdapter, ModalSandboxBackend
+
+            adapter = ModalAdapter()
+            backend: ModalSandboxBackend = adapter.build_backend({})  # type: ignore[assignment]
+            slim_image.pip_install.assert_not_called()
+            assert backend._image is slim_image
+
+    def test_build_backend_empty_packages_no_pip_install(self) -> None:
+        modal_mock, slim_image = _make_modal_mock_with_image_tracking()
+
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalAdapter, ModalSandboxBackend
+
+            adapter = ModalAdapter()
+            backend: ModalSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
+                {"dependencies": {"packages": []}}
+            )
+            slim_image.pip_install.assert_not_called()
+            assert backend._image is slim_image
+
+
+# ---------------------------------------------------------------------------
+# block_network wiring (internet_access_capability="boolean")
+# ---------------------------------------------------------------------------
+
+
+class TestBlockNetworkWiring:
+    def test_modal_internet_access_capability_is_boolean(self) -> None:
+        from phoenix.server.sandbox import SANDBOX_ADAPTER_METADATA
+
+        assert SANDBOX_ADAPTER_METADATA["MODAL"].internet_access_capability == "boolean"
+
+    @pytest.mark.asyncio
+    async def test_deny_mode_passes_block_network_true(self) -> None:
+        """internet_access.mode='deny' must reach Sandbox.create.aio() as block_network=True."""
+        modal_mock = _make_modal_mock()
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+            backend = ModalSandboxBackend(block_network=True)
+            await backend._create_sandbox()
+
+        _, kwargs = modal_mock.Sandbox.create.aio.call_args
+        assert kwargs.get("block_network") is True, f"Expected block_network=True, got {kwargs}"
+
+    @pytest.mark.asyncio
+    async def test_allow_mode_omits_block_network(self) -> None:
+        """internet_access.mode='allow' (default) must NOT pass block_network to Sandbox.create.aio()."""
+        modal_mock = _make_modal_mock()
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+            backend = ModalSandboxBackend(block_network=False)
+            await backend._create_sandbox()
+
+        _, kwargs = modal_mock.Sandbox.create.aio.call_args
+        assert "block_network" not in kwargs, (
+            f"block_network should be absent when not blocking; got {kwargs}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_omits_block_network(self) -> None:
+        """No internet_access config → block_network absent from Sandbox.create.aio()."""
+        modal_mock = _make_modal_mock()
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+            backend = ModalSandboxBackend()
+            await backend._create_sandbox()
+
+        _, kwargs = modal_mock.Sandbox.create.aio.call_args
+        assert "block_network" not in kwargs, (
+            f"block_network should be absent with default config; got {kwargs}"
+        )
+
+    def test_build_backend_deny_sets_block_network(self) -> None:
+        """build_backend with internet_access.mode='deny' produces backend with _block_network=True."""
+        modal_mock = _make_modal_mock()
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalAdapter, ModalSandboxBackend
+
+            adapter = ModalAdapter()
+            backend: ModalSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
+                {"internet_access": {"mode": "deny"}}
+            )
+        assert backend._block_network is True
+
+    def test_build_backend_allow_clears_block_network(self) -> None:
+        """build_backend with internet_access.mode='allow' produces backend with _block_network=False."""
+        modal_mock = _make_modal_mock()
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalAdapter, ModalSandboxBackend
+
+            adapter = ModalAdapter()
+            backend: ModalSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
+                {"internet_access": {"mode": "allow"}}
+            )
+        assert backend._block_network is False
+
+    def test_build_backend_no_internet_access_clears_block_network(self) -> None:
+        """build_backend with no internet_access config produces backend with _block_network=False."""
+        modal_mock = _make_modal_mock()
+        with patch.dict(sys.modules, {"modal": modal_mock}):
+            from phoenix.server.sandbox.modal_backend import ModalAdapter, ModalSandboxBackend
+
+            adapter = ModalAdapter()
+            backend: ModalSandboxBackend = adapter.build_backend({})  # type: ignore[assignment]
+        assert backend._block_network is False

--- a/tests/unit/server/sandbox/test_modal_backend.py
+++ b/tests/unit/server/sandbox/test_modal_backend.py
@@ -1,245 +1,117 @@
 """Unit tests for ModalSandboxBackend focusing on kwarg forwarding invariants.
 
-Tests that env vars passed through user_env reach Modal.Sandbox.create.aio()
-via the `env` kwarg (not the legacy `env_dict` kwarg which was never a valid
-Sandbox.create argument).
+Scope: Modal-specific SDK kwarg shapes that parametrized capability-matrix tests
+can't express — `env` vs `env_dict`, `block_network`, `Image.pip_install` wiring.
+Generic "capability rejected when unsupported" coverage lives in
+test_capability_matrix.py.
 """
 
 from __future__ import annotations
 
 import sys
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 
 def _make_modal_mock() -> MagicMock:
-    """Build a Modal SDK mock sufficient to instantiate ModalSandboxBackend."""
     modal = MagicMock()
     modal.App.lookup.return_value = MagicMock()
     modal.Image.debian_slim.return_value = MagicMock()
-    sandbox_mock = MagicMock()
     modal.Sandbox.create = MagicMock()
-    modal.Sandbox.create.aio = AsyncMock(return_value=sandbox_mock)
+    modal.Sandbox.create.aio = AsyncMock(return_value=MagicMock())
     return modal
 
 
-class TestCreateSandboxEnvKwarg:
-    @pytest.mark.asyncio
-    async def test_user_env_forwarded_as_env_kwarg(self) -> None:
-        """user_env dict must reach Sandbox.create.aio() as `env`, not `env_dict`."""
-        modal_mock = _make_modal_mock()
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "user_env,expect_env_kwarg",
+    [
+        ({"KEY": "value"}, {"KEY": "value"}),
+        ({}, None),
+        (None, None),
+    ],
+)
+async def test_user_env_reaches_sandbox_create_as_env_kwarg(
+    user_env: dict[str, str] | None, expect_env_kwarg: dict[str, str] | None
+) -> None:
+    """user_env must reach Sandbox.create.aio() as `env`, not `env_dict`; absent when empty/None."""
+    modal_mock = _make_modal_mock()
+    with patch.dict(sys.modules, {"modal": modal_mock}):
+        from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
 
-            backend = ModalSandboxBackend(user_env={"KEY": "value"})
-            await backend._create_sandbox()
+        backend = ModalSandboxBackend(user_env=user_env)
+        await backend._create_sandbox()
 
-        _, kwargs = modal_mock.Sandbox.create.aio.call_args
-        assert kwargs.get("env") == {"KEY": "value"}, f"Expected env={{KEY: value}}, got {kwargs}"
-        assert "env_dict" not in kwargs, (
-            f"env_dict should not appear in Sandbox.create.aio kwargs; got {kwargs}"
-        )
-
-    @pytest.mark.asyncio
-    async def test_empty_user_env_omits_env_kwarg(self) -> None:
-        """When user_env is empty, `env` kwarg must NOT be passed to Sandbox.create.aio()."""
-        modal_mock = _make_modal_mock()
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
-
-            backend = ModalSandboxBackend(user_env={})
-            await backend._create_sandbox()
-
-        _, kwargs = modal_mock.Sandbox.create.aio.call_args
-        assert "env" not in kwargs, f"env kwarg should be absent for empty user_env; got {kwargs}"
-        assert "env_dict" not in kwargs, (
-            f"env_dict should never appear in Sandbox.create.aio kwargs; got {kwargs}"
-        )
-
-    @pytest.mark.asyncio
-    async def test_none_user_env_omits_env_kwarg(self) -> None:
-        """When user_env is None, `env` kwarg must NOT be passed to Sandbox.create.aio()."""
-        modal_mock = _make_modal_mock()
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
-
-            backend = ModalSandboxBackend(user_env=None)
-            await backend._create_sandbox()
-
-        _, kwargs = modal_mock.Sandbox.create.aio.call_args
-        assert "env" not in kwargs, f"env kwarg should be absent for None user_env; got {kwargs}"
+    _, kwargs = modal_mock.Sandbox.create.aio.call_args
+    assert "env_dict" not in kwargs, f"env_dict is not a valid kwarg; got {kwargs}"
+    if expect_env_kwarg is None:
+        assert "env" not in kwargs, f"env should be absent; got {kwargs}"
+    else:
+        assert kwargs.get("env") == expect_env_kwarg
 
 
-# ---------------------------------------------------------------------------
-# Image.pip_install wiring
-# ---------------------------------------------------------------------------
+def test_pip_install_invoked_only_when_packages_present() -> None:
+    """Non-empty packages → Image.pip_install called with list; empty/None → not called."""
+    modal_mock = _make_modal_mock()
+    slim_image = modal_mock.Image.debian_slim.return_value
+    installed_image = MagicMock()
+    slim_image.pip_install.return_value = installed_image
 
+    with patch.dict(sys.modules, {"modal": modal_mock}):
+        from phoenix.server.sandbox.modal_backend import ModalAdapter
 
-def _make_modal_mock_with_image_tracking() -> tuple[MagicMock, MagicMock]:
-    """Return (modal_mock, slim_image_mock) so callers can assert on pip_install."""
-    modal = MagicMock()
-    modal.App.lookup.return_value = MagicMock()
-    slim_image = MagicMock()
-    modal.Image.debian_slim.return_value = slim_image
-    modal.Sandbox.create = MagicMock()
-    modal.Sandbox.create.aio = AsyncMock(return_value=MagicMock())
-    return modal, slim_image
-
-
-class TestPipInstallWiring:
-    def test_modal_dependencies_language_is_python(self) -> None:
-        from phoenix.server.sandbox import SANDBOX_ADAPTER_METADATA
-
-        assert SANDBOX_ADAPTER_METADATA["MODAL"].dependencies_language == "PYTHON"
-
-    def test_no_packages_uses_debian_slim_only(self) -> None:
-        modal_mock, slim_image = _make_modal_mock_with_image_tracking()
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
-
-            backend = ModalSandboxBackend(packages=None)
-
-        slim_image.pip_install.assert_not_called()
-        assert backend._image is slim_image
-
-    def test_packages_calls_pip_install(self) -> None:
-        modal_mock, slim_image = _make_modal_mock_with_image_tracking()
-        installed_image = MagicMock()
-        slim_image.pip_install.return_value = installed_image
-
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
-
-            backend = ModalSandboxBackend(packages=["cowsay"])
-
+        adapter = ModalAdapter()
+        with_pkgs: Any = adapter.build_backend({"dependencies": {"packages": ["cowsay"]}})
         slim_image.pip_install.assert_called_once_with(["cowsay"])
-        assert backend._image is installed_image
+        assert with_pkgs._image is installed_image
 
-    def test_build_backend_with_packages_wires_pip_install(self) -> None:
-        modal_mock, slim_image = _make_modal_mock_with_image_tracking()
-        installed_image = MagicMock()
-        slim_image.pip_install.return_value = installed_image
-
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalAdapter, ModalSandboxBackend
-
-            adapter = ModalAdapter()
-            backend: ModalSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
-                {"dependencies": {"packages": ["cowsay"]}}
-            )
-            slim_image.pip_install.assert_called_once_with(["cowsay"])
-            assert backend._image is installed_image
-
-    def test_build_backend_without_packages_no_pip_install(self) -> None:
-        modal_mock, slim_image = _make_modal_mock_with_image_tracking()
-
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalAdapter, ModalSandboxBackend
-
-            adapter = ModalAdapter()
-            backend: ModalSandboxBackend = adapter.build_backend({})  # type: ignore[assignment]
-            slim_image.pip_install.assert_not_called()
-            assert backend._image is slim_image
-
-    def test_build_backend_empty_packages_no_pip_install(self) -> None:
-        modal_mock, slim_image = _make_modal_mock_with_image_tracking()
-
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalAdapter, ModalSandboxBackend
-
-            adapter = ModalAdapter()
-            backend: ModalSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
-                {"dependencies": {"packages": []}}
-            )
-            slim_image.pip_install.assert_not_called()
-            assert backend._image is slim_image
+        slim_image.pip_install.reset_mock()
+        without_pkgs: Any = adapter.build_backend({"dependencies": {"packages": []}})
+        slim_image.pip_install.assert_not_called()
+        assert without_pkgs._image is slim_image
 
 
-# ---------------------------------------------------------------------------
-# block_network wiring (internet_access_capability="boolean")
-# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "block_network,expect_kwarg",
+    [(True, True), (False, None)],
+)
+async def test_block_network_kwarg_forwarding(
+    block_network: bool, expect_kwarg: bool | None
+) -> None:
+    """block_network=True reaches SDK; block_network=False omits the kwarg entirely."""
+    modal_mock = _make_modal_mock()
+    with patch.dict(sys.modules, {"modal": modal_mock}):
+        from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+        backend = ModalSandboxBackend(block_network=block_network)
+        await backend._create_sandbox()
+
+    _, kwargs = modal_mock.Sandbox.create.aio.call_args
+    if expect_kwarg is None:
+        assert "block_network" not in kwargs
+    else:
+        assert kwargs.get("block_network") is expect_kwarg
 
 
-class TestBlockNetworkWiring:
-    def test_modal_internet_access_capability_is_boolean(self) -> None:
-        from phoenix.server.sandbox import SANDBOX_ADAPTER_METADATA
+@pytest.mark.parametrize(
+    "config,expected",
+    [
+        ({"internet_access": {"mode": "deny"}}, True),
+        ({"internet_access": {"mode": "allow"}}, False),
+        ({}, False),
+    ],
+)
+def test_build_backend_sets_block_network_from_internet_access(
+    config: dict[str, Any], expected: bool
+) -> None:
+    """ModalAdapter.build_backend translates internet_access.mode → backend._block_network."""
+    modal_mock = _make_modal_mock()
+    with patch.dict(sys.modules, {"modal": modal_mock}):
+        from phoenix.server.sandbox.modal_backend import ModalAdapter
 
-        assert SANDBOX_ADAPTER_METADATA["MODAL"].internet_access_capability == "boolean"
-
-    @pytest.mark.asyncio
-    async def test_deny_mode_passes_block_network_true(self) -> None:
-        """internet_access.mode='deny' must reach Sandbox.create.aio() as block_network=True."""
-        modal_mock = _make_modal_mock()
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
-
-            backend = ModalSandboxBackend(block_network=True)
-            await backend._create_sandbox()
-
-        _, kwargs = modal_mock.Sandbox.create.aio.call_args
-        assert kwargs.get("block_network") is True, f"Expected block_network=True, got {kwargs}"
-
-    @pytest.mark.asyncio
-    async def test_allow_mode_omits_block_network(self) -> None:
-        """internet_access.mode='allow' (default) must NOT pass block_network to Sandbox.create.aio()."""
-        modal_mock = _make_modal_mock()
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
-
-            backend = ModalSandboxBackend(block_network=False)
-            await backend._create_sandbox()
-
-        _, kwargs = modal_mock.Sandbox.create.aio.call_args
-        assert "block_network" not in kwargs, (
-            f"block_network should be absent when not blocking; got {kwargs}"
-        )
-
-    @pytest.mark.asyncio
-    async def test_default_omits_block_network(self) -> None:
-        """No internet_access config → block_network absent from Sandbox.create.aio()."""
-        modal_mock = _make_modal_mock()
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
-
-            backend = ModalSandboxBackend()
-            await backend._create_sandbox()
-
-        _, kwargs = modal_mock.Sandbox.create.aio.call_args
-        assert "block_network" not in kwargs, (
-            f"block_network should be absent with default config; got {kwargs}"
-        )
-
-    def test_build_backend_deny_sets_block_network(self) -> None:
-        """build_backend with internet_access.mode='deny' produces backend with _block_network=True."""
-        modal_mock = _make_modal_mock()
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalAdapter, ModalSandboxBackend
-
-            adapter = ModalAdapter()
-            backend: ModalSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
-                {"internet_access": {"mode": "deny"}}
-            )
-        assert backend._block_network is True
-
-    def test_build_backend_allow_clears_block_network(self) -> None:
-        """build_backend with internet_access.mode='allow' produces backend with _block_network=False."""
-        modal_mock = _make_modal_mock()
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalAdapter, ModalSandboxBackend
-
-            adapter = ModalAdapter()
-            backend: ModalSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
-                {"internet_access": {"mode": "allow"}}
-            )
-        assert backend._block_network is False
-
-    def test_build_backend_no_internet_access_clears_block_network(self) -> None:
-        """build_backend with no internet_access config produces backend with _block_network=False."""
-        modal_mock = _make_modal_mock()
-        with patch.dict(sys.modules, {"modal": modal_mock}):
-            from phoenix.server.sandbox.modal_backend import ModalAdapter, ModalSandboxBackend
-
-            adapter = ModalAdapter()
-            backend: ModalSandboxBackend = adapter.build_backend({})  # type: ignore[assignment]
-        assert backend._block_network is False
+        adapter = ModalAdapter()
+        backend: Any = adapter.build_backend(config)
+    assert backend._block_network is expected

--- a/tests/unit/server/sandbox/test_sandbox_config_validation.py
+++ b/tests/unit/server/sandbox/test_sandbox_config_validation.py
@@ -16,7 +16,10 @@ to exercise pydantic's framework behaviour here.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
+from pydantic import BaseModel
 
 from phoenix.server.sandbox.types import (
     ConfigFieldSpec,
@@ -41,7 +44,6 @@ from phoenix.server.sandbox.types import (
 
 def _make_adapter(config_model_cls: type) -> SandboxAdapter:
     """Create a minimal SandboxAdapter with the given config_model."""
-    from typing import Any
 
     class _ConcreteAdapter(SandboxAdapter):
         key = "TEST"
@@ -63,19 +65,9 @@ def _make_adapter(config_model_cls: type) -> SandboxAdapter:
 
 
 class TestValidateConfigErrorPath:
-    def test_invalid_type_raises_value_error(self) -> None:
-        """A pydantic ValidationError is surfaced as ValueError."""
-        from pydantic import BaseModel, ConfigDict
+    """validate_config wraps pydantic ValidationError as ValueError for mutation-layer callers."""
 
-        class StrictModel(BaseModel):
-            model_config = ConfigDict(extra="allow")
-            count: int
-
-        adapter = _make_adapter(StrictModel)
-        with pytest.raises(ValueError):
-            adapter.validate_config({"count": "not-an-int"})
-
-    def test_missing_required_field_raises_value_error(self) -> None:
+    def test_pydantic_errors_surface_as_value_error(self) -> None:
         from pydantic import BaseModel, ConfigDict
 
         class RequiredFieldModel(BaseModel):
@@ -86,44 +78,41 @@ class TestValidateConfigErrorPath:
         with pytest.raises(ValueError, match="required_field"):
             adapter.validate_config({})
 
-    def test_valid_required_field_passes(self) -> None:
-        from pydantic import BaseModel, ConfigDict
-
-        class RequiredFieldModel(BaseModel):
-            model_config = ConfigDict(extra="allow")
-            required_field: str
-
-        adapter = _make_adapter(RequiredFieldModel)
-        out = adapter.validate_config({"required_field": "present"})
-        assert out["required_field"] == "present"
-
 
 # ---------------------------------------------------------------------------
 # EnvVarEntry discriminated union + extra="forbid" + secret_ref shape
 # ---------------------------------------------------------------------------
 
 
+_ENVVAR_ROUND_TRIP_CASES: list[tuple[dict[str, Any], type[BaseModel], dict[str, Any]]] = [
+    (
+        {"kind": "literal", "name": "FOO", "value": "bar"},
+        EnvVarLiteral,
+        {"name": "FOO", "value": "bar"},
+    ),
+    (
+        {"kind": "secret_ref", "name": "BAR", "secret_key": "my-secret"},
+        EnvVarSecretRef,
+        {"name": "BAR", "secret_key": "my-secret"},
+    ),
+]
+
+
 class TestEnvVarEntryDiscriminatedUnion:
-    def test_literal_round_trip(self) -> None:
+    @pytest.mark.parametrize("raw,expected_cls,expected_attrs", _ENVVAR_ROUND_TRIP_CASES)
+    def test_round_trip(
+        self,
+        raw: dict[str, Any],
+        expected_cls: type[BaseModel],
+        expected_attrs: dict[str, Any],
+    ) -> None:
         from pydantic import TypeAdapter
 
         ta: TypeAdapter[EnvVarEntry] = TypeAdapter(EnvVarEntry)
-        raw = {"kind": "literal", "name": "FOO", "value": "bar"}
         parsed = ta.validate_python(raw)
-        assert isinstance(parsed, EnvVarLiteral)
-        assert parsed.name == "FOO"
-        assert parsed.value == "bar"
-        assert ta.dump_python(parsed) == raw
-
-    def test_secret_ref_round_trip(self) -> None:
-        from pydantic import TypeAdapter
-
-        ta: TypeAdapter[EnvVarEntry] = TypeAdapter(EnvVarEntry)
-        raw = {"kind": "secret_ref", "name": "BAR", "secret_key": "my-secret"}
-        parsed = ta.validate_python(raw)
-        assert isinstance(parsed, EnvVarSecretRef)
-        assert parsed.name == "BAR"
-        assert parsed.secret_key == "my-secret"
+        assert isinstance(parsed, expected_cls)
+        for attr, val in expected_attrs.items():
+            assert getattr(parsed, attr) == val
         assert ta.dump_python(parsed) == raw
 
     def test_invalid_kind_raises(self) -> None:
@@ -133,52 +122,47 @@ class TestEnvVarEntryDiscriminatedUnion:
         with pytest.raises(ValidationError):
             ta.validate_python({"kind": "unknown", "name": "X"})
 
-    def test_literal_forbids_extra_fields(self) -> None:
+    @pytest.mark.parametrize(
+        "cls,payload",
+        [
+            (EnvVarLiteral, {"kind": "literal", "name": "X", "value": "v", "extra": "bad"}),
+            (
+                EnvVarSecretRef,
+                {"kind": "secret_ref", "name": "X", "secret_key": "k", "extra": "bad"},
+            ),
+        ],
+    )
+    def test_forbids_extra_fields(self, cls: type[BaseModel], payload: dict[str, Any]) -> None:
         from pydantic import ValidationError
 
         with pytest.raises(ValidationError):
-            EnvVarLiteral.model_validate(
-                {"kind": "literal", "name": "X", "value": "v", "extra": "bad"}
-            )
+            cls.model_validate(payload)
 
-    def test_secret_ref_forbids_extra_fields(self) -> None:
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
-            EnvVarSecretRef.model_validate(
-                {"kind": "secret_ref", "name": "X", "secret_key": "k", "extra": "bad"}
-            )
-
-    def test_secret_ref_does_not_contain_value_field(self) -> None:
+    def test_secret_ref_dump_has_no_value_field(self) -> None:
         raw = {"kind": "secret_ref", "name": "SECRET_VAR", "secret_key": "prod-api-key"}
-        parsed = EnvVarSecretRef.model_validate(raw)
-        dumped = parsed.model_dump()
-        assert "value" not in dumped
+        assert "value" not in EnvVarSecretRef.model_validate(raw).model_dump()
 
 
 # ---------------------------------------------------------------------------
-# Nested leaf-model extra="forbid" — one assertion per leaf model
+# Nested leaf-model extra="forbid"
 # ---------------------------------------------------------------------------
 
 
-class TestNestedLeafModelsForbidExtra:
-    def test_internet_access_forbids_extra_fields(self) -> None:
-        from pydantic import ValidationError
+@pytest.mark.parametrize(
+    "model_cls,payload",
+    [
+        (InternetAccessConfig, {"mode": "allow", "extra": "bad"}),
+        (PythonDependenciesConfig, {"packages": [], "unknown": "x"}),
+        (TypescriptDependenciesConfig, {"packages": [], "unknown": "x"}),
+    ],
+)
+def test_nested_leaf_models_forbid_extra_fields(
+    model_cls: type[BaseModel], payload: dict[str, Any]
+) -> None:
+    from pydantic import ValidationError
 
-        with pytest.raises(ValidationError):
-            InternetAccessConfig.model_validate({"mode": "allow", "extra": "bad"})
-
-    def test_python_dependencies_forbids_extra_fields(self) -> None:
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
-            PythonDependenciesConfig.model_validate({"packages": [], "unknown": "x"})
-
-    def test_typescript_dependencies_forbids_extra_fields(self) -> None:
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
-            TypescriptDependenciesConfig.model_validate({"packages": [], "unknown": "x"})
+    with pytest.raises(ValidationError):
+        model_cls.model_validate(payload)
 
 
 # ---------------------------------------------------------------------------
@@ -207,7 +191,9 @@ class TestConfigFieldSpecsFromModel:
         assert specs[0].field_type == "string"
         assert specs[0].display_name == "Name"
 
-    def test_nested_model_field_is_skipped(self) -> None:
+    def test_non_scalar_fields_are_skipped(self) -> None:
+        """Nested models, arrays, and Optional[Model] (anyOf+$ref) are all skipped;
+        only flat scalars get emitted."""
         from typing import Optional
 
         from pydantic import BaseModel, ConfigDict, Field
@@ -218,58 +204,18 @@ class TestConfigFieldSpecsFromModel:
         class M(BaseModel):
             model_config = ConfigDict(extra="allow")
             flat: str = "x"
-            nested: Optional[Inner] = Field(default=None)
-
-        specs = self._derive(M)
-        keys = [s.key for s in specs]
-        assert "flat" in keys
-        assert "nested" not in keys
-
-    def test_array_field_is_skipped(self) -> None:
-        from pydantic import BaseModel, ConfigDict, Field
-
-        class M(BaseModel):
-            model_config = ConfigDict(extra="allow")
-            flat: str = "x"
+            nested: Inner = Field(default_factory=Inner)
+            opt_nested: Optional[Inner] = Field(default=None)
             items: list[str] = Field(default_factory=list)
 
-        specs = self._derive(M)
-        keys = [s.key for s in specs]
-        assert "flat" in keys
-        assert "items" not in keys
+        keys = [s.key for s in self._derive(M)]
+        assert keys == ["flat"]
 
-    def test_e2b_config_env_vars_internet_access_dependencies_skipped(self) -> None:
-        """Representative real-adapter case: flat field present, the three nested
-        common fields (env_vars, internet_access, dependencies) all skipped."""
-        specs = self._derive(E2BConfig)
-        keys = [s.key for s in specs]
-        assert "template" in keys
-        assert "env_vars" not in keys
-        assert "internet_access" not in keys
-        assert "dependencies" not in keys
-
-    def test_wasm_config_empty_produces_no_specs(self) -> None:
-        specs = self._derive(WASMConfig)
-        assert specs == []
-
-    def test_optional_nested_model_via_anyof_ref_is_skipped(self) -> None:
-        """Schema produced for `Optional[Model]` uses anyOf+$ref; must still be skipped."""
-        from typing import Optional
-
-        from pydantic import BaseModel, ConfigDict, Field
-
-        class Inner(BaseModel):
-            x: int = 0
-
-        class M(BaseModel):
-            model_config = ConfigDict(extra="allow")
-            flat: str = "v"
-            opt_nested: Optional[Inner] = Field(default=None)
-
-        specs = self._derive(M)
-        keys = [s.key for s in specs]
-        assert "flat" in keys
-        assert "opt_nested" not in keys
+    def test_real_adapter_produces_zero_specs_post_strip(self) -> None:
+        """E2BConfig and WASMConfig declare only nested capability fields (or nothing)
+        after the D7 strip, so both emit zero ConfigFieldSpecs."""
+        assert self._derive(E2BConfig) == []
+        assert self._derive(WASMConfig) == []
 
 
 # ---------------------------------------------------------------------------
@@ -278,76 +224,50 @@ class TestConfigFieldSpecsFromModel:
 
 
 class TestEnvVarsEqual:
-    def test_equal_lists_same_order(self) -> None:
-        a = [{"kind": "literal", "name": "X", "value": "1", "secret_key": ""}]
-        assert _env_vars_equal(a, a)
+    """Non-obvious invariants in _env_vars_equal — see Phase 1 fixes."""
 
-    def test_equal_lists_different_order(self) -> None:
+    def test_order_independent(self) -> None:
         a = [
             {"kind": "literal", "name": "X", "value": "1", "secret_key": ""},
             {"kind": "literal", "name": "Y", "value": "2", "secret_key": ""},
         ]
-        b = [
-            {"kind": "literal", "name": "Y", "value": "2", "secret_key": ""},
-            {"kind": "literal", "name": "X", "value": "1", "secret_key": ""},
-        ]
-        assert _env_vars_equal(a, b)
+        assert _env_vars_equal(a, list(reversed(a)))
 
     def test_duplicate_multiplicity_not_collapsed(self) -> None:
-        """frozenset collapses duplicates; Counter must not — [X, X] != [X]."""
+        """Counter, not frozenset: [X, X] must not equal [X]."""
         entry = {"kind": "literal", "name": "X", "value": "1", "secret_key": ""}
         assert not _env_vars_equal([entry, entry], [entry])
 
-    def test_both_empty(self) -> None:
-        assert _env_vars_equal([], [])
-
-    def test_one_empty(self) -> None:
-        entry = {"kind": "literal", "name": "X", "value": "1", "secret_key": ""}
-        assert not _env_vars_equal([entry], [])
-
 
 class TestInternetAccessEqual:
-    def test_same_mode(self) -> None:
+    def test_mode_sensitivity_and_none_handling(self) -> None:
         assert _internet_access_equal({"mode": "allow"}, {"mode": "allow"})
-
-    def test_different_mode(self) -> None:
         assert not _internet_access_equal({"mode": "allow"}, {"mode": "deny"})
-
-    def test_both_none(self) -> None:
         assert _internet_access_equal(None, None)
-
-    def test_one_none(self) -> None:
         assert not _internet_access_equal({"mode": "allow"}, None)
 
-    def test_model_instance_vs_dict(self) -> None:
+    def test_model_instance_equals_dict(self) -> None:
+        """Comparison must unwrap pydantic model to dict — see Phase 1 fix."""
         model = InternetAccessConfig(mode="deny")
         assert _internet_access_equal(model, {"mode": "deny"})
         assert not _internet_access_equal(model, {"mode": "allow"})
 
 
 class TestPackagesEqual:
-    def test_same_packages_same_lockfile(self) -> None:
-        a = {"packages": ["requests"], "lockfile": "req.txt"}
-        assert _packages_equal(a, a)
-
-    def test_lockfile_change_not_equal(self) -> None:
-        """set(packages) alone was compared — lockfile change must now be detected."""
-        a = {"packages": ["requests"], "lockfile": "req.txt"}
-        b = {"packages": ["requests"], "lockfile": "req2.txt"}
-        assert not _packages_equal(a, b)
-
-    def test_lockfile_none_vs_value_not_equal(self) -> None:
-        a = {"packages": ["requests"], "lockfile": None}
-        b = {"packages": ["requests"], "lockfile": "req.txt"}
-        assert not _packages_equal(a, b)
-
-    def test_packages_set_order_independent(self) -> None:
+    def test_packages_are_set_compared(self) -> None:
+        """Order-independent set comparison — not list equality."""
         a = {"packages": ["boto3", "requests"], "lockfile": None}
         b = {"packages": ["requests", "boto3"], "lockfile": None}
         assert _packages_equal(a, b)
 
-    def test_both_empty(self) -> None:
-        assert _packages_equal({}, {})
-
-    def test_one_empty(self) -> None:
-        assert not _packages_equal({"packages": ["requests"]}, {})
+    def test_lockfile_is_part_of_equality(self) -> None:
+        """Phase 1 fix: lockfile must be compared, not just packages."""
+        same_pkgs = ["requests"]
+        assert not _packages_equal(
+            {"packages": same_pkgs, "lockfile": "req.txt"},
+            {"packages": same_pkgs, "lockfile": "req2.txt"},
+        )
+        assert not _packages_equal(
+            {"packages": same_pkgs, "lockfile": None},
+            {"packages": same_pkgs, "lockfile": "req.txt"},
+        )

--- a/tests/unit/server/sandbox/test_unified_config_contract.py
+++ b/tests/unit/server/sandbox/test_unified_config_contract.py
@@ -146,6 +146,40 @@ def test_dependencies_none_raises_for_non_empty_packages(adapter_key: str) -> No
 
 
 # ---------------------------------------------------------------------------
+# Contract test: installs_packages_at_runtime=True adapters reject the combo
+# of internet_access.mode='deny' + non-empty dependencies.packages. pip
+# cannot reach PyPI from a network-denied sandbox when install runs inside
+# the sandbox via run_code.
+# ---------------------------------------------------------------------------
+
+_RUNTIME_INSTALL_ADAPTERS = [
+    key
+    for key, meta in SANDBOX_ADAPTER_METADATA.items()
+    if meta.installs_packages_at_runtime and meta.dependencies_language is not None
+]
+
+_DENY_PLUS_PACKAGES_CONFIG = {
+    "internet_access": {"mode": "deny"},
+    "dependencies": {"packages": ["numpy"]},
+}
+
+
+@pytest.mark.parametrize("adapter_key", _RUNTIME_INSTALL_ADAPTERS)
+def test_runtime_install_rejects_deny_plus_packages(adapter_key: str) -> None:
+    adapter = _get_adapter(adapter_key)
+    with pytest.raises(UnsupportedOperation):
+        adapter.build_backend(_DENY_PLUS_PACKAGES_CONFIG)
+
+
+@pytest.mark.parametrize("adapter_key", _RUNTIME_INSTALL_ADAPTERS)
+def test_runtime_install_validate_config_rejects_deny_plus_packages(adapter_key: str) -> None:
+    """Same combo must be rejected at write-time validation (not just runtime)."""
+    adapter = _get_adapter(adapter_key)
+    with pytest.raises(ValueError):
+        adapter.validate_config(_DENY_PLUS_PACKAGES_CONFIG)
+
+
+# ---------------------------------------------------------------------------
 # Metadata structural contract: every key in SANDBOX_ADAPTER_METADATA must
 # have a registered adapter module entry so the runtime tests above cover it.
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/sandbox/test_vercel_backend.py
+++ b/tests/unit/server/sandbox/test_vercel_backend.py
@@ -1,0 +1,138 @@
+"""Unit tests for VercelSandboxBackend.
+
+Scope: Vercel-specific SDK kwarg shapes and OIDC token forwarding.
+Cross-adapter capability conformance lives in test_unified_config_contract.py.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from phoenix.server.sandbox.vercel_backend import (
+    ENV_VERCEL_OIDC_TOKEN,
+    VercelSandboxBackend,
+)
+
+
+def _make_vercel_sdk_mock() -> tuple[MagicMock, list[str | None]]:
+    """Return (sdk module mock, list capturing os.environ[VERCEL_OIDC_TOKEN]
+    snapshots taken at AsyncSandbox.create() invocation time).
+
+    The captured snapshots let tests assert what the SDK would have read from
+    the env synchronously at the top of create() — i.e. whether Phoenix's env
+    injection actually took effect at the moment the SDK reads it.
+    """
+    captured_env: list[str | None] = []
+
+    async def _create(**_: Any) -> Any:
+        captured_env.append(os.environ.get(ENV_VERCEL_OIDC_TOKEN))
+        sandbox = MagicMock()
+        sandbox.stop = AsyncMock()
+        sandbox.client = MagicMock()
+        sandbox.client.aclose = AsyncMock()
+        return sandbox
+
+    sdk = MagicMock()
+    sdk.AsyncSandbox = MagicMock()
+    sdk.AsyncSandbox.create = _create
+    return sdk, captured_env
+
+
+@pytest.fixture
+def patched_vercel_sdk() -> Any:
+    """Patch the vercel.sandbox module in sys.modules so the deferred import
+    inside _create_sandbox resolves to our mock.
+    """
+    sdk, captured_env = _make_vercel_sdk_mock()
+    parent = MagicMock()
+    parent.sandbox = sdk
+    with patch.dict(sys.modules, {"vercel": parent, "vercel.sandbox": sdk}):
+        yield sdk, captured_env
+
+
+@pytest.mark.asyncio
+async def test_oidc_token_injected_into_env_around_create(
+    patched_vercel_sdk: tuple[MagicMock, list[str | None]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When oidc_token is provided, _create_sandbox must place it in
+    os.environ[VERCEL_OIDC_TOKEN] BEFORE invoking AsyncSandbox.create().
+
+    Regression guard: previously the adapter passed use_oidc_env=True without
+    the token value, leaving _create_sandbox to call AsyncSandbox.create()
+    with no auth — the SDK then read an empty VERCEL_OIDC_TOKEN from env when
+    the token was sourced from the DB rather than the process environment.
+    """
+    _, captured_env = patched_vercel_sdk
+    monkeypatch.delenv(ENV_VERCEL_OIDC_TOKEN, raising=False)
+
+    backend = VercelSandboxBackend(oidc_token="db-resolved-token", language="PYTHON")
+    await backend._create_sandbox()
+
+    assert captured_env == ["db-resolved-token"], (
+        "AsyncSandbox.create() must observe the resolved OIDC token in "
+        f"os.environ[VERCEL_OIDC_TOKEN]; got {captured_env!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_oidc_token_env_restored_after_create(
+    patched_vercel_sdk: tuple[MagicMock, list[str | None]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After _create_sandbox returns, os.environ must be restored — set if it
+    was set, unset if it was unset. Otherwise per-evaluator OIDC tokens leak
+    process-wide.
+    """
+    monkeypatch.delenv(ENV_VERCEL_OIDC_TOKEN, raising=False)
+    backend = VercelSandboxBackend(oidc_token="ephemeral-token", language="PYTHON")
+    await backend._create_sandbox()
+    assert os.environ.get(ENV_VERCEL_OIDC_TOKEN) is None, (
+        "VERCEL_OIDC_TOKEN must be removed from env after create when it was "
+        "absent before — Phoenix's resolved token must not leak."
+    )
+
+
+@pytest.mark.asyncio
+async def test_preexisting_oidc_env_value_restored_after_create(
+    patched_vercel_sdk: tuple[MagicMock, list[str | None]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If VERCEL_OIDC_TOKEN was already set in env (e.g. user-provided),
+    _create_sandbox must restore that value after temporarily overriding it.
+    """
+    monkeypatch.setenv(ENV_VERCEL_OIDC_TOKEN, "user-env-token")
+    backend = VercelSandboxBackend(oidc_token="db-token", language="PYTHON")
+    _, captured_env = patched_vercel_sdk
+    await backend._create_sandbox()
+    # SDK saw the DB-sourced token (Phoenix's resolution wins).
+    assert captured_env == ["db-token"]
+    # Original env value is restored.
+    assert os.environ.get(ENV_VERCEL_OIDC_TOKEN) == "user-env-token"
+
+
+@pytest.mark.asyncio
+async def test_access_token_path_does_not_touch_oidc_env(
+    patched_vercel_sdk: tuple[MagicMock, list[str | None]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Access-token triple path passes credentials as create() kwargs; it must
+    NOT mutate VERCEL_OIDC_TOKEN env even briefly.
+    """
+    monkeypatch.delenv(ENV_VERCEL_OIDC_TOKEN, raising=False)
+    backend = VercelSandboxBackend(token="t", project_id="p", team_id="m", language="PYTHON")
+    _, captured_env = patched_vercel_sdk
+    await backend._create_sandbox()
+    # Env was never set during create.
+    assert captured_env == [None]
+    assert os.environ.get(ENV_VERCEL_OIDC_TOKEN) is None
+
+
+def test_constructor_rejects_no_credentials() -> None:
+    with pytest.raises(ValueError, match="oidc_token"):
+        VercelSandboxBackend(language="PYTHON")

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-27T18:32:16.252691Z"
+exclude-newer = "2026-04-27T20:06:34.476597Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -521,7 +521,7 @@ container = [
     { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
 daytona = [
-    { name = "daytona" },
+    { name = "daytona-sdk" },
 ]
 e2b = [
     { name = "e2b-code-interpreter" },
@@ -653,7 +653,7 @@ requires-dist = [
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.18.0" },
     { name = "azure-identity", marker = "extra == 'container'", specifier = ">=1.18.0" },
     { name = "cachetools" },
-    { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.140.0" },
+    { name = "daytona-sdk", marker = "extra == 'daytona'", specifier = ">=0.140.0" },
     { name = "e2b-code-interpreter", marker = "extra == 'e2b'", specifier = ">=0.0.12" },
     { name = "email-validator" },
     { name = "fastapi", specifier = ">=0.135.2" },
@@ -668,7 +668,7 @@ requires-dist = [
     { name = "jsonpath-ng" },
     { name = "jsonschema" },
     { name = "ldap3" },
-    { name = "modal", marker = "extra == 'modal'", specifier = ">=0.70.0" },
+    { name = "modal", marker = "extra == 'modal'", specifier = ">=1.2.0" },
     { name = "numpy" },
     { name = "openai", marker = "extra == 'container'", specifier = ">=2.14.0" },
     { name = "openinference-instrumentation", specifier = ">=0.1.44" },
@@ -1750,35 +1750,6 @@ wheels = [
 ]
 
 [[package]]
-name = "daytona"
-version = "0.167.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiofiles" },
-    { name = "daytona-api-client" },
-    { name = "daytona-api-client-async" },
-    { name = "daytona-toolbox-api-client" },
-    { name = "daytona-toolbox-api-client-async" },
-    { name = "deprecated" },
-    { name = "httpx" },
-    { name = "obstore" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation-aiohttp-client" },
-    { name = "opentelemetry-sdk" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "python-multipart" },
-    { name = "toml" },
-    { name = "urllib3" },
-    { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/11/ab9b78327316fd81aab5ca8d53242409019dd645e2b20e6d39f04ff2a2ad/daytona-0.167.0.tar.gz", hash = "sha256:b74673d5ed4d5ad160878827d49fd15a1f4e7aedc3297671c2a05dafb6be531d", size = 120927, upload-time = "2026-04-16T14:09:55.796Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/4b/8eeae072602529d8de4cb6b6ec3d677a063db4a2dab6179048da394d9893/daytona-0.167.0-py3-none-any.whl", hash = "sha256:84e1aeaa770179525d134b9091be79167770b189c1163369b64051b41de1c2e7", size = 149853, upload-time = "2026-04-16T14:09:54.092Z" },
-]
-
-[[package]]
 name = "daytona-api-client"
 version = "0.167.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1808,6 +1779,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/d2/6d9fa46ed2829a6e23c08a08f1f35c0a3cb106e1374c29b20488b3544704/daytona_api_client_async-0.167.0.tar.gz", hash = "sha256:e63eb3edd6111b2741d6eb350ed7c92100fd6147c46de5a4796e7dfc3009853c", size = 147781, upload-time = "2026-04-16T14:09:18.912Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/3f/06715c84e3bea9dd6ffa5886acb5c19e525e0107ab8ebde22107d61b57df/daytona_api_client_async-0.167.0-py3-none-any.whl", hash = "sha256:9cfc675c796cb8f008aa02b82d83e3496aef34287ec5187e624dd96ac471593c", size = 410077, upload-time = "2026-04-16T14:09:16.782Z" },
+]
+
+[[package]]
+name = "daytona-sdk"
+version = "0.167.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "daytona-api-client" },
+    { name = "daytona-api-client-async" },
+    { name = "daytona-toolbox-api-client" },
+    { name = "daytona-toolbox-api-client-async" },
+    { name = "deprecated" },
+    { name = "httpx" },
+    { name = "obstore" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-aiohttp-client" },
+    { name = "opentelemetry-sdk" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "python-multipart" },
+    { name = "toml" },
+    { name = "urllib3" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/f5/15865540138a4c8f1fe808f9bdf14487c76ee29e52d6431b1bfe9799d9a7/daytona_sdk-0.167.0.tar.gz", hash = "sha256:a633466a6ef649e7020e67ca9b23f5190c1932f3284dd13f1c55c6b32cbe3e3f", size = 120948, upload-time = "2026-04-16T14:09:59.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/28/52c1c8b6831215ed187254c67f9d79b0b19f9930b31ddc3580fa6e716b9a/daytona_sdk-0.167.0-py3-none-any.whl", hash = "sha256:c4cb199c274a1bcb95d42cc4da9189498d2cd9975a7737385409679066105695", size = 150365, upload-time = "2026-04-16T14:09:57.74Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Audit each sandbox provider adapter against its SDK, correct capability metadata, and plumb the newly-declared capabilities through build_backend / session creation / Sandbox.create.

- Modal: fix env_dict -> env kwarg (was broken on every modal version, since env_dict has never been a valid Sandbox.create kwarg); bump modal>=1.2.0 (first release with env kwarg); wire block_network and Image.debian_slim().pip_install(packages); flip internet_access_capability to "boolean" and dependencies_language to "PYTHON".
- Daytona: rename pyproject dependency daytona -> daytona-sdk (the adapter imports from daytona_sdk; prior pyproject was a silent ModuleNotFoundError); replace code_run(envs=...) with code_run(params=CodeRunParams(env=...)) (the SDK has never accepted an envs= kwarg); flip internet_access_capability to "boolean" and thread network_block_all through _create_kwargs() to client.create().
- E2B: flip internet_access_capability to "boolean" (wires allow_internet_access at AsyncSandbox.create) and dependencies_language to "PYTHON" (runtime pip install via commands.run using shlex.quote plus Python-list-literal embedding, never raw shell interpolation).
- Vercel: capability flags unchanged (Python SDK does not yet expose env or network_policy on AsyncSandbox.create); scaffolding comment updated to cite the exact SDK version checked.
- Phase 5 tests: add tests/unit/server/sandbox/test_capability_matrix.py with metadata-driven pytest.skip() guards so capability tests auto- activate as flags flip; per-adapter backend tests added for the new wiring. 161 sandbox tests pass.