### PR TITLE
docs(skills): add open-coding and axial-coding references to phoenix-cli skill

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -44,6 +44,25 @@ export PHOENIX_API_KEY=your-api-key  # if auth is enabled
 
 Always use `--format raw --no-progress` when piping to `jq`.
 
+## Quick Reference
+
+| Task | Files |
+| ---- | ----- |
+| Open code sampled traces | [references/open-coding](references/open-coding.md) |
+| Analyze errors (axial coding) | [references/axial-coding](references/axial-coding.md) |
+
+## Workflows
+
+**Error Analysis:**
+[open-coding](references/open-coding.md) → [axial-coding](references/axial-coding.md)
+
+## Reference Categories
+
+| Prefix | Description |
+| ------ | ----------- |
+| `references/open-coding` | Sample traces and label them with open codes |
+| `references/axial-coding` | Group open codes into error categories |
+
 ## Auth
 
 ```bash

--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phoenix-cli
-description: Debug LLM applications using the Phoenix CLI. Fetch traces, analyze errors, review experiments, inspect datasets, query annotation configs, and use the GraphQL API. Use when debugging AI/LLM applications, analyzing trace data, working with Phoenix observability, investigating LLM performance issues, or checking Phoenix auth status.
+description: Debug LLM applications using the Phoenix CLI. Fetch traces, analyze errors, structure trace review with open coding and axial coding, inspect datasets, review experiments, query annotation configs, and use the GraphQL API. Use whenever the user is analyzing traces or spans, investigating LLM/agent failures, deciding what to do after instrumenting an app, building failure taxonomies, choosing what evals to write, or asking "what's going wrong", "what kinds of mistakes", or "where do I focus" — even without naming a technique.
 license: Apache-2.0
 compatibility: Requires Node.js (for npx) or global install of @arizeai/phoenix-cli. Optionally requires jq for JSON processing.
 metadata:
@@ -48,20 +48,20 @@ Always use `--format raw --no-progress` when piping to `jq`.
 
 | Task | Files |
 | ---- | ----- |
-| Open code sampled traces | [references/open-coding](references/open-coding.md) |
-| Analyze errors (axial coding) | [references/axial-coding](references/axial-coding.md) |
+| Look at sampled traces and write specific notes about what went wrong (no taxonomy yet) | [references/open-coding](references/open-coding.md) |
+| Group those notes into a structured failure taxonomy and quantify what matters | [references/axial-coding](references/axial-coding.md) |
 
 ## Workflows
 
-**Error Analysis:**
-[open-coding](references/open-coding.md) → [axial-coding](references/axial-coding.md)
+**"What do I do after instrumenting?" / "Where do I focus?" / "What's going wrong?"**
+[open-coding](references/open-coding.md) → [axial-coding](references/axial-coding.md) → build evals for the top categories.
 
 ## Reference Categories
 
 | Prefix | Description |
 | ------ | ----------- |
-| `references/open-coding` | Sample traces and label them with open codes |
-| `references/axial-coding` | Group open codes into error categories |
+| `references/open-coding` | Free-form notes against sampled spans — reach for it whenever the user wants to make sense of traces but has no failure categories yet |
+| `references/axial-coding` | Inductive grouping of notes into a MECE taxonomy with counts — reach for it whenever the user has observations and needs categories or eval targets |
 
 ## Auth
 

--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -60,7 +60,7 @@ Always use `--format raw --no-progress` when piping to `jq`.
 
 | Prefix | Description |
 | ------ | ----------- |
-| `references/open-coding` | Free-form notes against sampled spans — reach for it whenever the user wants to make sense of traces but has no failure categories yet |
+| `references/open-coding` | Free-form notes against sampled traces — reach for it whenever the user wants to make sense of traces but has no failure categories yet |
 | `references/axial-coding` | Inductive grouping of notes into a MECE taxonomy with counts — reach for it whenever the user has observations and needs categories or eval targets |
 
 ## Auth

--- a/.agents/skills/phoenix-cli/references/axial-coding.md
+++ b/.agents/skills/phoenix-cli/references/axial-coding.md
@@ -1,15 +1,20 @@
 # Axial Coding
 
-Group open-ended notes into structured failure taxonomies. Axial coding is **step 3** of the 5-step error-analysis workflow: sample → open code → **axial code** → quantify → prioritize. See [open-coding.md](open-coding.md) for step 2 (adding open-coding notes to spans).
+Group open-ended notes into structured failure taxonomies. Axial coding is **step 3** of the 5-step error-analysis workflow: sample → open code → **axial code** → quantify → prioritize. See [open-coding.md](open-coding.md) for step 2 (adding open-coding notes).
 
 **Reach for this whenever** the user has observations and needs structure — e.g., "what categories of failures do we have", "what should I build evals for", "how do I prioritize fixes", "group these notes", "MECE breakdown", or any framing that asks for categories or counts grounded in real traces rather than invented top-down.
 
+## Choosing the unit
+
+Open-coding notes are usually **trace-level** (see [open-coding.md#choosing-the-unit](open-coding.md#choosing-the-unit)) — examples below lead with `px trace` and fall back to `px span` for span-level notes. **An axial label can live at a different level than the note that informed it** — that's a feature: a trace-level note "answered shipping when asked returns" can produce a span-level annotation on the retrieval span once a pattern reveals retrieval as the consistent culprit. Re-attribution at axial coding time is what axial coding *is*. Session-level rollups go through REST `/v1/projects/{id}/session_annotations` (no CLI write path).
+
 ## Process
 
-1. **Gather** - Collect open coding notes from reviewed spans
-2. **Pattern** - Group notes with common themes
-3. **Name** - Create actionable category names
-4. **Quantify** - Count failures per category
+1. **Gather** — Collect open-coding notes from the entities you reviewed (trace-level by default)
+2. **Pattern** — Group notes with common themes
+3. **Name** — Create actionable category names
+4. **Attribute** — Decide what level each category lives at; an axial label can move from the note's level to the component the pattern implicates
+5. **Quantify** — Count failures per category
 
 ## Example Taxonomy
 
@@ -39,12 +44,16 @@ failure_taxonomy:
 Open-coding notes are stored as annotations with `name="note"` and are only returned when `--include-notes` is passed. Use `--include-annotations` instead and you will get structured annotations but **not** notes — the server excludes notes from the annotations array.
 
 ```bash
