### PR TITLE
feat(tracing): always show metrics aside, remove legacy stats header

### DIFF
--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -238,7 +238,7 @@ function ProjectPageContentBody({
       <TopNavActions order={-1}>
         <StreamToggle project={data.project} />
       </TopNavActions>
-      <ProjectPageHeader project={data.project} />
+      <ProjectPageHeader />
       <ProjectPageQueryReferenceContext.Provider
         value={{
           spansQueryReference: spansQueryReference ?? null,

--- a/app/src/pages/project/ProjectPageHeader.tsx
+++ b/app/src/pages/project/ProjectPageHeader.tsx
@@ -1,89 +1,27 @@
-import { css } from "@emotion/react";
 import { Suspense } from "react";
 
 import { Loading, View } from "@phoenix/components";
 import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 
-import type { ProjectStats_project$key } from "./__generated__/ProjectStats_project.graphql";
-import { ProjectStats } from "./ProjectStats";
 import { ProjectTraceCountSparkline } from "./ProjectTraceCountSparkline";
 
-type ProjectPageHeaderProps = {
-  project: ProjectStats_project$key;
-};
-
-const headerViewProps = {
-  paddingStart: "size-200",
-  paddingEnd: "size-200",
-  paddingTop: "size-200",
-  paddingBottom: "size-50",
-  flex: "none",
-  overflow: "visible",
-} as const;
-
-export function ProjectPageHeader(props: ProjectPageHeaderProps) {
+export function ProjectPageHeader() {
   const isTracingUxEnabled = useFeatureFlag("tracing_ux");
-  if (isTracingUxEnabled) {
-    return <TracingUxProjectPageHeader />;
+  if (!isTracingUxEnabled) {
+    return null;
   }
-  return <LegacyProjectPageHeader {...props} />;
-}
-
-function TracingUxProjectPageHeader() {
   return (
-    <View {...headerViewProps}>
+    <View
+      paddingStart="size-200"
+      paddingEnd="size-200"
+      paddingTop="size-200"
+      paddingBottom="size-50"
+      flex="none"
+      overflow="visible"
+    >
       <Suspense fallback={<Loading size="S" />}>
         <ProjectTraceCountSparkline />
       </Suspense>
     </View>
   );
 }
-
-function LegacyProjectPageHeader({ project }: ProjectPageHeaderProps) {
-  return (
-    <View {...headerViewProps}>
-      <div css={statsScrollCSS}>
-        <ProjectStats project={project} />
-      </div>
-    </View>
-  );
-}
-
-const statsScrollCSS = css`
-  overflow-x: auto;
-  overflow-y: hidden;
-  flex: 1 1 auto;
-  background-image:
-    linear-gradient(
-      to right,
-      var(--global-color-gray-75),
-      var(--global-color-gray-75)
-    ),
-    linear-gradient(
-      to right,
-      var(--global-color-gray-75),
-      var(--global-color-gray-75)
-    ),
-    linear-gradient(
-      to right,
-      rgba(var(--global-color-gray-300-rgb), 0.9),
-      rgba(var(--global-color-gray-300-rgb), 0)
-    ),
-    linear-gradient(
-      to left,
-      rgba(var(--global-color-gray-300-rgb), 0.9),
-      rgba(var(--global-color-gray-300-rgb), 0)
-    );
-  background-repeat: no-repeat;
-  background-size:
-    32px 100%,
-    32px 100%,
-    32px 100%,
-    32px 100%;
-  background-position:
-    left center,
-    right center,
-    left center,
-    right center;
-  background-attachment: local, local, scroll, scroll;
-`;

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -61,7 +61,6 @@ import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon
 import { SpanTokenCosts } from "@phoenix/components/trace/SpanTokenCosts";
 import { SpanTokenCount } from "@phoenix/components/trace/SpanTokenCount";
 import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
-import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
@@ -207,7 +206,6 @@ export function SpansTable(props: SpansTableProps) {
   useAdvertiseAgentContext(advertisedRootSpansOnlyContext);
 
   const columnVisibility = useTracingContext((state) => state.columnVisibility);
-  const isTracingUxEnabled = useFeatureFlag("tracing_ux");
   const showTableAside = useProjectContext((state) => state.showTableAside);
   const setShowTableAside = useProjectContext(
     (state) => state.setShowTableAside
@@ -893,22 +891,20 @@ export function SpansTable(props: SpansTableProps) {
               </ToggleButtonGroup>
               <SpanColumnSelector columns={computedColumns} query={data} />
               <ProjectFilterConfigButton />
-              {isTracingUxEnabled ? (
-                <Button
-                  size="M"
-                  aria-label={
-                    showTableAside ? "Hide aside panel" : "Show aside panel"
-                  }
-                  leadingVisual={
-                    <Icon
-                      svg={
-                        showTableAside ? <Icons.SlideIn /> : <Icons.SlideOut />
-                      }
-                    />
-                  }
-                  onPress={() => setShowTableAside(!showTableAside)}
-                />
-              ) : null}
+              <Button
+                size="M"
+                aria-label={
+                  showTableAside ? "Hide aside panel" : "Show aside panel"
+                }
+                leadingVisual={
+                  <Icon
+                    svg={
+                      showTableAside ? <Icons.SlideIn /> : <Icons.SlideOut />
+                    }
+                  />
+                }
+                onPress={() => setShowTableAside(!showTableAside)}
+              />
             </Flex>
           </View>
           <div
@@ -1023,38 +1019,34 @@ export function SpansTable(props: SpansTableProps) {
           ) : null}
         </div>
       </Panel>
-      {isTracingUxEnabled ? (
-        <>
-          <Separator
-            css={compactResizeHandleCSS}
-            disabled={!showTableAside}
-            style={showTableAside ? undefined : { display: "none" }}
-          />
-          <Panel
-            panelRef={asidePanelRef}
-            defaultSize={ASIDE_PANEL_DEFAULT_SIZE_PIXELS}
-            collapsedSize={0}
-            minSize={ASIDE_PANEL_MIN_SIZE_PIXELS}
-            maxSize={ASIDE_PANEL_MAX_SIZE_PIXELS}
-            collapsible
-            onResize={(panelSize) => {
-              if (!didSyncAsideFromStoreRef.current) return;
-              const shouldBeVisible = panelSize.asPercentage > 0;
-              if (shouldBeVisible !== showTableAside) {
-                setShowTableAside(shouldBeVisible);
-              }
-            }}
-          >
-            {showTableAside ? (
-              <ErrorBoundary fallback={TextErrorBoundaryFallback}>
-                <Suspense fallback={<Loading size="S" />}>
-                  <SpansTableAside filterCondition={filterCondition} />
-                </Suspense>
-              </ErrorBoundary>
-            ) : null}
-          </Panel>
-        </>
-      ) : null}
+      <Separator
+        css={compactResizeHandleCSS}
+        disabled={!showTableAside}
+        style={showTableAside ? undefined : { display: "none" }}
+      />
+      <Panel
+        panelRef={asidePanelRef}
+        defaultSize={ASIDE_PANEL_DEFAULT_SIZE_PIXELS}
+        collapsedSize={0}
+        minSize={ASIDE_PANEL_MIN_SIZE_PIXELS}
+        maxSize={ASIDE_PANEL_MAX_SIZE_PIXELS}
+        collapsible
+        onResize={(panelSize) => {
+          if (!didSyncAsideFromStoreRef.current) return;
+          const shouldBeVisible = panelSize.asPercentage > 0;
+          if (shouldBeVisible !== showTableAside) {
+            setShowTableAside(shouldBeVisible);
+          }
+        }}
+      >
+        {showTableAside ? (
+          <ErrorBoundary fallback={TextErrorBoundaryFallback}>
+            <Suspense fallback={<Loading size="S" />}>
+              <SpansTableAside filterCondition={filterCondition} />
+            </Suspense>
+          </ErrorBoundary>
+        ) : null}
+      </Panel>
     </Group>
   );
 }


### PR DESCRIPTION
## Summary
- The `tracing_ux` feature flag now only toggles the trace-count sparkline at the top of the project page.
- The legacy `ProjectStats` header (the row of stats above the tabs) is removed.
- The metrics aside on the spans table is no longer gated by the flag — it is always available, and its visibility is controlled solely by the show/hide toggle button (`showTableAside`, default `true`).

### Default state (flag off)
- Tabs at the top of the project page (no chart).
- Metrics aside visible on the right of the spans table.

### Flag on
- Trace-count sparkline rendered above the tabs, on top of the same default state.

## Test plan
- [ ] Visit a project page with the `tracing_ux` flag off — confirm no header above the tabs and the metrics aside is visible on the right of the spans table.
- [ ] Enable the `tracing_ux` flag — confirm the sparkline appears above the tabs and the aside is unchanged.
- [ ] Toggle the aside via the slide button — confirm it collapses/expands.
- [ ] Existing TypeScript CI: typecheck, lint, format, relay codegen, openapi codegen, unit tests.
- [ ] Existing Playwright CI: end-to-end tests.