### PR TITLE
docs(skills): weekly audit — 2026-04-25

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -115,6 +115,11 @@ px span list --parent-id null --limit 10                   # only root spans
 px span list --parent-id <span-id> --limit 10              # only children of a span
 px span list --include-annotations --limit 10              # include annotation scores
 px span list --include-notes --limit 10                    # include span notes
+px span list --attribute llm.model_name:gpt-4 --limit 10  # filter by string attribute
+px span list --attribute llm.token_count.total:500 --limit 10  # filter by numeric attribute
+px span list --attribute 'user.id:"12345"' --limit 10     # force string match for numeric-looking value
+px span list --attribute session.id:sess:abc:123 --limit 20  # colon in value OK (split on first colon only)
+px span list --attribute llm.model_name:gpt-4 --attribute session.id:abc --limit 10  # AND multiple filters
 px span list output.json --limit 100                       # save to JSON file
 px span list --format raw --no-progress | jq '.[] | select(.status_code == "ERROR")'
 px span annotate <span-id> --name reviewer --label pass

--- a/.agents/skills/phoenix-tracing/references/metadata-python.md
+++ b/.agents/skills/phoenix-tracing/references/metadata-python.md
@@ -5,13 +5,13 @@ Add custom attributes to spans for richer observability.
 ## Install
 
 ```bash
-pip install openinference-instrumentation
+pip install arize-phoenix-otel  # context managers and SpanAttributes re-exported since 0.16.0
 ```
 
 ## Session
 
 ```python
-from openinference.instrumentation import using_session
+from phoenix.otel import using_session
 
 with using_session(session_id="my-session-id"):
     # Spans get: "session.id" = "my-session-id"
@@ -21,7 +21,7 @@ with using_session(session_id="my-session-id"):
 ## User
 
 ```python
-from openinference.instrumentation import using_user
+from phoenix.otel import using_user
 
 with using_user("my-user-id"):
     # Spans get: "user.id" = "my-user-id"
@@ -31,7 +31,7 @@ with using_user("my-user-id"):
 ## Metadata
 
 ```python
-from openinference.instrumentation import using_metadata
+from phoenix.otel import using_metadata
 
 with using_metadata({"key": "value", "experiment_id": "exp_123"}):
     # Spans get: "metadata" = '{"key": "value", "experiment_id": "exp_123"}'
@@ -41,7 +41,7 @@ with using_metadata({"key": "value", "experiment_id": "exp_123"}):
 ## Tags
 
 ```python
-from openinference.instrumentation import using_tags
+from phoenix.otel import using_tags
 
 with using_tags(["tag_1", "tag_2"]):
     # Spans get: "tag.tags" = '["tag_1", "tag_2"]'
@@ -51,7 +51,7 @@ with using_tags(["tag_1", "tag_2"]):
 ## Combined (using_attributes)
 
 ```python
-from openinference.instrumentation import using_attributes
+from phoenix.otel import using_attributes
 
 with using_attributes(
     session_id="my-session-id",
@@ -79,6 +79,8 @@ span.set_attribute("session.id", "session_456")
 All context managers can be used as decorators:
 
 ```python
+from phoenix.otel import using_session, using_user, using_metadata
+
 @using_session(session_id="my-session-id")
 @using_user("my-user-id")
 @using_metadata({"env": "prod"})

--- a/.agents/skills/phoenix-tracing/references/sessions-python.md
+++ b/.agents/skills/phoenix-tracing/references/sessions-python.md
@@ -5,7 +5,7 @@ Track multi-turn conversations by grouping traces with session IDs.
 ## Setup
 
 ```python
-from openinference.instrumentation import using_session
+from phoenix.otel import using_session
 
 with using_session(session_id="user_123_conv_456"):
     response = llm.invoke(prompt)
@@ -16,7 +16,7 @@ with using_session(session_id="user_123_conv_456"):
 **Bad: Only parent span gets session ID**
 
 ```python
-from openinference.semconv.trace import SpanAttributes
+from phoenix.otel import SpanAttributes
 from opentelemetry import trace
 
 span = trace.get_current_span()
