### PR TITLE
fix(sandbox): close mutation surface gaps and eliminate read-side N+1

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -600,7 +600,7 @@ input CreateChatPromptVersionInput {
 }
 
 input CreateCodeEvaluatorInput {
-  name: String!
+  name: Identifier!
   sourceCode: String!
   language: Language!
   description: String = null
@@ -747,7 +747,7 @@ input CreatePromptVersionTagInput {
 
 input CreateSandboxConfigInput {
   sandboxProviderId: ID!
-  name: String!
+  name: Identifier!
   description: String = null
   config: JSON = null
   timeout: Int = null
@@ -1239,9 +1239,18 @@ input DeletePromptVersionTagInput {
   promptVersionTagId: ID!
 }
 
+input DeleteSandboxConfigInput {
+  id: ID!
+}
+
 type DeleteSandboxConfigPayload {
   deletedId: ID!
   query: Query!
+}
+
+input DeleteSandboxCredentialInput {
+  backendType: String!
+  key: String!
 }
 
 type DeleteSandboxCredentialPayload {
@@ -2263,10 +2272,10 @@ type Mutation {
   unsetPromptLabels(input: UnsetPromptLabelsInput!): PromptLabelAssociationMutationPayload!
   createSandboxConfig(input: CreateSandboxConfigInput!): CreateSandboxConfigPayload!
   updateSandboxConfig(input: UpdateSandboxConfigInput!): UpdateSandboxConfigPayload!
-  deleteSandboxConfig(id: ID!): DeleteSandboxConfigPayload!
+  deleteSandboxConfig(input: DeleteSandboxConfigInput!): DeleteSandboxConfigPayload!
   updateSandboxProvider(input: UpdateSandboxProviderInput!): UpdateSandboxProviderPayload!
-  setSandboxCredential(backendType: String!, key: String!, value: String!): SetSandboxCredentialPayload!
-  deleteSandboxCredential(backendType: String!, key: String!): DeleteSandboxCredentialPayload!
+  setSandboxCredential(input: SetSandboxCredentialInput!): SetSandboxCredentialPayload!
+  deleteSandboxCredential(input: DeleteSandboxCredentialInput!): DeleteSandboxCredentialPayload!
   upsertOrDeleteSecrets(input: UpsertOrDeleteSecretsMutationInput!): UpsertOrDeleteSecretsMutationPayload!
   createSpanAnnotations(input: [CreateSpanAnnotationInput!]!): SpanAnnotationMutationPayload!
   createSpanNote(annotationInput: CreateSpanNoteInput!): SpanAnnotationMutationPayload!
@@ -3242,6 +3251,12 @@ input SetPromptVersionTagInput {
   description: String = null
 }
 
+input SetSandboxCredentialInput {
+  backendType: String!
+  key: String!
+  value: String!
+}
+
 type SetSandboxCredentialPayload {
   backendType: String!
   key: String!
@@ -3964,7 +3979,7 @@ input UpdateAnnotationInput {
 
 input UpdateCodeEvaluatorInput {
   id: ID!
-  name: String
+  name: Identifier
   sourceCode: String
   language: Language
   description: String
@@ -4016,6 +4031,7 @@ type UpdateModelMutationPayload {
 
 input UpdateSandboxConfigInput {
   id: ID!
+  name: Identifier
   description: String
   config: JSON
   timeout: Int

--- a/app/src/pages/settings/sandboxes/DeleteSandboxConfigButton.tsx
+++ b/app/src/pages/settings/sandboxes/DeleteSandboxConfigButton.tsx
@@ -35,8 +35,10 @@ export function DeleteSandboxConfigButton({
   const [isOpen, setIsOpen] = useState(false);
   const [commitDelete, isDeleting] =
     useMutation<DeleteSandboxConfigButtonDeleteSandboxConfigMutation>(graphql`
-      mutation DeleteSandboxConfigButtonDeleteSandboxConfigMutation($id: ID!) {
-        deleteSandboxConfig(id: $id) {
+      mutation DeleteSandboxConfigButtonDeleteSandboxConfigMutation(
+        $input: DeleteSandboxConfigInput!
+      ) {
+        deleteSandboxConfig(input: $input) {
           deletedId
           query {
             ...SettingsSandboxesPageFragment
@@ -48,7 +50,7 @@ export function DeleteSandboxConfigButton({
   const handleDelete = useCallback(() => {
     setError(null);
     commitDelete({
-      variables: { id: config.id },
+      variables: { input: { id: config.id } },
       onCompleted: () => {
         setIsOpen(false);
         notifySuccess({

--- a/app/src/pages/settings/sandboxes/__generated__/DeleteSandboxConfigButtonDeleteSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/DeleteSandboxConfigButtonDeleteSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a6b3d670fa7cfbced0aeac60e60cd4a2>>
+ * @generated SignedSource<<2e1337aeb865c6851eda732fd0164190>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,8 +10,11 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type DeleteSandboxConfigButtonDeleteSandboxConfigMutation$variables = {
+export type DeleteSandboxConfigInput = {
   id: string;
+};
+export type DeleteSandboxConfigButtonDeleteSandboxConfigMutation$variables = {
+  input: DeleteSandboxConfigInput;
 };
 export type DeleteSandboxConfigButtonDeleteSandboxConfigMutation$data = {
   readonly deleteSandboxConfig: {
@@ -31,14 +34,14 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "id"
+    "name": "input"
   }
 ],
 v1 = [
   {
     "kind": "Variable",
-    "name": "id",
-    "variableName": "id"
+    "name": "input",
+    "variableName": "input"
   }
 ],
 v2 = {
@@ -281,16 +284,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "63768ec92cb19d23d3d2ca6ad9e02b21",
+    "cacheID": "b5869c76782b1e2831c96b530f81241a",
     "id": null,
     "metadata": {},
     "name": "DeleteSandboxConfigButtonDeleteSandboxConfigMutation",
     "operationKind": "mutation",
-    "text": "mutation DeleteSandboxConfigButtonDeleteSandboxConfigMutation(\n  $id: ID!\n) {\n  deleteSandboxConfig(id: $id) {\n    deletedId\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation DeleteSandboxConfigButtonDeleteSandboxConfigMutation(\n  $input: DeleteSandboxConfigInput!\n) {\n  deleteSandboxConfig(input: $input) {\n    deletedId\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "31b1ce9a2f9da67df083832d678f5d0a";
+(node as any).hash = "814f1d281ae079e2a14d869109431b60";
 
 export default node;

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<277599302bd0f3a2ee6abfecbd3e6459>>
+ * @generated SignedSource<<d54369ccecade59bccb365375545f14c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type UpdateSandboxConfigInput = {
   description?: string | null;
   enabled?: boolean | null;
   id: string;
+  name?: string | null;
   timeout?: number | null;
 };
 export type SandboxConfigDialogUpdateSandboxConfigMutation$variables = {

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<66b2ba6804072366561474d441e0b77b>>
+ * @generated SignedSource<<4f0291e6cc0318c26d69e8a2dd4f123f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type UpdateSandboxConfigInput = {
   description?: string | null;
   enabled?: boolean | null;
   id: string;
+  name?: string | null;
   timeout?: number | null;
 };
 export type SandboxConfigsCardConfigEnabledSwitchMutation$variables = {

--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
         DocumentEvaluationsDataLoader,
         DocumentEvaluationSummaryDataLoader,
         DocumentRetrievalMetricsDataLoader,
+        EvaluatorByIdDataLoader,
         ExperimentAnnotationSummaryDataLoader,
         ExperimentDatasetSplitsDataLoader,
         ExperimentErrorRatesDataLoader,
@@ -60,6 +61,7 @@ if TYPE_CHECKING:
         PromptVersionSequenceNumberDataLoader,
         RecordCountDataLoader,
         SandboxConfigsByProviderDataLoader,
+        SandboxProviderByIdDataLoader,
         SecretsDataLoader,
         SessionAnnotationsBySessionDataLoader,
         SessionIODataLoader,
@@ -142,6 +144,7 @@ class DataLoaders:
     document_evaluation_summaries: DocumentEvaluationSummaryDataLoader
     document_evaluations: DocumentEvaluationsDataLoader
     document_retrieval_metrics: DocumentRetrievalMetricsDataLoader
+    evaluator_by_id: EvaluatorByIdDataLoader
     experiment_annotation_summaries: ExperimentAnnotationSummaryDataLoader
     experiment_dataset_splits: ExperimentDatasetSplitsDataLoader
     experiment_error_rates: ExperimentErrorRatesDataLoader
@@ -184,6 +187,7 @@ class DataLoaders:
     project_session_fields: TableFieldsDataLoader
     record_counts: RecordCountDataLoader
     sandbox_configs_by_provider: SandboxConfigsByProviderDataLoader
+    sandbox_provider_by_id: SandboxProviderByIdDataLoader
     secret_fields: TableFieldsDataLoader
     secrets: SecretsDataLoader
     session_annotations_by_session: SessionAnnotationsBySessionDataLoader

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -28,6 +28,7 @@ from .document_evaluation_summaries import (
 )
 from .document_evaluations import DocumentEvaluationsDataLoader
 from .document_retrieval_metrics import DocumentRetrievalMetricsDataLoader
+from .evaluator_by_id import EvaluatorByIdDataLoader
 from .experiment_annotation_summaries import ExperimentAnnotationSummaryDataLoader
 from .experiment_dataset_splits import ExperimentDatasetSplitsDataLoader
 from .experiment_error_rates import ExperimentErrorRatesDataLoader
@@ -58,6 +59,7 @@ from .prompt_version_sequence_number import PromptVersionSequenceNumberDataLoade
 from .prompt_versions import PromptVersionDataLoader
 from .record_counts import RecordCountCache, RecordCountDataLoader
 from .sandbox_configs_by_provider import SandboxConfigsByProviderDataLoader
+from .sandbox_provider_by_id import SandboxProviderByIdDataLoader
 from .secrets import SecretsDataLoader
 from .session_annotations_by_session import SessionAnnotationsBySessionDataLoader
 from .session_io import SessionIODataLoader
@@ -120,6 +122,7 @@ __all__ = [
     "DocumentEvaluationSummaryDataLoader",
     "DocumentEvaluationsDataLoader",
     "DocumentRetrievalMetricsDataLoader",
+    "EvaluatorByIdDataLoader",
     "ExperimentAnnotationSummaryDataLoader",
     "ExperimentErrorRatesDataLoader",
     "ExperimentJobsDataLoader",
@@ -145,6 +148,7 @@ __all__ = [
     "PromptVersionSequenceNumberDataLoader",
     "RecordCountDataLoader",
     "SandboxConfigsByProviderDataLoader",
+    "SandboxProviderByIdDataLoader",
     "SecretsDataLoader",
     "SessionAnnotationsBySessionDataLoader",
     "SessionIODataLoader",

--- a/src/phoenix/server/api/dataloaders/evaluator_by_id.py
+++ b/src/phoenix/server/api/dataloaders/evaluator_by_id.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from sqlalchemy import select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+EvaluatorId: TypeAlias = int
+Key: TypeAlias = EvaluatorId
+Result: TypeAlias = Optional[models.Evaluator]
+
+
+class EvaluatorByIdDataLoader(DataLoader[Key, Result]):
+    """Batches requests for evaluators by their primary key."""
+
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: list[Key]) -> list[Result]:
+        evaluator_ids = list(set(keys))
+        evaluators_by_id: dict[Key, models.Evaluator] = {}
+
+        async with self._db() as session:
+            data = await session.stream_scalars(
+                select(models.Evaluator).where(models.Evaluator.id.in_(evaluator_ids))
+            )
+            async for evaluator in data:
+                evaluators_by_id[evaluator.id] = evaluator
+
+        return [evaluators_by_id.get(key) for key in keys]

--- a/src/phoenix/server/api/dataloaders/sandbox_provider_by_id.py
+++ b/src/phoenix/server/api/dataloaders/sandbox_provider_by_id.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from sqlalchemy import select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+SandboxProviderId: TypeAlias = int
+Key: TypeAlias = SandboxProviderId
+Result: TypeAlias = Optional[models.SandboxProvider]
+
+
+class SandboxProviderByIdDataLoader(DataLoader[Key, Result]):
+    """Batches requests for sandbox providers by their primary key."""
+
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: list[Key]) -> list[Result]:
+        provider_ids = list(set(keys))
+        providers_by_id: dict[Key, models.SandboxProvider] = {}
+
+        async with self._db() as session:
+            data = await session.stream_scalars(
+                select(models.SandboxProvider).where(models.SandboxProvider.id.in_(provider_ids))
+            )
+            async for provider in data:
+                providers_by_id[provider.id] = provider
+
+        return [providers_by_id.get(key) for key in keys]

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -310,7 +310,7 @@ class DeleteDatasetEvaluatorsPayload:
 
 @strawberry.input
 class CreateCodeEvaluatorInput:
-    name: str
+    name: Identifier
     source_code: str
     language: Language
     description: Optional[str] = None
@@ -322,7 +322,7 @@ class CreateCodeEvaluatorInput:
 @strawberry.input
 class UpdateCodeEvaluatorInput:
     id: GlobalID
-    name: Optional[str] = UNSET
+    name: Optional[Identifier] = UNSET
     source_code: Optional[str] = UNSET
     language: Optional[Language] = UNSET
     description: Optional[str] = UNSET

--- a/src/phoenix/server/api/mutations/sandbox_config_mutations.py
+++ b/src/phoenix/server/api/mutations/sandbox_config_mutations.py
@@ -17,20 +17,26 @@ from typing import Any, cast
 
 import strawberry
 from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
+from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
 from strawberry.relay import GlobalID
 from strawberry.types import Info
 
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
+from phoenix.db.types.identifier import Identifier as IdentifierModel
 from phoenix.server.api.auth import IsAdminIfAuthEnabled, IsLocked, IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
-from phoenix.server.api.exceptions import BadRequest, NotFound
+from phoenix.server.api.exceptions import BadRequest, Conflict, NotFound
 from phoenix.server.api.queries import Query
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.SandboxConfig import (
     CreateSandboxConfigInput,
+    DeleteSandboxConfigInput,
+    DeleteSandboxCredentialInput,
     SandboxConfig,
+    SetSandboxCredentialInput,
     UpdateSandboxConfigInput,
     UpdateSandboxProviderInput,
     sandbox_config_from_input,
@@ -184,33 +190,46 @@ class SandboxConfigMutationMixin:
         """Create a new named sandbox configuration under an existing provider."""
         from sqlalchemy import select
 
-        async with info.context.db() as session:
-            provider_id = from_global_id_with_expected_type(
-                input.sandbox_provider_id,
-                expected_type_name=SandboxProviderType.__name__,
-            )
-            provider = await session.scalar(
-                select(models.SandboxProvider).where(models.SandboxProvider.id == provider_id)
-            )
-            if provider is None:
-                raise NotFound(f"SandboxProvider not found: {provider_id}")
+        try:
+            validated_name = IdentifierModel.model_validate(str(input.name))
+        except ValidationError as exc:
+            raise BadRequest(f"Invalid sandbox config name: {exc}")
+        if input.timeout is not None and input.timeout <= 0:
+            raise BadRequest("timeout must be a positive integer")
 
-            values = sandbox_config_from_input(input, provider_id=provider_id)
-            config_dict = values.get("config", {}) or {}
-            _check_env_var_collision(config_dict.get("env_vars"), provider.backend_type)
-            _check_reserved_top_level_keys(config_dict, provider.backend_type)
-            adapter = _SANDBOX_ADAPTERS.get(provider.backend_type)
-            if adapter is not None:
-                try:
-                    config_dict = adapter.validate_config(config_dict)
-                except (ValueError, ValidationError) as exc:
-                    raise BadRequest(str(exc))
-            values["config"] = config_dict
+        try:
+            async with info.context.db() as session:
+                provider_id = from_global_id_with_expected_type(
+                    input.sandbox_provider_id,
+                    expected_type_name=SandboxProviderType.__name__,
+                )
+                provider = await session.scalar(
+                    select(models.SandboxProvider).where(models.SandboxProvider.id == provider_id)
+                )
+                if provider is None:
+                    raise NotFound(f"SandboxProvider not found: {provider_id}")
 
-            row = models.SandboxConfig(**values)
-            session.add(row)
-            await session.flush()
-            await session.refresh(row)
+                values = sandbox_config_from_input(input, provider_id=provider_id)
+                values["name"] = validated_name.root
+                config_dict = values.get("config", {}) or {}
+                _check_env_var_collision(config_dict.get("env_vars"), provider.backend_type)
+                _check_reserved_top_level_keys(config_dict, provider.backend_type)
+                adapter = _SANDBOX_ADAPTERS.get(provider.backend_type)
+                if adapter is not None:
+                    try:
+                        config_dict = adapter.validate_config(config_dict)
+                    except (ValueError, ValidationError) as exc:
+                        raise BadRequest(str(exc))
+                values["config"] = config_dict
+
+                row = models.SandboxConfig(**values)
+                session.add(row)
+                await session.flush()
+                await session.refresh(row)
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            raise Conflict(
+                f"A sandbox config with name {input.name!r} already exists for this provider"
+            )
 
         return CreateSandboxConfigPayload(
             sandbox_config=to_gql_sandbox_config(row),
@@ -228,63 +247,83 @@ class SandboxConfigMutationMixin:
         """Update fields on an existing SandboxConfig."""
         from sqlalchemy import select
 
-        async with info.context.db() as session:
-            config_id = from_global_id_with_expected_type(
-                input.id,
-                expected_type_name=SandboxConfig.__name__,
-            )
-            row = await session.scalar(
-                select(models.SandboxConfig).where(models.SandboxConfig.id == config_id)
-            )
-            if row is None:
-                raise NotFound(f"SandboxConfig not found: {config_id}")
+        validated_name: str | None = None
+        if input.name is not strawberry.UNSET and input.name is not None:
+            try:
+                validated_name = IdentifierModel.model_validate(str(input.name)).root
+            except ValidationError as exc:
+                raise BadRequest(f"Invalid sandbox config name: {exc}")
+        if (
+            input.timeout is not strawberry.UNSET
+            and input.timeout is not None
+            and input.timeout <= 0
+        ):
+            raise BadRequest("timeout must be a positive integer")
 
-            if input.description is not strawberry.UNSET:
-                row.description = input.description
-            if input.config is not strawberry.UNSET:
-                stored_config = dict(row.config) if row.config else {}
-                config_dict: dict[str, Any] = (
-                    dict(cast(dict[str, Any], input.config)) if input.config is not None else {}
+        try:
+            async with info.context.db() as session:
+                config_id = from_global_id_with_expected_type(
+                    input.id,
+                    expected_type_name=SandboxConfig.__name__,
                 )
-                provider = await session.scalar(
-                    select(models.SandboxProvider).where(
-                        models.SandboxProvider.id == row.sandbox_provider_id
+                row = await session.scalar(
+                    select(models.SandboxConfig).where(models.SandboxConfig.id == config_id)
+                )
+                if row is None:
+                    raise NotFound(f"SandboxConfig not found: {config_id}")
+
+                if validated_name is not None:
+                    row.name = validated_name
+                if input.description is not strawberry.UNSET:
+                    row.description = input.description
+                if input.config is not strawberry.UNSET:
+                    stored_config = dict(row.config) if row.config else {}
+                    config_dict: dict[str, Any] = (
+                        dict(cast(dict[str, Any], input.config)) if input.config is not None else {}
                     )
-                )
-                if provider is not None:
-                    _check_env_var_collision(config_dict.get("env_vars"), provider.backend_type)
-                    _check_reserved_top_level_keys(config_dict, provider.backend_type)
-                    adapter = _SANDBOX_ADAPTERS.get(provider.backend_type)
-                    if adapter is not None:
-                        try:
-                            config_dict = adapter.validate_config(
-                                config_dict, stored_config=stored_config
-                            )
-                        except (ValueError, ValidationError) as exc:
-                            raise BadRequest(str(exc))
-                row.config = config_dict
-            if input.timeout is not strawberry.UNSET:
-                row.timeout = input.timeout if input.timeout is not None else 300
-            if input.enabled is not strawberry.UNSET and input.enabled is not None:
-                row.enabled = input.enabled
+                    provider = await session.scalar(
+                        select(models.SandboxProvider).where(
+                            models.SandboxProvider.id == row.sandbox_provider_id
+                        )
+                    )
+                    if provider is not None:
+                        _check_env_var_collision(config_dict.get("env_vars"), provider.backend_type)
+                        _check_reserved_top_level_keys(config_dict, provider.backend_type)
+                        adapter = _SANDBOX_ADAPTERS.get(provider.backend_type)
+                        if adapter is not None:
+                            try:
+                                config_dict = adapter.validate_config(
+                                    config_dict, stored_config=stored_config
+                                )
+                            except (ValueError, ValidationError) as exc:
+                                raise BadRequest(str(exc))
+                    row.config = config_dict
+                if input.timeout is not strawberry.UNSET:
+                    row.timeout = input.timeout if input.timeout is not None else 300
+                if input.enabled is not strawberry.UNSET and input.enabled is not None:
+                    row.enabled = input.enabled
 
-            await session.flush()
-            await session.refresh(row)
+                await session.flush()
+                await session.refresh(row)
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            raise Conflict("A sandbox config with that name already exists for this provider")
 
         return UpdateSandboxConfigPayload(
             sandbox_config=to_gql_sandbox_config(row),
             query=Query(),
         )
 
-    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked])  # type: ignore
+    @strawberry.mutation(
+        permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled, IsLocked]
+    )  # type: ignore
     async def delete_sandbox_config(
         self,
         info: Info[Context, None],
-        id: GlobalID,
+        input: DeleteSandboxConfigInput,
     ) -> DeleteSandboxConfigPayload:
         """Delete a SandboxConfig by GlobalID."""
         config_id = from_global_id_with_expected_type(
-            id,
+            input.id,
             expected_type_name=SandboxConfig.__name__,
         )
         async with info.context.db() as session:
@@ -293,9 +332,11 @@ class SandboxConfigMutationMixin:
                 raise NotFound(f"SandboxConfig not found: {config_id}")
             await session.delete(row)
 
-        return DeleteSandboxConfigPayload(deleted_id=id, query=Query())
+        return DeleteSandboxConfigPayload(deleted_id=input.id, query=Query())
 
-    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked])  # type: ignore
+    @strawberry.mutation(
+        permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled, IsLocked]
+    )  # type: ignore
     async def update_sandbox_provider(
         self,
         info: Info[Context, None],
@@ -344,13 +385,13 @@ class SandboxConfigMutationMixin:
     async def set_sandbox_credential(
         self,
         info: Info[Context, None],
-        backend_type: str,
-        key: str,
-        value: str,
+        input: SetSandboxCredentialInput,
     ) -> SetSandboxCredentialPayload:
         """Encrypt and upsert a sandbox provider credential into the secrets table."""
+        backend_type = input.backend_type
+        key = input.key
         _validate_sandbox_credential_key(backend_type, key)
-        value = value.strip()
+        value = input.value.strip()
         if not value:
             raise BadRequest("Credential value cannot be empty")
         encrypted = info.context.encrypt(value.encode("utf-8"))
@@ -380,10 +421,11 @@ class SandboxConfigMutationMixin:
     async def delete_sandbox_credential(
         self,
         info: Info[Context, None],
-        backend_type: str,
-        key: str,
+        input: DeleteSandboxCredentialInput,
     ) -> DeleteSandboxCredentialPayload:
         """Delete a sandbox provider credential from the secrets table."""
+        backend_type = input.backend_type
+        key = input.key
         _validate_sandbox_credential_key(backend_type, key)
         import sqlalchemy as sa
 

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -238,12 +238,7 @@ class CodeEvaluator(Evaluator, Node):
         )
         if language_id is None:
             return None
-        async with info.context.db() as session:
-            from sqlalchemy import select
-
-            row = await session.scalar(
-                select(models.Language).where(models.Language.id == language_id)
-            )
+        row = await info.context.data_loaders.language_by_id.load(language_id)
         return Language(row.name) if row is not None else None
 
     @strawberry.field
@@ -732,18 +727,17 @@ class DatasetEvaluator(Node):
         info: Info[Context, None],
     ) -> Evaluator:
         record = await self._get_record(info)
-        async with info.context.db.read() as session:
-            evaluator = await session.get(models.Evaluator, record.evaluator_id)
-            if evaluator is None:
-                raise NotFound(f"Evaluator not found: {record.evaluator_id}")
-            if isinstance(evaluator, models.LLMEvaluator):
-                return LLMEvaluator(id=evaluator.id)
-            elif isinstance(evaluator, models.CodeEvaluator):
-                return CodeEvaluator(id=evaluator.id)
-            elif isinstance(evaluator, models.BuiltinEvaluator):
-                return BuiltInEvaluator(id=evaluator.id)
-            else:
-                raise ValueError(f"Unknown evaluator type: {type(evaluator)}")
+        evaluator = await info.context.data_loaders.evaluator_by_id.load(record.evaluator_id)
+        if evaluator is None:
+            raise NotFound(f"Evaluator not found: {record.evaluator_id}")
+        if isinstance(evaluator, models.LLMEvaluator):
+            return LLMEvaluator(id=evaluator.id)
+        elif isinstance(evaluator, models.CodeEvaluator):
+            return CodeEvaluator(id=evaluator.id)
+        elif isinstance(evaluator, models.BuiltinEvaluator):
+            return BuiltInEvaluator(id=evaluator.id)
+        else:
+            raise ValueError(f"Unknown evaluator type: {type(evaluator)}")
 
     @strawberry.field
     async def description(
@@ -760,18 +754,17 @@ class DatasetEvaluator(Node):
         record = await self._get_record(info)
         if record.description is not None:
             return record.description
-        async with info.context.db.read() as session:
-            evaluator = await session.get(models.Evaluator, record.evaluator_id)
-            if evaluator is None:
-                return None
-            if isinstance(evaluator, models.BuiltinEvaluator):
-                builtin = get_builtin_evaluator_by_key(evaluator.key)
-                return builtin.description if builtin else None
-            elif isinstance(evaluator, models.LLMEvaluator):
-                return evaluator.description
-            elif isinstance(evaluator, models.CodeEvaluator):
-                return evaluator.description
+        evaluator = await info.context.data_loaders.evaluator_by_id.load(record.evaluator_id)
+        if evaluator is None:
             return None
+        if isinstance(evaluator, models.BuiltinEvaluator):
+            builtin = get_builtin_evaluator_by_key(evaluator.key)
+            return builtin.description if builtin else None
+        elif isinstance(evaluator, models.LLMEvaluator):
+            return evaluator.description
+        elif isinstance(evaluator, models.CodeEvaluator):
+            return evaluator.description
+        return None
 
     @strawberry.field
     async def output_configs(
@@ -788,25 +781,24 @@ class DatasetEvaluator(Node):
         configs = record.output_configs
         if configs is None:
             # Fall back to the base evaluator's stored configs
-            async with info.context.db.read() as session:
-                evaluator = await session.get(models.Evaluator, record.evaluator_id)
-                if evaluator is None:
+            evaluator = await info.context.data_loaders.evaluator_by_id.load(record.evaluator_id)
+            if evaluator is None:
+                return []
+            if isinstance(evaluator, models.LLMEvaluator):
+                configs = list(evaluator.output_configs)
+            elif isinstance(evaluator, models.CodeEvaluator):
+                configs = [
+                    config
+                    for config in evaluator.output_configs
+                    if isinstance(config, (CategoricalOutputConfig, ContinuousOutputConfig))
+                ]
+            elif isinstance(evaluator, models.BuiltinEvaluator):
+                builtin = get_builtin_evaluator_by_key(evaluator.key)
+                if builtin is None:
                     return []
-                if isinstance(evaluator, models.LLMEvaluator):
-                    configs = list(evaluator.output_configs)
-                elif isinstance(evaluator, models.CodeEvaluator):
-                    configs = [
-                        config
-                        for config in evaluator.output_configs
-                        if isinstance(config, (CategoricalOutputConfig, ContinuousOutputConfig))
-                    ]
-                elif isinstance(evaluator, models.BuiltinEvaluator):
-                    builtin = get_builtin_evaluator_by_key(evaluator.key)
-                    if builtin is None:
-                        return []
-                    configs = list(builtin().output_configs)
-                else:
-                    return []
+                configs = list(builtin().output_configs)
+            else:
+                return []
         configs_list: list[OutputConfigType] = configs if configs is not None else []
         return [
             _to_gql_output_config(

--- a/src/phoenix/server/api/types/SandboxConfig.py
+++ b/src/phoenix/server/api/types/SandboxConfig.py
@@ -20,6 +20,7 @@ from strawberry.types import Info
 
 from phoenix.db import models
 from phoenix.server.api.context import Context
+from phoenix.server.api.types.Identifier import Identifier
 from phoenix.server.sandbox import (
     SANDBOX_ADAPTER_METADATA,
     MissingSecretError,
@@ -211,7 +212,10 @@ class SandboxConfig(Node):
     @strawberry.field
     async def provider(self, info: Info[Context, None]) -> SandboxProvider:
         record = await self._get_record(info)
-        return SandboxProvider(id=record.sandbox_provider_id)
+        provider = await info.context.data_loaders.sandbox_provider_by_id.load(
+            record.sandbox_provider_id
+        )
+        return SandboxProvider(id=record.sandbox_provider_id, db_record=provider)
 
     @strawberry.field
     async def created_at(self, info: Info[Context, None]) -> datetime:
@@ -248,7 +252,7 @@ class SandboxConfig(Node):
 @strawberry.input
 class CreateSandboxConfigInput:
     sandbox_provider_id: GlobalID
-    name: str
+    name: Identifier
     description: Optional[str] = None
     config: Optional[JSON] = None
     timeout: Optional[int] = None
@@ -258,6 +262,7 @@ class CreateSandboxConfigInput:
 @strawberry.input
 class UpdateSandboxConfigInput:
     id: GlobalID
+    name: Optional[Identifier] = strawberry.UNSET
     description: Optional[str] = strawberry.UNSET
     config: Optional[JSON] = strawberry.UNSET
     timeout: Optional[int] = strawberry.UNSET
@@ -269,6 +274,24 @@ class UpdateSandboxProviderInput:
     id: GlobalID
     config: Optional[JSON] = strawberry.UNSET
     enabled: Optional[bool] = strawberry.UNSET
+
+
+@strawberry.input
+class DeleteSandboxConfigInput:
+    id: GlobalID
+
+
+@strawberry.input
+class SetSandboxCredentialInput:
+    backend_type: str
+    key: str
+    value: str
+
+
+@strawberry.input
+class DeleteSandboxCredentialInput:
+    backend_type: str
+    key: str
 
 
 # ---------------------------------------------------------------------------

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -99,6 +99,7 @@ from phoenix.server.api.dataloaders import (
     DocumentEvaluationsDataLoader,
     DocumentEvaluationSummaryDataLoader,
     DocumentRetrievalMetricsDataLoader,
+    EvaluatorByIdDataLoader,
     ExperimentAnnotationSummaryDataLoader,
     ExperimentDatasetSplitsDataLoader,
     ExperimentErrorRatesDataLoader,
@@ -125,6 +126,7 @@ from phoenix.server.api.dataloaders import (
     PromptVersionSequenceNumberDataLoader,
     RecordCountDataLoader,
     SandboxConfigsByProviderDataLoader,
+    SandboxProviderByIdDataLoader,
     SecretsDataLoader,
     SessionAnnotationsBySessionDataLoader,
     SessionIODataLoader,
@@ -814,6 +816,7 @@ def create_graphql_router(
                 document_annotation_fields=TableFieldsDataLoader(db, models.DocumentAnnotation),
                 document_evaluations=DocumentEvaluationsDataLoader(db),
                 document_retrieval_metrics=DocumentRetrievalMetricsDataLoader(db),
+                evaluator_by_id=EvaluatorByIdDataLoader(db),
                 annotation_summaries=AnnotationSummaryDataLoader(
                     db,
                     cache_map=(
@@ -886,6 +889,7 @@ def create_graphql_router(
                     cache_map=cache_for_dataloaders.record_count if cache_for_dataloaders else None,
                 ),
                 sandbox_configs_by_provider=SandboxConfigsByProviderDataLoader(db),
+                sandbox_provider_by_id=SandboxProviderByIdDataLoader(db),
                 secret_fields=TableFieldsDataLoader(db, models.Secret),
                 secrets=SecretsDataLoader(db),
                 session_annotations_by_session=SessionAnnotationsBySessionDataLoader(db),

--- a/tests/unit/server/api/dataloaders/test_evaluator_by_id.py
+++ b/tests/unit/server/api/dataloaders/test_evaluator_by_id.py
@@ -1,0 +1,48 @@
+from secrets import token_hex
+
+import sqlalchemy
+
+from phoenix.db import models
+from phoenix.db.types.identifier import Identifier
+from phoenix.server.api.dataloaders import EvaluatorByIdDataLoader
+from phoenix.server.types import DbSessionFactory
+
+
+async def test_evaluator_by_id_batches_lookups(db: DbSessionFactory) -> None:
+    """Loading N evaluator ids issues a single batched query and preserves key order."""
+    async with db() as session:
+        prompt = models.Prompt(name=Identifier(token_hex(4)))
+        session.add(prompt)
+        await session.flush()
+
+        evaluators = [
+            models.LLMEvaluator(name=Identifier(token_hex(4)), prompt_id=prompt.id)
+            for _ in range(5)
+        ]
+        session.add_all(evaluators)
+        await session.flush()
+        ids = [e.id for e in evaluators]
+
+    loader = EvaluatorByIdDataLoader(db)
+
+    query_count = 0
+
+    @sqlalchemy.event.listens_for(sqlalchemy.engine.Engine, "before_cursor_execute")
+    def count_queries(conn, cursor, statement, parameters, context, executemany):  # type: ignore[no-untyped-def]
+        nonlocal query_count
+        if "FROM evaluators" in statement:
+            query_count += 1
+
+    try:
+        # Include a duplicate id to exercise key-deduplication; the loader should
+        # still issue one underlying SELECT and return one row per requested key.
+        keys = [*ids, ids[0]]
+        results = await loader._load_fn(keys)
+    finally:
+        sqlalchemy.event.remove(sqlalchemy.engine.Engine, "before_cursor_execute", count_queries)
+
+    assert query_count == 1
+    assert [r.id if r is not None else None for r in results] == keys
+    # Unknown ids resolve to None without an extra query.
+    missing = await loader._load_fn([max(ids) + 1000])
+    assert missing == [None]

--- a/tests/unit/server/api/dataloaders/test_sandbox_provider_by_id.py
+++ b/tests/unit/server/api/dataloaders/test_sandbox_provider_by_id.py
@@ -1,0 +1,54 @@
+from secrets import token_hex
+
+import sqlalchemy
+from sqlalchemy import select
+
+from phoenix.db import models
+from phoenix.server.api.dataloaders import SandboxProviderByIdDataLoader
+from phoenix.server.types import DbSessionFactory
+
+
+async def test_sandbox_provider_by_id_batches_lookups(db: DbSessionFactory) -> None:
+    """Loading N provider ids issues a single batched query and preserves key order."""
+    async with db() as session:
+        language_id = await session.scalar(
+            select(models.Language.id).where(models.Language.name == "PYTHON")
+        )
+        if language_id is None:
+            language = models.Language(name="PYTHON")
+            session.add(language)
+            await session.flush()
+            language_id = language.id
+        providers = [
+            models.SandboxProvider(
+                backend_type=f"backend-{token_hex(3)}",
+                language_id=language_id,
+                config={},
+                enabled=True,
+            )
+            for _ in range(4)
+        ]
+        session.add_all(providers)
+        await session.flush()
+        ids = [p.id for p in providers]
+
+    loader = SandboxProviderByIdDataLoader(db)
+
+    query_count = 0
+
+    @sqlalchemy.event.listens_for(sqlalchemy.engine.Engine, "before_cursor_execute")
+    def count_queries(conn, cursor, statement, parameters, context, executemany):  # type: ignore[no-untyped-def]
+        nonlocal query_count
+        if "FROM sandbox_providers" in statement:
+            query_count += 1
+
+    try:
+        keys = [*ids, ids[0]]
+        results = await loader._load_fn(keys)
+    finally:
+        sqlalchemy.event.remove(sqlalchemy.engine.Engine, "before_cursor_execute", count_queries)
+
+    assert query_count == 1
+    assert [r.id if r is not None else None for r in results] == keys
+    missing = await loader._load_fn([max(ids) + 1000])
+    assert missing == [None]

--- a/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
+++ b/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
@@ -55,8 +55,8 @@ mutation UpdateSandboxConfig($input: UpdateSandboxConfigInput!) {
 """
 
 _DELETE = """
-mutation DeleteSandboxConfig($id: ID!) {
-    deleteSandboxConfig(id: $id) {
+mutation DeleteSandboxConfig($input: DeleteSandboxConfigInput!) {
+    deleteSandboxConfig(input: $input) {
         deletedId
     }
 }
@@ -275,7 +275,7 @@ class TestDeleteSandboxConfig:
         config_id = sandbox_config.id
         config_gid = _config_global_id(config_id)
 
-        result = await gql_client.execute(_DELETE, variables={"id": config_gid})
+        result = await gql_client.execute(_DELETE, variables={"input": {"id": config_gid}})
         assert result.data and not result.errors
         assert result.data["deleteSandboxConfig"]["deletedId"] == config_gid
 
@@ -289,7 +289,9 @@ class TestDeleteSandboxConfig:
         gql_client: AsyncGraphQLClient,
         seed_sandbox_providers: None,
     ) -> None:
-        result = await gql_client.execute(_DELETE, variables={"id": _config_global_id(99999)})
+        result = await gql_client.execute(
+            _DELETE, variables={"input": {"id": _config_global_id(99999)}}
+        )
         assert result.errors
 
 

--- a/tests/unit/server/api/mutations/test_sandbox_cache_invalidation.py
+++ b/tests/unit/server/api/mutations/test_sandbox_cache_invalidation.py
@@ -55,12 +55,8 @@ class _PermissiveTestConfig(BaseModel):
 
 
 _SET_CRED_MUTATION = """
-  mutation SetSandboxCredential(
-    $backendType: String!
-    $key: String!
-    $value: String!
-  ) {
-    setSandboxCredential(backendType: $backendType, key: $key, value: $value) {
+  mutation SetSandboxCredential($input: SetSandboxCredentialInput!) {
+    setSandboxCredential(input: $input) {
       backendType
       key
     }
@@ -151,9 +147,11 @@ class TestRebuildWithNewValue:
                 result = await gql_client.execute(
                     query=_SET_CRED_MUTATION,
                     variables={
-                        "backendType": backend_type,
-                        "key": cred_key,
-                        "value": "v2-plaintext",
+                        "input": {
+                            "backendType": backend_type,
+                            "key": cred_key,
+                            "value": "v2-plaintext",
+                        }
                     },
                     operation_name="SetSandboxCredential",
                 )
@@ -222,9 +220,11 @@ class TestSharedSpecInvalidation:
                 result = await gql_client.execute(
                     query=_SET_CRED_MUTATION,
                     variables={
-                        "backendType": py_adapter.key,
-                        "key": shared_spec_key,
-                        "value": "rotated",
+                        "input": {
+                            "backendType": py_adapter.key,
+                            "key": shared_spec_key,
+                            "value": "rotated",
+                        }
                     },
                     operation_name="SetSandboxCredential",
                 )

--- a/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
+++ b/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
@@ -660,3 +660,270 @@ class TestUpdateSandboxProviderNonCapabilityKeyRejected:
                 },
             )
         assert result.errors
+
+
+class TestPhase1AdminGates:
+    """Structural permission tests for the two newly-gated mutations."""
+
+    def test_delete_sandbox_config_has_admin_gate(self) -> None:
+        from phoenix.server.api.auth import IsAdminIfAuthEnabled
+        from phoenix.server.api.mutations.sandbox_config_mutations import (
+            SandboxConfigMutationMixin,
+        )
+
+        defn = SandboxConfigMutationMixin.__strawberry_definition__  # type: ignore[attr-defined]
+        field = next(f for f in defn.fields if f.name == "delete_sandbox_config")
+        assert IsAdminIfAuthEnabled in field.permission_classes
+
+    def test_update_sandbox_provider_has_admin_gate(self) -> None:
+        from phoenix.server.api.auth import IsAdminIfAuthEnabled
+        from phoenix.server.api.mutations.sandbox_config_mutations import (
+            SandboxConfigMutationMixin,
+        )
+
+        defn = SandboxConfigMutationMixin.__strawberry_definition__  # type: ignore[attr-defined]
+        field = next(f for f in defn.fields if f.name == "update_sandbox_provider")
+        assert IsAdminIfAuthEnabled in field.permission_classes
+
+
+class TestPhase1ValidationErrors:
+    """Integration tests for create/update SandboxConfig validation paths."""
+
+    async def test_create_duplicate_name_returns_error(
+        self,
+        gql_client: AsyncGraphQLClient,
+        seed_sandbox_providers: None,
+        db: DbSessionFactory,
+    ) -> None:
+        provider = await _get_provider(db, "WASM")
+        first = await gql_client.execute(
+            _CREATE,
+            variables={
+                "input": {
+                    "sandboxProviderId": _provider_global_id(provider.id),
+                    "name": "duplicate-cfg",
+                }
+            },
+        )
+        assert first.data and not first.errors
+
+        dup = await gql_client.execute(
+            _CREATE,
+            variables={
+                "input": {
+                    "sandboxProviderId": _provider_global_id(provider.id),
+                    "name": "duplicate-cfg",
+                }
+            },
+        )
+        assert dup.errors
+
+    async def test_update_rename_collision_returns_error(
+        self,
+        gql_client: AsyncGraphQLClient,
+        seed_sandbox_providers: None,
+        db: DbSessionFactory,
+    ) -> None:
+        provider = await _get_provider(db, "WASM")
+        async with db() as session:
+            existing = models.SandboxConfig(
+                sandbox_provider_id=provider.id,
+                name="existing-cfg",
+                config={},
+                timeout=30,
+            )
+            target = models.SandboxConfig(
+                sandbox_provider_id=provider.id,
+                name="target-cfg",
+                config={},
+                timeout=30,
+            )
+            session.add(existing)
+            session.add(target)
+            await session.flush()
+            target_id = target.id
+
+        result = await gql_client.execute(
+            _UPDATE,
+            variables={
+                "input": {
+                    "id": _config_global_id(target_id),
+                    "name": "existing-cfg",
+                }
+            },
+        )
+        assert result.errors
+
+    async def test_create_invalid_identifier_name_returns_error(
+        self,
+        gql_client: AsyncGraphQLClient,
+        seed_sandbox_providers: None,
+        db: DbSessionFactory,
+    ) -> None:
+        provider = await _get_provider(db, "WASM")
+        result = await gql_client.execute(
+            _CREATE,
+            variables={
+                "input": {
+                    "sandboxProviderId": _provider_global_id(provider.id),
+                    "name": "Has Spaces And Caps",
+                }
+            },
+        )
+        assert result.errors
+
+    async def test_create_zero_timeout_returns_error(
+        self,
+        gql_client: AsyncGraphQLClient,
+        seed_sandbox_providers: None,
+        db: DbSessionFactory,
+    ) -> None:
+        provider = await _get_provider(db, "WASM")
+        result = await gql_client.execute(
+            _CREATE_WITH_TIMEOUT,
+            variables={
+                "input": {
+                    "sandboxProviderId": _provider_global_id(provider.id),
+                    "name": "zero-timeout",
+                    "timeout": 0,
+                }
+            },
+        )
+        assert result.errors
+
+    async def test_update_negative_timeout_returns_error(
+        self,
+        gql_client: AsyncGraphQLClient,
+        seed_sandbox_providers: None,
+        db: DbSessionFactory,
+    ) -> None:
+        provider = await _get_provider(db, "WASM")
+        config = await _create_config_for_provider(db, provider)
+
+        result = await gql_client.execute(
+            _UPDATE_WITH_TIMEOUT,
+            variables={
+                "input": {
+                    "id": _config_global_id(config.id),
+                    "timeout": -5,
+                }
+            },
+        )
+        assert result.errors
+
+    async def test_update_rename_to_fresh_name_succeeds(
+        self,
+        gql_client: AsyncGraphQLClient,
+        seed_sandbox_providers: None,
+        db: DbSessionFactory,
+    ) -> None:
+        provider = await _get_provider(db, "WASM")
+        config = await _create_config_for_provider(db, provider)
+        original_id = config.id
+
+        result = await gql_client.execute(
+            """
+            mutation RenameSandboxConfig($input: UpdateSandboxConfigInput!) {
+                updateSandboxConfig(input: $input) {
+                    sandboxConfig { id name }
+                }
+            }
+            """,
+            variables={
+                "input": {
+                    "id": _config_global_id(config.id),
+                    "name": "renamed-cfg",
+                }
+            },
+        )
+        assert result.data and not result.errors
+        cfg = result.data["updateSandboxConfig"]["sandboxConfig"]
+        assert cfg["name"] == "renamed-cfg"
+        async with db() as session:
+            row = await session.get(models.SandboxConfig, original_id)
+        assert row is not None
+        assert row.name == "renamed-cfg"
+
+    async def test_update_name_null_is_noop(
+        self,
+        gql_client: AsyncGraphQLClient,
+        seed_sandbox_providers: None,
+        db: DbSessionFactory,
+    ) -> None:
+        provider = await _get_provider(db, "WASM")
+        config = await _create_config_for_provider(db, provider)
+        original_name = config.name
+
+        result = await gql_client.execute(
+            """
+            mutation NullRenameSandboxConfig($input: UpdateSandboxConfigInput!) {
+                updateSandboxConfig(input: $input) {
+                    sandboxConfig { id name }
+                }
+            }
+            """,
+            variables={
+                "input": {
+                    "id": _config_global_id(config.id),
+                    "name": None,
+                }
+            },
+        )
+        assert result.data and not result.errors
+        cfg = result.data["updateSandboxConfig"]["sandboxConfig"]
+        assert cfg["name"] == original_name
+
+
+class TestPhase1WrapperInputShape:
+    """Confirm the new wrapper input types route through the GraphQL parser."""
+
+    async def test_set_sandbox_credential_accepts_input_wrapper(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        from phoenix.server.sandbox import _BACKEND_CACHE, _SANDBOX_ADAPTERS
+        from phoenix.server.sandbox.types import (
+            ProviderCredentialSpec,
+            SandboxAdapter,
+            SandboxBackend,
+        )
+
+        backend_type = "WRAPPER_INPUT_TEST_BACKEND"
+        cred_key = "WRAPPER_INPUT_TEST_KEY"
+
+        class _Adapter(SandboxAdapter):
+            key = backend_type
+            display_name = "Wrapper Input Test Backend"
+            language = "PYTHON"
+            credential_specs = [
+                ProviderCredentialSpec(key=cred_key, display_name="Wrapper Test Cred")
+            ]
+
+            def build_backend(self, config, user_env=None):  # type: ignore[no-untyped-def]
+                return MagicMock(spec=SandboxBackend)
+
+        _SANDBOX_ADAPTERS[backend_type] = _Adapter()
+        try:
+            result = await gql_client.execute(
+                """
+                mutation SetCred($input: SetSandboxCredentialInput!) {
+                    setSandboxCredential(input: $input) { backendType key }
+                }
+                """,
+                variables={
+                    "input": {
+                        "backendType": backend_type,
+                        "key": cred_key,
+                        "value": "wrapped-secret",
+                    }
+                },
+            )
+            assert result.data and not result.errors
+            assert result.data["setSandboxCredential"]["backendType"] == backend_type
+        finally:
+            _SANDBOX_ADAPTERS.pop(backend_type, None)
+            for k in [k for k in list(_BACKEND_CACHE) if k[0] == backend_type]:
+                _BACKEND_CACHE.pop(k, None)

--- a/tests/unit/server/api/mutations/test_sandbox_credential_mutations.py
+++ b/tests/unit/server/api/mutations/test_sandbox_credential_mutations.py
@@ -15,12 +15,8 @@ from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
 
 _SET_MUTATION = """
-  mutation SetSandboxCredential(
-    $backendType: String!
-    $key: String!
-    $value: String!
-  ) {
-    setSandboxCredential(backendType: $backendType, key: $key, value: $value) {
+  mutation SetSandboxCredential($input: SetSandboxCredentialInput!) {
+    setSandboxCredential(input: $input) {
       backendType
       key
     }
@@ -28,8 +24,8 @@ _SET_MUTATION = """
 """
 
 _DELETE_MUTATION = """
-  mutation DeleteSandboxCredential($backendType: String!, $key: String!) {
-    deleteSandboxCredential(backendType: $backendType, key: $key) {
+  mutation DeleteSandboxCredential($input: DeleteSandboxCredentialInput!) {
+    deleteSandboxCredential(input: $input) {
       backendType
       key
     }
@@ -71,7 +67,13 @@ class TestSetSandboxCredential:
     ) -> None:
         result = await gql_client.execute(
             query=_SET_MUTATION,
-            variables={"backendType": _TEST_BACKEND, "key": _TEST_KEY, "value": "my-secret"},
+            variables={
+                "input": {
+                    "backendType": _TEST_BACKEND,
+                    "key": _TEST_KEY,
+                    "value": "my-secret",
+                }
+            },
             operation_name="SetSandboxCredential",
         )
         assert not result.errors
@@ -93,7 +95,13 @@ class TestSetSandboxCredential:
         for value in ("first-value", "second-value"):
             result = await gql_client.execute(
                 query=_SET_MUTATION,
-                variables={"backendType": _TEST_BACKEND, "key": _TEST_KEY, "value": value},
+                variables={
+                    "input": {
+                        "backendType": _TEST_BACKEND,
+                        "key": _TEST_KEY,
+                        "value": value,
+                    }
+                },
                 operation_name="SetSandboxCredential",
             )
             assert not result.errors
@@ -112,7 +120,7 @@ class TestSetSandboxCredential:
     ) -> None:
         result = await gql_client.execute(
             query=_SET_MUTATION,
-            variables={"backendType": "NONEXISTENT", "key": _TEST_KEY, "value": "v"},
+            variables={"input": {"backendType": "NONEXISTENT", "key": _TEST_KEY, "value": "v"}},
             operation_name="SetSandboxCredential",
         )
         assert result.errors
@@ -123,7 +131,7 @@ class TestSetSandboxCredential:
     ) -> None:
         result = await gql_client.execute(
             query=_SET_MUTATION,
-            variables={"backendType": _TEST_BACKEND, "key": "WRONG_KEY", "value": "v"},
+            variables={"input": {"backendType": _TEST_BACKEND, "key": "WRONG_KEY", "value": "v"}},
             operation_name="SetSandboxCredential",
         )
         assert result.errors
@@ -134,7 +142,7 @@ class TestSetSandboxCredential:
     ) -> None:
         result = await gql_client.execute(
             query=_SET_MUTATION,
-            variables={"backendType": _TEST_BACKEND, "key": _TEST_KEY, "value": "   "},
+            variables={"input": {"backendType": _TEST_BACKEND, "key": _TEST_KEY, "value": "   "}},
             operation_name="SetSandboxCredential",
         )
         assert result.errors
@@ -149,7 +157,13 @@ class TestSetSandboxCredential:
 
         await gql_client.execute(
             query=_SET_MUTATION,
-            variables={"backendType": _TEST_BACKEND, "key": _TEST_KEY, "value": "new-val"},
+            variables={
+                "input": {
+                    "backendType": _TEST_BACKEND,
+                    "key": _TEST_KEY,
+                    "value": "new-val",
+                }
+            },
             operation_name="SetSandboxCredential",
         )
 
@@ -164,13 +178,19 @@ class TestDeleteSandboxCredential:
     ) -> None:
         await gql_client.execute(
             query=_SET_MUTATION,
-            variables={"backendType": _TEST_BACKEND, "key": _TEST_KEY, "value": "to-delete"},
+            variables={
+                "input": {
+                    "backendType": _TEST_BACKEND,
+                    "key": _TEST_KEY,
+                    "value": "to-delete",
+                }
+            },
             operation_name="SetSandboxCredential",
         )
 
         result = await gql_client.execute(
             query=_DELETE_MUTATION,
-            variables={"backendType": _TEST_BACKEND, "key": _TEST_KEY},
+            variables={"input": {"backendType": _TEST_BACKEND, "key": _TEST_KEY}},
             operation_name="DeleteSandboxCredential",
         )
         assert not result.errors
@@ -189,7 +209,7 @@ class TestDeleteSandboxCredential:
     ) -> None:
         result = await gql_client.execute(
             query=_DELETE_MUTATION,
-            variables={"backendType": _TEST_BACKEND, "key": _TEST_KEY},
+            variables={"input": {"backendType": _TEST_BACKEND, "key": _TEST_KEY}},
             operation_name="DeleteSandboxCredential",
         )
         assert not result.errors
@@ -204,7 +224,7 @@ class TestDeleteSandboxCredential:
 
         await gql_client.execute(
             query=_DELETE_MUTATION,
-            variables={"backendType": _TEST_BACKEND, "key": _TEST_KEY},
+            variables={"input": {"backendType": _TEST_BACKEND, "key": _TEST_KEY}},
             operation_name="DeleteSandboxCredential",
         )
 
@@ -216,7 +236,7 @@ class TestDeleteSandboxCredential:
     ) -> None:
         result = await gql_client.execute(
             query=_DELETE_MUTATION,
-            variables={"backendType": "NONEXISTENT", "key": _TEST_KEY},
+            variables={"input": {"backendType": "NONEXISTENT", "key": _TEST_KEY}},
             operation_name="DeleteSandboxCredential",
         )
         assert result.errors
@@ -227,7 +247,7 @@ class TestDeleteSandboxCredential:
     ) -> None:
         result = await gql_client.execute(
             query=_DELETE_MUTATION,
-            variables={"backendType": _TEST_BACKEND, "key": "WRONG_KEY"},
+            variables={"input": {"backendType": _TEST_BACKEND, "key": "WRONG_KEY"}},
             operation_name="DeleteSandboxCredential",
         )
         assert result.errors


### PR DESCRIPTION
Ensures `IsAdminIfAuthEnabled` is applied to all sandbox mutations, normalizes the sandbox + code-evaluator mutation shape, tightens input validation, and eliminates four read-side N+1 hazards on the same surface.

### Read-side N+1 fixes

- **`CodeEvaluator.language`** non-`db_record` path now uses the existing `language_by_id` DataLoader instead of an inline `session.scalar(select(Language)…)` per row.
- **`DatasetEvaluator.evaluator`, `.description`, `.output_configs`** migrated to a new `EvaluatorByIdDataLoader`. Three resolvers on each row were each issuing `session.get(models.Evaluator, …)` independently.
- **`SandboxConfig.provider`** uses a new `SandboxProviderByIdDataLoader` and passes `db_record=` so subsequent `SandboxProvider` field resolvers short-circuit on the preloaded row.

Field names, return shapes, nullability, authorization, and error semantics are unchanged for read-side resolvers — these are performance-only.

## Test plan

- [ ] `uv run pytest tests/unit/server/api/mutations/test_sandbox_config_mutations.py tests/unit/server/api/mutations/test_sandbox_credential_mutations.py tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py tests/unit/server/api/mutations/test_sandbox_cache_invalidation.py tests/unit/server/api/mutations/test_evaluator_mutations.py -c pytest-quiet.ini -n auto` — covers admin-gate structural assertions, duplicate-name → `Conflict`, rename collision → `Conflict`, invalid `Identifier` → `BadRequest`, zero/negative `timeout` → `BadRequest`, name-rename preserves `sandbox_config_id`, name=`null` is no-op, and the new wrapper-input GraphQL shape.
- [ ] `uv run pytest tests/unit/server/api/dataloaders/test_evaluator_by_id.py tests/unit/server/api/dataloaders/test_sandbox_provider_by_id.py tests/unit/server/api/types/test_Evaluator.py -c pytest-quiet.ini -n auto` — query-counter tests assert N→1 batching for the new DataLoaders; existing resolver tests assert no semantic regression.
- [ ] Manual smoke: list `Query.evaluators` and `Query.sandbox_providers` with a populated DB and confirm DB query count does not scale with row count for `CodeEvaluator.language`, `DatasetEvaluator.{evaluator,description,output_configs}`, `SandboxConfig.provider`.
- [ ] Frontend: `DeleteSandboxConfigButton` Relay artifact will need regeneration via `relay-compiler` before the JS build is green; not regenerated here because the compiler isn't in this environment.