### PR TITLE
feat(ui): move toasts to top-center with sonner-style stacking

### DIFF
--- a/app/src/components/core/toast/Toast.tsx
+++ b/app/src/components/core/toast/Toast.tsx
@@ -10,10 +10,8 @@ import {
 import { Button } from "@phoenix/components/core/button";
 import { Text } from "@phoenix/components/core/content";
 import { Icon, Icons } from "@phoenix/components/core/icon";
-import {
-  toastCSS,
-  toastPositionerCSS,
-} from "@phoenix/components/core/toast/styles";
+import { toastCSS } from "@phoenix/components/core/toast/styles";
+import { ToastPositioner } from "@phoenix/components/core/toast/ToastPositioner";
 import {
   type NotificationParams,
   toastQueue,
@@ -60,15 +58,7 @@ export const Toast = <T extends QueuedToast<NotificationParams>>({
   );
   const icon = iconFromVariant(toast.content.variant);
   return (
-    <div
-      className="toast-positioner"
-      css={toastPositionerCSS}
-      style={{
-        // @ts-expect-error custom css property
-        "--toast-index": stackIndex,
-        zIndex: 100 - stackIndex,
-      }}
-    >
+    <ToastPositioner stackIndex={stackIndex}>
       <AriaToast
         toast={toast}
         css={toastCSS}
@@ -136,6 +126,6 @@ export const Toast = <T extends QueuedToast<NotificationParams>>({
           </div>
         ) : null}
       </AriaToast>
-    </div>
+    </ToastPositioner>
   );
 };

--- a/app/src/components/core/toast/Toast.tsx
+++ b/app/src/components/core/toast/Toast.tsx
@@ -1,14 +1,19 @@
 import { css } from "@emotion/react";
+import { useContext } from "react";
 import type { QueuedToast } from "react-aria-components";
 import {
   UNSTABLE_Toast as AriaToast,
   UNSTABLE_ToastContent as AriaToastContent,
+  UNSTABLE_ToastStateContext as ToastStateContext,
 } from "react-aria-components";
 
 import { Button } from "@phoenix/components/core/button";
 import { Text } from "@phoenix/components/core/content";
 import { Icon, Icons } from "@phoenix/components/core/icon";
-import { toastCss } from "@phoenix/components/core/toast/styles";
+import {
+  toastCss,
+  toastPositionerCss,
+} from "@phoenix/components/core/toast/styles";
 import {
   type NotificationParams,
   toastQueue,
@@ -47,75 +52,90 @@ export const Toast = <T extends QueuedToast<NotificationParams>>({
   toast: T;
 }) => {
   const { theme } = useTheme();
+  const state = useContext(ToastStateContext);
+  // 0 = front / newest toast in the stack.
+  const stackIndex = Math.max(
+    0,
+    state?.visibleToasts.findIndex((t) => t.key === toast.key) ?? 0
+  );
   const icon = iconFromVariant(toast.content.variant);
   return (
-    <AriaToast
-      toast={toast}
-      css={toastCss}
-      className="react-aria-Toast"
+    <div
+      className="toast-positioner"
+      css={toastPositionerCss}
       style={{
-        viewTransitionName: toast.key,
-        // @ts-expect-error incorrect react types
-        "--internal-token-color": colorFromVariant(toast.content.variant),
+        // @ts-expect-error custom css property
+        "--toast-index": stackIndex,
+        zIndex: 100 - stackIndex,
       }}
-      data-variant={toast.content.variant}
-      data-theme={theme}
     >
-      <div
-        css={css`
-          display: flex;
-          justify-content: space-between;
-          width: 100%;
-        `}
+      <AriaToast
+        toast={toast}
+        css={toastCss}
+        className="react-aria-Toast"
+        style={{
+          // @ts-expect-error incorrect react types
+          "--internal-token-color": colorFromVariant(toast.content.variant),
+        }}
+        data-variant={toast.content.variant}
+        data-theme={theme}
       >
-        <AriaToastContent>
-          <Text slot="title" size="M">
-            {icon}
-            {toast.content.title}
-          </Text>
-          <Text slot="description">{toast.content.message}</Text>
-        </AriaToastContent>
-        <Button
-          slot="close"
-          size="S"
-          type="button"
-          leadingVisual={<Icon svg={<Icons.CloseOutline />} />}
-        />
-      </div>
-      {toast.content.action ? (
-        <div className="toast-action-container">
-          {typeof toast.content.action === "object" &&
-          "text" in toast.content.action ? (
-            <Button
-              className="toast-action-button"
-              onPress={() => {
-                const action = toast.content.action;
-                if (
-                  typeof action === "object" &&
-                  action &&
-                  "onClick" in action
-                ) {
-                  // close on click by default
-                  const closeOnClick = action.closeOnClick ?? true;
-                  const close = () => {
-                    toastQueue?.close(toast.key);
-                  };
-                  // pass close callback to action for manual close ability
-                  action.onClick(close);
-                  if (closeOnClick) {
-                    close();
-                  }
-                }
-              }}
-              size="S"
-            >
-              {toast.content.action.text}
-            </Button>
-          ) : (
-            toast.content.action
-          )}
+        <div
+          css={css`
+            display: flex;
+            justify-content: space-between;
+            width: 100%;
+          `}
+        >
+          <AriaToastContent>
+            <Text slot="title" size="M">
+              {icon}
+              {toast.content.title}
+            </Text>
+            <Text slot="description">{toast.content.message}</Text>
+          </AriaToastContent>
+          <Button
+            slot="close"
+            size="S"
+            type="button"
+            leadingVisual={<Icon svg={<Icons.CloseOutline />} />}
+          />
         </div>
-      ) : null}
-    </AriaToast>
+        {toast.content.action ? (
+          <div className="toast-action-container">
+            {typeof toast.content.action === "object" &&
+            "text" in toast.content.action ? (
+              <Button
+                className="toast-action-button"
+                onPress={() => {
+                  const action = toast.content.action;
+                  if (
+                    typeof action === "object" &&
+                    action &&
+                    "onClick" in action
+                  ) {
+                    // close on click by default
+                    const closeOnClick = action.closeOnClick ?? true;
+                    const close = () => {
+                      toastQueue?.close(toast.key);
+                    };
+                    // pass close callback to action for manual close ability
+                    action.onClick(close);
+                    if (closeOnClick) {
+                      close();
+                    }
+                  }
+                }}
+                size="S"
+              >
+                {toast.content.action.text}
+              </Button>
+            ) : (
+              toast.content.action
+            )}
+          </div>
+        ) : null}
+      </AriaToast>
+    </div>
   );
 };

--- a/app/src/components/core/toast/Toast.tsx
+++ b/app/src/components/core/toast/Toast.tsx
@@ -11,8 +11,8 @@ import { Button } from "@phoenix/components/core/button";
 import { Text } from "@phoenix/components/core/content";
 import { Icon, Icons } from "@phoenix/components/core/icon";
 import {
-  toastCss,
-  toastPositionerCss,
+  toastCSS,
+  toastPositionerCSS,
 } from "@phoenix/components/core/toast/styles";
 import {
   type NotificationParams,
@@ -62,7 +62,7 @@ export const Toast = <T extends QueuedToast<NotificationParams>>({
   return (
     <div
       className="toast-positioner"
-      css={toastPositionerCss}
+      css={toastPositionerCSS}
       style={{
         // @ts-expect-error custom css property
         "--toast-index": stackIndex,
@@ -71,7 +71,7 @@ export const Toast = <T extends QueuedToast<NotificationParams>>({
     >
       <AriaToast
         toast={toast}
-        css={toastCss}
+        css={toastCSS}
         className="react-aria-Toast"
         style={{
           // @ts-expect-error incorrect react types

--- a/app/src/components/core/toast/ToastPositioner.tsx
+++ b/app/src/components/core/toast/ToastPositioner.tsx
@@ -1,0 +1,27 @@
+import type { PropsWithChildren } from "react";
+
+import { toastPositionerCSS } from "@phoenix/components/core/toast/styles";
+
+/**
+ * Wraps a single toast and owns its position within the stack.
+ *
+ * @param stackIndex Position of the toast in the visible stack (0 = front / newest).
+ */
+export function ToastPositioner({
+  stackIndex,
+  children,
+}: PropsWithChildren<{ stackIndex: number }>) {
+  return (
+    <div
+      className="toast-positioner"
+      css={toastPositionerCSS}
+      style={{
+        // @ts-expect-error custom css property
+        "--toast-index": stackIndex,
+        zIndex: 100 - stackIndex,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/app/src/components/core/toast/ToastRegion.tsx
+++ b/app/src/components/core/toast/ToastRegion.tsx
@@ -1,6 +1,6 @@
 import { UNSTABLE_ToastRegion as AriaToastRegion } from "react-aria-components";
 
-import { toastRegionCss } from "@phoenix/components/core/toast/styles";
+import { toastRegionCSS } from "@phoenix/components/core/toast/styles";
 import { toastQueue } from "@phoenix/contexts/NotificationContext";
 
 import { Toast } from "./Toast";
@@ -61,7 +61,7 @@ export const ToastRegion = () => {
     <AriaToastRegion
       ref={attachToastRegion}
       queue={toastQueue}
-      css={toastRegionCss}
+      css={toastRegionCSS}
       className="react-aria-ToastRegion"
     >
       {({ toast }) => {

--- a/app/src/components/core/toast/ToastRegion.tsx
+++ b/app/src/components/core/toast/ToastRegion.tsx
@@ -5,9 +5,61 @@ import { toastQueue } from "@phoenix/contexts/NotificationContext";
 
 import { Toast } from "./Toast";
 
+/**
+ * Measures the toast stack and exposes layout custom properties on the region
+ * (`--toast-count`, `--toast-row-height`, `--toast-stack-height`) and on each
+ * `.toast-positioner` (`--toast-offset`, the cumulative height of the toasts in
+ * front of it) so the CSS can size the animated region height and lay the
+ * toasts out — collapsed by default, un-stacked on hover/focus.
+ *
+ * Used as a `ref` callback; the returned function tears down the observers.
+ */
+function attachToastRegion(region: HTMLElement | null) {
+  if (!region) {
+    return;
+  }
+  const measure = () => {
+    const positioners =
+      region.querySelectorAll<HTMLElement>(".toast-positioner");
+    region.style.setProperty("--toast-count", String(positioners.length || 1));
+    let rowHeight = 0;
+    let stackHeight = 0;
+    positioners.forEach((positioner) => {
+      positioner.style.setProperty("--toast-offset", `${stackHeight}px`);
+      const card = positioner.querySelector<HTMLElement>(".react-aria-Toast");
+      const height = card ? card.offsetHeight : 0;
+      rowHeight = Math.max(rowHeight, height);
+      stackHeight += height;
+    });
+    if (rowHeight > 0) {
+      region.style.setProperty("--toast-row-height", `${rowHeight}px`);
+    }
+    region.style.setProperty("--toast-stack-height", `${stackHeight}px`);
+  };
+  const resizeObserver = new ResizeObserver(measure);
+  resizeObserver.observe(region);
+  const observeCards = () => {
+    region
+      .querySelectorAll<HTMLElement>(".react-aria-Toast")
+      .forEach((card) => resizeObserver.observe(card));
+  };
+  const mutationObserver = new MutationObserver(() => {
+    observeCards();
+    measure();
+  });
+  mutationObserver.observe(region, { childList: true, subtree: true });
+  observeCards();
+  measure();
+  return () => {
+    resizeObserver.disconnect();
+    mutationObserver.disconnect();
+  };
+}
+
 export const ToastRegion = () => {
   return (
     <AriaToastRegion
+      ref={attachToastRegion}
       queue={toastQueue}
       css={toastRegionCss}
       className="react-aria-ToastRegion"

--- a/app/src/components/core/toast/ToastRegion.tsx
+++ b/app/src/components/core/toast/ToastRegion.tsx
@@ -26,8 +26,8 @@ function attachToastRegion(region: HTMLElement | null) {
     let stackHeight = 0;
     positioners.forEach((positioner) => {
       positioner.style.setProperty("--toast-offset", `${stackHeight}px`);
-      const card = positioner.querySelector<HTMLElement>(".react-aria-Toast");
-      const height = card ? card.offsetHeight : 0;
+      const toast = positioner.querySelector<HTMLElement>(".react-aria-Toast");
+      const height = toast ? toast.offsetHeight : 0;
       rowHeight = Math.max(rowHeight, height);
       stackHeight += height;
     });
@@ -38,17 +38,17 @@ function attachToastRegion(region: HTMLElement | null) {
   };
   const resizeObserver = new ResizeObserver(measure);
   resizeObserver.observe(region);
-  const observeCards = () => {
+  const observeToasts = () => {
     region
       .querySelectorAll<HTMLElement>(".react-aria-Toast")
-      .forEach((card) => resizeObserver.observe(card));
+      .forEach((toast) => resizeObserver.observe(toast));
   };
   const mutationObserver = new MutationObserver(() => {
-    observeCards();
+    observeToasts();
     measure();
   });
   mutationObserver.observe(region, { childList: true, subtree: true });
-  observeCards();
+  observeToasts();
   measure();
   return () => {
     resizeObserver.disconnect();

--- a/app/src/components/core/toast/styles.ts
+++ b/app/src/components/core/toast/styles.ts
@@ -35,7 +35,7 @@ const slideInFromTop = keyframes`
  * `--toast-count` and `--toast-row-height` are written by `attachToastRegion`
  * in `ToastRegion.tsx` once the toasts have been measured.
  */
-export const toastRegionCss = css`
+export const toastRegionCSS = css`
   position: fixed;
   top: var(--global-dimension-static-size-200);
   left: 50%;
@@ -81,7 +81,7 @@ export const toastRegionCss = css`
  * Wraps each toast and owns its position within the stack. `--toast-index`
  * (0 = front / newest) is set inline by the `Toast` component.
  */
-export const toastPositionerCss = css`
+export const toastPositionerCSS = css`
   position: absolute;
   top: 0;
   left: 0;
@@ -101,7 +101,7 @@ export const toastPositionerCss = css`
   }
 `;
 
-export const toastCss = css`
+export const toastCSS = css`
   display: flex;
   flex-direction: column;
   gap: var(--global-dimension-static-size-100);

--- a/app/src/components/core/toast/styles.ts
+++ b/app/src/components/core/toast/styles.ts
@@ -1,14 +1,104 @@
-import { css } from "@emotion/react";
+import { css, keyframes } from "@emotion/react";
 
+/**
+ * How far (in px) each stacked toast peeks out from behind the front toast
+ * while the stack is collapsed.
+ */
+const COLLAPSED_PEEK = 16;
+/**
+ * Vertical gap (in px) between toasts when the stack is expanded (hovered /
+ * focused).
+ */
+const EXPANDED_GAP = 8;
+/**
+ * Amount each toast is scaled down per step behind the front toast while
+ * collapsed (sonner-like depth effect).
+ */
+const SCALE_STEP = 0.05;
+
+const slideInFromTop = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(-130%);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+/**
+ * The toast region is a fixed, top-centered container that lays out the toast
+ * stack. Toasts are absolutely positioned inside it; the region only owns the
+ * width and the (animated) height so the hover target tracks the visible stack.
+ *
+ * `--toast-count` and `--toast-row-height` are written by `attachToastRegion`
+ * in `ToastRegion.tsx` once the toasts have been measured.
+ */
 export const toastRegionCss = css`
   position: fixed;
-  bottom: 24px;
-  right: 24px;
-  display: flex;
-  flex-direction: column-reverse;
-  gap: 8px;
-  border-radius: 8px;
+  top: var(--global-dimension-static-size-200);
+  left: 50%;
+  width: 400px;
+  max-width: calc(100vw - var(--global-dimension-static-size-400));
+  transform: translateX(-50%);
   outline: none;
+  z-index: 100000;
+
+  --collapsed-peek: ${COLLAPSED_PEEK}px;
+  --expanded-gap: ${EXPANDED_GAP}px;
+  --toast-row-height: 72px;
+  --toast-count: 1;
+
+  height: calc(
+    var(--toast-row-height) + (var(--toast-count) - 1) * var(--collapsed-peek)
+  );
+  transition: height 300ms cubic-bezier(0.21, 1.02, 0.73, 1);
+
+  &[data-hovered],
+  &[data-focused] {
+    height: calc(
+      var(--toast-stack-height, var(--toast-row-height)) +
+        (var(--toast-count) - 1) * var(--expanded-gap)
+    );
+  }
+
+  /* Expand (un-stack) the toasts when the region is hovered or focused. */
+  &[data-hovered] .toast-positioner,
+  &[data-focused] .toast-positioner {
+    transform: translateY(
+      calc(var(--toast-offset, 0px) + var(--toast-index) * var(--expanded-gap))
+    );
+    opacity: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+`;
+
+/**
+ * Wraps each toast and owns its position within the stack. `--toast-index`
+ * (0 = front / newest) is set inline by the `Toast` component.
+ */
+export const toastPositionerCss = css`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  transform-origin: top center;
+  transform: translateY(
+      calc(var(--toast-index) * var(--collapsed-peek, ${COLLAPSED_PEEK}px))
+    )
+    scale(calc(1 - var(--toast-index) * ${SCALE_STEP}));
+  opacity: calc(1 - var(--toast-index) * 0.1);
+  transition:
+    transform 300ms cubic-bezier(0.21, 1.02, 0.73, 1),
+    opacity 300ms ease;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 `;
 
 export const toastCss = css`
@@ -19,8 +109,11 @@ export const toastCss = css`
     var(--global-dimension-static-size-100);
   border-radius: 8px;
   outline: none;
-  width: 400px;
+  width: 100%;
+  box-sizing: border-box;
   position: relative;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  animation: ${slideInFromTop} 280ms cubic-bezier(0.21, 1.02, 0.73, 1);
   --toast-border: 1px solid var(--global-border-color-default);
   --toast-color: var(--global-static-color-900);
   &[data-theme="light"] {
@@ -44,6 +137,10 @@ export const toastCss = css`
   background-color: var(--toast-background-color);
   border: var(--toast-border);
   color: var(--toast-color);
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 
   &[data-focus-visible] {
     outline: 2px solid slateblue;

--- a/app/src/contexts/NotificationContext/NotificationContext.tsx
+++ b/app/src/contexts/NotificationContext/NotificationContext.tsx
@@ -1,11 +1,16 @@
 import { useCallback } from "react";
 import { UNSTABLE_ToastQueue as ToastQueue } from "react-aria-components";
-import { flushSync } from "react-dom";
 
 /**
  * Default duration in milliseconds before toasts expire by default.
  */
 const DEFAULT_EXPIRY = 5_000;
+
+/**
+ * Maximum number of toasts rendered at once. Additional toasts are queued and
+ * shown as visible ones are dismissed. Matches the sonner-style stacked region.
+ */
+const MAX_VISIBLE_TOASTS = 3;
 
 type NotificationVariant = "success" | "error";
 
@@ -39,16 +44,7 @@ export type NotificationParams = {
 };
 
 export const toastQueue = new ToastQueue<NotificationParams>({
-  // Wrap state updates in a CSS view transition.
-  wrapUpdate(fn) {
-    if ("startViewTransition" in document) {
-      document?.startViewTransition(() => {
-        flushSync(fn);
-      });
-    } else {
-      fn();
-    }
-  },
+  maxVisibleToasts: MAX_VISIBLE_TOASTS,
 });
 
 export type NotificationHookParams = Omit<NotificationParams, "variant"> & {

--- a/app/stories/Toast.stories.tsx
+++ b/app/stories/Toast.stories.tsx
@@ -10,6 +10,16 @@ const meta: Meta = {
   parameters: {
     layout: "centered",
   },
+  decorators: [
+    // A single Toast positions itself absolutely within the toast region.
+    // Provide a relatively-positioned, region-sized container so it renders
+    // the way it would inside `ToastRegion`.
+    (Story) => (
+      <div style={{ position: "relative", width: 400, minHeight: 96 }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default meta;


### PR DESCRIPTION


https://github.com/user-attachments/assets/14a88946-a130-425d-94c7-c63ad70fc794

Closes #13174

## What

Moves notifications/toasts from the bottom-right corner to **top-center**, since the bottom-right now carries other critical UI. Toasts animate in from the top and stack like [shadcn's sonner](https://ui.shadcn.com/docs/components/radix/sonner).

## Changes

- **Position**: toast region is `position: fixed`, top-centered, with an animated height that tracks the visible stack.
- **Stacking**: max 3 visible toasts (`maxVisibleToasts: 3`); behind the front toast they're scaled down and peek out; hovering/focusing the region un-stacks them into a column. Expanded offsets are computed from each toast's real height with a small gap, so short toasts don't leave dead space.
- **Animation**: entry slide-in from the top via CSS keyframes; re-stacking and expand/collapse animate via CSS transitions (replaces the `startViewTransition` `wrapUpdate`). `prefers-reduced-motion` disables the motion.
- **Components**: same `Toast` / `ToastRegion` and `useNotify` / `useNotifySuccess` hooks; added a small `ToastPositioner` component that owns a toast's position in the stack. A ref callback on the region (`attachToastRegion`) measures toasts (ResizeObserver + MutationObserver) and writes the CSS layout vars; observers are torn down on unmount.
- Renamed the style consts to the repo's `...CSS` convention (`toastRegionCSS`, `toastCSS`, `toastPositionerCSS`).
- **Stories**: `Toast.stories.tsx` now wraps the single toast in a relatively-positioned, region-sized container so it renders correctly (a lone `Toast` positions itself absolutely within the region).

## Notes / follow-ups

- A toast that auto-dismisses currently pops out without an exit animation — react-aria-components doesn't expose an exiting state. Entry and re-stacking are animated. Can add an exit animation later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)