### PR TITLE
feat(sandbox): wire runtime dependency install for Vercel backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ dev = [
   "ldap3",
   "litellm>=1.83.14,<1.84",  # >=1.83.14 fixes CVE-2026-42208 (SQLi), MCP stdio RCE, SSTI, OIDC bypass, password hash exposure, privilege escalation; excludes 1.82.7-1.82.8 supply chain compromise; <1.84 caps the minor
   "modal>=1.2.0",  # type-checking only; runtime is gated by the [modal] extra
-  "vercel>=0.5.1",  # type-checking only; runtime is gated by the [vercel] extra
+  "vercel>=0.5.8",  # type-checking only; runtime is gated by the [vercel] extra. 0.5.8 exposes `network_policy` on AsyncSandbox.create.
   "mypy==1.19.1",
   "mypy-boto3-bedrock-runtime",
   "nest-asyncio",  # for executor testing
@@ -189,7 +189,7 @@ daytona = [
   "daytona-sdk>=0.140.0",
 ]
 vercel = [
-  "vercel>=0.5.1",
+  "vercel>=0.5.8",  # 0.5.8 exposes `network_policy` on AsyncSandbox.create
   "websockets>=14.0",
 ]
 modal = [
@@ -234,7 +234,7 @@ container = [
   "wasmtime>=15.0",
   "e2b-code-interpreter>=0.0.12",
   "daytona-sdk>=0.140.0",
-  "vercel>=0.5.1",
+  "vercel>=0.5.8",
   "websockets>=14.0",
   "modal>=1.2.0",
 ]

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -268,29 +268,47 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         installs_packages_at_runtime=True,
     ),
     # Vercel Python SDK checked: pyproject minimum vercel>=0.5.1; uv.lock resolves
-    # vercel==0.5.7. AsyncSandbox.create() in 0.5.7 does not accept `env` or
-    # `network_policy` kwargs — the TypeScript Vercel SDK exposes both, but the
-    # Python SDK has not yet ported them. Re-evaluate when Python SDK >=0.5.8
-    # ships; flip internet_access_capability to "boolean" and wire network_policy
-    # then. Until that lands, both Vercel adapters remain internet_access="none".
-    **{
-        f"VERCEL_{lang}": AdapterMetadata(
-            display_name="Vercel",
-            language=lang,
-            hosting_type="hosted",
-            dependency_hints=[
-                "Install Phoenix with the `vercel` extra.",
-                (
-                    "Set all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`. "
-                    "See https://vercel.com/docs/vercel-sandbox/concepts/authentication"
-                ),
-            ],
-            supports_env_vars=True,
-            internet_access_capability="none",
-            dependencies_language=None,
-        )
-        for lang in ("PYTHON", "TYPESCRIPT")
-    },
+    # vercel==0.5.7. Runtime dependency install is wired via `_install_packages`
+    # in VercelSandboxBackend: PYTHON → `python3 -m pip install --user <pkgs>`,
+    # TYPESCRIPT → `npm install <pkgs>`. AsyncSandbox.create() in 0.5.7 does not
+    # yet accept a `network_policy` kwarg — the TypeScript Vercel SDK exposes
+    # it but the Python SDK has not ported it. Re-evaluate when Python SDK
+    # >=0.5.8 ships; flip internet_access_capability to "boolean" and wire
+    # network_policy then. Until that lands, both Vercel adapters remain
+    # internet_access="none"; the runtime-install + network-deny interlock at
+    # types.py:664 / :788 is dormant because deny mode is unreachable.
+    "VERCEL_PYTHON": AdapterMetadata(
+        display_name="Vercel",
+        language="PYTHON",
+        hosting_type="hosted",
+        dependency_hints=[
+            "Install Phoenix with the `vercel` extra.",
+            (
+                "Set all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`. "
+                "See https://vercel.com/docs/vercel-sandbox/concepts/authentication"
+            ),
+        ],
+        supports_env_vars=True,
+        internet_access_capability="none",
+        dependencies_language="PYTHON",
+        installs_packages_at_runtime=True,
+    ),
+    "VERCEL_TYPESCRIPT": AdapterMetadata(
+        display_name="Vercel",
+        language="TYPESCRIPT",
+        hosting_type="hosted",
+        dependency_hints=[
+            "Install Phoenix with the `vercel` extra.",
+            (
+                "Set all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`. "
+                "See https://vercel.com/docs/vercel-sandbox/concepts/authentication"
+            ),
+        ],
+        supports_env_vars=True,
+        internet_access_capability="none",
+        dependencies_language="TYPESCRIPT",
+        installs_packages_at_runtime=True,
+    ),
     "DENO": AdapterMetadata(
         display_name="Deno",
         language="TYPESCRIPT",

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -267,16 +267,14 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         dependencies_language="PYTHON",
         installs_packages_at_runtime=True,
     ),
-    # Vercel Python SDK checked: pyproject minimum vercel>=0.5.1; uv.lock resolves
-    # vercel==0.5.7. Runtime dependency install is wired via `_install_packages`
+    # Vercel Python SDK checked: pyproject minimum vercel>=0.5.8; uv.lock resolves
+    # vercel==0.5.8. Runtime dependency install is wired via `_install_packages`
     # in VercelSandboxBackend: PYTHON → `python3 -m pip install --user <pkgs>`,
-    # TYPESCRIPT → `npm install <pkgs>`. AsyncSandbox.create() in 0.5.7 does not
-    # yet accept a `network_policy` kwarg — the TypeScript Vercel SDK exposes
-    # it but the Python SDK has not ported it. Re-evaluate when Python SDK
-    # >=0.5.8 ships; flip internet_access_capability to "boolean" and wire
-    # network_policy then. Until that lands, both Vercel adapters remain
-    # internet_access="none"; the runtime-install + network-deny interlock at
-    # types.py:664 / :788 is dormant because deny mode is unreachable.
+    # TYPESCRIPT → `npm install <pkgs>`. AsyncSandbox.create() in 0.5.8 accepts a
+    # `network_policy` kwarg — VercelSandboxBackend maps internet_access.mode
+    # to "allow-all" / "deny-all" string forms. internet_access_capability is
+    # "boolean"; the runtime-install + network-deny interlock at types.py:688 /
+    # :812 now rejects deny + non-empty dependencies.packages eagerly.
     "VERCEL_PYTHON": AdapterMetadata(
         display_name="Vercel",
         language="PYTHON",
@@ -289,7 +287,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
             ),
         ],
         supports_env_vars=True,
