### PR TITLE
feat(evaluators): add language-aware code evaluator templates

### DIFF
--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -717,7 +717,9 @@ const CodeEditor = ({
                   const { evaluator, setOutputConfigs } = store.getState();
                   const evaluatorName =
                     evaluator.name || evaluator.globalName || "";
-                  setOutputConfigs([template.getOutputConfig(evaluatorName)]);
+                  setOutputConfigs([
+                    { ...template.outputConfig, name: evaluatorName },
+                  ]);
                 }}
               >
                 {CODE_EVALUATOR_TEMPLATES.map((template) => (

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -38,12 +38,19 @@ import {
   DialogTitle,
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
+import {
+  Menu,
+  MenuContainer,
+  MenuItem,
+  MenuTrigger,
+} from "@phoenix/components/core/menu";
 import { createEvaluatorAutocompletion } from "@phoenix/components/evaluators/codeEvaluatorAutocomplete";
 import {
   CodeEvaluatorLanguageField,
   CodeEvaluatorSandboxField,
   type SandboxConfigOption,
 } from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
+import { CODE_EVALUATOR_TEMPLATES } from "@phoenix/components/evaluators/codeEvaluatorTemplates";
 import { CodeEvaluatorTestSection } from "@phoenix/components/evaluators/CodeEvaluatorTestSection";
 import { generateEvaluatorTypes } from "@phoenix/components/evaluators/codeEvaluatorTypeGeneration";
 import {
@@ -455,7 +462,7 @@ const EvaluatorMetadataForm = ({
         />
       </div>
       <div style={{ flex: "1 1 240px", minWidth: 180 }}>
-        <EvaluatorDescriptionInput />
+        <EvaluatorDescriptionInput placeholder="e.g. code evaluator description" />
       </div>
     </div>
   );
@@ -644,6 +651,7 @@ const CodeEditor = ({
 }) => {
   const { theme } = useTheme();
   const codeMirrorTheme = theme === "light" ? githubLight : githubDark;
+  const store = useEvaluatorStoreInstance();
 
   // The auto-generated type footer is hidden by default.
   const [showTypes, setShowTypes] = useState(false);
@@ -688,6 +696,47 @@ const CodeEditor = ({
           {descriptionText}
         </Text>
         <Flex direction="row" alignItems="center" gap="size-100" flex="none">
+          <MenuTrigger>
+            <Button
+              size="S"
+              variant="quiet"
+              leadingVisual={<Icon svg={<Icons.Code />} />}
+            >
+              Templates
+            </Button>
+            <MenuContainer placement="bottom end" maxWidth={360}>
+              <Menu
+                onAction={(key) => {
+                  const template = CODE_EVALUATOR_TEMPLATES.find(
+                    (t) => t.id === key
+                  );
+                  if (!template) {
+                    return;
+                  }
+                  onChange(template.getSource(language));
+                  const { evaluator, setOutputConfigs } = store.getState();
+                  const evaluatorName =
+                    evaluator.name || evaluator.globalName || "";
+                  setOutputConfigs([template.getOutputConfig(evaluatorName)]);
+                }}
+              >
+                {CODE_EVALUATOR_TEMPLATES.map((template) => (
+                  <MenuItem
+                    key={template.id}
+                    id={template.id}
+                    textValue={`${template.name}\n${template.description}`}
+                  >
+                    <Flex direction="column" gap="size-50">
+                      <Text weight="heavy">{template.name}</Text>
+                      <Text size="S" color="text-700">
+                        {template.description}
+                      </Text>
+                    </Flex>
+                  </MenuItem>
+                ))}
+              </Menu>
+            </MenuContainer>
+          </MenuTrigger>
           <Button
             size="S"
             variant="quiet"

--- a/app/src/components/evaluators/codeEvaluatorTemplates.ts
+++ b/app/src/components/evaluators/codeEvaluatorTemplates.ts
@@ -1,5 +1,13 @@
-import type { AnnotationConfig } from "@phoenix/store/evaluatorStore";
-import type { CodeEvaluatorLanguage } from "@phoenix/types";
+import type {
+  ClassificationEvaluatorAnnotationConfig,
+  CodeEvaluatorLanguage,
+} from "@phoenix/types";
+
+/** A template's annotation config, minus the name (set from the evaluator). */
+type TemplateOutputConfig = Omit<
+  ClassificationEvaluatorAnnotationConfig,
+  "name"
+>;
 
 /**
  * A pre-defined code evaluator snippet. The same idea as the built-in
@@ -18,24 +26,20 @@ export type CodeEvaluatorTemplate = {
   name: string;
   description: string;
   getSource: (language: CodeEvaluatorLanguage) => string;
-  /**
-   * Annotation (output) config matching the labels this template emits. The
-   * `name` is the evaluator name (the annotation name is fixed to it).
-   */
-  getOutputConfig: (name: string) => AnnotationConfig;
+  /** Annotation (output) config matching the labels this template emits. */
+  outputConfig: TemplateOutputConfig;
 };
 
 /**
  * Builds a categorical config from a `{ label: score }` map — the shape every
  * template below emits.
  */
-const getCategoricalConfigFromChoices =
-  (choices: Record<string, number>) =>
-  (name: string): AnnotationConfig => ({
-    name,
-    optimizationDirection: "NONE",
-    values: Object.entries(choices).map(([label, score]) => ({ label, score })),
-  });
+const getCategoricalConfigFromChoices = (
+  choices: Record<string, number>
+): TemplateOutputConfig => ({
+  optimizationDirection: "NONE",
+  values: Object.entries(choices).map(([label, score]) => ({ label, score })),
+});
 
 const PYTHON_SOURCES: Record<string, string> = {
   exact_match: `def evaluate(output, reference=None, input=None, metadata=None):
@@ -208,14 +212,14 @@ const makeTemplate = (
   id: string,
   name: string,
   description: string,
-  getOutputConfig: (name: string) => AnnotationConfig
+  outputConfig: TemplateOutputConfig
 ): CodeEvaluatorTemplate => ({
   id,
   name,
   description,
   getSource: (language) =>
     language === "PYTHON" ? PYTHON_SOURCES[id] : TYPESCRIPT_SOURCES[id],
-  getOutputConfig,
+  outputConfig,
 });
 
 export const CODE_EVALUATOR_TEMPLATES: readonly CodeEvaluatorTemplate[] = [

--- a/app/src/components/evaluators/codeEvaluatorTemplates.ts
+++ b/app/src/components/evaluators/codeEvaluatorTemplates.ts
@@ -1,0 +1,255 @@
+import type { AnnotationConfig } from "@phoenix/store/evaluatorStore";
+import type { CodeEvaluatorLanguage } from "@phoenix/types";
+
+/**
+ * A pre-defined code evaluator snippet. The same idea as the built-in
+ * evaluators (exact match, contains, regex, levenshtein distance, json
+ * distance) but expressed as editable source code for code evaluators.
+ *
+ * Each template returns a `{ label, score, explanation }` result and ships a
+ * matching annotation (output) config so the labels it emits are valid as
+ * soon as the template is applied.
+ *
+ * Templates are language-aware: {@link CodeEvaluatorTemplate.getSource}
+ * returns the appropriate Python or TypeScript implementation.
+ */
+export type CodeEvaluatorTemplate = {
+  id: string;
+  name: string;
+  description: string;
+  getSource: (language: CodeEvaluatorLanguage) => string;
+  /**
+   * Annotation (output) config matching the labels this template emits. The
+   * `name` is the evaluator name (the annotation name is fixed to it).
+   */
+  getOutputConfig: (name: string) => AnnotationConfig;
+};
+
+/**
+ * Builds a two-value categorical config where `passLabel` scores 1 and
+ * `failLabel` scores 0 — the shape every template below emits.
+ */
+const categoricalConfig =
+  (passLabel: string, failLabel: string) =>
+  (name: string): AnnotationConfig => ({
+    name,
+    optimizationDirection: "NONE",
+    values: [
+      { label: passLabel, score: 1 },
+      { label: failLabel, score: 0 },
+    ],
+  });
+
+const PYTHON_SOURCES: Record<string, string> = {
+  exact_match: `def evaluate(output, reference=None, input=None, metadata=None):
+    matched = str(output).strip() == str(reference).strip()
+    return {
+        "label": "match" if matched else "mismatch",
+        "score": 1.0 if matched else 0.0,
+        "explanation": (
+            "Output matches the reference."
+            if matched
+            else "Output does not match the reference."
+        ),
+    }
+`,
+  contains: `def evaluate(output, reference=None, input=None, metadata=None):
+    contained = str(reference) in str(output)
+    return {
+        "label": "contains" if contained else "missing",
+        "score": 1.0 if contained else 0.0,
+        "explanation": (
+            "Output contains the reference text."
+            if contained
+            else "Output does not contain the reference text."
+        ),
+    }
+`,
+  regex: `import re
+
+def evaluate(output, reference=None, input=None, metadata=None):
+    pattern = r"^[0-9]+$"
+    matched = re.search(pattern, str(output)) is not None
+    return {
+        "label": "match" if matched else "no_match",
+        "score": 1.0 if matched else 0.0,
+        "explanation": f"Output {'matches' if matched else 'does not match'} pattern {pattern!r}.",
+    }
+`,
+  levenshtein_distance: `def evaluate(output, reference=None, input=None, metadata=None):
+    a, b = str(output), str(reference)
+    if not a and not b:
+        similarity = 1.0
+    else:
+        rows, cols = len(a) + 1, len(b) + 1
+        dist = [[0] * cols for _ in range(rows)]
+        for i in range(rows):
+            dist[i][0] = i
+        for j in range(cols):
+            dist[0][j] = j
+        for i in range(1, rows):
+            for j in range(1, cols):
+                cost = 0 if a[i - 1] == b[j - 1] else 1
+                dist[i][j] = min(
+                    dist[i - 1][j] + 1,
+                    dist[i][j - 1] + 1,
+                    dist[i - 1][j - 1] + cost,
+                )
+        similarity = 1.0 - dist[rows - 1][cols - 1] / max(len(a), len(b))
+    return {
+        "label": "similar" if similarity >= 0.5 else "different",
+        "score": similarity,
+        "explanation": f"Normalized Levenshtein similarity is {similarity:.2f}.",
+    }
+`,
+  json_distance: `import json
+
+def evaluate(output, reference=None, input=None, metadata=None):
+    def _parse(value):
+        return json.loads(value) if isinstance(value, str) else value
+    try:
+        equal = _parse(output) == _parse(reference)
+    except (ValueError, TypeError):
+        equal = False
+    return {
+        "label": "equal" if equal else "not_equal",
+        "score": 1.0 if equal else 0.0,
+        "explanation": (
+            "Parsed JSON values are equal."
+            if equal
+            else "Parsed JSON values differ."
+        ),
+    }
+`,
+};
+
+const TYPESCRIPT_SOURCES: Record<string, string> = {
+  exact_match: `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
+  const matched = String(output).trim() === String(reference).trim();
+  return {
+    label: matched ? "match" : "mismatch",
+    score: matched ? 1 : 0,
+    explanation: matched
+      ? "Output matches the reference."
+      : "Output does not match the reference.",
+  };
+}
+`,
+  contains: `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
+  const contained = String(output).includes(String(reference));
+  return {
+    label: contained ? "contains" : "missing",
+    score: contained ? 1 : 0,
+    explanation: contained
+      ? "Output contains the reference text."
+      : "Output does not contain the reference text.",
+  };
+}
+`,
+  regex: `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
+  const pattern = /^[0-9]+$/;
+  const matched = pattern.test(String(output));
+  return {
+    label: matched ? "match" : "no_match",
+    score: matched ? 1 : 0,
+    explanation: \`Output \${matched ? "matches" : "does not match"} pattern \${pattern}.\`,
+  };
+}
+`,
+  levenshtein_distance: `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
+  const a = String(output);
+  const b = String(reference);
+  let similarity: number;
+  if (!a && !b) {
+    similarity = 1;
+  } else {
+    const dist: number[][] = Array.from({ length: a.length + 1 }, () =>
+      new Array<number>(b.length + 1).fill(0)
+    );
+    for (let i = 0; i <= a.length; i++) dist[i][0] = i;
+    for (let j = 0; j <= b.length; j++) dist[0][j] = j;
+    for (let i = 1; i <= a.length; i++) {
+      for (let j = 1; j <= b.length; j++) {
+        const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+        dist[i][j] = Math.min(
+          dist[i - 1][j] + 1,
+          dist[i][j - 1] + 1,
+          dist[i - 1][j - 1] + cost
+        );
+      }
+    }
+    similarity = 1 - dist[a.length][b.length] / Math.max(a.length, b.length);
+  }
+  return {
+    label: similarity >= 0.5 ? "similar" : "different",
+    score: similarity,
+    explanation: \`Normalized Levenshtein similarity is \${similarity.toFixed(2)}.\`,
+  };
+}
+`,
+  json_distance: `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
+  const parse = (value: unknown) =>
+    typeof value === "string" ? JSON.parse(value) : value;
+  let equal: boolean;
+  try {
+    equal = JSON.stringify(parse(output)) === JSON.stringify(parse(reference));
+  } catch {
+    equal = false;
+  }
+  return {
+    label: equal ? "equal" : "not_equal",
+    score: equal ? 1 : 0,
+    explanation: equal
+      ? "Parsed JSON values are equal."
+      : "Parsed JSON values differ.",
+  };
+}
+`,
+};
+
+const makeTemplate = (
+  id: string,
+  name: string,
+  description: string,
+  getOutputConfig: (name: string) => AnnotationConfig
+): CodeEvaluatorTemplate => ({
+  id,
+  name,
+  description,
+  getSource: (language) =>
+    language === "PYTHON" ? PYTHON_SOURCES[id] : TYPESCRIPT_SOURCES[id],
+  getOutputConfig,
+});
+
+export const CODE_EVALUATOR_TEMPLATES: readonly CodeEvaluatorTemplate[] = [
+  makeTemplate(
+    "exact_match",
+    "Exact match",
+    "Match/mismatch when the output equals the reference.",
+    categoricalConfig("match", "mismatch")
+  ),
+  makeTemplate(
+    "contains",
+    "Contains",
+    "Whether the output contains the reference text.",
+    categoricalConfig("contains", "missing")
+  ),
+  makeTemplate(
+    "regex",
+    "Regex",
+    "Whether the output matches a regular expression.",
+    categoricalConfig("match", "no_match")
+  ),
+  makeTemplate(
+    "levenshtein_distance",
+    "Levenshtein distance",
+    "Normalized edit-distance similarity between output and reference.",
+    categoricalConfig("similar", "different")
+  ),
+  makeTemplate(
+    "json_distance",
+    "JSON distance",
+    "Whether the output and reference are equal parsed as JSON.",
+    categoricalConfig("equal", "not_equal")
+  ),
+];

--- a/app/src/components/evaluators/codeEvaluatorTemplates.ts
+++ b/app/src/components/evaluators/codeEvaluatorTemplates.ts
@@ -26,18 +26,15 @@ export type CodeEvaluatorTemplate = {
 };
 
 /**
- * Builds a two-value categorical config where `passLabel` scores 1 and
- * `failLabel` scores 0 — the shape every template below emits.
+ * Builds a categorical config from a `{ label: score }` map — the shape every
+ * template below emits.
  */
-const categoricalConfig =
-  (passLabel: string, failLabel: string) =>
+const getCategoricalConfigFromChoices =
+  (choices: Record<string, number>) =>
   (name: string): AnnotationConfig => ({
     name,
     optimizationDirection: "NONE",
-    values: [
-      { label: passLabel, score: 1 },
-      { label: failLabel, score: 0 },
-    ],
+    values: Object.entries(choices).map(([label, score]) => ({ label, score })),
   });
 
 const PYTHON_SOURCES: Record<string, string> = {
@@ -226,30 +223,30 @@ export const CODE_EVALUATOR_TEMPLATES: readonly CodeEvaluatorTemplate[] = [
     "exact_match",
     "Exact match",
     "Match/mismatch when the output equals the reference.",
-    categoricalConfig("match", "mismatch")
+    getCategoricalConfigFromChoices({ match: 1, mismatch: 0 })
   ),
   makeTemplate(
     "contains",
     "Contains",
     "Whether the output contains the reference text.",
-    categoricalConfig("contains", "missing")
+    getCategoricalConfigFromChoices({ contains: 1, missing: 0 })
   ),
   makeTemplate(
     "regex",
     "Regex",
     "Whether the output matches a regular expression.",
-    categoricalConfig("match", "no_match")
+    getCategoricalConfigFromChoices({ match: 1, no_match: 0 })
   ),
   makeTemplate(
     "levenshtein_distance",
     "Levenshtein distance",
     "Normalized edit-distance similarity between output and reference.",
-    categoricalConfig("similar", "different")
+    getCategoricalConfigFromChoices({ similar: 1, different: 0 })
   ),
   makeTemplate(
     "json_distance",
     "JSON distance",
     "Whether the output and reference are equal parsed as JSON.",
-    categoricalConfig("equal", "not_equal")
+    getCategoricalConfigFromChoices({ equal: 1, not_equal: 0 })
   ),
 ];


### PR DESCRIPTION
## Summary
Adds a **Templates** dropdown to the top-right of the code evaluator code-editing section.

- Predefined snippets mirroring the built-in evaluators: Exact match, Contains, Regex, Levenshtein distance, JSON distance.
- Language-aware — inserts the Python or TypeScript implementation for the currently selected language.
- Each template returns `{ label, score, explanation }` so it works for both categorical-label and continuous-score configs.
- Selecting a template also applies a matching **annotation (output) config** automatically (categorical with the labels the snippet emits), so Test no longer fails with `Label '…' not in categorical output config values`.
- Also: sets a placeholder on the code evaluator description field.

## Implementation
- `app/src/components/evaluators/codeEvaluatorTemplates.ts` (new): static `CODE_EVALUATOR_TEMPLATES`, each with `getSource(language)` and a plain `outputConfig` (`Omit<ClassificationEvaluatorAnnotationConfig, "name">`). `getCategoricalConfigFromChoices({ label: score, ... })` builds the config from a label→score map.
- `app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx`: `MenuTrigger`/`Menu` "Templates" button in the editor toolbar; on select it sets the source and `setOutputConfigs([{ ...template.outputConfig, name: evaluatorName }])`.

## Notes
- Applying a template overwrites the current annotation config (output type / labels / bounds), same as the existing "Output type" select.
- Lint + typecheck pass.