### PR TITLE
test: Add agent Playwright smoke harness

### DIFF
--- a/.agents/skills/phoenix-pxi-playwright/SKILL.md
+++ b/.agents/skills/phoenix-pxi-playwright/SKILL.md
@@ -127,7 +127,7 @@ test.describe("PXI scenario", () => {
 Use isolated ports to avoid collisions with a local Phoenix dev server:
 
 ```bash
-PXI_E2E=true PHOENIX_PORT=16006 PHOENIX_GRPC_PORT=14317 pnpm exec playwright test tests/pxi/<spec>.spec.ts --project=chromium --reporter=list
+pnpm run test:e2e:pxi
 ```
 
 Real PXI specs require external model credentials. Keep tests skipped by default unless `PXI_E2E=true` is set.

--- a/.agents/skills/phoenix-pxi-playwright/SKILL.md
+++ b/.agents/skills/phoenix-pxi-playwright/SKILL.md
@@ -13,6 +13,8 @@ Use this skill when authoring or maintaining Playwright specs for PXI, Phoenix's
 
 - Read the existing example spec first: `app/tests/pxi/docs-smoke.spec.ts`.
 - Reuse the shared fixture and driver from `app/tests/pxi/fixtures.ts`.
+- Reuse shared constants from `app/tests/pxi/constants.ts` and shared types from `app/tests/pxi/types.ts`.
+- Put pure parsing/API helpers in `app/tests/pxi/utils.ts` rather than in specs or fixture classes.
 - Reuse the generic AI SDK judge from `app/tests/pxi/judge.ts`.
 - Reuse experiment persistence from `app/tests/pxi/experimentPersistence.ts`.
 - Do not create a bespoke PXI driver, duplicate experiment client, or duplicate PXI tool schemas in a spec.
@@ -22,6 +24,9 @@ Use this skill when authoring or maintaining Playwright specs for PXI, Phoenix's
 The current harness provides these abstractions:
 
 - `test` and `expect` from `./fixtures`: PXI-aware Playwright fixture exports.
+- `constants.ts`: default assistant and judge model/project constants.
+- `types.ts`: shared PXI harness types such as `PxiTurn`.
+- `utils.ts`: pure utilities for API response validation and span/tool parsing.
 - `pxi.open({ userInstructions })`: opens PXI with optional user instructions.
 - `pxi.acknowledgeConsent()`: accepts PXI consent for the test session.
 - `pxi.askAndWait(prompt)`: sends a user prompt and waits for the assistant turn.
@@ -29,6 +34,8 @@ The current harness provides these abstractions:
 - `pxi.expectDocsToolCalled(turn)`: asserts the PXI turn used runtime docs tooling via Phoenix-observed tool spans.
 - `pxi.getMetadata()`: collects PXI metadata for persistence.
 - `judge({ model, system, prompt, assistantText, rubric })`: evaluates an assistant answer with AI SDK `generateText` and structured `Output.object`.
+- `evaluatePxiOutcome({ assertions, judgeInput })`: runs deterministic assertions and LLM judging while preserving failed post-turn outcomes for experiment persistence.
+- `assertPxiOutcome(outcome)`: fails the Playwright test after persistence, preferring the original deterministic assertion failure when one exists.
 - `persistPxiExperiment({ request, record })`: stores the PXI interaction, judge result, and metadata as a Phoenix experiment.
 
 ## Authoring Workflow
@@ -36,8 +43,8 @@ The current harness provides these abstractions:
 1. Put the scenario prompt, PXI user instructions, and judge rubric in the spec file so the test is readable top-to-bottom.
 2. Drive PXI through the real UI with `pxi.open`, `pxi.acknowledgeConsent`, and `pxi.askAndWait`.
 3. Add deterministic assertions before judge assertions, such as expected text, no agent error, or expected tool use.
-4. Use `judge` for semantic outcome checks only after deterministic assertions pass.
-5. Persist the run with `persistPxiExperiment` so failures and quality drift can be inspected in Phoenix.
+4. After `pxi.askAndWait` returns a turn, persist both passing and failing outcomes. Do not let deterministic assertion failures skip experiment persistence.
+5. Use `evaluatePxiOutcome` instead of writing per-spec `try/catch` blocks. It runs `judge` even when deterministic Playwright assertions fail, then combines the judge explanation with a sanitized, truncated Playwright assertion message in the persisted failed evaluation.
 6. Run the targeted spec with isolated ports before reporting success.
 
 ## Spec Pattern
@@ -45,7 +52,8 @@ The current harness provides these abstractions:
 ```ts
 import { persistPxiExperiment } from "./experimentPersistence";
 import { expect, test } from "./fixtures";
-import { getRequiredJudgeApiKeyEnv, judge } from "./judge";
+import { getRequiredJudgeApiKeyEnv } from "./judge";
+import { assertPxiOutcome, evaluatePxiOutcome } from "./outcome";
 
 const AGENT_USER_INSTRUCTIONS = "Use the relevant Phoenix tools for this task.";
 const USER_PROMPT = "Ask PXI to do one user-visible task.";
@@ -84,14 +92,17 @@ test.describe("PXI scenario", () => {
     await pxi.acknowledgeConsent();
 
     const turn = await pxi.askAndWait(USER_PROMPT);
-    await pxi.expectNoAgentError();
-    expect(turn.assistantText).toContain("deterministic expected text");
-
-    const judgeResult = await judge({
-      system: "You are judging a Phoenix PXI E2E answer.",
-      prompt: USER_PROMPT,
-      assistantText: turn.assistantText,
-      rubric: JUDGE_RUBRIC,
+    const outcome = await evaluatePxiOutcome({
+      assertions: async () => {
+        await pxi.expectNoAgentError();
+        expect(turn.assistantText).toContain("deterministic expected text");
+      },
+      judgeInput: {
+        system: "You are judging a Phoenix PXI E2E answer.",
+        prompt: USER_PROMPT,
+        assistantText: turn.assistantText,
+        rubric: JUDGE_RUBRIC,
+      },
     });
 
     await persistPxiExperiment({
@@ -102,13 +113,13 @@ test.describe("PXI scenario", () => {
         calledTools: turn.calledTools,
         url: page.url(),
         durationMs: turn.durationMs,
-        judgeResult,
+        judgeResult: outcome.judgeResult,
         playwrightProject: testInfo.project.name,
         ...pxi.getMetadata(),
       },
     });
 
-    expect(judgeResult.label, judgeResult.explanation).toBe("pass");
+    assertPxiOutcome(outcome);
   });
 });
 ```
@@ -138,6 +149,8 @@ Real PXI specs require external model credentials. Keep tests skipped by default
 - Override with `PXI_E2E_EXPERIMENT_BASE_URL`.
 - Use `PXI_E2E_EXPERIMENT_BEARER_TOKEN` only when persisting to an authenticated Phoenix target.
 - Persist the complete test record: prompt, assistant text, called tools, duration, judge result, Playwright project, URL, and PXI metadata.
+- Persist failed post-turn outcomes too. If PXI returned an answer, the experiment run should exist even when deterministic assertions or judge checks fail.
+- Let `evaluatePxiOutcome` strip ANSI escape sequences and truncate Playwright assertion messages before they are added to `judgeResult.explanation`; raw Playwright error messages are terminal-formatted and too noisy for Phoenix experiment tables.
 
 ## Extending The Harness
 

--- a/.agents/skills/phoenix-pxi-playwright/SKILL.md
+++ b/.agents/skills/phoenix-pxi-playwright/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: phoenix-pxi-playwright
+description: Write, extend, and debug PXI Playwright E2E tests for Phoenix. Use when adding PXI agent frontend specs, authoring LLM-as-judge rubrics, asserting PXI tool use, persisting PXI test runs as Phoenix experiments, or debugging PXI E2E failures.
+metadata:
+  internal: true
+---
+
+# Phoenix PXI Playwright Tests
+
+Use this skill when authoring or maintaining Playwright specs for PXI, Phoenix's built-in AI assistant. The concrete harness lives in `app/tests/pxi/`; this skill is the authoring guide for using and extending that harness.
+
+## Start Here
+
+- Read the existing example spec first: `app/tests/pxi/docs-smoke.spec.ts`.
+- Reuse the shared fixture and driver from `app/tests/pxi/fixtures.ts`.
+- Reuse the generic AI SDK judge from `app/tests/pxi/judge.ts`.
+- Reuse experiment persistence from `app/tests/pxi/experimentPersistence.ts`.
+- Do not create a bespoke PXI driver, duplicate experiment client, or duplicate PXI tool schemas in a spec.
+
+## Current Harness
+
+The current harness provides these abstractions:
+
+- `test` and `expect` from `./fixtures`: PXI-aware Playwright fixture exports.
+- `pxi.open({ userInstructions })`: opens PXI with optional user instructions.
+- `pxi.acknowledgeConsent()`: accepts PXI consent for the test session.
+- `pxi.askAndWait(prompt)`: sends a user prompt and waits for the assistant turn.
+- `pxi.expectNoAgentError()`: asserts the visible PXI session did not surface an agent error.
+- `pxi.expectDocsToolCalled(turn)`: asserts the PXI turn used runtime docs tooling via Phoenix-observed tool spans.
+- `pxi.getMetadata()`: collects PXI metadata for persistence.
+- `judge({ model, system, prompt, assistantText, rubric })`: evaluates an assistant answer with AI SDK `generateText` and structured `Output.object`.
+- `persistPxiExperiment({ request, record })`: stores the PXI interaction, judge result, and metadata as a Phoenix experiment.
+
+## Authoring Workflow
+
+1. Put the scenario prompt, PXI user instructions, and judge rubric in the spec file so the test is readable top-to-bottom.
+2. Drive PXI through the real UI with `pxi.open`, `pxi.acknowledgeConsent`, and `pxi.askAndWait`.
+3. Add deterministic assertions before judge assertions, such as expected text, no agent error, or expected tool use.
+4. Use `judge` for semantic outcome checks only after deterministic assertions pass.
+5. Persist the run with `persistPxiExperiment` so failures and quality drift can be inspected in Phoenix.
+6. Run the targeted spec with isolated ports before reporting success.
+
+## Spec Pattern
+
+```ts
+import { persistPxiExperiment } from "./experimentPersistence";
+import { expect, test } from "./fixtures";
+import { getRequiredJudgeApiKeyEnv, judge } from "./judge";
+
+const AGENT_USER_INSTRUCTIONS = "Use the relevant Phoenix tools for this task.";
+const USER_PROMPT = "Ask PXI to do one user-visible task.";
+const JUDGE_RUBRIC = [
+  "The answer satisfies the user request.",
+  "The answer is grounded in the expected Phoenix context.",
+  "The answer does not invent unsupported facts.",
+];
+const JUDGE_API_KEY_ENV = getRequiredJudgeApiKeyEnv();
+
+test.describe("PXI scenario", () => {
+  test("handles the scenario", async ({
+    browserName,
+    page,
+    pxi,
+    request,
+  }, testInfo) => {
+    test.skip(
+      browserName !== "chromium",
+      "PXI real-LLM smoke runs once in chromium."
+    );
+    test.skip(
+      process.env.PXI_E2E !== "true",
+      "Set PXI_E2E=true to run PXI E2E tests."
+    );
+    test.skip(
+      !process.env.OPENAI_API_KEY,
+      "OPENAI_API_KEY is required for the PXI assistant."
+    );
+    test.skip(
+      !process.env[JUDGE_API_KEY_ENV],
+      `${JUDGE_API_KEY_ENV} is required for the PXI E2E judge.`
+    );
+
+    await pxi.open({ userInstructions: AGENT_USER_INSTRUCTIONS });
+    await pxi.acknowledgeConsent();
+
+    const turn = await pxi.askAndWait(USER_PROMPT);
+    await pxi.expectNoAgentError();
+    expect(turn.assistantText).toContain("deterministic expected text");
+
+    const judgeResult = await judge({
+      system: "You are judging a Phoenix PXI E2E answer.",
+      prompt: USER_PROMPT,
+      assistantText: turn.assistantText,
+      rubric: JUDGE_RUBRIC,
+    });
+
+    await persistPxiExperiment({
+      request,
+      record: {
+        prompt: USER_PROMPT,
+        assistantText: turn.assistantText,
+        calledTools: turn.calledTools,
+        url: page.url(),
+        durationMs: turn.durationMs,
+        judgeResult,
+        playwrightProject: testInfo.project.name,
+        ...pxi.getMetadata(),
+      },
+    });
+
+    expect(judgeResult.label, judgeResult.explanation).toBe("pass");
+  });
+});
+```
+
+## Judge Models
+
+- Pass judge models as `provider/model` strings.
+- Default: `openai/gpt-4.1` via `PXI_E2E_JUDGE_MODEL` fallback.
+- Supported providers are currently `openai` and `anthropic`.
+- `openai/...` requires `OPENAI_API_KEY`.
+- `anthropic/...` requires `ANTHROPIC_API_KEY`.
+- The judge must use AI SDK 6 structured output idioms: `generateText` with `Output.object({ schema })`. Do not use deprecated `generateObject`.
+
+## Running Specs
+
+Use isolated ports to avoid collisions with a local Phoenix dev server:
+
+```bash
+PXI_E2E=true PHOENIX_PORT=16006 PHOENIX_GRPC_PORT=14317 pnpm exec playwright test tests/pxi/<spec>.spec.ts --project=chromium --reporter=list
+```
+
+Real PXI specs require external model credentials. Keep tests skipped by default unless `PXI_E2E=true` is set.
+
+## Experiment Persistence
+
+- Persistence defaults to `http://localhost:6006` so real E2E runs can be inspected in the developer's local Phoenix instance.
+- Override with `PXI_E2E_EXPERIMENT_BASE_URL`.
+- Use `PXI_E2E_EXPERIMENT_BEARER_TOKEN` only when persisting to an authenticated Phoenix target.
+- Persist the complete test record: prompt, assistant text, called tools, duration, judge result, Playwright project, URL, and PXI metadata.
+
+## Extending The Harness
+
+If `fixtures.ts`, `judge.ts`, or `experimentPersistence.ts` do not satisfy a testing use case, use [`internal_docs/pxi_playwright_e2e_harness.md`](../../../internal_docs/pxi_playwright_e2e_harness.md) as the design guide for extending the harness, utilities, and this skill together. That internal doc describes the intended architecture for richer PXI drivers, seed fixtures, LLM modes, outcome assertions, experiment persistence, and debugging artifacts.
+
+Prefer small harness extensions that make future specs simpler. Do not add one-off logic to an individual spec if it should be reusable across PXI E2E scenarios.
+
+## Keep This Skill Fresh
+
+When a session creates new PXI Playwright capabilities, discovers a reliable assertion pattern, changes judge behavior, adds seed fixtures, or learns a debugging technique, update this skill in the same branch. Future developers and agents should not have to rediscover branch-specific harness behavior.

--- a/.agents/skills/phoenix-pxi-playwright/SKILL.md
+++ b/.agents/skills/phoenix-pxi-playwright/SKILL.md
@@ -27,7 +27,7 @@ The current harness provides these abstractions:
 - `constants.ts`: default assistant and judge model/project constants.
 - `types.ts`: shared PXI harness types such as `PxiTurn`.
 - `utils.ts`: pure utilities for API response validation and span/tool parsing.
-- `pxi.open({ userInstructions })`: opens PXI with optional user instructions.
+- `pxi.open()`: opens PXI for the test session.
 - `pxi.acknowledgeConsent()`: accepts PXI consent for the test session.
 - `pxi.askAndWait(prompt)`: sends a user prompt and waits for the assistant turn.
 - `pxi.expectNoAgentError()`: asserts the visible PXI session did not surface an agent error.
@@ -55,7 +55,6 @@ import { expect, test } from "./fixtures";
 import { getRequiredJudgeApiKeyEnv } from "./judge";
 import { assertPxiOutcome, evaluatePxiOutcome } from "./outcome";
 
-const AGENT_USER_INSTRUCTIONS = "Use the relevant Phoenix tools for this task.";
 const USER_PROMPT = "Ask PXI to do one user-visible task.";
 const JUDGE_RUBRIC = [
   "The answer satisfies the user request.",
@@ -88,7 +87,7 @@ test.describe("PXI scenario", () => {
       `${JUDGE_API_KEY_ENV} is required for the PXI E2E judge.`
     );
 
-    await pxi.open({ userInstructions: AGENT_USER_INSTRUCTIONS });
+    await pxi.open();
     await pxi.acknowledgeConsent();
 
     const turn = await pxi.askAndWait(USER_PROMPT);

--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "lint:fix": "oxlint --fix",
     "preinstall": "npx only-allow pnpm",
     "pretest:e2e": "pnpm build",
+    "pretest:e2e:pxi": "pnpm build",
     "pretest:e2e:ui": "pnpm build",
     "prod": "pnpm run build:static && pnpm run build && pnpm run prod:server",
     "prod:server": "source ./.env && uv run phoenix serve",

--- a/app/package.json
+++ b/app/package.json
@@ -104,6 +104,7 @@
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.69",
     "@ai-sdk/mcp": "1.0.26",
+    "@ai-sdk/openai": "3.0.46",
     "@arizeai/phoenix-client": "^6.6.2",
     "@arizeai/phoenix-evals": "^1.0.2",
     "@chromatic-com/storybook": "^5.0.2",

--- a/app/package.json
+++ b/app/package.json
@@ -32,6 +32,7 @@
     "storybook": "storybook dev -p 6007",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:e2e:pxi": "PXI_E2E=true PHOENIX_PORT=16006 PHOENIX_GRPC_PORT=14317 playwright test tests/pxi --project=chromium --reporter=list",
     "test:e2e:ui": "playwright test --ui",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -11,6 +11,10 @@ import { defineConfig, devices } from "@playwright/test";
 // Skip WebKit for CI because of recurring issues with caching binaries.
 const isCI = !!process.env.CI;
 const skipWebKit = process.env.CI_PLAYWRIGHT_SKIP_WEBKIT === "true";
+const baseURL =
+  process.env.PLAYWRIGHT_BASE_URL ??
+  `http://localhost:${process.env.PHOENIX_PORT ?? "6006"}`;
+const pxiTestIgnore = process.env.PXI_E2E === "true" ? [] : ["**/pxi/**"];
 
 const projects: Project[] = [
   {
@@ -25,7 +29,7 @@ const projects: Project[] = [
     },
     dependencies: ["setup"],
     // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
-    testIgnore: ["**/*.rate-limit.spec.ts", "**/*.setup.ts"],
+    testIgnore: ["**/*.rate-limit.spec.ts", "**/*.setup.ts", ...pxiTestIgnore],
   },
   {
     name: "firefox",
@@ -35,7 +39,7 @@ const projects: Project[] = [
     },
     dependencies: ["setup"],
     // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
-    testIgnore: ["**/*.rate-limit.spec.ts", "**/*.setup.ts"],
+    testIgnore: ["**/*.rate-limit.spec.ts", "**/*.setup.ts", ...pxiTestIgnore],
   },
 ];
 
@@ -48,7 +52,7 @@ if (!skipWebKit) {
     },
     dependencies: ["setup"],
     // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
-    testIgnore: ["**/*.rate-limit.spec.ts", "**/*.setup.ts"],
+    testIgnore: ["**/*.rate-limit.spec.ts", "**/*.setup.ts", ...pxiTestIgnore],
   });
 }
 
@@ -83,7 +87,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:6006",
+    baseURL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -98,7 +102,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: "pnpm run dev:server:test",
-    url: "http://localhost:6006",
+    url: baseURL,
     reuseExistingServer: !isCI,
     timeout: isCI ? 240_000 : 120_000,
   },

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       '@ai-sdk/mcp':
         specifier: 1.0.26
         version: 1.0.26(zod@4.3.6)
