### PR TITLE
feat(evaluators): lazy sandbox config tooltip + UI polish

### DIFF
--- a/.agents/skills/phoenix-frontend/rules/accessibility.md
+++ b/.agents/skills/phoenix-frontend/rules/accessibility.md
@@ -3,7 +3,7 @@
 ## Semantic elements
 
 - Interactive actions MUST use buttons, not clickable divs
-- Lists MUST use `<ul>`/`<ol>`
+- Lists MUST use `<ul>`/`<ol>` + `<li>`, never a stack of `<div>`s — even for non-bulleted layouts (key/value rows, menus, tag lists). Reset chrome with `list-style: none; margin: 0; padding: 0;` and apply your flex/grid layout on top.
 
 ## WCAG 2.1 AA baseline
 

--- a/.agents/skills/phoenix-frontend/rules/relay.md
+++ b/.agents/skills/phoenix-frontend/rules/relay.md
@@ -32,3 +32,9 @@ Do **not** use this hook when:
 - **Prefer `useQueryLoader` for component-owned query refs.** It handles retaining and disposal for refs the component loads itself.
 - **Use `useOwnedPreloadedQuery` for loader-owned query refs.** If a route loader returns a `loadQuery` ref that this component owns directly, read it with `useOwnedPreloadedQuery` instead of `usePreloadedQuery`.
 - **Treat disposal as an ownership decision.** Only the owner should dispose a query ref. Disposing a shared ref too early can make still-mounted readers hit missing-data or GC-related crashes later.
+
+## Don't over-fetch to look up one entity
+
+When you need a single object by id (e.g. a lazy tooltip, a detail popover), fetch it directly via the `node(id: $id)` root field with an inline fragment on the concrete type — do **not** fetch a whole collection and `.find()` the one you want on the client. Over-fetching a list to grab one row wastes a round trip and scales badly.
+
+If the type isn't yet exposed through the `node` interface, make it a `Node` on the backend (have its GQL type declare `id: NodeID[int]` / implement `Node`, resolve fields lazily from the id, and add an `elif type_name == X.__name__: return X(id=node_id)` branch to `Query.node` in `src/phoenix/server/api/queries.py`) rather than working around it with a collection query.

