### PR TITLE
docs(skills): weekly audit — 2026-05-06

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -36,6 +36,12 @@ px dataset get <name>
 px project list
 px annotation-config list
 px auth status
+px profile list
+px profile show [name]
+px profile create <name>
+px profile use <name>
+px profile edit <name>
+px profile delete <name>
 ```
 
 ## Setup
@@ -72,7 +78,34 @@ Always use `--format raw --no-progress` when piping to `jq`.
 ```bash
 px auth status                                # check connection and authentication
 px auth status --endpoint http://other:6006   # check a specific endpoint
+px auth status --profile staging              # check a named profile's connection
 ```
+
+## Profiles
+
+Named profiles let you switch between multiple Phoenix instances (local, staging, cloud) without juggling environment variables. Profiles are stored in `~/.px/settings.json` (or `$XDG_CONFIG_HOME/px/settings.json`).
+
+Configuration priority (highest to lowest): CLI flags > env vars > active profile > built-in defaults.
+
+```bash
+px profile list                              # list all profiles (shows active profile)
+px profile show                              # show the active profile's settings
+px profile show staging                      # show a named profile's settings
+px profile create prod --endpoint https://app.phoenix.arize.com --api-key <key> --activate
+px profile create local --endpoint http://localhost:6006 --project my-app
+px profile use prod                          # switch the active profile
+px profile edit prod                         # open profile JSON in $EDITOR (validates on save)
+px profile delete prod --yes                 # delete a profile (--yes skips confirmation)
+```
+
+Use `--profile <name>` on any command to target a specific profile without changing the active one:
+
+```bash
+px trace list --profile staging --limit 10 --format raw --no-progress | jq .
+px auth status --profile prod
+```
+
+`px profile create` options: `--endpoint <url>`, `--project <name>`, `--api-key <key>`, `--header <key=value>` (repeatable), `--activate`.
 
 ## Projects
 
@@ -102,6 +135,7 @@ px trace add-note <trace-id> --text "needs follow-up"
 ```
 Trace
   traceId, status ("OK"|"ERROR"), duration (ms), startTime, endTime
+  token_count_prompt, token_count_completion, token_count_total  — cumulative across all LLM spans (int, default 0)
   annotations[] (with --include-annotations, excludes note)
     name, result { score, label, explanation }
   notes[] (with --include-notes)
@@ -192,6 +226,7 @@ px session add-note <session-id> --text "verified by agent"
 SessionData
   id, session_id, project_id
   start_time, end_time
+  token_count_prompt, token_count_completion, token_count_total  — cumulative across all LLM spans in the session (int, default 0)
   annotations[] (with --include-annotations, excludes note)
     name, result { score, label, explanation }
   notes[] (with --include-notes)

--- a/.agents/skills/phoenix-evals/references/experiments-datasets-python.md
+++ b/.agents/skills/phoenix-evals/references/experiments-datasets-python.md
@@ -4,6 +4,8 @@ Creating and managing evaluation datasets.
 
 ## Creating Datasets
 
+`create_dataset()` upserts: if a dataset with the same name already exists it is updated in-place; re-running with identical inputs is a no-op.
+
 ```python
 from phoenix.client import Client
 
@@ -21,6 +23,19 @@ dataset = client.datasets.create_dataset(
     ],
 )
 
+# With stable example IDs for targeted updates across uploads
+dataset = client.datasets.create_dataset(
+    name="qa-test-v1",
+    examples=[
+        {
+            "id": "q-001",                      # stable ID — server updates this row, not inserts
+            "input": {"question": "What is 2+2?"},
+            "output": {"answer": "4"},
+            "metadata": {"category": "math"},
+        },
+    ],
+)
+
 # From DataFrame
 dataset = client.datasets.create_dataset(
     dataframe=df,
@@ -28,6 +43,8 @@ dataset = client.datasets.create_dataset(
     input_keys=["question"],
     output_keys=["answer"],
     metadata_keys=["category"],
+    split_key="split",        # single split column (use this instead of deprecated split_keys)
+    example_id_key="id",      # column containing stable example IDs
 )
 ```
 