+      '@ai-sdk/openai':
+        specifier: 3.0.46
+        version: 3.0.46(zod@4.3.6)
       '@arizeai/phoenix-client':
         specifier: ^6.6.2
         version: 6.6.2(@anthropic-ai/sdk@0.35.0)(@opentelemetry/api@1.9.0)(@opentelemetry/semantic-conventions@1.40.0)(ai@6.0.137(zod@4.3.6))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))
@@ -385,6 +388,12 @@ packages:
 
   '@ai-sdk/mcp@1.0.26':
     resolution: {integrity: sha512-D7MUEUmMTYxrVZeV5/oZ1GNvgehhdxLhz7Z8q+0wjB2i2HfZ+8mfHWDzztmbg4DUBjGFC0eZ2lvSMEOaS7SQBw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.46':
+    resolution: {integrity: sha512-8grBb4sAMU0MAC6uOOD/wP/+SyX/3MMS/Lf+ToGgeUzoF9oWU9dWBLkvgjXpn7Ro81bPDeycW2GCCT63V/Vnvg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -6101,6 +6110,12 @@ snapshots:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.20(zod@4.3.6)
       pkce-challenge: 5.0.1
+      zod: 4.3.6
+
+  '@ai-sdk/openai@3.0.46(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.20(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/provider-utils@4.0.20(zod@4.3.6)':

--- a/app/tests/pxi/constants.ts
+++ b/app/tests/pxi/constants.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_ASSISTANT_PROVIDER = "OPENAI";
+export const DEFAULT_ASSISTANT_MODEL = "gpt-5.4";
+export const DEFAULT_ASSISTANT_PROJECT_NAME = "assistant_agent";
+export const DEFAULT_JUDGE_MODEL = "openai/gpt-4.1";

--- a/app/tests/pxi/docs-smoke.spec.ts
+++ b/app/tests/pxi/docs-smoke.spec.ts
@@ -3,8 +3,6 @@ import { expect, test } from "./fixtures";
 import { getRequiredJudgeApiKeyEnv } from "./judge";
 import { assertPxiOutcome, evaluatePxiOutcome } from "./outcome";
 
-const AGENT_USER_INSTRUCTIONS = "";
-
 const USER_PROMPT = "How do I change the default project name";
 
 const JUDGE_RUBRIC = [
@@ -46,7 +44,7 @@ test.describe("PXI docs smoke", () => {
       "This MVP PXI E2E test currently supports OPENAI assistant runs."
     );
 
-    await pxi.open({ userInstructions: AGENT_USER_INSTRUCTIONS });
+    await pxi.open();
     await pxi.acknowledgeConsent();
 
     const turn = await pxi.askAndWait(USER_PROMPT);

--- a/app/tests/pxi/docs-smoke.spec.ts
+++ b/app/tests/pxi/docs-smoke.spec.ts
@@ -1,0 +1,82 @@
+import { persistPxiExperiment } from "./experimentPersistence";
+import { expect, test } from "./fixtures";
+import { getRequiredJudgeApiKeyEnv, judge } from "./judge";
+
+const AGENT_USER_INSTRUCTIONS =
+  "Use the Phoenix documentation tools when the user asks about Phoenix documentation.";
+
+const USER_PROMPT =
+  "Use the Phoenix documentation to answer: what environment variable controls the project name for Phoenix tracing? Include a link to the relevant Phoenix docs.";
+
+const JUDGE_RUBRIC = [
+  "The answer is grounded in Phoenix documentation.",
+  "The answer identifies PHOENIX_PROJECT_NAME as the environment variable for setting the Phoenix tracing project name.",
+  "The answer includes a canonical arize.com/docs/phoenix documentation link.",
+  "The answer does not invent or recommend a different environment variable.",
+];
+
+const JUDGE_SYSTEM =
+  "You are judging a Phoenix PXI E2E answer. Return a label, score, and brief explanation.";
+
+test.describe("PXI docs smoke", () => {
+  test("answers tracing project env var using runtime Mintlify MCP docs", async ({
+    browserName,
+    page,
+    pxi,
+    request,
+  }, testInfo) => {
+    test.skip(
+      browserName !== "chromium",
+      "PXI real-LLM smoke runs once in chromium."
+    );
+    test.skip(
+      process.env.PXI_E2E !== "true",
+      "Set PXI_E2E=true to run PXI E2E tests."
+    );
+    const judgeApiKeyEnv = getRequiredJudgeApiKeyEnv();
+    test.skip(
+      !process.env.OPENAI_API_KEY,
+      "OPENAI_API_KEY is required for the PXI assistant."
+    );
+    test.skip(
+      !process.env[judgeApiKeyEnv],
+      `${judgeApiKeyEnv} is required for the PXI E2E judge.`
+    );
+    test.skip(
+      (process.env.PXI_E2E_ASSISTANT_PROVIDER ?? "OPENAI") !== "OPENAI",
+      "This MVP PXI E2E test currently supports OPENAI assistant runs."
+    );
+
+    await pxi.open({ userInstructions: AGENT_USER_INSTRUCTIONS });
+    await pxi.acknowledgeConsent();
+
+    const turn = await pxi.askAndWait(USER_PROMPT);
+    await pxi.expectNoAgentError();
+    pxi.expectDocsToolCalled(turn);
+    expect(turn.assistantText).toContain("PHOENIX_PROJECT_NAME");
+
+    const judgeResult = await judge({
+      system: JUDGE_SYSTEM,
+      prompt: USER_PROMPT,
+      assistantText: turn.assistantText,
+      rubric: JUDGE_RUBRIC,
+    });
+
+    const metadata = pxi.getMetadata();
+    await persistPxiExperiment({
+      request,
+      record: {
+        prompt: USER_PROMPT,
+        assistantText: turn.assistantText,
+        calledTools: turn.calledTools,
+        url: page.url(),
+        durationMs: turn.durationMs,
+        judgeResult,
+        playwrightProject: testInfo.project.name,
+        ...metadata,
+      },
+    });
+
+    expect(judgeResult.label, judgeResult.explanation).toBe("pass");
+  });
+});

--- a/app/tests/pxi/docs-smoke.spec.ts
+++ b/app/tests/pxi/docs-smoke.spec.ts
@@ -6,7 +6,7 @@ const AGENT_USER_INSTRUCTIONS =
   "Use the Phoenix documentation tools when the user asks about Phoenix documentation.";
 
 const USER_PROMPT =
-  "Use the Phoenix documentation to answer: what environment variable controls the project name for Phoenix tracing? Include a link to the relevant Phoenix docs.";
+  "Use the Phoenix documentation to answer: for traces sent by a Phoenix SDK or OpenTelemetry instrumentation, what environment variable sets the project name? Include the relevant Phoenix docs link.";
 
 const JUDGE_RUBRIC = [
   "The answer is grounded in Phoenix documentation.",

--- a/app/tests/pxi/docs-smoke.spec.ts
+++ b/app/tests/pxi/docs-smoke.spec.ts
@@ -1,12 +1,11 @@
 import { persistPxiExperiment } from "./experimentPersistence";
 import { expect, test } from "./fixtures";
-import { getRequiredJudgeApiKeyEnv, judge } from "./judge";
+import { getRequiredJudgeApiKeyEnv } from "./judge";
+import { assertPxiOutcome, evaluatePxiOutcome } from "./outcome";
 
-const AGENT_USER_INSTRUCTIONS =
-  "Use the Phoenix documentation tools when the user asks about Phoenix documentation.";
+const AGENT_USER_INSTRUCTIONS = "";
 
-const USER_PROMPT =
-  "Use the Phoenix documentation to answer: for traces sent by a Phoenix SDK or OpenTelemetry instrumentation, what environment variable sets the project name? Include the relevant Phoenix docs link.";
+const USER_PROMPT = "How do I change the default project name";
 
 const JUDGE_RUBRIC = [
   "The answer is grounded in Phoenix documentation.",
@@ -51,15 +50,18 @@ test.describe("PXI docs smoke", () => {
     await pxi.acknowledgeConsent();
 
     const turn = await pxi.askAndWait(USER_PROMPT);
-    await pxi.expectNoAgentError();
-    pxi.expectDocsToolCalled(turn);
-    expect(turn.assistantText).toContain("PHOENIX_PROJECT_NAME");
-
-    const judgeResult = await judge({
-      system: JUDGE_SYSTEM,
-      prompt: USER_PROMPT,
-      assistantText: turn.assistantText,
-      rubric: JUDGE_RUBRIC,
+    const outcome = await evaluatePxiOutcome({
+      assertions: async () => {
+        await pxi.expectNoAgentError();
+        pxi.expectDocsToolCalled(turn);
+        expect(turn.assistantText).toContain("PHOENIX_PROJECT_NAME");
+      },
+      judgeInput: {
+        system: JUDGE_SYSTEM,
+        prompt: USER_PROMPT,
+        assistantText: turn.assistantText,
+        rubric: JUDGE_RUBRIC,
+      },
     });
 
     const metadata = pxi.getMetadata();
@@ -71,12 +73,12 @@ test.describe("PXI docs smoke", () => {
         calledTools: turn.calledTools,
         url: page.url(),
         durationMs: turn.durationMs,
-        judgeResult,
+        judgeResult: outcome.judgeResult,
         playwrightProject: testInfo.project.name,
         ...metadata,
       },
     });
 
-    expect(judgeResult.label, judgeResult.explanation).toBe("pass");
+    assertPxiOutcome(outcome);
   });
 });

--- a/app/tests/pxi/experimentPersistence.ts
+++ b/app/tests/pxi/experimentPersistence.ts
@@ -1,0 +1,188 @@
+import type { APIRequestContext } from "@playwright/test";
+
+const DATASET_NAME = "PXI E2E Agent Tests";
+const EXAMPLE_ID = "pxi-docs-smoke:tracing-project-env-var-v1";
+const EXPERIMENT_BASE_URL =
+  process.env.PXI_E2E_EXPERIMENT_BASE_URL ?? "http://localhost:6006";
+const EXPERIMENT_BEARER_TOKEN = process.env.PXI_E2E_EXPERIMENT_BEARER_TOKEN;
+
+type JudgeResult = {
+  label: "pass" | "fail";
+  score: number;
+  explanation: string;
+};
+
+type ExperimentRecord = {
+  prompt: string;
+  assistantText: string;
+  transcript?: unknown;
+  calledTools: string[];
+  url: string;
+  durationMs: number;
+  judgeResult: JudgeResult;
+  assistantModel: string;
+  assistantProvider: string;
+  judgeModel: string;
+  judgeProvider: string;
+  playwrightProject: string;
+};
+
+async function expectOK(
+  response: Awaited<ReturnType<APIRequestContext["post"]>>
+) {
+  if (!response.ok()) {
+    throw new Error(
+      `Phoenix API request failed: ${response.status()} ${await response.text()}`
+    );
+  }
+  return response.json() as Promise<{ data: Record<string, unknown> }>;
+}
+
+function getExperimentUrl(path: string) {
+  return new URL(path, EXPERIMENT_BASE_URL).toString();
+}
+
+function getExperimentHeaders() {
+  return {
+    "Content-Type": "application/json",
+    ...(EXPERIMENT_BEARER_TOKEN
+      ? { Authorization: `Bearer ${EXPERIMENT_BEARER_TOKEN}` }
+      : {}),
+  };
+}
+
+export async function persistPxiExperiment({
+  request,
+  record,
+}: {
+  request: APIRequestContext;
+  record: ExperimentRecord;
+}) {
+  const datasetResponse = await expectOK(
+    await request.post(getExperimentUrl("/v1/datasets/upload?sync=true"), {
+      headers: getExperimentHeaders(),
+      data: {
+        action: "update",
+        name: DATASET_NAME,
+        description:
+          "PXI Playwright E2E scenarios persisted from browser-driven tests.",
+        inputs: [{ prompt: record.prompt }],
+        outputs: [
+          {
+            expected:
+              "Answer names PHOENIX_PROJECT_NAME and cites Phoenix docs.",
+          },
+        ],
+        metadata: [{ kind: "pxi-playwright-e2e" }],
+        example_ids: [EXAMPLE_ID],
+      },
+    })
+  );
+  const datasetId = datasetResponse.data.dataset_id;
+  if (typeof datasetId !== "string") {
+    throw new Error("Dataset upload response did not include dataset_id.");
+  }
+
+  const examplesResponse = await request.get(
+    getExperimentUrl(`/v1/datasets/${datasetId}/examples`),
+    {
+      headers: getExperimentHeaders(),
+    }
+  );
+  const examplesBody = await expectOK(examplesResponse);
+  const examples = examplesBody.data.examples;
+  if (!Array.isArray(examples) || examples.length === 0) {
+    throw new Error("Dataset examples response did not include examples.");
+  }
+  const datasetExample = examples.find((example) => {
+    return (
+      typeof example === "object" &&
+      example !== null &&
+      (example as { id?: unknown }).id === EXAMPLE_ID
+    );
+  }) as { node_id?: unknown } | undefined;
+  if (typeof datasetExample?.node_id !== "string") {
+    throw new Error("Dataset example did not include node_id.");
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const experimentResponse = await expectOK(
+    await request.post(
+      getExperimentUrl(`/v1/datasets/${datasetId}/experiments`),
+      {
+        headers: getExperimentHeaders(),
+        data: {
+          name: `pxi-e2e-docs-smoke-${timestamp}`,
+          description:
+            "PXI docs smoke test driven through the Phoenix frontend.",
+          repetitions: 1,
+          metadata: {
+            assistantModel: record.assistantModel,
+            assistantProvider: record.assistantProvider,
+            judgeModel: record.judgeModel,
+            judgeProvider: record.judgeProvider,
+            playwrightProject: record.playwrightProject,
+            kind: "pxi-playwright-e2e",
+          },
+        },
+      }
+    )
+  );
+  const experimentId = experimentResponse.data.id;
+  if (typeof experimentId !== "string") {
+    throw new Error("Create experiment response did not include id.");
+  }
+
+  const now = new Date();
+  const runResponse = await expectOK(
+    await request.post(
+      getExperimentUrl(`/v1/experiments/${experimentId}/runs`),
+      {
+        headers: getExperimentHeaders(),
+        data: {
+          dataset_example_id: datasetExample.node_id,
+          output: {
+            prompt: record.prompt,
+            assistantText: record.assistantText,
+            transcript: record.transcript,
+            calledTools: record.calledTools,
+            url: record.url,
+            durationMs: record.durationMs,
+            judgeResult: record.judgeResult,
+          },
+          repetition_number: 1,
+          start_time: new Date(now.getTime() - record.durationMs).toISOString(),
+          end_time: now.toISOString(),
+        },
+      }
+    )
+  );
+  const experimentRunId = runResponse.data.id;
+  if (typeof experimentRunId !== "string") {
+    throw new Error("Create experiment run response did not include id.");
+  }
+
+  await expectOK(
+    await request.post(getExperimentUrl("/v1/experiment_evaluations"), {
+      headers: getExperimentHeaders(),
+      data: {
+        experiment_run_id: experimentRunId,
+        name: "pxi_outcome",
+        annotator_kind: "LLM",
+        start_time: now.toISOString(),
+        end_time: now.toISOString(),
+        result: {
+          label: record.judgeResult.label,
+          score: record.judgeResult.score,
+          explanation: record.judgeResult.explanation,
+        },
+        metadata: {
+          judgeModel: record.judgeModel,
+          judgeProvider: record.judgeProvider,
+        },
+      },
+    })
+  );
+
+  return { datasetId, experimentId, experimentRunId };
+}

--- a/app/tests/pxi/experimentPersistence.ts
+++ b/app/tests/pxi/experimentPersistence.ts
@@ -3,7 +3,9 @@ import type { APIRequestContext } from "@playwright/test";
 const DATASET_NAME = "PXI E2E Agent Tests";
 const EXAMPLE_ID = "pxi-docs-smoke:tracing-project-env-var-v1";
 const EXPERIMENT_BASE_URL =
-  process.env.PXI_E2E_EXPERIMENT_BASE_URL ?? "http://localhost:6006";
+  process.env.PXI_E2E_EXPERIMENT_BASE_URL ??
+  process.env.PLAYWRIGHT_BASE_URL ??
+  `http://localhost:${process.env.PHOENIX_PORT ?? "6006"}`;
 const EXPERIMENT_BEARER_TOKEN = process.env.PXI_E2E_EXPERIMENT_BEARER_TOKEN;
 
 type JudgeResult = {

--- a/app/tests/pxi/fixtures.ts
+++ b/app/tests/pxi/fixtures.ts
@@ -11,6 +11,7 @@ export type PxiTurn = {
 const DEFAULT_ASSISTANT_PROVIDER = "OPENAI";
 const DEFAULT_ASSISTANT_MODEL = "gpt-4.1-mini";
 const DEFAULT_ASSISTANT_PROJECT_NAME = "assistant_agent";
+const DEFAULT_JUDGE_MODEL = "openai/gpt-4.1";
 
 function getAssistantProvider() {
   return process.env.PXI_E2E_ASSISTANT_PROVIDER ?? DEFAULT_ASSISTANT_PROVIDER;
@@ -21,7 +22,12 @@ function getAssistantModel() {
 }
 
 function getJudgeModel() {
-  return process.env.PXI_E2E_JUDGE_MODEL ?? "gpt-4.1";
+  return process.env.PXI_E2E_JUDGE_MODEL ?? DEFAULT_JUDGE_MODEL;
+}
+
+function getJudgeProvider() {
+  const [provider] = getJudgeModel().split("/");
+  return provider?.toUpperCase() ?? "OPENAI";
 }
 
 function getAssistantProjectName() {
@@ -236,7 +242,7 @@ export class PxiDriver {
     return {
       assistantProvider: getAssistantProvider(),
       assistantModel: getAssistantModel(),
-      judgeProvider: "OPENAI",
+      judgeProvider: getJudgeProvider(),
       judgeModel: getJudgeModel(),
     };
   }

--- a/app/tests/pxi/fixtures.ts
+++ b/app/tests/pxi/fixtures.ts
@@ -1,0 +1,271 @@
+import { expect, test as base } from "@playwright/test";
+import type { APIRequestContext, Page, TestInfo } from "@playwright/test";
+
+export type PxiTurn = {
+  calledTools: string[];
+  assistantText: string;
+  traceId: string;
+  durationMs: number;
+};
+
+const DEFAULT_ASSISTANT_PROVIDER = "OPENAI";
+const DEFAULT_ASSISTANT_MODEL = "gpt-4.1-mini";
+const DEFAULT_ASSISTANT_PROJECT_NAME = "assistant_agent";
+
+function getAssistantProvider() {
+  return process.env.PXI_E2E_ASSISTANT_PROVIDER ?? DEFAULT_ASSISTANT_PROVIDER;
+}
+
+function getAssistantModel() {
+  return process.env.PXI_E2E_ASSISTANT_MODEL ?? DEFAULT_ASSISTANT_MODEL;
+}
+
+function getJudgeModel() {
+  return process.env.PXI_E2E_JUDGE_MODEL ?? "gpt-4.1";
+}
+
+function getAssistantProjectName() {
+  return (
+    process.env.PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME ??
+    DEFAULT_ASSISTANT_PROJECT_NAME
+  );
+}
+
+async function installAgentDefaults({
+  page,
+  userInstructions,
+}: {
+  page: Page;
+  userInstructions: string;
+}) {
+  const assistantProvider = getAssistantProvider();
+  const assistantModel = getAssistantModel();
+  await page.addInitScript(
+    ({ provider, modelName, instructions }) => {
+      localStorage.clear();
+      localStorage.setItem(
+        "arize-phoenix-feature-flags",
+        JSON.stringify({ agents: true, tracing_ux: false })
+      );
+      localStorage.setItem(
+        "arize-phoenix-agent",
+        JSON.stringify({
+          state: {
+            isOpen: false,
+            position: "detached",
+            sessions: [],
+            activeSessionId: null,
+            sessionMap: {},
+            defaultModelConfig: {
+              provider,
+              modelName,
+              invocationParameters: [],
+              supportedInvocationParameters: [],
+            },
+            userInstructions: instructions,
+            observability: {
+              storeLocalTraces: true,
+              exportRemoteTraces: false,
+              hasAcknowledgedConsent: false,
+            },
+          },
+          version: 5,
+        })
+      );
+    },
+    {
+      provider: assistantProvider,
+      modelName: assistantModel,
+      instructions: userInstructions,
+    }
+  );
+}
+
+async function expectOK(
+  response: Awaited<ReturnType<APIRequestContext["get"]>>
+) {
+  if (!response.ok()) {
+    throw new Error(
+      `Phoenix API request failed: ${response.status()} ${await response.text()}`
+    );
+  }
+  return response.json() as Promise<{ data: unknown }>;
+}
+
+function getSpanToolName(span: unknown): string | null {
+  if (typeof span !== "object" || span === null) {
+    return null;
+  }
+  const candidate = span as {
+    name?: unknown;
+    attributes?: Record<string, unknown>;
+  };
+  const attributeName = candidate.attributes?.["tool.name"];
+  if (typeof attributeName === "string" && attributeName.length > 0) {
+    return attributeName;
+  }
+  if (typeof candidate.name === "string" && candidate.name.length > 0) {
+    return candidate.name;
+  }
+  return null;
+}
+
+export class PxiDriver {
+  private page: Page;
+  private request: APIRequestContext;
+
+  constructor({
+    page,
+    request,
+  }: {
+    page: Page;
+    request: APIRequestContext;
+    testInfo: TestInfo;
+  }) {
+    this.page = page;
+    this.request = request;
+  }
+
+  async open({ userInstructions }: { userInstructions: string }) {
+    await installAgentDefaults({ page: this.page, userInstructions });
+    await this.page.goto("/projects");
+    await this.page.getByRole("button", { name: "Open agent chat" }).click();
+    await expect(
+      this.page.getByRole("heading", {
+        name: "I'm PXI, your Phoenix assistant",
+      })
+    ).toBeVisible();
+  }
+
+  async acknowledgeConsent() {
+    const acknowledgeButton = this.page.getByRole("button", {
+      name: "Acknowledge",
+    });
+    if (await acknowledgeButton.isVisible()) {
+      await acknowledgeButton.click();
+    }
+    await expect(this.page.getByLabel("Message input")).toBeVisible();
+  }
+
+  async askAndWait(message: string) {
+    const startedAt = Date.now();
+    await this.page.getByLabel("Message input").fill(message);
+    await this.page.getByRole("button", { name: "Send message" }).click();
+    const turnHandle = await this.page.waitForFunction(() => {
+      const stored = localStorage.getItem("arize-phoenix-agent");
+      if (!stored) {
+        return null;
+      }
+      const parsed = JSON.parse(stored) as {
+        state?: {
+          activeSessionId?: string | null;
+          sessionMap?: Record<
+            string,
+            {
+              messages?: Array<{
+                role?: string;
+                parts?: unknown[];
+                metadata?: {
+                  traceId?: unknown;
+                };
+              }>;
+            }
+          >;
+        };
+      };
+      const activeSessionId = parsed.state?.activeSessionId;
+      if (!activeSessionId) {
+        return null;
+      }
+      const messages = parsed.state?.sessionMap?.[activeSessionId]?.messages;
+      const assistantMessages = (messages ?? []).filter(
+        (candidate) => candidate.role === "assistant"
+      );
+      const latestAssistant = assistantMessages.at(-1);
+      const traceId = latestAssistant?.metadata?.traceId;
+      if (typeof traceId !== "string") {
+        return null;
+      }
+      const assistantText = (latestAssistant?.parts ?? [])
+        .map((part) => {
+          if (typeof part !== "object" || part === null) return "";
+          const candidate = part as { type?: unknown; text?: unknown };
+          return candidate.type === "text" && typeof candidate.text === "string"
+            ? candidate.text
+            : "";
+        })
+        .join("");
+      if (!assistantText) {
+        return null;
+      }
+      return { assistantText, traceId };
+    });
+    const turn = (await turnHandle.jsonValue()) as {
+      assistantText: string;
+      traceId: string;
+    };
+    await expect
+      .poll(
+        async () => (await this.getToolNamesForTrace(turn.traceId)).length,
+        {
+          message:
+            "Expected persisted PXI trace to include a backend TOOL span for the docs request.",
+        }
+      )
+      .toBeGreaterThan(0);
+    const calledTools = await this.getToolNamesForTrace(turn.traceId);
+    return {
+      ...turn,
+      calledTools,
+      durationMs: Date.now() - startedAt,
+    };
+  }
+
+  async expectNoAgentError() {
+    await expect(this.page.locator(".chat__error")).toHaveCount(0);
+  }
+
+  expectDocsToolCalled(turn: PxiTurn) {
+    expect(
+      turn.calledTools.length,
+      "Expected the PXI trace to include at least one backend TOOL span. In this docs smoke test, backend TOOL spans are runtime-discovered Mintlify MCP documentation tool calls."
+    ).toBeGreaterThan(0);
+  }
+
+  getMetadata() {
+    return {
+      assistantProvider: getAssistantProvider(),
+      assistantModel: getAssistantModel(),
+      judgeProvider: "OPENAI",
+      judgeModel: getJudgeModel(),
+    };
+  }
+
+  private async getToolNamesForTrace(traceId: string): Promise<string[]> {
+    const projectName = encodeURIComponent(getAssistantProjectName());
+    const response = await expectOK(
+      await this.request.get(`/v1/projects/${projectName}/spans`, {
+        params: {
+          trace_id: traceId,
+          span_kind: "TOOL",
+        },
+      })
+    );
+    const spans = response.data;
+    if (!Array.isArray(spans)) {
+      return [];
+    }
+    return spans.flatMap((span) => {
+      const toolName = getSpanToolName(span);
+      return toolName ? [toolName] : [];
+    });
+  }
+}
+
+export const test = base.extend<{ pxi: PxiDriver }>({
+  pxi: async ({ page, request }, provide, testInfo) => {
+    await provide(new PxiDriver({ page, request, testInfo }));
+  },
+});
+
+export { expect };

--- a/app/tests/pxi/fixtures.ts
+++ b/app/tests/pxi/fixtures.ts
@@ -36,17 +36,11 @@ function getAssistantProjectName() {
   );
 }
 
-async function installAgentDefaults({
-  page,
-  userInstructions,
-}: {
-  page: Page;
-  userInstructions: string;
-}) {
+async function installAgentDefaults({ page }: { page: Page }) {
   const assistantProvider = getAssistantProvider();
   const assistantModel = getAssistantModel();
   await page.addInitScript(
-    ({ provider, modelName, instructions }) => {
+    ({ provider, modelName }) => {
       localStorage.clear();
       localStorage.setItem(
         "arize-phoenix-feature-flags",
@@ -67,7 +61,7 @@ async function installAgentDefaults({
               invocationParameters: [],
               supportedInvocationParameters: [],
             },
-            userInstructions: instructions,
+            userInstructions: "",
             observability: {
               storeLocalTraces: true,
               exportRemoteTraces: false,
@@ -81,7 +75,6 @@ async function installAgentDefaults({
     {
       provider: assistantProvider,
       modelName: assistantModel,
-      instructions: userInstructions,
     }
   );
 }
@@ -102,8 +95,8 @@ export class PxiDriver {
     this.request = request;
   }
 
-  async open({ userInstructions }: { userInstructions: string }) {
-    await installAgentDefaults({ page: this.page, userInstructions });
+  async open() {
+    await installAgentDefaults({ page: this.page });
     await this.page.goto("/projects");
     await this.page.getByRole("button", { name: "Open agent chat" }).click();
     await expect(

--- a/app/tests/pxi/fixtures.ts
+++ b/app/tests/pxi/fixtures.ts
@@ -1,17 +1,16 @@
 import { expect, test as base } from "@playwright/test";
 import type { APIRequestContext, Page, TestInfo } from "@playwright/test";
 
-export type PxiTurn = {
-  calledTools: string[];
-  assistantText: string;
-  traceId: string;
-  durationMs: number;
-};
+import {
+  DEFAULT_ASSISTANT_MODEL,
+  DEFAULT_ASSISTANT_PROJECT_NAME,
+  DEFAULT_ASSISTANT_PROVIDER,
+  DEFAULT_JUDGE_MODEL,
+} from "./constants";
+import type { PxiTurn } from "./types";
+import { expectOK, getSpanToolName } from "./utils";
 
-const DEFAULT_ASSISTANT_PROVIDER = "OPENAI";
-const DEFAULT_ASSISTANT_MODEL = "gpt-4.1-mini";
-const DEFAULT_ASSISTANT_PROJECT_NAME = "assistant_agent";
-const DEFAULT_JUDGE_MODEL = "openai/gpt-4.1";
+export type { PxiTurn } from "./types";
 
 function getAssistantProvider() {
   return process.env.PXI_E2E_ASSISTANT_PROVIDER ?? DEFAULT_ASSISTANT_PROVIDER;
@@ -85,35 +84,6 @@ async function installAgentDefaults({
       instructions: userInstructions,
     }
   );
-}
-
-async function expectOK(
-  response: Awaited<ReturnType<APIRequestContext["get"]>>
-) {
-  if (!response.ok()) {
-    throw new Error(
-      `Phoenix API request failed: ${response.status()} ${await response.text()}`
-    );
-  }
-  return response.json() as Promise<{ data: unknown }>;
-}
-
-function getSpanToolName(span: unknown): string | null {
-  if (typeof span !== "object" || span === null) {
-    return null;
-  }
-  const candidate = span as {
-    name?: unknown;
-    attributes?: Record<string, unknown>;
-  };
-  const attributeName = candidate.attributes?.["tool.name"];
-  if (typeof attributeName === "string" && attributeName.length > 0) {
-    return attributeName;
-  }
-  if (typeof candidate.name === "string" && candidate.name.length > 0) {
-    return candidate.name;
-  }
-  return null;
 }
 
 export class PxiDriver {

--- a/app/tests/pxi/fixtures.ts
+++ b/app/tests/pxi/fixtures.ts
@@ -195,10 +195,24 @@ export class PxiDriver {
   }
 
   expectDocsToolCalled(turn: PxiTurn) {
+    // These names intentionally match Phoenix's docs tool prompt contract.
+    // If the docs tool names change, update this assertion with the prompt.
+    const docsToolNames = [
+      "search_phoenix",
+      "get_page_phoenix",
+      "query_docs_filesystem_phoenix",
+    ];
+    const hasCalledDocsTool = turn.calledTools.some((toolName) =>
+      docsToolNames.includes(toolName)
+    );
     expect(
-      turn.calledTools.length,
-      "Expected the PXI trace to include at least one backend TOOL span. In this docs smoke test, backend TOOL spans are runtime-discovered Mintlify MCP documentation tool calls."
-    ).toBeGreaterThan(0);
+      hasCalledDocsTool,
+      `Expected the PXI trace to include a documentation tool call (${docsToolNames.join(
+        ", "
+      )}). This assertion is intentionally coupled to Phoenix's current docs tool prompt contract; if those tool names change, update the smoke test alongside the prompt. Called tools: ${turn.calledTools.join(
+        ", "
+      )}`
+    ).toBe(true);
   }
 
   getMetadata() {

--- a/app/tests/pxi/judge.ts
+++ b/app/tests/pxi/judge.ts
@@ -104,5 +104,9 @@ export async function judge({
     }),
   });
 
+  if (!result.output) {
+    throw new Error("Judge model failed to produce structured output.");
+  }
+
   return result.output;
 }

--- a/app/tests/pxi/judge.ts
+++ b/app/tests/pxi/judge.ts
@@ -1,0 +1,108 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { openai } from "@ai-sdk/openai";
+import { generateText, Output, type LanguageModel } from "ai";
+import { z } from "zod";
+
+type JudgeOutcome = {
+  label: "pass" | "fail";
+  score: number;
+  explanation: string;
+};
+
+const DEFAULT_JUDGE_MODEL = "openai/gpt-4.1";
+const DEFAULT_JUDGE_SYSTEM =
+  "You are judging an AI assistant answer. Return a label, score, and concise explanation.";
+
+function getJudgeProvider(model: string) {
+  const [provider, ...modelParts] = model.split("/");
+  const providerModel = modelParts.join("/");
+  if (!provider || !providerModel) {
+    throw new Error(
+      `Judge model must use provider/model format, received: ${model}`
+    );
+  }
+
+  return { provider, providerModel };
+}
+
+export function getRequiredJudgeApiKeyEnv({
+  model = process.env.PXI_E2E_JUDGE_MODEL ?? DEFAULT_JUDGE_MODEL,
+}: {
+  model?: string;
+} = {}) {
+  const { provider } = getJudgeProvider(model);
+  if (provider === "openai") {
+    return "OPENAI_API_KEY";
+  }
+  if (provider === "anthropic") {
+    return "ANTHROPIC_API_KEY";
+  }
+
+  throw new Error(
+    `Unsupported judge model provider: ${provider}. Supported providers: openai, anthropic.`
+  );
+}
+
+function getJudgeModel(model: string): LanguageModel {
+  const { provider, providerModel } = getJudgeProvider(model);
+
+  if (provider === "openai") {
+    return openai(providerModel);
+  }
+  if (provider === "anthropic") {
+    return anthropic(providerModel);
+  }
+
+  throw new Error(
+    `Unsupported judge model provider: ${provider}. Supported providers: openai, anthropic.`
+  );
+}
+
+/**
+ * Minimal AI SDK-backed LLM-as-judge helper.
+ * @param params.model - Judge model in provider/model format, e.g. openai/gpt-4.1 or anthropic/claude-sonnet-4-5.
+ * @param params.system - System instructions for the judge.
+ * @param params.prompt - Original user prompt sent to PXI.
+ * @param params.assistantText - Final assistant answer to judge.
+ * @param params.rubric - Criteria the judge should apply.
+ */
+export async function judge({
+  model = process.env.PXI_E2E_JUDGE_MODEL ?? DEFAULT_JUDGE_MODEL,
+  system = DEFAULT_JUDGE_SYSTEM,
+  prompt,
+  assistantText,
+  rubric,
+}: {
+  model?: string;
+  system?: string;
+  prompt: string;
+  assistantText: string;
+  rubric: string[];
+}): Promise<JudgeOutcome> {
+  const result = await generateText({
+    model: getJudgeModel(model),
+    temperature: 0,
+    output: Output.object({
+      name: "JudgeOutcome",
+      description: "Evaluation result for an AI assistant answer.",
+      schema: z.object({
+        label: z.enum(["pass", "fail"]),
+        score: z.number(),
+        explanation: z.string(),
+      }),
+    }),
+    system,
+    prompt: JSON.stringify({
+      rubric,
+      prompt,
+      assistantText,
+      outputSchema: {
+        label: "pass | fail",
+        score: "1 for pass, 0 for fail",
+        explanation: "brief reason",
+      },
+    }),
+  });
+
+  return result.output;
+}

--- a/app/tests/pxi/judge.ts
+++ b/app/tests/pxi/judge.ts
@@ -3,7 +3,7 @@ import { openai } from "@ai-sdk/openai";
 import { generateText, Output, type LanguageModel } from "ai";
 import { z } from "zod";
 
-type JudgeOutcome = {
+export type JudgeOutcome = {
   label: "pass" | "fail";
   score: number;
   explanation: string;

--- a/app/tests/pxi/outcome.ts
+++ b/app/tests/pxi/outcome.ts
@@ -1,0 +1,111 @@
+import { judge } from "./judge";
+import type { JudgeOutcome } from "./judge";
+
+const MAX_PLAYWRIGHT_ERROR_LENGTH = 1_000;
+const ESCAPE_CHARACTER = String.fromCharCode(27);
+const CSI_SEQUENCE_PATTERN = /^\[[0-?]*[ -/]*[@-~]/;
+
+type JudgeInput = {
+  system?: string;
+  prompt: string;
+  assistantText: string;
+  rubric: string[];
+};
+
+type PxiOutcome = {
+  judgeResult: JudgeOutcome;
+  assertionFailure?: unknown;
+};
+
+function stripAnsi(message: string) {
+  const [firstPart, ...escapedParts] = message.split(ESCAPE_CHARACTER);
+  return [
+    firstPart,
+    ...escapedParts.map((part) => part.replace(CSI_SEQUENCE_PATTERN, "")),
+  ].join("");
+}
+
+function getSanitizedErrorMessage(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  const withoutAnsi = stripAnsi(message);
+  if (withoutAnsi.length <= MAX_PLAYWRIGHT_ERROR_LENGTH) {
+    return withoutAnsi;
+  }
+  return `${withoutAnsi.slice(0, MAX_PLAYWRIGHT_ERROR_LENGTH)}...`;
+}
+
+function getFailureExplanation({
+  judgeExplanation,
+  assertionError,
+}: {
+  judgeExplanation: string;
+  assertionError?: string;
+}) {
+  if (!assertionError) {
+    return judgeExplanation;
+  }
+  return `Judge explanation: ${judgeExplanation}\n\nPlaywright assertion: ${assertionError}`;
+}
+
+/**
+ * Runs deterministic assertions and LLM judging while preserving enough context
+ * to persist failed PXI turns as Phoenix experiment runs before rethrowing.
+ * @param params.assertions - Deterministic Playwright assertions for the PXI turn.
+ * @param params.judgeInput - Inputs for the reusable AI SDK judge.
+ */
+export async function evaluatePxiOutcome({
+  assertions,
+  judgeInput,
+}: {
+  assertions: () => Promise<void> | void;
+  judgeInput: JudgeInput;
+}): Promise<PxiOutcome> {
+  let assertionFailure: unknown;
+  let assertionError: string | undefined;
+  let judgeResult: JudgeOutcome = {
+    label: "fail",
+    score: 0,
+    explanation: "PXI outcome was not judged.",
+  };
+
+  try {
+    await assertions();
+  } catch (error) {
+    assertionFailure = error;
+    assertionError = getSanitizedErrorMessage(error);
+  }
+
+  try {
+    judgeResult = await judge(judgeInput);
+  } catch (error) {
+    assertionFailure ??= error;
+    judgeResult = {
+      label: "fail",
+      score: 0,
+      explanation: getSanitizedErrorMessage(error),
+    };
+  }
+
+  if (assertionError || judgeResult.label === "fail") {
+    judgeResult = {
+      ...judgeResult,
+      label: "fail",
+      score: 0,
+      explanation: getFailureExplanation({
+        judgeExplanation: judgeResult.explanation,
+        assertionError,
+      }),
+    };
+  }
+
+  return { judgeResult, assertionFailure };
+}
+
+export function assertPxiOutcome(outcome: PxiOutcome) {
+  if (outcome.assertionFailure) {
+    throw outcome.assertionFailure;
+  }
+  if (outcome.judgeResult.label !== "pass") {
+    throw new Error(outcome.judgeResult.explanation);
+  }
+}

--- a/app/tests/pxi/types.ts
+++ b/app/tests/pxi/types.ts
@@ -1,0 +1,6 @@
+export type PxiTurn = {
+  calledTools: string[];
+  assistantText: string;
+  traceId: string;
+  durationMs: number;
+};

--- a/app/tests/pxi/utils.ts
+++ b/app/tests/pxi/utils.ts
@@ -1,0 +1,30 @@
+import type { APIRequestContext } from "@playwright/test";
+
+export async function expectOK(
+  response: Awaited<ReturnType<APIRequestContext["get"]>>
+) {
+  if (!response.ok()) {
+    throw new Error(
+      `Phoenix API request failed: ${response.status()} ${await response.text()}`
+    );
+  }
+  return response.json() as Promise<{ data: unknown }>;
+}
+
+export function getSpanToolName(span: unknown): string | null {
+  if (typeof span !== "object" || span === null) {
+    return null;
+  }
+  const candidate = span as {
+    name?: unknown;
+    attributes?: Record<string, unknown>;
+  };
+  const attributeName = candidate.attributes?.["tool.name"];
+  if (typeof attributeName === "string" && attributeName.length > 0) {
+    return attributeName;
+  }
+  if (typeof candidate.name === "string" && candidate.name.length > 0) {
+    return candidate.name;
+  }
+  return null;
+}

--- a/app/tests/utils/testServer.mjs
+++ b/app/tests/utils/testServer.mjs
@@ -19,6 +19,11 @@ process.env["PHOENIX_SQL_DATABASE_URL"] = "sqlite:///:memory:";
 // The rate-limit.spec.ts test will re-enable it for its specific test
 process.env["PHOENIX_DISABLE_RATE_LIMIT"] = "True";
 
+if (process.env["PXI_E2E"] === "true") {
+  process.env["PHOENIX_DANGEROUSLY_ENABLE_AGENTS"] = "True";
+  process.env["PHOENIX_ALLOW_EXTERNAL_RESOURCES"] = "True";
+}
+
 console.log("Phoenix test server starting...");
 console.log("PHOENIX_SECRET: ", process.env["PHOENIX_SECRET"]);
 console.log("PHOENIX_WORKING_DIR: ", process.env["PHOENIX_WORKING_DIR"]);

--- a/internal_docs/pxi_playwright_e2e_harness.md
+++ b/internal_docs/pxi_playwright_e2e_harness.md
@@ -1,0 +1,544 @@
+# PXI Playwright E2E Harness Proposal
+
+This proposal describes a Playwright harness for evaluating PXI through the Phoenix frontend, grounded in the current PXI request flow and Phoenix experiment APIs.
+
+## Goals
+
+- Make PXI E2E tests easy to author for complex, frontend-driven agent scenarios.
+- Run Phoenix in an isolated test environment with deterministic seed data.
+- Exercise PXI through the real UI, including route context, model selection, streaming, and browser-executed tools.
+- Persist each test case as a Phoenix experiment run with an LLM-as-judge evaluation.
+- Capture enough artifacts to debug agent failures without rerunning locally.
+
+## Current PXI Mechanisms
+
+PXI chat is owned by the frontend runtime but server-defined at the model boundary.
+
+- `app/src/components/agent/useAgentChat.ts` creates an AI SDK `Chat` runtime and binds it to React with `useChat`.
+- `app/src/components/agent/useAgentChatPanelState.ts` builds the chat URL as `/chat?provider_type=...&provider=...&model_name=...` or `/chat?provider_type=custom&provider_id=...&model_name=...`.
+- `app/src/agent/chat/buildAgentChatRequestBody.ts` adds PXI-specific request fields: `userInstructions`, `traceNameSuffix`, `sessionId`, `ingestTraces`, `exportRemoteTraces`, `contexts`, and `capabilities`.
+- `src/phoenix/server/api/routers/chat.py` handles `POST /chat`, builds the model from query params, injects Phoenix context into the message history, resolves server-owned tools, and streams the response.
+- `src/phoenix/server/agents/tools/registry.py` advertises external tools and context-gated tools. External tools currently include `ask_user` and `bash`; contextual tools currently include `set_spans_filter` when required UI context is present.
+- `app/src/agent/extensions/toolRegistry.ts` dispatches browser-executed tools by name, validates tool inputs, checks capabilities, and returns tool outputs through the AI SDK runtime.
+- `app/src/store/agentStore.ts` persists sessions in local storage under `arize-phoenix-agent` and stores ephemeral runtime state for contexts, client actions, pending elicitations, and chat status.
+
+The harness should not duplicate tool schemas in tests. It should observe the same user-visible transcript and, where needed, instrument the existing stream/store/request surfaces.
+
+## Current Experiment APIs
+
+Phoenix already has the REST endpoints needed to persist PXI test results as experiments.
+
+- Create or update a dataset with examples: `POST /v1/datasets/upload?sync=true` from `src/phoenix/server/api/routers/v1/datasets.py`.
+- Create an experiment for a dataset: `POST /v1/datasets/{dataset_id}/experiments` from `src/phoenix/server/api/routers/v1/experiments.py`.
+- Create an experiment run: `POST /v1/experiments/{experiment_id}/runs` from `src/phoenix/server/api/routers/v1/experiment_runs.py`.
+- Upsert an experiment evaluation: `POST /v1/experiment_evaluations` from `src/phoenix/server/api/routers/v1/experiment_evaluations.py`.
+
+The TypeScript client already wraps most of this flow for normal task experiments in `js/packages/phoenix-client/src/experiments/runExperiment.ts`, but PXI tests should use direct REST calls or small wrappers because the task is an already-completed browser interaction, not a function that the experiment runner owns.
+
+## Harness Architecture
+
+Add a PXI-specific Playwright fixture under `app/tests/pxi/`.
+
+```ts
+import { test as base } from "@playwright/test";
+
+export const test = base.extend<{
+  phoenix: PhoenixE2EApp;
+  pxi: PxiDriver;
+}>({
+  phoenix: async ({}, use, testInfo) => {
+    const app = await startPhoenixForPxiTest(testInfo);
+    await use(app);
+    await app.stop();
+  },
+  pxi: async ({ page, phoenix }, use, testInfo) => {
+    const driver = new PxiDriver({ page, phoenix, testInfo });
+    await use(driver);
+    await driver.attachArtifactsOnFailure();
+  },
+});
+```
+
+`PhoenixE2EApp` should encapsulate server lifecycle and API access.
+
+```ts
+type PhoenixE2EApp = {
+  baseURL: string;
+  databaseURL: string;
+  api: PhoenixApiClient;
+  seed(seed: PxiSeedSpec): Promise<PxiSeedResult>;
+  logs(): Promise<string[]>;
+  stop(): Promise<void>;
+};
+```
+
+The first implementation can reuse the existing Playwright `webServer` path when practical, but the target state should be a per-worker Phoenix server so PXI tests can opt into LLM credentials, isolated DB paths, and seed scripts without affecting the rest of `app/tests`.
+
+## Skill Layer
+
+The PXI E2E workflow should also be packaged as an agent skill, but the skill should complement the concrete harness rather than replace it.
+
+The harness is required for deterministic runtime behavior: starting Phoenix, isolating SQLite, seeding data, driving Playwright, observing PXI turns, judging outcomes, persisting experiment records, and collecting artifacts. A skill cannot provide those guarantees by itself because tests still need importable code that runs in CI without an agent interpreting instructions.
+
+The skill should provide the authoring layer: reusable guidance, templates, examples, and scaffolding scripts for humans or coding agents adding new PXI E2E scenarios.
+
+Recommended skill name:
+
+```txt
+phoenix-pxi-playwright
+```
+
+Recommended location:
+
+```txt
+.agents/skills/phoenix-pxi-playwright/
+```
+
+Recommended structure:
+
+```txt
+.agents/skills/phoenix-pxi-playwright/
+  SKILL.md
+  resources/
+    authoring-guide.md
+    assertion-patterns.md
+    seed-fixtures.md
+    experiment-persistence.md
+    debugging-failures.md
+  templates/
+    pxi-scenario.spec.ts
+    pxi-seed.ts
+    pxi-outcome-rubric.md
+  scripts/
+    scaffold-pxi-test.ts
+```
+
+The skill metadata should trigger when someone asks to add, update, debug, or review PXI Playwright tests.
+
+```yaml
+---
+name: phoenix-pxi-playwright
+description: Write, extend, and debug PXI Playwright E2E tests for Phoenix. Use when adding PXI agent frontend tests, authoring LLM-as-judge outcomes, creating seed fixtures, persisting PXI test runs as Phoenix experiments, or debugging PXI E2E failures.
+---
+```
+
+`SKILL.md` should stay short and point to focused resources. It should instruct the agent to use the concrete harness under `app/tests/pxi/`, not to generate bespoke Playwright infrastructure in each test.
+
+The skill should include:
+
+- How to choose `real`, `recorded`, or `stubbed` LLM mode.
+- How to choose or create a seed fixture.
+- How to write deterministic assertions before judge assertions.
+- How to write a rubric for `assertOutcome()`.
+- How to persist a run as a Phoenix experiment.
+- How to inspect artifacts and experiment records after failure.
+- What PXI internals matter: `POST /chat`, `buildAgentChatRequestBody`, `agentStore`, `resolve_tools`, and frontend tool dispatch.
+
+The skill should not include:
+
+- A separate implementation of `PxiDriver`.
+- A duplicate experiment client.
+- Duplicated PXI tool schemas.
+- Instructions that ask agents to bypass the shared harness.
+
+The intended split is:
+
+```txt
+app/tests/pxi/*
+  Runtime code used by Playwright, CI, and humans.
+
+.agents/skills/phoenix-pxi-playwright/*
+  Authoring workflow used by coding agents and teammates.
+```
+
+Example skill-driven workflow:
+
+1. User asks: “Add a PXI E2E test for explaining trace errors.”
+2. The skill loads and tells the agent to inspect available seed fixtures.
+3. The agent scaffolds a test from `templates/pxi-scenario.spec.ts`.
+4. The test imports the shared `test` fixture and uses `pxi.askAndWait()`, `pxi.expectToolCalled()`, and `pxi.assertOutcome()`.
+5. The test persists its result through `pxi.persistExperiment()`.
+6. The agent runs the relevant Playwright command and reports experiment IDs or artifacts.
+
+## Phoenix Startup
+
+The harness should start Phoenix with an isolated SQLite database.
+
+Use a temporary file-backed SQLite database by default rather than literal `sqlite:///:memory:`. A file-backed DB is still isolated and disposable, but it avoids cross-process visibility issues if the test runner, seed script, and Phoenix server do not share a process.
+
+```ts
+type PhoenixStartupOptions = {
+  database: "temp-sqlite" | { sqlitePath: string };
+  seedScript?: string;
+  seedDatabasePath?: string;
+  env?: Record<string, string>;
+};
+```
+
+Set environment variables explicitly.
+
+```txt
+PHOENIX_SQL_DATABASE_URL=sqlite:////tmp/pxi-e2e/worker-0/phoenix.db
+PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME=pxi-e2e-agent-{workerIndex}
+PHOENIX_DISABLE_RATE_LIMIT=True
+```
+
+LLM credentials should be opt-in per run.
+
+```txt
+PXI_E2E_ASSISTANT_PROVIDER=OPENAI
+PXI_E2E_ASSISTANT_MODEL=gpt-4.1-mini
+PXI_E2E_JUDGE_PROVIDER=OPENAI
+PXI_E2E_JUDGE_MODEL=gpt-4.1
+OPENAI_API_KEY=...
+```
+
+The harness should skip real-LLM tests when required credentials are absent unless the test explicitly uses a stubbed or recorded mode.
+
+## LLM Modes
+
+PXI E2E tests need multiple reliability profiles.
+
+```ts
+type PxiLlmMode = "real" | "recorded" | "stubbed";
+```
+
+- `real`: use the selected built-in or custom model through `POST /chat`; best for nightly runs and release-blocking smoke tests.
+- `recorded`: replay a captured data stream or model/tool trajectory; best for deterministic CI checks around UI and protocol behavior.
+- `stubbed`: route `POST /chat` or the model provider to a deterministic response; best for frontend stream/tool-dispatch tests.
+
+The first pass should support `real` and leave clear seams for `recorded` and `stubbed`.
+
+## PXI Driver API
+
+`PxiDriver` should wrap user-visible actions and PXI-specific assertions.
+
+```ts
+class PxiDriver {
+  seed(seed: PxiSeedSpec): Promise<PxiSeedResult>;
+  gotoProject(projectIdOrName: string): Promise<void>;
+  gotoTrace(traceId: string): Promise<void>;
+  gotoSpan(spanId: string): Promise<void>;
+
+  open(): Promise<void>;
+  close(): Promise<void>;
+  setModel(config: PxiModelConfig): Promise<void>;
+  acknowledgeConsent(): Promise<void>;
+
+  sendMessage(message: string): Promise<void>;
+  waitForTurn(): Promise<PxiTurn>;
+  askAndWait(message: string): Promise<PxiTurn>;
+
+  messages(): Promise<PxiMessage[]>;
+  latestAssistantMessage(): Promise<string>;
+
+  enumerateTools(): Promise<PxiToolDefinition[]>;
+  expectToolCalled(name: string | RegExp): Promise<void>;
+  expectToolSequence(names: Array<string | RegExp>): Promise<void>;
+  expectNoAgentError(): Promise<void>;
+
+  assertOutcome(expectation: PxiOutcomeExpectation): Promise<PxiOutcomeAssertion>;
+  persistExperiment(record?: Partial<PxiExperimentRecord>): Promise<PxiPersistedExperiment>;
+}
+```
+
+`waitForTurn()` should wait for state, not time. It should observe that the submitted user message is rendered, the assistant has finished streaming, the `Thinking...` loading affordance is gone, there is no inline chat error, and any visible elicitation state is resolved or reported.
+
+```ts
+type PxiTurn = {
+  userMessage: string;
+  assistantText: string;
+  toolCalls: PxiToolCall[];
+  toolResults: PxiToolResult[];
+  errors: PxiError[];
+  request?: PxiChatRequestSnapshot;
+  responseMetadata?: unknown;
+  durationMs: number;
+};
+```
+
+The initial implementation can parse `AgentUIMessage.parts` from local storage or from an exposed test hook. A more robust implementation should add test-only instrumentation that records each PXI request, streamed assistant parts, tool calls, and tool outputs without relying on DOM text alone.
+
+`enumerateTools()` cannot be implemented reliably from the visible DOM today. It should come from instrumentation around the chat request/response path or a test-only server debug surface that captures the `ToolDefinition`s resolved by `src/phoenix/server/agents/tools/registry.py` for the current contexts.
+
+## Test Instrumentation
+
+The current UI does not expose all data that good PXI tests need. Add lightweight test-only instrumentation guarded by `import.meta.env.MODE === "test"` or an equivalent Playwright env flag.
+
+Expose a browser-global collector such as:
+
+```ts
+window.__PXI_E2E__ = {
+  requests: [],
+  turns: [],
+  toolCalls: [],
+  toolResults: [],
+  contexts: [],
+};
+```
+
+Recommended hooks:
+
+- In `buildAgentChatRequestBody`, record the outgoing `contexts`, `capabilities`, `sessionId`, `ingestTraces`, and model URL.
+- In `handleRegisteredAgentToolCall`, record raw tool calls, parse errors, capability errors, handler errors, and successful tool outputs.
+- In `useAgentChat` `onFinish`, record final messages and assistant metadata.
+
+This preserves production behavior while making tests reliable and inspectable.
+
+## Outcome Assertion
+
+`assertOutcome()` should be LLM-as-judge in the first pass. It should still run alongside deterministic assertions for tool usage and absence of agent errors.
+
+```ts
+await pxi.expectToolCalled("set_spans_filter");
+await pxi.expectNoAgentError();
+
+await pxi.assertOutcome({
+  name: "latency-root-cause",
+  rubric: `
+    The assistant identifies the slowest span as the root cause of latency.
+    It cites evidence from the trace or visible Phoenix context.
+    It does not invent services, spans, or errors that are not present.
+  `,
+  scoreThreshold: 0.8,
+});
+```
+
+The judge input should include the dataset example input, expected output if provided, page URL, PXI transcript, advertised/observed tools, tool results, and UI context snapshot.
+
+```ts
+type PxiOutcomeExpectation = {
+  name: string;
+  rubric: string;
+  scoreThreshold?: number;
+  mustMention?: string[];
+  mustNotMention?: string[];
+  mustUseTools?: string[];
+  metadata?: Record<string, unknown>;
+};
+
+type PxiOutcomeAssertion = {
+  passed: boolean;
+  label: "pass" | "fail";
+  score: number;
+  explanation: string;
+  evidence: string[];
+  metadata: Record<string, unknown>;
+};
+```
+
+The judge model must be stored separately from the PXI model under test.
+
+```ts
+type PxiModelConfig = {
+  assistantProvider: string;
+  assistantModel: string;
+  judgeProvider: string;
+  judgeModel: string;
+};
+```
+
+## Persisting As Phoenix Experiments
+
+Each PXI test case should map to one Phoenix dataset example. Each Playwright execution should map to one experiment run and one LLM evaluation annotation.
+
+Dataset name:
+
+```txt
+PXI E2E Agent Tests
+```
+
+Example ID:
+
+```txt
+{suiteName}:{testName}:{fixtureName}:{scenarioVersion}
+```
+
+Example shape:
+
+```ts
+type PxiDatasetExample = {
+  id: string;
+  input: {
+    prompt: string;
+    route: string;
+    seed: string;
+    scenario: string;
+  };
+  output: {
+    rubric: string;
+  };
+  metadata: {
+    suite: string;
+    test: string;
+    fixture: string;
+    version: string;
+  };
+};
+```
+
+Persist flow:
+
+1. Upsert the dataset with `POST /v1/datasets/upload?sync=true`, using `action: "update"` and stable `example_ids`.
+2. Fetch examples from `GET /v1/datasets/{id}/examples` to resolve the `DatasetExample` GlobalID needed by experiment runs.
+3. Create the experiment with `POST /v1/datasets/{dataset_id}/experiments`.
+4. Create a run with `POST /v1/experiments/{experiment_id}/runs`.
+5. Upsert the judge result with `POST /v1/experiment_evaluations`.
+
+Experiment naming:
+
+```txt
+pxi-e2e-{branch}-{sha}
+pxi-e2e-nightly-{date}
+pxi-e2e-local-{user}-{timestamp}
+```
+
+Experiment metadata:
+
+```ts
+type PxiExperimentMetadata = {
+  kind: "pxi-playwright-e2e";
+  branch?: string;
+  gitSha?: string;
+  playwrightProject: string;
+  assistantProvider: string;
+  assistantModel: string;
+  judgeProvider: string;
+  judgeModel: string;
+  seedDatabase?: string;
+  seedScript?: string;
+};
+```
+
+Experiment run output:
+
+```ts
+type PxiExperimentRunOutput = {
+  prompt: string;
+  assistantText: string;
+  transcript: PxiMessage[];
+  toolCalls: PxiToolCall[];
+  toolResults: PxiToolResult[];
+  contexts: unknown[];
+  capabilities: Record<string, boolean>;
+  url: string;
+  durationMs: number;
+  artifacts: Record<string, string>;
+};
+```
+
+Evaluation result:
+
+```ts
+{
+  name: "pxi_outcome",
+  annotator_kind: "LLM",
+  result: {
+    label: assertion.passed ? "pass" : "fail",
+    score: assertion.score,
+    explanation: assertion.explanation,
+  },
+  metadata: {
+    rubric: expectation.rubric,
+    evidence: assertion.evidence,
+    judgeModel,
+  },
+}
+```
+
+The test should be allowed to fail after persistence. If `assertOutcome()` fails, the experiment run and failed evaluation are more valuable when they are still recorded.
+
+## Seed Fixtures
+
+Seed fixtures should be scenario-oriented instead of table-oriented.
+
+```txt
+empty-project
+project-with-traces
+trace-with-slow-span
+trace-with-error
+project-with-span-filterable-traces
+dataset-with-experiments
+```
+
+Each seed should return stable handles.
+
+```ts
+type PxiSeedResult = {
+  fixture: string;
+  projectId?: string;
+  projectName?: string;
+  traceId?: string;
+  spanId?: string;
+  datasetId?: string;
+  metadata: Record<string, unknown>;
+};
+```
+
+Seed scripts can either copy a prepared SQLite DB into the worker temp directory or run a script against `PHOENIX_SQL_DATABASE_URL` before the server starts.
+
+## Example Test
+
+```ts
+import { test } from "./pxi";
+
+test("PXI explains trace latency", async ({ pxi }) => {
+  const seed = await pxi.seed("trace-with-slow-span");
+
+  await pxi.gotoTrace(seed.traceId);
+  await pxi.open();
+  await pxi.acknowledgeConsent();
+
+  const turn = await pxi.askAndWait("Why is this trace slow?");
+
+  await pxi.expectNoAgentError();
+  await pxi.expectToolCalled(/bash|set_spans_filter/);
+
+  const assertion = await pxi.assertOutcome({
+    name: "latency-root-cause",
+    rubric: `
+      The assistant should identify the slowest span and explain that it dominates trace latency.
+      The answer should cite evidence from the trace or UI context.
+      The answer should not claim that no trace is selected.
+    `,
+    scoreThreshold: 0.8,
+    metadata: { traceId: seed.traceId },
+  });
+
+  await pxi.persistExperiment({ assertion, turn });
+});
+```
+
+The exact expected tool names should be scenario-specific. Today, `set_spans_filter` is the only contextual PXI tool in the checked code, while `ask_user` and `bash` are always advertised external tools.
+
+## Debug Artifacts
+
+On failure, the harness should attach:
+
+- Playwright trace.
+- Browser console logs.
+- Network failures and failed `POST /chat` responses.
+- Phoenix server logs.
+- PXI request body snapshots.
+- Streamed PXI message snapshots.
+- Tool calls and tool outputs.
+- Active route contexts and mounted contexts.
+- Experiment IDs, run IDs, and evaluation IDs when persistence succeeded.
+
+## Implementation Plan
+
+1. Add `app/tests/pxi/fixtures.ts` with `PhoenixE2EApp` and `PxiDriver` fixtures.
+2. Add per-worker Phoenix startup with temp file-backed SQLite and env injection.
+3. Add seed fixture convention and one `trace-with-slow-span` seed.
+4. Add test-only PXI instrumentation for request, turn, tool, and context snapshots.
+5. Implement `open`, `acknowledgeConsent`, `sendMessage`, `waitForTurn`, `askAndWait`, `expectNoAgentError`, and transcript extraction.
+6. Implement `assertOutcome()` with a configured judge model and structured JSON output.
+7. Implement experiment persistence through the existing REST endpoints.
+8. Add one real-LLM smoke test and one deterministic/stubbed harness test.
+
+## Open Questions
+
+- Should PXI E2E tests live in the normal `app/tests` Playwright project or in a separate project that only runs on demand/nightly because it requires LLM credentials?
+- Should experiment persistence go to the same isolated Phoenix instance under test, or optionally to a long-lived Phoenix instance for trend tracking across CI runs?
+- Should test-only PXI instrumentation be browser-global, or should it be exposed through a small app-level testing provider to avoid globals?
+- Should `recorded` mode replay the full AI SDK data stream, or should it stub at the model provider layer before the stream protocol?

--- a/src/phoenix/server/agents/prompts.py
+++ b/src/phoenix/server/agents/prompts.py
@@ -99,6 +99,8 @@ _ASK_USER_TOOL_SYSTEM_PROMPT_LINES = (
 _STATIC_SYSTEM_PROMPT_LINES = (
     "<role>",
     "You are PXI, Arize AI's Phoenix in-product agent. You emit your responses in markdown format.",
+    "Ground your answers in truth using Phoenix documentation, and system data accessed via your ",
+    "tools. When you don't know something, say you don't know instead of making it up.",
     "</role>",
     "",
     "<tools>",


### PR DESCRIPTION
## Summary
- Adds an opt-in PXI Playwright smoke harness that drives PXI through the UI, asserts docs tool usage, judges the answer, and persists results as Phoenix experiments.
- Keeps PXI E2E specs out of default CI unless `PXI_E2E=true` is set.
- Adds an internal design doc and `phoenix-pxi-playwright` skill for future spec authoring.

## Testing
- `pnpm run typecheck`
- `PXI_E2E=true PHOENIX_PORT=16006 PHOENIX_GRPC_PORT=14317 pnpm exec playwright test tests/pxi/docs-smoke.spec.ts --project=chromium --reporter=list`
- `pnpm run dev:e2e:pxi`