### PR TITLE
fix(server): require auth for custom provider credential test (SSRF)

### DIFF
--- a/.agents/skills/phoenix-server/SKILL.md
+++ b/.agents/skills/phoenix-server/SKILL.md
@@ -59,3 +59,12 @@ tests/unit/server/api/
 | Adding or modifying a mutation, type, subscription, or input | `references/graphql-patterns.md` |
 | Writing or modifying tests | `references/test-patterns.md` |
 | Adding a migration or modifying database models | `references/database-patterns.md` |
+
+## Hard Rules
+
+- **Side effects belong on `Mutation`, not `Query`.** A resolver that makes outbound
+  network calls, reads secrets, writes state, or accepts a user-supplied URL/host
+  MUST be a `@strawberry.mutation` with `permission_classes=[...]`. Query fields
+  bypass the `make check-graphql-permissions` CI guard and are reachable
+  unauthenticated by default — this has been exploited as an SSRF vector. See
+  `references/graphql-patterns.md` → "Query vs Mutation".

--- a/.agents/skills/phoenix-server/references/graphql-patterns.md
+++ b/.agents/skills/phoenix-server/references/graphql-patterns.md
@@ -2,6 +2,35 @@
 
 Full templates and patterns for mutations, types, subscriptions, and input types.
 
+## Query vs Mutation: Side Effects MUST Be Mutations
+
+A GraphQL field belongs on `Mutation` (not `Query`) if it does any of the following:
+
+- Makes outbound HTTP, gRPC, or other network calls to user-controlled or
+  user-influenced destinations (URLs, hostnames, headers, kwargs)
+- Calls a "test connection" / "validate credentials" / "ping" style operation
+- Writes to the database, the filesystem, or an external store
+- Reads or decrypts secrets
+- Triggers a side effect that costs money, time, or external rate limits
+
+**Why this matters:** `Query` fields are conventionally treated as safe, cacheable
+reads. They are easy to forget on the auth path, they are reachable through
+introspection, and `permission_classes` are far less commonly applied to query
+resolvers than to mutations. A query resolver that issues HTTP requests with a
+user-supplied `base_url` is an unauthenticated SSRF vector — this has happened
+in this codebase (`testGenerativeModelCustomProviderCredentials` was originally
+a query and was used to reach internal cloud metadata endpoints).
+
+If you find yourself writing a `@strawberry.field` on `Query` that takes a URL,
+a config object, credentials, or anything that ends up making a network call:
+**stop and make it a mutation** with `permission_classes=[...]`. The CI guard
+`make check-graphql-permissions` enforces that all mutations and subscriptions
+declare permission classes; queries get no such guarantee.
+
+When in doubt, ask: "could an unauthenticated attacker who can reach `/graphql`
+abuse this field to do something they should not?" If the answer is anything
+other than a confident no, it must be a mutation behind auth.
+
 ## Adding a Mutation
 
 ### Step-by-step

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -33,6 +33,16 @@ An implementation is compliant if it satisfies all "MUST", "MUST NOT", "REQUIRED
 - Cache or store mutations MUST update affected collections to prevent stale lists in the UI
 - Form fields MUST have validation rules on required inputs
 