@@ -58,6 +75,9 @@ df = dataset.to_dataframe()
 | `input_keys` | Columns for task input |
 | `output_keys` | Columns for expected output |
 | `metadata_keys` | Additional context |
+| `example_id_key` | Column with stable example IDs; server updates the matching row instead of inserting |
+| `split_key` | Single column for split assignment (replaces deprecated `split_keys`) |
+| `split_keys` | **Deprecated** — use `split_key` (singular) instead |
 
 ## Using Evaluators in Experiments
 
@@ -128,6 +148,8 @@ See `tutorials/evals/evals-2/evals_2.0_rag_demo.ipynb` for a full worked example
 
 ## Best Practices
 
-- **Versioning**: Create new datasets (e.g., `qa-test-v2`), don't modify
+- **Upsert by default**: Re-upload to the same name to update in-place; use `example_id_key` so the server targets specific rows instead of treating every upload as new data
+- **Versioning**: Version with tags or new names (e.g., `qa-test-v2`) when you want a clean snapshot, not just incremental edits
 - **Metadata**: Track source, category, difficulty
 - **Balance**: Ensure diverse coverage across categories
+- **Avoid `split_keys`**: Pass `split_key` (singular) — `split_keys` is deprecated and emits a `DeprecationWarning`

--- a/.agents/skills/phoenix-evals/references/experiments-datasets-typescript.md
+++ b/.agents/skills/phoenix-evals/references/experiments-datasets-typescript.md
@@ -4,6 +4,8 @@ Creating and managing evaluation datasets.
 
 ## Creating Datasets
 
+`createDataset()` upserts: if a dataset with the same name already exists it is updated to match the provided examples. Re-running with identical inputs is a no-op.
+
 ```typescript
 import { createClient } from "@arizeai/phoenix-client";
 import { createDataset } from "@arizeai/phoenix-client/datasets";
@@ -21,15 +23,32 @@ const { datasetId } = await createDataset({
     },
   ],
 });
+
+// With stable example IDs for targeted updates across uploads
+const { datasetId } = await createDataset({
+  client,
+  name: "qa-test-v1",
+  examples: [
+    {
+      id: "q-001",                        // stable ID — server updates this row, not inserts
+      input: { question: "What is 2+2?" },
+      output: { answer: "4" },
+      metadata: { category: "math" },
+    },
+  ],
+});
 ```
 
 ## Example Structure
 
 ```typescript
-interface DatasetExample {
+interface Example {
   input: Record<string, unknown>;    // Task input
-  output?: Record<string, unknown>;  // Expected output
-  metadata?: Record<string, unknown>; // Additional context
+  output?: Record<string, unknown> | null;  // Expected output
+  metadata?: Record<string, unknown> | null; // Additional context
+  splits?: string | string[] | null; // Split assignment ("train", ["train", "easy"], etc.)
+  spanId?: string | null;            // OTEL span ID to link back to source trace
+  id?: string | null;                // Stable user-provided ID; server updates matching row
 }
 ```
 
@@ -64,6 +83,7 @@ const all = await listDatasets({ client });
 
 ## Best Practices
 
-- **Versioning**: Create new datasets, don't modify existing
+- **Upsert by default**: Re-upload to the same name to update in-place; use `id` on examples so the server targets specific rows instead of treating every upload as new data
+- **Versioning**: Version with new names (e.g., `qa-test-v2`) when you want a clean snapshot, not just incremental edits
 - **Metadata**: Track source, category, provenance
-- **Type safety**: Use TypeScript interfaces for structure
+- **Type safety**: Use the `Example` type from `@arizeai/phoenix-client/datasets`


### PR DESCRIPTION
# Phoenix Skills Audit — 2026-04-29 through 2026-05-06

**Audited against:** `origin/main` at `e3c6b6461`
**Commits analyzed:** ~55 (5 user-facing, 50 skipped)

## Edits applied

### phoenix-cli

- `SKILL.md` — added `px profile list|show|create|use|edit|delete` to the invocation
  command list (commit `ab62d3d0a`; source:
  `js/packages/phoenix-cli/src/commands/profile.ts`,
  `js/packages/phoenix-cli/src/cli.ts`).

