### PR TITLE
fix: settle PXI chat interruption boundary

### DIFF
--- a/app/src/agent/chat/PhoenixAgentChatTransport.ts
+++ b/app/src/agent/chat/PhoenixAgentChatTransport.ts
@@ -1,0 +1,97 @@
+import { DefaultChatTransport, type UIMessageChunk } from "ai";
+import type { UIMessage } from "ai";
+
+type AbortableStreamOptions<TChunk> = {
+  stream: ReadableStream<TChunk>;
+  signal: AbortSignal;
+};
+
+/**
+ * Stops forwarding UI message chunks as soon as the request is aborted.
+ *
+ * AI SDK's `stop()` aborts the fetch signal, but queued stream work can still
+ * unwind after a newer request has started. This wrapper makes abort a local
+ * client boundary by cancelling the reader and closing the stream seen by AI
+ * SDK's message writer.
+ */
+export function closeStreamOnAbort<TChunk>({
+  stream,
+  signal,
+}: AbortableStreamOptions<TChunk>): ReadableStream<TChunk> {
+  let reader: ReadableStreamDefaultReader<TChunk> | null = null;
+  return new ReadableStream<TChunk>({
+    start(controller) {
+      const streamReader = stream.getReader();
+      reader = streamReader;
+      let isDone = false;
+
+      const closeController = () => {
+        if (isDone) {
+          return;
+        }
+        isDone = true;
+        controller.close();
+      };
+
+      const abort = () => {
+        void streamReader.cancel().catch(() => undefined);
+        closeController();
+      };
+
+      if (signal.aborted) {
+        abort();
+        return;
+      }
+
+      signal.addEventListener("abort", abort, { once: true });
+
+      const pump = async () => {
+        try {
+          while (!signal.aborted) {
+            const { done, value } = await streamReader.read();
+            if (done || signal.aborted) {
+              break;
+            }
+            controller.enqueue(value);
+          }
+          closeController();
+        } catch (error) {
+          if (signal.aborted) {
+            closeController();
+            return;
+          }
+          isDone = true;
+          controller.error(error);
+        } finally {
+          signal.removeEventListener("abort", abort);
+        }
+      };
+
+      void pump();
+    },
+    cancel(reason) {
+      return reader?.cancel(reason);
+    },
+  });
+}
+
+/**
+ * Phoenix-specific AI SDK transport that closes the browser-side stream on
+ * abort instead of relying on the server to stop producing immediately.
+ */
+export class PhoenixAgentChatTransport<
+  UI_MESSAGE extends UIMessage,
+> extends DefaultChatTransport<UI_MESSAGE> {
+  override async sendMessages(
+    options: Parameters<DefaultChatTransport<UI_MESSAGE>["sendMessages"]>[0]
+  ): Promise<ReadableStream<UIMessageChunk>> {
+    const stream = await super.sendMessages(options);
+    if (!options.abortSignal) {
+      return stream;
+    }
+    return closeStreamOnAbort({
+      stream,
+      signal: options.abortSignal,
+    });
+  }
+}

--- a/app/src/agent/chat/__tests__/PhoenixAgentChatTransport.test.ts
+++ b/app/src/agent/chat/__tests__/PhoenixAgentChatTransport.test.ts
@@ -1,0 +1,64 @@
+import type { UIMessageChunk } from "ai";
+
+import { closeStreamOnAbort } from "@phoenix/agent/chat/PhoenixAgentChatTransport";
+
+function createTextStartChunk(id: string): UIMessageChunk {
+  return { type: "text-start", id };
+}
+
+describe("closeStreamOnAbort", () => {
+  it("cancels the source stream and closes the wrapped stream on abort", async () => {
+    let sourceController: ReadableStreamDefaultController<UIMessageChunk>;
+    let isSourceCancelled = false;
+    const source = new ReadableStream<UIMessageChunk>({
+      start(controller) {
+        sourceController = controller;
+      },
+      cancel() {
+        isSourceCancelled = true;
+      },
+    });
+    const abortController = new AbortController();
+    const stream = closeStreamOnAbort({
+      stream: source,
+      signal: abortController.signal,
+    });
+    const reader = stream.getReader();
+
+    sourceController!.enqueue(createTextStartChunk("part-1"));
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: createTextStartChunk("part-1"),
+    });
+
+    abortController.abort();
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    expect(isSourceCancelled).toBe(true);
+  });
+
+  it("closes immediately when the signal is already aborted", async () => {
+    let isSourceCancelled = false;
+    const source = new ReadableStream<UIMessageChunk>({
+      cancel() {
+        isSourceCancelled = true;
+      },
+    });
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const stream = closeStreamOnAbort({
+      stream: source,
+      signal: abortController.signal,
+    });
+    const reader = stream.getReader();
+
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    expect(isSourceCancelled).toBe(true);
+  });
+});

