### PR TITLE
docs: adopt phoenix.otel re-exports for manual instrumentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1156,6 +1156,7 @@
               {
                 "group": "04.2026",
                 "pages": [
+                  "docs/phoenix/release-notes/04-2026/04-24-2026-phoenix-otel-python-0-16",
                   "docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id",
                   "docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7",
                   "docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres",

--- a/docs/phoenix/integrations/python/dspy/dspy-tracing.mdx
+++ b/docs/phoenix/integrations/python/dspy/dspy-tracing.mdx
@@ -45,7 +45,7 @@ class BasicQA(dspy.Signature):
 
 
 if __name__ == "__main__":
-    from openinference.instrumentation import using_attributes
+    from phoenix.otel import using_attributes  # requires arize-phoenix-otel>=0.16.0
 
     turbo = dspy.LM("openai/gpt-3.5-turbo")
 

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -7,6 +7,17 @@ description: The latest from the Phoenix team.
 GitHub
 </Card>
 
+<Update label="04.24.2026">
+## [04.24.2026: arize-phoenix-otel 0.16](/docs/phoenix/release-notes/04-2026/04-24-2026-phoenix-otel-python-0-16)
+**Available in arize-phoenix-otel 0.16.0+**
+
+`arize-phoenix-otel` now re-exports the most common OpenInference context managers and semantic conventions, so manual instrumentation no longer requires installing `openinference-instrumentation` or `openinference-semantic-conventions` as separate dependencies.
+
+- **Context managers** — `using_session`, `using_user`, `using_metadata`, `using_tags`, `using_attributes`, `using_prompt_template`, `suppress_tracing` (usable as `with` blocks or decorators)
+- **Semantic conventions** — `SpanAttributes`, `OpenInferenceSpanKindValues`, `OpenInferenceMimeTypeValues`
+- **Single install** — `pip install "arize-phoenix-otel>=0.16.0"` is enough for `register()` + context propagation
+</Update>
+
 <Update label="04.22.2026">
 ## [04.22.2026: Secrets Settings Page](/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id)
 **Available in arize-phoenix 14.11.0+**

--- a/docs/phoenix/release-notes/04-2026/04-24-2026-phoenix-otel-python-0-16.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-24-2026-phoenix-otel-python-0-16.mdx
@@ -1,0 +1,96 @@
+---
+title: "04.24.2026 arize-phoenix-otel 0.16"
+description: "OpenInference context managers and semantic conventions ship from a single phoenix.otel import — no second install required."
+---
+
+**Available in arize-phoenix-otel 0.16.0+**
+
+`arize-phoenix-otel` now re-exports the most common OpenInference context managers and semantic conventions, so manual instrumentation no longer requires pulling in `openinference-instrumentation` or `openinference-semantic-conventions` as separate dependencies.
+
+## Install
+
+```bash
+pip install "arize-phoenix-otel>=0.16.0"
+```
+
+<Note>
+`phoenix.otel` re-exports require **0.16.0 or later**. On older versions you must continue to import from `openinference.instrumentation` and `openinference.semconv.trace`.
+</Note>
+
+## Context Managers
+
+Propagate session IDs, user IDs, metadata, tags, prompt templates, and custom attributes to every span inside a block. Each helper works as both a `with` context manager and a function decorator.
+
+```python
+from phoenix.otel import (
+    register,
+    suppress_tracing,
+    using_attributes,
+    using_metadata,
+    using_prompt_template,
+    using_session,
+    using_tags,
+    using_user,
+)
+
+register(project_name="my-app", auto_instrument=True)
+
+with using_session(session_id="sess-123"), using_user("user-456"):
+    # auto-instrumented spans inside this block inherit session.id and user.id
+    ...
+
+@using_attributes(
+    session_id="sess-123",
+    metadata={"environment": "production"},
+    tags=["checkout", "v2"],
+)
+def handle_request(payload):
+    ...
+
+with suppress_tracing():
+    # spans created inside this block are dropped
+    ...
+```
+
+## OpenInference Semantic Conventions
+
+`SpanAttributes`, `OpenInferenceSpanKindValues`, and `OpenInferenceMimeTypeValues` are re-exported for use when building spans by hand.
+
+```python
+from phoenix.otel import (
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
+from opentelemetry import trace
+
+tracer = trace.get_tracer(__name__)
+
+with tracer.start_as_current_span(
+    "support-agent",
+    attributes={
+        SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.AGENT.value,
+        SpanAttributes.INPUT_VALUE: "where is my order?",
+        SpanAttributes.INPUT_MIME_TYPE: OpenInferenceMimeTypeValues.TEXT.value,
+    },
+) as span:
+    ...
+```
+
+## What's Not Re-exported
+
+Lower-level helpers continue to live in `openinference-instrumentation` and need a separate install when you use them:
+
+- Attribute builders — `get_llm_attributes`, `get_input_attributes`, `get_output_attributes`, `get_retriever_attributes`, `get_embedding_attributes`, `get_tool_attributes`
+- Trace redaction — `TraceConfig`
+- OpenInference message types — `Message`, `Image`, `TextMessageContent`, `ImageMessageContent`, `ToolCall`
+- Auto-instrumentor packages — `openinference-instrumentation-openai`, `openinference-instrumentation-langchain`, …
+
+<CardGroup cols={2}>
+  <Card title="arize-phoenix-otel Reference" icon="book" href="/docs/phoenix/sdk-api-reference/python/arize-phoenix-otel">
+    Full API reference for register, OTel primitives, and manual instrumentation helpers.
+  </Card>
+  <Card title="Using Tracing Helpers" icon="at" href="/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument">
+    Manual instrumentation walkthrough with decorators, context managers, and span kinds.
+  </Card>
+</CardGroup>

--- a/docs/phoenix/sdk-api-reference/python/arize-phoenix-otel.mdx
+++ b/docs/phoenix/sdk-api-reference/python/arize-phoenix-otel.mdx
@@ -10,8 +10,12 @@ Provides a lightweight wrapper around OpenTelemetry primitives with Phoenix-awar
 ## Installation
 
 ```sh
-pip install arize-phoenix-otel
+pip install "arize-phoenix-otel>=0.16.0"
 ```
+
+<Note>
+Starting in **0.16.0**, `phoenix.otel` re-exports the OpenInference context managers and semantic conventions, so manual instrumentation no longer requires separately installing `openinference-instrumentation` or `openinference-semantic-conventions`.
+</Note>
 
 ## Quick Start
 
@@ -95,6 +99,39 @@ tracer_provider = register(
 <Note>
 Spans may not be exported if still queued in the processor when your process exits. With `batch=True`, call `tracer_provider.shutdown()` to explicitly flush before exit. Alternatively, use `batch=False` for immediate export or a context manager (`with register(...) as tracer_provider`).
 </Note>
+
+---
+
+## Manual Instrumentation Helpers
+
+`phoenix.otel` re-exports the OpenInference context managers and semantic conventions so you can add session, user, metadata, tag, prompt template, and suppression context — plus set OpenInference span attributes — from a single import:
+
+```python
+from phoenix.otel import (
+    # Context managers (usable as `with` blocks or decorators)
+    suppress_tracing,
+    using_attributes,
+    using_metadata,
+    using_prompt_template,
+    using_session,
+    using_tags,
+    using_user,
+    # OpenInference semantic conventions
+    SpanAttributes,
+    OpenInferenceSpanKindValues,
+    OpenInferenceMimeTypeValues,
+)
+
+with using_session(session_id="abc-123"):
+    # auto-instrumented spans inside this block inherit session.id
+    ...
+```
+
+<Info>
+Requires `arize-phoenix-otel>=0.16.0`. Lower-level helpers (`get_llm_attributes`, `TraceConfig`, `Message`, `Image`, …) continue to live in the `openinference-instrumentation` package.
+</Info>
+
+See [Using Tracing Helpers](/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument) for a full walkthrough of manual instrumentation.
 
 ---
 

--- a/docs/phoenix/sdk-api-reference/python/arize-phoenix-otel.mdx
+++ b/docs/phoenix/sdk-api-reference/python/arize-phoenix-otel.mdx
@@ -14,7 +14,7 @@ pip install "arize-phoenix-otel>=0.16.0"
 ```
 
 <Note>
-Starting in **0.16.0**, `phoenix.otel` re-exports the OpenInference context managers and semantic conventions, so manual instrumentation no longer requires separately installing `openinference-instrumentation` or `openinference-semantic-conventions`.
+Starting in **0.16.0**, `phoenix.otel` re-exports the OpenInference context managers and semantic conventions, so manual instrumentation no longer requires separately installing `openinference-instrumentation` or `openinference-semantic-conventions`. On older versions, import them from `openinference.instrumentation` and `openinference.semconv.trace` instead.
 </Note>
 
 ## Quick Start

--- a/docs/phoenix/tracing/how-to-tracing/add-metadata/customize-spans.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/add-metadata/customize-spans.mdx
@@ -4,7 +4,7 @@ title: "Add Attributes, Metadata, Users"
 
 ### Using context to customize spans
 
-In order to customize spans that are created via auto-instrumentation, The Otel Context can be used to set span attributes created during a block of code (think child spans or spans under that block of code). Our [`openinference`](https://github.com/Arize-ai/openinference/tree/main) packages offer convenient tools to write and read from the OTel Context. Phoenix re-exports those TypeScript helpers from `@arizeai/phoenix-otel`, so you can register tracing and manage context attributes from the same package. The benefit of this approach is that OpenInference auto [instrumentors](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation) will pass (e.g. inherit) these attributes to all spans underneath a parent trace.
+In order to customize spans that are created via auto-instrumentation, The Otel Context can be used to set span attributes created during a block of code (think child spans or spans under that block of code). Our [`openinference`](https://github.com/Arize-ai/openinference/tree/main) packages offer convenient tools to write and read from the OTel Context. Phoenix re-exports those helpers directly from `arize-phoenix-otel` (Python, >=0.16.0) and `@arizeai/phoenix-otel` (TypeScript), so you can register tracing and manage context attributes from the same package. The benefit of this approach is that OpenInference auto [instrumentors](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation) will pass (e.g. inherit) these attributes to all spans underneath a parent trace.
 
 Supported Context Attributes include:
 
@@ -24,17 +24,19 @@ Supported Context Attributes include:
 
   * **Variables** key-value pairs applied to the prompt template.
 
-### Install Core Instrumentation Package
+### Install Phoenix OTEL
 
 <Tabs>
 
   <Tab title="Python" icon="python">
 
-    Install the core instrumentation package:
+    ```bash
+    pip install "arize-phoenix-otel>=0.16.0"
+    ```
 
-    ```
-    pip install openinference-instrumentation
-    ```
+    <Note>
+    Requires `arize-phoenix-otel` **0.16.0 or later** to import the context managers directly from `phoenix.otel`. Older versions must import from `openinference.instrumentation`.
+    </Note>
 
   </Tab>
 
@@ -57,7 +59,7 @@ Supported Context Attributes include:
     We provide a `using_session` context manager to add session a ID to the current OpenTelemetry Context. OpenInference auto [instrumentators](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation) will read this Context and pass the session ID as a span attribute, following the OpenInference [semantic conventions](https://github.com/Arize-ai/openinference/tree/main/python/openinference-semantic-conventions). Its input, the session ID, must be a non-empty string.
 
     ```python
-    from openinference.instrumentation import using_session
+    from phoenix.otel import using_session
 
     with using_session(session_id="my-session-id"):
         # Calls within this block will generate spans with the attributes:
@@ -106,7 +108,7 @@ Supported Context Attributes include:
     We provide a `using_user` context manager to add user ID to the current OpenTelemetry Context. OpenInference auto [instrumentators](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation) will read this Context and pass the user ID as a span attribute, following the OpenInference [semantic conventions](https://github.com/Arize-ai/openinference/tree/main/python/openinference-semantic-conventions). Its input, the user ID, must be a non-empty string.
 
     ```python
-    from openinference.instrumentation import using_user
+    from phoenix.otel import using_user
     with using_user("my-user-id"):
         # Calls within this block will generate spans with the attributes:
         # "user.id" = "my-user-id"
@@ -154,7 +156,7 @@ Supported Context Attributes include:
     We provide a `using_metadata` context manager to add metadata to the current OpenTelemetry Context. OpenInference auto [instrumentators](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation) will read this Context and pass the metadata as a span attribute, following the OpenInference [semantic conventions](https://github.com/Arize-ai/openinference/tree/main/python/openinference-semantic-conventions). Its input, the metadata, must be a dictionary with string keys. This dictionary will be serialized to JSON when saved to the OTEL Context and remain a JSON string when sent as a span attribute.
 
     ```python
-    from openinference.instrumentation import using_metadata
+    from phoenix.otel import using_metadata
     metadata = {
         "key-1": value_1,
         "key-2": value_2,
@@ -207,7 +209,7 @@ Supported Context Attributes include:
     We provide a `using_tags` context manager to add tags to the current OpenTelemetry Context. OpenInference auto [instrumentators](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation) will read this Context and pass the tags as a span attribute, following the OpenInference [semantic conventions](https://github.com/Arize-ai/openinference/tree/main/python/openinference-semantic-conventions). The input, the tag list, must be a list of strings.
 
     ```python
-    from openinference.instrumentation import using_tags
+    from phoenix.otel import using_tags
     tags = ["tag_1", "tag_2", ...]
     with using_tags(tags):
         # Calls within this block will generate spans with the attributes:
@@ -256,7 +258,7 @@ Supported Context Attributes include:
     We provide a `using_attributes` context manager to add attributes to the current OpenTelemetry Context. OpenInference auto [instrumentators](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation) will read this Context and pass the attributes fields as span attributes, following the OpenInference [semantic conventions](https://github.com/Arize-ai/openinference/tree/main/python/openinference-semantic-conventions). This is a convenient context manager to use if you find yourself using many of the previous ones in conjunction.
 
     ```python expandable
-    from openinference.instrumentation import using_attributes
+    from phoenix.otel import using_attributes
     tags = ["tag_1", "tag_2", ...]
     metadata = {
         "key-1": value_1,

--- a/docs/phoenix/tracing/how-to-tracing/add-metadata/customize-spans.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/add-metadata/customize-spans.mdx
@@ -35,7 +35,7 @@ Supported Context Attributes include:
     ```
 
     <Note>
-    Requires `arize-phoenix-otel` **0.16.0 or later** to import the context managers directly from `phoenix.otel`. Older versions must import from `openinference.instrumentation`.
+    Requires `arize-phoenix-otel` **0.16.0 or later** to import the context managers directly from `phoenix.otel`. On older versions, import them from `openinference.instrumentation` instead.
     </Note>
 
   </Tab>

--- a/docs/phoenix/tracing/how-to-tracing/add-metadata/instrumenting-prompt-templates-and-prompt-variables.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/add-metadata/instrumenting-prompt-templates-and-prompt-variables.mdx
@@ -17,7 +17,7 @@ Instrumenting prompt templates and variables allows you to track and visualize p
     * Variables: a dictionary with string keys. This dictionary will be serialized to JSON when saved to the OTEL Context and remain a JSON string when sent as a span attribute.
 
     ```python
-    from openinference.instrumentation import using_prompt_template
+    from phoenix.otel import using_prompt_template
 
     prompt_template = "Please describe the weather forecast for {city} on {date}"
     prompt_template_variables = {"city": "Johannesburg", "date":"July 11"}

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument.mdx
@@ -16,8 +16,14 @@ Ensure you have Phoenix OTEL installed:
 <Tabs>
 <Tab title="Python" icon="python">
 ```bash
-pip install arize-phoenix-otel
+pip install "arize-phoenix-otel>=0.16.0"
 ```
+
+<Note>
+**Version `arize-phoenix-otel>=0.16.0` is required for the examples on this page.** Starting in 0.16.0, `phoenix.otel` re-exports the OpenInference context managers (`using_session`, `using_user`, `using_metadata`, `using_tags`, `using_attributes`, `using_prompt_template`, `suppress_tracing`) and semantic conventions (`SpanAttributes`, `OpenInferenceSpanKindValues`, `OpenInferenceMimeTypeValues`) directly — no need to also install `openinference-instrumentation` or `openinference-semantic-conventions`.
+
+On older versions, import the same symbols from `openinference.instrumentation` and `openinference.semconv.trace` instead.
+</Note>
 </Tab>
 
 <Tab title="TypeScript" icon="js">
@@ -545,11 +551,15 @@ openai_client.chat.completions.create(
 )
 ```
 
-The snippets above produce LLM spans with input and output values, but don't offer rich UI for messages, tools, invocation parameters, etc. In order to manually instrument LLM spans with these features, users can define their own functions to wrangle the input and output of their LLM calls into OpenInference format. The `openinference-instrumentation` library contains helper functions that produce valid OpenInference attributes for LLM spans:
+The snippets above produce LLM spans with input and output values, but don't offer rich UI for messages, tools, invocation parameters, etc. In order to manually instrument LLM spans with these features, users can define their own functions to wrangle the input and output of their LLM calls into OpenInference format. These richer LLM attribute helpers are not re-exported from `phoenix.otel` — install `openinference-instrumentation` to access them:
 
 * `get_llm_attributes`
 * `get_input_attributes`
 * `get_output_attributes`
+
+```bash
+pip install openinference-instrumentation
+```
 
 For OpenAI, these functions might look like this:
 
@@ -1104,6 +1114,8 @@ The OpenInference Tracer shown above respects context Managers for [Suppressing 
 <Tabs>
 <Tab title="Python" icon="python">
 ```python
+from phoenix.otel import suppress_tracing
+
 with suppress_tracing():
     # this trace will not be recorded
     with tracer.start_as_current_span(
@@ -1148,6 +1160,8 @@ await context.with(suppressTracing(context.active()), async () => {
 <Tabs>
 <Tab title="Python" icon="python">
 ```python
+from phoenix.otel import using_attributes
+
 with using_attributes(session_id="123"):
     # this trace has session id "123"
     with tracer.start_as_current_span(

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-sessions.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-sessions.mdx
@@ -36,18 +36,21 @@ Below is an example of logging conversations:
 
     First make sure you have the required dependencies installed
 
-    ```
-    pip install openinference-instrumentation
+    ```bash
+    pip install "arize-phoenix-otel>=0.16.0"
     ```
 
-    Below is an example of how to use `openinference.instrumentation` to the traces created.
+    <Note>
+    Requires `arize-phoenix-otel` **0.16.0 or later** for `using_session` and `SpanAttributes` to be importable directly from `phoenix.otel`. On older versions, import them from `openinference.instrumentation` and `openinference.semconv.trace`.
+    </Note>
+
+    Below is an example of how to propagate session IDs to auto-instrumented spans.
 
     ```python
     import uuid
 
     import openai
-    from openinference.instrumentation import using_session
-    from openinference.semconv.trace import SpanAttributes
+    from phoenix.otel import SpanAttributes, using_session
     from opentelemetry import trace
 
     client = openai.Client()

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
@@ -47,8 +47,12 @@ The Phoenix OTEL SDK provides a lightweight wrapper around OpenTelemetry with se
 <Tabs>
   <Tab title="Python" icon="python">
     ```bash
-    pip install arize-phoenix-otel
+    pip install "arize-phoenix-otel>=0.16.0"
     ```
+
+    <Note>
+    Version **0.16.0** or later is required to import OpenInference helpers, context managers, and semantic conventions directly from `phoenix.otel`. On earlier versions you must import them from `openinference-instrumentation` and `openinference-semantic-conventions`.
+    </Note>
   </Tab>
   <Tab title="TypeScript" icon="js">
     ```bash
@@ -82,7 +86,10 @@ You can find your collector endpoint and API key in the **Settings** page of you
 
 Call `register()` to initialize tracing. The SDK automatically reads your environment variables.
 
-For manual tracing, the same package also exports `withSpan`, `traceChain`, `traceAgent`, `traceTool`, `observe`, and context setters like `setSession` and `setMetadata`.
+For manual instrumentation, `arize-phoenix-otel` (>=0.16.0) and `@arizeai/phoenix-otel` re-export all commonly used OpenInference helpers so a single dependency is sufficient:
+
+- **Python**: context managers (`using_session`, `using_user`, `using_metadata`, `using_tags`, `using_attributes`, `using_prompt_template`, `suppress_tracing`) and semantic conventions (`SpanAttributes`, `OpenInferenceSpanKindValues`, `OpenInferenceMimeTypeValues`).
+- **TypeScript**: `withSpan`, `traceChain`, `traceAgent`, `traceTool`, `observe`, and context setters like `setSession` and `setMetadata`.
 
 <Tabs>
   <Tab title="Python" icon="python">

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
@@ -51,7 +51,7 @@ The Phoenix OTEL SDK provides a lightweight wrapper around OpenTelemetry with se
     ```
 
     <Note>
-    Version **0.16.0** or later is required to import OpenInference helpers, context managers, and semantic conventions directly from `phoenix.otel`. On earlier versions you must import them from `openinference-instrumentation` and `openinference-semantic-conventions`.
+    Version **0.16.0** or later is required to import OpenInference context managers and semantic conventions directly from `phoenix.otel`. On earlier versions, import them from `openinference.instrumentation` and `openinference.semconv.trace` instead.
     </Note>
   </Tab>
   <Tab title="TypeScript" icon="js">

--- a/docs/phoenix/tracing/tutorial/sessions.mdx
+++ b/docs/phoenix/tracing/tutorial/sessions.mdx
@@ -53,8 +53,12 @@ You'll need Phoenix OTEL to register tracing and set session context:
 
   <Tab title="Python" icon="python">
     ```bash
-    pip install openinference-instrumentation
+    pip install "arize-phoenix-otel>=0.16.0"
     ```
+
+    <Note>
+    `arize-phoenix-otel` **0.16.0+** is required to import `using_session` and `SpanAttributes` from `phoenix.otel`. On older versions, install `openinference-instrumentation` and `openinference-semantic-conventions` and import from those packages instead.
+    </Note>
   </Tab>
 </Tabs>
 
@@ -113,8 +117,7 @@ Here's how to modify your support agent to support sessions:
   <Tab title="Python" icon="python">
     ```python
     from opentelemetry import trace
-    from openinference.instrumentation import using_session
-    from openinference.semconv.trace import SpanAttributes
+    from phoenix.otel import SpanAttributes, using_session
 
     tracer = trace.get_tracer("support-agent")
 
@@ -490,7 +493,7 @@ Here's the full evaluation flow. First, fetch spans from Phoenix and group them 
     import json
     from typing import Dict, List, Any
     from phoenix.client.resources.spans import SpanAnnotationData
-    from openinference.semconv.trace import SpanAttributes
+    from phoenix.otel import SpanAttributes
 
     # Fetch all agent spans
     spans = phoenix_client.spans.get_spans(

--- a/docs/phoenix/tracing/tutorial/your-first-traces.mdx
+++ b/docs/phoenix/tracing/tutorial/your-first-traces.mdx
@@ -57,8 +57,12 @@ First, install the dependencies and configure OpenTelemetry to send traces to Ph
 
   <Tab title="Python" icon="python">
     ```bash
-    pip install arize-phoenix-otel arize-phoenix-client openai openinference-instrumentation-openai numpy
+    pip install "arize-phoenix-otel>=0.16.0" arize-phoenix-client openai openinference-instrumentation-openai numpy
     ```
+
+    <Note>
+    `arize-phoenix-otel` **0.16.0+** is required to import `SpanAttributes` and the OpenInference context managers directly from `phoenix.otel`.
+    </Note>
   </Tab>
 </Tabs>
 
@@ -395,7 +399,7 @@ To see all operations for a single request as one trace, wrap them in a parent s
   <Tab title="Python" icon="python">
     ```python
     from opentelemetry import trace
-    from openinference.semconv.trace import SpanAttributes
+    from phoenix.otel import SpanAttributes
 
     def handle_support_query(user_query: str) -> AgentResponse:
         tracer = trace.get_tracer("support-agent")

--- a/docs/phoenix/tracing/tutorial/your-first-traces.mdx
+++ b/docs/phoenix/tracing/tutorial/your-first-traces.mdx
@@ -61,7 +61,7 @@ First, install the dependencies and configure OpenTelemetry to send traces to Ph
     ```
 
     <Note>
-    `arize-phoenix-otel` **0.16.0+** is required to import `SpanAttributes` and the OpenInference context managers directly from `phoenix.otel`.
+    `arize-phoenix-otel` **0.16.0+** is required to import `SpanAttributes` and the OpenInference context managers directly from `phoenix.otel`. On older versions, import them from `openinference.instrumentation` and `openinference.semconv.trace` instead.
     </Note>
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

Rewrite Python manual instrumentation docs to use the new `phoenix.otel` re-exports shipped in [arize-phoenix-otel 0.16.0](https://github.com/Arize-ai/phoenix/commit/23576da85d9de51527b525b3d20625785e175b23). Users can now register tracing and add context managers + OpenInference semantic conventions from a single `phoenix.otel` import.

- Replaced `from openinference.instrumentation import using_* / suppress_tracing` and `from openinference.semconv.trace import SpanAttributes / OpenInferenceSpanKindValues / OpenInferenceMimeTypeValues` with `from phoenix.otel import ...` across the tracing how-to guides, tutorials, and the DSPy integration page.
- Pinned the install commands to `pip install "arize-phoenix-otel>=0.16.0"` and added callouts explaining that 0.16.0+ is required for the re-exports (older versions must continue to import from `openinference-instrumentation` / `openinference-semantic-conventions`).
- Added a new **Manual Instrumentation Helpers** section to the `arize-phoenix-otel` SDK reference listing what was re-exported and what still lives in `openinference-instrumentation` (`TraceConfig`, `get_llm_attributes`, `Message`, `Image`, …).
- Added a release-notes entry (`04-24-2026-phoenix-otel-python-0-16`) and wired it into both `docs.json` and `docs/phoenix/release-notes.mdx`.

## Test plan
- [ ] `mintlify dev` (or `vercel preview`) renders the updated pages without broken `<Note>` / `<Tabs>` / `<CardGroup>` structures
- [ ] Release notes index shows the 04.24.2026 entry at the top of the list
- [ ] Navigation sidebar shows the new release notes page under `04.2026`
- [ ] Copy samples from `customize-spans`, `setup-sessions`, `instrument`, and `tutorial/sessions` execute without import errors on arize-phoenix-otel 0.16.0
- [ ] Confirm older-version fallback text (`openinference.instrumentation` imports) is accurate for <=0.15.x users