### PR TITLE
fix: show label-only annotations in summary cells

### DIFF
--- a/app/src/components/annotation/AnnotationSummaryGroup.tsx
+++ b/app/src/components/annotation/AnnotationSummaryGroup.tsx
@@ -9,6 +9,7 @@ import { AnnotationSummaryPopover } from "@phoenix/components/annotation/Annotat
 import {
   Summary,
   SummaryValue,
+  SummaryValueLabelPreview,
   SummaryValuePreview,
 } from "@phoenix/pages/project/AnnotationSummary";
 import type { AnnotationConfigCategorical } from "@phoenix/pages/settings/types";
@@ -178,7 +179,11 @@ export const AnnotationSummaryGroupTokens = ({
                     categoricalAnnotationConfigsByName[latestAnnotation.name]
                   }
                 />
-              ) : null}
+              ) : (
+                <SummaryValueLabelPreview
+                  labelFractions={summary.labelFractions}
+                />
+              )}
             </AnnotationLabel>
           </AnnotationSummaryPopover>
         );

--- a/app/src/components/annotation/SessionAnnotationSummaryGroup.tsx
+++ b/app/src/components/annotation/SessionAnnotationSummaryGroup.tsx
@@ -9,6 +9,7 @@ import { AnnotationSummaryPopover } from "@phoenix/components/annotation/Annotat
 import {
   Summary,
   SummaryValue,
+  SummaryValueLabelPreview,
   SummaryValuePreview,
 } from "@phoenix/pages/project/AnnotationSummary";
 import type { AnnotationConfigCategorical } from "@phoenix/pages/settings/types";
@@ -172,7 +173,11 @@ export const SessionAnnotationSummaryGroupTokens = ({
                     categoricalAnnotationConfigsByName[latestAnnotation.name]
                   }
                 />
-              ) : null}
+              ) : (
+                <SummaryValueLabelPreview
+                  labelFractions={summary.labelFractions}
+                />
+              )}
             </AnnotationLabel>
           </AnnotationSummaryPopover>
         );

--- a/app/src/components/annotation/TraceAnnotationSummaryGroup.tsx
+++ b/app/src/components/annotation/TraceAnnotationSummaryGroup.tsx
@@ -6,7 +6,10 @@ import { Flex } from "@phoenix/components";
 import type { TraceAnnotationSummaryGroup$key } from "@phoenix/components/annotation/__generated__/TraceAnnotationSummaryGroup.graphql";
 import { AnnotationLabel } from "@phoenix/components/annotation/AnnotationLabel";
 import { AnnotationSummaryPopover } from "@phoenix/components/annotation/AnnotationSummaryPopover";
-import { SummaryValuePreview } from "@phoenix/pages/project/AnnotationSummary";
+import {
+  SummaryValueLabelPreview,
+  SummaryValuePreview,
+} from "@phoenix/pages/project/AnnotationSummary";
 import type { AnnotationConfigCategorical } from "@phoenix/pages/settings/types";
 
 const useTraceAnnotationSummaryGroup = (
@@ -176,7 +179,11 @@ export const TraceAnnotationSummaryGroupTokens = ({
                     categoricalAnnotationConfigsByName[latestAnnotation.name]
                   }
                 />
-              ) : null}
+              ) : (
+                <SummaryValueLabelPreview
+                  labelFractions={summary.labelFractions}
+                />
+              )}
             </AnnotationLabel>
           </AnnotationSummaryPopover>
         );

--- a/app/src/pages/project/AnnotationSummary.tsx
+++ b/app/src/pages/project/AnnotationSummary.tsx
@@ -408,6 +408,37 @@ export function SummaryValuePreview({
   );
 }
 
+export function SummaryValueLabelPreview({
+  labelFractions,
+}: {
+  labelFractions: readonly { label: string; fraction: number }[];
+}) {
+  const largestFraction = labelFractions.reduce((max, current) => {
+    return Math.max(max, current.fraction);
+  }, 0);
+  const largestFractionLabel = labelFractions.find(
+    (fraction) => fraction.fraction === largestFraction
+  )?.label;
+  const totalCount = labelFractions.length - 1;
+  const hasMoreThanOneLabel = totalCount > 0;
+  if (!largestFractionLabel) {
+    return null;
+  }
+  return (
+    <Flex
+      direction="row"
+      alignItems="center"
+      gap="size-50"
+      maxWidth={hasMoreThanOneLabel ? "80%" : "99%"}
+    >
+      <Token style={{ maxWidth: "100%" }}>
+        <Truncate maxWidth="100%">{largestFractionLabel}</Truncate>
+      </Token>
+      {hasMoreThanOneLabel && <Token>+ {totalCount}</Token>}
+    </Flex>
+  );
+}
+
 export function SummaryValueBreakdown({
   annotationName,
   labelFractions,
@@ -470,34 +501,13 @@ export function SummaryValueLabels({
   labelFractions: readonly { label: string; fraction: number }[];
   annotationConfig?: AnnotationConfig;
 }) {
-  const largestFraction = labelFractions.reduce((max, current) => {
-    return Math.max(max, current.fraction);
-  }, 0);
-  const largestFractionLabel = labelFractions.find(
-    (fraction) => fraction.fraction === largestFraction
-  )?.label;
-  const totalCount = labelFractions.length - 1;
-  const hasMoreThanOneLabel = totalCount > 0;
-  if (!largestFractionLabel) {
+  if (labelFractions.length === 0) {
     return null;
   }
   return (
     <TooltipTrigger delay={0}>
       <TriggerWrap>
-        <Flex
-          direction="row"
-          alignItems="center"
-          gap="size-50"
-          // Shrinks the container of tokens to allow for the + count to be visible
-          // while still truncating the biggest label
-          // otherwise, just shrink the container slightly for padding
-          maxWidth={hasMoreThanOneLabel ? "80%" : "99%"}
-        >
-          <Token style={{ maxWidth: "100%" }}>
-            <Truncate maxWidth="100%">{largestFractionLabel}</Truncate>
-          </Token>
-          {hasMoreThanOneLabel && <Token>+ {totalCount}</Token>}
-        </Flex>
+        <SummaryValueLabelPreview labelFractions={labelFractions} />
       </TriggerWrap>
       <RichTooltip placement="bottom">
         <SummaryValueBreakdown


### PR DESCRIPTION
## Summary
- show label-only annotation summaries in compact span, trace, and session annotation cells
- extract the top-label + count rendering into a reusable `SummaryValueLabelPreview`
- keep existing score display behavior when annotations have a mean score

## Screenshots
Label-only annotation cells now show the top label and compact `+n` count while score annotations continue to show their mean score.

![Label-only annotation cells](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/12898-label-only-annotation-cells.png)

## Test plan
- `pnpm --dir app exec tsc --noEmit --pretty false`
- pre-commit app formatting/lint hooks passed during commit
- verified locally in Phoenix with label-only span annotation data on `localhost:6006`
