### PR TITLE
fix(pxi): resolve interrupted tool calls

### DIFF
--- a/app/src/agent/chat/interruptToolCalls.ts
+++ b/app/src/agent/chat/interruptToolCalls.ts
@@ -1,0 +1,49 @@
+import {
+  getToolName,
+  isToolUIPart,
+  type DynamicToolUIPart,
+  type UIMessage,
+} from "ai";
+
+export type UnresolvedToolCall = {
+  tool: string;
+  toolCallId: string;
+};
+
+/**
+ * Finds tool calls that have not reached a terminal output state on the last
+ * assistant turn. AI SDK's `addToolOutput` only updates the current last
+ * message, so older assistant turns are intentionally ignored here.
+ */
+export function getUnresolvedToolCalls(
+  messages: UIMessage[]
+): UnresolvedToolCall[] {
+  const message = messages[messages.length - 1];
+  if (!message || message.role !== "assistant") {
+    return [];
+  }
+
+  return message.parts
+    .filter(isToolUIPart)
+    .filter(
+      (part) => !part.providerExecuted && isUnresolvedToolState(part.state)
+    )
+    .map((part) => ({
+      tool: getToolName(part),
+      toolCallId: part.toolCallId,
+    }));
+}
+
+function isUnresolvedToolState(state: DynamicToolUIPart["state"]): boolean {
+  switch (state) {
+    case "input-streaming":
+    case "input-available":
+    case "approval-requested":
+    case "approval-responded":
+      return true;
+    case "output-available":
+    case "output-error":
+    case "output-denied":
+      return false;
+  }
+}

