### PR TITLE
fix(server): preserve deleteEvaluators response ids

### DIFF
--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -612,12 +612,14 @@ class EvaluatorMutationMixin:
     async def delete_evaluators(
         self, info: Info[Context, None], input: DeleteEvaluatorsInput
     ) -> DeleteEvaluatorsPayload:
+        parsed_evaluators: list[tuple[GlobalID, int]] = []
         evaluator_rowids: set[int] = set()
         for evaluator_gid in input.evaluator_ids:
             try:
                 evaluator_rowid, _ = _parse_evaluator_id(evaluator_gid)
             except ValueError:
                 raise BadRequest(f"Invalid evaluator id: {str(evaluator_gid)}")
+            parsed_evaluators.append((evaluator_gid, evaluator_rowid))
             evaluator_rowids.add(evaluator_rowid)
 
         # Query DB to find which evaluators are builtins (can't be deleted)
@@ -631,7 +633,7 @@ class EvaluatorMutationMixin:
 
         filtered_rowids: list[int] = []
         filtered_gids: list[GlobalID] = []
-        for gid, rowid in zip(input.evaluator_ids, evaluator_rowids):
+        for gid, rowid in parsed_evaluators:
             if rowid in builtin_evaluator_ids:
                 continue
             filtered_rowids.append(rowid)

--- a/tests/unit/server/api/mutations/test_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_evaluator_mutations.py
@@ -2849,6 +2849,66 @@ async def llm_evaluator(
         await session.execute(sa.delete(models.Prompt).where(models.Prompt.id == prompt.id))
 
 
+class TestDeleteEvaluators:
+    """Tests for the delete_evaluators mutation."""
+
+    _DELETE_MUTATION = """
+      mutation($input: DeleteEvaluatorsInput!) {
+        deleteEvaluators(input: $input) {
+          evaluatorIds
+          query { __typename }
+        }
+      }
+    """
+
+    async def test_delete_mixed_builtin_response_keeps_input_gid_mapping(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+        llm_evaluator: models.LLMEvaluator,
+        synced_builtin_evaluators: None,
+    ) -> None:
+        async with db() as session:
+            builtin_evaluator_id = await session.scalar(select(models.BuiltinEvaluator.id).limit(1))
+        assert builtin_evaluator_id is not None, "No builtin evaluators available for testing"
+
+        llm_gid = str(GlobalID("LLMEvaluator", str(llm_evaluator.id)))
+        builtin_gid = str(GlobalID("BuiltInEvaluator", str(builtin_evaluator_id)))
+
+        result = await gql_client.execute(
+            self._DELETE_MUTATION,
+            {"input": {"evaluatorIds": [llm_gid, builtin_gid]}},
+        )
+
+        assert not result.errors
+        assert result.data is not None
+        assert result.data["deleteEvaluators"]["evaluatorIds"] == [llm_gid]
+
+        async with db() as session:
+            deleted_llm_evaluator = await session.get(models.LLMEvaluator, llm_evaluator.id)
+            kept_builtin_evaluator = await session.get(
+                models.BuiltinEvaluator, builtin_evaluator_id
+            )
+        assert deleted_llm_evaluator is None
+        assert kept_builtin_evaluator is not None
+
+    async def test_delete_duplicate_evaluator_ids_does_not_truncate_payload(
+        self,
+        gql_client: AsyncGraphQLClient,
+        llm_evaluator: models.LLMEvaluator,
+    ) -> None:
+        llm_gid = str(GlobalID("LLMEvaluator", str(llm_evaluator.id)))
+
+        result = await gql_client.execute(
+            self._DELETE_MUTATION,
+            {"input": {"evaluatorIds": [llm_gid, llm_gid]}},
+        )
+
+        assert not result.errors
+        assert result.data is not None
+        assert result.data["deleteEvaluators"]["evaluatorIds"] == [llm_gid, llm_gid]
+
+
 class TestDeleteDatasetEvaluators:
     """Tests for the delete_dataset_evaluators mutation."""
 


### PR DESCRIPTION
﻿Fixes #13091

`deleteEvaluators` parsed incoming global ids into a set of row ids, then zipped that unordered set back against the original input ids. When a built-in evaluator was filtered out, the response could report the wrong global id. Duplicate ids could also shorten the response payload because the set had already deduplicated row ids.

This keeps the ordered `(global id, row id)` pairs from parsing through filtering, while still using the row-id set for the built-in lookup. The delete query stays row-id based, but the GraphQL payload now reflects the input ids that actually passed the built-in filter.

Validation:
- `python -m uv run pytest tests\unit\server\api\mutations\test_evaluator_mutations.py::TestDeleteEvaluators -q`
- `python -m uv run ruff check src\phoenix\server\api\mutations\evaluator_mutations.py tests\unit\server\api\mutations\test_evaluator_mutations.py`
- `python -m uv run ruff format --check src\phoenix\server\api\mutations\evaluator_mutations.py tests\unit\server\api\mutations\test_evaluator_mutations.py`
- `python -m py_compile src\phoenix\server\api\mutations\evaluator_mutations.py tests\unit\server\api\mutations\test_evaluator_mutations.py`
- `git diff --check`

The focused pytest run uses the repo default sqlite configuration; the postgres parametrizations are skipped unless `--db postgres` is selected.
