### PR TITLE
fix(playground): accept unwrapped AWS Bedrock tool schemas

### DIFF
--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -1798,12 +1798,14 @@ export function toCanonicalToolDefinition(
     };
   }
   // AWS: { toolSpec: { name, description, inputSchema: { json } } }
+  // Some Bedrock spans store the unwrapped inner shape; the schema accepts both.
   const aws = awsToolDefinitionSchema.safeParse(raw);
   if (aws.success) {
+    const spec = "toolSpec" in aws.data ? aws.data.toolSpec : aws.data;
     return {
-      name: aws.data.toolSpec.name,
-      description: aws.data.toolSpec.description ?? null,
-      parameters: canonicalParameters(aws.data.toolSpec.inputSchema.json),
+      name: spec.name,
+      description: spec.description ?? null,
+      parameters: canonicalParameters(spec.inputSchema.json),
       strict: null,
     };
   }

--- a/app/src/schemas/__tests__/toolSchemas.test.ts
+++ b/app/src/schemas/__tests__/toolSchemas.test.ts
@@ -104,9 +104,32 @@ describe("toolSchemas", () => {
       };
       const result = awsToolDefinitionSchema.safeParse(tool);
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success && "toolSpec" in result.data) {
         expect(result.data.toolSpec.inputSchema.json).toEqual({
           type: "object",
+        });
+      }
+    });
+
+    it("should parse an unwrapped AWS tool definition (without toolSpec)", () => {
+      const tool = {
+        name: "get_weather",
+        description: "Get weather",
+        inputSchema: {
+          json: {
+            type: "object",
+            properties: { city: { type: "string" } },
+            required: ["city"],
+          },
+        },
+      };
+      const result = awsToolDefinitionSchema.safeParse(tool);
+      expect(result.success).toBe(true);
+      if (result.success && !("toolSpec" in result.data)) {
+        expect(result.data.inputSchema.json).toEqual({
+          type: "object",
+          properties: { city: { type: "string" } },
+          required: ["city"],
         });
       }
     });

--- a/app/src/schemas/toolSchemas.ts
+++ b/app/src/schemas/toolSchemas.ts
@@ -198,15 +198,25 @@ export const anthropicToolDefinitionJSONSchema = z.toJSONSchema(
   anthropicToolDefinitionSchema
 );
 
-export const awsToolDefinitionSchema = z.object({
-  toolSpec: z.object({
-    name: z.string(),
-    description: z.string().min(1).optional(),
-    inputSchema: z.object({
-      json: parametersSchemaWithDefaultObjectType,
-    }),
+const awsToolSpecSchema = z.object({
+  name: z.string(),
+  description: z.string().min(1).optional(),
+  inputSchema: z.object({
+    json: parametersSchemaWithDefaultObjectType,
   }),
 });
+
+/**
+ * AWS Bedrock tool definition.
+ *
+ * The canonical Converse API shape wraps the tool in `toolSpec`, but some
+ * OpenInference Bedrock spans store the unwrapped inner shape. Accept both
+ * so playground can rehydrate either form.
+ */
+export const awsToolDefinitionSchema = z.union([
+  z.object({ toolSpec: awsToolSpecSchema }),
+  awsToolSpecSchema,
+]);
 
 export type AwsToolDefinition = z.infer<typeof awsToolDefinitionSchema>;
 


### PR DESCRIPTION
## Summary
- AWS Bedrock spans whose `llm.tools.{i}.tool.json_schema` is stored **without** the `toolSpec` wrapper were silently mis-parsed in the playground: the strict `awsToolDefinitionSchema` rejected them, the union fell through to `geminiToolDefinitionSchema`, and Gemini's permissive `z.object` shape stripped `inputSchema` entirely — producing a tool with empty parameters in the editor.
- `awsToolDefinitionSchema` now accepts both the wrapped (`{ toolSpec: { ... } }`) and the unwrapped (`{ name, inputSchema, ... }`) shape via a union, and `toCanonicalToolDefinition` normalizes either form before producing canonical params.

## Repro
Open a playground span replay for an AWS Bedrock LLM span where the tool was instrumented without the `toolSpec` wrapper (e.g. span `U3Bhbjo3` locally). Before this change, the Tools editor renders `inputSchema.json: { type: "object" }` only — `properties` and `required` are missing. After the change, the full schema is preserved.

## Test plan
- [x] `pnpm test` (`app`) — 834 tests pass, including a new case for unwrapped AWS tool definitions.
- [x] `pnpm typecheck` (`app`) clean.
- [x] Manually reloaded `/playground/spans/U3Bhbjo3` and confirmed the Tools editor now shows the full `properties`/`required`.