--- a/app/src/components/agent/__tests__/useAgentChat.test.ts
+++ b/app/src/components/agent/__tests__/useAgentChat.test.ts
@@ -1,0 +1,123 @@
+import { USER_INTERRUPT_ERROR } from "@phoenix/agent/chat/shouldSendAutomatically";
+import type { AgentUIMessage } from "@phoenix/agent/chat/types";
+import {
+  EDIT_PROMPT_TOOL_NAME,
+  READ_PROMPT_TOOL_NAME,
+} from "@phoenix/agent/tools/playgroundPrompt";
+import type { AgentChatTurn } from "@phoenix/contexts/AgentChatRuntimeContext";
+
+import {
+  createGuardedAddToolOutput,
+  resolveInterruptedMessages,
+  shouldSendAutomaticallyForTurn,
+} from "../useAgentChat";
+
+function createTurn(isCurrent: boolean): AgentChatTurn {
+  return {
+    generation: isCurrent ? 1 : 0,
+    isCurrent: () => isCurrent,
+  };
+}
+
+describe("createGuardedAddToolOutput", () => {
+  it("does not write stale tool outputs", async () => {
+    const addToolOutput = vi.fn().mockResolvedValue(undefined);
+    const guardedAddToolOutput = createGuardedAddToolOutput({
+      addToolOutput,
+      turn: createTurn(false),
+    });
+
+    await guardedAddToolOutput({
+      tool: READ_PROMPT_TOOL_NAME,
+      toolCallId: "tool-call-1",
+      output: "late output",
+    });
+
+    expect(addToolOutput).not.toHaveBeenCalled();
+  });
+});
+
+describe("shouldSendAutomaticallyForTurn", () => {
+  it("does not auto-continue stale turns", () => {
+    const messages: AgentUIMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: `tool-${READ_PROMPT_TOOL_NAME}`,
+            toolCallId: "tool-call-1",
+            state: "output-available",
+            input: {},
+            output: "done",
+          },
+        ],
+      },
+    ];
+
+    expect(
+      shouldSendAutomaticallyForTurn({
+        messages,
+        turn: createTurn(false),
+      })
+    ).toBe(false);
+  });
+});
+
+describe("resolveInterruptedMessages", () => {
+  it("marks unresolved tool calls interrupted before removing tool input parts", () => {
+    const messages: AgentUIMessage[] = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "actually, what is a trace" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "A trace is", state: "streaming" },
+          {
+            type: `tool-${READ_PROMPT_TOOL_NAME}`,
+            toolCallId: "tool-call-1",
+            state: "input-available",
+            input: { instanceId: 1 },
+          },
+          {
+            type: `tool-${EDIT_PROMPT_TOOL_NAME}`,
+            toolCallId: "tool-call-2",
+            state: "input-streaming",
+            input: undefined,
+          },
+        ],
+      },
+    ];
+
+    const result = resolveInterruptedMessages({
+      messages,
+      errorText: USER_INTERRUPT_ERROR,
+    });
+
+    expect(result.interruptedToolCalls).toEqual([
+      { tool: READ_PROMPT_TOOL_NAME, toolCallId: "tool-call-1" },
+      { tool: EDIT_PROMPT_TOOL_NAME, toolCallId: "tool-call-2" },
+    ]);
+    expect(result.messages.at(-1)?.parts).toEqual([
+      { type: "text", text: "A trace is", state: "streaming" },
+      {
+        type: `tool-${READ_PROMPT_TOOL_NAME}`,
+        toolCallId: "tool-call-1",
+        state: "output-error",
+        input: { instanceId: 1 },
+        errorText: USER_INTERRUPT_ERROR,
+      },
+      {
+        type: `tool-${EDIT_PROMPT_TOOL_NAME}`,
+        toolCallId: "tool-call-2",
+        state: "output-error",
+        input: {},
+        errorText: USER_INTERRUPT_ERROR,
+      },
+    ]);
+  });
+});

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -1,11 +1,21 @@
-import { Chat, useChat } from "@ai-sdk/react";
+import { Chat } from "@ai-sdk/react";
 import type { ChatStatus } from "ai";
