### PR TITLE
docs: disable sidebar drilldown navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -13,6 +13,9 @@
   "background": {
     "decoration": "gradient"
   },
+  "interaction": {
+    "drilldown": false
+  },
   "fonts": {
     "heading": {
       "family": "Roboto"


### PR DESCRIPTION
**Before:** Opening a sidebar section dropdown immediately navigates the user to the first page in that section.

**After:** Opening a sidebar section dropdown shows the contents but keeps the user on their current page.

This prevents readers (especially mid-tutorial) from being unexpectedly redirected.

### Change
  3-line addition to `docs.json` enabling Mintlify's `interaction.drilldown: false`.