### PR TITLE
feat(phoenix-otel): re-export openinference helpers, decorators, and semconv

### DIFF
--- a/packages/phoenix-otel/pyproject.toml
+++ b/packages/phoenix-otel/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
 ]
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
   "opentelemetry-semantic-conventions",
   "opentelemetry-exporter-otlp",

--- a/packages/phoenix-otel/src/phoenix/otel/__init__.py
+++ b/packages/phoenix-otel/src/phoenix/otel/__init__.py
@@ -1,3 +1,17 @@
+from openinference.instrumentation import (
+    suppress_tracing,
+    using_attributes,
+    using_metadata,
+    using_prompt_template,
+    using_session,
+    using_tags,
+    using_user,
+)
+from openinference.semconv.trace import (
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
 from opentelemetry.sdk.resources import Resource
 
 from .otel import (
@@ -33,4 +47,14 @@ __all__ = [
     "PROJECT_NAME",
     "register",
     "__version__",
+    "suppress_tracing",
+    "using_attributes",
+    "using_metadata",
+    "using_prompt_template",
+    "using_session",
+    "using_tags",
+    "using_user",
+    "SpanAttributes",
+    "OpenInferenceSpanKindValues",
+    "OpenInferenceMimeTypeValues",
 ]

--- a/packages/phoenix-otel/tests/test_exports.py
+++ b/packages/phoenix-otel/tests/test_exports.py
@@ -1,0 +1,49 @@
+"""Tests that openinference helpers, decorators, and semantic conventions are
+re-exported from phoenix.otel, so users do not need a separate dependency."""
+
+import pytest
+
+import phoenix.otel as phoenix_otel
+
+
+@pytest.mark.parametrize(
+    "name,source_module,source_attr",
+    [
+        ("suppress_tracing", "openinference.instrumentation", "suppress_tracing"),
+        ("using_attributes", "openinference.instrumentation", "using_attributes"),
+        ("using_metadata", "openinference.instrumentation", "using_metadata"),
+        ("using_prompt_template", "openinference.instrumentation", "using_prompt_template"),
+        ("using_session", "openinference.instrumentation", "using_session"),
+        ("using_tags", "openinference.instrumentation", "using_tags"),
+        ("using_user", "openinference.instrumentation", "using_user"),
+        ("SpanAttributes", "openinference.semconv.trace", "SpanAttributes"),
+        ("OpenInferenceSpanKindValues", "openinference.semconv.trace", "OpenInferenceSpanKindValues"),
+        ("OpenInferenceMimeTypeValues", "openinference.semconv.trace", "OpenInferenceMimeTypeValues"),
+    ],
+)
+def test_re_export_identity(name: str, source_module: str, source_attr: str) -> None:
+    """Each re-exported name must be the same object as its upstream source."""
+    import importlib
+
+    upstream = getattr(importlib.import_module(source_module), source_attr)
+    assert getattr(phoenix_otel, name) is upstream
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "suppress_tracing",
+        "using_attributes",
+        "using_metadata",
+        "using_prompt_template",
+        "using_session",
+        "using_tags",
+        "using_user",
+        "SpanAttributes",
+        "OpenInferenceSpanKindValues",
+        "OpenInferenceMimeTypeValues",
+    ],
+)
+def test_name_in_dunder_all(name: str) -> None:
+    """Every re-exported name must appear in phoenix.otel.__all__."""
+    assert name in phoenix_otel.__all__

--- a/packages/phoenix-otel/tests/test_exports.py
+++ b/packages/phoenix-otel/tests/test_exports.py
@@ -17,8 +17,16 @@ import phoenix.otel as phoenix_otel
         ("using_tags", "openinference.instrumentation", "using_tags"),
         ("using_user", "openinference.instrumentation", "using_user"),
         ("SpanAttributes", "openinference.semconv.trace", "SpanAttributes"),
-        ("OpenInferenceSpanKindValues", "openinference.semconv.trace", "OpenInferenceSpanKindValues"),
-        ("OpenInferenceMimeTypeValues", "openinference.semconv.trace", "OpenInferenceMimeTypeValues"),
+        (
+            "OpenInferenceSpanKindValues",
+            "openinference.semconv.trace",
+            "OpenInferenceSpanKindValues",
+        ),
+        (
+            "OpenInferenceMimeTypeValues",
+            "openinference.semconv.trace",
+            "OpenInferenceMimeTypeValues",
+        ),
     ],
 )
 def test_re_export_identity(name: str, source_module: str, source_attr: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-19T00:54:03.270120537Z"
+exclude-newer = "2026-04-21T16:57:34.149961Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -871,7 +871,7 @@ provides-extras = ["dev", "test"]
 
 [[package]]
 name = "arize-phoenix-otel"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "packages/phoenix-otel" }
 dependencies = [
     { name = "openinference-instrumentation" },


### PR DESCRIPTION
## Summary

Closes #12843

Re-exports openinference context managers, decorators, and semantic conventions from `arize-phoenix-otel` so users can fully instrument their applications with a single dependency, mirroring what the TypeScript `@arizeai/phoenix-otel` package already does.

**New exports from `phoenix.otel`:**

Context managers / decorators (from `openinference-instrumentation`):
- `suppress_tracing` - disable tracing for a code block
- `using_attributes` - attach session, user, metadata, tags, and prompt template in one call
- `using_metadata` - attach custom metadata dict to spans
- `using_prompt_template` - associate a prompt template with spans
- `using_session` - set the session ID for all spans in a context
- `using_tags` - attach string tags to spans
- `using_user` - set the user ID for all spans in a context

Semantic conventions (from `openinference-semantic-conventions`):
- `SpanAttributes` - string constants for OpenInference span attributes
- `OpenInferenceSpanKindValues` - enum of span kinds (LLM, AGENT, TOOL, ...)
- `OpenInferenceMimeTypeValues` - enum of MIME types (TEXT, JSON)

**Before:**
```python
from openinference.instrumentation import using_session, suppress_tracing
from openinference.semconv.trace import SpanAttributes
from phoenix.otel import register
```

**After:**
```python
from phoenix.otel import register, using_session, suppress_tracing, SpanAttributes
```

## What changed

- `packages/phoenix-otel/src/phoenix/otel/__init__.py`: Added 10 re-exports from `openinference-instrumentation` and `openinference-semantic-conventions`
- `packages/phoenix-otel/pyproject.toml`: Bumped version 0.15.0 to 0.16.0
- `packages/phoenix-otel/tests/test_exports.py`: New test file verifying re-export identity and `__all__` membership

Both `openinference-instrumentation` and `openinference-semantic-conventions` are already declared as runtime dependencies in `pyproject.toml`, so no new dependencies are introduced.

## Test plan

- `test_re_export_identity` - verifies each re-exported name is the same object as its upstream source
- `test_name_in_dunder_all` - verifies each re-exported name appears in `phoenix.otel.__all__`

Generated with [Claude Code](https://claude.com/claude-code)
