### PR TITLE
docs: Add Phoenix release notes for 05-05-2026

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1184,6 +1184,8 @@
               {
                 "group": "05.2026",
                 "pages": [
+                  "docs/phoenix/release-notes/05-2026/05-05-2026-vendor-provider-tools",
+                  "docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-improvements",
                   "docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing"
                 ]
               },

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -7,6 +7,30 @@ description: The latest from the Phoenix team.
 GitHub
 </Card>
 
+<Update label="05.05.2026">
+## [05.05.2026: Provider Tools](/docs/phoenix/release-notes/05-2026/05-05-2026-vendor-provider-tools)
+**Available in arize-phoenix 15.4.0+**
+
+Phoenix prompts now support **provider tools** — built-in, vendor-hosted capabilities like web search, file search, code execution, computer use, and grounding. Paste the provider's tool JSON into the Playground and Phoenix forwards it verbatim to the underlying model.
+
+- **Anthropic** — `web_search`, `web_fetch`, `code_execution`, `tool_search_tool`, `bash`, `text_editor`, `computer`, `memory`
+- **OpenAI Responses API** — `web_search`, `file_search`, `code_interpreter`, `computer`, `tool_search`
+- **Google Gemini** — `google_search` grounding
+- **Amazon Bedrock** — Nova `nova_grounding`
+- **Round-trip preservation** — provider tools survive storage, GraphQL, and SDK export untouched
+</Update>
+
+<Update label="05.05.2026">
+## [05.05.2026: REST API Improvements](/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-improvements)
+**Available in arize-phoenix 15.4.0+**
+
+Cumulative token counts now appear directly on trace and session payloads, and three new filter-based DELETE endpoints close the rollback loop for annotation cleanup.
+
+- **Token counts** — `token_count_prompt`, `token_count_completion`, `token_count_total` on `/traces` and `/sessions`
+- **Bulk delete annotations** — `DELETE /v1/projects/{id}/{span,trace,session}_annotations` with filters by `name`, `identifier`, `annotator_kind`, and time window
+- **Safety guard** — every delete request must supply a bounded time window or set `delete_all=true`
+</Update>
+
 <Update label="05.01.2026">
 ## [05.01.2026: TanStack AI Tracing](/docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing)
 **Available in @arizeai/openinference-tanstack-ai 0.1.0+**

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -27,7 +27,7 @@ Phoenix prompts now support **provider tools** — built-in, vendor-hosted capab
 Cumulative token counts now appear directly on trace and session payloads, and three new filter-based DELETE endpoints close the rollback loop for annotation cleanup.
 
 - **Token counts** — `token_count_prompt`, `token_count_completion`, `token_count_total` on `/traces` and `/sessions`
-- **Bulk delete annotations** — `DELETE /v1/projects/{id}/{span,trace,session}_annotations` with filters by `name`, `identifier`, `annotator_kind`, and time window
+- **Bulk delete annotations** — `DELETE /v1/projects/{project_identifier}/{span,trace,session}_annotations` with filters by `name`, `identifier`, `annotator_kind`, and time window
 - **Safety guard** — every delete request must supply a bounded time window or set `delete_all=true`
 </Update>
 