-        internet_access_capability="none",
+        internet_access_capability="boolean",
         dependencies_language="PYTHON",
         installs_packages_at_runtime=True,
     ),
@@ -305,7 +303,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
             ),
         ],
         supports_env_vars=True,
-        internet_access_capability="none",
+        internet_access_capability="boolean",
         dependencies_language="TYPESCRIPT",
         installs_packages_at_runtime=True,
     ),

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -115,6 +115,7 @@ class VercelSandboxBackend(SandboxBackend):
         team_id: Optional[str] = None,
         language: str = _DEFAULT_LANGUAGE,
         user_env: Optional[dict[str, str]] = None,
+        packages: Optional[list[str]] = None,
     ) -> None:
         self._oidc_token = oidc_token
         self._token = token
@@ -126,6 +127,7 @@ class VercelSandboxBackend(SandboxBackend):
             )
         self._language = language.upper() if language else _DEFAULT_LANGUAGE
         self._user_env: dict[str, str] = user_env or {}
+        self._packages: list[str] = packages or []
         self._sessions: dict[str, AsyncSandbox] = {}
         self._session_locks: dict[str, asyncio.Lock] = {}
         self.secret_values = compose_secret_values(user_env, self._oidc_token, self._token)
@@ -160,6 +162,34 @@ class VercelSandboxBackend(SandboxBackend):
         create_kwargs["team_id"] = self._team_id
         return await AsyncSandbox.create(**create_kwargs)
 
+    async def _install_packages(self, sandbox: AsyncSandbox) -> None:
+        """Run language-routed install for configured packages before user code.
+
+        PYTHON → `python3 -m pip install --user <pkgs>` (invoked through the
+        same `python3` binary the exec path uses, so install and execute target
+        the same interpreter; `--user` avoids needing sudo and writes to the
+        sandbox user's ~/.local).
+        TYPESCRIPT → `npm install <pkgs>` from the default cwd.
+
+        Raises RuntimeError(stderr) on non-zero exit so callers (start_session
+        and ephemeral execute) can either propagate as a fail-fast session
+        startup error or surface as an ExecutionResult.error.
+        """
+        if not self._packages:
+            return
+        if self._language == "PYTHON":
+            cmd = "python3"
+            args = ["-m", "pip", "install", "--user", *self._packages]
+        else:
+            cmd = "npm"
+            args = ["install", *self._packages]
+        result = await sandbox.run_command(cmd, args)
+        if result.exit_code != 0:
+            stderr = await result.stderr()
+            raise RuntimeError(
+                f"{cmd} install {self._packages!r} failed (exit {result.exit_code}): {stderr}"
+            )
+
     async def start_session(self, session_key: str) -> None:
         if session_key not in self._session_locks:
             self._session_locks[session_key] = asyncio.Lock()
@@ -168,6 +198,29 @@ class VercelSandboxBackend(SandboxBackend):
                 logger.debug(f"Vercel session '{session_key}' already exists; reusing")
                 return
             sandbox = await self._create_sandbox()
+            try:
+                await self._install_packages(sandbox)
+            except Exception:
+                # Install failed — the sandbox is live but unusable. Stop and
+                # close it before re-raising so we don't leak a billable
+                # Vercel resource that lingers until the SDK's idle timeout.
+                try:
+                    await sandbox.stop()
+                except Exception:
+                    logger.debug(
+                        f"Error stopping Vercel sandbox after install failure for "
+                        f"session '{session_key}'",
+                        exc_info=True,
+                    )
+                try:
+                    await sandbox.client.aclose()
+                except Exception:
+                    logger.debug(
+                        f"Error closing Vercel client after install failure for "
+                        f"session '{session_key}'",
+                        exc_info=True,
+                    )
+                raise
             self._sessions[session_key] = sandbox
         logger.debug(f"Started Vercel session '{session_key}'")
 
@@ -213,9 +266,10 @@ class VercelSandboxBackend(SandboxBackend):
             if sandbox is not None:
                 return await self._exec_code(sandbox, code, env=session_env)
             else:
-                # Ephemeral: create, exec, stop.
+                # Ephemeral: create, install (if configured), exec, stop.
                 sandbox = await self._create_sandbox()
                 try:
+                    await self._install_packages(sandbox)
                     return await self._exec_code(sandbox, code, env=session_env)
                 finally:
                     try:
@@ -302,8 +356,15 @@ class VercelPythonAdapter(SandboxAdapter):
     ) -> SandboxBackend:
         self._enforce_capabilities(config, user_env)
         oidc_token = _resolve_vercel_oidc_token(config)
+        deps = config.get("dependencies") or {}
+        packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []
         if oidc_token:
