### PR TITLE
feat(evaluators): add code evaluator versions list with diff view

### DIFF
--- a/.agents/skills/phoenix-design/SKILL.md
+++ b/.agents/skills/phoenix-design/SKILL.md
@@ -25,3 +25,4 @@ Read the relevant file(s) based on the task:
 | `rules/bem.md` | Naming CSS classes |
 | `rules/tokens.md` | Creating or consuming CSS design tokens |
 | `rules/icons.md` | Picking an icon for a noun (project, trace, span, file, etc.) |
+| `rules/counters.md` | Displaying counts in tabs, headings, or filter buttons |

--- a/.agents/skills/phoenix-design/rules/counters.md
+++ b/.agents/skills/phoenix-design/rules/counters.md
@@ -1,0 +1,27 @@
+# Counters
+
+When displaying a count alongside a label (e.g. in a `Tab`, section heading, or filter button), you MUST use the `Counter` component from `@phoenix/components/core/counter`.
+
+You MUST NOT inline the count using brackets or parentheses (e.g. `Versions (3)` or `Versions [3]`). The `Counter` provides consistent typography, spacing, and a pill background that distinguishes the count from the label.
+
+## Correct
+
+```tsx
+import { Counter } from "@phoenix/components/core/counter";
+
+<Tab id="versions">
+  Versions <Counter>{versionsCount}</Counter>
+</Tab>
+```
+
+## Incorrect
+
+```tsx
+<Tab id="versions">{`Versions (${versionsCount})`}</Tab>
+```
+
+## Variants
+
+- `default` — standard count badge
+- `quiet` — borderless, transparent background; use inside selected/active tabs where the count should recede
+- `danger` — use only when the count itself signals an error condition

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -505,6 +505,7 @@ type CodeEvaluator implements Evaluator & Node {
   outputConfigs: [BuiltInEvaluatorOutputConfig!]!
   currentVersion: CodeEvaluatorVersion
   version(versionId: ID!): CodeEvaluatorVersion
+  versionCount: Int!
   versions(first: Int = 50, last: Int, after: String, before: String): CodeEvaluatorVersionConnection!
   inputSchema: JSON
   sourceCode: String!

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -261,17 +261,19 @@ const router = createBrowserRouter(
                   }}
                 />
               </Route>
-              <Route
-                id={EVALUATOR_DETAILS_ROUTE_ID}
-                path="evaluators/:evaluatorId"
-                element={<DatasetEvaluatorDetailsPage />}
-                loader={datasetEvaluatorDetailsLoader}
-                handle={{
-                  crumb: (data: DatasetEvaluatorDetailsLoaderData) =>
-                    data?.evaluatorDisplayName || "evaluator",
-                }}
-              >
-                <Route path=":traceId" element={<EvaluatorTracePage />} />
+              <Route path="evaluators" handle={{ crumb: () => "evaluators" }}>
+                <Route
+                  id={EVALUATOR_DETAILS_ROUTE_ID}
+                  path=":evaluatorId"
+                  element={<DatasetEvaluatorDetailsPage />}
+                  loader={datasetEvaluatorDetailsLoader}
+                  handle={{
+                    crumb: (data: DatasetEvaluatorDetailsLoaderData) =>
+                      data?.evaluatorDisplayName || "evaluator",
+                  }}
+                >
+                  <Route path=":traceId" element={<EvaluatorTracePage />} />
+                </Route>
               </Route>
               <Route
                 path="compare"

--- a/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
+++ b/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   Flex,
   Label,
-  Link,
   ListBox,
   Popover,
   Select,
@@ -12,7 +11,6 @@ import {
   SelectItem,
   SelectValue,
   Text,
-  View,
 } from "@phoenix/components";
 import { PythonSVG, TypeScriptSVG } from "@phoenix/components/core/icon/Icons";
 import { SandboxProviderIcon } from "@phoenix/components/sandbox/SandboxProviderIcon";
