### PR TITLE
chore: add changed-file hooks for Codex

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[features]
+codex_hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/.codex/hooks/run_changed_file_checks.sh\"",
+            "statusMessage": "Running changed-file checks"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/run_changed_file_checks.sh
+++ b/.codex/hooks/run_changed_file_checks.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -o pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 2
+
+# Files changed relative to HEAD, plus new untracked files. The diff filter
+# includes regular edits and excludes deletions, because these checks need
+# paths that still exist on disk. We use git instead of hook tool input because
+# Codex apply_patch provides the patch text in tool_input.command, not a single
+# file_path like Claude Write/Edit hooks.
+files="$(
+  {
+  git diff --name-only --diff-filter=ACMRTUXB HEAD --
+  git ls-files --others --exclude-standard
+  } | sort -u
+)"
+
+status=0
+hook_state_dir="$(git rev-parse --git-path codex-hooks)"
+mkdir -p "$hook_state_dir"
+
+run() {
+  "$@" || status=2
+}
+
+# macOS ships Bash 3, which does not support mapfile.
+collect_matches() {
+  local pattern="$1"
+  local output="$2"
+
+  eval "$output=()"
+  while IFS= read -r file; do
+    eval "$output+=(\"\$file\")"
+  done < <(grep -E "$pattern" <<<"$files" || true)
+}
+
+hash_files() {
+  printf '%s\n' "$@" | sort -u | while IFS= read -r file; do
+    [ -f "$file" ] && shasum -a 256 "$file"
+  done | shasum -a 256 | awk '{print $1}'
+}
+
+# Run `command...` once per `files...` content hash, storing state under `key`.
+# Usage: run_once_for_hash key files... -- command...
+run_once_for_hash() {
+  local key="$1"
+  shift
+
+  local -a watched_files=()
+  while (($#)); do
+    if [[ "$1" == "--" ]]; then
+      shift
+      break
+    fi
+    watched_files+=("$1")
+    shift
+  done
+
+  local current_hash
+  current_hash="$(hash_files "${watched_files[@]}")"
+
+  local hash_file="$hook_state_dir/$key.sha"
+  local previous_hash
+  previous_hash="$(cat "$hash_file" 2>/dev/null || true)"
+
+  [ "$current_hash" != "$previous_hash" ] || return 0
+
+  if "$@"; then
+    printf '%s\n' "$current_hash" >"$hash_file"
+  else
+    status=2
+  fi
+}
+
+collect_matches '\.py$' py_files
+collect_matches 'src/phoenix/db/migrations/versions' migration_files
+collect_matches '(^|/)(pyproject\.toml|uv\.lock)$' python_dep_files
+collect_matches 'schemas/openapi\.json$' openapi_files
+
+if ((${#py_files[@]})); then
+  run uv tool run ruff format "${py_files[@]}"
+  run uv tool run ruff check --fix --unfixable=F401 "${py_files[@]}"
+fi
+
+if ((${#migration_files[@]})); then
+  run_once_for_hash schema-ddl "${migration_files[@]}" -- \
+    sh -c 'make schema-ddl >&2'
+fi
+
+if ((${#python_dep_files[@]})); then
+  run_once_for_hash python-deps "${python_dep_files[@]}" -- \
+    sh -c 'uv sync >&2'
+fi
+
+if ((${#openapi_files[@]})); then
+  run_once_for_hash openapi "${openapi_files[@]}" -- \
+    sh -c 'cd js && { pnpm i && pnpm build; } >&2'
+fi
+
+exit "$status"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@094bd24d575e7b30ac1576024817bf1a97c81262 # v1.0.80
         with:
+          github_token: ${{ github.token }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: 'claude, cursor, codex, gitbook-bot, github-actions, dependabot[bot], cursoragent, mintlify[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,21 @@ Before submitting a pull request, please make sure the following is done:
 - Make sure your code lints with `pnpm lint` for app changes.
 - Run type checking with `make typecheck-python` and `npm run typecheck` for app changes.
 
+### Claude Code Review On Forks
+
+The Claude Code Review workflow runs on pull requests and uses `ANTHROPIC_API_KEY`.
+For repository-owned branches, this is an upstream repository secret configured by
+maintainers.
+
+If you want to run the same workflow in your own fork before opening or updating a
+pull request, add `ANTHROPIC_API_KEY` as a repository secret in your fork at
+`https://github.com/{username}/phoenix/settings/secrets/actions`. Use a repository
+secret, not an environment secret.
+
+GitHub does not pass fork repository secrets to pull request workflows running in
+the upstream repository. Maintainers may need to rerun or review Claude results
+from a trusted repository context for external fork pull requests.
+
 ### Pull Request (PR) Descriptions
 
 A PR description is a public record of what change is being made and why it was made. It will become a permanent part of our version control history, and will possibly be read by many people other than your reviewers over the years. Follow the following guidelines when writing a PR description:


### PR DESCRIPTION
Adds Codex hook configuration triggered on file changes. 
For codex a shared `.agents/hooks/run_changed_file_checks.sh` file doing the checks was needed as the Codex hook doesn't give us the file name as with Claude's `.tool_input.file_path`. 

For alignment, the same script is also used by Claude with this PR.

Changes:
- Adds `.codex/config.toml` to enable Codex hooks
- Adds `.codex/hooks.json` to run changed-file checks after `Edit` and `Write` tool use.
- Adds a shared hook runner to `.agents/hooks/run_changed_file_checks.sh`.
- Updates Claude settings to call the same shared hook runner.

Tested:
- Verified with Codex `0.128.0` 