### PR TITLE
feat(agents): backfill TOOL spans for external tool returns

### DIFF
--- a/src/phoenix/server/agents/pydantic_ai/openinference_agent_wrapper.py
+++ b/src/phoenix/server/agents/pydantic_ai/openinference_agent_wrapper.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Iterator, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, TypeAlias
 
 from openinference.instrumentation import (
     OITracer,
@@ -11,15 +11,31 @@ from openinference.instrumentation import (
     get_input_attributes,
     get_output_attributes,
     get_span_kind_attributes,
+    safe_json_dumps,
 )
-from openinference.semconv.trace import OpenInferenceMimeTypeValues
+from openinference.semconv.trace import (
+    OpenInferenceMimeTypeValues,
+    SpanAttributes,
+    ToolCallAttributes,
+)
 from opentelemetry.trace import Status, StatusCode, Tracer, TracerProvider
 from pydantic_ai.agent.abstract import AbstractAgent
 from pydantic_ai.agent.wrapper import WrapperAgent
-from pydantic_ai.messages import UserContent
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturnPart,
+    UserContent,
+)
 from pydantic_ai.output import OutputDataT
 from pydantic_ai.run import AgentRun, AgentRunResult
 from pydantic_ai.tools import AgentDepsT
+
+from phoenix.server.agents.toolsets.external.tools import get_external_tool_definition
+
+ToolCallId: TypeAlias = str
 
 
 @dataclass(init=False)
