### PR TITLE
ci: retarget experimental Docker workflow to version-sandboxes

### DIFF
--- a/.github/workflows/docker-build-experimental.yml
+++ b/.github/workflows/docker-build-experimental.yml
@@ -4,7 +4,7 @@ permissions:
 on:
   push:
     branches:
-      - feat/version-12
+      - version-sandboxes
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
Update `.github/workflows/docker-build-experimental.yml` to build off of version-sandboxes