### PR TITLE
ci: trigger CI, Playwright, and nightly image builds on version-* branches

### DIFF
--- a/.github/workflows/docker-build-nightly.yml
+++ b/.github/workflows/docker-build-nightly.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - version-*
 
 jobs:
   push_to_registry:

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -6,11 +6,11 @@ on:
   push:
     branches:
       - main
-      - version-15
+      - version-*
   pull_request:
     branches:
       - main
-      - version-15
+      - version-*
   schedule:
     - cron: "0 16 * * 1-5"
   workflow_dispatch:

--- a/.github/workflows/typescript-CI.yml
+++ b/.github/workflows/typescript-CI.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - version-*
   pull_request:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Update GitHub Actions so CI, Playwright, and the nightly Docker image build run on `version-*` branches and PRs targeting them.

- `typescript-CI.yml`: add `version-*` to push branches (PR trigger already runs for any target).
- `playwright.yaml`: broaden `version-15` to `version-*` on both push and PR triggers.
- `docker-build-nightly.yml`: add `version-*` to push branches.
- `python-CI.yml`: already triggers on `version-*` (no change).

## Test plan
- [ ] Push to a `version-*` branch and confirm Python CI, TypeScript CI, Playwright, and the nightly Docker build all run.
- [ ] Open a PR targeting a `version-*` branch and confirm Playwright runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_0177kuZo9ba5hwGDE7qRVa9s)_