### PR TITLE
docs: Add Phoenix release notes for 04-29-2026 through 05-05-2026

### DIFF
--- a/.agents/skills/phoenix-release-notes/SKILL.md
+++ b/.agents/skills/phoenix-release-notes/SKILL.md
@@ -138,13 +138,32 @@ docs/phoenix/release-notes/{MM-YYYY}/{MM-DD-YYYY}-{slug-title}.mdx
 
 Create the month directory if it doesn't exist: `mkdir -p docs/phoenix/release-notes/MM-YYYY`
 
+### Frontmatter title rules (apply to BOTH formats)
+
+Every release note MDX file — single-topic or multi-topic — **must** have a descriptive,
+date-prefixed `title` in its frontmatter. The title appears in browser tabs, the sidebar,
+and search results, so a generic `"Release Notes"` makes the page indistinguishable from
+the index page.
+
+Required format: `title: "MM.DD.YYYY: Descriptive Title"`
+
+- ✅ `title: "04.29.2026: Dataset Upsert"`
+- ✅ `title: "05.05.2026: REST API Updates"`
+- ✅ `title: "04.30.2026: Annotation Enhancements"`
+- ❌ `title: "Release Notes"` — never use this; it collides with the index page
+- ❌ `title: "Dataset Upsert"` — missing the date prefix
+- ❌ `title: "04.29.2026 Dataset Upsert"` — missing the colon separator
+
+For multi-topic files, the title summarizes the theme of the bundle (e.g.
+`"04.30.2026: Annotation Enhancements"`), not any single feature inside it.
+
 ### Format A: Single-topic file
 
 Use when one feature is significant enough to warrant its own page.
 
 ```mdx
 ---
-title: "MM.DD.YYYY Feature Title"
+title: "MM.DD.YYYY: Feature Title"
 description: "One-sentence description of the feature."
 ---
 
@@ -172,11 +191,13 @@ Introductory paragraph explaining what users can now do.
 
 ### Format B: Multi-topic file
 
-Use when several features from a date range are combined into one file.
+Use when several features from a date range are combined into one file. The frontmatter
+`title` still follows the `MM.DD.YYYY: Theme` rule (see "Frontmatter title rules" above) —
+**never** use `"Release Notes"`.
 
 ```mdx
 ---
-title: "Release Notes"
+title: "MM.DD.YYYY: Theme Title"
 ---
 
 # Feature Title One
@@ -228,8 +249,9 @@ Match the version line to which packages are involved:
 
 File: `docs/phoenix/release-notes.mdx`
 
-Add `<Update>` blocks at the top of the file (after the GitHub card), in reverse-chronological
-order. Each block is a condensed summary linking to the individual file.
+Insert each new `<Update>` block at the correct chronological position relative to **all**
+existing blocks — not as a contiguous group at the top. Each block is a condensed summary
+linking to the individual file.
 
 ```mdx
 <Update label="MM.DD.YYYY">
@@ -248,7 +270,35 @@ Rules:
 - Link path has no `.mdx` extension
 - Keep each block to 5-10 lines
 - If one MDX file covers multiple features, create separate `<Update>` blocks per feature date
-- Maintain strict reverse-chronological order (newest first)
+
+### Reverse-chronological insertion (do not skip this)
+
+The aggregate file is sorted strictly newest-first by date. Existing entries are already
+ordered, so inserting a batch of new entries is a **merge**, not an append.
+
+**Wrong** — stacking all new entries at the top as a contiguous block:
+
+```
+[NEW 05.05] [NEW 05.05] [NEW 04.30] [NEW 04.30] [NEW 04.29] [old 05.01] [old 04.28] ...
+                                                              ^^^^^^^^^^
+                                          older date appears AFTER newer dates — broken
+```
+
+**Right** — interleave each new entry with existing entries by date:
+
+```
+[NEW 05.05] [NEW 05.05] [old 05.01] [NEW 04.30] [NEW 04.30] [NEW 04.29] [old 04.28] ...
+```
+
+Procedure when adding multiple entries:
+
+1. List every date you are adding.
+2. Read the existing labels in order: `grep -n 'Update label=' docs/phoenix/release-notes.mdx`
+3. For **each** new entry, find the first existing label whose date is strictly older, and
+   insert the new block immediately before it. Same-date ties stay together.
+4. After inserting, re-run the grep and read the dates top-to-bottom — they must be
+   monotonically non-increasing. If any older date appears above a newer one, fix it
+   before moving on.
 
 ## Step 5: Update the Year Overview
 
@@ -349,6 +399,16 @@ grep -oP '(?<=\()/docs/phoenix/release-notes/[^)]+' docs/phoenix/release-notes.m
   file="${path}.mdx"
   [ -f "$file" ] || echo "MISSING: $file"
 done
+
+# Catch any new file that still has the generic "Release Notes" title
+grep -l '^title: "Release Notes"$' docs/phoenix/release-notes/**/*.mdx 2>/dev/null \
+  && echo "FAIL: file(s) above use the generic 'Release Notes' title — must be 'MM.DD.YYYY: ...'" \
+  || echo "OK: all per-date files have descriptive titles"
+
+# Confirm reverse-chronological order in the aggregate file
+grep -oP 'Update label="\K[\d.]+' docs/phoenix/release-notes.mdx \
+  | awk -F. '{ printf "%s%s%s\n", $3, $1, $2 }' \
+  | awk 'NR>1 && $0>prev { print "OUT OF ORDER at line " NR ": " $0 " > " prev; bad=1 } { prev=$0 } END { if (!bad) print "OK: reverse-chronological order intact" }'
 ```
 
 ## Decision Quick Reference