-import { DefaultChatTransport, isToolUIPart } from "ai";
-import { useEffect, useRef } from "react";
+import { isToolUIPart } from "ai";
+import {
+  useCallback,
+  useEffect,
+  useReducer,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 
 import { buildAgentChatRequestBody } from "@phoenix/agent/chat/buildAgentChatRequestBody";
 import { handleAgentToolCall } from "@phoenix/agent/chat/handleAgentToolCall";
-import { getUnresolvedToolCalls } from "@phoenix/agent/chat/interruptToolCalls";
+import {
+  getUnresolvedToolCalls,
+  type UnresolvedToolCall,
+} from "@phoenix/agent/chat/interruptToolCalls";
+import { PhoenixAgentChatTransport } from "@phoenix/agent/chat/PhoenixAgentChatTransport";
 import {
   shouldSendAutomaticallyAfterToolOutput,
   SYSTEM_INTERRUPT_ERROR,
@@ -19,7 +29,11 @@ import type {
 } from "@phoenix/agent/tools/elicit";
 import { EDIT_PROMPT_TOOL_NAME } from "@phoenix/agent/tools/playgroundPrompt";
 import { authFetch } from "@phoenix/authFetch";
-import { useAgentChatRuntime } from "@phoenix/contexts/AgentChatRuntimeContext";
+import {
+  type AgentChatRuntimeChat,
+  type AgentChatTurn,
+  useAgentChatRuntime,
+} from "@phoenix/contexts/AgentChatRuntimeContext";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 
 import {
@@ -27,16 +41,92 @@ import {
   type ChatSearchParams,
 } from "./useGenerateSessionSummary";
 
+type AddToolOutput = Chat<AgentUIMessage>["addToolOutput"];
+const EMPTY_MESSAGES: AgentUIMessage[] = [];
+
+export function createGuardedAddToolOutput({
+  addToolOutput,
+  turn,
+}: {
+  addToolOutput: AddToolOutput;
+  turn: AgentChatTurn;
+}): AddToolOutput {
+  return async (output: Parameters<AddToolOutput>[0]) => {
+    if (!turn.isCurrent()) {
+      return;
+    }
+    return addToolOutput(output);
+  };
+}
+
+export function shouldSendAutomaticallyForTurn({
+  messages,
+  turn,
+}: {
+  messages: AgentUIMessage[];
+  turn: AgentChatTurn;
+}): boolean {
+  if (!turn.isCurrent()) {
+    return false;
+  }
+  return shouldSendAutomaticallyAfterToolOutput({ messages });
+}
+
+function useRuntimeChat(chatInstance: Chat<AgentUIMessage> | null) {
+  const subscribeToMessages = useCallback(
+    (update: () => void) => {
+      return (
+        chatInstance?.["~registerMessagesCallback"](update) ?? (() => undefined)
+      );
+    },
+    [chatInstance]
+  );
+  const subscribeToStatus = useCallback(
+    (update: () => void) => {
+      return (
+        chatInstance?.["~registerStatusCallback"](update) ?? (() => undefined)
+      );
+    },
+    [chatInstance]
+  );
+  const subscribeToError = useCallback(
+    (update: () => void) => {
+      return (
+        chatInstance?.["~registerErrorCallback"](update) ?? (() => undefined)
+      );
+    },
+    [chatInstance]
+  );
+
+  const messages = useSyncExternalStore(
+    subscribeToMessages,
+    () => chatInstance?.messages ?? EMPTY_MESSAGES,
+    () => EMPTY_MESSAGES
+  );
+  const status = useSyncExternalStore(
+    subscribeToStatus,
+    () => chatInstance?.status ?? "ready",
+    () => "ready"
+  );
+  const error = useSyncExternalStore(
+    subscribeToError,
+    () => chatInstance?.error,
+    () => undefined
+  );
+
+  return { messages, status, error };
+}
+
 /**
  * Subscribes the current render surface to the persistent AI SDK chat runtime
  * for a single agent session/model pair.
  *
- * `useChat` alone is tied to the current mounted component, which is too short-
- * lived for this agent UX: the visible chat surface can move between the docked
- * panel and the trace slideover, and model changes intentionally replace the
- * underlying transport. This hook keeps the imperative AI SDK `Chat` instance
- * in the app-level runtime registry, then binds the current React surface to
- * whichever runtime instance should own the session right now.
+ * A component-owned AI SDK chat is too short-lived for this agent UX: the
+ * visible chat surface can move between the docked panel and the trace
+ * slideover, and model changes intentionally replace the underlying transport.
+ * This hook keeps the imperative AI SDK `Chat` instance in the app-level
+ * runtime registry, then binds the current React surface to whichever runtime
+ * instance should own the session right now.
  *
  * Durable state still lives in the agent store:
  * - messages are mirrored into Zustand so an idle chat can be reconstructed
@@ -56,158 +146,189 @@ export function useAgentChat({
   const store = useAgentStore();
   const runtime = useAgentChatRuntime();
   const { generateSummary } = useGenerateSessionSummary({ chatSearchParams });
+  const [, forceChatBinding] = useReducer((version: number) => version + 1, 0);
   const pendingElicitation = useAgentContext((state) =>
     sessionId ? (state.pendingElicitationBySessionId[sessionId] ?? null) : null
   );
 
+  const createChat = (turn: AgentChatTurn) => {
+    // Rehydrate from store-backed messages so evicted idle runtimes can
+    // be recreated without losing visible conversation history.
+    const initialMessages =
+      sessionId == null
+        ? []
+        : (store.getState().sessionMap[sessionId]?.messages ?? []);
+    const chatRef: { current: Chat<AgentUIMessage> | null } = {
+      current: null,
+    };
+    const guardedAddToolOutput = createGuardedAddToolOutput({
+      addToolOutput: async (output) => {
+        await chatRef.current?.addToolOutput(output);
+      },
+      turn,
+    });
+    const chat = new Chat<AgentUIMessage>({
+      id: sessionId ?? "agent-chat",
+      messages: initialMessages,
+      transport: new PhoenixAgentChatTransport({
+        api: chatApiUrl,
+        fetch: authFetch,
+        prepareSendMessagesRequest: ({
+          body,
+          id,
+          messages,
+          trigger,
+          messageId,
+        }) => ({
+          body: buildAgentChatRequestBody({
+            body,
+            id,
+            messages,
+            trigger,
+            messageId,
+            capabilities: store.getState().capabilities,
+            observability: store.getState().observability,
+            hasRemoteCollector: Boolean(
+              store.getState().agentsConfig.collectorEndpoint
+            ),
+            contexts: selectActiveContexts(store.getState()),
+          }),
+        }),
+      }),
+      // Tool execution must target the runtime-owned chat instance so
+      // tool outputs continue to attach to the correct conversation
+      // even if the visible React surface remounts during the request.
+      onToolCall: ({ toolCall }) => {
+        if (!turn.isCurrent()) {
+          return;
+        }
+        void handleAgentToolCall({
+          toolCall,
+          sessionId,
+          addToolOutput: guardedAddToolOutput,
+          agentStore: store,
+        });
+      },
+      sendAutomaticallyWhen: ({ messages }) => {
+        return shouldSendAutomaticallyForTurn({ messages, turn });
+      },
+      onFinish: ({
+        messages: finalMessages,
+        message,
+        isAbort,
+        isDisconnect,
+        isError,
+      }) => {
+        if (!turn.isCurrent() || isAbort || isDisconnect || isError) {
+          return;
+        }
+        if (!sessionId) {
+          return;
+        }
+        const usage = message.metadata?.usage;
+        if (usage != null) {
+          store.getState().setSessionUsage(sessionId, {
+            ...usage.tokens,
+            ...(usage.promptDetails
+              ? { promptDetails: usage.promptDetails }
+              : {}),
+          });
+        }
+        // Finalized history is mirrored into the durable store so idle
+        // runtimes can be reclaimed and later reconstructed from state.
+        if (finalMessages) {
+          store.getState().setSessionMessages(sessionId, finalMessages);
+          generateSummary({ sessionId });
+        }
+      },
+    });
+    chatRef.current = chat;
+    return chat;
+  };
+
   // Resolve the imperative runtime instance for this session/model pair. The
   // runtime owns replacement semantics when the transport changes, while the
   // hook simply binds the current render surface to the selected instance.
-  const chatInstance =
+  const runtimeChat =
     sessionId === null
       ? null
       : runtime.getOrCreateChat({
           sessionId,
           chatApiUrl,
-          createChat: () => {
-            // Rehydrate from store-backed messages so evicted idle runtimes can
-            // be recreated without losing visible conversation history.
-            const initialMessages =
-              store.getState().sessionMap[sessionId]?.messages ?? [];
-            const chat = new Chat<AgentUIMessage>({
-              id: sessionId,
-              messages: initialMessages,
-              transport: new DefaultChatTransport({
-                api: chatApiUrl,
-                fetch: authFetch,
-                prepareSendMessagesRequest: ({
-                  body,
-                  id,
-                  messages,
-                  trigger,
-                  messageId,
-                }) => ({
-                  body: buildAgentChatRequestBody({
-                    body,
-                    id,
-                    messages,
-                    trigger,
-                    messageId,
-                    capabilities: store.getState().capabilities,
-                    observability: store.getState().observability,
-                    hasRemoteCollector: Boolean(
-                      store.getState().agentsConfig.collectorEndpoint
-                    ),
-                    contexts: selectActiveContexts(store.getState()),
-                  }),
-                }),
-              }),
-              // Tool execution must target the runtime-owned chat instance so
-              // tool outputs continue to attach to the correct conversation
-              // even if the visible React surface remounts during the request.
-              onToolCall: ({ toolCall }) => {
-                void handleAgentToolCall({
-                  toolCall,
-                  sessionId,
-                  addToolOutput: chat.addToolOutput,
-                  agentStore: store,
-                });
-              },
-              sendAutomaticallyWhen: shouldSendAutomaticallyAfterToolOutput,
-              onFinish: ({ messages: finalMessages, message }) => {
-                const usage = message.metadata?.usage;
-                if (usage != null) {
-                  store.getState().setSessionUsage(sessionId, {
-                    ...usage.tokens,
-                    ...(usage.promptDetails
-                      ? { promptDetails: usage.promptDetails }
-                      : {}),
-                  });
-                }
-                // Finalized history is mirrored into the durable store so idle
-                // runtimes can be reclaimed and later reconstructed from state.
-                if (finalMessages) {
-                  store.getState().setSessionMessages(sessionId, finalMessages);
-                  generateSummary({ sessionId });
-                }
-              },
-            });
-            return chat;
-          },
+          createChat,
         });
+  const chatInstance = runtimeChat?.chat ?? null;
 
-  // `useChat` subscribes the current React tree to the already-created runtime
-  // instance. When `sessionId` is null we intentionally expose an inert chat
-  // shape rather than creating a shared fallback runtime through this hook.
-  const chat = useChat<AgentUIMessage>(
-    chatInstance ? { chat: chatInstance } : { id: undefined, messages: [] }
-  );
-  const {
-    messages,
-    sendMessage,
-    status,
-    error,
-    addToolOutput,
-    stop,
-    setMessages,
-  } = chat;
+  const { messages, status, error } = useRuntimeChat(chatInstance);
 
-  // Anthropic doesn't accept unresolved tool calls, so we resolve them by
-  // marking them as error before the next request goes out.
-  const addInterruptedToolOutputs = async ({
-    messages,
-    errorText,
+  const clearInterruptedToolState = ({
+    interruptedToolCalls,
   }: {
-    messages: AgentUIMessage[];
-    errorText: string;
+    interruptedToolCalls: ReturnType<typeof getUnresolvedToolCalls>;
   }) => {
-    const unresolvedToolCalls = getUnresolvedToolCalls(messages);
-
-    unresolvedToolCalls.forEach((toolCall) => {
+    interruptedToolCalls.forEach((toolCall) => {
       if (toolCall.tool === EDIT_PROMPT_TOOL_NAME) {
         // The generic interruption output resolves the AI SDK tool call; clear
         // the live approval state too so stale Accept/Reject actions disappear.
         store.getState().setPendingPromptEdit(toolCall.toolCallId, null);
       }
+      if (toolCall.tool === "ask_user" && sessionId) {
+        store.getState().setPendingElicitation(sessionId, null);
+      }
     });
+  };
 
-    await Promise.all(
-      unresolvedToolCalls.map((toolCall) =>
-        addToolOutput({
-          tool: toolCall.tool,
-          toolCallId: toolCall.toolCallId,
-          errorText,
-          state: "output-error",
-        })
-      )
-    );
+  const interruptActiveChat = async ({
+    errorText,
+  }: {
+    errorText: string;
+  }): Promise<AgentChatRuntimeChat | null> => {
+    if (!sessionId || !runtimeChat) {
+      return null;
+    }
+
+    const latestMessages = runtimeChat.chat.messages.length
+      ? runtimeChat.chat.messages
+      : messages;
+    const { messages: interruptedMessages, interruptedToolCalls } =
+      resolveInterruptedMessages({
+        messages: latestMessages,
+        errorText,
+      });
+    clearInterruptedToolState({ interruptedToolCalls });
+
+    if (isRequestActive(runtimeChat.chat.status)) {
+      await runtimeChat.chat.stop();
+    }
+
+    runtimeChat.chat.messages = interruptedMessages;
+    store.getState().setSessionMessages(sessionId, interruptedMessages);
+
+    const nextRuntimeChat = runtime.replaceChat({
+      sessionId,
+      chatApiUrl,
+      createChat,
+    });
+    forceChatBinding();
+    return nextRuntimeChat;
   };
 
   const handleStopWithToolCleanup = async () => {
-    await stop();
-    setMessages(removeInterruptedToolInputParts);
-
-    const latestMessages = chatInstance?.messages ?? messages;
-    await addInterruptedToolOutputs({
-      messages: latestMessages,
-      errorText: USER_INTERRUPT_ERROR,
-    });
+    await interruptActiveChat({ errorText: USER_INTERRUPT_ERROR });
   };
 
-  const handleSendMessage = async (...args: Parameters<typeof sendMessage>) => {
-    if (chatInstance && isRequestActive(chatInstance.status)) {
-      await stop();
+  const handleSendMessage = async (
+    ...args: Parameters<Chat<AgentUIMessage>["sendMessage"]>
+  ) => {
+    let targetChat = chatInstance;
+    if (runtimeChat && isRequestActive(runtimeChat.chat.status)) {
+      const nextRuntimeChat = await interruptActiveChat({
+        errorText: SYSTEM_INTERRUPT_ERROR,
+      });
+      targetChat = nextRuntimeChat?.chat ?? null;
     }
 
-    setMessages(removeInterruptedToolInputParts);
-
-    const latestMessages = chatInstance?.messages ?? messages;
-    await addInterruptedToolOutputs({
-      messages: latestMessages,
-      errorText: SYSTEM_INTERRUPT_ERROR,
-    });
-
-    await sendMessage(...args);
+    await targetChat?.sendMessage(...args);
   };
 
   const messagesRef = useRef(messages);
@@ -227,10 +348,10 @@ export function useAgentChat({
   // Elicitation responses are written back through the runtime-owned chat so
   // the pending tool call resolves against the correct assistant turn.
   const handleElicitationSubmit = (output: ElicitToolOutput) => {
-    if (!pendingElicitation || !sessionId) {
+    if (!pendingElicitation || !sessionId || !runtimeChat?.isCurrent()) {
       return;
     }
-    void addToolOutput({
+    void runtimeChat.chat.addToolOutput({
       tool: "ask_user",
       toolCallId: pendingElicitation.toolCallId,
       output,
@@ -239,10 +360,10 @@ export function useAgentChat({
   };
 
   const handleElicitationCancel = () => {
-    if (!pendingElicitation || !sessionId) {
+    if (!pendingElicitation || !sessionId || !runtimeChat?.isCurrent()) {
       return;
     }
-    void addToolOutput({
+    void runtimeChat.chat.addToolOutput({
       state: "output-error",
       tool: "ask_user",
       toolCallId: pendingElicitation.toolCallId,
@@ -262,7 +383,7 @@ export function useAgentChat({
     handleElicitationCancel,
   } as {
     messages: AgentUIMessage[];
-    sendMessage: (message: { text: string }) => void;
+    sendMessage: (message: { text: string }) => Promise<void>;
     stop: () => Promise<void>;
     status: ChatStatus;
     error: Error | undefined;
@@ -287,6 +408,57 @@ function removeInterruptedToolInputParts(
       }),
     };
   });
+}
+
+export function resolveInterruptedMessages({
+  messages,
+  errorText,
+}: {
+  messages: AgentUIMessage[];
+  errorText: string;
+}): {
+  messages: AgentUIMessage[];
+  interruptedToolCalls: UnresolvedToolCall[];
+} {
+  const interruptedToolCalls = getUnresolvedToolCalls(messages);
+  if (interruptedToolCalls.length === 0) {
+    return { messages, interruptedToolCalls };
+  }
+
+  const interruptedToolCallIds = new Set(
+    interruptedToolCalls.map((toolCall) => toolCall.toolCallId)
+  );
+
+  return {
+    interruptedToolCalls,
+    messages: removeInterruptedToolInputParts(
+      messages.map((message, messageIndex) => {
+        const isLastMessage = messageIndex === messages.length - 1;
+        if (!isLastMessage || message.role !== "assistant") {
+          return message;
+        }
+        return {
+          ...message,
+          parts: message.parts.map((part) => {
+            if (
+              !isToolUIPart(part) ||
+              !interruptedToolCallIds.has(part.toolCallId)
+            ) {
+              return part;
+            }
+            const input =
+              "input" in part && part.input != null ? part.input : {};
+            return {
+              ...part,
+              state: "output-error",
+              input,
+              errorText,
+            } as typeof part;
+          }),
+        };
+      })
+    ),
+  };
 }
 
 function isRequestActive(status: ChatStatus): boolean {

--- a/app/src/components/ai/prompt-input/PromptInputSubmit.tsx
+++ b/app/src/components/ai/prompt-input/PromptInputSubmit.tsx
@@ -10,8 +10,8 @@ import type { PromptInputSubmitProps } from "./types";
  *
  * - **ready / error** — arrow icon; pressing sends the message.
  * - **streaming, empty input** — stop icon; pressing stops generation.
- * - **streaming, user has typed** — arrow icon; pressing stops generation
- *   then sends the message.
+ * - **streaming, user has typed** — arrow icon; pressing submits through the
+ *   chat owner, which handles interruption before sending the next message.
  *
  * Automatically disables when `status` is `"ready"` and the textarea is empty.
  */
@@ -37,7 +37,7 @@ export function PromptInputSubmit({
     ariaLabel ?? (showSend ? "Send message" : "Stop generation");
 
   const handlePress = () => {
-    if (isStreaming) {
+    if (isStreaming && isEmpty) {
       onStop?.();
     }
     if (!isEmpty) {

--- a/app/src/components/ai/prompt-input/types.ts
+++ b/app/src/components/ai/prompt-input/types.ts
@@ -192,7 +192,8 @@ export interface PromptInputTextareaProps {
  * | Status                    | Icon              | Press action               |
  * |---------------------------|-------------------|----------------------------|
  * | `"ready"` or `"error"`    | Arrow up (send)   | Calls `context.onSubmit()` |
- * | `"submitted"` / `"streaming"` | Stop circle   | Calls `onPress` prop       |
+ * | `"submitted"` / `"streaming"` with empty input | Stop circle | Calls `onPress` prop |
+ * | `"submitted"` / `"streaming"` with typed input | Arrow up | Calls `context.onSubmit()` |
  *
  * Automatically disables when `status` is `"ready"` and the textarea is empty.
  */

--- a/app/src/contexts/AgentChatRuntimeContext.tsx
+++ b/app/src/contexts/AgentChatRuntimeContext.tsx
@@ -6,6 +6,17 @@ import { createContext, useContext, useEffect, useState } from "react";
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 
+export type AgentChatTurn = {
+  generation: number;
+  isCurrent: () => boolean;
+};
+
+export type AgentChatRuntimeChat = {
+  chat: Chat<AgentUIMessage>;
+} & AgentChatTurn;
+
+type CreateAgentChat = (turn: AgentChatTurn) => Chat<AgentUIMessage>;
+
 type AgentChatRuntime = {
   /**
    * Returns the runtime-owned AI SDK chat for a session/model pair, creating or
@@ -23,8 +34,21 @@ type AgentChatRuntime = {
   }: {
     sessionId: string;
     chatApiUrl: string;
-    createChat: () => Chat<AgentUIMessage>;
-  }) => Chat<AgentUIMessage>;
+    createChat: CreateAgentChat;
+  }) => AgentChatRuntimeChat;
+  /**
+   * Invalidates the current chat generation and replaces the runtime-owned
+   * chat with a fresh instance seeded by the caller's `createChat` function.
+   */
+  replaceChat: ({
+    sessionId,
+    chatApiUrl,
+    createChat,
+  }: {
+    sessionId: string;
+    chatApiUrl: string;
+    createChat: CreateAgentChat;
+  }) => AgentChatRuntimeChat;
   /**
    * Reconciles the runtime registry against current app state, reclaiming chats
    * that no longer need to remain imperative singletons.
@@ -96,37 +120,97 @@ export function AgentChatRuntimeProvider({ children }: PropsWithChildren) {
         chatApiUrl: string;
         chat: Chat<AgentUIMessage>;
         unsubscribe: () => void;
+        generation: number;
       }
     >();
+    const chatGenerations = new Map<string, number>();
+
+    const createTurn = ({
+      sessionId,
+      generation,
+    }: {
+      sessionId: string;
+      generation: number;
+    }): AgentChatTurn => ({
+      generation,
+      isCurrent: () => chatRegistry.get(sessionId)?.generation === generation,
+    });
+
+    const setEntry = ({
+      sessionId,
+      chatApiUrl,
+      createChat,
+      generation,
+    }: {
+      sessionId: string;
+      chatApiUrl: string;
+      createChat: CreateAgentChat;
+      generation: number;
+    }): AgentChatRuntimeChat => {
+      const existingEntry = chatRegistry.get(sessionId);
+      if (existingEntry) {
+        existingEntry.unsubscribe();
+        chatRegistry.delete(sessionId);
+        void existingEntry.chat.stop();
+      }
+
+      chatGenerations.set(sessionId, generation);
+      const turn = createTurn({ sessionId, generation });
+      const chat = createChat(turn);
+      // Mirror transient AI SDK status into the store so other surfaces
+      // (session list, FAB, retention policy) can react without holding a
+      // direct reference to the runtime instance. Stale generations are ignored
+      // because their callbacks can still unwind after replacement.
+      const unsubscribe = chat["~registerStatusCallback"](() => {
+        if (turn.isCurrent()) {
+          store.getState().setSessionChatStatus(sessionId, chat.status);
+        }
+      });
+      chatRegistry.set(sessionId, {
+        chatApiUrl,
+        chat,
+        unsubscribe,
+        generation,
+      });
+      // Defer initial status sync to avoid updating state during render,
+      // which triggers React warnings and can break component lifecycles.
+      queueMicrotask(() => {
+        if (turn.isCurrent()) {
+          store.getState().setSessionChatStatus(sessionId, chat.status);
+        }
+      });
+      return { chat, ...turn };
+    };
 
     return {
       getOrCreateChat: ({ sessionId, chatApiUrl, createChat }) => {
         const existingEntry = chatRegistry.get(sessionId);
         if (existingEntry && existingEntry.chatApiUrl === chatApiUrl) {
-          return existingEntry.chat;
+          return {
+            chat: existingEntry.chat,
+            ...createTurn({
+              sessionId,
+              generation: existingEntry.generation,
+            }),
+          };
         }
 
-        // A model/transport swap replaces the runtime for this session. We do
-        // not keep multiple chat variants per session alive; instead we detach
-        // the old status subscription and let retention/pruning reclaim it.
-        if (existingEntry) {
-          existingEntry.unsubscribe();
-        }
-
-        const chat = createChat();
-        // Mirror transient AI SDK status into the store so other surfaces
-        // (session list, FAB, retention policy) can react without holding a
-        // direct reference to the runtime instance.
-        const unsubscribe = chat["~registerStatusCallback"](() => {
-          store.getState().setSessionChatStatus(sessionId, chat.status);
+        const generation =
+          existingEntry == null ? 0 : (chatGenerations.get(sessionId) ?? 0) + 1;
+        return setEntry({
+          sessionId,
+          chatApiUrl,
+          createChat,
+          generation,
         });
-        chatRegistry.set(sessionId, { chatApiUrl, chat, unsubscribe });
-        // Defer initial status sync to avoid updating state during render,
-        // which triggers React warnings and can break component lifecycles.
-        queueMicrotask(() => {
-          store.getState().setSessionChatStatus(sessionId, chat.status);
+      },
+      replaceChat: ({ sessionId, chatApiUrl, createChat }) => {
+        return setEntry({
+          sessionId,
+          chatApiUrl,
+          createChat,
+          generation: (chatGenerations.get(sessionId) ?? 0) + 1,
         });
-        return chat;
       },
       pruneChats: ({ activeSessionId, liveSessionIds }) => {
         const liveSessionIdSet = new Set(liveSessionIds);
@@ -148,6 +232,7 @@ export function AgentChatRuntimeProvider({ children }: PropsWithChildren) {
           // becomes the only durable source of truth until the chat is created
           // again for a future surface/session visit.
           entry?.unsubscribe();
+          void entry?.chat.stop();
           chatRegistry.delete(sessionId);
           store.getState().setSessionChatStatus(sessionId, "ready");
         }


### PR DESCRIPTION
## Summary
- add a Phoenix agent chat transport that closes the browser-side AI SDK stream on abort
- add per-session chat generations and runtime replacement so stale callbacks cannot mutate the active transcript
- freeze interrupted partial assistant messages, mark unresolved tools interrupted, and route typed-while-streaming submits through the chat owner

## Testing
- pnpm --dir app typecheck
- pnpm --dir app lint
- pnpm --dir app test -- PhoenixAgentChatTransport useAgentChat shouldSendAutomatically toolRegistry AgentChatRuntimeContext

Related: #12716