### PR TITLE
docs: add REST API pages for filter-based annotation DELETE endpoints

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -883,7 +883,10 @@
                     "pages": [
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-span-annotations-for-a-list-of-span_ids",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-trace-annotations-for-a-list-of-trace_ids",
-                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-session-annotations-for-a-list-of-session_ids"
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/get-session-annotations-for-a-list-of-session_ids",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/delete-span-annotations-by-filter",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/delete-trace-annotations-by-filter",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/delete-session-annotations-by-filter"
                     ]
                   },
                   {

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations.mdx
@@ -1,5 +1,5 @@
 ---
 title: "Annotations"
 sidebarTitle: "Overview"
-description: "REST API methods for retrieving annotations on spans, traces, and sessions"
+description: "REST API methods for retrieving and deleting annotations on spans, traces, and sessions"
 ---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/delete-session-annotations-by-filter.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/delete-session-annotations-by-filter.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/projects/{project_identifier}/session_annotations
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/delete-span-annotations-by-filter.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/delete-span-annotations-by-filter.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/projects/{project_identifier}/span_annotations
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/delete-trace-annotations-by-filter.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/delete-trace-annotations-by-filter.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/projects/{project_identifier}/trace_annotations
+---


### PR DESCRIPTION
Adds doc pages and navigation entries for the three project-scoped DELETE annotation endpoints introduced in #12928, which were missing from the REST API reference.