### PR TITLE
fix(app): resolve project routes that use project names

### DIFF
--- a/app/__tests__/projectLoader.test.ts
+++ b/app/__tests__/projectLoader.test.ts
@@ -1,0 +1,81 @@
+import type * as ReactRelay from "react-relay";
+import { fetchQuery } from "react-relay";
+import type { LoaderFunctionArgs } from "react-router";
+
+import { projectLoader } from "@phoenix/pages/project/projectLoader";
+
+vi.mock("@phoenix/RelayEnvironment", () => ({
+  default: {},
+}));
+
+vi.mock("react-relay", async () => {
+  const actual = await vi.importActual<typeof ReactRelay>("react-relay");
+  return {
+    ...actual,
+    fetchQuery: vi.fn(),
+  };
+});
+
+function makeLoaderArgs(
+  projectId: string,
+  url: string
+): LoaderFunctionArgs<unknown> {
+  return {
+    params: { projectId },
+    request: new Request(url),
+    context: undefined,
+  } as unknown as LoaderFunctionArgs<unknown>;
+}
+
+describe("projectLoader", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirects name-based project routes to the global-id route", async () => {
+    vi.mocked(fetchQuery).mockReturnValueOnce({
+      toPromise: vi.fn().mockResolvedValue({
+        getProjectByName: {
+          id: "UHJvamVjdDox",
+          name: "default",
+        },
+      }),
+    } as never);
+
+    const response = await projectLoader(
+      makeLoaderArgs("default", "http://localhost:6006/projects/default/traces")
+    ).catch((error: unknown) => error);
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(302);
+    expect((response as Response).headers.get("Location")).toBe(
+      "/projects/UHJvamVjdDox/traces"
+    );
+    expect(fetchQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads project data directly when the route already uses a global id", async () => {
+    const projectResponse = {
+      project: {
+        id: "UHJvamVjdDox",
+        name: "default",
+      },
+    };
+    vi.mocked(fetchQuery).mockReturnValueOnce({
+      toPromise: vi.fn().mockResolvedValue(projectResponse),
+    } as never);
+
+    const response = await projectLoader(
+      makeLoaderArgs(
+        "UHJvamVjdDox",
+        "http://localhost:6006/projects/UHJvamVjdDox/traces"
+      )
+    );
+
+    expect(response).toEqual(projectResponse);
+    expect(fetchQuery).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fetchQuery).mock.calls[0]?.[2]).toEqual({
+      id: "UHJvamVjdDox",
+    });
+  });
+});

--- a/app/src/pages/project/__generated__/projectLoaderByNameQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/projectLoaderByNameQuery.graphql.ts
@@ -1,0 +1,97 @@
+/**
+ * @generated SignedSource<<d3236c17ff3576bf5d6e482eb79a1039>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type projectLoaderByNameQuery$variables = {
+  name: string;
+};
+export type projectLoaderByNameQuery$data = {
+  readonly getProjectByName: {
+    readonly id: string;
+    readonly name: string;
+  } | null;
+};
+export type projectLoaderByNameQuery = {
+  response: projectLoaderByNameQuery$data;
+  variables: projectLoaderByNameQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "name"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "name",
+        "variableName": "name"
+      }
+    ],
+    "concreteType": "Project",
+    "kind": "LinkedField",
+    "name": "getProjectByName",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "name",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "projectLoaderByNameQuery",
+    "selections": (v1/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "projectLoaderByNameQuery",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "162d12574e7276cfbd99ef2bdeb935e4",
+    "id": null,
+    "metadata": {},
+    "name": "projectLoaderByNameQuery",
+    "operationKind": "query",
+    "text": "query projectLoaderByNameQuery(\n  $name: String!\n) {\n  getProjectByName(name: $name) {\n    id\n    name\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "9d1959b255769363df9a95c58aa98670";
+
+export default node;

--- a/app/src/pages/project/projectLoader.ts
+++ b/app/src/pages/project/projectLoader.ts
@@ -1,15 +1,58 @@
 import { fetchQuery, graphql } from "react-relay";
+import { redirect } from "react-router";
 import type { LoaderFunctionArgs } from "react-router";
 
 import RelayEnvironment from "@phoenix/RelayEnvironment";
 
+import type { projectLoaderByNameQuery } from "./__generated__/projectLoaderByNameQuery.graphql";
 import type { projectLoaderQuery } from "./__generated__/projectLoaderQuery.graphql";
+
+const RELAY_GLOBAL_ID_PATTERN = /^[^:]+:[^:]+(?:[:][^:]+)*$/;
+
+function looksLikeRelayGlobalId(value: string) {
+  try {
+    return RELAY_GLOBAL_ID_PATTERN.test(atob(value));
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Loads in the necessary page data for the project page
  */