--- a/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-improvements.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-improvements.mdx
@@ -1,0 +1,78 @@
+---
+title: "05.05.2026 REST API Improvements"
+description: "Cumulative token counts on trace and session payloads, plus filter-based bulk DELETE for annotations."
+---
+
+# Token Counts in Trace and Session Payloads
+
+May 5, 2026
+
+**Available in arize-phoenix 15.4.0+**
+
+Trace and session REST responses now include cumulative token usage directly in the payload, so external clients can read aggregate consumption without falling back to GraphQL or recomputing from raw OpenInference attributes.
+
+Three new integer fields are returned on every trace and session:
+
+- **`token_count_prompt`** — cumulative prompt tokens across all spans
+- **`token_count_completion`** — cumulative completion tokens across all spans
+- **`token_count_total`** — derived sum of prompt and completion
+
+```python
+from phoenix.client import Client
+
+client = Client()
+traces = client.traces.get_traces(project_identifier="my-project")
+for trace in traces:
+    print(trace["trace_id"], trace["token_count_prompt"], trace["token_count_completion"])
+```
+
+```typescript
+import { createClient } from "@arizeai/phoenix-client";
+import { getTraces } from "@arizeai/phoenix-client/traces";
+
+const client = createClient();
+const { traces } = await getTraces({ client, project: "my-project" });
+
+for (const trace of traces) {
+  console.log(trace.trace_id, trace.token_count_prompt, trace.token_count_completion);
+}
+```
+
+The `/spans` endpoint is unchanged — per-span token counts continue to surface under `attributes["llm.token_count.prompt"]` and `attributes["llm.token_count.completion"]`.
+
+# Bulk Delete Annotations by Filter
+
+May 5, 2026
+
+**Available in arize-phoenix 15.4.0+**
+
+Three new project-scoped DELETE endpoints remove annotations matching an explicit filter set — closing the rollback loop for callers that tag their annotations with a custom `identifier` on creation.
+
+| Method | Path |
+|---|---|
+| DELETE | `/v1/projects/{project_identifier}/span_annotations` |
+| DELETE | `/v1/projects/{project_identifier}/trace_annotations` |
+| DELETE | `/v1/projects/{project_identifier}/session_annotations` |
+
+Filter by any combination of `name`, `identifier`, `annotator_kind`, and a `[start_time, end_time)` window. To prevent accidental unbounded sweeps, every request must satisfy a guard:
+
+- Either supply both `start_time` and `end_time` (bounded window), **or**
+- Set `delete_all=true` to explicitly opt into an unbounded sweep
+
+Half-bounded ranges and naked filter-only requests are rejected with 422.
+
+```bash
+# Delete all annotations created by an evaluator within a time window
+curl -X DELETE "https://phoenix.example.com/v1/projects/my-project/span_annotations?identifier=eval-run-42&start_time=2026-05-01T00:00:00Z&end_time=2026-05-05T00:00:00Z" \
+  -H "Authorization: Bearer $PHOENIX_API_KEY"
+```
+
+- **Idempotent** — zero matches returns `204 No Content`, same as a successful delete
+- **Project-scoped** — every query carries a parent-FK predicate, so rows in other projects are unreachable
+- **Auth-aware** — non-admin callers under authentication only delete annotations they own; admins delete all matching rows
+
+<CardGroup cols={2}>
+  <Card title="REST API Reference" icon="code" href="/docs/phoenix/sdk-api-reference/rest-api">
+    Full endpoint catalog and parameter details.
+  </Card>
+</CardGroup>

