### PR TITLE
feat(agent): remove user instructions from PXI

### DIFF
--- a/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
+++ b/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
@@ -6,14 +6,13 @@ import { buildAgentChatRequestBody } from "../buildAgentChatRequestBody";
 import type { AgentUIMessage } from "../types";
 
 describe("buildAgentChatRequestBody", () => {
-  it("sends only user-editable instructions for server prompt insertion", () => {
+  it("merges the transport body with PXI chat metadata and omits client-supplied prompt overrides", () => {
     const body = buildAgentChatRequestBody({
       body: { existing: true },
       id: "session-1",
       messages: [] as AgentUIMessage[],
       trigger: "submit-message",
       messageId: undefined,
-      userInstructions: "Prefer concise answers.",
       sessionId: "session-1",
       capabilities: createDefaultAgentCapabilities(),
       observability: {
@@ -27,7 +26,6 @@ describe("buildAgentChatRequestBody", () => {
 
     expect(body).toMatchObject({
       existing: true,
-      userInstructions: "Prefer concise answers.",
       traceNameSuffix: "Turn",
     });
     expect(body).not.toHaveProperty("system");

--- a/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -15,8 +15,6 @@ type BuildAgentChatRequestBodyOptions = {
   trigger: "submit-message" | "regenerate-message";
   /** Optional message identifier for regenerate flows. */
   messageId: string | undefined;
-  /** User-editable instructions from agent settings (persisted in the agent store). */
-  userInstructions: string;
   /** Optional PXI session id used to associate traces across turns. */
   sessionId?: string | null;
   /** Runtime capability snapshot to expose to the model for this turn. */
@@ -39,8 +37,6 @@ type BuildAgentChatRequestBodyResult = Record<string, unknown> & {
   trigger: "submit-message" | "regenerate-message";
   /** Optional message identifier for regenerate flows. */
   messageId: string | undefined;
-  /** User-editable instructions inserted into the server-owned PXI system prompt. */
-  userInstructions: string;
   /** Distinguishes normal chat turns from other PXI chat request types. */
   traceNameSuffix: "Turn";
   /** Optional PXI session id used to associate traces across turns. */
@@ -59,9 +55,9 @@ type BuildAgentChatRequestBodyResult = Record<string, unknown> & {
  * Merges the AI SDK transport payload with PXI chat metadata. Tool definitions
  * are intentionally omitted because the server is the model-facing authority.
  *
- * The exported request body includes three agent-specific additions beyond the
- * raw AI SDK payload: custom user instructions, runtime capabilities, and typed
- * UI contexts. Tool definitions and prompt assembly are owned by the server.
+ * The exported request body includes two agent-specific additions beyond the
+ * raw AI SDK payload: runtime capabilities and typed UI contexts. Tool
+ * definitions and prompt assembly are owned by the server.
  */
 export function buildAgentChatRequestBody({
   body,
@@ -69,7 +65,6 @@ export function buildAgentChatRequestBody({
   messages,
   trigger,
   messageId,
-  userInstructions,
   sessionId,
   capabilities,
   observability,
@@ -82,7 +77,6 @@ export function buildAgentChatRequestBody({
     messages,
     trigger,
     messageId,
-    userInstructions,
     traceNameSuffix: "Turn",
     ingestTraces: observability.storeLocalTraces,
     exportRemoteTraces: observability.exportRemoteTraces && hasRemoteCollector,

--- a/app/src/components/agent/AgentSettingsForm.tsx
+++ b/app/src/components/agent/AgentSettingsForm.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { Controller, useForm } from "react-hook-form";
 
-import { Button, Flex, Label, TextArea, TextField } from "@phoenix/components";
+import { Button, Flex, Label } from "@phoenix/components";
 import { fieldBaseCSS } from "@phoenix/components/core/field/styles";
 import type { ModelMenuValue } from "@phoenix/components/generative/ModelMenu";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
@@ -21,7 +21,6 @@ function defaultModelConfigToMenuValue(config: ModelConfig): ModelMenuValue {
 
 export type AgentSettingsFormValues = {
   model: ModelMenuValue;
-  userInstructions: string;
 };
 
 export function AgentSettingsForm() {
@@ -32,18 +31,11 @@ export function AgentSettingsForm() {
   const setDefaultModelConfig = useAgentContext(
     (state) => state.setDefaultModelConfig
   );
-  const userInstructionsFromStore = useAgentContext(
-    (state) => state.userInstructions
-  );
-  const setUserInstructions = useAgentContext(
-    (state) => state.setUserInstructions
-  );
 
   const { control, handleSubmit, formState, reset } =
     useForm<AgentSettingsFormValues>({
       defaultValues: {
         model: defaultModelConfigToMenuValue(defaultModelConfig),
-        userInstructions: userInstructionsFromStore,
       },
     });
 
@@ -55,7 +47,6 @@ export function AgentSettingsForm() {
       modelName: data.model.modelName,
       customProvider: data.model.customProvider ?? null,
     });
-    setUserInstructions(data.userInstructions);
     reset(data);
   };
 
@@ -78,19 +69,6 @@ export function AgentSettingsForm() {
           )}
         />
       </div>
-      <Controller
-        name="userInstructions"
-        control={control}
-        render={({ field }) => (
-          <TextField {...field} value={field.value ?? undefined}>
-            <Label>Custom Instructions</Label>
-            <TextArea
-              rows={10}
-              placeholder="Optional instructions inserted into PXI's system prompt"
-            />
-          </TextField>
-        )}
-      />
       <Flex direction="row" gap="size-100" justifyContent="end" width="100%">
         <Button type="submit" variant="primary" isDisabled={!formState.isDirty}>
           Save

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -88,7 +88,6 @@ export function useAgentChat({
                     messages,
                     trigger,
                     messageId,
-                    userInstructions: store.getState().userInstructions,
                     sessionId,
                     capabilities: store.getState().capabilities,
                     observability: store.getState().observability,

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -74,15 +74,6 @@ describe("agentStore", () => {
     });
   });
 
-  describe("setUserInstructions", () => {
-    it("updates userInstructions", () => {
-      const store = createAgentStore();
-      expect(store.getState().userInstructions).toBe("");
-      store.getState().setUserInstructions("custom");
-      expect(store.getState().userInstructions).toBe("custom");
-    });
-  });
-
   describe("observability", () => {
     it("updates observability settings without clobbering other fields", () => {
       const store = createAgentStore();

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -139,10 +139,6 @@ export interface AgentProps {
   sessionMap: Record<string, AgentSession>;
   /** Default model configuration applied to newly created sessions. */
   defaultModelConfig: ModelConfig;
-  /**
-   * User-editable instructions inserted into the server-owned PXI prompt.
-   */
-  userInstructions: string;
   /** Server-provided PXI config used to describe trace destinations in the UI. */
   agentsConfig: AgentServerConfig;
   /** Per-user PXI observability preferences and consent acknowledgement state. */
@@ -172,7 +168,6 @@ export interface AgentState extends AgentProps {
   removeSessionContext: (sessionId: string, context: string) => void;
   setSessionMessages: (sessionId: string, messages: AgentUIMessage[]) => void;
   setDefaultModelConfig: (config: ModelConfig) => void;
-  setUserInstructions: (userInstructions: string) => void;
   setObservability: (patch: Partial<AgentObservabilitySettings>) => void;
   acknowledgeConsent: () => void;
   clearAllSessions: () => void;
@@ -270,7 +265,6 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
     activeSessionId: null,
     sessionMap: {},
     defaultModelConfig: { ...DEFAULT_MODEL_CONFIG },
-    userInstructions: "",
     agentsConfig: DEFAULT_AGENT_SERVER_CONFIG,
     observability: DEFAULT_AGENT_OBSERVABILITY_SETTINGS,
     capabilities: createDefaultAgentCapabilities(),
@@ -441,9 +435,6 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
       set({ defaultModelConfig: config }, false, {
         type: "setDefaultModelConfig",
       });
-    },
-    setUserInstructions: (userInstructions) => {
-      set({ userInstructions }, false, { type: "setUserInstructions" });
     },
     setObservability: (patch) => {
       set(
@@ -643,16 +634,18 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
   return create<AgentState>()(
     persist(devtools(agentStore, { name: "agentStore" }), {
       name: "arize-phoenix-agent",
-      version: 5,
+      version: 6,
       migrate: (persisted, version) => {
-        const state = persisted as Partial<AgentProps> & {
-          capabilities?: Partial<AgentCapabilities>;
-          observability?: Partial<AgentObservabilitySettings>;
-          debug?: {
-            retainInactiveBashSessions?: boolean;
-            dangerouslyEnableMutations?: boolean;
+        const { userInstructions: _droppedUserInstructions, ...state } =
+          persisted as Partial<AgentProps> & {
+            capabilities?: Partial<AgentCapabilities>;
+            observability?: Partial<AgentObservabilitySettings>;
+            debug?: {
+              retainInactiveBashSessions?: boolean;
+              dangerouslyEnableMutations?: boolean;
+            };
+            userInstructions?: string;
           };
-        };
         const migratedSessionMap: Record<string, AgentSession> = {};
 
         for (const [sessionId, session] of Object.entries(
@@ -684,7 +677,6 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         return {
           ...state,
           sessionMap: migratedSessionMap,
-          userInstructions: state.userInstructions ?? "",
           observability: {
             ...DEFAULT_AGENT_OBSERVABILITY_SETTINGS,
             ...(state.observability ?? {}),
@@ -699,7 +691,6 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         activeSessionId: state.activeSessionId,
         sessionMap: state.sessionMap,
         defaultModelConfig: state.defaultModelConfig,
-        userInstructions: state.userInstructions,
         observability: state.observability,
         capabilities: state.capabilities,
       }),

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -634,18 +634,16 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
   return create<AgentState>()(
     persist(devtools(agentStore, { name: "agentStore" }), {
       name: "arize-phoenix-agent",
-      version: 6,
+      version: 5,
       migrate: (persisted, version) => {
-        const { userInstructions: _droppedUserInstructions, ...state } =
-          persisted as Partial<AgentProps> & {
-            capabilities?: Partial<AgentCapabilities>;
-            observability?: Partial<AgentObservabilitySettings>;
-            debug?: {
-              retainInactiveBashSessions?: boolean;
-              dangerouslyEnableMutations?: boolean;
-            };
-            userInstructions?: string;
+        const state = persisted as Partial<AgentProps> & {
+          capabilities?: Partial<AgentCapabilities>;
+          observability?: Partial<AgentObservabilitySettings>;
+          debug?: {
+            retainInactiveBashSessions?: boolean;
+            dangerouslyEnableMutations?: boolean;
           };
+        };
         const migratedSessionMap: Record<string, AgentSession> = {};
 
         for (const [sessionId, session] of Object.entries(

--- a/src/phoenix/server/agents/prompts.py
+++ b/src/phoenix/server/agents/prompts.py
@@ -135,7 +135,6 @@ AGENT_STATIC_SYSTEM_PROMPT = "\n".join(_STATIC_SYSTEM_PROMPT_LINES)
 
 def build_agent_dynamic_system_prompt(
     *,
-    user_instructions: str | None,
     capabilities: AgentCapabilities,
 ) -> str | None:
     """Render request-specific PXI system guidance after the static prompt."""
@@ -145,17 +144,6 @@ def build_agent_dynamic_system_prompt(
     if capability_prompt:
         sections.append(capability_prompt)
 
-    if user_instructions and (stripped := user_instructions.strip()):
-        sections.append(
-            "\n".join(
-                [
-                    "<user_custom_instructions>",
-                    stripped,
-                    "</user_custom_instructions>",
-                ]
-            )
-        )
-
     if not sections:
         return None
     return "\n\n".join(sections)
@@ -163,13 +151,11 @@ def build_agent_dynamic_system_prompt(
 
 def build_agent_system_prompts(
     *,
-    user_instructions: str | None,
     capabilities: AgentCapabilities,
 ) -> list[str]:
     """Return PXI system prompt blocks ordered for provider prompt caching."""
     prompts = [AGENT_STATIC_SYSTEM_PROMPT]
     if dynamic_prompt := build_agent_dynamic_system_prompt(
-        user_instructions=user_instructions,
         capabilities=capabilities,
     ):
         prompts.append(dynamic_prompt)

--- a/src/phoenix/server/api/routers/data_stream_protocol.py
+++ b/src/phoenix/server/api/routers/data_stream_protocol.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from starlette.requests import Request
 from starlette.responses import StreamingResponse
 
@@ -117,7 +117,6 @@ def _get_vercel_request_class() -> Any:
         class _VercelRequest(SubmitMessage):
             output_tools: list[ExternalTool] | None = None
             system: str | None = None
-            user_instructions: str | None = Field(default=None, alias="userInstructions")
             session_id: str | None = None
             contexts: list[ChatContext] | None = None
             capabilities: AgentCapabilities = AgentCapabilities()
@@ -136,7 +135,6 @@ class ChatBody:
     messages: list[ModelMessage]
     instruction_parts: list[InstructionPart] = field(default_factory=list)
     output_tools: list[ExternalTool] | None = None
-    user_instructions: str | None = None
     session_id: str | None = None
     capabilities: AgentCapabilities = field(default_factory=AgentCapabilities)
     export_remote_traces: bool = False
@@ -179,7 +177,6 @@ def parse_chat_body(raw_body: bytes) -> ChatBody:
 
     messages: list[Any] = VercelAIAdapter.load_messages(body.messages)
     system_prompts = build_agent_system_prompts(
-        user_instructions=body.user_instructions,
         capabilities=body.capabilities,
     )
 
@@ -197,7 +194,6 @@ def parse_chat_body(raw_body: bytes) -> ChatBody:
         messages=messages,
         instruction_parts=instruction_parts,
         output_tools=body.output_tools,
-        user_instructions=body.user_instructions,
         session_id=body.session_id,
         capabilities=body.capabilities,
         export_remote_traces=body.export_remote_traces,

--- a/tests/unit/server/agents/test_prompts.py
+++ b/tests/unit/server/agents/test_prompts.py
@@ -13,20 +13,17 @@ class TestAgentPrompts:
         assert '<tool name="ask_user">' in AGENT_STATIC_SYSTEM_PROMPT
         assert "<link_formatting>" in AGENT_STATIC_SYSTEM_PROMPT
 
-    def test_dynamic_prompt_inserts_user_instructions_after_capabilities(self) -> None:
+    def test_dynamic_prompt_renders_capability_guidance(self) -> None:
         prompt = build_agent_dynamic_system_prompt(
-            user_instructions="Prefer short answers.",
             capabilities=AgentCapabilities(graphql_mutations=True),
         )
 
         assert prompt is not None
         assert prompt.startswith("Runtime capability state for this conversation:")
         assert "GraphQL mutations are enabled" in prompt
-        assert "<user_custom_instructions>\nPrefer short answers." in prompt
 
     def test_system_prompts_keep_static_prefix_separate_from_dynamic_prompt(self) -> None:
         prompts = build_agent_system_prompts(
-            user_instructions="Prefer short answers.",
             capabilities=AgentCapabilities(graphql_mutations=False),
         )
 

--- a/tests/unit/server/api/routers/test_data_stream_protocol.py
+++ b/tests/unit/server/api/routers/test_data_stream_protocol.py
@@ -34,7 +34,6 @@ class TestParseChatBody:
         assert body.export_remote_traces is False
         assert body.ingest_traces is True
         assert body.trace_name_suffix == "Turn"
-        assert body.user_instructions is None
         assert len(body.messages) >= 1
 
     def test_parses_session_id_and_trace_destination_flags(self) -> None:
@@ -81,30 +80,6 @@ class TestParseChatBody:
         body = parse_chat_body(raw)
         assert isinstance(body, ChatBody)
 
-    def test_parses_user_instructions(self) -> None:
-        raw = json.dumps(
-            {
-                "trigger": "submit-message",
-                "id": "test-1",
-                "messages": [
-                    {
-                        "id": "msg-1",
-                        "role": "user",
-                        "parts": [{"type": "text", "text": "Hello"}],
-                    }
-                ],
-                "userInstructions": "Prefer concise answers.",
-            }
-        ).encode()
-        body = parse_chat_body(raw)
-        assert body.user_instructions == "Prefer concise answers."
-
-        static_part, dynamic_part = body.instruction_parts
-        assert static_part.content.startswith("<role>")
-        assert static_part.dynamic is False
-        assert dynamic_part.dynamic is True
-        assert "<user_custom_instructions>\nPrefer concise answers." in dynamic_part.content
-
     def test_appends_capability_guidance_to_system_prompt(self) -> None:
         raw = json.dumps(
             {
@@ -117,7 +92,6 @@ class TestParseChatBody:
                         "parts": [{"type": "text", "text": "Hello"}],
                     }
                 ],
-                "userInstructions": "Prefer concise answers.",
                 "capabilities": {
                     "bash.retainInactiveSessions": False,
                     "graphql.mutations": True,
@@ -126,11 +100,12 @@ class TestParseChatBody:
         ).encode()
         body = parse_chat_body(raw)
 
-        system_part = body.instruction_parts[1]
+        static_part, system_part = body.instruction_parts
+        assert static_part.content.startswith("<role>")
+        assert static_part.dynamic is False
+        assert system_part.dynamic is True
         assert system_part.content.startswith("Runtime capability state for this conversation:")
         assert "GraphQL mutations are enabled" in system_part.content
-        assert "<user_custom_instructions>\nPrefer concise answers." in system_part.content
-        assert body.user_instructions == "Prefer concise answers."
         assert body.capabilities.graphql_mutations is True
 
 
@@ -198,7 +173,6 @@ class TestBuildTraceMessages:
                         "parts": [{"type": "text", "text": "Hello"}],
                     }
                 ],
-                "userInstructions": "Prefer concise answers.",
             }
         ).encode()
         body = parse_chat_body(raw)


### PR DESCRIPTION
## Summary
- Drops the **Custom Instructions** textarea from the agent settings form, plus the matching `userInstructions` slice/action on the agent Zustand store.
- Removes `userInstructions` from the chat request body builder and the `/chat` request schema (`_VercelRequest`, `ChatBody`), and stops wrapping it in `<user_custom_instructions>` inside the PXI system prompt.
- Bumps the persist version (5 → 6) and destructures `userInstructions` out of migrated state so the legacy key is purged from existing localStorage on rehydrate.

## Test plan
- [x] `pnpm typecheck` (app)
- [x] `pnpm lint` (app)
- [x] `uv run mypy --strict` on touched server files
- [x] `pnpm vitest run` for `agentStore` + `buildAgentChatRequestBody`
- [x] `uv run pytest` for `tests/unit/server/agents/test_prompts.py` and `tests/unit/server/api/routers/test_data_stream_protocol.py`
- [ ] Manual: open the agent settings panel and verify the Custom Instructions field is gone; send a chat turn and confirm the request body and system prompt no longer include user instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)