### PR TITLE
chore: release arize-phoenix-client 2.6.0

### DIFF
--- a/packages/phoenix-client/README.md
+++ b/packages/phoenix-client/README.md
@@ -20,7 +20,7 @@
     </a>
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=8e8e8b34-7900-43fa-a38f-1f070bd48c64&page=packages/phoenix-client/README.md" />
 </p>
-Phoenix Client provides a interface for interacting with the Phoenix platform via its REST API, enabling you to manage datasets, run experiments, analyze traces, and collect feedback programmatically.
+Phoenix Client provides an interface for interacting with the Phoenix platform via its REST API, enabling you to manage datasets, run experiments, analyze traces, and collect feedback programmatically.
 
 ## Features
 


### PR DESCRIPTION
## Summary

Instructs release-please to set the next `arize-phoenix-client` release version to `2.6.0` via a [`Release-As`](https://github.com/googleapis/release-please#how-do-i-change-the-version-number) commit footer.

Release-please only inspects commits that touch a package's path, so this PR also makes a tiny in-package change: fixes a grammatical typo in `packages/phoenix-client/README.md` ("provides a interface" → "provides an interface"). Without that, release-please wouldn't see any change scoped to `packages/phoenix-client/`.

After this PR merges to `main`, release-please should open (or update) its `arize-phoenix-client` release PR targeting `2.6.0` (current manifest is `2.5.0`).

## Test plan

- [ ] Confirm the release-please workflow runs after merge and the resulting `release-please--branches--main--components--arize-phoenix-client` PR proposes version `2.6.0`.

Release-As: 2.6.0