-            return VercelSandboxBackend(oidc_token=oidc_token, language="PYTHON", user_env=user_env)
+            return VercelSandboxBackend(
+                oidc_token=oidc_token,
+                language="PYTHON",
+                user_env=user_env,
+                packages=packages,
+            )
 
         token = _resolve_vercel_access_token(config)
         project_id = _resolve_vercel_project_id(config)
@@ -315,6 +376,7 @@ class VercelPythonAdapter(SandboxAdapter):
                 team_id=team_id,
                 language="PYTHON",
                 user_env=user_env,
+                packages=packages,
             )
         raise ValueError(
             "Vercel sandbox authentication is not configured. Set "
@@ -343,9 +405,14 @@ class VercelTypescriptAdapter(SandboxAdapter):
     ) -> SandboxBackend:
         self._enforce_capabilities(config, user_env)
         oidc_token = _resolve_vercel_oidc_token(config)
+        deps = config.get("dependencies") or {}
+        packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []
         if oidc_token:
             return VercelSandboxBackend(
-                oidc_token=oidc_token, language="TYPESCRIPT", user_env=user_env
+                oidc_token=oidc_token,
+                language="TYPESCRIPT",
+                user_env=user_env,
+                packages=packages,
             )
 
         token = _resolve_vercel_access_token(config)
@@ -358,6 +425,7 @@ class VercelTypescriptAdapter(SandboxAdapter):
                 team_id=team_id,
                 language="TYPESCRIPT",
                 user_env=user_env,
+                packages=packages,
             )
         raise ValueError(
             "Vercel sandbox authentication is not configured. Set "

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -93,7 +93,7 @@ _VERCEL_OIDC_ENV_LOCK = asyncio.Lock()
 
 
 class VercelSandboxBackend(SandboxBackend):
-    """Sandbox backend executing code via Vercel Sandbox (vercel >= 0.5.1).
+    """Sandbox backend executing code via Vercel Sandbox (vercel >= 0.5.8).
 
     Supports named sessions via start_session/stop_session for sandbox reuse
     across multiple execute() calls, or ephemeral execution (no session) which
@@ -104,6 +104,11 @@ class VercelSandboxBackend(SandboxBackend):
     the SDK only autodiscovers OIDC from env), or the access-token triple
     ``token``/``project_id``/``team_id`` (forwarded directly to
     ``AsyncSandbox.create`` as kwargs).