@@ -401,6 +461,8 @@ Every code example must be grounded in real code — no hallucinated APIs:
 ### Formatting and linting
 
 - [ ] **Valid MDX**: Each file has YAML frontmatter with at least `title`, all JSX components are properly closed
+- [ ] **Frontmatter title is date-prefixed**: `title: "MM.DD.YYYY: Descriptive Title"` — never `"Release Notes"` (which is reserved for the index page) and never missing the date prefix
+- [ ] **Aggregate order is reverse-chronological**: After inserting new entries, read the labels top-to-bottom in `release-notes.mdx`. Dates must be monotonically non-increasing — no older date ever appears above a newer one. New entries must be **interleaved** with existing ones by date, not stacked as a contiguous block at the top.
 - [ ] **No trailing whitespace or extra blank lines**
 - [ ] **Fenced code blocks have language tags**: Every ` ``` ` block specifies `python`, `typescript`, `bash`, `json`, etc.
 - [ ] **Links have no `.mdx` extension**: All internal doc links use extensionless paths

--- a/.agents/skills/phoenix-release-notes/SKILL.md
+++ b/.agents/skills/phoenix-release-notes/SKILL.md
@@ -406,9 +406,9 @@ grep -l '^title: "Release Notes"$' docs/phoenix/release-notes/**/*.mdx 2>/dev/nu
   || echo "OK: all per-date files have descriptive titles"
 
 # Confirm reverse-chronological order in the aggregate file
-grep -oP 'Update label="\K[\d.]+' docs/phoenix/release-notes.mdx \
-  | awk -F. '{ printf "%s%s%s\n", $3, $1, $2 }' \
-  | awk 'NR>1 && $0>prev { print "OUT OF ORDER at line " NR ": " $0 " > " prev; bad=1 } { prev=$0 } END { if (!bad) print "OK: reverse-chronological order intact" }'
+grep -nP 'Update label="[\d.]+' docs/phoenix/release-notes.mdx \
+  | awk -F'[:."]' '{ printf "%s %s%s%s\n", $1, $5, $3, $4 }' \
+  | awk 'NR>1 && $2>prev { print "OUT OF ORDER at release-notes.mdx:" $1 " — " $2 " appears above " prev; bad=1 } { prev=$2 } END { if (!bad) print "OK: reverse-chronological order intact" }'
 ```
 
 ## Decision Quick Reference

