### PR TITLE
test(sandbox): escape Windows path in pytest.raises match

### DIFF
--- a/tests/unit/server/sandbox/test_wasm_download.py
+++ b/tests/unit/server/sandbox/test_wasm_download.py
@@ -9,6 +9,7 @@ in the GraphQL ``SandboxBackends`` resolver.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -133,7 +134,7 @@ class TestEnsureWasmBinaryEnvVarOverride:
         monkeypatch.setenv(PHOENIX_WASM_BINARY_PATH_ENV, str(missing))
 
         with patch("phoenix.server.sandbox._download.urllib.request.urlretrieve") as mock_retrieve:
-            with pytest.raises(WASMBinaryUnavailable, match=str(missing)):
+            with pytest.raises(WASMBinaryUnavailable, match=re.escape(str(missing))):
                 ensure_wasm_binary(
                     cache_dir=tmp_path / "unused-cache",
                     expected_sha256="",


### PR DESCRIPTION
## Summary
- Fixes the only failing test in the [scheduled \"main Python All Platforms\" run](https://github.com/Arize-ai/phoenix/actions/runs/25575452608): `tests/unit/server/sandbox/test_wasm_download.py::TestEnsureWasmBinaryEnvVarOverride::test_env_var_set_and_file_missing_raises` on Windows runners.
- Root cause: `pytest.raises(WASMBinaryUnavailable, match=str(missing))` treats `match` as a regex. On Windows, `tmp_path` produces paths like `C:\Users\...` whose `\U` (and `\_`, `\p`, etc.) are invalid Python regex escapes, so `re.compile` raises `re.error: incomplete escape \U` before the test can assert the message.
- Wrapped the path in `re.escape(...)` so it's matched as a literal substring. No production code change.

Why only `version-sandboxes` failed: the test was added in [f61a7bcf9](https://github.com/Arize-ai/phoenix/commit/f61a7bcf9) which only lives on `version-sandboxes`; `main` Windows runs in the same workflow passed because they don't have this test yet. PR is targeted at `version-sandboxes` for that reason.

## Test plan
- [ ] Re-run the scheduled `main Python All Platforms` workflow against `version-sandboxes` and confirm both Windows unit-test jobs (3.10 and 3.13) go green.