@@ -50,25 +66,105 @@ class OpenInferenceAgentWrapper(WrapperAgent[AgentDepsT, OutputDataT]):
     async def iter(
         self,
         user_prompt: str | Sequence[UserContent] | None = None,
+        *,
+        message_history: Sequence[ModelMessage] | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[AgentRun[AgentDepsT, Any]]:
-        with self._span(user_prompt=user_prompt, kwargs=kwargs) as set_result:
-            async with super().iter(user_prompt, **kwargs) as agent_run:
+        with self._span(
+            user_prompt=user_prompt,
+            message_history=message_history,
+            kwargs=kwargs,
+        ) as set_result:
+            # TODO(https://github.com/Arize-ai/phoenix/issues/13173): remove
+            # once the frontend emits TOOL spans for external tools at
+            # execution time. Until then, backfill TOOL spans for the
+            # previous turn's external tool calls by replaying the trailing
+            # tool returns in the inbound history.
+            self._emit_resolved_external_tool_spans(message_history=message_history)
+            async with super().iter(
+                user_prompt, message_history=message_history, **kwargs
+            ) as agent_run:
                 yield agent_run
                 set_result(agent_run.result)
+
+    def _emit_resolved_external_tool_spans(
+        self,
+        *,
+        message_history: Sequence[ModelMessage] | None,
+    ) -> None:
+        """Emit TOOL spans for external tools resolved since the previous turn.
+
+        External tools are not instrumented at execution time. Their results
+        arrive on trailing ``ModelRequest`` messages as ``ToolReturnPart``s —
+        possibly alongside a fresh ``UserPromptPart`` when the user submits a
+        new turn in the same request. Replay each such ``ToolReturnPart`` as
+        a synthetic TOOL span parented to the current AGENT span.
+        """
+        if not message_history:
+            return
+        messages = list(message_history)
+        trailing_tool_return_parts, first_trailing_request_index = (
+            _collect_trailing_tool_return_parts(messages)
+        )
+        if not trailing_tool_return_parts:
+            return
+        tool_call_parts_by_call_id = _get_tool_call_parts_by_id(
+            messages[:first_trailing_request_index]
+        )
+        for tool_return_part in trailing_tool_return_parts:
+            matching_tool_call_part = tool_call_parts_by_call_id.get(tool_return_part.tool_call_id)
+            self._emit_tool_span(
+                tool_return_part=tool_return_part,
+                tool_call_part=matching_tool_call_part,
+            )
+
+    def _emit_tool_span(
+        self,
+        *,
+        tool_return_part: ToolReturnPart,
+        tool_call_part: ToolCallPart | None,
+    ) -> None:
+        tool_arguments = tool_call_part.args_as_dict() if tool_call_part is not None else {}
+        tool_name = tool_return_part.tool_name
+        attributes: dict[str, Any] = {
+            **get_span_kind_attributes("tool"),
+            SpanAttributes.TOOL_NAME: tool_name,
+            **get_input_attributes(tool_arguments, mime_type=OpenInferenceMimeTypeValues.JSON),
+            **get_output_attributes(tool_return_part.content),
+            ToolCallAttributes.TOOL_CALL_ID: tool_return_part.tool_call_id,
+        }
+        tool_def = get_external_tool_definition(tool_name)
+        if tool_def is not None:
+            attributes[SpanAttributes.TOOL_PARAMETERS] = safe_json_dumps(
+                tool_def.parameters_json_schema
+            )
+            if tool_def.description is not None:
+                attributes[SpanAttributes.TOOL_DESCRIPTION] = tool_def.description
+        with self._tracer.start_as_current_span(name=tool_name, attributes=attributes) as span:
+            outcome = tool_return_part.outcome
+            if outcome == "success":
+                span.set_status(Status(StatusCode.OK))
+            else:
+                error_message = (
+                    str(tool_return_part.content)
+                    if tool_return_part.content is not None
+                    else outcome
+                )
+                span.record_exception(Exception(error_message))
+                span.set_status(Status(StatusCode.ERROR, f"tool {outcome}: {error_message}"))
 
     @contextmanager
     def _span(
         self,
         *,
         user_prompt: str | Sequence[UserContent] | None,
+        message_history: Sequence[ModelMessage] | None,
         kwargs: dict[str, Any],
     ) -> Iterator[Callable[[AgentRunResult[Any] | None], None]]:
         input_value: dict[str, Any] = {
             "user_prompt": user_prompt,
             **{k: v for k, v in kwargs.items() if v is not None},
         }
-        message_history = input_value.get("message_history")
         if message_history is not None:
             input_value["message_history"] = list(message_history)
         attributes = {
@@ -88,3 +184,42 @@ class OpenInferenceAgentWrapper(WrapperAgent[AgentDepsT, OutputDataT]):
 
             yield set_result
             span.set_status(Status(StatusCode.OK))
+
+
+def _collect_trailing_tool_return_parts(
+    messages: Sequence[ModelMessage],
+) -> tuple[list[ToolReturnPart], int]:
+    """Collect ``ToolReturnPart``s from the trailing run of ``ModelRequest``s.
+
+    A trailing ``ModelRequest`` may mix ``ToolReturnPart``s with other parts
+    (e.g. a ``UserPromptPart`` when the user submits a new turn alongside
+    the external tool results); the returns are still collected. The walk
+    stops at the first non-``ModelRequest`` message or at the first
+    ``ModelRequest`` carrying no ``ToolReturnPart``s. Returns the collected
+    tool returns alongside the index of the earliest message in that
+    trailing block (or ``len(messages)`` when none are found).
+    """
+    trailing_tool_return_parts: list[ToolReturnPart] = []
+    first_trailing_request_index = len(messages)
+    for index, message in reversed(list(enumerate(messages))):
+        if not isinstance(message, ModelRequest):
+            break
+        return_parts_in_message = [p for p in message.parts if isinstance(p, ToolReturnPart)]
+        if not return_parts_in_message:
+            break
+        trailing_tool_return_parts.extend(return_parts_in_message)
+        first_trailing_request_index = index
+    return trailing_tool_return_parts, first_trailing_request_index
+
+
+def _get_tool_call_parts_by_id(
+    messages: Sequence[ModelMessage],
+) -> dict[ToolCallId, ToolCallPart]:
+    tool_calls_by_call_id: dict[ToolCallId, ToolCallPart] = {}
+    for model_response in reversed(messages):
+        if not isinstance(model_response, ModelResponse):
+            break
+        for part in model_response.parts:
+            if isinstance(part, ToolCallPart):
+                tool_calls_by_call_id[part.tool_call_id] = part
+    return tool_calls_by_call_id

--- a/src/phoenix/server/agents/toolsets/external/tools/__init__.py
+++ b/src/phoenix/server/agents/toolsets/external/tools/__init__.py
@@ -1,3 +1,5 @@
+from pydantic_ai.tools import ToolDefinition
+
 from phoenix.server.agents.toolsets.external.tools.ask_user import ASK_USER_TOOL_DEFINITION
 from phoenix.server.agents.toolsets.external.tools.bash import BASH_TOOL_DEFINITION
 from phoenix.server.agents.toolsets.external.tools.clone_prompt_instance import (
@@ -16,6 +18,25 @@ from phoenix.server.agents.toolsets.external.tools.set_time_range import (
     SET_TIME_RANGE_TOOL_DEFINITION,
 )
 
+_EXTERNAL_TOOL_DEFINITIONS_BY_NAME: dict[str, ToolDefinition] = {
+    tool_def.name: tool_def
+    for tool_def in (
+        ASK_USER_TOOL_DEFINITION,
+        BASH_TOOL_DEFINITION,
+        CLONE_PROMPT_INSTANCE_TOOL_DEFINITION,
+        EDIT_PROMPT_TOOL_DEFINITION,
+        READ_PROMPT_TOOL_DEFINITION,
+        SET_SPANS_FILTER_TOOL_DEFINITION,
+        SET_TIME_RANGE_TOOL_DEFINITION,
+    )
+}
+
+
+def get_external_tool_definition(name: str) -> ToolDefinition | None:
+    """Look up a registered external tool definition by name."""
+    return _EXTERNAL_TOOL_DEFINITIONS_BY_NAME.get(name)
+
+
 __all__ = [
     "ASK_USER_TOOL_DEFINITION",
     "BASH_TOOL_DEFINITION",
@@ -24,4 +45,5 @@ __all__ = [
     "READ_PROMPT_TOOL_DEFINITION",
     "SET_SPANS_FILTER_TOOL_DEFINITION",
     "SET_TIME_RANGE_TOOL_DEFINITION",
+    "get_external_tool_definition",
 ]

--- a/src/phoenix/tracers.py
+++ b/src/phoenix/tracers.py
@@ -26,7 +26,7 @@ from phoenix.db import models
 from phoenix.db.insertion.helpers import should_calculate_span_cost
 from phoenix.server.daemons.span_cost_calculator import SpanCostCalculator
 from phoenix.server.telemetry import normalize_http_collector_endpoint
-from phoenix.trace.attributes import get_attribute_value, unflatten
+from phoenix.trace.attributes import get_attribute_value, load_json_strings, unflatten
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +269,7 @@ def _get_db_span(
 
     attributes = {}
     if otel_span.attributes:
-        attributes = unflatten(otel_span.attributes.items())
+        attributes = unflatten(load_json_strings(otel_span.attributes.items()))
 
     span_kind_attribute_value = get_attribute_value(
         attributes, SpanAttributes.OPENINFERENCE_SPAN_KIND

--- a/tests/unit/server/agents/pydantic_ai/test_openinference_agent_wrapper.py
+++ b/tests/unit/server/agents/pydantic_ai/test_openinference_agent_wrapper.py
@@ -10,13 +10,22 @@ from openinference.semconv.trace import (
     OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
+    ToolCallAttributes,
 )
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import StatusCode
 from pydantic_ai import Agent
-from pydantic_ai.messages import ModelMessage, ModelResponse
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
 from pydantic_ai.models import ModelRequestParameters, StreamedResponse
 from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.test import TestModel
@@ -27,6 +36,11 @@ from pydantic_ai.settings import ModelSettings
 from phoenix.server.agents.pydantic_ai import (
     OpenInferenceAgentWrapper,
     OpenInferenceModelWrapper,
+)
+from phoenix.server.agents.toolsets.external.tools import (
+    ASK_USER_TOOL_DEFINITION,
+    BASH_TOOL_DEFINITION,
+    SET_TIME_RANGE_TOOL_DEFINITION,
 )
 from tests.unit.vcr import CustomVCR
 
@@ -114,6 +128,19 @@ def raising_agent(
     return OpenInferenceAgentWrapper(inner, tracer_provider=tracer_provider)
 
 
+@pytest.fixture
+def test_model_agent(
+    tracer_provider: TracerProvider,
+) -> OpenInferenceAgentWrapper[None, str]:
+    """An OpenInferenceAgentWrapper backed by TestModel — no network, no VCR.
+
+    Used by tests that exercise behavior triggered by the inbound history
+    (e.g. external tool span backfill) and don't care about model output.
+    """
+    inner: Agent[None, str] = Agent(TestModel(), deps_type=type(None))
+    return OpenInferenceAgentWrapper(inner, tracer_provider=tracer_provider)
+
+
 def _get_agent_span(spans: tuple[ReadableSpan, ...]) -> ReadableSpan:
     matches = [
         span for span in spans if (span.attributes or {}).get(OPENINFERENCE_SPAN_KIND) == AGENT
@@ -124,6 +151,10 @@ def _get_agent_span(spans: tuple[ReadableSpan, ...]) -> ReadableSpan:
 
 def _get_llm_spans(spans: tuple[ReadableSpan, ...]) -> list[ReadableSpan]:
     return [s for s in spans if (s.attributes or {}).get(OPENINFERENCE_SPAN_KIND) == LLM]
+
+
+def _get_tool_spans(spans: tuple[ReadableSpan, ...]) -> list[ReadableSpan]:
+    return [s for s in spans if (s.attributes or {}).get(OPENINFERENCE_SPAN_KIND) == TOOL]
 
 
 async def test_iter_emits_agent_span_for_text_response(
@@ -300,6 +331,338 @@ async def test_iter_records_exception_when_run_fails(
     assert not attributes
 
 
+async def test_backfills_tool_span_for_trailing_external_tool_return(
+    test_model_agent: OpenInferenceAgentWrapper[None, str],
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    tool_name = BASH_TOOL_DEFINITION.name
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="run tool")]),
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name=tool_name,
+                    args={"command": "ls"},
+                    tool_call_id="call-1",
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name=tool_name,
+                    content="file1\nfile2",
+                    tool_call_id="call-1",
+                )
+            ]
+        ),
+    ]
+    await test_model_agent.run("continue", message_history=history)
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    agent_span = _get_agent_span(spans)
+    tool_spans = _get_tool_spans(spans)
+    assert len(tool_spans) == 1
+    tool_span = tool_spans[0]
+    assert tool_span.name == tool_name
+    assert tool_span.parent is not None
+    assert tool_span.parent.span_id == agent_span.context.span_id
+    assert tool_span.context.trace_id == agent_span.context.trace_id
+    assert tool_span.status.status_code == StatusCode.OK
+
+    attributes = dict(tool_span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == TOOL
+    assert attributes.pop(TOOL_NAME) == tool_name
+    assert attributes.pop(TOOL_CALL_ID) == "call-1"
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert json.loads(input_value) == {"command": "ls"}
+    assert attributes.pop(INPUT_MIME_TYPE) == JSON
+    assert attributes.pop(OUTPUT_VALUE) == "file1\nfile2"
+    assert attributes.pop(OUTPUT_MIME_TYPE) == TEXT
+    assert attributes.pop(TOOL_DESCRIPTION) == BASH_TOOL_DEFINITION.description
+    tool_parameters = attributes.pop(TOOL_PARAMETERS)
+    assert isinstance(tool_parameters, str)
+    assert json.loads(tool_parameters) == dict(BASH_TOOL_DEFINITION.parameters_json_schema)
+    assert not attributes
+
+
+async def test_backfills_multiple_tool_spans_joined_by_tool_call_id(
+    test_model_agent: OpenInferenceAgentWrapper[None, str],
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    bash_tool = BASH_TOOL_DEFINITION.name
+    ask_user_tool = ASK_USER_TOOL_DEFINITION.name
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="parallel tools")]),
+        ModelResponse(
+            parts=[
+                ToolCallPart(tool_name=bash_tool, args={"command": "ls"}, tool_call_id="a"),
+                ToolCallPart(tool_name=ask_user_tool, args={"prompt": "ok?"}, tool_call_id="b"),
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(tool_name=ask_user_tool, content="yes", tool_call_id="b"),
+                ToolReturnPart(tool_name=bash_tool, content="ok", tool_call_id="a"),
+            ]
+        ),
+    ]
+    await test_model_agent.run("continue", message_history=history)
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    agent_span = _get_agent_span(spans)
+    tool_spans = _get_tool_spans(spans)
+    assert len(tool_spans) == 2
+    by_call_id = {(s.attributes or {})[TOOL_CALL_ID]: s for s in tool_spans}
+    assert set(by_call_id) == {"a", "b"}
+
+    bash_span = by_call_id["a"]
+    assert bash_span.name == bash_tool
+    assert bash_span.parent is not None
+    assert bash_span.parent.span_id == agent_span.context.span_id
+    assert bash_span.context.trace_id == agent_span.context.trace_id
+    assert bash_span.status.status_code == StatusCode.OK
+    bash_attrs = dict(bash_span.attributes or {})
+    assert bash_attrs.pop(OPENINFERENCE_SPAN_KIND) == TOOL
+    assert bash_attrs.pop(TOOL_NAME) == bash_tool
+    assert bash_attrs.pop(TOOL_CALL_ID) == "a"
+    bash_input = bash_attrs.pop(INPUT_VALUE)
+    assert isinstance(bash_input, str)
+    assert json.loads(bash_input) == {"command": "ls"}
+    assert bash_attrs.pop(INPUT_MIME_TYPE) == JSON
+    assert bash_attrs.pop(OUTPUT_VALUE) == "ok"
+    assert bash_attrs.pop(OUTPUT_MIME_TYPE) == TEXT
+    assert bash_attrs.pop(TOOL_DESCRIPTION) == BASH_TOOL_DEFINITION.description
+    bash_params = bash_attrs.pop(TOOL_PARAMETERS)
+    assert isinstance(bash_params, str)
+    assert json.loads(bash_params) == dict(BASH_TOOL_DEFINITION.parameters_json_schema)
+    assert not bash_attrs
+
+    ask_user_span = by_call_id["b"]
+    assert ask_user_span.name == ask_user_tool
+    assert ask_user_span.parent is not None
+    assert ask_user_span.parent.span_id == agent_span.context.span_id
+    assert ask_user_span.context.trace_id == agent_span.context.trace_id
+    assert ask_user_span.status.status_code == StatusCode.OK
+    ask_user_attrs = dict(ask_user_span.attributes or {})
+    assert ask_user_attrs.pop(OPENINFERENCE_SPAN_KIND) == TOOL
+    assert ask_user_attrs.pop(TOOL_NAME) == ask_user_tool
+    assert ask_user_attrs.pop(TOOL_CALL_ID) == "b"
+    ask_user_input = ask_user_attrs.pop(INPUT_VALUE)
+    assert isinstance(ask_user_input, str)
+    assert json.loads(ask_user_input) == {"prompt": "ok?"}
+    assert ask_user_attrs.pop(INPUT_MIME_TYPE) == JSON
+    assert ask_user_attrs.pop(OUTPUT_VALUE) == "yes"
+    assert ask_user_attrs.pop(OUTPUT_MIME_TYPE) == TEXT
+    assert ask_user_attrs.pop(TOOL_DESCRIPTION) == ASK_USER_TOOL_DEFINITION.description
+    ask_user_params = ask_user_attrs.pop(TOOL_PARAMETERS)
+    assert isinstance(ask_user_params, str)
+    assert json.loads(ask_user_params) == dict(ASK_USER_TOOL_DEFINITION.parameters_json_schema)
+    assert not ask_user_attrs
+
+
+async def test_does_not_emit_tool_spans_for_history_ending_in_user_prompt(
+    test_model_agent: OpenInferenceAgentWrapper[None, str],
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="hi")]),
+        ModelResponse(parts=[TextPart(content="hello")]),
+        ModelRequest(parts=[UserPromptPart(content="another question")]),
+    ]
+    await test_model_agent.run("continue", message_history=history)
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert _get_tool_spans(spans) == []
+
+
+async def test_emits_tool_span_for_tool_return_in_mixed_trailing_request(
+    test_model_agent: OpenInferenceAgentWrapper[None, str],
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """A trailing ``ModelRequest`` may carry a ``ToolReturnPart`` alongside a
+    ``UserPromptPart`` when the user submits a new turn in the same request
+    that delivers the external tool's result. The tool return still gets a
+    backfilled TOOL span."""
+    tool_name = BASH_TOOL_DEFINITION.name
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="run tool")]),
+        ModelResponse(
+            parts=[ToolCallPart(tool_name=tool_name, args={"command": "ls"}, tool_call_id="call-1")]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(tool_name=tool_name, content="ok", tool_call_id="call-1"),
+                UserPromptPart(content="also tell me about it"),
+            ]
+        ),
+    ]
+    await test_model_agent.run("continue", message_history=history)
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    agent_span = _get_agent_span(spans)
+    tool_spans = _get_tool_spans(spans)
+    assert len(tool_spans) == 1
+    tool_span = tool_spans[0]
+    assert tool_span.name == tool_name
+    assert tool_span.parent is not None
+    assert tool_span.parent.span_id == agent_span.context.span_id
+    assert tool_span.context.trace_id == agent_span.context.trace_id
+    assert tool_span.status.status_code == StatusCode.OK
+
+    attributes = dict(tool_span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == TOOL
+    assert attributes.pop(TOOL_NAME) == tool_name
+    assert attributes.pop(TOOL_CALL_ID) == "call-1"
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert json.loads(input_value) == {"command": "ls"}
+    assert attributes.pop(INPUT_MIME_TYPE) == JSON
+    assert attributes.pop(OUTPUT_VALUE) == "ok"
+    assert attributes.pop(OUTPUT_MIME_TYPE) == TEXT
+    assert attributes.pop(TOOL_DESCRIPTION) == BASH_TOOL_DEFINITION.description
+    tool_parameters = attributes.pop(TOOL_PARAMETERS)
+    assert isinstance(tool_parameters, str)
+    assert json.loads(tool_parameters) == dict(BASH_TOOL_DEFINITION.parameters_json_schema)
+    assert not attributes
+
+
+async def test_tool_span_args_come_from_prior_tool_call_part(
+    test_model_agent: OpenInferenceAgentWrapper[None, str],
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """``ToolReturnPart`` has no ``args`` field; the span's ``input.value``
+    must be recovered by joining on ``tool_call_id`` with the preceding
+    ``ModelResponse``'s ``ToolCallPart``."""
+    tool_name = SET_TIME_RANGE_TOOL_DEFINITION.name
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="search")]),
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name=tool_name,
+                    args={"start": "2026-01-01", "end": "2026-02-01"},
+                    tool_call_id="t1",
+                )
+            ]
+        ),
+        ModelRequest(parts=[ToolReturnPart(tool_name=tool_name, content="set", tool_call_id="t1")]),
+    ]
+    await test_model_agent.run("continue", message_history=history)
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    agent_span = _get_agent_span(spans)
+    tool_spans = _get_tool_spans(spans)
+    assert len(tool_spans) == 1
+    tool_span = tool_spans[0]
+    assert tool_span.name == tool_name
+    assert tool_span.parent is not None
+    assert tool_span.parent.span_id == agent_span.context.span_id
+    assert tool_span.context.trace_id == agent_span.context.trace_id
+    assert tool_span.status.status_code == StatusCode.OK
+
+    attributes = dict(tool_span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == TOOL
+    assert attributes.pop(TOOL_NAME) == tool_name
+    assert attributes.pop(TOOL_CALL_ID) == "t1"
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert json.loads(input_value) == {"start": "2026-01-01", "end": "2026-02-01"}
+    assert attributes.pop(INPUT_MIME_TYPE) == JSON
+    assert attributes.pop(OUTPUT_VALUE) == "set"
+    assert attributes.pop(OUTPUT_MIME_TYPE) == TEXT
+    assert attributes.pop(TOOL_DESCRIPTION) == SET_TIME_RANGE_TOOL_DEFINITION.description
+    tool_parameters = attributes.pop(TOOL_PARAMETERS)
+    assert isinstance(tool_parameters, str)
+    assert json.loads(tool_parameters) == dict(
+        SET_TIME_RANGE_TOOL_DEFINITION.parameters_json_schema
+    )
+    assert not attributes
+
+
+async def test_backfilled_tool_span_omits_schema_and_description_for_unregistered_tool(
+    test_model_agent: OpenInferenceAgentWrapper[None, str],
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """When the trailing tool return's name is not registered in the
+    external-tool registry, ``tool.parameters`` and ``tool.description``
+    are omitted rather than set to stale or empty values."""
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="run a thing")]),
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="some_unregistered_tool",
+                    args={"x": 1},
+                    tool_call_id="call-1",
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="some_unregistered_tool",
+                    content="ok",
+                    tool_call_id="call-1",
+                )
+            ]
+        ),
+    ]
+    await test_model_agent.run("continue", message_history=history)
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    tool_spans = _get_tool_spans(spans)
+    assert len(tool_spans) == 1
+    tool_attrs = tool_spans[0].attributes or {}
+    assert TOOL_PARAMETERS not in tool_attrs
+    assert TOOL_DESCRIPTION not in tool_attrs
+
+
+async def test_failed_tool_return_records_exception_event(
+    test_model_agent: OpenInferenceAgentWrapper[None, str],
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """A non-success outcome on a trailing ``ToolReturnPart`` sets ERROR
+    status on the synthetic TOOL span and records an ``exception`` event
+    whose message comes from the part's ``content``."""
+    error_content = "command not found: bsh"
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="run bsh")]),
+        ModelResponse(
+            parts=[ToolCallPart(tool_name="bash", args={"command": "bsh"}, tool_call_id="call-1")]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="bash",
+                    content=error_content,
+                    tool_call_id="call-1",
+                    outcome="failed",
+                )
+            ]
+        ),
+    ]
+    await test_model_agent.run("continue", message_history=history)
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    tool_spans = _get_tool_spans(spans)
+    assert len(tool_spans) == 1
+    tool_span = tool_spans[0]
+    assert tool_span.status.status_code == StatusCode.ERROR
+    assert tool_span.status.description == f"tool failed: {error_content}"
+
+    assert len(tool_span.events) == 1
+    (exception_event,) = tool_span.events
+    assert exception_event.name == "exception"
+    event_attributes = dict(exception_event.attributes or {})
+    assert event_attributes.pop("exception.type") == "Exception"
+    assert event_attributes.pop("exception.message") == error_content
+    assert isinstance(event_attributes.pop("exception.stacktrace"), str)
+    assert event_attributes.pop("exception.escaped") == "False"
+    assert not event_attributes
+
+
 # OpenInference attribute keys
 OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND
 INPUT_VALUE = SpanAttributes.INPUT_VALUE
