### PR TITLE
docs: add LinkedIn social links alongside X/Bluesky

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
     <a target="_blank" href="https://x.com/ArizePhoenix">
         <img src="https://img.shields.io/badge/-ArizePhoenix-blue.svg?color=blue&labelColor=gray&logo=x">
     </a>
+    <a target="_blank" href="https://www.linkedin.com/showcase/113218220">
+        <img src="https://img.shields.io/badge/-ArizePhoenix-blue.svg?color=blue&labelColor=gray&logo=linkedin">
+    </a>
     <a target="_blank" href="https://pypi.org/project/arize-phoenix/">
         <img src="https://img.shields.io/pypi/v/arize-phoenix?color=blue">
     </a>
@@ -189,6 +192,7 @@ Join our community to connect with thousands of AI builders.
 - 🌟 Leave a star on our [GitHub](https://github.com/Arize-ai/phoenix).
 - 🐞 Report bugs with [GitHub Issues](https://github.com/Arize-ai/phoenix/issues).
 - 𝕏 Follow us on [𝕏](https://twitter.com/ArizePhoenix).
+- 💼 Follow us on [LinkedIn](https://www.linkedin.com/showcase/113218220).
 - 🗺️ Check out our [roadmap](https://github.com/orgs/Arize-ai/projects/45) to see where we're heading next.
 - 🧑‍🏫 Deep dive into everything [Agents](http://arize.com/ai-agents/) and [LLM Evaluations](https://arize.com/llm-evaluation) on Arize's Learning Hubs.
 

--- a/api_reference/source/conf.py
+++ b/api_reference/source/conf.py
@@ -179,6 +179,11 @@ html_theme_options = {
             "url": "https://x.com/ArizePhoenix",
             "icon": "fa-brands fa-twitter",
         },
+        {
+            "name": "LinkedIn",
+            "url": "https://www.linkedin.com/showcase/113218220",
+            "icon": "fa-brands fa-linkedin",
+        },
     ],
     "external_links": [
         {"name": "Phoenix Otel", "url": "https://phoenix-otel.readthedocs.io/"},

--- a/app/src/pages/auth/AuthLayout.tsx
+++ b/app/src/pages/auth/AuthLayout.tsx
@@ -56,7 +56,8 @@ export function AuthLayout({ children }: PropsWithChildren) {
         <a href="https://join.slack.com/t/arize-ai/shared_invite/zt-3r07iavnk-ammtATWSlF0pSrd1DsMW7g">
           Community
         </a>
-        |<a href="https://twitter.com/ArizePhoenix">Social</a>|
+        |<a href="https://twitter.com/ArizePhoenix">X</a>|
+        <a href="https://www.linkedin.com/showcase/113218220">LinkedIn</a>|
         <a href="https://github.com/Arize-ai/phoenix">GitHub</a>|
         <a href="https://github.com/Arize-ai/phoenix/releases">{`arize-phoenix v${window.Config.platformVersion}`}</a>
       </footer>

--- a/docs.json
+++ b/docs.json
@@ -1433,7 +1433,7 @@
       },
       {
         "label": "",
-        "href": "https://www.linkedin.com/company/arizeai/",
+        "href": "https://www.linkedin.com/showcase/113218220",
         "title": "LinkedIn",
         "icon": "linkedin"
       },

--- a/js/.changeset/linkedin-social-links.md
+++ b/js/.changeset/linkedin-social-links.md
@@ -1,0 +1,10 @@
+---
+"@arizeai/phoenix-mcp": patch
+"@arizeai/phoenix-cli": patch
+"@arizeai/phoenix-evals": patch
+"@arizeai/phoenix-config": patch
+"@arizeai/phoenix-client": patch
+"@arizeai/phoenix-otel": patch
+---
+
+Add LinkedIn link to the Community section of the README.

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -624,3 +624,4 @@ Trace JSON structure:
 - 🌟 [GitHub](https://github.com/Arize-ai/phoenix)
 - 🐞 [Report bugs](https://github.com/Arize-ai/phoenix/issues)
 - 𝕏 [@ArizePhoenix](https://twitter.com/ArizePhoenix)
+- 💼 [LinkedIn](https://www.linkedin.com/showcase/113218220)

--- a/js/packages/phoenix-client/README.md
+++ b/js/packages/phoenix-client/README.md
@@ -649,4 +649,5 @@ Join our community to connect with thousands of AI builders:
 - 🌟 Leave a star on our [GitHub](https://github.com/Arize-ai/phoenix).
 - 🐞 Report bugs with [GitHub Issues](https://github.com/Arize-ai/phoenix/issues).
 - 𝕏 Follow us on [𝕏](https://twitter.com/ArizePhoenix).
+- 💼 Follow us on [LinkedIn](https://www.linkedin.com/showcase/113218220).
 - 🗺️ Check out our [roadmap](https://github.com/orgs/Arize-ai/projects/45) to see where we're heading next.

--- a/js/packages/phoenix-config/README.md
+++ b/js/packages/phoenix-config/README.md
@@ -122,3 +122,4 @@ Join our community to connect with thousands of AI builders:
 - 🌟 Leave a star on our [GitHub](https://github.com/Arize-ai/phoenix).
 - 🐞 Report bugs with [GitHub Issues](https://github.com/Arize-ai/phoenix/issues).
 - 𝕏 Follow us on [𝕏](https://twitter.com/ArizePhoenix).
+- 💼 Follow us on [LinkedIn](https://www.linkedin.com/showcase/113218220).

--- a/js/packages/phoenix-evals/README.md
+++ b/js/packages/phoenix-evals/README.md
@@ -278,4 +278,5 @@ Join our community to connect with thousands of AI builders:
 - 🌟 Leave a star on our [GitHub](https://github.com/Arize-ai/phoenix).
 - 🐞 Report bugs with [GitHub Issues](https://github.com/Arize-ai/phoenix/issues).
 - 𝕏 Follow us on [𝕏](https://twitter.com/ArizePhoenix).
+- 💼 Follow us on [LinkedIn](https://www.linkedin.com/showcase/113218220).
 - 🗺️ Check out our [roadmap](https://github.com/orgs/Arize-ai/projects/45) to see where we're heading next.

--- a/js/packages/phoenix-mcp/README.md
+++ b/js/packages/phoenix-mcp/README.md
@@ -142,6 +142,7 @@ Join our community to connect with thousands of AI builders:
 - 🌟 Leave a star on our [GitHub](https://github.com/Arize-ai/phoenix).
 - 🐞 Report bugs with [GitHub Issues](https://github.com/Arize-ai/phoenix/issues).
 - 𝕏 Follow us on [𝕏](https://twitter.com/ArizePhoenix).
+- 💼 Follow us on [LinkedIn](https://www.linkedin.com/showcase/113218220).
 - 🗺️ Check out our [roadmap](https://github.com/orgs/Arize-ai/projects/45) to see where we're heading next.
 
 ## License

--- a/js/packages/phoenix-otel/README.md
+++ b/js/packages/phoenix-otel/README.md
@@ -581,4 +581,5 @@ Join our community to connect with thousands of AI builders:
 - 🌟 Leave a star on our [GitHub](https://github.com/Arize-ai/phoenix)
 - 🐞 Report bugs with [GitHub Issues](https://github.com/Arize-ai/phoenix/issues)
 - 𝕏 Follow us on [𝕏](https://twitter.com/ArizePhoenix)
+- 💼 Follow us on [LinkedIn](https://www.linkedin.com/showcase/113218220)
 - 🗺️ Check out our [roadmap](https://github.com/orgs/Arize-ai/projects/45)

--- a/packages/phoenix-client/README.md
+++ b/packages/phoenix-client/README.md
@@ -431,4 +431,5 @@ Join our community to connect with thousands of AI builders:
 - 🌟 Leave a star on our [GitHub](https://github.com/Arize-ai/phoenix).
 - 🐞 Report bugs with [GitHub Issues](https://github.com/Arize-ai/phoenix/issues).
 - 𝕏 Follow us on [𝕏](https://twitter.com/ArizePhoenix).
+- 💼 Follow us on [LinkedIn](https://www.linkedin.com/showcase/113218220).
 - 🗺️ Check out our [roadmap](https://github.com/orgs/Arize-ai/projects/45) to see where we're heading next.

--- a/packages/phoenix-client/docs/source/conf.py
+++ b/packages/phoenix-client/docs/source/conf.py
@@ -113,6 +113,11 @@ html_theme_options = {
             "url": "https://x.com/ArizePhoenix",
             "icon": "fa-brands fa-x-twitter",
         },
+        {
+            "name": "LinkedIn",
+            "url": "https://www.linkedin.com/showcase/113218220",
+            "icon": "fa-brands fa-linkedin",
+        },
     ],
     "external_links": [
         {"name": "Phoenix Docs", "url": "https://arize.com/docs/phoenix"},

--- a/packages/phoenix-evals/README.md
+++ b/packages/phoenix-evals/README.md
@@ -183,4 +183,5 @@ Join our community to connect with thousands of AI builders:
 - 🌟 Leave a star on our [GitHub](https://github.com/Arize-ai/phoenix).
 - 🐞 Report bugs with [GitHub Issues](https://github.com/Arize-ai/phoenix/issues).
 - 𝕏 Follow us on [𝕏](https://twitter.com/ArizePhoenix).
+- 💼 Follow us on [LinkedIn](https://www.linkedin.com/showcase/113218220).
 - 🗺️ Check out our [roadmap](https://github.com/orgs/Arize-ai/projects/45) to see where we're heading next.

--- a/packages/phoenix-evals/docs/source/conf.py
+++ b/packages/phoenix-evals/docs/source/conf.py
@@ -113,6 +113,11 @@ html_theme_options = {
             "url": "https://x.com/ArizePhoenix",
             "icon": "fa-brands fa-x-twitter",
         },
+        {
+            "name": "LinkedIn",
+            "url": "https://www.linkedin.com/showcase/113218220",
+            "icon": "fa-brands fa-linkedin",
+        },
     ],
     "external_links": [
         {"name": "Phoenix Docs", "url": "https://arize.com/docs/phoenix"},

--- a/packages/phoenix-otel/README.md
+++ b/packages/phoenix-otel/README.md
@@ -203,4 +203,5 @@ Join our community to connect with thousands of AI builders:
 - 🌟 Leave a star on our [GitHub](https://github.com/Arize-ai/phoenix).
 - 🐞 Report bugs with [GitHub Issues](https://github.com/Arize-ai/phoenix/issues).
 - 𝕏 Follow us on [𝕏](https://twitter.com/ArizePhoenix).
+- 💼 Follow us on [LinkedIn](https://www.linkedin.com/showcase/113218220).
 - 🗺️ Check out our [roadmap](https://github.com/orgs/Arize-ai/projects/45) to see where we're heading next.

--- a/packages/phoenix-otel/docs/source/conf.py
+++ b/packages/phoenix-otel/docs/source/conf.py
@@ -112,6 +112,11 @@ html_theme_options = {
             "url": "https://x.com/ArizePhoenix",
             "icon": "fa-brands fa-x-twitter",
         },
+        {
+            "name": "LinkedIn",
+            "url": "https://www.linkedin.com/showcase/113218220",
+            "icon": "fa-brands fa-linkedin",
+        },
     ],
     "external_links": [
         {"name": "Phoenix Docs", "url": "https://arize.com/docs/phoenix"},


### PR DESCRIPTION
## Summary
- Adds LinkedIn (https://www.linkedin.com/showcase/113218220) wherever X or Bluesky links appear: root `README.md` badges + Community section, all Python and JS package READMEs, Sphinx `conf.py` icon links, the Mintlify `docs.json` site chrome, and the auth footer in `app/src/pages/auth/AuthLayout.tsx`.
- Updates the existing LinkedIn entry in `docs.json` from the Arize company page (`/company/arizeai/`) to the Phoenix showcase URL.
- Splits the generic "Social" link in the auth footer into explicit "X" and "LinkedIn" entries.

## Test plan
- [ ] Render `README.md` on GitHub and confirm the new LinkedIn badge appears next to the X badge
- [ ] Build the Mintlify docs and confirm the navbar LinkedIn icon points at the showcase URL
- [ ] Build each Sphinx docs site (`api_reference`, `phoenix-evals`, `phoenix-client`, `phoenix-otel`) and confirm the LinkedIn icon renders next to the X icon
- [ ] Load the auth page and confirm the footer shows X and LinkedIn as separate links