### PR TITLE
docs: document all REST API endpoints and index them in llms.txt

### DIFF
--- a/.agents/skills/phoenix-llms-txt/SKILL.md
+++ b/.agents/skills/phoenix-llms-txt/SKILL.md
@@ -25,34 +25,35 @@ Sections use `##` headings, subsections use `###`. Subsections inherit their par
 
 ## Coverage rules
 
+Default to **including** every published `.mdx` page that exists in `docs.json` navigation. The AFDocs Agent Score (`afdocs.dev`) measures llms.txt coverage against the sitemap and flags anything under 80%. Aim for ≥ 90% coverage of nav-published pages.
+
 **Include as individual entries:**
 - All workflow docs (tracing, evaluation, experiments, prompts)
-- SDK and API reference pages
+- SDK and API reference pages, including each REST API endpoint
 - Self-hosting and deployment guides
 - Quick start guides (Python and TypeScript)
 - Server-side evaluation pages
-**Index-level only (one entry, not every sub-page):**
-- REST API endpoints — the `api-reference` overview is sufficient
-- Legacy evaluation pages
-- Cookbooks — link to the cookbook index page only, since individual cookbook pages are typically Colab notebooks that agents cannot parse
-- Evaluation integrations — link to the evaluation-integrations index (`https://arize.com/docs/phoenix/integrations/evaluation-integrations`) only; do NOT list individual 3rd-party eval library pages (e.g., Ragas, Cleanlab, UQLM, MLflow). These are thin wrappers around external tools and change frequently.
-- Pre-built evaluation metrics — link to the pre-built-metrics index page and the server-evals pre-built-metrics index only; do NOT list each individual metric page (e.g., faithfulness, toxicity, hallucination). The index pages enumerate all available metrics.
+- Pre-built evaluation metrics — list each metric page (faithfulness, toxicity, hallucination, RAG relevance, etc.) so agents can find them by name
+- Evaluation integrations — list each provider's evals page (Ragas, Cleanlab, UQLM, MLflow, OpenAI evals, Anthropic evals, etc.); these are real docs pages with usable code
+- Release notes — list each individual release note. Group by year under a `## Release Notes` section with `### YYYY` subsections so the section stays scannable
+- Cookbook pages with substantial prose content (code samples, written explanation, configuration walkthroughs)
 
 **Include as individual entries under Integrations:**
 - All LLM provider pages (OpenAI, Anthropic, Bedrock, Google GenAI, etc.) and their tracing/evals sub-pages
 - All framework integration pages (LangChain, LlamaIndex, Vercel AI SDK, etc.) and their tracing sub-pages
 - All platform integration pages (Dify, Flowise, LangFlow, etc.)
 - Developer tools (Coding Agents, MCP Server)
+- Vector databases (each provider page)
 
-**Exclude — content agents cannot use or does not help them:**
-- Agent-assisted setup page — this is for AI coding agents, not for human developers or LLM documentation consumers
+**Exclude — content agents cannot use:**
+- Agent-assisted setup page — for AI coding agents, not human developers or LLM documentation consumers
 - Interactive demos and sandbox links (e.g., Phoenix Demo) — agents cannot interact with live demos
 - Colab / Jupyter notebook links (e.g., End-to-End Features Notebook) — agents cannot parse `.ipynb` hosted on Colab
-- Cookbook pages that are **only** notebook links without prose documentation — if the page is just a Colab embed, exclude it; if it has substantial written content with code snippets, include it
+- Cookbook pages that are **only** a Colab embed with no prose
 - Bare external links that have no docs page behind them (e.g., a raw `github.com` URL). Note: docs *about* GitHub (issues, contributing) are fine to keep
-- Individual release notes
 - Translated pages (`documentation/jp.mdx`, `zh.mdx`)
 - Draft or temporary pages
+- Orphan `.mdx` files not in `docs.json` navigation — these aren't routed by Mintlify and 404 in production
 - Duplicate entries — if a page already appears in one section, do not repeat it in another (e.g., don't list "User Guide" in both Overview and Concepts)
 
 **Always include:**
@@ -62,13 +63,26 @@ Sections use `##` headings, subsections use `###`. Subsections inherit their par
 
 Every time you add, remove, or audit llms.txt entries you **must** traverse the full docs tree to verify coverage. Follow these steps in order:
 
-### Step 1 — Enumerate all docs pages
+### Step 1 — Enumerate published nav pages (intersect docs.json with .mdx files)
+
+`docs.json` is the source of truth for what Mintlify routes. Pages on disk but not in nav 404 in production. Pages in nav with no `.mdx` file are broken nav entries. Use the intersection.
 
 ```bash
-# Build a sorted list of every .mdx page in the docs tree
+# All nav-published page paths
+python3 -c "
+import re, json
+raw = open('docs.json').read()
+nav = sorted({p.replace('docs/phoenix/','') for p in re.findall(r'\"(docs/phoenix/[a-zA-Z0-9/_-]+)\"', raw)})
+print('\n'.join(f'https://arize.com/docs/phoenix/{p}' for p in nav))
+" | sort > /tmp/nav_urls.txt
+
+# All .mdx files on disk
 find docs/phoenix -name "*.mdx" -type f | \
-  sed 's|docs/phoenix/||; s|\.mdx$||' | \
-  sed 's|^|https://arize.com/docs/phoenix/|' | sort > /tmp/fs_urls.txt
+  sed 's|docs/phoenix/||; s|\.mdx$||; s|^|https://arize.com/docs/phoenix/|' | \
+  sort > /tmp/fs_urls.txt
+
+# Use the intersection — these are the URLs that actually serve content
+comm -12 /tmp/nav_urls.txt /tmp/fs_urls.txt > /tmp/published_urls.txt
 ```
 
 ### Step 2 — Extract current llms.txt URLs
@@ -81,23 +95,31 @@ grep -oE '\(https://[^)]+\)' docs/phoenix/llms.txt | \
 ### Step 3 — Diff for missing and stale entries
 
 ```bash
-# Pages in docs but NOT in llms.txt (potential gaps)
-comm -23 /tmp/fs_urls.txt /tmp/llms_urls.txt > /tmp/missing.txt
+# Pages published but NOT in llms.txt (gaps to fill)
+comm -23 /tmp/published_urls.txt /tmp/llms_urls.txt > /tmp/missing.txt
 
-# URLs in llms.txt but NOT in docs (potential stale entries)
-comm -13 /tmp/fs_urls.txt /tmp/llms_urls.txt > /tmp/stale.txt
+# URLs in llms.txt but NOT published (stale — remove)
+comm -13 /tmp/published_urls.txt /tmp/llms_urls.txt > /tmp/stale.txt
 ```
 
 ### Step 4 — Triage each result
 
 For every entry in `/tmp/missing.txt`, open the `.mdx` file and decide:
-- **Include** — if it's a real docs page with prose content that an agent could benefit from
-- **Skip** — if it matches an exclusion rule above (notebook-only, demo, translated, etc.)
-- **Index-only** — if it's a sub-page of a section that should only have one entry (e.g., individual cookbook notebooks, REST API endpoints)
+- **Include** — default, unless the page matches an exclusion rule (notebook-only, demo, translated, agent-assisted-setup)
+- **Skip** — only when an exclusion rule applies
 
 For every entry in `/tmp/stale.txt`:
 - Check if the URL is a non-filesystem resource that is still valid (e.g., the OpenAPI spec, external TypeScript SDK docs). These are expected "stale" results — keep them.
-- If the `.mdx` file was genuinely deleted, remove the entry from llms.txt.
+- If the `.mdx` file was deleted or renamed, remove the entry.
+
+### Step 5 — Verify coverage % against the AFDocs threshold
+
+```bash
+published=$(wc -l < /tmp/published_urls.txt)
+indexed=$(comm -12 /tmp/published_urls.txt /tmp/llms_urls.txt | wc -l)
+echo "scale=1; $indexed * 100 / $published" | bc
+# Target: ≥ 90 (AFDocs flags < 80)
+```
 
 ### Step 5 — Spot-check by section
 

--- a/docs.json
+++ b/docs.json
@@ -878,7 +878,8 @@
                     "group": "Annotations",
                     "pages": [
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-span-annotations-for-a-list-of-span_ids",
-                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-trace-annotations-for-a-list-of-trace_ids"
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-trace-annotations-for-a-list-of-trace_ids",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-session-annotations-for-a-list-of-session_ids"
                     ]
                   },
                   {
@@ -891,6 +892,7 @@
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/upload-dataset-from-json-csv-or-pyarrow",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/get-examples-from-a-dataset",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-csv-file",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-jsonl-file",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-openai-fine-tuning-jsonl-file",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-openai-evals-jsonl-file"
                     ]
@@ -901,18 +903,23 @@
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/list-experiments-by-dataset",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/create-experiment-on-a-dataset",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/get-experiment-by-id",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/delete-experiment-by-id",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/download-experiment-runs-as-a-json-file",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/download-experiment-runs-as-a-csv-file",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/list-runs-for-an-experiment",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/create-run-for-an-experiment",
-                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/create-or-update-evaluation-for-an-experiment-run"
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/get-incomplete-runs-for-an-experiment",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/create-or-update-evaluation-for-an-experiment-run",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/get-incomplete-evaluations-for-an-experiment"
                     ]
                   },
                   {
                     "group": "Traces",
                     "pages": [
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/list-traces-for-a-project",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/delete-a-trace-by-identifier",
-                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/create-trace-annotations"
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/create-trace-annotations",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/create-a-trace-note"
                     ]
                   },
                   {
@@ -922,6 +929,7 @@
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/list-spans-with-simple-filters-no-dsl",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/create-spans",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/create-span-annotations",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/create-a-span-note",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/annotate-span-documents",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/delete-a-span-by-span_identifier"
                     ]