@@ -91,8 +89,6 @@ export type CodeEvaluatorSandboxFieldProps = {
   onSelectionChange: (sandboxConfigId: string | null) => void;
   /** Optional size variant */
   size?: "M" | "L";
-  /** Whether to show the helper text below the field */
-  showHelperText?: boolean;
 };
 
 /**
@@ -105,7 +101,6 @@ export const CodeEvaluatorSandboxField = ({
   selectedSandboxConfigId,
   onSelectionChange,
   size = "M",
-  showHelperText = false,
 }: CodeEvaluatorSandboxFieldProps) => {
   // Filter configs to only show those matching the current language
   const compatibleConfigs = useMemo(
@@ -121,66 +116,50 @@ export const CodeEvaluatorSandboxField = ({
     ? selectedSandboxConfigId
     : null;
 
-  if (sandboxConfigs.length === 0) {
-    // No sandbox providers enabled at all
-    return (
-      <Flex direction="column" gap="size-50">
-        <Label>Sandbox</Label>
-        <Text color="text-500" size="S">
-          No sandbox providers enabled.{" "}
-          <Link to="/settings/sandboxes">Configure in Settings</Link>.
-        </Text>
-      </Flex>
-    );
-  }
+  const hasNoProviders = sandboxConfigs.length === 0;
+  const hasNoCompatibleConfigs = compatibleConfigs.length === 0;
 
   return (
-    <View>
-      <Select
-        size={size}
-        selectedKey={validSelectedId != null ? String(validSelectedId) : null}
-        onSelectionChange={(key) => {
-          onSelectionChange(typeof key === "string" ? key : null);
-        }}
-        isDisabled={compatibleConfigs.length === 0}
-        placeholder={
-          compatibleConfigs.length > 0
-            ? "Select a sandbox..."
-            : "None available"
-        }
-      >
-        <Label>Sandbox</Label>
-        <Button>
-          <SelectValue />
-          <SelectChevronUpDownIcon />
-        </Button>
-        <Popover>
-          <ListBox items={compatibleConfigs}>
-            {(item) => (
-              <SelectItem
-                id={String(item.id)}
-                key={item.id}
-                textValue={item.name}
-              >
-                <Flex direction="row" gap="size-100" alignItems="center">
-                  <SandboxProviderIcon
-                    backendType={item.providerBackendType}
-                    height={18}
-                  />
-                  <Text>{item.name}</Text>
-                </Flex>
-              </SelectItem>
-            )}
-          </ListBox>
-        </Popover>
-      </Select>
-      {showHelperText && (
-        <Text color="text-500" size="S">
-          Code evaluators run in a sandbox. Configure reusable sandbox configs
-          in Settings if none are available here.
-        </Text>
-      )}
-    </View>
+    <Select
+      size={size}
+      selectedKey={validSelectedId != null ? String(validSelectedId) : null}
+      onSelectionChange={(key) => {
+        onSelectionChange(typeof key === "string" ? key : null);
+      }}
+      isDisabled={hasNoCompatibleConfigs}
+      placeholder={
+        hasNoProviders
+          ? "No sandboxes configured"
+          : hasNoCompatibleConfigs
+            ? "None available"
+            : "Select a sandbox..."
+      }
+    >
+      <Label>Sandbox</Label>
+      <Button>
+        <SelectValue />
+        <SelectChevronUpDownIcon />
+      </Button>
+      <Popover>
+        <ListBox items={compatibleConfigs}>
+          {(item) => (
+            <SelectItem
+              id={String(item.id)}
+              key={item.id}
+              textValue={item.name}
+            >
+              <Flex direction="row" gap="size-100" alignItems="center">
+                <SandboxProviderIcon
+                  backendType={item.providerBackendType}
+                  height={18}
+                />
+                <Text>{item.name}</Text>
+              </Flex>
+            </SelectItem>
+          )}
+        </ListBox>
+      </Popover>
+    </Select>
   );
 };
 

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -384,7 +384,6 @@ export const EditCodeEvaluatorDialogContent = ({
                   sandboxConfigs={sandboxConfigs}
                   selectedSandboxConfigId={selectedSandboxConfigId}
                   onSandboxChange={setSandboxConfigId}
-                  showSandboxHelperText={hasNoSandboxConfigs}
                   isLanguageEditable={mode === "create"}
                 />
                 <CodeEditor
@@ -429,7 +428,6 @@ const EvaluatorMetadataForm = ({
   sandboxConfigs,
   selectedSandboxConfigId,
   onSandboxChange,
-  showSandboxHelperText,
   isLanguageEditable,
 }: {
   language: CodeEvaluatorLanguage;
@@ -437,7 +435,6 @@ const EvaluatorMetadataForm = ({
   sandboxConfigs: SandboxConfigOption[];
   selectedSandboxConfigId: string | null;
   onSandboxChange: (sandboxConfigId: string | null) => void;
-  showSandboxHelperText?: boolean;
   isLanguageEditable?: boolean;
 }) => {
   return (
@@ -458,7 +455,6 @@ const EvaluatorMetadataForm = ({
           language={language}
           selectedSandboxConfigId={selectedSandboxConfigId}
           onSelectionChange={onSandboxChange}
-          showHelperText={showSandboxHelperText}
         />
       </div>
       <div style={{ flex: "1 1 240px", minWidth: 180 }}>

--- a/app/src/pages/dataset/evaluators/BuiltInDatasetEvaluatorDetails.tsx
+++ b/app/src/pages/dataset/evaluators/BuiltInDatasetEvaluatorDetails.tsx
@@ -1,12 +1,10 @@
 import { css } from "@emotion/react";
 import type { ReactNode } from "react";
 import { useFragment } from "react-relay";
-import { useRevalidator } from "react-router";
 import { graphql } from "relay-runtime";
 
 import { Flex, Heading, Text } from "@phoenix/components";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
-import { EditBuiltInDatasetEvaluatorSlideover } from "@phoenix/components/dataset/EditBuiltInDatasetEvaluatorSlideover";
 import { ContainsEvaluatorCodeBlock } from "@phoenix/components/evaluators/ContainsEvaluatorCodeBlock";
 import { ContainsEvaluatorDetails } from "@phoenix/components/evaluators/ContainsEvaluatorDetails";
 import { ExactMatchEvaluatorCodeBlock } from "@phoenix/components/evaluators/ExactMatchEvaluatorCodeBlock";
@@ -117,16 +115,9 @@ function OutputConfigsSection({
 
 export function BuiltInDatasetEvaluatorDetails({
   datasetEvaluatorRef,
-  datasetId,
-  isEditSlideoverOpen,
-  onEditSlideoverOpenChange,
 }: {
   datasetEvaluatorRef: BuiltInDatasetEvaluatorDetails_datasetEvaluator$key;
-  datasetId: string;
-  isEditSlideoverOpen: boolean;
-  onEditSlideoverOpenChange: (isOpen: boolean) => void;
 }) {
-  const { revalidate } = useRevalidator();
   const datasetEvaluator = useFragment(
     graphql`
       fragment BuiltInDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {
@@ -230,25 +221,16 @@ export function BuiltInDatasetEvaluatorDetails({
   const parseStrings = literalMapping?.parse_strings !== false;
 
   return (
-    <>
-      <Flex direction="column" gap="size-200">
-        <Section title="Input Mapping">
-          <DetailsComponent inputMapping={inputMapping} />
-        </Section>
-        <OutputConfigsSection configs={outputConfigs} />
-        {name === "json_distance" ? (
-          <JSONDistanceEvaluatorCodeBlock parseStrings={parseStrings} />
-        ) : (
-          <CodeBlockComponent />
-        )}
-      </Flex>
-      <EditBuiltInDatasetEvaluatorSlideover
-        datasetEvaluatorId={datasetEvaluator.id}
-        datasetId={datasetId}
-        isOpen={isEditSlideoverOpen}
-        onOpenChange={onEditSlideoverOpenChange}
-        onUpdate={() => revalidate()}
-      />
-    </>
+    <Flex direction="column" gap="size-200">
+      <Section title="Input Mapping">
+        <DetailsComponent inputMapping={inputMapping} />
+      </Section>
+      <OutputConfigsSection configs={outputConfigs} />
+      {name === "json_distance" ? (
+        <JSONDistanceEvaluatorCodeBlock parseStrings={parseStrings} />
+      ) : (
+        <CodeBlockComponent />
+      )}
+    </Flex>
   );
 }

--- a/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorDetails.tsx
+++ b/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorDetails.tsx
@@ -2,7 +2,6 @@ import { css } from "@emotion/react";
 import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { useFragment } from "react-relay";
-import { useRevalidator } from "react-router";
 import { graphql } from "relay-runtime";
 import invariant from "tiny-invariant";
 
@@ -18,7 +17,6 @@ import {
   Text,
   View,
 } from "@phoenix/components";
-import { EditCodeDatasetEvaluatorSlideover } from "@phoenix/components/dataset/EditCodeDatasetEvaluatorSlideover";
 import { CodeEvaluatorSourceCodeBlock } from "@phoenix/components/evaluators/CodeEvaluatorSourceCodeBlock";
 import { SandboxProviderIcon } from "@phoenix/components/sandbox/SandboxProviderIcon";
 import type { CodeDatasetEvaluatorDetails_datasetEvaluator$key } from "@phoenix/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorDetails_datasetEvaluator.graphql";
@@ -410,18 +408,11 @@ function getDependenciesLabel(
 
 export function CodeDatasetEvaluatorDetails({
   datasetEvaluatorRef,
-  datasetId,
   sandboxBackends,
-  isEditSlideoverOpen,
-  onEditSlideoverOpenChange,
 }: {
   datasetEvaluatorRef: CodeDatasetEvaluatorDetails_datasetEvaluator$key;
-  datasetId: string;
   sandboxBackends: ReadonlyArray<SandboxBackendInfo>;
-  isEditSlideoverOpen: boolean;
-  onEditSlideoverOpenChange: (isOpen: boolean) => void;
 }) {
-  const { revalidate } = useRevalidator();
   const datasetEvaluator = useFragment(
     graphql`
       fragment CodeDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {
@@ -564,146 +555,131 @@ export function CodeDatasetEvaluatorDetails({
   invariant(evaluator.language, "code evaluator language is required");
 
   return (
-    <>
-      <Flex direction="column" gap="size-200">
-        <Card
-          title="Source Code"
-          extra={<LanguageWithIcon language={evaluator.language} />}
-        >
-          <CodeEvaluatorSourceCodeBlock
-            language={evaluator.language}
-            sourceCode={currentVersion.sourceCode}
-          />
-        </Card>
-        <div css={splitLayoutCSS}>
-          <Flex direction="column" gap="size-200" flex="2 1 0" minWidth={0}>
-            <Card
-              title={
-                outputConfigs.length > 1
-                  ? `Evaluator Annotations (${outputConfigs.length})`
-                  : "Evaluator Annotation"
-              }
-            >
-              <View padding="size-200">
-                <Flex direction="column" gap="size-200">
-                  {outputConfigs.map((config, idx) => (
-                    <OutputConfigBlock
-                      key={config.name || idx}
-                      config={config as OutputConfig}
-                    />
-                  ))}
-                </Flex>
-              </View>
-            </Card>
-            <Card title="Input Mapping">
-              <View padding="size-200">
-                <div css={mapGridCSS}>
-                  <MappingTile
-                    title="Path mapping"
-                    description="Map function args to fields on the example"
-                    entries={pathMappingEntries}
-                    emptyLabel="No paths set"
-                    formatValue={formatPathMappingValue}
+    <Flex direction="column" gap="size-200">
+      <Card
+        title="Source Code"
+        extra={<LanguageWithIcon language={evaluator.language} />}
+      >
+        <CodeEvaluatorSourceCodeBlock
+          language={evaluator.language}
+          sourceCode={currentVersion.sourceCode}
+        />
+      </Card>
+      <div css={splitLayoutCSS}>
+        <Flex direction="column" gap="size-200" flex="2 1 0" minWidth={0}>
+          <Card
+            title={
+              outputConfigs.length > 1
+                ? `Evaluator Annotations (${outputConfigs.length})`
+                : "Evaluator Annotation"
+            }
+          >
+            <View padding="size-200">
+              <Flex direction="column" gap="size-200">
+                {outputConfigs.map((config, idx) => (
+                  <OutputConfigBlock
+                    key={config.name || idx}
+                    config={config as OutputConfig}
                   />
-                  <MappingTile
-                    title="Literal mapping"
-                    description="Pass fixed literal values to function args"
-                    entries={literalMappingEntries}
-                    emptyLabel="No literals set"
-                    formatValue={formatLiteral}
-                  />
-                </div>
+                ))}
+              </Flex>
+            </View>
+          </Card>
+          <Card title="Input Mapping">
+            <View padding="size-200">
+              <div css={mapGridCSS}>
+                <MappingTile
+                  title="Path mapping"
+                  description="Map function args to fields on the example"
+                  entries={pathMappingEntries}
+                  emptyLabel="No paths set"
+                  formatValue={formatPathMappingValue}
+                />
+                <MappingTile
+                  title="Literal mapping"
+                  description="Pass fixed literal values to function args"
+                  entries={literalMappingEntries}
+                  emptyLabel="No literals set"
+                  formatValue={formatLiteral}
+                />
+              </div>
+            </View>
+          </Card>
+        </Flex>
+        <Flex direction="column" gap="size-200" flex="1 1 0" minWidth={0}>
+          <Card
+            title={
+              <Flex direction="row" gap="size-100" alignItems="center">
+                <Icon svg={<Icons.HardDriveOutline />} />
+                <span>Sandbox</span>
+              </Flex>
+            }
+          >
+            {sandboxConfig == null ? (
+              <View padding="size-200">
+                <Text color="text-700">No sandbox configuration selected.</Text>
               </View>
-            </Card>
-          </Flex>
-          <Flex direction="column" gap="size-200" flex="1 1 0" minWidth={0}>
-            <Card
-              title={
-                <Flex direction="row" gap="size-100" alignItems="center">
-                  <Icon svg={<Icons.HardDriveOutline />} />
-                  <span>Sandbox</span>
-                </Flex>
-              }
-            >
-              {sandboxConfig == null ? (
-                <View padding="size-200">
-                  <Text color="text-700">
-                    No sandbox configuration selected.
-                  </Text>
-                </View>
-              ) : (
-                <List size="M">
+            ) : (
+              <List size="M">
+                <ListItem>
+                  <SandboxRow
+                    label="Config"
+                    value={
+                      <Text size="S" fontFamily="mono">
+                        {sandboxConfig.name}
+                      </Text>
+                    }
+                  />
+                </ListItem>
+                {sandboxConfig.description ? (
                   <ListItem>
                     <SandboxRow
-                      label="Config"
-                      value={
-                        <Text size="S" fontFamily="mono">
-                          {sandboxConfig.name}
-                        </Text>
-                      }
+                      label="Description"
+                      value={sandboxConfig.description}
                     />
                   </ListItem>
-                  {sandboxConfig.description ? (
-                    <ListItem>
-                      <SandboxRow
-                        label="Description"
-                        value={sandboxConfig.description}
+                ) : null}
+                <ListItem>
+                  <SandboxRow
+                    label="Provider"
+                    labelExtra={
+                      <ProviderCapabilitiesHelp
+                        sandboxBackend={sandboxBackend}
                       />
-                    </ListItem>
-                  ) : null}
-                  <ListItem>
-                    <SandboxRow
-                      label="Provider"
-                      labelExtra={
-                        <ProviderCapabilitiesHelp
-                          sandboxBackend={sandboxBackend}
+                    }
+                    value={
+                      <Flex direction="row" gap="size-100" alignItems="center">
+                        <SandboxProviderIcon
+                          backendType={sandboxConfig.provider.backendType}
+                          height={16}
                         />
-                      }
-                      value={
-                        <Flex
-                          direction="row"
-                          gap="size-100"
-                          alignItems="center"
-                        >
-                          <SandboxProviderIcon
-                            backendType={sandboxConfig.provider.backendType}
-                            height={16}
-                          />
-                          <Text size="S">
-                            {sandboxBackend?.displayName ??
-                              sandboxConfig.provider.backendType}
-                          </Text>
-                        </Flex>
-                      }
-                    />
-                  </ListItem>
-                  <ListItem>
+                        <Text size="S">
+                          {sandboxBackend?.displayName ??
+                            sandboxConfig.provider.backendType}
+                        </Text>
+                      </Flex>
+                    }
+                  />
+                </ListItem>
+                <ListItem>
+                  <SandboxRow
+                    label="Timeout"
+                    value={`${sandboxConfig.timeout} seconds`}
+                  />
+                </ListItem>
+                {flattenedCustomSettings.map(([key, v]) => (
+                  <ListItem key={key}>
                     <SandboxRow
-                      label="Timeout"
-                      value={`${sandboxConfig.timeout} seconds`}
+                      label={friendlySettingLabel(key)}
+                      value={<SettingValue keyPath={key} value={v} />}
                     />
                   </ListItem>
-                  {flattenedCustomSettings.map(([key, v]) => (
-                    <ListItem key={key}>
-                      <SandboxRow
-                        label={friendlySettingLabel(key)}
-                        value={<SettingValue keyPath={key} value={v} />}
-                      />
-                    </ListItem>
-                  ))}
-                </List>
-              )}
-            </Card>
-          </Flex>
-        </div>
-      </Flex>
-      <EditCodeDatasetEvaluatorSlideover
-        datasetEvaluatorId={datasetEvaluator.id}
-        datasetId={datasetId}
-        isOpen={isEditSlideoverOpen}
-        onOpenChange={onEditSlideoverOpenChange}
-        onUpdate={() => revalidate()}
-      />
-    </>
+                ))}
+              </List>
+            )}
+          </Card>
+        </Flex>
+      </div>
+    </Flex>
   );
 }

--- a/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorVersions.tsx
+++ b/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorVersions.tsx
@@ -3,8 +3,8 @@ import { parseDiffFromFile } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
 import { formatRelative } from "date-fns/formatRelative";
 import { useMemo, useState } from "react";
-import { useFragment } from "react-relay";
-import { graphql } from "relay-runtime";
+import { graphql, useLazyLoadQuery } from "react-relay";
+import invariant from "tiny-invariant";
 
 import {
   Card,
@@ -21,12 +21,15 @@ import { UserPicture } from "@phoenix/components/user/UserPicture";
 import { useTheme } from "@phoenix/contexts";
 import { useCurrentTime } from "@phoenix/hooks";
 import type {
-  CodeDatasetEvaluatorVersions_datasetEvaluator$data,
-  CodeDatasetEvaluatorVersions_datasetEvaluator$key,
-} from "@phoenix/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorVersions_datasetEvaluator.graphql";
+  CodeDatasetEvaluatorVersionsQuery,
+  CodeDatasetEvaluatorVersionsQuery$data,
+} from "@phoenix/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorVersionsQuery.graphql";
 
 type CodeEvaluator = Extract<
-  CodeDatasetEvaluatorVersions_datasetEvaluator$data["evaluator"],
+  Extract<
+    CodeDatasetEvaluatorVersionsQuery$data["node"],
+    { readonly __typename: "DatasetEvaluator" }
+  >["evaluator"],
   { readonly __typename: "CodeEvaluator" }
 >;
 
@@ -213,50 +216,58 @@ function VersionDetail({
   );
 }
 
-export const codeDatasetEvaluatorVersionsFragment = graphql`
-  fragment CodeDatasetEvaluatorVersions_datasetEvaluator on DatasetEvaluator {
-    evaluator {
-      __typename
-      ... on CodeEvaluator {
-        id
-        language
-        versions(first: 50) {
-          edges {
-            node {
-              id
-              sequenceNumber
-              sourceCode
-              createdAt
-              user {
+export function CodeDatasetEvaluatorVersions({
+  datasetEvaluatorId,
+}: {
+  datasetEvaluatorId: string;
+}) {
+  const data = useLazyLoadQuery<CodeDatasetEvaluatorVersionsQuery>(
+    graphql`
+      query CodeDatasetEvaluatorVersionsQuery($datasetEvaluatorId: ID!) {
+        node(id: $datasetEvaluatorId) {
+          __typename
+          ... on DatasetEvaluator {
+            evaluator {
+              __typename
+              ... on CodeEvaluator {
                 id
-                username
-                profilePictureUrl
-              }
-              previousVersion {
-                id
-                sourceCode
+                language
+                versions(first: 50) {
+                  edges {
+                    node {
+                      id
+                      sequenceNumber
+                      sourceCode
+                      createdAt
+                      user {
+                        id
+                        username
+                        profilePictureUrl
+                      }
+                      previousVersion {
+                        id
+                        sourceCode
+                      }
+                    }
+                  }
+                }
               }
             }
           }
         }
       }
-    }
-  }
-`;
-
-export function CodeDatasetEvaluatorVersions({
-  datasetEvaluatorRef,
-}: {
-  datasetEvaluatorRef: CodeDatasetEvaluatorVersions_datasetEvaluator$key;
-}) {
-  const datasetEvaluator = useFragment(
-    codeDatasetEvaluatorVersionsFragment,
-    datasetEvaluatorRef
+    `,
+    { datasetEvaluatorId }
   );
-  const evaluator = datasetEvaluator.evaluator;
-  if (evaluator.__typename !== "CodeEvaluator") {
-    throw new Error("Invalid evaluator for CodeDatasetEvaluatorVersions");
-  }
+  invariant(
+    data.node.__typename === "DatasetEvaluator",
+    "Invalid node for CodeDatasetEvaluatorVersions"
+  );
+  const evaluator = data.node.evaluator;
+  invariant(
+    evaluator.__typename === "CodeEvaluator",
+    "Invalid evaluator for CodeDatasetEvaluatorVersions"
+  );
   const versions = useMemo(
     () => evaluator.versions.edges.map((edge) => edge.node),
     [evaluator.versions.edges]
@@ -264,8 +275,6 @@ export function CodeDatasetEvaluatorVersions({
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(
     versions[0]?.id ?? null
   );
-  const selectedVersion =
-    versions.find((v) => v.id === selectedVersionId) ?? versions[0] ?? null;
 
   if (versions.length === 0) {
     return (
@@ -275,6 +284,9 @@ export function CodeDatasetEvaluatorVersions({
     );
   }
 
+  const selectedVersion =
+    versions.find((v) => v.id === selectedVersionId) ?? versions[0];
+
   return (
     <div css={splitLayoutCSS}>
       <div css={listColCSS}>
@@ -283,19 +295,17 @@ export function CodeDatasetEvaluatorVersions({
             <VersionListItem
               key={version.id}
               version={version}
-              active={selectedVersion?.id === version.id}
+              active={selectedVersion.id === version.id}
               onSelect={setSelectedVersionId}
             />
           ))}
         </Flex>
       </div>
       <div css={detailColCSS}>
-        {selectedVersion && (
-          <VersionDetail
-            language={evaluator.language!}
-            version={selectedVersion}
-          />
-        )}
+        <VersionDetail
+          language={evaluator.language!}
+          version={selectedVersion}
+        />
       </div>
     </div>
   );

--- a/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorVersions.tsx
+++ b/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorVersions.tsx
@@ -1,0 +1,302 @@
+import { css } from "@emotion/react";
+import { parseDiffFromFile } from "@pierre/diffs";
+import { FileDiff } from "@pierre/diffs/react";
+import { formatRelative } from "date-fns/formatRelative";
+import { useMemo, useState } from "react";
+import { useFragment } from "react-relay";
+import { graphql } from "relay-runtime";
+
+import {
+  Card,
+  Empty,
+  Flex,
+  Switch,
+  Text,
+  Token,
+  View,
+} from "@phoenix/components";
+import { Truncate } from "@phoenix/components/core/utility/Truncate";
+import { CodeEvaluatorSourceCodeBlock } from "@phoenix/components/evaluators/CodeEvaluatorSourceCodeBlock";
+import { UserPicture } from "@phoenix/components/user/UserPicture";
+import { useTheme } from "@phoenix/contexts";
+import { useCurrentTime } from "@phoenix/hooks";
+import type {
+  CodeDatasetEvaluatorVersions_datasetEvaluator$data,
+  CodeDatasetEvaluatorVersions_datasetEvaluator$key,
+} from "@phoenix/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorVersions_datasetEvaluator.graphql";
+
+type CodeEvaluator = Extract<
+  CodeDatasetEvaluatorVersions_datasetEvaluator$data["evaluator"],
+  { readonly __typename: "CodeEvaluator" }
+>;
+
+type VersionEdge = NonNullable<CodeEvaluator>["versions"]["edges"][number];
+type Version = VersionEdge["node"];
+
+const VERSIONS_LIST_WIDTH = 360;
+
+const splitLayoutCSS = css`
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  width: 100%;
+  min-height: 0;
+`;
+
+const listColCSS = css`
+  width: ${VERSIONS_LIST_WIDTH}px;
+  min-width: ${VERSIONS_LIST_WIDTH}px;
+  height: 100%;
+  overflow: auto;
+  border-right: 1px solid var(--global-color-gray-300);
+`;
+
+const detailColCSS = css`
+  flex: 1 1 auto;
+  height: 100%;
+  overflow: auto;
+  min-width: 0;
+`;
+
+const versionItemCSS = css`
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--global-color-gray-300);
+  text-align: left;
+  cursor: pointer;
+  padding: 0;
+  color: inherit;
+  transition: background-color 0.1s ease-in;
+
+  &[data-active="true"],
+  &:hover {
+    background-color: var(--global-color-gray-200);
+  }
+`;
+
+function VersionListItem({
+  version,
+  active,
+  onSelect,
+}: {
+  version: Version;
+  active: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const { nowEpochMs } = useCurrentTime();
+  return (
+    <button
+      type="button"
+      css={versionItemCSS}
+      data-active={active}
+      onClick={() => onSelect(version.id)}
+    >
+      <View width="100%" paddingY="size-100" paddingX="size-200">
+        <Flex direction="column" gap="size-50">
+          <Flex direction="row" gap="size-100" alignItems="center">
+            <Token color="var(--global-color-blue-900)">
+              {`v${version.sequenceNumber}`}
+            </Token>
+            <Truncate maxWidth="100%">
+              <Text size="XS" color="text-700" fontFamily="mono">
+                {version.id}
+              </Text>
+            </Truncate>
+          </Flex>
+          <View paddingStart="size-400">
+            <Flex
+              direction="row"
+              justifyContent="space-between"
+              alignItems="center"
+              gap="size-100"
+            >
+              <Flex direction="row" gap="size-50" alignItems="center">
+                <UserPicture
+                  size={14}
+                  name={version.user?.username || "system"}
+                  profilePictureUrl={version.user?.profilePictureUrl || null}
+                />
+                <Text size="XS">{version.user?.username || "system"}</Text>
+              </Flex>
+              <Text color="text-300" size="XS">
+                {formatRelative(version.createdAt, nowEpochMs)}
+              </Text>
+            </Flex>
+          </View>
+        </Flex>
+      </View>
+    </button>
+  );
+}
+
+function VersionDiffView({
+  language,
+  current,
+  previous,
+}: {
+  language: CodeEvaluator["language"];
+  current: Version;
+  previous: NonNullable<Version["previousVersion"]>;
+}) {
+  const { theme } = useTheme();
+  const filename = language === "PYTHON" ? "evaluator.py" : "evaluator.ts";
+  const fileDiff = useMemo(
+    () =>
+      parseDiffFromFile(
+        { name: filename, contents: previous.sourceCode },
+        { name: filename, contents: current.sourceCode }
+      ),
+    [filename, previous.sourceCode, current.sourceCode]
+  );
+  return (
+    <FileDiff
+      fileDiff={fileDiff}
+      options={{
+        diffStyle: "unified",
+        disableFileHeader: true,
+        theme: { light: "pierre-light", dark: "pierre-dark" },
+        themeType: theme,
+      }}
+    />
+  );
+}
+
+function VersionDetail({
+  language,
+  version,
+}: {
+  language: CodeEvaluator["language"];
+  version: Version;
+}) {
+  const [showDiff, setShowDiff] = useState(false);
+  const previousVersion = version.previousVersion;
+  const hasPreviousVersion = previousVersion != null;
+
+  return (
+    <View padding="size-200" width="100%">
+      <Flex
+        direction="column"
+        gap="size-200"
+        maxWidth={1000}
+        marginStart="auto"
+        marginEnd="auto"
+      >
+        <Card
+          title={`Version ${version.sequenceNumber}`}
+          extra={
+            <Switch
+              labelPlacement="start"
+              isSelected={showDiff && hasPreviousVersion}
+              isDisabled={!hasPreviousVersion}
+              onChange={setShowDiff}
+            >
+              Diff
+            </Switch>
+          }
+        >
+          {showDiff && previousVersion ? (
+            <VersionDiffView
+              language={language}
+              current={version}
+              previous={previousVersion}
+            />
+          ) : (
+            <CodeEvaluatorSourceCodeBlock
+              language={language}
+              sourceCode={version.sourceCode}
+            />
+          )}
+        </Card>
+      </Flex>
+    </View>
+  );
+}
+
+export const codeDatasetEvaluatorVersionsFragment = graphql`
+  fragment CodeDatasetEvaluatorVersions_datasetEvaluator on DatasetEvaluator {
+    evaluator {
+      __typename
+      ... on CodeEvaluator {
+        id
+        language
+        versions(first: 50) {
+          edges {
+            node {
+              id
+              sequenceNumber
+              sourceCode
+              createdAt
+              user {
+                id
+                username
+                profilePictureUrl
+              }
+              previousVersion {
+                id
+                sourceCode
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export function CodeDatasetEvaluatorVersions({
+  datasetEvaluatorRef,
+}: {
+  datasetEvaluatorRef: CodeDatasetEvaluatorVersions_datasetEvaluator$key;
+}) {
+  const datasetEvaluator = useFragment(
+    codeDatasetEvaluatorVersionsFragment,
+    datasetEvaluatorRef
+  );
+  const evaluator = datasetEvaluator.evaluator;
+  if (evaluator.__typename !== "CodeEvaluator") {
+    throw new Error("Invalid evaluator for CodeDatasetEvaluatorVersions");
+  }
+  const versions = useMemo(
+    () => evaluator.versions.edges.map((edge) => edge.node),
+    [evaluator.versions.edges]
+  );
+  const [selectedVersionId, setSelectedVersionId] = useState<string | null>(
+    versions[0]?.id ?? null
+  );
+  const selectedVersion =
+    versions.find((v) => v.id === selectedVersionId) ?? versions[0] ?? null;
+
+  if (versions.length === 0) {
+    return (
+      <Flex flex={1} alignItems="center" justifyContent="center">
+        <Empty message="This code evaluator has no versions yet." />
+      </Flex>
+    );
+  }
+
+  return (
+    <div css={splitLayoutCSS}>
+      <div css={listColCSS}>
+        <Flex direction="column">
+          {versions.map((version) => (
+            <VersionListItem
+              key={version.id}
+              version={version}
+              active={selectedVersion?.id === version.id}
+              onSelect={setSelectedVersionId}
+            />
+          ))}
+        </Flex>
+      </div>
+      <div css={detailColCSS}>
+        {selectedVersion && (
+          <VersionDetail
+            language={evaluator.language!}
+            version={selectedVersion}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/pages/dataset/evaluators/DatasetEvaluatorDetailsPage.tsx
+++ b/app/src/pages/dataset/evaluators/DatasetEvaluatorDetailsPage.tsx
@@ -1,6 +1,7 @@
 import { css } from "@emotion/react";
 import { Suspense, useState } from "react";
-import { Outlet, useLoaderData, useParams } from "react-router";
+import { useFragment } from "react-relay";
+import { Outlet, useLoaderData, useParams, useRevalidator } from "react-router";
 import invariant from "tiny-invariant";
 
 import {
@@ -17,11 +18,20 @@ import {
   Tabs,
   View,
 } from "@phoenix/components";
+import { Counter } from "@phoenix/components/core/counter";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
+import { EditBuiltInDatasetEvaluatorSlideover } from "@phoenix/components/dataset/EditBuiltInDatasetEvaluatorSlideover";
+import { EditCodeDatasetEvaluatorSlideover } from "@phoenix/components/dataset/EditCodeDatasetEvaluatorSlideover";
+import { EditLLMDatasetEvaluatorSlideover } from "@phoenix/components/dataset/EditLLMDatasetEvaluatorSlideover";
 import { useOwnedPreloadedQuery } from "@phoenix/hooks";
+import type { CodeDatasetEvaluatorVersions_datasetEvaluator$key } from "@phoenix/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorVersions_datasetEvaluator.graphql";
 import type { datasetEvaluatorDetailsLoaderQuery } from "@phoenix/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql";
 import { BuiltInDatasetEvaluatorDetails } from "@phoenix/pages/dataset/evaluators/BuiltInDatasetEvaluatorDetails";
 import { CodeDatasetEvaluatorDetails } from "@phoenix/pages/dataset/evaluators/CodeDatasetEvaluatorDetails";
+import {
+  CodeDatasetEvaluatorVersions,
+  codeDatasetEvaluatorVersionsFragment,
+} from "@phoenix/pages/dataset/evaluators/CodeDatasetEvaluatorVersions";
 import type { datasetEvaluatorDetailsLoader } from "@phoenix/pages/dataset/evaluators/datasetEvaluatorDetailsLoader";
 import { datasetEvaluatorDetailsLoaderGQL } from "@phoenix/pages/dataset/evaluators/datasetEvaluatorDetailsLoader";
 import { DatasetEvaluatorSpans } from "@phoenix/pages/dataset/evaluators/DatasetEvaluatorSpans";
@@ -69,10 +79,20 @@ function DatasetEvaluatorDetailsPageContent({
   invariant(datasetEvaluator, "datasetEvaluator is required");
   const evaluator = datasetEvaluator.evaluator;
   const [isEditSlideoverOpen, setIsEditSlideoverOpen] = useState(false);
+  const { revalidate } = useRevalidator();
 
   const isLLMEvaluator = evaluator.__typename === "LLMEvaluator";
   const isBuiltInEvaluator = evaluator.__typename === "BuiltInEvaluator";
   const isCodeEvaluator = evaluator.__typename === "CodeEvaluator";
+  const versionsData =
+    useFragment<CodeDatasetEvaluatorVersions_datasetEvaluator$key>(
+      codeDatasetEvaluatorVersionsFragment,
+      datasetEvaluator
+    );
+  const versionsCount =
+    versionsData.evaluator.__typename === "CodeEvaluator"
+      ? versionsData.evaluator.versions.edges.length
+      : 0;
 
   return (
     <main css={mainCSS}>
@@ -99,6 +119,11 @@ function DatasetEvaluatorDetailsPageContent({
       <Tabs defaultSelectedKey="configuration">
         <TabList>
           <Tab id="configuration">Configuration</Tab>
+          {isCodeEvaluator && (
+            <Tab id="versions">
+              Versions <Counter>{versionsCount}</Counter>
+            </Tab>
+          )}
           <Tab id="spans">Spans</Tab>
         </TabList>
         <LazyTabPanel id="configuration">
@@ -114,36 +139,61 @@ function DatasetEvaluatorDetailsPageContent({
                 {isLLMEvaluator && (
                   <LLMDatasetEvaluatorDetails
                     datasetEvaluatorRef={datasetEvaluator}
-                    datasetId={datasetId}
-                    isEditSlideoverOpen={isEditSlideoverOpen}
-                    onEditSlideoverOpenChange={setIsEditSlideoverOpen}
                   />
                 )}
                 {isBuiltInEvaluator && (
                   <BuiltInDatasetEvaluatorDetails
                     datasetEvaluatorRef={datasetEvaluator}
-                    datasetId={datasetId}
-                    isEditSlideoverOpen={isEditSlideoverOpen}
-                    onEditSlideoverOpenChange={setIsEditSlideoverOpen}
                   />
                 )}
                 {isCodeEvaluator && (
                   <CodeDatasetEvaluatorDetails
                     datasetEvaluatorRef={datasetEvaluator}
-                    datasetId={datasetId}
                     sandboxBackends={data.sandboxBackends}
-                    isEditSlideoverOpen={isEditSlideoverOpen}
-                    onEditSlideoverOpenChange={setIsEditSlideoverOpen}
                   />
                 )}
               </Flex>
             </View>
           </View>
         </LazyTabPanel>
+        {isCodeEvaluator && (
+          <LazyTabPanel id="versions">
+            <CodeDatasetEvaluatorVersions
+              datasetEvaluatorRef={datasetEvaluator}
+            />
+          </LazyTabPanel>
+        )}
         <LazyTabPanel id="spans">
           <DatasetEvaluatorSpans projectRef={datasetEvaluator.project} />
         </LazyTabPanel>
       </Tabs>
+      {isLLMEvaluator && (
+        <EditLLMDatasetEvaluatorSlideover
+          datasetEvaluatorId={datasetEvaluator.id}
+          datasetId={datasetId}
+          isOpen={isEditSlideoverOpen}
+          onOpenChange={setIsEditSlideoverOpen}
+          onUpdate={() => revalidate()}
+        />
+      )}
+      {isBuiltInEvaluator && (
+        <EditBuiltInDatasetEvaluatorSlideover
+          datasetEvaluatorId={datasetEvaluator.id}
+          datasetId={datasetId}
+          isOpen={isEditSlideoverOpen}
+          onOpenChange={setIsEditSlideoverOpen}
+          onUpdate={() => revalidate()}
+        />
+      )}
+      {isCodeEvaluator && (
+        <EditCodeDatasetEvaluatorSlideover
+          datasetEvaluatorId={datasetEvaluator.id}
+          datasetId={datasetId}
+          isOpen={isEditSlideoverOpen}
+          onOpenChange={setIsEditSlideoverOpen}
+          onUpdate={() => revalidate()}
+        />
+      )}
       <Suspense>
         <Outlet />
       </Suspense>

--- a/app/src/pages/dataset/evaluators/DatasetEvaluatorDetailsPage.tsx
+++ b/app/src/pages/dataset/evaluators/DatasetEvaluatorDetailsPage.tsx
@@ -1,6 +1,5 @@
 import { css } from "@emotion/react";
 import { Suspense, useState } from "react";
-import { useFragment } from "react-relay";
 import { Outlet, useLoaderData, useParams, useRevalidator } from "react-router";
 import invariant from "tiny-invariant";
 
@@ -24,14 +23,10 @@ import { EditBuiltInDatasetEvaluatorSlideover } from "@phoenix/components/datase
 import { EditCodeDatasetEvaluatorSlideover } from "@phoenix/components/dataset/EditCodeDatasetEvaluatorSlideover";
 import { EditLLMDatasetEvaluatorSlideover } from "@phoenix/components/dataset/EditLLMDatasetEvaluatorSlideover";
 import { useOwnedPreloadedQuery } from "@phoenix/hooks";
-import type { CodeDatasetEvaluatorVersions_datasetEvaluator$key } from "@phoenix/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorVersions_datasetEvaluator.graphql";
 import type { datasetEvaluatorDetailsLoaderQuery } from "@phoenix/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql";
 import { BuiltInDatasetEvaluatorDetails } from "@phoenix/pages/dataset/evaluators/BuiltInDatasetEvaluatorDetails";
 import { CodeDatasetEvaluatorDetails } from "@phoenix/pages/dataset/evaluators/CodeDatasetEvaluatorDetails";
-import {
-  CodeDatasetEvaluatorVersions,
-  codeDatasetEvaluatorVersionsFragment,
-} from "@phoenix/pages/dataset/evaluators/CodeDatasetEvaluatorVersions";
+import { CodeDatasetEvaluatorVersions } from "@phoenix/pages/dataset/evaluators/CodeDatasetEvaluatorVersions";
 import type { datasetEvaluatorDetailsLoader } from "@phoenix/pages/dataset/evaluators/datasetEvaluatorDetailsLoader";
 import { datasetEvaluatorDetailsLoaderGQL } from "@phoenix/pages/dataset/evaluators/datasetEvaluatorDetailsLoader";
 import { DatasetEvaluatorSpans } from "@phoenix/pages/dataset/evaluators/DatasetEvaluatorSpans";
@@ -84,15 +79,8 @@ function DatasetEvaluatorDetailsPageContent({
   const isLLMEvaluator = evaluator.__typename === "LLMEvaluator";
   const isBuiltInEvaluator = evaluator.__typename === "BuiltInEvaluator";
   const isCodeEvaluator = evaluator.__typename === "CodeEvaluator";
-  const versionsData =
-    useFragment<CodeDatasetEvaluatorVersions_datasetEvaluator$key>(
-      codeDatasetEvaluatorVersionsFragment,
-      datasetEvaluator
-    );
   const versionsCount =
-    versionsData.evaluator.__typename === "CodeEvaluator"
-      ? versionsData.evaluator.versions.edges.length
-      : 0;
+    evaluator.__typename === "CodeEvaluator" ? evaluator.versionCount : 0;
 
   return (
     <main css={mainCSS}>
@@ -158,9 +146,11 @@ function DatasetEvaluatorDetailsPageContent({
         </LazyTabPanel>
         {isCodeEvaluator && (
           <LazyTabPanel id="versions">
-            <CodeDatasetEvaluatorVersions
-              datasetEvaluatorRef={datasetEvaluator}
-            />
+            <Suspense fallback={<Loading />}>
+              <CodeDatasetEvaluatorVersions
+                datasetEvaluatorId={datasetEvaluator.id}
+              />
+            </Suspense>
           </LazyTabPanel>
         )}
         <LazyTabPanel id="spans">

--- a/app/src/pages/dataset/evaluators/LLMDatasetEvaluatorDetails.tsx
+++ b/app/src/pages/dataset/evaluators/LLMDatasetEvaluatorDetails.tsx
@@ -1,11 +1,9 @@
 import { css } from "@emotion/react";
 import { useFragment } from "react-relay";
-import { useRevalidator } from "react-router";
 import { graphql } from "relay-runtime";
 
 import { Flex, Heading, Text } from "@phoenix/components";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
-import { EditLLMDatasetEvaluatorSlideover } from "@phoenix/components/dataset/EditLLMDatasetEvaluatorSlideover";
 import { inferIncludeExplanationFromPrompt } from "@phoenix/components/evaluators/utils";
 import { GenerativeProviderIcon } from "@phoenix/components/generative/GenerativeProviderIcon";
 import { PromptChatMessages } from "@phoenix/components/prompt/PromptChatMessagesCard";
@@ -14,17 +12,9 @@ import { PromptLink } from "@phoenix/pages/evaluators/PromptCell";
 
 export function LLMDatasetEvaluatorDetails({
   datasetEvaluatorRef,
-  datasetId,
-  isEditSlideoverOpen,
-  onEditSlideoverOpenChange,
 }: {
   datasetEvaluatorRef: LLMDatasetEvaluatorDetails_datasetEvaluator$key;
-  datasetId: string;
-  isEditSlideoverOpen: boolean;
-  onEditSlideoverOpenChange: (isOpen: boolean) => void;
 }) {
-  // this is so evaluator name updates are reflected in the breadcrumbs
-  const { revalidate } = useRevalidator();
   const datasetEvaluator = useFragment(
     graphql`
       fragment LLMDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {
@@ -97,99 +87,88 @@ export function LLMDatasetEvaluatorDetails({
   );
 
   return (
-    <>
-      <Flex direction="column" gap="size-300">
-        {datasetEvaluator.outputConfigs &&
-          datasetEvaluator.outputConfigs.length > 0 &&
-          (() => {
-            const outputConfig = datasetEvaluator.outputConfigs[0];
-            return (
-              <Flex direction="column" gap="size-100">
-                <Heading level={2}>Evaluator Annotation</Heading>
-                <div
-                  css={css`
-                    border-radius: var(--global-rounding-medium);
-                    padding: var(--global-dimension-static-size-200);
-                    margin-top: var(--global-dimension-static-size-50);
-                    border: 1px solid var(--global-border-color-default);
-                    overflow: hidden;
-                  `}
-                >
-                  <Flex direction="column" gap="size-100">
-                    <Truncate title={outputConfig.name}>
-                      <Text size="S">
-                        <Text weight="heavy">Name:</Text> {outputConfig.name}
-                      </Text>
-                    </Truncate>
-                    {outputConfig.optimizationDirection && (
-                      <Text size="S">
-                        <Text weight="heavy">Optimization Direction:</Text>{" "}
-                        {outputConfig.optimizationDirection}
-                      </Text>
-                    )}
-                    {outputConfig.values && outputConfig.values.length > 0 && (
-                      <Text>
-                        <Text size="S" weight="heavy">
-                          Values:{" "}
-                        </Text>
-                        {outputConfig.values.map((v, valIdx, arr) => (
-                          <Text key={valIdx} size="S">
-                            {v.label}
-                            {v.score != null ? ` (${v.score})` : ""}
-                            {valIdx < arr.length - 1 ? ", " : ""}
-                          </Text>
-                        ))}
-                      </Text>
-                    )}
+    <Flex direction="column" gap="size-300">
+      {datasetEvaluator.outputConfigs &&
+        datasetEvaluator.outputConfigs.length > 0 &&
+        (() => {
+          const outputConfig = datasetEvaluator.outputConfigs[0];
+          return (
+            <Flex direction="column" gap="size-100">
+              <Heading level={2}>Evaluator Annotation</Heading>
+              <div
+                css={css`
+                  border-radius: var(--global-rounding-medium);
+                  padding: var(--global-dimension-static-size-200);
+                  margin-top: var(--global-dimension-static-size-50);
+                  border: 1px solid var(--global-border-color-default);
+                  overflow: hidden;
+                `}
+              >
+                <Flex direction="column" gap="size-100">
+                  <Truncate title={outputConfig.name}>
                     <Text size="S">
-                      <Text weight="heavy">Explanations:</Text>{" "}
-                      {includeExplanation ? "Enabled" : "Disabled"}
+                      <Text weight="heavy">Name:</Text> {outputConfig.name}
                     </Text>
-                  </Flex>
-                </div>
-              </Flex>
-            );
-          })()}
-        <Flex direction="column" gap="size-100">
-          <Heading level={2}>Prompt</Heading>
-          <Flex justifyContent="space-between" alignItems="center">
-            {evaluator.prompt?.id && evaluator.prompt.name ? (
-              <PromptLink
-                promptId={evaluator.prompt.id}
-                promptName={evaluator.prompt.name}
-                promptVersionTag={evaluator.promptVersionTag?.name}
+                  </Truncate>
+                  {outputConfig.optimizationDirection && (
+                    <Text size="S">
+                      <Text weight="heavy">Optimization Direction:</Text>{" "}
+                      {outputConfig.optimizationDirection}
+                    </Text>
+                  )}
+                  {outputConfig.values && outputConfig.values.length > 0 && (
+                    <Text>
+                      <Text size="S" weight="heavy">
+                        Values:{" "}
+                      </Text>
+                      {outputConfig.values.map((v, valIdx, arr) => (
+                        <Text key={valIdx} size="S">
+                          {v.label}
+                          {v.score != null ? ` (${v.score})` : ""}
+                          {valIdx < arr.length - 1 ? ", " : ""}
+                        </Text>
+                      ))}
+                    </Text>
+                  )}
+                  <Text size="S">
+                    <Text weight="heavy">Explanations:</Text>{" "}
+                    {includeExplanation ? "Enabled" : "Disabled"}
+                  </Text>
+                </Flex>
+              </div>
+            </Flex>
+          );
+        })()}
+      <Flex direction="column" gap="size-100">
+        <Heading level={2}>Prompt</Heading>
+        <Flex justifyContent="space-between" alignItems="center">
+          {evaluator.prompt?.id && evaluator.prompt.name ? (
+            <PromptLink
+              promptId={evaluator.prompt.id}
+              promptName={evaluator.prompt.name}
+              promptVersionTag={evaluator.promptVersionTag?.name}
+            />
+          ) : (
+            <div />
+          )}
+          {evaluator.promptVersion?.modelName && (
+            <Flex alignItems="center" gap="size-50">
+              <GenerativeProviderIcon
+                provider={evaluator.promptVersion.modelProvider}
+                height={14}
               />
-            ) : (
-              <div />
-            )}
-            {evaluator.promptVersion?.modelName && (
-              <Flex alignItems="center" gap="size-50">
-                <GenerativeProviderIcon
-                  provider={evaluator.promptVersion.modelProvider}
-                  height={14}
-                />
-                <Text size="S" color="text-700">
-                  {evaluator.promptVersion.modelName}
-                </Text>
-              </Flex>
-            )}
-          </Flex>
-          {evaluator.promptVersion && (
-            <PromptChatMessages promptVersion={evaluator.promptVersion} />
+              <Text size="S" color="text-700">
+                {evaluator.promptVersion.modelName}
+              </Text>
+            </Flex>
           )}
         </Flex>
-        <LLMEvaluatorInputMapping inputMapping={inputMapping} />
+        {evaluator.promptVersion && (
+          <PromptChatMessages promptVersion={evaluator.promptVersion} />
+        )}
       </Flex>
-      <EditLLMDatasetEvaluatorSlideover
-        datasetEvaluatorId={datasetEvaluator.id}
-        datasetId={datasetId}
-        isOpen={isEditSlideoverOpen}
-        onOpenChange={onEditSlideoverOpenChange}
-        onUpdate={() => {
-          revalidate();
-        }}
-      />
-    </>
+      <LLMEvaluatorInputMapping inputMapping={inputMapping} />
+    </Flex>
   );
 }
 

--- a/app/src/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorVersionsQuery.graphql.ts
+++ b/app/src/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorVersionsQuery.graphql.ts
@@ -1,0 +1,310 @@
+/**
+ * @generated SignedSource<<e52c44ad2a3ffcfe673e1276714eff64>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type Language = "PYTHON" | "TYPESCRIPT";
+export type CodeDatasetEvaluatorVersionsQuery$variables = {
+  datasetEvaluatorId: string;
+};
+export type CodeDatasetEvaluatorVersionsQuery$data = {
+  readonly node: {
+    readonly __typename: "DatasetEvaluator";
+    readonly evaluator: {
+      readonly __typename: "CodeEvaluator";
+      readonly id: string;
+      readonly language: Language;
+      readonly versions: {
+        readonly edges: ReadonlyArray<{
+          readonly node: {
+            readonly createdAt: string;
+            readonly id: string;
+            readonly previousVersion: {
+              readonly id: string;
+              readonly sourceCode: string;
+            } | null;
+            readonly sequenceNumber: number;
+            readonly sourceCode: string;
+            readonly user: {
+              readonly id: string;
+              readonly profilePictureUrl: string | null;
+              readonly username: string;
+            } | null;
+          };
+        }>;
+      };
+    } | {
+      // This will never be '%other', but we need some
+      // value in case none of the concrete values match.
+      readonly __typename: "%other";
+    };
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  };
+};
+export type CodeDatasetEvaluatorVersionsQuery = {
+  response: CodeDatasetEvaluatorVersionsQuery$data;
+  variables: CodeDatasetEvaluatorVersionsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "datasetEvaluatorId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "datasetEvaluatorId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "language",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "sourceCode",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "first",
+      "value": 50
+    }
+  ],
+  "concreteType": "CodeEvaluatorVersionConnection",
+  "kind": "LinkedField",
+  "name": "versions",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CodeEvaluatorVersionEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "CodeEvaluatorVersion",
+          "kind": "LinkedField",
+          "name": "node",
+          "plural": false,
+          "selections": [
+            (v3/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "sequenceNumber",
+              "storageKey": null
+            },
+            (v5/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "createdAt",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "User",
+              "kind": "LinkedField",
+              "name": "user",
+              "plural": false,
+              "selections": [
+                (v3/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "username",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "profilePictureUrl",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "CodeEvaluatorVersion",
+              "kind": "LinkedField",
+              "name": "previousVersion",
+              "plural": false,
+              "selections": [
+                (v3/*: any*/),
+                (v5/*: any*/)
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": "versions(first:50)"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "CodeDatasetEvaluatorVersionsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "evaluator",
+                "plural": false,
+                "selections": [
+                  (v2/*: any*/),
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      (v6/*: any*/)
+                    ],
+                    "type": "CodeEvaluator",
+                    "abstractKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "DatasetEvaluator",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "CodeDatasetEvaluatorVersionsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "evaluator",
+                "plural": false,
+                "selections": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v4/*: any*/),
+                      (v6/*: any*/)
+                    ],
+                    "type": "CodeEvaluator",
+                    "abstractKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "DatasetEvaluator",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "57ff6e03100fc60e91946bbcae697554",
+    "id": null,
+    "metadata": {},
+    "name": "CodeDatasetEvaluatorVersionsQuery",
+    "operationKind": "query",
+    "text": "query CodeDatasetEvaluatorVersionsQuery(\n  $datasetEvaluatorId: ID!\n) {\n  node(id: $datasetEvaluatorId) {\n    __typename\n    ... on DatasetEvaluator {\n      evaluator {\n        __typename\n        ... on CodeEvaluator {\n          id\n          language\n          versions(first: 50) {\n            edges {\n              node {\n                id\n                sequenceNumber\n                sourceCode\n                createdAt\n                user {\n                  id\n                  username\n                  profilePictureUrl\n                }\n                previousVersion {\n                  id\n                  sourceCode\n                }\n              }\n            }\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "3f38ac39cc570588e9ff3f32426ab3a3";
+
+export default node;

