### PR TITLE
fix(ui): remove unused sticky positioning on Drawer dialog header

### DIFF
--- a/app/src/components/core/overlay/Drawer.tsx
+++ b/app/src/components/core/overlay/Drawer.tsx
@@ -90,12 +90,6 @@ const drawerCSS = css`
     color: var(--global-text-color-900);
     border-left: 1px solid var(--global-border-color-default);
     outline: none;
-
-    & .dialog__header {
-      position: sticky;
-      top: 0;
-      z-index: 1;
-    }
   }
 `;
 


### PR DESCRIPTION
## Summary
- The Drawer's dialog never scrolls — inner content panels handle their own scrolling — so `position: sticky` on `.dialog__header` served no functional purpose.
- Safari has a known rendering bug where sticky elements inside flex containers can render at incorrect coordinates, causing the dialog header to visually overlap with content below (issue only reproduces in Safari, not Chrome).
- `Modal.tsx` retains its sticky header CSS, since the modal's dialog has `overflow: auto` where sticky is actually needed.

Fixes #12953

## Test plan
- [ ] Open a trace details drawer in Safari and confirm the header renders cleanly without overlap.
- [ ] Verify the same drawer still renders correctly in Chrome.
- [ ] Confirm Modal headers (which still use sticky) continue to behave correctly when modal content scrolls.