### PR TITLE
feat(evaluators): differentiate dialog titles by evaluator type

### DIFF
--- a/app/src/components/evaluators/EditBuiltInEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditBuiltInEvaluatorDialogContent.tsx
@@ -42,7 +42,9 @@ export const EditBuiltInEvaluatorDialogContent = ({
     <DialogContent>
       <DialogHeader>
         <DialogTitle>
-          {mode === "create" ? "Create Evaluator" : "Edit Evaluator"}
+          {mode === "create"
+            ? "Create Built-in Code Evaluator"
+            : "Edit Built-in Code Evaluator"}
         </DialogTitle>
         <DialogTitleExtra>
           <Button slot="close" isDisabled={isSubmitting}>

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -292,7 +292,7 @@ export const EditCodeEvaluatorDialogContent = ({
     <DialogContent>
       <DialogHeader>
         <DialogTitle>
-          {mode === "create" ? "Create Evaluator" : "Edit Evaluator"}
+          {mode === "create" ? "Create Code Evaluator" : "Edit Code Evaluator"}
         </DialogTitle>
         <DialogTitleExtra>
           {onCancel ? (

--- a/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
@@ -44,7 +44,7 @@ export const EditLLMEvaluatorDialogContent = ({
     <DialogContent>
       <DialogHeader>
         <DialogTitle>
-          {mode === "create" ? "Create Evaluator" : "Edit Evaluator"}
+          {mode === "create" ? "Create LLM Evaluator" : "Edit LLM Evaluator"}
         </DialogTitle>
         <DialogTitleExtra>
           <Button slot="close" isDisabled={isSubmitting}>

--- a/app/tests/code-evaluators.spec.ts
+++ b/app/tests/code-evaluators.spec.ts
@@ -252,7 +252,7 @@ async function openEvaluatorEditor(page: Page, evaluatorName: string) {
   await evaluatorRow.getByRole("button").last().click();
   await page.getByRole("menuitem", { name: "Edit" }).click();
   await expect(
-    page.getByRole("heading", { name: "Edit Evaluator" })
+    page.getByRole("heading", { name: "Edit Code Evaluator" })
   ).toBeVisible();
 }
 
@@ -276,7 +276,7 @@ async function createCustomCodeEvaluator({
 
   const dialog = page.getByRole("dialog");
   await expect(
-    dialog.getByRole("heading", { name: "Create Evaluator" })
+    dialog.getByRole("heading", { name: "Create Code Evaluator" })
   ).toBeVisible();
 
   await dialog
@@ -600,7 +600,7 @@ test.describe.serial("Code Evaluators", () => {
 
     const dialog = page.getByRole("dialog");
     await expect(
-      dialog.getByRole("heading", { name: "Create Evaluator" })
+      dialog.getByRole("heading", { name: "Create Code Evaluator" })
     ).toBeVisible();
 
     await dialog
@@ -684,7 +684,7 @@ test.describe.serial("Code Evaluators", () => {
 
     const dialog = page.getByRole("dialog");
     await expect(
-      dialog.getByRole("heading", { name: "Create Evaluator" })
+      dialog.getByRole("heading", { name: "Create Code Evaluator" })
     ).toBeVisible();
 
     await dialog
@@ -761,7 +761,7 @@ test.describe.serial("Code Evaluators", () => {
 
     const dialog = page.getByRole("dialog");
     await expect(
-      dialog.getByRole("heading", { name: "Create Evaluator" })
+      dialog.getByRole("heading", { name: "Create Code Evaluator" })
     ).toBeVisible();
 
     await dialog
@@ -806,7 +806,7 @@ test.describe.serial("Code Evaluators", () => {
 
     const dialog = page.getByRole("dialog");
     await expect(
-      dialog.getByRole("heading", { name: "Create Evaluator" })
+      dialog.getByRole("heading", { name: "Create Code Evaluator" })
     ).toBeVisible();
 
     await dialog
@@ -938,7 +938,7 @@ test.describe.serial("Code Evaluators", () => {
 
     const dialog = page.getByRole("dialog");
     await expect(
-      dialog.getByRole("heading", { name: "Create Evaluator" })
+      dialog.getByRole("heading", { name: "Create Code Evaluator" })
     ).toBeVisible();
 
     // Pin the editor to the static continuous fallback by clearing the
@@ -977,7 +977,7 @@ test.describe.serial("Code Evaluators", () => {
       .click();
     const dialog = page.getByRole("dialog");
     await expect(
-      dialog.getByRole("heading", { name: "Create Evaluator" })
+      dialog.getByRole("heading", { name: "Create Code Evaluator" })
     ).toBeVisible();
     await selectSandbox(page, dialog, pythonSandboxName);
 

--- a/app/tests/server-evaluators.spec.ts
+++ b/app/tests/server-evaluators.spec.ts
@@ -148,9 +148,9 @@ test.describe.serial("Server Evaluators", () => {
       .first()
       .click();
 
-    // Verify the Create Evaluator dialog opens with prefilled template
+    // Verify the Create LLM Evaluator dialog opens with prefilled template
     await expect(
-      page.getByRole("heading", { name: "Create Evaluator" })
+      page.getByRole("heading", { name: "Create LLM Evaluator" })
     ).toBeVisible();
 
     // Update the name to our unique test name
@@ -189,9 +189,9 @@ test.describe.serial("Server Evaluators", () => {
     // Wait for submenu to appear and click "exact_match"
     await page.getByRole("menuitem", { name: /exact_match/i }).click();
 
-    // Verify the Create Evaluator dialog opens
+    // Verify the Create Built-in Code Evaluator dialog opens
     await expect(
-      page.getByRole("heading", { name: "Create Evaluator" })
+      page.getByRole("heading", { name: "Create Built-in Code Evaluator" })
     ).toBeVisible();
 
     // Update the name to our unique test name
@@ -243,9 +243,9 @@ test.describe.serial("Server Evaluators", () => {
     // Click "Edit" from the menu
     await page.getByRole("menuitem", { name: "Edit" }).click();
 
-    // Verify the Edit Evaluator dialog opens
+    // Verify the Edit Built-in Code Evaluator dialog opens
     await expect(
-      page.getByRole("heading", { name: "Edit Evaluator" })
+      page.getByRole("heading", { name: "Edit Built-in Code Evaluator" })
     ).toBeVisible();
 
     // Find the Expected field's input mode selector and verify it exists
@@ -297,9 +297,9 @@ test.describe.serial("Server Evaluators", () => {
       .getByRole("menuitem", { name: "Create new LLM evaluator" })
       .click();
 
-    // Verify the Create Evaluator dialog opens
+    // Verify the Create LLM Evaluator dialog opens
     await expect(
-      page.getByRole("heading", { name: "Create Evaluator" })
+      page.getByRole("heading", { name: "Create LLM Evaluator" })
     ).toBeVisible();
 
     // Fill in the evaluator name
@@ -367,9 +367,9 @@ test.describe.serial("Server Evaluators", () => {
     // Click "Edit" from the menu
     await page.getByRole("menuitem", { name: "Edit" }).click();
 
-    // Verify the Edit Evaluator dialog opens
+    // Verify the Edit LLM Evaluator dialog opens
     await expect(
-      page.getByRole("heading", { name: "Edit Evaluator" })
+      page.getByRole("heading", { name: "Edit LLM Evaluator" })
     ).toBeVisible();
 
     // Update the description
@@ -410,9 +410,9 @@ test.describe.serial("Server Evaluators", () => {
     // Click "Edit" from the menu
     await page.getByRole("menuitem", { name: "Edit" }).click();
 
-    // Verify the Edit Evaluator dialog opens
+    // Verify the Edit LLM Evaluator dialog opens
     await expect(
-      page.getByRole("heading", { name: "Edit Evaluator" })
+      page.getByRole("heading", { name: "Edit LLM Evaluator" })
     ).toBeVisible();
 
     // Verify the updated description is present


### PR DESCRIPTION
## Summary
- Replace the shared "Create/Edit Evaluator" dialog title with type-specific titles so users can tell which kind of evaluator they are editing.
- Code evaluator dialog: "Create/Edit Code Evaluator"
- LLM evaluator dialog: "Create/Edit LLM Evaluator"
- Built-in evaluator dialog: "Create/Edit Built-in Code Evaluator"
- Update affected Playwright specs (`code-evaluators.spec.ts`, `server-evaluators.spec.ts`) to assert the new titles.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec playwright test tests/server-evaluators.spec.ts tests/code-evaluators.spec.ts --project=chromium` (28 passed, 1 skipped — unrelated)