--- a/app/src/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorVersions_datasetEvaluator.graphql.ts
+++ b/app/src/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorVersions_datasetEvaluator.graphql.ts
@@ -1,0 +1,206 @@
+/**
+ * @generated SignedSource<<3f931906387bd2a66823b370727199d1>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type Language = "PYTHON" | "TYPESCRIPT";
+import { FragmentRefs } from "relay-runtime";
+export type CodeDatasetEvaluatorVersions_datasetEvaluator$data = {
+  readonly evaluator: {
+    readonly __typename: "CodeEvaluator";
+    readonly id: string;
+    readonly language: Language;
+    readonly versions: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly createdAt: string;
+          readonly id: string;
+          readonly previousVersion: {
+            readonly id: string;
+            readonly sourceCode: string;
+          } | null;
+          readonly sequenceNumber: number;
+          readonly sourceCode: string;
+          readonly user: {
+            readonly id: string;
+            readonly profilePictureUrl: string | null;
+            readonly username: string;
+          } | null;
+        };
+      }>;
+    };
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  };
+  readonly " $fragmentType": "CodeDatasetEvaluatorVersions_datasetEvaluator";
+};
+export type CodeDatasetEvaluatorVersions_datasetEvaluator$key = {
+  readonly " $data"?: CodeDatasetEvaluatorVersions_datasetEvaluator$data;
+  readonly " $fragmentSpreads": FragmentRefs<"CodeDatasetEvaluatorVersions_datasetEvaluator">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "sourceCode",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "CodeDatasetEvaluatorVersions_datasetEvaluator",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "evaluator",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "__typename",
+          "storageKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            (v0/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "language",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "first",
+                  "value": 50
+                }
+              ],
+              "concreteType": "CodeEvaluatorVersionConnection",
+              "kind": "LinkedField",
+              "name": "versions",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "CodeEvaluatorVersionEdge",
+                  "kind": "LinkedField",
+                  "name": "edges",
+                  "plural": true,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "CodeEvaluatorVersion",
+                      "kind": "LinkedField",
+                      "name": "node",
+                      "plural": false,
+                      "selections": [
+                        (v0/*: any*/),
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "sequenceNumber",
+                          "storageKey": null
+                        },
+                        (v1/*: any*/),
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "createdAt",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "User",
+                          "kind": "LinkedField",
+                          "name": "user",
+                          "plural": false,
+                          "selections": [
+                            (v0/*: any*/),
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "username",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "profilePictureUrl",
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "CodeEvaluatorVersion",
+                          "kind": "LinkedField",
+                          "name": "previousVersion",
+                          "plural": false,
+                          "selections": [
+                            (v0/*: any*/),
+                            (v1/*: any*/)
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": "versions(first:50)"
+            }
+          ],
+          "type": "CodeEvaluator",
+          "abstractKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "DatasetEvaluator",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "b9f92e89efe87f3c731b00b97a3c6e3e";
+
+export default node;

