### PR TITLE
fix(sandbox): type-check Vercel SDK invocation and use native env var names

### DIFF
--- a/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
+++ b/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
@@ -100,12 +100,16 @@ The rows below correspond exactly to the entries in `SANDBOX_ADAPTER_METADATA`. 
 | **WebAssembly (local)** (`WASM`) | Python | Yes — CPython WASM bundled at `$PHOENIX_WASM_BINARY_PATH` | `pip install 'arize-phoenix[wasm]'`; optionally set `PHOENIX_WASM_BINARY_PATH` | None | In-process (`wasmtime`) |
 | **E2B** (`E2B`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[e2b]'` | `PHOENIX_SANDBOX_E2B_API_KEY` | External API |
 | **Daytona** (`DAYTONA_PYTHON`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[daytona]'` | `PHOENIX_SANDBOX_DAYTONA_API_KEY` | External API |
-| **Vercel Sandbox — Python** (`VERCEL_PYTHON`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[vercel]'` | `VERCEL_OIDC_TOKEN`, or `PHOENIX_SANDBOX_VERCEL_TOKEN` + `PHOENIX_SANDBOX_VERCEL_PROJECT_ID` + `PHOENIX_SANDBOX_VERCEL_TEAM_ID` | External API |
-| **Vercel Sandbox — TypeScript** (`VERCEL_TYPESCRIPT`) | TypeScript | Ready with credentials — SDK in container | `pip install 'arize-phoenix[vercel]'` | Same as `VERCEL_PYTHON` | External API |
+| **Vercel Sandbox — Python** (`VERCEL_PYTHON`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[vercel]'` | `VERCEL_OIDC_TOKEN`, or `VERCEL_TOKEN` + `VERCEL_PROJECT_ID` + `VERCEL_TEAM_ID` ([auth docs](https://vercel.com/docs/vercel-sandbox/concepts/authentication)) | External API |
+| **Vercel Sandbox — TypeScript** (`VERCEL_TYPESCRIPT`) | TypeScript | Ready with credentials — SDK in container | `pip install 'arize-phoenix[vercel]'` | Same as `VERCEL_PYTHON` ([auth docs](https://vercel.com/docs/vercel-sandbox/concepts/authentication)) | External API |
 | **Modal** (`MODAL`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[modal]'` | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` | External API |
 
 <Info>
 "Container-ready" means the SDK or binary is present in `arizephoenix/phoenix`. External providers still need their credentials configured before the GraphQL `status` flips from `MISSING_CREDENTIALS` to `AVAILABLE`. Local providers (Deno, WASM) become `AVAILABLE` immediately after the container starts.
+</Info>
+
+<Info>
+**Where to find Vercel credentials.** `VERCEL_TOKEN` is a personal access token created at [Account Settings → Tokens](https://vercel.com/account/tokens). `VERCEL_PROJECT_ID` is the project's resource ID under Project Settings → General. `VERCEL_TEAM_ID` is the team's resource ID at `https://vercel.com/teams/<your-team>/settings#team-id`. Full provisioning steps: [Vercel Sandbox authentication](https://vercel.com/docs/vercel-sandbox/concepts/authentication).
 </Info>
 
 ## Troubleshooting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ dev = [
   "ldap3",
   "litellm>=1.83.14,<1.84",  # >=1.83.14 fixes CVE-2026-42208 (SQLi), MCP stdio RCE, SSTI, OIDC bypass, password hash exposure, privilege escalation; excludes 1.82.7-1.82.8 supply chain compromise; <1.84 caps the minor
   "modal>=1.2.0",  # type-checking only; runtime is gated by the [modal] extra
+  "vercel>=0.5.1",  # type-checking only; runtime is gated by the [vercel] extra
   "mypy==1.19.1",
   "mypy-boto3-bedrock-runtime",
   "nest-asyncio",  # for executor testing
@@ -338,7 +339,6 @@ module = [
   "google.*",
   "mistralai.*",
   "jsonpath_ng",
-  "vercel.*",
   "wasmtime",
 ]
 ignore_missing_imports = true

--- a/src/phoenix/server/api/mutations/sandbox_config_mutations.py
+++ b/src/phoenix/server/api/mutations/sandbox_config_mutations.py
@@ -415,7 +415,7 @@ class SandboxConfigMutationMixin:
                 )
             )
         # Key-level fan-out covers shared credential_specs (e.g.,
-        # PHOENIX_SANDBOX_VERCEL_TOKEN shared between VERCEL_PYTHON and
+        # VERCEL_TOKEN shared between VERCEL_PYTHON and
         # VERCEL_TYPESCRIPT). Per-backend_type
         # invalidation remains as a defense-in-depth backstop.
         await invalidate_backend_cache_for_key(key)

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -254,7 +254,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
     # then. Until that lands, both Vercel adapters remain internet_access="none".
     **{
         f"VERCEL_{lang}": AdapterMetadata(
-            display_name="Vercel Sandbox",
+            display_name="Vercel",
             language=lang,
             dependency_hints=[
                 "Install Phoenix with the `vercel` extra.",

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -258,11 +258,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
             language=lang,
             dependency_hints=[
                 "Install Phoenix with the `vercel` extra.",
-                (
-                    "Set all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, "
-                    "`PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and "
-                    "`PHOENIX_SANDBOX_VERCEL_TEAM_ID`."
-                ),
+                ("Set all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`."),
             ],
             supports_env_vars=True,
             internet_access_capability="none",
@@ -407,7 +403,7 @@ async def invalidate_backend_cache_for_key(key: str) -> None:
 
     Broader than `invalidate_backend_cache` because one credential key may be
     shared by multiple backend_types (e.g.
-    PHOENIX_SANDBOX_VERCEL_TOKEN across VERCEL_PYTHON and VERCEL_TYPESCRIPT).
+    VERCEL_TOKEN across VERCEL_PYTHON and VERCEL_TYPESCRIPT).
     A per-adapter eviction failure logs and continues —
     a rotation must not stall because one backend failed to close.
     """
@@ -594,9 +590,9 @@ async def get_missing_sandbox_auth_detail(
         # deployments or after `vercel env pull`) but is not exposed in the UI.
         oidc_key = "VERCEL_OIDC_TOKEN"
         access_keys = [
-            "PHOENIX_SANDBOX_VERCEL_TOKEN",
-            "PHOENIX_SANDBOX_VERCEL_PROJECT_ID",
-            "PHOENIX_SANDBOX_VERCEL_TEAM_ID",
+            "VERCEL_TOKEN",
+            "VERCEL_PROJECT_ID",
+            "VERCEL_TEAM_ID",
         ]
         resolved = await _resolve_named_credentials(session, decrypt, [oidc_key, *access_keys])
         if oidc_key in resolved or all(key in resolved for key in access_keys):
@@ -723,7 +719,7 @@ async def get_or_create_backend(
 # successfully — *regardless* of whether its SDK probe passes. The
 # reserved-credential-name set is derived from this list (not from
 # _SANDBOX_ADAPTERS), so adapter-declared credential keys (e.g.
-# PHOENIX_SANDBOX_VERCEL_TOKEN) remain reserved on installs that don't have
+# VERCEL_TOKEN) remain reserved on installs that don't have
 # the optional SDK. Without this, a missing optional extra would silently
 # narrow the reserved set and let a user-supplied env_var or secret_ref
 # shadow a provider credential name.
@@ -834,7 +830,7 @@ def _build_reserved_credential_names() -> frozenset[str]:
     NOT ``_SANDBOX_ADAPTERS`` (only adapters whose SDK probe passed). The
     distinction matters: an installation without the ``vercel`` extra has
     ``VercelPythonAdapter`` in _KNOWN_ADAPTER_CLASSES but not in
-    _SANDBOX_ADAPTERS, and ``PHOENIX_SANDBOX_VERCEL_TOKEN`` MUST remain
+    _SANDBOX_ADAPTERS, and ``VERCEL_TOKEN`` MUST remain
     reserved regardless of whether the SDK is installed — otherwise a
     user-supplied env_var or secret_ref on that name could shadow the
     provider credential the moment the SDK is later installed.
@@ -849,8 +845,7 @@ def _build_reserved_credential_names() -> frozenset[str]:
 def is_reserved_credential_name(name: str) -> bool:
     """Return True if `name` collides with a reserved provider-credential key.
 
-    Comparison is case-insensitive: `PHOENIX_SANDBOX_VERCEL_TOKEN`,
-    `Phoenix_Sandbox_Vercel_Token`, and `phoenix_sandbox_vercel_token` are all
-    reserved.
+    Comparison is case-insensitive: `VERCEL_TOKEN`, `Vercel_Token`, and
+    `vercel_token` are all reserved.
     """
     return name.lower() in _build_reserved_credential_names()

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -258,7 +258,10 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
             language=lang,
             dependency_hints=[
                 "Install Phoenix with the `vercel` extra.",
-                ("Set all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`."),
+                (
+                    "Set all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`. "
+                    "See https://vercel.com/docs/vercel-sandbox/concepts/authentication"
+                ),
             ],
             supports_env_vars=True,
             internet_access_capability="none",

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -249,21 +249,29 @@ def _resolve_vercel_oidc_token(config: dict[str, Any]) -> str:
 # VERCEL_OIDC_TOKEN is present in the process environment (e.g. `vercel env
 # pull` or running on Vercel) — see get_missing_sandbox_auth_detail and
 # build_backend below — but is not exposed as a configurable secret.
+# Linked from credential descriptions and authentication error messages so
+# users hitting either surface have a direct pointer to provisioning steps.
+_VERCEL_AUTH_DOCS_URL = "https://vercel.com/docs/vercel-sandbox/concepts/authentication"
+
 _VERCEL_ENV_VAR_SPECS = [
     ProviderCredentialSpec(
         key=ENV_VERCEL_TOKEN,
         display_name="Vercel Access Token",
-        description="Vercel personal access token.",
+        description=f"Vercel personal access token. See {_VERCEL_AUTH_DOCS_URL}",
     ),
     ProviderCredentialSpec(
         key=ENV_VERCEL_PROJECT_ID,
         display_name="Vercel Project ID",
-        description="Vercel project ID.",
+        description=f"Vercel project ID. See {_VERCEL_AUTH_DOCS_URL}",
     ),
     ProviderCredentialSpec(
         key=ENV_VERCEL_TEAM_ID,
         display_name="Vercel Team ID",
-        description="Vercel team ID.",
+        description=(
+            "Vercel team ID — find it under Team Settings → General "
+            "(https://vercel.com/teams/your_team_name_here/settings#team-id). "
+            f"See {_VERCEL_AUTH_DOCS_URL}"
+        ),
     ),
 ]
 

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -284,7 +284,7 @@ def _probe_vercel_sdk() -> None:
 class VercelPythonAdapter(SandboxAdapter):
     key = "VERCEL_PYTHON"
     family = "VERCEL"
-    display_name = "Vercel Sandbox"
+    display_name = "Vercel"
     language = "PYTHON"
     config_model = VercelPythonConfig
     credential_specs = _VERCEL_ENV_VAR_SPECS
@@ -325,7 +325,7 @@ class VercelPythonAdapter(SandboxAdapter):
 class VercelTypescriptAdapter(SandboxAdapter):
     key = "VERCEL_TYPESCRIPT"
     family = "VERCEL"
-    display_name = "Vercel Sandbox"
+    display_name = "Vercel"
     language = "TYPESCRIPT"
     config_model = VercelTypescriptConfig
     credential_specs = _VERCEL_ENV_VAR_SPECS

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -15,9 +15,8 @@ error during evaluation.
 
 Authentication follows the Vercel Sandbox SDK: either ``VERCEL_OIDC_TOKEN``
 (for local ``vercel env pull`` or deployments on Vercel — read directly from
-the process environment by the SDK), or the Phoenix-scoped access-token triple
-``PHOENIX_SANDBOX_VERCEL_TOKEN``, ``PHOENIX_SANDBOX_VERCEL_PROJECT_ID``, and
-``PHOENIX_SANDBOX_VERCEL_TEAM_ID``. See
+the process environment by the SDK), or the access-token triple ``VERCEL_TOKEN``,
+``VERCEL_PROJECT_ID``, and ``VERCEL_TEAM_ID``. See
 https://vercel.com/docs/vercel-sandbox/concepts/authentication
 
 Language routing
@@ -31,7 +30,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, TypedDict
 
 from .types import (
     ExecutionResult,
@@ -42,15 +41,25 @@ from .types import (
     VercelTypescriptConfig,
 )
 
-# OIDC token is read directly from the SDK-native env var because
-# AsyncSandbox.create() with no token kwargs reads VERCEL_OIDC_TOKEN from
-# os.environ — renaming this would silently break authentication.
+if TYPE_CHECKING:
+    from vercel.sandbox import AsyncSandbox
+
+
+class _LanguageConfig(TypedDict):
+    runtime: str
+    cmd: str
+    args_prefix: list[str]
+
+
+# Vercel SDK env-var names. AsyncSandbox.create() with no token kwargs reads
+# VERCEL_OIDC_TOKEN / VERCEL_TOKEN / VERCEL_PROJECT_ID / VERCEL_TEAM_ID from
+# os.environ — using the SDK-native names here means a user who exports them
+# in the process environment gets the same auth resolution Phoenix performs
+# from DB-stored secrets, with no rename surprises.
 ENV_VERCEL_OIDC_TOKEN = "VERCEL_OIDC_TOKEN"
-# Phoenix-scoped Vercel access-token credentials. These flow through
-# AsyncSandbox.create() as kwargs, so the rename is purely Phoenix-internal.
-ENV_PHOENIX_SANDBOX_VERCEL_TOKEN = "PHOENIX_SANDBOX_VERCEL_TOKEN"
-ENV_PHOENIX_SANDBOX_VERCEL_PROJECT_ID = "PHOENIX_SANDBOX_VERCEL_PROJECT_ID"
-ENV_PHOENIX_SANDBOX_VERCEL_TEAM_ID = "PHOENIX_SANDBOX_VERCEL_TEAM_ID"
+ENV_VERCEL_TOKEN = "VERCEL_TOKEN"
+ENV_VERCEL_PROJECT_ID = "VERCEL_PROJECT_ID"
+ENV_VERCEL_TEAM_ID = "VERCEL_TEAM_ID"
 
 logger = logging.getLogger(__name__)
 
@@ -58,17 +67,17 @@ logger = logging.getLogger(__name__)
 # Language → runtime + command mapping
 # ---------------------------------------------------------------------------
 
-_LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
-    "PYTHON": {
-        "runtime": "python3.13",
-        "cmd": "python3",
-        "args_prefix": ["-c"],
-    },
-    "TYPESCRIPT": {
-        "runtime": "node24",
-        "cmd": "node",
-        "args_prefix": ["--input-type=module-typescript", "-e"],
-    },
+_LANGUAGE_CONFIGS: dict[str, _LanguageConfig] = {
+    "PYTHON": _LanguageConfig(
+        runtime="python3.13",
+        cmd="python3",
+        args_prefix=["-c"],
+    ),
+    "TYPESCRIPT": _LanguageConfig(
+        runtime="node24",
+        cmd="node",
+        args_prefix=["--input-type=module-typescript", "-e"],
+    ),
 }
 _DEFAULT_LANGUAGE = "TYPESCRIPT"
 
@@ -116,13 +125,13 @@ class VercelSandboxBackend(SandboxBackend):
             )
         self._language = language.upper() if language else _DEFAULT_LANGUAGE
         self._user_env: dict[str, str] = user_env or {}
-        self._sessions: dict[str, Any] = {}
+        self._sessions: dict[str, AsyncSandbox] = {}
         self._session_locks: dict[str, asyncio.Lock] = {}
 
-    def _lang_cfg(self) -> dict[str, Any]:
+    def _lang_cfg(self) -> _LanguageConfig:
         return _LANGUAGE_CONFIGS.get(self._language, _LANGUAGE_CONFIGS[_DEFAULT_LANGUAGE])
 
-    async def _create_sandbox(self) -> Any:
+    async def _create_sandbox(self) -> AsyncSandbox:
         from vercel.sandbox import AsyncSandbox
 
         runtime: str = self._lang_cfg()["runtime"]
@@ -172,7 +181,7 @@ class VercelSandboxBackend(SandboxBackend):
 
     async def _exec_code(
         self,
-        sandbox: Any,
+        sandbox: AsyncSandbox,
         code: str,
         env: Optional[dict[str, str]] = None,
     ) -> ExecutionResult:
@@ -180,10 +189,7 @@ class VercelSandboxBackend(SandboxBackend):
         lang_cfg = self._lang_cfg()
         cmd: str = lang_cfg["cmd"]
         args: list[str] = lang_cfg["args_prefix"] + [code]
-        run_kwargs: dict[str, Any] = {}
-        if env:
-            run_kwargs["env"] = env
-        result = await sandbox.run_command(cmd, args, **run_kwargs)
+        result = await sandbox.run_command(cmd, args, env=env)
         stdout, stderr = await asyncio.gather(result.stdout(), result.stderr())
         exit_code = result.exit_code
         error: Optional[str] = stderr if exit_code != 0 else None
@@ -224,21 +230,15 @@ class VercelSandboxBackend(SandboxBackend):
 
 
 def _resolve_vercel_access_token(config: dict[str, Any]) -> str:
-    return str(config.get(ENV_PHOENIX_SANDBOX_VERCEL_TOKEN) or "") or os.environ.get(
-        ENV_PHOENIX_SANDBOX_VERCEL_TOKEN, ""
-    )
+    return str(config.get(ENV_VERCEL_TOKEN) or "") or os.environ.get(ENV_VERCEL_TOKEN, "")
 
 
 def _resolve_vercel_project_id(config: dict[str, Any]) -> str:
-    return str(config.get(ENV_PHOENIX_SANDBOX_VERCEL_PROJECT_ID) or "") or os.environ.get(
-        ENV_PHOENIX_SANDBOX_VERCEL_PROJECT_ID, ""
-    )
+    return str(config.get(ENV_VERCEL_PROJECT_ID) or "") or os.environ.get(ENV_VERCEL_PROJECT_ID, "")
 
 
 def _resolve_vercel_team_id(config: dict[str, Any]) -> str:
-    return str(config.get(ENV_PHOENIX_SANDBOX_VERCEL_TEAM_ID) or "") or os.environ.get(
-        ENV_PHOENIX_SANDBOX_VERCEL_TEAM_ID, ""
-    )
+    return str(config.get(ENV_VERCEL_TEAM_ID) or "") or os.environ.get(ENV_VERCEL_TEAM_ID, "")
 
 
 def _resolve_vercel_oidc_token(config: dict[str, Any]) -> str:
@@ -251,17 +251,17 @@ def _resolve_vercel_oidc_token(config: dict[str, Any]) -> str:
 # build_backend below — but is not exposed as a configurable secret.
 _VERCEL_ENV_VAR_SPECS = [
     ProviderCredentialSpec(
-        key="PHOENIX_SANDBOX_VERCEL_TOKEN",
+        key=ENV_VERCEL_TOKEN,
         display_name="Vercel Access Token",
         description="Vercel personal access token.",
     ),
     ProviderCredentialSpec(
-        key="PHOENIX_SANDBOX_VERCEL_PROJECT_ID",
+        key=ENV_VERCEL_PROJECT_ID,
         display_name="Vercel Project ID",
         description="Vercel project ID.",
     ),
     ProviderCredentialSpec(
-        key="PHOENIX_SANDBOX_VERCEL_TEAM_ID",
+        key=ENV_VERCEL_TEAM_ID,
         display_name="Vercel Team ID",
         description="Vercel team ID.",
     ),
@@ -309,8 +309,7 @@ class VercelPythonAdapter(SandboxAdapter):
         raise ValueError(
             "Vercel sandbox authentication is not configured. Set "
             "VERCEL_OIDC_TOKEN (e.g. from `vercel env pull`), "
-            "or set all of PHOENIX_SANDBOX_VERCEL_TOKEN, "
-            "PHOENIX_SANDBOX_VERCEL_PROJECT_ID, and PHOENIX_SANDBOX_VERCEL_TEAM_ID. See "
+            "or set all of VERCEL_TOKEN, VERCEL_PROJECT_ID, and VERCEL_TEAM_ID. See "
             "https://vercel.com/docs/vercel-sandbox/concepts/authentication"
         )
 
@@ -353,7 +352,6 @@ class VercelTypescriptAdapter(SandboxAdapter):
         raise ValueError(
             "Vercel sandbox authentication is not configured. Set "
             "VERCEL_OIDC_TOKEN (e.g. from `vercel env pull`), "
-            "or set all of PHOENIX_SANDBOX_VERCEL_TOKEN, "
-            "PHOENIX_SANDBOX_VERCEL_PROJECT_ID, and PHOENIX_SANDBOX_VERCEL_TEAM_ID. See "
+            "or set all of VERCEL_TOKEN, VERCEL_PROJECT_ID, and VERCEL_TEAM_ID. See "
             "https://vercel.com/docs/vercel-sandbox/concepts/authentication"
         )

--- a/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
+++ b/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
@@ -959,10 +959,9 @@ class TestConfigValidationPath:
         db: DbSessionFactory,
         seed_sandbox_providers: None,
     ) -> None:
-        """Prefixed adapter-owned credentials like PHOENIX_SANDBOX_VERCEL_TOKEN
-        must also be rejected at createSandboxConfig time —
-        reserved-name coverage is derived from every adapter's credential_specs,
-        not just the PHOENIX_SANDBOX_ prefix."""
+        """Adapter-owned credentials like VERCEL_TOKEN must also be rejected at
+        createSandboxConfig time — reserved-name coverage is derived from every
+        adapter's credential_specs, regardless of naming prefix."""
         async with db() as session:
             provider = await session.scalar(
                 select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "E2B")
@@ -981,7 +980,7 @@ class TestConfigValidationPath:
                             "env_vars": [
                                 {
                                     "kind": "secret_ref",
-                                    "name": "PHOENIX_SANDBOX_VERCEL_TOKEN",
+                                    "name": "VERCEL_TOKEN",
                                     "secret_key": "anything",
                                 }
                             ]
@@ -996,16 +995,16 @@ class TestConfigValidationPath:
                     "input": {
                         "sandboxProviderId": _provider_global_id(provider.id),
                         "name": "e2b-vercel-token-top",
-                        "config": {"PHOENIX_SANDBOX_VERCEL_TOKEN": "attacker-value"},
+                        "config": {"VERCEL_TOKEN": "attacker-value"},
                     }
                 },
             )
         assert env_var_result.errors, (
-            "Expected BadRequest for PHOENIX_SANDBOX_VERCEL_TOKEN in env_vars; "
+            "Expected BadRequest for VERCEL_TOKEN in env_vars; "
             "reserved-name enforcement may not cover adapter-owned credentials"
         )
         assert top_level_result.errors, (
-            "Expected BadRequest for PHOENIX_SANDBOX_VERCEL_TOKEN as top-level config key; "
+            "Expected BadRequest for VERCEL_TOKEN as top-level config key; "
             "reserved-name enforcement may not cover top-level SandboxConfig.config"
         )
 
@@ -1015,7 +1014,7 @@ class TestConfigValidationPath:
         db: DbSessionFactory,
         seed_sandbox_providers: None,
     ) -> None:
-        """PHOENIX_SANDBOX_* names are also rejected on update."""
+        """Reserved provider-credential names are also rejected on update."""
         async with db() as session:
             provider = await session.scalar(
                 select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "E2B")
@@ -1043,7 +1042,7 @@ class TestConfigValidationPath:
                             "env_vars": [
                                 {
                                     "kind": "secret_ref",
-                                    "name": "PHOENIX_SANDBOX_VERCEL_TOKEN",
+                                    "name": "VERCEL_TOKEN",
                                     "secret_key": "my-secret",
                                 }
                             ]

--- a/tests/unit/server/api/mutations/test_reserved_credential_names.py
+++ b/tests/unit/server/api/mutations/test_reserved_credential_names.py
@@ -33,7 +33,7 @@ _e2b_adapter = E2BAdapter()
 _RESERVED_NAMES = [
     "MODAL_TOKEN_SECRET",
     "MODAL_TOKEN_ID",
-    "PHOENIX_SANDBOX_VERCEL_TOKEN",
+    "VERCEL_TOKEN",
     "VERCEL_OIDC_TOKEN",
 ]
 
@@ -190,7 +190,7 @@ class TestReservedCredentialNamesCaseInsensitive:
                             "env_vars": [
                                 {
                                     "kind": "literal",
-                                    "name": "phoenix_sandbox_vercel_token",
+                                    "name": "vercel_token",
                                     "value": "shadow-attempt",
                                 }
                             ]

--- a/tests/unit/server/api/mutations/test_sandbox_cache_invalidation.py
+++ b/tests/unit/server/api/mutations/test_sandbox_cache_invalidation.py
@@ -8,7 +8,7 @@ Three scenarios covered:
 1. Rebuild-with-new-value via setSandboxCredential — backend rebuilt with v2
    plaintext after rotation.
 2. Shared-spec invalidation — VERCEL_PYTHON and VERCEL_TYPESCRIPT share
-   `credential_specs` referencing PHOENIX_SANDBOX_VERCEL_TOKEN; rotating via
+   `credential_specs` referencing VERCEL_TOKEN; rotating via
    either backend_type
    evicts BOTH cache entries.
 3. upsertOrDeleteSecrets + SandboxConfig.secret_ref — rotating a user Secret
@@ -178,8 +178,7 @@ class TestRebuildWithNewValue:
 
 
 class TestSharedSpecInvalidation:
-    """Scenario 2: PHOENIX_SANDBOX_VERCEL_TOKEN is shared by VERCEL_PYTHON and
-    VERCEL_TYPESCRIPT.
+    """Scenario 2: VERCEL_TOKEN is shared by VERCEL_PYTHON and VERCEL_TYPESCRIPT.
 
     Rotating via either backend_type must evict BOTH cache entries.
     """

--- a/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
+++ b/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
@@ -383,7 +383,7 @@ class TestReservedSecretKeyRejected:
                                 {
                                     "kind": "secret_ref",
                                     "name": "MY_TOKEN",
-                                    "secret_key": "PHOENIX_SANDBOX_VERCEL_TOKEN",
+                                    "secret_key": "VERCEL_TOKEN",
                                 }
                             ]
                         },
@@ -414,7 +414,7 @@ class TestReservedSecretKeyRejected:
                                 {
                                     "kind": "secret_ref",
                                     "name": "MY_TOKEN",
-                                    "secret_key": "PHOENIX_SANDBOX_VERCEL_TOKEN",
+                                    "secret_key": "VERCEL_TOKEN",
                                 }
                             ]
                         },
@@ -444,7 +444,7 @@ class TestReservedSecretKeyRejected:
                                 {
                                     "kind": "secret_ref",
                                     "name": "MY_TOKEN",
-                                    "secret_key": "phoenix_sandbox_vercel_token",
+                                    "secret_key": "vercel_token",
                                 }
                             ]
                         },

--- a/tests/unit/server/api/test_sandbox_queries.py
+++ b/tests/unit/server/api/test_sandbox_queries.py
@@ -144,7 +144,7 @@ async def test_sandbox_backends_and_providers_can_be_loaded_together(
     ]
     assert backends["VERCEL_PYTHON"]["dependencyHints"] == [
         "Install Phoenix with the `vercel` extra.",
-        "Set all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`.",
+        "Set all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`. See https://vercel.com/docs/vercel-sandbox/concepts/authentication",
     ]
     assert backends["DENO"]["dependencyHints"] == [
         "Install the Deno runtime and ensure the `deno` binary is available on PATH.",

--- a/tests/unit/server/api/test_sandbox_queries.py
+++ b/tests/unit/server/api/test_sandbox_queries.py
@@ -144,7 +144,7 @@ async def test_sandbox_backends_and_providers_can_be_loaded_together(
     ]
     assert backends["VERCEL_PYTHON"]["dependencyHints"] == [
         "Install Phoenix with the `vercel` extra.",
-        "Set all of `PHOENIX_SANDBOX_VERCEL_TOKEN`, `PHOENIX_SANDBOX_VERCEL_PROJECT_ID`, and `PHOENIX_SANDBOX_VERCEL_TEAM_ID`.",
+        "Set all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`.",
     ]
     assert backends["DENO"]["dependencyHints"] == [
         "Install the Deno runtime and ensure the `deno` binary is available on PATH.",

--- a/tests/unit/server/sandbox/test_env_var_resolution.py
+++ b/tests/unit/server/sandbox/test_env_var_resolution.py
@@ -69,11 +69,9 @@ class TestResolveUserEnvReservedSecretKey:
         """secret_ref whose `secret_key` matches a reserved provider-credential
         name raises MissingSecretError before any DB query — fail-closed
         defense-in-depth for rows persisted before the mutation-layer guard."""
-        raw = [
-            {"kind": "secret_ref", "name": "MY_TOKEN", "secret_key": "PHOENIX_SANDBOX_VERCEL_TOKEN"}
-        ]
-        session = _make_session({"PHOENIX_SANDBOX_VERCEL_TOKEN": b"should-not-reach-here"})
-        with pytest.raises(MissingSecretError, match="PHOENIX_SANDBOX_VERCEL_TOKEN"):
+        raw = [{"kind": "secret_ref", "name": "MY_TOKEN", "secret_key": "VERCEL_TOKEN"}]
+        session = _make_session({"VERCEL_TOKEN": b"should-not-reach-here"})
+        with pytest.raises(MissingSecretError, match="VERCEL_TOKEN"):
             await _resolve_user_env(raw, session, _identity_decrypt)
         session.scalars.assert_not_called()
 
@@ -82,19 +80,17 @@ class TestResolveUserEnvReservedSecretKey:
         """An EnvVarLiteral whose `name` matches a reserved provider-credential name
         raises MissingSecretError — pre-mutation-guard rows with reserved literal
         names must not pass resolution at runtime (asymmetry-bug closure)."""
-        raw = [{"kind": "literal", "name": "PHOENIX_SANDBOX_VERCEL_TOKEN", "value": "x"}]
+        raw = [{"kind": "literal", "name": "VERCEL_TOKEN", "value": "x"}]
         session = _make_session({})
-        with pytest.raises(MissingSecretError, match="PHOENIX_SANDBOX_VERCEL_TOKEN"):
+        with pytest.raises(MissingSecretError, match="VERCEL_TOKEN"):
             await _resolve_user_env(raw, session, _identity_decrypt)
         session.scalars.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_reserved_check_is_case_insensitive(self) -> None:
         """Reserved-name comparison is case-insensitive in both positions."""
-        raw = [
-            {"kind": "secret_ref", "name": "MY_TOKEN", "secret_key": "phoenix_sandbox_vercel_token"}
-        ]
-        session = _make_session({"phoenix_sandbox_vercel_token": b"should-not-reach-here"})
+        raw = [{"kind": "secret_ref", "name": "MY_TOKEN", "secret_key": "vercel_token"}]
+        session = _make_session({"vercel_token": b"should-not-reach-here"})
         with pytest.raises(MissingSecretError):
             await _resolve_user_env(raw, session, _identity_decrypt)
         session.scalars.assert_not_called()
@@ -126,8 +122,8 @@ class TestReservedCredentialNameHelper:
 
     def test_non_modal_reserved_names_still_reserved(self) -> None:
         assert is_reserved_credential_name("PHOENIX_SANDBOX_E2B_API_KEY")
-        assert is_reserved_credential_name("PHOENIX_SANDBOX_VERCEL_TOKEN")
-        assert is_reserved_credential_name("phoenix_sandbox_vercel_token")
+        assert is_reserved_credential_name("VERCEL_TOKEN")
+        assert is_reserved_credential_name("vercel_token")
         assert is_reserved_credential_name("VERCEL_OIDC_TOKEN")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -651,6 +651,7 @@ dev = [
     { name = "typing-extensions" },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
     { name = "vcrpy" },
+    { name = "vercel" },
 ]
 
 [package.metadata]
@@ -836,6 +837,7 @@ dev = [
     { name = "typing-extensions" },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
     { name = "vcrpy" },
+    { name = "vercel", specifier = ">=0.5.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
<img width="1161" height="667" alt="Screenshot 2026-05-08 at 11 48 42 AM" src="https://github.com/user-attachments/assets/1dfdd4af-0ad1-4b3a-b38e-08b1c038d33c" />

- Adds the Vercel SDK to dev deps (matching the daytona/modal pattern) and replaces `Any` annotations in `vercel_backend.py` with proper SDK types via `TYPE_CHECKING` imports plus a `_LanguageConfig` TypedDict; removes the `vercel.*` mypy override.
- Renames the Vercel access-token credentials from `PHOENIX_SANDBOX_VERCEL_TOKEN` / `_PROJECT_ID` / `_TEAM_ID` to the native `VERCEL_TOKEN` / `VERCEL_PROJECT_ID` / `VERCEL_TEAM_ID` names — these are exactly what the Vercel Python SDK already auto-discovers from `os.environ` (see `vercel/oidc/credentials.py`), and matches the convention Modal already uses (`MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`).
- Updates affected unit tests, comments, dependency hints, and error messages.