- `SKILL.md` — added new **Profiles** section documenting named auth profile
  management: settings file path (`~/.px/settings.json` or
  `$XDG_CONFIG_HOME/px/settings.json`, verified in
  `js/packages/phoenix-cli/src/settings.ts:298-310`), configuration priority
  chain (CLI flags > env vars > active profile > built-in defaults, verified in
  `js/packages/phoenix-cli/src/config.ts:165-184`), `--profile <name>` per-command
  flag, and full command examples (commit `ab62d3d0a`).

- `SKILL.md` — added `token_count_prompt`, `token_count_completion`,
  `token_count_total` to the **Trace JSON shape** block — cumulative across all LLM
  spans in the trace, `int`, default 0. Verified against
  `schemas/openapi.json:12264-12281` (commit `c0c0edba4`).

- `SKILL.md` — added the same three token-count fields to the **Session JSON shape**
  block — cumulative across all LLM spans in the session. Verified against
  `schemas/openapi.json:11371-11388` (commit `c0c0edba4`).

### phoenix-evals

- `references/experiments-datasets-python.md` — updated **Creating Datasets**
  section to document upsert behavior (`create_dataset()` now updates in-place when
  a dataset with the same name exists); added stable-ID example using `id` key in
  `_InputDatasetExample` (commit `957573865`;
  `packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py:50`);
  added DataFrame example with new `example_id_key` and `split_key` parameters
  (verified at `:796-798`).

- `references/experiments-datasets-python.md` — expanded **Key Parameters** table
  with `example_id_key`, `split_key` (new), and `split_keys` (deprecated) rows
  (commit `957573865`; docstring at `:818-826`).

- `references/experiments-datasets-python.md` — replaced stale "don't modify
  existing datasets" best-practice bullet with upsert-first guidance and a warning
  about the deprecated `split_keys` parameter (commit `957573865`).

- `references/experiments-datasets-typescript.md` — updated **Creating Datasets**
  section to document upsert behavior; added stable-ID example using `id` field on
  `Example` (commit `957573865`;
  `js/packages/phoenix-client/src/types/datasets.ts:65`).

- `references/experiments-datasets-typescript.md` — replaced `DatasetExample`
  interface snippet with the accurate `Example` interface from
  `js/packages/phoenix-client/src/types/datasets.ts:44-66`, which includes `splits`,
  `spanId`, and `id` fields missing from the old snippet (commit `957573865`).

- `references/experiments-datasets-typescript.md` — replaced stale "don't modify
  existing datasets" best-practice bullet with upsert-first guidance (commit
  `957573865`).

### phoenix-tracing

No edits — no user-facing changes to Python/TypeScript OTEL packages or
OpenInference attributes this week.

## Skipped commits