@@ -309,7 +672,13 @@ OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
 
 AGENT = OpenInferenceSpanKindValues.AGENT.value
 LLM = OpenInferenceSpanKindValues.LLM.value
+TOOL = OpenInferenceSpanKindValues.TOOL.value
 JSON = OpenInferenceMimeTypeValues.JSON.value
 TEXT = OpenInferenceMimeTypeValues.TEXT.value
+
+TOOL_DESCRIPTION = SpanAttributes.TOOL_DESCRIPTION
+TOOL_NAME = SpanAttributes.TOOL_NAME
+TOOL_PARAMETERS = SpanAttributes.TOOL_PARAMETERS
+TOOL_CALL_ID = ToolCallAttributes.TOOL_CALL_ID
 
 MODEL_NAME = "claude-haiku-4-5"

--- a/tests/unit/test_tracers.py
+++ b/tests/unit/test_tracers.py
@@ -1,3 +1,4 @@
+import json
 import re
 from datetime import datetime, timezone
 from typing import Sequence
@@ -223,6 +224,32 @@ class TestTracer:
                 }
             },
             "custom_attr": "child_value",
+        }
+
+    @pytest.mark.asyncio
+    async def test_save_db_traces_parses_json_string_attributes(
+        self, db: DbSessionFactory, project: models.Project, tracer: Tracer
+    ) -> None:
+        tool_parameters_schema = {
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"],
+        }
+        with tracer.start_as_current_span(
+            "bash",
+            attributes={OPENINFERENCE_SPAN_KIND: "TOOL"},
+        ) as span:
+            span.set_attribute(TOOL_PARAMETERS, json.dumps(tool_parameters_schema))
+            span.set_status(Status(StatusCode.OK))
+
+        returned_traces = tracer.get_db_traces(project_id=project.id)
+        assert len(returned_traces) == 1
+        returned_spans = returned_traces[0].spans
+        assert len(returned_spans) == 1
+        tool_span = returned_spans[0]
+        assert tool_span.attributes == {
+            "openinference": {"span": {"kind": "TOOL"}},
+            "tool": {"parameters": tool_parameters_schema},
         }
 
     @pytest.mark.asyncio