--- a/app/src/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql.ts
+++ b/app/src/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1f8c738aac57578db5a21410df326609>>
+ * @generated SignedSource<<275a8c46dadb207cf9a13e14ede45af8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,6 +31,7 @@ export type datasetEvaluatorDetailsLoaderQuery$data = {
         readonly __typename: string;
         readonly description: string | null;
         readonly kind: EvaluatorKind;
+        readonly versionCount?: number;
       };
       readonly id: string;
       readonly name: string;
@@ -38,7 +39,7 @@ export type datasetEvaluatorDetailsLoaderQuery$data = {
         readonly id: string;
         readonly " $fragmentSpreads": FragmentRefs<"DatasetEvaluatorSpans_project">;
       };
-      readonly " $fragmentSpreads": FragmentRefs<"BuiltInDatasetEvaluatorDetails_datasetEvaluator" | "CodeDatasetEvaluatorDetails_datasetEvaluator" | "CodeDatasetEvaluatorVersions_datasetEvaluator" | "LLMDatasetEvaluatorDetails_datasetEvaluator">;
+      readonly " $fragmentSpreads": FragmentRefs<"BuiltInDatasetEvaluatorDetails_datasetEvaluator" | "CodeDatasetEvaluatorDetails_datasetEvaluator" | "LLMDatasetEvaluatorDetails_datasetEvaluator">;
     };
     readonly id: string;
   };
