### PR TITLE
fix(playground): avoid duplicate Responses output messages

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -992,7 +992,7 @@ class OpenAIBaseStreamingClient(PlaygroundStreamingClient["AsyncOpenAI"]):
                 span.set_attributes(
                     dict(_ResponsesApiAttributes._get_attributes_from_response(completed_response))
                 )
-            if text_chunks or tool_call_chunks:
+            elif text_chunks or tool_call_chunks:
                 span.set_attributes(dict(_llm_output_messages(text_chunks, tool_call_chunks)))
             return
 
@@ -1211,7 +1211,7 @@ class OpenAIBaseStreamingClient(PlaygroundStreamingClient["AsyncOpenAI"]):
             span.set_attributes(
                 dict(_ResponsesApiAttributes._get_attributes_from_response(completed_response))
             )
-        if text_chunks or tool_call_chunks:
+        elif text_chunks or tool_call_chunks:
             span.set_attributes(dict(_llm_output_messages(text_chunks, tool_call_chunks)))
 
     def _to_openai_chat_completion_message_param(


### PR DESCRIPTION
## Summary
- Avoid writing `llm.output_messages` twice for OpenAI Responses playground spans when a completed response is available.
- Preserve the chunk-derived `_llm_output_messages` path as a fallback for cases without a completed response.

## Test plan
- `uv run python -m py_compile src/phoenix/server/api/helpers/playground_clients.py`
- Pre-commit hooks from commit: format python, lint python