### PR TITLE
fix: select traces within session view

### DIFF
--- a/app/src/components/trace/TraceTree.tsx
+++ b/app/src/components/trace/TraceTree.tsx
@@ -23,12 +23,18 @@ export type TraceTreeProps = {
   spans: ISpanItem[];
   onSpanClick?: (span: ISpanItem) => void;
   selectedSpanNodeId: string;
+  scrollSelectedSpanIntoView?: boolean;
 };
 
 export { TraceTreeProvider } from "./TraceTreeContext";
 
 export function TraceTree(props: TraceTreeProps) {
-  const { spans, onSpanClick, selectedSpanNodeId } = props;
+  const {
+    spans,
+    onSpanClick,
+    selectedSpanNodeId,
+    scrollSelectedSpanIntoView = true,
+  } = props;
   const spanTree = createSpanTree(spans);
   const rootSpan = spanTree[0].span;
   const overallTimeRange = {
@@ -62,6 +68,7 @@ export function TraceTree(props: TraceTreeProps) {
             overallTimeRange={overallTimeRange}
             onSpanClick={onSpanClick}
             selectedSpanNodeId={selectedSpanNodeId}
+            scrollSelectedSpanIntoView={scrollSelectedSpanIntoView}
           />
         ))}
       </ul>
@@ -81,6 +88,7 @@ const spanNameCSS = css`
 interface SpanTreeItemProps<TSpan extends ISpanItem> {
   node: SpanTreeNode<TSpan>;
   selectedSpanNodeId: string;
+  scrollSelectedSpanIntoView: boolean;
   overallTimeRange: TimeRange;
   onSpanClick?: (span: ISpanItem) => void;
   /**
@@ -96,6 +104,7 @@ function SpanTreeItem<TSpan extends ISpanItem>(
   const {
     node,
     selectedSpanNodeId,
+    scrollSelectedSpanIntoView,
     onSpanClick,
     nestingLevel = 0,
     overallTimeRange,
@@ -112,13 +121,13 @@ function SpanTreeItem<TSpan extends ISpanItem>(
 
   // Scroll into view when selected
   useEffect(() => {
-    if (isSelected && itemRef.current) {
+    if (scrollSelectedSpanIntoView && isSelected && itemRef.current) {
       itemRef.current.scrollIntoView({
         behavior: "smooth",
         block: "nearest",
       });
     }
-  }, [isSelected]);
+  }, [isSelected, scrollSelectedSpanIntoView]);
 
   // React to global changes to the trace tree state and change local state
   useEffect(() => {
@@ -243,6 +252,7 @@ function SpanTreeItem<TSpan extends ISpanItem>(
                   overallTimeRange={overallTimeRange}
                   onSpanClick={onSpanClick}
                   selectedSpanNodeId={selectedSpanNodeId}
+                  scrollSelectedSpanIntoView={scrollSelectedSpanIntoView}
                   nestingLevel={nestingLevel + 1}
                 />
               </li>

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -13,7 +13,8 @@ import {
   Separator,
   useDefaultLayout,
 } from "react-resizable-panels";
-import { useSearchParams } from "react-router";
+import type { To } from "react-router";
+import { useLocation, useSearchParams } from "react-router";
 
 import {
   Flex,
@@ -38,6 +39,7 @@ import { TraceTokenCosts } from "@phoenix/components/trace/TraceTokenCosts";
 import {
   SELECTED_SPAN_NODE_ID_PARAM,
   SELECTED_TRACE_ID_PARAM,
+  SESSION_VIEW_PARAM,
 } from "@phoenix/constants/searchParams";
 import { useTimeFormatters } from "@phoenix/hooks";
 import { useChatMessageStyles } from "@phoenix/hooks/useChatMessageStyles";
@@ -76,6 +78,27 @@ const getUserFromRootSpanAttributes = (attributes: string) => {
   }
   const userId = userAttributes[UserAttributePostfixes.id];
   return isString(userId) || isNumber(userId) ? userId : null;
+};
+
+const getSessionTraceUrl = ({
+  pathname,
+  search,
+  traceId,
+  spanNodeId,
+}: {
+  pathname: string;
+  search: string;
+  traceId: string;
+  spanNodeId: string;
+}): To => {
+  const params = new URLSearchParams(search);
+  params.set(SESSION_VIEW_PARAM, "traces");
+  params.set(SELECTED_TRACE_ID_PARAM, traceId);
+  params.set(SELECTED_SPAN_NODE_ID_PARAM, spanNodeId);
+  return {
+    pathname,
+    search: params.toString(),
+  };
 };
 
 function RootSpanMessage({
@@ -119,6 +142,7 @@ function RootSpanDetails({
   rootSpan,
   index,
 }: RootSpanProps & { traceId: string; index: number }) {
+  const location = useLocation();
   const { fullTimeFormatter } = useTimeFormatters();
   const startDate = useMemo(() => {
     return new Date(rootSpan.startTime);
@@ -139,7 +163,12 @@ function RootSpanDetails({
           <Flex direction={"row"} justifyContent={"space-between"}>
             <Text>Trace #{index + 1}</Text>
             <Link
-              to={`/projects/${rootSpan.project.id}/traces/${traceId}?${SELECTED_SPAN_NODE_ID_PARAM}=${rootSpan.id}`}
+              to={getSessionTraceUrl({
+                pathname: location.pathname,
+                search: location.search,
+                traceId,
+                spanNodeId: rootSpan.id,
+              })}
             >
               <Flex alignItems={"center"}>
                 View Trace

--- a/app/src/pages/trace/SessionDetailsTracesView.tsx
+++ b/app/src/pages/trace/SessionDetailsTracesView.tsx
@@ -1,6 +1,13 @@
 import { css } from "@emotion/react";
 import { throttle } from "lodash";
-import { Suspense, useCallback, useMemo, useState } from "react";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { PreloadedQuery } from "react-relay";
 import {
   graphql,
@@ -32,7 +39,10 @@ import { TokenCosts } from "@phoenix/components/trace/TokenCosts";
 import { TokenCount } from "@phoenix/components/trace/TokenCount";
 import { TraceTreeProvider } from "@phoenix/components/trace/TraceTree";
 import { TraceTreeSkeleton } from "@phoenix/components/trace/TraceTreeSkeleton";
-import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
+import {
+  SELECTED_SPAN_NODE_ID_PARAM,
+  SELECTED_TRACE_ID_PARAM,
+} from "@phoenix/constants/searchParams";
 import { useTimeFormatters } from "@phoenix/hooks";
 import type {
   SessionDetailsTracesView_traces$data,
@@ -66,7 +76,21 @@ type SessionTraceRow = NonNullable<
   >;
 };
 
-type SpanClickHandler = (span: { id: string }) => void;
+type SpanClickHandler = ({
+  traceId,
+  spanNodeId,
+}: {
+  traceId: string;
+  spanNodeId: string;
+}) => void;
+
+type TraceSelectHandler = ({
+  traceId,
+  spanNodeId,
+}: {
+  traceId: string;
+  spanNodeId: string;
+}) => void;
 
 export function SessionDetailsTracesView({
   queryRef,
@@ -140,6 +164,10 @@ export function SessionDetailsTracesView({
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedSpanNodeId = searchParams.get(SELECTED_SPAN_NODE_ID_PARAM);
+  const selectedTraceId = searchParams.get(SELECTED_TRACE_ID_PARAM);
+  const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const initialSelectedTraceIdRef = useRef(selectedTraceId);
+  const hasScrolledInitialSelectionRef = useRef(false);
 
   const toggleExpanded = (id: string) => {
     setExpandedIds((prev) => {
@@ -153,15 +181,35 @@ export function SessionDetailsTracesView({
     });
   };
 
-  const handleSpanClick: SpanClickHandler = (span) => {
+  const handleTraceSelect: TraceSelectHandler = ({ traceId, spanNodeId }) => {
     setSearchParams(
       (params) => {
-        params.set(SELECTED_SPAN_NODE_ID_PARAM, span.id);
+        params.set(SELECTED_TRACE_ID_PARAM, traceId);
+        params.set(SELECTED_SPAN_NODE_ID_PARAM, spanNodeId);
         return params;
       },
       { replace: true }
     );
   };
+
+  const handleSpanClick: SpanClickHandler = ({ traceId, spanNodeId }) => {
+    handleTraceSelect({ traceId, spanNodeId });
+  };
+
+  useEffect(() => {
+    const initialSelectedTraceId = initialSelectedTraceIdRef.current;
+    if (
+      initialSelectedTraceId == null ||
+      hasScrolledInitialSelectionRef.current
+    ) {
+      return;
+    }
+    const el = rowRefs.current.get(initialSelectedTraceId);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+      hasScrolledInitialSelectionRef.current = true;
+    }
+  }, [traces.length]);
 
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: "session-traces-view-layout",
@@ -204,9 +252,12 @@ export function SessionDetailsTracesView({
             <TraceRowList
               traces={traces}
               expandedIds={expandedIds}
+              selectedTraceId={selectedTraceId}
               selectedSpanNodeId={selectedSpanNodeId}
               onToggleExpanded={toggleExpanded}
+              onTraceSelect={handleTraceSelect}
               onSpanClick={handleSpanClick}
+              rowRefs={rowRefs}
               isLoadingNext={isLoadingNext}
               onScroll={(e) =>
                 throttledFetchMoreOnBottomReached(e.target as HTMLDivElement)
@@ -226,17 +277,23 @@ export function SessionDetailsTracesView({
 function TraceRowList({
   traces,
   expandedIds,
+  selectedTraceId,
   selectedSpanNodeId,
   onToggleExpanded,
+  onTraceSelect,
   onSpanClick,
+  rowRefs,
   isLoadingNext,
   onScroll,
 }: {
   traces: SessionTraceRow[];
   expandedIds: Set<string>;
+  selectedTraceId: string | null;
   selectedSpanNodeId: string | null;
   onToggleExpanded: (id: string) => void;
+  onTraceSelect: TraceSelectHandler;
   onSpanClick: SpanClickHandler;
+  rowRefs: { current: Map<string, HTMLDivElement> };
   isLoadingNext: boolean;
   onScroll: (e: React.UIEvent<HTMLDivElement>) => void;
 }) {
@@ -255,10 +312,26 @@ function TraceRowList({
               key={trace.id}
               trace={trace}
               index={index}
-              isExpanded={expandedIds.has(trace.id)}
+              isSelected={trace.traceId === selectedTraceId}
+              isExpanded={
+                expandedIds.has(trace.id) || trace.traceId === selectedTraceId
+              }
               selectedSpanNodeId={selectedSpanNodeId}
               onToggleExpanded={() => onToggleExpanded(trace.id)}
+              onTraceSelect={() =>
+                onTraceSelect({
+                  traceId: trace.traceId,
+                  spanNodeId: trace.rootSpan.id,
+                })
+              }
               onSpanClick={onSpanClick}
+              setTraceRowRef={({ traceId, el }) => {
+                if (el) {
+                  rowRefs.current.set(traceId, el);
+                } else {
+                  rowRefs.current.delete(traceId);
+                }
+              }}
             />
           ))}
           {isLoadingNext && (
@@ -279,25 +352,46 @@ function TraceRowList({
 function TraceRow({
   trace,
   index,
+  isSelected,
   isExpanded,
   selectedSpanNodeId,
   onToggleExpanded,
+  onTraceSelect,
   onSpanClick,
+  setTraceRowRef,
 }: {
   trace: SessionTraceRow;
   index: number;
+  isSelected: boolean;
   isExpanded: boolean;
   selectedSpanNodeId: string | null;
   onToggleExpanded: () => void;
+  onTraceSelect: () => void;
   onSpanClick: SpanClickHandler;
+  setTraceRowRef: ({
+    traceId,
+    el,
+  }: {
+    traceId: string;
+    el: HTMLDivElement | null;
+  }) => void;
 }) {
   return (
-    <div css={traceRowCSS} data-testid="session-trace-row">
+    <div
+      css={traceRowCSS}
+      data-selected={isSelected || undefined}
+      data-testid="session-trace-row"
+      ref={(el) => {
+        setTraceRowRef({ traceId: trace.traceId, el });
+      }}
+    >
       <TraceRowHeader
         trace={trace}
         index={index}
+        isSelected={isSelected}
         isExpanded={isExpanded}
         onToggleExpanded={onToggleExpanded}
+        onTraceSelect={onTraceSelect}
       />
       {isExpanded ? (
         <TraceTreeContainer
@@ -314,20 +408,31 @@ function TraceRow({
 function TraceRowHeader({
   trace,
   index,
+  isSelected,
   isExpanded,
   onToggleExpanded,
+  onTraceSelect,
 }: {
   trace: SessionTraceRow;
   index: number;
+  isSelected: boolean;
   isExpanded: boolean;
   onToggleExpanded: () => void;
+  onTraceSelect: () => void;
 }) {
   return (
     <button
       type="button"
       css={traceRowHeaderCSS}
       aria-expanded={isExpanded}
-      onClick={onToggleExpanded}
+      onClick={() => {
+        if (!isSelected) {
+          onTraceSelect();
+        }
+        if (!isExpanded) {
+          onToggleExpanded();
+        }
+      }}
       data-testid="session-trace-row-header"
     >
       <TraceRowChevron isExpanded={isExpanded} />
@@ -440,7 +545,7 @@ function TraceTreeContainer({
           traceId={traceId}
           projectId={projectId}
           selectedSpanNodeId={selectedSpanNodeId}
-          onSpanClick={onSpanClick}
+          onSpanClick={({ spanNodeId }) => onSpanClick({ traceId, spanNodeId })}
         />
       </Suspense>
     </div>
@@ -506,7 +611,7 @@ function LazyTraceTree({
       <ConnectedTraceTree
         trace={trace}
         selectedSpanNodeId={selectedSpanNodeId ?? ""}
-        onSpanClick={onSpanClick}
+        onSpanClick={(span) => onSpanClick({ traceId, spanNodeId: span.id })}
       />
     </TraceTreeProvider>
   );
@@ -534,6 +639,12 @@ const traceRowCSS = css`
   display: flex;
   flex-direction: column;
   border-bottom: 1px solid var(--global-border-color-default);