@@ -51,7 +51,7 @@ Bad: `"session_1"`, `"test"`, empty string
 
 ```python
 import uuid
-from openinference.instrumentation import using_session
+from phoenix.otel import using_session
 
 session_id = str(uuid.uuid4())
 messages = []
@@ -73,7 +73,7 @@ def send_message(user_input: str) -> str:
 ## Additional Attributes
 
 ```python
-from openinference.instrumentation import using_attributes
+from phoenix.otel import using_attributes
 
 with using_attributes(
     user_id="user_123",


### PR DESCRIPTION
# Phoenix Skills Audit — 2026-04-18 to 2026-04-25

**Audited against:** `origin/main` at `3d6cc81a7a6a360dd230e49173ae684caf022682`
**Commits analyzed:** 45 total (4 user-facing, 41 skipped)

## Edits applied

### phoenix-tracing

- `references/metadata-python.md` — updated install instruction (no longer requires a separate
  `openinference-instrumentation` package; `arize-phoenix-otel` re-exports everything since 0.16.0)
  and replaced all five `from openinference.instrumentation import using_*` imports with
  `from phoenix.otel import using_*` (commit `23576da85`; verified against
  `packages/phoenix-otel/src/phoenix/otel/__init__.py` `__all__` additions). Also added explicit
  import to the decorator example block.
- `references/sessions-python.md` — replaced three stale imports sourced from
  `openinference.instrumentation` and `openinference.semconv.trace` with their canonical
  `phoenix.otel` equivalents (`using_session`, `SpanAttributes`, `using_attributes`) per the same
  commit `23576da85`.

### phoenix-cli

- `SKILL.md` — added five `px span list --attribute` examples to the `## Spans` section documenting
  the new type-aware attribute filter (commit `c0badfaa0`; flag name and behavior verified against
  `js/packages/phoenix-cli/src/commands/span.ts` lines 385–387 and Python client
  `packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py` lines 476–526).
  Covers: string match, numeric match, forced-string JSON-quoting (`"value"`), colon-in-value
  semantics (split on first `:` only), and AND-semantics for repeated flags. Requires Phoenix
  server >= 14.9.0.

### phoenix-evals

No edits needed — the Stability sections in `experiments-running-python.md`,
`experiments-running-typescript.md`, and the `Single-run scoring` anti-pattern row in
`fundamentals-anti-patterns.md` were already applied in commit `fab5d89b1` by the author who
landed the feature.

## Skipped commits

| Commit | Reason |
|--------|--------|
| `3d6cc81a7` feat(skills): add phoenix-skills-audit skill | Meta — adds this skill itself; no client/CLI/API surface change |
| `ce1489ee9` chore(main): release arize-phoenix-client 2.5.0 | Release bookkeeping |
| `449a98479` chore: update phoenix version 14.14.0 kustomize/helm | Infra only |
| `e9cadd5de` feat(app): add sessions_ux flag with Turns/Traces toggle | Feature flag + frontend only |
| `5109896bc` chore(js): update versions | Version bookkeeping |
| `38f8629d0` / `228821fd3` / `cec235e0f` / `a3d2cfa65` / `01feb0e88` / `b9d5bf82d` / `852ab3b20` / `5beaa2025` | Release bookkeeping chores |
| `833c18943` docs: adopt phoenix.otel re-exports for manual instrumentation | Docs update that mirrors the code change already captured above (skill edits made to source, not docs) |
| `4f360a92d` chore(main): release arize-phoenix-otel 0.16.0 | Release bookkeeping |
| `c83d9ec32` feat(ui): add trace notes column to spans table | Frontend only |
| `9944c8f09` docs: fill 4 HIGH gaps from weekly audit | Mintlify docs only |
| `5a8f5c8eb` docs: Add Phoenix release notes | Mintlify docs only |
| `ff5b646a3` / `a3fbce09c` fix(cost): update built-in model token prices | Internal server — no public surface |
| `ec6565ea3` feat: Add a dedicated span notes column | Frontend only |
| `2d49516a7` / `bff91c200` docs: Audit and update llms.txt | llms.txt docs only |
| `ec35f3caf` fix: demote redundant experiment failure logs to debug | Internal server |
| `38b26d1d9` feat: aggregate span info on traces | GraphQL server — new `Trace` fields (`errorCount`, `spanCountsByKind`); CLI does not expose these fields in its JSON output shape yet |
| `51be82b4f` / `ae6da8c21` / `21680aee0` / `041b8e54b` / `86336cbc2` chore(deps) | Dependency bumps |
| `f251ddc59` feat: add trace annotations column to spans table | Frontend + GraphQL schema (new `traceAnnotations` field on `Span`); not yet surfaced in CLI JSON shape |
| `d17ae1272` fix: retain authenticated root Relay query data | Frontend only |
| `07038b3ce` chore: test out cli schema | CI + schema file addition (no command changes) |
| `e2bc44c01` feat(app): portal page controls into top nav | Frontend only |
| `9211d0ade` fix(app): update secrets list synchronously on mutation | Frontend only |
| `a671056c2` chore(deps): bump python-dotenv in examples | Example deps |
| `63a6b2ee3` chore(main): release arize-phoenix-client 2.4.0 | Release bookkeeping (changes captured separately in `c0badfaa0`) |
| `f91199221` feat(secrets): Add secrets settings page | Frontend only |
| `d55dadf20` fix(app): use Empty component for annotations empty state | Frontend only |
| `81db7aa7e` feat(ui): add Show Table Aside toggle (featureflagged) | Feature flag + frontend |
| `f5f9bea1e` fix(deps): migrate authlib.jose to joserfc | Internal auth dep swap |
| `c31fd9783` feat(app): show root span name in session turn list | Frontend only |
| `b2a42f390` fix(playground): align connectionConfig keys | Frontend only |
| `c30591951` feat(agent): Display token count for chat sessions | PXI agent internal |
| `cc606d843` fix(deps): pin authlib<1.7.0 | Dep pin (superseded by f5f9bea1e) |
| `d37bdfaa2` fix(db): wrap Azure AsyncEngine with ObjectProxy | Internal DB fix |
| `3dc0a01db` chore(js): update versions | Version bookkeeping |
| `e19a038fe` chore: add changesets for span attribute filter | Internal changeset scaffolding |
| `0bf480cdf` fix: remove force_flush from get_db_traces | Internal tracer fix |
| `ebc9997d0` feat: Add PXI consent and trace-sharing controls | PXI agent frontend/internal |
| `219a24c64` docs: add version notes for self-hosting configuration | Mintlify docs only |
| `e90491112` Offload tracer.shutdown() to a thread in /chat cleanup | Internal |
| `e5e7f1a5a` fix(graphql): remove default_factory=dict on Strawberry JSON fields | Internal GraphQL fix |
| `04fee9021` / `0268fb2b0` / `0a7a6b4e8` chore: update sitemap.xml | Infra |
| `d7687a9f3` / `2da252047` / `3efae2dc3` / `989a9d794` chore: update phoenix version kustomize/helm | Infra |

## Out-of-scope findings

- **`38b26d1d9` aggregate span info on traces** — adds `errorCount`, `errorsByType`, and
  `spanCountsByKind` GraphQL fields to the `Trace` type. The CLI does not yet expose these in its
  JSON output shape, so no CLI skill edit was made. If a future PR surfaces them in `px trace list`
  / `px trace get` output, the CLI skill `## Trace JSON shape` block will need updating.
- **`f251ddc59` add trace annotations column** — adds a `traceAnnotations` field to the GraphQL
  `Span` type. Frontend-only today; no CLI surface change.
- **`a4dad8b9b` / `ed66c0280` trace note CLI + REST** — CLI SKILL.md was already patched by the
  author in the same commit (`a4dad8b9b`). No further edits needed.
- **Python-only `get_spans(attributes=...)` in `arize-phoenix-client`** — the TS mirror
  (`@arizeai/phoenix-client` `getSpans`) also received an `attribute` parameter in the same PR
  (`c0badfaa0`). Neither the tracing skill nor a standalone client skill currently documents the
  Python/TS SDK `get_spans` call, so no skill edit was made for the SDK surface (only the CLI
  wrapper was documented, which is in scope for `phoenix-cli`).
