### PR TITLE
feat(cli): add session annotations and notes

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -175,7 +175,7 @@ SessionData
   start_time, end_time
   annotations[] (with --include-annotations, excludes note)
     name, result { score, label, explanation }
-  notes[] (with --include-notes; requires Phoenix server 14.17.0+)
+  notes[] (with --include-notes)
     name="note", result { explanation }
   traces[]
     id, trace_id, start_time, end_time

--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires Node.js (for npx) or global install of @arizeai/phoenix-cli. Optionally requires jq for JSON processing.
 metadata:
   author: arize-ai
-  version: "3.2.0"
+  version: "3.3.0"
 ---
 
 # Phoenix CLI
@@ -27,6 +27,10 @@ px trace add-note <trace-id>
 px span list
 px span annotate <span-id>
 px span add-note <span-id>
+px session list
+px session get <session-id>
+px session annotate <session-id>
+px session add-note <session-id>
 px dataset list
 px dataset get <name>
 px project list
@@ -154,8 +158,13 @@ Span
 ```bash
 px session list --limit 10 --format raw --no-progress | jq .
 px session list --order asc --format raw --no-progress | jq '.[].session_id'
+px session list --include-annotations --include-notes --format raw --no-progress | jq '.[].notes'
 px session get <session-id> --format raw | jq .
-px session get <session-id> --include-annotations --format raw | jq '.annotations'
+px session get <session-id> --include-annotations --format raw | jq '.session.annotations'
+px session get <session-id> --include-notes --format raw | jq '.session.notes'
+px session annotate <session-id> --name reviewer --label pass
+px session annotate <session-id> --name reviewer --score 0.9 --format raw --no-progress
+px session add-note <session-id> --text "verified by agent"
 ```
 
 ### Session JSON shape
@@ -164,13 +173,12 @@ px session get <session-id> --include-annotations --format raw | jq '.annotation
 SessionData
   id, session_id, project_id
   start_time, end_time
+  annotations[] (with --include-annotations, excludes note)
+    name, result { score, label, explanation }
+  notes[] (with --include-notes; requires Phoenix server 14.17.0+)
+    name="note", result { explanation }
   traces[]
     id, trace_id, start_time, end_time
-
-SessionAnnotation (with --include-annotations)
-  id, name, annotator_kind ("LLM"|"CODE"|"HUMAN"), session_id
-  result { label, score, explanation }
-  metadata, identifier, source, created_at, updated_at
 ```
 
 ## Datasets / Experiments / Prompts

--- a/js/.changeset/session-cli-annotations-notes.md
+++ b/js/.changeset/session-cli-annotations-notes.md
@@ -1,0 +1,6 @@
+---
+"@arizeai/phoenix-cli": patch
+"@arizeai/phoenix-client": patch
+---
+
+Add session annotation and note commands to the Phoenix CLI, and add a session note helper to the TypeScript client. Session note creation requires Phoenix server 14.17.0 or newer.

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -318,14 +318,14 @@ px session list --format raw --no-progress | jq '.[].session_id'
 px session list --include-annotations --include-notes --format raw | jq '.[].notes'
 ```
 
-| Option                  | Description                                       | Default  |
-| ----------------------- | ------------------------------------------------- | -------- |
-| `-n, --limit <number>`  | Maximum number of sessions                        | `10`     |
-| `--order <order>`       | Sort order: `asc` or `desc`                       | `desc`   |
-| `--include-annotations` | Include session annotations, excluding notes      | —        |
-| `--include-notes`       | Include session notes; requires Phoenix `14.17.0` | —        |
-| `--format <format>`     | `pretty`, `json`, or `raw`                        | `pretty` |
-| `--no-progress`         | Suppress progress output                          | —        |
+| Option                  | Description                                  | Default  |
+| ----------------------- | -------------------------------------------- | -------- |
+| `-n, --limit <number>`  | Maximum number of sessions                   | `10`     |
+| `--order <order>`       | Sort order: `asc` or `desc`                  | `desc`   |
+| `--include-annotations` | Include session annotations, excluding notes | —        |
+| `--include-notes`       | Include session notes when present           | —        |
+| `--format <format>`     | `pretty`, `json`, or `raw`                   | `pretty` |
+| `--no-progress`         | Suppress progress output                     | —        |
 
 ---
 
@@ -340,13 +340,13 @@ px session get my-session-id --include-annotations --format raw | jq '.session.a
 px session get my-session-id --include-notes --format raw | jq '.session.notes'
 ```
 
-| Option                  | Description                                       | Default  |
-| ----------------------- | ------------------------------------------------- | -------- |
-| `--file <path>`         | Save session to file instead of stdout            | —        |
-| `--include-annotations` | Include session annotations, excluding notes      | —        |
-| `--include-notes`       | Include session notes; requires Phoenix `14.17.0` | —        |
-| `--format <format>`     | `pretty`, `json`, or `raw`                        | `pretty` |
-| `--no-progress`         | Suppress progress output                          | —        |
+| Option                  | Description                                  | Default  |
+| ----------------------- | -------------------------------------------- | -------- |
+| `--file <path>`         | Save session to file instead of stdout       | —        |
+| `--include-annotations` | Include session annotations, excluding notes | —        |
+| `--include-notes`       | Include session notes when present           | —        |
+| `--format <format>`     | `pretty`, `json`, or `raw`                   | `pretty` |
+| `--no-progress`         | Suppress progress output                     | —        |
 
 ---
 

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -315,14 +315,17 @@ List sessions for a project.
 px session list                                            # latest 10 sessions
 px session list --limit 20 --order asc                     # oldest first
 px session list --format raw --no-progress | jq '.[].session_id'
+px session list --include-annotations --include-notes --format raw | jq '.[].notes'
 ```
 
-| Option                 | Description                 | Default  |
-| ---------------------- | --------------------------- | -------- |
-| `-n, --limit <number>` | Maximum number of sessions  | `10`     |
-| `--order <order>`      | Sort order: `asc` or `desc` | `desc`   |
-| `--format <format>`    | `pretty`, `json`, or `raw`  | `pretty` |
-| `--no-progress`        | Suppress progress output    | —        |
+| Option                  | Description                                       | Default  |
+| ----------------------- | ------------------------------------------------- | -------- |
+| `-n, --limit <number>`  | Maximum number of sessions                        | `10`     |
+| `--order <order>`       | Sort order: `asc` or `desc`                       | `desc`   |
+| `--include-annotations` | Include session annotations, excluding notes      | —        |
+| `--include-notes`       | Include session notes; requires Phoenix `14.17.0` | —        |
+| `--format <format>`     | `pretty`, `json`, or `raw`                        | `pretty` |
+| `--no-progress`         | Suppress progress output                          | —        |
 
 ---
 
@@ -333,15 +336,41 @@ View a session's conversation flow.
 ```bash
 px session get my-session-id
 px session get my-session-id --file session.json
-px session get my-session-id --include-annotations --format raw | jq '.traces'
+px session get my-session-id --include-annotations --format raw | jq '.session.annotations'
+px session get my-session-id --include-notes --format raw | jq '.session.notes'
 ```
 
-| Option                  | Description                            | Default  |
-| ----------------------- | -------------------------------------- | -------- |
-| `--file <path>`         | Save session to file instead of stdout | —        |
-| `--include-annotations` | Include session annotations            | —        |
-| `--format <format>`     | `pretty`, `json`, or `raw`             | `pretty` |
-| `--no-progress`         | Suppress progress output               | —        |
+| Option                  | Description                                       | Default  |
+| ----------------------- | ------------------------------------------------- | -------- |
+| `--file <path>`         | Save session to file instead of stdout            | —        |
+| `--include-annotations` | Include session annotations, excluding notes      | —        |
+| `--include-notes`       | Include session notes; requires Phoenix `14.17.0` | —        |
+| `--format <format>`     | `pretty`, `json`, or `raw`                        | `pretty` |
+| `--no-progress`         | Suppress progress output                          | —        |
+
+---
+
+### `px session annotate <session-id>`
+
+Create or update a human session annotation by GlobalID or user-provided `session_id`.
+
+```bash
+px session annotate my-session-id --name reviewer --label pass
+px session annotate my-session-id --name reviewer --score 0.9 --format raw --no-progress
+px session annotate my-session-id --name evaluator --label pass --annotator-kind LLM
+px session annotate my-session-id --name reviewer --explanation "needs follow-up"
+```
+
+---
+
+### `px session add-note <session-id>`
+
+Add a note to a session by GlobalID or user-provided `session_id`. Requires Phoenix server `14.17.0` or newer.
+
+```bash
+px session add-note my-session-id --text "needs follow-up"
+px session add-note my-session-id --text "agent triage complete" --format raw --no-progress
+```
 
 ---
 

--- a/js/packages/phoenix-cli/src/commands/annotationMutationUtils.ts
+++ b/js/packages/phoenix-cli/src/commands/annotationMutationUtils.ts
@@ -1,7 +1,7 @@
 import { InvalidArgumentError } from "../exitCodes";
 import { parseNumber, trimToUndefined } from "../normalize";
 