+
+  &[data-selected="true"] > button {
+    background: var(--global-list-item-selected-background-color);
+    color: var(--global-text-color-900);
+    border-left-color: var(--global-list-item-selected-border-color);
+  }
 `;
 
 const traceRowHeaderCSS = css`
@@ -544,11 +655,13 @@ const traceRowHeaderCSS = css`
   padding: var(--global-dimension-static-size-200);
   background: transparent;
   border: none;
+  border-left: 4px solid transparent;
   width: 100%;
   text-align: left;
   cursor: pointer;
   color: inherit;
   font: inherit;
+  box-sizing: border-box;
 
   &:hover {
     background: var(--global-list-item-hover-background-color);

--- a/app/src/pages/trace/SessionDetailsTracesView.tsx
+++ b/app/src/pages/trace/SessionDetailsTracesView.tsx
@@ -58,6 +58,8 @@ import { SessionViewTabs } from "./SessionViewTabs";
 import type { SessionView } from "./SessionViewTabs";
 import { SpanDetails } from "./SpanDetails";
 
+const INITIAL_SELECTED_TRACE_MAX_PAGES = 3;
+
 export const sessionDetailsTracesViewQuery = graphql`
   query SessionDetailsTracesViewQuery($id: ID!, $first: Int!) {
     session: node(id: $id) {
@@ -168,6 +170,7 @@ export function SessionDetailsTracesView({
   const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const initialSelectedTraceIdRef = useRef(selectedTraceId);
   const hasScrolledInitialSelectionRef = useRef(false);
+  const initialSelectedTracePagesLoadedRef = useRef(0);
 
   const toggleExpanded = (id: string) => {
     setExpandedIds((prev) => {
@@ -196,8 +199,8 @@ export function SessionDetailsTracesView({
     handleTraceSelect({ traceId, spanNodeId });
   };
 
-  // The URL can preselect a trace before its paginated row is loaded. Page until
-  // that row exists, expand it once, then scroll it into view.
+  // The URL can preselect a trace before its paginated row is loaded. Page a
+  // bounded amount until that row exists, then expand it once and scroll it into view.
   useEffect(() => {
     const initialSelectedTraceId = initialSelectedTraceIdRef.current;
     if (
@@ -210,9 +213,19 @@ export function SessionDetailsTracesView({
       (trace) => trace.traceId === initialSelectedTraceId
     );
     if (initialSelectedTrace == null) {
-      if (hasNext && !isLoadingNext) {
-        loadNext(SESSION_DETAILS_PAGE_SIZE);
+      if (isLoadingNext) {
+        return;
       }
+      if (
+        hasNext &&
+        initialSelectedTracePagesLoadedRef.current <
+          INITIAL_SELECTED_TRACE_MAX_PAGES
+      ) {
+        initialSelectedTracePagesLoadedRef.current += 1;
+        loadNext(SESSION_DETAILS_PAGE_SIZE);
+        return;
+      }
+      hasScrolledInitialSelectionRef.current = true;
       return;
     }
     const el = rowRefs.current.get(initialSelectedTraceId);

--- a/app/src/pages/trace/SessionDetailsTracesView.tsx
+++ b/app/src/pages/trace/SessionDetailsTracesView.tsx
@@ -196,6 +196,8 @@ export function SessionDetailsTracesView({
     handleTraceSelect({ traceId, spanNodeId });
   };
 
+  // The URL can preselect a trace before its paginated row is loaded. Page until
+  // that row exists, expand it once, then scroll it into view.
   useEffect(() => {
     const initialSelectedTraceId = initialSelectedTraceIdRef.current;
     if (
@@ -204,12 +206,29 @@ export function SessionDetailsTracesView({
     ) {
       return;
     }
+    const initialSelectedTrace = traces.find(
+      (trace) => trace.traceId === initialSelectedTraceId
+    );
+    if (initialSelectedTrace == null) {
+      if (hasNext && !isLoadingNext) {
+        loadNext(SESSION_DETAILS_PAGE_SIZE);
+      }
+      return;
+    }
     const el = rowRefs.current.get(initialSelectedTraceId);
     if (el) {
+      setExpandedIds((prev) => {
+        if (prev.has(initialSelectedTrace.id)) {
+          return prev;
+        }
+        const next = new Set(prev);
+        next.add(initialSelectedTrace.id);
+        return next;
+      });
       el.scrollIntoView({ behavior: "smooth", block: "start" });
       hasScrolledInitialSelectionRef.current = true;
     }
-  }, [traces.length]);
+  }, [hasNext, isLoadingNext, loadNext, traces]);
 
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: "session-traces-view-layout",
@@ -313,9 +332,7 @@ function TraceRowList({
               trace={trace}
               index={index}
               isSelected={trace.traceId === selectedTraceId}
-              isExpanded={
-                expandedIds.has(trace.id) || trace.traceId === selectedTraceId
-              }
+              isExpanded={expandedIds.has(trace.id)}
               selectedSpanNodeId={selectedSpanNodeId}
               onToggleExpanded={() => onToggleExpanded(trace.id)}
               onTraceSelect={() =>
@@ -428,10 +445,12 @@ function TraceRowHeader({
       onClick={() => {
         if (!isSelected) {
           onTraceSelect();
+          if (!isExpanded) {
+            onToggleExpanded();
+          }
+          return;
         }
-        if (!isExpanded) {
-          onToggleExpanded();
-        }
+        onToggleExpanded();
       }}
       data-testid="session-trace-row-header"
     >

--- a/app/src/pages/trace/SessionDetailsTracesView.tsx
+++ b/app/src/pages/trace/SessionDetailsTracesView.tsx
@@ -688,6 +688,7 @@ const traceRowHeaderCSS = css`
   padding: var(--global-dimension-static-size-200);
   background: transparent;
   border: none;
+  /* Reserve space for the selected-state indicator so rows do not shift when selected. */
   border-left: 4px solid transparent;
   width: 100%;
   text-align: left;

--- a/app/src/pages/trace/SessionDetailsTracesView.tsx
+++ b/app/src/pages/trace/SessionDetailsTracesView.tsx
@@ -630,6 +630,7 @@ function LazyTraceTree({
       <ConnectedTraceTree
         trace={trace}
         selectedSpanNodeId={selectedSpanNodeId ?? ""}
+        scrollSelectedSpanIntoView={false}
         onSpanClick={(span) => onSpanClick({ traceId, spanNodeId: span.id })}
       />
     </TraceTreeProvider>


### PR DESCRIPTION
## Summary
- keep the session turn `View Trace` action inside the session drawer by updating URL state instead of linking to the standalone trace route
- select the Traces tab, selected trace row, and selected span from session URL params
- auto-page the session traces list until an initially selected trace row is loaded, then expand and scroll it into view
- keep trace row expansion user-controllable so selected rows can collapse/re-expand and already-expanded rows stay visible when selected

## Compared to main
- `SessionDetailsTraceList.tsx` now builds a same-session trace URL with `sessionView=traces`, `selectedTraceId`, and `selectedSpanNodeId` while preserving the current pathname/search params.
- `SessionDetailsTracesView.tsx` now tracks selected trace URL state, registers trace row refs, syncs trace/span selection on row and span clicks, styles the selected row, and restores initial deep links even when the target trace is beyond the first loaded page.

## Validation
- `pnpm --dir app lint`
- `pnpm --dir app typecheck`
- Browser-tested on `localhost:6006` with a seeded 75-trace session: trace 60 deep link auto-loaded page 2, selected/expanded/scrolled the row, showed span details, and preserved collapse/re-expand behavior.

Related issue: N/A