+## Security
+
+- GraphQL resolvers that perform side effects — outbound HTTP/RPC, "test connection" / credential validation, database writes, secret reads, filesystem writes, or any operation that takes a user-supplied URL, hostname, or set of HTTP headers — MUST be exposed as `@strawberry.mutation` (or `@strawberry.subscription`), NEVER as a `Query` field. Query fields are reachable through introspection, are not covered by the `make check-graphql-permissions` CI guard, and have historically been used to bypass auth (SSRF against internal services, including cloud metadata endpoints).
+- All `@strawberry.mutation` and `@strawberry.subscription` definitions MUST declare `permission_classes=[...]` — at minimum `IsNotReadOnly`, `IsNotViewer`, and (where appropriate) `IsAdminIfAuthEnabled` and/or `IsLocked`. The `make check-graphql-permissions` script enforces this in CI; do not bypass it.
+- User-supplied URLs, hostnames, base URLs, or endpoint overrides that the server will dial out to MUST be treated as untrusted. They MUST NOT be allowed to resolve to link-local, loopback, private, or cloud metadata addresses (e.g. `169.254.169.254`, `metadata.google.internal`, `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `::1`, `fc00::/7`, `fe80::/10`) unless the feature explicitly requires it and is gated behind admin-only auth.
+- User-supplied HTTP headers and client kwargs MUST NOT be forwarded to internal or privileged services without an allowlist. Headers like `Metadata-Flavor`, `X-Forwarded-For`, `Authorization`, and `Host` are particularly sensitive.
+- Secrets (API keys, tokens, encrypted config) MUST NOT appear in error messages, log lines, GraphQL error payloads, or telemetry. Error messages from upstream providers MAY be surfaced verbatim only when the upstream is the user's own configured provider; otherwise they MUST be sanitized.
+- GraphQL introspection-discoverable fields that perform privileged operations MUST have a regression test that asserts both the schema location (mutation, not query) and the presence of the required `permission_classes`. See `tests/unit/server/api/mutations/test_generative_model_custom_provider_mutations.py::test_test_credentials_is_an_auth_gated_mutation_not_a_query` for the canonical pattern.
+- Authentication and authorization checks MUST NOT be implemented only on the frontend. Server-side enforcement is REQUIRED for every privileged operation.
+
 ## Skip
 
 - Generated files under `__generated__` directories

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2145,6 +2145,7 @@ type Mutation {
   deleteExperiments(input: DeleteExperimentsInput!): ExperimentMutationPayload!
   createGenerativeModelCustomProvider(input: CreateGenerativeModelCustomProviderMutationInput!): CreateGenerativeModelCustomProviderMutationPayload!
   patchGenerativeModelCustomProvider(input: PatchGenerativeModelCustomProviderMutationInput!): PatchGenerativeModelCustomProviderMutationPayload!
+  testGenerativeModelCustomProviderCredentials(input: GenerativeModelCustomerProviderConfigInput!): TestGenerativeModelCustomProviderCredentialsResult!
   deleteGenerativeModelCustomProvider(input: DeleteGenerativeModelCustomProviderMutationInput!): DeleteGenerativeModelCustomProviderMutationPayload!
   createModel(input: CreateModelMutationInput!): CreateModelMutationPayload!
   updateModel(input: UpdateModelMutationInput!): UpdateModelMutationPayload!
@@ -2936,7 +2937,6 @@ type Query {
   modelProviders: [GenerativeProvider!]!
   generativeModelCustomProviders(first: Int = 50, last: Int, after: String, before: String): GenerativeModelCustomProviderConnection!
   secrets(keys: [String!] = null, first: Int = 50, last: Int, after: String, before: String): SecretConnection!
-  testGenerativeModelCustomProviderCredentials(input: GenerativeModelCustomerProviderConfigInput!): TestGenerativeModelCustomProviderCredentialsResult!
   generativeModels(first: Int = 50, last: Int, after: String, before: String): GenerativeModelConnection!
   playgroundModels(input: ModelsInput = null): [PlaygroundModel!]!
   modelInvocationParameters(input: ModelsInput = null): [InvocationParameter!]!

--- a/app/src/pages/settings/CustomProviderForm.tsx
+++ b/app/src/pages/settings/CustomProviderForm.tsx
@@ -11,7 +11,7 @@ import {
 } from "react";
 import type { Control, UseFormGetValues, UseFormReset } from "react-hook-form";
 import { Controller, useForm, useWatch } from "react-hook-form";
-import { fetchQuery, graphql, useRelayEnvironment } from "react-relay";
+import { graphql, useMutation } from "react-relay";
 import invariant from "tiny-invariant";
 
 import {
@@ -51,7 +51,7 @@ import {
 } from "@phoenix/constants/generativeConstants";
 import { httpHeadersJSONSchema } from "@phoenix/schemas/httpHeadersSchema";
 
-import type { CustomProviderFormTestCredentialsQuery } from "./__generated__/CustomProviderFormTestCredentialsQuery.graphql";
+import type { CustomProviderFormTestCredentialsMutation } from "./__generated__/CustomProviderFormTestCredentialsMutation.graphql";
 import { providerFormSchema } from "./customProviderFormSchema";
 import {
   buildClientConfig,
@@ -1071,8 +1071,8 @@ export const ProviderForm = ({
   );
 };
 
-const testCredentialsQuery = graphql`
-  query CustomProviderFormTestCredentialsQuery(
+const testCredentialsMutation = graphql`
+  mutation CustomProviderFormTestCredentialsMutation(
     $input: GenerativeModelCustomerProviderConfigInput!
   ) {
     testGenerativeModelCustomProviderCredentials(input: $input) {
@@ -1224,7 +1224,10 @@ function TestConnectionButton({
   getValues: UseFormGetValues<ProviderFormData>;
   sdk: GenerativeModelSDK;
 }) {
-  const environment = useRelayEnvironment();
+  const [commitTestCredentials] =
+    useMutation<CustomProviderFormTestCredentialsMutation>(
+      testCredentialsMutation
+    );
   const [testConnectionState, dispatchTestConnectionState] = useReducer(
     testConnectionReducer,
     INITIAL_TEST_CONNECTION_STATE
@@ -1288,11 +1291,15 @@ function TestConnectionButton({
     try {
       const formValues = getValues();
       const clientConfig = buildClientConfig(formValues);
-      const result = await fetchQuery<CustomProviderFormTestCredentialsQuery>(
-        environment,
-        testCredentialsQuery,
-        { input: clientConfig }
-      ).toPromise();
+      const result = await new Promise<
+        CustomProviderFormTestCredentialsMutation["response"] | null
+      >((resolve, reject) => {
+        commitTestCredentials({
+          variables: { input: clientConfig },
+          onCompleted: (response) => resolve(response),
+          onError: (error) => reject(error),
+        });
+      });
 
       // Ignore result if form changed during request
       if (shouldIgnoreResultRef.current) {
@@ -1348,7 +1355,7 @@ function TestConnectionButton({
     } finally {
       dispatchTestConnectionState({ type: "complete" });
     }
-  }, [canTest, environment, getValues]);
+  }, [canTest, commitTestCredentials, getValues]);
 
   const hasResult = testStatus !== "idle" && testStatus !== "testing";
 

--- a/app/src/pages/settings/__generated__/CustomProviderFormTestCredentialsMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/CustomProviderFormTestCredentialsMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3588f2463972c70e29be86b0524a5051>>
+ * @generated SignedSource<<542ea59620127fb6e3a68057d18cfd45>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -93,17 +93,17 @@ export type GoogleGenAIHttpOptionsInput = {
   baseUrl?: string | null;
   headers?: any | null;
 };
-export type CustomProviderFormTestCredentialsQuery$variables = {
+export type CustomProviderFormTestCredentialsMutation$variables = {
   input: GenerativeModelCustomerProviderConfigInput;
 };
-export type CustomProviderFormTestCredentialsQuery$data = {
+export type CustomProviderFormTestCredentialsMutation$data = {
   readonly testGenerativeModelCustomProviderCredentials: {
     readonly error: string | null;
   };
 };
-export type CustomProviderFormTestCredentialsQuery = {
-  response: CustomProviderFormTestCredentialsQuery$data;
-  variables: CustomProviderFormTestCredentialsQuery$variables;
+export type CustomProviderFormTestCredentialsMutation = {
+  response: CustomProviderFormTestCredentialsMutation$data;
+  variables: CustomProviderFormTestCredentialsMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -145,29 +145,29 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "CustomProviderFormTestCredentialsQuery",
+    "name": "CustomProviderFormTestCredentialsMutation",
     "selections": (v1/*: any*/),
-    "type": "Query",
+    "type": "Mutation",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "CustomProviderFormTestCredentialsQuery",
+    "name": "CustomProviderFormTestCredentialsMutation",
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "1f6f6ef6861d65fb66b2e37cd46f2bd2",
+    "cacheID": "7680aac239abb387cb84f787e2b9c2dc",
     "id": null,
     "metadata": {},
-    "name": "CustomProviderFormTestCredentialsQuery",
-    "operationKind": "query",
-    "text": "query CustomProviderFormTestCredentialsQuery(\n  $input: GenerativeModelCustomerProviderConfigInput!\n) {\n  testGenerativeModelCustomProviderCredentials(input: $input) {\n    error\n  }\n}\n"
+    "name": "CustomProviderFormTestCredentialsMutation",
+    "operationKind": "mutation",
+    "text": "mutation CustomProviderFormTestCredentialsMutation(\n  $input: GenerativeModelCustomerProviderConfigInput!\n) {\n  testGenerativeModelCustomProviderCredentials(input: $input) {\n    error\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "b14fa4b352682df4c07814d53900a9f4";
+(node as any).hash = "dff7b8eedafccb0a37f2748ccb1a7be6";
 
 export default node;

--- a/src/phoenix/server/api/mutations/generative_model_custom_provider_mutations.py
+++ b/src/phoenix/server/api/mutations/generative_model_custom_provider_mutations.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
+from secrets import token_hex
 from typing import Mapping, Sequence
 
+import anyio
 import sqlalchemy as sa
 import strawberry
 from pydantic import ValidationError
@@ -32,6 +34,11 @@ from phoenix.server.api.types.GenerativeModelCustomProvider import (
 )
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.bearer_auth import PhoenixUser
+
+
+@strawberry.type
+class TestGenerativeModelCustomProviderCredentialsResult:
+    error: str | None = None
 
 
 def _get_sdk_from_config(
@@ -260,6 +267,108 @@ class GenerativeModelCustomProviderMutationMixin:
             provider=GenerativeModelCustomProvider(id=provider.id, db_record=provider),
             query=Query(),
         )
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled])  # type: ignore
+    async def test_generative_model_custom_provider_credentials(
+        self,
+        info: Info[Context, None],
+        input: GenerativeModelCustomerProviderConfigInput,
+    ) -> TestGenerativeModelCustomProviderCredentialsResult:
+        """
+        Test provider credentials by making a lightweight API call.
+        Uses models.list() where available, or a dummy model name where
+        non-auth errors indicate valid credentials.
+        """
+        config = input.to_orm()
+
+        if config.root.type == "openai":
+            try:
+                with anyio.move_on_after(10) as scope:
+                    async with config.root.get_client_factory()() as openai_client:
+                        await openai_client.models.list(timeout=10)
+                if scope.cancelled_caught:
+                    return TestGenerativeModelCustomProviderCredentialsResult(
+                        error="Request timed out after 10 seconds"
+                    )
+            except Exception as e:
+                return TestGenerativeModelCustomProviderCredentialsResult(error=str(e))
+        elif config.root.type == "azure_openai":
+            try:
+                with anyio.move_on_after(10) as scope:
+                    async with config.root.get_client_factory()() as azure_openai_client:
+                        await azure_openai_client.models.list(timeout=10)
+                if scope.cancelled_caught:
+                    return TestGenerativeModelCustomProviderCredentialsResult(
+                        error="Request timed out after 10 seconds"
+                    )
+            except Exception as e:
+                return TestGenerativeModelCustomProviderCredentialsResult(error=str(e))
+        elif config.root.type == "anthropic":
+            try:
+                from anthropic import NotFoundError as AnthropicNotFoundError
+
+                # Use dummy model - non-auth errors mean credentials are valid
+                with anyio.move_on_after(10) as scope:
+                    async with config.root.get_client_factory()() as anthropic_client:
+                        await anthropic_client.messages.create(
+                            model="test-credential-check",
+                            messages=[{"role": "user", "content": "Hi"}],
+                            max_tokens=10,
+                            timeout=10,
+                        )
+                if scope.cancelled_caught:
+                    return TestGenerativeModelCustomProviderCredentialsResult(
+                        error="Request timed out after 10 seconds"
+                    )
+            except AnthropicNotFoundError:
+                pass  # Fall through to return VALID
+            except Exception as e:
+                return TestGenerativeModelCustomProviderCredentialsResult(error=str(e))
+        elif config.root.type == "aws_bedrock":
+            try:
+                from botocore.exceptions import ClientError  # type: ignore[import-untyped]
+
+                # Use dummy model - ValidationException means credentials are valid
+                # Use async aioboto3 client
+                with anyio.move_on_after(10) as scope:
+                    async with config.root.get_client_factory()() as client:
+                        await client.converse(
+                            modelId=f"test-credential-check-{token_hex(4)}",
+                            messages=[{"role": "user", "content": [{"text": "Hi"}]}],
+                            inferenceConfig={"maxTokens": 10},
+                        )
+                if scope.cancelled_caught:
+                    return TestGenerativeModelCustomProviderCredentialsResult(
+                        error="Request timed out after 10 seconds"
+                    )
+            except ClientError as e:
+                error_code = e.response.get("Error", {}).get("Code", "")
+                # ValidationException means credentials are valid but model ID is wrong
+                # This is still a successful credential test
+                if error_code == "ValidationException":
+                    pass  # Fall through to return VALID
+                else:
+                    return TestGenerativeModelCustomProviderCredentialsResult(error=str(e))
+            except Exception as e:
+                return TestGenerativeModelCustomProviderCredentialsResult(error=str(e))
+        elif config.root.type == "google_genai":
+            try:
+                from google.genai.types import HttpOptions, ListModelsConfig
+
+                with anyio.move_on_after(10) as scope:
+                    async with config.root.get_client_factory()() as google_genai_client:
+                        await google_genai_client.models.list(
+                            config=ListModelsConfig(http_options=HttpOptions(timeout=10_000))
+                        )
+                if scope.cancelled_caught:
+                    return TestGenerativeModelCustomProviderCredentialsResult(
+                        error="Request timed out after 10 seconds"
+                    )
+            except Exception as e:
+                return TestGenerativeModelCustomProviderCredentialsResult(error=str(e))
+        else:
+            raise BadRequest("Invalid input")
+        return TestGenerativeModelCustomProviderCredentialsResult(error=None)
 
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled, IsLocked]

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -2,11 +2,9 @@ import json
 import re
 from collections import defaultdict
 from datetime import datetime
-from secrets import token_hex
 from typing import Any, Iterable, Iterator, Literal, Optional
 from typing import cast as type_cast
 
-import anyio
 import strawberry
 from sqlalchemy import ColumnElement, String, and_, case, cast, exists, func, or_, select, text
 from sqlalchemy.orm import joinedload, load_only, with_polymorphic
@@ -61,9 +59,6 @@ from phoenix.server.api.input_types.DatasetFilter import DatasetFilter
 from phoenix.server.api.input_types.DatasetSort import DatasetSort
 from phoenix.server.api.input_types.EvaluatorFilter import EvaluatorFilter
 from phoenix.server.api.input_types.EvaluatorSort import EvaluatorSort
-from phoenix.server.api.input_types.GenerativeModelCustomerProviderConfigInput import (
-    GenerativeModelCustomerProviderConfigInput,
-)
 from phoenix.server.api.input_types.InvocationParameters import InvocationParameter
 from phoenix.server.api.input_types.ModelClientOptionsInput import OpenAIApiType
 from phoenix.server.api.input_types.PlaygroundEvaluatorInput import EvaluatorInputMappingInput
@@ -212,11 +207,6 @@ class ExperimentRunMetricComparisons:
 
 
 @strawberry.type
-class TestGenerativeModelCustomProviderCredentialsResult:
-    error: str | None = None
-
-
-@strawberry.type
 class Query:
     @strawberry.field
     async def model_providers(self, info: Info[Context, None]) -> list[GenerativeProvider]:
@@ -318,107 +308,6 @@ class Query:
             has_previous_page=has_previous_page,
             has_next_page=has_next_page,
         )
-
-    @strawberry.field
-    async def test_generative_model_custom_provider_credentials(
-        self,
-        input: GenerativeModelCustomerProviderConfigInput,
-    ) -> TestGenerativeModelCustomProviderCredentialsResult:
-        """
-        Test provider credentials by making a lightweight API call.
-        Uses models.list() where available, or a dummy model name where
-        non-auth errors indicate valid credentials.
-        """
-        config = input.to_orm()
-
-        if config.root.type == "openai":
-            try:
-                with anyio.move_on_after(10) as scope:
-                    async with config.root.get_client_factory()() as openai_client:
-                        await openai_client.models.list(timeout=10)
-                if scope.cancelled_caught:
-                    return TestGenerativeModelCustomProviderCredentialsResult(
-                        error="Request timed out after 10 seconds"
-                    )
-            except Exception as e:
-                return TestGenerativeModelCustomProviderCredentialsResult(error=str(e))
-        elif config.root.type == "azure_openai":
-            try:
-                with anyio.move_on_after(10) as scope:
-                    async with config.root.get_client_factory()() as azure_openai_client:
-                        await azure_openai_client.models.list(timeout=10)
-                if scope.cancelled_caught:
-                    return TestGenerativeModelCustomProviderCredentialsResult(
-                        error="Request timed out after 10 seconds"
-                    )
-            except Exception as e:
-                return TestGenerativeModelCustomProviderCredentialsResult(error=str(e))
-        elif config.root.type == "anthropic":
-            try:
-                from anthropic import NotFoundError as AnthropicNotFoundError
-
-                # Use dummy model - non-auth errors mean credentials are valid
-                with anyio.move_on_after(10) as scope:
-                    async with config.root.get_client_factory()() as anthropic_client:
-                        await anthropic_client.messages.create(
-                            model="test-credential-check",
-                            messages=[{"role": "user", "content": "Hi"}],
-                            max_tokens=10,
-                            timeout=10,
-                        )
-                if scope.cancelled_caught:
-                    return TestGenerativeModelCustomProviderCredentialsResult(
-                        error="Request timed out after 10 seconds"
-                    )
-            except AnthropicNotFoundError:
-                pass  # Fall through to return VALID
-            except Exception as e:
-                return TestGenerativeModelCustomProviderCredentialsResult(error=str(e))
-        elif config.root.type == "aws_bedrock":
-            try:
-                from botocore.exceptions import ClientError  # type: ignore[import-untyped]
-
-                # Use dummy model - ValidationException means credentials are valid
-                # Use async aioboto3 client
-                with anyio.move_on_after(10) as scope:
-                    async with config.root.get_client_factory()() as client:
-                        await client.converse(
-                            modelId=f"test-credential-check-{token_hex(4)}",
-                            messages=[{"role": "user", "content": [{"text": "Hi"}]}],
-                            inferenceConfig={"maxTokens": 10},
-                        )
-                if scope.cancelled_caught:
-                    return TestGenerativeModelCustomProviderCredentialsResult(
-                        error="Request timed out after 10 seconds"
-                    )
-            except ClientError as e:
-                error_code = e.response.get("Error", {}).get("Code", "")
-                # ValidationException means credentials are valid but model ID is wrong
-                # This is still a successful credential test
-                if error_code == "ValidationException":
-                    pass  # Fall through to return VALID
-                else:
-                    return TestGenerativeModelCustomProviderCredentialsResult(error=str(e))
-            except Exception as e:
-                return TestGenerativeModelCustomProviderCredentialsResult(error=str(e))
-        elif config.root.type == "google_genai":
-            try:
-                from google.genai.types import HttpOptions, ListModelsConfig
-
-                with anyio.move_on_after(10) as scope:
-                    async with config.root.get_client_factory()() as google_genai_client:
-                        await google_genai_client.models.list(
-                            config=ListModelsConfig(http_options=HttpOptions(timeout=10_000))
-                        )
-                if scope.cancelled_caught:
-                    return TestGenerativeModelCustomProviderCredentialsResult(
-                        error="Request timed out after 10 seconds"
-                    )
-            except Exception as e:
-                return TestGenerativeModelCustomProviderCredentialsResult(error=str(e))
-        else:
-            raise BadRequest("Invalid input")
-        return TestGenerativeModelCustomProviderCredentialsResult(error=None)
 
     @strawberry.field
     async def generative_models(

--- a/tests/unit/server/api/mutations/test_generative_model_custom_provider_mutations.py
+++ b/tests/unit/server/api/mutations/test_generative_model_custom_provider_mutations.py
@@ -3,6 +3,8 @@ from typing import Any
 
 from strawberry.relay.types import GlobalID
 
+from phoenix.server.api.auth import IsAdminIfAuthEnabled, IsNotReadOnly, IsNotViewer
+from phoenix.server.api.schema import _EXPORTED_GRAPHQL_SCHEMA
 from tests.unit.graphql import AsyncGraphQLClient
 
 
@@ -122,6 +124,51 @@ class TestGenerativeModelCustomProviderMutations:
         }
       }
     """
+
+    async def test_test_credentials_is_an_auth_gated_mutation_not_a_query(
+        self,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        """Security regression: testGenerativeModelCustomProviderCredentials must be a
+        mutation with auth permission classes, not an unauthenticated query field. The
+        resolver makes user-controlled outbound HTTP requests, which is an SSRF vector
+        if exposed via the unauthenticated Query type.
+        """
+        introspection = """
+          query SchemaShape {
+            queryType: __type(name: "Query") { fields { name } }
+            mutationType: __type(name: "Mutation") { fields { name } }
+          }
+        """
+        result = await gql_client.execute(query=introspection)
+        assert not result.errors
+        assert result.data is not None
+
+        query_field_names = {f["name"] for f in result.data["queryType"]["fields"]}
+        mutation_field_names = {f["name"] for f in result.data["mutationType"]["fields"]}
+
+        assert "testGenerativeModelCustomProviderCredentials" not in query_field_names, (
+            "testGenerativeModelCustomProviderCredentials must not be exposed as a Query "
+            "field — it triggers user-controlled outbound HTTP and would be reachable "
+            "without authentication."
+        )
+        assert "testGenerativeModelCustomProviderCredentials" in mutation_field_names
+
+        from strawberry.types.base import StrawberryObjectDefinition
+
+        mutation_definition = _EXPORTED_GRAPHQL_SCHEMA.schema_converter.type_map[
+            "Mutation"
+        ].definition
+        assert isinstance(mutation_definition, StrawberryObjectDefinition)
+        resolver_field = next(
+            f
+            for f in mutation_definition.fields
+            if f.python_name == "test_generative_model_custom_provider_credentials"
+        )
+        permission_classes = set(resolver_field.permission_classes)
+        assert IsNotReadOnly in permission_classes
+        assert IsNotViewer in permission_classes
+        assert IsAdminIfAuthEnabled in permission_classes
 
     async def test_all_provider_mutations_comprehensive(
         self,


### PR DESCRIPTION
## Summary

- Move `testGenerativeModelCustomProviderCredentials` from `Query` to `Mutation` and gate it with `IsNotReadOnly`, `IsNotViewer`, and `IsAdminIfAuthEnabled`. As a query field it was unauthenticated and reachable via introspection; combined with its user-supplied `baseUrl` and arbitrary headers, this was an SSRF vector usable against cloud metadata endpoints (e.g. `metadata.google.internal`).
- Add a regression test (`test_test_credentials_is_an_auth_gated_mutation_not_a_query`) that asserts the field is **not** on `Query`, **is** on `Mutation`, and carries the required `permission_classes`.
- Update the `phoenix-server` skill (`SKILL.md` hard rules + `graphql-patterns.md` "Query vs Mutation" section) and `REVIEW.md` (new `## Security` section) so side-effecting fields cannot land on `Query` again.
- Update the frontend (`CustomProviderForm.tsx`) to invoke the field via `useMutation` instead of `fetchQuery`; regenerate Relay artifacts.

## Test plan

- [x] `make schema-graphql` regenerates `app/schema.graphql` with the field on `Mutation` only
- [x] `pnpm run build:relay`, `pnpm run typecheck`, `pnpm run lint` all pass
- [x] `ruff check` and `mypy --strict` pass on touched Python files
- [x] `make check-graphql-permissions` still passes (82 mutations / 2 subscriptions all gated)
- [x] New unit test passes: `uv run pytest tests/unit/server/api/mutations/test_generative_model_custom_provider_mutations.py::TestGenerativeModelCustomProviderMutations::test_test_credentials_is_an_auth_gated_mutation_not_a_query`
- [ ] Manual: confirm the "Test Credentials" button in the custom provider form still works end-to-end against a real provider