### PR TITLE
chore: auto-label external issues and PRs for triage

### DIFF
--- a/.github/.scripts/collect-customer-issues.js
+++ b/.github/.scripts/collect-customer-issues.js
@@ -56,7 +56,7 @@ async function getParticipants(github, issue) {
   }
 }
 
-// Helper function to filter issues based on required labels and a cutoff date
+// Helper function to filter issues (excluding PRs) by required labels and cutoff
 function filterIssues(issues, requiredLabels, cutoffDate) {
   return issues
     .filter((issue) => {
@@ -64,6 +64,18 @@ function filterIssues(issues, requiredLabels, cutoffDate) {
       const isRecent = new Date(issue.created_at) > cutoffDate;
       const isNotPR = !issue.pull_request;
       return hasLabels && isRecent && isNotPR;
+    })
+    .sort((a, b) => new Date(b.created_at) - new Date(a.created_at)); // Sort by creation date, newest first
+}
+
+// Helper function to filter PRs based on required labels and a cutoff date
+function filterPRs(issues, requiredLabels, cutoffDate) {
+  return issues
+    .filter((issue) => {
+      const hasLabels = hasLabel(issue.labels, requiredLabels);
+      const isRecent = new Date(issue.created_at) > cutoffDate;
+      const isPR = !!issue.pull_request;
+      return hasLabels && isRecent && isPR;
     })
     .sort((a, b) => new Date(b.created_at) - new Date(a.created_at)); // Sort by creation date, newest first
 }
@@ -135,7 +147,7 @@ async function formatIssueLine(github, issue, index) {
 // Helper function to build a message for Slack with grouped and formatted issues
 async function buildSlackMessage(github, issueGroups, lookbackDays) {
   const messageLines = [
-    `*🛠️ Customer Issues Opened in the Last ${lookbackDays} Day(s) Pending Triage*\n`,
+    `*🛠️ Customer Issues and Pull Requests Opened in the Last ${lookbackDays} Day(s) Pending Triage*\n`,
   ];
 
   for (const [issuesArray, header] of issueGroups) {
@@ -176,9 +188,10 @@ module.exports = async ({ github, context, core }) => {
     issues.push(...repoIssues);
   }
 
-  // Filter issues by label and date, then categorize by staleness and type
+  // Filter issues and PRs separately by label and date, then categorize
   const filteredIssues = filterIssues(issues, requiredLabels, cutoffDate);
-  if (filteredIssues.length === 0) {
+  const filteredPRs = filterPRs(issues, requiredLabels, cutoffDate);
+  if (filteredIssues.length === 0 && filteredPRs.length === 0) {
     core.setOutput("has_issues", "false");
     return;
   }
@@ -195,6 +208,7 @@ module.exports = async ({ github, context, core }) => {
     [bugIssues, "*🐛 Bugs*"],
     [enhancementIssues, "*💡 Enhancements or Inquiries*"],
     [staleIssues, `*🥀 Stale Issues (>${stalenessThreshold} days)*`],
+    [filteredPRs, "*🔧 Pull Requests Pending Review*"],
   ];
 
   // Build the Slack message and set as output

--- a/.github/workflows/auto-label-external-issues.yaml
+++ b/.github/workflows/auto-label-external-issues.yaml
@@ -1,0 +1,60 @@
+name: Auto-label external issues for triage
+
+on:
+  issues:
+    types: [opened]
+  # `pull_request_target` runs in the context of the base repo so the
+  # default token has write permissions even for fork PRs. We only react
+  # to the `opened` event and do not check out the PR head, so the
+  # elevated token is not exposed to untrusted code.
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  label:
+    name: Label external issues and PRs
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add triage label for non-team contributors
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const payload = context.payload.issue || context.payload.pull_request;
+            if (!payload) {
+              core.info("No issue or pull_request payload — nothing to label");
+              return;
+            }
+
+            // Skip bot authors (Dependabot, github-actions[bot], etc.)
+            if (payload.user?.type === "Bot") {
+              core.info(`Skipping bot author: ${payload.user.login}`);
+              return;
+            }
+
+            // Treat MEMBER / OWNER / COLLABORATOR as internal. Everything
+            // else (CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE)
+            // is external and gets routed to triage.
+            const internal = ["MEMBER", "OWNER", "COLLABORATOR"];
+            const association = payload.author_association;
+            if (internal.includes(association)) {
+              core.info(
+                `Skipping internal contributor (author_association=${association})`
+              );
+              return;
+            }
+
+            core.info(
+              `External contributor (author_association=${association}); applying triage label`
+            );
+
+            const label = "triage";
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: payload.number,
+              labels: [label],
+            });
+            core.info(`Added "${label}" to #${payload.number}`);


### PR DESCRIPTION
Adds a workflow that applies the `triage` label to issues and PRs opened by non-team contributors at creation time, and extends the existing customer-issues digest to surface those PRs alongside issues in the daily Slack message.

The on-call now gets one daily Slack message with every external item still needing triage. Bots and team members (MEMBER/OWNER/COLLABORATOR) are skipped.