@@ -931,12 +939,14 @@
                     "pages": [
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/list-all-prompts",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/create-a-new-prompt",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/delete-a-prompt",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/list-prompt-versions",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/get-prompt-version-by-id",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/get-prompt-version-by-tag",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/get-latest-prompt-version",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/list-prompt-version-tags",
-                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/add-tag-to-prompt-version"
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/add-tag-to-prompt-version",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/delete-a-tag-from-a-prompt-version"
                     ]
                   },
                   {
@@ -954,8 +964,11 @@
                     "pages": [
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/list-project-sessions",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/get-session-by-id",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/delete-a-session-by-identifier",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/bulk-delete-sessions",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/create-session-annotations",
-                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/list-session-annotations"
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/list-session-annotations",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/create-a-session-note"
                     ]
                   },
                   {
@@ -969,7 +982,8 @@
                     "pages": [
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/users/list-all-users",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/users/create-a-new-user",
-                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/users/delete-a-user-by-id"
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/users/delete-a-user-by-id",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/users/get-the-authenticated-user"
                     ]
                   }
                 ]

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -458,61 +458,106 @@
 - [OpenInference JavaScript](https://arize.com/docs/phoenix/sdk-api-reference/openinference-sdk/openinference-javascript): Build custom JS instrumentors with OpenInference semantic conventions
 
 
-### REST API — Endpoints
+### REST API — Annotation Configs
 
-- [Create An Annotation Configuration](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/create-an-annotation-configuration): Create An Annotation Configuration
-- [Delete An Annotation Configuration](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/delete-an-annotation-configuration): Delete An Annotation Configuration
-- [Get An Annotation Configuration By Id Or Name](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/get-an-annotation-configuration-by-id-or-name): Get An Annotation Configuration By Id Or Name
-- [List Annotation Configurations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/list-annotation-configurations): List Annotation Configurations
-- [Update An Annotation Configuration](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/update-an-annotation-configuration): Update An Annotation Configuration
-- [Get Span Annotations For A List Of Span_Ids](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-span-annotations-for-a-list-of-span_ids): Get Span Annotations For A List Of Span_Ids
-- [Get Trace Annotations For A List Of Trace_Ids](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-trace-annotations-for-a-list-of-trace_ids): Get Trace Annotations For A List Of Trace_Ids
-- [Delete Dataset By Id](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/delete-dataset-by-id): Delete Dataset By Id
-- [Download Dataset Examples As Csv File](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-csv-file): Download Dataset Examples As Csv File
-- [Download Dataset Examples As Openai Evals Jsonl File](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-openai-evals-jsonl-file): Download Dataset Examples As Openai Evals Jsonl File
-- [Download Dataset Examples As Openai Fine Tuning Jsonl File](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-openai-fine-tuning-jsonl-file): Download Dataset Examples As Openai Fine Tuning Jsonl File
-- [Get Dataset By Id](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/get-dataset-by-id): Get Dataset By Id
-- [Get Examples From A Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/get-examples-from-a-dataset): Get Examples From A Dataset
-- [List Dataset Versions](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/list-dataset-versions): List Dataset Versions
-- [List Datasets](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/list-datasets): List Datasets
-- [Upload Dataset From Json Csv Or Pyarrow](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/upload-dataset-from-json-csv-or-pyarrow): Upload Dataset From Json Csv Or Pyarrow
-- [Create Experiment On A Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/create-experiment-on-a-dataset): Create Experiment On A Dataset
-- [Create Or Update Evaluation For An Experiment Run](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/create-or-update-evaluation-for-an-experiment-run): Create Or Update Evaluation For An Experiment Run
-- [Create Run For An Experiment](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/create-run-for-an-experiment): Create Run For An Experiment
-- [Download Experiment Runs As A Csv File](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/download-experiment-runs-as-a-csv-file): Download Experiment Runs As A Csv File
-- [Download Experiment Runs As A Json File](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/download-experiment-runs-as-a-json-file): Download Experiment Runs As A Json File
-- [Get Experiment By Id](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/get-experiment-by-id): Get Experiment By Id
-- [List Experiments By Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/list-experiments-by-dataset): List Experiments By Dataset
-- [List Runs For An Experiment](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/list-runs-for-an-experiment): List Runs For An Experiment
-- [Create A New Project](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/create-a-new-project): Create A New Project
-- [Delete A Project By Id Or Name](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/delete-a-project-by-id-or-name): Delete A Project By Id Or Name
-- [Get Project By Id Or Name](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/get-project-by-id-or-name): Get Project By Id Or Name
-- [List All Projects](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/list-all-projects): List All Projects
-- [Update A Project By Id Or Name](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/update-a-project-by-id-or-name): Update A Project By Id Or Name
-- [Add Tag To Prompt Version](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/add-tag-to-prompt-version): Add Tag To Prompt Version
-- [Create A New Prompt](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/create-a-new-prompt): Create A New Prompt
-- [Get Latest Prompt Version](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/get-latest-prompt-version): Get Latest Prompt Version
-- [Get Prompt Version By Id](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/get-prompt-version-by-id): Get Prompt Version By Id
-- [Get Prompt Version By Tag](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/get-prompt-version-by-tag): Get Prompt Version By Tag
-- [List All Prompts](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/list-all-prompts): List All Prompts
-- [List Prompt Version Tags](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/list-prompt-version-tags): List Prompt Version Tags
-- [List Prompt Versions](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/list-prompt-versions): List Prompt Versions
-- [Upsert Or Delete Secrets](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/secrets/upsert-or-delete-secrets): Upsert Or Delete Secrets
-- [Create Session Annotations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/create-session-annotations): Create Session Annotations
-- [Get Session By Id](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/get-session-by-id): Get Session By Id
-- [List Project Sessions](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/list-project-sessions): List Project Sessions
-- [List Session Annotations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/list-session-annotations): List Session Annotations
-- [Annotate Span Documents](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/annotate-span-documents): Annotate Span Documents
-- [Create Span Annotations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/create-span-annotations): Create Span Annotations
-- [Create Spans](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/create-spans): Create Spans
-- [Delete A Span By Span_Identifier](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/delete-a-span-by-span_identifier): Delete A Span By Span_Identifier
-- [List Spans With Simple Filters No Dsl](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/list-spans-with-simple-filters-no-dsl): List Spans With Simple Filters No Dsl
-- [Search Spans With Simple Filters No Dsl](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/search-spans-with-simple-filters-no-dsl): Search Spans With Simple Filters No Dsl
-- [Create Trace Annotations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/create-trace-annotations): Create Trace Annotations
-- [Delete A Trace By Identifier](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/delete-a-trace-by-identifier): Delete A Trace By Identifier
-- [Create A New User](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/users/create-a-new-user): Create A New User
-- [Delete A User By Id](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/users/delete-a-user-by-id): Delete A User By Id
-- [List All Users](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/users/list-all-users): List All Users
+- [List Annotation Configurations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/list-annotation-configurations): GET /v1/annotation_configs — paginate all annotation configurations
+- [Create An Annotation Configuration](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/create-an-annotation-configuration): POST /v1/annotation_configs — define a new categorical, continuous, or freeform config
+- [Get An Annotation Configuration By ID Or Name](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/get-an-annotation-configuration-by-id-or-name): GET /v1/annotation_configs/{config_identifier} — fetch a single annotation config
+- [Update An Annotation Configuration](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/update-an-annotation-configuration): PUT /v1/annotation_configs/{config_id} — modify an existing config's options or rubric
+- [Delete An Annotation Configuration](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/delete-an-annotation-configuration): DELETE /v1/annotation_configs/{config_id} — remove an annotation config
+
+### REST API — Annotations
+
+- [Get Span Annotations By Span IDs](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-span-annotations-for-a-list-of-span_ids): GET /v1/projects/{project_identifier}/span_annotations — fetch annotations across many spans in one call
+- [Get Trace Annotations By Trace IDs](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-trace-annotations-for-a-list-of-trace_ids): GET /v1/projects/{project_identifier}/trace_annotations — fetch annotations across many traces in one call
+- [Get Session Annotations By Session IDs](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-session-annotations-for-a-list-of-session_ids): GET /v1/projects/{project_identifier}/session_annotations — fetch annotations across many sessions in one call
+
+### REST API — Datasets
+
+- [List Datasets](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/list-datasets): GET /v1/datasets — paginate datasets in the workspace
+- [Get Dataset By ID](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/get-dataset-by-id): GET /v1/datasets/{id} — retrieve dataset metadata
+- [Delete Dataset By ID](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/delete-dataset-by-id): DELETE /v1/datasets/{id} — remove a dataset and its versions
+- [List Dataset Versions](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/list-dataset-versions): GET /v1/datasets/{id}/versions — paginate version history for a dataset
+- [Upload Dataset From JSON, JSONL, CSV, Or PyArrow](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/upload-dataset-from-json-csv-or-pyarrow): POST /v1/datasets/upload — create or append examples from JSON, JSONL, CSV, or PyArrow
+- [Get Examples From A Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/get-examples-from-a-dataset): GET /v1/datasets/{id}/examples — retrieve examples at a specific dataset version
+- [Download Dataset Examples As CSV](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-csv-file): GET /v1/datasets/{id}/csv — stream dataset examples as a CSV file
+- [Download Dataset Examples As JSONL](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-jsonl-file): GET /v1/datasets/{id}/jsonl — stream dataset examples as a JSONL file
+- [Download Dataset Examples As OpenAI Fine-Tuning JSONL](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-openai-fine-tuning-jsonl-file): GET /v1/datasets/{id}/jsonl/openai_ft — export examples in OpenAI fine-tuning format
+- [Download Dataset Examples As OpenAI Evals JSONL](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-openai-evals-jsonl-file): GET /v1/datasets/{id}/jsonl/openai_evals — export examples in OpenAI evals format
+
+### REST API — Experiments
+
+- [List Experiments By Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/list-experiments-by-dataset): GET /v1/datasets/{dataset_id}/experiments — list experiments tied to a dataset
+- [Create Experiment On A Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/create-experiment-on-a-dataset): POST /v1/datasets/{dataset_id}/experiments — start a new experiment over a dataset version
+- [Get Experiment By ID](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/get-experiment-by-id): GET /v1/experiments/{experiment_id} — fetch experiment metadata
+- [Delete Experiment By ID](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/delete-experiment-by-id): DELETE /v1/experiments/{experiment_id} — delete an experiment and its runs
+- [Download Experiment Runs As JSON](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/download-experiment-runs-as-a-json-file): GET /v1/experiments/{experiment_id}/json — export full experiment runs as JSON
+- [Download Experiment Runs As CSV](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/download-experiment-runs-as-a-csv-file): GET /v1/experiments/{experiment_id}/csv — export experiment runs as CSV
+- [List Runs For An Experiment](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/list-runs-for-an-experiment): GET /v1/experiments/{experiment_id}/runs — list run rows for an experiment
+- [Create Run For An Experiment](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/create-run-for-an-experiment): POST /v1/experiments/{experiment_id}/runs — submit a run output for an experiment
+- [Get Incomplete Runs For An Experiment](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/get-incomplete-runs-for-an-experiment): GET /v1/experiments/{experiment_id}/incomplete-runs — list dataset rows still missing runs
+- [Create Or Update Evaluation For An Experiment Run](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/create-or-update-evaluation-for-an-experiment-run): POST /v1/experiment_evaluations — upsert an evaluator score on an experiment run
+- [Get Incomplete Evaluations For An Experiment](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/get-incomplete-evaluations-for-an-experiment): GET /v1/experiments/{experiment_id}/incomplete-evaluations — list runs still missing a given evaluator's score
+
+### REST API — Projects
+
+- [List All Projects](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/list-all-projects): GET /v1/projects — paginate projects in the workspace
+- [Create A New Project](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/create-a-new-project): POST /v1/projects — create a project for tracing
+- [Get Project By ID Or Name](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/get-project-by-id-or-name): GET /v1/projects/{project_identifier} — fetch a project by ID or name
+- [Update A Project By ID Or Name](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/update-a-project-by-id-or-name): PUT /v1/projects/{project_identifier} — rename or update project description
+- [Delete A Project By ID Or Name](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/delete-a-project-by-id-or-name): DELETE /v1/projects/{project_identifier} — delete a project and its data
+
+### REST API — Prompts
+
+- [List All Prompts](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/list-all-prompts): GET /v1/prompts — paginate all prompts
+- [Create A New Prompt](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/create-a-new-prompt): POST /v1/prompts — create a prompt or push a new prompt version
+- [Delete A Prompt](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/delete-a-prompt): DELETE /v1/prompts/{prompt_identifier} — delete a prompt and all of its versions
+- [List Prompt Versions](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/list-prompt-versions): GET /v1/prompts/{prompt_identifier}/versions — paginate versions of a prompt
+- [Get Prompt Version By ID](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/get-prompt-version-by-id): GET /v1/prompt_versions/{prompt_version_id} — fetch a specific prompt version
+- [Get Prompt Version By Tag](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/get-prompt-version-by-tag): GET /v1/prompts/{prompt_identifier}/tags/{tag_name} — resolve a tag to a prompt version
+- [Get Latest Prompt Version](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/get-latest-prompt-version): GET /v1/prompts/{prompt_identifier}/latest — fetch the most recent prompt version
+- [List Prompt Version Tags](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/list-prompt-version-tags): GET /v1/prompt_versions/{prompt_version_id}/tags — list tags applied to a prompt version
+- [Add Tag To Prompt Version](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/add-tag-to-prompt-version): POST /v1/prompt_versions/{prompt_version_id}/tags — apply a named tag to a prompt version
+- [Delete A Tag From A Prompt Version](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/delete-a-tag-from-a-prompt-version): DELETE /v1/prompt_versions/{prompt_version_id}/tags/{tag_name} — remove a tag from a prompt version
+
+### REST API — Secrets
+
+- [Upsert Or Delete Secrets](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/secrets/upsert-or-delete-secrets): PUT /v1/secrets — set or remove server-side secret values used by Phoenix
+
+### REST API — Sessions
+
+- [List Project Sessions](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/list-project-sessions): GET /v1/projects/{project_identifier}/sessions — paginate sessions in a project
+- [Get Session By ID](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/get-session-by-id): GET /v1/sessions/{session_identifier} — fetch a session by ID or session_id
+- [Delete A Session By Identifier](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/delete-a-session-by-identifier): DELETE /v1/sessions/{session_identifier} — delete a single session
+- [Bulk Delete Sessions](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/bulk-delete-sessions): POST /v1/sessions/delete — delete many sessions in one request
+- [Create Session Annotations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/create-session-annotations): POST /v1/session_annotations — write one or more annotations on sessions
+- [List Session Annotations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/list-session-annotations): GET /v1/projects/{project_identifier}/session_annotations — list session annotations for a project
+- [Create A Session Note](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/create-a-session-note): POST /v1/session_notes — attach a free-text note to a session
+
+### REST API — Spans
+
+- [List Spans (No DSL)](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/list-spans-with-simple-filters-no-dsl): GET /v1/projects/{project_identifier}/spans — paginate spans with simple query filters
+- [Search Spans (OTLP)](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/search-spans-with-simple-filters-no-dsl): GET /v1/projects/{project_identifier}/spans/otlpv1 — query spans returned in OTLP-style format
+- [Create Spans](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/create-spans): POST /v1/projects/{project_identifier}/spans — ingest spans into a project (non-OTLP path)
+- [Create Span Annotations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/create-span-annotations): POST /v1/span_annotations — write one or more annotations on spans
+- [Create A Span Note](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/create-a-span-note): POST /v1/span_notes — attach a free-text note to a span
+- [Annotate Span Documents](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/annotate-span-documents): POST /v1/document_annotations — write annotations on retrieved documents within a span
+- [Delete A Span By Identifier](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/delete-a-span-by-span_identifier): DELETE /v1/spans/{span_identifier} — delete a single span by ID or span_id
+
+### REST API — Traces
+
+- [List Traces For A Project](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/list-traces-for-a-project): GET /v1/projects/{project_identifier}/traces — paginate traces in a project
+- [Delete A Trace By Identifier](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/delete-a-trace-by-identifier): DELETE /v1/traces/{trace_identifier} — delete a trace by ID or trace_id
+- [Create Trace Annotations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/create-trace-annotations): POST /v1/trace_annotations — write one or more annotations on traces
+- [Create A Trace Note](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/create-a-trace-note): POST /v1/trace_notes — attach a free-text note to a trace
+
+### REST API — Users
+
+- [Get The Authenticated User](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/users/get-the-authenticated-user): GET /v1/user — fetch the user record for the current API key
+- [List All Users](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/users/list-all-users): GET /v1/users — paginate users in the workspace (admin)
+- [Create A New User](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/users/create-a-new-user): POST /v1/users — provision a new user (admin)
+- [Delete A User By ID](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/users/delete-a-user-by-id): DELETE /v1/users/{user_id} — remove a user (admin)
+
 ## Self-Hosting
 
 - [Self-Hosting Overview](https://arize.com/docs/phoenix/self-hosting): Choose a self-hosting deployment option and get started

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -11,7 +11,6 @@
 
 ## Quick Start
 
-- [Get Started Overview](https://arize.com/docs/phoenix/get-started): Walk through the full Phoenix workflow from tracing to experiments
 - [Tracing Quickstart](https://arize.com/docs/phoenix/get-started/get-started-tracing): Instrument an app and send your first traces to Phoenix
 - [Evaluations Quickstart](https://arize.com/docs/phoenix/get-started/get-started-evaluations): Run your first LLM evaluator and view results
 - [Playground Quickstart](https://arize.com/docs/phoenix/get-started/get-started-prompt-playground): Test prompt variations against real examples in the Playground
@@ -23,7 +22,6 @@
 
 ## Tracing
 
-- [Tracing Features](https://arize.com/docs/phoenix/tracing/features-tracing): Discover tracing capabilities — auto-instrumentation, manual spans, annotations, sessions
 
 ### Tutorial
 
@@ -77,19 +75,15 @@
 - [Modifying Spans](https://arize.com/docs/phoenix/tracing/how-to-tracing/advanced/modifying-spans): Use SpanProcessors to filter or enrich spans
 - [Multimodal Tracing](https://arize.com/docs/phoenix/tracing/how-to-tracing/advanced/multimodal-tracing): Capture image, audio, and multimodal data in traces
 - [Suppress Tracing](https://arize.com/docs/phoenix/tracing/how-to-tracing/advanced/suppress-tracing): Disable tracing for specific code blocks
-- [Construct Shareable URLs](https://arize.com/docs/phoenix/tracing/how-to-tracing/advanced/constructing-urls): Link to projects, traces, spans, and sessions by human-readable identifiers
 
+
+- [How to: Tracing](https://arize.com/docs/phoenix/tracing/how-to-tracing): Guides on how to use traces
 ## Evaluation
 
-- [Python Quickstart](https://arize.com/docs/phoenix/evaluation/python-quickstart): Get started with evaluations in Python
-- [TypeScript Quickstart](https://arize.com/docs/phoenix/evaluation/typescript-quickstart): Get started with evaluations in TypeScript
 
 ### Overview
 
 - [LLM Evals](https://arize.com/docs/phoenix/evaluation/llm-evals): LLM-as-judge evaluation with pre-built and custom evaluators
-- [Use Any LLM](https://arize.com/docs/phoenix/evaluation/llm-evals/use-any-llm): Configure any LLM provider as an evaluation model
-- [Executors](https://arize.com/docs/phoenix/evaluation/llm-evals/executors): Concurrency, rate limits, batching for evaluations
-- [Evaluator Traces](https://arize.com/docs/phoenix/evaluation/llm-evals/evaluator-traces): View evaluation execution details and model reasoning
 
 ### How-to
 
@@ -109,19 +103,46 @@
 
 ### Pre-Built Metrics
 
-- [Pre-Built Metrics](https://arize.com/docs/phoenix/evaluation/pre-built-metrics): All pre-built LLM and code evaluators — faithfulness, hallucination, toxicity, RAG relevance, tool calling, and more
+- [Pre-Built Metrics](https://arize.com/docs/phoenix/evaluation/pre-built-metrics): All pre-built LLM and code evaluators — faithfulness, hallucination, toxicity, RAG relevance, tool calling
 
 ### Server-Side Evaluations
 
 - [Server Evals Overview](https://arize.com/docs/phoenix/evaluation/server-evals/overview): Attach evaluators to datasets so they run server-side on every Playground experiment
 - [LLM Evaluators](https://arize.com/docs/phoenix/evaluation/server-evals/llm-evaluators): Configure LLM-as-judge evaluators server-side
-- [Built-in Evaluators](https://arize.com/docs/phoenix/evaluation/server-evals/builtin-evaluators): Pre-built server-side evaluators
 - [Server Eval Input Mapping](https://arize.com/docs/phoenix/evaluation/server-evals/input-mapping): Map span attributes to server-side evaluator input variables
-- [Server Pre-Built Metrics](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics): All server-side code metrics — contains, exact match, regex, JSON distance, Levenshtein, tool selection/invocation
+- [Server Pre-Built Metrics](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics): All server-side code metrics — contains, exact match, regex, JSON distance, Levenshtein, tool
 
+
+### Pre-Built Metrics — Individual Pages
+
+- [Conciseness](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/conciseness): Evaluate whether LLM responses are concise and free of unnecessary content
+- [Correctness](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/correctness): Evaluate whether LLM responses are generally correct and complete
+- [Document Relevance](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/document-relevance): Evaluate whether retrieved documents are relevant to user queries
+- [Exact Match](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/exact-match): Evaluate if output exactly matches expected value
+- [Faithfulness](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/faithfulness): Evaluate whether LLM responses are faithful to the provided context
+- [Matches Regex](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/matches-regex): Evaluate if output matches a regular expression pattern
+- [Precision / Recall / F-Score](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/precision-recall-fscore): Compute precision, recall, and F-beta scores for classification tasks
+- [Q&A on Retrieved Data](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/q-and-a-on-retrieved-data): Q&A on Retrieved Data
+- [Refusal](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/refusal): Detect when an LLM refuses or declines to answer a user query
+- [Retrieval (RAG) Relevance](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/retrieval-rag-relevance): Retrieval (RAG) Relevance
+- [SQL Generation](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/sql-generation-eval): SQL Generation is a common approach to using an LLM. In many cases the goal is to take a human description of
+- [Summarization](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/summarization-eval): Summarization
+- [Agent Function Calling Eval](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-calling-eval): The Agent Function Call eval can be used to determine how well a model selects a tool to use, extracts the
+- [Tool Invocation](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-invocation): Evaluate whether LLM tool calls have correct arguments and formatting
+- [Tool Response Handling](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-response-handling): Evaluate whether AI agents correctly process tool results, including error handling, data extraction, and
+- [Tool Selection](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-selection): Evaluate whether LLMs select the correct tools for given tasks
+- [Toxicity](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/toxicity): Toxicity
+
+- [Contains](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/contains): Check whether a text contains one or more specified words
+- [Correctness](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/correctness): Evaluate whether LLM responses are generally correct and complete using a Phoenix-managed judge model
+- [Exact Match](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/exact-match): Check whether two strings are identical
+- [JSON Distance](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/json-distance): Measure the number of structural differences between two JSON values
+- [Levenshtein Distance](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/levenshtein-distance): Measure the edit distance between two strings
+- [Regex Match](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/regex): Check whether a text matches a regular expression pattern
+- [Tool Invocation](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/tool-invocation): Evaluate whether LLM tool calls have correct arguments and formatting using a Phoenix-managed judge model
+- [Tool Selection](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/tool-selection): Evaluate whether LLMs select the correct tools for given tasks using a Phoenix-managed judge model
 ## Datasets & Experiments
 
-- [Quickstart](https://arize.com/docs/phoenix/datasets-and-experiments/quickstart-datasets): Create datasets and run experiments quickly
 
 ### Tutorial
 
@@ -144,6 +165,10 @@
 - [Repetitions](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/repetitions): Run multiple iterations for statistical confidence
 - [Splits](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/splits): Organize datasets into train/test/validation splits
 
+
+- [How to: Datasets](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets): Datasets are critical assets for building robust prompts, evals, fine-tuning,
+- [How to: Experiments](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments): How to: Experiments
+- [Run Experiments in the Background](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background): Start experiments from the Playground that keep running after you close the browser, survive server restarts
 ## Prompt Engineering
 
 ### Tutorial
@@ -171,6 +196,8 @@
 - [Tag a Prompt](https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/tag-a-prompt): Tag prompts for deployment control across environments
 - [Using a Prompt](https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/using-a-prompt): Load prompts programmatically via SDK
 
+
+- [How to: Prompts](https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts): Guides on how to do prompt engineering with Phoenix
 ## Integrations
 
 - [Integrations Overview](https://arize.com/docs/phoenix/integrations): All Phoenix integrations — LLM providers, frameworks, platforms
@@ -184,29 +211,19 @@
 
 - [OpenAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/openai/openai-tracing): Auto-instrument OpenAI Python SDK with openinference-instrumentation-openai
 - [OpenAI Agents SDK Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/openai/openai-agents-sdk-tracing): Trace OpenAI Agents SDK workflows including tool calls and handoffs
-- [OpenAI Evals](https://arize.com/docs/phoenix/integrations/llm-providers/openai/openai-evals): Use OpenAI models as evaluation judges
 - [OpenAI Node.js SDK](https://arize.com/docs/phoenix/integrations/llm-providers/openai/openai-node-js-sdk): Instrument OpenAI calls in TypeScript/Node.js
 - [Anthropic Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/anthropic/anthropic-tracing): Auto-instrument Anthropic Python SDK
-- [Anthropic Evals](https://arize.com/docs/phoenix/integrations/llm-providers/anthropic/anthropic-evals): Use Claude models as evaluation judges
 - [Anthropic TypeScript SDK](https://arize.com/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-typescript): Instrument Anthropic calls in TypeScript
 - [Amazon Bedrock Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock/amazon-bedrock-tracing): Auto-instrument Bedrock SDK with openinference-instrumentation-bedrock
 - [Amazon Bedrock Agents Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock/amazon-bedrock-agents-tracing): Trace Bedrock agent orchestration workflows
-- [Amazon Bedrock Evals](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock/amazon-bedrock-evals): Use Bedrock models as evaluation judges
 - [Amazon Bedrock Agent Runtime JS](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock/amazon-bedrock-agent-runtime-js): Instrument Bedrock Agent Runtime in TypeScript
 - [Amazon Bedrock SDK JS](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock/amazon-bedrock-sdk-js): Instrument Bedrock SDK in TypeScript
 - [Google GenAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai/google-genai-tracing): Auto-instrument Google GenAI SDK
-- [Gemini Evals](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-evals): Use Gemini models as evaluation judges
-- [Google GenAI Evals](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai/google-gen-ai-evals): Configure Google GenAI as eval provider
-- [Evaluate CrewAI with Google Gen AI](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai/google-gen-ai-evals-1): Instrument and evaluate CrewAI multi-agent systems using Google Vertex AI evaluation and Phoenix tracing
-- [Google ADK Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/google-adk/google-adk-tracing): Trace Google Agent Development Kit workflows
 - [Groq Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/groq/groq-tracing): Auto-instrument Groq SDK
 - [LiteLLM Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/litellm/litellm-tracing): Auto-instrument LiteLLM unified API calls
-- [LiteLLM Evals](https://arize.com/docs/phoenix/integrations/llm-providers/litellm/litellm-evals): Use LiteLLM as eval model proxy
 - [MistralAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/mistralai/mistralai-tracing): Auto-instrument MistralAI SDK
-- [MistralAI Evals](https://arize.com/docs/phoenix/integrations/llm-providers/mistralai/mistralai-evals): Use MistralAI as evaluation judge
 - [OpenRouter Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/openrouter/openai-tracing): Trace OpenRouter API calls
 - [VertexAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/vertexai/vertexai-tracing): Auto-instrument VertexAI SDK
-- [VertexAI Evals](https://arize.com/docs/phoenix/integrations/llm-providers/vertexai/vertexai-evals): Use VertexAI as evaluation judge
 
 ### Python Frameworks
 
@@ -261,8 +278,71 @@
 
 ### Evaluation Integrations
 
-- [Evaluation Integrations](https://arize.com/docs/phoenix/integrations/evaluation-integrations): Third-party evaluation libraries — Ragas, Cleanlab, MLflow, and UQLM — integrated with Phoenix
 
+
+### Evaluation Integrations — Individual Libraries
+
+- [Cleanlab](https://arize.com/docs/phoenix/integrations/evaluation-integrations/cleanlab): Cleanlab
+- [MLflow](https://arize.com/docs/phoenix/integrations/evaluation-integrations/mlflow): Use Phoenix evaluators as MLflow scorers for GenAI evaluation workflows
+- [Ragas](https://arize.com/docs/phoenix/integrations/evaluation-integrations/ragas): This guide will walk you through the process of creating and evaluating agents using Ragas and Arize Phoenix
+- [UQLM Confidence & Hallucination Risk](https://arize.com/docs/phoenix/integrations/evaluation-integrations/uqlm): UQLM Confidence & Hallucination Risk
+
+### Platforms — Additional
+
+- [Dify](https://arize.com/docs/phoenix/integrations/platforms/dify): Dify lets you visually build, orchestrate, and deploy AI-native apps using LLMs, with low-code workflows and
+- [Flowise](https://arize.com/docs/phoenix/integrations/platforms/flowise): Flowise is a low-code platform for building customized chatflows and agentflows
+- [LangFlow](https://arize.com/docs/phoenix/integrations/platforms/langflow): Langflow is an open-source visual framework that enables developers to rapidly design, prototype, and deploy
+- [Prompt flow](https://arize.com/docs/phoenix/integrations/platforms/prompt-flow): PromptFlow is a framework for designing, orchestrating, testing, and monitoring end-to-end LLM prompt
+
+### Java Frameworks — Additional
+
+- [Arconia](https://arize.com/docs/phoenix/integrations/java/arconia): Arconia is an open-source framework and set of tools for building modern, cloud-native enterprise
+- [LangChain4j](https://arize.com/docs/phoenix/integrations/java/langchain4j): LangChain4j is a Java library that provides APIs, tools, and patterns to easily build and integrate
+- [Spring AI](https://arize.com/docs/phoenix/integrations/java/springai): Spring AI extends the Spring Framework, making it easier to integrate AI capabilities into Java applications
+
+### TypeScript Frameworks — Additional
+
+- [BeeAI](https://arize.com/docs/phoenix/integrations/typescript/beeai): BeeAI is an open-source platform that enables developers to discover, run, and compose AI agents from any
+- [LangChain](https://arize.com/docs/phoenix/integrations/typescript/langchain): LangChain is an open-source framework for building language model applications with prompt chaining, memory
+- [Mastra](https://arize.com/docs/phoenix/integrations/typescript/mastra): Mastra is an open-source TypeScript AI agent framework designed for building production-ready AI applications
+- [MCP](https://arize.com/docs/phoenix/integrations/typescript/mcp): Model Context Protocol (MCP) is an open protocol that enables secure connections between AI assistants and
+- [TanStack AI](https://arize.com/docs/phoenix/integrations/typescript/tanstack-ai): TanStack AI is a TypeScript framework for building chat, tool-calling, and agent-loop experiences across any
+- [Vercel](https://arize.com/docs/phoenix/integrations/typescript/vercel): Vercel is a cloud platform that simplifies building, deploying, and scaling modern web applications with
+
+### Python Frameworks — Additional
+
+- [Agent Spec](https://arize.com/docs/phoenix/integrations/python/agentspec): Open Agent Spec (Agent Spec) is a portable language for defining agentic systems. It defines building blocks
+- [Agno](https://arize.com/docs/phoenix/integrations/python/agno): Agno is an open-source Python framework for building lightweight, model-agnostic AI agents with built-in
+- [AutoGen](https://arize.com/docs/phoenix/integrations/python/autogen): AutoGen is an open-source Python framework for orchestrating multi-agent LLM interactions with shared memory
+- [BeeAI](https://arize.com/docs/phoenix/integrations/python/beeai): BeeAI is an open-source platform that enables developers to discover, run, and compose AI agents from any
+- [CrewAI](https://arize.com/docs/phoenix/integrations/python/crewai): CrewAI is an open-source Python framework for orchestrating role-playing, autonomous AI agents into
+- [DSPy](https://arize.com/docs/phoenix/integrations/python/dspy): DSPy is an open-source Python framework for declaratively programming modular LLM pipelines and automatically
+- [Google ADK](https://arize.com/docs/phoenix/integrations/python/google-adk): Google ADK is a Python SDK for building AI applications with Google's Gemini models and agent framework
+- [Graphite](https://arize.com/docs/phoenix/integrations/python/graphite): >-
+- [Guardrails AI](https://arize.com/docs/phoenix/integrations/python/guardrails-ai): Guardrails is an open-source Python framework for adding programmable input/output validators to LLM
+- [Haystack](https://arize.com/docs/phoenix/integrations/python/haystack): Haystack is an open-source framework for building scalable semantic search and QA pipelines with document
+- [Hugging Face Smolagents](https://arize.com/docs/phoenix/integrations/python/hugging-face-smolagents): Hugging Face smolagents is a minimalist Python library for building powerful AI agents with simple
+- [Instructor](https://arize.com/docs/phoenix/integrations/python/instructor): Instructor is a library that helps you define structured output formats for LLMs
+- [LangChain](https://arize.com/docs/phoenix/integrations/python/langchain): LangChain is an open-source framework for building language model applications with prompt chaining, memory
+- [LangGraph](https://arize.com/docs/phoenix/integrations/python/langgraph): LangGraph is an open-source framework for building graph-based LLM pipelines with modular nodes and seamless
+- [LlamaIndex](https://arize.com/docs/phoenix/integrations/python/llamaindex): LlamaIndex is an open-source framework that streamlines connecting, ingesting, indexing, and retrieving
+- [NVIDIA](https://arize.com/docs/phoenix/integrations/python/nvidia): NVIDIA NeMo Agent Toolkit is a flexible, lightweight library for connecting enterprise agents to data sources
+- [Portkey](https://arize.com/docs/phoenix/integrations/python/portkey): Portkey is an AI Gateway and observability platform that provides routing,  guardrails, caching, and
+- [Pydantic AI](https://arize.com/docs/phoenix/integrations/python/pydantic): PydanticAI is a Python agent framework designed to make it less painful to  build production-grade
+- [Restate](https://arize.com/docs/phoenix/integrations/python/restate): Restate is a durable execution platform that makes AI agents and workflows resumable and resilient, with
+- [Strands Agents](https://arize.com/docs/phoenix/integrations/python/strands-agents): Strands Agents is an open-source AI agent SDK that uses model-driven orchestration to build production-ready
+
+### LLM Providers — Additional
+
+- [Amazon Bedrock](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock): Amazon Bedrock is a managed service that provides access to top AI models for building scalable applications
+- [Anthropic](https://arize.com/docs/phoenix/integrations/llm-providers/anthropic): Anthropic is an AI research company that develops LLMs, including Claude, with a focus on alignment and
+- [Google](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai): Google GenAI is a suite of AI tools and models from Google Cloud, designed to help businesses build, deploy
+- [Groq](https://arize.com/docs/phoenix/integrations/llm-providers/groq): Groq provides ultra-low latency inference for LLMs through its custom-built LPU™ architecture
+- [LiteLLM](https://arize.com/docs/phoenix/integrations/llm-providers/litellm): LiteLLM is an open-source platform that provides a unified interface to manage and access over 100 LLMs from
+- [MistralAI](https://arize.com/docs/phoenix/integrations/llm-providers/mistralai): Mistral AI develops open-weight large language models, focusing on efficiency, customization, and
+- [OpenAI](https://arize.com/docs/phoenix/integrations/llm-providers/openai): OpenAI provides state-of-the-art LLMs for natural language understanding and generation
+- [OpenRouter](https://arize.com/docs/phoenix/integrations/llm-providers/openrouter): OpenRouter is a platform that connects developers to multiple AI models through a unified API, making it
+- [VertexAI](https://arize.com/docs/phoenix/integrations/llm-providers/vertexai): Vertex AI is a fully managed platform by Google Cloud for building, deploying, and scaling machine learning
 ## Settings
 
 - [Access Control RBAC](https://arize.com/docs/phoenix/settings/access-control-rbac): Role-based permissions and project access
@@ -293,11 +373,6 @@
 ### Evaluation
 
 - [LLM as a Judge](https://arize.com/docs/phoenix/evaluation/concepts-evals/llm-as-a-judge): LLM-based evaluation best practices
-- [Evaluators](https://arize.com/docs/phoenix/evaluation/concepts-evals/evaluators): LLM and code evaluator types and score properties
-- [Evaluation Types](https://arize.com/docs/phoenix/evaluation/concepts-evals/evaluation-types): Categorical vs score evaluations
-- [Building Your Own Evals](https://arize.com/docs/phoenix/evaluation/concepts-evals/building-your-own-evals): Design custom evaluator templates
-- [Evaluating Multi-Agent Systems](https://arize.com/docs/phoenix/evaluation/concepts-evals/evaluating-multi-agent-systems): Multi-agent evaluation strategies
-- [Eval Input Mapping](https://arize.com/docs/phoenix/evaluation/concepts-evals/input-mapping): Understand how evaluators transform complex data structures into input variables
 
 ## Resources
 
@@ -305,9 +380,29 @@
 - [Contribute](https://arize.com/docs/phoenix/resources/contribute-to-phoenix): Open-source contribution guide
 - [Phoenix to Arize AX Migration](https://arize.com/docs/phoenix/resources/phoenix-to-arize-ax-migration): Migration guide from Phoenix to Arize AX
 
+
+- [Braintrust Open Source Alternative? LLM Evaluation Platform Comparison](https://arize.com/docs/phoenix/resources/frequently-asked-questions/braintrust-open-source-alternative-llm-evaluation-platform-comparison): Braintrust is an evaluation platform that serves as an alternative to Arize Phoenix. Both platforms support
+- [Can I add other users to my Phoenix Instance?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-add-other-users-to-my-phoenix-instance): Can I add other users to my Phoenix Instance?
+- [Can I persist data in a notebook?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-persist-data-in-a-notebook): You can persist data in the notebook by either setting the `use_temp_dir` flag to false in `px.launch_app`
+- [Can I run Phoenix on Sagemaker?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-run-phoenix-on-sagemaker): With SageMaker notebooks, phoenix leverages the jupyter-server-proy to host the server under
+- [Can I use Azure OpenAI?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-use-azure-openai): Can I use Azure OpenAI?
+- [Can I use gRPC for trace collection?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-use-grpc-for-trace-collection): Phoenix does natively support gRPC for trace collection post 4.0 release. See
+- [Can I use Phoenix locally from a remote Jupyter instance?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-use-phoenix-locally-from-a-remote-jupyter-instance): Yes, you can use either of the two methods below
+- [How can I configure the backend to send the data to the phoenix UI in another container?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/how-can-i-configure-the-backend-to-send-the-data-to-the-phoenix-ui-in-another-container): _If you are working on an API whose endpoints perform RAG, but would like the phoenix server not to be
+- [How do I resolve Phoenix Evals showing NOT\_PARSABLE?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/how-do-i-resolve-phoenix-evals-showing-not_parsable): `NOT_PARSABLE` errors often occur when LLM responses exceed the `max_tokens` limit or produce incomplete JSON
+- [Langfuse alternative? Arize Phoenix vs Langfuse: Key differences](https://arize.com/docs/phoenix/resources/frequently-asked-questions/langfuse-alternative-arize-phoenix-vs-langfuse-key-differences): Langfuse alternative? Arize Phoenix vs Langfuse: Key differences
+- [Phoenix Cloud Migration Guide: Legacy to New Version](https://arize.com/docs/phoenix/resources/frequently-asked-questions/phoenix-cloud-migration-guide-legacy-to-new-version): To move to the new Phoenix Cloud, simply [create a new Phoenix
+- [What is LlamaTrace vs Phoenix Cloud?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-llamatrace-vs-phoenix-cloud): LlamaTrace and Phoenix Cloud are the same tool. They are the hosted version of Phoenix provided on
+- [What is my Phoenix Endpoint?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-my-phoenix-endpoint): What is my Phoenix Endpoint?
+- [What is the difference between GRPC and HTTP?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-grpc-and-http): gRPC and HTTP are communication protocols used to transfer data between client and server applications
+- [What is the difference between Phoenix and Arize?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize): Arize is the company that makes Phoenix. Phoenix is an open source LLM observability tool offered by Arize
+- [Will Phoenix Cloud be on the latest version of Phoenix?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/will-phoenix-cloud-be-on-the-latest-version-of-phoenix): We update the Phoenix version used by Phoenix Cloud on a weekly basis
+- [Github](https://arize.com/docs/phoenix/resources/github): Github
+- [OpenInference](https://arize.com/docs/phoenix/resources/openinference): OpenInference
+- [Python SDK](https://arize.com/docs/phoenix/resources/python-api): Python SDK
+- [TypeScript SDK](https://arize.com/docs/phoenix/resources/typescript-api): TypeScript SDK
 ## Use Cases
 
-- [RAG Evaluation](https://arize.com/docs/phoenix/use-cases/rag-evaluation): Build and evaluate RAG pipelines
 
 ## SDK & API Reference
 
@@ -354,7 +449,6 @@
 ### REST API
 
 - [REST API Overview](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/overview): Authenticate and call the Phoenix REST API
-- [API Reference](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference): Endpoint docs for annotations, datasets, experiments, traces, spans, prompts, projects
 - [OpenAPI Spec](https://raw.githubusercontent.com/Arize-ai/phoenix/refs/heads/main/schemas/openapi.json): Machine-readable OpenAPI 3 specification
 
 ### OpenInference
@@ -363,6 +457,62 @@
 - [OpenInference Java](https://arize.com/docs/phoenix/sdk-api-reference/openinference-sdk/openinference-java): Build custom Java instrumentors with OpenInference semantic conventions
 - [OpenInference JavaScript](https://arize.com/docs/phoenix/sdk-api-reference/openinference-sdk/openinference-javascript): Build custom JS instrumentors with OpenInference semantic conventions
 
+
+### REST API — Endpoints
+
+- [Create An Annotation Configuration](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/create-an-annotation-configuration): Create An Annotation Configuration
+- [Delete An Annotation Configuration](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/delete-an-annotation-configuration): Delete An Annotation Configuration
+- [Get An Annotation Configuration By Id Or Name](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/get-an-annotation-configuration-by-id-or-name): Get An Annotation Configuration By Id Or Name
+- [List Annotation Configurations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/list-annotation-configurations): List Annotation Configurations
+- [Update An Annotation Configuration](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/update-an-annotation-configuration): Update An Annotation Configuration
+- [Get Span Annotations For A List Of Span_Ids](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-span-annotations-for-a-list-of-span_ids): Get Span Annotations For A List Of Span_Ids
+- [Get Trace Annotations For A List Of Trace_Ids](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-trace-annotations-for-a-list-of-trace_ids): Get Trace Annotations For A List Of Trace_Ids
+- [Delete Dataset By Id](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/delete-dataset-by-id): Delete Dataset By Id
+- [Download Dataset Examples As Csv File](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-csv-file): Download Dataset Examples As Csv File
+- [Download Dataset Examples As Openai Evals Jsonl File](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-openai-evals-jsonl-file): Download Dataset Examples As Openai Evals Jsonl File
+- [Download Dataset Examples As Openai Fine Tuning Jsonl File](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-openai-fine-tuning-jsonl-file): Download Dataset Examples As Openai Fine Tuning Jsonl File
+- [Get Dataset By Id](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/get-dataset-by-id): Get Dataset By Id
+- [Get Examples From A Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/get-examples-from-a-dataset): Get Examples From A Dataset
+- [List Dataset Versions](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/list-dataset-versions): List Dataset Versions
+- [List Datasets](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/list-datasets): List Datasets
+- [Upload Dataset From Json Csv Or Pyarrow](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/upload-dataset-from-json-csv-or-pyarrow): Upload Dataset From Json Csv Or Pyarrow
+- [Create Experiment On A Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/create-experiment-on-a-dataset): Create Experiment On A Dataset
+- [Create Or Update Evaluation For An Experiment Run](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/create-or-update-evaluation-for-an-experiment-run): Create Or Update Evaluation For An Experiment Run
+- [Create Run For An Experiment](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/create-run-for-an-experiment): Create Run For An Experiment
+- [Download Experiment Runs As A Csv File](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/download-experiment-runs-as-a-csv-file): Download Experiment Runs As A Csv File
+- [Download Experiment Runs As A Json File](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/download-experiment-runs-as-a-json-file): Download Experiment Runs As A Json File
+- [Get Experiment By Id](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/get-experiment-by-id): Get Experiment By Id
+- [List Experiments By Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/list-experiments-by-dataset): List Experiments By Dataset
+- [List Runs For An Experiment](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/list-runs-for-an-experiment): List Runs For An Experiment
+- [Create A New Project](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/create-a-new-project): Create A New Project
+- [Delete A Project By Id Or Name](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/delete-a-project-by-id-or-name): Delete A Project By Id Or Name
+- [Get Project By Id Or Name](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/get-project-by-id-or-name): Get Project By Id Or Name
+- [List All Projects](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/list-all-projects): List All Projects
+- [Update A Project By Id Or Name](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects/update-a-project-by-id-or-name): Update A Project By Id Or Name
+- [Add Tag To Prompt Version](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/add-tag-to-prompt-version): Add Tag To Prompt Version
+- [Create A New Prompt](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/create-a-new-prompt): Create A New Prompt
+- [Get Latest Prompt Version](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/get-latest-prompt-version): Get Latest Prompt Version
+- [Get Prompt Version By Id](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/get-prompt-version-by-id): Get Prompt Version By Id
+- [Get Prompt Version By Tag](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/get-prompt-version-by-tag): Get Prompt Version By Tag
+- [List All Prompts](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/list-all-prompts): List All Prompts
+- [List Prompt Version Tags](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/list-prompt-version-tags): List Prompt Version Tags
+- [List Prompt Versions](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/list-prompt-versions): List Prompt Versions
+- [Upsert Or Delete Secrets](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/secrets/upsert-or-delete-secrets): Upsert Or Delete Secrets
+- [Create Session Annotations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/create-session-annotations): Create Session Annotations
+- [Get Session By Id](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/get-session-by-id): Get Session By Id
+- [List Project Sessions](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/list-project-sessions): List Project Sessions
+- [List Session Annotations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/list-session-annotations): List Session Annotations
+- [Annotate Span Documents](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/annotate-span-documents): Annotate Span Documents
+- [Create Span Annotations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/create-span-annotations): Create Span Annotations
+- [Create Spans](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/create-spans): Create Spans
+- [Delete A Span By Span_Identifier](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/delete-a-span-by-span_identifier): Delete A Span By Span_Identifier
+- [List Spans With Simple Filters No Dsl](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/list-spans-with-simple-filters-no-dsl): List Spans With Simple Filters No Dsl
+- [Search Spans With Simple Filters No Dsl](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/spans/search-spans-with-simple-filters-no-dsl): Search Spans With Simple Filters No Dsl
+- [Create Trace Annotations](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/create-trace-annotations): Create Trace Annotations
+- [Delete A Trace By Identifier](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/delete-a-trace-by-identifier): Delete A Trace By Identifier
+- [Create A New User](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/users/create-a-new-user): Create A New User
+- [Delete A User By Id](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/users/delete-a-user-by-id): Delete A User By Id
+- [List All Users](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/users/list-all-users): List All Users
 ## Self-Hosting
 
 - [Self-Hosting Overview](https://arize.com/docs/phoenix/self-hosting): Choose a self-hosting deployment option and get started
@@ -394,6 +544,8 @@
 - [Privacy](https://arize.com/docs/phoenix/self-hosting/security/privacy): Privacy and data protection
 - [Self-Hosting FAQs](https://arize.com/docs/phoenix/self-hosting/misc/frequently-asked-questions): Troubleshoot common self-hosting issues
 
+
+- [Network Security](https://arize.com/docs/phoenix/self-hosting/security/network-security): Understanding outbound network requests and how to secure your self-hosted Phoenix deployment
 ## Phoenix Cloud
 
 - [Phoenix Cloud](https://arize.com/docs/phoenix/phoenix-cloud): Managed service overview
@@ -401,3 +553,192 @@
 ## Cookbooks
 
 - [Cookbook Index](https://arize.com/docs/phoenix/cookbook): All examples — agents, evaluation, tracing, prompt engineering, datasets
+
+
+### Individual Cookbook Pages
+
+- [Agent Workflow Patterns](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns): Workflows are the backbone of many successful LLM applications. They define how language models interact with
+- [AutoGen](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/autogen): Use Phoenix to trace and evaluate AutoGen agents
+- [CrewAI](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/crewai): **CrewAI** is an open-source framework for building and orchestrating collaborative AI agents that act like a
+- [Google GenAI SDK (manual orchestration)](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/google-genai-sdk-manual-orchestration): Everything you need to know about Google's GenAI framework
+- [LangGraph](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/langgraph): Use Phoenix to trace and evaluate agent frameworks built using Langgraph
+- [OpenAI Agents](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/openai-agents): [**OpenAI-Agents**](https://openai.github.io/openai-agents-python/) is a lightweight Python library for
+- [Smolagents](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/smolagents): **SmolAgents** is a lightweight Python library for composing tool-using, task-oriented agents. This guide
+- [Analyzing Customer Review Evals with Repetition Experiments](https://arize.com/docs/phoenix/cookbook/ai-engineering-workflows/analyzing-customer-review-evals-with-repetition-experiments): Analyzing Customer Review Evals with Repetition Experiments
+- [Iterative Evaluation & Experimentation Workflow (Python)](https://arize.com/docs/phoenix/cookbook/ai-engineering-workflows/iterative-evaluation-and-experimentation-workflow-python): Phoenix Tracing, Evaluating, and Experimentation Walkthrough
+- [Iterative Evaluation & Experimentation Workflow (TypeScript)](https://arize.com/docs/phoenix/cookbook/ai-engineering-workflows/iterative-evaluation-and-experimentation-workflow-typescript): Phoenix Tracing, Evaluating, and Experimentation Walkthrough
+- [Analyzing Customer Review Evals with Repetition Experiments](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/analyzing-customer-review-evals-with-repetition-experiments): Large Language Models (LLMs) are probabilistic; the same prompt can yield different outputs across runs. This
+- [Comparing LlamaIndex Query Engines with a Pairwise Evaluator](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/comparing-llamaindex-query-engines-with-a-pairwise-evaluator): This tutorial sets up an experiment to determine which LlamaIndex query engine is preferred by an evaluation
+- [More Cookbooks](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/cookbooks): More Cookbooks
+- [Experiment with a Customer Support Agent](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/experiment-with-a-customer-support-agent): This guide shows you how to create and evaluate agents with Phoenix to improve performance
+- [Prompt Template Iteration for a Summarization Service](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/summarization): Imagine you're deploying a service for your media company's summarization model that condenses daily news
+- [Text2SQL Experiments](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/text2sql): Building effective text-to-SQL systems requires rigorous evaluation and systematic experimentation. In this
+- [Code Readability Evaluation](https://arize.com/docs/phoenix/cookbook/evaluation/code-readability-evaluation): >-
+- [More Cookbooks](https://arize.com/docs/phoenix/cookbook/evaluation/cookbooks): Use Phoenix Evals to evaluate your application for faithfulness, toxicity, relevance of retrieved documents
+- [Evaluate a Talk-to-Your-Data Agent](https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-an-agent): Evaluate a Talk-to-Your-Data Agent
+- [Evaluate RAG](https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-rag): Building a RAG pipeline and evaluating it with Phoenix Evals
+- [OpenAI Agents SDK Cookbook](https://arize.com/docs/phoenix/cookbook/evaluation/openai-agents-sdk-cookbook): This guide shows you how to create and evaluate agents with Phoenix to improve performance
+- [Relevance Classification Evaluation](https://arize.com/docs/phoenix/cookbook/evaluation/relevance-classification-evaluation): Evaluate the relevance of documents retrieved by RAG applications using Phoenix's evaluation framework
+- [Using Ragas to Evaluate a Math Problem-Solving Agent](https://arize.com/docs/phoenix/cookbook/evaluation/using-ragas-to-evaluate-a-math-problem-solving-agent): Using Ragas to Evaluate a Math Problem-Solving Agent
+- [Aligning LLM Evals with Human Feedback (TypeScript)](https://arize.com/docs/phoenix/cookbook/human-in-the-loop-workflows-annotations/aligning-llm-evals-with-human-annotations-typescript): In this tutorial, we’ll run a Mastra agent and build a custom evaluator for it. The goal is to understand the
+- [Creating a Custom LLM Evaluator with a Benchmark Dataset](https://arize.com/docs/phoenix/cookbook/human-in-the-loop-workflows-annotations/creating-a-custom-llm-evaluator-with-a-benchmark-dataset): Learn how to build a custom LLM-as-a-Judge evaluator by creating a benchmark dataset tailored to your use
+- [Using Human Annotations for Eval Driven Development](https://arize.com/docs/phoenix/cookbook/human-in-the-loop-workflows-annotations/using-human-annotations-for-eval-driven-development): How to leverage human annotations to build evaluations and experiments that improve your system
+- [Chain of Thought Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/chain-of-thought-prompting): Chain of Thought Prompting
+- [Few Shot Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/few-shot-prompting): Few-shot prompting is a powerful technique in prompt engineering that helps LLMs perform tasks more
+- [LLM-as-a-Judge Prompt Optimization](https://arize.com/docs/phoenix/cookbook/prompt-engineering/llm-as-a-judge-prompt-optimization): LLM-as-a-Judge Prompt Optimization
+- [Optimizing Coding Agent Prompts - Prompt Learning](https://arize.com/docs/phoenix/cookbook/prompt-engineering/optimizing-coding-agent-prompts-prompt-learning): Optimizing coding agent prompts and tracking coding agent improvement
+- [Optimizing Prompts for LLM Classification - Prompt Learning](https://arize.com/docs/phoenix/cookbook/prompt-engineering/prompt-learning-optimizing-prompts-for-classification): Using Prompt Learning to boost accuracy on a classification dataset
+- [Prompt Optimization Techniques](https://arize.com/docs/phoenix/cookbook/prompt-engineering/prompt-optimization): This tutorial will use Phoenix to compare the performance of different prompt optimization techniques
+- [ReAct Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/react-prompting): **ReAct (Reasoning + Acting)** is a prompting technique that enables LLMs to think step-by-step before taking
+- [Agentic RAG Tracing](https://arize.com/docs/phoenix/cookbook/tracing/agentic-rag-tracing): >-
+- [More Cookbooks](https://arize.com/docs/phoenix/cookbook/tracing/cookbooks): Trace through the execution of your LLM application to understand its internal structure and to troubleshoot
+- [Generating Synthetic Datasets for LLM Evaluators & Agents](https://arize.com/docs/phoenix/cookbook/tracing/generating-synthetic-datasets-for-llm-evaluators-and-agents): Learn different strategies for dataset generation and show how they can be used to run experiments and test
+- [Product Recommendation Agent: Google Agent Engine & LangGraph](https://arize.com/docs/phoenix/cookbook/tracing/product-recommendation-agent-google-agent-engine-and-langgraph): This notebook is adapted from Google's \"Building and Deploying a LangGraph Application with Agent Engine in
+- [Structured Data Extraction](https://arize.com/docs/phoenix/cookbook/tracing/structured-data-extraction): Structured Data Extraction
+
+## Release Notes
+
+- [Release Notes Index](https://arize.com/docs/phoenix/release-notes): Browse all Phoenix release notes by date
+
+### 2024
+
+- [07.02.2024: Function call evaluations](https://arize.com/docs/phoenix/release-notes/2024/07-02-2024-function-call-evaluations): Available in Phoenix 4.6+
+- [07.03.2024: Datasets & experiments](https://arize.com/docs/phoenix/release-notes/2024/07-03-2024-datasets-and-experiments): Available in Phoenix 4.6+
+- [07.11.2024: Hosted Phoenix and llamatrace](https://arize.com/docs/phoenix/release-notes/2024/07-11-2024-hosted-phoenix-and-llamatrace): Phoenix is now available for deployment as a fully hosted service
+- [07.18.2024: Guardrails AI integrations](https://arize.com/docs/phoenix/release-notes/2024/07-18-2024-guardrails-ai-integrations): Available in Phoenix 4.11+
+- [09.26.2024: Authentication & RBAC](https://arize.com/docs/phoenix/release-notes/2024/09-26-2024-authentication-and-rbac): Available in Phoenix 5.0+
+- [11.18.2024: Prompt playground](https://arize.com/docs/phoenix/release-notes/2024/11-18-2024-prompt-playground): Available in Phoenix 6.0+
+- [12.09.2024: Sessions](https://arize.com/docs/phoenix/release-notes/2024/12-09-2024-sessions): Available in Phoenix 7.0+
+
+### 2026
+
+- [01.17.2026 Phoenix CLI: Terminal Access for AI Coding Assistants](https://arize.com/docs/phoenix/release-notes/01-2026/01-17-2026-phoenix-cli-ai-agent-debugging): 01.17.2026 Phoenix CLI: Terminal Access for AI Coding Assistants
+- [Phoenix 13.0](https://arize.com/docs/phoenix/release-notes/02-2026/02-14-2026-phoenix-13-0): Dataset Evaluators, custom model providers, OpenAI Responses API support, and major Playground and experiment
+- [02.27.2026 Sessions API and CLI Support](https://arize.com/docs/phoenix/release-notes/02-2026/02-27-2026-cli-sessions-and-rest-api): 02.27.2026 Sessions API and CLI Support
+- [03.05.2026 SDK Session Retrieval](https://arize.com/docs/phoenix/release-notes/03-2026/03-05-2026-sdk-session-retrieval): Get and list sessions programmatically from Python and TypeScript
+- [03.08.2026 New Playground Providers and Project Settings](https://arize.com/docs/phoenix/release-notes/03-2026/03-08-2026-new-playground-providers-and-project-settings): Phoenix v13.10.0 adds Cerebras, Fireworks AI, Groq, and Moonshot as first-class playground providers, plus
+- [Release Notes](https://arize.com/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api): Release Notes
+- [Release Notes](https://arize.com/docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements): Release Notes
+- [Release Notes](https://arize.com/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api): Release Notes
+- [Release Notes](https://arize.com/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates): Release Notes
+- [Release Notes](https://arize.com/docs/phoenix/release-notes/03-2026/03-30-2026-delete-prompts-api): Release Notes
+- [Release Notes](https://arize.com/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314): Release Notes
+- [04.03.2026 ATIF Trajectory Upload](https://arize.com/docs/phoenix/release-notes/04-2026/04-03-2026-atif-trajectory-upload): Upload Harbor ATIF agent trajectories as structured Phoenix traces
+- [Release Notes](https://arize.com/docs/phoenix/release-notes/04-2026/04-07-2026-phoenix-v14-breaking-changes): Breaking changes in Phoenix v14.0.0: CLI restructuring, legacy client removal, evaluations endpoint removal
+- [04.07.2026 PostgreSQL Read Replica Routing](https://arize.com/docs/phoenix/release-notes/04-2026/04-07-2026-postgresql-read-replica): Route read-only queries to a PostgreSQL read replica to reduce load on the primary under high ingestion
+- [04.10.2026 Shareable Project URLs](https://arize.com/docs/phoenix/release-notes/04-2026/04-10-2026-shareable-url-redirects): Link to Phoenix projects by name without looking up internal IDs
+- [04.13.2026 @arizeai/phoenix-otel 1.0](https://arize.com/docs/phoenix/release-notes/04-2026/04-13-2026-phoenix-otel-ts-1-0): Tracing helpers, decorators, context setters, and OpenInference semantic conventions ship from a single
+- [04.14.2026 CLI Annotation Commands](https://arize.com/docs/phoenix/release-notes/04-2026/04-14-2026-cli-annotation-commands): Write span and trace annotations from the terminal with px span annotate and px trace annotate
+- [04.16.2026 Azure Managed Identity for PostgreSQL](https://arize.com/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres): Connect Phoenix to Azure Database for PostgreSQL using managed identity — no static passwords required
+- [04.20.2026 Span Attribute Filtering, CLI Notes, and Claude Opus 4.7](https://arize.com/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7): Filter spans by attributes across Python, TypeScript, REST, and CLI; add notes to spans via `px span
+- [04.22.2026 Secrets Settings Page and Evaluator Trace ID](https://arize.com/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id): Manage LLM provider secrets in the UI; pass trace IDs to experiment evaluators for correlation and debugging
+- [04.24.2026 arize-phoenix-otel 0.16](https://arize.com/docs/phoenix/release-notes/04-2026/04-24-2026-phoenix-otel-python-0-16): OpenInference context managers and semantic conventions ship from a single phoenix.otel import — no second
+- [04.24.2026 Trace Notes API](https://arize.com/docs/phoenix/release-notes/04-2026/04-24-2026-trace-notes-api): Add trace notes via REST endpoint, TypeScript client, or CLI; reserve the note annotation name for
+- [04.28.2026 Session Notes API](https://arize.com/docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api): Add session notes through a dedicated REST endpoint and reserve the note annotation name for session note APIs
+- [05.01.2026 TanStack AI Tracing](https://arize.com/docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing): Instrument TanStack AI chat, tool-calling, and agent loops with the new @arizeai/openinference-tanstack-ai
+
+### 2025
+
+- [01.18.2025: Automatic & manual span tracing](https://arize.com/docs/phoenix/release-notes/01-2025/01-18-2025-automatic-and-manual-span-tracing): Available in Phoenix 7.9+
+- [02.18.2025: One line instrumentation](https://arize.com/docs/phoenix/release-notes/02-2025/02-18-2025-one-line-instrumentation): Available in Phoenix 8.0+
+- [02.19.2025: Prompts](https://arize.com/docs/phoenix/release-notes/02-2025/02-19-2025-prompts): Available in Phoenix 8.0+
+- [03.06.2025: Project improvements](https://arize.com/docs/phoenix/release-notes/03-2025/03-06-2025-project-improvements): Available in Phoenix 8.5+
+- [03.07.2025: Model config enhancements for prompts](https://arize.com/docs/phoenix/release-notes/03-2025/03-07-2025-model-config-enhancements-for-prompts): Available in Phoenix 8.11+
+- [03.07.2025: New prompt playground, evals, and integration support](https://arize.com/docs/phoenix/release-notes/03-2025/03-07-2025-new-prompt-playground-evals-and-integration-support): Available in Phoenix 8.9+
+- [03.14.2025: OpenAI agents instrumentation](https://arize.com/docs/phoenix/release-notes/03-2025/03-14-2025-openai-agents-instrumentation): Available in Phoenix 8.13+
+- [03.18.2025: Resize span, trace, and session tables](https://arize.com/docs/phoenix/release-notes/03-2025/03-18-2025-resize-span-trace-and-session-tables): Available in Phoenix 8.14+
+- [03.19.2025: Access to new integrations in projects](https://arize.com/docs/phoenix/release-notes/03-2025/03-19-2025-access-to-new-integrations-in-projects): Available in Phoenix 8.15+
+- [03.20.2025: Delete experiment from action menu](https://arize.com/docs/phoenix/release-notes/03-2025/03-20-2025-delete-experiment-from-action-menu): Available in Phoenix 8.19+
+- [03.21.2025: Environment variable based admin user configuration](https://arize.com/docs/phoenix/release-notes/03-2025/03-21-2025-environment-variable-based-admin-user-configuration): Available in Phoenix 8.17+
+- [03.24.2025: Tracing configuration tab](https://arize.com/docs/phoenix/release-notes/03-2025/03-24-2025-tracing-configuration-tab): Available in Phoenix 8.19+
+- [03.27.2025 span view improvements](https://arize.com/docs/phoenix/release-notes/03-2025/03-27-2025-span-view-improvements): Available in Phoenix 8.20+
+- [04.01.2025: Support for MCP span tool info in OpenAI agents SDK](https://arize.com/docs/phoenix/release-notes/04-2025/04-01-2025-support-for-mcp-span-tool-info-in-openai-agents-sdk): Available in Phoenix 8.20+
+- [04.02.2025 improved span annotation editor](https://arize.com/docs/phoenix/release-notes/04-2025/04-02-2025-improved-span-annotation-editor): Available in Phoenix 8.21+
+- [04.03.2025: Phoenix client prompt tagging](https://arize.com/docs/phoenix/release-notes/04-2025/04-03-2025-phoenix-client-prompt-tagging): Available in Phoenix 8.22+
+- [04.09.2025: New REST API for projects with RBAC](https://arize.com/docs/phoenix/release-notes/04-2025/04-09-2025-new-rest-api-for-projects-with-rbac): Available in Phoenix 8.23+
+- [04.09.2025: Project management API enhancements](https://arize.com/docs/phoenix/release-notes/04-2025/04-09-2025-project-management-api-enhancements): Available in Phoenix 8.24+
+- [04.15.2025: Display tool call and result ids in span details](https://arize.com/docs/phoenix/release-notes/04-2025/04-15-2025-display-tool-call-and-result-ids-in-span-details): Available in Phoenix 8.25+
+- [04.16.2025: API key generation via API](https://arize.com/docs/phoenix/release-notes/04-2025/04-16-2025-api-key-generation-via-api): Available in Phoenix 8.26+
+- [04.18.2025: Tracing for MCP client server applications](https://arize.com/docs/phoenix/release-notes/04-2025/04-18-2025-tracing-for-mcp-client-server-applications): Available in Phoenix 8.26+
+- [04.25.2025: Scroll selected span into view](https://arize.com/docs/phoenix/release-notes/04-2025/04-25-2025-scroll-selected-span-into-view): Available in Phoenix 8.27+
+- [04.28.2025: Improved shutdown handling](https://arize.com/docs/phoenix/release-notes/04-2025/04-28-2025-improved-shutdown-handling): Available in Phoenix 8.28+
+- [04.28.2025: TLS support for Phoenix server](https://arize.com/docs/phoenix/release-notes/04-2025/04-28-2025-tls-support-for-phoenix-server): Available in Phoenix 8.29+
+- [04.30.2025: Span querying & data extraction for Phoenix client](https://arize.com/docs/phoenix/release-notes/04-2025/04-30-2025-span-querying-and-data-extraction-for-phoenix-client): Available in Phoenix 8.30+
+- [05.05.2025: OpenInference Google GenAI instrumentation](https://arize.com/docs/phoenix/release-notes/05-2025/05-05-2025-openinference-google-genai-instrumentation): 05.05.2025: OpenInference Google GenAI instrumentation
+- [05.09.2025: Annotations, data retention policies, hotkeys](https://arize.com/docs/phoenix/release-notes/05-2025/05-09-2025-annotations-data-retention-policies-hotkeys): Available in Phoenix 9.0.0+
+- [05.14.2025: Experiments in the JS client](https://arize.com/docs/phoenix/release-notes/05-2025/05-14-2025-experiments-in-the-js-client): 05.14.2025: Experiments in the JS client
+- [05.20.2025: Datasets and experiment evaluations in the JS client](https://arize.com/docs/phoenix/release-notes/05-2025/05-20-2025-datasets-and-experiment-evaluations-in-the-js-client): 05.20.2025: Datasets and experiment evaluations in the JS client
+- [05.30.2025: XAI and deepseek support in playground](https://arize.com/docs/phoenix/release-notes/05-2025/05-30-2025-xai-and-deepseek-support-in-playground): Available in Phoenix 10.5+
+- [06.03.2025: Deploy via helm](https://arize.com/docs/phoenix/release-notes/06-2025/06-03-2025-deploy-via-helm): Available in Phoenix 10.6+
+- [06.04.2025: Ollama support in playground](https://arize.com/docs/phoenix/release-notes/06-2025/06-04-2025-ollama-support-in-playground): Available in Phoenix 10.7+
+- [06.06.2025: Experiment progress graph](https://arize.com/docs/phoenix/release-notes/06-2025/06-06-2025-experiment-progress-graph): Available in Phoenix 10.9+
+- [06.12.2025: Dataset filtering](https://arize.com/docs/phoenix/release-notes/06-2025/06-12-2025-dataset-filtering): Available in Phoenix 10.11+
+- [06.13.2025: Enhanced span creation and logging](https://arize.com/docs/phoenix/release-notes/06-2025/06-13-2025-enhanced-span-creation-and-logging): Available in Phoenix 10.12+
+- [06.13.2025: Session filtering](https://arize.com/docs/phoenix/release-notes/06-2025/06-13-2025-session-filtering): Available in Phoenix 10.12+
+- [06.25.2025: Amazon Bedrock support in playground](https://arize.com/docs/phoenix/release-notes/06-2025/06-25-2025-amazon-bedrock-support-in-playground): Available in Phoenix 10.15+
+- [06.25.2025: Cost tracking](https://arize.com/docs/phoenix/release-notes/06-2025/06-25-2025-cost-tracking): Available in Phoenix 11.0+
+- [06.25.2025: New Phoenix Cloud](https://arize.com/docs/phoenix/release-notes/06-2025/06-25-2025-new-phoenix-cloud): 06.25.2025: New Phoenix Cloud
+- [07.02.2025: Cursor MCP button](https://arize.com/docs/phoenix/release-notes/07-2025/07-02-2025-cursor-mcp-button): Available in Phoenix 11.3+
+- [07.03.2025: Cost summaries in trace headers](https://arize.com/docs/phoenix/release-notes/07-2025/07-03-2025-cost-summaries-in-trace-headers): Available in Phoenix 11.4+
+- [07.07.2025: Database disk usage monitor](https://arize.com/docs/phoenix/release-notes/07-2025/07-07-2025-databse-disk-usage-monitor): Available in Phoenix 11.5+
+- [07.09.2025: Baseline for experiment comparisons](https://arize.com/docs/phoenix/release-notes/07-2025/07-09-2025-baseline-for-experiment-comparisons): Available in Phoenix 11.4+
+- [07.13.2025: Experiments module in phoenix-client](https://arize.com/docs/phoenix/release-notes/07-2025/07-13-2025-experiments-module-in-phoenix-client): Available in Phoenix 11.7+
+- [07.18.2025: OpenInference Java](https://arize.com/docs/phoenix/release-notes/07-2025/07-18-2025-openinference-java): 07.18.2025: OpenInference Java
+- [07.21.2025: Project and trace management via GraphQL](https://arize.com/docs/phoenix/release-notes/07-2025/07-21-2025-project-and-trace-management-via-graphql): Available in Phoenix 11.9+
+- [07.25.2025: Average metrics in experiment comparison table](https://arize.com/docs/phoenix/release-notes/07-2025/07-25-2025-average-metrics-in-experiment-comparison-table): Available in Phoenix 11.12+
+- [07.25.2025: Project dashboards](https://arize.com/docs/phoenix/release-notes/07-2025/07-25-2025-project-dashboards): Available in Phoenix 11.12+
+- [07.29.2025: Google GenAI evals](https://arize.com/docs/phoenix/release-notes/07-2025/07-29-2025-google-genai-evals): 07.29.2025: Google GenAI evals
+- [08.03.2025: Delete Spans via REST API](https://arize.com/docs/phoenix/release-notes/08-2025/08-03-2025-delete-spans-via-rest-api): Available in Phoenix 11.19+
+- [08.04.2025: Manual Project Creation & Trace Duplication](https://arize.com/docs/phoenix/release-notes/08-2025/08-04-2025-manual-project-creation-and-trace-duplication): Available in Phoenix 11.19+
+- [08.05.2025: Claude Opus 4-1 Support](https://arize.com/docs/phoenix/release-notes/08-2025/08-05-2025-claude-opus-4-1-support): Available in Phoenix 11.19+
+- [08.06.2025: Expanded Search Capabilities](https://arize.com/docs/phoenix/release-notes/08-2025/08-06-2025-expanded-search-capabilities): Available in Phoenix 11.19+
+- [08.07.2025: Improved Error Handling in Prompt Playground](https://arize.com/docs/phoenix/release-notes/08-2025/08-07-2025-improved-error-handling-in-prompt-playground): Available in Phoenix 11.20+
+- [08.09.2025: Playground Support for GPT-5](https://arize.com/docs/phoenix/release-notes/08-2025/08-09-2025-playground-support-for-gpt-5): Available in Phoenix 11.21+
+- [08.12.2025: UI Design Overhauls](https://arize.com/docs/phoenix/release-notes/08-2025/08-12-2025-ui-design-overhauls): Available in Phoenix 11.22+
+- [08.14.2025: Trace Transfer for Long-Term Storage](https://arize.com/docs/phoenix/release-notes/08-2025/08-14-2025-trace-transfer-for-long-term-storage): Available in Phoenix 11.23+
+- [08.15.2025: Enhance Experiment Comparison Views](https://arize.com/docs/phoenix/release-notes/08-2025/08-15-2025-enhance-experiment-comparison-views): Available in Phoenix 11.24+
+- [08.20.2025: New Experiment and Annotation Quick Filters](https://arize.com/docs/phoenix/release-notes/08-2025/08-20-2025-new-experiment-and-annotation-quick-filters): Available in Phoenix 11.25+
+- [08.22.2025: New Trace Timeline View](https://arize.com/docs/phoenix/release-notes/08-2025/08-22-2025-new-trace-timeline-view): Available in Phoenix 11.26+
+- [08.28.2025: New arize-phoenix-client Package](https://arize.com/docs/phoenix/release-notes/08-2025/08-28-2025-new-arize-phoenix-client-package): We’re excited to announce the release of **`arize-phoenix-client`**, a lightweight, fully-featured package
+- [09.03.2025: Add Methods to Log Document Annotations](https://arize.com/docs/phoenix/release-notes/09-2025/09-03-2025-add-methods-to-log-document-annotations): Available in Phoenix 11.31+
+- [09.04.2025: Experiment Lists Page Frontend Enhancements](https://arize.com/docs/phoenix/release-notes/09-2025/09-04-2025-experiment-lists-page-frontend-enhancements): Available in Phoenix 11.32+
+- [09.08.2025: Experiment Annotation Popover in Detail View](https://arize.com/docs/phoenix/release-notes/09-2025/09-08-2025-experiment-annotation-popover-in-detail-view): Available in Phoenix 11.33+
+- [09.12.2025: Enable Paging in Experiment Compare Details](https://arize.com/docs/phoenix/release-notes/09-2025/09-12-2025-enable-paging-in-experiment-compare-details): Available in Phoenix 11.33+
+- [09.15.2025: Prompt Labels](https://arize.com/docs/phoenix/release-notes/09-2025/09-15-2025-prompt-labels): Available in Phoenix 11.33+
+- [09.17.2025: Experiment compare details slideover in list view](https://arize.com/docs/phoenix/release-notes/09-2025/09-17-2025-experiment-compare-details-slideover-in-list-view): Available in Phoenix 11.34+
+- [09.22.2025: Helm configurable image registry & IPv6 support](https://arize.com/docs/phoenix/release-notes/09-2025/09-22-2025-helm-configurable-image-registry-and-ipv6-support): Available in Phoenix 11.35+
+- [09.23.2025: Repetitions in experiment compare slideover](https://arize.com/docs/phoenix/release-notes/09-2025/09-23-2025-repetitions-in-experiment-compare-slideover): Available in Phoenix 11.35+
+- [09.24.2025: Custom HTTP headers for requests in Playground](https://arize.com/docs/phoenix/release-notes/09-2025/09-24-2025-custom-http-headers-for-requests-in-playground): Available in Phoenix 11.36+
+- [09.25.2025: Repetitions](https://arize.com/docs/phoenix/release-notes/09-2025/09-25-2025-repetitions): Available in Phoenix 11.38+
+- [09.26.2025: Session Annotations](https://arize.com/docs/phoenix/release-notes/09-2025/09-26-2025-session-annotations): Available in Phoenix 12.0+
+- [09.27.2025: Dataset Splits](https://arize.com/docs/phoenix/release-notes/09-2025/09-27-2025-dataset-splits): Available in Phoenix 12.0+
+- [10.03.2025: Prompt Version Editing in Playground](https://arize.com/docs/phoenix/release-notes/10-2025/10-03-2025-prompt-version-editing-in-playground): Available in Phoenix 12.2+
+- [10.05.2025: Load Prompt by Tag into Playground](https://arize.com/docs/phoenix/release-notes/10-2025/10-05-2025-load-prompt-by-tag-into-playground): Available in Phoenix 12.2+
+- [10.06.2025: Paginate Compare Experiments](https://arize.com/docs/phoenix/release-notes/10-2025/10-06-2025-paginate-compare-experiments): Available in Phoenix 12.3+
+- [10.08.2025: Dataset Labels](https://arize.com/docs/phoenix/release-notes/10-2025/10-08-2025-dataset-labels): Available in Phoenix 12.3+
+- [10.10.2025: Viewer Role](https://arize.com/docs/phoenix/release-notes/10-2025/10-10-2025-viewer-role): Available in Phoenix 12.5+
+- [10.13.2025: View Traces in Compare Experiments](https://arize.com/docs/phoenix/release-notes/10-2025/10-13-2025-view-traces-in-compare-experiments): Available in Phoenix 12.5+
+- [10.15.2025: Enhanced Filtering for Examples Table](https://arize.com/docs/phoenix/release-notes/10-2025/10-15-2025-enhanced-filtering-for-examples-table): Available in Phoenix 12.5+
+- [10.18.2025: Filter Annotations in Compare Experiments Slideover](https://arize.com/docs/phoenix/release-notes/10-2025/10-18-2025-filter-annotations-in-compare-experiments-slideover): Available in Phoenix 12.7+
+- [10.20.2025: Splits ䷖](https://arize.com/docs/phoenix/release-notes/10-2025/10-20-2025-splits): Available in Phoenix 12.7+
+- [10.24.2025: Filter Prompts Page by Label](https://arize.com/docs/phoenix/release-notes/10-2025/10-24-2025-filter-prompts-page-by-label): Available in Phoenix 12.7+
+- [10.26.2025: Add Split Edit Menu to Examples ䷖](https://arize.com/docs/phoenix/release-notes/10-2025/10-26-2025-add-split-edit-menu-to-examples): Available in Phoenix 12.8+
+- [10.28.2025: Enable AWS IAM Auth for DB Configuration](https://arize.com/docs/phoenix/release-notes/10-2025/10-28-2025-enable-aws-iam-auth-for-db-configuration): Available in Phoenix 12.9+
+- [10.30.2025: Metadata Support for Experiment Run Annotations](https://arize.com/docs/phoenix/release-notes/10-2025/10-30-2025-metadata-support-for-experiment-run-annotations): Available in Phoenix 12.9+
+- [11.01.2025: Resume Experiments and Evaluations](https://arize.com/docs/phoenix/release-notes/11-2025/11-01-2025-resume-experiments-and-evaluations): Available in Phoenix 12.10+
+- [11.03.2025: Playground Dataset Label Display](https://arize.com/docs/phoenix/release-notes/11-2025/11-03-2025-playground-dataset-label-display): Available in Phoenix 12.10+
+- [11.05.2025: Metadata for Prompts](https://arize.com/docs/phoenix/release-notes/11-2025/11-05-2025-metadata-for-prompts): Available in Phoenix 12.10+
+- [11.07.2025: Timezone Preference](https://arize.com/docs/phoenix/release-notes/11-2025/11-07-2025-timezone-preference): Available in Phoenix 12.11+
+- [11.09.2025 OpenInference TypeScript 2.0](https://arize.com/docs/phoenix/release-notes/11-2025/11-09-2025-openinference-typescript-2-0): 11.09.2025 OpenInference TypeScript 2.0
+- [11.12.2025: Updated Anthropic Model List](https://arize.com/docs/phoenix/release-notes/11-2025/11-12-2025-updated-anthropic-model-list): Available in Phoenix 12.15+
+- [11.23.2025: Repetitions for Manual Playground Invocations](https://arize.com/docs/phoenix/release-notes/11-2025/11-23-2025-repetitions-for-manual-playground-invocations): Available in Phoenix 12.17+
+- [11.25.2025: Split Assignments When Uploading a Dataset](https://arize.com/docs/phoenix/release-notes/11-2025/11-25-2025-split-assignments-when-uploading-a-dataset): Available in Phoenix 12.18+
+- [11.27.2025: Show Server Credential Setup in Playground API Keys](https://arize.com/docs/phoenix/release-notes/11-2025/11-27-2025-show-server-credential-setup-in-playground-api-keys): Available in Phoenix 12.18+
+- [11.29.2025: Add support for Claude Opus 4-5](https://arize.com/docs/phoenix/release-notes/11-2025/11-29-2025-add-support-for-claude-opus-4-5): Available in Phoenix 12.18+
+- [12.01.2025: Splits on Experiments Table](https://arize.com/docs/phoenix/release-notes/12-2025/12-01-2025-splits-on-experiments-table): Available in Phoenix 12.20+
+- [12.03.2025: TypeScript createEvaluator](https://arize.com/docs/phoenix/release-notes/12-2025/12-03-2025-typescript-create-evaluator): Available in @arizeai/phoenix-evals 2.0+
+- [12.04.2025: Evaluator Message Formats](https://arize.com/docs/phoenix/release-notes/12-2025/12-04-2025-evaluator-message-formats): Available in phoenix-evals 0.22+ (Python) and @arizeai/phoenix-evals 2.0+ (TypeScript)
+- [12.06.2025: LDAP Authentication Support](https://arize.com/docs/phoenix/release-notes/12-2025/12-06-2025-ldap-authentication-support): Available in Phoenix 12.20+
+- [12.09.2025: Span Notes API](https://arize.com/docs/phoenix/release-notes/12-2025/12-09-2025-span-notes-api): Available in Phoenix 12.21+
+- [12.12.2025: Support for Gemini Tool Calls](https://arize.com/docs/phoenix/release-notes/12-2025/12-12-2025-support-for-gemini-tool-calls): Available in Phoenix 12.25+
+- [12.20.2025: Improved User Preferences](https://arize.com/docs/phoenix/release-notes/12-2025/12-20-2025-improved-user-preferences): Available in Phoenix 12.27+

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-jsonl-file.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-jsonl-file.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/datasets/{id}/jsonl
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/delete-a-prompt.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/delete-a-prompt.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/prompts/{prompt_identifier}
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/delete-a-tag-from-a-prompt-version.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts/delete-a-tag-from-a-prompt-version.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/prompt_versions/{prompt_version_id}/tags/{tag_name}
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/bulk-delete-sessions.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/bulk-delete-sessions.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/sessions/delete
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/create-a-session-note.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/create-a-session-note.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/session_notes
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/delete-a-session-by-identifier.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions/delete-a-session-by-identifier.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/sessions/{session_identifier}
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/create-a-trace-note.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/create-a-trace-note.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/trace_notes
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/list-traces-for-a-project.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/traces/list-traces-for-a-project.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/projects/{project_identifier}/traces
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/users/get-the-authenticated-user.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/users/get-the-authenticated-user.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/user
+---


### PR DESCRIPTION
## Summary

- Add doc pages for 9 v1 REST endpoints that lacked `.mdx` files: dataset JSONL download, delete prompt, delete prompt-version tag, create/delete/bulk-delete sessions, session note, list traces for a project, trace note, get authenticated user.
- Surface 5 endpoint pages that already existed on disk but were missing from `docs.json` navigation: session-annotations getter, delete experiment, two incomplete-experiment endpoints, and span note. The full REST API reference now lists 67 endpoints.
- Rewrite the REST API portion of `docs/phoenix/llms.txt` with per-resource subsections (Annotation Configs, Annotations, Datasets, Experiments, Projects, Prompts, Secrets, Sessions, Spans, Traces, Users). Each entry now uses an action-oriented description that includes the HTTP method and `/v1/...` path, replacing the old "Title: Title" placeholder descriptions.

Coverage: 99.5% of nav-published pages indexed in llms.txt — the 3 unindexed pages are excluded per the phoenix-llms-txt skill rules (agent-assisted-setup, demo, Colab notebook).

## Test plan

- [x] `pnpm test test/docs.test.ts` in `js/packages/phoenix-cli` — 25 tests pass
- [ ] Mintlify preview renders the new endpoint pages and the expanded nav groups
- [ ] Spot-check llms.txt entries point to live URLs