+
+    Network policy: pass ``internet_access`` as ``True`` (allow-all),
+    ``False`` (deny-all), or ``None`` (omit — let the SDK default apply).
+    The string form is forwarded to ``AsyncSandbox.create(network_policy=)``;
+    the SDK accepts ``"allow-all"`` / ``"deny-all"`` and converts internally.
     """
 
     def __init__(
@@ -116,6 +121,7 @@ class VercelSandboxBackend(SandboxBackend):
         language: str = _DEFAULT_LANGUAGE,
         user_env: Optional[dict[str, str]] = None,
         packages: Optional[list[str]] = None,
+        internet_access: Optional[bool] = None,
     ) -> None:
         self._oidc_token = oidc_token
         self._token = token
@@ -128,6 +134,7 @@ class VercelSandboxBackend(SandboxBackend):
         self._language = language.upper() if language else _DEFAULT_LANGUAGE
         self._user_env: dict[str, str] = user_env or {}
         self._packages: list[str] = packages or []
+        self._internet_access = internet_access
         self._sessions: dict[str, AsyncSandbox] = {}
         self._session_locks: dict[str, asyncio.Lock] = {}
         self.secret_values = compose_secret_values(user_env, self._oidc_token, self._token)
@@ -135,11 +142,25 @@ class VercelSandboxBackend(SandboxBackend):
     def _lang_cfg(self) -> _LanguageConfig:
         return _LANGUAGE_CONFIGS.get(self._language, _LANGUAGE_CONFIGS[_DEFAULT_LANGUAGE])
 
+    def _network_policy(self) -> Optional[str]:
+        """Map ``internet_access`` (True/False/None) to the SDK string form.
+
+        Returned values: ``"allow-all"``, ``"deny-all"``, or ``None`` to omit
+        the kwarg entirely (SDK default applies). The Vercel SDK accepts these
+        string aliases on ``AsyncSandbox.create(network_policy=)`` as of 0.5.8.
+        """
+        if self._internet_access is None:
+            return None
+        return "allow-all" if self._internet_access else "deny-all"
+
     async def _create_sandbox(self) -> AsyncSandbox:
         from vercel.sandbox import AsyncSandbox
 
         runtime: str = self._lang_cfg()["runtime"]
         create_kwargs: dict[str, Any] = {"runtime": runtime}
+        network_policy = self._network_policy()
+        if network_policy is not None:
+            create_kwargs["network_policy"] = network_policy
         if self._oidc_token:
             # SDK reads VERCEL_OIDC_TOKEN from os.environ synchronously at the
             # top of AsyncSandbox.create() (before any await), then captures
@@ -301,6 +322,29 @@ def _resolve_vercel_oidc_token(config: dict[str, Any]) -> str:
     return str(config.get(ENV_VERCEL_OIDC_TOKEN) or "") or os.environ.get(ENV_VERCEL_OIDC_TOKEN, "")
 
 
+def _resolve_internet_access(config: dict[str, Any]) -> Optional[bool]:
+    """Project an InternetAccessConfig mode onto a tri-state bool/None.
+
+    ``None`` means the config did not specify internet_access at all — let
+    the Vercel SDK default apply (i.e., omit network_policy=). ``True`` →
+    "allow-all", ``False`` → "deny-all"; the string mapping lives in
+    ``VercelSandboxBackend._network_policy``.
+    """
+    internet_access = config.get("internet_access")
+    if internet_access is None:
+        return None
+    mode = (
+        internet_access.get("mode")
+        if isinstance(internet_access, dict)
+        else getattr(internet_access, "mode", None)
+    )
+    if mode == "deny":
+        return False
+    if mode == "allow":
+        return True
+    return None
+
+
 # UI surfaces only the access-token triple. OIDC is still honored when
 # VERCEL_OIDC_TOKEN is present in the process environment (e.g. `vercel env
 # pull` or running on Vercel) — see get_missing_sandbox_auth_detail and
@@ -358,12 +402,14 @@ class VercelPythonAdapter(SandboxAdapter):
         oidc_token = _resolve_vercel_oidc_token(config)
         deps = config.get("dependencies") or {}
         packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []
+        internet_access = _resolve_internet_access(config)
         if oidc_token:
             return VercelSandboxBackend(
                 oidc_token=oidc_token,
                 language="PYTHON",
                 user_env=user_env,
                 packages=packages,
+                internet_access=internet_access,
             )
 
         token = _resolve_vercel_access_token(config)
@@ -377,6 +423,7 @@ class VercelPythonAdapter(SandboxAdapter):
                 language="PYTHON",
                 user_env=user_env,
                 packages=packages,
+                internet_access=internet_access,
             )
         raise ValueError(
             "Vercel sandbox authentication is not configured. Set "
@@ -407,12 +454,14 @@ class VercelTypescriptAdapter(SandboxAdapter):
         oidc_token = _resolve_vercel_oidc_token(config)
         deps = config.get("dependencies") or {}
         packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []
+        internet_access = _resolve_internet_access(config)
         if oidc_token:
             return VercelSandboxBackend(
                 oidc_token=oidc_token,
                 language="TYPESCRIPT",
                 user_env=user_env,
                 packages=packages,
+                internet_access=internet_access,
             )
 
         token = _resolve_vercel_access_token(config)
@@ -426,6 +475,7 @@ class VercelTypescriptAdapter(SandboxAdapter):
                 language="TYPESCRIPT",
                 user_env=user_env,
                 packages=packages,
+                internet_access=internet_access,
             )
         raise ValueError(
             "Vercel sandbox authentication is not configured. Set "

--- a/tests/unit/server/sandbox/test_capability_matrix.py
+++ b/tests/unit/server/sandbox/test_capability_matrix.py
@@ -257,6 +257,21 @@ def test_daytona_build_backend_wires_packages_to_backend() -> None:
     assert backend._packages == packages
 
 
+@pytest.mark.parametrize("adapter_key", ["VERCEL_PYTHON", "VERCEL_TYPESCRIPT"])
+def test_vercel_build_backend_wires_packages_to_backend(adapter_key: str) -> None:
+    """VERCEL_* build_backend forwards packages list to VercelSandboxBackend._packages."""
+    adapter = _get_adapter(adapter_key)
+    packages = ["requests", "numpy"]
+    config = {
+        "VERCEL_TOKEN": "t",
+        "VERCEL_PROJECT_ID": "p",
+        "VERCEL_TEAM_ID": "m",
+        "dependencies": {"packages": packages},
+    }
+    backend = adapter.build_backend(config)
+    assert backend._packages == packages
+
+
 def test_modal_build_backend_wires_packages_to_image() -> None:
     """MODAL build_backend calls Image.pip_install with packages."""
     modal_mock = _modal_mock()

--- a/tests/unit/server/sandbox/test_unified_config_contract.py
+++ b/tests/unit/server/sandbox/test_unified_config_contract.py
@@ -19,8 +19,8 @@ or deploy; targeted coverage is added then.
 
 SDK mocking strategy:
 - Modal: sys.modules["modal"] must be patched before ModalSandboxBackend.__init__
-- Vercel: the unsupported-capability guard fires before credential access so no
-  env patching is needed for the rejection tests.
+- Vercel: the unsupported-capability and interlock guards fire before credential
+  access so no env patching is needed for the rejection tests.
 - Deno/Daytona/E2B/WASM: construct without external SDKs.
 """
 
@@ -104,11 +104,6 @@ def test_internet_access_none_raises_for_non_none_config(adapter_key: str) -> No
             adapter = _get_adapter(adapter_key)
             with pytest.raises(UnsupportedOperation):
                 adapter.build_backend(_INTERNET_ACCESS_CONFIG)
-    elif adapter_key in ("VERCEL_PYTHON", "VERCEL_TYPESCRIPT"):
-        # Guard fires before credential check; no env patching needed.
-        adapter = _get_adapter(adapter_key)
-        with pytest.raises(UnsupportedOperation):
-            adapter.build_backend(_INTERNET_ACCESS_CONFIG)
     else:
         adapter = _get_adapter(adapter_key)
         with pytest.raises(UnsupportedOperation):

--- a/tests/unit/server/sandbox/test_vercel_backend.py
+++ b/tests/unit/server/sandbox/test_vercel_backend.py
@@ -19,18 +19,26 @@ from phoenix.server.sandbox.vercel_backend import (
 )
 
 