-export type AnnotationTargetType = "span" | "trace";
+export type AnnotationTargetType = "span" | "trace" | "session";
 export type AnnotatorKind = "HUMAN" | "LLM" | "CODE";
 
 export interface AnnotationMutationResult {
@@ -34,7 +34,13 @@ function getTargetIdPlaceholder({
 }: {
   targetType: AnnotationTargetType;
 }): string {
-  return targetType === "span" ? "<span-id>" : "<trace-id>";
+  if (targetType === "span") {
+    return "<span-id>";
+  }
+  if (targetType === "trace") {
+    return "<trace-id>";
+  }
+  return "<session-id>";
 }
 
 function getAnnotateUsage({

--- a/js/packages/phoenix-cli/src/commands/annotationMutationUtils.ts
+++ b/js/packages/phoenix-cli/src/commands/annotationMutationUtils.ts
@@ -34,13 +34,20 @@ function getTargetIdPlaceholder({
 }: {
   targetType: AnnotationTargetType;
 }): string {
-  if (targetType === "span") {
-    return "<span-id>";
+  switch (targetType) {
+    case "span":
+      return "<span-id>";
+    case "trace":
+      return "<trace-id>";
+    case "session":
+      return "<session-id>";
+    default:
+      return assertNever(targetType);
   }
-  if (targetType === "trace") {
-    return "<trace-id>";
-  }
-  return "<session-id>";
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unsupported annotation target type: ${String(value)}`);
 }
 
 function getAnnotateUsage({

--- a/js/packages/phoenix-cli/src/commands/chunkArray.ts
+++ b/js/packages/phoenix-cli/src/commands/chunkArray.ts
@@ -1,0 +1,13 @@
+export function chunkArray<T>({
+  items,
+  size,
+}: {
+  items: T[];
+  size: number;
+}): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}

--- a/js/packages/phoenix-cli/src/commands/formatSessions.ts
+++ b/js/packages/phoenix-cli/src/commands/formatSessions.ts
@@ -24,11 +24,15 @@ export type SessionWithAnnotations = SessionData & {
 export interface FormatSessionsOutputOptions {
   sessions: SessionWithAnnotations[];
   format?: OutputFormat;
+  includeAnnotations?: boolean;
+  includeNotes?: boolean;
 }
 
 export function formatSessionsOutput({
   sessions,
   format,
+  includeAnnotations,
+  includeNotes,
 }: FormatSessionsOutputOptions): string {
   const selected = format || "pretty";
   if (selected === "raw") {
@@ -37,60 +41,49 @@ export function formatSessionsOutput({
   if (selected === "json") {
     return JSON.stringify(sessions, null, 2);
   }
-  return formatSessionsPretty(sessions);
+  return formatSessionsPretty({ sessions, includeAnnotations, includeNotes });
 }
 
 export interface FormatSessionOutputOptions {
   session: SessionWithAnnotations;
-  annotations?: SessionAnnotation[];
-  notes?: SessionNote[];
   format?: OutputFormat;
 }
 
 export function formatSessionOutput({
   session,
-  annotations,
-  notes,
   format,
 }: FormatSessionOutputOptions): string {
-  const sessionWithAnnotations: SessionWithAnnotations = {
-    ...session,
-    ...(annotations ? { annotations } : {}),
-    ...(notes ? { notes } : {}),
-  };
   const selected = format || "pretty";
   if (selected === "raw") {
-    return JSON.stringify({
-      session: sessionWithAnnotations,
-      annotations,
-      notes,
-    });
+    return JSON.stringify({ session });
   }
   if (selected === "json") {
-    return JSON.stringify(
-      {
-        session: sessionWithAnnotations,
-        annotations,
-        notes,
-      },
-      null,
-      2
-    );
+    return JSON.stringify({ session }, null, 2);
   }
-  return formatSessionPretty(sessionWithAnnotations);
+  return formatSessionPretty(session);
 }
 
-function formatSessionsPretty(sessions: SessionWithAnnotations[]): string {
+function formatSessionsPretty({
+  sessions,
+  includeAnnotations,
+  includeNotes,
+}: {
+  sessions: SessionWithAnnotations[];
+  includeAnnotations?: boolean;
+  includeNotes?: boolean;
+}): string {
   if (sessions.length === 0) {
     return "No sessions found";
   }
 
-  const hasAnnotations = sessions.some(
-    (session) => session.annotations && session.annotations.length > 0
-  );
-  const hasNotes = sessions.some(
-    (session) => session.notes && session.notes.length > 0
-  );
+  const hasAnnotations =
+    Boolean(includeAnnotations) ||
+    sessions.some(
+      (session) => session.annotations && session.annotations.length > 0
+    );
+  const hasNotes =
+    Boolean(includeNotes) ||
+    sessions.some((session) => session.notes && session.notes.length > 0);
 
   const rows = sessions.map((s) => ({
     session_id: s.session_id,

--- a/js/packages/phoenix-cli/src/commands/formatSessions.ts
+++ b/js/packages/phoenix-cli/src/commands/formatSessions.ts
@@ -76,12 +76,12 @@ function formatSessionsPretty({
     return "No sessions found";
   }
 
-  const hasAnnotations =
+  const shouldShowAnnotationsColumn =
     Boolean(includeAnnotations) ||
     sessions.some(
       (session) => session.annotations && session.annotations.length > 0
     );
-  const hasNotes =
+  const shouldShowNotesColumn =
     Boolean(includeNotes) ||
     sessions.some((session) => session.notes && session.notes.length > 0);
 
@@ -92,10 +92,10 @@ function formatSessionsPretty({
     duration: formatDuration(s.start_time, s.end_time),
     started: formatDate(s.start_time),
     ended: formatDate(s.end_time),
-    ...(hasAnnotations
+    ...(shouldShowAnnotationsColumn
       ? { annotations: formatAnnotations(s.annotations) }
       : {}),
-    ...(hasNotes ? { notes: formatNotes(s.notes) } : {}),
+    ...(shouldShowNotesColumn ? { notes: formatNotes(s.notes) } : {}),
   }));
 
   return formatTable(rows);

--- a/js/packages/phoenix-cli/src/commands/formatSessions.ts
+++ b/js/packages/phoenix-cli/src/commands/formatSessions.ts
@@ -7,8 +7,22 @@ export type OutputFormat = "pretty" | "json" | "raw";
 type SessionData = componentsV1["schemas"]["SessionData"];
 type SessionAnnotation = componentsV1["schemas"]["SessionAnnotation"];
 
+type NoteResult = {
+  explanation?: string | null;
+};
+
+export type SessionNote = Omit<SessionAnnotation, "name" | "result"> & {
+  name: "note";
+  result?: NoteResult | null;
+};
+
+export type SessionWithAnnotations = SessionData & {
+  annotations?: SessionAnnotation[];
+  notes?: SessionNote[];
+};
+
 export interface FormatSessionsOutputOptions {
-  sessions: SessionData[];
+  sessions: SessionWithAnnotations[];
   format?: OutputFormat;
 }
 
@@ -27,30 +41,56 @@ export function formatSessionsOutput({
 }
 
 export interface FormatSessionOutputOptions {
-  session: SessionData;
+  session: SessionWithAnnotations;
   annotations?: SessionAnnotation[];
+  notes?: SessionNote[];
   format?: OutputFormat;
 }
 
 export function formatSessionOutput({
   session,
   annotations,
+  notes,
   format,
 }: FormatSessionOutputOptions): string {
+  const sessionWithAnnotations: SessionWithAnnotations = {
+    ...session,
+    ...(annotations ? { annotations } : {}),
+    ...(notes ? { notes } : {}),
+  };
   const selected = format || "pretty";
   if (selected === "raw") {
-    return JSON.stringify({ session, annotations });
+    return JSON.stringify({
+      session: sessionWithAnnotations,
+      annotations,
+      notes,
+    });
   }
   if (selected === "json") {
-    return JSON.stringify({ session, annotations }, null, 2);
+    return JSON.stringify(
+      {
+        session: sessionWithAnnotations,
+        annotations,
+        notes,
+      },
+      null,
+      2
+    );
   }
-  return formatSessionPretty(session, annotations);
+  return formatSessionPretty(sessionWithAnnotations);
 }
 
-function formatSessionsPretty(sessions: SessionData[]): string {
+function formatSessionsPretty(sessions: SessionWithAnnotations[]): string {
   if (sessions.length === 0) {
     return "No sessions found";
   }
+
+  const hasAnnotations = sessions.some(
+    (session) => session.annotations && session.annotations.length > 0
+  );
+  const hasNotes = sessions.some(
+    (session) => session.notes && session.notes.length > 0
+  );
 
   const rows = sessions.map((s) => ({
     session_id: s.session_id,
@@ -59,15 +99,16 @@ function formatSessionsPretty(sessions: SessionData[]): string {
     duration: formatDuration(s.start_time, s.end_time),
     started: formatDate(s.start_time),
     ended: formatDate(s.end_time),
+    ...(hasAnnotations
+      ? { annotations: formatAnnotations(s.annotations) }
+      : {}),
+    ...(hasNotes ? { notes: formatNotes(s.notes) } : {}),
   }));
 
   return formatTable(rows);
 }
 
-function formatSessionPretty(
-  session: SessionData,
-  annotations?: SessionAnnotation[]
-): string {
+function formatSessionPretty(session: SessionWithAnnotations): string {
   const lines: string[] = [];
 
   lines.push(`┌─ Session: ${session.session_id}`);
@@ -104,10 +145,10 @@ function formatSessionPretty(
     }
   }
 
-  if (annotations && annotations.length > 0) {
+  if (session.annotations && session.annotations.length > 0) {
     lines.push(`│`);
     lines.push(`│  Annotations:`);
-    for (const annotation of annotations) {
+    for (const annotation of session.annotations) {
       const parts: string[] = [];
       if (annotation.result?.score != null) {
         parts.push(`score=${annotation.result.score}`);
@@ -122,9 +163,46 @@ function formatSessionPretty(
     }
   }
 
+  if (session.notes && session.notes.length > 0) {
+    lines.push(`│`);
+    lines.push(`│  Notes:`);
+    for (const note of session.notes) {
+      const noteText = note.result?.explanation?.trim();
+      if (noteText) {
+        lines.push(`│    - ${noteText}`);
+      }
+    }
+  }
+
   lines.push(`└─`);
 
   return lines.join("\n");
+}
+
+function formatAnnotations(
+  annotations: SessionAnnotation[] | undefined
+): string {
+  if (!annotations || annotations.length === 0) return "";
+  return annotations
+    .map((annotation) => {
+      const pieces: string[] = [annotation.name];
+      if (annotation.result?.score != null) {
+        pieces.push(`=${annotation.result.score}`);
+      }
+      if (annotation.result?.label) {
+        pieces.push(`(${annotation.result.label})`);
+      }
+      return pieces.join("");
+    })
+    .join(", ");
+}
+
+function formatNotes(notes: SessionNote[] | undefined): string {
+  if (!notes || notes.length === 0) return "";
+  return notes
+    .map((note) => note.result?.explanation?.replace(/\s+/g, " ").trim() || "")
+    .filter((noteText) => noteText.length > 0)
+    .join(" | ");
 }
 
 function formatDate(dateStr: string): string {

--- a/js/packages/phoenix-cli/src/commands/formatSpans.ts
+++ b/js/packages/phoenix-cli/src/commands/formatSpans.ts
@@ -38,10 +38,10 @@ function formatSpansPretty({
   includeAnnotations?: boolean;
   includeNotes?: boolean;
 }): string {
-  const hasAnnotations =
+  const shouldShowAnnotationsColumn =
     Boolean(includeAnnotations) ||
     spans.some((s) => s.annotations && s.annotations.length > 0);
-  const hasNotes =
+  const shouldShowNotesColumn =
     Boolean(includeNotes) || spans.some((s) => s.notes && s.notes.length > 0);
 
   const rows = spans.map((span) => {
@@ -57,10 +57,10 @@ function formatSpansPretty({
       time: formatTimestamp(span.start_time),
     };
 
-    if (hasAnnotations) {
+    if (shouldShowAnnotationsColumn) {
       row.annotations = formatAnnotations(span.annotations);
     }
-    if (hasNotes) {
+    if (shouldShowNotesColumn) {
       row.notes = formatNotes(span.notes);
     }
 

--- a/js/packages/phoenix-cli/src/commands/formatSpans.ts
+++ b/js/packages/phoenix-cli/src/commands/formatSpans.ts
@@ -6,11 +6,15 @@ export type OutputFormat = "pretty" | "json" | "raw";
 export interface FormatSpansOutputOptions {
   spans: SpanWithAnnotations[];
   format?: OutputFormat;
+  includeAnnotations?: boolean;
+  includeNotes?: boolean;
 }
 
 export function formatSpansOutput({
   spans,
   format,
+  includeAnnotations,
+  includeNotes,
 }: FormatSpansOutputOptions): string {
   const selected = format || "pretty";
   if (selected === "raw") {
@@ -22,14 +26,23 @@ export function formatSpansOutput({
   if (spans.length === 0) {
     return "No spans found";
   }
-  return formatSpansPretty(spans);
+  return formatSpansPretty({ spans, includeAnnotations, includeNotes });
 }
 
-function formatSpansPretty(spans: SpanWithAnnotations[]): string {
-  const hasAnnotations = spans.some(
-    (s) => s.annotations && s.annotations.length > 0
-  );
-  const hasNotes = spans.some((s) => s.notes && s.notes.length > 0);
+function formatSpansPretty({
+  spans,
+  includeAnnotations,
+  includeNotes,
+}: {
+  spans: SpanWithAnnotations[];
+  includeAnnotations?: boolean;
+  includeNotes?: boolean;
+}): string {
+  const hasAnnotations =
+    Boolean(includeAnnotations) ||
+    spans.some((s) => s.annotations && s.annotations.length > 0);
+  const hasNotes =
+    Boolean(includeNotes) || spans.some((s) => s.notes && s.notes.length > 0);
 
   const rows = spans.map((span) => {
     const statusCode = span.status_code || "UNSET";

--- a/js/packages/phoenix-cli/src/commands/noteMutationUtils.ts
+++ b/js/packages/phoenix-cli/src/commands/noteMutationUtils.ts
@@ -1,7 +1,7 @@
 import { InvalidArgumentError } from "../exitCodes";
 import { trimToUndefined } from "../normalize";
 
-export type NoteTargetType = "span" | "trace";
+export type NoteTargetType = "span" | "trace" | "session";
 export const NOTE_ANNOTATION_NAME = "note";
 
 export interface NoteMutationResult {
@@ -16,7 +16,13 @@ function getTargetIdPlaceholder({
 }: {
   targetType: NoteTargetType;
 }): string {
-  return targetType === "span" ? "<span-id>" : "<trace-id>";
+  if (targetType === "span") {
+    return "<span-id>";
+  }
+  if (targetType === "trace") {
+    return "<trace-id>";
+  }
+  return "<session-id>";
 }
 
 function getAddNoteUsage({

--- a/js/packages/phoenix-cli/src/commands/noteMutationUtils.ts
+++ b/js/packages/phoenix-cli/src/commands/noteMutationUtils.ts
@@ -16,13 +16,20 @@ function getTargetIdPlaceholder({
 }: {
   targetType: NoteTargetType;
 }): string {
-  if (targetType === "span") {
-    return "<span-id>";
+  switch (targetType) {
+    case "span":
+      return "<span-id>";
+    case "trace":
+      return "<trace-id>";
+    case "session":
+      return "<session-id>";
+    default:
+      return assertNever(targetType);
   }
-  if (targetType === "trace") {
-    return "<trace-id>";
-  }
-  return "<session-id>";
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unsupported note target type: ${String(value)}`);
 }
 
 function getAddNoteUsage({

--- a/js/packages/phoenix-cli/src/commands/session.ts
+++ b/js/packages/phoenix-cli/src/commands/session.ts
@@ -1,6 +1,10 @@
 import * as fs from "fs";
 import type { componentsV1, PhoenixClient } from "@arizeai/phoenix-client";
-import { deleteSession } from "@arizeai/phoenix-client/sessions";
+import {
+  addSessionAnnotation,
+  addSessionNote,
+  deleteSession,
+} from "@arizeai/phoenix-client/sessions";
 import { Command } from "commander";
 
 import { createPhoenixClient, resolveProjectId } from "../client";
@@ -13,41 +17,92 @@ import { assertDeletesEnabled, confirmOrExit } from "../confirm";
 import { ExitCode, getExitCodeForError } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import {
+  buildAnnotationMutationResult,
+  getAnnotationMutationHelpText,
+  normalizeAnnotationInput,
+} from "./annotationMutationUtils";
+import { chunkArray } from "./chunkArray";
+import {
+  formatAnnotationMutationOutput,
+  type OutputFormat as AnnotationMutationOutputFormat,
+} from "./formatAnnotationMutation";
+import {
+  formatNoteMutationOutput,
+  type OutputFormat as NoteMutationOutputFormat,
+} from "./formatNoteMutation";
+import {
   formatSessionOutput,
   formatSessionsOutput,
-  type OutputFormat,
+  type OutputFormat as SessionOutputFormat,
+  type SessionNote,
+  type SessionWithAnnotations,
 } from "./formatSessions";
+import {
+  buildNoteMutationResult,
+  NOTE_ANNOTATION_NAME,
+  normalizeNoteText,
+} from "./noteMutationUtils";
 
 type SessionData = componentsV1["schemas"]["SessionData"];
 type SessionAnnotation = componentsV1["schemas"]["SessionAnnotation"];
+
+const DEFAULT_PAGE_LIMIT = 1000;
+const DEFAULT_SESSION_IDS_CHUNK_SIZE = 100;
+const DEFAULT_MAX_CONCURRENT = 5;
 
 interface SessionGetOptions {
   endpoint?: string;
   project?: string;
   apiKey?: string;
-  format?: OutputFormat;
+  format?: SessionOutputFormat;
   progress?: boolean;
   file?: string;
   includeAnnotations?: boolean;
+  includeNotes?: boolean;
 }
 
 interface SessionListOptions {
   endpoint?: string;
   project?: string;
   apiKey?: string;
-  format?: OutputFormat;
+  format?: SessionOutputFormat;
   progress?: boolean;
   limit?: number;
   order?: "asc" | "desc";
+  includeAnnotations?: boolean;
+  includeNotes?: boolean;
+}
+
+interface SessionAnnotateOptions {
+  endpoint?: string;
+  apiKey?: string;
+  format?: AnnotationMutationOutputFormat;
+  progress?: boolean;
+  name?: string;
+  label?: string;
+  score?: string;
+  explanation?: string;
+  annotatorKind?: string;
+}
+
+interface SessionAddNoteOptions {
+  endpoint?: string;
+  apiKey?: string;
+  format?: NoteMutationOutputFormat;
+  progress?: boolean;
+  text?: string;
 }
 
 /**
  * Fetch a single session by identifier
  */
-async function fetchSession(
-  client: PhoenixClient,
-  sessionIdentifier: string
-): Promise<SessionData> {
+async function fetchSession({
+  client,
+  sessionIdentifier,
+}: {
+  client: PhoenixClient;
+  sessionIdentifier: string;
+}): Promise<SessionData> {
   const response = await client.GET("/v1/sessions/{session_identifier}", {
     params: {
       path: {
@@ -66,11 +121,72 @@ async function fetchSession(
 /**
  * Fetch annotations for a session
  */
-async function fetchSessionAnnotations(
-  client: PhoenixClient,
-  projectIdentifier: string,
-  sessionId: string
-): Promise<SessionAnnotation[]> {
+async function fetchSessionAnnotations({
+  client,
+  projectIdentifier,
+  sessionIds,
+  includeAnnotationNames,
+  excludeAnnotationNames,
+  pageLimit = DEFAULT_PAGE_LIMIT,
+  maxConcurrent = DEFAULT_MAX_CONCURRENT,
+}: {
+  client: PhoenixClient;
+  projectIdentifier: string;
+  sessionIds: string[];
+  includeAnnotationNames?: string[];
+  excludeAnnotationNames?: string[];
+  pageLimit?: number;
+  maxConcurrent?: number;
+}): Promise<SessionAnnotation[]> {
+  if (sessionIds.length === 0) {
+    return [];
+  }
+
+  const uniqueSessionIds = Array.from(new Set(sessionIds));
+  const chunks = chunkArray({
+    items: uniqueSessionIds,
+    size: DEFAULT_SESSION_IDS_CHUNK_SIZE,
+  });
+  const allAnnotations: SessionAnnotation[] = [];
+
+  for (let index = 0; index < chunks.length; index += maxConcurrent) {
+    const batch = chunks.slice(index, index + maxConcurrent);
+    const batchResults = await Promise.all(
+      batch.map((sessionIdsChunk) =>
+        fetchSessionAnnotationsForChunk({
+          client,
+          projectIdentifier,
+          sessionIds: sessionIdsChunk,
+          includeAnnotationNames,
+          excludeAnnotationNames,
+          pageLimit,
+        })
+      )
+    );
+
+    for (const result of batchResults) {
+      allAnnotations.push(...result);
+    }
+  }
+
+  return allAnnotations;
+}
+
+async function fetchSessionAnnotationsForChunk({
+  client,
+  projectIdentifier,
+  sessionIds,
+  includeAnnotationNames,
+  excludeAnnotationNames,
+  pageLimit,
+}: {
+  client: PhoenixClient;
+  projectIdentifier: string;
+  sessionIds: string[];
+  includeAnnotationNames?: string[];
+  excludeAnnotationNames?: string[];
+  pageLimit: number;
+}): Promise<SessionAnnotation[]> {
   const allAnnotations: SessionAnnotation[] = [];
   let cursor: string | undefined;
 
@@ -83,9 +199,11 @@ async function fetchSessionAnnotations(
             project_identifier: projectIdentifier,
           },
           query: {
-            session_ids: [sessionId],
+            session_ids: sessionIds,
+            include_annotation_names: includeAnnotationNames,
+            exclude_annotation_names: excludeAnnotationNames,
             cursor,
-            limit: 100,
+            limit: pageLimit,
           },
         },
       }
@@ -100,6 +218,65 @@ async function fetchSessionAnnotations(
   } while (cursor);
 
   return allAnnotations;
+}
+
+function buildSessionNote(annotation: SessionAnnotation): SessionNote {
+  return {
+    ...annotation,
+    name: NOTE_ANNOTATION_NAME,
+    result:
+      annotation.result == null
+        ? annotation.result
+        : { explanation: annotation.result.explanation ?? null },
+  };
+}
+
+function attachSessionAnnotations({
+  sessions,
+  annotations,
+}: {
+  sessions: SessionWithAnnotations[];
+  annotations: SessionAnnotation[];
+}): void {
+  const annotationsBySessionId = new Map<string, SessionAnnotation[]>();
+  for (const annotation of annotations) {
+    const annotationSessionId = annotation.session_id;
+    if (!annotationsBySessionId.has(annotationSessionId)) {
+      annotationsBySessionId.set(annotationSessionId, []);
+    }
+    annotationsBySessionId.get(annotationSessionId)!.push(annotation);
+  }
+
+  for (const session of sessions) {
+    const sessionAnnotations = annotationsBySessionId.get(session.session_id);
+    if (sessionAnnotations) {
+      session.annotations = sessionAnnotations;
+    }
+  }
+}
+
+function attachSessionNotes({
+  sessions,
+  notes,
+}: {
+  sessions: SessionWithAnnotations[];
+  notes: SessionAnnotation[];
+}): void {
+  const notesBySessionId = new Map<string, SessionNote[]>();
+  for (const note of notes) {
+    const noteSessionId = note.session_id;
+    if (!notesBySessionId.has(noteSessionId)) {
+      notesBySessionId.set(noteSessionId, []);
+    }
+    notesBySessionId.get(noteSessionId)!.push(buildSessionNote(note));
+  }
+
+  for (const session of sessions) {
+    const sessionNotes = notesBySessionId.get(session.session_id);
+    if (sessionNotes) {
+      session.notes = sessionNotes;
+    }
+  }
 }
 
 /**
@@ -185,7 +362,10 @@ async function sessionGetHandler(
     });
 
     // Fetch session
-    const session = await fetchSession(client, sessionId);
+    const session = await fetchSession({
+      client,
+      sessionIdentifier: sessionId,
+    });
 
     writeProgress({
       message: `Fetched session with ${session.traces.length} trace(s)`,
@@ -200,11 +380,12 @@ async function sessionGetHandler(
         noProgress: !options.progress,
       });
 
-      annotations = await fetchSessionAnnotations(
+      annotations = await fetchSessionAnnotations({
         client,
-        session.project_id,
-        session.session_id
-      );
+        projectIdentifier: session.project_id,
+        sessionIds: [session.session_id],
+        excludeAnnotationNames: [NOTE_ANNOTATION_NAME],
+      });
 
       writeProgress({
         message: `Found ${annotations.length} annotation(s)`,
@@ -212,8 +393,29 @@ async function sessionGetHandler(
       });
     }
 
+    let notes: SessionNote[] | undefined;
+    if (options.includeNotes) {
+      writeProgress({
+        message: "Fetching session notes...",
+        noProgress: !options.progress,
+      });
+
+      const noteAnnotations = await fetchSessionAnnotations({
+        client,
+        projectIdentifier: session.project_id,
+        sessionIds: [session.session_id],
+        includeAnnotationNames: [NOTE_ANNOTATION_NAME],
+      });
+      notes = noteAnnotations.map(buildSessionNote);
+
+      writeProgress({
+        message: `Found ${notes.length} note(s)`,
+        noProgress: !options.progress,
+      });
+    }
+
     // Determine output format
-    const outputFormat: OutputFormat = options.file
+    const outputFormat: SessionOutputFormat = options.file
       ? "json"
       : options.format || "pretty";
 
@@ -227,6 +429,7 @@ async function sessionGetHandler(
     const output = formatSessionOutput({
       session,
       annotations,
+      notes,
       format: outputFormat,
     });
 
@@ -293,10 +496,14 @@ async function sessionListHandler(options: SessionListOptions): Promise<void> {
       noProgress: !options.progress,
     });
 
-    const sessions = await fetchSessions(client, projectId, {
-      limit,
-      order: options.order,
-    });
+    const sessions: SessionWithAnnotations[] = await fetchSessions(
+      client,
+      projectId,
+      {
+        limit,
+        order: options.order,
+      }
+    );
 
     if (sessions.length === 0) {
       writeProgress({
@@ -310,6 +517,37 @@ async function sessionListHandler(options: SessionListOptions): Promise<void> {
       message: `Found ${sessions.length} session(s)`,
       noProgress: !options.progress,
     });
+
+    const sessionIds = sessions.map((session) => session.session_id);
+    if (options.includeAnnotations) {
+      writeProgress({
+        message: "Fetching session annotations...",
+        noProgress: !options.progress,
+      });
+
+      const annotations = await fetchSessionAnnotations({
+        client,
+        projectIdentifier: projectId,
+        sessionIds,
+        excludeAnnotationNames: [NOTE_ANNOTATION_NAME],
+      });
+      attachSessionAnnotations({ sessions, annotations });
+    }
+
+    if (options.includeNotes) {
+      writeProgress({
+        message: "Fetching session notes...",
+        noProgress: !options.progress,
+      });
+
+      const notes = await fetchSessionAnnotations({
+        client,
+        projectIdentifier: projectId,
+        sessionIds,
+        includeAnnotationNames: [NOTE_ANNOTATION_NAME],
+      });
+      attachSessionNotes({ sessions, notes });
+    }
 
     const output = formatSessionsOutput({
       sessions,
@@ -342,6 +580,7 @@ export function createSessionGetCommand(): Command {
     .option("--no-progress", "Disable progress indicators")
     .option("--file <path>", "Save session to file instead of stdout")
     .option("--include-annotations", "Include session annotations")
+    .option("--include-notes", "Include session notes")
     .action(sessionGetHandler);
 }
 
@@ -357,6 +596,8 @@ export function createSessionListCommand(): Command {
       "pretty"
     )
     .option("--no-progress", "Disable progress indicators")
+    .option("--include-annotations", "Include session annotations")
+    .option("--include-notes", "Include session notes")
     .option(
       "-n, --limit <number>",
       "Maximum number of sessions to return",
@@ -365,6 +606,206 @@ export function createSessionListCommand(): Command {
     )
     .option("--order <order>", "Sort order: asc or desc", "desc")
     .action(sessionListHandler);
+}
+
+async function sessionAnnotateHandler(
+  sessionId: string,
+  options: SessionAnnotateOptions
+): Promise<void> {
+  try {
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    const validation = validateConfig({ config, projectRequired: false });
+    if (!validation.valid) {
+      writeError({
+        message: getConfigErrorMessage({ errors: validation.errors }),
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+
+    const annotationInput = normalizeAnnotationInput({
+      targetType: "session",
+      name: options.name,
+      label: options.label,
+      score: options.score,
+      explanation: options.explanation,
+      annotatorKind: options.annotatorKind,
+    });
+
+    const client = createPhoenixClient({ config });
+
+    writeProgress({
+      message: `Resolving session ${sessionId}...`,
+      noProgress: !options.progress,
+    });
+
+    const session = await fetchSession({
+      client,
+      sessionIdentifier: sessionId,
+    });
+
+    writeProgress({
+      message: `Annotating session ${session.session_id}...`,
+      noProgress: !options.progress,
+    });
+
+    const result = await addSessionAnnotation({
+      client,
+      sync: true,
+      sessionAnnotation: {
+        sessionId: session.session_id,
+        name: annotationInput.name,
+        label: annotationInput.label ?? undefined,
+        score: annotationInput.score ?? undefined,
+        explanation: annotationInput.explanation ?? undefined,
+        annotatorKind: annotationInput.annotatorKind,
+        identifier: "",
+      },
+    });
+
+    if (!result?.id) {
+      throw new Error("Failed to add session annotation: no data returned");
+    }
+
+    const output = formatAnnotationMutationOutput({
+      annotation: buildAnnotationMutationResult({
+        id: result.id,
+        targetType: "session",
+        targetId: session.session_id,
+        annotationInput,
+      }),
+      format: options.format,
+    });
+    writeOutput({ message: output });
+  } catch (error) {
+    writeError({
+      message: `Error annotating session: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(getExitCodeForError(error));
+  }
+}
+
+export function createSessionAnnotateCommand(): Command {
+  return new Command("annotate")
+    .description("Add or update an annotation on a session")
+    .argument(
+      "<session-id>",
+      "Session identifier (GlobalID or user-provided session_id)"
+    )
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option("--name <name>", "Annotation name")
+    .option("--label <label>", "Annotation label")
+    .option("--score <number>", "Annotation score")
+    .option("--explanation <text>", "Annotation explanation")
+    .option(
+      "--annotator-kind <kind>",
+      "Annotator kind: HUMAN, LLM, or CODE",
+      "HUMAN"
+    )
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .addHelpText(
+      "after",
+      getAnnotationMutationHelpText({ targetType: "session" })
+    )
+    .action(sessionAnnotateHandler);
+}
+
+async function sessionAddNoteHandler(
+  sessionId: string,
+  options: SessionAddNoteOptions
+): Promise<void> {
+  try {
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    const validation = validateConfig({ config, projectRequired: false });
+    if (!validation.valid) {
+      writeError({
+        message: getConfigErrorMessage({ errors: validation.errors }),
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+
+    const text = normalizeNoteText({
+      targetType: "session",
+      text: options.text,
+    });
+
+    const client = createPhoenixClient({ config });
+
+    writeProgress({
+      message: `Resolving session ${sessionId}...`,
+      noProgress: !options.progress,
+    });
+
+    const session = await fetchSession({
+      client,
+      sessionIdentifier: sessionId,
+    });
+
+    writeProgress({
+      message: `Adding note to session ${session.session_id}...`,
+      noProgress: !options.progress,
+    });
+
+    const result = await addSessionNote({
+      client,
+      sessionNote: {
+        sessionId: session.session_id,
+        note: text,
+      },
+    });
+
+    const output = formatNoteMutationOutput({
+      note: buildNoteMutationResult({
+        id: result.id,
+        targetType: "session",
+        targetId: session.session_id,
+        text,
+      }),
+      format: options.format,
+    });
+    writeOutput({ message: output });
+  } catch (error) {
+    writeError({
+      message: `Error adding session note: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(getExitCodeForError(error));
+  }
+}
+
+export function createSessionAddNoteCommand(): Command {
+  return new Command("add-note")
+    .description("Add a note to a session")
+    .argument(
+      "<session-id>",
+      "Session identifier (GlobalID or user-provided session_id)"
+    )
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option("--text <text>", "Note text")
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .action(sessionAddNoteHandler);
 }
 
 interface SessionDeleteOptions {
@@ -442,6 +883,8 @@ export function createSessionCommand(): Command {
   command.description("Manage Phoenix sessions");
   command.addCommand(createSessionListCommand());
   command.addCommand(createSessionGetCommand());
+  command.addCommand(createSessionAnnotateCommand());
+  command.addCommand(createSessionAddNoteCommand());
   command.addCommand(createSessionDeleteCommand());
   return command;
 }

--- a/js/packages/phoenix-cli/src/commands/session.ts
+++ b/js/packages/phoenix-cli/src/commands/session.ts
@@ -425,11 +425,15 @@ async function sessionGetHandler(
       });
     }
 
+    const sessionWithAnnotations: SessionWithAnnotations = {
+      ...session,
+      ...(annotations ? { annotations } : {}),
+      ...(notes ? { notes } : {}),
+    };
+
     // Format output
     const output = formatSessionOutput({
-      session,
-      annotations,
-      notes,
+      session: sessionWithAnnotations,
       format: outputFormat,
     });
 
@@ -552,6 +556,8 @@ async function sessionListHandler(options: SessionListOptions): Promise<void> {
     const output = formatSessionsOutput({
       sessions,
       format: options.format,
+      includeAnnotations: options.includeAnnotations,
+      includeNotes: options.includeNotes,
     });
     writeOutput({ message: output });
   } catch (error) {

--- a/js/packages/phoenix-cli/src/commands/span.ts
+++ b/js/packages/phoenix-cli/src/commands/span.ts
@@ -328,7 +328,12 @@ async function spanListHandler(
         noProgress: !options.progress,
       });
     } else {
-      const output = formatSpansOutput({ spans, format: options.format });
+      const output = formatSpansOutput({
+        spans,
+        format: options.format,
+        includeAnnotations: options.includeAnnotations,
+        includeNotes: options.includeNotes,
+      });
       writeOutput({ message: output });
     }
   } catch (error) {

--- a/js/packages/phoenix-cli/src/commands/spanAnnotations.ts
+++ b/js/packages/phoenix-cli/src/commands/spanAnnotations.ts
@@ -1,5 +1,7 @@
 import type { componentsV1, PhoenixClient } from "@arizeai/phoenix-client";
 
+import { chunkArray } from "./chunkArray";
+
 export type SpanAnnotation = componentsV1["schemas"]["SpanAnnotation"];
 
 const DEFAULT_PAGE_LIMIT = 1000;
@@ -14,14 +16,6 @@ interface FetchSpanAnnotationsOptions {
   excludeAnnotationNames?: string[];
   pageLimit?: number;
   maxConcurrent?: number;
-}
-
-function chunkArray<T>(items: T[], size: number): T[][] {
-  const chunks: T[][] = [];
-  for (let i = 0; i < items.length; i += size) {
-    chunks.push(items.slice(i, i + size));
-  }
-  return chunks;
 }
 
 async function fetchSpanAnnotationsForChunk({
@@ -88,11 +82,14 @@ export async function fetchSpanAnnotations({
   }
 
   const uniqueSpanIds = Array.from(new Set(spanIds));
-  const chunks = chunkArray(uniqueSpanIds, DEFAULT_SPAN_IDS_CHUNK_SIZE);
+  const chunks = chunkArray({
+    items: uniqueSpanIds,
+    size: DEFAULT_SPAN_IDS_CHUNK_SIZE,
+  });
   const allAnnotations: SpanAnnotation[] = [];
 
-  for (let i = 0; i < chunks.length; i += maxConcurrent) {
-    const batch = chunks.slice(i, i + maxConcurrent);
+  for (let index = 0; index < chunks.length; index += maxConcurrent) {
+    const batch = chunks.slice(index, index + maxConcurrent);
     const batchResults = await Promise.all(
       batch.map((spanIdsChunk) =>
         fetchSpanAnnotationsForChunk({

--- a/js/packages/phoenix-cli/src/commands/traceAnnotations.ts
+++ b/js/packages/phoenix-cli/src/commands/traceAnnotations.ts
@@ -1,5 +1,7 @@
 import type { componentsV1, PhoenixClient } from "@arizeai/phoenix-client";
 
+import { chunkArray } from "./chunkArray";
+
 export type TraceAnnotation = componentsV1["schemas"]["TraceAnnotation"];
 
 const DEFAULT_PAGE_LIMIT = 1000;
@@ -14,14 +16,6 @@ interface FetchTraceAnnotationsOptions {
   excludeAnnotationNames?: string[];
   pageLimit?: number;
   maxConcurrent?: number;
-}
-
-function chunkArray<T>(items: T[], size: number): T[][] {
-  const chunks: T[][] = [];
-  for (let i = 0; i < items.length; i += size) {
-    chunks.push(items.slice(i, i + size));
-  }
-  return chunks;
 }
 
 async function fetchTraceAnnotationsForChunk({
@@ -88,11 +82,14 @@ export async function fetchTraceAnnotations({
   }
 
   const uniqueTraceIds = Array.from(new Set(traceIds));
-  const chunks = chunkArray(uniqueTraceIds, DEFAULT_TRACE_IDS_CHUNK_SIZE);
+  const chunks = chunkArray({
+    items: uniqueTraceIds,
+    size: DEFAULT_TRACE_IDS_CHUNK_SIZE,
+  });
   const allAnnotations: TraceAnnotation[] = [];
 
-  for (let i = 0; i < chunks.length; i += maxConcurrent) {
-    const batch = chunks.slice(i, i + maxConcurrent);
+  for (let index = 0; index < chunks.length; index += maxConcurrent) {
+    const batch = chunks.slice(index, index + maxConcurrent);
     const batchResults = await Promise.all(
       batch.map((traceIdsChunk) =>
         fetchTraceAnnotationsForChunk({

--- a/js/packages/phoenix-cli/test/cli.test.ts
+++ b/js/packages/phoenix-cli/test/cli.test.ts
@@ -97,7 +97,7 @@ describe("Phoenix CLI", () => {
     ).toBeUndefined();
   });
 
-  it("should register session list and session get as the primary session commands", () => {
+  it("should register session commands", () => {
     const program = createProgram();
     const sessionCommand = program.commands.find(
       (command) => command.name() === "session"
@@ -105,8 +105,13 @@ describe("Phoenix CLI", () => {
 
     expect(sessionCommand).toBeDefined();
     expect(sessionCommand?.commands.map((command) => command.name())).toEqual(
-      expect.arrayContaining(["list", "get"])
+      expect.arrayContaining(["list", "get", "annotate", "add-note"])
     );
+    const listCommand = sessionCommand?.commands.find(
+      (command) => command.name() === "list"
+    );
+    expect(listCommand?.helpInformation()).toContain("--include-annotations");
+    expect(listCommand?.helpInformation()).toContain("--include-notes");
     expect(
       program.commands.find((command) => command.name() === "sessions")
     ).toBeUndefined();

--- a/js/packages/phoenix-cli/test/output.test.ts
+++ b/js/packages/phoenix-cli/test/output.test.ts
@@ -334,6 +334,18 @@ describe("Output Formatting", () => {
   });
 
   describe("span output - pretty", () => {
+    it("should include requested empty annotation and note columns", () => {
+      const output = formatSpansOutput({
+        spans: [mockSpan1],
+        format: "pretty",
+        includeAnnotations: true,
+        includeNotes: true,
+      });
+
+      expect(output).toContain("annotations");
+      expect(output).toContain("notes");
+    });
+
     it("should include a notes column when notes are present", () => {
       const output = formatSpansOutput({
         spans: mockTraceWithNotes.spans,

--- a/js/packages/phoenix-cli/test/sessionAnnotationsNotes.test.ts
+++ b/js/packages/phoenix-cli/test/sessionAnnotationsNotes.test.ts
@@ -1,0 +1,696 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createSessionCommand } from "../src/commands/session";
+import { ExitCode } from "../src/exitCodes";
+
+function makeFetchMock(
+  responses: Array<
+    | {
+        ok: boolean;
+        status?: number;
+        body?: unknown;
+        text?: string;
+        headers?: Record<string, string>;
+      }
+    | { error: Error }
+  >
+) {
+  let callIndex = 0;
+  return vi.fn().mockImplementation((requestOrUrl: Request | string) => {
+    const response = responses[callIndex++] ?? responses[responses.length - 1];
+    if ("error" in response) {
+      return Promise.reject(response.error);
+    }
+    const status = response.status ?? (response.ok ? 200 : 500);
+    const url =
+      requestOrUrl instanceof Request ? requestOrUrl.url : requestOrUrl;
+    return Promise.resolve({
+      ok: response.ok,
+      status,
+      statusText: response.ok ? "OK" : "Error",
+      url,
+      headers: new Headers(response.headers),
+      json: () => Promise.resolve(response.body ?? {}),
+      text: () => Promise.resolve(response.text ?? ""),
+    });
+  });
+}
+
+function getFetchUrl(arg: unknown): string {
+  if (arg instanceof Request) return arg.url;
+  return String(arg);
+}
+
+function getFetchMethod(arg: unknown, init?: RequestInit): string {
+  if (arg instanceof Request) return arg.method;
+  return init?.method ?? "GET";
+}
+
+async function getFetchBody(
+  arg: unknown,
+  init?: RequestInit
+): Promise<unknown> {
+  if (arg instanceof Request) {
+    const text = await arg.clone().text();
+    return text ? JSON.parse(text) : undefined;
+  }
+  if (typeof init?.body === "string") {
+    return JSON.parse(init.body);
+  }
+  return undefined;
+}
+
+function makeProjectResponse() {
+  return {
+    ok: true,
+    body: {
+      data: {
+        id: "project-default",
+      },
+    },
+  } as const;
+}
+
+function makeSessionResponse() {
+  return {
+    ok: true,
+    body: {
+      data: {
+        id: "U2Vzc2lvbjox",
+        session_id: "session-123",
+        project_id: "project-default",
+        start_time: "2026-01-13T10:00:00.000Z",
+        end_time: "2026-01-13T10:01:00.000Z",
+        traces: [],
+      },
+    },
+  } as const;
+}
+
+function makeSessionPageResponse() {
+  return {
+    ok: true,
+    body: {
+      data: [
+        {
+          id: "U2Vzc2lvbjox",
+          session_id: "session-123",
+          project_id: "project-default",
+          start_time: "2026-01-13T10:00:00.000Z",
+          end_time: "2026-01-13T10:01:00.000Z",
+          traces: [],
+        },
+      ],
+      next_cursor: null,
+    },
+  } as const;
+}
+
+function makeSessionAnnotationResponse() {
+  return {
+    ok: true,
+    body: {
+      data: [
+        {
+          id: "session-annotation-1",
+          created_at: "2026-01-13T10:00:00.500Z",
+          updated_at: "2026-01-13T10:00:00.500Z",
+          source: "API",
+          user_id: null,
+          name: "reviewer",
+          annotator_kind: "HUMAN",
+          result: {
+            label: "pass",
+          },
+          metadata: null,
+          identifier: "",
+          session_id: "session-123",
+        },
+      ],
+      next_cursor: null,
+    },
+  } as const;
+}
+
+function makeSessionNoteResponse() {
+  return {
+    ok: true,
+    body: {
+      data: [
+        {
+          id: "session-note-1",
+          created_at: "2026-01-13T10:00:00.750Z",
+          updated_at: "2026-01-13T10:00:00.750Z",
+          source: "API",
+          user_id: null,
+          name: "note",
+          annotator_kind: "HUMAN",
+          result: {
+            explanation: "session note text",
+          },
+          metadata: null,
+          identifier: "px-session-note:1",
+          session_id: "session-123",
+        },
+      ],
+      next_cursor: null,
+    },
+  } as const;
+}
+
+const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
+const SERVER_VERSION_RESPONSE = {
+  ok: true,
+  text: "14.17.0",
+} as const;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("session annotate", () => {
+  it("resolves a session and posts a sync session annotation", async () => {
+    const fetchMock = makeFetchMock([
+      makeSessionResponse(),
+      SERVER_VERSION_RESPONSE,
+      {
+        ok: true,
+        body: { data: [{ id: "session-annotation-1" }] },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSessionCommand().parseAsync(
+      [
+        "annotate",
+        "U2Vzc2lvbjox",
+        "--name",
+        " reviewer ",
+        "--label",
+        " pass ",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
+      "/v1/sessions/U2Vzc2lvbjox"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
+      "/v1/session_annotations"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain("sync=true");
+    expect(
+      getFetchMethod(fetchMock.mock.calls[2][0], fetchMock.mock.calls[2][1])
+    ).toBe("POST");
+    await expect(
+      getFetchBody(fetchMock.mock.calls[2][0], fetchMock.mock.calls[2][1])
+    ).resolves.toEqual({
+      data: [
+        {
+          session_id: "session-123",
+          name: "reviewer",
+          annotator_kind: "HUMAN",
+          result: { label: "pass" },
+          metadata: null,
+          identifier: "",
+        },
+      ],
+    });
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        id: "session-annotation-1",
+        targetType: "session",
+        targetId: "session-123",
+        name: "reviewer",
+        label: "pass",
+        score: null,
+        explanation: null,
+        annotatorKind: "HUMAN",
+        identifier: "",
+      })
+    );
+  });
+
+  it("validates missing annotation names before network calls", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSessionCommand().parseAsync(
+        ["annotate", "session-123", "--label", "pass", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Missing required flag --name.")
+    );
+  });
+
+  it("validates invalid scores before network calls", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSessionCommand().parseAsync(
+        [
+          "annotate",
+          "session-123",
+          "--name",
+          "score",
+          "--score",
+          "nope",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid value for --score: nope. Expected a finite number."
+      )
+    );
+  });
+
+  it("validates empty annotation results before network calls", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSessionCommand().parseAsync(
+        ["annotate", "session-123", "--name", "reviewer", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "At least one of --label, --score, or --explanation must be provided."
+      )
+    );
+  });
+
+  it("validates invalid annotator kinds before network calls", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSessionCommand().parseAsync(
+        [
+          "annotate",
+          "session-123",
+          "--name",
+          "reviewer",
+          "--label",
+          "pass",
+          "--annotator-kind",
+          "bot",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid value for --annotator-kind: bot")
+    );
+  });
+
+  it("reports API errors from session annotation", async () => {
+    const fetchMock = makeFetchMock([
+      makeSessionResponse(),
+      SERVER_VERSION_RESPONSE,
+      {
+        ok: false,
+        status: 400,
+        body: { detail: "The name 'note' is reserved for session notes." },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSessionCommand().parseAsync(
+        [
+          "annotate",
+          "session-123",
+          "--name",
+          "note",
+          "--label",
+          "pass",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow();
+
+    expect(exitSpy).toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Error annotating session:")
+    );
+  });
+});
+
+describe("session add-note", () => {
+  it("resolves a session and posts a session note", async () => {
+    const fetchMock = makeFetchMock([
+      makeSessionResponse(),
+      SERVER_VERSION_RESPONSE,
+      {
+        ok: true,
+        body: { data: { id: "session-note-1" } },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSessionCommand().parseAsync(
+      [
+        "add-note",
+        "U2Vzc2lvbjox",
+        "--text",
+        "  needs review  ",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
+      "/v1/sessions/U2Vzc2lvbjox"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain(
+      "/arize_phoenix_version"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
+      "/v1/session_notes"
+    );
+    await expect(
+      getFetchBody(fetchMock.mock.calls[2][0], fetchMock.mock.calls[2][1])
+    ).resolves.toEqual({
+      data: {
+        session_id: "session-123",
+        note: "needs review",
+      },
+    });
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        id: "session-note-1",
+        targetType: "session",
+        targetId: "session-123",
+        text: "needs review",
+      })
+    );
+  });
+
+  it("validates blank note text before network calls", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSessionCommand().parseAsync(
+        ["add-note", "session-123", "--text", "   ", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid value for --text: <empty>. Expected non-empty text."
+      )
+    );
+  });
+
+  it("fails fast on older Phoenix servers", async () => {
+    const fetchMock = makeFetchMock([
+      makeSessionResponse(),
+      {
+        ok: true,
+        text: "14.16.0",
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSessionCommand().parseAsync(
+        [
+          "add-note",
+          "session-123",
+          "--text",
+          "needs review",
+          "--format",
+          "raw",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow();
+
+    expect(exitSpy).toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("requires Phoenix server >= 14.17.0")
+    );
+  });
+});
+
+describe("session annotation and note readback", () => {
+  it("includes notes in session get raw output when requested", async () => {
+    const fetchMock = makeFetchMock([
+      makeSessionResponse(),
+      makeSessionNoteResponse(),
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSessionCommand().parseAsync(
+      [
+        "get",
+        "session-123",
+        "--include-notes",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain(
+      "/v1/projects/project-default/session_annotations"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain(
+      "include_annotation_names=note"
+    );
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const parsedOutput = JSON.parse(String(output));
+    expect(parsedOutput.session.notes).toEqual([
+      expect.objectContaining({ id: "session-note-1", name: "note" }),
+    ]);
+    expect(parsedOutput.notes).toEqual([
+      expect.objectContaining({ id: "session-note-1", name: "note" }),
+    ]);
+  });
+
+  it("excludes notes from session get annotations", async () => {
+    const fetchMock = makeFetchMock([
+      makeSessionResponse(),
+      makeSessionAnnotationResponse(),
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSessionCommand().parseAsync(
+      [
+        "get",
+        "session-123",
+        "--include-annotations",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain(
+      "exclude_annotation_names=note"
+    );
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const parsedOutput = JSON.parse(String(output));
+    expect(parsedOutput.session.annotations).toEqual([
+      expect.objectContaining({ id: "session-annotation-1", name: "reviewer" }),
+    ]);
+    expect(parsedOutput.session.annotations).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "note" })])
+    );
+  });
+
+  it("includes annotations and notes in session list raw output", async () => {
+    const fetchMock = makeFetchMock([
+      makeProjectResponse(),
+      makeSessionPageResponse(),
+      makeSessionAnnotationResponse(),
+      makeSessionNoteResponse(),
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSessionCommand().parseAsync(
+      [
+        "list",
+        "--project",
+        "default",
+        "--include-annotations",
+        "--include-notes",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    const annotationsUrl = new URL(getFetchUrl(fetchMock.mock.calls[2][0]));
+    const notesUrl = new URL(getFetchUrl(fetchMock.mock.calls[3][0]));
+    expect(annotationsUrl.searchParams.getAll("session_ids")).toEqual([
+      "session-123",
+    ]);
+    expect(
+      annotationsUrl.searchParams.getAll("exclude_annotation_names")
+    ).toEqual(["note"]);
+    expect(notesUrl.searchParams.getAll("session_ids")).toEqual([
+      "session-123",
+    ]);
+    expect(notesUrl.searchParams.getAll("include_annotation_names")).toEqual([
+      "note",
+    ]);
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const parsedOutput = JSON.parse(String(output));
+    expect(parsedOutput[0].annotations).toEqual([
+      expect.objectContaining({ id: "session-annotation-1", name: "reviewer" }),
+    ]);
+    expect(parsedOutput[0].notes).toEqual([
+      expect.objectContaining({ id: "session-note-1", name: "note" }),
+    ]);
+  });
+
+  it("chunks session annotation reads for session list", async () => {
+    const sessionIds = Array.from(
+      { length: 101 },
+      (_, index) => `session-${index + 1}`
+    );
+    const fetchMock = makeFetchMock([
+      makeProjectResponse(),
+      {
+        ok: true,
+        body: {
+          data: sessionIds.map((sessionId, index) => ({
+            id: `U2Vzc2lvbjox${index}`,
+            session_id: sessionId,
+            project_id: "project-default",
+            start_time: "2026-01-13T10:00:00.000Z",
+            end_time: "2026-01-13T10:01:00.000Z",
+            traces: [],
+          })),
+          next_cursor: null,
+        },
+      },
+      { ok: true, body: { data: [], next_cursor: null } },
+      { ok: true, body: { data: [], next_cursor: null } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSessionCommand().parseAsync(
+      [
+        "list",
+        "--project",
+        "default",
+        "--limit",
+        "101",
+        "--include-annotations",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    const firstAnnotationsUrl = new URL(
+      getFetchUrl(fetchMock.mock.calls[2][0])
+    );
+    const secondAnnotationsUrl = new URL(
+      getFetchUrl(fetchMock.mock.calls[3][0])
+    );
+    expect(firstAnnotationsUrl.searchParams.getAll("session_ids")).toHaveLength(
+      100
+    );
+    expect(secondAnnotationsUrl.searchParams.getAll("session_ids")).toEqual([
+      "session-101",
+    ]);
+  });
+});

--- a/js/packages/phoenix-cli/test/sessionAnnotationsNotes.test.ts
+++ b/js/packages/phoenix-cli/test/sessionAnnotationsNotes.test.ts
@@ -547,9 +547,7 @@ describe("session annotation and note readback", () => {
     expect(parsedOutput.session.notes).toEqual([
       expect.objectContaining({ id: "session-note-1", name: "note" }),
     ]);
-    expect(parsedOutput.notes).toEqual([
-      expect.objectContaining({ id: "session-note-1", name: "note" }),
-    ]);
+    expect(parsedOutput.notes).toBeUndefined();
   });
 
   it("excludes notes from session get annotations", async () => {
@@ -582,9 +580,38 @@ describe("session annotation and note readback", () => {
     expect(parsedOutput.session.annotations).toEqual([
       expect.objectContaining({ id: "session-annotation-1", name: "reviewer" }),
     ]);
+    expect(parsedOutput.annotations).toBeUndefined();
     expect(parsedOutput.session.annotations).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ name: "note" })])
     );
+  });
+
+  it("renders requested empty annotation and note columns in session list pretty output", async () => {
+    const fetchMock = makeFetchMock([
+      makeProjectResponse(),
+      makeSessionPageResponse(),
+      { ok: true, body: { data: [], next_cursor: null } },
+      { ok: true, body: { data: [], next_cursor: null } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSessionCommand().parseAsync(
+      [
+        "list",
+        "--project",
+        "default",
+        "--include-annotations",
+        "--include-notes",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    const output = String(stdoutSpy.mock.calls[0]?.[0]);
+    expect(output).toContain("annotations");
+    expect(output).toContain("notes");
   });
 
   it("includes annotations and notes in session list raw output", async () => {

--- a/js/packages/phoenix-client/README.md
+++ b/js/packages/phoenix-client/README.md
@@ -505,6 +505,7 @@ import {
   listSessions,
   getSession,
   addSessionAnnotation,
+  addSessionNote,
 } from "@arizeai/phoenix-client/sessions";
 
 // List all sessions for a project
@@ -533,6 +534,19 @@ await addSessionAnnotation({
     label: "satisfied",
     score: 0.9,
     annotatorKind: "HUMAN",
+  },
+});
+```
+
+### Adding Session Notes
+
+Session notes require Phoenix server `14.17.0` or newer.
+
+```ts
+await addSessionNote({
+  sessionNote: {
+    sessionId: "my-session-id",
+    note: "Needs review",
   },
 });
 ```

--- a/js/packages/phoenix-client/src/constants/serverRequirements.ts
+++ b/js/packages/phoenix-client/src/constants/serverRequirements.ts
@@ -60,6 +60,13 @@ export const ADD_TRACE_NOTE: RouteRequirement = {
   minServerVersion: [14, 13, 0],
 };
 
+export const ADD_SESSION_NOTE: RouteRequirement = {
+  kind: "route",
+  method: "POST",
+  path: "/v1/session_notes",
+  minServerVersion: [14, 17, 0],
+};
+
 export const GET_SPANS_TRACE_IDS: ParameterRequirement = {
   kind: "parameter",
   parameterName: "trace_id",
@@ -104,6 +111,7 @@ export const ALL_REQUIREMENTS: readonly CapabilityRequirement[] = [
   LIST_PROJECT_SESSIONS,
   ANNOTATE_SESSIONS,
   ADD_TRACE_NOTE,
+  ADD_SESSION_NOTE,
   GET_SPANS_TRACE_IDS,
   GET_SPANS_FILTERS,
   GET_SPANS_BY_ATTRIBUTE,

--- a/js/packages/phoenix-client/src/sessions/addSessionNote.ts
+++ b/js/packages/phoenix-client/src/sessions/addSessionNote.ts
@@ -1,0 +1,73 @@
+import { createClient } from "../client";
+import { ADD_SESSION_NOTE } from "../constants/serverRequirements";
+import type { ClientFn } from "../types/core";
+import { ensureServerCapability } from "../utils/serverVersionUtils";
+
+/**
+ * Parameters for a single session note.
+ */
+export interface SessionNote {
+  /**
+   * The session ID used to track a conversation, thread, or session.
+   */
+  sessionId: string;
+  /**
+   * The note text to add to the session.
+   */
+  note: string;
+}
+
+/**
+ * Parameters to add a session note.
+ */
+export interface AddSessionNoteParams extends ClientFn {
+  sessionNote: SessionNote;
+}
+
+/**
+ * Add a note to a session.
+ *
+ * Notes are a special type of annotation that allow multiple entries per session.
+ * Each note gets a unique UUIDv4 identifier.
+ *
+ * @param params - The parameters to add a session note.
+ * @returns The ID of the created note annotation.
+ *
+ * @requires Phoenix server >= 14.17.0
+ *
+ * @example
+ * ```ts
+ * const result = await addSessionNote({
+ *   sessionNote: {
+ *     sessionId: "my-session",
+ *     note: "Needs review"
+ *   }
+ * });
+ * ```
+ */
+export async function addSessionNote({
+  client: _client,
+  sessionNote,
+}: AddSessionNoteParams): Promise<{ id: string }> {
+  const client = _client ?? createClient();
+  await ensureServerCapability({ client, requirement: ADD_SESSION_NOTE });
+
+  const { data, error } = await client.POST("/v1/session_notes", {
+    body: {
+      data: {
+        session_id: sessionNote.sessionId.trim(),
+        note: sessionNote.note,
+      },
+    },
+  });
+
+  if (error) {
+    throw new Error(`Failed to add session note: ${error}`);
+  }
+
+  if (!data?.data) {
+    throw new Error("Failed to add session note: no data returned");
+  }
+
+  return data.data;
+}

--- a/js/packages/phoenix-client/src/sessions/addSessionNote.ts
+++ b/js/packages/phoenix-client/src/sessions/addSessionNote.ts
@@ -1,6 +1,7 @@
 import { createClient } from "../client";
 import { ADD_SESSION_NOTE } from "../constants/serverRequirements";
 import type { ClientFn } from "../types/core";
+import { formatApiError } from "../utils/apiErrorUtils";
 import { ensureServerCapability } from "../utils/serverVersionUtils";
 
 /**
@@ -62,7 +63,7 @@ export async function addSessionNote({
   });
 
   if (error) {
-    throw new Error(`Failed to add session note: ${error}`);
+    throw new Error(`Failed to add session note: ${formatApiError(error)}`);
   }
 
   if (!data?.data) {

--- a/js/packages/phoenix-client/src/sessions/index.ts
+++ b/js/packages/phoenix-client/src/sessions/index.ts
@@ -1,4 +1,5 @@
 export * from "./addSessionAnnotation";
+export * from "./addSessionNote";
 export * from "./deleteSession";
 export * from "./deleteSessions";
 export * from "./getSession";

--- a/js/packages/phoenix-client/src/spans/addSpanNote.ts
+++ b/js/packages/phoenix-client/src/spans/addSpanNote.ts
@@ -1,5 +1,6 @@
 import { createClient } from "../client";
 import type { ClientFn } from "../types/core";
+import { formatApiError } from "../utils/apiErrorUtils";
 
 /**
  * Parameters for a single span note
@@ -58,7 +59,7 @@ export async function addSpanNote({
   });
 
   if (error) {
-    throw new Error(`Failed to add span note: ${error}`);
+    throw new Error(`Failed to add span note: ${formatApiError(error)}`);
   }
 
   if (!data?.data) {

--- a/js/packages/phoenix-client/src/traces/addTraceNote.ts
+++ b/js/packages/phoenix-client/src/traces/addTraceNote.ts
@@ -1,6 +1,7 @@
 import { createClient } from "../client";
 import { ADD_TRACE_NOTE } from "../constants/serverRequirements";
 import type { ClientFn } from "../types/core";
+import { formatApiError } from "../utils/apiErrorUtils";
 import { ensureServerCapability } from "../utils/serverVersionUtils";
 
 /**
@@ -60,7 +61,7 @@ export async function addTraceNote({
   });
 
   if (error) {
-    throw new Error(`Failed to add trace note: ${error}`);
+    throw new Error(`Failed to add trace note: ${formatApiError(error)}`);
   }
 
   if (!data?.data) {

--- a/js/packages/phoenix-client/src/utils/apiErrorUtils.ts
+++ b/js/packages/phoenix-client/src/utils/apiErrorUtils.ts
@@ -1,0 +1,17 @@
+export function formatApiError(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error && typeof error === "object") {
+    const errorWithDetail = error as { detail?: unknown };
+    if (typeof errorWithDetail.detail === "string") {
+      return errorWithDetail.detail;
+    }
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+  return String(error);
+}

--- a/js/packages/phoenix-client/test/sessions/addSessionNote.test.ts
+++ b/js/packages/phoenix-client/test/sessions/addSessionNote.test.ts
@@ -72,6 +72,23 @@ describe("addSessionNote", () => {
     ).rejects.toThrow("Failed to add session note: Session not found");
   });
 
+  it("formats FastAPI detail errors", async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: { detail: "Session not found" },
+    });
+
+    await expect(
+      addSessionNote({
+        client: makeClient() as never,
+        sessionNote: {
+          sessionId: "missing-session",
+          note: "This will fail",
+        },
+      })
+    ).rejects.toThrow("Failed to add session note: Session not found");
+  });
+
   it("throws when no data is returned", async () => {
     mockPOST.mockResolvedValueOnce({
       data: undefined,

--- a/js/packages/phoenix-client/test/sessions/addSessionNote.test.ts
+++ b/js/packages/phoenix-client/test/sessions/addSessionNote.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.unmock("../../src/utils/serverVersionUtils");
+
+import { addSessionNote } from "../../src/sessions/addSessionNote";
+
+const mockPOST = vi.fn();
+
+describe("addSessionNote", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPOST.mockResolvedValue({
+      data: {
+        data: { id: "test-session-note-id-1" },
+      },
+      error: null,
+    });
+  });
+
+  function makeClient() {
+    return {
+      getServerVersion: async () => [14, 17, 0] as [number, number, number],
+      POST: mockPOST,
+    };
+  }
+
+  it("adds a session note", async () => {
+    const result = await addSessionNote({
+      client: makeClient() as never,
+      sessionNote: {
+        sessionId: "session-123",
+        note: "This is a session note",
+      },
+    });
+
+    expect(result).toEqual({ id: "test-session-note-id-1" });
+  });
+
+  it("trims the session ID", async () => {
+    await addSessionNote({
+      client: makeClient() as never,
+      sessionNote: {
+        sessionId: "  session-123  ",
+        note: "This is a session note",
+      },
+    });
+
+    expect(mockPOST).toHaveBeenCalledWith("/v1/session_notes", {
+      body: {
+        data: {
+          session_id: "session-123",
+          note: "This is a session note",
+        },
+      },
+    });
+  });
+
+  it("throws when the API returns an error", async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: "Session not found",
+    });
+
+    await expect(
+      addSessionNote({
+        client: makeClient() as never,
+        sessionNote: {
+          sessionId: "missing-session",
+          note: "This will fail",
+        },
+      })
+    ).rejects.toThrow("Failed to add session note: Session not found");
+  });
+
+  it("throws when no data is returned", async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: undefined,
+    });
+
+    await expect(
+      addSessionNote({
+        client: makeClient() as never,
+        sessionNote: {
+          sessionId: "session-123",
+          note: "This will fail",
+        },
+      })
+    ).rejects.toThrow("Failed to add session note: no data returned");
+  });
+
+  it("fails fast on older Phoenix servers", async () => {
+    const guardedPOST = vi.fn();
+    const mockClient = {
+      getServerVersion: async () => [14, 16, 0] as [number, number, number],
+      POST: guardedPOST,
+    };
+
+    await expect(
+      addSessionNote({
+        client: mockClient as never,
+        sessionNote: {
+          sessionId: "session-123",
+          note: "This is a session note",
+        },
+      })
+    ).rejects.toThrow(/requires Phoenix server >= 14\.17\.0/);
+
+    expect(guardedPOST).not.toHaveBeenCalled();
+  });
+});

--- a/js/packages/phoenix-client/test/spans/addSpanNote.test.ts
+++ b/js/packages/phoenix-client/test/spans/addSpanNote.test.ts
@@ -76,6 +76,22 @@ describe("addSpanNote", () => {
     ).rejects.toThrow("Failed to add span note: Span not found");
   });
 
+  it("should format FastAPI detail errors", async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: { detail: "Span not found" },
+    });
+
+    await expect(
+      addSpanNote({
+        spanNote: {
+          spanId: "nonexistent",
+          note: "This will fail",
+        },
+      })
+    ).rejects.toThrow("Failed to add span note: Span not found");
+  });
+
   it("should throw error when no data is returned", async () => {
     mockPOST.mockResolvedValueOnce({
       data: undefined,

--- a/js/packages/phoenix-client/test/traces/addTraceNote.test.ts
+++ b/js/packages/phoenix-client/test/traces/addTraceNote.test.ts
@@ -72,6 +72,23 @@ describe("addTraceNote", () => {
     ).rejects.toThrow("Failed to add trace note: Trace not found");
   });
 
+  it("formats FastAPI detail errors", async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: { detail: "Trace not found" },
+    });
+
+    await expect(
+      addTraceNote({
+        client: makeClient() as never,
+        traceNote: {
+          traceId: "missing-trace",
+          note: "This will fail",
+        },
+      })
+    ).rejects.toThrow("Failed to add trace note: Trace not found");
+  });
+
   it("throws when no data is returned", async () => {
     mockPOST.mockResolvedValueOnce({
       data: undefined,

--- a/src/phoenix/server/api/routers/v1/sessions.py
+++ b/src/phoenix/server/api/routers/v1/sessions.py
@@ -446,8 +446,14 @@ async def annotate_sessions(
             )
             inserted_ids.append(session_annotation_id)
 
+    request.state.event_queue.put(ProjectSessionAnnotationInsertEvent(tuple(inserted_ids)))
     return AnnotateSessionsResponseBody(
-        data=[InsertedSessionAnnotation(id=str(inserted_id)) for inserted_id in inserted_ids]
+        data=[
+            InsertedSessionAnnotation(
+                id=str(GlobalID(SessionAnnotationNodeType.__name__, str(inserted_id)))
+            )
+            for inserted_id in inserted_ids
+        ]
     )
 
 

--- a/tests/unit/server/api/routers/v1/test_sessions.py
+++ b/tests/unit/server/api/routers/v1/test_sessions.py
@@ -15,6 +15,8 @@ from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.Project import Project as ProjectNodeType
 from phoenix.server.api.types.ProjectSession import ProjectSession as ProjectSessionNodeType
 from phoenix.server.api.types.Trace import Trace as TraceNodeType
+from phoenix.server.dml_event import ProjectSessionAnnotationInsertEvent
+from phoenix.server.dml_event_handler import DmlEventHandler
 from phoenix.server.types import DbSessionFactory
 
 
@@ -251,6 +253,58 @@ class TestDeleteSessions:
 
 
 class TestAnnotateSessions:
+    async def test_rest_session_annotation_sync_returns_global_ids_and_emits_dml_event(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+        monkeypatch: Any,
+    ) -> None:
+        _, session_model, _ = await _insert_session_with_traces(db)
+        events: list[Any] = []
+        original_put = DmlEventHandler.put
+
+        def spy_put(self: DmlEventHandler, event: Any) -> None:
+            events.append(event)
+            original_put(self, event)
+
+        monkeypatch.setattr(DmlEventHandler, "put", spy_put)
+
+        request_body = {
+            "data": [
+                {
+                    "session_id": session_model.session_id,
+                    "name": "reviewer",
+                    "annotator_kind": "HUMAN",
+                    "result": {"label": "pass"},
+                    "metadata": {},
+                    "identifier": "identifier-name",
+                }
+            ]
+        }
+        response = await httpx_client.post("v1/session_annotations?sync=true", json=request_body)
+
+        assert response.status_code == 200
+        annotation_id = response.json()["data"][0]["id"]
+        rowid = from_global_id_with_expected_type(
+            GlobalID.from_id(annotation_id), "ProjectSessionAnnotation"
+        )
+        dml_events = [
+            event for event in events if isinstance(event, ProjectSessionAnnotationInsertEvent)
+        ]
+        assert dml_events == [ProjectSessionAnnotationInsertEvent((rowid,))]
+
+        async with db() as session:
+            orm_annotation = await session.scalar(
+                select(models.ProjectSessionAnnotation).where(
+                    models.ProjectSessionAnnotation.id == rowid,
+                    models.ProjectSessionAnnotation.name == "reviewer",
+                )
+            )
+
+        assert orm_annotation is not None
+        assert orm_annotation.project_session_id == session_model.id
+        assert orm_annotation.label == "pass"
+
     async def test_rest_session_annotation_rejects_note_name(
         self,
         httpx_client: httpx.AsyncClient,


### PR DESCRIPTION
## Summary

Adds session annotation and note support to the Phoenix CLI, matching the existing trace/span annotation and note flows.

- adds `px session annotate <session-id>` for creating/updating session annotations
- adds `px session add-note <session-id> --text <note>` backed by `POST /v1/session_notes`
- supports both session GlobalIDs and user-facing `session_id` values by resolving through `GET /v1/sessions/{session_identifier}` before writes
- adds `--include-annotations` and `--include-notes` to `px session list`, plus `--include-notes` to `px session get`
- keeps notes separate from regular annotations by fetching `name=note` separately and excluding notes from annotation reads
- adds `addSessionNote` to `@arizeai/phoenix-client` with Phoenix server `14.17.0` capability gating
- aligns sync `POST /v1/session_annotations` with trace/span behavior by returning annotation GlobalIDs and emitting `ProjectSessionAnnotationInsertEvent`
- extracts the CLI annotation ID chunking helper so trace, span, and session annotation reads use the same chunking pattern

## Sample CLI usage

```bash
# Show session annotations and notes in list output
px session list --project assistant_agent --include-annotations --include-notes --format raw --no-progress \
  | jq '.[0] | {session_id, annotations, notes}'
```

```bash
# Add a label annotation to a session by GlobalID or user-facing session_id
px session annotate <session-id-or-global-id> \
  --name reviewer \
  --label pass \
  --format raw \
  --no-progress
```

```bash
# Add a score annotation with an explanation
px session annotate <session-id-or-global-id> \
  --name quality \
  --score 0.9 \
  --explanation "verified via CLI" \
  --format raw \
  --no-progress
```

```bash
# Add a session note; requires Phoenix server 14.17.0+
px session add-note <session-id-or-global-id> \
  --text "reviewed by agent" \
  --format raw \
  --no-progress
```

```bash
# Read annotations and notes back separately
px session get <session-id-or-global-id> \
  --project assistant_agent \
  --include-annotations \
  --include-notes \
  --format raw \
  --no-progress \
  | jq '{annotations: .session.annotations, notes: .session.notes}'
```

## Testing

- `uv run pytest tests/unit/server/api/routers/v1/test_sessions.py -q`
- `pnpm --dir js --filter @arizeai/phoenix-client build`
- `pnpm --dir js --filter @arizeai/phoenix-client exec vitest run test/sessions/addSessionNote.test.ts`
- `pnpm --dir js --filter @arizeai/phoenix-cli exec vitest run test/sessionAnnotationsNotes.test.ts test/cli.test.ts`
- `pnpm --dir js --filter @arizeai/phoenix-cli typecheck`
- `pnpm --dir js --filter @arizeai/phoenix-client typecheck`
- `pnpm --dir js lint -- packages/phoenix-cli/src/commands/chunkArray.ts packages/phoenix-cli/src/commands/spanAnnotations.ts packages/phoenix-cli/src/commands/traceAnnotations.ts packages/phoenix-cli/src/commands/session.ts packages/phoenix-cli/test/sessionAnnotationsNotes.test.ts packages/phoenix-client/src/sessions/addSessionNote.ts packages/phoenix-client/test/sessions/addSessionNote.test.ts`
- `uv run ruff check src/phoenix/server/api/routers/v1/sessions.py tests/unit/server/api/routers/v1/test_sessions.py`
- `./node_modules/.bin/oxfmt --check packages/phoenix-cli/src/commands/chunkArray.ts packages/phoenix-cli/src/commands/spanAnnotations.ts packages/phoenix-cli/src/commands/traceAnnotations.ts packages/phoenix-cli/src/commands/session.ts packages/phoenix-cli/test/sessionAnnotationsNotes.test.ts packages/phoenix-client/src/sessions/addSessionNote.ts packages/phoenix-client/test/sessions/addSessionNote.test.ts`
- `git diff --check`

## Manual dogfood

Tested locally against `localhost:6006` using the `assistant_agent` project. The dogfood transcript is intentionally left out of the PR because it contains local project/session/trace identifiers.