@@ -950,3 +977,4 @@ LLM_PROVIDER = SpanAttributes.LLM_PROVIDER
 LLM_TOKEN_COUNT_COMPLETION = SpanAttributes.LLM_TOKEN_COUNT_COMPLETION
 LLM_TOKEN_COUNT_PROMPT = SpanAttributes.LLM_TOKEN_COUNT_PROMPT
 OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND
+TOOL_PARAMETERS = SpanAttributes.TOOL_PARAMETERS


### PR DESCRIPTION
## Summary
- The agent wrapper now backfills synthetic TOOL spans for external tools (pydantic-ai's `ExternalToolset`) whose results arrive on trailing `ModelRequest`s as `ToolReturnPart`s — including the mixed case where a fresh `UserPromptPart` accompanies the returns. Args are recovered from the matching prior `ToolCallPart` by `tool_call_id`; non-success outcomes get a `record_exception` event plus `ERROR` status with the content surfaced in the description.
- Stopgap until the frontend emits these TOOL spans at execution time.

Part of #11598. Related to #13173 (tracks the longer-term move to client-side TOOL span emission, which removes this backfill).

## Test plan
- [ ] `uv run pytest tests/unit/server/agents/pydantic_ai/test_openinference_agent_wrapper.py` — 6 new tests cover single-tool backfill, multi-tool backfill keyed by `tool_call_id`, mixed trailing request, args-recovery from prior `ToolCallPart`, the negative case (history ending in `UserPromptPart`), and the failure path with `exception` event assertions.
- [ ] Manual: send a turn whose history ends in an external tool return and confirm a TOOL span appears under the AGENT span in Phoenix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)