-export async function projectLoader(args: LoaderFunctionArgs) {
-  const { projectId } = args.params;
+export async function projectLoader({ params, request }: LoaderFunctionArgs) {
+  const { projectId } = params;
+
+  if (!projectId) {
+    throw new Error("Project page requires a project ID or project name");
+  }
+
+  if (!looksLikeRelayGlobalId(projectId)) {
+    const response = await fetchQuery<projectLoaderByNameQuery>(
+      RelayEnvironment,
+      graphql`
+        query projectLoaderByNameQuery($name: String!) {
+          getProjectByName(name: $name) {
+            id
+            name
+          }
+        }
+      `,
+      {
+        name: projectId,
+      }
+    ).toPromise();
+
+    if (response?.getProjectByName) {
+      const url = new URL(request.url);
+      url.pathname = url.pathname.replace(
+        `/projects/${projectId}`,
+        `/projects/${response.getProjectByName.id}`
+      );
+      throw redirect(`${url.pathname}${url.search}${url.hash}`);
+    }
+  }
+
   return await fetchQuery<projectLoaderQuery>(
     RelayEnvironment,
     graphql`
@@ -23,7 +66,7 @@ export async function projectLoader(args: LoaderFunctionArgs) {
       }
     `,
     {
-      id: projectId as string,
+      id: projectId,
     }
   ).toPromise();
 }

--- a/src/phoenix/server/api/types/node.py
+++ b/src/phoenix/server/api/types/node.py
@@ -1,5 +1,6 @@
 import re
 from base64 import b64decode
+from binascii import Error as BinasciiError
 
 from strawberry.relay import GlobalID
 
@@ -7,7 +8,10 @@ _COMPOSITE_GLOBAL_ID_PATTERN = re.compile(r"[^:]+:[^:]+(:[^:]+)+")
 
 
 def is_composite_global_id(node_id: str) -> bool:
-    decoded_node_id = b64decode(node_id).decode()
+    try:
+        decoded_node_id = b64decode(node_id).decode()
+    except (BinasciiError, UnicodeDecodeError):
+        return False
     return _COMPOSITE_GLOBAL_ID_PATTERN.match(decoded_node_id) is not None
 
 

--- a/tests/unit/server/api/types/test_node.py
+++ b/tests/unit/server/api/types/test_node.py
@@ -1,7 +1,11 @@
 import pytest
 from strawberry.relay import GlobalID
 
-from phoenix.server.api.types.node import from_global_id, from_global_id_with_expected_type
+from phoenix.server.api.types.node import (
+    from_global_id,
+    from_global_id_with_expected_type,
+    is_composite_global_id,
+)
 
 
 def test_from_global_id_returns_type_name_and_node_id() -> None:
@@ -21,3 +25,11 @@ def test_from_global_id_with_expected_type_raises_value_error_for_unexpected_typ
     global_id = GlobalID(type_name="EmbeddingDimension", node_id=str(1))
     with pytest.raises(ValueError):
         from_global_id_with_expected_type(global_id=global_id, expected_type_name="Dimension")
+
+
+def test_is_composite_global_id_returns_false_for_invalid_base64() -> None:
+    assert is_composite_global_id("default") is False
+
+
+def test_is_composite_global_id_returns_true_for_composite_global_id() -> None:
+    assert is_composite_global_id("RXhwZXJpbWVudFJlcGVhdGVkUnVuR3JvdXA6MToy") is True


### PR DESCRIPTION
fixes #12908

This keeps `/projects/<name>/...` links working by resolving project names to the canonical Relay global ID before the project loader queries `node(id: ...)`.

It also hardens `is_composite_global_id()` so invalid base64 strings return `False` instead of bubbling a decode error through GraphQL.

Validation:
- `pnpm --dir app exec oxlint src/pages/project/projectLoader.ts __tests__/projectLoader.test.ts`
- `pnpm --dir app exec tsc --noEmit`
- `pnpm --dir app exec vitest run __tests__/projectLoader.test.ts`
- `uv run ruff check src/phoenix/server/api/types/node.py tests/unit/server/api/types/test_node.py`
- `uv run pytest tests/unit/server/api/types/test_node.py`
