### PR TITLE
fix(datasets): surface pre-upsert examples to the upsert diff

### DIFF
--- a/src/phoenix/db/insertion/dataset.py
+++ b/src/phoenix/db/insertion/dataset.py
@@ -484,11 +484,6 @@ async def _get_external_ids_and_content_hashes_for_most_recent_version(
         latest_version_id, dataset_id=dataset_id
     ).subquery()
 
-    # Pre-upsert revisions have NULL content_hash because the column was added
-    # without a backfill. They are surfaced here so that action=update can mark
-    # them for deletion (otherwise they would be invisible orphans), and so that
-    # users can patch them by GlobalID. They cannot participate in content-hash
-    # dedup; see _ExampleMatcher.
     result = await session.execute(
         select(
             revisions_subq.c.dataset_example_id,
@@ -588,8 +583,9 @@ class _ExampleMatcher:
       - If external_id is provided:  node_id match > external_id match > no match
       - If external_id is absent:    content_hash match > no match
 
-    Pre-upsert examples (NULL content_hash) are reachable only via node_id;
-    they cannot participate in content-hash dedup or external_id lookup.
+    Examples from pre-v15 datasets (NULL content_hash) are reachable only via
+    node_id; they cannot participate in content-hash dedup or external_id
+    lookup.
     """
 
     def __init__(self, previous: list[tuple[DatasetExampleId, ExternalID, ContentHash]]) -> None:
@@ -643,10 +639,6 @@ def _diff_examples(
       - Unmatched incoming           → CREATE
       - Unmatched previous           → DELETE (skipped when skip_deletes=True)
 
-    Pre-upsert examples (NULL content_hash) appear in `previous` so that
-    action=update can mark them for deletion when not matched, and so users
-    can patch them by GlobalID. A patched pre-upsert example acquires a
-    content_hash and joins the tracked population from then on.
     """
     matcher = _ExampleMatcher(previous)
     examples_to_create: list[ExampleWithHash] = []

--- a/src/phoenix/db/insertion/dataset.py
+++ b/src/phoenix/db/insertion/dataset.py
@@ -484,16 +484,19 @@ async def _get_external_ids_and_content_hashes_for_most_recent_version(
         latest_version_id, dataset_id=dataset_id
     ).subquery()
 
+    # Pre-upsert revisions have NULL content_hash because the column was added
+    # without a backfill. They are surfaced here so that action=update can mark
+    # them for deletion (otherwise they would be invisible orphans), and so that
+    # users can patch them by GlobalID. They cannot participate in content-hash
+    # dedup; see _ExampleMatcher.
     result = await session.execute(
         select(
             revisions_subq.c.dataset_example_id,
             models.DatasetExample.external_id,
             revisions_subq.c.content_hash,
-        )
-        .join(
+        ).join(
             models.DatasetExample, models.DatasetExample.id == revisions_subq.c.dataset_example_id
         )
-        .where(revisions_subq.c.content_hash.isnot(None))
     )
 
     return [(row.dataset_example_id, row.external_id, row.content_hash) for row in result]
@@ -584,6 +587,9 @@ class _ExampleMatcher:
     Priority:
       - If external_id is provided:  node_id match > external_id match > no match
       - If external_id is absent:    content_hash match > no match
+
+    Pre-upsert examples (NULL content_hash) are reachable only via node_id;
+    they cannot participate in content-hash dedup or external_id lookup.
     """
 
     def __init__(self, previous: list[tuple[DatasetExampleId, ExternalID, ContentHash]]) -> None:
@@ -595,7 +601,8 @@ class _ExampleMatcher:
             self._example_info_by_db_id[example_id] = info
             if external_id is not None:
                 self._example_info_by_external_id[external_id] = info
-            self._example_ids_by_content_hash.setdefault(content_hash, []).append(example_id)
+            if content_hash is not None:
+                self._example_ids_by_content_hash.setdefault(content_hash, []).append(example_id)
         self._already_matched: set[DatasetExampleId] = set()
 
     def find_match(self, incoming: ExampleWithHash) -> Optional[ExistingExampleInfo]:
@@ -635,6 +642,11 @@ def _diff_examples(
       - Matched + different hash     → PATCH
       - Unmatched incoming           → CREATE
       - Unmatched previous           → DELETE (skipped when skip_deletes=True)
+
+    Pre-upsert examples (NULL content_hash) appear in `previous` so that
+    action=update can mark them for deletion when not matched, and so users
+    can patch them by GlobalID. A patched pre-upsert example acquires a
+    content_hash and joins the tracked population from then on.
     """
     matcher = _ExampleMatcher(previous)
     examples_to_create: list[ExampleWithHash] = []

--- a/tests/unit/db/insertion/test_dataset.py
+++ b/tests/unit/db/insertion/test_dataset.py
@@ -855,9 +855,9 @@ async def test_bulk_assign_examples_to_splits_various_batch_sizes(
 
 async def _simulate_pre_upsert_state(db: DbSessionFactory, dataset_name: str) -> list[int]:
     """Null out content_hash and external_id on every revision/example in the
-    given dataset so it looks like a dataset that existed before the upsert
-    feature shipped (the migration adds those columns as nullable without a
-    backfill). Returns the example db ids in insertion order."""
+    given dataset so it looks like a pre-v15 dataset (the v15 migration adds
+    those columns as nullable without a backfill). Returns the example db ids
+    in insertion order."""
     async with db() as session:
         example_ids = list(
             (
@@ -886,10 +886,10 @@ async def _simulate_pre_upsert_state(db: DbSessionFactory, dataset_name: str) ->
 async def test_action_update_deletes_pre_upsert_examples(
     db: DbSessionFactory,
 ) -> None:
-    """Pre-upsert examples (NULL content_hash, NULL external_id from the
-    nullable-without-backfill migration) must be deleted under action=update
-    when not referenced by the incoming payload — otherwise they remain as
-    invisible orphans."""
+    """Examples in pre-v15 datasets (NULL content_hash, NULL external_id from
+    the nullable-without-backfill migration) must be deleted under
+    action=update when not referenced by the incoming payload — otherwise they
+    remain as invisible orphans."""
     name = "pre-upsert-update-delete"
     async with db() as session:
         await add_dataset_examples(
@@ -925,9 +925,9 @@ async def test_action_update_deletes_pre_upsert_examples(
 async def test_action_update_can_patch_pre_upsert_example_by_global_id(
     db: DbSessionFactory,
 ) -> None:
-    """A pre-upsert example referenced by its DatasetExample GlobalID is
-    matched via the node_id branch and PATCHed (acquiring a content_hash);
-    other unmatched pre-upsert examples are deleted."""
+    """An example in a pre-v15 dataset referenced by its DatasetExample
+    GlobalID is matched via the node_id branch and PATCHed (acquiring a
+    content_hash); other unmatched pre-v15 examples are deleted."""
     name = "pre-upsert-update-patch"
     async with db() as session:
         await add_dataset_examples(

--- a/tests/unit/db/insertion/test_dataset.py
+++ b/tests/unit/db/insertion/test_dataset.py
@@ -853,7 +853,7 @@ async def test_bulk_assign_examples_to_splits_various_batch_sizes(
         assert len(all_assignments) == 10
 
 
-async def _simulate_pre_upsert_state(db: DbSessionFactory, dataset_name: str) -> list[int]:
+async def _simulate_pre_v15_dataset(db: DbSessionFactory, dataset_name: str) -> list[int]:
     """Null out content_hash and external_id on every revision/example in the
     given dataset so it looks like a pre-v15 dataset (the v15 migration adds
     those columns as nullable without a backfill). Returns the example db ids
@@ -904,7 +904,7 @@ async def test_action_update_deletes_pre_upsert_examples(
             action=DatasetAction.CREATE,
         )
 
-    await _simulate_pre_upsert_state(db, name)
+    await _simulate_pre_v15_dataset(db, name)
 
     async with db() as session:
         event = await add_dataset_examples(
@@ -942,7 +942,7 @@ async def test_action_update_can_patch_pre_upsert_example_by_global_id(
             action=DatasetAction.CREATE,
         )
 
-    example_ids = await _simulate_pre_upsert_state(db, name)
+    example_ids = await _simulate_pre_v15_dataset(db, name)
     target_example_id = example_ids[0]
     target_global_id = str(GlobalID(type_name="DatasetExample", node_id=str(target_example_id)))
 

--- a/tests/unit/db/insertion/test_dataset.py
+++ b/tests/unit/db/insertion/test_dataset.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timezone
 
 import pytest
-from sqlalchemy import insert, select
+from sqlalchemy import insert, select, update
+from strawberry.relay import GlobalID
 
 from phoenix.db import models
 from phoenix.db.insertion.dataset import (
@@ -850,3 +851,123 @@ async def test_bulk_assign_examples_to_splits_various_batch_sizes(
         )
         all_assignments = result.scalars().all()
         assert len(all_assignments) == 10
+
+
+async def _simulate_pre_upsert_state(db: DbSessionFactory, dataset_name: str) -> list[int]:
+    """Null out content_hash and external_id on every revision/example in the
+    given dataset so it looks like a dataset that existed before the upsert
+    feature shipped (the migration adds those columns as nullable without a
+    backfill). Returns the example db ids in insertion order."""
+    async with db() as session:
+        example_ids = list(
+            (
+                await session.scalars(
+                    select(models.DatasetExample.id)
+                    .join(models.Dataset)
+                    .where(models.Dataset.name == dataset_name)
+                    .order_by(models.DatasetExample.id)
+                )
+            ).all()
+        )
+        await session.execute(
+            update(models.DatasetExampleRevision)
+            .where(models.DatasetExampleRevision.dataset_example_id.in_(example_ids))
+            .values(content_hash=None)
+        )
+        await session.execute(
+            update(models.DatasetExample)
+            .where(models.DatasetExample.id.in_(example_ids))
+            .values(external_id=None)
+        )
+        await session.commit()
+    return example_ids
+
+
+async def test_action_update_deletes_pre_upsert_examples(
+    db: DbSessionFactory,
+) -> None:
+    """Pre-upsert examples (NULL content_hash, NULL external_id from the
+    nullable-without-backfill migration) must be deleted under action=update
+    when not referenced by the incoming payload — otherwise they remain as
+    invisible orphans."""
+    name = "pre-upsert-update-delete"
+    async with db() as session:
+        await add_dataset_examples(
+            session=session,
+            examples=_hash_examples(
+                [
+                    ExampleContent(input={"x": 1}, output={"y": 1}, external_id="a"),
+                    ExampleContent(input={"x": 2}, output={"y": 2}, external_id="b"),
+                ]
+            ),
+            name=name,
+            action=DatasetAction.CREATE,
+        )
+
+    await _simulate_pre_upsert_state(db, name)
+
+    async with db() as session:
+        event = await add_dataset_examples(
+            session=session,
+            examples=_hash_examples(
+                [
+                    ExampleContent(input={"x": 9}, output={"y": 9}, external_id="z"),
+                ]
+            ),
+            name=name,
+            action=DatasetAction.UPDATE,
+        )
+    assert event.num_created_examples == 1
+    assert event.num_patched_examples == 0
+    assert event.num_deleted_examples == 2
+
+
+async def test_action_update_can_patch_pre_upsert_example_by_global_id(
+    db: DbSessionFactory,
+) -> None:
+    """A pre-upsert example referenced by its DatasetExample GlobalID is
+    matched via the node_id branch and PATCHed (acquiring a content_hash);
+    other unmatched pre-upsert examples are deleted."""
+    name = "pre-upsert-update-patch"
+    async with db() as session:
+        await add_dataset_examples(
+            session=session,
+            examples=_hash_examples(
+                [
+                    ExampleContent(input={"x": 1}, output={"y": 1}, external_id="a"),
+                    ExampleContent(input={"x": 2}, output={"y": 2}, external_id="b"),
+                ]
+            ),
+            name=name,
+            action=DatasetAction.CREATE,
+        )
+
+    example_ids = await _simulate_pre_upsert_state(db, name)
+    target_example_id = example_ids[0]
+    target_global_id = str(GlobalID(type_name="DatasetExample", node_id=str(target_example_id)))
+
+    async with db() as session:
+        event = await add_dataset_examples(
+            session=session,
+            examples=_hash_examples(
+                [
+                    ExampleContent(input={"x": 1}, output={"y": 100}, external_id=target_global_id),
+                ]
+            ),
+            name=name,
+            action=DatasetAction.UPDATE,
+        )
+    assert event.num_created_examples == 0
+    assert event.num_patched_examples == 1
+    assert event.num_deleted_examples == 1
+
+    async with db() as session:
+        latest_revision = await session.scalar(
+            select(models.DatasetExampleRevision)
+            .where(models.DatasetExampleRevision.dataset_example_id == target_example_id)
+            .order_by(models.DatasetExampleRevision.id.desc())
+            .limit(1)
+        )
+        assert latest_revision is not None
+        assert latest_revision.content_hash is not None
+        assert latest_revision.output == {"y": 100}


### PR DESCRIPTION
## Summary

The `dataset_upsert` migration adds `content_hash` as a nullable column with no backfill, so any `DatasetExampleRevision` rows that existed before the upsert feature shipped (\"pre-upsert examples\") have `content_hash IS NULL`. The previous-revisions query in `_get_external_ids_and_content_hashes_for_most_recent_version` filtered those rows out entirely, which left two latent bugs:

- **`action=update`**: pre-upsert examples were never marked for deletion. They became invisible orphans — the user's update silently *added* to the dataset instead of replacing it.
- **`action=append`**: incoming examples whose content matched a pre-upsert example couldn't be deduplicated by hash, so they were written as CREATEs (silent duplicates).

This PR drops the `.where(content_hash.isnot(None))` filter so pre-upsert rows surface in `previous`. The diff algorithm now handles them correctly:

- Under `action=update`, unmatched pre-upsert rows fall into `delete_ids` and get a DELETE revision (soft delete via the revision mechanism — the underlying `dataset_examples` row stays, FKs intact).
- A pre-upsert example referenced by its `DatasetExample` GlobalID gets PATCHed and acquires a content_hash, joining the tracked population from then on.
- `_ExampleMatcher` no longer buckets NULL hashes into `_example_ids_by_content_hash` (defensive — incoming hashes are never NULL, but this prevents misuse if `find_match` is refactored).

`action=append` against a dataset with pre-upsert rows still cannot dedup by content (NULL hash ≠ any incoming hash). That's a separate decision (accept + document, or compute hashes lazily per request) and is out of scope here.

Targets `feat/dataset-upsert`.

## Test plan
- [x] New unit test: `test_action_update_deletes_pre_upsert_examples` — pre-upsert dataset + `action=update` with new examples → all pre-upsert deleted, new created.
- [x] New unit test: `test_action_update_can_patch_pre_upsert_example_by_global_id` — pre-upsert dataset + `action=update` referencing one example by `DatasetExample` GlobalID → that one PATCHed (acquires content_hash), others deleted.
- [x] Both pass on sqlite and postgresql.
- [x] No regressions in the rest of \`tests/unit/db/insertion/test_dataset.py\` (24 sqlite tests pass).
- [x] \`mypy\` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)