### PR TITLE
feat: Update session details turns layout

### DIFF
--- a/app/src/pages/trace/SessionDetails.tsx
+++ b/app/src/pages/trace/SessionDetails.tsx
@@ -18,6 +18,7 @@ import {
   TriggerWrap,
   View,
 } from "@phoenix/components";
+import { SessionAnnotationSummaryGroupTokens } from "@phoenix/components/annotation/SessionAnnotationSummaryGroup";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SessionTokenCount } from "@phoenix/components/trace/SessionTokenCount";
 import { SESSION_VIEW_PARAM } from "@phoenix/constants/searchParams";
@@ -41,13 +42,13 @@ import {
 import type { SessionView } from "./SessionViewTabs";
 
 function SessionDetailsHeader({
-  traceCount,
+  session,
   costSummary,
   tokenUsage,
   latencyP50,
   sessionId,
 }: {
-  traceCount: number;
+  session: NonNullable<SessionDetailsQuery$data["session"]>;
   tokenUsage?: NonNullable<SessionDetailsQuery$data["session"]>["tokenUsage"];
   costSummary?: NonNullable<SessionDetailsQuery$data["session"]>["costSummary"];
   latencyP50?: number | null;
@@ -59,69 +60,78 @@ function SessionDetailsHeader({
       borderBottomWidth={"thin"}
       borderBottomColor="default"
     >
-      <Flex direction="row" gap="size-400" alignItems="center">
-        <Flex direction={"column"}>
-          <Text elementType={"h3"} color={"text-700"}>
-            Traces Count
-          </Text>
-          <Text size="L">{traceCount}</Text>
+      <Flex
+        direction="row"
+        gap="size-400"
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        <Flex direction="row" gap="size-400" alignItems="center">
+          {tokenUsage != null ? (
+            <Flex direction={"column"}>
+              <Text elementType={"h3"} color={"text-700"}>
+                Total Tokens
+              </Text>
+              <SessionTokenCount
+                tokenCountTotal={tokenUsage.total}
+                nodeId={sessionId}
+                size="L"
+              />
+            </Flex>
+          ) : null}
+          {costSummary != null ? (
+            <Flex direction="column" flex="none">
+              <Text elementType="h3" size="S" color="text-700">
+                Total Cost
+              </Text>
+              <TooltipTrigger delay={0}>
+                <TriggerWrap>
+                  <Text size="L">
+                    {costFormatter(costSummary.total?.cost ?? 0)}
+                  </Text>
+                </TriggerWrap>
+                <RichTooltip placement="bottom">
+                  <View width="size-2400">
+                    <Flex direction="column">
+                      <Flex justifyContent="space-between">
+                        <Text>Prompt Cost</Text>
+                        <Text>
+                          {costFormatter(costSummary.prompt?.cost ?? 0)}
+                        </Text>
+                      </Flex>
+                      <Flex justifyContent="space-between">
+                        <Text>Completion Cost</Text>
+                        <Text>
+                          {costFormatter(costSummary.completion?.cost ?? 0)}
+                        </Text>
+                      </Flex>
+                      <Flex justifyContent="space-between">
+                        <Text>Total Cost</Text>
+                        <Text>
+                          {costFormatter(costSummary.total?.cost ?? 0)}
+                        </Text>
+                      </Flex>
+                    </Flex>
+                  </View>
+                </RichTooltip>
+              </TooltipTrigger>
+            </Flex>
+          ) : null}
+          {latencyP50 != null ? (
+            <Flex direction={"column"}>
+              <Text elementType={"h3"} color={"text-700"}>
+                Latency P50
+              </Text>
+              <LatencyText latencyMs={latencyP50} size="L" />
+            </Flex>
+          ) : null}
         </Flex>
-        {tokenUsage != null ? (
-          <Flex direction={"column"}>
-            <Text elementType={"h3"} color={"text-700"}>
-              Total Tokens
-            </Text>
-            <SessionTokenCount
-              tokenCountTotal={tokenUsage.total}
-              nodeId={sessionId}
-              size="L"
-            />
-          </Flex>
-        ) : null}
-        {costSummary != null ? (
-          <Flex direction="column" flex="none">
-            <Text elementType="h3" size="S" color="text-700">
-              Total Cost
-            </Text>
-            <TooltipTrigger delay={0}>
-              <TriggerWrap>
-                <Text size="L">
-                  {costFormatter(costSummary.total?.cost ?? 0)}
-                </Text>
-              </TriggerWrap>
-              <RichTooltip placement="bottom">
-                <View width="size-2400">
-                  <Flex direction="column">
-                    <Flex justifyContent="space-between">
-                      <Text>Prompt Cost</Text>
-                      <Text>
-                        {costFormatter(costSummary.prompt?.cost ?? 0)}
-                      </Text>
-                    </Flex>
-                    <Flex justifyContent="space-between">
-                      <Text>Completion Cost</Text>
-                      <Text>
-                        {costFormatter(costSummary.completion?.cost ?? 0)}
-                      </Text>
-                    </Flex>
-                    <Flex justifyContent="space-between">
-                      <Text>Total Cost</Text>
-                      <Text>{costFormatter(costSummary.total?.cost ?? 0)}</Text>
-                    </Flex>
-                  </Flex>
-                </View>
-              </RichTooltip>
-            </TooltipTrigger>
-          </Flex>
-        ) : null}
-        {latencyP50 != null ? (
-          <Flex direction={"column"}>
-            <Text elementType={"h3"} color={"text-700"}>
-              Latency P50
-            </Text>
-            <LatencyText latencyMs={latencyP50} size="L" />
-          </Flex>
-        ) : null}
+        <Flex direction="row" justifyContent="end">
+          <SessionAnnotationSummaryGroupTokens
+            session={session}
+            renderEmptyState={() => null}
+          />
+        </Flex>
       </Flex>
     </View>
   );
@@ -179,6 +189,7 @@ export function SessionDetails(props: SessionDetailsProps) {
             }
             sessionId
             latencyP50: traceLatencyMsQuantile(probability: 0.50)
+            ...SessionAnnotationSummaryGroup
           }
         }
       }
@@ -279,7 +290,7 @@ export function SessionDetails(props: SessionDetailsProps) {
       `}
     >
       <SessionDetailsHeader
-        traceCount={traceCount}
+        session={data.session}
         costSummary={data.session.costSummary}
         tokenUsage={data.session.tokenUsage}
         latencyP50={data.session.latencyP50}

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -7,12 +7,6 @@ import { isNumber, isString, throttle } from "lodash";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { PreloadedQuery } from "react-relay";
 import { graphql, usePaginationFragment, usePreloadedQuery } from "react-relay";
-import {
-  Group,
-  Panel,
-  Separator,
-  useDefaultLayout,
-} from "react-resizable-panels";
 import type { To } from "react-router";
 import { useLocation, useSearchParams } from "react-router";
 
@@ -30,7 +24,6 @@ import {
 } from "@phoenix/components";
 import { AnnotationSummaryGroupTokens } from "@phoenix/components/annotation/AnnotationSummaryGroup";
 import { DynamicContent } from "@phoenix/components/DynamicContent";
-import { compactResizeHandleCSS } from "@phoenix/components/resize";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanCumulativeTokenCount } from "@phoenix/components/trace/SpanCumulativeTokenCount";
 import { TokenCosts } from "@phoenix/components/trace/TokenCosts";
@@ -102,13 +95,16 @@ const getSessionTraceUrl = ({
 };
 
 function RootSpanMessage({
+  label,
   role,
   value,
 }: {
+  label?: string;
   role: "HUMAN" | "AI";
   value: unknown;
 }) {
   const styles = useChatMessageStyles(role === "HUMAN" ? "user" : "assistant");
+  const defaultLabel = role === "HUMAN" ? "INPUT" : "OUTPUT";
   return (
     <View
       alignSelf={role === "HUMAN" ? "start" : "end"}
@@ -120,7 +116,7 @@ function RootSpanMessage({
       {...styles}
     >
       <Flex direction={"column"} gap={"size-50"}>
-        <Text color="text-700">{role}</Text>
+        <Text color="text-700">{label ?? defaultLabel}</Text>
         <DynamicContent value={value} />
       </Flex>
     </View>
@@ -137,102 +133,101 @@ type RootSpanProps = {
   rootSpan: SessionTraceRootSpan;
 };
 
-function RootSpanDetails({
-  traceId,
-  rootSpan,
-  index,
-}: RootSpanProps & { traceId: string; index: number }) {
-  const location = useLocation();
+function RootSpanStartTime({ rootSpan }: RootSpanProps) {
   const { fullTimeFormatter } = useTimeFormatters();
-  const startDate = useMemo(() => {
-    return new Date(rootSpan.startTime);
-  }, [rootSpan.startTime]);
+  const startDate = new Date(rootSpan.startTime);
 
-  const user = useMemo(
-    () => getUserFromRootSpanAttributes(rootSpan.attributes),
-    [rootSpan.attributes]
-  );
   return (
-    <View height={"100%"}>
-      <Flex
-        direction={"column"}
-        justifyContent={"space-between"}
-        height={"100%"}
-      >
-        <Flex direction={"column"} gap="size-200">
-          <Flex direction={"row"} justifyContent={"space-between"}>
-            <Text>Trace #{index + 1}</Text>
-            <Link
-              to={getSessionTraceUrl({
-                pathname: location.pathname,
-                search: location.search,
-                traceId,
-                spanNodeId: rootSpan.id,
-              })}
-            >
-              <Flex alignItems={"center"}>
-                View Trace
-                <Icon svg={<Icons.ArrowIosForwardOutline />} />
-              </Flex>
-            </Link>
-          </Flex>
-          <Flex direction={"row"} justifyContent={"space-between"}>
-            {user != null ? <Text color="text-700">user: {user}</Text> : null}
-            <Text color="text-700" flex={"end"} marginStart={"auto"}>
-              {fullTimeFormatter(startDate)}
-            </Text>
-          </Flex>
-          <Flex direction={"row"} gap={"size-100"}>
-            <SpanCumulativeTokenCount
-              tokenCountTotal={rootSpan.cumulativeTokenCountTotal || 0}
-              nodeId={rootSpan.id}
-            />
-            {rootSpan.trace.costSummary?.total?.cost != null && (
-              <TraceTokenCosts
-                totalCost={rootSpan.trace.costSummary.total.cost}
-                nodeId={rootSpan.trace.id}
-              />
-            )}
-            {rootSpan.latencyMs != null ? (
-              <LatencyText latencyMs={rootSpan.latencyMs} />
-            ) : (
-              "--"
-            )}
-          </Flex>
-        </Flex>
-        <Flex
-          direction={"row"}
-          justifyContent={"space-between"}
-          alignItems="end"
-        >
-          <Flex direction={"column"} gap={"size-100"} maxWidth={"50%"}>
-            <Text>Feedback</Text>
-            <Flex gap={"size-50"} direction={"column"}>
-              <AnnotationSummaryGroupTokens
-                span={rootSpan}
-                renderEmptyState={() => "--"}
-              />
-            </Flex>
-          </Flex>
-          <span>
-            <EditSpanAnnotationsButton
-              size="S"
-              spanNodeId={rootSpan.id}
-              projectId={rootSpan.project.id}
-              buttonText="Annotate"
-            />
-          </span>
-        </Flex>
-      </Flex>
-    </View>
+    <Text color="text-700" size="XS">
+      {fullTimeFormatter(startDate)}
+    </Text>
   );
 }
 
-function RootSpanInputOutput({ rootSpan }: RootSpanProps) {
+function RootSpanOutputHeader({
+  traceId,
+  rootSpan,
+}: RootSpanProps & { traceId: string }) {
+  const location = useLocation();
+
   return (
-    <Flex direction={"column"} gap={"size-100"}>
-      <RootSpanMessage role={"HUMAN"} value={rootSpan.input?.value} />
-      <RootSpanMessage role={"AI"} value={rootSpan.output?.value} />
+    <Flex direction="row" justifyContent="end">
+      <Link
+        to={getSessionTraceUrl({
+          pathname: location.pathname,
+          search: location.search,
+          traceId,
+          spanNodeId: rootSpan.id,
+        })}
+      >
+        <Flex alignItems="center">
+          View Trace
+          <Icon svg={<Icons.ArrowIosForwardOutline />} />
+        </Flex>
+      </Link>
+    </Flex>
+  );
+}
+
+function RootSpanOutputMetadata({ rootSpan }: RootSpanProps) {
+  return (
+    <Flex
+      direction="row"
+      justifyContent="space-between"
+      alignItems="center"
+      gap="size-200"
+      wrap
+    >
+      <Flex direction="row" alignItems="center" gap="size-100" wrap>
+        <SpanCumulativeTokenCount
+          tokenCountTotal={rootSpan.cumulativeTokenCountTotal || 0}
+          nodeId={rootSpan.id}
+        />
+        {rootSpan.trace.costSummary?.total?.cost != null && (
+          <TraceTokenCosts
+            totalCost={rootSpan.trace.costSummary.total.cost}
+            nodeId={rootSpan.trace.id}
+          />
+        )}
+        {rootSpan.latencyMs != null ? (
+          <LatencyText latencyMs={rootSpan.latencyMs} />
+        ) : null}
+        <AnnotationSummaryGroupTokens span={rootSpan} />
+      </Flex>
+      <span>
+        <EditSpanAnnotationsButton
+          size="S"
+          spanNodeId={rootSpan.id}
+          projectId={rootSpan.project.id}
+          buttonText="Annotate"
+        />
+      </span>
+    </Flex>
+  );
+}
+
+function SessionTurnDetail({
+  traceId,
+  rootSpan,
+}: RootSpanProps & { traceId: string }) {
+  const user = getUserFromRootSpanAttributes(rootSpan.attributes);
+  const inputLabel = user != null ? `USER: ${user}` : "INPUT";
+
+  return (
+    <Flex direction="column" gap="size-200">
+      <Flex direction="column" gap="size-100">
+        <RootSpanMessage
+          label={inputLabel}
+          role="HUMAN"
+          value={rootSpan.input?.value}
+        />
+        <RootSpanStartTime rootSpan={rootSpan} />
+      </Flex>
+      <Flex direction="column" gap="size-100">
+        <RootSpanOutputHeader traceId={traceId} rootSpan={rootSpan} />
+        <RootSpanMessage role="AI" value={rootSpan.output?.value} />
+        <RootSpanOutputMetadata rootSpan={rootSpan} />
+      </Flex>
     </Flex>
   );
 }
@@ -367,6 +362,26 @@ const panelContentCSS = css`
   overflow: hidden;
 `;
 
+const turnsViewCSS = css`
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(220px, 28%) minmax(0, 1fr);
+  overflow: hidden;
+`;
+
+const turnsListPanelCSS = css`
+  min-width: 0;
+  border-right: 1px solid var(--global-border-color-default);
+  overflow: hidden;
+`;
+
+const turnDetailsPanelCSS = css`
+  min-width: 0;
+  height: 100%;
+  overflow: auto;
+`;
+
 export function SessionDetailsTraceList({
   queryRef,
   sessionView,
@@ -471,11 +486,6 @@ export function SessionDetailsTraceList({
   );
 
   const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
-  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
-    id: "session-details-layout",
-    storage: localStorage,
-  });
-
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedTraceId = searchParams.get(SELECTED_TRACE_ID_PARAM);
 
@@ -526,16 +536,8 @@ export function SessionDetailsTraceList({
   );
 
   return (
-    <Group
-      orientation="horizontal"
-      defaultLayout={defaultLayout}
-      onLayoutChanged={onLayoutChanged}
-      css={css`
-        flex: 1 1 auto;
-        overflow: hidden;
-      `}
-    >
-      <Panel id="session-turns" defaultSize="20%" minSize="10%">
+    <div css={turnsViewCSS}>
+      <div css={turnsListPanelCSS}>
         <div css={panelContentCSS}>
           <SessionViewTabs
             sessionView={sessionView}
@@ -545,63 +547,45 @@ export function SessionDetailsTraceList({
             {turnListPanel}
           </SessionViewTabs>
         </div>
-      </Panel>
-      <Separator css={compactResizeHandleCSS} />
-      <Panel id="session-turn-details">
-        <div
-          css={css`
-            height: 100%;
-            overflow: auto;
-          `}
-          onScroll={(e) =>
-            debouncedFetchMoreOnBottomReached(e.target as HTMLDivElement)
-          }
-        >
-          {sessionRootSpans.map(({ traceId, rootSpan }, index) => (
-            <div
-              key={rootSpan.spanId}
-              css={turnDetailRowCSS}
-              data-selected={traceId === selectedTraceId || undefined}
-              ref={(el) => {
-                if (el) {
-                  rowRefs.current.set(traceId, el);
-                } else {
-                  rowRefs.current.delete(traceId);
-                }
-              }}
-            >
-              <View borderBottomColor="default" borderBottomWidth={"thin"}>
-                <Flex direction={"row"}>
-                  <View
-                    borderRightWidth={"thin"}
-                    borderEndColor="default"
-                    padding="size-200"
-                    flex={"1 1 auto"}
-                  >
-                    <RootSpanInputOutput rootSpan={rootSpan} />
-                  </View>
-                  <View width={350} padding="size-200" flex="none">
-                    <RootSpanDetails
-                      traceId={traceId}
-                      rootSpan={rootSpan}
-                      index={index}
-                    />
-                  </View>
-                </Flex>
-              </View>
-            </div>
-          ))}
-          {isLoadingNext && (
+      </div>
+      <div
+        css={turnDetailsPanelCSS}
+        onScroll={(e) =>
+          debouncedFetchMoreOnBottomReached(e.target as HTMLDivElement)
+        }
+      >
+        {sessionRootSpans.map(({ traceId, rootSpan }) => (
+          <div
+            key={rootSpan.spanId}
+            css={turnDetailRowCSS}
+            data-selected={traceId === selectedTraceId || undefined}
+            ref={(el) => {
+              if (el) {
+                rowRefs.current.set(traceId, el);
+              } else {
+                rowRefs.current.delete(traceId);
+              }
+            }}
+          >
             <View
               borderBottomColor="default"
-              borderBottomWidth={"thin"}
+              borderBottomWidth="thin"
               padding="size-200"
             >
-              <Loading />
+              <SessionTurnDetail traceId={traceId} rootSpan={rootSpan} />
             </View>
-          )}
-        </div>
-      </Panel>
-    </Group>
+          </div>
+        ))}
+        {isLoadingNext && (
+          <View
+            borderBottomColor="default"
+            borderBottomWidth={"thin"}
+            padding="size-200"
+          >
+            <Loading />
+          </View>
+        )}
+      </div>
+    </div>
   );
 }

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -102,10 +102,12 @@ const getSessionTraceUrl = ({
   };
 };
 
-const inputMessageWrapCSS = css`
+const messageWrapCSS = css`
   width: fit-content;
   max-width: 70%;
 `;
+
+type RootSpanMessageRole = "INPUT" | "OUTPUT";
 
 type RootSpanMessageProps = {
   /**
@@ -114,26 +116,25 @@ type RootSpanMessageProps = {
    */
   extra?: ReactNode;
   label?: string;
-  role: "HUMAN" | "AI";
+  role: RootSpanMessageRole;
   value: unknown;
 };
 
 function RootSpanMessage({ extra, label, role, value }: RootSpanMessageProps) {
-  const isInput = role === "HUMAN";
+  const isInput = role === "INPUT";
   const styles = useChatMessageStyles(isInput ? "user" : "assistant");
   const defaultLabel = isInput ? "INPUT" : "OUTPUT";
   return (
     <Flex
       direction="column"
       gap="size-50"
-      alignSelf={isInput ? "end" : "stretch"}
-      alignItems={isInput ? "end" : "start"}
-      width={isInput ? undefined : "100%"}
-      css={isInput ? inputMessageWrapCSS : undefined}
+      alignSelf={isInput ? "start" : "end"}
+      alignItems={isInput ? "start" : "end"}
+      css={messageWrapCSS}
     >
       <Flex
         direction="row"
-        justifyContent={isInput ? "end" : "space-between"}
+        justifyContent="space-between"
         alignItems="center"
         width="100%"
       >
@@ -249,10 +250,10 @@ function SessionTurnDetail({
 
   return (
     <Flex direction="column" gap="size-200">
-      <Flex direction="column" gap="size-100" alignItems="end">
+      <Flex direction="column" gap="size-100" alignItems="start">
         <RootSpanMessage
           label={inputLabel}
-          role="HUMAN"
+          role="INPUT"
           value={rootSpan.input?.value}
         />
         <RootSpanStartTime rootSpan={rootSpan} />
@@ -260,7 +261,7 @@ function SessionTurnDetail({
       <Flex direction="column" gap="size-100">
         <RootSpanMessage
           extra={<RootSpanTraceLink traceId={traceId} rootSpan={rootSpan} />}
-          role="AI"
+          role="OUTPUT"
           value={rootSpan.output?.value}
         />
         <RootSpanOutputMetadata rootSpan={rootSpan} />
@@ -276,18 +277,34 @@ type SessionTurnRow = {
 
 type IndexedSessionTurnRow = SessionTurnRow & { index: number };
 
-function RootSpanPreviewLine({ value }: { value?: string | null }) {
+function RootSpanPreviewLine({
+  role,
+  value,
+}: {
+  role: RootSpanMessageRole;
+  value?: string | null;
+}) {
+  const isInput = role === "INPUT";
+  const styles = useChatMessageStyles(isInput ? "user" : "assistant");
   if (!value) {
     return null;
   }
   return (
-    <Flex minWidth={0}>
-      <Truncate maxWidth="100%" title={value}>
-        <Text color="text-700" size="XS">
-          {value}
-        </Text>
-      </Truncate>
-    </Flex>
+    <View
+      borderStartColor={styles.borderColor}
+      borderStartWidth="thick"
+      minWidth={0}
+      paddingStart="size-75"
+      width="100%"
+    >
+      <Flex direction="row" alignItems="center" gap="size-75" minWidth={0}>
+        <Truncate maxWidth="100%" title={value}>
+          <Text color="text-700" size="XS">
+            {value}
+          </Text>
+        </Truncate>
+      </Flex>
+    </View>
   );
 }
 
@@ -385,9 +402,11 @@ function SessionTurnList({
               </Flex>
               <Flex direction="column" gap="size-50" minWidth={0}>
                 <RootSpanPreviewLine
+                  role="INPUT"
                   value={row.rootSpan.input?.truncatedValue}
                 />
                 <RootSpanPreviewLine
+                  role="OUTPUT"
                   value={row.rootSpan.output?.truncatedValue}
                 />
               </Flex>

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -145,7 +145,7 @@ function RootSpanStartTime({ rootSpan }: RootSpanProps) {
   const startDate = new Date(rootSpan.startTime);
 
   return (
-    <Text color="text-700" size="XS">
+    <Text color="text-700" marginStart="size-200" size="XS">
       {fullTimeFormatter(startDate)}
     </Text>
   );
@@ -251,6 +251,21 @@ type SessionTurnRow = {
 
 type IndexedSessionTurnRow = SessionTurnRow & { index: number };
 
+function RootSpanPreviewLine({ value }: { value?: string | null }) {
+  if (!value) {
+    return null;
+  }
+  return (
+    <Flex minWidth={0}>
+      <Truncate maxWidth="100%" title={value}>
+        <Text color="text-700" size="XS">
+          {value}
+        </Text>
+      </Truncate>
+    </Flex>
+  );
+}
+
 const turnListCSS = css`
   height: 100%;
   max-height: 100%;
@@ -320,38 +335,45 @@ function SessionTurnList({
                 alignItems="center"
                 gap="size-100"
               >
-                <Flex
-                  direction="row"
-                  gap="size-100"
-                  alignItems="center"
-                  flex={1}
-                  minWidth={0}
-                >
-                  <Text fontFamily="mono" color="text-500">
-                    {paddedIndex}
-                  </Text>
-                  <Flex flex={1} minWidth={0}>
-                    <Truncate maxWidth="100%" title={row.rootSpan.name}>
-                      <Text weight="heavy">{row.rootSpan.name}</Text>
-                    </Truncate>
-                  </Flex>
-                </Flex>
+                <Text fontFamily="mono" color="text-500">
+                  {paddedIndex}
+                </Text>
                 <Text color="text-700" size="XS">
                   {fullTimeFormatter(new Date(row.rootSpan.startTime))}
                 </Text>
               </Flex>
-              <Flex direction="row" gap="size-100" alignItems="center" wrap>
-                <TokenCount size="S">
-                  {row.rootSpan.cumulativeTokenCountTotal ?? 0}
-                </TokenCount>
-                {row.rootSpan.trace.costSummary?.total?.cost != null ? (
-                  <TokenCosts size="S">
-                    {row.rootSpan.trace.costSummary.total.cost}
-                  </TokenCosts>
-                ) : null}
-                {row.rootSpan.latencyMs != null ? (
-                  <LatencyText latencyMs={row.rootSpan.latencyMs} size="S" />
-                ) : null}
+              <Flex direction="row" gap="size-200" alignItems="start">
+                <Flex direction="column" gap="size-100" flex={1} minWidth={0}>
+                  <Flex minWidth={0}>
+                    <Truncate maxWidth="100%" title={row.rootSpan.name}>
+                      <Text weight="heavy">{row.rootSpan.name}</Text>
+                    </Truncate>
+                  </Flex>
+                  <Flex direction="row" gap="size-100" alignItems="center" wrap>
+                    <TokenCount size="S">
+                      {row.rootSpan.cumulativeTokenCountTotal ?? 0}
+                    </TokenCount>
+                    {row.rootSpan.trace.costSummary?.total?.cost != null ? (
+                      <TokenCosts size="S">
+                        {row.rootSpan.trace.costSummary.total.cost}
+                      </TokenCosts>
+                    ) : null}
+                    {row.rootSpan.latencyMs != null ? (
+                      <LatencyText
+                        latencyMs={row.rootSpan.latencyMs}
+                        size="S"
+                      />
+                    ) : null}
+                  </Flex>
+                </Flex>
+                <Flex direction="column" gap="size-50" flex={1} minWidth={0}>
+                  <RootSpanPreviewLine
+                    value={row.rootSpan.input?.truncatedValue}
+                  />
+                  <RootSpanPreviewLine
+                    value={row.rootSpan.output?.truncatedValue}
+                  />
+                </Flex>
               </Flex>
             </Flex>
           </ListBoxItem>
@@ -427,10 +449,12 @@ export function SessionDetailsTraceList({
                 }
                 input {
                   value
+                  truncatedValue
                   mimeType
                 }
                 output {
                   value
+                  truncatedValue
                   mimeType
                 }
                 cumulativeTokenCountTotal

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -4,6 +4,7 @@ import {
 } from "@arizeai/openinference-semantic-conventions";
 import { css } from "@emotion/react";
 import { isNumber, isString, throttle } from "lodash";
+import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { PreloadedQuery } from "react-relay";
 import { graphql, usePaginationFragment, usePreloadedQuery } from "react-relay";
@@ -101,32 +102,54 @@ const getSessionTraceUrl = ({
   };
 };
 
+const inputMessageWrapCSS = css`
+  width: fit-content;
+  max-width: 70%;
+`;
+
 function RootSpanMessage({
+  endContent,
   label,
   role,
   value,
 }: {
+  endContent?: ReactNode;
   label?: string;
   role: "HUMAN" | "AI";
   value: unknown;
 }) {
-  const styles = useChatMessageStyles(role === "HUMAN" ? "user" : "assistant");
-  const defaultLabel = role === "HUMAN" ? "INPUT" : "OUTPUT";
+  const isInput = role === "HUMAN";
+  const styles = useChatMessageStyles(isInput ? "user" : "assistant");
+  const defaultLabel = isInput ? "INPUT" : "OUTPUT";
   return (
-    <View
-      alignSelf={role === "HUMAN" ? "start" : "end"}
-      borderRadius={"medium"}
-      borderColor="default"
-      borderWidth={"thin"}
-      padding="size-200"
-      maxWidth={"70%"}
-      {...styles}
+    <Flex
+      direction="column"
+      gap="size-50"
+      alignSelf={isInput ? "end" : "stretch"}
+      alignItems={isInput ? "end" : "start"}
+      width={isInput ? undefined : "100%"}
+      css={isInput ? inputMessageWrapCSS : undefined}
     >
-      <Flex direction={"column"} gap={"size-50"}>
+      <Flex
+        direction="row"
+        justifyContent={isInput ? "end" : "space-between"}
+        alignItems="center"
+        width="100%"
+      >
         <Text color="text-700">{label ?? defaultLabel}</Text>
-        <DynamicContent value={value} />
+        {endContent}
       </Flex>
-    </View>
+      <View
+        borderRadius={"medium"}
+        borderColor="default"
+        borderWidth={"thin"}
+        padding="size-200"
+        width="100%"
+        {...styles}
+      >
+        <DynamicContent value={value} />
+      </View>
+    </Flex>
   );
 }
 
@@ -145,7 +168,7 @@ function RootSpanStartTime({ rootSpan }: RootSpanProps) {
   const startDate = new Date(rootSpan.startTime);
 
   return (
-    <Text color="text-700" marginStart="size-200" size="XS">
+    <Text color="text-700" size="XS">
       {fullTimeFormatter(startDate)}
     </Text>
   );
@@ -158,21 +181,19 @@ function RootSpanTraceLink({
   const location = useLocation();
 
   return (
-    <Flex direction="row" justifyContent="end">
-      <LinkButton
-        size="S"
-        variant="quiet"
-        leadingVisual={<Icon svg={<Icons.Trace />} />}
-        to={getSessionTraceUrl({
-          pathname: location.pathname,
-          search: location.search,
-          traceId,
-          spanNodeId: rootSpan.id,
-        })}
-      >
-        Trace
-      </LinkButton>
-    </Flex>
+    <LinkButton
+      size="S"
+      variant="quiet"
+      leadingVisual={<Icon svg={<Icons.Trace />} />}
+      to={getSessionTraceUrl({
+        pathname: location.pathname,
+        search: location.search,
+        traceId,
+        spanNodeId: rootSpan.id,
+      })}
+    >
+      Trace
+    </LinkButton>
   );
 }
 
@@ -227,7 +248,7 @@ function SessionTurnDetail({
 
   return (
     <Flex direction="column" gap="size-200">
-      <Flex direction="column" gap="size-100">
+      <Flex direction="column" gap="size-100" alignItems="end">
         <RootSpanMessage
           label={inputLabel}
           role="HUMAN"
@@ -236,8 +257,13 @@ function SessionTurnDetail({
         <RootSpanStartTime rootSpan={rootSpan} />
       </Flex>
       <Flex direction="column" gap="size-100">
-        <RootSpanTraceLink traceId={traceId} rootSpan={rootSpan} />
-        <RootSpanMessage role="AI" value={rootSpan.output?.value} />
+        <RootSpanMessage
+          endContent={
+            <RootSpanTraceLink traceId={traceId} rootSpan={rootSpan} />
+          }
+          role="AI"
+          value={rootSpan.output?.value}
+        />
         <RootSpanOutputMetadata rootSpan={rootSpan} />
       </Flex>
     </Flex>

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -635,11 +635,7 @@ export function SessionDetailsTraceList({
                 borderBottomWidth="thin"
                 padding="size-200"
               >
-                <View
-                  width="100%"
-                  maxWidth="var(--global-dimension-size-8500)"
-                  marginX="auto"
-                >
+                <View width="100%" maxWidth="size-8500" marginX="auto">
                   <SessionTurnDetail traceId={traceId} rootSpan={rootSpan} />
                 </View>
               </View>
@@ -651,11 +647,7 @@ export function SessionDetailsTraceList({
               borderBottomWidth={"thin"}
               padding="size-200"
             >
-              <View
-                width="100%"
-                maxWidth="var(--global-dimension-size-8500)"
-                marginX="auto"
-              >
+              <View width="100%" maxWidth="size-8500" marginX="auto">
                 <Loading />
               </View>
             </View>

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -107,17 +107,18 @@ const inputMessageWrapCSS = css`
   max-width: 70%;
 `;
 
-function RootSpanMessage({
-  endContent,
-  label,
-  role,
-  value,
-}: {
-  endContent?: ReactNode;
+type RootSpanMessageProps = {
+  /**
+   * Optional content rendered opposite the message label in the header,
+   * typically a small action like the trace link.
+   */
+  extra?: ReactNode;
   label?: string;
   role: "HUMAN" | "AI";
   value: unknown;
-}) {
+};
+
+function RootSpanMessage({ extra, label, role, value }: RootSpanMessageProps) {
   const isInput = role === "HUMAN";
   const styles = useChatMessageStyles(isInput ? "user" : "assistant");
   const defaultLabel = isInput ? "INPUT" : "OUTPUT";
@@ -137,7 +138,7 @@ function RootSpanMessage({
         width="100%"
       >
         <Text color="text-700">{label ?? defaultLabel}</Text>
-        {endContent}
+        {extra}
       </Flex>
       <View
         borderRadius={"medium"}
@@ -258,9 +259,7 @@ function SessionTurnDetail({
       </Flex>
       <Flex direction="column" gap="size-100">
         <RootSpanMessage
-          endContent={
-            <RootSpanTraceLink traceId={traceId} rootSpan={rootSpan} />
-          }
+          extra={<RootSpanTraceLink traceId={traceId} rootSpan={rootSpan} />}
           role="AI"
           value={rootSpan.output?.value}
         />
@@ -299,7 +298,8 @@ const turnListCSS = css`
 
   .react-aria-ListBoxItem {
     margin: 0;
-    padding: var(--global-dimension-static-size-200);
+    padding: var(--global-dimension-static-size-150)
+      var(--global-dimension-static-size-200);
     border-radius: 0;
     border-left: 4px solid transparent;
     border-bottom: 1px solid var(--global-border-color-default);
@@ -354,52 +354,55 @@ function SessionTurnList({
         const turnLabel = `${paddedIndex} | ${row.rootSpan.name}`;
         return (
           <ListBoxItem id={row.traceId} textValue={turnLabel}>
-            <Flex direction="column" gap="size-100">
+            <Flex direction="column" gap="size-50">
               <Flex
                 direction="row"
-                justifyContent="space-between"
                 alignItems="center"
+                justifyContent="space-between"
                 gap="size-100"
               >
-                <Text fontFamily="mono" color="text-500">
-                  {paddedIndex}
-                </Text>
-                <Text color="text-700" size="XS">
-                  {fullTimeFormatter(new Date(row.rootSpan.startTime))}
-                </Text>
+                <Flex
+                  direction="row"
+                  alignItems="center"
+                  gap="size-75"
+                  flex={1}
+                  minWidth={0}
+                >
+                  <Text fontFamily="mono" color="text-500">
+                    {paddedIndex}
+                  </Text>
+                  <Truncate maxWidth="100%" title={row.rootSpan.name}>
+                    <Text weight="heavy" size="S">
+                      {row.rootSpan.name}
+                    </Text>
+                  </Truncate>
+                </Flex>
+                <Flex flexShrink={0}>
+                  <Text color="text-700" size="XS">
+                    {fullTimeFormatter(new Date(row.rootSpan.startTime))}
+                  </Text>
+                </Flex>
               </Flex>
-              <Flex direction="row" gap="size-200" alignItems="start">
-                <Flex direction="column" gap="size-100" flex={1} minWidth={0}>
-                  <Flex minWidth={0}>
-                    <Truncate maxWidth="100%" title={row.rootSpan.name}>
-                      <Text weight="heavy">{row.rootSpan.name}</Text>
-                    </Truncate>
-                  </Flex>
-                  <Flex direction="row" gap="size-100" alignItems="center" wrap>
-                    <TokenCount size="S">
-                      {row.rootSpan.cumulativeTokenCountTotal ?? 0}
-                    </TokenCount>
-                    {row.rootSpan.trace.costSummary?.total?.cost != null ? (
-                      <TokenCosts size="S">
-                        {row.rootSpan.trace.costSummary.total.cost}
-                      </TokenCosts>
-                    ) : null}
-                    {row.rootSpan.latencyMs != null ? (
-                      <LatencyText
-                        latencyMs={row.rootSpan.latencyMs}
-                        size="S"
-                      />
-                    ) : null}
-                  </Flex>
-                </Flex>
-                <Flex direction="column" gap="size-50" flex={1} minWidth={0}>
-                  <RootSpanPreviewLine
-                    value={row.rootSpan.input?.truncatedValue}
-                  />
-                  <RootSpanPreviewLine
-                    value={row.rootSpan.output?.truncatedValue}
-                  />
-                </Flex>
+              <Flex direction="column" gap="size-50" minWidth={0}>
+                <RootSpanPreviewLine
+                  value={row.rootSpan.input?.truncatedValue}
+                />
+                <RootSpanPreviewLine
+                  value={row.rootSpan.output?.truncatedValue}
+                />
+              </Flex>
+              <Flex direction="row" gap="size-100" alignItems="center" wrap>
+                <TokenCount size="S">
+                  {row.rootSpan.cumulativeTokenCountTotal ?? 0}
+                </TokenCount>
+                {row.rootSpan.trace.costSummary?.total?.cost != null ? (
+                  <TokenCosts size="S">
+                    {row.rootSpan.trace.costSummary.total.cost}
+                  </TokenCosts>
+                ) : null}
+                {row.rootSpan.latencyMs != null ? (
+                  <LatencyText latencyMs={row.rootSpan.latencyMs} size="S" />
+                ) : null}
               </Flex>
             </Flex>
           </ListBoxItem>
@@ -632,7 +635,13 @@ export function SessionDetailsTraceList({
                 borderBottomWidth="thin"
                 padding="size-200"
               >
-                <SessionTurnDetail traceId={traceId} rootSpan={rootSpan} />
+                <View
+                  width="100%"
+                  maxWidth="var(--global-dimension-size-8500)"
+                  marginX="auto"
+                >
+                  <SessionTurnDetail traceId={traceId} rootSpan={rootSpan} />
+                </View>
               </View>
             </div>
           ))}
@@ -642,7 +651,13 @@ export function SessionDetailsTraceList({
               borderBottomWidth={"thin"}
               padding="size-200"
             >
-              <Loading />
+              <View
+                width="100%"
+                maxWidth="var(--global-dimension-size-8500)"
+                marginX="auto"
+              >
+                <Loading />
+              </View>
             </View>
           )}
         </div>

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -14,7 +14,7 @@ import {
   Flex,
   Icon,
   Icons,
-  Link,
+  LinkButton,
   ListBox,
   ListBoxItem,
   Loading,
@@ -144,7 +144,7 @@ function RootSpanStartTime({ rootSpan }: RootSpanProps) {
   );
 }
 
-function RootSpanOutputHeader({
+function RootSpanTraceLink({
   traceId,
   rootSpan,
 }: RootSpanProps & { traceId: string }) {
@@ -152,7 +152,10 @@ function RootSpanOutputHeader({
 
   return (
     <Flex direction="row" justifyContent="end">
-      <Link
+      <LinkButton
+        size="S"
+        variant="quiet"
+        leadingVisual={<Icon svg={<Icons.Trace />} />}
         to={getSessionTraceUrl({
           pathname: location.pathname,
           search: location.search,
@@ -160,48 +163,50 @@ function RootSpanOutputHeader({
           spanNodeId: rootSpan.id,
         })}
       >
-        <Flex alignItems="center">
-          View Trace
-          <Icon svg={<Icons.ArrowIosForwardOutline />} />
-        </Flex>
-      </Link>
+        Trace
+      </LinkButton>
     </Flex>
   );
 }
 
 function RootSpanOutputMetadata({ rootSpan }: RootSpanProps) {
   return (
-    <Flex
-      direction="row"
-      justifyContent="space-between"
-      alignItems="center"
-      gap="size-200"
-      wrap
-    >
-      <Flex direction="row" alignItems="center" gap="size-100" wrap>
-        <SpanCumulativeTokenCount
-          tokenCountTotal={rootSpan.cumulativeTokenCountTotal || 0}
-          nodeId={rootSpan.id}
-        />
-        {rootSpan.trace.costSummary?.total?.cost != null && (
-          <TraceTokenCosts
-            totalCost={rootSpan.trace.costSummary.total.cost}
-            nodeId={rootSpan.trace.id}
+    <Flex direction="column" gap="size-100">
+      <Flex
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        gap="size-200"
+        wrap
+      >
+        <Flex direction="row" alignItems="center" gap="size-100" wrap>
+          <SpanCumulativeTokenCount
+            tokenCountTotal={rootSpan.cumulativeTokenCountTotal || 0}
+            nodeId={rootSpan.id}
           />
-        )}
-        {rootSpan.latencyMs != null ? (
-          <LatencyText latencyMs={rootSpan.latencyMs} />
-        ) : null}
-        <AnnotationSummaryGroupTokens span={rootSpan} />
+          {rootSpan.trace.costSummary?.total?.cost != null && (
+            <TraceTokenCosts
+              totalCost={rootSpan.trace.costSummary.total.cost}
+              nodeId={rootSpan.trace.id}
+            />
+          )}
+          {rootSpan.latencyMs != null ? (
+            <LatencyText latencyMs={rootSpan.latencyMs} />
+          ) : null}
+        </Flex>
+        <span>
+          <EditSpanAnnotationsButton
+            size="S"
+            spanNodeId={rootSpan.id}
+            projectId={rootSpan.project.id}
+            buttonText="Annotate"
+          />
+        </span>
       </Flex>
-      <span>
-        <EditSpanAnnotationsButton
-          size="S"
-          spanNodeId={rootSpan.id}
-          projectId={rootSpan.project.id}
-          buttonText="Annotate"
-        />
-      </span>
+      <AnnotationSummaryGroupTokens
+        span={rootSpan}
+        renderEmptyState={() => null}
+      />
     </Flex>
   );
 }
@@ -224,7 +229,7 @@ function SessionTurnDetail({
         <RootSpanStartTime rootSpan={rootSpan} />
       </Flex>
       <Flex direction="column" gap="size-100">
-        <RootSpanOutputHeader traceId={traceId} rootSpan={rootSpan} />
+        <RootSpanTraceLink traceId={traceId} rootSpan={rootSpan} />
         <RootSpanMessage role="AI" value={rootSpan.output?.value} />
         <RootSpanOutputMetadata rootSpan={rootSpan} />
       </Flex>

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -7,6 +7,12 @@ import { isNumber, isString, throttle } from "lodash";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { PreloadedQuery } from "react-relay";
 import { graphql, usePaginationFragment, usePreloadedQuery } from "react-relay";
+import {
+  Group,
+  Panel,
+  Separator,
+  useDefaultLayout,
+} from "react-resizable-panels";
 import type { To } from "react-router";
 import { useLocation, useSearchParams } from "react-router";
 
@@ -24,6 +30,7 @@ import {
 } from "@phoenix/components";
 import { AnnotationSummaryGroupTokens } from "@phoenix/components/annotation/AnnotationSummaryGroup";
 import { DynamicContent } from "@phoenix/components/DynamicContent";
+import { compactResizeHandleCSS } from "@phoenix/components/resize";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanCumulativeTokenCount } from "@phoenix/components/trace/SpanCumulativeTokenCount";
 import { TokenCosts } from "@phoenix/components/trace/TokenCosts";
@@ -367,26 +374,6 @@ const panelContentCSS = css`
   overflow: hidden;
 `;
 
-const turnsViewCSS = css`
-  flex: 1 1 auto;
-  min-height: 0;
-  display: grid;
-  grid-template-columns: minmax(220px, 28%) minmax(0, 1fr);
-  overflow: hidden;
-`;
-
-const turnsListPanelCSS = css`
-  min-width: 0;
-  border-right: 1px solid var(--global-border-color-default);
-  overflow: hidden;
-`;
-
-const turnDetailsPanelCSS = css`
-  min-width: 0;
-  height: 100%;
-  overflow: auto;
-`;
-
 export function SessionDetailsTraceList({
   queryRef,
   sessionView,
@@ -491,6 +478,11 @@ export function SessionDetailsTraceList({
   );
 
   const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: "session-details-layout",
+    panelIds: ["session-turns", "session-turn-details"],
+    storage: localStorage,
+  });
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedTraceId = searchParams.get(SELECTED_TRACE_ID_PARAM);
 
@@ -541,8 +533,16 @@ export function SessionDetailsTraceList({
   );
 
   return (
-    <div css={turnsViewCSS}>
-      <div css={turnsListPanelCSS}>
+    <Group
+      orientation="horizontal"
+      defaultLayout={defaultLayout}
+      onLayoutChanged={onLayoutChanged}
+      css={css`
+        flex: 1 1 auto;
+        overflow: hidden;
+      `}
+    >
+      <Panel id="session-turns" defaultSize="20%" minSize="10%">
         <div css={panelContentCSS}>
           <SessionViewTabs
             sessionView={sessionView}
@@ -552,45 +552,51 @@ export function SessionDetailsTraceList({
             {turnListPanel}
           </SessionViewTabs>
         </div>
-      </div>
-      <div
-        css={turnDetailsPanelCSS}
-        onScroll={(e) =>
-          debouncedFetchMoreOnBottomReached(e.target as HTMLDivElement)
-        }
-      >
-        {sessionRootSpans.map(({ traceId, rootSpan }) => (
-          <div
-            key={rootSpan.spanId}
-            css={turnDetailRowCSS}
-            data-selected={traceId === selectedTraceId || undefined}
-            ref={(el) => {
-              if (el) {
-                rowRefs.current.set(traceId, el);
-              } else {
-                rowRefs.current.delete(traceId);
-              }
-            }}
-          >
+      </Panel>
+      <Separator css={compactResizeHandleCSS} />
+      <Panel id="session-turn-details">
+        <div
+          css={css`
+            height: 100%;
+            overflow: auto;
+          `}
+          onScroll={(e) =>
+            debouncedFetchMoreOnBottomReached(e.target as HTMLDivElement)
+          }
+        >
+          {sessionRootSpans.map(({ traceId, rootSpan }) => (
+            <div
+              key={rootSpan.spanId}
+              css={turnDetailRowCSS}
+              data-selected={traceId === selectedTraceId || undefined}
+              ref={(el) => {
+                if (el) {
+                  rowRefs.current.set(traceId, el);
+                } else {
+                  rowRefs.current.delete(traceId);
+                }
+              }}
+            >
+              <View
+                borderBottomColor="default"
+                borderBottomWidth="thin"
+                padding="size-200"
+              >
+                <SessionTurnDetail traceId={traceId} rootSpan={rootSpan} />
+              </View>
+            </div>
+          ))}
+          {isLoadingNext && (
             <View
               borderBottomColor="default"
-              borderBottomWidth="thin"
+              borderBottomWidth={"thin"}
               padding="size-200"
             >
-              <SessionTurnDetail traceId={traceId} rootSpan={rootSpan} />
+              <Loading />
             </View>
-          </div>
-        ))}
-        {isLoadingNext && (
-          <View
-            borderBottomColor="default"
-            borderBottomWidth={"thin"}
-            padding="size-200"
-          >
-            <Loading />
-          </View>
-        )}
-      </div>
-    </div>
+          )}
+        </div>
+      </Panel>
+    </Group>
   );
 }

--- a/app/src/pages/trace/__generated__/SessionDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<45acb1c17ddb3721e3e1286eb25cf103>>
+ * @generated SignedSource<<62f53d5ca9bed89ae99dd0010cb4bf2f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type SessionDetailsQuery$variables = {
   id: string;
 };
@@ -34,6 +35,7 @@ export type SessionDetailsQuery$data = {
     readonly tokenUsage?: {
       readonly total: number;
     };
+    readonly " $fragmentSpreads": FragmentRefs<"SessionAnnotationSummaryGroup">;
   };
 };
 export type SessionDetailsQuery = {
@@ -56,7 +58,32 @@ v1 = [
     "variableName": "id"
   }
 ],
-v2 = [
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "numTraces",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "TokenUsage",
+  "kind": "LinkedField",
+  "name": "tokenUsage",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "total",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v4 = [
   {
     "alias": null,
     "args": null,
@@ -72,98 +99,101 @@ v2 = [
     "storageKey": null
   }
 ],
-v3 = {
-  "kind": "InlineFragment",
+v5 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "SpanCostSummary",
+  "kind": "LinkedField",
+  "name": "costSummary",
+  "plural": false,
   "selections": [
     {
       "alias": null,
       "args": null,
-      "kind": "ScalarField",
-      "name": "numTraces",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "TokenUsage",
+      "concreteType": "CostBreakdown",
       "kind": "LinkedField",
-      "name": "tokenUsage",
+      "name": "total",
       "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "total",
-          "storageKey": null
-        }
-      ],
+      "selections": (v4/*: any*/),
       "storageKey": null
     },
     {
       "alias": null,
       "args": null,
-      "concreteType": "SpanCostSummary",
+      "concreteType": "CostBreakdown",
       "kind": "LinkedField",
-      "name": "costSummary",
+      "name": "prompt",
       "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "CostBreakdown",
-          "kind": "LinkedField",
-          "name": "total",
-          "plural": false,
-          "selections": (v2/*: any*/),
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "CostBreakdown",
-          "kind": "LinkedField",
-          "name": "prompt",
-          "plural": false,
-          "selections": (v2/*: any*/),
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "CostBreakdown",
-          "kind": "LinkedField",
-          "name": "completion",
-          "plural": false,
-          "selections": (v2/*: any*/),
-          "storageKey": null
-        }
-      ],
+      "selections": (v4/*: any*/),
       "storageKey": null
     },
     {
       "alias": null,
       "args": null,
-      "kind": "ScalarField",
-      "name": "sessionId",
+      "concreteType": "CostBreakdown",
+      "kind": "LinkedField",
+      "name": "completion",
+      "plural": false,
+      "selections": (v4/*: any*/),
       "storageKey": null
-    },
-    {
-      "alias": "latencyP50",
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "probability",
-          "value": 0.5
-        }
-      ],
-      "kind": "ScalarField",
-      "name": "traceLatencyMsQuantile",
-      "storageKey": "traceLatencyMsQuantile(probability:0.5)"
     }
   ],
-  "type": "ProjectSession",
-  "abstractKey": null
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "sessionId",
+  "storageKey": null
+},
+v7 = {
+  "alias": "latencyP50",
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "probability",
+      "value": 0.5
+    }
+  ],
+  "kind": "ScalarField",
+  "name": "traceLatencyMsQuantile",
+  "storageKey": "traceLatencyMsQuantile(probability:0.5)"
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "score",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -180,7 +210,23 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v3/*: any*/)
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "SessionAnnotationSummaryGroup"
+              }
+            ],
+            "type": "ProjectSession",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
@@ -202,37 +248,219 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
+          (v8/*: any*/),
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Project",
+                "kind": "LinkedField",
+                "name": "project",
+                "plural": false,
+                "selections": [
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigConnection",
+                    "kind": "LinkedField",
+                    "name": "annotationConfigs",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "AnnotationConfigEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": null,
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v8/*: any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "annotationType",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "AnnotationConfigBase",
+                                "abstractKey": "__isAnnotationConfigBase"
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v9/*: any*/),
+                                  (v10/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "optimizationDirection",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "CategoricalAnnotationValue",
+                                    "kind": "LinkedField",
+                                    "name": "values",
+                                    "plural": true,
+                                    "selections": [
+                                      (v11/*: any*/),
+                                      (v12/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "CategoricalAnnotationConfig",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v9/*: any*/)
+                                ],
+                                "type": "Node",
+                                "abstractKey": "__isNode"
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ProjectSessionAnnotation",
+                "kind": "LinkedField",
+                "name": "sessionAnnotations",
+                "plural": true,
+                "selections": [
+                  (v9/*: any*/),
+                  (v10/*: any*/),
+                  (v11/*: any*/),
+                  (v12/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "annotatorKind",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "user",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "username",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "profilePictureUrl",
+                        "storageKey": null
+                      },
+                      (v9/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AnnotationSummary",
+                "kind": "LinkedField",
+                "name": "sessionAnnotationSummaries",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "LabelFraction",
+                    "kind": "LinkedField",
+                    "name": "labelFractions",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "fraction",
+                        "storageKey": null
+                      },
+                      (v11/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "meanScore",
+                    "storageKey": null
+                  },
+                  (v10/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "ProjectSession",
+            "abstractKey": null
           },
-          (v3/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v9/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "df5f2c77d477ebcaab60db728e116a62",
+    "cacheID": "ad7b02326890779ca659cbd2cfc9f519",
     "id": null,
     "metadata": {},
     "name": "SessionDetailsQuery",
     "operationKind": "query",
-    "text": "query SessionDetailsQuery(\n  $id: ID!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      numTraces\n      tokenUsage {\n        total\n      }\n      costSummary {\n        total {\n          cost\n          tokens\n        }\n        prompt {\n          cost\n          tokens\n        }\n        completion {\n          cost\n          tokens\n        }\n      }\n      sessionId\n      latencyP50: traceLatencyMsQuantile(probability: 0.5)\n    }\n    id\n  }\n}\n"
+    "text": "query SessionDetailsQuery(\n  $id: ID!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      numTraces\n      tokenUsage {\n        total\n      }\n      costSummary {\n        total {\n          cost\n          tokens\n        }\n        prompt {\n          cost\n          tokens\n        }\n        completion {\n          cost\n          tokens\n        }\n      }\n      sessionId\n      latencyP50: traceLatencyMsQuantile(probability: 0.5)\n      ...SessionAnnotationSummaryGroup\n    }\n    id\n  }\n}\n\nfragment SessionAnnotationSummaryGroup on ProjectSession {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  sessionAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  sessionAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "003bfef919872d11be6d21c5837dcee4";
+(node as any).hash = "cedc9ac0855e1b1ca9361fef4c69f6c5";
 
 export default node;

--- a/app/src/pages/trace/__generated__/SessionDetailsTraceListQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsTraceListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9b0ff6270d79b22f9d6d71551d88a462>>
+ * @generated SignedSource<<de1b9fef1c78275cf587a5e96be0a898>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -90,6 +90,13 @@ v9 = [
     "args": null,
     "kind": "ScalarField",
     "name": "value",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "truncatedValue",
     "storageKey": null
   },
   {
@@ -570,12 +577,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5d15692b4a4e4ba52e74667c2717a9fb",
+    "cacheID": "9f82284161ce916a8334bfbe7eea414a",
     "id": null,
     "metadata": {},
     "name": "SessionDetailsTraceListQuery",
     "operationKind": "query",
-    "text": "query SessionDetailsTraceListQuery(\n  $id: ID!\n  $first: Int!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      ...SessionDetailsTraceList_traces_3ASum4\n    }\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_3ASum4 on ProjectSession {\n  numTraces\n  traces(first: $first) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          trace {\n            id\n            costSummary {\n              total {\n                cost\n              }\n            }\n          }\n          id\n          name\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            mimeType\n          }\n          output {\n            value\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query SessionDetailsTraceListQuery(\n  $id: ID!\n  $first: Int!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      ...SessionDetailsTraceList_traces_3ASum4\n    }\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_3ASum4 on ProjectSession {\n  numTraces\n  traces(first: $first) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          trace {\n            id\n            costSummary {\n              total {\n                cost\n              }\n            }\n          }\n          id\n          name\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            truncatedValue\n            mimeType\n          }\n          output {\n            value\n            truncatedValue\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/app/src/pages/trace/__generated__/SessionDetailsTraceListRefetchQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsTraceListRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<297e648009bbb0433832cac469186188>>
+ * @generated SignedSource<<236de2b9fab524db77027c1051be9a04>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -103,6 +103,13 @@ v8 = [
     "args": null,
     "kind": "ScalarField",
     "name": "value",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "truncatedValue",
     "storageKey": null
   },
   {
@@ -570,16 +577,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "04e5809fa468803809de8e257597b4bd",
+    "cacheID": "86ce0cadcd8157074d1732fd836ebadf",
     "id": null,
     "metadata": {},
     "name": "SessionDetailsTraceListRefetchQuery",
     "operationKind": "query",
-    "text": "query SessionDetailsTraceListRefetchQuery(\n  $after: String = null\n  $first: Int = 50\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionDetailsTraceList_traces_2HEEH6\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_2HEEH6 on ProjectSession {\n  numTraces\n  traces(first: $first, after: $after) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          trace {\n            id\n            costSummary {\n              total {\n                cost\n              }\n            }\n          }\n          id\n          name\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            mimeType\n          }\n          output {\n            value\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query SessionDetailsTraceListRefetchQuery(\n  $after: String = null\n  $first: Int = 50\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionDetailsTraceList_traces_2HEEH6\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_2HEEH6 on ProjectSession {\n  numTraces\n  traces(first: $first, after: $after) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          trace {\n            id\n            costSummary {\n              total {\n                cost\n              }\n            }\n          }\n          id\n          name\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            truncatedValue\n            mimeType\n          }\n          output {\n            value\n            truncatedValue\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a8c766a3e99780c2b1c0d17747eb5bfb";
+(node as any).hash = "78d860d4c19b7111632899f55e7da5fc";
 
 export default node;

--- a/app/src/pages/trace/__generated__/SessionDetailsTraceList_traces.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsTraceList_traces.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<14ef3a15ef3943ee204ad28dc999ced8>>
+ * @generated SignedSource<<34f653fb4eae908a5000f3e5a49cac71>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -24,12 +24,14 @@ export type SessionDetailsTraceList_traces$data = {
           readonly id: string;
           readonly input: {
             readonly mimeType: MimeType;
+            readonly truncatedValue: string;
             readonly value: string;
           } | null;
           readonly latencyMs: number | null;
           readonly name: string;
           readonly output: {
             readonly mimeType: MimeType;
+            readonly truncatedValue: string;
             readonly value: string;
           } | null;
           readonly project: {
@@ -77,6 +79,13 @@ v2 = [
     "args": null,
     "kind": "ScalarField",
     "name": "value",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "truncatedValue",
     "storageKey": null
   },
   {
@@ -368,6 +377,6 @@ return {
 };
 })();
 
-(node as any).hash = "a8c766a3e99780c2b1c0d17747eb5bfb";
+(node as any).hash = "78d860d4c19b7111632899f55e7da5fc";
 
 export default node;


### PR DESCRIPTION
## Summary
- Refactor the Session Details `Turns` tab so each turn renders as a single middle-detail row without the per-turn right pane.
- Move turn metadata into the turn detail row: timestamp under the input, Trace navigation above the output, and token/cost/latency plus annotations below the output.
- Update the turn list with index-first rows and truncated input/output previews.
- Remove the aggregate traces count from the session header and show session annotation summaries alongside aggregate token, cost, and latency metrics.

## Screenshots
<img width="1717" height="874" alt="image" src="https://github.com/user-attachments/assets/543507b0-dcaf-4081-826a-9d40e84cab17" />


## Test plan
- `cd app && pnpm run lint -- src/pages/trace/SessionDetails.tsx src/pages/trace/SessionDetailsTraceList.tsx`
- `cd app && pnpm run typecheck`
- Browser-tested the local `codex-realistic-ai-session-20260505` session on `localhost:6006`.

Closes #12875