### PR TITLE
chore: Improve vite dev server boot times

### DIFF
--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -44,6 +44,13 @@ export default defineConfig(() => {
     publicDir: resolve(__dirname, "static"),
     server: {
       port: parseInt(process.env.VITE_PORT || "5173"),
+      warmup: {
+        clientFiles: [
+          "./index.tsx",
+          "./App.tsx",
+          "./Routes.tsx",
+        ],
+      },
       headers: {
         // Prevent browser caching during development to ensure fresh assets
         // after code changes. This fixes 304 responses causing stale files.

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -45,11 +45,7 @@ export default defineConfig(() => {
     server: {
       port: parseInt(process.env.VITE_PORT || "5173"),
       warmup: {
-        clientFiles: [
-          "./index.tsx",
-          "./App.tsx",
-          "./Routes.tsx",
-        ],
+        clientFiles: ["./index.tsx", "./App.tsx", "./Routes.tsx"],
       },
       headers: {
         // Prevent browser caching during development to ensure fresh assets


### PR DESCRIPTION
Now the dev server will starting transforming files as soon as it boots, rather than waiting for the first connection from your browser.