### PR TITLE
test(playwright): align e2e tests with new dataset-upsert UI

### DIFF
--- a/app/tests/dataset-file-upload.spec.ts
+++ b/app/tests/dataset-file-upload.spec.ts
@@ -410,14 +410,16 @@ test.describe("Dataset File Upload", () => {
       await expect(collapseSwitch).toBeVisible();
     });
 
-    test("can toggle collapse and see collapsed data in preview", async ({
+    test("auto-enables collapse and shows collapsed data in preview", async ({
       page,
     }) => {
       /**
-       * This test verifies that toggling collapse:
-       * 1. The column assigner keeps showing original top-level keys (input, output, id)
+       * This test verifies that when a file with collapsible top-level keys is
+       * uploaded:
+       * 1. The collapse toggle is automatically turned on
+       * 2. The column assigner keeps showing original top-level keys (input, output, id)
        *    because those are what get sent to the backend for assignment
-       * 2. The dataset preview shows the collapsed/flattened data structure
+       * 3. The dataset preview shows the collapsed/flattened data structure
        *
        * The backend handles the actual flattening - the frontend just passes
        * which keys to flatten via flatten_keys parameter.
@@ -433,18 +435,18 @@ test.describe("Dataset File Upload", () => {
 
       await expect(dialog.getByText("nested.jsonl")).toBeVisible();
 
-      // Without collapse, we should see top-level keys: input, output, id
+      // Even with collapse enabled, the column assigner still shows the original
+      // top-level keys: input, output, id
       // "input" and "output" should be auto-assigned to their buckets
       await expectColumnInBucket(page, "input", "INPUT");
       await expectColumnInBucket(page, "output", "OUTPUT");
       await expectColumnInBucket(page, "id", "KEYS");
 
-      // Enable collapse - click on the label text instead of the switch for Firefox compatibility
+      // Collapse is automatically enabled when collapsible keys are detected
       const collapseSwitch = dialog.getByRole("switch", {
         name: "Collapse top-level keys",
       });
       await expect(collapseSwitch).toBeVisible();
-      await dialog.getByText("Collapse top-level keys").click();
       await expect(collapseSwitch).toBeChecked();
 
       // Column assigner still shows original keys (backend does the flattening)
@@ -484,13 +486,11 @@ test.describe("Dataset File Upload", () => {
 
       await expect(dialog.getByText("nested.jsonl")).toBeVisible();
 
-      // Enable collapse - click on the label text instead of the switch for Firefox compatibility
+      // Collapse is automatically enabled when collapsible keys are detected
       const collapseSwitch = dialog.getByRole("switch", {
         name: "Collapse top-level keys",
       });
       await expect(collapseSwitch).toBeVisible();
-      // Click on the text label which triggers the switch more reliably across browsers
-      await dialog.getByText("Collapse top-level keys").click();
       await expect(collapseSwitch).toBeChecked();
 
       // Set dataset name
@@ -548,12 +548,11 @@ test.describe("Dataset File Upload", () => {
 
       await expect(dialog.getByText("nested.jsonl")).toBeVisible();
 
-      // Enable collapse - click on the label text instead of the switch for Firefox compatibility
+      // Collapse is automatically enabled when collapsible keys are detected
       const collapseSwitch = dialog.getByRole("switch", {
         name: "Collapse top-level keys",
       });
       await expect(collapseSwitch).toBeVisible();
-      await dialog.getByText("Collapse top-level keys").click();
       await expect(collapseSwitch).toBeChecked();
 
       // Switch to "Dataset Preview" tab to see the preview table

--- a/app/tests/playground.spec.ts
+++ b/app/tests/playground.spec.ts
@@ -104,10 +104,10 @@ test.describe("Playground", () => {
     const datasetId = datasetMatch ? datasetMatch[1] : "";
     expect(datasetId).toBeTruthy();
 
-    await page
-      .getByRole("button", { name: "Add Dataset Example" })
-      .or(page.getByRole("button", { name: "Example" }))
-      .click();
+    // The Examples button opens a menu with options to add an example manually
+    // or upload from a file. Choose the manual option to open the dialog.
+    await page.getByRole("button", { name: "Add Dataset Example" }).click();
+    await page.getByRole("menuitem", { name: "Add Example Manually" }).click();
     await expect(page.getByRole("dialog")).toBeVisible();
 
     const longContent = `${"lorem-ipsum-".repeat(45)}`;

--- a/app/tests/server-evaluators.spec.ts
+++ b/app/tests/server-evaluators.spec.ts
@@ -59,11 +59,11 @@ test.describe.serial("Server Evaluators", () => {
       page.getByRole("heading", { name: datasetName })
     ).toBeVisible();
 
-    // Add an example to the dataset (required for playground to work)
-    await page
-      .getByRole("button", { name: "Add Dataset Example" })
-      .or(page.getByRole("button", { name: "Example" }))
-      .click();
+    // Add an example to the dataset (required for playground to work).
+    // The Examples button opens a menu with options to add an example manually
+    // or upload from a file. Choose the manual option to open the dialog.
+    await page.getByRole("button", { name: "Add Dataset Example" }).click();
+    await page.getByRole("menuitem", { name: "Add Example Manually" }).click();
 
     // Wait for the Add Example dialog to open
     await expect(page.getByRole("dialog")).toBeVisible();


### PR DESCRIPTION
## Summary

Two UI changes in this branch silently broke five Playwright e2e tests in [the latest CI run on #11860](https://github.com/Arize-ai/phoenix/actions/runs/25111676740/job/73587179830?pr=11860). This PR updates the tests to match the new behavior.

### 1. Collapse-top-level-keys toggle is auto-enabled

[DatasetFromFileForm.tsx:423,449](app/src/pages/datasets/DatasetFromFileForm.tsx) now calls \`setCollapseKeys(result.collapsibleColumns.length > 0)\` after parsing, so the toggle starts in the ON state whenever the uploaded file has collapsible columns. The three failing \`dataset-file-upload.spec.ts\` tests were still clicking the label to \"enable\" it — which actually toggled it off — and then asserting \`toBeChecked()\`. The fix: drop the click and just assert the default-on state. The first test was renamed from \"can toggle collapse...\" to \"auto-enables collapse...\" to reflect what's actually being verified.

### 2. \"Add Dataset Example\" button opens a menu

[AddDatasetExampleButton.tsx](app/src/pages/dataset/AddDatasetExampleButton.tsx) was rewritten to open a \`MenuTrigger\` popover with two options (\"Add Example Manually\" and \"Update Dataset From File\") instead of opening the manual-add dialog directly. The \`playground.spec.ts\` and \`server-evaluators.spec.ts\` tests were treating the button as a single-click open of the dialog and so never reached the CodeMirror editor inside. The fix: click the \"Add Example Manually\" menu item after pressing the button.

## Failing tests addressed

- \`dataset-file-upload.spec.ts\` — \"can toggle collapse and see collapsed data in preview\"
- \`dataset-file-upload.spec.ts\` — \"can create dataset with collapse enabled\"
- \`dataset-file-upload.spec.ts\` — \"preview table values match created dataset examples (round-trip verification)\"
- \`playground.spec.ts\` — \"keeps dataset examples table interactive with expansion\"
- \`server-evaluators.spec.ts\` — \"can create a dataset with an example\"

## Test plan

- [ ] CI Playwright run on this PR passes the five tests above
- [ ] No regressions in the other passing Playwright tests on chromium/firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)