### PR TITLE
fix(ui): remove redundant Ask PXI button from trace details drawer

### DIFF
--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -2,14 +2,12 @@ import { Suspense } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 
 import {
-  Button,
   Dialog,
   Drawer,
   Flex,
   Loading,
   TitleWithID,
 } from "@phoenix/components";
-import { PxiGlyph } from "@phoenix/components/agent/PxiGlyph";
 import {
   DialogCloseButton,
   DialogContent,
@@ -21,8 +19,6 @@ import { DRAWER_DEFAULT_MIN_SIZE } from "@phoenix/components/core/overlay/consta
 import { useDefaultDrawerSize } from "@phoenix/components/core/overlay/useDefaultDrawerSize";
 import { ShareLinkButton } from "@phoenix/components/ShareLinkButton";
 import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
-import { useAgentContext } from "@phoenix/contexts/AgentContext";
-import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
 import { TraceDetailsPaginator } from "@phoenix/pages/trace/TraceDetailsPaginator";
 
@@ -35,8 +31,6 @@ export function TracePage() {
   const { traceId, projectId } = useParams();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const isAgentsEnabled = useFeatureFlag("agents");
-  const setIsOpen = useAgentContext((state) => state.setIsOpen);
   const { rootPath, tab } = useProjectRootPath();
   const selectedSpanNodeId = searchParams.get(SELECTED_SPAN_NODE_ID_PARAM);
   const { defaultSize, onSizeChange } = useDefaultDrawerSize({
@@ -67,18 +61,6 @@ export function TracePage() {
                 </DialogTitle>
               </Flex>
               <DialogTitleExtra>
-                {isAgentsEnabled ? (
-                  /* The global FAB is intentionally hidden while a modal overlay
-                      is open, so traces expose a local PXI entrypoint here. */
-                  <Button
-                    size="S"
-                    variant="primary"
-                    leadingVisual={<PxiGlyph variant="resting" />}
-                    onPress={() => setIsOpen(true)}
-                  >
-                    Ask PXI
-                  </Button>
-                ) : null}
                 <ShareLinkButton
                   preserveSearchParams
                   buttonText="Share"


### PR DESCRIPTION
## Summary
- Removes the "Ask PXI" button from the trace details drawer header — it duplicated the entrypoint already provided by the PXI widget.
- Cleans up now-unused imports (`Button`, `PxiGlyph`, `useAgentContext`, `useFeatureFlag`).

## Test plan
- [ ] Open a trace details drawer with the agents feature flag on; confirm no "Ask PXI" button in the header and the PXI widget remains the sole entrypoint.
- [ ] Confirm the Share button still renders and works as before.