### PR TITLE
fix(evals): suppress spurious DeprecationWarning on import of phoenix.evals

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__init__.py
@@ -1,6 +1,6 @@
 from importlib.metadata import version
 
-from . import llm, metrics, templating, tracing, utils
+from . import llm, metrics, tracing, utils
 from .evaluators import (
     ClassificationEvaluator,
     EvalInput,
@@ -19,6 +19,20 @@ from .llm import LLM, phoenix_prompt_to_prompt_template
 from .utils import download_benchmark_dataset
 
 __version__ = version("arize-phoenix-evals")
+
+
+def __getattr__(name: str) -> object:
+    """Lazily load the deprecated ``templating`` submodule (PEP 562).
+
+    Deferring the import means the ``DeprecationWarning`` only fires when a
+    caller explicitly accesses ``phoenix.evals.templating``, not on every
+    ``import phoenix.evals``.
+    """
+    if name == "templating":
+        from . import templating
+
+        return templating
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [

--- a/packages/phoenix-evals/tests/phoenix/evals/test_package_init.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/test_package_init.py
@@ -1,0 +1,59 @@
+"""Tests for phoenix.evals package initialization behavior."""
+
+import subprocess
+import sys
+
+
+def test_importing_phoenix_evals_does_not_emit_templating_deprecation_warning():
+    """Importing ``phoenix.evals`` must not trigger the templating deprecation warning.
+
+    The ``templating`` submodule is deprecated and emits a ``DeprecationWarning``
+    when imported.  Previously, ``phoenix/evals/__init__.py`` imported it eagerly,
+    which meant every ``import phoenix.evals`` triggered the warning — even for
+    callers that never use ``templating``.
+
+    The fix uses module ``__getattr__`` to defer the import until the caller
+    explicitly accesses ``phoenix.evals.templating``.
+
+    Regression test for https://github.com/Arize-ai/phoenix/issues/12872.
+    """
+    # Run in a subprocess so the module is freshly imported with no caching.
+    code = (
+        "import warnings; "
+        "warnings.simplefilter('error', DeprecationWarning); "
+        "import phoenix.evals"
+    )
+    result = subprocess.run(
+        [sys.executable, "-W", "error::DeprecationWarning", "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "Importing phoenix.evals raised a DeprecationWarning:\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )
+
+
+def test_accessing_templating_submodule_emits_deprecation_warning():
+    """Accessing ``phoenix.evals.templating`` must still emit a ``DeprecationWarning``.
+
+    Even though the import is now lazy, the warning must fire when a caller
+    actually accesses the deprecated submodule so that users are informed to
+    migrate to ``phoenix.evals.llm.prompts``.
+    """
+    import warnings
+
+    import phoenix.evals
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ = phoenix.evals.templating  # noqa: F841 — access triggers lazy import
+
+    deprecation_warnings = [
+        w for w in caught if issubclass(w.category, DeprecationWarning) and "templating" in str(w.message)
+    ]
+    assert deprecation_warnings, (
+        "Expected a DeprecationWarning mentioning 'templating' when accessing "
+        "phoenix.evals.templating, but none was raised."
+    )


### PR DESCRIPTION
## Summary

Fixes #12872.

Importing `phoenix.evals` was emitting a `DeprecationWarning` on **every import**, even for callers who never use the deprecated `phoenix.evals.templating` submodule:

```
phoenix/evals/__init__.py:3: DeprecationWarning: The phoenix.evals.templating module is
deprecated and will be removed in a future version. Please use phoenix.evals.llm.prompts instead.
  from . import llm, metrics, templating, tracing, utils
```

Root cause: `__init__.py` eagerly imported `templating` at module load time, which triggered the warning inside `templating/__init__.py`.

## Fix

Apply [PEP 562](https://peps.python.org/pep-0562/) module-level `__getattr__` to defer the import of `templating` until a caller explicitly accesses `phoenix.evals.templating`. The deprecation warning now only fires when the deprecated API is actually used.

**Before:**
```python
from . import llm, metrics, templating, tracing, utils  # triggers warning on every import
```

**After:**
```python
from . import llm, metrics, tracing, utils  # no warning

def __getattr__(name: str) -> object:
    if name == "templating":
        from . import templating  # warning fires here, only when accessed
        return templating
    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
```

Backward compatibility is fully preserved: `from phoenix.evals import templating`, `phoenix.evals.templating`, and `from phoenix.evals import *` all continue to work.

## Test plan

- New test `test_importing_phoenix_evals_does_not_emit_templating_deprecation_warning` verifies that `import phoenix.evals` emits **no** `DeprecationWarning` (runs in a subprocess with `-W error::DeprecationWarning` to catch any warning as an error)
- New test `test_accessing_templating_submodule_emits_deprecation_warning` verifies that accessing `phoenix.evals.templating` **still** emits the expected warning (backward-compat for the intentional deprecation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