@@ -129,10 +130,17 @@ v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "backendType",
+  "name": "versionCount",
   "storageKey": null
 },
 v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "backendType",
+  "storageKey": null
+},
+v13 = {
   "alias": null,
   "args": null,
   "concreteType": "SandboxBackendInfo",
@@ -140,7 +148,7 @@ v12 = {
   "name": "sandboxBackends",
   "plural": true,
   "selections": [
-    (v11/*: any*/),
+    (v12/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -172,28 +180,35 @@ v12 = {
   ],
   "storageKey": null
 },
-v13 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "optimizationDirection",
-  "storageKey": null
-},
 v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "label",
+  "name": "language",
   "storageKey": null
 },
 v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "score",
+  "name": "optimizationDirection",
   "storageKey": null
 },
 v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+},
+v17 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "score",
+  "storageKey": null
+},
+v18 = {
   "alias": null,
   "args": null,
   "concreteType": "CategoricalAnnotationValue",
@@ -201,12 +216,12 @@ v16 = {
   "name": "values",
   "plural": true,
   "selections": [
-    (v14/*: any*/),
-    (v15/*: any*/)
+    (v16/*: any*/),
+    (v17/*: any*/)
   ],
   "storageKey": null
 },
-v17 = {
+v19 = {
   "kind": "InlineFragment",
   "selections": [
     (v5/*: any*/)
@@ -214,7 +229,7 @@ v17 = {
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v18 = {
+v20 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -227,8 +242,8 @@ v18 = {
       "kind": "InlineFragment",
       "selections": [
         (v7/*: any*/),
-        (v13/*: any*/),
-        (v16/*: any*/)
+        (v15/*: any*/),
+        (v18/*: any*/)
       ],
       "type": "CategoricalAnnotationConfig",
       "abstractKey": null
@@ -237,7 +252,7 @@ v18 = {
       "kind": "InlineFragment",
       "selections": [
         (v7/*: any*/),
-        (v13/*: any*/),
+        (v15/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -256,64 +271,29 @@ v18 = {
       "type": "ContinuousAnnotationConfig",
       "abstractKey": null
     },
-    (v17/*: any*/)
+    (v19/*: any*/)
   ],
   "storageKey": null
 },
-v19 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "language",
-  "storageKey": null
-},
-v20 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "sourceCode",
-  "storageKey": null
-},
-v21 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "createdAt",
-  "storageKey": null
-},
-v22 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "username",
-  "storageKey": null
-},
-v23 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "profilePictureUrl",
-  "storageKey": null
-},
-v24 = [
+v21 = [
   (v5/*: any*/),
   (v7/*: any*/)
 ],
-v25 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "strict",
   "storageKey": null
 },
-v26 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "toolCallId",
   "storageKey": null
 },
-v27 = [
+v24 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -343,7 +323,7 @@ v27 = [
     "variableName": "timeRange"
   }
 ],
-v28 = {
+v25 = {
   "alias": null,
   "args": null,
   "concreteType": "LabelFraction",
@@ -358,18 +338,18 @@ v28 = {
       "name": "fraction",
       "storageKey": null
     },
-    (v14/*: any*/)
+    (v16/*: any*/)
   ],
   "storageKey": null
 },
-v29 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "meanScore",
   "storageKey": null
 },
-v30 = {
+v27 = {
   "alias": null,
   "args": null,
   "concreteType": "Project",
@@ -422,13 +402,13 @@ v30 = {
                   "selections": [
                     (v5/*: any*/),
                     (v7/*: any*/),
-                    (v13/*: any*/),
-                    (v16/*: any*/)
+                    (v15/*: any*/),
+                    (v18/*: any*/)
                   ],
                   "type": "CategoricalAnnotationConfig",
                   "abstractKey": null
                 },
-                (v17/*: any*/)
+                (v19/*: any*/)
               ],
               "storageKey": null
             }
@@ -441,11 +421,11 @@ v30 = {
   ],
   "storageKey": null
 },
