### PR TITLE
fix(playground): prevent OTel context leak in single chat completion subscription

### DIFF
--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -14,6 +14,7 @@ from typing import (
 
 import strawberry
 from openinference.semconv.trace import SpanAttributes
+from opentelemetry.context import Context as OtelContext
 from sqlalchemy import and_, insert, select
 from sqlalchemy import func as sa_func
 from strawberry.types import Info
@@ -80,6 +81,7 @@ async def _stream_single_chat_completion(
     project_id: int,
     on_span_insertion: Callable[[], None],
     span_cost_calculator: SpanCostCalculator,
+    otel_context: OtelContext,
 ) -> ChatStream:
     messages = prompt_chat_template_to_playground_messages(input.prompt_version.template.to_orm())
     if template_options := input.template:
@@ -105,6 +107,7 @@ async def _stream_single_chat_completion(
             response_format=response_format,
             invocation_parameters=invocation_parameters,
             tracer=tracer,
+            otel_context=otel_context,
             stream_model_output=input.stream_model_output,
         ):
             chunk.repetition_number = repetition_number
@@ -235,6 +238,7 @@ class Subscription:
                         SpanInsertEvent(ids=(playground_project_id,))
                     ),
                     span_cost_calculator=info.context.span_cost_calculator,
+                    otel_context=OtelContext(),
                 ),
             )
             for repetition_number in range(1, input.repetitions + 1)


### PR DESCRIPTION
## Summary
- `_stream_single_chat_completion` in `subscriptions.py` was calling `chat_completion_create` without an explicit `otel_context`, so the playground LLM span inherited the ambient OTel context attached by Strawberry's `OpenTelemetryExtension` / FastAPI instrumentation and was silently reparented under the subscription span instead of starting as a fresh root.
- The dataset-example and experiment-runner paths already pass `otel_context=OtelContext()` for this exact reason; this change brings the single-completion path in line.
- Threaded `otel_context: OtelContext` through `_stream_single_chat_completion` as a required keyword argument and pass `OtelContext()` from the call site.

## Test plan
- [ ] Run a prompt in the playground (non-dataset) with `PHOENIX_SERVER_INSTRUMENTATION_OTLP_TRACE_COLLECTOR_HTTP_ENDPOINT` set so Strawberry's OTel extension is active.
- [ ] Confirm the resulting playground span has no parent and its trace_id is unique (not equal to the subscription span's trace_id).
- [ ] Run a dataset-example completion to confirm that path still behaves correctly.