### PR TITLE
fix(agents): drop user-supplied connection params from /chat (SSRF)

### DIFF
--- a/src/phoenix/server/agents/chat_params.py
+++ b/src/phoenix/server/agents/chat_params.py
@@ -40,20 +40,15 @@ class CustomProviderChatSearchParams(BaseModel):
 class BuiltInProviderChatSearchParams(BaseModel):
     """Chat against a Phoenix built-in provider.
 
-    Credentials are resolved from the secret store first, then from the
-    environment. ``base_url``, ``endpoint``, ``region``, and
-    ``custom_headers`` override the defaults baked into ``model_factory``.
-    ``openai_api_type`` is honoured by the OpenAI and Azure OpenAI
-    branches; other providers ignore it.
+    Credentials and connection details (base URL, Azure endpoint, AWS
+    region) are resolved from the secret store first and the process
+    environment second. ``openai_api_type`` is honoured by the OpenAI and
+    Azure OpenAI branches; other providers ignore it.
     """
 
     provider_type: Literal["builtin"]
     provider: ModelProvider
     model_name: str
-    base_url: str | None = None
-    endpoint: str | None = None
-    region: str | None = None
-    custom_headers: dict[str, str] | None = None
     openai_api_type: Literal["chat_completions", "responses"] = "responses"
 
 

