### PR TITLE
fix: replace crypto.randomUUID with context-safe fallback

### DIFF
--- a/app/src/agent/context/useAdvertiseAgentContext.ts
+++ b/app/src/agent/context/useAdvertiseAgentContext.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
+import { generateUUID } from "@phoenix/utils/uuidUtils";
 
 import type { AgentContext } from "./agentContextTypes";
 
@@ -23,7 +24,7 @@ export function useAdvertiseAgentContext(context: AgentContext | null): void {
   const mountIdRef = useRef<string | null>(null);
 
   if (mountIdRef.current === null) {
-    mountIdRef.current = crypto.randomUUID();
+    mountIdRef.current = generateUUID();
   }
 
   const serialized = context ? JSON.stringify(context) : null;

--- a/app/src/components/agent/useGenerateSessionSummary.ts
+++ b/app/src/components/agent/useGenerateSessionSummary.ts
@@ -8,6 +8,7 @@ import { useCallback, useRef } from "react";
 
 import { authFetch } from "@phoenix/authFetch";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
+import { generateUUID } from "@phoenix/utils/uuidUtils";
 
 import {
   SUMMARY_OUTPUT_TOOL,
@@ -69,19 +70,19 @@ async function fetchSummary({
 
   const chunkStream = await transport.sendMessages({
     trigger: "submit-message",
-    chatId: crypto.randomUUID(),
+    chatId: generateUUID(),
     messageId: undefined,
     body: {
       output_tools: [SUMMARY_OUTPUT_TOOL],
     },
     messages: [
       {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         role: "system" as const,
         parts: [{ type: "text" as const, text: SUMMARY_SYSTEM_PROMPT }],
       },
       {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         role: "user" as const,
         parts: [{ type: "text" as const, text: summarizePrompt }],
       },

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -14,6 +14,7 @@ import {
   type AgentCapabilityKey,
 } from "@phoenix/agent/extensions/capabilities";
 import type { PendingElicitation } from "@phoenix/agent/tools/elicit";
+import { generateUUID } from "@phoenix/utils/uuidUtils";
 
 import type { ModelConfig } from "./playground/types";
 
@@ -292,7 +293,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
       });
     },
     createSession: () => {
-      const sessionId = crypto.randomUUID();
+      const sessionId = generateUUID();
       set(
         (state) => {
           const session: AgentSession = {

--- a/app/src/utils/__tests__/uuidUtils.test.ts
+++ b/app/src/utils/__tests__/uuidUtils.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { generateUUID } from "../uuidUtils";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe("generateUUID", () => {
+  it("returns a valid UUID v4 format", () => {
+    const id = generateUUID();
+    expect(id).toMatch(UUID_PATTERN);
+  });
+
+  it("returns unique values on successive calls", () => {
+    const ids = new Set(Array.from({ length: 20 }, () => generateUUID()));
+    expect(ids.size).toBe(20);
+  });
+
+  describe("when crypto.randomUUID is unavailable (non-secure context)", () => {
+    const originalRandomUUID = crypto.randomUUID;
+
+    beforeEach(() => {
+      // Simulate a non-secure context where randomUUID is not exposed
+      // @ts-expect-error — intentionally removing for test
+      crypto.randomUUID = undefined;
+    });
+
+    afterEach(() => {
+      crypto.randomUUID = originalRandomUUID;
+    });
+
+    it("falls back to crypto.getRandomValues and returns a valid UUID v4", () => {
+      const id = generateUUID();
+      expect(id).toMatch(UUID_PATTERN);
+    });
+
+    it("returns unique values via the fallback path", () => {
+      const ids = new Set(Array.from({ length: 20 }, () => generateUUID()));
+      expect(ids.size).toBe(20);
+    });
+  });
+});

--- a/app/src/utils/uuidUtils.ts
+++ b/app/src/utils/uuidUtils.ts
@@ -1,0 +1,26 @@
+/**
+ * Generates a RFC 4122 version 4 UUID.
+ *
+ * Works in both secure (HTTPS) and non-secure (HTTP) browser contexts,
+ * making it safe for use in Docker deployments served over plain HTTP.
+ *
+ * @returns A lowercase UUID v4 string, e.g. "110e8400-e29b-41d4-a716-446655440000"
+ */
+export function generateUUID(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  // crypto.randomUUID is unavailable in non-secure (HTTP) contexts.
+  // crypto.getRandomValues is available in all contexts, including HTTP.
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}


### PR DESCRIPTION
## Summary

Fixes #12987 — Phoenix crashes with `crypto.randomUUID is not a function` when viewing traces in a Docker deployment served over plain HTTP.

- **Root cause**: `crypto.randomUUID()` is only available in secure contexts (HTTPS). The default Docker image serves over HTTP, so the browser does not expose this API.
- **Fix**: Introduce `generateUUID()` in `app/src/utils/uuidUtils.ts` which prefers the native `crypto.randomUUID()` when available and falls back to `crypto.getRandomValues()` — available in all contexts including HTTP.
- All three call-sites that used `crypto.randomUUID()` directly are updated to use the new utility.

## Files changed

| File | Change |
|---|---|
| `app/src/utils/uuidUtils.ts` | New `generateUUID()` utility with HTTP fallback |
| `app/src/utils/__tests__/uuidUtils.test.ts` | Tests covering both native and fallback paths |
| `app/src/agent/context/useAdvertiseAgentContext.ts` | Use `generateUUID()` |
| `app/src/store/agentStore.ts` | Use `generateUUID()` |
| `app/src/components/agent/useGenerateSessionSummary.ts` | Use `generateUUID()` |

## How to verify

1. Start Phoenix via Docker over HTTP (not HTTPS).
2. Send some traces.
3. Navigate to the Traces view — it should load without crashing.
4. Previously: `Something went wrong — crypto.randomUUID is not a function`.

Generated with [Claude Code](https://claude.com/claude-code)