--- a/docs.json
+++ b/docs.json
@@ -1187,12 +1187,17 @@
               {
                 "group": "05.2026",
                 "pages": [
+                  "docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools",
+                  "docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates",
                   "docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing"
                 ]
               },
               {
                 "group": "04.2026",
                 "pages": [
+                  "docs/phoenix/release-notes/04-2026/04-30-2026-cli-auth-profiles",
+                  "docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements",
+                  "docs/phoenix/release-notes/04-2026/04-29-2026-dataset-upsert",
                   "docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api",
                   "docs/phoenix/release-notes/04-2026/04-24-2026-trace-notes-api",
                   "docs/phoenix/release-notes/04-2026/04-24-2026-phoenix-otel-python-0-16",

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -13,7 +13,7 @@ GitHub
 
 Phoenix Playground and the Prompts library now support vendor-native tools — web search, code execution, computer use, grounding, and more — alongside existing function tools. Paste any provider's tool JSON into the Playground and Phoenix stores and round-trips it verbatim.
 
-- **Supported providers** — Anthropic (`web_search`, `code_execution`, `computer`, and more), OpenAI Responses API (`web_search`, `file_search`, `code_interpreter`), Google Gemini (`google_search`), Amazon Bedrock (`nova_grounding`)
+- **Generic passthrough** — any tool the provider SDK accepts works without a library update; verified examples include Anthropic `web_search` / `code_execution` / `computer_use`, OpenAI Responses `web_search` / `file_search` / `code_interpreter` / `computer_use_preview`, and Gemini `google_search` grounding
 - **Mix with function tools** — provider tools and function tools coexist on the same prompt version
 - **SDK export** — Python and TypeScript clients preserve provider tools when formatting prompts
 </Update>

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -7,6 +7,55 @@ description: The latest from the Phoenix team.
 GitHub
 </Card>
 
+<Update label="05.05.2026">
+## [05.05.2026: Provider Tools in Playground and Prompts](/docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools)
+**Available in arize-phoenix 15.4.0+**
+
+Phoenix Playground and the Prompts library now support vendor-native tools — web search, code execution, computer use, grounding, and more — alongside existing function tools. Paste any provider's tool JSON into the Playground and Phoenix stores and round-trips it verbatim.
+
+- **Supported providers** — Anthropic (`web_search`, `code_execution`, `computer`, and more), OpenAI Responses API (`web_search`, `file_search`, `code_interpreter`), Google Gemini (`google_search`), Amazon Bedrock (`nova_grounding`)
+- **Mix with function tools** — provider tools and function tools coexist on the same prompt version
+- **SDK export** — Python and TypeScript clients preserve provider tools when formatting prompts
+</Update>
+
+<Update label="05.05.2026">
+## [05.05.2026: REST API Updates — Annotation Delete, Token Counts, and More](/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates)
+**Available in arize-phoenix 15.3.0–15.4.0+, arize-phoenix-evals 3.1.0+**
+
+- **Filter-based annotation DELETE** — `DELETE /v1/projects/{project}/span_annotations`, `trace_annotations`, and `session_annotations` bulk-remove annotations by `identifier`, `name`, `annotator_kind`, or time range
+- **Token counts in REST** — trace and session list endpoints now return `cumulative_token_count_prompt`, `_completion`, and `_total` fields
+- **Experiment CSV metadata** — downloading an experiment as CSV now includes per-example dataset metadata as `metadata_<key>` columns
+- **Evals runtime capability detection** — OpenAI reasoning models (`o1`, `o3`, `o3-mini`, `o4-mini`) now work with `ClassificationEvaluator` automatically
+</Update>
+
+<Update label="04.30.2026">
+## [04.30.2026: CLI Named Auth Profiles](/docs/phoenix/release-notes/04-2026/04-30-2026-cli-auth-profiles)
+**Available in @arizeai/phoenix-cli 1.4.0+**
+
+`px profile` commands let you store named connection profiles — endpoint, project, API key, and headers — and switch between Phoenix instances without re-exporting environment variables. The active profile slots into the existing config resolution chain below env vars, so existing scripts are unaffected.
+
+- **Commands** — `px profile create`, `list`, `show`, `edit`, `use`, `delete`
+- **Profile status** — `px auth status` surfaces the active profile name
+- **Editor autocomplete** — JSON Schema published for `~/.px/profiles.json`
+</Update>
+
+<Update label="04.30.2026">
+## [04.30.2026: Annotation Enhancements — Sessions, TypeScript, and Identifier Queries](/docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements)
+**Available in arize-phoenix 15.1.0+ (server), @arizeai/phoenix-cli 1.4.0+ (CLI), @arizeai/phoenix-client 6.9.0+ (TypeScript)**
+
+- **CLI session annotations** — `px session annotate <id>` and `px session add-note <id>` with `--include-annotations` / `--include-notes` flags on list and get
+- **TypeScript trace annotations** — `addTraceAnnotation` and `logTraceAnnotations` exported from `@arizeai/phoenix-client/traces`
+- **`addSessionNote`** in `@arizeai/phoenix-client/sessions`
+- **Query by identifier** — GET annotation endpoints for spans, traces, and sessions accept `?identifier=` to retrieve all annotations sharing a tag, project-wide
+</Update>
+
+<Update label="04.29.2026">
+## [04.29.2026: Dataset Upsert](/docs/phoenix/release-notes/04-2026/04-29-2026-dataset-upsert)
+**Breaking change in arize-phoenix-client 2.6.0+ (Python) and arize-phoenix 15.0.0+ (server)**
+
+`client.datasets.create_dataset()` now defaults to upsert semantics: if a dataset with the same name exists, examples are merged into the latest version rather than returning a conflict error. Supply a stable `id` on each example for deterministic in-place updates on re-upload.
+</Update>
+
 <Update label="05.01.2026">
 ## [05.01.2026: TanStack AI Tracing](/docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing)
 **Available in @arizeai/openinference-tanstack-ai 0.1.0+**

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -28,6 +28,17 @@ Phoenix Playground and the Prompts library now support vendor-native tools — w
 - **Evals runtime capability detection** — OpenAI reasoning models (`o1`, `o3`, `o3-mini`, `o4-mini`) now work with `ClassificationEvaluator` automatically
 </Update>
 
+<Update label="05.01.2026">
+## [05.01.2026: TanStack AI Tracing](/docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing)
+**Available in @arizeai/openinference-tanstack-ai 0.1.0+**
+
+A new OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/docs/getting-started/overview) emits `AGENT`, `LLM`, and `TOOL` spans for `chat()` calls — covering streaming, non-streaming, and tool-loop flows across any TanStack AI provider adapter.
+
+- **Install** — `npm install --save @arizeai/openinference-tanstack-ai @tanstack/ai`
+- **Usage** — drop `openInferenceMiddleware()` into the `middleware` option of any `chat()` call
+- **Feedback welcome** — this integration is brand new; please reach out via the [OpenInference repo](https://github.com/Arize-ai/openinference)
+</Update>
+
 <Update label="04.30.2026">
 ## [04.30.2026: CLI Named Auth Profiles](/docs/phoenix/release-notes/04-2026/04-30-2026-cli-auth-profiles)
 **Available in @arizeai/phoenix-cli 1.4.0+**
@@ -54,17 +65,6 @@ Phoenix Playground and the Prompts library now support vendor-native tools — w
 **Breaking change in arize-phoenix-client 2.6.0+ (Python) and arize-phoenix 15.0.0+ (server)**
 
 `client.datasets.create_dataset()` now defaults to upsert semantics: if a dataset with the same name exists, examples are merged into the latest version rather than returning a conflict error. Supply a stable `id` on each example for deterministic in-place updates on re-upload.
-</Update>
-
-<Update label="05.01.2026">
-## [05.01.2026: TanStack AI Tracing](/docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing)
-**Available in @arizeai/openinference-tanstack-ai 0.1.0+**
-
-A new OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/docs/getting-started/overview) emits `AGENT`, `LLM`, and `TOOL` spans for `chat()` calls — covering streaming, non-streaming, and tool-loop flows across any TanStack AI provider adapter.
-
-- **Install** — `npm install --save @arizeai/openinference-tanstack-ai @tanstack/ai`
-- **Usage** — drop `openInferenceMiddleware()` into the `middleware` option of any `chat()` call
-- **Feedback welcome** — this integration is brand new; please reach out via the [OpenInference repo](https://github.com/Arize-ai/openinference)
 </Update>
 
 <Update label="04.28.2026">

--- a/docs/phoenix/release-notes/04-2026/04-29-2026-dataset-upsert.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-29-2026-dataset-upsert.mdx
@@ -1,0 +1,57 @@
+---
+title: "04.29.2026: Dataset Upsert"
+description: "create_dataset now upserts — if a dataset with the same name exists, examples are updated in place rather than raising a conflict error."
+---
+
+**Breaking change in arize-phoenix-client 2.6.0+ (Python) and arize-phoenix 15.0.0+ (server)**
+
+`client.datasets.create_dataset()` now defaults to upsert semantics: if a dataset with the given name already exists, incoming examples are merged into the latest version rather than returning a `409 Conflict`. New examples are created; existing examples matched by their stable `id` are updated. This is a breaking change for callers that relied on the old fail-on-duplicate behavior.
+
+## Upsert behavior
+
+- **New dataset** — created as before; no behavior change.
+- **Existing dataset, no `id` on examples** — examples are appended as new examples in a new version.
+- **Existing dataset, `id` supplied** — examples whose `id` matches an existing example are updated in place; unmatched `id`s are inserted as new examples.
+
+To opt back in to the strict create-only behavior, pass `action="create"` directly on the REST endpoint — the Python client does not expose this option, as upsert is now the recommended default.
+
+```python
+from phoenix.client import Client
+
+client = Client()
+
+# Upsert: creates the dataset on first call, merges on subsequent calls
+dataset = client.datasets.create_dataset(
+    name="golden-set",
+    examples=[
+        {"input": {"query": "What is RAG?"}, "output": {"answer": "Retrieval-Augmented Generation"}, "id": "ex-001"},
+        {"input": {"query": "What is an LLM?"}, "output": {"answer": "Large Language Model"}, "id": "ex-002"},
+    ],
+)
+print(dataset.name, dataset.example_count)
+```
+
+## Supply stable example IDs for deterministic updates
+
+Provide an `id` field on each example so re-uploads update the same row rather than inserting duplicates:
+
+```python
+import pandas as pd
+from phoenix.client import Client
+
+client = Client()
+
+df = pd.DataFrame({
+    "question": ["What is RAG?", "What is an LLM?"],
+    "answer":   ["Retrieval-Augmented Generation", "Large Language Model"],
+    "example_id": ["ex-001", "ex-002"],
+})
+
+dataset = client.datasets.create_dataset(
+    name="golden-set",
+    dataframe=df,
+    input_keys=["question"],
+    output_keys=["answer"],
+    example_id_key="example_id",
+)
+```

--- a/docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements.mdx
@@ -1,0 +1,98 @@
+---
+title: "Release Notes"
+---
+
+# Session Annotations and Notes (CLI and TypeScript)
+
+April 30, 2026
+
+**Available in arize-phoenix 15.1.0+ (server), @arizeai/phoenix-cli 1.4.0+ (CLI), @arizeai/phoenix-client 6.9.0+ (TypeScript)**
+
+Phoenix now supports session annotations and notes in the CLI and TypeScript client, bringing sessions to full parity with spans and traces.
+
+- **`px session annotate <session-id>`** — add or update a label/score annotation on a session
+- **`px session add-note <session-id> --text "..."`** — append a free-text note to a session (requires server 14.17.0+)
+- **`--include-annotations`** and **`--include-notes`** flags on `px session list` and `px session get`
+- **`addSessionNote`** is now available in `@arizeai/phoenix-client/sessions`
+
+Both GlobalIDs and user-facing `session_id` values are accepted everywhere; the CLI resolves them automatically.
+
+```bash
+# Annotate a session with a label
+px session annotate <session-id> \
+  --name quality \
+  --label pass \
+  --score 0.95
+
+# Add a free-text note
+px session add-note <session-id> \
+  --text "Reviewed and verified by QA"
+
+# List sessions including annotations and notes
+px session list --project my-project \
+  --include-annotations --include-notes
+```
+
+```typescript
+import { addSessionNote } from "@arizeai/phoenix-client/sessions";
+
+await addSessionNote({
+  sessionNote: {
+    sessionId: "abc123",
+    note: "Reviewed and verified by QA",
+  },
+});
+```
+
+# TypeScript Trace Annotations
+
+April 30, 2026
+
+**Available in @arizeai/phoenix-client 6.9.0+**
+
+`@arizeai/phoenix-client` now exports `addTraceAnnotation` and `logTraceAnnotations` from `@arizeai/phoenix-client/traces`, bringing TypeScript to parity with the Python client for trace-level annotation.
+
+- **`addTraceAnnotation`** — add or update a single trace annotation
+- **`logTraceAnnotations`** — batch-write multiple trace annotations in one request
+- The reserved name `note` is rejected — use `addTraceNote` for free-form text
+
+```typescript
+import { addTraceAnnotation, logTraceAnnotations } from "@arizeai/phoenix-client/traces";
+
+// Single annotation
+await addTraceAnnotation({
+  traceAnnotation: {
+    traceId: "abc123",
+    name: "correctness",
+    label: "correct",
+    score: 1.0,
+    annotatorKind: "HUMAN",
+    identifier: "run-001",
+  },
+  sync: true,
+});
+
+// Batch annotations
+await logTraceAnnotations({
+  traceAnnotations: [
+    { traceId: "abc123", name: "faithfulness", label: "faithful", score: 0.9, annotatorKind: "LLM" },
+    { traceId: "def456", name: "faithfulness", label: "unfaithful", score: 0.2, annotatorKind: "LLM" },
+  ],
+});
+```
+
+# Query Annotations by Identifier
+
+April 30, 2026
+
+**Available in arize-phoenix 15.1.0+**
+
+The GET annotation endpoints for spans, traces, and sessions now accept an optional `identifier` query parameter. This lets you retrieve all annotations created with a specific `identifier` tag across an entire project without knowing the individual span/trace/session IDs.
+
+```
+GET /v1/projects/{project_identifier}/span_annotations?identifier=run-001
+GET /v1/projects/{project_identifier}/trace_annotations?identifier=run-001
+GET /v1/projects/{project_identifier}/session_annotations?identifier=run-001
+```
+
+Combined with the existing `*_ids` parameter, the two filters compose as an AND intersection. Querying by `identifier` alone (without `*_ids`) returns `200` with an empty list when no rows match — rather than `404` — since an empty result is a valid outcome.

--- a/docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Release Notes"
+title: "04.30.2026: Annotation Enhancements"
 ---
 
 # Session Annotations and Notes (CLI and TypeScript)

--- a/docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements.mdx
@@ -89,7 +89,7 @@ April 30, 2026
 
 The GET annotation endpoints for spans, traces, and sessions now accept an optional `identifier` query parameter. This lets you retrieve all annotations created with a specific `identifier` tag across an entire project without knowing the individual span/trace/session IDs.
 
-```
+```http
 GET /v1/projects/{project_identifier}/span_annotations?identifier=run-001
 GET /v1/projects/{project_identifier}/trace_annotations?identifier=run-001
 GET /v1/projects/{project_identifier}/session_annotations?identifier=run-001

--- a/docs/phoenix/release-notes/04-2026/04-30-2026-cli-auth-profiles.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-30-2026-cli-auth-profiles.mdx
@@ -1,0 +1,73 @@
+---
+title: "04.30.2026: CLI Named Auth Profiles"
+description: "px profile commands let you store named Phoenix connection profiles and switch between them without re-exporting environment variables."
+---
+
+**Available in @arizeai/phoenix-cli 1.4.0+**
+
+The `px profile` command group lets you store named connection profiles — each bundling an endpoint, project, API key, and custom headers under a single name like `prod` or `staging`. Activate a profile once and every `px` command picks it up automatically, so you no longer need to re-export environment variables when switching between Phoenix instances.
+
+## Profile resolution order
+
+```
+CLI flags → environment variables → active profile → built-in defaults
+```
+
+Existing scripts that set `PHOENIX_HOST` / `PHOENIX_API_KEY` / etc. keep working without modification.
+
+## Managing profiles
+
+```bash
+# Create a profile (interactive prompts fill in the details)
+px profile create prod
+
+# Create a profile with all values supplied upfront
+px profile create staging \
+  --endpoint https://staging.phoenix.example.com \
+  --project my-project \
+  --api-key $STAGING_API_KEY
+
+# Switch the active profile
+px profile use prod
+
+# List all profiles (active profile is marked)
+px profile list
+
+# Inspect a specific profile
+px profile show prod
+
+# Edit a profile in $EDITOR
+px profile edit staging
+
+# Delete a profile
+px profile delete staging
+```
+
+## Check which profile is active
+
+`px auth status` now surfaces the active profile name alongside the resolved endpoint and authentication state:
+
+```bash
+px auth status
+# Endpoint:       https://prod.phoenix.example.com
+# Active profile: prod
+# Auth:           API key configured
+```
+
+## Editor autocomplete via JSON Schema
+
+The CLI publishes a JSON Schema for the settings file (`~/.px/profiles.json`). Add a `$schema` key to enable autocomplete and validation in editors that support JSON Schema:
+
+```json
+{
+  "$schema": "https://unpkg.com/@arizeai/phoenix-cli/schemas/phoenix-cli-settings.json",
+  "activeProfile": "prod",
+  "profiles": {
+    "prod": {
+      "endpoint": "https://prod.phoenix.example.com",
+      "apiKey": "...",
+      "project": "production"
+    }
+  }
+}
+```

--- a/docs/phoenix/release-notes/04-2026/04-30-2026-cli-auth-profiles.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-30-2026-cli-auth-profiles.mdx
@@ -9,7 +9,7 @@ The `px profile` command group lets you store named connection profiles — each
 
 ## Profile resolution order
 
-```
+```text
 CLI flags → environment variables → active profile → built-in defaults
 ```
 

--- a/docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools.mdx
@@ -9,14 +9,21 @@ Phoenix Playground and the Prompts library now support **provider tools** — bu
 
 Provider tools sit alongside Phoenix's existing portable function tools: function tools stay normalized and provider-agnostic; provider tools preserve provider-specific JSON for capabilities only that vendor offers.
 
-## Supported provider tools
+## What Phoenix forwards
 
-| Provider | Tools |
-|----------|-------|
-| **Anthropic** | `web_search`, `web_fetch`, `code_execution`, `bash`, `text_editor`, `computer`, `memory` |
-| **OpenAI Responses API** | `web_search`, `file_search`, `code_interpreter`, `computer`, `tool_search` |
+Phoenix doesn't maintain a hardcoded list of supported provider tools — anything the
+underlying provider SDK accepts is round-tripped as-is. Examples that have been verified
+end-to-end against the playground:
+
+| Provider | Examples verified in Phoenix |
+|----------|-------------------------------|
+| **Anthropic** | `web_search`, `code_execution`, `computer_use` |
+| **OpenAI Responses API** | `web_search`, `file_search`, `code_interpreter`, `computer_use_preview`, `tool_search` |
 | **Google Gemini** | `google_search` grounding |
-| **Amazon Bedrock** | Nova `nova_grounding` |
+| **Amazon Bedrock** | provider-specific tool blocks are forwarded verbatim |
+
+If a provider ships a new built-in tool, it works in Phoenix immediately — no library
+update required. Mismatches surface as errors from the provider SDK at request time.
 
 ## Using provider tools
 

--- a/docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools.mdx
@@ -1,0 +1,50 @@
+---
+title: "05.05.2026: Provider Tools in Playground and Prompts"
+description: "Phoenix Playground and Prompts now support vendor-native tools — web search, code execution, computer use, grounding, and more — alongside existing function tools."
+---
+
+**Available in arize-phoenix 15.4.0+**
+
+Phoenix Playground and the Prompts library now support **provider tools** — built-in, vendor-hosted capabilities like web search, code execution, computer use, and grounding. Paste any provider's tool JSON into the Playground and Phoenix stores and round-trips it verbatim, so your prompt runs against the underlying provider exactly as defined.
+
+Provider tools sit alongside Phoenix's existing portable function tools: function tools stay normalized and provider-agnostic; provider tools preserve provider-specific JSON for capabilities only that vendor offers.
+
+## Supported provider tools
+
+| Provider | Tools |
+|----------|-------|
+| **Anthropic** | `web_search`, `web_fetch`, `code_execution`, `bash`, `text_editor`, `computer`, `memory` |
+| **OpenAI Responses API** | `web_search`, `file_search`, `code_interpreter`, `computer`, `tool_search` |
+| **Google Gemini** | `google_search` grounding |
+| **Amazon Bedrock** | Nova `nova_grounding` |
+
+## Using provider tools
+
+**In the Playground** — open the tool editor, switch to JSON mode, and paste the provider's tool definition. Phoenix detects the shape automatically: function-tool shapes are stored as function tools; everything else is stored as a provider tool.
+
+**"Open in Playground" on a captured trace** — replays the exact tool payload that hit the model, including any provider tools that were active.
+
+**Mix with function tools** — function tools and provider tools coexist on the same prompt version. Switching the provider or API type drops attached provider tools (since the JSON is provider-specific), while function tools survive provider changes.
+
+## SDK prompt export
+
+Both the Python and TypeScript clients preserve provider tools when exporting prompts:
+
+```python
+from phoenix.client import Client
+
+client = Client()
+prompt = client.prompts.get(name="my-research-prompt")
+
+# Provider tools are included in the formatted prompt
+openai_messages = prompt.format(formatter="openai")
+# openai_messages["tools"] contains both function tools and provider tools
+```
+
+```typescript
+import { getPrompt } from "@arizeai/phoenix-client/prompts";
+
+const prompt = await getPrompt({ name: "my-research-prompt" });
+const formatted = prompt.format({ formatter: "openai" });
+// formatted.tools includes provider tools verbatim
+```

--- a/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates.mdx
@@ -10,7 +10,7 @@ May 5, 2026
 
 Three new `DELETE` endpoints let you bulk-remove annotations from a project by filter — without knowing every individual span/trace/session ID. This closes the annotation lifecycle loop for automated pipelines that tag annotations with a custom `identifier` on creation and need to roll them back later.
 
-```
+```http
 DELETE /v1/projects/{project_identifier}/span_annotations
 DELETE /v1/projects/{project_identifier}/trace_annotations
 DELETE /v1/projects/{project_identifier}/session_annotations

--- a/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates.mdx
@@ -1,0 +1,78 @@
+---
+title: "Release Notes"
+---
+
+# Filter-Based Annotation Delete Endpoints
+
+May 5, 2026
+
+**Available in arize-phoenix 15.4.0+**
+
+Three new `DELETE` endpoints let you bulk-remove annotations from a project by filter — without knowing every individual span/trace/session ID. This closes the annotation lifecycle loop for automated pipelines that tag annotations with a custom `identifier` on creation and need to roll them back later.
+
+```
+DELETE /v1/projects/{project_identifier}/span_annotations
+DELETE /v1/projects/{project_identifier}/trace_annotations
+DELETE /v1/projects/{project_identifier}/session_annotations
+```
+
+**Query parameters** (all optional, but at least one time-bound or `delete_all=true` is required):
+
+| Parameter | Description |
+|-----------|-------------|
+| `name` | Exact match on annotation name |
+| `identifier` | Exact match on annotation identifier |
+| `annotator_kind` | `LLM`, `CODE`, or `HUMAN` |
+| `start_time` | Inclusive lower bound on `created_at` |
+| `end_time` | Exclusive upper bound on `created_at` |
+| `delete_all` | Set `true` to waive the time-bound requirement |
+
+```bash
+# Delete all annotations tagged with identifier "eval-run-42" on spans
+curl -X DELETE \
+  "https://your-phoenix/v1/projects/my-project/span_annotations?identifier=eval-run-42" \
+  -H "Authorization: Bearer $PHOENIX_API_KEY"
+
+# Delete LLM annotations older than a cutoff
+curl -X DELETE \
+  "https://your-phoenix/v1/projects/my-project/trace_annotations?annotator_kind=LLM&end_time=2026-05-01T00:00:00Z" \
+  -H "Authorization: Bearer $PHOENIX_API_KEY"
+```
+
+# Token Counts in Trace and Session REST Payloads
+
+May 5, 2026
+
+**Available in arize-phoenix 15.4.0+**
+
+The `GET /v1/projects/{project_identifier}/traces` and `GET /v1/projects/{project_identifier}/sessions` endpoints now include cumulative token usage fields — `cumulative_token_count_prompt`, `cumulative_token_count_completion`, and `cumulative_token_count_total` — so you can read aggregate token consumption directly from the REST API without recomputing from raw span attributes.
+
+Values are summed from root spans and default to `0` for traces or sessions with no LLM calls. The `/v1/spans` endpoint is unchanged — span-level token counts remain in the existing `attributes` dictionary.
+
+# Experiment CSV Export Includes Dataset Metadata
+
+May 5, 2026
+
+**Available in arize-phoenix 15.3.0+**
+
+Downloading an experiment as CSV now includes per-example dataset metadata columns. Each metadata key appears as a `metadata_<key>` column — matching the format used by the dataset CSV export — so you can cross-reference experiment results with the original dataset context without a separate download.
+
+# Evals: Runtime Model Capability Detection
+
+May 5, 2026
+
+**Available in arize-phoenix-evals 3.1.0+**
+
+The OpenAI evaluator adapter now detects structured-output and tool-call support at runtime rather than checking against a hardcoded model list. This unblocks OpenAI reasoning models (`o1`, `o3`, `o3-mini`, `o4-mini`) for use with `ClassificationEvaluator` and ensures new models work automatically without requiring a library update.
+
+The adapter tries structured output first, falls back to tool calling if unsupported, and caches the result per adapter instance — matching the approach already used by the Google GenAI adapter.
+
+```python
+from phoenix.evals import ClassificationEvaluator, OpenAIModel
+
+# Reasoning models now work without any special configuration
+evaluator = ClassificationEvaluator(
+    model=OpenAIModel(model="o3-mini"),
+    template="my-eval-template",
+)
+```

--- a/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Release Notes"
+title: "05.05.2026: REST API Updates"
 ---
 
 # Filter-Based Annotation Delete Endpoints

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,12 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools" arrow="true" title="05.05.2026" icon="calendar" description="Vendor-native tools (web search, code execution, computer use, grounding) in Playground and Prompts"/>
+    <Card href="/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates" arrow="true" title="05.05.2026" icon="calendar" description="Filter-based annotation DELETE; token counts in trace/session REST payloads; evals runtime model detection"/>
+    <Card href="/docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing" arrow="true" title="05.01.2026" icon="calendar" description="OpenInference middleware for TanStack AI — AGENT, LLM, and TOOL spans for chat() calls"/>
+    <Card href="/docs/phoenix/release-notes/04-2026/04-30-2026-cli-auth-profiles" arrow="true" title="04.30.2026" icon="calendar" description="px profile commands for named auth profiles; switch Phoenix instances without re-exporting env vars"/>
+    <Card href="/docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements" arrow="true" title="04.30.2026" icon="calendar" description="CLI session annotations and notes; TypeScript trace annotations; query annotations by identifier"/>
+    <Card href="/docs/phoenix/release-notes/04-2026/04-29-2026-dataset-upsert" arrow="true" title="04.29.2026" icon="calendar" description="Breaking change: create_dataset now upserts — merges examples into existing datasets instead of failing"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api" arrow="true" title="04.28.2026" icon="calendar" description="Dedicated session notes REST API; reserve the note annotation name for session note endpoint"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-24-2026-trace-notes-api" arrow="true" title="04.24.2026" icon="calendar" description="Trace notes via REST, TypeScript client, and CLI; px trace add-note command"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id" arrow="true" title="04.22.2026" icon="calendar" description="Secrets settings page in Phoenix UI; trace_id parameter in experiment evaluators"/>


### PR DESCRIPTION
## Summary

- **04.29.2026** — Dataset upsert: `create_dataset` now upserts by default (breaking change in arize-phoenix-client 2.6 / server 15.0)
- **04.30.2026** — CLI named auth profiles: `px profile` command group for managing named Phoenix connection profiles
- **04.30.2026** — Annotation enhancements: CLI session annotations/notes, TypeScript trace annotations, query-by-identifier on GET annotation endpoints
- **05.05.2026** — Provider tools in Playground and Prompts: Anthropic, OpenAI, Gemini, and Bedrock native tools (web search, code execution, computer use, grounding)
- **05.05.2026** — REST API updates: filter-based annotation DELETE endpoints, token counts in trace/session payloads, experiment CSV metadata, evals runtime model detection

Also adds the missing 05.01.2026 TanStack AI card to the 2026 year overview.

Covers releases: arize-phoenix v14.17-v15.4, arize-phoenix-client v2.6, arize-phoenix-evals v3.1, arize-phoenix-otel v0.16.1.

## Test plan

- [ ] All new MDX files have valid frontmatter
- [ ] Links in release-notes.mdx match actual file paths
- [ ] docs.json entries match file paths (no .mdx extension, forward slashes)
- [ ] Year overview cards point to correct paths
- [ ] Entries are in reverse-chronological order throughout

Generated with Claude Code