### PR TITLE
chore(agents): drop unused user and db fields from ChatDependencies

### DIFF
--- a/src/phoenix/server/agents/dependencies.py
+++ b/src/phoenix/server/agents/dependencies.py
@@ -1,17 +1,13 @@
 from dataclasses import dataclass
-from typing import Any
 
 from pydantic_ai.mcp import MCPServerStreamableHTTP
 
 from phoenix.server.agents.capabilities import AgentCapabilities
 from phoenix.server.agents.context import ResolvedContexts
-from phoenix.server.types import DbSessionFactory
 
 
 @dataclass
 class ChatDependencies:
-    user: Any
-    db: DbSessionFactory
     contexts: ResolvedContexts
     capabilities: AgentCapabilities
     docs_mcp_toolset: MCPServerStreamableHTTP | None

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -315,8 +315,6 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             accept=request.headers.get("accept"),
         )
         deps = ChatDependencies(
-            user=request.scope.get("user") if hasattr(request, "scope") else None,
-            db=request.app.state.db,
             contexts=resolve_contexts(body.contexts),
             capabilities=body.capabilities,
             docs_mcp_toolset=request.app.state.docs_mcp_toolset,


### PR DESCRIPTION
## Summary
- Removes the `user` and `db` fields from `ChatDependencies`; they were populated at the chat route construction site but never read by any downstream consumer (agent factory, tools, or tests).
- Drops the now-unneeded `Any` and `DbSessionFactory` imports from `dependencies.py`.

## Test plan
- [x] `make lint-python`
- [x] `make typecheck-python`
- [x] `uv run pytest tests/unit/server/agents/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)