### PR TITLE
feat(sandbox): add PHOENIX_ALLOWED_SANDBOX_PROVIDERS allowlist

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,21 @@
 # Migrations
 
+## v15.x to v16.0.0
+
+### Sandbox provider allowlist (`PHOENIX_ALLOWED_SANDBOX_PROVIDERS`)
+
+A new optional environment variable, `PHOENIX_ALLOWED_SANDBOX_PROVIDERS`, restricts which sandbox provider families are available for code-evaluator execution. 
+
+*When unset, all providers remain available. Set to `NONE` to disable all sandbox providers.*
+
+To restrict the set of usable sandboxes, set the variable to a comma-separated list of family names:
+
+```shell
+PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO
+```
+
+Accepted values: `WASM`, `E2B`, `DAYTONA`, `VERCEL`, `DENO`, `MODAL` (case-insensitive). Listing a family covers all of its language variants — for example, `VERCEL` covers both `VERCEL_PYTHON` and `VERCEL_TYPESCRIPT`.
+
 ## v14.x to v15.0.0
 
 No action is required to upgrade from v14.x to v15.0.0.

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -35,6 +35,7 @@ from phoenix.utilities.re import parse_env_headers
 
 if TYPE_CHECKING:
     from phoenix.server.oauth2 import OAuth2Clients
+    from phoenix.server.sandbox.types import SandboxProviderFamily
 
 # Assignable roles (SYSTEM is internal-only and not included)
 AssignableUserRoleName: TypeAlias = Literal["ADMIN", "MEMBER", "VIEWER"]