--- a/app/src/agent/chat/shouldSendAutomatically.ts
+++ b/app/src/agent/chat/shouldSendAutomatically.ts
@@ -28,16 +28,22 @@ export function shouldSendAutomaticallyAfterToolOutput({
 }): boolean {
   // if we just marked tool calls as interrupted (on message send or stream stop), we don't
   // want to trigger another message send event
-  if (hasUserInterruptedToolCall(messages)) {
+  if (hasInterruptedToolCall({ messages, errorText: USER_INTERRUPT_ERROR })) {
     return false;
   }
-  if (hasSystemInterruptedToolCall(messages)) {
+  if (hasInterruptedToolCall({ messages, errorText: SYSTEM_INTERRUPT_ERROR })) {
     return false;
   }
   return lastAssistantMessageIsCompleteWithToolCalls({ messages });
 }
 
-function hasUserInterruptedToolCall(messages: UIMessage[]): boolean {
+function hasInterruptedToolCall({
+  messages,
+  errorText,
+}: {
+  messages: UIMessage[];
+  errorText: string;
+}): boolean {
   const message = messages[messages.length - 1];
   if (!message || message.role !== "assistant") {
     return false;
@@ -46,24 +52,6 @@ function hasUserInterruptedToolCall(messages: UIMessage[]): boolean {
     if (!isToolUIPart(part)) {
       return false;
     }
-    return (
-      part.state === "output-error" && part.errorText === USER_INTERRUPT_ERROR
-    );
-  });
-}
-
-// we don't want to send automatically after we've set a synthetic tool error
-function hasSystemInterruptedToolCall(messages: UIMessage[]): boolean {
-  const message = messages[messages.length - 1];
-  if (!message || message.role !== "assistant") {
-    return false;
-  }
-  return message.parts.some((part) => {
-    if (!isToolUIPart(part)) {
-      return false;
-    }
-    return (
-      part.state === "output-error" && part.errorText === SYSTEM_INTERRUPT_ERROR
-    );
+    return part.state === "output-error" && part.errorText === errorText;
   });
 }

--- a/app/src/agent/chat/shouldSendAutomatically.ts
+++ b/app/src/agent/chat/shouldSendAutomatically.ts
@@ -1,0 +1,69 @@
+import {
+  isToolUIPart,
+  lastAssistantMessageIsCompleteWithToolCalls,
+  type UIMessage,
+} from "ai";
+
+export const USER_INTERRUPT_ERROR = "The user has interrupted this tool call.";
+export const SYSTEM_INTERRUPT_ERROR =
+  "This tool call has been interrupted by unexpected system conditions.";
+
+/**
+ * Gate AI SDK's automatic tool-result continuation.
+ *
+ * `addToolOutput` always asks `sendAutomaticallyWhen` whether it should submit
+ * the next model request. Most completed tool calls should continue via AI
+ * SDK's `lastAssistantMessageIsCompleteWithToolCalls` helper. Some UI-owned
+ * tools, however, can complete because the live UI surface disappeared rather
+ * than because the user finished the requested action. Those terminal results
+ * should update the transcript, but should not make PXI continue unprompted.
+ *
+ * Extend this by adding narrow predicates for other terminal tool outputs that
+ * are UX/lifecycle cancellations rather than actionable results for the model.
+ */
+export function shouldSendAutomaticallyAfterToolOutput({
+  messages,
+}: {
+  messages: UIMessage[];
+}): boolean {
+  // if we just marked tool calls as interrupted (on message send or stream stop), we don't
+  // want to trigger another message send event
+  if (hasUserInterruptedToolCall(messages)) {
+    return false;
+  }
+  if (hasSystemInterruptedToolCall(messages)) {
+    return false;
+  }
+  return lastAssistantMessageIsCompleteWithToolCalls({ messages });
+}
+
+function hasUserInterruptedToolCall(messages: UIMessage[]): boolean {
+  const message = messages[messages.length - 1];
+  if (!message || message.role !== "assistant") {
+    return false;
+  }
+  return message.parts.some((part) => {
+    if (!isToolUIPart(part)) {
+      return false;
+    }
+    return (
+      part.state === "output-error" && part.errorText === USER_INTERRUPT_ERROR
+    );
+  });
+}
+
+// we don't want to send automatically after we've set a synthetic tool error
+function hasSystemInterruptedToolCall(messages: UIMessage[]): boolean {
+  const message = messages[messages.length - 1];
+  if (!message || message.role !== "assistant") {
+    return false;
+  }
+  return message.parts.some((part) => {
+    if (!isToolUIPart(part)) {
+      return false;
+    }
+    return (
+      part.state === "output-error" && part.errorText === SYSTEM_INTERRUPT_ERROR
+    );
+  });
+}

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -155,37 +155,36 @@ export function useAgentChat({
     setMessages,
   } = chat;
 
-  const handleStopWithToolCleanup = async () => {
-    await stop();
-    // filter out messages where the input hasn't streamed in yet
-    // these break pydantic's requirement that input must be present
-    setMessages((prevMessages) => {
-      return prevMessages.map((message) => {
-        return {
-          ...message,
-          parts: message.parts.filter(
-            (part) =>
-              !isToolUIPart(part) ||
-              (part.state !== "input-streaming" &&
-                part.state !== "input-available")
-          ),
-        };
-      });
-    });
-
-    const latestMessages = chatInstance?.messages ?? messages;
-    const unresolvedToolCalls = getUnresolvedToolCalls(latestMessages);
+  const addInterruptedToolOutputs = async ({
+    messages,
+    errorText,
+  }: {
+    messages: AgentUIMessage[];
+    errorText: string;
+  }) => {
+    const unresolvedToolCalls = getUnresolvedToolCalls(messages);
 
     await Promise.all(
       unresolvedToolCalls.map((toolCall) =>
         addToolOutput({
           tool: toolCall.tool,
           toolCallId: toolCall.toolCallId,
-          errorText: USER_INTERRUPT_ERROR,
+          errorText,
           state: "output-error",
         })
       )
     );
+  };
+
+  const handleStopWithToolCleanup = async () => {
+    await stop();
+    setMessages(removeInterruptedToolInputParts);
+
+    const latestMessages = chatInstance?.messages ?? messages;
+    await addInterruptedToolOutputs({
+      messages: latestMessages,
+      errorText: USER_INTERRUPT_ERROR,
+    });
   };
 
   const handleSendMessage = async (...args: Parameters<typeof sendMessage>) => {
@@ -193,33 +192,13 @@ export function useAgentChat({
       await stop();
     }
 
-    setMessages((prevMessages) => {
-      return prevMessages.map((message) => {
-        return {
-          ...message,
-          parts: message.parts.filter(
-            (part) =>
-              !isToolUIPart(part) ||
-              (part.state !== "input-streaming" &&
-                part.state !== "input-available")
-          ),
-        };
-      });
-    });
+    setMessages(removeInterruptedToolInputParts);
 
     const latestMessages = chatInstance?.messages ?? messages;
-    const unresolvedToolCalls = getUnresolvedToolCalls(latestMessages);
-
-    await Promise.all(
-      unresolvedToolCalls.map((toolCall) =>
-        addToolOutput({
-          tool: toolCall.tool,
-          toolCallId: toolCall.toolCallId,
-          errorText: SYSTEM_INTERRUPT_ERROR,
-          state: "output-error",
-        })
-      )
-    );
+    await addInterruptedToolOutputs({
+      messages: latestMessages,
+      errorText: SYSTEM_INTERRUPT_ERROR,
+    });
 
     await sendMessage(...args);
   };
@@ -284,6 +263,22 @@ export function useAgentChat({
     handleElicitationSubmit: (output: ElicitToolOutput) => void;
     handleElicitationCancel: () => void;
   };
+}
+
+function removeInterruptedToolInputParts(
+  messages: AgentUIMessage[]
+): AgentUIMessage[] {
+  return messages.map((message) => {
+    return {
+      ...message,
+      parts: message.parts.filter((part) => {
+        return (
+          !isToolUIPart(part) ||
+          (part.state !== "input-streaming" && part.state !== "input-available")
+        );
+      }),
+    };
+  });
 }
 
 function isRequestActive(status: ChatStatus): boolean {

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -1,13 +1,16 @@
 import { Chat, useChat } from "@ai-sdk/react";
 import type { ChatStatus } from "ai";
-import {
-  DefaultChatTransport,
-  lastAssistantMessageIsCompleteWithToolCalls,
-} from "ai";
+import { DefaultChatTransport, isToolUIPart } from "ai";
 import { useEffect, useRef } from "react";
 
 import { buildAgentChatRequestBody } from "@phoenix/agent/chat/buildAgentChatRequestBody";
 import { handleAgentToolCall } from "@phoenix/agent/chat/handleAgentToolCall";
+import { getUnresolvedToolCalls } from "@phoenix/agent/chat/interruptToolCalls";
+import {
+  shouldSendAutomaticallyAfterToolOutput,
+  SYSTEM_INTERRUPT_ERROR,
+  USER_INTERRUPT_ERROR,
+} from "@phoenix/agent/chat/shouldSendAutomatically";
 import {
   assistantMessageMetadataSchema,
   type AgentUIMessage,
@@ -109,9 +112,15 @@ export function useAgentChat({
                   agentStore: store,
                 });
               },
-              sendAutomaticallyWhen:
-                lastAssistantMessageIsCompleteWithToolCalls,
-              onFinish: ({ messages: finalMessages, message }) => {
+              sendAutomaticallyWhen: shouldSendAutomaticallyAfterToolOutput,
+              onFinish: ({
+                messages: finalMessages,
+                message,
+                finishReason,
+                isAbort,
+                isError,
+              }) => {
+                console.log("in Finish: ", { finishReason, isAbort, isError });
                 const usage = message.metadata?.usage;
                 if (usage != null) {
                   store.getState().setSessionUsage(sessionId, {
@@ -123,8 +132,9 @@ export function useAgentChat({
                 }
                 // Finalized history is mirrored into the durable store so idle
                 // runtimes can be reclaimed and later reconstructed from state.
-                if (finalMessages) {
+                if (finalMessages && finishReason !== "stop") {
                   store.getState().setSessionMessages(sessionId, finalMessages);
+                  console.log("setting final messages to ", { finalMessages });
                   generateSummary({ sessionId });
                 }
               },
@@ -139,7 +149,89 @@ export function useAgentChat({
   const chat = useChat<AgentUIMessage>(
     chatInstance ? { chat: chatInstance } : { id: undefined, messages: [] }
   );
-  const { messages, sendMessage, status, error, addToolOutput, stop } = chat;
+  const {
+    messages,
+    sendMessage,
+    status,
+    error,
+    addToolOutput,
+    stop,
+    setMessages,
+  } = chat;
+
+  const handleStopWithToolCleanup = async () => {
+    await stop();
+    // filter out messages where the input hasn't streamed in yet
+    // these break pydantic's requirement that input must be present
+    setMessages((prevMessages) => {
+      return prevMessages.map((message) => {
+        return {
+          ...message,
+          parts: message.parts.filter(
+            (part) =>
+              !isToolUIPart(part) ||
+              (part.state !== "input-streaming" &&
+                part.state !== "input-available")
+          ),
+        };
+      });
+    });
+
+    const latestMessages = chatInstance?.messages ?? messages;
+    const unresolvedToolCalls = getUnresolvedToolCalls(latestMessages);
+
+    await Promise.all(
+      unresolvedToolCalls.map((toolCall) =>
+        addToolOutput({
+          tool: toolCall.tool,
+          toolCallId: toolCall.toolCallId,
+          errorText: USER_INTERRUPT_ERROR,
+          state: "output-error",
+        })
+      )
+    );
+  };
+
+  const handleSendMessage = async (...args: Parameters<typeof sendMessage>) => {
+    console.log("in handleSendMessage: ", { messages });
+
+    if (chatInstance && isRequestActive(chatInstance.status)) {
+      console.log("STOPPING");
+      await stop();
+    }
+
+    setMessages((prevMessages) => {
+      return prevMessages.map((message) => {
+        return {
+          ...message,
+          parts: message.parts.filter(
+            (part) =>
+              !isToolUIPart(part) ||
+              (part.state !== "input-streaming" &&
+                part.state !== "input-available")
+          ),
+        };
+      });
+    });
+
+    const latestMessages = chatInstance?.messages ?? messages;
+    const unresolvedToolCalls = getUnresolvedToolCalls(latestMessages);
+
+    await Promise.all(
+      unresolvedToolCalls.map((toolCall) =>
+        addToolOutput({
+          tool: toolCall.tool,
+          toolCallId: toolCall.toolCallId,
+          errorText: SYSTEM_INTERRUPT_ERROR,
+          state: "output-error",
+        })
+      )
+    );
+
+    console.log("sanitized messages: ", chatInstance?.messages ?? messages);
+
+    await sendMessage(...args);
+  };
 
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
@@ -184,8 +276,8 @@ export function useAgentChat({
 
   return {
     messages,
-    sendMessage,
-    stop,
+    sendMessage: handleSendMessage,
+    stop: handleStopWithToolCleanup,
     status,
     error,
     pendingElicitation,
@@ -201,4 +293,8 @@ export function useAgentChat({
     handleElicitationSubmit: (output: ElicitToolOutput) => void;
     handleElicitationCancel: () => void;
   };
+}
+
+function isRequestActive(status: ChatStatus): boolean {
+  return status === "submitted" || status === "streaming";
 }

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -117,10 +117,7 @@ export function useAgentChat({
                 messages: finalMessages,
                 message,
                 finishReason,
-                isAbort,
-                isError,
               }) => {
-                console.log("in Finish: ", { finishReason, isAbort, isError });
                 const usage = message.metadata?.usage;
                 if (usage != null) {
                   store.getState().setSessionUsage(sessionId, {
@@ -134,7 +131,6 @@ export function useAgentChat({
                 // runtimes can be reclaimed and later reconstructed from state.
                 if (finalMessages && finishReason !== "stop") {
                   store.getState().setSessionMessages(sessionId, finalMessages);
-                  console.log("setting final messages to ", { finalMessages });
                   generateSummary({ sessionId });
                 }
               },
@@ -193,10 +189,7 @@ export function useAgentChat({
   };
 
   const handleSendMessage = async (...args: Parameters<typeof sendMessage>) => {
-    console.log("in handleSendMessage: ", { messages });
-
     if (chatInstance && isRequestActive(chatInstance.status)) {
-      console.log("STOPPING");
       await stop();
     }
 
@@ -227,8 +220,6 @@ export function useAgentChat({
         })
       )
     );
-
-    console.log("sanitized messages: ", chatInstance?.messages ?? messages);
 
     await sendMessage(...args);
   };

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -113,11 +113,7 @@ export function useAgentChat({
                 });
               },
               sendAutomaticallyWhen: shouldSendAutomaticallyAfterToolOutput,
-              onFinish: ({
-                messages: finalMessages,
-                message,
-                finishReason,
-              }) => {
+              onFinish: ({ messages: finalMessages, message }) => {
                 const usage = message.metadata?.usage;
                 if (usage != null) {
                   store.getState().setSessionUsage(sessionId, {
@@ -129,7 +125,7 @@ export function useAgentChat({
                 }
                 // Finalized history is mirrored into the durable store so idle
                 // runtimes can be reclaimed and later reconstructed from state.
-                if (finalMessages && finishReason !== "stop") {
+                if (finalMessages) {
                   store.getState().setSessionMessages(sessionId, finalMessages);
                   generateSummary({ sessionId });
                 }
@@ -155,6 +151,8 @@ export function useAgentChat({
     setMessages,
   } = chat;
 
+  // Anthropic doesn't accept unresolved tool calls, so we resolve them by marking
+  // as error
   const addInterruptedToolOutputs = async ({
     messages,
     errorText,
@@ -265,6 +263,7 @@ export function useAgentChat({
   };
 }
 
+// Pydantic will error if given tool calls without inputs, so we filter them out
 function removeInterruptedToolInputParts(
   messages: AgentUIMessage[]
 ): AgentUIMessage[] {


### PR DESCRIPTION
## Summary

- add PXI interruption cleanup that marks unresolved tool calls as synthetic `output-error` results when a user stops the stream or sends a new message mid-turn
- replace the default AI SDK auto-continuation predicate with a PXI-aware guard so these synthetic interruption outputs do not trigger another automatic model request
- filter partially streamed tool-call input parts before the next request so the transcript is valid for the backend parser

## Why

Interrupting a PXI turn can leave the transcript with tool calls that are no longer going to produce normal outputs. Anthropic does not accept unresolved tool calls in the message history, so the client needs to close those calls with an explicit error result before submitting the next turn.

There is a separate parser constraint on our side: Pydantic errors when a tool-call part is present without its input payload. For interrupted tool calls whose input never fully streamed, we remove those incomplete input parts before resubmitting the transcript.

## Current limitation

This does not make `stop()` a fully settled cancellation boundary. AI SDK `stop()` aborts the active request, but old stream/tool work can still finish asynchronously. This PR makes the transcript more valid when we clean up around an interrupt, but it does not fully solve stale stream chunks or long-running browser tools continuing after stop.

## Verification

- commit hooks passed: `oxfmt`, `oxlint`