### PR TITLE
chore(uv): exempt arize-phoenix-* packages from exclude-newer window

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -357,7 +357,7 @@ required-version = "==0.11.8"  # When updating this version, also update the `ba
 exclude-newer = "3 days"
 # Exempt our own workspace packages from the `exclude-newer` window so freshly
 # published versions are immediately resolvable.
-exclude-newer-package = { arize-phoenix-client = "2099-12-31", arize-phoenix-evals = "2099-12-31", arize-phoenix-otel = "2099-12-31" }
+exclude-newer-package = { arize-phoenix-client = "2099-12-31T00:00:00Z", arize-phoenix-evals = "2099-12-31T00:00:00Z", arize-phoenix-otel = "2099-12-31T00:00:00Z" }
 
 [tool.uv.workspace]
 members = ["packages/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -355,6 +355,9 @@ script_location = "src/phoenix/db/migrations"  # enables `uv run alembic <comman
 [tool.uv]
 required-version = "==0.11.8"  # When updating this version, also update the `backend-builder` image in the Dockerfile
 exclude-newer = "3 days"
+# Exempt our own workspace packages from the `exclude-newer` window so freshly
+# published versions are immediately resolvable.
+exclude-newer-package = { arize-phoenix-client = "2099-12-31", arize-phoenix-evals = "2099-12-31", arize-phoenix-otel = "2099-12-31" }
 
 [tool.uv.workspace]
 members = ["packages/*"]

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,11 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
+[options.exclude-newer-package]
+arize-phoenix-evals = "2100-01-01T07:00:00Z"
+arize-phoenix-client = "2100-01-01T07:00:00Z"
+arize-phoenix-otel = "2100-01-01T07:00:00Z"
+
 [manifest]
 members = [
     "arize-phoenix",

--- a/uv.lock
+++ b/uv.lock
@@ -19,9 +19,9 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
-arize-phoenix-evals = "2100-01-01T07:00:00Z"
-arize-phoenix-client = "2100-01-01T07:00:00Z"
-arize-phoenix-otel = "2100-01-01T07:00:00Z"
+arize-phoenix-evals = "2099-12-31T00:00:00Z"
+arize-phoenix-client = "2099-12-31T00:00:00Z"
+arize-phoenix-otel = "2099-12-31T00:00:00Z"
 
 [manifest]
 members = [


### PR DESCRIPTION
## Summary
- The repo-wide `exclude-newer = "3 days"` setting in `[tool.uv]` blocks freshly published versions of our own workspace packages from being resolved for ~3 days after release.
- Adds an `exclude-newer-package` override for `arize-phoenix-client`, `arize-phoenix-evals`, and `arize-phoenix-otel` (set to `2099-12-31`) so first-party packages are always resolvable immediately, while third-party deps continue to honor the 3-day window.

## Test plan
- [x] `uv lock --check` resolves cleanly with the new config.
- [ ] Verify a fresh install picks up a just-released `arize-phoenix-*` version without bumping `exclude-newer`.