### PR TITLE
docs: document OPENINFERENCE_HIDE_LLM_TOOLS / hide_llm_tools trace config option

### DIFF
--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/manual-spans.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/manual-spans.mdx
@@ -149,6 +149,7 @@ const tracer = new OITracer({
     hideInputs: true,
     hideOutputText: true,
     hideEmbeddingVectors: true,
+    hideLLMTools: true,
     base64ImageMaxLength: 8_000,
   },
 });
@@ -175,6 +176,7 @@ You can also configure masking via environment variables:
 - `OPENINFERENCE_HIDE_EMBEDDING_VECTORS`
 - `OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH`
 - `OPENINFERENCE_HIDE_PROMPTS`
+- `OPENINFERENCE_HIDE_LLM_TOOLS`
 
 ## Utility Helpers
 

--- a/docs/phoenix/tracing/how-to-tracing/advanced/masking-span-attributes.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/advanced/masking-span-attributes.mdx
@@ -21,7 +21,10 @@ The possible settings are:
 | OPENINFERENCE\_HIDE\_EMBEDDING\_VECTORS          | Hides returned embedding vectors                             | bool | False   |
 | OPENINFERENCE\_HIDE\_LLM\_INVOCATION\_PARAMETERS | Hides LLM invocation parameters                              | bool | False   |
 | OPENINFERENCE\_HIDE\_LLM\_PROMPTS                | Hides LLM prompts span attributes                            | bool | False   |
+| OPENINFERENCE\_HIDE\_LLM\_TOOLS                  | Hides tool definitions advertised to the LLM (`llm.tools.*`)  | bool | False   |
 | OPENINFERENCE\_BASE64\_IMAGE\_MAX\_LENGTH        | Limits characters of a base64 encoding of an image           | int  | 32,000  |
+
+Note: `OPENINFERENCE_HIDE_LLM_TOOLS` is also applied when `OPENINFERENCE_HIDE_INPUTS` is enabled, consistent with how `OPENINFERENCE_HIDE_INPUT_MESSAGES` and `OPENINFERENCE_HIDE_LLM_PROMPTS` behave.
 
 To set up this configuration you can either:
 
@@ -58,6 +61,7 @@ Below is an example of how to set these values in code using our OpenAI Python a
         hide_embedding_vectors=...,
         hide_llm_invocation_parameters=...,
         hide_llm_prompts=...,
+        hide_llm_tools=...,
         base64_image_max_length=...,
     )
 
@@ -77,7 +81,10 @@ Below is an example of how to set these values in code using our OpenAI Python a
     * Everything left out of here will fallback to
     * environment variables then defaults
     */
-    const traceConfig = { hideInputs: true }
+    const traceConfig = {
+      hideInputs: true,
+      hideLLMTools: true,
+    }
 
     const instrumentation = new OpenAIInstrumentation({ traceConfig })
     ```

--- a/js/.changeset/document-hide-llm-tools.md
+++ b/js/.changeset/document-hide-llm-tools.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-otel": patch
+---
+
+Document `hideLLMTools` / `OPENINFERENCE_HIDE_LLM_TOOLS` trace config option in README

--- a/js/packages/phoenix-otel/README.md
+++ b/js/packages/phoenix-otel/README.md
@@ -365,6 +365,7 @@ const tracer = new OITracer({
     hideInputs: true,
     hideOutputText: true,
     hideEmbeddingVectors: true,
+    hideLLMTools: true,
     base64ImageMaxLength: 8_000,
   },
 });
@@ -391,6 +392,7 @@ Supported environment variables include:
 - `OPENINFERENCE_HIDE_EMBEDDING_VECTORS`
 - `OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH`
 - `OPENINFERENCE_HIDE_PROMPTS`
+- `OPENINFERENCE_HIDE_LLM_TOOLS`
 
 ### Raw OpenTelemetry Spans
 


### PR DESCRIPTION
## Summary

Closes #13166

Documents the new `OPENINFERENCE_HIDE_LLM_TOOLS` masking option introduced in OpenInference across all Phoenix tracing reference docs:

- **`docs/phoenix/tracing/how-to-tracing/advanced/masking-span-attributes.mdx`** — added `OPENINFERENCE_HIDE_LLM_TOOLS` to the env var table, added `hide_llm_tools` to the Python `TraceConfig` code example, added `hideLLMTools` to the TypeScript example, and added a prose note explaining it is also applied when `HIDE_INPUTS` is enabled
- **`docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/manual-spans.mdx`** — added `OPENINFERENCE_HIDE_LLM_TOOLS` to the env var list and `hideLLMTools` to the `OITracer` `traceConfig` example
- **`js/packages/phoenix-otel/README.md`** — added `OPENINFERENCE_HIDE_LLM_TOOLS` to the env var list and `hideLLMTools` to the `OITracer` example (missed in the original scope; found during review)
- **`js/.changeset/document-hide-llm-tools.md`** — patch changeset for the README update

## What changed and why

The new option hides the `llm.tools.*` span attributes (tool definitions advertised to the LLM). It is also applied implicitly when `HIDE_INPUTS` is true, matching the behaviour of `HIDE_INPUT_MESSAGES` and `HIDE_LLM_PROMPTS`.

- Python: `TraceConfig(hide_llm_tools=...)` / env var `OPENINFERENCE_HIDE_LLM_TOOLS`
- JS/TS: `TraceConfigOptions.hideLLMTools` / env var `OPENINFERENCE_HIDE_LLM_TOOLS`

## How to verify

Review the updated docs pages:
- `docs/phoenix/tracing/how-to-tracing/advanced/masking-span-attributes.mdx` — confirm table row and prose note are present
- `docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/manual-spans.mdx` — confirm `OPENINFERENCE_HIDE_LLM_TOOLS` appears in the env var list
- `js/packages/phoenix-otel/README.md` — confirm `hideLLMTools` appears in the `OITracer` example and env var list

🤖 Generated with [Claude Code](https://claude.com/claude-code)