-def _make_vercel_sdk_mock() -> tuple[MagicMock, list[str | None]]:
+def _make_vercel_sdk_mock(
+    captured_kwargs: list[dict[str, Any]] | None = None,
+) -> tuple[MagicMock, list[str | None]]:
     """Return (sdk module mock, list capturing os.environ[VERCEL_OIDC_TOKEN]
     snapshots taken at AsyncSandbox.create() invocation time).
 
     The captured snapshots let tests assert what the SDK would have read from
     the env synchronously at the top of create() — i.e. whether Phoenix's env
     injection actually took effect at the moment the SDK reads it.
+
+    If ``captured_kwargs`` is provided, every create() call appends a snapshot
+    of its kwargs dict so tests can assert the SDK kwarg shape (e.g.,
+    network_policy presence/value).
     """
     captured_env: list[str | None] = []
 
-    async def _create(**_: Any) -> Any:
+    async def _create(**kwargs: Any) -> Any:
         captured_env.append(os.environ.get(ENV_VERCEL_OIDC_TOKEN))
+        if captured_kwargs is not None:
+            captured_kwargs.append(dict(kwargs))
         sandbox = MagicMock()
         sandbox.stop = AsyncMock()
         sandbox.client = MagicMock()
@@ -53,6 +61,20 @@ def patched_vercel_sdk() -> Any:
     parent.sandbox = sdk
     with patch.dict(sys.modules, {"vercel": parent, "vercel.sandbox": sdk}):
         yield sdk, captured_env
+
+
+@pytest.fixture
+def patched_vercel_sdk_with_kwargs() -> Any:
+    """Like ``patched_vercel_sdk`` but also yields a list capturing the kwargs
+    passed to every AsyncSandbox.create() call. Tests use this to assert the
+    network_policy kwarg shape forwarded to the Vercel SDK.
+    """
+    captured_kwargs: list[dict[str, Any]] = []
+    sdk, captured_env = _make_vercel_sdk_mock(captured_kwargs=captured_kwargs)
+    parent = MagicMock()
+    parent.sandbox = sdk
+    with patch.dict(sys.modules, {"vercel": parent, "vercel.sandbox": sdk}):
+        yield sdk, captured_env, captured_kwargs
 
 
 @pytest.mark.asyncio
@@ -318,3 +340,149 @@ async def test_ephemeral_execute_install_failure_surfaces_as_execution_error(
     sandbox_mock.stop.assert_awaited_once()
     sandbox_mock.client.aclose.assert_awaited_once()
     assert "ephemeral" not in backend._sessions
+
+
+# ---------------------------------------------------------------------------
+# network_policy forwarding — internet_access → AsyncSandbox.create(network_policy=)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_forwards_network_policy_allow_all(
+    patched_vercel_sdk_with_kwargs: tuple[MagicMock, list[str | None], list[dict[str, Any]]],
+) -> None:
+    """internet_access=True → AsyncSandbox.create receives network_policy='allow-all'.
+
+    Vercel SDK >=0.5.8 accepts the string alias and converts internally; we
+    forward the alias rather than constructing a NetworkPolicyCustom.
+    """
+    _, _captured_env, captured_kwargs = patched_vercel_sdk_with_kwargs
+    backend = VercelSandboxBackend(oidc_token="t", language="PYTHON", internet_access=True)
+    await backend._create_sandbox()
+    assert len(captured_kwargs) == 1
+    assert captured_kwargs[0].get("network_policy") == "allow-all", (
+        f"Expected network_policy='allow-all'; got {captured_kwargs[0]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_forwards_network_policy_deny_all(
+    patched_vercel_sdk_with_kwargs: tuple[MagicMock, list[str | None], list[dict[str, Any]]],
+) -> None:
+    """internet_access=False → AsyncSandbox.create receives network_policy='deny-all'."""
+    _, _captured_env, captured_kwargs = patched_vercel_sdk_with_kwargs
+    backend = VercelSandboxBackend(oidc_token="t", language="PYTHON", internet_access=False)
+    await backend._create_sandbox()
+    assert len(captured_kwargs) == 1
+    assert captured_kwargs[0].get("network_policy") == "deny-all", (
+        f"Expected network_policy='deny-all'; got {captured_kwargs[0]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_omits_network_policy_when_internet_access_unset(
+    patched_vercel_sdk_with_kwargs: tuple[MagicMock, list[str | None], list[dict[str, Any]]],
+) -> None:
+    """internet_access=None → network_policy kwarg is not forwarded.
+
+    Omitting (rather than passing None) lets the SDK default apply. If the SDK
+    changes its default behavior in the future we won't accidentally override it.
+    """
+    _, _captured_env, captured_kwargs = patched_vercel_sdk_with_kwargs
+    backend = VercelSandboxBackend(oidc_token="t", language="PYTHON")
+    await backend._create_sandbox()
+    assert len(captured_kwargs) == 1
+    assert "network_policy" not in captured_kwargs[0], (
+        f"network_policy must be omitted when internet_access is None; got {captured_kwargs[0]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adapter-level wiring — config internet_access.mode → backend internet_access
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "adapter_module_path,adapter_cls_name,language",
+    [
+        ("phoenix.server.sandbox.vercel_backend", "VercelPythonAdapter", "PYTHON"),
+        ("phoenix.server.sandbox.vercel_backend", "VercelTypescriptAdapter", "TYPESCRIPT"),
+    ],
+)
+def test_adapter_build_backend_maps_internet_access_allow(
+    adapter_module_path: str, adapter_cls_name: str, language: str
+) -> None:
+    """Adapter build_backend extracts internet_access.mode='allow' from config
+    and constructs VercelSandboxBackend(internet_access=True).
+    """
+    import importlib
+
+    mod = importlib.import_module(adapter_module_path)
+    adapter = getattr(mod, adapter_cls_name)()
+    backend = adapter.build_backend(
+        {
+            "internet_access": {"mode": "allow"},
+            "VERCEL_TOKEN": "t",
+            "VERCEL_PROJECT_ID": "p",
+            "VERCEL_TEAM_ID": "m",
+        }
+    )
+    assert backend._internet_access is True
+    assert backend._language == language
+
+
+@pytest.mark.parametrize(
+    "adapter_module_path,adapter_cls_name",
+    [
+        ("phoenix.server.sandbox.vercel_backend", "VercelPythonAdapter"),
+        ("phoenix.server.sandbox.vercel_backend", "VercelTypescriptAdapter"),
+    ],
+)
+def test_adapter_build_backend_maps_internet_access_deny_no_packages(
+    adapter_module_path: str, adapter_cls_name: str
+) -> None:
+    """internet_access.mode='deny' without packages → backend(internet_access=False).
+
+    The runtime-install + deny interlock only fires when packages are non-empty;
+    deny alone is permitted.
+    """
+    import importlib
+
+    mod = importlib.import_module(adapter_module_path)
+    adapter = getattr(mod, adapter_cls_name)()
+    backend = adapter.build_backend(
+        {
+            "internet_access": {"mode": "deny"},
+            "VERCEL_TOKEN": "t",
+            "VERCEL_PROJECT_ID": "p",
+            "VERCEL_TEAM_ID": "m",
+        }
+    )
+    assert backend._internet_access is False
+
+
+@pytest.mark.parametrize(
+    "adapter_module_path,adapter_cls_name",
+    [
+        ("phoenix.server.sandbox.vercel_backend", "VercelPythonAdapter"),
+        ("phoenix.server.sandbox.vercel_backend", "VercelTypescriptAdapter"),
+    ],
+)
+def test_adapter_build_backend_omits_internet_access_when_absent(
+    adapter_module_path: str, adapter_cls_name: str
+) -> None:
+    """When config has no internet_access field, backend._internet_access is None
+    so AsyncSandbox.create is called without the network_policy kwarg.
+    """
+    import importlib
+
+    mod = importlib.import_module(adapter_module_path)
+    adapter = getattr(mod, adapter_cls_name)()
+    backend = adapter.build_backend(
+        {
+            "VERCEL_TOKEN": "t",
+            "VERCEL_PROJECT_ID": "p",
+            "VERCEL_TEAM_ID": "m",
+        }
+    )
+    assert backend._internet_access is None

