### PR TITLE
feat: simplify trace/span status icons, use status badge in panel views

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1104,15 +1104,15 @@ const badgeSizingCSS = (theme: Theme) => css`
   :root,
   .theme--${theme} {
     --global-badge-padding-y-s: 0px;
-    --global-badge-padding-x-s: var(--global-dimension-size-75);
+    --global-badge-padding-x-s: var(--global-dimension-size-50);
     --global-badge-font-size-s: var(--global-font-size-xs);
 
     --global-badge-padding-y-m: var(--global-dimension-size-25);
-    --global-badge-padding-x-m: var(--global-dimension-size-100);
+    --global-badge-padding-x-m: var(--global-dimension-size-75);
     --global-badge-font-size-m: var(--global-font-size-s);
 
     --global-badge-padding-y-l: var(--global-dimension-size-50);
-    --global-badge-padding-x-l: var(--global-dimension-size-100);
+    --global-badge-padding-x-l: var(--global-dimension-size-75);
     --global-badge-font-size-l: var(--global-font-size-m);
 
     --global-badge-gap: var(--global-dimension-size-50);

--- a/app/src/components/trace/SpanStatusBadge.tsx
+++ b/app/src/components/trace/SpanStatusBadge.tsx
@@ -1,0 +1,90 @@
+import { css } from "@emotion/react";
+
+import { Badge, Text } from "@phoenix/components";
+import type { BadgeVariant } from "@phoenix/components/core/badge/types";
+import type { TextColorValue } from "@phoenix/components/core/types/style";
+
+import type { SpanStatusCodeType } from "./types";
+
+function getStatusVariant(statusCode: SpanStatusCodeType): BadgeVariant {
+  switch (statusCode) {
+    case "OK":
+      return "success";
+    case "ERROR":
+      return "danger";
+    case "UNSET":
+      return "default";
+  }
+}
+
+function getStatusTextColor(
+  statusCode: SpanStatusCodeType,
+  labelVariant: "full" | "short"
+): TextColorValue {
+  switch (statusCode) {
+    case "OK":
+      return "success";
+    case "ERROR":
+      return "danger";
+    case "UNSET":
+      return labelVariant === "short" ? "text-300" : "text-700";
+  }
+}
+
+function getStatusLabel(
+  statusCode: SpanStatusCodeType,
+  labelVariant: "full" | "short"
+): string {
+  switch (statusCode) {
+    case "OK":
+      return "OK";
+    case "ERROR":
+      return labelVariant === "full" ? "Error" : "ERR";
+    case "UNSET":
+      return labelVariant === "full" ? "Unset" : "––";
+  }
+}
+
+type SpanStatusBadgeVariant = "default" | "bare";
+
+export function SpanStatusBadge({
+  statusCode,
+  variant = "default",
+  labelVariant = "short",
+}: {
+  statusCode: SpanStatusCodeType;
+  variant?: SpanStatusBadgeVariant;
+  labelVariant?: "full" | "short";
+}) {
+  const label = getStatusLabel(statusCode, labelVariant);
+
+  if (variant === "bare") {
+    return (
+      <Text
+        size="S"
+        color={getStatusTextColor(statusCode, labelVariant)}
+        css={css`
+          font-weight: 500;
+        `}
+      >
+        {label}
+      </Text>
+    );
+  }
+
+  return (
+    <Badge
+      variant={getStatusVariant(statusCode)}
+      size="M"
+      css={
+        statusCode === "UNSET"
+          ? css`
+              --badge-base-color: var(--global-color-gray-400);
+            `
+          : undefined
+      }
+    >
+      {label}
+    </Badge>
+  );
+}

--- a/app/src/components/trace/SpanStatusCodeIcon.tsx
+++ b/app/src/components/trace/SpanStatusCodeIcon.tsx
@@ -10,17 +10,17 @@ export function SpanStatusCodeIcon<TCode extends SpanStatusCodeType>({
 }: {
   statusCode: TCode;
 }) {
-  let iconSVG = <Icons.MinusCircleOutline />;
+  let iconSVG = <Icons.MinusOutline />;
   const color = useSpanStatusCodeColor(statusCode);
   switch (statusCode) {
     case "OK":
-      iconSVG = <Icons.CheckmarkCircleOutline />;
+      iconSVG = <Icons.CheckmarkOutline />;
       break;
     case "ERROR":
       iconSVG = <Icons.AlertCircleOutline />;
       break;
     case "UNSET":
-      iconSVG = <Icons.MinusCircleOutline />;
+      iconSVG = <Icons.MinusOutline />;
       break;
     default:
       assertUnreachable(statusCode);

--- a/app/src/components/trace/index.tsx
+++ b/app/src/components/trace/index.tsx
@@ -18,3 +18,4 @@ export * from "./TraceTokenCosts";
 export * from "./TraceTokenCostsDetails";
 export * from "./SessionTokenCosts";
 export * from "./SessionTokenCostsDetails";
+export * from "./SpanStatusBadge";

--- a/app/src/pages/SpanHeader.tsx
+++ b/app/src/pages/SpanHeader.tsx
@@ -5,7 +5,7 @@ import { graphql, useFragment } from "react-relay";
 import { Flex, IDBadge, Text } from "@phoenix/components";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanKindToken } from "@phoenix/components/trace/SpanKindToken";
-import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
+import { SpanStatusBadge } from "@phoenix/components/trace/SpanStatusBadge";
 import { SpanTokenCosts } from "@phoenix/components/trace/SpanTokenCosts";
 import { SpanTokenCount } from "@phoenix/components/trace/SpanTokenCount";
 import { useTimeFormatters } from "@phoenix/hooks";
@@ -54,12 +54,7 @@ export function SpanHeader(props: SpanHeaderProps) {
         <Flex direction="row" gap="size-100" alignItems="center">
           <SpanKindToken spanKind={span.spanKind} />
           <Text size="L">{span.name}</Text>
-          <SpanStatusCodeIcon
-            statusCode={span.code}
-            css={css`
-              font-size: var(--global-font-size-m);
-            `}
-          />
+          <SpanStatusBadge statusCode={span.code} labelVariant="full" />
         </Flex>
         <Flex direction="row" gap="size-100" alignItems="center">
           <IDBadge id={span.spanId} />

--- a/app/src/pages/SpanHeader.tsx
+++ b/app/src/pages/SpanHeader.tsx
@@ -1,4 +1,3 @@
-import { css } from "@emotion/react";
 import { useMemo } from "react";
 import { graphql, useFragment } from "react-relay";
 

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -512,7 +512,7 @@ export function SpansTable(props: SpansTableProps) {
   const columns: ColumnDef<TableRow>[] = [
     {
       id: "select",
-      maxSize: 32,
+      maxSize: 24,
       header: ({ table }) => (
         <IndeterminateCheckboxCell
           {...{
@@ -538,7 +538,7 @@ export function SpansTable(props: SpansTableProps) {
       accessorKey: "statusCode",
       enableSorting: false,
       minSize: 50,
-      maxSize: 75,
+      maxSize: 50,
       cell: ({ getValue }) => {
         const statusCode = getValue() as SpanStatusCode;
         return <SpanStatusCodeIcon statusCode={statusCode} />;

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -607,7 +607,7 @@ export function TracesTable(props: TracesTableProps) {
     () => [
       {
         id: "select",
-        maxSize: 32,
+        maxSize: 24,
         header: ({ table }) => (
           <IndeterminateCheckboxCell
             {...{
@@ -638,7 +638,7 @@ export function TracesTable(props: TracesTableProps) {
         accessorKey: "statusCode",
         enableSorting: false,
         minSize: 50,
-        maxSize: 75,
+        maxSize: 50,
         cell: ({ getValue, row }) => {
           if (row.original.__additionalRow) {
             return null;

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -25,10 +25,10 @@ import {
 import { TraceAgentChatPanel } from "@phoenix/components/agent/TraceAgentChatPanel";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
-import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
+import { SpanStatusBadge } from "@phoenix/components/trace/SpanStatusBadge";
 import { TraceTreeProvider } from "@phoenix/components/trace/TraceTree";
 import { TraceTreeToolbar } from "@phoenix/components/trace/TraceTreeToolbar";
-import { useSpanStatusCodeColor } from "@phoenix/components/trace/useSpanStatusCodeColor";
+import type { SpanStatusCodeType } from "@phoenix/components/trace/types";
 import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { costFormatter } from "@phoenix/utils/numberFormatUtils";
 
@@ -196,10 +196,7 @@ function TraceHeader({
   sessionId?: string | null;
   projectId: string;
 }) {
-  const { statusCode } = rootSpan ?? {
-    statusCode: "UNSET",
-  };
-  const statusColor = useSpanStatusCodeColor(statusCode);
+  const statusCode = (rootSpan?.statusCode ?? "UNSET") as SpanStatusCodeType;
   return (
     <View
       paddingTop="size-100"
@@ -211,23 +208,30 @@ function TraceHeader({
       <Flex
         direction="row"
         gap="size-400"
-        alignItems="center"
+        alignItems="start"
         css={css`
           box-sizing: content-box;
         `}
       >
-        <Flex direction="column">
+        <Flex
+          direction="column"
+          alignItems="start"
+          css={css`
+            align-self: stretch;
+          `}
+        >
           <Text elementType="h3" size="S" color="text-700">
-            Trace Status
+            Status
           </Text>
-          <Text size="XL">
-            <Flex direction="row" gap="size-50" alignItems="center">
-              <SpanStatusCodeIcon statusCode={statusCode} />
-              <Text size="L" color={statusColor}>
-                {statusCode}
-              </Text>
-            </Flex>
-          </Text>
+          <div
+            css={css`
+              flex: 1 1 auto;
+              display: flex;
+              align-items: center;
+            `}
+          >
+            <SpanStatusBadge statusCode={statusCode} labelVariant="full" />
+          </div>
         </Flex>
         <Flex direction="column">
           <Text elementType="h3" size="S" color="text-700">
@@ -267,13 +271,11 @@ function TraceHeader({
           <Text elementType="h3" size="S" color="text-700">
             Latency
           </Text>
-          <Text size="XL">
-            {typeof latencyMs === "number" ? (
-              <LatencyText latencyMs={latencyMs} size="L" />
-            ) : (
-              "--"
-            )}
-          </Text>
+          {typeof latencyMs === "number" ? (
+            <LatencyText latencyMs={latencyMs} size="L" />
+          ) : (
+            <Text size="L">--</Text>
+          )}
         </Flex>
         {rootSpan ? (
           <TraceHeaderRootSpanAnnotations spanId={rootSpan.id} />
@@ -281,6 +283,7 @@ function TraceHeader({
         {sessionId && (
           <span
             css={css`
+              align-self: center;
               margin-left: auto;
             `}
           >


### PR DESCRIPTION
Addresses #12735 

* Updates the non-error span status icons to be subtler
* Uses the status badge from experiment job status in the panel view
* Consistent sizing and alignment for metrics/feedback row
* Slight improvements in table spacing

<img width="1847" height="1261" alt="status-badge-all" src="https://github.com/user-attachments/assets/638b4f0c-531d-4aea-a301-c1d0d44cb27d" />
<img width="1959" height="1482" alt="status-badge-ok" src="https://github.com/user-attachments/assets/64b02cc8-472d-4925-b764-161f323027c5" />
