### PR TITLE
feat(api): add session notes endpoint

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1156,6 +1156,7 @@
               {
                 "group": "04.2026",
                 "pages": [
+                  "docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api",
                   "docs/phoenix/release-notes/04-2026/04-24-2026-phoenix-otel-python-0-16",
                   "docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id",
                   "docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7",

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -7,6 +7,13 @@ description: The latest from the Phoenix team.
 GitHub
 </Card>
 
+<Update label="04.28.2026">
+## [04.28.2026: Session Notes API](/docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api)
+**Available in arize-phoenix 14.16.0+**
+
+Phoenix now supports creating session notes through `POST /v1/session_notes`. The generic session annotation endpoint now reserves `name="note"` for note-specific APIs, so use `POST /v1/session_notes` for session notes and `POST /v1/session_annotations` for regular annotations.
+</Update>
+
 <Update label="04.24.2026">
 ## [04.24.2026: arize-phoenix-otel 0.16](/docs/phoenix/release-notes/04-2026/04-24-2026-phoenix-otel-python-0-16)
 **Available in arize-phoenix-otel 0.16.0+**

--- a/docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api.mdx
@@ -1,0 +1,15 @@
+---
+title: "04.28.2026 Session Notes API"
+description: "Add session notes through a dedicated REST endpoint and reserve the note annotation name for session note APIs."
+---
+
+## Session Notes API
+
+**Available in arize-phoenix 14.16.0+**
+
+Phoenix now supports creating session notes through `POST /v1/session_notes`, giving session-level review workflows the same note-specific REST pattern used by traces and spans.
+
+To keep note behavior consistent across APIs, the reserved annotation name `note` is no longer accepted on the generic session annotation endpoint. Use the dedicated note endpoint instead:
+
+- `POST /v1/session_notes` for session notes
+- `POST /v1/session_annotations` for regular session annotations

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,7 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api" arrow="true" title="04.28.2026" icon="calendar" description="Dedicated session notes REST API; reserve the note annotation name for session note endpoint"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-24-2026-trace-notes-api" arrow="true" title="04.24.2026" icon="calendar" description="Dedicated trace notes REST API; reserve the note annotation name for trace and span note endpoints"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id" arrow="true" title="04.22.2026" icon="calendar" description="Secrets settings page in Phoenix UI; trace_id parameter in experiment evaluators"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7" arrow="true" title="04.20.2026" icon="calendar" description="Span attribute filtering (Python, TypeScript, REST, CLI); px span add-note; Claude Opus 4.7 in playground"/>

--- a/js/.changeset/session-notes-api.md
+++ b/js/.changeset/session-notes-api.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+Regenerate REST API types for the session notes endpoint.

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -914,6 +914,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/session_notes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a session note
+         * @description Add a note annotation to a session. Notes are special annotations that allow multiple entries per session (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv4 identifier.
+         */
+        post: operations["createSessionNote"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/document_annotations": {
         parameters: {
             query?: never;
@@ -1284,6 +1304,14 @@ export interface components {
         /** CreatePromptResponseBody */
         CreatePromptResponseBody: {
             data: components["schemas"]["PromptVersion"];
+        };
+        /** CreateSessionNoteRequestBody */
+        CreateSessionNoteRequestBody: {
+            data: components["schemas"]["SessionNoteData"];
+        };
+        /** CreateSessionNoteResponseBody */
+        CreateSessionNoteResponseBody: {
+            data: components["schemas"]["InsertedSessionAnnotation"];
         };
         /** CreateSpanNoteRequestBody */
         CreateSpanNoteRequestBody: {
@@ -2946,6 +2974,19 @@ export interface components {
             end_time: string;
             /** Traces */
             traces: components["schemas"]["SessionTraceData"][];
+        };
+        /** SessionNoteData */
+        SessionNoteData: {
+            /**
+             * Session Id
+             * @description Session ID
+             */
+            session_id: string;
+            /**
+             * Note
+             * @description The note text to add to the session
+             */
+            note: string;
         };
         /** SessionTraceData */
         SessionTraceData: {
@@ -6534,6 +6575,57 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnnotateSessionsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Session not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    createSessionNote: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateSessionNoteRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Session note created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateSessionNoteResponseBody"];
                 };
             };
             /** @description Forbidden */

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -503,6 +503,11 @@ class SessionAnnotationsResponseBody(TypedDict):
     next_cursor: Optional[str]
 
 
+class SessionNoteData(TypedDict):
+    session_id: str
+    note: str
+
+
 class SessionTraceData(TypedDict):
     id: str
     trace_id: str
@@ -751,6 +756,14 @@ class CreateExperimentRunResponseBody(TypedDict):
 
 class CreateProjectResponseBody(TypedDict):
     data: Project
+
+
+class CreateSessionNoteRequestBody(TypedDict):
+    data: SessionNoteData
+
+
+class CreateSessionNoteResponseBody(TypedDict):
+    data: InsertedSessionAnnotation
 
 
 class CreateSpanNoteRequestBody(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -5029,6 +5029,68 @@
         }
       }
     },
+    "/v1/session_notes": {
+      "post": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Create a session note",
+        "description": "Add a note annotation to a session. Notes are special annotations that allow multiple entries per session (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv4 identifier.",
+        "operationId": "createSessionNote",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSessionNoteRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Session note created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateSessionNoteResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/document_annotations": {
       "post": {
         "tags": [
@@ -6118,6 +6180,30 @@
           "data"
         ],
         "title": "CreatePromptResponseBody"
+      },
+      "CreateSessionNoteRequestBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SessionNoteData"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "CreateSessionNoteRequestBody"
+      },
+      "CreateSessionNoteResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/InsertedSessionAnnotation"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "CreateSessionNoteResponseBody"
       },
       "CreateSpanNoteRequestBody": {
         "properties": {
@@ -10351,6 +10437,28 @@
           "traces"
         ],
         "title": "SessionData"
+      },
+      "SessionNoteData": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Session Id",
+            "description": "Session ID"
+          },
+          "note": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Note",
+            "description": "The note text to add to the session"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "note"
+        ],
+        "title": "SessionNoteData"
       },
       "SessionTraceData": {
         "properties": {

--- a/src/phoenix/server/api/routers/v1/sessions.py
+++ b/src/phoenix/server/api/routers/v1/sessions.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-import warnings
 from collections import defaultdict
 from datetime import datetime
-from typing import Literal, Optional
+from typing import Annotated, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
-from pydantic import Field
-from sqlalchemy import delete, select
+from pydantic import BeforeValidator, Field
+from sqlalchemy import delete, insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 from strawberry.relay import GlobalID
@@ -15,6 +14,7 @@ from strawberry.relay import GlobalID
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
+from phoenix.server.api.helpers.annotations import get_note_identifier
 from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
 from phoenix.server.api.routers.v1.utils import (
     PaginatedResponseBody,
@@ -25,10 +25,17 @@ from phoenix.server.api.routers.v1.utils import (
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.Project import Project as ProjectNodeType
 from phoenix.server.api.types.ProjectSession import ProjectSession as ProjectSessionNodeType
+from phoenix.server.api.types.ProjectSessionAnnotation import (
+    ProjectSessionAnnotation as SessionAnnotationNodeType,
+)
 from phoenix.server.api.types.Trace import Trace as TraceNodeType
-from phoenix.server.authorization import is_not_locked
+from phoenix.server.authorization import (
+    is_not_locked,
+    prevent_access_in_read_only_mode,
+    restrict_access_by_viewers,
+)
 from phoenix.server.bearer_auth import PhoenixUser
-from phoenix.server.dml_event import SpanDeleteEvent
+from phoenix.server.dml_event import ProjectSessionAnnotationInsertEvent, SpanDeleteEvent
 
 from .annotations import SessionAnnotationData
 from .utils import RequestBody
@@ -59,6 +66,23 @@ class AnnotateSessionsRequestBody(RequestBody[list[SessionAnnotationData]]):
 
 
 class AnnotateSessionsResponseBody(ResponseBody[list[InsertedSessionAnnotation]]):
+    pass
+
+
+class SessionNoteData(V1RoutesBaseModel):
+    session_id: Annotated[
+        str, BeforeValidator(lambda value: value.strip() if isinstance(value, str) else value)
+    ] = Field(min_length=1, description="Session ID")
+    note: Annotated[
+        str, BeforeValidator(lambda value: value.strip() if isinstance(value, str) else value)
+    ] = Field(min_length=1, description="The note text to add to the session")
+
+
+class CreateSessionNoteRequestBody(RequestBody[SessionNoteData]):
+    data: SessionNoteData
+
+
+class CreateSessionNoteResponseBody(ResponseBody[InsertedSessionAnnotation]):
     pass
 
 
@@ -370,22 +394,20 @@ async def annotate_sessions(
 ) -> AnnotateSessionsResponseBody:
     if not request_body.data:
         return AnnotateSessionsResponseBody(data=[])
+    if any(data.name == "note" for data in request_body.data):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "The name 'note' is reserved for session notes. Use POST /v1/session_notes instead."
+            ),
+        )
 
     user_id: Optional[int] = None
     if request.app.state.authentication_enabled and isinstance(request.user, PhoenixUser):
         user_id = int(request.user.identity)
 
     session_annotations = request_body.data
-    filtered_session_annotations = list(filter(lambda d: d.name != "note", session_annotations))
-    if len(filtered_session_annotations) != len(session_annotations):
-        warnings.warn(
-            (
-                "Session annotations with the name 'note' are not supported in this endpoint. "
-                "They will be ignored."
-            ),
-            UserWarning,
-        )
-    precursors = [d.as_precursor(user_id=user_id) for d in filtered_session_annotations]
+    precursors = [d.as_precursor(user_id=user_id) for d in session_annotations]
     if not sync:
         await request.state.enqueue_annotations(*precursors)
         return AnnotateSessionsResponseBody(data=[])
@@ -426,4 +448,71 @@ async def annotate_sessions(
 
     return AnnotateSessionsResponseBody(
         data=[InsertedSessionAnnotation(id=str(inserted_id)) for inserted_id in inserted_ids]
+    )
+
+
+@router.post(
+    "/session_notes",
+    dependencies=[
+        Depends(prevent_access_in_read_only_mode),
+        Depends(restrict_access_by_viewers),
+        Depends(is_not_locked),
+    ],
+    operation_id="createSessionNote",
+    summary="Create a session note",
+    description=(
+        "Add a note annotation to a session. Notes are special annotations that allow "
+        "multiple entries per session (unlike regular annotations which are unique by name "
+        "and identifier). Each note gets a unique UUIDv4 identifier."
+    ),
+    responses=add_errors_to_responses([{"status_code": 404, "description": "Session not found"}]),
+    response_description="Session note created successfully",
+    status_code=200,
+)
+async def create_session_note(
+    request: Request,
+    request_body: CreateSessionNoteRequestBody,
+) -> CreateSessionNoteResponseBody:
+    note_data = request_body.data
+
+    user_id: Optional[int] = None
+    if request.app.state.authentication_enabled and isinstance(request.user, PhoenixUser):
+        user_id = int(request.user.identity)
+
+    async with request.app.state.db() as session:
+        project_session_id = await session.scalar(
+            select(models.ProjectSession.id).where(
+                models.ProjectSession.session_id == note_data.session_id
+            )
+        )
+
+        if project_session_id is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Session with session_id {note_data.session_id} not found",
+            )
+
+        result = await session.execute(
+            insert(models.ProjectSessionAnnotation)
+            .values(
+                project_session_id=project_session_id,
+                name="note",
+                label=None,
+                score=None,
+                explanation=note_data.note,
+                annotator_kind="HUMAN",
+                metadata_={},
+                identifier=get_note_identifier("px-session-note"),
+                source="API",
+                user_id=user_id,
+            )
+            .returning(models.ProjectSessionAnnotation.id)
+        )
+        annotation_id = result.scalar_one()
+
+    request.state.event_queue.put(ProjectSessionAnnotationInsertEvent((annotation_id,)))
+    return CreateSessionNoteResponseBody(
+        data=InsertedSessionAnnotation(
+            id=str(GlobalID(SessionAnnotationNodeType.__name__, str(annotation_id)))
+        )
     )

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2241,6 +2241,7 @@ _VIEWER_BLOCKED_WRITE_OPERATIONS = (
     (422, "POST", "v1/prompts"),
     (422, "POST", "v1/prompt_versions/fake-id-{}/tags"),
     (422, "POST", "v1/session_annotations"),
+    (422, "POST", "v1/session_notes"),
     (422, "POST", "v1/span_annotations"),
     (422, "POST", "v1/span_notes"),
     (422, "POST", "v1/spans"),

--- a/tests/unit/server/api/routers/v1/test_sessions.py
+++ b/tests/unit/server/api/routers/v1/test_sessions.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from secrets import token_hex
 from typing import Any
+from uuid import UUID
 
 import httpx
+from sqlalchemy import select
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
@@ -245,6 +247,140 @@ class TestDeleteSessions:
         httpx_client: httpx.AsyncClient,
     ) -> None:
         response = await httpx_client.post("v1/sessions/delete", json={"session_identifiers": []})
+        assert response.status_code == 422
+
+
+class TestAnnotateSessions:
+    async def test_rest_session_annotation_rejects_note_name(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        _, session_model, _ = await _insert_session_with_traces(db)
+
+        request_body = {
+            "data": [
+                {
+                    "session_id": session_model.session_id,
+                    "name": "note",
+                    "annotator_kind": "HUMAN",
+                    "result": {"explanation": "This should use the notes endpoint"},
+                }
+            ]
+        }
+        response = await httpx_client.post("v1/session_annotations?sync=true", json=request_body)
+
+        assert response.status_code == 400
+        assert (
+            "The name 'note' is reserved for session notes. Use POST /v1/session_notes instead."
+            in response.text
+        )
+
+
+class TestCreateSessionNote:
+    async def test_rest_create_session_note(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        _, session_model, _ = await _insert_session_with_traces(db)
+        note_text = "Review complete"
+
+        response = await httpx_client.post(
+            "v1/session_notes",
+            json={"data": {"session_id": session_model.session_id, "note": note_text}},
+        )
+
+        assert response.status_code == 200
+        annotation_id = response.json()["data"]["id"]
+        rowid = from_global_id_with_expected_type(
+            GlobalID.from_id(annotation_id), "ProjectSessionAnnotation"
+        )
+
+        async with db() as session:
+            orm_annotation = await session.scalar(
+                select(models.ProjectSessionAnnotation).where(
+                    models.ProjectSessionAnnotation.id == rowid,
+                    models.ProjectSessionAnnotation.name == "note",
+                    models.ProjectSessionAnnotation.explanation == note_text,
+                )
+            )
+
+        assert orm_annotation is not None
+        assert orm_annotation.project_session_id == session_model.id
+        assert orm_annotation.name == "note"
+        assert orm_annotation.label is None
+        assert orm_annotation.score is None
+        assert orm_annotation.explanation == note_text
+        assert orm_annotation.annotator_kind == "HUMAN"
+        assert orm_annotation.metadata_ == {}
+        assert orm_annotation.source == "API"
+        assert orm_annotation.identifier.startswith("px-session-note:")
+        assert UUID(orm_annotation.identifier.removeprefix("px-session-note:")).version == 4
+
+    async def test_rest_create_session_note_not_found(
+        self,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        missing_session_id = token_hex(16)
+
+        response = await httpx_client.post(
+            "v1/session_notes",
+            json={"data": {"session_id": missing_session_id, "note": "This should fail"}},
+        )
+
+        assert response.status_code == 404
+        assert f"Session with session_id {missing_session_id} not found" in response.text
+
+    async def test_rest_create_multiple_session_notes(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        _, session_model, _ = await _insert_session_with_traces(db)
+        note_texts = ["first note", "second note", "third note"]
+
+        for note_text in note_texts:
+            response = await httpx_client.post(
+                "v1/session_notes",
+                json={"data": {"session_id": session_model.session_id, "note": note_text}},
+            )
+            assert response.status_code == 200
+
+        async with db() as session:
+            annotations = list(
+                (
+                    await session.scalars(
+                        select(models.ProjectSessionAnnotation).where(
+                            models.ProjectSessionAnnotation.project_session_id == session_model.id,
+                            models.ProjectSessionAnnotation.name == "note",
+                        )
+                    )
+                ).all()
+            )
+
+        assert len(annotations) == 3
+        assert {annotation.explanation for annotation in annotations} == set(note_texts)
+        identifiers = [annotation.identifier for annotation in annotations]
+        assert len(set(identifiers)) == 3
+        assert all(identifier.startswith("px-session-note:") for identifier in identifiers)
+        assert all(
+            UUID(identifier.removeprefix("px-session-note:")).version == 4
+            for identifier in identifiers
+        )
+
+    async def test_rest_create_session_note_blank_text_rejected(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        _, session_model, _ = await _insert_session_with_traces(db)
+
+        response = await httpx_client.post(
+            "v1/session_notes",
+            json={"data": {"session_id": session_model.session_id, "note": "   "}},
+        )
+
         assert response.status_code == 422
 
 


### PR DESCRIPTION
## Summary

Adds REST API support for session notes, matching the existing trace/span note pattern.

- adds `POST /v1/session_notes` for creating session note annotations
- reserves `name="note"` on `POST /v1/session_annotations` and directs callers to the note endpoint
- emits `ProjectSessionAnnotationInsertEvent` for created session notes
- regenerates OpenAPI, Python client, and TypeScript client types
- adds release note coverage for the new endpoint and breaking generic-annotation behavior

## Testing

- `make openapi`
- `uv run pytest tests/unit/server/api/routers/v1/test_sessions.py -q`
- `uv run pytest tests/integration/server/test_launch_app.py::TestLaunchApp::test_api_access -q`
- `uv run pytest 'tests/integration/auth/test_auth.py::TestApiAccessViaCookiesOrApiKeys::test_role_based_access_control[UserRoleInput.VIEWER]' -q`
- `make lint-python`
- `pnpm --dir js --filter @arizeai/phoenix-client typecheck`

## Manual REST dogfooding

Started a local Phoenix server with the `project_sessions_llama_index_rag_arize_docs` fixture and verified:

- `POST /v1/session_notes` returns `200` with a `ProjectSessionAnnotation` GlobalID
- `GET /v1/projects/SESSIONS-DEMO/session_annotations?session_ids=<id>&include_annotation_names=note` reads the note back
- blank note text returns `422`
- nonexistent session returns `404`
- `POST /v1/session_annotations?sync=true` with `name="note"` returns `400` with remediation text

## Notes

This intentionally does not add CLI commands; CLI support will be handled in a follow-up PR.
