### PR TITLE
feat(sandbox): clarify sandbox configuration settings display

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3223,6 +3223,7 @@ enum RevisionKind {
 type SandboxBackendInfo {
   backendType: String!
   displayName: String!
+  hostingType: SandboxHostingType!
   supportedLanguages: [Language!]!
   status: SandboxBackendStatus!
   statusDetail: String
@@ -3256,6 +3257,11 @@ type SandboxConfig implements Node {
   provider: SandboxProvider!
   createdAt: DateTime!
   updatedAt: DateTime!
+}
+
+enum SandboxHostingType {
+  LOCAL
+  HOSTED
 }
 
 type SandboxProvider implements Node {

--- a/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorDetails.tsx
+++ b/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorDetails.tsx
@@ -22,6 +22,7 @@ import { SandboxProviderIcon } from "@phoenix/components/sandbox/SandboxProvider
 import type { CodeDatasetEvaluatorDetails_datasetEvaluator$key } from "@phoenix/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorDetails_datasetEvaluator.graphql";
 import type { datasetEvaluatorDetailsLoaderQuery } from "@phoenix/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql";
 import {
+  friendlySettingLabel,
   getDisplaySandboxConfig,
   LanguageWithIcon,
   languageLabel,
@@ -271,27 +272,6 @@ function OutputConfigBlock({ config }: { config: OutputConfig }) {
 // Keys that are presented as a single row (not flattened into dot-paths) so
 // we can apply a friendly human-readable summary value.
 const COLLAPSED_SETTING_KEYS = new Set(["env_vars", "internet_access"]);
-
-const FRIENDLY_SETTING_LABELS: Record<string, string> = {
-  env_vars: "Environment Variables",
-  internet_access: "Internet Access",
-  dependencies: "Dependencies",
-};
-
-function friendlySettingLabel(key: string): string {
-  if (FRIENDLY_SETTING_LABELS[key]) return FRIENDLY_SETTING_LABELS[key];
-  return key
-    .split(".")
-    .map((part) =>
-      part
-        .split("_")
-        .map((s) =>
-          s.length === 0 ? s : s.charAt(0).toUpperCase() + s.slice(1)
-        )
-        .join(" ")
-    )
-    .join(" / ");
-}
 
 function flattenSettings(
   value: unknown,

--- a/app/src/pages/settings/__generated__/settingsSandboxesPageLoaderQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/settingsSandboxesPageLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<359835c47c2950d6506ba98bfc4b3011>>
+ * @generated SignedSource<<c761e26049f7bf76e60c5c30d89d8974>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -101,6 +101,13 @@ return {
         "selections": [
           (v0/*: any*/),
           (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "hostingType",
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
@@ -236,12 +243,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f72d6844eddf024afd3192ad11e821f8",
+    "cacheID": "5f6072e0eac5e1c867306c26ed490d33",
     "id": null,
     "metadata": {},
     "name": "settingsSandboxesPageLoaderQuery",
     "operationKind": "query",
-    "text": "query settingsSandboxesPageLoaderQuery {\n  ...SettingsSandboxesPageFragment\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "query settingsSandboxesPageLoaderQuery {\n  ...SettingsSandboxesPageFragment\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    hostingType\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/SandboxConfigsCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigsCard.tsx
@@ -9,6 +9,7 @@ import {
   Switch,
   Text,
 } from "@phoenix/components";
+import { SandboxProviderIcon } from "@phoenix/components/sandbox/SandboxProviderIcon";
 import { TableEmpty } from "@phoenix/components/table";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
@@ -23,7 +24,11 @@ import {
   subtitleCSS,
 } from "./styles";
 import type { ConfigRow, ProviderRow } from "./types";
-import { getSandboxConfigSettings, LanguageWithIcon } from "./utils";
+import {
+  getSandboxConfigSettings,
+  LanguageWithIcon,
+  SandboxHostingTypeBadge,
+} from "./utils";
 
 export function SandboxConfigsCard({
   configRows,
@@ -70,7 +75,16 @@ export function SandboxConfigsCard({
                       </Flex>
                     </td>
                     <td>
-                      <Text>{backend.displayName}</Text>
+                      <Flex direction="row" gap="size-100" alignItems="center">
+                        <SandboxProviderIcon
+                          backendType={backend.backendType}
+                          height={18}
+                        />
+                        <Text>{backend.displayName}</Text>
+                        <SandboxHostingTypeBadge
+                          hostingType={backend.hostingType}
+                        />
+                      </Flex>
                     </td>
                     <td>
                       <LanguageWithIcon language={provider.language} />

--- a/app/src/pages/settings/sandboxes/SandboxConfigsCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigsCard.tsx
@@ -1,7 +1,14 @@
 import { useState } from "react";
 import { graphql, useMutation } from "react-relay";
 
-import { Card, Flex, Label, Switch, Text } from "@phoenix/components";
+import {
+  Card,
+  ContextualHelp,
+  Flex,
+  Label,
+  Switch,
+  Text,
+} from "@phoenix/components";
 import { TableEmpty } from "@phoenix/components/table";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
@@ -11,18 +18,12 @@ import { SandboxConfigDialogTrigger } from "./SandboxConfigDialog";
 import {
   configNameCSS,
   configNameCellCSS,
-  inlineTokenRowCSS,
   sandboxesTableCSS,
   sandboxesTableWrapCSS,
   subtitleCSS,
 } from "./styles";
 import type { ConfigRow, ProviderRow } from "./types";
-import {
-  ConfigStatusText,
-  hasConfig,
-  LanguageWithIcon,
-  summarizeConfig,
-} from "./utils";
+import { getSandboxConfigSettings, LanguageWithIcon } from "./utils";
 
 export function SandboxConfigsCard({
   configRows,
@@ -33,8 +34,12 @@ export function SandboxConfigsCard({
 }) {
   return (
     <Card
-      title="Code Sandboxes"
-      subTitle="Configure reusable sandbox configurations for code evaluators."
+      title="Sandbox Configurations"
+      titleExtra={
+        <ContextualHelp variant="info">
+          Reusable sandbox configurations for code evaluators.
+        </ContextualHelp>
+      }
       extra={
         <SandboxConfigDialogTrigger mode="create" providers={providerRows} />
       }
@@ -46,79 +51,82 @@ export function SandboxConfigsCard({
               <th>Name</th>
               <th>Provider</th>
               <th>Language</th>
-              <th>Status</th>
               <th>Settings</th>
               <th />
             </tr>
           </thead>
           {configRows.length > 0 ? (
             <tbody>
-              {configRows.map(({ backend, provider, config }) => (
-                <tr key={config.id}>
-                  <td css={configNameCellCSS}>
-                    <Flex direction="column" gap="size-25">
-                      <span css={configNameCSS}>{config.name}</span>
-                      <span css={subtitleCSS}>
-                        {config.description || "No description"}
-                      </span>
-                    </Flex>
-                  </td>
-                  <td>
-                    <Text>{backend.displayName}</Text>
-                  </td>
-                  <td>
-                    <LanguageWithIcon language={provider.language} />
-                  </td>
-                  <td>
-                    <div css={inlineTokenRowCSS}>
-                      <ConfigStatusText
-                        config={config}
-                        provider={provider}
-                        backend={backend}
-                      />
-                    </div>
-                  </td>
-                  <td>
-                    <Flex direction="column" gap="size-25">
-                      <Text>{config.timeout}s timeout</Text>
-                      <Text
-                        color={
-                          hasConfig(config.config) ? undefined : "text-700"
-                        }
-                      >
-                        {hasConfig(config.config)
-                          ? summarizeConfig(config.config)
-                          : "No custom settings"}
-                      </Text>
-                    </Flex>
-                  </td>
-                  <td>
-                    <Flex
-                      gap="size-100"
-                      alignItems="center"
-                      justifyContent="space-between"
-                    >
-                      <ConfigEnabledSwitch
-                        config={config}
-                        canEnable={provider.enabled}
-                      />
+              {configRows.map(({ backend, provider, config }) => {
+                const settings = getSandboxConfigSettings(config.config);
+                return (
+                  <tr key={config.id}>
+                    <td css={configNameCellCSS}>
+                      <Flex direction="column" gap="size-25">
+                        <span css={configNameCSS}>{config.name}</span>
+                        <span css={subtitleCSS}>
+                          {config.description || "No description"}
+                        </span>
+                      </Flex>
+                    </td>
+                    <td>
+                      <Text>{backend.displayName}</Text>
+                    </td>
+                    <td>
+                      <LanguageWithIcon language={provider.language} />
+                    </td>
+                    <td>
+                      <Flex direction="column" gap="size-50" alignItems="start">
+                        <Text>{config.timeout}s timeout</Text>
+                        {settings.length > 0 ? (
+                          settings.map(({ key, label, value }) => (
+                            <Flex
+                              key={key}
+                              direction="row"
+                              gap="size-50"
+                              alignItems="baseline"
+                            >
+                              <Text size="S" color="text-700">
+                                {label}:
+                              </Text>
+                              <Text size="S" fontFamily="mono">
+                                {value}
+                              </Text>
+                            </Flex>
+                          ))
+                        ) : (
+                          <Text color="text-700">No custom settings</Text>
+                        )}
+                      </Flex>
+                    </td>
+                    <td>
                       <Flex
-                        justifyContent="end"
                         gap="size-100"
                         alignItems="center"
+                        justifyContent="space-between"
                       >
-                        <SandboxConfigDialogTrigger
-                          mode="edit"
-                          provider={provider}
-                          backend={backend}
+                        <ConfigEnabledSwitch
                           config={config}
+                          canEnable={provider.enabled}
                         />
-                        <DeleteSandboxConfigButton config={config} />
+                        <Flex
+                          justifyContent="end"
+                          gap="size-100"
+                          alignItems="center"
+                        >
+                          <SandboxConfigDialogTrigger
+                            mode="edit"
+                            provider={provider}
+                            backend={backend}
+                            config={config}
+                          />
+                          <DeleteSandboxConfigButton config={config} />
+                        </Flex>
                       </Flex>
-                    </Flex>
-                  </td>
-                </tr>
-              ))}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           ) : (
             <TableEmpty message="No sandbox configs" />

--- a/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
@@ -39,7 +39,12 @@ export function SandboxProvidersCard({
   return (
     <Card
       title="Sandbox Providers"
-      subTitle="Manage shared provider settings and whether each sandbox runtime can be enabled."
+      titleExtra={
+        <ContextualHelp variant="info">
+          Shared provider settings and whether each sandbox runtime can be
+          enabled.
+        </ContextualHelp>
+      }
     >
       <table css={sandboxesTableCSS}>
         <thead>

--- a/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
@@ -26,6 +26,7 @@ import {
   formatTimestamp,
   getBackendDescription,
   LanguageWithIcon,
+  SandboxHostingTypeBadge,
   StatusText,
 } from "./utils";
 
@@ -68,6 +69,9 @@ export function SandboxProvidersCard({
                       height={18}
                     />
                     <span>{backend.displayName}</span>
+                    <SandboxHostingTypeBadge
+                      hostingType={backend.hostingType}
+                    />
                     <ContextualHelp variant="info">
                       {getBackendDescription(backend.backendType)}
                     </ContextualHelp>

--- a/app/src/pages/settings/sandboxes/SettingsSandboxesPage.tsx
+++ b/app/src/pages/settings/sandboxes/SettingsSandboxesPage.tsx
@@ -53,6 +53,7 @@ function SettingsSandboxesPageContent({
         sandboxBackends {
           backendType
           displayName
+          hostingType
           dependencyHints
           supportedLanguages
           status
@@ -108,8 +109,8 @@ function SettingsSandboxesPageContent({
       .sort((a, b) => {
         // Local providers first, then alphabetical by display name, then by
         // language for stable ordering when two providers share a name.
-        const aLocal = a.backend.displayName.includes("(local)") ? 0 : 1;
-        const bLocal = b.backend.displayName.includes("(local)") ? 0 : 1;
+        const aLocal = a.backend.hostingType === "LOCAL" ? 0 : 1;
+        const bLocal = b.backend.hostingType === "LOCAL" ? 0 : 1;
         if (aLocal !== bLocal) return aLocal - bLocal;
         const nameCmp = a.backend.displayName.localeCompare(
           b.backend.displayName

--- a/app/src/pages/settings/sandboxes/__generated__/DeleteSandboxConfigButtonDeleteSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/DeleteSandboxConfigButtonDeleteSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<41c12d440009ef51ec9e9eebc1f6017b>>
+ * @generated SignedSource<<5a1da2205b2e899214aea172f093dd42>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -176,6 +176,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "hostingType",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "dependencyHints",
                     "storageKey": null
                   },
@@ -313,12 +320,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0bf963f01c6121f14acffc6e8ab64c2f",
+    "cacheID": "69b6d374b41085e163d935bd86fa9be0",
     "id": null,
     "metadata": {},
     "name": "DeleteSandboxConfigButtonDeleteSandboxConfigMutation",
     "operationKind": "mutation",
-    "text": "mutation DeleteSandboxConfigButtonDeleteSandboxConfigMutation(\n  $input: DeleteSandboxConfigInput!\n) {\n  deleteSandboxConfig(input: $input) {\n    deletedId\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation DeleteSandboxConfigButtonDeleteSandboxConfigMutation(\n  $input: DeleteSandboxConfigInput!\n) {\n  deleteSandboxConfig(input: $input) {\n    deletedId\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    hostingType\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogCreateSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogCreateSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d2355cba6441cedff74a35c98be9b26a>>
+ * @generated SignedSource<<909f9fc51fcad3c92417a3b4ce03cad0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -171,6 +171,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "hostingType",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "dependencyHints",
                     "storageKey": null
                   },
@@ -308,12 +315,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "27d6be5f9728e43cf5b0f70698e5da26",
+    "cacheID": "e24595377279971053e84607e19b98b3",
     "id": null,
     "metadata": {},
     "name": "SandboxConfigDialogCreateSandboxConfigMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxConfigDialogCreateSandboxConfigMutation(\n  $input: CreateSandboxConfigInput!\n) {\n  createSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxConfigDialogCreateSandboxConfigMutation(\n  $input: CreateSandboxConfigInput!\n) {\n  createSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    hostingType\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8630291fe112440b2780990ff13f5278>>
+ * @generated SignedSource<<da3266ace249e86d6f6b86c39591a756>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -171,6 +171,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "hostingType",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "dependencyHints",
                     "storageKey": null
                   },
@@ -308,12 +315,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ea5f240ae4bb08d23773749ee8d1199b",
+    "cacheID": "5c6e07e7982004534fa247e62c2779f3",
     "id": null,
     "metadata": {},
     "name": "SandboxConfigDialogUpdateSandboxConfigMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxConfigDialogUpdateSandboxConfigMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxConfigDialogUpdateSandboxConfigMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    hostingType\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<dfb8d81b3e841aee3814228b2438b13b>>
+ * @generated SignedSource<<908dff9764ea3cae7111c6063bb67c1d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -171,6 +171,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "hostingType",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "dependencyHints",
                     "storageKey": null
                   },
@@ -308,12 +315,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "913db21ba8f034bf568f88dfc915ebb8",
+    "cacheID": "9bed11c7d4b9657bf2f0291d47f2d54a",
     "id": null,
     "metadata": {},
     "name": "SandboxConfigsCardConfigEnabledSwitchMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxConfigsCardConfigEnabledSwitchMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxConfigsCardConfigEnabledSwitchMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    hostingType\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxProvidersCardProviderEnabledSwitchMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxProvidersCardProviderEnabledSwitchMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8233062f1791fe0f020c01aedea745ef>>
+ * @generated SignedSource<<975e0dcddbfdde7989bd1fa0ae30617e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -168,6 +168,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "hostingType",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "dependencyHints",
                     "storageKey": null
                   },
@@ -305,12 +312,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ea97054a7c9cdaf1aa3e38e483a090bc",
+    "cacheID": "7d27ad49640bb5f17e259279c7a5b1eb",
     "id": null,
     "metadata": {},
     "name": "SandboxProvidersCardProviderEnabledSwitchMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxProvidersCardProviderEnabledSwitchMutation(\n  $input: UpdateSandboxProviderInput!\n) {\n  updateSandboxProvider(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxProvidersCardProviderEnabledSwitchMutation(\n  $input: UpdateSandboxProviderInput!\n) {\n  updateSandboxProvider(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    hostingType\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7476bb35d721b8ab7789bce19d1a5979>>
+ * @generated SignedSource<<c01ef8b700447190e929b784366e42ab>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ReaderFragment } from 'relay-runtime';
 export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type SandboxBackendStatus = "AVAILABLE" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
+export type SandboxHostingType = "HOSTED" | "LOCAL";
 import { FragmentRefs } from "relay-runtime";
 export type SettingsSandboxesPageFragment$data = {
   readonly sandboxBackends: ReadonlyArray<{
@@ -25,6 +26,7 @@ export type SettingsSandboxesPageFragment$data = {
     readonly dependenciesLanguage: Language | null;
     readonly dependencyHints: ReadonlyArray<string>;
     readonly displayName: string;
+    readonly hostingType: SandboxHostingType;
     readonly internetAccess: InternetAccessMode;
     readonly status: SandboxBackendStatus;
     readonly statusDetail: string | null;
@@ -129,6 +131,13 @@ return {
       "selections": [
         (v0/*: any*/),
         (v1/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "hostingType",
+          "storageKey": null
+        },
         {
           "alias": null,
           "args": null,
@@ -267,6 +276,6 @@ return {
 };
 })();
 
-(node as any).hash = "ecf4493da709473f1f05e97b6ab7e787";
+(node as any).hash = "1f6d50525ca2ee2e7197dc1a1347ea5e";
 
 export default node;

--- a/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageRefetchQuery.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6c18fc33d917bf8ade66ce1c90a65da2>>
+ * @generated SignedSource<<e9fbe1a105812ef8281214dcfa3826e7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -101,6 +101,13 @@ return {
         "selections": [
           (v0/*: any*/),
           (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "hostingType",
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
@@ -236,16 +243,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cd9fbbdf0396ecc309ca3d5d25ac79b7",
+    "cacheID": "f7b2b8496f4a7be87f46483d0b1e7c14",
     "id": null,
     "metadata": {},
     "name": "SettingsSandboxesPageRefetchQuery",
     "operationKind": "query",
-    "text": "query SettingsSandboxesPageRefetchQuery {\n  ...SettingsSandboxesPageFragment\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "query SettingsSandboxesPageRefetchQuery {\n  ...SettingsSandboxesPageFragment\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    hostingType\n    dependencyHints\n    supportedLanguages\n    status\n    statusDetail\n    supportsEnvVars\n    internetAccess\n    dependenciesLanguage\n    credentialSpecs {\n      key\n      displayName\n      description\n      isRequired\n    }\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ecf4493da709473f1f05e97b6ab7e787";
+(node as any).hash = "1f6d50525ca2ee2e7197dc1a1347ea5e";
 
 export default node;

--- a/app/src/pages/settings/sandboxes/styles.ts
+++ b/app/src/pages/settings/sandboxes/styles.ts
@@ -24,6 +24,6 @@ export const configNameCSS = css`
 `;
 
 export const subtitleCSS = css`
-  color: var(--ac-global-text-color-700);
+  color: var(--global-text-color-700);
   font-size: var(--global-font-size-s);
 `;

--- a/app/src/pages/settings/sandboxes/styles.ts
+++ b/app/src/pages/settings/sandboxes/styles.ts
@@ -15,10 +15,6 @@ export const sandboxesTableCSS = css(
   `
 );
 
-export const emptyStateWrapCSS = css`
-  padding: var(--global-dimension-size-500) var(--global-dimension-size-300);
-`;
-
 export const configNameCellCSS = css`
   min-width: 260px;
 `;
@@ -30,11 +26,4 @@ export const configNameCSS = css`
 export const subtitleCSS = css`
   color: var(--ac-global-text-color-700);
   font-size: var(--global-font-size-s);
-`;
-
-export const inlineTokenRowCSS = css`
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--global-dimension-size-50);
-  align-items: center;
 `;

--- a/app/src/pages/settings/sandboxes/utils.tsx
+++ b/app/src/pages/settings/sandboxes/utils.tsx
@@ -13,7 +13,6 @@ import { isPlainObject } from "@phoenix/utils/jsonUtils";
 
 import type {
   BackendInfo,
-  SandboxConfig,
   SandboxConfigFormValues,
   SandboxProvider,
 } from "./types";
@@ -21,79 +20,6 @@ import type {
 type Language =
   | SandboxProvider["language"]
   | BackendInfo["supportedLanguages"][number];
-
-/**
- * Status pill for a config row: a "union" of backend health and the
- * config/provider enabled toggles.
- *
- * Precedence (top wins): config-disabled > provider-disabled > backend status.
- *
- * Why user toggles win over backend health: a disabled config is "off" by
- * explicit user intent — its backend health is moot until re-enabled, and
- * any backend issue stays visible in the providers section above. Showing
- * "Disabled" matches the toggle UI in the actions column.
- */
-export function ConfigStatusText({
-  config,
-  provider,
-  backend,
-}: {
-  config: Pick<SandboxConfig, "enabled">;
-  provider: Pick<SandboxProvider, "enabled">;
-  backend: Pick<BackendInfo, "status" | "statusDetail" | "dependencyHints">;
-}) {
-  if (!config.enabled) {
-    return (
-      <DisabledStatusText
-        label="Disabled"
-        tooltip="Toggle this config on to make it available."
-      />
-    );
-  }
-  if (!provider.enabled) {
-    return (
-      <DisabledStatusText
-        label="Provider disabled"
-        tooltip="Enable the provider in the Sandbox Providers section above."
-      />
-    );
-  }
-  return (
-    <StatusText
-      status={backend.status}
-      detail={backend.statusDetail}
-      dependencyHints={backend.dependencyHints}
-    />
-  );
-}
-
-function DisabledStatusText({
-  label,
-  tooltip,
-}: {
-  label: string;
-  tooltip: string;
-}) {
-  return (
-    <TooltipTrigger delay={100}>
-      <TriggerWrap>
-        <Text
-          color="text-700"
-          css={css`
-            text-decoration: underline dotted;
-            text-underline-offset: 2px;
-            cursor: help;
-          `}
-        >
-          {label}
-        </Text>
-      </TriggerWrap>
-      <RichTooltip width={320}>
-        <Text>{tooltip}</Text>
-      </RichTooltip>
-    </TooltipTrigger>
-  );
-}
 
 export function StatusText({
   status,
@@ -314,8 +240,111 @@ export function summarizeConfig(config: unknown) {
   return `${keys.length} settings: ${keys.slice(0, 2).join(", ")}${keys.length > 2 ? ", ..." : ""}`;
 }
 
-export function hasConfig(config: unknown) {
-  return isPlainObject(config) && Object.keys(config).length > 0;
+const FRIENDLY_SETTING_LABELS: Record<string, string> = {
+  env_vars: "Environment Variables",
+  internet_access: "Internet Access",
+  dependencies: "Dependencies",
+};
+
+/**
+ * Human-readable label for a sandbox config setting key. Falls back to
+ * title-casing snake_case segments and joining dot-paths with " / " so
+ * unknown keys still render cleanly.
+ */
+export function friendlySettingLabel(key: string): string {
+  if (FRIENDLY_SETTING_LABELS[key]) return FRIENDLY_SETTING_LABELS[key];
+  return key
+    .split(".")
+    .map((part) =>
+      part
+        .split("_")
+        .map((s) =>
+          s.length === 0 ? s : s.charAt(0).toUpperCase() + s.slice(1)
+        )
+        .join(" ")
+    )
+    .join(" / ");
+}
+
+export type SandboxConfigSetting = {
+  /** The raw config key, e.g. "env_vars". */
+  key: string;
+  /** Human-readable label, e.g. "Environment Variables". */
+  label: string;
+  /** Compact, display-safe value summary, e.g. "FOO, BAR" or "on". */
+  value: string;
+};
+
+/**
+ * Flattens a sandbox config into display-ready `label → value` pairs for the
+ * settings summary shown in the configs table.
+ *
+ * Env-var literal values are already redacted by {@link getDisplaySandboxConfig};
+ * we surface the variable *names* (not values) so it is clear which variables
+ * are set without leaking secrets. Internet access is normalized to a plain
+ * "on" / "off" (or an allowlist) so it is obvious whether it is enabled.
+ */
+export function getSandboxConfigSettings(
+  config: unknown
+): SandboxConfigSetting[] {
+  const display = getDisplaySandboxConfig(config);
+  if (!isPlainObject(display)) {
+    return [];
+  }
+  return Object.entries(display).map(([key, value]) => ({
+    key,
+    label: friendlySettingLabel(key),
+    value: summarizeSandboxSettingValue(key, value),
+  }));
+}
+
+function summarizeSandboxSettingValue(key: string, value: unknown): string {
+  switch (key) {
+    case "env_vars": {
+      if (!Array.isArray(value) || value.length === 0) {
+        return "none";
+      }
+      return value
+        .map((entry) =>
+          isPlainObject(entry) && typeof entry["name"] === "string"
+            ? entry["name"]
+            : "?"
+        )
+        .join(", ");
+    }
+    case "internet_access":
+      return summarizeInternetAccess(value);
+    case "dependencies": {
+      if (!isPlainObject(value)) {
+        return "configured";
+      }
+      const packages = Array.isArray(value["packages"]) ? value["packages"] : [];
+      return packages.length > 0
+        ? packages.map((p) => String(p)).join(", ")
+        : "none";
+    }
+    default:
+      if (value == null) return "—";
+      return typeof value === "object" ? JSON.stringify(value) : String(value);
+  }
+}
+
+function summarizeInternetAccess(value: unknown): string {
+  if (value == null) return "off";
+  if (typeof value === "string") {
+    return value.toLowerCase() === "deny" ? "off" : value;
+  }
+  if (isPlainObject(value)) {
+    const rawMode = value["mode"];
+    const mode = typeof rawMode === "string" ? rawMode.toLowerCase() : null;
+    if (mode == null || mode === "deny") return "off";
+    const domains = value["domains"];
+    if (Array.isArray(domains) && domains.length > 0) {
+      return `allowlist · ${domains.map((d) => String(d)).join(", ")}`;
+    }
+    return mode === "allow" ? "on" : mode;
+  }
+  return "on";
 }
 
 export function formValuesToConfigPatch(

--- a/app/src/pages/settings/sandboxes/utils.tsx
+++ b/app/src/pages/settings/sandboxes/utils.tsx
@@ -1,6 +1,7 @@
 import { css } from "@emotion/react";
 
 import {
+  Badge,
   Flex,
   RichTooltip,
   Text,
@@ -35,7 +36,7 @@ export function StatusText({
       ? "var(--global-color-success)"
       : status === "UNAVAILABLE" || status === "MISSING_CREDENTIALS"
         ? "var(--global-color-warning)"
-        : "var(--ac-global-text-color-700)";
+        : "var(--global-text-color-700)";
   const label = statusLabel(status);
   const tooltipLines = detail ? [detail] : dependencyHints;
 
@@ -63,6 +64,57 @@ export function StatusText({
             <Text key={line}>{line}</Text>
           ))}
         </Flex>
+      </RichTooltip>
+    </TooltipTrigger>
+  );
+}
+
+type HostingType = BackendInfo["hostingType"];
+
+export function hostingTypeLabel(hostingType: HostingType) {
+  switch (hostingType) {
+    case "LOCAL":
+      return "Local";
+    case "HOSTED":
+      return "Hosted";
+    default:
+      assertUnreachable(hostingType);
+  }
+}
+
+const HOSTING_TYPE_TOOLTIP: Record<HostingType, string> = {
+  LOCAL:
+    "Runs on the same machine as the Phoenix server. Code is sandboxed, but " +
+    "execution consumes Phoenix's CPU and memory.",
+  HOSTED:
+    "Code runs on an external provider's infrastructure. Execution happens " +
+    "off-server — Phoenix only orchestrates the run.",
+};
+
+/**
+ * A badge identifying whether a sandbox backend executes locally (on the
+ * Phoenix server) or on a hosted provider, with a tooltip explaining the
+ * resource trade-off.
+ */
+export function SandboxHostingTypeBadge({
+  hostingType,
+}: {
+  hostingType: HostingType;
+}) {
+  return (
+    <TooltipTrigger delay={100}>
+      <TriggerWrap>
+        <Badge
+          variant={hostingType === "LOCAL" ? "warning" : "info"}
+          css={css`
+            cursor: help;
+          `}
+        >
+          {hostingTypeLabel(hostingType)}
+        </Badge>
+      </TriggerWrap>
+      <RichTooltip width={280}>
+        <Text>{HOSTING_TYPE_TOOLTIP[hostingType]}</Text>
       </RichTooltip>
     </TooltipTrigger>
   );
@@ -318,7 +370,9 @@ function summarizeSandboxSettingValue(key: string, value: unknown): string {
       if (!isPlainObject(value)) {
         return "configured";
       }
-      const packages = Array.isArray(value["packages"]) ? value["packages"] : [];
+      const packages = Array.isArray(value["packages"])
+        ? value["packages"]
+        : [];
       return packages.length > 0
         ? packages.map((p) => String(p)).join(", ")
         : "none";

--- a/src/phoenix/server/api/types/SandboxConfig.py
+++ b/src/phoenix/server/api/types/SandboxConfig.py
@@ -85,6 +85,18 @@ class InternetAccessMode(Enum):
     ALLOWLIST = "allowlist"
 
 
+@strawberry.enum
+class SandboxHostingType(Enum):
+    """Where a sandbox backend physically executes code."""
+
+    LOCAL = "local"
+    """The runtime executes on the same machine as the Phoenix server —
+    sandboxed, but consuming Phoenix's CPU/memory (e.g. WebAssembly, Deno)."""
+    HOSTED = "hosted"
+    """Execution is delegated to an external provider over the network
+    (e.g. E2B, Daytona, Vercel, Modal); Phoenix only orchestrates."""
+
+
 @strawberry.type
 class SandboxBackendInfo:
     """
@@ -96,6 +108,7 @@ class SandboxBackendInfo:
 
     backend_type: str
     display_name: str
+    hosting_type: SandboxHostingType
     supported_languages: list[Language]
     status: SandboxBackendStatus
     status_detail: Optional[str]
@@ -450,6 +463,7 @@ async def _get_sandbox_backend_info_with_session(
             SandboxBackendInfo(
                 backend_type=backend_type,
                 display_name=meta.display_name,
+                hosting_type=SandboxHostingType(meta.hosting_type),
                 supported_languages=[Language(meta.language)] if meta.language else [],
                 status=status,
                 status_detail=status_detail,

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -162,6 +162,15 @@ class AdapterMetadata:
     dependency_hints: list[str] = field(default_factory=list)
     config_field_specs: list[ConfigFieldSpec] = field(default_factory=list)
 
+    # Where the sandbox's code execution physically happens.
+    # 'local' → the runtime executes on the same machine as the Phoenix
+    # server (sandboxed, but consuming Phoenix's CPU/memory; e.g. WASM, Deno).
+    # 'hosted' → execution is delegated to an external provider over the
+    # network (e.g. E2B, Daytona, Vercel, Modal); Phoenix only orchestrates.
+    # UI: rendered as a "Local" / "Hosted" badge on the providers table with a
+    # tooltip explaining the resource trade-off.
+    hosting_type: Literal["local", "hosted"] = "hosted"
+
     # True/False semantics: True → build_backend MUST accept user_env (the
     # pre-resolved name→value dict) and pass it to the runtime at constructor
     # time; execute() has no per-call env override. False → build_backend MUST
@@ -209,8 +218,9 @@ class AdapterMetadata:
 # ---------------------------------------------------------------------------
 SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
     "WASM": AdapterMetadata(
-        display_name="WebAssembly (local)",
+        display_name="WebAssembly",
         language="PYTHON",
+        hosting_type="local",
         dependency_hints=[
             "Install Phoenix with the `wasm` extra so `wasmtime` is available.",
             (
@@ -225,6 +235,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
     "E2B": AdapterMetadata(
         display_name="E2B",
         language="PYTHON",
+        hosting_type="hosted",
         dependency_hints=[
             "Install Phoenix with the `e2b` extra.",
             "Provide `E2B_API_KEY`.",
@@ -237,6 +248,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
     "DAYTONA_PYTHON": AdapterMetadata(
         display_name="Daytona",
         language="PYTHON",
+        hosting_type="hosted",
         dependency_hints=[
             "Install Phoenix with the `daytona` extra.",
             "Provide `PHOENIX_SANDBOX_DAYTONA_API_KEY`.",
@@ -256,6 +268,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         f"VERCEL_{lang}": AdapterMetadata(
             display_name="Vercel",
             language=lang,
+            hosting_type="hosted",
             dependency_hints=[
                 "Install Phoenix with the `vercel` extra.",
                 (
@@ -270,8 +283,9 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         for lang in ("PYTHON", "TYPESCRIPT")
     },
     "DENO": AdapterMetadata(
-        display_name="Deno (local)",
+        display_name="Deno",
         language="TYPESCRIPT",
+        hosting_type="local",
         dependency_hints=[
             "Install the Deno runtime and ensure the `deno` binary is available on PATH.",
         ],
@@ -282,6 +296,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
     "MODAL": AdapterMetadata(
         display_name="Modal",
         language="PYTHON",
+        hosting_type="hosted",
         dependency_hints=[
             "Install Phoenix with the `modal` extra.",
             "Provide `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` environment variables.",

--- a/src/phoenix/server/sandbox/deno_backend.py
+++ b/src/phoenix/server/sandbox/deno_backend.py
@@ -124,7 +124,7 @@ class DenoSandboxBackend(BaseNoSessionBackend):
 class DenoAdapter(SandboxAdapter):
     key = "DENO"
     family = "DENO"
-    display_name = "Deno (local)"
+    display_name = "Deno"
     language = "TYPESCRIPT"
     config_model = DenoConfig
 

--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -174,7 +174,7 @@ class WASMBinaryProbe:
 class WASMAdapter(SandboxAdapter):
     key = "WASM"
     family = "WASM"
-    display_name = "WebAssembly (local)"
+    display_name = "WebAssembly"
     language = "PYTHON"
     config_model = WASMConfig
 

--- a/tests/unit/server/api/test_capability_advertisement.py
+++ b/tests/unit/server/api/test_capability_advertisement.py
@@ -16,6 +16,7 @@ _SANDBOX_BACKENDS_QUERY = """
     sandboxBackends {
       backendType
       displayName
+      hostingType
       supportedLanguages
       status
       dependencyHints
@@ -29,6 +30,8 @@ _SANDBOX_BACKENDS_QUERY = """
     }
   }
 """
+
+_LOCAL_BACKEND_TYPES = {"WASM", "DENO"}
 
 _CREATE = """
 mutation CreateSandboxConfig($input: CreateSandboxConfigInput!) {
@@ -75,6 +78,8 @@ async def test_sandbox_backends_full_ui_query_shape(
         assert "supportsEnvVars" in backend, bt
         assert "internetAccess" in backend, bt
         assert "dependenciesLanguage" in backend, bt
+        expected_hosting = "LOCAL" if bt in _LOCAL_BACKEND_TYPES else "HOSTED"
+        assert backend["hostingType"] == expected_hosting, bt
 
 
 @pytest.mark.parametrize("backend_type", list(SANDBOX_ADAPTER_METADATA.keys()))


### PR DESCRIPTION

<img width="1384" height="760" alt="Screenshot 2026-05-11 at 12 47 43 PM" src="https://github.com/user-attachments/assets/12bc06fe-984f-4361-adc1-48ce179f03a4" />

Cleans up the **Settings → Sandboxes** tab so the configuration is easier to read at a glance.

- Card descriptions moved from subtitles to **info tooltips** on the card title (`titleExtra`).
- Renamed the **Code Sandboxes** card to **Sandbox Configurations**.
- Removed the redundant **Status** column from the configurations table — the Enabled/Disabled switch already conveys that.
- The **Settings** column now renders **`label → value` pairs** instead of an opaque `N settings: ...` summary:
  - `env_vars` → the variable **names** (values stay redacted) so it's clear which vars are set
  - `internet_access` → normalized to `on` / `off` (or an allowlist) so it's obvious whether it's enabled
  - `dependencies` → the package list
- Shared `friendlySettingLabel` between the settings page and the code-evaluator details page (removed the duplicate).