--- a/tests/unit/server/sandbox/test_vercel_backend.py
+++ b/tests/unit/server/sandbox/test_vercel_backend.py
@@ -136,3 +136,185 @@ async def test_access_token_path_does_not_touch_oidc_env(
 def test_constructor_rejects_no_credentials() -> None:
     with pytest.raises(ValueError, match="oidc_token"):
         VercelSandboxBackend(language="PYTHON")
+
+
+# ---------------------------------------------------------------------------
+# Package install — language-routed run_command argv shape
+# ---------------------------------------------------------------------------
+
+
+def _make_install_sandbox_mock(
+    install_exit_code: int = 0,
+    install_stderr: str = "",
+) -> tuple[MagicMock, list[tuple[str, list[str]]]]:
+    """Return (sandbox mock, list of (cmd, args) captured from run_command calls).
+
+    The first run_command call records the install command shape; subsequent
+    calls record exec invocations. exit_code/stderr on the install result are
+    configurable to exercise the failure path.
+    """
+    captured: list[tuple[str, list[str]]] = []
+
+    async def _run_command(cmd: str, args: list[str], **kwargs: Any) -> Any:
+        captured.append((cmd, list(args)))
+        result = MagicMock()
+        # First call is the install; subsequent (exec) calls behave normally.
+        is_install = len(captured) == 1
+        result.exit_code = install_exit_code if is_install else 0
+        result.stdout = AsyncMock(return_value="")
+        result.stderr = AsyncMock(return_value=install_stderr if is_install else "")
+        return result
+
+    sandbox = MagicMock()
+    sandbox.run_command = _run_command
+    sandbox.stop = AsyncMock()
+    sandbox.client = MagicMock()
+    sandbox.client.aclose = AsyncMock()
+    return sandbox, captured
+
+
+@pytest.mark.asyncio
+async def test_start_session_installs_python_packages_with_pip_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PYTHON + packages → start_session issues `python3 -m pip install --user <pkgs>`."""
+    sandbox_mock, captured = _make_install_sandbox_mock()
+    backend = VercelSandboxBackend(
+        oidc_token="t",
+        language="PYTHON",
+        packages=["requests", "numpy"],
+    )
+
+    async def _fake_create_sandbox() -> Any:
+        return sandbox_mock
+
+    monkeypatch.setattr(backend, "_create_sandbox", _fake_create_sandbox)
+    await backend.start_session("s1")
+
+    assert captured == [("python3", ["-m", "pip", "install", "--user", "requests", "numpy"])], (
+        f"Expected python3 -m pip install --user argv; got {captured!r}"
+    )
+    assert "s1" in backend._sessions
+
+
+@pytest.mark.asyncio
+async def test_start_session_installs_typescript_packages_with_npm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TYPESCRIPT + packages → start_session issues `npm install <pkgs>`."""
+    sandbox_mock, captured = _make_install_sandbox_mock()
+    backend = VercelSandboxBackend(
+        oidc_token="t",
+        language="TYPESCRIPT",
+        packages=["lodash"],
+    )
+
+    async def _fake_create_sandbox() -> Any:
+        return sandbox_mock
+
+    monkeypatch.setattr(backend, "_create_sandbox", _fake_create_sandbox)
+    await backend.start_session("s1")
+
+    assert captured == [("npm", ["install", "lodash"])], (
+        f"Expected npm install argv; got {captured!r}"
+    )
+    assert "s1" in backend._sessions
+
+
+@pytest.mark.asyncio
+async def test_start_session_install_failure_stops_sandbox_and_does_not_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When _install_packages raises, start_session must stop the sandbox,
+    aclose the client, NOT cache the session, and propagate the RuntimeError.
+    """
+    sandbox_mock, _captured = _make_install_sandbox_mock(
+        install_exit_code=1,
+        install_stderr="pip: package not found",
+    )
+    backend = VercelSandboxBackend(
+        oidc_token="t",
+        language="PYTHON",
+        packages=["nonexistent-package"],
+    )
+
+    async def _fake_create_sandbox() -> Any:
+        return sandbox_mock
+
+    monkeypatch.setattr(backend, "_create_sandbox", _fake_create_sandbox)
+
+    with pytest.raises(RuntimeError, match="pip: package not found"):
+        await backend.start_session("s1")
+
+    sandbox_mock.stop.assert_awaited_once()
+    sandbox_mock.client.aclose.assert_awaited_once()
+    assert "s1" not in backend._sessions, (
+        "Failed install must not leave a session cached in self._sessions"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_execute_runs_install_before_user_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When execute() runs without a cached session, the ephemeral branch must
+    issue the install run_command before the user-code run_command, then stop
+    the sandbox and aclose the client in the finally block.
+    """
+    sandbox_mock, captured = _make_install_sandbox_mock()
+    backend = VercelSandboxBackend(
+        oidc_token="t",
+        language="PYTHON",
+        packages=["requests"],
+    )
+
+    async def _fake_create_sandbox() -> Any:
+        return sandbox_mock
+
+    monkeypatch.setattr(backend, "_create_sandbox", _fake_create_sandbox)
+
+    result = await backend.execute("print('hello')", session_key="ephemeral")
+
+    # First run_command call is the install; second is the user-code exec.
+    assert len(captured) >= 2, f"Expected install + exec calls; got {captured!r}"
+    assert captured[0] == ("python3", ["-m", "pip", "install", "--user", "requests"]), (
+        f"Install must run before user code; first call was {captured[0]!r}"
+    )
+    # Ephemeral path always stops + acloses the sandbox in finally.
+    sandbox_mock.stop.assert_awaited_once()
+    sandbox_mock.client.aclose.assert_awaited_once()
+    # Nothing is cached on the ephemeral path.
+    assert "ephemeral" not in backend._sessions
+    # Successful exec returns a normal ExecutionResult (no error).
+    assert result.error is None or result.error == ""
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_execute_install_failure_surfaces_as_execution_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An install failure on the ephemeral path must surface as
+    ExecutionResult.error (not a raised exception) while stop + aclose still
+    run in the finally block.
+    """
+    sandbox_mock, _captured = _make_install_sandbox_mock(
+        install_exit_code=1,
+        install_stderr="pip: package not found",
+    )
+    backend = VercelSandboxBackend(
+        oidc_token="t",
+        language="PYTHON",
+        packages=["nonexistent-package"],
+    )
+
+    async def _fake_create_sandbox() -> Any:
+        return sandbox_mock
+
+    monkeypatch.setattr(backend, "_create_sandbox", _fake_create_sandbox)
+
+    result = await backend.execute("print('hello')", session_key="ephemeral")
+
+    assert result.error is not None and "pip: package not found" in result.error
+    sandbox_mock.stop.assert_awaited_once()
+    sandbox_mock.client.aclose.assert_awaited_once()
+    assert "ephemeral" not in backend._sessions

--- a/uv.lock
+++ b/uv.lock
@@ -712,8 +712,8 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.6" },
     { name = "uvicorn" },
     { name = "uvloop", marker = "sys_platform != 'win32' and extra == 'container'" },
-    { name = "vercel", marker = "extra == 'container'", specifier = ">=0.5.1" },
-    { name = "vercel", marker = "extra == 'vercel'", specifier = ">=0.5.1" },
+    { name = "vercel", marker = "extra == 'container'", specifier = ">=0.5.8" },
+    { name = "vercel", marker = "extra == 'vercel'", specifier = ">=0.5.8" },
     { name = "wasmtime", marker = "extra == 'container'", specifier = ">=15.0" },
     { name = "wasmtime", marker = "extra == 'wasm'", specifier = ">=15.0" },
     { name = "websockets", marker = "extra == 'container'", specifier = ">=14.0" },
@@ -817,7 +817,7 @@ dev = [
     { name = "typing-extensions" },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
     { name = "vcrpy" },
-    { name = "vercel", specifier = ">=0.5.1" },
+    { name = "vercel", specifier = ">=0.5.8" },
 ]
 
 [[package]]


### PR DESCRIPTION
This brings `VercelSandboxBackend` to parity with `DaytonaSandboxBackend` on runtime package install. Before this change, both `VercelPythonAdapter` and `VercelTypescriptAdapter` advertised `dependencies_language=None` and silently dropped `config["dependencies"]["packages"]` — so configs that declared dependencies built a sandbox that hit `ModuleNotFoundError` on first `import`. The Vercel Python SDK exposes `AsyncSandbox.run_command()`, which can drive `pip install` and `npm install` against the runtime image's package manager; this PR wires a real install step and flips both adapters' capability metadata so the existing two-tier capability gate enforces the contract.

Install is implemented as an `_install_packages(sandbox)` helper on `VercelSandboxBackend` that branches on `self._language`. PYTHON dispatches `python3 -m pip install --user <pkgs>` — invoking pip through the same interpreter the exec path uses, mirroring Daytona's `[sys.executable, '-m', 'pip', 'install']` shape. TYPESCRIPT dispatches `npm install <pkgs>` from the default cwd. Non-zero exit raises `RuntimeError(stderr)` — no log-and-continue path. The helper is called from `start_session()` *before* caching, so a failed install never leaves a half-initialized session in `self._sessions` (and on failure, `sandbox.stop()` + `sandbox.client.aclose()` run best-effort before the exception propagates so the live Vercel sandbox is not leaked). It is also called from the ephemeral branch of `execute()` inside the existing try/finally so `sandbox.stop()` still runs.

```
build_backend(config, user_env)        [VercelPythonAdapter | VercelTypescriptAdapter]
  │
  │  deps = config.get("dependencies") or {}
  │  packages = deps.get("packages", [])
  │
  └─► VercelSandboxBackend(language=…, packages=packages, …)
                              │
              ┌───────────────┴────────────────────────────┐
              ▼                                            ▼
        start_session(key)                             execute(code, key)
              │                                            │  sandbox = self._sessions.get(key)
              │  sandbox = await self._create_sandbox()    │  if sandbox:
              │  try:                                      │      return await self._exec_code(...)
              │      await self._install_packages(sandbox) │  else:
              │  except Exception:                         │      sandbox = await self._create_sandbox()
              │      await sandbox.stop()                  │      try:
              │      await sandbox.client.aclose()         │          await self._install_packages(sandbox)
              │      raise                                 │          return await self._exec_code(...)
              │  self._sessions[key] = sandbox             │      finally:
              │                                            │          await sandbox.stop()
              │                                            │          await sandbox.client.aclose()
              │
              └─► _install_packages(sandbox)
                    │  if not self._packages: return
                    ├─ PYTHON     ──► run_command("python3",
                    │                 ["-m", "pip", "install", "--user", *pkgs])
                    └─ TYPESCRIPT ──► run_command("npm", ["install", *pkgs])
                    │
                    └─► if result.exit_code != 0:
                            raise RuntimeError(f"… (exit {code}): {stderr}")
```

`SANDBOX_ADAPTER_METADATA["VERCEL_PYTHON"]` and `["VERCEL_TYPESCRIPT"]` are flipped to advertise `dependencies_language` (`"PYTHON"` / `"TYPESCRIPT"`) and `installs_packages_at_runtime=True`. The flip arms the runtime-install + network-deny interlock that already exists in the capability gate at `types.py:664` (validate) and `:788` (build); `internet_access_capability` stays `"none"` until the Python SDK exposes `network_policy=` on `AsyncSandbox.create()`, so the deny path remains unreachable but the guard is correct for the day it lands. Capability flips are migration-safe — `validate_config(config, stored_config=...)` lets unchanged sections round-trip without re-evaluation, so existing stored configs continue to validate. The dict-comprehension that built the VERCEL_* entries was expanded into two explicit `AdapterMetadata` blocks so mypy can narrow `language` to `Literal["PYTHON", "TYPESCRIPT"]` (required by the now-typed `dependencies_language` field).

`pip install --user` was chosen over `sudo=True` for a smaller blast radius — Vercel's Amazon Linux 2023 image places `~/.local/bin` on PATH and `~/.local/lib/python3.13/site-packages` on the sandbox user's `sys.path`. If the live smoke (below) reveals that `--user` site-packages is not on the `python3` interpreter's import path, the fallback is `sudo=True` (drop `--user`) and a bump of the `vercel` floor in `pyproject.toml` to the earliest version exposing `sudo=` on `AsyncSandbox.run_command`.

## Test plan
- [x] `uv run pytest tests/unit/server/sandbox/test_vercel_backend.py tests/unit/server/sandbox/test_capability_matrix.py -x -q` → 57 passed, 2 skipped (skips are expected: VERCEL_* no longer in `_ADAPTERS_DEPENDENCIES_GATE_PATH` after the metadata flip).
- [x] `VercelPythonAdapter().validate_config({"dependencies": {"packages": ["requests"]}})` returns the validated dict without raising.
- [x] `VercelPythonAdapter().validate_config({"dependencies": {"packages": ["requests"]}, "internet_access": {"mode": "deny"}})` raises `pydantic.ValidationError` with `capability_violation` — the runtime-install + network-deny interlock activates via the flipped `installs_packages_at_runtime=True`.
- [x] mypy clean on the touched files.
- [x] Existing OIDC env-injection / env-restore / no-leak tests in `test_vercel_backend.py` continue to pass unchanged.
- [ ] **Pre-merge live smoke (manual, merge-blocking)**: against live Vercel credentials, deploy a PYTHON config with `dependencies.packages=["requests"]` and execute `import requests; print(requests.__version__)` — expect exit 0 with the version string on stdout. Deploy a TYPESCRIPT config with one small npm package and execute user code that imports it. If the PYTHON path fails because `~/.local/lib/python3.13/site-packages` is not on `python3`'s `sys.path`, switch the helper to `sudo=True` (drop `--user`) and bump the `vercel` floor in `pyproject.toml` to the earliest version exposing `sudo=`. If the TYPESCRIPT path fails resolution from the default cwd, pass `cwd="/vercel/sandbox"` explicitly to both the install and exec `run_command` calls. I do not have live Vercel credentials available — a credentialed teammate must run this before merge.