+# Trace-level notes (default for open coding)
+px trace list --include-notes --format raw --no-progress | jq '
+  [ .[] | select((.notes // []) | length > 0) ]
+  | map({ trace_id: .traceId, notes: [ .notes[].result.explanation ] })
+'
+
+# Span-level notes (when open coding dropped to span for mechanical failures)
 px span list --include-notes --format raw --no-progress | jq '
-  [ .[] | select(.notes | length > 0) ]
-  | map({
-      span_id: .context.span_id,
-      notes: [ .notes[].result.explanation ]
-    })
+  [ .[] | select((.notes // []) | length > 0) ]
+  | map({ span_id: .context.span_id, notes: [ .notes[].result.explanation ] })
 '
 ```
 
@@ -54,11 +63,11 @@ Review the note text collected above. Manually identify recurring themes and dra
 
 ### 3. Record — write axial-coding annotations
 
-Write one annotation per span using `px span annotate`. See the **Recording** section below.
+Write one annotation per entity using `px trace annotate` or `px span annotate`. The level can differ from where the source note lives — see the **Recording** section below.
 
 ### 4. Quantify — count per category
 
-After recording, use `--include-annotations` to count how many spans carry each label:
+After recording, use `--include-annotations` to count how many entities carry each label. Examples below show span-level counts; for trace-level annotations, swap `px span list` for `px trace list` (the `.annotations[]` shape is the same).
 
 ```bash
 px span list --include-annotations --format raw --no-progress | jq '
@@ -80,35 +89,45 @@ px span list --include-annotations --format raw --no-progress | jq '
 
 ## Recording
 
-Use `px span annotate` to write an axial-coding label for each span:
+Use the matching annotate command for the level the **label** belongs at — which may differ from where the source note lives (see [Choosing the unit](#choosing-the-unit)):
 
 ```bash
+# Trace-level label (most common — the trace as a whole exhibits the failure)
+px trace annotate <trace-id> \
+  --name failure_category \
+  --label answered_off_topic \
+  --explanation "asked about returns; answer covered shipping" \
+  --annotator-kind HUMAN
+
+# Span-level label (when the pattern implicates a specific component)
 px span annotate <span-id> \
   --name failure_category \
-  --label hallucination \
-  --explanation "invented a feature that does not exist" \
+  --label retrieval_off_topic \
+  --explanation "retrieved shipping docs for a returns query" \
   --annotator-kind HUMAN
 ```
 
-Accepted flags: `--name`, `--label`, `--score`, `--explanation`, `--annotator-kind` (`HUMAN`, `LLM`, `CODE`). There are no `--identifier` or `--sync` flags on this command.
+Accepted flags: `--name`, `--label`, `--score`, `--explanation`, `--annotator-kind` (`HUMAN`, `LLM`, `CODE`). There are no `--identifier` or `--sync` flags on these commands.
 
 ### Bulk recording
 
-Axial coding categorizes the spans you took notes on during open coding, so stream span IDs from spans that already carry an open-coding note. Do **not** filter by `--status-code ERROR` — that captures only spans where Python raised, which excludes most failure modes (hallucination, wrong tone, retrieval miss). See [open-coding.md](open-coding.md#inspection) for the full reasoning.
+Axial coding categorizes the entities you took notes on during open coding. Do **not** filter by `--status-code ERROR` — that captures only spans where Python raised, which excludes most failure modes (hallucination, wrong tone, retrieval miss). See [open-coding.md](open-coding.md#inspection) for the full reasoning.
 
 ```bash
-# Bulk-annotate spans that already have open-coding notes
-px span list --include-notes --format raw --no-progress \
-  | jq -r '.[] | select((.notes // []) | length > 0) | .context.span_id' \
-  | while read sid; do
-      px span annotate "$sid" \
+# Bulk-annotate traces that already have open-coding notes
+px trace list --include-notes --format raw --no-progress \
+  | jq -r '.[] | select((.notes // []) | length > 0) | .traceId' \
+  | while read tid; do
+      px trace annotate "$tid" \
         --name failure_category \
-        --label hallucination \
+        --label answered_off_topic \
         --annotator-kind HUMAN
     done
 ```
 
-Aside: for Node-based bulk scripts, `@arizeai/phoenix-client` exposes `addSpanAnnotation` and `addSpanNote`.
+The same pattern works for span-level notes — swap `px trace` for `px span` and `.traceId` for `.context.span_id`.
+
+Aside: for Node-based bulk scripts, `@arizeai/phoenix-client` exposes `addSpanAnnotation`, `addSpanNote`, and `addTraceNote`. (No `addTraceAnnotation` is exported today; use the REST endpoint or `px trace annotate` for trace-level annotations.)
 
 Aside: `px api graphql` rejects mutations — it cannot write annotations.
 

--- a/.agents/skills/phoenix-cli/references/axial-coding.md
+++ b/.agents/skills/phoenix-cli/references/axial-coding.md
@@ -73,7 +73,7 @@ Filter to a specific annotation name to check coverage:
 
 ```bash
 px span list --include-annotations --format raw --no-progress | jq '
-  [ .[] | select(.annotations | map(select(.name == "failure_category")) | length > 0) ]
+  [ .[] | select((.annotations // []) | any(.name == "failure_category")) ]
   | length
 '
 ```

--- a/.agents/skills/phoenix-cli/references/axial-coding.md
+++ b/.agents/skills/phoenix-cli/references/axial-coding.md
@@ -2,6 +2,8 @@
 
 Group open-ended notes into structured failure taxonomies. Axial coding is **step 3** of the 5-step error-analysis workflow: sample → open code → **axial code** → quantify → prioritize. See [open-coding.md](open-coding.md) for step 2 (adding open-coding notes to spans).
 
+**Reach for this whenever** the user has observations and needs structure — e.g., "what categories of failures do we have", "what should I build evals for", "how do I prioritize fixes", "group these notes", "MECE breakdown", or any framing that asks for categories or counts grounded in real traces rather than invented top-down.
+
 ## Process
 
 1. **Gather** - Collect open coding notes from reviewed spans

--- a/.agents/skills/phoenix-cli/references/axial-coding.md
+++ b/.agents/skills/phoenix-cli/references/axial-coding.md
@@ -1,0 +1,156 @@
+# Axial Coding
+
+Group open-ended notes into structured failure taxonomies. Axial coding is **step 3** of the 5-step error-analysis workflow: sample → open code → **axial code** → quantify → prioritize. See [open-coding.md](open-coding.md) for step 2 (adding open-coding notes to spans).
+
+## Process
+
+1. **Gather** - Collect open coding notes from reviewed spans
+2. **Pattern** - Group notes with common themes
+3. **Name** - Create actionable category names
+4. **Quantify** - Count failures per category
+
+## Example Taxonomy
+
+```yaml
+failure_taxonomy:
+  content_quality:
+    hallucination: [invented_facts, fictional_citations]
+    incompleteness: [partial_answer, missing_key_info]
+    inaccuracy: [wrong_numbers, wrong_dates]
+
+  communication:
+    tone_mismatch: [too_casual, too_formal]
+    clarity: [ambiguous, jargon_heavy]
+
+  context:
+    user_context: [ignored_preferences, misunderstood_intent]
+    retrieved_context: [ignored_documents, wrong_context]
+
+  safety:
+    missing_disclaimers: [legal, medical, financial]
+```
+
+## Reading
+
+### 1. Gather — extract open-coding notes
+
+Open-coding notes are stored as annotations with `name="note"` and are only returned when `--include-notes` is passed. Use `--include-annotations` instead and you will get structured annotations but **not** notes — the server excludes notes from the annotations array.
+
+```bash
+px span list --include-notes --format raw --no-progress | jq '
+  [ .[] | select(.notes | length > 0) ]
+  | map({
+      span_id: .context.span_id,
+      notes: [ .notes[].result.explanation ]
+    })
+'
+```
+
+### 2. Group — synthesize categories
+
+Review the note text collected above. Manually identify recurring themes and draft candidate category names. Aim for MECE coverage: each note should fit exactly one category.
+
+### 3. Record — write axial-coding annotations
+
+Write one annotation per span using `px span annotate`. See the **Recording** section below.
+
+### 4. Quantify — count per category
+
+After recording, use `--include-annotations` to count how many spans carry each label:
+
+```bash
+px span list --include-annotations --format raw --no-progress | jq '
+  [ .[] | .annotations[]? | select(.name == "failure_category" and .result.label != null) ]
+  | group_by(.result.label)
+  | map({ label: .[0].result.label, count: length })
+  | sort_by(-.count)
+'
+```
+
+Filter to a specific annotation name to check coverage:
+
+```bash
+px span list --include-annotations --format raw --no-progress | jq '
+  [ .[] | select(.annotations | map(select(.name == "failure_category")) | length > 0) ]
+  | length
+'
+```
+
+## Recording
+
+Use `px span annotate` to write an axial-coding label for each span:
+
+```bash
+px span annotate <span-id> \
+  --name failure_category \
+  --label hallucination \
+  --explanation "invented a feature that does not exist" \
+  --annotator-kind HUMAN
+```
+
+Accepted flags: `--name`, `--label`, `--score`, `--explanation`, `--annotator-kind` (`HUMAN`, `LLM`, `CODE`). There are no `--identifier` or `--sync` flags on this command.
+
+### Bulk recording
+
+Stream span IDs from `px span list` and apply `px span annotate` per span:
+
+```bash
+px span list --status-code ERROR --format raw --no-progress \
+  | jq -r '.[].context.span_id' \
+  | while read sid; do
+      px span annotate "$sid" \
+        --name failure_category \
+        --label hallucination \
+        --annotator-kind HUMAN
+    done
+```
+
+Aside: for Node-based bulk scripts, `@arizeai/phoenix-client` exposes `addSpanAnnotation` and `addSpanNote`.
+
+Aside: `px api graphql` rejects mutations — it cannot write annotations.
+
+## Agent Failure Taxonomy
+
+```yaml
+agent_failures:
+  planning: [wrong_plan, incomplete_plan]
+  tool_selection: [wrong_tool, missed_tool, unnecessary_call]
+  tool_execution: [wrong_parameters, type_error]
+  state_management: [lost_context, stuck_in_loop]
+  error_recovery: [no_fallback, wrong_fallback]
+```
+
+### Transition Matrix — jq sketch
+
+To find where failures occur between agent states, identify the last-OK span before each first-ERROR span within a trace:
+
+```bash
+px span list --format raw --no-progress | jq '
+  group_by(.context.trace_id)
+  | map(
+      sort_by(.start_time)
+      | { trace_id: .[0].context.trace_id,
+          last_ok:    map(select(.status_code == "OK"))    | last | .name,
+          first_err:  map(select(.status_code == "ERROR")) | first | .name }
+    )
+  | [ .[] | select(.first_err != null) ]
+  | group_by([.last_ok, .first_err])
+  | map({ transition: "\(.[0].last_ok) → \(.[0].first_err)", count: length })
+  | sort_by(-.count)
+'
+```
+
+Use the output to tally which state-to-state transitions are most failure-prone and add them to your taxonomy.
+
+## What Makes a Good Category
+
+A useful category is:
+- **Named for the cause**, not the symptom ("wrong_tool_selected", not "bad_output")
+- **Tied to a fix** — if you can't name a remediation, the category is too vague
+- **Grounded in data** — emerged from actual note text, not assumed upfront
+
+## Principles
+
+- **MECE** - Each failure fits ONE category
+- **Actionable** - Categories suggest fixes
+- **Bottom-up** - Let categories emerge from data

--- a/.agents/skills/phoenix-cli/references/axial-coding.md
+++ b/.agents/skills/phoenix-cli/references/axial-coding.md
@@ -1,6 +1,6 @@
 # Axial Coding
 
-Group open-ended notes into structured failure taxonomies. Axial coding is **step 3** of the 5-step error-analysis workflow: sample → open code → **axial code** → quantify → prioritize. See [open-coding.md](open-coding.md) for step 2 (adding open-coding notes).
+Group open-ended observations into structured failure taxonomies. Axial coding turns notes, trace observations, or open-coding output into named categories with counts, supporting downstream work like eval design and fix prioritization. It works well after [open coding](open-coding.md), but can start from any set of open-ended observations.
 
 **Reach for this whenever** the user has observations and needs structure — e.g., "what categories of failures do we have", "what should I build evals for", "how do I prioritize fixes", "group these notes", "MECE breakdown", or any framing that asks for categories or counts grounded in real traces rather than invented top-down.
 

--- a/.agents/skills/phoenix-cli/references/axial-coding.md
+++ b/.agents/skills/phoenix-cli/references/axial-coding.md
@@ -94,11 +94,12 @@ Accepted flags: `--name`, `--label`, `--score`, `--explanation`, `--annotator-ki
 
 ### Bulk recording
 
-Stream span IDs from `px span list` and apply `px span annotate` per span:
+Axial coding categorizes the spans you took notes on during open coding, so stream span IDs from spans that already carry an open-coding note. Do **not** filter by `--status-code ERROR` — that captures only spans where Python raised, which excludes most failure modes (hallucination, wrong tone, retrieval miss). See [open-coding.md](open-coding.md#inspection) for the full reasoning.
 
 ```bash
-px span list --status-code ERROR --format raw --no-progress \
-  | jq -r '.[].context.span_id' \
+# Bulk-annotate spans that already have open-coding notes
+px span list --include-notes --format raw --no-progress \
+  | jq -r '.[] | select((.notes // []) | length > 0) | .context.span_id' \
   | while read sid; do
       px span annotate "$sid" \
         --name failure_category \

--- a/.agents/skills/phoenix-cli/references/axial-coding.md
+++ b/.agents/skills/phoenix-cli/references/axial-coding.md
@@ -124,7 +124,7 @@ agent_failures:
 
 ### Transition Matrix — jq sketch
 
-To find where failures occur between agent states, identify the last-OK span before each first-ERROR span within a trace:
+To find where failures occur between agent states, identify the last non-error span before each first-error span within a trace. Note: OTel leaves most spans at `status_code == "UNSET"` and only sets `"OK"` when code explicitly does so — match `!= "ERROR"` rather than `== "OK"` so the matrix works on typical OTel data.
 
 ```bash
 px span list --format raw --no-progress | jq '
@@ -132,12 +132,12 @@ px span list --format raw --no-progress | jq '
   | map(
       sort_by(.start_time)
       | { trace_id: .[0].context.trace_id,
-          last_ok:    map(select(.status_code == "OK"))    | last | .name,
-          first_err:  map(select(.status_code == "ERROR")) | first | .name }
+          last_non_error: map(select(.status_code != "ERROR")) | last | .name,
+          first_err:      map(select(.status_code == "ERROR")) | first | .name }
     )
   | [ .[] | select(.first_err != null) ]
-  | group_by([.last_ok, .first_err])
-  | map({ transition: "\(.[0].last_ok) → \(.[0].first_err)", count: length })
+  | group_by([.last_non_error, .first_err])
+  | map({ transition: "\(.[0].last_non_error) → \(.[0].first_err)", count: length })
   | sort_by(-.count)
 '
 ```

--- a/.agents/skills/phoenix-cli/references/open-coding.md
+++ b/.agents/skills/phoenix-cli/references/open-coding.md
@@ -6,34 +6,36 @@ Free-form note-writing against sampled traces, before any taxonomy exists. Open 
 
 ## Process
 
-1. **Inspect** — fetch a span or trace from your sample
+1. **Inspect** — fetch a trace from your sample, then drill to the relevant span
 2. **Read** — look at input, output, exceptions, tool calls, retrieved context
 3. **Note** — write one specific sentence describing what went wrong (or skip if correct)
 4. **Record** — attach the note to the span with `px span add-note`
-5. **Iterate** — move to the next span; repeat until the sample is exhausted or saturation hits
+5. **Iterate** — move to the next trace; repeat until the sample is exhausted or saturation hits
 
 ## Inspection
 
-Use `px` to read span context before writing a note. Sampling commands are covered in SKILL.md's Spans section — this reference assumes you already have a set of span IDs to review.
+Use `px` to read trace and span context before writing a note. Open coding samples by **trace** — read the input → tool calls → retrieved context → output as a unit, then drill to the specific span the failure landed on.
+
+> **Don't filter the sample by `--status-code ERROR`.** OTel's `status_code` only flips to `ERROR` when an instrumentor catches a raised Python exception (network failure, 5xx, parse error). Hallucinations, wrong tone, retrieval misses, and bad tool selection all complete cleanly and arrive as `OK` or `UNSET`. Sampling for open coding by `--status-code ERROR` excludes the population this workflow exists to surface.
 
 ```bash
-# Peek at error spans — input, output, status
-px span list --status-code ERROR --limit 20 --format raw --no-progress | jq '
-  .[] | {span_id: .context.span_id, name, status_code,
-         input: .attributes["input.value"],
-         output: .attributes["output.value"]}
+# Sample recent traces — the unit of inspection in open coding
+px trace list --limit 100 --format raw --no-progress | jq '
+  .[] | {trace_id: .traceId, root: .rootSpan.name, status,
+         input: .rootSpan.attributes["input.value"],
+         output: .rootSpan.attributes["output.value"]}
 '
-
-# Full attribute set for one span (drilldown by span_id — px span get does not exist)
-px span list --trace-id <trace-id> --format raw --no-progress \
-  | jq '.[] | select(.context.span_id == "<span-id>")'
 
 # Trace-level context — all spans in one trace, ordered by start_time
 px trace get <trace-id> --format raw | jq '
-  .spans | sort_by(.start_time) | map({name, status_code,
+  .spans | sort_by(.start_time) | map({span_id: .context.span_id, name, status_code,
     input: .attributes["input.value"],
     output: .attributes["output.value"]})
 '
+
+# Drill to one span (px span get does not exist; filter via span list)
+px span list --trace-id <trace-id> --format raw --no-progress \
+  | jq '.[] | select(.context.span_id == "<span-id>")'
 
 # Check existing notes on spans you are about to review
 # Notes are stored as annotations with name="note"; use --include-notes (not --include-annotations)
@@ -47,28 +49,31 @@ Always pipe through `jq` with `--format raw --no-progress` when scripting.
 
 ## Recording Notes
 
-The primary write path is `px span add-note <span-id> --text "..."`.
+The primary write path is `px span add-note <span-id> --text "..."`. Notes are span-level — when a trace fails, attach the note to the span the failure landed on (often the LLM or tool span, not always the root).
 
 ```bash
 # Add a note to a single span
 px span add-note <span-id> --text "Cited a product feature that does not exist in the schema"
 
-# Automated loop — tag all error spans with a fixed label (LLM-driven or scripted)
-px span list --status-code ERROR --last-n-minutes 60 --format raw --no-progress \
-  | jq -r '.[].context.span_id' \
-  | while read sid; do
-      px span add-note "$sid" --text "error span flagged for review"
-    done
-
-# Interactive loop — review each span and write a custom note or skip
-px span list --status-code ERROR --last-n-minutes 60 --format raw --no-progress \
-  | jq -r '.[].context.span_id' \
-  | while read sid; do
-      read -p "Note for $sid (blank to skip): " note
+# Interactive loop — walk a trace sample, drill to a span, write a note
+px trace list --last-n-minutes 60 --limit 50 --format raw --no-progress \
+  | jq -r '.[].traceId' \
+  | while read tid; do
+      echo "── trace $tid ──"
+      px trace get "$tid" --format raw | jq '
+        .spans | sort_by(.start_time)
+        | map({span_id: .context.span_id, name, status_code,
+               output: .attributes["output.value"]})
+      '
+      read -p "Span ID to annotate (blank to skip trace): " sid
+      [ -z "$sid" ] && continue
+      read -p "Note for $sid: " note
       [ -z "$note" ] && continue
       px span add-note "$sid" --text "$note"
     done
 ```
+
+Bulk auto-tagging by status code (e.g. `px span list --status-code ERROR | xargs ... add-note "error"`) is **not open coding** — open coding is manual, observation-grounded, and ranges over all failure modes, not just spans where Python raised. Skip the bulk-by-status-code shortcut; it produces fewer, less informative notes than walking traces.
 
 **Fallback write paths (one-line asides):**
 

--- a/.agents/skills/phoenix-cli/references/open-coding.md
+++ b/.agents/skills/phoenix-cli/references/open-coding.md
@@ -1,0 +1,105 @@
+# Open Coding
+
+Free-form note-writing against sampled traces, before any taxonomy exists. Open coding is step 2 of the 5-step error-analysis workflow: sample → **open code** → axial code → quantify → prioritize. After you pick a sample of traces, read each one and write a short, specific observation of what went wrong. These raw notes become the raw material for [axial coding](axial-coding.md), where they are grouped into named failure categories.
+
+## Process
+
+1. **Inspect** — fetch a span or trace from your sample
+2. **Read** — look at input, output, exceptions, tool calls, retrieved context
+3. **Note** — write one specific sentence describing what went wrong (or skip if correct)
+4. **Record** — attach the note to the span with `px span add-note`
+5. **Iterate** — move to the next span; repeat until the sample is exhausted or saturation hits
+
+## Inspection
+
+Use `px` to read span context before writing a note. Sampling commands are covered in SKILL.md's Spans section — this reference assumes you already have a set of span IDs to review.
+
+```bash
+# Peek at error spans — input, output, status
+px span list --status-code ERROR --limit 20 --format raw --no-progress | jq '
+  .[] | {span_id: .context.span_id, name, status_code,
+         input: .attributes["input.value"],
+         output: .attributes["output.value"]}
+'
+
+# Full attribute set for one span (drilldown by span_id — px span get does not exist)
+px span list --trace-id <trace-id> --format raw --no-progress \
+  | jq '.[] | select(.context.span_id == "<span-id>")'
+
+# Trace-level context — all spans in one trace, ordered by start_time
+px trace get <trace-id> --format raw | jq '
+  .spans | sort_by(.start_time) | map({name, status_code,
+    input: .attributes["input.value"],
+    output: .attributes["output.value"]})
+'
+
+# Check existing notes on spans you are about to review
+# Notes are stored as annotations with name="note"; use --include-notes (not --include-annotations)
+px span list --include-notes --limit 10 --format raw --no-progress | jq '
+  .[] | select(.notes | length > 0)
+  | {span_id: .context.span_id, notes: [.notes[] | .result.explanation]}
+'
+```
+
+Always pipe through `jq` with `--format raw --no-progress` when scripting.
+
+## Recording Notes
+
+The primary write path is `px span add-note <span-id> --text "..."`.
+
+```bash
+# Add a note to a single span
+px span add-note <span-id> --text "Cited a product feature that does not exist in the schema"
+
+# Automated loop — tag all error spans with a fixed label (LLM-driven or scripted)
+px span list --status-code ERROR --last-n-minutes 60 --format raw --no-progress \
+  | jq -r '.[].context.span_id' \
+  | while read sid; do
+      px span add-note "$sid" --text "error span flagged for review"
+    done
+
+# Interactive loop — review each span and write a custom note or skip
+px span list --status-code ERROR --last-n-minutes 60 --format raw --no-progress \
+  | jq -r '.[].context.span_id' \
+  | while read sid; do
+      read -p "Note for $sid (blank to skip): " note
+      [ -z "$note" ] && continue
+      px span add-note "$sid" --text "$note"
+    done
+```
+
+**Fallback write paths (one-line asides):**
+
+- `POST /v1/span_notes` — accepts one `{data: {span_id, note}}` object per request (not a batch array); use for scripted writes outside the CLI.
+- `@arizeai/phoenix-client` `addSpanNote` — wraps the same REST endpoint; single-call-per-note, no batch efficiency.
+- `px api graphql` rejects mutations with `"Only queries are permitted."` — use `px span add-note` or the REST endpoint instead.
+
+## What Makes a Good Note
+
+| Weak note            | Why it's weak             | Good note                                                                  | Why it's strong                             |
+| -------------------- | ------------------------- | -------------------------------------------------------------------------- | ------------------------------------------- |
+| "Wrong answer"       | No observable detail      | "Said the store closes at 6pm but policy is 9pm"                           | Quotes observed vs. correct value           |
+| "Bad tone"           | Vague judgment            | "Used first-name greeting for an enterprise support ticket"                | Specifies the context mismatch              |
+| "Hallucination"      | Labels before observing   | "Cited a product feature ('auto-renew') that does not exist in the schema" | Describes what was fabricated               |
+| "Retrieval issue"    | Category, not observation | "Retrieved docs about shipping when the question was about returns"        | States what was retrieved vs. needed        |
+| "Model confused"     | Opaque                    | "Answered in Spanish when the user wrote in English"                       | Observable and reproducible                 |
+
+Write what you saw, not the category you think it belongs to — categorization happens in [axial coding](axial-coding.md). Short prefixes like `TONE:` or `FACTUAL:` are a personal shorthand, not a repo convention.
+
+## Saturation
+
+Stop writing notes when observations stop being new. Signals:
+
+- **Repeats** — the last 10–15 spans produced notes that describe failures you've already seen.
+- **Paraphrase convergence** — you catch yourself writing minor variations of earlier notes.
+- **Skips outnumber notes** — most recent spans are correct and need no note.
+
+At saturation, move on to [axial coding](axial-coding.md) to group what you have. Continuing past saturation adds spans but not insight. You do not need to annotate every span — annotating correct spans dilutes signal.
+
+## Principles
+
+- **Free-form over structured** — do not pre-commit to a taxonomy during open coding; categories emerge in axial coding.
+- **Specific over general** — quote or paraphrase the observed failure; vague labels ("bad response") carry no signal.
+- **Context before labeling** — inspect input, output, and retrieved context before writing any note.
+- **Iterate before categorizing** — work through the full sample first; resist grouping while still collecting.
+- **Skip is valid** — a correct span needs no note; annotating everything dilutes signal.

--- a/.agents/skills/phoenix-cli/references/open-coding.md
+++ b/.agents/skills/phoenix-cli/references/open-coding.md
@@ -1,6 +1,6 @@
 # Open Coding
 
-Free-form note-writing against sampled traces, before any taxonomy exists. Open coding is step 2 of the 5-step error-analysis workflow: sample → **open code** → axial code → quantify → prioritize. After you pick a sample of traces, read each one and write a short, specific observation of what went wrong. These raw notes become the raw material for [axial coding](axial-coding.md), where they are grouped into named failure categories.
+Free-form note-writing against sampled traces, before any taxonomy exists. After you pick a sample of traces, read each one and write a short, specific observation of what went wrong. These raw notes feed [axial coding](axial-coding.md), where they get grouped into named failure categories — and ultimately into eval targets or fix priorities.
 
 **Reach for this whenever** the user wants to look at traces or spans without a fixed taxonomy yet — e.g., "what's going wrong with this agent", "I just instrumented my app, where do I start", "review these traces", "what kinds of mistakes is the model making", "help me make sense of these outputs", or any framing that needs grounded observations before categories.
 

--- a/.agents/skills/phoenix-cli/references/open-coding.md
+++ b/.agents/skills/phoenix-cli/references/open-coding.md
@@ -2,6 +2,8 @@
 
 Free-form note-writing against sampled traces, before any taxonomy exists. Open coding is step 2 of the 5-step error-analysis workflow: sample → **open code** → axial code → quantify → prioritize. After you pick a sample of traces, read each one and write a short, specific observation of what went wrong. These raw notes become the raw material for [axial coding](axial-coding.md), where they are grouped into named failure categories.
 
+**Reach for this whenever** the user wants to look at traces or spans without a fixed taxonomy yet — e.g., "what's going wrong with this agent", "I just instrumented my app, where do I start", "review these traces", "what kinds of mistakes is the model making", "help me make sense of these outputs", or any framing that needs grounded observations before categories.
+
 ## Process
 
 1. **Inspect** — fetch a span or trace from your sample

--- a/.agents/skills/phoenix-cli/references/open-coding.md
+++ b/.agents/skills/phoenix-cli/references/open-coding.md
@@ -4,17 +4,30 @@ Free-form note-writing against sampled traces, before any taxonomy exists. Open 
 
 **Reach for this whenever** the user wants to look at traces or spans without a fixed taxonomy yet — e.g., "what's going wrong with this agent", "I just instrumented my app, where do I start", "review these traces", "what kinds of mistakes is the model making", "help me make sense of these outputs", or any framing that needs grounded observations before categories.
 
+## Choosing the unit
+
+Open coding has two scopes that don't have to match:
+
+- **Review scope** — the **trace**. Read input → tool calls → retrieved context → output as one story.
+- **Recording scope** — **default to the trace**. The honest observation is usually trace-shaped ("asked X, got Y; the answer didn't address the question"), and forcing localization to a span at this stage commits to causal attribution you don't yet have data to support — that's axial coding's job.
+
+  Drop to a **span** only when one of:
+  - The span, read in isolation, is still wrong: an exception fired, a tool returned an error response, the output is malformed.
+  - You already know the domain well enough to attribute the failure on sight without inferring across spans.
+
+Session-level findings are axial-coding rollup targets, not open-coding notes — Phoenix has REST `/v1/projects/{id}/session_annotations` but no session `add-note` path.
+
 ## Process
 
-1. **Inspect** — fetch a trace from your sample, then drill to the relevant span
+1. **Inspect** — fetch a trace from your sample
 2. **Read** — look at input, output, exceptions, tool calls, retrieved context
 3. **Note** — write one specific sentence describing what went wrong (or skip if correct)
-4. **Record** — attach the note to the span with `px span add-note`
+4. **Record** — attach the note to the trace with `px trace add-note` (default), or to a span with `px span add-note` for in-isolation/mechanical failures
 5. **Iterate** — move to the next trace; repeat until the sample is exhausted or saturation hits
 
 ## Inspection
 
-Use `px` to read trace and span context before writing a note. Open coding samples by **trace** — read the input → tool calls → retrieved context → output as a unit, then drill to the specific span the failure landed on.
+Use `px` to read trace and span context before writing a note. Open coding reviews by **trace** — read input → tool calls → retrieved context → output as a unit. Record on the trace by default; drill to a specific span only when the failure is mechanical (exception, error response, malformed output) or you can attribute on sight (see [Choosing the unit](#choosing-the-unit)).
 
 > **Don't filter the sample by `--status-code ERROR`.** OTel's `status_code` only flips to `ERROR` when an instrumentor catches a raised Python exception (network failure, 5xx, parse error). Hallucinations, wrong tone, retrieval misses, and bad tool selection all complete cleanly and arrive as `OK` or `UNSET`. Sampling for open coding by `--status-code ERROR` excludes the population this workflow exists to surface.
 
@@ -37,39 +50,41 @@ px trace get <trace-id> --format raw | jq '
 px span list --trace-id <trace-id> --format raw --no-progress \
   | jq '.[] | select(.context.span_id == "<span-id>")'
 
-# Check existing notes on spans you are about to review
+# Check existing notes on traces (default) or spans you are about to review
 # Notes are stored as annotations with name="note"; use --include-notes (not --include-annotations)
-px span list --include-notes --limit 10 --format raw --no-progress | jq '
-  .[] | select(.notes | length > 0)
-  | {span_id: .context.span_id, notes: [.notes[] | .result.explanation]}
+px trace list --include-notes --limit 10 --format raw --no-progress | jq '
+  .[] | select((.notes // []) | length > 0)
+  | {trace_id: .traceId, notes: [.notes[] | .result.explanation]}
 '
+# Same shape on spans — swap px trace for px span and use .context.span_id
 ```
 
 Always pipe through `jq` with `--format raw --no-progress` when scripting.
 
 ## Recording Notes
 
-The primary write path is `px span add-note <span-id> --text "..."`. Notes are span-level — when a trace fails, attach the note to the span the failure landed on (often the LLM or tool span, not always the root).
+Default write path is `px trace add-note <trace-id> --text "..."` — most observations are trace-shaped and shouldn't pre-commit to localization. Drop to `px span add-note <span-id>` when the failure is in-isolation wrong (exception, error response, malformed output) or you already know the failure structure on sight.
 
 ```bash
-# Add a note to a single span
-px span add-note <span-id> --text "Cited a product feature that does not exist in the schema"
+# Trace-level note (default)
+px trace add-note <trace-id> --text "Asked about returns; final answer covered shipping policy instead"
 
-# Interactive loop — walk a trace sample, drill to a span, write a note
+# Span-level note (mechanical or attributable-on-sight failures)
+px span add-note <span-id> --text "Tool call returned 500 — vendor API unreachable"
+
+# Interactive loop — walk traces, write a trace-level note per failing trace
 px trace list --last-n-minutes 60 --limit 50 --format raw --no-progress \
   | jq -r '.[].traceId' \
   | while read tid; do
       echo "── trace $tid ──"
       px trace get "$tid" --format raw | jq '
-        .spans | sort_by(.start_time)
-        | map({span_id: .context.span_id, name, status_code,
-               output: .attributes["output.value"]})
+        {input: .rootSpan.attributes["input.value"],
+         output: .rootSpan.attributes["output.value"],
+         spans: (.spans | sort_by(.start_time) | map({name, status_code}))}
       '
-      read -p "Span ID to annotate (blank to skip trace): " sid
-      [ -z "$sid" ] && continue
-      read -p "Note for $sid: " note
+      read -p "Note for $tid (blank to skip): " note
       [ -z "$note" ] && continue
-      px span add-note "$sid" --text "$note"
+      px trace add-note "$tid" --text "$note"
     done
 ```
 
@@ -77,9 +92,9 @@ Bulk auto-tagging by status code (e.g. `px span list --status-code ERROR | xargs
 
 **Fallback write paths (one-line asides):**
 
-- `POST /v1/span_notes` — accepts one `{data: {span_id, note}}` object per request (not a batch array); use for scripted writes outside the CLI.
-- `@arizeai/phoenix-client` `addSpanNote` — wraps the same REST endpoint; single-call-per-note, no batch efficiency.
-- `px api graphql` rejects mutations with `"Only queries are permitted."` — use `px span add-note` or the REST endpoint instead.
+- `POST /v1/trace_notes` and `POST /v1/span_notes` — accept one `{data: {trace_id|span_id, note}}` per request; use for scripted writes outside the CLI.
+- `@arizeai/phoenix-client` `addTraceNote` and `addSpanNote` wrap the same endpoints.
+- `px api graphql` rejects mutations with `"Only queries are permitted."` — use `px trace/span add-note` or the REST endpoints instead.
 
 ## What Makes a Good Note
 
@@ -97,11 +112,11 @@ Write what you saw, not the category you think it belongs to — categorization 
 
 Stop writing notes when observations stop being new. Signals:
 
-- **Repeats** — the last 10–15 spans produced notes that describe failures you've already seen.
+- **Repeats** — the last 10–15 traces produced notes that describe failures you've already seen.
 - **Paraphrase convergence** — you catch yourself writing minor variations of earlier notes.
-- **Skips outnumber notes** — most recent spans are correct and need no note.
+- **Skips outnumber notes** — most recent traces are correct and need no note.
 
-At saturation, move on to [axial coding](axial-coding.md) to group what you have. Continuing past saturation adds spans but not insight. You do not need to annotate every span — annotating correct spans dilutes signal.
+At saturation, move on to [axial coding](axial-coding.md) to group what you have. Continuing past saturation adds traces but not insight. You do not need to annotate every trace — annotating correct ones dilutes signal.
 
 ## Principles
 


### PR DESCRIPTION
## Summary

- Adds `.agents/skills/phoenix-cli/references/open-coding.md` and `references/axial-coding.md` covering the two-step CLI error-analysis workflow.
- Open-coding teaches sampling spans and labeling them with `px span add-note --text "..."`; axial-coding teaches grouping notes into a failure taxonomy and recording categories with `px span annotate <span-id> --name <category> --label <value>`.
- Wires both references into `SKILL.md` via Quick Reference, Workflows, and Reference Categories sections — following the multi-file skill pattern used in `phoenix-evals` and `phoenix-tracing`.

The references rely on the native CLI annotation/note write surface that landed upstream:
- `feat: Add span and trace annotation commands to the Phoenix CLI` (#12664)
- `feat(cli): split out span note support` (#12739)
- `feat(cli): add trace note support to px` (#12711)

## Test plan

- [ ] Verify `SKILL.md` renders cleanly on GitHub (Quick Reference, Workflows, Reference Categories tables and links)
- [ ] Verify `references/open-coding.md` and `references/axial-coding.md` render cleanly and all relative links resolve
- [ ] Spot-check `px` commands shown in examples against the CLI surface (`px span list --include-annotations`, `px span list --include-notes`, `px span annotate`, `px span add-note`)
- [ ] Confirm SKILL.md size stays under ~260 lines (Level-2 progressive-disclosure economy)

Closes #12627
Closes #12628