-v31 = [
+v28 = [
   (v5/*: any*/),
   (v7/*: any*/),
-  (v14/*: any*/),
-  (v15/*: any*/),
+  (v16/*: any*/),
+  (v17/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -453,7 +433,13 @@ v31 = [
     "name": "annotatorKind",
     "storageKey": null
   },
-  (v21/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "createdAt",
+    "storageKey": null
+  },
   {
     "alias": null,
     "args": null,
@@ -462,14 +448,26 @@ v31 = [
     "name": "user",
     "plural": false,
     "selections": [
-      (v22/*: any*/),
-      (v23/*: any*/),
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "username",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "profilePictureUrl",
+        "storageKey": null
+      },
       (v5/*: any*/)
     ],
     "storageKey": null
   }
 ],
-v32 = [
+v29 = [
   {
     "alias": "value",
     "args": null,
@@ -523,7 +521,15 @@ return {
                     "selections": [
                       (v9/*: any*/),
                       (v10/*: any*/),
-                      (v8/*: any*/)
+                      (v8/*: any*/),
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          (v11/*: any*/)
+                        ],
+                        "type": "CodeEvaluator",
+                        "abstractKey": null
+                      }
                     ],
                     "storageKey": null
                   },
@@ -557,11 +563,6 @@ return {
                   {
                     "args": null,
                     "kind": "FragmentSpread",
-                    "name": "CodeDatasetEvaluatorVersions_datasetEvaluator"
-                  },
-                  {
-                    "args": null,
-                    "kind": "FragmentSpread",
                     "name": "LLMDatasetEvaluatorDetails_datasetEvaluator"
                   }
                 ],
@@ -574,7 +575,7 @@ return {
         ],
         "storageKey": null
       },
-      (v12/*: any*/)
+      (v13/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -630,16 +631,9 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v18/*: any*/)
-                        ],
-                        "type": "BuiltInEvaluator",
-                        "abstractKey": null
-                      },
-                      {
-                        "kind": "InlineFragment",
-                        "selections": [
-                          (v19/*: any*/),
-                          (v18/*: any*/),
+                          (v11/*: any*/),
+                          (v14/*: any*/),
+                          (v20/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -673,8 +667,8 @@ return {
                                 "name": "provider",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*: any*/),
-                                  (v19/*: any*/),
+                                  (v12/*: any*/),
+                                  (v14/*: any*/),
                                   (v5/*: any*/)
                                 ],
                                 "storageKey": null
@@ -690,89 +684,27 @@ return {
                             "name": "currentVersion",
                             "plural": false,
                             "selections": [
-                              (v20/*: any*/),
-                              (v5/*: any*/)
-                            ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "first",
-                                "value": 50
-                              }
-                            ],
-                            "concreteType": "CodeEvaluatorVersionConnection",
-                            "kind": "LinkedField",
-                            "name": "versions",
-                            "plural": false,
-                            "selections": [
                               {
                                 "alias": null,
                                 "args": null,
-                                "concreteType": "CodeEvaluatorVersionEdge",
-                                "kind": "LinkedField",
-                                "name": "edges",
-                                "plural": true,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "CodeEvaluatorVersion",
-                                    "kind": "LinkedField",
-                                    "name": "node",
-                                    "plural": false,
-                                    "selections": [
-                                      (v5/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "sequenceNumber",
-                                        "storageKey": null
-                                      },
-                                      (v20/*: any*/),
-                                      (v21/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "User",
-                                        "kind": "LinkedField",
-                                        "name": "user",
-                                        "plural": false,
-                                        "selections": [
-                                          (v5/*: any*/),
-                                          (v22/*: any*/),
-                                          (v23/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "CodeEvaluatorVersion",
-                                        "kind": "LinkedField",
-                                        "name": "previousVersion",
-                                        "plural": false,
-                                        "selections": [
-                                          (v5/*: any*/),
-                                          (v20/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  }
-                                ],
+                                "kind": "ScalarField",
+                                "name": "sourceCode",
                                 "storageKey": null
-                              }
+                              },
+                              (v5/*: any*/)
                             ],
-                            "storageKey": "versions(first:50)"
+                            "storageKey": null
                           }
                         ],
                         "type": "CodeEvaluator",
+                        "abstractKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          (v20/*: any*/)
+                        ],
+                        "type": "BuiltInEvaluator",
                         "abstractKey": null
                       },
                       {
@@ -785,7 +717,7 @@ return {
                             "kind": "LinkedField",
                             "name": "prompt",
                             "plural": false,
-                            "selections": (v24/*: any*/),
+                            "selections": (v21/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -847,7 +779,7 @@ return {
                                               },
                                               (v7/*: any*/),
                                               (v8/*: any*/),
-                                              (v25/*: any*/)
+                                              (v22/*: any*/)
                                             ],
                                             "storageKey": null
                                           }
@@ -922,7 +854,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "customProvider",
                                 "plural": false,
-                                "selections": (v24/*: any*/),
+                                "selections": (v21/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -950,7 +882,7 @@ return {
                                         "name": "schema",
                                         "storageKey": null
                                       },
-                                      (v25/*: any*/)
+                                      (v22/*: any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -1029,7 +961,7 @@ return {
                                                     "name": "toolCall",
                                                     "plural": false,
                                                     "selections": [
-                                                      (v26/*: any*/),
+                                                      (v23/*: any*/),
                                                       {
                                                         "alias": null,
                                                         "args": null,
@@ -1067,7 +999,7 @@ return {
                                                     "name": "toolResult",
                                                     "plural": false,
                                                     "selections": [
-                                                      (v26/*: any*/),
+                                                      (v23/*: any*/),
                                                       {
                                                         "alias": null,
                                                         "args": null,
@@ -1179,7 +1111,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v27/*: any*/),
+                        "args": (v24/*: any*/),
                         "concreteType": "SpanConnection",
                         "kind": "LinkedField",
                         "name": "spans",
@@ -1305,7 +1237,7 @@ return {
                                         "name": "traceAnnotationSummaries",
                                         "plural": true,
                                         "selections": [
-                                          (v28/*: any*/),
+                                          (v25/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -1313,12 +1245,12 @@ return {
                                             "name": "count",
                                             "storageKey": null
                                           },
-                                          (v29/*: any*/),
+                                          (v26/*: any*/),
                                           (v7/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
-                                      (v30/*: any*/),
+                                      (v27/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -1326,7 +1258,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "traceAnnotations",
                                         "plural": true,
-                                        "selections": (v31/*: any*/),
+                                        "selections": (v28/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
@@ -1339,7 +1271,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "input",
                                     "plural": false,
-                                    "selections": (v32/*: any*/),
+                                    "selections": (v29/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -1349,7 +1281,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "output",
                                     "plural": false,
-                                    "selections": (v32/*: any*/),
+                                    "selections": (v29/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -1359,7 +1291,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "spanAnnotations",
                                     "plural": true,
-                                    "selections": (v31/*: any*/),
+                                    "selections": (v28/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -1370,8 +1302,8 @@ return {
                                     "name": "spanAnnotationSummaries",
                                     "plural": true,
                                     "selections": [
-                                      (v28/*: any*/),
-                                      (v29/*: any*/),
+                                      (v25/*: any*/),
+                                      (v26/*: any*/),
                                       (v7/*: any*/)
                                     ],
                                     "storageKey": null
@@ -1415,7 +1347,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v30/*: any*/)
+                                  (v27/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -1472,7 +1404,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v27/*: any*/),
+                        "args": (v24/*: any*/),
                         "filters": [
                           "sort",
                           "rootSpansOnly",
@@ -1513,7 +1445,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v18/*: any*/)
+                  (v20/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1524,20 +1456,20 @@ return {
         ],
         "storageKey": null
       },
-      (v12/*: any*/)
+      (v13/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "8a7a1ac11a5165c8065672cd4ecd3299",
+    "cacheID": "66e993be56028b8f55791d04cee7cbff",
     "id": null,
     "metadata": {},
     "name": "datasetEvaluatorDetailsLoaderQuery",
     "operationKind": "query",
-    "text": "query datasetEvaluatorDetailsLoaderQuery(\n  $datasetId: ID!\n  $datasetEvaluatorId: ID!\n  $timeRange: TimeRange\n  $orphanSpanAsRootSpan: Boolean!\n) {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      id\n      datasetEvaluator(datasetEvaluatorId: $datasetEvaluatorId) {\n        id\n        name\n        description\n        evaluator {\n          __typename\n          kind\n          description\n          id\n        }\n        project {\n          id\n          ...DatasetEvaluatorSpans_project\n        }\n        ...BuiltInDatasetEvaluatorDetails_datasetEvaluator\n        ...CodeDatasetEvaluatorDetails_datasetEvaluator\n        ...CodeDatasetEvaluatorVersions_datasetEvaluator\n        ...LLMDatasetEvaluatorDetails_datasetEvaluator\n      }\n    }\n  }\n  sandboxBackends {\n    backendType\n    displayName\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment BuiltInDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    name\n    ... on BuiltInEvaluator {\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment CodeDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    ... on CodeEvaluator {\n      id\n      name\n      description\n      language\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      sandboxConfig {\n        id\n        name\n        description\n        timeout\n        config\n        provider {\n          backendType\n          language\n          id\n        }\n      }\n      currentVersion {\n        sourceCode\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment CodeDatasetEvaluatorVersions_datasetEvaluator on DatasetEvaluator {\n  evaluator {\n    __typename\n    ... on CodeEvaluator {\n      id\n      language\n      versions(first: 50) {\n        edges {\n          node {\n            id\n            sequenceNumber\n            sourceCode\n            createdAt\n            user {\n              id\n              username\n              profilePictureUrl\n            }\n            previousVersion {\n              id\n              sourceCode\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment DatasetEvaluatorSpans_project on Project {\n  id\n  ...SpansTable_spans\n}\n\nfragment LLMDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        tools {\n          tools {\n            __typename\n            ... on PromptToolFunction {\n              function {\n                parameters\n              }\n            }\n            ... on PromptToolRaw {\n              raw\n            }\n          }\n        }\n        ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n        ...PromptChatMessagesCard__main\n        id\n      }\n      promptVersionTag {\n        name\n        id\n      }\n    }\n    id\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment PromptChatMessagesCard__main on PromptVersion {\n  provider: modelProvider\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                arguments\n                name\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpanColumnSelector_traceAnnotations on Project {\n  traceAnnotationsNames\n}\n\nfragment SpansTable_spans on Project {\n  name\n  spanAnnotationNames\n  ...SpanColumnSelector_annotations\n  ...SpanColumnSelector_traceAnnotations\n  spans(first: 30, sort: {col: startTime, dir: desc}, rootSpansOnly: true, orphanSpanAsRootSpan: $orphanSpanAsRootSpan, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        spanId\n        trace {\n          id\n          traceId\n          costSummary {\n            total {\n              cost\n            }\n          }\n          traceAnnotationSummaries {\n            labelFractions {\n              fraction\n              label\n            }\n            count\n            meanScore\n            name\n          }\n          ...TraceAnnotationSummaryGroup\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n          createdAt\n        }\n        spanAnnotationSummaries {\n          labelFractions {\n            fraction\n            label\n          }\n          meanScore\n          name\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        ...AnnotationSummaryGroup\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment TraceAnnotationSummaryGroup on Trace {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  traceAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  traceAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  customProvider {\n    id\n    name\n  }\n  responseFormat {\n    jsonSchema {\n      name\n      description\n      schema\n      strict\n    }\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    tools {\n      __typename\n      ... on PromptToolFunction {\n        function {\n          name\n          description\n          parameters\n          strict\n        }\n      }\n      ... on PromptToolRaw {\n        raw\n      }\n    }\n    toolChoice {\n      type\n      functionName\n    }\n    disableParallelToolCalls\n  }\n}\n"
+    "text": "query datasetEvaluatorDetailsLoaderQuery(\n  $datasetId: ID!\n  $datasetEvaluatorId: ID!\n  $timeRange: TimeRange\n  $orphanSpanAsRootSpan: Boolean!\n) {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      id\n      datasetEvaluator(datasetEvaluatorId: $datasetEvaluatorId) {\n        id\n        name\n        description\n        evaluator {\n          __typename\n          kind\n          description\n          ... on CodeEvaluator {\n            versionCount\n          }\n          id\n        }\n        project {\n          id\n          ...DatasetEvaluatorSpans_project\n        }\n        ...BuiltInDatasetEvaluatorDetails_datasetEvaluator\n        ...CodeDatasetEvaluatorDetails_datasetEvaluator\n        ...LLMDatasetEvaluatorDetails_datasetEvaluator\n      }\n    }\n  }\n  sandboxBackends {\n    backendType\n    displayName\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment BuiltInDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    name\n    ... on BuiltInEvaluator {\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment CodeDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    ... on CodeEvaluator {\n      id\n      name\n      description\n      language\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      sandboxConfig {\n        id\n        name\n        description\n        timeout\n        config\n        provider {\n          backendType\n          language\n          id\n        }\n      }\n      currentVersion {\n        sourceCode\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment DatasetEvaluatorSpans_project on Project {\n  id\n  ...SpansTable_spans\n}\n\nfragment LLMDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        tools {\n          tools {\n            __typename\n            ... on PromptToolFunction {\n              function {\n                parameters\n              }\n            }\n            ... on PromptToolRaw {\n              raw\n            }\n          }\n        }\n        ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n        ...PromptChatMessagesCard__main\n        id\n      }\n      promptVersionTag {\n        name\n        id\n      }\n    }\n    id\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment PromptChatMessagesCard__main on PromptVersion {\n  provider: modelProvider\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                arguments\n                name\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpanColumnSelector_traceAnnotations on Project {\n  traceAnnotationsNames\n}\n\nfragment SpansTable_spans on Project {\n  name\n  spanAnnotationNames\n  ...SpanColumnSelector_annotations\n  ...SpanColumnSelector_traceAnnotations\n  spans(first: 30, sort: {col: startTime, dir: desc}, rootSpansOnly: true, orphanSpanAsRootSpan: $orphanSpanAsRootSpan, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        spanId\n        trace {\n          id\n          traceId\n          costSummary {\n            total {\n              cost\n            }\n          }\n          traceAnnotationSummaries {\n            labelFractions {\n              fraction\n              label\n            }\n            count\n            meanScore\n            name\n          }\n          ...TraceAnnotationSummaryGroup\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n          createdAt\n        }\n        spanAnnotationSummaries {\n          labelFractions {\n            fraction\n            label\n          }\n          meanScore\n          name\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        ...AnnotationSummaryGroup\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment TraceAnnotationSummaryGroup on Trace {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  traceAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  traceAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  customProvider {\n    id\n    name\n  }\n  responseFormat {\n    jsonSchema {\n      name\n      description\n      schema\n      strict\n    }\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    tools {\n      __typename\n      ... on PromptToolFunction {\n        function {\n          name\n          description\n          parameters\n          strict\n        }\n      }\n      ... on PromptToolRaw {\n        raw\n      }\n    }\n    toolChoice {\n      type\n      functionName\n    }\n    disableParallelToolCalls\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "dab09624ea67655c56d8314305b45eb3";
+(node as any).hash = "d1748b1f7582c1fcefaaa227f921bc93";
 
 export default node;

--- a/app/src/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql.ts
+++ b/app/src/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6f2e7e3b12b1e11affe02edb7b13052a>>
+ * @generated SignedSource<<1f8c738aac57578db5a21410df326609>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -38,7 +38,7 @@ export type datasetEvaluatorDetailsLoaderQuery$data = {
         readonly id: string;
         readonly " $fragmentSpreads": FragmentRefs<"DatasetEvaluatorSpans_project">;
       };
-      readonly " $fragmentSpreads": FragmentRefs<"BuiltInDatasetEvaluatorDetails_datasetEvaluator" | "CodeDatasetEvaluatorDetails_datasetEvaluator" | "LLMDatasetEvaluatorDetails_datasetEvaluator">;
+      readonly " $fragmentSpreads": FragmentRefs<"BuiltInDatasetEvaluatorDetails_datasetEvaluator" | "CodeDatasetEvaluatorDetails_datasetEvaluator" | "CodeDatasetEvaluatorVersions_datasetEvaluator" | "LLMDatasetEvaluatorDetails_datasetEvaluator">;
     };
     readonly id: string;
   };
@@ -267,25 +267,53 @@ v19 = {
   "name": "language",
   "storageKey": null
 },
-v20 = [
-  (v5/*: any*/),
-  (v7/*: any*/)
-],
+v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "sourceCode",
+  "storageKey": null
+},
 v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "strict",
+  "name": "createdAt",
   "storageKey": null
 },
 v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "username",
+  "storageKey": null
+},
+v23 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "profilePictureUrl",
+  "storageKey": null
+},
+v24 = [
+  (v5/*: any*/),
+  (v7/*: any*/)
+],
+v25 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "strict",
+  "storageKey": null
+},
+v26 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "toolCallId",
   "storageKey": null
 },
-v23 = [
+v27 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -315,7 +343,7 @@ v23 = [
     "variableName": "timeRange"
   }
 ],
-v24 = {
+v28 = {
   "alias": null,
   "args": null,
   "concreteType": "LabelFraction",
@@ -334,14 +362,14 @@ v24 = {
   ],
   "storageKey": null
 },
-v25 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "meanScore",
   "storageKey": null
 },
-v26 = {
+v30 = {
   "alias": null,
   "args": null,
   "concreteType": "Project",
@@ -413,7 +441,7 @@ v26 = {
   ],
   "storageKey": null
 },
-v27 = [
+v31 = [
   (v5/*: any*/),
   (v7/*: any*/),
   (v14/*: any*/),
@@ -425,13 +453,7 @@ v27 = [
     "name": "annotatorKind",
     "storageKey": null
   },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "createdAt",
-    "storageKey": null
-  },
+  (v21/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -440,26 +462,14 @@ v27 = [
     "name": "user",
     "plural": false,
     "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "username",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "profilePictureUrl",
-        "storageKey": null
-      },
+      (v22/*: any*/),
+      (v23/*: any*/),
       (v5/*: any*/)
     ],
     "storageKey": null
   }
 ],
-v28 = [
+v32 = [
   {
     "alias": "value",
     "args": null,
@@ -543,6 +553,11 @@ return {
                     "args": null,
                     "kind": "FragmentSpread",
                     "name": "CodeDatasetEvaluatorDetails_datasetEvaluator"
+                  },
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "CodeDatasetEvaluatorVersions_datasetEvaluator"
                   },
                   {
                     "args": null,
@@ -675,16 +690,86 @@ return {
                             "name": "currentVersion",
                             "plural": false,
                             "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "sourceCode",
-                                "storageKey": null
-                              },
+                              (v20/*: any*/),
                               (v5/*: any*/)
                             ],
                             "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "first",
+                                "value": 50
+                              }
+                            ],
+                            "concreteType": "CodeEvaluatorVersionConnection",
+                            "kind": "LinkedField",
+                            "name": "versions",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CodeEvaluatorVersionEdge",
+                                "kind": "LinkedField",
+                                "name": "edges",
+                                "plural": true,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "CodeEvaluatorVersion",
+                                    "kind": "LinkedField",
+                                    "name": "node",
+                                    "plural": false,
+                                    "selections": [
+                                      (v5/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "sequenceNumber",
+                                        "storageKey": null
+                                      },
+                                      (v20/*: any*/),
+                                      (v21/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "User",
+                                        "kind": "LinkedField",
+                                        "name": "user",
+                                        "plural": false,
+                                        "selections": [
+                                          (v5/*: any*/),
+                                          (v22/*: any*/),
+                                          (v23/*: any*/)
+                                        ],
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "CodeEvaluatorVersion",
+                                        "kind": "LinkedField",
+                                        "name": "previousVersion",
+                                        "plural": false,
+                                        "selections": [
+                                          (v5/*: any*/),
+                                          (v20/*: any*/)
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "versions(first:50)"
                           }
                         ],
                         "type": "CodeEvaluator",
@@ -700,7 +785,7 @@ return {
                             "kind": "LinkedField",
                             "name": "prompt",
                             "plural": false,
-                            "selections": (v20/*: any*/),
+                            "selections": (v24/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -762,7 +847,7 @@ return {
                                               },
                                               (v7/*: any*/),
                                               (v8/*: any*/),
-                                              (v21/*: any*/)
+                                              (v25/*: any*/)
                                             ],
                                             "storageKey": null
                                           }
@@ -837,7 +922,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "customProvider",
                                 "plural": false,
-                                "selections": (v20/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -865,7 +950,7 @@ return {
                                         "name": "schema",
                                         "storageKey": null
                                       },
-                                      (v21/*: any*/)
+                                      (v25/*: any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -944,7 +1029,7 @@ return {
                                                     "name": "toolCall",
                                                     "plural": false,
                                                     "selections": [
-                                                      (v22/*: any*/),
+                                                      (v26/*: any*/),
                                                       {
                                                         "alias": null,
                                                         "args": null,
@@ -982,7 +1067,7 @@ return {
                                                     "name": "toolResult",
                                                     "plural": false,
                                                     "selections": [
-                                                      (v22/*: any*/),
+                                                      (v26/*: any*/),
                                                       {
                                                         "alias": null,
                                                         "args": null,
@@ -1094,7 +1179,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v23/*: any*/),
+                        "args": (v27/*: any*/),
                         "concreteType": "SpanConnection",
                         "kind": "LinkedField",
                         "name": "spans",
@@ -1220,7 +1305,7 @@ return {
                                         "name": "traceAnnotationSummaries",
                                         "plural": true,
                                         "selections": [
-                                          (v24/*: any*/),
+                                          (v28/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -1228,12 +1313,12 @@ return {
                                             "name": "count",
                                             "storageKey": null
                                           },
-                                          (v25/*: any*/),
+                                          (v29/*: any*/),
                                           (v7/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
-                                      (v26/*: any*/),
+                                      (v30/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -1241,7 +1326,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "traceAnnotations",
                                         "plural": true,
-                                        "selections": (v27/*: any*/),
+                                        "selections": (v31/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
@@ -1254,7 +1339,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "input",
                                     "plural": false,
-                                    "selections": (v28/*: any*/),
+                                    "selections": (v32/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -1264,7 +1349,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "output",
                                     "plural": false,
-                                    "selections": (v28/*: any*/),
+                                    "selections": (v32/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -1274,7 +1359,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "spanAnnotations",
                                     "plural": true,
-                                    "selections": (v27/*: any*/),
+                                    "selections": (v31/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -1285,8 +1370,8 @@ return {
                                     "name": "spanAnnotationSummaries",
                                     "plural": true,
                                     "selections": [
-                                      (v24/*: any*/),
-                                      (v25/*: any*/),
+                                      (v28/*: any*/),
+                                      (v29/*: any*/),
                                       (v7/*: any*/)
                                     ],
                                     "storageKey": null
@@ -1330,7 +1415,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v26/*: any*/)
+                                  (v30/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -1387,7 +1472,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v23/*: any*/),
+                        "args": (v27/*: any*/),
                         "filters": [
                           "sort",
                           "rootSpansOnly",
@@ -1443,16 +1528,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "30759a4c0b759883f14ce22105110e5a",
+    "cacheID": "8a7a1ac11a5165c8065672cd4ecd3299",
     "id": null,
     "metadata": {},
     "name": "datasetEvaluatorDetailsLoaderQuery",
     "operationKind": "query",
-    "text": "query datasetEvaluatorDetailsLoaderQuery(\n  $datasetId: ID!\n  $datasetEvaluatorId: ID!\n  $timeRange: TimeRange\n  $orphanSpanAsRootSpan: Boolean!\n) {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      id\n      datasetEvaluator(datasetEvaluatorId: $datasetEvaluatorId) {\n        id\n        name\n        description\n        evaluator {\n          __typename\n          kind\n          description\n          id\n        }\n        project {\n          id\n          ...DatasetEvaluatorSpans_project\n        }\n        ...BuiltInDatasetEvaluatorDetails_datasetEvaluator\n        ...CodeDatasetEvaluatorDetails_datasetEvaluator\n        ...LLMDatasetEvaluatorDetails_datasetEvaluator\n      }\n    }\n  }\n  sandboxBackends {\n    backendType\n    displayName\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment BuiltInDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    name\n    ... on BuiltInEvaluator {\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment CodeDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    ... on CodeEvaluator {\n      id\n      name\n      description\n      language\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      sandboxConfig {\n        id\n        name\n        description\n        timeout\n        config\n        provider {\n          backendType\n          language\n          id\n        }\n      }\n      currentVersion {\n        sourceCode\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment DatasetEvaluatorSpans_project on Project {\n  id\n  ...SpansTable_spans\n}\n\nfragment LLMDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        tools {\n          tools {\n            __typename\n            ... on PromptToolFunction {\n              function {\n                parameters\n              }\n            }\n            ... on PromptToolRaw {\n              raw\n            }\n          }\n        }\n        ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n        ...PromptChatMessagesCard__main\n        id\n      }\n      promptVersionTag {\n        name\n        id\n      }\n    }\n    id\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment PromptChatMessagesCard__main on PromptVersion {\n  provider: modelProvider\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                arguments\n                name\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpanColumnSelector_traceAnnotations on Project {\n  traceAnnotationsNames\n}\n\nfragment SpansTable_spans on Project {\n  name\n  spanAnnotationNames\n  ...SpanColumnSelector_annotations\n  ...SpanColumnSelector_traceAnnotations\n  spans(first: 30, sort: {col: startTime, dir: desc}, rootSpansOnly: true, orphanSpanAsRootSpan: $orphanSpanAsRootSpan, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        spanId\n        trace {\n          id\n          traceId\n          costSummary {\n            total {\n              cost\n            }\n          }\n          traceAnnotationSummaries {\n            labelFractions {\n              fraction\n              label\n            }\n            count\n            meanScore\n            name\n          }\n          ...TraceAnnotationSummaryGroup\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n          createdAt\n        }\n        spanAnnotationSummaries {\n          labelFractions {\n            fraction\n            label\n          }\n          meanScore\n          name\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        ...AnnotationSummaryGroup\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment TraceAnnotationSummaryGroup on Trace {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  traceAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  traceAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  customProvider {\n    id\n    name\n  }\n  responseFormat {\n    jsonSchema {\n      name\n      description\n      schema\n      strict\n    }\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    tools {\n      __typename\n      ... on PromptToolFunction {\n        function {\n          name\n          description\n          parameters\n          strict\n        }\n      }\n      ... on PromptToolRaw {\n        raw\n      }\n    }\n    toolChoice {\n      type\n      functionName\n    }\n    disableParallelToolCalls\n  }\n}\n"
+    "text": "query datasetEvaluatorDetailsLoaderQuery(\n  $datasetId: ID!\n  $datasetEvaluatorId: ID!\n  $timeRange: TimeRange\n  $orphanSpanAsRootSpan: Boolean!\n) {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      id\n      datasetEvaluator(datasetEvaluatorId: $datasetEvaluatorId) {\n        id\n        name\n        description\n        evaluator {\n          __typename\n          kind\n          description\n          id\n        }\n        project {\n          id\n          ...DatasetEvaluatorSpans_project\n        }\n        ...BuiltInDatasetEvaluatorDetails_datasetEvaluator\n        ...CodeDatasetEvaluatorDetails_datasetEvaluator\n        ...CodeDatasetEvaluatorVersions_datasetEvaluator\n        ...LLMDatasetEvaluatorDetails_datasetEvaluator\n      }\n    }\n  }\n  sandboxBackends {\n    backendType\n    displayName\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment BuiltInDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    name\n    ... on BuiltInEvaluator {\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment CodeDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  evaluator {\n    __typename\n    kind\n    ... on CodeEvaluator {\n      id\n      name\n      description\n      language\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      sandboxConfig {\n        id\n        name\n        description\n        timeout\n        config\n        provider {\n          backendType\n          language\n          id\n        }\n      }\n      currentVersion {\n        sourceCode\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment CodeDatasetEvaluatorVersions_datasetEvaluator on DatasetEvaluator {\n  evaluator {\n    __typename\n    ... on CodeEvaluator {\n      id\n      language\n      versions(first: 50) {\n        edges {\n          node {\n            id\n            sequenceNumber\n            sourceCode\n            createdAt\n            user {\n              id\n              username\n              profilePictureUrl\n            }\n            previousVersion {\n              id\n              sourceCode\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment DatasetEvaluatorSpans_project on Project {\n  id\n  ...SpansTable_spans\n}\n\nfragment LLMDatasetEvaluatorDetails_datasetEvaluator on DatasetEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        tools {\n          tools {\n            __typename\n            ... on PromptToolFunction {\n              function {\n                parameters\n              }\n            }\n            ... on PromptToolRaw {\n              raw\n            }\n          }\n        }\n        ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n        ...PromptChatMessagesCard__main\n        id\n      }\n      promptVersionTag {\n        name\n        id\n      }\n    }\n    id\n  }\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment PromptChatMessagesCard__main on PromptVersion {\n  provider: modelProvider\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                arguments\n                name\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpanColumnSelector_traceAnnotations on Project {\n  traceAnnotationsNames\n}\n\nfragment SpansTable_spans on Project {\n  name\n  spanAnnotationNames\n  ...SpanColumnSelector_annotations\n  ...SpanColumnSelector_traceAnnotations\n  spans(first: 30, sort: {col: startTime, dir: desc}, rootSpansOnly: true, orphanSpanAsRootSpan: $orphanSpanAsRootSpan, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        spanId\n        trace {\n          id\n          traceId\n          costSummary {\n            total {\n              cost\n            }\n          }\n          traceAnnotationSummaries {\n            labelFractions {\n              fraction\n              label\n            }\n            count\n            meanScore\n            name\n          }\n          ...TraceAnnotationSummaryGroup\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n          createdAt\n        }\n        spanAnnotationSummaries {\n          labelFractions {\n            fraction\n            label\n          }\n          meanScore\n          name\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        ...AnnotationSummaryGroup\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment TraceAnnotationSummaryGroup on Trace {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  traceAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  traceAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  customProvider {\n    id\n    name\n  }\n  responseFormat {\n    jsonSchema {\n      name\n      description\n      schema\n      strict\n    }\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    tools {\n      __typename\n      ... on PromptToolFunction {\n        function {\n          name\n          description\n          parameters\n          strict\n        }\n      }\n      ... on PromptToolRaw {\n        raw\n      }\n    }\n    toolChoice {\n      type\n      functionName\n    }\n    disableParallelToolCalls\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f1d5c0973d0b857860202056b87fb6d0";
+(node as any).hash = "dab09624ea67655c56d8314305b45eb3";
 
 export default node;

--- a/app/src/pages/dataset/evaluators/datasetEvaluatorDetailsLoader.ts
+++ b/app/src/pages/dataset/evaluators/datasetEvaluatorDetailsLoader.ts
@@ -32,6 +32,7 @@ export const datasetEvaluatorDetailsLoaderGQL = graphql`
           }
           ...BuiltInDatasetEvaluatorDetails_datasetEvaluator
           ...CodeDatasetEvaluatorDetails_datasetEvaluator
+          ...CodeDatasetEvaluatorVersions_datasetEvaluator
           ...LLMDatasetEvaluatorDetails_datasetEvaluator
         }
       }

--- a/app/src/pages/dataset/evaluators/datasetEvaluatorDetailsLoader.ts
+++ b/app/src/pages/dataset/evaluators/datasetEvaluatorDetailsLoader.ts
@@ -25,6 +25,9 @@ export const datasetEvaluatorDetailsLoaderGQL = graphql`
             __typename
             kind
             description
+            ... on CodeEvaluator {
+              versionCount
+            }
           }
           project {
             id
@@ -32,7 +35,6 @@ export const datasetEvaluatorDetailsLoaderGQL = graphql`
           }
           ...BuiltInDatasetEvaluatorDetails_datasetEvaluator
           ...CodeDatasetEvaluatorDetails_datasetEvaluator
-          ...CodeDatasetEvaluatorVersions_datasetEvaluator
           ...LLMDatasetEvaluatorDetails_datasetEvaluator
         }
       }

--- a/app/tests/code-evaluators.spec.ts
+++ b/app/tests/code-evaluators.spec.ts
@@ -483,7 +483,12 @@ test.describe.serial("Code Evaluators", () => {
     await expectEvaluatorDetailsPage(page, updatedPythonEvaluatorName);
   });
 
-  test("submits a cleared sandbox when switching back to the original language", async ({
+  // Language is no longer editable in the Edit slideover (gated to create mode
+  // since the revision-history feature). The original scenario — switch
+  // language to force a sandbox clear and assert patchCodeEvaluator submits
+  // sandboxConfigId: null — can no longer be exercised via edit, so skip
+  // until the boundary is exposed through a different UI entry point.
+  test.skip("submits a cleared sandbox when switching back to the original language", async ({
     page,
   }) => {
     await gotoDatasetEvaluators(page, datasetName);
@@ -907,7 +912,11 @@ test.describe.serial("Code Evaluators", () => {
     await expect(page.getByTestId("dialog")).not.toBeVisible();
   });
 
-  test("language switch on categorical evaluator swaps the editor between Python and TypeScript defaults", async ({
+  // Language is no longer editable in the Edit slideover (gated to create mode
+  // since the revision-history feature). The original scenario depends on
+  // toggling Language inside the editor; revisit when language switching is
+  // exposed in another flow.
+  test.skip("language switch on categorical evaluator swaps the editor between Python and TypeScript defaults", async ({
     page,
   }) => {
     await gotoDatasetEvaluators(page, datasetName);

--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         AverageExperimentRepeatedRunGroupLatencyDataLoader,
         AverageExperimentRunLatencyDataLoader,
         CacheForDataLoaders,
+        CodeEvaluatorVersionCountDataLoader,
         CodeEvaluatorVersionSequenceNumberDataLoader,
         DatasetDatasetSplitsDataLoader,
         DatasetEvaluatorsByEvaluatorDataLoader,
@@ -123,6 +124,7 @@ class DataLoaders:
     )
     average_experiment_run_latency: AverageExperimentRunLatencyDataLoader
     code_evaluator_fields: TableFieldsDataLoader
+    code_evaluator_version_count: CodeEvaluatorVersionCountDataLoader
     code_evaluator_version_sequence_number: CodeEvaluatorVersionSequenceNumberDataLoader
     dataset_evaluator_fields: TableFieldsDataLoader
     dataset_evaluators_by_evaluator: DatasetEvaluatorsByEvaluatorDataLoader

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -10,6 +10,7 @@ from .average_experiment_repeated_run_group_latency import (
     AverageExperimentRepeatedRunGroupLatencyDataLoader,
 )
 from .average_experiment_run_latency import AverageExperimentRunLatencyDataLoader
+from .code_evaluator_version_count import CodeEvaluatorVersionCountDataLoader
 from .code_evaluator_version_sequence_number import CodeEvaluatorVersionSequenceNumberDataLoader
 from .dataset_dataset_splits import DatasetDatasetSplitsDataLoader
 from .dataset_evaluators import DatasetEvaluatorsDataLoader
@@ -109,6 +110,7 @@ __all__ = [
     "AverageExperimentRepeatedRunGroupLatencyDataLoader",
     "AverageExperimentRunLatencyDataLoader",
     "CacheForDataLoaders",
+    "CodeEvaluatorVersionCountDataLoader",
     "CodeEvaluatorVersionSequenceNumberDataLoader",
     "DatasetDatasetSplitsDataLoader",
     "DatasetEvaluatorsByEvaluatorDataLoader",

--- a/src/phoenix/server/api/dataloaders/code_evaluator_version_count.py
+++ b/src/phoenix/server/api/dataloaders/code_evaluator_version_count.py
@@ -1,0 +1,36 @@
+from typing import Iterable
+
+from sqlalchemy import func, select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+CodeEvaluatorId: TypeAlias = int
+
+Key: TypeAlias = CodeEvaluatorId
+Result: TypeAlias = int
+
+
+class CodeEvaluatorVersionCountDataLoader(DataLoader[Key, Result]):
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: Iterable[Key]) -> list[Result]:
+        code_evaluator_ids = list(set(keys))
+        result: dict[Key, Result] = {}
+        stmt = (
+            select(
+                models.CodeEvaluatorVersion.code_evaluator_id,
+                func.count(),
+            )
+            .where(models.CodeEvaluatorVersion.code_evaluator_id.in_(code_evaluator_ids))
+            .group_by(models.CodeEvaluatorVersion.code_evaluator_id)
+        )
+        async with self._db.read() as session:
+            data = await session.stream(stmt)
+            async for code_evaluator_id, count in data:
+                result[code_evaluator_id] = count
+        return [result.get(code_evaluator_id, 0) for code_evaluator_id in keys]

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -318,6 +318,13 @@ class CodeEvaluator(Evaluator, Node):
         return to_gql_code_evaluator_version(version)
 
     @strawberry.field
+    async def version_count(
+        self,
+        info: Info[Context, None],
+    ) -> int:
+        return await info.context.data_loaders.code_evaluator_version_count.load(self.id)
+
+    @strawberry.field
     async def versions(
         self,
         info: Info[Context, None],

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -90,6 +90,7 @@ from phoenix.server.api.dataloaders import (
     AverageExperimentRepeatedRunGroupLatencyDataLoader,
     AverageExperimentRunLatencyDataLoader,
     CacheForDataLoaders,
+    CodeEvaluatorVersionCountDataLoader,
     CodeEvaluatorVersionSequenceNumberDataLoader,
     DatasetDatasetSplitsDataLoader,
     DatasetEvaluatorsByEvaluatorDataLoader,
@@ -795,6 +796,7 @@ def create_graphql_router(
                 ),
                 average_experiment_run_latency=AverageExperimentRunLatencyDataLoader(db),
                 code_evaluator_fields=TableFieldsDataLoader(db, models.CodeEvaluator),
+                code_evaluator_version_count=CodeEvaluatorVersionCountDataLoader(db),
                 code_evaluator_version_sequence_number=CodeEvaluatorVersionSequenceNumberDataLoader(
                     db
                 ),


### PR DESCRIPTION
## Summary
- Adds a Versions tab to the code evaluator details page with a list of revisions and a detail pane showing source code or a diff against the previous version
- Displays author with avatar (falls back to "system" when no user is associated, matching the pattern used in annotations/feedback)
- Restyles the version ID in monospace so it reads as an ID field next to the `v{n}` token
- Refactors the dataset evaluator details pages and dialog content to share the new layout, and registers a `phoenix-design` rule for counter usage

## Test plan
- [ ] Open a code evaluator with multiple versions and verify the Versions tab shows each revision with the correct author/timestamp
- [ ] Toggle the Diff switch and confirm the unified diff renders against the previous version (and is disabled for v1)
- [ ] Confirm the "system" fallback (avatar + label) renders when a version has no associated user
- [ ] Verify the LLM and built-in evaluator details pages still render correctly after the shared-layout refactor