### PR TITLE
feat(sandbox): credentials dialog, provider table polish, Vercel triple-only auth

### DIFF
--- a/.agents/skills/phoenix-design/SKILL.md
+++ b/.agents/skills/phoenix-design/SKILL.md
@@ -20,6 +20,7 @@ Read the relevant file(s) based on the task:
 |-----------|-------------|
 | `rules/layout.md` | Layout stability, scroll behavior, interaction patterns |
 | `rules/dialogs.md` | Alert dialog usage, variants, and content writing |
+| `rules/form-dialogs.md` | Form dialog structure, footer/submit placement, field metadata |
 | `rules/error-display.md` | Error scoping, inline alerts, input validation |
 | `rules/bem.md` | Naming CSS classes |
 | `rules/tokens.md` | Creating or consuming CSS design tokens |

--- a/.agents/skills/phoenix-design/rules/dialogs.md
+++ b/.agents/skills/phoenix-design/rules/dialogs.md
@@ -2,6 +2,8 @@
 
 Alert dialogs are interruptive — they block all other interaction until resolved. They MUST only be used when a user must acknowledge important information or confirm a consequential action before proceeding.
 
+For dialogs that collect input (create, edit, configure), see `form-dialogs.md` instead.
+
 ## When to use
 
 - Confirming a destructive or irreversible action (delete project, clear traces, remove data)

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3141,6 +3141,7 @@ type SandboxBackendInfo {
   supportsEnvVars: Boolean!
   internetAccess: InternetAccessMode!
   dependenciesLanguage: Language
+  credentialSpecs: [SandboxProviderCredentialSpec!]!
 }
 
 enum SandboxBackendStatus {
@@ -3177,6 +3178,14 @@ type SandboxProvider implements Node {
   createdAt: DateTime!
   updatedAt: DateTime!
   configs: [SandboxConfig!]!
+}
+
+type SandboxProviderCredentialSpec {
+  key: String!
+  displayName: String!
+  description: String!
+  isSet: Boolean!
+  isRequired: Boolean!
 }
 
 type Secret implements Node {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3184,7 +3184,6 @@ type SandboxProviderCredentialSpec {
   key: String!
   displayName: String!
   description: String!
-  isSet: Boolean!
   isRequired: Boolean!
 }
 

--- a/app/src/pages/settings/__generated__/settingsSandboxesPageLoaderQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/settingsSandboxesPageLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9e76e9132a30d488fb038b8067254526>>
+ * @generated SignedSource<<359835c47c2950d6506ba98bfc4b3011>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -171,13 +171,6 @@ return {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "isSet",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
                 "name": "isRequired",
                 "storageKey": null
               }
@@ -243,12 +236,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3340b59919e4b38cfe89f7478ac8fd98",
+    "cacheID": "f72d6844eddf024afd3192ad11e821f8",
     "id": null,
     "metadata": {},
     "name": "settingsSandboxesPageLoaderQuery",
     "operationKind": "query",
-    "text": "query settingsSandboxesPageLoaderQuery {\n  ...SettingsSandboxesPageFragment\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "query settingsSandboxesPageLoaderQuery {\n  ...SettingsSandboxesPageFragment\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/SandboxConfigsCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigsCard.tsx
@@ -12,7 +12,6 @@ import {
   configNameCSS,
   configNameCellCSS,
   inlineTokenRowCSS,
-  pageIntroCSS,
   sandboxesTableCSS,
   sandboxesTableWrapCSS,
   subtitleCSS,
@@ -36,17 +35,11 @@ export function SandboxConfigsCard({
   return (
     <Card
       title="Code Sandboxes"
+      subTitle="Configure reusable sandbox configurations for code evaluators."
       extra={
         <SandboxConfigDialogTrigger mode="create" providers={providerRows} />
       }
     >
-      <div css={pageIntroCSS}>
-        <Flex justifyContent="space-between" alignItems="center" gap="size-200">
-          <Text color="text-700">
-            Configure reusable sandbox configurations for code evaluators.
-          </Text>
-        </Flex>
-      </div>
       <div css={sandboxesTableWrapCSS}>
         <table css={sandboxesTableCSS}>
           <thead>

--- a/app/src/pages/settings/sandboxes/SandboxProviderCredentialsDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxProviderCredentialsDialog.tsx
@@ -1,0 +1,391 @@
+import { css } from "@emotion/react";
+import { Suspense, useCallback, useMemo, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
+
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogCloseButton,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTitleExtra,
+  Flex,
+  Form,
+  RedactedCredentialField,
+  Text,
+} from "@phoenix/components";
+import { useNotifySuccess } from "@phoenix/contexts";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
+
+import type { SandboxProviderCredentialsDialogQuery } from "./__generated__/SandboxProviderCredentialsDialogQuery.graphql";
+import type { SandboxProviderCredentialsDialogUpsertMutation } from "./__generated__/SandboxProviderCredentialsDialogUpsertMutation.graphql";
+import type { BackendInfo } from "./types";
+
+type CredentialSpec = BackendInfo["credentialSpecs"][number];
+type CredentialFormValues = Record<string, string>;
+
+const dialogFormCSS = css`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+`;
+
+const dialogBodyCSS = css`
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--global-dimension-size-200);
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-size-200);
+`;
+
+const credentialFieldFooterCSS = css`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--global-dimension-size-200);
+  margin-top: var(--global-dimension-size-50);
+`;
+
+const credentialDescriptionCSS = css`
+  flex: 1 1 auto;
+  color: var(--ac-global-text-color-700);
+  font-size: var(--ac-global-font-size-xs);
+`;
+
+const credentialEnvVarCSS = css`
+  flex: 0 0 auto;
+  font-family: "Geist Mono", monospace;
+  font-size: var(--ac-global-font-size-xs);
+  color: var(--ac-global-text-color-500);
+  white-space: nowrap;
+`;
+
+export function SandboxProviderCredentialsDialog({
+  backend,
+  onClose,
+  onRefresh,
+}: {
+  backend: BackendInfo;
+  onClose: () => void;
+  onRefresh: () => void;
+}) {
+  return (
+    <Dialog>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Configure {backend.displayName} Credentials</DialogTitle>
+          <DialogTitleExtra>
+            <DialogCloseButton slot="close" />
+          </DialogTitleExtra>
+        </DialogHeader>
+        <Suspense
+          fallback={
+            <div css={dialogBodyCSS}>
+              <Text color="text-700">Loading credentials…</Text>
+            </div>
+          }
+        >
+          <CredentialsForm
+            backend={backend}
+            onClose={onClose}
+            onRefresh={onRefresh}
+          />
+        </Suspense>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CredentialsForm({
+  backend,
+  onClose,
+  onRefresh,
+}: {
+  backend: BackendInfo;
+  onClose: () => void;
+  onRefresh: () => void;
+}) {
+  const notifySuccess = useNotifySuccess();
+  const [error, setError] = useState<string | null>(null);
+  const [fetchKey, setFetchKey] = useState(0);
+
+  const credentialSpecs = backend.credentialSpecs;
+  const secretKeys = useMemo(
+    () => credentialSpecs.map((spec) => spec.key),
+    [credentialSpecs]
+  );
+
+  const data = useLazyLoadQuery<SandboxProviderCredentialsDialogQuery>(
+    graphql`
+      query SandboxProviderCredentialsDialogQuery($keys: [String!]!) {
+        secrets(keys: $keys) {
+          edges {
+            node {
+              key
+              value {
+                __typename
+                ... on DecryptedSecret {
+                  value
+                }
+                ... on UnparsableSecret {
+                  parseError
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    { keys: secretKeys },
+    { fetchKey, fetchPolicy: "store-and-network" }
+  );
+
+  const { savedValues, unparsable } = useMemo(() => {
+    const decrypted = new Map<string, string>();
+    const errors = new Map<string, string>();
+    for (const { node } of data.secrets.edges) {
+      const { value } = node;
+      if (value.__typename === "DecryptedSecret") {
+        const trimmed = value.value?.trim();
+        if (trimmed) {
+          decrypted.set(node.key, trimmed);
+        }
+      } else if (value.__typename === "UnparsableSecret") {
+        errors.set(node.key, value.parseError);
+      } else {
+        errors.set(node.key, "Secret type not supported by this client");
+      }
+    }
+    const values: CredentialFormValues = {};
+    for (const spec of credentialSpecs) {
+      values[spec.key] = decrypted.get(spec.key) ?? "";
+    }
+    return { savedValues: values, unparsable: errors };
+  }, [data.secrets.edges, credentialSpecs]);
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { isDirty },
+  } = useForm<CredentialFormValues>({
+    defaultValues: savedValues,
+    values: savedValues,
+    mode: "onChange",
+  });
+
+  const [commit, isCommitting] =
+    useMutation<SandboxProviderCredentialsDialogUpsertMutation>(graphql`
+      mutation SandboxProviderCredentialsDialogUpsertMutation(
+        $input: UpsertOrDeleteSecretsMutationInput!
+      ) {
+        upsertOrDeleteSecrets(input: $input) {
+          query {
+            ...SettingsSandboxesPageFragment
+          }
+        }
+      }
+    `);
+
+  const existingKeys = useMemo(
+    () => [
+      ...Object.entries(savedValues)
+        .filter(([, v]) => v.trim())
+        .map(([k]) => k),
+      ...unparsable.keys(),
+    ],
+    [savedValues, unparsable]
+  );
+
+  const onSubmit = useCallback(
+    (formValues: CredentialFormValues) => {
+      setError(null);
+      const secrets = credentialSpecs
+        .map((spec) => {
+          const next = formValues[spec.key]?.trim() || null;
+          const prev = savedValues[spec.key]?.trim() || null;
+          if (next === prev) return null;
+          return { key: spec.key, value: next };
+        })
+        .filter((s): s is { key: string; value: string | null } => s !== null);
+
+      if (secrets.length === 0) {
+        onClose();
+        return;
+      }
+
+      commit({
+        variables: { input: { secrets } },
+        onCompleted: () => {
+          setFetchKey((k) => k + 1);
+          onRefresh();
+          notifySuccess({
+            title: "Credentials updated",
+            message: `${secrets.length} credential${
+              secrets.length === 1 ? "" : "s"
+            } saved`,
+          });
+          onClose();
+        },
+        onError: (mutationError) => {
+          setError(
+            getErrorMessagesFromRelayMutationError(mutationError)?.[0] ??
+              "Failed to update credentials"
+          );
+        },
+      });
+    },
+    [credentialSpecs, savedValues, commit, notifySuccess, onClose, onRefresh]
+  );
+
+  const handleDelete = useCallback(() => {
+    if (existingKeys.length === 0) return;
+    setError(null);
+    const secrets = existingKeys.map((key) => ({ key, value: null }));
+    commit({
+      variables: { input: { secrets } },
+      onCompleted: () => {
+        setFetchKey((k) => k + 1);
+        const cleared: CredentialFormValues = {};
+        credentialSpecs.forEach((spec) => {
+          cleared[spec.key] = "";
+        });
+        reset(cleared);
+        onRefresh();
+        notifySuccess({
+          title: "Credentials cleared",
+          message: `${existingKeys.length} credential${
+            existingKeys.length === 1 ? "" : "s"
+          } removed`,
+        });
+        onClose();
+      },
+      onError: (mutationError) => {
+        setError(
+          getErrorMessagesFromRelayMutationError(mutationError)?.[0] ??
+            "Failed to clear credentials"
+        );
+      },
+    });
+  }, [
+    existingKeys,
+    commit,
+    credentialSpecs,
+    reset,
+    notifySuccess,
+    onClose,
+    onRefresh,
+  ]);
+
+  if (credentialSpecs.length === 0) {
+    return (
+      <div css={dialogBodyCSS}>
+        <Text color="text-700">
+          This sandbox does not require any credentials.
+        </Text>
+      </div>
+    );
+  }
+
+  const unparsableList = credentialSpecs
+    .filter((spec) => unparsable.has(spec.key))
+    .map((spec) => ({ key: spec.key, parseError: unparsable.get(spec.key)! }));
+
+  return (
+    <Form onSubmit={handleSubmit(onSubmit)} css={dialogFormCSS}>
+      <div css={dialogBodyCSS}>
+        <Text size="XS" color="text-700">
+          These environment variables are stored as encrypted secrets and shared
+          across the server. They override any matching variables in the process
+          environment.
+        </Text>
+        {error ? <Alert variant="danger">{error}</Alert> : null}
+        {unparsableList.map(({ key, parseError }) => (
+          <Alert key={key} variant="danger" title={key}>
+            {parseError}
+          </Alert>
+        ))}
+        <Flex direction="column" gap="size-200">
+          {credentialSpecs.map((spec: CredentialSpec) => (
+            <CredentialFormField key={spec.key} spec={spec} control={control} />
+          ))}
+        </Flex>
+      </div>
+      <DialogFooter>
+        {existingKeys.length > 0 ? (
+          <Button
+            variant="danger"
+            size="M"
+            isDisabled={isCommitting}
+            onPress={handleDelete}
+          >
+            Clear
+          </Button>
+        ) : null}
+        <Button
+          variant={isDirty ? "primary" : "default"}
+          size="M"
+          type="submit"
+          isDisabled={!isDirty || isCommitting}
+          isPending={isCommitting}
+        >
+          Save
+        </Button>
+      </DialogFooter>
+    </Form>
+  );
+}
+
+function CredentialFormField({
+  spec,
+  control,
+}: {
+  spec: CredentialSpec;
+  control: ReturnType<typeof useForm<CredentialFormValues>>["control"];
+}) {
+  return (
+    <Controller
+      name={spec.key}
+      control={control}
+      rules={{
+        validate: spec.isRequired
+          ? (value) => !!value?.trim() || `${spec.key} is required`
+          : undefined,
+      }}
+      render={({
+        field: { name, onChange, onBlur, value },
+        fieldState: { error: fieldError },
+      }) => (
+        <div>
+          <RedactedCredentialField
+            label={spec.displayName || spec.key}
+            isRequired={spec.isRequired}
+            name={name}
+            value={value ?? ""}
+            onChange={onChange}
+            onBlur={onBlur}
+            errorMessage={fieldError?.message}
+          />
+          <div css={credentialFieldFooterCSS}>
+            {spec.description ? (
+              <span css={credentialDescriptionCSS}>{spec.description}</span>
+            ) : (
+              <span css={credentialDescriptionCSS} />
+            )}
+            <span css={credentialEnvVarCSS} title="Environment variable name">
+              {spec.key}
+            </span>
+          </div>
+        </div>
+      )}
+    />
+  );
+}

--- a/app/src/pages/settings/sandboxes/SandboxProviderCredentialsDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxProviderCredentialsDialog.tsx
@@ -309,6 +309,7 @@ function CredentialsForm({
       <DialogFooter>
         {existingKeys.length > 0 ? (
           <Button
+            type="button"
             variant="danger"
             size="M"
             isDisabled={isCommitting}

--- a/app/src/pages/settings/sandboxes/SandboxProviderCredentialsDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxProviderCredentialsDialog.tsx
@@ -115,7 +115,6 @@ function CredentialsForm({
 }) {
   const notifySuccess = useNotifySuccess();
   const [error, setError] = useState<string | null>(null);
-  const [fetchKey, setFetchKey] = useState(0);
 
   const credentialSpecs = backend.credentialSpecs;
   const secretKeys = useMemo(
@@ -145,7 +144,7 @@ function CredentialsForm({
       }
     `,
     { keys: secretKeys },
-    { fetchKey, fetchPolicy: "store-and-network" }
+    { fetchPolicy: "store-and-network" }
   );
 
   const { savedValues, unparsable } = useMemo(() => {
@@ -188,9 +187,7 @@ function CredentialsForm({
         $input: UpsertOrDeleteSecretsMutationInput!
       ) {
         upsertOrDeleteSecrets(input: $input) {
-          query {
-            ...SettingsSandboxesPageFragment
-          }
+          __typename
         }
       }
     `);
@@ -205,9 +202,34 @@ function CredentialsForm({
     [savedValues, unparsable]
   );
 
+  const runMutation = useCallback(
+    (
+      secrets: { key: string; value: string | null }[],
+      successTitle: string,
+      successMessage: string,
+      errorFallback: string
+    ) => {
+      setError(null);
+      commit({
+        variables: { input: { secrets } },
+        onCompleted: () => {
+          onRefresh();
+          notifySuccess({ title: successTitle, message: successMessage });
+          onClose();
+        },
+        onError: (mutationError) => {
+          setError(
+            getErrorMessagesFromRelayMutationError(mutationError)?.[0] ??
+              errorFallback
+          );
+        },
+      });
+    },
+    [commit, notifySuccess, onClose, onRefresh]
+  );
+
   const onSubmit = useCallback(
     (formValues: CredentialFormValues) => {
-      setError(null);
       const secrets = credentialSpecs
         .map((spec) => {
           const next = formValues[spec.key]?.trim() || null;
@@ -222,68 +244,33 @@ function CredentialsForm({
         return;
       }
 
-      commit({
-        variables: { input: { secrets } },
-        onCompleted: () => {
-          setFetchKey((k) => k + 1);
-          onRefresh();
-          notifySuccess({
-            title: "Credentials updated",
-            message: `${secrets.length} credential${
-              secrets.length === 1 ? "" : "s"
-            } saved`,
-          });
-          onClose();
-        },
-        onError: (mutationError) => {
-          setError(
-            getErrorMessagesFromRelayMutationError(mutationError)?.[0] ??
-              "Failed to update credentials"
-          );
-        },
-      });
+      runMutation(
+        secrets,
+        "Credentials updated",
+        `${secrets.length} credential${secrets.length === 1 ? "" : "s"} saved`,
+        "Failed to update credentials"
+      );
     },
-    [credentialSpecs, savedValues, commit, notifySuccess, onClose, onRefresh]
+    [credentialSpecs, savedValues, runMutation, onClose]
   );
 
   const handleDelete = useCallback(() => {
     if (existingKeys.length === 0) return;
-    setError(null);
     const secrets = existingKeys.map((key) => ({ key, value: null }));
-    commit({
-      variables: { input: { secrets } },
-      onCompleted: () => {
-        setFetchKey((k) => k + 1);
-        const cleared: CredentialFormValues = {};
-        credentialSpecs.forEach((spec) => {
-          cleared[spec.key] = "";
-        });
-        reset(cleared);
-        onRefresh();
-        notifySuccess({
-          title: "Credentials cleared",
-          message: `${existingKeys.length} credential${
-            existingKeys.length === 1 ? "" : "s"
-          } removed`,
-        });
-        onClose();
-      },
-      onError: (mutationError) => {
-        setError(
-          getErrorMessagesFromRelayMutationError(mutationError)?.[0] ??
-            "Failed to clear credentials"
-        );
-      },
+    const cleared: CredentialFormValues = {};
+    credentialSpecs.forEach((spec) => {
+      cleared[spec.key] = "";
     });
-  }, [
-    existingKeys,
-    commit,
-    credentialSpecs,
-    reset,
-    notifySuccess,
-    onClose,
-    onRefresh,
-  ]);
+    reset(cleared);
+    runMutation(
+      secrets,
+      "Credentials cleared",
+      `${existingKeys.length} credential${
+        existingKeys.length === 1 ? "" : "s"
+      } removed`,
+      "Failed to clear credentials"
+    );
+  }, [existingKeys, credentialSpecs, reset, runMutation]);
 
   if (credentialSpecs.length === 0) {
     return (

--- a/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
@@ -1,13 +1,27 @@
 import { useState } from "react";
 import { graphql, useMutation } from "react-relay";
 
-import { Card, Flex, Label, Switch, Text } from "@phoenix/components";
+import {
+  Button,
+  Card,
+  ContextualHelp,
+  DialogTrigger,
+  Flex,
+  Icon,
+  Icons,
+  Label,
+  Modal,
+  ModalOverlay,
+  Switch,
+  Text,
+} from "@phoenix/components";
 import { SandboxProviderIcon } from "@phoenix/components/sandbox/SandboxProviderIcon";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import type { SandboxProvidersCardProviderEnabledSwitchMutation } from "./__generated__/SandboxProvidersCardProviderEnabledSwitchMutation.graphql";
+import { SandboxProviderCredentialsDialog } from "./SandboxProviderCredentialsDialog";
 import { cardIntroCSS, sandboxesTableCSS } from "./styles";
-import type { ProviderRow, SandboxProvider } from "./types";
+import type { BackendInfo, ProviderRow, SandboxProvider } from "./types";
 import {
   formatTimestamp,
   getBackendDescription,
@@ -17,8 +31,10 @@ import {
 
 export function SandboxProvidersCard({
   providers,
+  onRefresh,
 }: {
   providers: ProviderRow[];
+  onRefresh: () => void;
 }) {
   return (
     <Card title="Sandbox Providers">
@@ -33,9 +49,8 @@ export function SandboxProvidersCard({
           <tr>
             <th>Provider</th>
             <th>Language</th>
-            <th>Runtime</th>
-            <th>Status</th>
             <th>Updated</th>
+            <th>Status</th>
             <th />
           </tr>
         </thead>
@@ -51,22 +66,14 @@ export function SandboxProvidersCard({
                       height={18}
                     />
                     <span>{backend.displayName}</span>
+                    <ContextualHelp variant="info">
+                      {getBackendDescription(backend.backendType)}
+                    </ContextualHelp>
                   </Flex>
                 </td>
                 <td>
                   <LanguageWithIcon language={provider.language} />
                 </td>
-                <td>
-                  <Text>{getBackendDescription(backend.backendType)}</Text>
-                </td>
-                <td>
-                  <StatusText
-                    status={backend.status}
-                    detail={backend.statusDetail}
-                    dependencyHints={backend.dependencyHints}
-                  />
-                </td>
-
                 <td>{formatTimestamp(provider.updatedAt)}</td>
                 <td>
                   {canEnable ? (
@@ -75,10 +82,20 @@ export function SandboxProvidersCard({
                       canEnable={canEnable}
                     />
                   ) : (
-                    <Text color="text-700" size="S">
-                      Unavailable
-                    </Text>
+                    <StatusText
+                      status={backend.status}
+                      detail={backend.statusDetail}
+                      dependencyHints={backend.dependencyHints}
+                    />
                   )}
+                </td>
+                <td>
+                  <Flex justifyContent="end">
+                    <ConfigureCredentialsButton
+                      backend={backend}
+                      onRefresh={onRefresh}
+                    />
+                  </Flex>
                 </td>
               </tr>
             );
@@ -86,6 +103,40 @@ export function SandboxProvidersCard({
         </tbody>
       </table>
     </Card>
+  );
+}
+
+function ConfigureCredentialsButton({
+  backend,
+  onRefresh,
+}: {
+  backend: BackendInfo;
+  onRefresh: () => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const hasCredentialSpecs = backend.credentialSpecs.length > 0;
+  return (
+    <DialogTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
+      <Button
+        size="S"
+        aria-label={
+          hasCredentialSpecs
+            ? `Configure ${backend.displayName} credentials`
+            : `${backend.displayName} requires no credentials`
+        }
+        isDisabled={!hasCredentialSpecs}
+        leadingVisual={<Icon svg={<Icons.SettingsOutline />} />}
+      />
+      <ModalOverlay>
+        <Modal size="M">
+          <SandboxProviderCredentialsDialog
+            backend={backend}
+            onClose={() => setIsOpen(false)}
+            onRefresh={onRefresh}
+          />
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
   );
 }
 

--- a/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
@@ -20,7 +20,7 @@ import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtil
 
 import type { SandboxProvidersCardProviderEnabledSwitchMutation } from "./__generated__/SandboxProvidersCardProviderEnabledSwitchMutation.graphql";
 import { SandboxProviderCredentialsDialog } from "./SandboxProviderCredentialsDialog";
-import { cardIntroCSS, sandboxesTableCSS } from "./styles";
+import { sandboxesTableCSS } from "./styles";
 import type { BackendInfo, ProviderRow, SandboxProvider } from "./types";
 import {
   formatTimestamp,
@@ -37,13 +37,10 @@ export function SandboxProvidersCard({
   onRefresh: () => void;
 }) {
   return (
-    <Card title="Sandbox Providers">
-      <div css={cardIntroCSS}>
-        <Text color="text-700">
-          Manage shared provider settings and whether each sandbox runtime can
-          be enabled.
-        </Text>
-      </div>
+    <Card
+      title="Sandbox Providers"
+      subTitle="Manage shared provider settings and whether each sandbox runtime can be enabled."
+    >
       <table css={sandboxesTableCSS}>
         <thead>
           <tr>

--- a/app/src/pages/settings/sandboxes/SettingsSandboxesPage.tsx
+++ b/app/src/pages/settings/sandboxes/SettingsSandboxesPage.tsx
@@ -1,5 +1,9 @@
-import { useMemo } from "react";
-import { graphql, useFragment, usePreloadedQuery } from "react-relay";
+import { startTransition, useCallback, useMemo } from "react";
+import {
+  graphql,
+  usePreloadedQuery,
+  useRefetchableFragment,
+} from "react-relay";
 import { useLoaderData } from "react-router";
 import invariant from "tiny-invariant";
 
@@ -9,6 +13,7 @@ import type { settingsSandboxesPageLoaderQuery } from "@phoenix/pages/settings/_
 import type { SettingsSandboxesPageLoaderType } from "@phoenix/pages/settings/settingsSandboxesPageLoader";
 import { settingsSandboxesPageLoaderGql } from "@phoenix/pages/settings/settingsSandboxesPageLoader";
 
+import type { SettingsSandboxesPageRefetchQuery } from "./__generated__/SettingsSandboxesPageRefetchQuery.graphql";
 import { SandboxConfigsCard } from "./SandboxConfigsCard";
 import { SandboxProvidersCard } from "./SandboxProvidersCard";
 import type {
@@ -38,9 +43,13 @@ function SettingsSandboxesPageContent({
 }: {
   query: SettingsSandboxesPageFragment$key;
 }) {
-  const data = useFragment(
+  const [data, refetch] = useRefetchableFragment<
+    SettingsSandboxesPageRefetchQuery,
+    SettingsSandboxesPageFragment$key
+  >(
     graphql`
-      fragment SettingsSandboxesPageFragment on Query {
+      fragment SettingsSandboxesPageFragment on Query
+      @refetchable(queryName: "SettingsSandboxesPageRefetchQuery") {
         sandboxBackends {
           backendType
           displayName
@@ -51,6 +60,13 @@ function SettingsSandboxesPageContent({
           supportsEnvVars
           internetAccess
           dependenciesLanguage
+          credentialSpecs {
+            key
+            displayName
+            description
+            isSet
+            isRequired
+          }
         }
         sandboxProviders {
           id
@@ -114,9 +130,15 @@ function SettingsSandboxesPageContent({
     [providerRows]
   );
 
+  const refresh = useCallback(() => {
+    startTransition(() => {
+      refetch({}, { fetchPolicy: "network-only" });
+    });
+  }, [refetch]);
+
   return (
     <Flex direction="column" gap="size-200">
-      <SandboxProvidersCard providers={providerRows} />
+      <SandboxProvidersCard providers={providerRows} onRefresh={refresh} />
       <SandboxConfigsCard configRows={configRows} providerRows={providerRows} />
     </Flex>
   );

--- a/app/src/pages/settings/sandboxes/SettingsSandboxesPage.tsx
+++ b/app/src/pages/settings/sandboxes/SettingsSandboxesPage.tsx
@@ -64,7 +64,6 @@ function SettingsSandboxesPageContent({
             key
             displayName
             description
-            isSet
             isRequired
           }
         }
@@ -107,18 +106,16 @@ function SettingsSandboxesPageContent({
           row.backend != null
       )
       .sort((a, b) => {
-        // any provider with (local) in the name should be first
-        if (
-          a.backend.displayName.includes("(local)") &&
-          !b.backend.displayName.includes("(local)")
-        )
-          return -1;
-        if (
-          !a.backend.displayName.includes("(local)") &&
-          b.backend.displayName.includes("(local)")
-        )
-          return 1;
-        return 0;
+        // Local providers first, then alphabetical by display name, then by
+        // language for stable ordering when two providers share a name.
+        const aLocal = a.backend.displayName.includes("(local)") ? 0 : 1;
+        const bLocal = b.backend.displayName.includes("(local)") ? 0 : 1;
+        if (aLocal !== bLocal) return aLocal - bLocal;
+        const nameCmp = a.backend.displayName.localeCompare(
+          b.backend.displayName
+        );
+        if (nameCmp !== 0) return nameCmp;
+        return a.provider.language.localeCompare(b.provider.language);
       }) satisfies ProviderRow[];
   }, [data.sandboxBackends, data.sandboxProviders]);
 

--- a/app/src/pages/settings/sandboxes/__generated__/DeleteSandboxConfigButtonDeleteSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/DeleteSandboxConfigButtonDeleteSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2e1337aeb865c6851eda732fd0164190>>
+ * @generated SignedSource<<966e149475b2f810bbf703f79b849a47>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -62,24 +62,38 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "displayName",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "enabled",
+  "name": "description",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "config",
+  "name": "id",
   "storageKey": null
 },
 v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "enabled",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "config",
+  "storageKey": null
+},
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -157,13 +171,7 @@ return {
                 "plural": true,
                 "selections": [
                   (v3/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "displayName",
-                    "storageKey": null
-                  },
+                  (v4/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -212,6 +220,40 @@ return {
                     "kind": "ScalarField",
                     "name": "dependenciesLanguage",
                     "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "SandboxProviderCredentialSpec",
+                    "kind": "LinkedField",
+                    "name": "credentialSpecs",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "key",
+                        "storageKey": null
+                      },
+                      (v4/*: any*/),
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSet",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isRequired",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
                   }
                 ],
                 "storageKey": null
@@ -224,7 +266,7 @@ return {
                 "name": "sandboxProviders",
                 "plural": true,
                 "selections": [
-                  (v4/*: any*/),
+                  (v6/*: any*/),
                   (v3/*: any*/),
                   {
                     "alias": null,
@@ -233,9 +275,9 @@ return {
                     "name": "language",
                     "storageKey": null
                   },
-                  (v5/*: any*/),
-                  (v6/*: any*/),
                   (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -244,7 +286,7 @@ return {
                     "name": "configs",
                     "plural": true,
                     "selections": [
-                      (v4/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -252,13 +294,7 @@ return {
                         "name": "name",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "description",
-                        "storageKey": null
-                      },
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -266,9 +302,9 @@ return {
                         "name": "timeout",
                         "storageKey": null
                       },
-                      (v5/*: any*/),
-                      (v6/*: any*/),
-                      (v7/*: any*/)
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -284,12 +320,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b5869c76782b1e2831c96b530f81241a",
+    "cacheID": "579f3d8ca5f961cd3928f486f4126b61",
     "id": null,
     "metadata": {},
     "name": "DeleteSandboxConfigButtonDeleteSandboxConfigMutation",
     "operationKind": "mutation",
-    "text": "mutation DeleteSandboxConfigButtonDeleteSandboxConfigMutation(\n  $input: DeleteSandboxConfigInput!\n) {\n  deleteSandboxConfig(input: $input) {\n    deletedId\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation DeleteSandboxConfigButtonDeleteSandboxConfigMutation(\n  $input: DeleteSandboxConfigInput!\n) {\n  deleteSandboxConfig(input: $input) {\n    deletedId\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/DeleteSandboxConfigButtonDeleteSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/DeleteSandboxConfigButtonDeleteSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<966e149475b2f810bbf703f79b849a47>>
+ * @generated SignedSource<<41c12d440009ef51ec9e9eebc1f6017b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -242,13 +242,6 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "isSet",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
                         "name": "isRequired",
                         "storageKey": null
                       }
@@ -320,12 +313,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "579f3d8ca5f961cd3928f486f4126b61",
+    "cacheID": "0bf963f01c6121f14acffc6e8ab64c2f",
     "id": null,
     "metadata": {},
     "name": "DeleteSandboxConfigButtonDeleteSandboxConfigMutation",
     "operationKind": "mutation",
-    "text": "mutation DeleteSandboxConfigButtonDeleteSandboxConfigMutation(\n  $input: DeleteSandboxConfigInput!\n) {\n  deleteSandboxConfig(input: $input) {\n    deletedId\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation DeleteSandboxConfigButtonDeleteSandboxConfigMutation(\n  $input: DeleteSandboxConfigInput!\n) {\n  deleteSandboxConfig(input: $input) {\n    deletedId\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogCreateSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogCreateSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<81689e3353eb257ab8579c01f845760f>>
+ * @generated SignedSource<<d2355cba6441cedff74a35c98be9b26a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -237,13 +237,6 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "isSet",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
                         "name": "isRequired",
                         "storageKey": null
                       }
@@ -315,12 +308,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "95d0566d347a7a13ec0b164a33c6b02f",
+    "cacheID": "27d6be5f9728e43cf5b0f70698e5da26",
     "id": null,
     "metadata": {},
     "name": "SandboxConfigDialogCreateSandboxConfigMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxConfigDialogCreateSandboxConfigMutation(\n  $input: CreateSandboxConfigInput!\n) {\n  createSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxConfigDialogCreateSandboxConfigMutation(\n  $input: CreateSandboxConfigInput!\n) {\n  createSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d54369ccecade59bccb365375545f14c>>
+ * @generated SignedSource<<10541c365b56e4b187c5391d5cee96de>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -59,24 +59,38 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "displayName",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "enabled",
+  "name": "description",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "config",
+  "name": "id",
   "storageKey": null
 },
 v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "enabled",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "config",
+  "storageKey": null
+},
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -152,13 +166,7 @@ return {
                 "plural": true,
                 "selections": [
                   (v2/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "displayName",
-                    "storageKey": null
-                  },
+                  (v3/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -207,6 +215,40 @@ return {
                     "kind": "ScalarField",
                     "name": "dependenciesLanguage",
                     "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "SandboxProviderCredentialSpec",
+                    "kind": "LinkedField",
+                    "name": "credentialSpecs",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "key",
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSet",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isRequired",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
                   }
                 ],
                 "storageKey": null
@@ -219,7 +261,7 @@ return {
                 "name": "sandboxProviders",
                 "plural": true,
                 "selections": [
-                  (v3/*: any*/),
+                  (v5/*: any*/),
                   (v2/*: any*/),
                   {
                     "alias": null,
@@ -228,9 +270,9 @@ return {
                     "name": "language",
                     "storageKey": null
                   },
-                  (v4/*: any*/),
-                  (v5/*: any*/),
                   (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -239,7 +281,7 @@ return {
                     "name": "configs",
                     "plural": true,
                     "selections": [
-                      (v3/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -247,13 +289,7 @@ return {
                         "name": "name",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "description",
-                        "storageKey": null
-                      },
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -261,9 +297,9 @@ return {
                         "name": "timeout",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
-                      (v5/*: any*/),
-                      (v6/*: any*/)
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -279,12 +315,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "406bd380df0c43502c0364b3ad39dba3",
+    "cacheID": "c3b99f98e6b523bb7fa812d37c352761",
     "id": null,
     "metadata": {},
     "name": "SandboxConfigDialogUpdateSandboxConfigMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxConfigDialogUpdateSandboxConfigMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxConfigDialogUpdateSandboxConfigMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<10541c365b56e4b187c5391d5cee96de>>
+ * @generated SignedSource<<8630291fe112440b2780990ff13f5278>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -237,13 +237,6 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "isSet",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
                         "name": "isRequired",
                         "storageKey": null
                       }
@@ -315,12 +308,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c3b99f98e6b523bb7fa812d37c352761",
+    "cacheID": "ea5f240ae4bb08d23773749ee8d1199b",
     "id": null,
     "metadata": {},
     "name": "SandboxConfigDialogUpdateSandboxConfigMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxConfigDialogUpdateSandboxConfigMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxConfigDialogUpdateSandboxConfigMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4f0291e6cc0318c26d69e8a2dd4f123f>>
+ * @generated SignedSource<<b4672f35491441f00dc3bdbde8b16117>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -59,24 +59,38 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "displayName",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "enabled",
+  "name": "description",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "config",
+  "name": "id",
   "storageKey": null
 },
 v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "enabled",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "config",
+  "storageKey": null
+},
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -152,13 +166,7 @@ return {
                 "plural": true,
                 "selections": [
                   (v2/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "displayName",
-                    "storageKey": null
-                  },
+                  (v3/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -207,6 +215,40 @@ return {
                     "kind": "ScalarField",
                     "name": "dependenciesLanguage",
                     "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "SandboxProviderCredentialSpec",
+                    "kind": "LinkedField",
+                    "name": "credentialSpecs",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "key",
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSet",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isRequired",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
                   }
                 ],
                 "storageKey": null
@@ -219,7 +261,7 @@ return {
                 "name": "sandboxProviders",
                 "plural": true,
                 "selections": [
-                  (v3/*: any*/),
+                  (v5/*: any*/),
                   (v2/*: any*/),
                   {
                     "alias": null,
@@ -228,9 +270,9 @@ return {
                     "name": "language",
                     "storageKey": null
                   },
-                  (v4/*: any*/),
-                  (v5/*: any*/),
                   (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -239,7 +281,7 @@ return {
                     "name": "configs",
                     "plural": true,
                     "selections": [
-                      (v3/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -247,13 +289,7 @@ return {
                         "name": "name",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "description",
-                        "storageKey": null
-                      },
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -261,9 +297,9 @@ return {
                         "name": "timeout",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
-                      (v5/*: any*/),
-                      (v6/*: any*/)
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -279,12 +315,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1fabd9a2d9bb3f1f7552ab52144f8f53",
+    "cacheID": "6b15678395ce9eb44ee70c51af7e7f11",
     "id": null,
     "metadata": {},
     "name": "SandboxConfigsCardConfigEnabledSwitchMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxConfigsCardConfigEnabledSwitchMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxConfigsCardConfigEnabledSwitchMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b4672f35491441f00dc3bdbde8b16117>>
+ * @generated SignedSource<<dfb8d81b3e841aee3814228b2438b13b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -237,13 +237,6 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "isSet",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
                         "name": "isRequired",
                         "storageKey": null
                       }
@@ -315,12 +308,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6b15678395ce9eb44ee70c51af7e7f11",
+    "cacheID": "913db21ba8f034bf568f88dfc915ebb8",
     "id": null,
     "metadata": {},
     "name": "SandboxConfigsCardConfigEnabledSwitchMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxConfigsCardConfigEnabledSwitchMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxConfigsCardConfigEnabledSwitchMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxProviderCredentialsDialogQuery.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxProviderCredentialsDialogQuery.graphql.ts
@@ -1,0 +1,217 @@
+/**
+ * @generated SignedSource<<16719f943ada670930c0cb8c3c17ca13>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type SandboxProviderCredentialsDialogQuery$variables = {
+  keys: ReadonlyArray<string>;
+};
+export type SandboxProviderCredentialsDialogQuery$data = {
+  readonly secrets: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly key: string;
+        readonly value: {
+          readonly __typename: "DecryptedSecret";
+          readonly value: string;
+        } | {
+          readonly __typename: "UnparsableSecret";
+          readonly parseError: string;
+        } | {
+          // This will never be '%other', but we need some
+          // value in case none of the concrete values match.
+          readonly __typename: "%other";
+        };
+      };
+    }>;
+  };
+};
+export type SandboxProviderCredentialsDialogQuery = {
+  response: SandboxProviderCredentialsDialogQuery$data;
+  variables: SandboxProviderCredentialsDialogQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "keys"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "keys",
+    "variableName": "keys"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "key",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": null,
+  "kind": "LinkedField",
+  "name": "value",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "__typename",
+      "storageKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        }
+      ],
+      "type": "DecryptedSecret",
+      "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "parseError",
+          "storageKey": null
+        }
+      ],
+      "type": "UnparsableSecret",
+      "abstractKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SandboxProviderCredentialsDialogQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "SecretConnection",
+        "kind": "LinkedField",
+        "name": "secrets",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SecretEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Secret",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v2/*: any*/),
+                  (v3/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SandboxProviderCredentialsDialogQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "SecretConnection",
+        "kind": "LinkedField",
+        "name": "secrets",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SecretEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Secret",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "7294d9dbf09c5416dcc44e8aecae1e66",
+    "id": null,
+    "metadata": {},
+    "name": "SandboxProviderCredentialsDialogQuery",
+    "operationKind": "query",
+    "text": "query SandboxProviderCredentialsDialogQuery(\n  $keys: [String!]!\n) {\n  secrets(keys: $keys) {\n    edges {\n      node {\n        key\n        value {\n          __typename\n          ... on DecryptedSecret {\n            value\n          }\n          ... on UnparsableSecret {\n            parseError\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "408ebbf47688845566ffb2610d98a5fd";
+
+export default node;

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxProviderCredentialsDialogUpsertMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxProviderCredentialsDialogUpsertMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<81689e3353eb257ab8579c01f845760f>>
+ * @generated SignedSource<<58b7f13224c7804b68bb526fe9b189ab>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,27 +10,26 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type CreateSandboxConfigInput = {
-  config?: any | null;
-  description?: string | null;
-  enabled?: boolean;
-  name: string;
-  sandboxProviderId: string;
-  timeout?: number | null;
+export type UpsertOrDeleteSecretsMutationInput = {
+  secrets: ReadonlyArray<SecretKeyValueInput>;
 };
-export type SandboxConfigDialogCreateSandboxConfigMutation$variables = {
-  input: CreateSandboxConfigInput;
+export type SecretKeyValueInput = {
+  key: string;
+  value?: string | null;
 };
-export type SandboxConfigDialogCreateSandboxConfigMutation$data = {
-  readonly createSandboxConfig: {
+export type SandboxProviderCredentialsDialogUpsertMutation$variables = {
+  input: UpsertOrDeleteSecretsMutationInput;
+};
+export type SandboxProviderCredentialsDialogUpsertMutation$data = {
+  readonly upsertOrDeleteSecrets: {
     readonly query: {
       readonly " $fragmentSpreads": FragmentRefs<"SettingsSandboxesPageFragment">;
     };
   };
 };
-export type SandboxConfigDialogCreateSandboxConfigMutation = {
-  response: SandboxConfigDialogCreateSandboxConfigMutation$data;
-  variables: SandboxConfigDialogCreateSandboxConfigMutation$variables;
+export type SandboxProviderCredentialsDialogUpsertMutation = {
+  response: SandboxProviderCredentialsDialogUpsertMutation$data;
+  variables: SandboxProviderCredentialsDialogUpsertMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -102,14 +101,14 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "SandboxConfigDialogCreateSandboxConfigMutation",
+    "name": "SandboxProviderCredentialsDialogUpsertMutation",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "CreateSandboxConfigPayload",
+        "concreteType": "UpsertOrDeleteSecretsMutationPayload",
         "kind": "LinkedField",
-        "name": "createSandboxConfig",
+        "name": "upsertOrDeleteSecrets",
         "plural": false,
         "selections": [
           {
@@ -139,14 +138,14 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "SandboxConfigDialogCreateSandboxConfigMutation",
+    "name": "SandboxProviderCredentialsDialogUpsertMutation",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "CreateSandboxConfigPayload",
+        "concreteType": "UpsertOrDeleteSecretsMutationPayload",
         "kind": "LinkedField",
-        "name": "createSandboxConfig",
+        "name": "upsertOrDeleteSecrets",
         "plural": false,
         "selections": [
           {
@@ -315,16 +314,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "95d0566d347a7a13ec0b164a33c6b02f",
+    "cacheID": "212b8bf564eeb9d0a4798f2e21c07233",
     "id": null,
     "metadata": {},
-    "name": "SandboxConfigDialogCreateSandboxConfigMutation",
+    "name": "SandboxProviderCredentialsDialogUpsertMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxConfigDialogCreateSandboxConfigMutation(\n  $input: CreateSandboxConfigInput!\n) {\n  createSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxProviderCredentialsDialogUpsertMutation(\n  $input: UpsertOrDeleteSecretsMutationInput!\n) {\n  upsertOrDeleteSecrets(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "882dc58fcb9292c723e14e97dcc4447f";
+(node as any).hash = "3b42883adbb85683e3d1b00bfc9c3cce";
 
 export default node;

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxProviderCredentialsDialogUpsertMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxProviderCredentialsDialogUpsertMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<58b7f13224c7804b68bb526fe9b189ab>>
+ * @generated SignedSource<<2b49d159c7e6048d045f9efe634b5bbe>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,6 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-import { FragmentRefs } from "relay-runtime";
 export type UpsertOrDeleteSecretsMutationInput = {
   secrets: ReadonlyArray<SecretKeyValueInput>;
 };
@@ -22,9 +21,7 @@ export type SandboxProviderCredentialsDialogUpsertMutation$variables = {
 };
 export type SandboxProviderCredentialsDialogUpsertMutation$data = {
   readonly upsertOrDeleteSecrets: {
-    readonly query: {
-      readonly " $fragmentSpreads": FragmentRefs<"SettingsSandboxesPageFragment">;
-    };
+    readonly __typename: "UpsertOrDeleteSecretsMutationPayload";
   };
 };
 export type SandboxProviderCredentialsDialogUpsertMutation = {
@@ -42,95 +39,37 @@ var v0 = [
 ],
 v1 = [
   {
-    "kind": "Variable",
-    "name": "input",
-    "variableName": "input"
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpsertOrDeleteSecretsMutationPayload",
+    "kind": "LinkedField",
+    "name": "upsertOrDeleteSecrets",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
   }
-],
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "backendType",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "displayName",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "description",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "enabled",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "config",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "updatedAt",
-  "storageKey": null
-};
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "SandboxProviderCredentialsDialogUpsertMutation",
-    "selections": [
-      {
-        "alias": null,
-        "args": (v1/*: any*/),
-        "concreteType": "UpsertOrDeleteSecretsMutationPayload",
-        "kind": "LinkedField",
-        "name": "upsertOrDeleteSecrets",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Query",
-            "kind": "LinkedField",
-            "name": "query",
-            "plural": false,
-            "selections": [
-              {
-                "args": null,
-                "kind": "FragmentSpread",
-                "name": "SettingsSandboxesPageFragment"
-              }
-            ],
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
+    "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
@@ -139,191 +78,19 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "SandboxProviderCredentialsDialogUpsertMutation",
-    "selections": [
-      {
-        "alias": null,
-        "args": (v1/*: any*/),
-        "concreteType": "UpsertOrDeleteSecretsMutationPayload",
-        "kind": "LinkedField",
-        "name": "upsertOrDeleteSecrets",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Query",
-            "kind": "LinkedField",
-            "name": "query",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "SandboxBackendInfo",
-                "kind": "LinkedField",
-                "name": "sandboxBackends",
-                "plural": true,
-                "selections": [
-                  (v2/*: any*/),
-                  (v3/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "dependencyHints",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "supportedLanguages",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "status",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "statusDetail",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "supportsEnvVars",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "internetAccess",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "dependenciesLanguage",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "SandboxProviderCredentialSpec",
-                    "kind": "LinkedField",
-                    "name": "credentialSpecs",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "key",
-                        "storageKey": null
-                      },
-                      (v3/*: any*/),
-                      (v4/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isSet",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isRequired",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "SandboxProvider",
-                "kind": "LinkedField",
-                "name": "sandboxProviders",
-                "plural": true,
-                "selections": [
-                  (v5/*: any*/),
-                  (v2/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "language",
-                    "storageKey": null
-                  },
-                  (v6/*: any*/),
-                  (v7/*: any*/),
-                  (v8/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "SandboxConfig",
-                    "kind": "LinkedField",
-                    "name": "configs",
-                    "plural": true,
-                    "selections": [
-                      (v5/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "name",
-                        "storageKey": null
-                      },
-                      (v4/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "timeout",
-                        "storageKey": null
-                      },
-                      (v6/*: any*/),
-                      (v7/*: any*/),
-                      (v8/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ]
+    "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "212b8bf564eeb9d0a4798f2e21c07233",
+    "cacheID": "a775a5f565425ed85902547d8bc52df8",
     "id": null,
     "metadata": {},
     "name": "SandboxProviderCredentialsDialogUpsertMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxProviderCredentialsDialogUpsertMutation(\n  $input: UpsertOrDeleteSecretsMutationInput!\n) {\n  upsertOrDeleteSecrets(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxProviderCredentialsDialogUpsertMutation(\n  $input: UpsertOrDeleteSecretsMutationInput!\n) {\n  upsertOrDeleteSecrets(input: $input) {\n    __typename\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "3b42883adbb85683e3d1b00bfc9c3cce";
+(node as any).hash = "faec43c877e07052b1acfb5c81f2efb1";
 
 export default node;

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxProvidersCardProviderEnabledSwitchMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxProvidersCardProviderEnabledSwitchMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a2b2ec5e6486a8903a7de258e416e1fc>>
+ * @generated SignedSource<<1f15a6a422d735205521f6ba00084299>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -56,24 +56,38 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "displayName",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "enabled",
+  "name": "description",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "config",
+  "name": "id",
   "storageKey": null
 },
 v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "enabled",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "config",
+  "storageKey": null
+},
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -149,13 +163,7 @@ return {
                 "plural": true,
                 "selections": [
                   (v2/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "displayName",
-                    "storageKey": null
-                  },
+                  (v3/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -204,6 +212,40 @@ return {
                     "kind": "ScalarField",
                     "name": "dependenciesLanguage",
                     "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "SandboxProviderCredentialSpec",
+                    "kind": "LinkedField",
+                    "name": "credentialSpecs",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "key",
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSet",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isRequired",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
                   }
                 ],
                 "storageKey": null
@@ -216,7 +258,7 @@ return {
                 "name": "sandboxProviders",
                 "plural": true,
                 "selections": [
-                  (v3/*: any*/),
+                  (v5/*: any*/),
                   (v2/*: any*/),
                   {
                     "alias": null,
@@ -225,9 +267,9 @@ return {
                     "name": "language",
                     "storageKey": null
                   },
-                  (v4/*: any*/),
-                  (v5/*: any*/),
                   (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -236,7 +278,7 @@ return {
                     "name": "configs",
                     "plural": true,
                     "selections": [
-                      (v3/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -244,13 +286,7 @@ return {
                         "name": "name",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "description",
-                        "storageKey": null
-                      },
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -258,9 +294,9 @@ return {
                         "name": "timeout",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
-                      (v5/*: any*/),
-                      (v6/*: any*/)
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -276,12 +312,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f66b48ce2c240d4889c8d1e352c3fcc5",
+    "cacheID": "c8fb9e84168b6af3967494be865a7d8f",
     "id": null,
     "metadata": {},
     "name": "SandboxProvidersCardProviderEnabledSwitchMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxProvidersCardProviderEnabledSwitchMutation(\n  $input: UpdateSandboxProviderInput!\n) {\n  updateSandboxProvider(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxProvidersCardProviderEnabledSwitchMutation(\n  $input: UpdateSandboxProviderInput!\n) {\n  updateSandboxProvider(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxProvidersCardProviderEnabledSwitchMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxProvidersCardProviderEnabledSwitchMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1f15a6a422d735205521f6ba00084299>>
+ * @generated SignedSource<<8233062f1791fe0f020c01aedea745ef>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -234,13 +234,6 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "isSet",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
                         "name": "isRequired",
                         "storageKey": null
                       }
@@ -312,12 +305,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c8fb9e84168b6af3967494be865a7d8f",
+    "cacheID": "ea97054a7c9cdaf1aa3e38e483a090bc",
     "id": null,
     "metadata": {},
     "name": "SandboxProvidersCardProviderEnabledSwitchMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxProvidersCardProviderEnabledSwitchMutation(\n  $input: UpdateSandboxProviderInput!\n) {\n  updateSandboxProvider(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxProvidersCardProviderEnabledSwitchMutation(\n  $input: UpdateSandboxProviderInput!\n) {\n  updateSandboxProvider(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<46ac7b213c1828bde2ab142944fecf7c>>
+ * @generated SignedSource<<7476bb35d721b8ab7789bce19d1a5979>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,7 +20,6 @@ export type SettingsSandboxesPageFragment$data = {
       readonly description: string;
       readonly displayName: string;
       readonly isRequired: boolean;
-      readonly isSet: boolean;
       readonly key: string;
     }>;
     readonly dependenciesLanguage: Language | null;
@@ -200,13 +199,6 @@ return {
               "alias": null,
               "args": null,
               "kind": "ScalarField",
-              "name": "isSet",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
               "name": "isRequired",
               "storageKey": null
             }
@@ -275,6 +267,6 @@ return {
 };
 })();
 
-(node as any).hash = "cb16b4155368e327356016c1ff3465dd";
+(node as any).hash = "ecf4493da709473f1f05e97b6ab7e787";
 
 export default node;

--- a/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0f6f6a12695141fa562ec06945810b44>>
+ * @generated SignedSource<<46ac7b213c1828bde2ab142944fecf7c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,13 @@ import { FragmentRefs } from "relay-runtime";
 export type SettingsSandboxesPageFragment$data = {
   readonly sandboxBackends: ReadonlyArray<{
     readonly backendType: string;
+    readonly credentialSpecs: ReadonlyArray<{
+      readonly description: string;
+      readonly displayName: string;
+      readonly isRequired: boolean;
+      readonly isSet: boolean;
+      readonly key: string;
+    }>;
     readonly dependenciesLanguage: Language | null;
     readonly dependencyHints: ReadonlyArray<string>;
     readonly displayName: string;
@@ -49,6 +56,8 @@ export type SettingsSandboxesPageFragment$key = {
   readonly " $fragmentSpreads": FragmentRefs<"SettingsSandboxesPageFragment">;
 };
 
+import SettingsSandboxesPageRefetchQuery_graphql from './SettingsSandboxesPageRefetchQuery.graphql';
+
 const node: ReaderFragment = (function(){
 var v0 = {
   "alias": null,
@@ -61,24 +70,38 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "displayName",
   "storageKey": null
 },
 v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "enabled",
+  "name": "description",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "config",
+  "name": "id",
   "storageKey": null
 },
 v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "enabled",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "config",
+  "storageKey": null
+},
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -88,7 +111,13 @@ v4 = {
 return {
   "argumentDefinitions": [],
   "kind": "Fragment",
-  "metadata": null,
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [],
+      "operation": SettingsSandboxesPageRefetchQuery_graphql
+    }
+  },
   "name": "SettingsSandboxesPageFragment",
   "selections": [
     {
@@ -100,13 +129,7 @@ return {
       "plural": true,
       "selections": [
         (v0/*: any*/),
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "displayName",
-          "storageKey": null
-        },
+        (v1/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -155,6 +178,40 @@ return {
           "kind": "ScalarField",
           "name": "dependenciesLanguage",
           "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SandboxProviderCredentialSpec",
+          "kind": "LinkedField",
+          "name": "credentialSpecs",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "key",
+              "storageKey": null
+            },
+            (v1/*: any*/),
+            (v2/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "isSet",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "isRequired",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
         }
       ],
       "storageKey": null
@@ -167,7 +224,7 @@ return {
       "name": "sandboxProviders",
       "plural": true,
       "selections": [
-        (v1/*: any*/),
+        (v3/*: any*/),
         (v0/*: any*/),
         {
           "alias": null,
@@ -176,9 +233,9 @@ return {
           "name": "language",
           "storageKey": null
         },
-        (v2/*: any*/),
-        (v3/*: any*/),
         (v4/*: any*/),
+        (v5/*: any*/),
+        (v6/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -187,7 +244,7 @@ return {
           "name": "configs",
           "plural": true,
           "selections": [
-            (v1/*: any*/),
+            (v3/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -195,13 +252,7 @@ return {
               "name": "name",
               "storageKey": null
             },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "description",
-              "storageKey": null
-            },
+            (v2/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -209,9 +260,9 @@ return {
               "name": "timeout",
               "storageKey": null
             },
-            (v2/*: any*/),
-            (v3/*: any*/),
-            (v4/*: any*/)
+            (v4/*: any*/),
+            (v5/*: any*/),
+            (v6/*: any*/)
           ],
           "storageKey": null
         }
@@ -224,6 +275,6 @@ return {
 };
 })();
 
-(node as any).hash = "fbfdf2c6bcd4f7119c65cc9dbcf52876";
+(node as any).hash = "cb16b4155368e327356016c1ff3465dd";
 
 export default node;

--- a/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageRefetchQuery.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1a29b8ffa9bdd678d955d836edc23282>>
+ * @generated SignedSource<<6c18fc33d917bf8ade66ce1c90a65da2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -171,13 +171,6 @@ return {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "isSet",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
                 "name": "isRequired",
                 "storageKey": null
               }
@@ -243,16 +236,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "473b4083ba2ad067722fe44ea0aa312b",
+    "cacheID": "cd9fbbdf0396ecc309ca3d5d25ac79b7",
     "id": null,
     "metadata": {},
     "name": "SettingsSandboxesPageRefetchQuery",
     "operationKind": "query",
-    "text": "query SettingsSandboxesPageRefetchQuery {\n  ...SettingsSandboxesPageFragment\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "query SettingsSandboxesPageRefetchQuery {\n  ...SettingsSandboxesPageFragment\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "cb16b4155368e327356016c1ff3465dd";
+(node as any).hash = "ecf4493da709473f1f05e97b6ab7e787";
 
 export default node;

--- a/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageRefetchQuery.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9e76e9132a30d488fb038b8067254526>>
+ * @generated SignedSource<<1a29b8ffa9bdd678d955d836edc23282>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,13 +10,13 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type settingsSandboxesPageLoaderQuery$variables = Record<PropertyKey, never>;
-export type settingsSandboxesPageLoaderQuery$data = {
+export type SettingsSandboxesPageRefetchQuery$variables = Record<PropertyKey, never>;
+export type SettingsSandboxesPageRefetchQuery$data = {
   readonly " $fragmentSpreads": FragmentRefs<"SettingsSandboxesPageFragment">;
 };
-export type settingsSandboxesPageLoaderQuery = {
-  response: settingsSandboxesPageLoaderQuery$data;
-  variables: settingsSandboxesPageLoaderQuery$variables;
+export type SettingsSandboxesPageRefetchQuery = {
+  response: SettingsSandboxesPageRefetchQuery$data;
+  variables: SettingsSandboxesPageRefetchQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -74,7 +74,7 @@ return {
     "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "settingsSandboxesPageLoaderQuery",
+    "name": "SettingsSandboxesPageRefetchQuery",
     "selections": [
       {
         "args": null,
@@ -89,7 +89,7 @@ return {
   "operation": {
     "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "settingsSandboxesPageLoaderQuery",
+    "name": "SettingsSandboxesPageRefetchQuery",
     "selections": [
       {
         "alias": null,
@@ -243,16 +243,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3340b59919e4b38cfe89f7478ac8fd98",
+    "cacheID": "473b4083ba2ad067722fe44ea0aa312b",
     "id": null,
     "metadata": {},
-    "name": "settingsSandboxesPageLoaderQuery",
+    "name": "SettingsSandboxesPageRefetchQuery",
     "operationKind": "query",
-    "text": "query settingsSandboxesPageLoaderQuery {\n  ...SettingsSandboxesPageFragment\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "query SettingsSandboxesPageRefetchQuery {\n  ...SettingsSandboxesPageFragment\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isSet\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "8b7c1366afbed5a07d5e628b48bd100c";
+(node as any).hash = "cb16b4155368e327356016c1ff3465dd";
 
 export default node;

--- a/app/src/pages/settings/sandboxes/styles.ts
+++ b/app/src/pages/settings/sandboxes/styles.ts
@@ -2,11 +2,6 @@ import { css } from "@emotion/react";
 
 import { tableCSS } from "@phoenix/components/table/styles";
 
-export const cardIntroCSS = css`
-  padding: var(--global-dimension-size-200);
-  border-bottom: 1px solid var(--global-border-color-default);
-`;
-
 export const sandboxesTableWrapCSS = css`
   overflow: hidden;
 `;

--- a/app/src/pages/settings/sandboxes/styles.ts
+++ b/app/src/pages/settings/sandboxes/styles.ts
@@ -2,11 +2,6 @@ import { css } from "@emotion/react";
 
 import { tableCSS } from "@phoenix/components/table/styles";
 
-export const pageIntroCSS = css`
-  padding: var(--global-dimension-size-200);
-  border-bottom: 1px solid var(--global-border-color-default);
-`;
-
 export const cardIntroCSS = css`
   padding: var(--global-dimension-size-200);
   border-bottom: 1px solid var(--global-border-color-default);

--- a/src/phoenix/server/api/types/SandboxConfig.py
+++ b/src/phoenix/server/api/types/SandboxConfig.py
@@ -24,6 +24,7 @@ from phoenix.server.api.types.Identifier import Identifier
 from phoenix.server.sandbox import (
     SANDBOX_ADAPTER_METADATA,
     MissingSecretError,
+    _resolve_named_credentials,
     get_missing_sandbox_auth_detail,
     get_or_create_backend,
 )
@@ -42,6 +43,17 @@ class ConfigFieldSpecType:
     required: bool
     description: str
     choices: Optional[list[str]]
+
+
+@strawberry.type
+class SandboxProviderCredentialSpec:
+    """GQL mirror of ProviderCredentialSpec, plus runtime resolution status."""
+
+    key: str
+    display_name: str
+    description: str
+    is_set: bool
+    is_required: bool
 
 
 @strawberry.enum
@@ -92,6 +104,7 @@ class SandboxBackendInfo:
     supports_env_vars: bool
     internet_access: InternetAccessMode
     dependencies_language: Optional[Language]
+    credential_specs: list[SandboxProviderCredentialSpec]
 
 
 @strawberry.type
@@ -353,6 +366,49 @@ def _probe_wasm_binary(backend_type: str) -> Optional[str]:
     return probe.detail
 
 
+def _required_credential_keys_for_backend(backend_type: str) -> set[str]:
+    """Return the subset of credential keys the backend treats as required.
+
+    Every credential surfaced in the UI is required.
+    """
+    from phoenix.server.sandbox import _SANDBOX_ADAPTERS
+
+    adapter = _SANDBOX_ADAPTERS.get(backend_type)
+    if adapter is None:
+        return set()
+    return {spec.key for spec in adapter.credential_specs}
+
+
+async def _build_credential_specs(
+    backend_type: str,
+    session: Optional[Any],
+    decrypt: Optional[Any],
+) -> list[SandboxProviderCredentialSpec]:
+    """Resolve credential specs into GQL types with is_set populated."""
+    import os
+
+    from phoenix.server.sandbox import _SANDBOX_ADAPTERS
+
+    adapter = _SANDBOX_ADAPTERS.get(backend_type)
+    if adapter is None or not adapter.credential_specs:
+        return []
+    required_keys = _required_credential_keys_for_backend(backend_type)
+    keys = [spec.key for spec in adapter.credential_specs]
+    resolved: dict[str, str] = {}
+    if session is not None and decrypt is not None:
+        resolved = await _resolve_named_credentials(session, decrypt, keys)
+    return [
+        SandboxProviderCredentialSpec(
+            key=spec.key,
+            display_name=spec.display_name,
+            description=spec.description,
+            is_set=(spec.key in resolved) or bool(os.getenv(spec.key)),
+            is_required=spec.key in required_keys,
+        )
+        for spec in adapter.credential_specs
+    ]
+
+
 async def _get_sandbox_backend_info_with_session(
     session: Optional[Any],
     decrypt: Optional[Any],
@@ -410,6 +466,7 @@ async def _get_sandbox_backend_info_with_session(
                         status = SandboxBackendStatus.UNAVAILABLE
                         status_detail = str(exc)
         raw_specs = getattr(meta, "config_field_specs", [])
+        credential_specs = await _build_credential_specs(backend_type, session, decrypt)
         infos.append(
             SandboxBackendInfo(
                 backend_type=backend_type,
@@ -434,6 +491,7 @@ async def _get_sandbox_backend_info_with_session(
                 dependencies_language=(
                     Language(meta.dependencies_language) if meta.dependencies_language else None
                 ),
+                credential_specs=credential_specs,
             )
         )
     return infos

--- a/src/phoenix/server/api/types/SandboxConfig.py
+++ b/src/phoenix/server/api/types/SandboxConfig.py
@@ -24,7 +24,6 @@ from phoenix.server.api.types.Identifier import Identifier
 from phoenix.server.sandbox import (
     SANDBOX_ADAPTER_METADATA,
     MissingSecretError,
-    _resolve_named_credentials,
     get_missing_sandbox_auth_detail,
     get_or_create_backend,
 )
@@ -47,12 +46,11 @@ class ConfigFieldSpecType:
 
 @strawberry.type
 class SandboxProviderCredentialSpec:
-    """GQL mirror of ProviderCredentialSpec, plus runtime resolution status."""
+    """GQL mirror of ProviderCredentialSpec."""
 
     key: str
     display_name: str
     description: str
-    is_set: bool
     is_required: bool
 
 
@@ -366,32 +364,21 @@ def _probe_wasm_binary(backend_type: str) -> Optional[str]:
     return probe.detail
 
 
-async def _build_credential_specs(
+def _build_credential_specs(
     backend_type: str,
-    session: Optional[Any],
-    decrypt: Optional[Any],
 ) -> list[SandboxProviderCredentialSpec]:
-    """Resolve credential specs into GQL types with is_set populated.
-
-    Every adapter-declared credential is treated as required (is_required=True).
-    """
+    """Mirror an adapter's credential_specs into GQL types."""
     from phoenix.server.sandbox import _SANDBOX_ADAPTERS
 
     adapter = _SANDBOX_ADAPTERS.get(backend_type)
     if adapter is None or not adapter.credential_specs:
         return []
-    keys = [spec.key for spec in adapter.credential_specs]
-    # _resolve_named_credentials already falls back to os.getenv when the DB
-    # lookup misses (or when session/decrypt are None), so resolved represents
-    # the full DB+env view.
-    resolved = await _resolve_named_credentials(session, decrypt, keys)
     return [
         SandboxProviderCredentialSpec(
             key=spec.key,
             display_name=spec.display_name,
             description=spec.description,
-            is_set=spec.key in resolved,
-            is_required=True,
+            is_required=spec.is_required,
         )
         for spec in adapter.credential_specs
     ]
@@ -454,7 +441,7 @@ async def _get_sandbox_backend_info_with_session(
                         status = SandboxBackendStatus.UNAVAILABLE
                         status_detail = str(exc)
         raw_specs = getattr(meta, "config_field_specs", [])
-        credential_specs = await _build_credential_specs(backend_type, session, decrypt)
+        credential_specs = _build_credential_specs(backend_type)
         infos.append(
             SandboxBackendInfo(
                 backend_type=backend_type,

--- a/src/phoenix/server/api/types/SandboxConfig.py
+++ b/src/phoenix/server/api/types/SandboxConfig.py
@@ -366,44 +366,32 @@ def _probe_wasm_binary(backend_type: str) -> Optional[str]:
     return probe.detail
 
 
-def _required_credential_keys_for_backend(backend_type: str) -> set[str]:
-    """Return the subset of credential keys the backend treats as required.
-
-    Every credential surfaced in the UI is required.
-    """
-    from phoenix.server.sandbox import _SANDBOX_ADAPTERS
-
-    adapter = _SANDBOX_ADAPTERS.get(backend_type)
-    if adapter is None:
-        return set()
-    return {spec.key for spec in adapter.credential_specs}
-
-
 async def _build_credential_specs(
     backend_type: str,
     session: Optional[Any],
     decrypt: Optional[Any],
 ) -> list[SandboxProviderCredentialSpec]:
-    """Resolve credential specs into GQL types with is_set populated."""
-    import os
+    """Resolve credential specs into GQL types with is_set populated.
 
+    Every adapter-declared credential is treated as required (is_required=True).
+    """
     from phoenix.server.sandbox import _SANDBOX_ADAPTERS
 
     adapter = _SANDBOX_ADAPTERS.get(backend_type)
     if adapter is None or not adapter.credential_specs:
         return []
-    required_keys = _required_credential_keys_for_backend(backend_type)
     keys = [spec.key for spec in adapter.credential_specs]
-    resolved: dict[str, str] = {}
-    if session is not None and decrypt is not None:
-        resolved = await _resolve_named_credentials(session, decrypt, keys)
+    # _resolve_named_credentials already falls back to os.getenv when the DB
+    # lookup misses (or when session/decrypt are None), so resolved represents
+    # the full DB+env view.
+    resolved = await _resolve_named_credentials(session, decrypt, keys)
     return [
         SandboxProviderCredentialSpec(
             key=spec.key,
             display_name=spec.display_name,
             description=spec.description,
-            is_set=(spec.key in resolved) or bool(os.getenv(spec.key)),
-            is_required=spec.key in required_keys,
+            is_set=spec.key in resolved,
+            is_required=True,
         )
         for spec in adapter.credential_specs
     ]

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -244,36 +244,24 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
     # Python SDK has not yet ported them. Re-evaluate when Python SDK >=0.5.8
     # ships; flip internet_access_capability to "boolean" and wire network_policy
     # then. Until that lands, both Vercel adapters remain internet_access="none".
-    "VERCEL_PYTHON": AdapterMetadata(
-        display_name="Vercel Sandbox",
-        language="PYTHON",
-        dependency_hints=[
-            "Install Phoenix with the `vercel` extra.",
-            (
-                "Set all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, "
-                "`PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and "
-                "`PHOENIX_SANDBOX_VERCEL_TEAM_ID`."
-            ),
-        ],
-        supports_env_vars=True,
-        internet_access_capability="none",
-        dependencies_language=None,
-    ),
-    "VERCEL_TYPESCRIPT": AdapterMetadata(
-        display_name="Vercel Sandbox",
-        language="TYPESCRIPT",
-        dependency_hints=[
-            "Install Phoenix with the `vercel` extra.",
-            (
-                "Set all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, "
-                "`PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and "
-                "`PHOENIX_SANDBOX_VERCEL_TEAM_ID`."
-            ),
-        ],
-        supports_env_vars=True,
-        internet_access_capability="none",
-        dependencies_language=None,
-    ),
+    **{
+        f"VERCEL_{lang}": AdapterMetadata(
+            display_name="Vercel Sandbox",
+            language=lang,
+            dependency_hints=[
+                "Install Phoenix with the `vercel` extra.",
+                (
+                    "Set all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, "
+                    "`PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and "
+                    "`PHOENIX_SANDBOX_VERCEL_TEAM_ID`."
+                ),
+            ],
+            supports_env_vars=True,
+            internet_access_capability="none",
+            dependencies_language=None,
+        )
+        for lang in ("PYTHON", "TYPESCRIPT")
+    },
     "DENO": AdapterMetadata(
         display_name="Deno (local)",
         language="TYPESCRIPT",

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -555,9 +555,7 @@ async def get_missing_sandbox_auth_detail(
     if backend_type == "MODAL":
         modal_keys = ["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"]
         resolved = await _resolve_named_credentials(session, decrypt, modal_keys)
-        missing_modal_keys = [
-            key for key in modal_keys if key not in resolved and not os.getenv(key)
-        ]
+        missing_modal_keys = [key for key in modal_keys if key not in resolved]
         if not missing_modal_keys:
             return None
         return f"Set {_format_required_keys(missing_modal_keys)}."
@@ -729,12 +727,11 @@ except ImportError:
 
 _PHOENIX_RESERVED_CREDENTIAL_ONLY_KEYS: frozenset[str] = frozenset(
     {
-        # Reservation-only names: NOT settable via setSandboxCredential mutation.
-        # Contrast with SandboxAdapter.credential_specs (adapter-declared, settable
-        # via mutation). RESERVED_CREDENTIAL_NAMES is the derived union of both.
-        # Modal remains env-var-only, so reserve its names explicitly.
-        "MODAL_TOKEN_ID",
-        "MODAL_TOKEN_SECRET",
+        # Reservation-only names: reserved against user env_var / config-key
+        # collisions even though they are not exposed via the credentials UI.
+        # Adapter-declared credential_specs are unioned in by
+        # _build_reserved_credential_names — this set is only for keys that
+        # are NOT advertised through credential_specs.
         # VERCEL_OIDC_TOKEN is read by the Vercel SDK directly from os.environ.
         # We no longer surface it in the UI (only the access-token triple is
         # configurable), but it must stay reserved so a user-supplied env_var

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -250,8 +250,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         dependency_hints=[
             "Install Phoenix with the `vercel` extra.",
             (
-                "Set `VERCEL_OIDC_TOKEN`, or all of "
-                "`PHOENIX_SANDBOX_VERCEL_TOKEN`, "
+                "Set all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, "
                 "`PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and "
                 "`PHOENIX_SANDBOX_VERCEL_TEAM_ID`."
             ),
@@ -266,8 +265,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         dependency_hints=[
             "Install Phoenix with the `vercel` extra.",
             (
-                "Set `VERCEL_OIDC_TOKEN`, or all of "
-                "`PHOENIX_SANDBOX_VERCEL_TOKEN`, "
+                "Set all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, "
                 "`PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and "
                 "`PHOENIX_SANDBOX_VERCEL_TEAM_ID`."
             ),
@@ -552,6 +550,8 @@ async def get_missing_sandbox_auth_detail(
         return "Set `PHOENIX_SANDBOX_DAYTONA_API_KEY`."
 
     if backend_type in {"VERCEL_PYTHON", "VERCEL_TYPESCRIPT"}:
+        # OIDC is still honored as an environment fallback (e.g. on Vercel
+        # deployments or after `vercel env pull`) but is not exposed in the UI.
         oidc_key = "VERCEL_OIDC_TOKEN"
         access_keys = [
             "PHOENIX_SANDBOX_VERCEL_TOKEN",
@@ -562,20 +562,13 @@ async def get_missing_sandbox_auth_detail(
         if oidc_key in resolved or all(key in resolved for key in access_keys):
             return None
         missing_access_keys = [key for key in access_keys if key not in resolved]
-        if len(missing_access_keys) < len(access_keys):
-            return (
-                "Set `VERCEL_OIDC_TOKEN`, or add "
-                f"{_format_required_keys(missing_access_keys)} to complete "
-                "the Vercel access token configuration."
-            )
-        return (
-            "Set `VERCEL_OIDC_TOKEN`, or all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, "
-            "`PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and `PHOENIX_SANDBOX_VERCEL_TEAM_ID`."
-        )
+        return f"Set {_format_required_keys(missing_access_keys)}."
 
     if backend_type == "MODAL":
+        modal_keys = ["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"]
+        resolved = await _resolve_named_credentials(session, decrypt, modal_keys)
         missing_modal_keys = [
-            key for key in ("MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET") if not os.getenv(key)
+            key for key in modal_keys if key not in resolved and not os.getenv(key)
         ]
         if not missing_modal_keys:
             return None
@@ -754,6 +747,11 @@ _PHOENIX_RESERVED_CREDENTIAL_ONLY_KEYS: frozenset[str] = frozenset(
         # Modal remains env-var-only, so reserve its names explicitly.
         "MODAL_TOKEN_ID",
         "MODAL_TOKEN_SECRET",
+        # VERCEL_OIDC_TOKEN is read by the Vercel SDK directly from os.environ.
+        # We no longer surface it in the UI (only the access-token triple is
+        # configurable), but it must stay reserved so a user-supplied env_var
+        # cannot shadow the SDK's auth resolution at execute time.
+        "VERCEL_OIDC_TOKEN",
     }
 )
 

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import threading
 from typing import Any, Optional
 
 from .types import (
@@ -39,6 +40,16 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 600
 _DEFAULT_IDLE_TIMEOUT = 300
+
+_ENV_MODAL_TOKEN_ID = "MODAL_TOKEN_ID"
+_ENV_MODAL_TOKEN_SECRET = "MODAL_TOKEN_SECRET"
+
+# Modal SDK reads MODAL_TOKEN_ID / MODAL_TOKEN_SECRET from os.environ at client
+# init time. When DB-stored secrets are resolved we inject them around the
+# Modal client construction and restore the originals afterward; the lock
+# serializes that env-mutation window across concurrent backend constructions
+# so two instances cannot leak each other's credentials into the process env.
+_MODAL_TOKEN_ENV_LOCK = threading.Lock()
 
 
 class ModalSandboxBackend(SandboxBackend):
@@ -61,15 +72,30 @@ class ModalSandboxBackend(SandboxBackend):
         token_secret: Optional[str] = None,
     ) -> None:
         # Modal SDK reads MODAL_TOKEN_ID / MODAL_TOKEN_SECRET from os.environ at
-        # client init time. Inject DB-resolved values before the SDK is touched
-        # so admins can configure Modal via the secrets table without having to
-        # also export the variables in the server process.
-        if token_id:
-            os.environ["MODAL_TOKEN_ID"] = token_id
-        if token_secret:
-            os.environ["MODAL_TOKEN_SECRET"] = token_secret
+        # client init time. Inject DB-resolved values around the SDK import +
+        # App.lookup() and restore the originals afterward so credentials don't
+        # linger in the process environment after construction returns.
+        with _MODAL_TOKEN_ENV_LOCK:
+            previous_token_id = os.environ.get(_ENV_MODAL_TOKEN_ID)
+            previous_token_secret = os.environ.get(_ENV_MODAL_TOKEN_SECRET)
+            try:
+                if token_id:
+                    os.environ[_ENV_MODAL_TOKEN_ID] = token_id
+                if token_secret:
+                    os.environ[_ENV_MODAL_TOKEN_SECRET] = token_secret
 
-        import modal  # type: ignore[import-not-found]
+                import modal  # type: ignore[import-not-found]
+
+                app = modal.App.lookup(app_name, create_if_missing=True)
+            finally:
+                if previous_token_id is None:
+                    os.environ.pop(_ENV_MODAL_TOKEN_ID, None)
+                else:
+                    os.environ[_ENV_MODAL_TOKEN_ID] = previous_token_id
+                if previous_token_secret is None:
+                    os.environ.pop(_ENV_MODAL_TOKEN_SECRET, None)
+                else:
+                    os.environ[_ENV_MODAL_TOKEN_SECRET] = previous_token_secret
 
         self._timeout = timeout
         self._idle_timeout = idle_timeout
@@ -77,7 +103,7 @@ class ModalSandboxBackend(SandboxBackend):
         self._block_network = block_network
         self._sessions: dict[str, Any] = {}
         self._session_locks: dict[str, asyncio.Lock] = {}
-        self._app = modal.App.lookup(app_name, create_if_missing=True)
+        self._app = app
         base_image = modal.Image.debian_slim()
         self._image = base_image.pip_install(packages) if packages else base_image
 

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -4,9 +4,10 @@ Modal sandbox backend.
 Requires the ``modal`` package (optional extra).
 Import is deferred to avoid top-level failures when the extra is absent.
 
-Authentication is env-var-only: Modal picks up MODAL_TOKEN_ID and
-MODAL_TOKEN_SECRET automatically from the environment (D6 design decision —
-no credentials stored in DB config).
+Authentication: Modal SDK reads MODAL_TOKEN_ID and MODAL_TOKEN_SECRET from
+``os.environ``. When DB-stored secrets are resolved for these keys, the
+backend writes them into ``os.environ`` before invoking the Modal SDK so
+the SDK picks them up.
 
 Session lifecycle
 -----------------
@@ -23,11 +24,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from typing import Any, Optional
 
 from .types import (
     ExecutionResult,
     ModalConfig,
+    ProviderCredentialSpec,
     SandboxAdapter,
     SandboxBackend,
 )
@@ -54,7 +57,18 @@ class ModalSandboxBackend(SandboxBackend):
         user_env: Optional[dict[str, str]] = None,
         packages: Optional[list[str]] = None,
         block_network: bool = False,
+        token_id: Optional[str] = None,
+        token_secret: Optional[str] = None,
     ) -> None:
+        # Modal SDK reads MODAL_TOKEN_ID / MODAL_TOKEN_SECRET from os.environ at
+        # client init time. Inject DB-resolved values before the SDK is touched
+        # so admins can configure Modal via the secrets table without having to
+        # also export the variables in the server process.
+        if token_id:
+            os.environ["MODAL_TOKEN_ID"] = token_id
+        if token_secret:
+            os.environ["MODAL_TOKEN_SECRET"] = token_secret
+
         import modal  # type: ignore[import-not-found]
 
         self._timeout = timeout
@@ -146,6 +160,18 @@ class ModalAdapter(SandboxAdapter):
     display_name = "Modal"
     language = "PYTHON"
     config_model = ModalConfig
+    credential_specs = [
+        ProviderCredentialSpec(
+            key="MODAL_TOKEN_ID",
+            display_name="Modal Token ID",
+            description="Token ID issued by `modal token new`.",
+        ),
+        ProviderCredentialSpec(
+            key="MODAL_TOKEN_SECRET",
+            display_name="Modal Token Secret",
+            description="Token secret issued by `modal token new`.",
+        ),
+    ]
 
     def build_backend(
         self,
@@ -158,6 +184,8 @@ class ModalAdapter(SandboxAdapter):
         ia = config.get("internet_access") or {}
         mode = ia.get("mode") if isinstance(ia, dict) else getattr(ia, "mode", None)
         block_network: bool = mode == "deny"
+        token_id = config.get("MODAL_TOKEN_ID") or None
+        token_secret = config.get("MODAL_TOKEN_SECRET") or None
         return ModalSandboxBackend(
             timeout=_DEFAULT_TIMEOUT,
             idle_timeout=_DEFAULT_IDLE_TIMEOUT,
@@ -165,4 +193,6 @@ class ModalAdapter(SandboxAdapter):
             user_env=user_env,
             packages=packages or None,
             block_network=block_network,
+            token_id=token_id,
+            token_secret=token_secret,
         )

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import threading
 from typing import Any, Optional
 
 from .types import (
@@ -40,16 +39,6 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 600
 _DEFAULT_IDLE_TIMEOUT = 300
-
-_ENV_MODAL_TOKEN_ID = "MODAL_TOKEN_ID"
-_ENV_MODAL_TOKEN_SECRET = "MODAL_TOKEN_SECRET"
-
-# Modal SDK reads MODAL_TOKEN_ID / MODAL_TOKEN_SECRET from os.environ at client
-# init time. When DB-stored secrets are resolved we inject them around the
-# Modal client construction and restore the originals afterward; the lock
-# serializes that env-mutation window across concurrent backend constructions
-# so two instances cannot leak each other's credentials into the process env.
-_MODAL_TOKEN_ENV_LOCK = threading.Lock()
 
 
 class ModalSandboxBackend(SandboxBackend):
@@ -72,30 +61,15 @@ class ModalSandboxBackend(SandboxBackend):
         token_secret: Optional[str] = None,
     ) -> None:
         # Modal SDK reads MODAL_TOKEN_ID / MODAL_TOKEN_SECRET from os.environ at
-        # client init time. Inject DB-resolved values around the SDK import +
-        # App.lookup() and restore the originals afterward so credentials don't
-        # linger in the process environment after construction returns.
-        with _MODAL_TOKEN_ENV_LOCK:
-            previous_token_id = os.environ.get(_ENV_MODAL_TOKEN_ID)
-            previous_token_secret = os.environ.get(_ENV_MODAL_TOKEN_SECRET)
-            try:
-                if token_id:
-                    os.environ[_ENV_MODAL_TOKEN_ID] = token_id
-                if token_secret:
-                    os.environ[_ENV_MODAL_TOKEN_SECRET] = token_secret
+        # client init time. Inject DB-resolved values before the SDK is touched
+        # so admins can configure Modal via the secrets table without having to
+        # also export the variables in the server process.
+        if token_id:
+            os.environ["MODAL_TOKEN_ID"] = token_id
+        if token_secret:
+            os.environ["MODAL_TOKEN_SECRET"] = token_secret
 
-                import modal  # type: ignore[import-not-found]
-
-                app = modal.App.lookup(app_name, create_if_missing=True)
-            finally:
-                if previous_token_id is None:
-                    os.environ.pop(_ENV_MODAL_TOKEN_ID, None)
-                else:
-                    os.environ[_ENV_MODAL_TOKEN_ID] = previous_token_id
-                if previous_token_secret is None:
-                    os.environ.pop(_ENV_MODAL_TOKEN_SECRET, None)
-                else:
-                    os.environ[_ENV_MODAL_TOKEN_SECRET] = previous_token_secret
+        import modal  # type: ignore[import-not-found]
 
         self._timeout = timeout
         self._idle_timeout = idle_timeout
@@ -103,7 +77,7 @@ class ModalSandboxBackend(SandboxBackend):
         self._block_network = block_network
         self._sessions: dict[str, Any] = {}
         self._session_locks: dict[str, asyncio.Lock] = {}
-        self._app = app
+        self._app = modal.App.lookup(app_name, create_if_missing=True)
         base_image = modal.Image.debian_slim()
         self._image = base_image.pip_install(packages) if packages else base_image
 

--- a/src/phoenix/server/sandbox/types.py
+++ b/src/phoenix/server/sandbox/types.py
@@ -93,6 +93,7 @@ class ProviderCredentialSpec:
     key: str
     display_name: str
     description: str = ""
+    is_required: bool = True
 
 
 # ---------------------------------------------------------------------------

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -240,32 +240,25 @@ def _resolve_vercel_oidc_token(config: dict[str, Any]) -> str:
     return str(config.get(ENV_VERCEL_OIDC_TOKEN) or "") or os.environ.get(ENV_VERCEL_OIDC_TOKEN, "")
 
 
+# UI surfaces only the access-token triple. OIDC is still honored when
+# VERCEL_OIDC_TOKEN is present in the process environment (e.g. `vercel env
+# pull` or running on Vercel) — see get_missing_sandbox_auth_detail and
+# build_backend below — but is not exposed as a configurable secret.
 _VERCEL_ENV_VAR_SPECS = [
-    ProviderCredentialSpec(
-        key="VERCEL_OIDC_TOKEN",
-        display_name="Vercel OIDC Token",
-        description="OIDC token for Vercel sandbox (e.g. from `vercel env pull`).",
-    ),
     ProviderCredentialSpec(
         key="PHOENIX_SANDBOX_VERCEL_TOKEN",
         display_name="Vercel Access Token",
-        description="Vercel personal access token (used with PHOENIX_SANDBOX_VERCEL_PROJECT_ID and PHOENIX_SANDBOX_VERCEL_TEAM_ID).",  # noqa: E501
+        description="Vercel personal access token.",
     ),
     ProviderCredentialSpec(
         key="PHOENIX_SANDBOX_VERCEL_PROJECT_ID",
         display_name="Vercel Project ID",
-        description=(
-            "Vercel project ID (used with PHOENIX_SANDBOX_VERCEL_TOKEN and "
-            "PHOENIX_SANDBOX_VERCEL_TEAM_ID)."
-        ),
+        description="Vercel project ID.",
     ),
     ProviderCredentialSpec(
         key="PHOENIX_SANDBOX_VERCEL_TEAM_ID",
         display_name="Vercel Team ID",
-        description=(
-            "Vercel team ID (used with PHOENIX_SANDBOX_VERCEL_TOKEN and "
-            "PHOENIX_SANDBOX_VERCEL_PROJECT_ID)."
-        ),
+        description="Vercel team ID.",
     ),
 ]
 

--- a/tests/unit/server/api/test_sandbox_queries.py
+++ b/tests/unit/server/api/test_sandbox_queries.py
@@ -143,7 +143,7 @@ async def test_sandbox_backends_and_providers_can_be_loaded_together(
     ]
     assert backends["VERCEL_PYTHON"]["dependencyHints"] == [
         "Install Phoenix with the `vercel` extra.",
-        "Set `VERCEL_OIDC_TOKEN`, or all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, `PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and `PHOENIX_SANDBOX_VERCEL_TEAM_ID`.",
+        "Set all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, `PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and `PHOENIX_SANDBOX_VERCEL_TEAM_ID`.",
     ]
     assert backends["DENO"]["dependencyHints"] == [
         "Install the Deno runtime and ensure the `deno` binary is available on PATH.",


### PR DESCRIPTION

<img width="1910" height="884" alt="Screenshot 2026-05-06 at 9 49 28 AM" src="https://github.com/user-attachments/assets/a00f612a-82c4-40b0-8d55-942fe84a4744" />


- **Credentials dialog**: new `SandboxProviderCredentialsDialog` for editing per-provider env-var secrets (Save/Clear, redacted inputs, suspense loading).
- **Provider table**: consolidated the duplicative *Status* and *Enabled* columns into a single column — shows the enable toggle when the backend is `AVAILABLE`, otherwise renders `StatusText` (e.g. *Authentication required*, *Unavailable*, *Not installed*) with the existing tooltip detail.
- **Refresh-after-credentials-mutate**: `SettingsSandboxesPageFragment` is now `@refetchable`; the page passes a refresh callback through `SandboxProvidersCard` → `ConfigureCredentialsButton` → `SandboxProviderCredentialsDialog`, so saving or clearing credentials forces a network refetch and the provider status updates immediately.
- **Configs card subtitle**: moved the intro copy ("Configure reusable sandbox configurations…") into the Card's `subTitle` prop and dropped the now-unused page-intro container.
- **Vercel auth (triple-only UI)**: dropped `VERCEL_OIDC_TOKEN` from the configurable credential specs — only the `PHOENIX_SANDBOX_VERCEL_{TOKEN,PROJECT_ID,TEAM_ID}` triple is surfaced in the UI. OIDC is still honored as a process-env fallback (so existing `vercel env pull` / on-Vercel deployments continue to work) and is still reserved via `_PHOENIX_RESERVED_CREDENTIAL_ONLY_KEYS` so user env_vars can't shadow the SDK's auth resolution. Triple keys are now marked required, and `dependency_hints` / status detail messages are simplified accordingly.