--- a/src/phoenix/server/agents/model_factory.py
+++ b/src/phoenix/server/agents/model_factory.py
@@ -356,7 +356,7 @@ async def _get_pydantic_ai_model_from_builtin_provider(
 
     if params.provider == ModelProvider.OPENAI:
         api_key = await _resolve_secret_or_env(session, decrypt, "OPENAI_API_KEY")
-        base_url = params.base_url or getenv("OPENAI_BASE_URL")
+        base_url = getenv("OPENAI_BASE_URL")
         api_key = _placeholder_or_error_for_openai_compatible_provider(
             api_key=api_key,
             base_url=base_url,
@@ -367,11 +367,7 @@ async def _get_pydantic_ai_model_from_builtin_provider(
             ),
         )
         openai_provider = OpenAIProvider(
-            openai_client=AsyncOpenAI(
-                api_key=api_key,
-                base_url=base_url,
-                default_headers=params.custom_headers,
-            )
+            openai_client=AsyncOpenAI(api_key=api_key, base_url=base_url)
         )
         return _build_openai_model(
             model_name=params.model_name,
@@ -380,7 +376,7 @@ async def _get_pydantic_ai_model_from_builtin_provider(
         )
     if params.provider == ModelProvider.AZURE_OPENAI:
         api_key = await _resolve_secret_or_env(session, decrypt, "AZURE_OPENAI_API_KEY")
-        azure_endpoint = params.endpoint or getenv("AZURE_OPENAI_ENDPOINT")
+        azure_endpoint = getenv("AZURE_OPENAI_ENDPOINT")
         if not azure_endpoint:
             raise ProviderCredentialsError(
                 "An Azure endpoint is required for Azure OpenAI models. "
@@ -389,11 +385,7 @@ async def _get_pydantic_ai_model_from_builtin_provider(
         base_url = azure_endpoint_to_base_url(azure_endpoint)
         if api_key:
             openai_provider = OpenAIProvider(
-                openai_client=AsyncOpenAI(
-                    api_key=api_key,
-                    base_url=base_url,
-                    default_headers=params.custom_headers,
-                )
+                openai_client=AsyncOpenAI(api_key=api_key, base_url=base_url)
             )
         else:
             try:
@@ -408,11 +400,7 @@ async def _get_pydantic_ai_model_from_builtin_provider(
                 "https://cognitiveservices.azure.com/.default",
             )
             openai_provider = OpenAIProvider(
-                openai_client=AsyncOpenAI(
-                    api_key=token_provider,
-                    base_url=base_url,
-                    default_headers=params.custom_headers,
-                )
+                openai_client=AsyncOpenAI(api_key=token_provider, base_url=base_url)
             )
         return _build_openai_model(
             model_name=params.model_name,
@@ -428,13 +416,7 @@ async def _get_pydantic_ai_model_from_builtin_provider(
                 "An API key is required for Anthropic models. "
                 "Set the ANTHROPIC_API_KEY environment variable or store it in Phoenix secrets."
             )
-        anthropic_provider = AnthropicProvider(
-            anthropic_client=AsyncAnthropic(
-                api_key=api_key,
-                base_url=params.base_url,
-                default_headers=params.custom_headers,
-            )
-        )
+        anthropic_provider = AnthropicProvider(anthropic_client=AsyncAnthropic(api_key=api_key))
         return AnthropicModel(params.model_name, provider=anthropic_provider)
     if params.provider == ModelProvider.GOOGLE:
         api_key = await _resolve_secret_or_env(session, decrypt, "GEMINI_API_KEY", "GOOGLE_API_KEY")
@@ -443,7 +425,7 @@ async def _get_pydantic_ai_model_from_builtin_provider(
                 "An API key is required for Google GenAI models. "
                 "Set GEMINI_API_KEY or GOOGLE_API_KEY in the environment or Phoenix secrets."
             )
-        google_provider = GoogleProvider(api_key=api_key, base_url=params.base_url)
+        google_provider = GoogleProvider(api_key=api_key)
         return GoogleModel(params.model_name, provider=google_provider)
     if params.provider == ModelProvider.AWS:
         aws_creds = await _resolve_secrets_or_env(
@@ -457,8 +439,7 @@ async def _get_pydantic_ai_model_from_builtin_provider(
             aws_access_key_id=aws_creds["AWS_ACCESS_KEY_ID"],
             aws_secret_access_key=aws_creds["AWS_SECRET_ACCESS_KEY"],
             aws_session_token=aws_creds["AWS_SESSION_TOKEN"],
-            region_name=params.region or getenv("AWS_REGION") or "us-east-1",
-            base_url=params.base_url,
+            region_name=getenv("AWS_REGION") or "us-east-1",
         )
         return BedrockConverseModel(params.model_name, provider=bedrock_provider)
     if params.provider in {
@@ -478,64 +459,62 @@ async def _get_pydantic_ai_model_from_builtin_provider(
         ] = {
             ModelProvider.DEEPSEEK: (
                 "DEEPSEEK_API_KEY",
-                params.base_url or getenv("DEEPSEEK_BASE_URL") or "https://api.deepseek.com",
+                getenv("DEEPSEEK_BASE_URL") or "https://api.deepseek.com",
                 "https://api.deepseek.com",
                 "An API key is required for DeepSeek models. "
                 "Set DEEPSEEK_API_KEY in the environment or Phoenix secrets.",
             ),
             ModelProvider.XAI: (
                 "XAI_API_KEY",
-                params.base_url or getenv("XAI_BASE_URL") or "https://api.x.ai/v1",
+                getenv("XAI_BASE_URL") or "https://api.x.ai/v1",
                 "https://api.x.ai/v1",
                 "An API key is required for xAI models. "
                 "Set XAI_API_KEY in the environment or Phoenix secrets.",
             ),
             ModelProvider.OLLAMA: (
                 None,
-                params.base_url or getenv("OLLAMA_BASE_URL"),
+                getenv("OLLAMA_BASE_URL"),
                 None,
                 "A base URL is required for Ollama models. Set OLLAMA_BASE_URL (for example http://localhost:11434/v1).",
             ),
             ModelProvider.CEREBRAS: (
                 "CEREBRAS_API_KEY",
-                params.base_url or getenv("CEREBRAS_BASE_URL") or "https://api.cerebras.ai/v1",
+                getenv("CEREBRAS_BASE_URL") or "https://api.cerebras.ai/v1",
                 "https://api.cerebras.ai/v1",
                 "An API key is required for Cerebras models. "
                 "Set CEREBRAS_API_KEY in the environment or Phoenix secrets.",
             ),
             ModelProvider.FIREWORKS: (
                 "FIREWORKS_API_KEY",
-                params.base_url
-                or getenv("FIREWORKS_BASE_URL")
-                or "https://api.fireworks.ai/inference/v1",
+                getenv("FIREWORKS_BASE_URL") or "https://api.fireworks.ai/inference/v1",
                 "https://api.fireworks.ai/inference/v1",
                 "An API key is required for Fireworks models. "
                 "Set FIREWORKS_API_KEY in the environment or Phoenix secrets.",
             ),
             ModelProvider.GROQ: (
                 "GROQ_API_KEY",
-                params.base_url or getenv("GROQ_BASE_URL") or "https://api.groq.com/openai/v1",
+                getenv("GROQ_BASE_URL") or "https://api.groq.com/openai/v1",
                 "https://api.groq.com/openai/v1",
                 "An API key is required for Groq models. "
                 "Set GROQ_API_KEY in the environment or Phoenix secrets.",
             ),
             ModelProvider.MOONSHOT: (
                 "MOONSHOT_API_KEY",
-                params.base_url or getenv("MOONSHOT_BASE_URL") or "https://api.moonshot.ai/v1",
+                getenv("MOONSHOT_BASE_URL") or "https://api.moonshot.ai/v1",
                 "https://api.moonshot.ai/v1",
                 "An API key is required for Moonshot models. "
                 "Set MOONSHOT_API_KEY in the environment or Phoenix secrets.",
             ),
             ModelProvider.PERPLEXITY: (
                 "PERPLEXITY_API_KEY",
-                params.base_url or getenv("PERPLEXITY_BASE_URL") or "https://api.perplexity.ai",
+                getenv("PERPLEXITY_BASE_URL") or "https://api.perplexity.ai",
                 "https://api.perplexity.ai",
                 "An API key is required for Perplexity models. "
                 "Set PERPLEXITY_API_KEY in the environment or Phoenix secrets.",
             ),
             ModelProvider.TOGETHER: (
                 "TOGETHER_API_KEY",
-                params.base_url or getenv("TOGETHER_BASE_URL") or "https://api.together.xyz/v1",
+                getenv("TOGETHER_BASE_URL") or "https://api.together.xyz/v1",
                 "https://api.together.xyz/v1",
                 "An API key is required for Together AI models. "
                 "Set TOGETHER_API_KEY in the environment or Phoenix secrets.",
@@ -561,11 +540,7 @@ async def _get_pydantic_ai_model_from_builtin_provider(
                 missing_credential_message=missing_credential_message,
             )
         openai_provider = OpenAIProvider(
-            openai_client=AsyncOpenAI(
-                api_key=api_key,
-                base_url=base_url,
-                default_headers=params.custom_headers,
-            )
+            openai_client=AsyncOpenAI(api_key=api_key, base_url=base_url)
         )
         return _build_openai_model(
             model_name=params.model_name,

--- a/tests/unit/server/api/routers/test_chat.py
+++ b/tests/unit/server/api/routers/test_chat.py
@@ -141,30 +141,6 @@ class TestChatRouter:
 
         _assert_successful_chat_stream(response, session_id="test-session-1")
 
-    async def test_chat_ignores_user_supplied_connection_query_params(
-        self,
-        httpx_client: httpx.AsyncClient,
-        anthropic_api_key: str,
-        custom_vcr: CustomVCR,
-    ) -> None:
-        # Regression for https://github.com/Arize-ai/phoenix/issues/12915.
-        # ``base_url``/``endpoint``/``region``/``custom_headers`` were once
-        # honoured as request inputs and let an authenticated caller redirect
-        # the server's outbound traffic. They must now be inert. VCR enforces
-        # the assertion: if any of these were still consumed, the recorded
-        # cassette (pinned to the upstream provider host) would fail to match.
-        params = {
-            **_CHAT_PARAMS,
-            "base_url": "http://169.254.169.254/",
-            "endpoint": "http://169.254.169.254/",
-            "region": "attacker-region",
-            "custom_headers": "x-injected: 1",
-        }
-        with custom_vcr.use_cassette(path=_EXISTING_CHAT_CASSETTE):
-            response = await httpx_client.post("/chat", params=params, json=_CHAT_BODY)
-
-        _assert_successful_chat_stream(response, session_id="test-session-1")
-
     async def test_chat_returns_404_for_missing_custom_provider(
         self,
         httpx_client: httpx.AsyncClient,

--- a/tests/unit/server/api/routers/test_chat.py
+++ b/tests/unit/server/api/routers/test_chat.py
@@ -141,6 +141,30 @@ class TestChatRouter:
 
         _assert_successful_chat_stream(response, session_id="test-session-1")
 
+    async def test_chat_ignores_user_supplied_connection_query_params(
+        self,
+        httpx_client: httpx.AsyncClient,
+        anthropic_api_key: str,
+        custom_vcr: CustomVCR,
+    ) -> None:
+        # Regression for https://github.com/Arize-ai/phoenix/issues/12915.
+        # ``base_url``/``endpoint``/``region``/``custom_headers`` were once
+        # honoured as request inputs and let an authenticated caller redirect
+        # the server's outbound traffic. They must now be inert. VCR enforces
+        # the assertion: if any of these were still consumed, the recorded
+        # cassette (pinned to the upstream provider host) would fail to match.
+        params = {
+            **_CHAT_PARAMS,
+            "base_url": "http://169.254.169.254/",
+            "endpoint": "http://169.254.169.254/",
+            "region": "attacker-region",
+            "custom_headers": "x-injected: 1",
+        }
+        with custom_vcr.use_cassette(path=_EXISTING_CHAT_CASSETTE):
+            response = await httpx_client.post("/chat", params=params, json=_CHAT_BODY)
+
+        _assert_successful_chat_stream(response, session_id="test-session-1")
+
     async def test_chat_returns_404_for_missing_custom_provider(
         self,
         httpx_client: httpx.AsyncClient,


### PR DESCRIPTION
## Summary

Closes #12915.

The `/chat` endpoint accepted `base_url`, `endpoint`, `region`, and `custom_headers` as query parameters on `BuiltInProviderChatSearchParams` and threaded them straight into provider client constructors with no host validation. An authenticated caller could redirect Phoenix's outbound traffic to loopback, link-local (e.g. `http://169.254.169.254/` for AWS IMDS), or RFC1918 hosts.

The frontend never sets these fields — the only caller is [`useAgentChatPanelState.ts`](app/src/components/agent/useAgentChatPanelState.ts#L174-L183), which sends only `model_name`, `provider_type`, and `provider`/`provider_id`. Provider URLs and AWS region are resolved from env vars (`OPENAI_BASE_URL`, `AZURE_OPENAI_ENDPOINT`, `AWS_REGION`, etc.) on the server, so removing the request fields does not change operator-facing configurability — only the attacker surface.

### Changes

- Remove `base_url`, `endpoint`, `region`, `custom_headers` from `BuiltInProviderChatSearchParams`.
- Strip the corresponding fallbacks from every branch of `_get_pydantic_ai_model_from_builtin_provider` so provider connection details come exclusively from server-side env vars and built-in defaults.
- Add a regression test that fires the offending query params at `/chat` and relies on VCR to enforce the contract: if any branch were still consuming them, the recorded cassette (pinned to the upstream provider host) would fail to match.

### Out of scope

- `openai_api_type` is also currently unsent by the frontend but is not an SSRF vector (closed enum). Left in place.
- The custom-provider branch (`_get_pydantic_ai_model_from_generative_model_custom_provider`) reads URLs from a stored, encrypted config record — not from request input — so it is unaffected.

## Test plan

- [x] `uv run pytest tests/unit/server/api/routers/test_chat.py` (5 passed, including the new `test_chat_ignores_user_supplied_connection_query_params`)
- [x] `uv run mypy --strict src/phoenix/server/agents/{chat_params,model_factory}.py`
- [x] `uv run ruff format` + `uv run ruff check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)