| SHA | Reason |
|-----|--------|
| `e3c6b6461` | sitemap only |
| `ff470526f` | llms.txt docs only |
| `bdb668442` | release notes docs only |
| `770655498` | PXI `/chat-v2` behind `*_EXPERIMENTAL_*` toggle — feature flag |
| `4c34e42ab` | CI workflow only |
| `fc01ed755` | docs.json sidebar config |
| `d9858f824` `b2dfdd05b` | helm/kustomize version bumps, release-please |
| `d8e391533` `0d4e16bcc` `5c643d93d` | frontend-only (`app/src/`) |
| `115c08ba0` | PXI internal `set_time_range` tool — not in phoenix-tracing/cli/evals scope |
| `85eb2cbfd` `0a87ce01a` `2ae4fab0c` `a13317de9` `898a64e1a` | sitemap only |
| `41e8fe027` | vendor passthrough tools — affects `js/packages/phoenix-cli/src/commands/formatPrompt.ts` only for prompt serialization to AI SDKs; no new CLI subcommand or flag for users of `px`; changes are internal prompt-format helpers |
| `12779fbf1` | filter-based DELETE for annotations — REST-only; CLI does not wrap annotation deletion |
| `6eac409e8` | scratch data removal |
| `e899b36cf` | fixes jinja2 import warning in phoenix-evals; no public API change |
| `48156022c` | PXI playwright test infra |
| `d0cc4c4c4` | openapi-fetch dep bump in JS packages |
| `99209e8f5` | frontend trace-selection fix |
| `a61e80532` `5b363ba30` `4f849773c` `c024f0e13` `5a92df210` `261266e10` `5ae64b1a7` | version bumps, release-please |
| `0548fbb38` | docs edit |
| `6062d649f` | PXI prompt assembly refactor (internal server agents) |
| `d2c66a064` `71611d067` `3056a634f` `d2c66a064` | JS version bumps (changelogs only) |
| `7bff140b0` `130076345` `fdc4ebe0d` | dep bump commits (pyproject.toml updates pointing to new package releases; the upstream package changes are covered by `957573865` and `2993b04a3`) |
| `2ec728ac3` | REST API docs only |
| `64cb481e1` | experiment CSV export fix — server-only, not surfaced in CLI |
| `5d14f2359` | LinkedIn social links in READMEs |
| `90fdf6bce` `145de3b45` `9d7ba62ae` `c6dee52a9` | dep bumps |
| `d7f144f83` | llms.txt audit |
| `688134510` | uv tooling |
| `775b27080` | SSRF fix in PXI agent (internal) |
| `62b6acec2` | frontend UUID util |
| `382b165b6` | TanStack AI integration — frontend snippet + docs; no change to `js/packages/phoenix-otel/` or instrumentation packages; no skill edit warranted |
| `fbb527013` | evals adapter internals (normalize_role, validate_message_dict helpers); no change to public evaluator API or call signatures |
| `a9d1673af` | CI GitHub scripts |
| `aed96fd7c` `bb44c39e6` `ceeb89b1f` | docs only |
| `f223f9224` | PXI server-side prompt caching (internal) |
| `746247cbb` | model token price update (internal cost tracking) |
| `863e9ca3c` `d6a5f9048` | frontend UI fixes |
| `e2a1de927` | annotation GET by identifier — REST-only; CLI does not wrap this query param |
| `ac81055f3` | uv/CI workflow bump |
| `0972f3dd6` | already patched skill (open-coding/axial-coding references added) |
| `e1c75b71f` | PXI tool authority refactor — touches `phoenix-pxi` skill, out of scope |
| `4e202674a` | session annotations/notes — commit already patched `phoenix-cli/SKILL.md` |
| `2993b04a3` | TS trace annotations — commit already patched `phoenix-tracing/references/annotations-*.md` |
| `b450f107a` | playground AWS Bedrock schema fix (frontend) |
| `284cd5e83` | release-please |
| `e3818859e` | version-gate for dataset upload params — compatibility shim, not user-facing behavior change |
| `4bd2b437e` | phoenix-release-please skill added — out of scope |
| `380584bf4` `3e57c0300` | version bumps |
| `883a4eb9a` | release-please readme |
| `1499ca956` | DB prompt type extension (invocation parameters) — affects server and python-client internally; prompt SDK helpers updated but no new public method added |
| `8d38d5a2f` | version-15 branch config |
| `3f09c7b4f` | PXI custom providers — out of scope (touches `phoenix-server` skill) |

## Out-of-scope findings

- `3f09c7b4f` (PXI custom providers / secret store): changes the PXI agent's model-selection surface; belongs in the `phoenix-server` or `phoenix-pxi` skill, not the three skills this audit owns.
- `e1c75b71f` (move tool authority to server): touches `.agents/skills/phoenix-pxi/` already; out of scope.
- `382b165b6` (TanStack AI tracing integration): adds a new framework integration; if `phoenix-tracing/references/instrumentation-auto-typescript.md` should cover TanStack AI, that's a gap to fill in a future audit once the `@tanstack/ai-otel` (or equivalent) instrumentation package is published separately from the Phoenix UI snippet.
- `fbb527013` (evals adapter message handling): the `normalize_role` / `validate_message_dict` helpers are internal to the adapters. The behavioral fix for LiteLLM "developer" role preservation may be worth a note in evaluator adapter docs if those are ever added to the `phoenix-evals` skill.
