### PR TITLE
feat(sandbox): sandbox config UX in code evaluator flows

### DIFF
--- a/app/src/components/core/button/LinkButton.tsx
+++ b/app/src/components/core/button/LinkButton.tsx
@@ -8,7 +8,7 @@ import type { ButtonProps } from "./types";
 
 interface LinkButtonProps
   extends
-    Pick<LinkProps, "to" | "children">,
+    Pick<LinkProps, "to" | "children" | "aria-label">,
     Pick<
       ButtonProps,
       | "size"
@@ -45,6 +45,7 @@ function LinkButton({
     css: propCSS,
     isDisabled,
     to,
+    "aria-label": ariaLabel,
   } = props;
   return (
     <Link
@@ -55,6 +56,7 @@ function LinkButton({
       data-disabled={isDisabled}
       css={css(buttonCSS, linkButtonCSS, propCSS)}
       to={to}
+      aria-label={ariaLabel}
     >
       {leadingVisual}
       {children}

--- a/app/src/components/evaluators/CodeEvaluatorTestSection.tsx
+++ b/app/src/components/evaluators/CodeEvaluatorTestSection.tsx
@@ -7,7 +7,6 @@ import {
   Card,
   DialogTrigger,
   Flex,
-  Heading,
   Icon,
   IconButton,
   Icons,
@@ -326,11 +325,12 @@ export const CodeEvaluatorTestSection = ({
         </Flex>
       )}
 
-      {/* Test button and description */}
-      <Flex justifyContent="space-between" alignItems="center">
-        <Heading weight="heavy" level={3}>
-          Test Evaluator
-        </Heading>
+      {/* Description and test button */}
+      <Flex justifyContent="space-between" alignItems="center" gap="size-200">
+        <Text color="text-500" size="XS">
+          Run your evaluator against the example data to verify it works
+          correctly before saving.
+        </Text>
         <Button
           size="S"
           onPress={onTestEvaluator}
@@ -351,10 +351,6 @@ export const CodeEvaluatorTestSection = ({
           {isLoading ? "Testing..." : "Test"}
         </Button>
       </Flex>
-      <Text color="text-500" size="XS">
-        Run your evaluator against the example data to verify it works correctly
-        before saving.
-      </Text>
     </Flex>
   );
 };

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -10,6 +10,7 @@ import { Group, Panel, Separator } from "react-resizable-panels";
 import {
   Alert,
   Button,
+  CopyToClipboardButton,
   Flex,
   Heading,
   Icon,
@@ -26,6 +27,7 @@ import {
   SelectChevronUpDownIcon,
   SelectItem,
   SelectValue,
+  Switch,
   Text,
   TextField,
   View,
@@ -643,6 +645,9 @@ const CodeEditor = ({
   const { theme } = useTheme();
   const codeMirrorTheme = theme === "light" ? githubLight : githubDark;
 
+  // The auto-generated type footer is hidden by default.
+  const [showTypes, setShowTypes] = useState(false);
+
   // Get the evaluator mapping source from the store for type generation
   const evaluatorMappingSource = useEvaluatorStore(
     (state) => state.evaluatorMappingSource
@@ -731,7 +736,7 @@ const CodeEditor = ({
           </Panel>
 
           {/* Read-only type footer panel */}
-          {typeFooter && (
+          {showTypes && typeFooter && (
             <>
               <Separator css={compactResizeHandleCSS} />
               <Panel defaultSize="25%" minSize="10%" style={editorPanelStyle}>
@@ -756,6 +761,28 @@ const CodeEditor = ({
             </>
           )}
         </Group>
+        {/* Editor footer toolbar: copy code + toggle the type footer */}
+        <div css={editorFooterCSS}>
+          {typeFooter ? (
+            <Switch
+              isSelected={showTypes}
+              onChange={setShowTypes}
+              labelPlacement="end"
+            >
+              <Text size="XS" color="text-700">
+                Show types
+              </Text>
+            </Switch>
+          ) : (
+            <span />
+          )}
+          <CopyToClipboardButton
+            text={sourceCode}
+            size="S"
+            variant="quiet"
+            tooltipText="Copy code"
+          />
+        </div>
       </div>
     </Flex>
   );
@@ -1196,6 +1223,17 @@ const typeFooterCSS = css`
   & .cm-scroller {
     overflow: auto !important;
   }
+`;
+
+const editorFooterCSS = css`
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--global-dimension-size-100);
+  padding: var(--global-dimension-size-50) var(--global-dimension-size-100);
+  border-top: 1px solid var(--global-border-color-default);
+  background-color: var(--ac-global-color-grey-100);
 `;
 
 const choiceGridCSS = css`

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -21,6 +21,7 @@ import {
   ListItem,
   ListBox,
   Popover,
+  SectionHeading,
   Select,
   SelectChevronUpDownIcon,
   SelectItem,
@@ -35,12 +36,6 @@ import {
   DialogTitle,
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
-import {
-  Disclosure,
-  DisclosureGroup,
-  DisclosurePanel,
-  DisclosureTrigger,
-} from "@phoenix/components/core/disclosure";
 import { createEvaluatorAutocompletion } from "@phoenix/components/evaluators/codeEvaluatorAutocomplete";
 import {
   CodeEvaluatorLanguageField,
@@ -476,50 +471,48 @@ const ConfiguratorSidebar = ({
   language: CodeEvaluatorLanguage;
 }) => {
   return (
-    <DisclosureGroup defaultExpandedKeys={["test-section"]}>
-      <Disclosure id="test-section" defaultExpanded={false}>
-        <DisclosureTrigger arrowPosition="start">
+    <>
+      {/* Scrollable "Test Evaluator" region */}
+      <div css={sidebarScrollAreaCSS}>
+        <SectionHeading bordered={false}>
           <Text weight="heavy" size="S">
             Test Evaluator
           </Text>
-        </DisclosureTrigger>
-        <DisclosurePanel>
-          <div css={accordionContentCSS}>
-            <View marginY="size-100" paddingX="size-200">
-              <CodeEvaluatorTestSection
-                sourceCode={sourceCode}
-                language={language}
-                sandboxConfigId={selectedSandboxConfigId}
-              />
-            </View>
-            <View paddingX="size-200" paddingTop="size-50">
-              <EvaluatorExampleDataset />
-            </View>
-            <View marginTop="size-100">
-              <EvaluatorInputPreview />
-            </View>
-          </div>
-        </DisclosurePanel>
-      </Disclosure>
+        </SectionHeading>
+        <div css={sectionContentCSS}>
+          <View marginY="size-100" paddingX="size-200">
+            <CodeEvaluatorTestSection
+              sourceCode={sourceCode}
+              language={language}
+              sandboxConfigId={selectedSandboxConfigId}
+            />
+          </View>
+          <View paddingX="size-200" paddingTop="size-50">
+            <EvaluatorExampleDataset />
+          </View>
+          <View marginTop="size-100">
+            <EvaluatorInputPreview />
+          </View>
+        </div>
+      </div>
 
-      <Disclosure id="sandbox-runtime" defaultExpanded={false}>
-        <DisclosureTrigger arrowPosition="start">
+      {/* "Sandbox Runtime" pinned to the bottom and always visible */}
+      <div css={sidebarFooterCSS}>
+        <SectionHeading bordered={false}>
           <Text weight="heavy" size="S">
             Sandbox Runtime
           </Text>
-        </DisclosureTrigger>
-        <DisclosurePanel>
-          <div css={accordionContentCSS}>
-            <View paddingTop="size-100">
-              <SandboxCapabilitySummaryCard
-                selectedSandboxConfig={selectedSandboxConfig}
-                description="Review the selected runtime before testing execution behavior or saving this evaluator."
-              />
-            </View>
-          </div>
-        </DisclosurePanel>
-      </Disclosure>
-    </DisclosureGroup>
+        </SectionHeading>
+        <div css={sectionContentCSS}>
+          <View paddingTop="size-100">
+            <SandboxCapabilitySummaryCard
+              selectedSandboxConfig={selectedSandboxConfig}
+              description="Review the selected runtime before testing execution behavior or saving this evaluator."
+            />
+          </View>
+        </div>
+      </div>
+    </>
   );
 };
 
@@ -1200,11 +1193,28 @@ const sidebarPanelCSS = css`
   height: 100%;
   padding: 0;
   box-sizing: border-box;
-  overflow-y: auto;
+  overflow: hidden;
   border-left: 1px solid var(--global-border-color-default);
 `;
 
-const accordionContentCSS = css`
+// The "Test Evaluator" region grows to fill the panel and scrolls on overflow.
+const sidebarScrollAreaCSS = css`
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+`;
+
+// The "Sandbox Runtime" region is pinned to the bottom of the panel and stays
+// visible. It scrolls internally if its content gets tall, but is capped so the
+// test region always keeps room.
+const sidebarFooterCSS = css`
+  flex: 0 0 auto;
+  max-height: 50%;
+  overflow-y: auto;
+  border-top: 1px solid var(--global-border-color-default);
+`;
+
+const sectionContentCSS = css`
   padding: var(--global-dimension-size-50) 0;
   padding-bottom: var(--global-dimension-size-150);
 `;

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -503,13 +503,7 @@ const ConfiguratorSidebar = ({
             Sandbox Runtime
           </Text>
         </SectionHeading>
-        <div css={sectionContentCSS}>
-          <View paddingTop="size-100">
-            <SandboxRuntimeSummary
-              selectedSandboxConfig={selectedSandboxConfig}
-            />
-          </View>
-        </div>
+        <SandboxRuntimeSummary selectedSandboxConfig={selectedSandboxConfig} />
       </div>
     </>
   );
@@ -522,7 +516,7 @@ const SandboxRuntimeSummary = ({
 }) => {
   if (selectedSandboxConfig == null) {
     return (
-      <View paddingX="size-200">
+      <View padding="size-200">
         <Text color="text-500" size="XS">
           Choose a sandbox to review its configured execution settings.
         </Text>

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -676,28 +676,58 @@ const CodeEditor = ({
 
   return (
     <Flex direction="column" gap="size-100">
-      {/* Editor header with reset button */}
+      {/* Editor header with controls */}
       <Flex
         direction="row"
         justifyContent="space-between"
         alignItems="center"
+        gap="size-200"
         flex="none"
       >
         <Text color="text-500" size="XS">
           {descriptionText}
         </Text>
-        <Button
-          size="S"
-          variant="quiet"
-          onPress={() =>
-            onChange(
-              getDefaultCodeEvaluatorSource(language, outputShape, outputConfig)
-            )
-          }
+        <Flex
+          direction="row"
+          alignItems="center"
+          gap="size-150"
+          flex="none"
+          minWidth={0}
         >
-          <Icon svg={<Icons.Refresh />} />
-          Reset
-        </Button>
+          {typeFooter ? (
+            <Switch
+              isSelected={showTypes}
+              onChange={setShowTypes}
+              labelPlacement="end"
+            >
+              <Text size="XS" color="text-700">
+                Show types
+              </Text>
+            </Switch>
+          ) : null}
+          <CopyToClipboardButton
+            text={sourceCode}
+            size="S"
+            variant="quiet"
+            tooltipText="Copy code"
+          />
+          <Button
+            size="S"
+            variant="quiet"
+            onPress={() =>
+              onChange(
+                getDefaultCodeEvaluatorSource(
+                  language,
+                  outputShape,
+                  outputConfig
+                )
+              )
+            }
+          >
+            <Icon svg={<Icons.Refresh />} />
+            Reset
+          </Button>
+        </Flex>
       </Flex>
 
       {/* Code editor and type footer with resizable panels */}
@@ -761,28 +791,6 @@ const CodeEditor = ({
             </>
           )}
         </Group>
-        {/* Editor footer toolbar: copy code + toggle the type footer */}
-        <div css={editorFooterCSS}>
-          {typeFooter ? (
-            <Switch
-              isSelected={showTypes}
-              onChange={setShowTypes}
-              labelPlacement="end"
-            >
-              <Text size="XS" color="text-700">
-                Show types
-              </Text>
-            </Switch>
-          ) : (
-            <span />
-          )}
-          <CopyToClipboardButton
-            text={sourceCode}
-            size="S"
-            variant="quiet"
-            tooltipText="Copy code"
-          />
-        </div>
       </div>
     </Flex>
   );
@@ -1223,17 +1231,6 @@ const typeFooterCSS = css`
   & .cm-scroller {
     overflow: auto !important;
   }
-`;
-
-const editorFooterCSS = css`
-  flex: none;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--global-dimension-size-100);
-  padding: var(--global-dimension-size-50) var(--global-dimension-size-100);
-  border-top: 1px solid var(--global-border-color-default);
-  background-color: var(--ac-global-color-grey-100);
 `;
 
 const choiceGridCSS = css`

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -687,33 +687,11 @@ const CodeEditor = ({
         <Text color="text-500" size="XS">
           {descriptionText}
         </Text>
-        <Flex
-          direction="row"
-          alignItems="center"
-          gap="size-150"
-          flex="none"
-          minWidth={0}
-        >
-          {typeFooter ? (
-            <Switch
-              isSelected={showTypes}
-              onChange={setShowTypes}
-              labelPlacement="end"
-            >
-              <Text size="XS" color="text-700">
-                Show types
-              </Text>
-            </Switch>
-          ) : null}
-          <CopyToClipboardButton
-            text={sourceCode}
-            size="S"
-            variant="quiet"
-            tooltipText="Copy code"
-          />
+        <Flex direction="row" alignItems="center" gap="size-100" flex="none">
           <Button
             size="S"
             variant="quiet"
+            leadingVisual={<Icon svg={<Icons.Refresh />} />}
             onPress={() =>
               onChange(
                 getDefaultCodeEvaluatorSource(
@@ -724,9 +702,25 @@ const CodeEditor = ({
               )
             }
           >
-            <Icon svg={<Icons.Refresh />} />
             Reset
           </Button>
+          <CopyToClipboardButton
+            text={sourceCode}
+            size="S"
+            variant="quiet"
+            tooltipText="Copy code"
+          >
+            Copy
+          </CopyToClipboardButton>
+          {typeFooter ? (
+            <Switch
+              isSelected={showTypes}
+              onChange={setShowTypes}
+              labelPlacement="start"
+            >
+              <Text size="S">Show types</Text>
+            </Switch>
+          ) : null}
         </Flex>
       </Flex>
 

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -505,9 +505,8 @@ const ConfiguratorSidebar = ({
         </SectionHeading>
         <div css={sectionContentCSS}>
           <View paddingTop="size-100">
-            <SandboxCapabilitySummaryCard
+            <SandboxRuntimeSummary
               selectedSandboxConfig={selectedSandboxConfig}
-              description="Review the selected runtime before testing execution behavior or saving this evaluator."
             />
           </View>
         </div>
@@ -516,131 +515,48 @@ const ConfiguratorSidebar = ({
   );
 };
 
-const SandboxCapabilitySummaryCard = ({
+const SandboxRuntimeSummary = ({
   selectedSandboxConfig,
-  description,
 }: {
   selectedSandboxConfig: SandboxConfigOption | null;
-  description: string;
 }) => {
+  if (selectedSandboxConfig == null) {
+    return (
+      <View paddingX="size-200">
+        <Text color="text-500" size="XS">
+          Choose a sandbox to review its configured execution settings.
+        </Text>
+      </View>
+    );
+  }
   return (
-    <Flex direction="column" gap="size-100">
-      <Flex direction="column" gap="size-25">
-        <View paddingX="size-200">
-          <Text color="text-500" size="XS">
-            {description}
-          </Text>
-        </View>
-      </Flex>
-      {selectedSandboxConfig == null ? (
-        <View paddingX="size-200">
-          <Text color="text-500" size="XS">
-            Choose a sandbox to review its configured execution settings.
-          </Text>
-        </View>
-      ) : (
-        <Flex direction="column" gap="size-150">
-          <Flex direction="column" gap="size-50">
-            <View paddingX="size-200">
-              <Text weight="heavy" size="XS">
-                Runtime supports
-              </Text>
-            </View>
-            <List size="S">
-              <SandboxCapabilityRow
-                label="env_vars"
-                value={getRuntimeEnvVarsSupportLabel(selectedSandboxConfig)}
-              />
-              <SandboxCapabilityRow
-                label="internet_access"
-                value={getRuntimeInternetAccessSupportLabel(
-                  selectedSandboxConfig
-                )}
-              />
-              <SandboxCapabilityRow
-                label="dependencies"
-                value={getRuntimeDependenciesSupportLabel(
-                  selectedSandboxConfig
-                )}
-              />
-            </List>
-          </Flex>
-          <Flex direction="column" gap="size-50">
-            <View paddingX="size-200">
-              <Text weight="heavy" size="XS">
-                Configured
-              </Text>
-            </View>
-            <List size="S">
-              <SandboxCapabilityRow
-                label="config"
-                value={selectedSandboxConfig.name}
-              />
-              {selectedSandboxConfig.timeout != null ? (
-                <SandboxCapabilityRow
-                  label="timeout"
-                  value={`${selectedSandboxConfig.timeout} seconds`}
-                />
-              ) : null}
-              <SandboxCapabilityRow
-                label="env_vars"
-                value={getSandboxEnvVarsLabel(selectedSandboxConfig.config)}
-              />
-              <SandboxCapabilityRow
-                label="internet_access"
-                value={getSandboxInternetAccessConfigLabel(
-                  selectedSandboxConfig.config
-                )}
-              />
-              <SandboxCapabilityRow
-                label="dependencies"
-                value={getSandboxDependenciesConfigLabel(
-                  selectedSandboxConfig.config
-                )}
-              />
-            </List>
-          </Flex>
-        </Flex>
-      )}
-    </Flex>
+    <List size="S">
+      <SandboxConfigRow label="config" value={selectedSandboxConfig.name} />
+      {selectedSandboxConfig.timeout != null ? (
+        <SandboxConfigRow
+          label="timeout"
+          value={`${selectedSandboxConfig.timeout} seconds`}
+        />
+      ) : null}
+      <SandboxConfigRow
+        label="env_vars"
+        value={getSandboxEnvVarsLabel(selectedSandboxConfig.config)}
+      />
+      <SandboxConfigRow
+        label="internet_access"
+        value={getSandboxInternetAccessConfigLabel(
+          selectedSandboxConfig.config
+        )}
+      />
+      <SandboxConfigRow
+        label="dependencies"
+        value={getSandboxDependenciesConfigLabel(selectedSandboxConfig.config)}
+      />
+    </List>
   );
 };
 
-function getRuntimeEnvVarsSupportLabel(option: SandboxConfigOption) {
-  if (option.supportsEnvVars == null) {
-    return "not advertised";
-  }
-  return option.supportsEnvVars ? "supported" : "not supported";
-}
-
-function getRuntimeInternetAccessSupportLabel(option: SandboxConfigOption) {
-  const value = option.internetAccess;
-  if (value == null) {
-    return "not advertised";
-  }
-  switch (value) {
-    case "BOOLEAN":
-      return "configurable";
-    case "ALLOWLIST":
-      return "allowlist";
-    case "NONE":
-      return "not supported";
-    default:
-      return value;
-  }
-}
-
-function getRuntimeDependenciesSupportLabel(option: SandboxConfigOption) {
-  if (option.dependenciesLanguage === undefined) {
-    return "not advertised";
-  }
-  if (option.dependenciesLanguage == null) {
-    return "not supported";
-  }
-  return option.dependenciesLanguage === "PYTHON" ? "Python" : "TypeScript";
-}
-
-const SandboxCapabilityRow = ({
+const SandboxConfigRow = ({
   label,
   value,
 }: {

--- a/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorDetails.tsx
+++ b/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorDetails.tsx
@@ -12,6 +12,7 @@ import {
   Flex,
   Icon,
   Icons,
+  LinkButton,
   List,
   ListItem,
   Text,
@@ -19,6 +20,7 @@ import {
 } from "@phoenix/components";
 import { CodeEvaluatorSourceCodeBlock } from "@phoenix/components/evaluators/CodeEvaluatorSourceCodeBlock";
 import { SandboxProviderIcon } from "@phoenix/components/sandbox/SandboxProviderIcon";
+import { useViewerCanManageSandboxes } from "@phoenix/contexts";
 import type { CodeDatasetEvaluatorDetails_datasetEvaluator$key } from "@phoenix/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorDetails_datasetEvaluator.graphql";
 import type { datasetEvaluatorDetailsLoaderQuery } from "@phoenix/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql";
 import {
@@ -508,6 +510,8 @@ export function CodeDatasetEvaluatorDetails({
     [datasetEvaluator.inputMapping.literalMapping]
   );
 
+  const canManageSandboxes = useViewerCanManageSandboxes();
+
   const customSettings = useMemo(() => {
     if (sandboxConfig == null) return null;
     if (summarizeConfig(sandboxConfig.config) === "No custom settings") {
@@ -593,6 +597,16 @@ export function CodeDatasetEvaluatorDetails({
                 <Icon svg={<Icons.HardDriveOutline />} />
                 <span>Sandbox</span>
               </Flex>
+            }
+            extra={
+              canManageSandboxes ? (
+                <LinkButton
+                  size="S"
+                  to="/settings/sandboxes"
+                  aria-label="Configure sandboxes"
+                  leadingVisual={<Icon svg={<Icons.SettingsOutline />} />}
+                />
+              ) : undefined
             }
           >
             {sandboxConfig == null ? (

--- a/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorVersions.tsx
+++ b/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorVersions.tsx
@@ -8,6 +8,7 @@ import invariant from "tiny-invariant";
 
 import {
   Card,
+  CopyToClipboardButton,
   Empty,
   Flex,
   Switch,
@@ -188,14 +189,21 @@ function VersionDetail({
         <Card
           title={`Version ${version.sequenceNumber}`}
           extra={
-            <Switch
-              labelPlacement="start"
-              isSelected={showDiff && hasPreviousVersion}
-              isDisabled={!hasPreviousVersion}
-              onChange={setShowDiff}
-            >
-              Diff
-            </Switch>
+            <Flex direction="row" alignItems="center" gap="size-200">
+              <Switch
+                labelPlacement="start"
+                isSelected={showDiff && hasPreviousVersion}
+                isDisabled={!hasPreviousVersion}
+                onChange={setShowDiff}
+              >
+                Diff
+              </Switch>
+              <CopyToClipboardButton
+                text={version.sourceCode}
+                size="S"
+                tooltipText="Copy code"
+              />
+            </Flex>
           }
         >
           {showDiff && previousVersion ? (

--- a/app/tests/code-evaluators.spec.ts
+++ b/app/tests/code-evaluators.spec.ts
@@ -666,22 +666,20 @@ test.describe.serial("Code Evaluators", () => {
       await selectSandbox(page, dialog, pythonSandboxName);
     }
 
-    // The Test Evaluator disclosure is expanded by default in the editor
-    // (DisclosureGroup defaultExpandedKeys includes test-section), so the
-    // contents should be visible without an explicit click.
+    // The "Test Evaluator" region is always rendered in the sidebar (no
+    // disclosure to expand), labeled by a section heading, so its contents
+    // are visible without any interaction.
+    await expect(
+      dialog.getByRole("heading", { name: "Test Evaluator" })
+    ).toBeVisible();
+
     const testButton = dialog.getByRole("button", {
       name: "Test",
       exact: true,
     });
     await expect(testButton).toBeVisible();
 
-    // The disclosure trigger lives inside the dialog as a button labeled
-    // "Test Evaluator" with aria-expanded=true on first render.
-    await expect(
-      dialog.getByRole("button", { name: "Test Evaluator" })
-    ).toHaveAttribute("aria-expanded", "true");
-
-    // The descriptive copy under the Test button.
+    // The descriptive copy next to the Test button.
     await expect(
       dialog.getByText(
         "Run your evaluator against the example data to verify it works correctly"


### PR DESCRIPTION

<img width="2433" height="1326" alt="Screenshot 2026-05-11 at 2 07 08 PM" src="https://github.com/user-attachments/assets/05998cf8-7ba5-4ca8-a0a8-aa7509598779" />


A handful of related UI tweaks around sandbox configuration in the code evaluator flows.

### 1. Config link button on the evaluator details page

The **Sandbox** card on the code evaluator details page now has a gear link-button in its top-right (`extra`) slot that navigates to `/settings/sandboxes`. It's only rendered when the viewer can manage sandboxes (`useViewerCanManageSandboxes()` — admin role, or auth disabled).

`LinkButton` previously dropped `aria-label` (it only picked a fixed set of props). It now forwards `aria-label` to the underlying `<Link>`, so the icon-only variant has an accessible name — matching the existing `<Button variant="quiet" size="S" leadingVisual={...} aria-label={...} />` pattern used elsewhere (e.g. `PromptLabelConfigButton`).

Note: this links to the sandboxes settings list page; there's no per-config deep-link route.

### 2. Code evaluator edit/create sidebar layout

The right-hand sidebar in the code evaluator edit/create dialog no longer wraps its sections in a collapsible `DisclosureGroup`. Instead:
- **Test Evaluator** fills the panel and scrolls on overflow.
- **Sandbox Runtime** is pinned to the bottom of the panel and stays visible (it scrolls internally and is capped at 50% height so the test region always keeps room).

Section headers use the shared `SectionHeading` component. Removed the redundant inner `Test Evaluator` heading from `CodeEvaluatorTestSection` (the section header already labels it) — the "Test" button now sits at the top-right next to the description.

### 3. Trimmed Sandbox Runtime summary

The Sandbox Runtime section no longer shows the intro blurb or the "Runtime supports" capability list. It now just shows the configured fields that matter: `config`, `timeout`, `env_vars`, `internet_access`, `dependencies` (and a "Choose a sandbox…" placeholder when none is selected). Also dropped the extra padding around the list so it sits flush under the section heading.

### 4. Code editor header controls

The code editor's header (next to the **Reset** button) gets a copy-code button and a **Show types** switch that toggles the auto-generated read-only type footer. The type footer is now hidden by default.

### 5. Copy-code button on the version history card

The version detail card in the code evaluator **Versions** tab gets a copy-to-clipboard button in its top-right (`extra`) slot, alongside the existing **Diff** switch, so the source for any version can be copied.

## Changes
- `app/src/pages/dataset/evaluators/CodeDatasetEvaluatorDetails.tsx` — add `extra` gear `LinkButton` to the Sandbox `Card`, gated on `useViewerCanManageSandboxes()`.
- `app/src/components/core/button/LinkButton.tsx` — forward `aria-label` through to the link.
- `app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx` — replace the sidebar `DisclosureGroup` with a scroll region + pinned footer; trim the runtime summary; tidy padding; add the copy + show-types controls to the editor header (types hidden by default); rename `accordionContentCSS` → `sectionContentCSS`, `SandboxCapabilitySummaryCard` → `SandboxRuntimeSummary`, `SandboxCapabilityRow` → `SandboxConfigRow`.
- `app/src/components/evaluators/CodeEvaluatorTestSection.tsx` — drop the redundant inner `Test Evaluator` heading; move the Test button next to the description.
- `app/src/pages/dataset/evaluators/CodeDatasetEvaluatorVersions.tsx` — add a `CopyToClipboardButton` to the version detail card's `extra` slot next to the Diff switch.

## Test plan
- [ ] As an admin (or auth disabled), open a code evaluator's details page → gear button appears top-right of the Sandbox card and links to `/settings/sandboxes`.
- [ ] As a non-admin viewer, the gear button is not rendered.
- [ ] In the code evaluator edit/create dialog, the "Test Evaluator" section scrolls and "Sandbox Runtime" stays pinned at the bottom of the right panel.
- [ ] The Sandbox Runtime section shows only config / timeout / env_vars / internet_access / dependencies, with no duplicate "Test Evaluator" heading above the test section.
- [ ] The code editor header has a copy button and a "Show types" switch (next to Reset); the switch is off by default and toggling it shows/hides the generated type footer.
- [ ] In the Versions tab, the version detail card has a copy button next to the Diff switch that copies that version's source.