@@ -778,6 +779,14 @@ The default sandbox backend type to use for code evaluator execution.
 Accepted values: WASM, E2B, DAYTONA_PYTHON, VERCEL_PYTHON, VERCEL_TYPESCRIPT, DENO, MODAL.
 When not set, the WASM (local WebAssembly) backend is used.
 """
+ENV_PHOENIX_ALLOWED_SANDBOX_PROVIDERS = "PHOENIX_ALLOWED_SANDBOX_PROVIDERS"
+"""
+A comma-separated list of sandbox provider families to allow.
+Accepted values: WASM, E2B, DAYTONA, VERCEL, DENO, MODAL.
+Listing a family allows all of its language variants. Case-insensitive.
+When not set, all providers are allowed. To disable all sandbox providers, set to NONE.
+Example: PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO
+"""
 
 
 @dataclass(frozen=True)
@@ -1196,6 +1205,47 @@ def validate_env_allowed_providers() -> None:
             f"PHOENIX_ALLOWED_PROVIDERS contains unrecognized provider names: "
             f"{', '.join(sorted(invalid))}. "
             f"Valid names are: {', '.join(sorted(valid_names))}"
+        )
+
+
+def get_env_allowed_sandbox_providers() -> frozenset[SandboxProviderFamily]:
+    """Effective set of allowed sandbox provider family names.
+
+    - Unset → ``SANDBOX_PROVIDER_FAMILIES`` (all families allowed).
+    - Parsed tokens include ``NONE`` → empty frozenset (kill switch; other
+      tokens in the same value are not applied).
+    - Otherwise → frozenset of stripped, uppercased comma-separated tokens.
+
+    The concrete return value is always a ``frozenset``. It is annotated
+    as ``frozenset[SandboxProviderFamily]`` because callers only need
+    membership tests against the closed family set; the parsed branch uses
+    ``typing.cast`` since parsing alone would infer ``frozenset[str]``.
+    ``validate_env_allowed_sandbox_providers`` runs at startup and rejects
+    unknown names before the server reads this setting for allowlisting.
+    """
+    from phoenix.server.sandbox.types import SANDBOX_PROVIDER_FAMILIES
+
+    raw = getenv(ENV_PHOENIX_ALLOWED_SANDBOX_PROVIDERS)
+    if not raw:
+        return SANDBOX_PROVIDER_FAMILIES
+    names = frozenset(name.strip().upper() for name in raw.split(",") if name.strip())
+    if "NONE" in names:
+        return frozenset()
+    return cast("frozenset[SandboxProviderFamily]", names)
+
+
+def validate_env_allowed_sandbox_providers() -> None:
+    """Raise ValueError if PHOENIX_ALLOWED_SANDBOX_PROVIDERS contains unknown
+    family names. Called at startup so typos fail fast rather than silently
+    locking out every provider.
+    """
+    from phoenix.server.sandbox.types import SANDBOX_PROVIDER_FAMILIES
+
+    if names := get_env_allowed_sandbox_providers() - SANDBOX_PROVIDER_FAMILIES:
+        raise ValueError(
+            f"PHOENIX_ALLOWED_SANDBOX_PROVIDERS contains unrecognized family names: "
+            f"{', '.join(sorted(names))}. "
+            f"Valid names are: {', '.join(sorted(SANDBOX_PROVIDER_FAMILIES))}"
         )
 
 
@@ -3341,6 +3391,7 @@ def verify_server_environment_variables() -> None:
     get_env_max_spans_queue_size()
     validate_env_support_email()
     validate_env_allowed_providers()
+    validate_env_allowed_sandbox_providers()
 
     # Notify users about deprecated environment variables if they are being used.
     if os.getenv("PHOENIX_ENABLE_WEBSOCKETS") is not None:

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -25,8 +25,9 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, MutableMapping, Optional
 
+from phoenix.config import get_env_allowed_sandbox_providers
 from phoenix.server.sandbox.types import (
     ConfigFieldSpec,
     EnvVarEntry,
@@ -296,7 +297,51 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
 # Runtime registry — populated only when the backend's optional deps are
 # installed. Modified via register_sandbox_adapter().
 # ---------------------------------------------------------------------------
-_SANDBOX_ADAPTERS: dict[str, SandboxAdapter] = {}
+
+
+class _AllowlistGatedAdapterRegistry(MutableMapping[str, SandboxAdapter]):
+    """Registry of sandbox adapters with read-time allowlist filtering.
+
+    Storage is delegated to an internal dict. Reads consult
+    PHOENIX_ALLOWED_SANDBOX_PROVIDERS via ``get_env_allowed_sandbox_providers()``
+    and skip adapters whose ``family`` is not in the allowed set. Writes
+    are unfiltered — registration at import time should always succeed;
+    the gate filters who can reach the value afterward.
+
+    Disallowed keys appear absent: ``__getitem__`` raises KeyError,
+    ``.get()`` returns the default, ``in`` returns False, and iteration /
+    len / keys / values / items skip them.
+    """
+
+    def __init__(self) -> None:
+        self._adapters: dict[str, SandboxAdapter] = {}
+
+    @staticmethod
+    def _allowed(adapter: SandboxAdapter) -> bool:
+        return adapter.family in get_env_allowed_sandbox_providers()
+
+    def __getitem__(self, key: str) -> SandboxAdapter:
+        adapter = self._adapters[key]
+        if not self._allowed(adapter):
+            raise KeyError(key)
+        return adapter
+
+    def __setitem__(self, key: str, value: SandboxAdapter) -> None:
+        self._adapters[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._adapters[key]
+
+    def __iter__(self) -> Iterator[str]:
+        allowed = get_env_allowed_sandbox_providers()
+        return (k for k, v in self._adapters.items() if v.family in allowed)
+
+    def __len__(self) -> int:
+        allowed = get_env_allowed_sandbox_providers()
+        return sum(1 for v in self._adapters.values() if v.family in allowed)
+
+
+_SANDBOX_ADAPTERS: MutableMapping[str, SandboxAdapter] = _AllowlistGatedAdapterRegistry()
 
 # ---------------------------------------------------------------------------
 # Session cache — (backend_type, config_hash) → SandboxBackend instance.

--- a/src/phoenix/server/sandbox/daytona_backend.py
+++ b/src/phoenix/server/sandbox/daytona_backend.py
@@ -140,6 +140,7 @@ class DaytonaSandboxBackend(SandboxBackend):
 
 class DaytonaPythonAdapter(SandboxAdapter):
     key = "DAYTONA_PYTHON"
+    family = "DAYTONA"
     display_name = "Daytona"
     language = "PYTHON"
     config_model = DaytonaPythonConfig

--- a/src/phoenix/server/sandbox/deno_backend.py
+++ b/src/phoenix/server/sandbox/deno_backend.py
@@ -123,6 +123,7 @@ class DenoSandboxBackend(BaseNoSessionBackend):
 
 class DenoAdapter(SandboxAdapter):
     key = "DENO"
+    family = "DENO"
     display_name = "Deno (local)"
     language = "TYPESCRIPT"
     config_model = DenoConfig

--- a/src/phoenix/server/sandbox/e2b_backend.py
+++ b/src/phoenix/server/sandbox/e2b_backend.py
@@ -162,6 +162,7 @@ class E2BSandboxBackend(SandboxBackend):
 
 class E2BAdapter(SandboxAdapter):
     key = "E2B"
+    family = "E2B"
     display_name = "E2B"
     language = "PYTHON"
     config_model = E2BConfig

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -161,6 +161,7 @@ class ModalSandboxBackend(SandboxBackend):
 
 class ModalAdapter(SandboxAdapter):
     key = "MODAL"
+    family = "MODAL"
     display_name = "Modal"
     language = "PYTHON"
     config_model = ModalConfig

--- a/src/phoenix/server/sandbox/types.py
+++ b/src/phoenix/server/sandbox/types.py
@@ -9,13 +9,41 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Annotated, Any, Literal, Optional, Type, Union
+from typing import (
+    Annotated,
+    Any,
+    Literal,
+    Optional,
+    Type,
+    Union,
+    get_args,
+)
 
 from pydantic import BaseModel, ConfigDict, Field
 
 
 class UnsupportedOperation(Exception):
     """Raised when a sandbox backend does not support a requested operation."""
+
+
+# ---------------------------------------------------------------------------
+# SandboxProviderFamily — closed set of provider families used as the trust
+# boundary for PHOENIX_ALLOWED_SANDBOX_PROVIDERS. Adding a new provider
+# family requires adding its name here AND setting `family = "..."` on the
+# adapter class. Pyright/mypy will reject mismatches at type-check time.
+#
+# The family of an adapter is the unit at which the allowlist operates:
+# all (backend_type, language) variants of a family share one allowlist
+# entry. Extending an existing family with a new language is just a new
+# adapter class with the same `family`; extending Phoenix with a new
+# provider family adds a literal here.
+# ---------------------------------------------------------------------------
+SandboxProviderFamily = Literal["WASM", "E2B", "DAYTONA", "VERCEL", "DENO", "MODAL"]
+
+
+SANDBOX_PROVIDER_FAMILIES: frozenset[SandboxProviderFamily] = frozenset(
+    get_args(SandboxProviderFamily)
+)
 
 
 # ---------------------------------------------------------------------------
@@ -385,6 +413,12 @@ class SandboxAdapter(ABC):
 
     #: Unique key identifying this adapter (matches backend_type in sandbox_providers).
     key: str
+
+    #: Provider family — the trust boundary for PHOENIX_ALLOWED_SANDBOX_PROVIDERS.
+    #: All adapters that share infrastructure / SDK / credentials / isolation
+    #: boundary (e.g. VercelPythonAdapter and VercelTypescriptAdapter both
+    #: family="VERCEL") share an allowlist entry.
+    family: SandboxProviderFamily
 
     #: Human-readable name for display in the UI.
     display_name: str

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -275,6 +275,7 @@ def _probe_vercel_sdk() -> None:
 
 class VercelPythonAdapter(SandboxAdapter):
     key = "VERCEL_PYTHON"
+    family = "VERCEL"
     display_name = "Vercel Sandbox"
     language = "PYTHON"
     config_model = VercelPythonConfig
@@ -316,6 +317,7 @@ class VercelPythonAdapter(SandboxAdapter):
 
 class VercelTypescriptAdapter(SandboxAdapter):
     key = "VERCEL_TYPESCRIPT"
+    family = "VERCEL"
     display_name = "Vercel Sandbox"
     language = "TYPESCRIPT"
     config_model = VercelTypescriptConfig

--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -173,6 +173,7 @@ class WASMBinaryProbe:
 
 class WASMAdapter(SandboxAdapter):
     key = "WASM"
+    family = "WASM"
     display_name = "WebAssembly (local)"
     language = "PYTHON"
     config_model = WASMConfig

--- a/tests/unit/server/api/mutations/test_sandbox_cache_invalidation.py
+++ b/tests/unit/server/api/mutations/test_sandbox_cache_invalidation.py
@@ -85,6 +85,8 @@ class _CapturingAdapter(SandboxAdapter):
         credential_specs: list[ProviderCredentialSpec],
     ) -> None:
         self.key = key
+        # Any canonical family — gate doesn't filter for these tests.
+        self.family = "WASM"
         self.display_name = f"Capturing {key}"
         self.language = "PYTHON"
         self.credential_specs = credential_specs

--- a/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
+++ b/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
@@ -904,6 +904,7 @@ class TestPhase1WrapperInputShape:
 
         class _Adapter(SandboxAdapter):
             key = backend_type
+            family = "WASM"  # any canonical family — gate doesn't filter here
             display_name = "Wrapper Input Test Backend"
             language = "PYTHON"
             credential_specs = [

--- a/tests/unit/server/api/mutations/test_sandbox_credential_mutations.py
+++ b/tests/unit/server/api/mutations/test_sandbox_credential_mutations.py
@@ -38,6 +38,7 @@ _TEST_KEY = "TEST_CRED_KEY"
 
 class _TestCredAdapter(SandboxAdapter):
     key = _TEST_BACKEND
+    family = "WASM"  # any canonical family — gate doesn't filter for these tests
     display_name = "Test Cred Backend"
     language = "PYTHON"
     credential_specs = [ProviderCredentialSpec(key=_TEST_KEY, display_name="Test Credential")]

--- a/tests/unit/server/api/test_sandbox_queries.py
+++ b/tests/unit/server/api/test_sandbox_queries.py
@@ -22,6 +22,7 @@ _TEST_AUTH_KEY = "TEST_AUTH_KEY"
 
 class _TestAuthAdapter(SandboxAdapter):
     key = _TEST_AUTH_BACKEND
+    family = "WASM"  # any canonical family — gate doesn't filter for these tests
     display_name = "Test Auth Backend"
     language = "PYTHON"
     credential_specs = [ProviderCredentialSpec(key=_TEST_AUTH_KEY, display_name="Test Auth Key")]

--- a/tests/unit/server/sandbox/test_get_or_create_backend.py
+++ b/tests/unit/server/sandbox/test_get_or_create_backend.py
@@ -43,6 +43,7 @@ def _identity_decrypt(data: bytes) -> bytes:
 def _make_adapter(received: dict[str, Any], cred_key: str = "CRED_X") -> SandboxAdapter:
     class _StubAdapter(SandboxAdapter):
         key = "STUB"
+        family = "WASM"  # any canonical family — gate doesn't filter for these tests
         display_name = "Stub"
         language = "PYTHON"
         config_model = _StubConfig
@@ -232,6 +233,20 @@ class TestGetOrCreateBackendCache:
     async def test_unregistered_backend_returns_none(self) -> None:
         result = await get_or_create_backend("NONEXISTENT", config={}, session=None, decrypt=None)
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_disallowed_backend_returns_none_without_building(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        received: dict[str, Any] = {}
+        adapter = _make_adapter(received, "CRED_X")
+        monkeypatch.setenv("PHOENIX_ALLOWED_SANDBOX_PROVIDERS", "NONE")
+
+        with patch.dict(_SANDBOX_ADAPTERS, {"STUB": adapter}):
+            result = await get_or_create_backend("STUB", config={}, session=None, decrypt=None)
+
+        assert result is None
+        assert received == {}
 
 
 class TestProviderMergeSSRFBlocked:

--- a/tests/unit/server/sandbox/test_sandbox_config_validation.py
+++ b/tests/unit/server/sandbox/test_sandbox_config_validation.py
@@ -47,6 +47,7 @@ def _make_adapter(config_model_cls: type) -> SandboxAdapter:
 
     class _ConcreteAdapter(SandboxAdapter):
         key = "TEST"
+        family = "WASM"  # any canonical family — gate doesn't filter for these tests
         display_name = "Test"
         language = "PYTHON"
         config_model = config_model_cls

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2229,6 +2229,81 @@ class TestValidateEnvAllowedProviders:
             validate_env_allowed_providers()
 
 
+class TestGetEnvAllowedSandboxProviders:
+    def test_unset_returns_all_known_families(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.delenv("PHOENIX_ALLOWED_SANDBOX_PROVIDERS", raising=False)
+        from phoenix.config import get_env_allowed_sandbox_providers
+        from phoenix.server.sandbox.types import SANDBOX_PROVIDER_FAMILIES
+
+        assert get_env_allowed_sandbox_providers() == SANDBOX_PROVIDER_FAMILIES
+
+    def test_none_returns_empty_set(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("PHOENIX_ALLOWED_SANDBOX_PROVIDERS", "NONE")
+        from phoenix.config import get_env_allowed_sandbox_providers
+
+        assert get_env_allowed_sandbox_providers() == frozenset()
+
+    def test_basic_parsing(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("PHOENIX_ALLOWED_SANDBOX_PROVIDERS", "WASM,DENO")
+        from phoenix.config import get_env_allowed_sandbox_providers
+
+        assert get_env_allowed_sandbox_providers() == frozenset({"WASM", "DENO"})
+
+    def test_case_insensitive(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("PHOENIX_ALLOWED_SANDBOX_PROVIDERS", "vercel,Wasm")
+        from phoenix.config import get_env_allowed_sandbox_providers
+
+        assert get_env_allowed_sandbox_providers() == frozenset({"VERCEL", "WASM"})
+
+    def test_whitespace_handling(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("PHOENIX_ALLOWED_SANDBOX_PROVIDERS", " WASM , DENO ")
+        from phoenix.config import get_env_allowed_sandbox_providers
+
+        assert get_env_allowed_sandbox_providers() == frozenset({"WASM", "DENO"})
+
+    def test_empty_entries_ignored(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("PHOENIX_ALLOWED_SANDBOX_PROVIDERS", "WASM,,DENO,")
+        from phoenix.config import get_env_allowed_sandbox_providers
+
+        assert get_env_allowed_sandbox_providers() == frozenset({"WASM", "DENO"})
+
+
+class TestValidateEnvAllowedSandboxProviders:
+    def test_unset_does_not_raise(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.delenv("PHOENIX_ALLOWED_SANDBOX_PROVIDERS", raising=False)
+        from phoenix.config import validate_env_allowed_sandbox_providers
+
+        validate_env_allowed_sandbox_providers()  # should not raise
+
+    def test_none_does_not_raise(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("PHOENIX_ALLOWED_SANDBOX_PROVIDERS", "NONE")
+        from phoenix.config import validate_env_allowed_sandbox_providers
+
+        validate_env_allowed_sandbox_providers()  # should not raise
+
+    def test_valid_families_do_not_raise(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("PHOENIX_ALLOWED_SANDBOX_PROVIDERS", "WASM,VERCEL,DENO")
+        from phoenix.config import validate_env_allowed_sandbox_providers
+
+        validate_env_allowed_sandbox_providers()  # should not raise
+
+    def test_invalid_family_raises(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("PHOENIX_ALLOWED_SANDBOX_PROVIDERS", "WASM,VERCLE")
+        from phoenix.config import validate_env_allowed_sandbox_providers
+
+        with pytest.raises(ValueError, match="VERCLE"):
+            validate_env_allowed_sandbox_providers()
+
+    def test_full_backend_type_rejected(self, monkeypatch: MonkeyPatch) -> None:
+        # Allowlist operates on family names, not full backend_type keys —
+        # listing VERCEL_PYTHON instead of VERCEL is wrong-shape input.
+        monkeypatch.setenv("PHOENIX_ALLOWED_SANDBOX_PROVIDERS", "VERCEL_PYTHON")
+        from phoenix.config import validate_env_allowed_sandbox_providers
+
+        with pytest.raises(ValueError, match="VERCEL_PYTHON"):
+            validate_env_allowed_sandbox_providers()
+
+
 class TestPostgresConnectionStringManagedIdentity:
     """Tests for Azure managed identity path in get_env_postgres_connection_str()."""
 


### PR DESCRIPTION
## Summary
- New `PHOENIX_ALLOWED_SANDBOX_PROVIDERS` env var lets operators restrict which sandbox provider families are usable for code-evaluator execution. Unset = all allowed; `NONE` = none allowed; comma-separated list (e.g. `WASM,DENO`) = only those families.
- Adapters now declare a `family` (closed `SandboxProviderFamily` literal — `WASM`, `E2B`, `DAYTONA`, `VERCEL`, `DENO`, `MODAL`). The allowlist gates families, so `VERCEL` covers both `VERCEL_PYTHON` and `VERCEL_TYPESCRIPT`.
- Adapter registry (`_AllowlistGatedAdapterRegistry`) filters reads through the allowlist; registration is unfiltered so import-time wiring still succeeds. Disallowed keys appear absent (KeyError, `in` is False, iteration skips).
- Startup validation rejects unknown family names (typos like `VERCLE`) and wrong-shape input (full backend keys like `VERCEL_PYTHON`) so misconfiguration fails fast.
- `MIGRATION.md` documents the new env var for v15→v16.

resolves #13069