--- a/app/src/components/evaluators/AddEvaluatorMenu.tsx
+++ b/app/src/components/evaluators/AddEvaluatorMenu.tsx
@@ -67,6 +67,7 @@ export const AddEvaluatorMenu = ({
     <>
       <MenuTrigger {...props}>
         <Button
+          variant="primary"
           size={size}
           leadingVisual={<Icon svg={<Icons.PlusOutline />} />}
         >

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -505,20 +505,20 @@ const ConfiguratorSidebar = ({
         </div>
       </div>
 
-      {/* "Sandbox Runtime" pinned to the bottom and always visible */}
+      {/* "Sandbox Config" pinned to the bottom and always visible */}
       <div css={sidebarFooterCSS}>
         <SectionHeading bordered={false}>
-          <Text weight="heavy" size="S">
-            Sandbox Runtime
+          <Text weight="heavy" size="M">
+            Sandbox Config
           </Text>
         </SectionHeading>
-        <SandboxRuntimeSummary selectedSandboxConfig={selectedSandboxConfig} />
+        <SandboxConfigSummary selectedSandboxConfig={selectedSandboxConfig} />
       </div>
     </>
   );
 };
 
-const SandboxRuntimeSummary = ({
+const SandboxConfigSummary = ({
   selectedSandboxConfig,
 }: {
   selectedSandboxConfig: SandboxConfigOption | null;
@@ -533,26 +533,26 @@ const SandboxRuntimeSummary = ({
     );
   }
   return (
-    <List size="S">
-      <SandboxConfigRow label="config" value={selectedSandboxConfig.name} />
+    <List size="M">
+      <SandboxConfigRow label="Name" value={selectedSandboxConfig.name} />
       {selectedSandboxConfig.timeout != null ? (
         <SandboxConfigRow
-          label="timeout"
+          label="Timeout"
           value={`${selectedSandboxConfig.timeout} seconds`}
         />
       ) : null}
       <SandboxConfigRow
-        label="env_vars"
+        label="Environment variables"
         value={getSandboxEnvVarsLabel(selectedSandboxConfig.config)}
       />
       <SandboxConfigRow
-        label="internet_access"
+        label="Internet access"
         value={getSandboxInternetAccessConfigLabel(
           selectedSandboxConfig.config
         )}
       />
       <SandboxConfigRow
-        label="dependencies"
+        label="Dependencies"
         value={getSandboxDependenciesConfigLabel(selectedSandboxConfig.config)}
       />
     </List>
@@ -569,11 +569,11 @@ const SandboxConfigRow = ({
   return (
     <ListItem>
       <View paddingStart="size-100" paddingEnd="size-100">
-        <Flex direction="row" justifyContent="space-between">
-          <Text size="XS" color="text-700">
+        <Flex direction="row" justifyContent="space-between" gap="size-200">
+          <Text size="S" color="text-700">
             {label}
           </Text>
-          <Text size="XS">{value}</Text>
+          <Text size="S">{value}</Text>
         </Flex>
       </View>
     </ListItem>
@@ -1194,7 +1194,7 @@ const sidebarScrollAreaCSS = css`
   overflow-y: auto;
 `;
 
-// The "Sandbox Runtime" region is pinned to the bottom of the panel and stays
+// The "Sandbox Config" region is pinned to the bottom of the panel and stays
 // visible. It scrolls internally if its content gets tall, but is capped so the
 // test region always keeps room.
 const sidebarFooterCSS = css`

--- a/app/src/components/sandbox/SandboxConfigLabel.tsx
+++ b/app/src/components/sandbox/SandboxConfigLabel.tsx
@@ -66,6 +66,9 @@ export function SandboxConfigLabel({
 }
 
 const settingsListCSS = css`
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: var(--global-dimension-static-size-50);
@@ -107,21 +110,21 @@ function SandboxConfigLabelDetails({
   const settings = getSandboxConfigSettings(sandboxConfig.config);
 
   return (
-    <div css={settingsListCSS}>
-      <div css={settingRowCSS}>
+    <ul css={settingsListCSS}>
+      <li css={settingRowCSS}>
         <Text size="S" color="text-700">
           Timeout
         </Text>
         <Text size="S">{sandboxConfig.timeout}s</Text>
-      </div>
+      </li>
       {settings.map((setting) => (
-        <div css={settingRowCSS} key={setting.key}>
+        <li css={settingRowCSS} key={setting.key}>
           <Text size="S" color="text-700">
             {setting.label}
           </Text>
           <Text size="S">{setting.value}</Text>
-        </div>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 }

--- a/app/src/components/sandbox/SandboxConfigLabel.tsx
+++ b/app/src/components/sandbox/SandboxConfigLabel.tsx
@@ -1,0 +1,127 @@
+import { css } from "@emotion/react";
+import { Suspense } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+
+import {
+  Flex,
+  Loading,
+  RichTooltip,
+  RichTooltipTitle,
+  Text,
+  TooltipArrow,
+  TooltipTrigger,
+  TriggerWrap,
+} from "@phoenix/components";
+import { Truncate } from "@phoenix/components/core/utility/Truncate";
+import { SandboxProviderIcon } from "@phoenix/components/sandbox/SandboxProviderIcon";
+import { getSandboxConfigSettings } from "@phoenix/pages/settings/sandboxes/utils";
+
+import type { SandboxConfigLabelDetailsQuery } from "./__generated__/SandboxConfigLabelDetailsQuery.graphql";
+
+type SandboxConfigLabelProps = {
+  /**
+   * The Relay node id of the SandboxConfig. Used to lazily load the config
+   * details when the tooltip is opened.
+   */
+  sandboxConfigId: string;
+  /**
+   * The display name of the sandbox config.
+   */
+  name: string;
+  /**
+   * The backend type of the sandbox provider, used to render the provider icon.
+   */
+  backendType: string;
+};
+
+/**
+ * Renders a sandbox config as a provider icon + name, with a tooltip that
+ * lazily loads the config's settings (dependencies, internet access, env vars,
+ * timeout, ...) on hover.
+ */
+export function SandboxConfigLabel({
+  sandboxConfigId,
+  name,
+  backendType,
+}: SandboxConfigLabelProps) {
+  return (
+    <TooltipTrigger delay={500}>
+      <TriggerWrap>
+        <Flex direction="row" gap="size-100" alignItems="center" minWidth={0}>
+          <SandboxProviderIcon backendType={backendType} height={18} />
+          <Text minWidth={0}>
+            <Truncate>{name}</Truncate>
+          </Text>
+        </Flex>
+      </TriggerWrap>
+      <RichTooltip>
+        <TooltipArrow />
+        <RichTooltipTitle>{name}</RichTooltipTitle>
+        <Suspense fallback={<Loading />}>
+          <SandboxConfigLabelDetails sandboxConfigId={sandboxConfigId} />
+        </Suspense>
+      </RichTooltip>
+    </TooltipTrigger>
+  );
+}
+
+const settingsListCSS = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-static-size-50);
+`;
+
+const settingRowCSS = css`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--global-dimension-static-size-200);
+`;
+
+function SandboxConfigLabelDetails({
+  sandboxConfigId,
+}: {
+  sandboxConfigId: string;
+}) {
+  const data = useLazyLoadQuery<SandboxConfigLabelDetailsQuery>(
+    graphql`
+      query SandboxConfigLabelDetailsQuery($id: ID!) {
+        node(id: $id) {
+          __typename
+          ... on SandboxConfig {
+            timeout
+            config
+          }
+        }
+      }
+    `,
+    { id: sandboxConfigId }
+  );
+
+  if (data.node.__typename !== "SandboxConfig") {
+    return <Text size="S">Sandbox config not found</Text>;
+  }
+  const sandboxConfig = data.node;
+
+  const settings = getSandboxConfigSettings(sandboxConfig.config);
+
+  return (
+    <div css={settingsListCSS}>
+      <div css={settingRowCSS}>
+        <Text size="S" color="text-700">
+          Timeout
+        </Text>
+        <Text size="S">{sandboxConfig.timeout}s</Text>
+      </div>
+      {settings.map((setting) => (
+        <div css={settingRowCSS} key={setting.key}>
+          <Text size="S" color="text-700">
+            {setting.label}
+          </Text>
+          <Text size="S">{setting.value}</Text>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/src/components/sandbox/__generated__/SandboxConfigLabelDetailsQuery.graphql.ts
+++ b/app/src/components/sandbox/__generated__/SandboxConfigLabelDetailsQuery.graphql.ts
@@ -1,0 +1,139 @@
+/**
+ * @generated SignedSource<<7e34ba99a8ba3848064821c2bbd6ceda>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type SandboxConfigLabelDetailsQuery$variables = {
+  id: string;
+};
+export type SandboxConfigLabelDetailsQuery$data = {
+  readonly node: {
+    readonly __typename: "SandboxConfig";
+    readonly config: any;
+    readonly timeout: number;
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  };
+};
+export type SandboxConfigLabelDetailsQuery = {
+  response: SandboxConfigLabelDetailsQuery$data;
+  variables: SandboxConfigLabelDetailsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "timeout",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "config",
+      "storageKey": null
+    }
+  ],
+  "type": "SandboxConfig",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SandboxConfigLabelDetailsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SandboxConfigLabelDetailsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "143c987b1e62b57f1d7d1427b77e7f49",
+    "id": null,
+    "metadata": {},
+    "name": "SandboxConfigLabelDetailsQuery",
+    "operationKind": "query",
+    "text": "query SandboxConfigLabelDetailsQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on SandboxConfig {\n      timeout\n      config\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "3290cd829ca344394ae719da9a22f8bc";
+
+export default node;

--- a/app/src/pages/evaluators/DatasetEvaluatorsTable.tsx
+++ b/app/src/pages/evaluators/DatasetEvaluatorsTable.tsx
@@ -27,7 +27,7 @@ import { LineClamp } from "@phoenix/components/core/utility/LineClamp";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { EvaluatorKindToken } from "@phoenix/components/evaluators/EvaluatorKindToken";
 import { GenerativeProviderIcon } from "@phoenix/components/generative";
-import { SandboxProviderIcon } from "@phoenix/components/sandbox/SandboxProviderIcon";
+import { SandboxConfigLabel } from "@phoenix/components/sandbox/SandboxConfigLabel";
 import { TextCell } from "@phoenix/components/table";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
@@ -388,20 +388,11 @@ export const DatasetEvaluatorsTable = ({
             return <Text color="text-700">—</Text>;
           }
           return (
-            <Flex
-              direction="row"
-              gap="size-100"
-              alignItems="center"
-              minWidth={0}
-            >
-              <SandboxProviderIcon
-                backendType={sandboxConfig.provider.backendType}
-                height={18}
-              />
-              <Text minWidth={0}>
-                <Truncate>{sandboxConfig.name}</Truncate>
-              </Text>
-            </Flex>
+            <SandboxConfigLabel
+              sandboxConfigId={sandboxConfig.id}
+              name={sandboxConfig.name}
+              backendType={sandboxConfig.provider.backendType}
+            />
           );
         },
       },

--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -97,7 +97,7 @@ export function SandboxConfigDialogTrigger(
         />
       )}
       <ModalOverlay>
-        <Modal size="L">
+        <Modal size="M">
           <Dialog>
             <DialogContent>
               <DialogHeader>

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -127,6 +127,7 @@ from phoenix.server.api.types.PromptVersionTemplate import (
 )
 from phoenix.server.api.types.SandboxConfig import (
     SandboxBackendInfo,
+    SandboxConfig,
     SandboxProvider,
     get_sandbox_backend_info,
 )
@@ -1066,6 +1067,10 @@ class Query:
             return BuiltInEvaluator(id=node_id)
         elif type_name == DatasetEvaluator.__name__:
             return DatasetEvaluator(id=node_id)
+        elif type_name == SandboxConfig.__name__:
+            return SandboxConfig(id=node_id)
+        elif type_name == SandboxProvider.__name__:
+            return SandboxProvider(id=node_id)
         if type_name == GenerativeModelCustomProvider.__name__:
             return GenerativeModelCustomProvider(id=node_id)
         raise NotFound(f"Unknown node type: {type_name}")


### PR DESCRIPTION

<img width="540" height="300" alt="Screenshot 2026-05-12 at 7 39 28 AM" src="https://github.com/user-attachments/assets/9a34faae-080d-4a03-894b-6e0d80a138ad" />

adds a tooltip to show you a tooltip of the sandbox config on the evaluator table for quick audits.