### PR TITLE
docs: Audit and update llms.txt

### DIFF
--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -197,6 +197,7 @@
 - [Google GenAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai/google-genai-tracing): Auto-instrument Google GenAI SDK
 - [Gemini Evals](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-evals): Use Gemini models as evaluation judges
 - [Google GenAI Evals](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai/google-gen-ai-evals): Configure Google GenAI as eval provider
+- [Evaluate CrewAI with Google Gen AI](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai/google-gen-ai-evals-1): Instrument and evaluate CrewAI multi-agent systems using Google Vertex AI evaluation and Phoenix tracing
 - [Google ADK Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/google-adk/google-adk-tracing): Trace Google Agent Development Kit workflows
 - [Groq Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/groq/groq-tracing): Auto-instrument Groq SDK
 - [LiteLLM Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/litellm/litellm-tracing): Auto-instrument LiteLLM unified API calls


### PR DESCRIPTION
## Summary

- Audited all 610 `.mdx` files in `docs/phoenix/` against the current `llms.txt` index
- All existing entries are valid (no stale URLs found)
- Added one missing page: the Google Gen AI + CrewAI multi-agent evaluation guide (`google-gen-ai-evals-1`)

## What was checked

- Individual REST API endpoint pages — correctly excluded (index-only rule)
- Individual pre-built metric pages — correctly excluded (index-only rule)
- Individual evaluation integration pages — correctly excluded (index-only rule)  
- Individual cookbook pages — correctly excluded (index-only rule; index already present)
- Release notes pages — correctly excluded
- Demo/notebook/agent-setup pages — correctly excluded
- Integration hub/index pages (e.g. `agno.mdx`, `langchain.mdx`) — correctly excluded (no prose content)
- Resource redirect pages (`github.mdx`, `openinference.mdx`) — correctly excluded (bare external links)

## Test plan

- [ ] `docs/phoenix/llms.txt` parses without error via the CLI parser tests
- [ ] New entry `Evaluate CrewAI with Google Gen AI` appears correctly in `px docs fetch` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)