### PR TITLE
docs: fix typo in docker.mdx

### DIFF
--- a/docs/phoenix/self-hosting/deployment-options/docker.mdx
+++ b/docs/phoenix/self-hosting/deployment-options/docker.mdx
@@ -106,7 +106,7 @@ For the full details of on how to configure Phoenix, check out the Configuration
 
 ## PostgreSQL
 
-You can quickly launch Phoenix with a PostGreSQL backend using docker compose.
+You can quickly launch Phoenix with a PostgreSQL backend using docker compose.
 
 First, ensure that Docker Compose is installed on your machine [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/).
 


### PR DESCRIPTION
## Summary

Fix a typo in docker.mdx (PostGreSQL -> PostgreSQL)