### PR TITLE
fix(evals): avoid templating warning on import

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__init__.py
@@ -1,6 +1,8 @@
+import importlib
 from importlib.metadata import version
+from typing import Any
 
-from . import llm, metrics, templating, tracing, utils
+from . import llm, metrics, tracing, utils
 from .evaluators import (
     ClassificationEvaluator,
     EvalInput,
@@ -19,6 +21,12 @@ from .llm import LLM, phoenix_prompt_to_prompt_template
 from .utils import download_benchmark_dataset
 
 __version__ = version("arize-phoenix-evals")
+
+
+def __getattr__(name: str) -> Any:
+    if name == "templating":
+        return importlib.import_module(f"{__name__}.templating")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [

--- a/packages/phoenix-evals/src/phoenix/evals/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__init__.py
@@ -24,6 +24,9 @@ __version__ = version("arize-phoenix-evals")
 
 
 def __getattr__(name: str) -> Any:
+    # TODO(v4): drop this lazy alias and delete phoenix/evals/templating/.
+    # Deprecated 2025-12-04 in favor of phoenix.evals.llm.prompts; kept lazy
+    # so importing phoenix.evals does not trigger the templating DeprecationWarning.
     if name == "templating":
         return importlib.import_module(f"{__name__}.templating")
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/phoenix-evals/tests/phoenix/evals/test_imports.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/test_imports.py
@@ -16,7 +16,9 @@ def test_importing_phoenix_evals_does_not_warn_about_deprecated_templating() -> 
         warnings.simplefilter("always", DeprecationWarning)
         importlib.import_module("phoenix.evals")
 
-    assert not any("phoenix.evals.templating module is deprecated" in str(w.message) for w in caught)
+    assert not any(
+        "phoenix.evals.templating module is deprecated" in str(w.message) for w in caught
+    )
 
 
 def test_accessing_templating_still_warns_and_returns_module() -> None:

--- a/packages/phoenix-evals/tests/phoenix/evals/test_imports.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/test_imports.py
@@ -1,0 +1,31 @@
+import importlib
+import sys
+import warnings
+
+
+def _clear_modules(prefix: str) -> None:
+    for name in list(sys.modules):
+        if name == prefix or name.startswith(f"{prefix}."):
+            sys.modules.pop(name, None)
+
+
+def test_importing_phoenix_evals_does_not_warn_about_deprecated_templating() -> None:
+    _clear_modules("phoenix.evals")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        importlib.import_module("phoenix.evals")
+
+    assert not any("phoenix.evals.templating module is deprecated" in str(w.message) for w in caught)
+
+
+def test_accessing_templating_still_warns_and_returns_module() -> None:
+    _clear_modules("phoenix.evals")
+    module = importlib.import_module("phoenix.evals")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        templating = module.templating
+
+    assert any("phoenix.evals.templating module is deprecated" in str(w.message) for w in caught)
+    assert templating.Template is not None


### PR DESCRIPTION
refs #12872

Stop importing `phoenix.evals.templating` eagerly from `phoenix.evals.__init__`.
That deprecated module now loads lazily, so importing `phoenix.evals` no longer emits the templating deprecation warning unless a caller actually uses the deprecated path.

Validation:
- `uvx --from 'uv==0.9.18' uv run pytest packages/phoenix-evals/tests/phoenix/evals/test_imports.py`
- `uvx --from 'uv==0.9.18' uv run ruff check packages/phoenix-evals/src/phoenix/evals/__init__.py packages/phoenix-evals/tests/phoenix/evals/test_imports.py`
