### PR TITLE
test(playwright): fix e2e tests for dataset upsert UI changes

### DIFF
--- a/app/tests/dataset-file-upload.spec.ts
+++ b/app/tests/dataset-file-upload.spec.ts
@@ -26,6 +26,27 @@ async function expectColumnInBucket(
   await expect(bucket.getByRole("option", { name: columnName })).toBeVisible();
 }
 
+/**
+ * Locate a cell in a preview table by row index and column header text.
+ * Resolves the column position from the rendered <thead> so the test does
+ * not depend on a fixed column ordering.
+ */
+async function getPreviewCell(
+  table: Locator,
+  rowIndex: number,
+  headerText: string
+): Promise<Locator> {
+  const headers = table.locator("thead th");
+  const headerCount = await headers.count();
+  for (let i = 0; i < headerCount; i++) {
+    const text = (await headers.nth(i).textContent()) ?? "";
+    if (text.includes(headerText)) {
+      return table.locator("tbody tr").nth(rowIndex).locator("td").nth(i);
+    }
+  }
+  throw new Error(`Preview table column with header "${headerText}" not found`);
+}
+
 test.describe("Dataset File Upload", () => {
   test.describe("CSV Upload", () => {
     test("can upload a simple CSV file and see columns", async ({ page }) => {
@@ -454,17 +475,16 @@ test.describe("Dataset File Upload", () => {
       await expectColumnInBucket(page, "output", "OUTPUT");
       await expectColumnInBucket(page, "id", "KEYS");
 
-      // Switch to Dataset Preview to verify collapsed data structure
-      await dialog.getByRole("tab", { name: "Dataset Preview" }).click();
+      // Switch to Examples Preview to verify collapsed data structure
+      await dialog.getByRole("tab", { name: "Examples Preview" }).click();
 
       // Wait for preview table
       const previewTable = dialog.locator("table");
       await expect(previewTable).toBeVisible();
 
       // The preview should show flattened child keys (question, context)
-      // instead of nested JSON under "input"
-      const firstRow = previewTable.locator("tbody tr").first();
-      const inputCell = firstRow.locator("td").nth(0);
+      // instead of nested JSON under "input".
+      const inputCell = await getPreviewCell(previewTable, 0, "Input");
       const inputText = await inputCell.textContent();
 
       // Should contain the child keys from the flattened structure
@@ -555,23 +575,18 @@ test.describe("Dataset File Upload", () => {
       await expect(collapseSwitch).toBeVisible();
       await expect(collapseSwitch).toBeChecked();
 
-      // Switch to "Dataset Preview" tab to see the preview table
-      await dialog.getByRole("tab", { name: "Dataset Preview" }).click();
+      // Switch to "Examples Preview" tab to see the preview table
+      await dialog.getByRole("tab", { name: "Examples Preview" }).click();
 
       // Wait for the preview table to render
       const previewTable = dialog.locator("table");
       await expect(previewTable).toBeVisible();
 
-      // Get the first row's Input and Output cell content from the preview
-      // The table has columns: Input, Output, Metadata
-      const previewFirstRow = previewTable.locator("tbody tr").first();
-
-      // Extract the text content of the first row's Input cell (first td)
-      const previewInputCell = previewFirstRow.locator("td").nth(0);
+      // Get the first row's Input and Output cell content from the preview.
+      const previewInputCell = await getPreviewCell(previewTable, 0, "Input");
       const previewInputText = await previewInputCell.textContent();
 
-      // Extract the text content of the first row's Output cell (second td)
-      const previewOutputCell = previewFirstRow.locator("td").nth(1);
+      const previewOutputCell = await getPreviewCell(previewTable, 0, "Output");
       const previewOutputText = await previewOutputCell.textContent();
 
       // The preview should show the collapsed structure:

--- a/app/tests/playground.spec.ts
+++ b/app/tests/playground.spec.ts
@@ -49,7 +49,7 @@ async function addDatasetExample(
   await setCodeMirrorValue(page, inputJson);
   await Promise.all([
     page.waitForResponse((resp) =>
-      isGraphQLMutationResponse(resp, "AddDatasetExampleDialogMutation")
+      isGraphQLMutationResponse(resp, "AddExampleFromScratchFormMutation")
     ),
     addBtn.click(),
   ]);
@@ -108,7 +108,7 @@ test.describe("Playground", () => {
     // or upload from a file. Choose the manual option to open the dialog.
     await page.getByRole("button", { name: "Add Dataset Example" }).click();
     await page.getByRole("menuitem", { name: "Add Example Manually" }).click();
-    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByTestId("dialog")).toBeVisible();
 
     const longContent = `${"lorem-ipsum-".repeat(45)}`;
 

--- a/app/tests/server-evaluators.spec.ts
+++ b/app/tests/server-evaluators.spec.ts
@@ -66,12 +66,12 @@ test.describe.serial("Server Evaluators", () => {
     await page.getByRole("menuitem", { name: "Add Example Manually" }).click();
 
     // Wait for the Add Example dialog to open
-    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByTestId("dialog")).toBeVisible();
 
     // Fill in the input field with valid JSON
     // JSONEditor renders a CodeMirror editor with .cm-content
     // Scope to the dialog to avoid picking up background editors
-    const dialog = page.getByRole("dialog");
+    const dialog = page.getByTestId("dialog");
     const inputTextArea = dialog.locator(".cm-content").first();
     await expect(inputTextArea).toBeVisible();
     await inputTextArea.click();
@@ -92,7 +92,7 @@ test.describe.serial("Server Evaluators", () => {
     await page.getByRole("button", { name: "Add Example" }).click();
 
     // Wait for dialog to close
-    await expect(page.getByRole("dialog")).not.toBeVisible();
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
 
     // Verify the example appears in the table (or at least the table is no longer empty)
     await expect(page.getByRole("row")).toHaveCount(2); // header + 1 example


### PR DESCRIPTION
## Summary

Targets `feat/dataset-upsert`. Fixes three independent CI failures on the feature branch's Playwright suite.

- **Tab rename:** Preview tab `"Dataset Preview"` → `"Examples Preview"` in [DatasetFromFileForm.tsx](app/src/pages/datasets/DatasetFromFileForm.tsx). Two collapse tests in [dataset-file-upload.spec.ts](app/tests/dataset-file-upload.spec.ts) were timing out clicking the old name.
- **Column index shift:** The preview table now renders an `Example ID` column when a KEYS column is assigned, so the `nested.jsonl` fixture (which auto-assigns `id` → KEYS) shifts Input/Output positions. Replaced hardcoded `td.nth(N)` with a `getPreviewCell(table, row, headerText)` helper that resolves cells by `<thead>` text — no more position dependency.
- **Dialog strict-mode collision:** React Aria's `MenuTrigger` popover has `role="dialog"` and overlapped with the modal during exit animation, so `getByRole('dialog')` matched two elements in playground and server-evaluators. Switched the affected assertions to `getByTestId('dialog')`.
- **Renamed mutation:** `AddDatasetExampleDialog.tsx` → `AddExampleFromScratchForm.tsx`, so the GraphQL operation name `AddDatasetExampleDialogMutation` → `AddExampleFromScratchFormMutation`. Updated the `waitForResponse` matcher in playground.

## Test plan

- [x] `pnpm exec playwright test tests/dataset-file-upload.spec.ts tests/playground.spec.ts tests/server-evaluators.spec.ts --project=chromium` — 29/29 pass
- [x] Same suite on `--project=firefox` — 29/29 pass
- [ ] Full Playwright CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)