### PR TITLE
feat(phoenix-client): add TS trace annotations + clarify note semantics + skills audit

### DIFF
--- a/.agents/skills/phoenix-tracing/references/annotations-python.md
+++ b/.agents/skills/phoenix-tracing/references/annotations-python.md
@@ -55,6 +55,17 @@ client.traces.add_trace_annotation(
 )
 ```
 
+## Span Notes
+
+Notes are a special annotation type that allow multiple entries per span (unlike regular annotations which are unique by name). Each note gets a unique UUIDv4 identifier automatically.
+
+```python
+client.spans.add_span_note(
+    span_id="abc123def456",
+    note="Unexpected token in response, needs review",
+)
+```
+
 ## Session Annotations
 
 Feedback on multi-turn conversations:

--- a/.agents/skills/phoenix-tracing/references/annotations-python.md
+++ b/.agents/skills/phoenix-tracing/references/annotations-python.md
@@ -57,7 +57,9 @@ client.traces.add_trace_annotation(
 
 ## Span Notes
 
-Notes are a special type of annotation for free-form text — useful for open coding, where reviewers leave qualitative observations on a span before any rubric exists. Later, those notes can be aggregated and distilled into structured labels or scores. Because they are open-ended, multiple notes can coexist on the same span (unlike regular annotations, which are unique by name). Each note gets a unique UUIDv4 identifier automatically.
+Notes are a special type of annotation for free-form text — useful for open coding, where reviewers leave qualitative observations on a span before any rubric exists. Later, those notes can be aggregated and distilled into structured labels or scores.
+
+Notes are **append-only**: each call auto-generates a UUIDv4 identifier, so multiple notes naturally accumulate on the same span. Structured annotations are keyed by `(name, span_id, identifier)` — you can have many same-named annotations on one span by supplying distinct identifiers (e.g. one per reviewer); writing the same `(name, span_id, identifier)` overwrites the existing entry.
 
 ```python
 client.spans.add_span_note(

--- a/.agents/skills/phoenix-tracing/references/annotations-python.md
+++ b/.agents/skills/phoenix-tracing/references/annotations-python.md
@@ -57,7 +57,7 @@ client.traces.add_trace_annotation(
 
 ## Span Notes
 
-Notes are a special annotation type that allow multiple entries per span (unlike regular annotations which are unique by name). Each note gets a unique UUIDv4 identifier automatically.
+Notes are a special type of annotation for free-form text — useful for open coding, where reviewers leave qualitative observations on a span before any rubric exists. Later, those notes can be aggregated and distilled into structured labels or scores. Because they are open-ended, multiple notes can coexist on the same span (unlike regular annotations, which are unique by name). Each note gets a unique UUIDv4 identifier automatically.
 
 ```python
 client.spans.add_span_note(

--- a/.agents/skills/phoenix-tracing/references/annotations-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/annotations-typescript.md
@@ -33,7 +33,9 @@ await addSpanAnnotation({
 
 ## Span Notes
 
-Notes are a special type of annotation for free-form text — useful for open coding, where reviewers leave qualitative observations on a span before any rubric exists. Later, those notes can be aggregated and distilled into structured labels or scores. Because they are open-ended, multiple notes can coexist on the same span (unlike regular annotations, which are unique by name). Each note gets a unique UUIDv4 identifier automatically.
+Notes are a special type of annotation for free-form text — useful for open coding, where reviewers leave qualitative observations on a span before any rubric exists. Later, those notes can be aggregated and distilled into structured labels or scores.
+
+Notes are **append-only**: each call auto-generates a UUIDv4 identifier, so multiple notes naturally accumulate on the same span. Structured annotations are keyed by `(name, spanId, identifier)` — you can have many same-named annotations on one span by supplying distinct identifiers (e.g. one per reviewer); writing the same `(name, spanId, identifier)` overwrites the existing entry.
 
 ```typescript
 import { addSpanNote } from "@arizeai/phoenix-client/spans";

--- a/.agents/skills/phoenix-tracing/references/annotations-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/annotations-typescript.md
@@ -5,7 +5,7 @@ Add feedback to spans, traces, documents, and sessions using the TypeScript clie
 ## Client Setup
 
 ```typescript
-import { createClient } from "phoenix-client";
+import { createClient } from "@arizeai/phoenix-client";
 const client = createClient();  // Default: http://localhost:6006
 ```
 
@@ -14,7 +14,7 @@ const client = createClient();  // Default: http://localhost:6006
 Add feedback to individual spans:
 
 ```typescript
-import { addSpanAnnotation } from "phoenix-client";
+import { addSpanAnnotation } from "@arizeai/phoenix-client/spans";
 
 await addSpanAnnotation({
   client,
@@ -31,12 +31,28 @@ await addSpanAnnotation({
 });
 ```
 
+## Span Notes
+
+Notes are a special annotation type that allow multiple entries per span (unlike regular annotations which are unique by name). Each note gets a unique UUIDv4 identifier automatically.
+
+```typescript
+import { addSpanNote } from "@arizeai/phoenix-client/spans";
+
+await addSpanNote({
+  client,
+  spanNote: {
+    spanId: "abc123",
+    note: "This span shows unexpected behavior, needs review"
+  }
+});
+```
+
 ## Document Annotations
 
 Rate individual documents in RETRIEVER spans:
 
 ```typescript
-import { addDocumentAnnotation } from "phoenix-client";
+import { addDocumentAnnotation } from "@arizeai/phoenix-client/spans";
 
 await addDocumentAnnotation({
   client,
@@ -56,7 +72,7 @@ await addDocumentAnnotation({
 Feedback on entire traces:
 
 ```typescript
-import { addTraceAnnotation } from "phoenix-client";
+import { addTraceAnnotation } from "@arizeai/phoenix-client/traces";
 
 await addTraceAnnotation({
   client,
@@ -70,12 +86,28 @@ await addTraceAnnotation({
 });
 ```
 
+## Trace Notes
+
+Notes on entire traces (multiple notes allowed per trace):
+
+```typescript
+import { addTraceNote } from "@arizeai/phoenix-client/traces";
+
+await addTraceNote({
+  client,
+  traceNote: {
+    traceId: "abc123def456",
+    note: "Needs follow-up — unexpected tool call sequence"
+  }
+});
+```
+
 ## Session Annotations
 
 Feedback on multi-turn conversations:
 
 ```typescript
-import { addSessionAnnotation } from "phoenix-client";
+import { addSessionAnnotation } from "@arizeai/phoenix-client/sessions";
 
 await addSessionAnnotation({
   client,
@@ -92,7 +124,9 @@ await addSessionAnnotation({
 ## RAG Pipeline Example
 
 ```typescript
-import { createClient, logDocumentAnnotations, addSpanAnnotation, addTraceAnnotation } from "phoenix-client";
+import { createClient } from "@arizeai/phoenix-client";
+import { logDocumentAnnotations, addSpanAnnotation } from "@arizeai/phoenix-client/spans";
+import { addTraceAnnotation } from "@arizeai/phoenix-client/traces";
 
 const client = createClient();
 

--- a/.agents/skills/phoenix-tracing/references/annotations-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/annotations-typescript.md
@@ -33,7 +33,7 @@ await addSpanAnnotation({
 
 ## Span Notes
 
-Notes are a special annotation type that allow multiple entries per span (unlike regular annotations which are unique by name). Each note gets a unique UUIDv4 identifier automatically.
+Notes are a special type of annotation for free-form text — useful for open coding, where reviewers leave qualitative observations on a span before any rubric exists. Later, those notes can be aggregated and distilled into structured labels or scores. Because they are open-ended, multiple notes can coexist on the same span (unlike regular annotations, which are unique by name). Each note gets a unique UUIDv4 identifier automatically.
 
 ```typescript
 import { addSpanNote } from "@arizeai/phoenix-client/spans";
@@ -63,25 +63,6 @@ await addDocumentAnnotation({
     annotatorKind: "LLM",
     label: "relevant",
     score: 0.95
-  }
-});
-```
-
-## Trace Annotations
-
-Feedback on entire traces:
-
-```typescript
-import { addTraceAnnotation } from "@arizeai/phoenix-client/traces";
-
-await addTraceAnnotation({
-  client,
-  traceAnnotation: {
-    traceId: "trace_abc",
-    name: "correctness",
-    annotatorKind: "HUMAN",
-    label: "correct",
-    score: 1.0
   }
 });
 ```
@@ -126,7 +107,7 @@ await addSessionAnnotation({
 ```typescript
 import { createClient } from "@arizeai/phoenix-client";
 import { logDocumentAnnotations, addSpanAnnotation } from "@arizeai/phoenix-client/spans";
-import { addTraceAnnotation } from "@arizeai/phoenix-client/traces";
+import { addTraceNote } from "@arizeai/phoenix-client/traces";
 
 const client = createClient();
 
@@ -153,18 +134,17 @@ await addSpanAnnotation({
   }
 });
 
-// Overall trace quality
-await addTraceAnnotation({
+// Trace-level qualitative note
+await addTraceNote({
   client,
-  traceAnnotation: {
+  traceNote: {
     traceId: "trace_123",
-    name: "correctness",
-    annotatorKind: "HUMAN",
-    label: "correct",
-    score: 1.0
+    note: "End-to-end answer was correct and well-grounded"
   }
 });
 ```
+
+> **Note:** Structured trace annotations (label/score by name) are not yet exposed in the TypeScript client — only `addTraceNote` is available. For structured trace annotations, use the Python client (`client.traces.add_trace_annotation`) or the REST API directly.
 
 ## API Reference
 

--- a/.agents/skills/phoenix-tracing/references/annotations-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/annotations-typescript.md
@@ -67,6 +67,25 @@ await addDocumentAnnotation({
 });
 ```
 
+## Trace Annotations
+
+Feedback on entire traces:
+
+```typescript
+import { addTraceAnnotation } from "@arizeai/phoenix-client/traces";
+
+await addTraceAnnotation({
+  client,
+  traceAnnotation: {
+    traceId: "trace_abc",
+    name: "correctness",
+    annotatorKind: "HUMAN",
+    label: "correct",
+    score: 1.0
+  }
+});
+```
+
 ## Trace Notes
 
 Notes on entire traces (multiple notes allowed per trace):
@@ -107,7 +126,7 @@ await addSessionAnnotation({
 ```typescript
 import { createClient } from "@arizeai/phoenix-client";
 import { logDocumentAnnotations, addSpanAnnotation } from "@arizeai/phoenix-client/spans";
-import { addTraceNote } from "@arizeai/phoenix-client/traces";
+import { addTraceAnnotation } from "@arizeai/phoenix-client/traces";
 
 const client = createClient();
 
@@ -134,17 +153,18 @@ await addSpanAnnotation({
   }
 });
 
-// Trace-level qualitative note
-await addTraceNote({
+// Overall trace quality
+await addTraceAnnotation({
   client,
-  traceNote: {
+  traceAnnotation: {
     traceId: "trace_123",
-    note: "End-to-end answer was correct and well-grounded"
+    name: "correctness",
+    annotatorKind: "HUMAN",
+    label: "correct",
+    score: 1.0
   }
 });
 ```
-
-> **Note:** Structured trace annotations (label/score by name) are not yet exposed in the TypeScript client — only `addTraceNote` is available. For structured trace annotations, use the Python client (`client.traces.add_trace_annotation`) or the REST API directly.
 
 ## API Reference
 

--- a/js/.changeset/notes-vs-annotations-docs.md
+++ b/js/.changeset/notes-vs-annotations-docs.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+Clarify TSDoc and regenerated OpenAPI descriptions for `addSpanNote` and `addTraceNote`. Previous wording implied structured annotations were "unique by name", which is incorrect — annotations are keyed by `(name, target_id, identifier)`, so multiple annotations with the same name can coexist on the same span/trace/session by supplying distinct identifiers. Notes remain append-only via auto-generated UUIDv4 identifiers.

--- a/js/.changeset/trace-annotations-ts-client.md
+++ b/js/.changeset/trace-annotations-ts-client.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Add `addTraceAnnotation` and `logTraceAnnotations` to the `traces` subpath. Brings the TypeScript client to parity with the Python client by exposing the existing `/v1/trace_annotations` REST endpoint for structured (label/score/explanation) feedback on traces.

--- a/js/packages/phoenix-client/README.md
+++ b/js/packages/phoenix-client/README.md
@@ -368,6 +368,69 @@ do {
 
 > **Note:** Requires Phoenix server >= 13.15.0.
 
+### Trace Annotations
+
+Add structured feedback (label/score by name) to entire traces. Use `addTraceAnnotation` for one trace or `logTraceAnnotations` for batches.
+
+```ts
+import {
+  addTraceAnnotation,
+  logTraceAnnotations,
+} from "@arizeai/phoenix-client/traces";
+
+// Single annotation
+const result = await addTraceAnnotation({
+  traceAnnotation: {
+    traceId: "abc123",
+    name: "correctness",
+    label: "correct",
+    score: 1.0,
+    annotatorKind: "HUMAN",
+  },
+  sync: true, // returns { id: "..." } when sync, null when async
+});
+
+// Batch
+await logTraceAnnotations({
+  traceAnnotations: [
+    {
+      traceId: "abc123",
+      name: "correctness",
+      label: "correct",
+      score: 1.0,
+      annotatorKind: "HUMAN",
+    },
+    {
+      traceId: "def456",
+      name: "faithfulness",
+      label: "faithful",
+      score: 0.9,
+      annotatorKind: "LLM",
+    },
+  ],
+  sync: true,
+});
+```
+
+The reserved name `note` is rejected — use `addTraceNote` instead for free-form notes (see below).
+
+### Trace Notes
+
+Notes are a special type of annotation for free-form text — useful for open coding, where reviewers leave qualitative observations on a trace before any rubric exists. Multiple notes can coexist on the same trace.
+
+```ts
+import { addTraceNote } from "@arizeai/phoenix-client/traces";
+
+await addTraceNote({
+  traceNote: {
+    traceId: "abc123",
+    note: "Needs follow-up — unexpected tool call sequence",
+  },
+});
+```
+
+> **Note:** `addTraceNote` requires Phoenix server >= 14.13.0.
+
 ## Spans
 
 The `@arizeai/phoenix-client` package provides a `spans` export for querying spans with powerful filtering.

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -486,7 +486,7 @@ export interface paths {
         put?: never;
         /**
          * Create a trace note
-         * @description Add a note annotation to a trace. Notes are special annotations that allow multiple entries per trace (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv4 identifier.
+         * @description Add a note annotation to a trace. Each call appends a new note with an auto-generated UUIDv4 identifier, so multiple notes accumulate on the same trace. Structured annotations, by contrast, are keyed by (name, trace_id, identifier) — re-writing the same key overwrites the existing annotation, so to keep multiple structured annotations with the same name on a trace you must supply distinct identifiers.
          */
         post: operations["createTraceNote"];
         delete?: never;
@@ -591,7 +591,7 @@ export interface paths {
         put?: never;
         /**
          * Create a span note
-         * @description Add a note annotation to a span. Notes are special annotations that allow multiple entries per span (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv4 identifier.
+         * @description Add a note annotation to a span. Each call appends a new note with an auto-generated UUIDv4 identifier, so multiple notes accumulate on the same span. Structured annotations, by contrast, are keyed by (name, span_id, identifier) — re-writing the same key overwrites the existing annotation, so to keep multiple structured annotations with the same name on a span you must supply distinct identifiers.
          */
         post: operations["createSpanNote"];
         delete?: never;
@@ -942,7 +942,7 @@ export interface paths {
         put?: never;
         /**
          * Create a session note
-         * @description Add a note annotation to a session. Notes are special annotations that allow multiple entries per session (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv4 identifier.
+         * @description Add a note annotation to a session. Each call appends a new note with an auto-generated UUIDv4 identifier, so multiple notes accumulate on the same session. Structured annotations, by contrast, are keyed by (name, session_id, identifier) — re-writing the same key overwrites the existing annotation, so to keep multiple structured annotations with the same name on a session you must supply distinct identifiers.
          */
         post: operations["createSessionNote"];
         delete?: never;

--- a/js/packages/phoenix-client/src/spans/addSpanNote.ts
+++ b/js/packages/phoenix-client/src/spans/addSpanNote.ts
@@ -25,9 +25,11 @@ export interface AddSpanNoteParams extends ClientFn {
 /**
  * Add a note to a span.
  *
- * Notes are a special type of annotation that allow multiple entries per span
- * (unlike regular annotations which are unique by name and identifier).
- * Each note gets a unique UUIDv4 identifier.
+ * Notes are append-only: each call creates a new note with an auto-generated
+ * UUIDv4 identifier, so multiple notes accumulate on the same span. Structured
+ * annotations, by contrast, are keyed by `(name, spanId, identifier)` — to keep
+ * multiple structured annotations with the same name on a span, supply distinct
+ * identifiers; otherwise re-writing the same name overwrites the existing one.
  *
  * @param params - The parameters to add a span note
  * @returns The ID of the created note annotation

--- a/js/packages/phoenix-client/src/traces/addTraceAnnotation.ts
+++ b/js/packages/phoenix-client/src/traces/addTraceAnnotation.ts
@@ -1,0 +1,65 @@
+import { createClient } from "../client";
+import type { ClientFn } from "../types/core";
+import type { TraceAnnotation } from "./types";
+import { toTraceAnnotationData } from "./types";
+
+/**
+ * Parameters to add a trace annotation
+ */
+export interface AddTraceAnnotationParams extends ClientFn {
+  traceAnnotation: TraceAnnotation;
+  /**
+   * If true, the request will be fulfilled synchronously and return the annotation ID.
+   * If false, the request will be processed asynchronously and return null.
+   * @default false
+   */
+  sync?: boolean;
+}
+
+/**
+ * Add an annotation to a trace.
+ *
+ * The annotation can be of type "LLM", "CODE", or "HUMAN" and can include a label, score, and metadata.
+ * If an identifier is provided and an annotation with that identifier already exists, it will be updated.
+ *
+ * @param params - The parameters to add a trace annotation
+ * @returns The ID of the created or updated annotation
+ *
+ * @example
+ * ```ts
+ * const result = await addTraceAnnotation({
+ *   traceAnnotation: {
+ *     traceId: "abc123",
+ *     name: "correctness",
+ *     label: "correct",
+ *     score: 1.0,
+ *     annotatorKind: "HUMAN",
+ *     identifier: "custom_id_123",
+ *     metadata: { reviewer: "alice" }
+ *   },
+ *   sync: true,
+ * });
+ * ```
+ */
+export async function addTraceAnnotation({
+  client: _client,
+  traceAnnotation,
+  sync = false,
+}: AddTraceAnnotationParams): Promise<{ id: string } | null> {
+  const client = _client ?? createClient();
+
+  const { data, error } = await client.POST("/v1/trace_annotations", {
+    params: {
+      query: { sync },
+    },
+    body: {
+      data: [toTraceAnnotationData(traceAnnotation)],
+    },
+  });
+
+  if (error) {
+    throw new Error(`Failed to add trace annotation: ${error}`);
+  }
+
+  return data?.data?.[0] || null;
+}

--- a/js/packages/phoenix-client/src/traces/addTraceNote.ts
+++ b/js/packages/phoenix-client/src/traces/addTraceNote.ts
@@ -27,8 +27,11 @@ export interface AddTraceNoteParams extends ClientFn {
 /**
  * Add a note to a trace.
  *
- * Notes are a special type of annotation that allow multiple entries per trace.
- * Each note gets a unique timestamp-based identifier.
+ * Notes are append-only: each call creates a new note with an auto-generated
+ * UUIDv4 identifier, so multiple notes accumulate on the same trace. Structured
+ * annotations, by contrast, are keyed by `(name, traceId, identifier)` — to keep
+ * multiple structured annotations with the same name on a trace, supply distinct
+ * identifiers; otherwise re-writing the same name overwrites the existing one.
  *
  * @param params - The parameters to add a trace note.
  * @returns The ID of the created note annotation.

--- a/js/packages/phoenix-client/src/traces/index.ts
+++ b/js/packages/phoenix-client/src/traces/index.ts
@@ -1,2 +1,5 @@
+export * from "./addTraceAnnotation";
 export * from "./addTraceNote";
 export * from "./getTraces";
+export * from "./logTraceAnnotations";
+export type { TraceAnnotation } from "./types";

--- a/js/packages/phoenix-client/src/traces/logTraceAnnotations.ts
+++ b/js/packages/phoenix-client/src/traces/logTraceAnnotations.ts
@@ -1,0 +1,75 @@
+import { createClient } from "../client";
+import type { ClientFn } from "../types/core";
+import type { TraceAnnotation } from "./types";
+import { toTraceAnnotationData } from "./types";
+
+/**
+ * Parameters to log multiple trace annotations
+ */
+export interface LogTraceAnnotationsParams extends ClientFn {
+  /**
+   * The trace annotations to log
+   */
+  traceAnnotations: TraceAnnotation[];
+  /**
+   * If true, the request will be fulfilled synchronously and return the annotation IDs.
+   * If false, the request will be processed asynchronously and return null.
+   * @default false
+   */
+  sync?: boolean;
+}
+
+/**
+ * Log multiple trace annotations in a single request.
+ *
+ * Each annotation can be of type "LLM", "CODE", or "HUMAN" and can include a label, score, and metadata.
+ * If an identifier is provided and an annotation with that identifier already exists, it will be updated.
+ *
+ * @param params - The parameters to log trace annotations
+ * @returns The IDs of the created or updated annotations
+ *
+ * @example
+ * ```ts
+ * const results = await logTraceAnnotations({
+ *   traceAnnotations: [
+ *     {
+ *       traceId: "abc123",
+ *       name: "correctness",
+ *       label: "correct",
+ *       score: 1.0,
+ *       annotatorKind: "HUMAN",
+ *     },
+ *     {
+ *       traceId: "def456",
+ *       name: "faithfulness",
+ *       label: "faithful",
+ *       score: 0.9,
+ *       annotatorKind: "LLM",
+ *     },
+ *   ],
+ *   sync: true,
+ * });
+ * ```
+ */
+export async function logTraceAnnotations({
+  client: _client,
+  traceAnnotations,
+  sync = false,
+}: LogTraceAnnotationsParams): Promise<{ id: string }[]> {
+  const client = _client ?? createClient();
+
+  const { data, error } = await client.POST("/v1/trace_annotations", {
+    params: {
+      query: { sync },
+    },
+    body: {
+      data: traceAnnotations.map(toTraceAnnotationData),
+    },
+  });
+
+  if (error) {
+    throw new Error(`Failed to log trace annotations: ${error}`);
+  }
+
+  return data?.data || [];
+}

--- a/js/packages/phoenix-client/src/traces/types.ts
+++ b/js/packages/phoenix-client/src/traces/types.ts
@@ -1,0 +1,72 @@
+import type { paths } from "../__generated__/api/v1";
+import type { Annotation, AnnotationResult } from "../types/annotations";
+
+type TraceAnnotationData =
+  paths["/v1/trace_annotations"]["post"]["requestBody"]["content"]["application/json"]["data"][0];
+
+/**
+ * Parameters for a single trace annotation
+ */
+export interface TraceAnnotation extends Annotation {
+  /**
+   * The OpenTelemetry Trace ID (hex format without 0x prefix)
+   */
+  traceId: string;
+  /**
+   * The kind of annotator used for the annotation
+   * Can be "HUMAN", "LLM", or "CODE"
+   * @default "HUMAN"
+   */
+  annotatorKind?: TraceAnnotationData["annotator_kind"];
+}
+
+/**
+ * Build and validate annotation result fields
+ */
+function buildTraceAnnotationResult(
+  annotation: Pick<TraceAnnotation, "label" | "score" | "explanation">
+): AnnotationResult {
+  const result: AnnotationResult = {};
+
+  if (annotation.label !== undefined) {
+    result.label = annotation.label.trim() || null;
+  }
+  if (annotation.score !== undefined) {
+    result.score = annotation.score;
+  }
+  if (annotation.explanation !== undefined) {
+    result.explanation = annotation.explanation.trim() || null;
+  }
+
+  const hasValidResult =
+    result.label || result.score !== undefined || result.explanation;
+  if (!hasValidResult) {
+    throw new Error(
+      "At least one of label, score, or explanation must be provided for trace annotation"
+    );
+  }
+  return result;
+}
+
+/**
+ * Convert a TraceAnnotation to the API format
+ */
+export function toTraceAnnotationData(
+  annotation: TraceAnnotation
+): TraceAnnotationData {
+  if (annotation.name.trim() === "note") {
+    throw new Error(
+      'The name "note" is reserved for trace and span notes. Use addTraceNote instead.'
+    );
+  }
+  const result = buildTraceAnnotationResult(annotation);
+
+  return {
+    trace_id: annotation.traceId.trim(),
+    name: annotation.name.trim(),
+    annotator_kind: annotation.annotatorKind ?? "HUMAN",
+    result,
+    metadata: annotation.metadata ?? null,
+    identifier: annotation.identifier?.trim() ?? "",
+  };
+}

--- a/js/packages/phoenix-client/test/traces/addTraceAnnotation.test.ts
+++ b/js/packages/phoenix-client/test/traces/addTraceAnnotation.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { addTraceAnnotation } from "../../src/traces/addTraceAnnotation";
+
+const mockPOST = vi.fn();
+
+vi.mock("openapi-fetch", () => ({
+  default: () => ({
+    POST: mockPOST.mockResolvedValue({
+      data: {
+        data: [{ id: "test-id-1" }],
+      },
+      error: null,
+    }),
+    use: () => {},
+  }),
+}));
+
+describe("addTraceAnnotation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPOST.mockResolvedValue({
+      data: {
+        data: [{ id: "test-id-1" }],
+      },
+      error: null,
+    });
+  });
+
+  it("should add a trace annotation with all fields", async () => {
+    const result = await addTraceAnnotation({
+      traceAnnotation: {
+        traceId: "abc123",
+        name: "correctness",
+        label: "correct",
+        score: 1.0,
+        annotatorKind: "HUMAN",
+        identifier: "test-identifier",
+        metadata: { reviewer: "alice" },
+      },
+      sync: true,
+    });
+
+    expect(result).toEqual({ id: "test-id-1" });
+    expect(mockPOST).toHaveBeenCalledWith("/v1/trace_annotations", {
+      params: { query: { sync: true } },
+      body: {
+        data: [
+          {
+            trace_id: "abc123",
+            name: "correctness",
+            annotator_kind: "HUMAN",
+            result: { label: "correct", score: 1.0 },
+            metadata: { reviewer: "alice" },
+            identifier: "test-identifier",
+          },
+        ],
+      },
+    });
+  });
+
+  it("should add a trace annotation with explanation only", async () => {
+    const result = await addTraceAnnotation({
+      traceAnnotation: {
+        traceId: "abc123",
+        name: "correctness",
+        explanation: "Looks correct end-to-end",
+        annotatorKind: "LLM",
+      },
+      sync: true,
+    });
+
+    expect(result).toEqual({ id: "test-id-1" });
+  });
+
+  it("should return null when sync=false (default)", async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: undefined,
+    });
+
+    const result = await addTraceAnnotation({
+      traceAnnotation: {
+        traceId: "abc123",
+        name: "correctness",
+        label: "correct",
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("should throw when no result fields are provided", async () => {
+    await expect(
+      addTraceAnnotation({
+        traceAnnotation: {
+          traceId: "abc123",
+          name: "correctness",
+        },
+      })
+    ).rejects.toThrow(
+      "At least one of label, score, or explanation must be provided for trace annotation"
+    );
+  });
+
+  it("should reject the reserved name 'note'", async () => {
+    await expect(
+      addTraceAnnotation({
+        traceAnnotation: {
+          traceId: "abc123",
+          name: "note",
+          label: "anything",
+        },
+      })
+    ).rejects.toThrow(/reserved for trace and span notes/);
+  });
+});

--- a/js/packages/phoenix-client/test/traces/logTraceAnnotations.test.ts
+++ b/js/packages/phoenix-client/test/traces/logTraceAnnotations.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { logTraceAnnotations } from "../../src/traces/logTraceAnnotations";
+
+const mockPOST = vi.fn();
+
+vi.mock("openapi-fetch", () => ({
+  default: () => ({
+    POST: mockPOST.mockResolvedValue({
+      data: {
+        data: [{ id: "test-id-1" }, { id: "test-id-2" }],
+      },
+      error: null,
+    }),
+    use: () => {},
+  }),
+}));
+
+describe("logTraceAnnotations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPOST.mockResolvedValue({
+      data: {
+        data: [{ id: "test-id-1" }, { id: "test-id-2" }],
+      },
+      error: null,
+    });
+  });
+
+  it("should log multiple trace annotations", async () => {
+    const result = await logTraceAnnotations({
+      traceAnnotations: [
+        {
+          traceId: "abc123",
+          name: "correctness",
+          label: "correct",
+          score: 1.0,
+          annotatorKind: "HUMAN",
+        },
+        {
+          traceId: "def456",
+          name: "faithfulness",
+          label: "faithful",
+          score: 0.9,
+          annotatorKind: "LLM",
+        },
+      ],
+      sync: true,
+    });
+
+    expect(result).toEqual([{ id: "test-id-1" }, { id: "test-id-2" }]);
+  });
+
+  it("should return empty array when sync=false (default)", async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: undefined,
+    });
+
+    const result = await logTraceAnnotations({
+      traceAnnotations: [
+        {
+          traceId: "abc123",
+          name: "correctness",
+          label: "correct",
+        },
+      ],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("should throw when an annotation has no result fields", async () => {
+    await expect(
+      logTraceAnnotations({
+        traceAnnotations: [
+          {
+            traceId: "abc123",
+            name: "correctness",
+            label: "correct",
+          },
+          {
+            traceId: "def456",
+            name: "faithfulness",
+          },
+        ],
+      })
+    ).rejects.toThrow(
+      "At least one of label, score, or explanation must be provided for trace annotation"
+    );
+  });
+});

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -829,9 +829,11 @@ class Spans:
     ) -> InsertedSpanAnnotation:
         """Add a note to a span.
 
-        Notes are a special type of annotation that allow multiple entries per span
-        (unlike regular annotations which are unique by name and identifier). Each note
-        gets a unique UUIDv4 identifier automatically.
+        Notes are append-only: each call creates a new note with an auto-generated
+        UUIDv4 identifier, so multiple notes accumulate on the same span. Structured
+        annotations, by contrast, are keyed by (name, span_id, identifier) — to keep
+        multiple structured annotations with the same name on a span, supply distinct
+        identifiers; otherwise re-writing the same name overwrites the existing one.
 
         Args:
             span_id (str): The OpenTelemetry span ID of the span to add the note to.
@@ -2104,9 +2106,11 @@ class AsyncSpans:
     ) -> InsertedSpanAnnotation:
         """Add a note to a span asynchronously.
 
-        Notes are a special type of annotation that allow multiple entries per span
-        (unlike regular annotations which are unique by name and identifier). Each note
-        gets a unique UUIDv4 identifier automatically.
+        Notes are append-only: each call creates a new note with an auto-generated
+        UUIDv4 identifier, so multiple notes accumulate on the same span. Structured
+        annotations, by contrast, are keyed by (name, span_id, identifier) — to keep
+        multiple structured annotations with the same name on a span, supply distinct
+        identifiers; otherwise re-writing the same name overwrites the existing one.
 
         Args:
             span_id (str): The OpenTelemetry span ID of the span to add the note to.

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2828,7 +2828,7 @@
           "traces"
         ],
         "summary": "Create a trace note",
-        "description": "Add a note annotation to a trace. Notes are special annotations that allow multiple entries per trace (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv4 identifier.",
+        "description": "Add a note annotation to a trace. Each call appends a new note with an auto-generated UUIDv4 identifier, so multiple notes accumulate on the same trace. Structured annotations, by contrast, are keyed by (name, trace_id, identifier) \u2014 re-writing the same key overwrites the existing annotation, so to keep multiple structured annotations with the same name on a trace you must supply distinct identifiers.",
         "operationId": "createTraceNote",
         "requestBody": {
           "content": {
@@ -3601,7 +3601,7 @@
           "spans"
         ],
         "summary": "Create a span note",
-        "description": "Add a note annotation to a span. Notes are special annotations that allow multiple entries per span (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv4 identifier.",
+        "description": "Add a note annotation to a span. Each call appends a new note with an auto-generated UUIDv4 identifier, so multiple notes accumulate on the same span. Structured annotations, by contrast, are keyed by (name, span_id, identifier) \u2014 re-writing the same key overwrites the existing annotation, so to keep multiple structured annotations with the same name on a span you must supply distinct identifiers.",
         "operationId": "createSpanNote",
         "requestBody": {
           "content": {
@@ -5131,7 +5131,7 @@
           "sessions"
         ],
         "summary": "Create a session note",
-        "description": "Add a note annotation to a session. Notes are special annotations that allow multiple entries per session (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv4 identifier.",
+        "description": "Add a note annotation to a session. Each call appends a new note with an auto-generated UUIDv4 identifier, so multiple notes accumulate on the same session. Structured annotations, by contrast, are keyed by (name, session_id, identifier) \u2014 re-writing the same key overwrites the existing annotation, so to keep multiple structured annotations with the same name on a session you must supply distinct identifiers.",
         "operationId": "createSessionNote",
         "requestBody": {
           "content": {

--- a/src/phoenix/server/api/routers/v1/sessions.py
+++ b/src/phoenix/server/api/routers/v1/sessions.py
@@ -461,9 +461,12 @@ async def annotate_sessions(
     operation_id="createSessionNote",
     summary="Create a session note",
     description=(
-        "Add a note annotation to a session. Notes are special annotations that allow "
-        "multiple entries per session (unlike regular annotations which are unique by name "
-        "and identifier). Each note gets a unique UUIDv4 identifier."
+        "Add a note annotation to a session. Each call appends a new note with an "
+        "auto-generated UUIDv4 identifier, so multiple notes accumulate on the same "
+        "session. Structured annotations, by contrast, are keyed by (name, session_id, "
+        "identifier) — re-writing the same key overwrites the existing annotation, "
+        "so to keep multiple structured annotations with the same name on a session "
+        "you must supply distinct identifiers."
     ),
     responses=add_errors_to_responses([{"status_code": 404, "description": "Session not found"}]),
     response_description="Session note created successfully",

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -1205,9 +1205,12 @@ class CreateSpanNoteResponseBody(ResponseBody[InsertedSpanAnnotation]):
     operation_id="createSpanNote",
     summary="Create a span note",
     description=(
-        "Add a note annotation to a span. Notes are special annotations that allow "
-        "multiple entries per span (unlike regular annotations which are unique by name "
-        "and identifier). Each note gets a unique UUIDv4 identifier."
+        "Add a note annotation to a span. Each call appends a new note with an "
+        "auto-generated UUIDv4 identifier, so multiple notes accumulate on the same "
+        "span. Structured annotations, by contrast, are keyed by (name, span_id, "
+        "identifier) — re-writing the same key overwrites the existing annotation, "
+        "so to keep multiple structured annotations with the same name on a span you "
+        "must supply distinct identifiers."
     ),
     responses=add_errors_to_responses([{"status_code": 404, "description": "Span not found"}]),
     response_description="Span note created successfully",

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -450,9 +450,12 @@ class CreateTraceNoteResponseBody(ResponseBody[InsertedTraceAnnotation]):
     operation_id="createTraceNote",
     summary="Create a trace note",
     description=(
-        "Add a note annotation to a trace. Notes are special annotations that allow "
-        "multiple entries per trace (unlike regular annotations which are unique by name "
-        "and identifier). Each note gets a unique UUIDv4 identifier."
+        "Add a note annotation to a trace. Each call appends a new note with an "
+        "auto-generated UUIDv4 identifier, so multiple notes accumulate on the same "
+        "trace. Structured annotations, by contrast, are keyed by (name, trace_id, "
+        "identifier) — re-writing the same key overwrites the existing annotation, "
+        "so to keep multiple structured annotations with the same name on a trace you "
+        "must supply distinct identifiers."
     ),
     responses=add_errors_to_responses([{"status_code": 404, "description": "Trace not found"}]),
     response_description="Trace note created successfully",

--- a/tests/integration/client/test_spans.py
+++ b/tests/integration/client/test_spans.py
@@ -1834,8 +1834,10 @@ class TestClientForSpanNotes:
     ) -> None:
         """Test multiple notes can be added to a span and verify content via GraphQL.
 
-        Notes are a special type of annotation that allow multiple entries per span
-        (unlike regular annotations which are unique by name and identifier).
+        Notes are append-only: each call creates a new note with an auto-generated
+        UUIDv4 identifier, so multiple notes accumulate on the same span. Structured
+        annotations are keyed by (name, span_id, identifier) — distinct identifiers
+        let you keep multiple same-named annotations on one span.
         """
         assert _existing_spans, "At least one existing span is required for this test"
         existing_span = choice(_existing_spans)


### PR DESCRIPTION
This PR bundles three related changes that all touch the trace/span/session annotation surface:

## 1. New TS client feature — trace annotations (parity with Python)

Adds `addTraceAnnotation` and `logTraceAnnotations` to `@arizeai/phoenix-client/traces`, exposing the existing `/v1/trace_annotations` REST endpoint. Brings the TS client to parity with the Python client.

```ts
import { addTraceAnnotation, logTraceAnnotations } from \"@arizeai/phoenix-client/traces\";

await addTraceAnnotation({
  traceAnnotation: {
    traceId: \"abc123\",
    name: \"correctness\",
    label: \"correct\",
    score: 1.0,
    annotatorKind: \"HUMAN\",
  },
  sync: true,
});
```

- Source: `js/packages/phoenix-client/src/traces/{addTraceAnnotation,logTraceAnnotations,types}.ts`
- Tests: `js/packages/phoenix-client/test/traces/{addTraceAnnotation,logTraceAnnotations}.test.ts`
- Reserved name `note` is rejected — use `addTraceNote` for free-form text.
- Changeset: `js/.changeset/trace-annotations-ts-client.md` (minor)

## 2. Cross-stack docstring clarification — notes vs structured annotations

Previous wording (TSDoc, Python docstrings, OpenAPI descriptions, server router descriptions) said annotations are *\"unique by name\"*. This is wrong: annotations are keyed by **`(name, target_id, identifier)`**. Multiple annotations with the same name can coexist on the same span/trace/session by supplying distinct identifiers.

Notes remain append-only — each call auto-generates a UUIDv4 identifier so multiple notes accumulate naturally.

Updated in:
- `js/packages/phoenix-client/src/spans/addSpanNote.ts`
- `js/packages/phoenix-client/src/traces/addTraceNote.ts`
- `packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py` (sync + async)
- `src/phoenix/server/api/routers/v1/{spans,traces,sessions}.py`
- `schemas/openapi.json` and the regenerated `js/packages/phoenix-client/src/__generated__/api/v1.ts`
- `tests/integration/client/test_spans.py` test docstring

Changeset: `js/.changeset/notes-vs-annotations-docs.md` (patch).

## 3. Weekly skills audit — 2026-04-29

**Audited against:** `origin/main` at `966e595b5af8b198edbd859e3abfe697f412184e`
**Window:** 2026-04-22 to 2026-04-29 — 52 commits (2 user-facing edits applied, 2 out-of-scope findings, rest skipped)

### Edits applied

#### phoenix-tracing
- `references/annotations-typescript.md` — fixed all broken package imports (`\"phoenix-client\"` → `\"@arizeai/phoenix-client/<subpath>\"`); added **Span Notes** (`addSpanNote` from `/spans`) and **Trace Notes** (`addTraceNote` from `/traces`) sections (commits `ed66c0280`, `a4dad8b9b`).
- `references/annotations-python.md` — added **Span Notes** section for `client.spans.add_span_note(...)` (commit `ed66c0280`). No Python `add_trace_note` helper exists yet.

#### phoenix-cli
No edits needed. `px trace add-note` and `px span add-note` were already documented in the prior audit (`a394e1b5f`).

#### phoenix-evals
No user-facing changes in window.

### Out-of-scope findings (track for next audit)

- **`187df7e8a` — session notes REST endpoint** (`POST /v1/session_notes`): server endpoint shipped, but no Python `client.sessions.add_session_note()` or TS `addSessionNote()` helper, and no `px session add-note` CLI command yet. Document once a higher-level helper ships.
- **`38b26d1d9` — GraphQL `Trace` aggregate fields** (`spanCountsByKind`, `errorCount`, `errorsByType`): accessible via `px api graphql` but no CLI command surfaces them. Update `phoenix-cli/SKILL.md` if a `px trace summary` command is added.
- **Python-only gap — no `add_trace_note`**: TS shipped `addTraceNote` and the REST endpoint (`POST /v1/trace_notes`) exists, but the Python `Traces` resource has no `add_trace_note()`. When added, document in `phoenix-tracing/references/annotations-python.md`.

### Skipped commits

Release bookkeeping, helm/kustomize bumps, cost manifest updates, JS/Python version bumps, frontend-only changes, internal server fixes, dep bumps, sitemap/docs-only edits, and the prior skills-audit + skills-audit-skill commits. Full list in commit `329d107ed`.