### PR TITLE
feat(client): gate v15 dataset upload params by server version

### DIFF
--- a/js/.changeset/phoenix-client-dataset-example-ids-gate.md
+++ b/js/.changeset/phoenix-client-dataset-example-ids-gate.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+Gate `example_ids` on dataset upload (`createDataset`, `appendDatasetExamples`) by server version, so callers see a clear capability error when targeting a Phoenix server older than 15.0.0 instead of a confusing server-side failure.

--- a/js/packages/phoenix-client/src/constants/serverRequirements.ts
+++ b/js/packages/phoenix-client/src/constants/serverRequirements.ts
@@ -91,6 +91,14 @@ export const GET_SPANS_BY_ATTRIBUTE: ParameterRequirement = {
   minServerVersion: [14, 9, 0],
 };
 
+export const DATASET_UPLOAD_EXAMPLE_IDS: ParameterRequirement = {
+  kind: "parameter",
+  parameterName: "example_ids",
+  parameterLocation: "body",
+  route: "POST /v1/datasets/upload",
+  minServerVersion: [15, 0, 0],
+};
+
 /**
  * Aggregate list of every known capability requirement.
  *
@@ -108,4 +116,5 @@ export const ALL_REQUIREMENTS: readonly CapabilityRequirement[] = [
   GET_SPANS_FILTERS,
   GET_SPANS_BY_ATTRIBUTE,
   LIST_PROJECT_TRACES,
+  DATASET_UPLOAD_EXAMPLE_IDS,
 ] as const;

--- a/js/packages/phoenix-client/src/datasets/appendDatasetExamples.ts
+++ b/js/packages/phoenix-client/src/datasets/appendDatasetExamples.ts
@@ -1,8 +1,10 @@
 import invariant from "tiny-invariant";
 
 import { createClient } from "../client";
+import { DATASET_UPLOAD_EXAMPLE_IDS } from "../constants/serverRequirements";
 import type { ClientFn } from "../types/core";
 import type { DatasetSelector, Example } from "../types/datasets";
+import { ensureServerCapability } from "../utils/serverVersionUtils";
 import { getDatasetInfo } from "./getDatasetInfo";
 
 export type AppendDatasetExamplesParams = ClientFn & {
@@ -92,6 +94,12 @@ export async function appendDatasetExamples({
       dataset,
     });
     datasetName = datasetInfo.name;
+  }
+  if (hasExampleIds) {
+    await ensureServerCapability({
+      client,
+      requirement: DATASET_UPLOAD_EXAMPLE_IDS,
+    });
   }
   const appendResponse = await client.POST("/v1/datasets/upload", {
     params: {

--- a/js/packages/phoenix-client/src/datasets/createDataset.ts
+++ b/js/packages/phoenix-client/src/datasets/createDataset.ts
@@ -1,8 +1,10 @@
 import invariant from "tiny-invariant";
 
 import { createClient } from "../client";
+import { DATASET_UPLOAD_EXAMPLE_IDS } from "../constants/serverRequirements";
 import type { ClientFn } from "../types/core";
 import type { Example } from "../types/datasets";
+import { ensureServerCapability } from "../utils/serverVersionUtils";
 
 export type CreateDatasetParams = ClientFn & {
   /**
@@ -112,6 +114,12 @@ export async function createDataset({
       },
     });
 
+  if (hasExampleIds) {
+    await ensureServerCapability({
+      client,
+      requirement: DATASET_UPLOAD_EXAMPLE_IDS,
+    });
+  }
   let createDatasetResponse = await post("update");
   if (isUnsupportedUpdateActionResponse(createDatasetResponse)) {
     warnUpdateFallback();

--- a/js/packages/phoenix-client/test/datasets/appendDatasetExamples.test.ts
+++ b/js/packages/phoenix-client/test/datasets/appendDatasetExamples.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.unmock("../../src/utils/serverVersionUtils");
 
+import type { PhoenixClient } from "../../src/client";
 import { appendDatasetExamples } from "../../src/datasets/appendDatasetExamples";
 
 // Mock the fetch module
@@ -15,15 +16,20 @@ vi.mock("openapi-fetch", () => ({
   }),
 }));
 
-// Tests that exercise the example_ids gate must supply a client whose
-// `getServerVersion` returns a known version (otherwise the auto-created
-// client would try to `fetch("/arize_phoenix_version")` for real).
-function makeClient(version: [number, number, number]) {
+/**
+ * Build a stub {@link PhoenixClient} whose `getServerVersion` returns the
+ * given version.
+ *
+ * Tests that exercise the `example_ids` capability gate must supply such a
+ * client; otherwise the auto-created client would try to
+ * `fetch("/arize_phoenix_version")` for real.
+ */
+function makeClient(version: [number, number, number]): PhoenixClient {
   return {
     getServerVersion: async () => version,
     POST: mockPost,
     GET: mockGet,
-  };
+  } as unknown as PhoenixClient;
 }
 
 describe("appendDatasetExamples", () => {
@@ -349,7 +355,7 @@ describe("appendDatasetExamples", () => {
     });
 
     await appendDatasetExamples({
-      client: makeClient([15, 0, 0]) as never,
+      client: makeClient([15, 0, 0]),
       dataset: { datasetName: "test-dataset" },
       examples: [
         {
@@ -394,7 +400,7 @@ describe("appendDatasetExamples", () => {
     });
 
     await appendDatasetExamples({
-      client: makeClient([15, 0, 0]) as never,
+      client: makeClient([15, 0, 0]),
       dataset: { datasetName: "test-dataset" },
       examples: [
         {
@@ -502,7 +508,7 @@ describe("appendDatasetExamples", () => {
     it("fails fast on Phoenix < 15.0.0 when an example carries a stable id", async () => {
       await expect(
         appendDatasetExamples({
-          client: makeClient([14, 17, 0]) as never,
+          client: makeClient([14, 17, 0]),
           dataset: { datasetName: "ds" },
           examples: [{ input: { q: 1 }, id: "stable-id" }],
         })
@@ -516,7 +522,7 @@ describe("appendDatasetExamples", () => {
       const getServerVersionSpy = vi.spyOn(client, "getServerVersion");
 
       await appendDatasetExamples({
-        client: client as never,
+        client,
         dataset: { datasetName: "ds" },
         examples: [{ input: { q: 1 } }],
       });
@@ -527,7 +533,7 @@ describe("appendDatasetExamples", () => {
 
     it("succeeds on Phoenix >= 15.0.0 when examples carry ids", async () => {
       await appendDatasetExamples({
-        client: makeClient([15, 0, 0]) as never,
+        client: makeClient([15, 0, 0]),
         dataset: { datasetName: "ds" },
         examples: [{ input: { q: 1 }, id: "stable-id" }],
       });

--- a/js/packages/phoenix-client/test/datasets/appendDatasetExamples.test.ts
+++ b/js/packages/phoenix-client/test/datasets/appendDatasetExamples.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.unmock("../../src/utils/serverVersionUtils");
+
 import { appendDatasetExamples } from "../../src/datasets/appendDatasetExamples";
 
 // Mock the fetch module
@@ -12,6 +14,15 @@ vi.mock("openapi-fetch", () => ({
     use: () => {},
   }),
 }));
+
+// Auto-created clients call `fetch("/arize_phoenix_version")` inside
+// `getServerVersion()`. Stub it to a recent version so the example_ids gate
+// succeeds for tests that don't supply their own client. Gating-specific tests
+// pass a custom client and bypass this entirely.
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => new Response("15.0.0", { status: 200 }))
+);
 
 describe("appendDatasetExamples", () => {
   beforeEach(() => {
@@ -480,6 +491,51 @@ describe("appendDatasetExamples", () => {
         splits: [null],
         span_ids: ["span-abc123"],
       },
+    });
+  });
+
+  describe("server version gating for example_ids", () => {
+    function makeClient(version: [number, number, number]) {
+      return {
+        getServerVersion: async () => version,
+        POST: mockPost,
+      };
+    }
+
+    it("fails fast on Phoenix < 15.0.0 when an example carries a stable id", async () => {
+      await expect(
+        appendDatasetExamples({
+          client: makeClient([14, 17, 0]) as never,
+          dataset: { datasetName: "ds" },
+          examples: [{ input: { q: 1 }, id: "stable-id" }],
+        })
+      ).rejects.toThrow(/requires Phoenix server >= 15\.0\.0/);
+
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("does not check server version when no example carries an id", async () => {
+      const client = makeClient([14, 17, 0]);
+      const getServerVersionSpy = vi.spyOn(client, "getServerVersion");
+
+      await appendDatasetExamples({
+        client: client as never,
+        dataset: { datasetName: "ds" },
+        examples: [{ input: { q: 1 } }],
+      });
+
+      expect(getServerVersionSpy).not.toHaveBeenCalled();
+      expect(mockPost).toHaveBeenCalled();
+    });
+
+    it("succeeds on Phoenix >= 15.0.0 when examples carry ids", async () => {
+      await appendDatasetExamples({
+        client: makeClient([15, 0, 0]) as never,
+        dataset: { datasetName: "ds" },
+        examples: [{ input: { q: 1 }, id: "stable-id" }],
+      });
+
+      expect(mockPost).toHaveBeenCalled();
     });
   });
 });

--- a/js/packages/phoenix-client/test/datasets/appendDatasetExamples.test.ts
+++ b/js/packages/phoenix-client/test/datasets/appendDatasetExamples.test.ts
@@ -15,14 +15,16 @@ vi.mock("openapi-fetch", () => ({
   }),
 }));
 
-// Auto-created clients call `fetch("/arize_phoenix_version")` inside
-// `getServerVersion()`. Stub it to a recent version so the example_ids gate
-// succeeds for tests that don't supply their own client. Gating-specific tests
-// pass a custom client and bypass this entirely.
-vi.stubGlobal(
-  "fetch",
-  vi.fn(async () => new Response("15.0.0", { status: 200 }))
-);
+// Tests that exercise the example_ids gate must supply a client whose
+// `getServerVersion` returns a known version (otherwise the auto-created
+// client would try to `fetch("/arize_phoenix_version")` for real).
+function makeClient(version: [number, number, number]) {
+  return {
+    getServerVersion: async () => version,
+    POST: mockPost,
+    GET: mockGet,
+  };
+}
 
 describe("appendDatasetExamples", () => {
   beforeEach(() => {
@@ -347,6 +349,7 @@ describe("appendDatasetExamples", () => {
     });
 
     await appendDatasetExamples({
+      client: makeClient([15, 0, 0]) as never,
       dataset: { datasetName: "test-dataset" },
       examples: [
         {
@@ -391,6 +394,7 @@ describe("appendDatasetExamples", () => {
     });
 
     await appendDatasetExamples({
+      client: makeClient([15, 0, 0]) as never,
       dataset: { datasetName: "test-dataset" },
       examples: [
         {
@@ -495,13 +499,6 @@ describe("appendDatasetExamples", () => {
   });
 
   describe("server version gating for example_ids", () => {
-    function makeClient(version: [number, number, number]) {
-      return {
-        getServerVersion: async () => version,
-        POST: mockPost,
-      };
-    }
-
     it("fails fast on Phoenix < 15.0.0 when an example carries a stable id", async () => {
       await expect(
         appendDatasetExamples({

--- a/js/packages/phoenix-client/test/datasets/createDataset.test.ts
+++ b/js/packages/phoenix-client/test/datasets/createDataset.test.ts
@@ -13,14 +13,15 @@ vi.mock("openapi-fetch", () => ({
   }),
 }));
 
-// Auto-created clients call `fetch("/arize_phoenix_version")` inside
-// `getServerVersion()`. Stub it to a recent version so the example_ids gate
-// succeeds for tests that don't supply their own client. Gating-specific tests
-// pass a custom client and bypass this entirely.
-vi.stubGlobal(
-  "fetch",
-  vi.fn(async () => new Response("15.0.0", { status: 200 }))
-);
+// Tests that exercise the example_ids gate must supply a client whose
+// `getServerVersion` returns a known version (otherwise the auto-created
+// client would try to `fetch("/arize_phoenix_version")` for real).
+function makeClient(version: [number, number, number]) {
+  return {
+    getServerVersion: async () => version,
+    POST: mockPost,
+  };
+}
 
 describe("createDataset", () => {
   beforeEach(() => {
@@ -330,6 +331,7 @@ describe("createDataset", () => {
     });
 
     await createDataset({
+      client: makeClient([15, 0, 0]) as never,
       name: "test-dataset",
       description: "A dataset with IDs",
       examples: [
@@ -376,6 +378,7 @@ describe("createDataset", () => {
     });
 
     await createDataset({
+      client: makeClient([15, 0, 0]) as never,
       name: "test-dataset",
       description: "A dataset with partial IDs",
       examples: [
@@ -534,13 +537,6 @@ describe("createDataset", () => {
   });
 
   describe("server version gating for example_ids", () => {
-    function makeClient(version: [number, number, number]) {
-      return {
-        getServerVersion: async () => version,
-        POST: mockPost,
-      };
-    }
-
     it("fails fast on Phoenix < 15.0.0 when an example carries a stable id", async () => {
       await expect(
         createDataset({

--- a/js/packages/phoenix-client/test/datasets/createDataset.test.ts
+++ b/js/packages/phoenix-client/test/datasets/createDataset.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.unmock("../../src/utils/serverVersionUtils");
+
 import { createDataset } from "../../src/datasets/createDataset";
 
 // Mock the fetch module
@@ -10,6 +12,15 @@ vi.mock("openapi-fetch", () => ({
     use: () => {},
   }),
 }));
+
+// Auto-created clients call `fetch("/arize_phoenix_version")` inside
+// `getServerVersion()`. Stub it to a recent version so the example_ids gate
+// succeeds for tests that don't supply their own client. Gating-specific tests
+// pass a custom client and bypass this entirely.
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => new Response("15.0.0", { status: 200 }))
+);
 
 describe("createDataset", () => {
   beforeEach(() => {
@@ -519,6 +530,54 @@ describe("createDataset", () => {
         })
       ).rejects.toThrow();
       expect(mockPost).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("server version gating for example_ids", () => {
+    function makeClient(version: [number, number, number]) {
+      return {
+        getServerVersion: async () => version,
+        POST: mockPost,
+      };
+    }
+
+    it("fails fast on Phoenix < 15.0.0 when an example carries a stable id", async () => {
+      await expect(
+        createDataset({
+          client: makeClient([14, 17, 0]) as never,
+          name: "ds",
+          description: "x",
+          examples: [{ input: { q: 1 }, id: "stable-id" }],
+        })
+      ).rejects.toThrow(/requires Phoenix server >= 15\.0\.0/);
+
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("does not check server version when no example carries an id", async () => {
+      const client = makeClient([14, 17, 0]);
+      const getServerVersionSpy = vi.spyOn(client, "getServerVersion");
+
+      await createDataset({
+        client: client as never,
+        name: "ds",
+        description: "x",
+        examples: [{ input: { q: 1 } }],
+      });
+
+      expect(getServerVersionSpy).not.toHaveBeenCalled();
+      expect(mockPost).toHaveBeenCalled();
+    });
+
+    it("succeeds on Phoenix >= 15.0.0 when examples carry ids", async () => {
+      await createDataset({
+        client: makeClient([15, 0, 0]) as never,
+        name: "ds",
+        description: "x",
+        examples: [{ input: { q: 1 }, id: "stable-id" }],
+      });
+
+      expect(mockPost).toHaveBeenCalled();
     });
   });
 });

--- a/js/packages/phoenix-client/test/datasets/createDataset.test.ts
+++ b/js/packages/phoenix-client/test/datasets/createDataset.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.unmock("../../src/utils/serverVersionUtils");
 
+import type { PhoenixClient } from "../../src/client";
 import { createDataset } from "../../src/datasets/createDataset";
 
 // Mock the fetch module
@@ -13,14 +14,19 @@ vi.mock("openapi-fetch", () => ({
   }),
 }));
 
-// Tests that exercise the example_ids gate must supply a client whose
-// `getServerVersion` returns a known version (otherwise the auto-created
-// client would try to `fetch("/arize_phoenix_version")` for real).
-function makeClient(version: [number, number, number]) {
+/**
+ * Build a stub {@link PhoenixClient} whose `getServerVersion` returns the
+ * given version.
+ *
+ * Tests that exercise the `example_ids` capability gate must supply such a
+ * client; otherwise the auto-created client would try to
+ * `fetch("/arize_phoenix_version")` for real.
+ */
+function makeClient(version: [number, number, number]): PhoenixClient {
   return {
     getServerVersion: async () => version,
     POST: mockPost,
-  };
+  } as unknown as PhoenixClient;
 }
 
 describe("createDataset", () => {
@@ -331,7 +337,7 @@ describe("createDataset", () => {
     });
 
     await createDataset({
-      client: makeClient([15, 0, 0]) as never,
+      client: makeClient([15, 0, 0]),
       name: "test-dataset",
       description: "A dataset with IDs",
       examples: [
@@ -378,7 +384,7 @@ describe("createDataset", () => {
     });
 
     await createDataset({
-      client: makeClient([15, 0, 0]) as never,
+      client: makeClient([15, 0, 0]),
       name: "test-dataset",
       description: "A dataset with partial IDs",
       examples: [
@@ -540,7 +546,7 @@ describe("createDataset", () => {
     it("fails fast on Phoenix < 15.0.0 when an example carries a stable id", async () => {
       await expect(
         createDataset({
-          client: makeClient([14, 17, 0]) as never,
+          client: makeClient([14, 17, 0]),
           name: "ds",
           description: "x",
           examples: [{ input: { q: 1 }, id: "stable-id" }],
@@ -555,7 +561,7 @@ describe("createDataset", () => {
       const getServerVersionSpy = vi.spyOn(client, "getServerVersion");
 
       await createDataset({
-        client: client as never,
+        client,
         name: "ds",
         description: "x",
         examples: [{ input: { q: 1 } }],
@@ -567,7 +573,7 @@ describe("createDataset", () => {
 
     it("succeeds on Phoenix >= 15.0.0 when examples carry ids", async () => {
       await createDataset({
-        client: makeClient([15, 0, 0]) as never,
+        client: makeClient([15, 0, 0]),
         name: "ds",
         description: "x",
         examples: [{ input: { q: 1 }, id: "stable-id" }],

--- a/packages/phoenix-client/src/phoenix/client/constants/server_requirements.py
+++ b/packages/phoenix-client/src/phoenix/client/constants/server_requirements.py
@@ -62,3 +62,24 @@ LIST_PROJECT_TRACES = RouteRequirement(
     path="/v1/projects/{project_identifier}/traces",
     min_server_version=Version(13, 15, 0),
 )
+
+DATASET_UPLOAD_EXAMPLE_IDS = ParameterRequirement(
+    parameter_name="example_ids",
+    parameter_location="body",
+    route="POST /v1/datasets/upload",
+    min_server_version=Version(15, 0, 0),
+)
+
+DATASET_UPLOAD_EXAMPLE_ID_KEY = ParameterRequirement(
+    parameter_name="example_id_key",
+    parameter_location="form",
+    route="POST /v1/datasets/upload",
+    min_server_version=Version(15, 0, 0),
+)
+
+DATASET_UPLOAD_SPLIT_KEY = ParameterRequirement(
+    parameter_name="split_key",
+    parameter_location="form",
+    route="POST /v1/datasets/upload",
+    min_server_version=Version(15, 0, 0),
+)

--- a/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
@@ -29,6 +29,11 @@ if TYPE_CHECKING:
     import pandas as pd
 
 from phoenix.client.__generated__ import v1
+from phoenix.client.constants.server_requirements import (
+    DATASET_UPLOAD_EXAMPLE_ID_KEY,
+    DATASET_UPLOAD_EXAMPLE_IDS,
+    DATASET_UPLOAD_SPLIT_KEY,
+)
 from phoenix.client.utils.id_handling import is_node_id
 from phoenix.client.utils.server_requirements import AsyncServerVersionGuard, ServerVersionGuard
 
@@ -1178,6 +1183,11 @@ class Datasets:
                 )
             file = _prepare_dataframe_as_csv(table, keys)
 
+        if keys.split_key:
+            self._guard.require(DATASET_UPLOAD_SPLIT_KEY)
+        if keys.example_id:
+            self._guard.require(DATASET_UPLOAD_EXAMPLE_ID_KEY)
+
         logger.info("Uploading dataset...")
         data_dict: dict[str, Any] = {
             "action": action,
@@ -1298,6 +1308,7 @@ class Datasets:
             payload["span_ids"] = span_ids_list
         if example_ids_list and any(s is not None for s in example_ids_list):
             payload["example_ids"] = example_ids_list
+            self._guard.require(DATASET_UPLOAD_EXAMPLE_IDS)
         if dataset_description is not None:
             payload["description"] = dataset_description
 
@@ -2037,6 +2048,11 @@ class AsyncDatasets:
                 )
             file = _prepare_dataframe_as_csv(table, keys)
 
+        if keys.split_key:
+            await self._guard.require(DATASET_UPLOAD_SPLIT_KEY)
+        if keys.example_id:
+            await self._guard.require(DATASET_UPLOAD_EXAMPLE_ID_KEY)
+
         logger.info("Uploading dataset...")
         data_dict: dict[str, Any] = {
             "action": action,
@@ -2155,6 +2171,7 @@ class AsyncDatasets:
             payload["span_ids"] = span_ids_list
         if example_ids_list and any(s is not None for s in example_ids_list):
             payload["example_ids"] = example_ids_list
+            await self._guard.require(DATASET_UPLOAD_EXAMPLE_IDS)
         if dataset_description is not None:
             payload["description"] = dataset_description
 

--- a/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
@@ -910,6 +910,10 @@ class Datasets:
             ]
 
         if has_tabular:
+            if split_key:
+                self._guard.require(DATASET_UPLOAD_SPLIT_KEY)
+            if example_id_key:
+                self._guard.require(DATASET_UPLOAD_EXAMPLE_ID_KEY)
             table = dataframe if dataframe is not None else csv_file_path
             assert table is not None
             return self._upload_tabular_dataset(
@@ -927,6 +931,8 @@ class Datasets:
                 timeout=timeout,
             )
         else:
+            if any(s is not None for s in example_ids_from_examples):
+                self._guard.require(DATASET_UPLOAD_EXAMPLE_IDS)
             return self._upload_json_dataset(
                 dataset_name=name,
                 inputs=inputs,
@@ -1062,6 +1068,10 @@ class Datasets:
             ]
 
         if has_tabular:
+            if split_key:
+                self._guard.require(DATASET_UPLOAD_SPLIT_KEY)
+            if example_id_key:
+                self._guard.require(DATASET_UPLOAD_EXAMPLE_ID_KEY)
             table = dataframe if dataframe is not None else csv_file_path
             assert table is not None
             return self._upload_tabular_dataset(
@@ -1079,6 +1089,8 @@ class Datasets:
                 timeout=timeout,
             )
         else:
+            if any(s is not None for s in example_ids_from_examples):
+                self._guard.require(DATASET_UPLOAD_EXAMPLE_IDS)
             return self._upload_json_dataset(
                 dataset_name=resolved_name,
                 inputs=inputs,
@@ -1182,11 +1194,6 @@ class Datasets:
                     "pandas is required to upload DataFrames. Install it with 'pip install pandas'"
                 )
             file = _prepare_dataframe_as_csv(table, keys)
-
-        if keys.split_key:
-            self._guard.require(DATASET_UPLOAD_SPLIT_KEY)
-        if keys.example_id:
-            self._guard.require(DATASET_UPLOAD_EXAMPLE_ID_KEY)
 
         logger.info("Uploading dataset...")
         data_dict: dict[str, Any] = {
@@ -1308,7 +1315,6 @@ class Datasets:
             payload["span_ids"] = span_ids_list
         if example_ids_list and any(s is not None for s in example_ids_list):
             payload["example_ids"] = example_ids_list
-            self._guard.require(DATASET_UPLOAD_EXAMPLE_IDS)
         if dataset_description is not None:
             payload["description"] = dataset_description
 
@@ -1795,6 +1801,10 @@ class AsyncDatasets:
             ]
 
         if has_tabular:
+            if split_key:
+                await self._guard.require(DATASET_UPLOAD_SPLIT_KEY)
+            if example_id_key:
+                await self._guard.require(DATASET_UPLOAD_EXAMPLE_ID_KEY)
             table = dataframe if dataframe is not None else csv_file_path
             assert table is not None
             return await self._upload_tabular_dataset(
@@ -1812,6 +1822,8 @@ class AsyncDatasets:
                 timeout=timeout,
             )
         else:
+            if any(s is not None for s in example_ids_from_examples):
+                await self._guard.require(DATASET_UPLOAD_EXAMPLE_IDS)
             return await self._upload_json_dataset(
                 dataset_name=name,
                 inputs=inputs,
@@ -1942,6 +1954,10 @@ class AsyncDatasets:
             ]
 
         if has_tabular:
+            if split_key:
+                await self._guard.require(DATASET_UPLOAD_SPLIT_KEY)
+            if example_id_key:
+                await self._guard.require(DATASET_UPLOAD_EXAMPLE_ID_KEY)
             table = dataframe if dataframe is not None else csv_file_path
             assert table is not None
             return await self._upload_tabular_dataset(
@@ -1959,6 +1975,8 @@ class AsyncDatasets:
                 timeout=timeout,
             )
         else:
+            if any(s is not None for s in example_ids_from_examples):
+                await self._guard.require(DATASET_UPLOAD_EXAMPLE_IDS)
             return await self._upload_json_dataset(
                 dataset_name=resolved_name,
                 inputs=inputs,
@@ -2047,11 +2065,6 @@ class AsyncDatasets:
                     "pandas is required to upload DataFrames. Install it with 'pip install pandas'"
                 )
             file = _prepare_dataframe_as_csv(table, keys)
-
-        if keys.split_key:
-            await self._guard.require(DATASET_UPLOAD_SPLIT_KEY)
-        if keys.example_id:
-            await self._guard.require(DATASET_UPLOAD_EXAMPLE_ID_KEY)
 
         logger.info("Uploading dataset...")
         data_dict: dict[str, Any] = {
@@ -2171,7 +2184,6 @@ class AsyncDatasets:
             payload["span_ids"] = span_ids_list
         if example_ids_list and any(s is not None for s in example_ids_list):
             payload["example_ids"] = example_ids_list
-            await self._guard.require(DATASET_UPLOAD_EXAMPLE_IDS)
         if dataset_description is not None:
             payload["description"] = dataset_description
 


### PR DESCRIPTION
## Summary

- Add `ParameterRequirement` constants for the v15-only fields on `POST /v1/datasets/upload` (`example_ids`, `example_id_key`, `split_key`) in both the Python and TypeScript clients, and call the existing version guard before sending those fields.
- The `action="update"` enum value is intentionally **not** gated: both clients already retry as `action="create"` on a 422, so the existing fallback handles older servers.
- Add TS tests for the new gate (fails fast on Phoenix < 15.0.0 when an example carries a stable id; no version probe when no example carries an id) following the precedent in `test/traces/addTraceNote.test.ts`.

## Test plan

- [x] `cd js/packages/phoenix-client && pnpm test` — 327/327 pass
- [x] `cd js/packages/phoenix-client && pnpm typecheck` — clean
- [x] `cd packages/phoenix-client && uv run pytest tests/client/utils/test_server_requirements.py tests/client/resources/datasets/test_datasets.py` — 54/54 pass
- [ ] Manual smoke against a v14 Phoenix server: `createDataset({ examples: [{..., id: "abc"}] })` rejects with `requires Phoenix server >= 15.0.0`; without `id`, the call succeeds without a version probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)