--- a/docs/phoenix/release-notes/05-2026/05-05-2026-vendor-provider-tools.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-05-2026-vendor-provider-tools.mdx
@@ -1,0 +1,57 @@
+---
+title: "05.05.2026 Provider Tools"
+description: "Attach built-in, vendor-hosted tools — web search, file search, code execution, grounding — to any Phoenix prompt."
+---
+
+**Available in arize-phoenix 15.4.0+**
+
+Phoenix prompts now support **provider tools**: built-in capabilities the model vendor hosts itself. Paste the provider's tool JSON into the Playground tool editor and Phoenix forwards it verbatim through storage, GraphQL, and SDK export — so the prompt runs against the underlying provider exactly as defined. Function tools and provider tools can be mixed on the same prompt version.
+
+<Frame>
+  <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/provider_tools.png" alt="Phoenix Playground side-by-side comparison: gemini-2.5-flash-lite answering 'Who won Euro 2024?' with google_search grounding (Spain beat England 2-1) versus without (model says the tournament hasn't been played yet)" />
+</Frame>
+
+## Supported providers
+
+- **Anthropic** — `web_search`, `web_fetch`, `code_execution`, `tool_search_tool`, `bash`, `text_editor`, `computer`, `memory`
+- **OpenAI Responses API** — `web_search`, `file_search`, `code_interpreter`, `computer`, `tool_search`
+- **Google Gemini** — `google_search` grounding
+- **Amazon Bedrock** — Nova `nova_grounding`
+
+## Adding a provider tool
+
+In the Playground, click **Add tool** and paste the provider's JSON. For example, Anthropic web search:
+
+```json
+{
+  "type": "web_search_20250305",
+  "name": "web_search",
+  "max_uses": 5
+}
+```
+
+Or Google Gemini grounding:
+
+```json
+{
+  "google_search": {}
+}
+```
+
+On save, Phoenix inspects the JSON: function-tool shapes are stored as function tools; everything else is preserved as a raw provider tool.
+
+## Behavior
+
+- **Provider switching drops provider tools** — provider-specific JSON does not translate across vendors. Function tools survive provider changes.
+- **"Open in Playground" replays exactly** — captured traces preserve the original tool payload.
+- **SDK round-trip** — `@arizeai/phoenix-client` and `arize-phoenix-client` preserve provider tools when exporting prompts to OpenAI, Anthropic, and AI SDK shapes.
+- **Evaluator output tools remain function tools.**
+
+<CardGroup cols={2}>
+  <Card title="Use Provider Tools" icon="book" href="/docs/phoenix/prompt-engineering/how-to-prompts/use-provider-tools">
+    Per-provider JSON shapes, source-of-truth links, and Playground walkthrough.
+  </Card>
+  <Card title="Prompts Concepts" icon="lightbulb" href="/docs/phoenix/prompt-engineering/concepts-prompts/prompts-concepts">
+    How function tools and provider tools fit into the Phoenix prompt model.
+  </Card>
+</CardGroup>

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,9 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/05-2026/05-05-2026-vendor-provider-tools" arrow="true" title="05.05.2026" icon="calendar" description="Provider tools: vendor-hosted web search, file search, code execution, and grounding for Anthropic, OpenAI, Gemini, and Bedrock"/>
+    <Card href="/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-improvements" arrow="true" title="05.05.2026" icon="calendar" description="Cumulative token counts on trace and session payloads; filter-based bulk DELETE for annotations"/>
+    <Card href="/docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing" arrow="true" title="05.01.2026" icon="calendar" description="OpenInference middleware for TanStack AI: emits AGENT, LLM, and TOOL spans for chat() calls"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api" arrow="true" title="04.28.2026" icon="calendar" description="Dedicated session notes REST API; reserve the note annotation name for session note endpoint"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-24-2026-trace-notes-api" arrow="true" title="04.24.2026" icon="calendar" description="Trace notes via REST, TypeScript client, and CLI; px trace add-note command"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id" arrow="true" title="04.22.2026" icon="calendar" description="Secrets settings page in Phoenix UI; trace_id parameter in experiment evaluators"/>


### PR DESCRIPTION
## Summary

- **05.05.2026 Provider Tools** (new): Phoenix prompts now support vendor-hosted built-in tools — web search, file search, code execution, computer use, and grounding — for Anthropic, OpenAI Responses API, Google Gemini, and Amazon Bedrock (`arize-phoenix 15.4.0+`)
- **05.05.2026 REST API Improvements** (new): Cumulative `token_count_prompt` / `_completion` / `_total` fields on trace and session payloads; three filter-based DELETE endpoints for span/trace/session annotations (`arize-phoenix 15.4.0+`)
- Wired both entries into `release-notes.mdx`, `2026.mdx`, and `docs.json`
- Also back-filled the missing 05-01-2026 TanStack card in `2026.mdx` (gap from #12984)

## Test plan

- [ ] Verify MDX files render correctly in Mintlify preview
- [ ] Confirm all internal links resolve (no `.mdx` extensions, paths match files)
- [ ] Check reverse-chronological order in aggregate file and year overview
- [ ] Confirm provider-tools image loads from GCS

🤖 Generated with [Claude Code](https://claude.com/claude-code)