### PR TITLE
feat(agents): populate project_sessions for /chat and /summary traces

### DIFF
--- a/.agents/skills/phoenix-server/SKILL.md
+++ b/.agents/skills/phoenix-server/SKILL.md
@@ -70,6 +70,16 @@ tests/unit/server/api/
   unauthenticated by default — this has been exploited as an SSRF vector. See
   `references/graphql-patterns.md` → "Query vs Mutation".
 
+## Naming
+
+- **Avoid acronyms and single/double-letter abbreviations for local variables.**
+  Prefer the full noun: `session` / `project_session` over `ps`, `trace` over `t`,
+  `dataset_example` over `de`. The cost of a longer identifier is trivial; the
+  cost of having to mentally expand an acronym while reading unfamiliar code is
+  not. Loop variables in tiny scopes (`for i in range(n)`) are the only exception.
+- Established domain acronyms used in the codebase (`db`, `gql`, `otel`, `llm`)
+  are fine — they're vocabulary, not abbreviations of local nouns.
+
 ## Docstrings
 
 The project rule of "default to no comments" is about **inline comments**, not

--- a/.agents/skills/phoenix-server/SKILL.md
+++ b/.agents/skills/phoenix-server/SKILL.md
@@ -74,9 +74,9 @@ tests/unit/server/api/
 
 - **Avoid acronyms and single/double-letter abbreviations for local variables.**
   Prefer the full noun: `session` / `project_session` over `ps`, `trace` over `t`,
-  `dataset_example` over `de`. The cost of a longer identifier is trivial; the
+  `example` / `dataset_example` over `de`. The cost of a longer identifier is trivial; the
   cost of having to mentally expand an acronym while reading unfamiliar code is
-  not. Loop variables in tiny scopes (`for i in range(n)`) are the only exception.
+  not.
 - Established domain acronyms used in the codebase (`db`, `gql`, `otel`, `llm`)
   are fine — they're vocabulary, not abbreviations of local nouns.
 

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -231,6 +231,31 @@ def _build_message_metadata_chunk(
     )
 
 
+async def _persist_db_traces(
+    *,
+    session: AsyncSession,
+    db_traces: list[models.Trace],
+) -> None:
+    """
+    Upsert any ProjectSession rows attached to ``db_traces``, re-point each
+    trace at the resolved rowid, then add the traces to the session and flush.
+    """
+    project_sessions = [
+        db_trace.project_session for db_trace in db_traces if db_trace.project_session is not None
+    ]
+    rowid_by_session_id = await _upsert_project_sessions(session, project_sessions)
+    for db_trace in db_traces:
+        project_session = db_trace.project_session
+        if project_session is None:
+            continue
+        _apply_project_session_rowid(
+            db_trace=db_trace,
+            project_session_rowid=rowid_by_session_id[project_session.session_id],
+        )
+    session.add_all(db_traces)
+    await session.flush()
+
+
 async def _ensure_project_exists(db: DbSessionFactory, project_name: str) -> int:
     """Resolve project_id by name, creating the project row if missing."""
     async with db() as session:
@@ -310,27 +335,6 @@ def _apply_project_session_rowid(
     """
     db_trace.project_session = None  # type: ignore[assignment]
     db_trace.project_session_rowid = project_session_rowid
-
-
-async def _persist_db_traces(
-    *,
-    session: AsyncSession,
-    db_traces: list[models.Trace],
-) -> None:
-    project_sessions = [
-        db_trace.project_session for db_trace in db_traces if db_trace.project_session is not None
-    ]
-    rowid_by_session_id = await _upsert_project_sessions(session, project_sessions)
-    for db_trace in db_traces:
-        project_session = db_trace.project_session
-        if project_session is None:
-            continue
-        _apply_project_session_rowid(
-            db_trace=db_trace,
-            project_session_rowid=rowid_by_session_id[project_session.session_id],
-        )
-    session.add_all(db_traces)
-    await session.flush()
 
 
 def create_agents_router(authentication_enabled: bool) -> APIRouter:

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -312,6 +312,30 @@ def _apply_project_session_rowid(
     db_trace.project_session_rowid = project_session_rowid
 
 
+async def _link_project_sessions_to_traces(
+    *,
+    session: AsyncSession,
+    db_traces: list[models.Trace],
+) -> None:
+    """
+    For any traces with an attached in-memory ProjectSession, upsert the
+    ProjectSession rows and re-point each trace at the resolved rowid. Mutates
+    ``db_traces`` in place. Does not add or flush the traces themselves.
+    """
+    project_sessions = [
+        db_trace.project_session for db_trace in db_traces if db_trace.project_session is not None
+    ]
+    rowid_by_session_id = await _upsert_project_sessions(session, project_sessions)
+    for db_trace in db_traces:
+        project_session = db_trace.project_session
+        if project_session is None:
+            continue
+        _apply_project_session_rowid(
+            db_trace=db_trace,
+            project_session_rowid=rowid_by_session_id[project_session.session_id],
+        )
+
+
 def create_agents_router(authentication_enabled: bool) -> APIRouter:
     dependencies = [Depends(is_authenticated)] if authentication_enabled else []
     router = APIRouter(tags=["chat"], dependencies=dependencies)
@@ -409,24 +433,9 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                         db_traces = tracer.get_db_traces(project_id=project_id)
                         if db_traces:
                             async with request.app.state.db() as session:
-                                project_sessions = [
-                                    db_trace.project_session
-                                    for db_trace in db_traces
-                                    if db_trace.project_session is not None
-                                ]
-                                rowid_by_session_id = await _upsert_project_sessions(
-                                    session, project_sessions
+                                await _link_project_sessions_to_traces(
+                                    session=session, db_traces=db_traces
                                 )
-                                for db_trace in db_traces:
-                                    project_session = db_trace.project_session
-                                    if project_session is None:
-                                        continue
-                                    _apply_project_session_rowid(
-                                        db_trace=db_trace,
-                                        project_session_rowid=rowid_by_session_id[
-                                            project_session.session_id
-                                        ],
-                                    )
                                 session.add_all(db_traces)
                                 await session.flush()
                     tracer.tracer_provider.shutdown()
@@ -483,24 +492,9 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     db_traces = tracer.get_db_traces(project_id=project_id)
                     if db_traces:
                         async with request.app.state.db() as session:
-                            project_sessions = [
-                                db_trace.project_session
-                                for db_trace in db_traces
-                                if db_trace.project_session is not None
-                            ]
-                            rowid_by_session_id = await _upsert_project_sessions(
-                                session, project_sessions
+                            await _link_project_sessions_to_traces(
+                                session=session, db_traces=db_traces
                             )
-                            for db_trace in db_traces:
-                                project_session = db_trace.project_session
-                                if project_session is None:
-                                    continue
-                                _apply_project_session_rowid(
-                                    db_trace=db_trace,
-                                    project_session_rowid=rowid_by_session_id[
-                                        project_session.session_id
-                                    ],
-                                )
                             session.add_all(db_traces)
                             await session.flush()
                 tracer.tracer_provider.shutdown()

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -298,22 +298,17 @@ async def _upsert_project_sessions(
     return {session_id: rowid for rowid, session_id in id_rows.all()}
 
 
-def _apply_project_session_rowids(
-    db_traces: list[models.Trace],
-    rowid_by_session_id: dict[str, int],
+def _apply_project_session_rowid(
+    db_trace: models.Trace,
+    project_session_rowid: int,
 ) -> None:
     """
-    For each trace with an attached in-memory ProjectSession, detach the
-    relationship and assign the resolved rowid as the foreign key. Mutates
-    ``db_traces`` in place. Detaching avoids a duplicate INSERT via the ORM's
-    save-update cascade when the trace is later added to a session.
+    Detach the in-memory ProjectSession from ``db_trace`` and assign the
+    resolved rowid as the foreign key. Detaching avoids a duplicate INSERT via
+    the ORM's save-update cascade when the trace is later added to a session.
     """
-    for db_trace in db_traces:
-        project_session = db_trace.project_session
-        if project_session is None:
-            continue
-        db_trace.project_session = None  # type: ignore[assignment]
-        db_trace.project_session_rowid = rowid_by_session_id[project_session.session_id]
+    db_trace.project_session = None  # type: ignore[assignment]
+    db_trace.project_session_rowid = project_session_rowid
 
 
 def create_agents_router(authentication_enabled: bool) -> APIRouter:
@@ -421,7 +416,14 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                                 rowid_by_session_id = await _upsert_project_sessions(
                                     session, project_sessions
                                 )
-                                _apply_project_session_rowids(db_traces, rowid_by_session_id)
+                                for db_trace in db_traces:
+                                    project_session = db_trace.project_session
+                                    if project_session is None:
+                                        continue
+                                    _apply_project_session_rowid(
+                                        db_trace,
+                                        rowid_by_session_id[project_session.session_id],
+                                    )
                                 session.add_all(db_traces)
                                 await session.flush()
                     tracer.tracer_provider.shutdown()
@@ -486,7 +488,14 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                             rowid_by_session_id = await _upsert_project_sessions(
                                 session, project_sessions
                             )
-                            _apply_project_session_rowids(db_traces, rowid_by_session_id)
+                            for db_trace in db_traces:
+                                project_session = db_trace.project_session
+                                if project_session is None:
+                                    continue
+                                _apply_project_session_rowid(
+                                    db_trace,
+                                    rowid_by_session_id[project_session.session_id],
+                                )
                             session.add_all(db_traces)
                             await session.flush()
                 tracer.tracer_provider.shutdown()

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -19,10 +19,13 @@ from pydantic_ai.ui.vercel_ai.request_types import (
     UIMessage,
 )
 from pydantic_ai.ui.vercel_ai.response_types import BaseChunk, MessageMetadataChunk
-from sqlalchemy import select
+from sqlalchemy import Insert, func, select
+from sqlalchemy.dialects.postgresql import insert as insert_postgresql
+from sqlalchemy.dialects.sqlite import insert as insert_sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 from starlette.responses import Response
+from typing_extensions import assert_never
 
 from phoenix.config import get_env_phoenix_agents_assistant_project_name
 from phoenix.db import models
@@ -236,11 +239,6 @@ async def _persist_db_traces(
     session: AsyncSession,
     db_traces: list[models.Trace],
 ) -> None:
-    """
-    Upsert any ProjectSession rows attached to ``db_traces``, re-point each
-    trace at the persistent ORM object, then add the traces to the session and
-    flush.
-    """
     project_sessions = [
         db_trace.project_session for db_trace in db_traces if db_trace.project_session is not None
     ]
@@ -308,21 +306,39 @@ async def _upsert_project_sessions(
         }
         for project_session in project_sessions_by_session_id.values()
     ]
-    await session.execute(
-        insert_on_conflict(
-            *records,
-            table=models.ProjectSession,
-            dialect=dialect,
-            unique_by=("session_id",),
-            on_conflict=OnConflict.DO_UPDATE,
+    upsert: Insert
+    if dialect is SupportedSQLDialect.POSTGRESQL:
+        pg_insert = insert_postgresql(models.ProjectSession).values(records)
+        upsert = pg_insert.on_conflict_do_update(
+            index_elements=["session_id"],
+            set_={
+                "start_time": func.least(
+                    models.ProjectSession.start_time, pg_insert.excluded.start_time
+                ),
+                "end_time": func.greatest(
+                    models.ProjectSession.end_time, pg_insert.excluded.end_time
+                ),
+            },
         )
-    )
-    persistent_rows = await session.scalars(
-        select(models.ProjectSession).where(
-            models.ProjectSession.session_id.in_(project_sessions_by_session_id.keys())
+    elif dialect is SupportedSQLDialect.SQLITE:
+        # SQLite has no LEAST/GREATEST; min(a, b) / max(a, b) as scalar
+        # functions (i.e. with >1 argument) are the equivalent.
+        sqlite_insert = insert_sqlite(models.ProjectSession).values(records)
+        upsert = sqlite_insert.on_conflict_do_update(
+            index_elements=["session_id"],
+            set_={
+                "start_time": func.min(
+                    models.ProjectSession.start_time, sqlite_insert.excluded.start_time
+                ),
+                "end_time": func.max(
+                    models.ProjectSession.end_time, sqlite_insert.excluded.end_time
+                ),
+            },
         )
-    )
-    return {row.session_id: row for row in persistent_rows}
+    else:
+        assert_never(dialect)
+    returned_rows = await session.scalars(upsert.returning(models.ProjectSession))
+    return {row.session_id: row for row in returned_rows}
 
 
 def create_agents_router(authentication_enabled: bool) -> APIRouter:

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -20,11 +20,13 @@ from pydantic_ai.ui.vercel_ai.request_types import (
 )
 from pydantic_ai.ui.vercel_ai.response_types import BaseChunk, MessageMetadataChunk
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 from starlette.responses import Response
 
 from phoenix.config import get_env_phoenix_agents_assistant_project_name
 from phoenix.db import models
+from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.server.agents.agent_factory import ChatOutput, build_agent
 from phoenix.server.agents.capabilities import AgentCapabilities
@@ -246,14 +248,14 @@ async def _ensure_project_exists(db: DbSessionFactory, project_name: str) -> int
         return project_id
 
 
-async def _persist_db_traces_with_sessions(
-    db: DbSessionFactory,
+async def _upsert_project_sessions(
+    session: AsyncSession,
     db_traces: list[models.Trace],
 ) -> None:
     """
-    Persist tracer-built traces, upserting any attached ProjectSession rows by
-    session_id so concurrent requests sharing a session don't collide on the
-    UNIQUE constraint.
+    Upsert any ProjectSession rows attached to ``db_traces`` (keyed by session_id),
+    then re-point each trace at the resolved rowid. Does NOT persist the traces
+    themselves — the caller is responsible for adding them to the session.
     """
     sessions_by_session_id: dict[str, models.ProjectSession] = {}
     for db_trace in db_traces:
@@ -269,42 +271,42 @@ async def _persist_db_traces_with_sessions(
             if existing.end_time < ps.end_time:
                 existing.end_time = ps.end_time
 
-    async with db() as session:
-        if sessions_by_session_id:
-            records = [
-                {
-                    "session_id": ps.session_id,
-                    "project_id": ps.project_id,
-                    "start_time": ps.start_time,
-                    "end_time": ps.end_time,
-                }
-                for ps in sessions_by_session_id.values()
-            ]
-            await session.execute(
-                insert_on_conflict(
-                    *records,
-                    table=models.ProjectSession,
-                    dialect=db.dialect,
-                    unique_by=("session_id",),
-                    on_conflict=OnConflict.DO_UPDATE,
-                )
-            )
-            id_rows = await session.execute(
-                select(models.ProjectSession.id, models.ProjectSession.session_id).where(
-                    models.ProjectSession.session_id.in_(sessions_by_session_id.keys())
-                )
-            )
-            session_id_to_rowid = {session_id: id_ for id_, session_id in id_rows.all()}
-            for db_trace in db_traces:
-                ps = db_trace.project_session
-                if ps is None:
-                    continue
-                # detach in-memory ProjectSession to avoid cascading insert; use the
-                # resolved rowid from the upsert instead.
-                db_trace.project_session = None  # type: ignore[assignment]
-                db_trace.project_session_rowid = session_id_to_rowid[ps.session_id]
-        session.add_all(db_traces)
-        await session.flush()
+    if not sessions_by_session_id:
+        return
+
+    dialect = SupportedSQLDialect(session.bind.dialect.name)
+    records = [
+        {
+            "session_id": ps.session_id,
+            "project_id": ps.project_id,
+            "start_time": ps.start_time,
+            "end_time": ps.end_time,
+        }
+        for ps in sessions_by_session_id.values()
+    ]
+    await session.execute(
+        insert_on_conflict(
+            *records,
+            table=models.ProjectSession,
+            dialect=dialect,
+            unique_by=("session_id",),
+            on_conflict=OnConflict.DO_UPDATE,
+        )
+    )
+    id_rows = await session.execute(
+        select(models.ProjectSession.id, models.ProjectSession.session_id).where(
+            models.ProjectSession.session_id.in_(sessions_by_session_id.keys())
+        )
+    )
+    session_id_to_rowid = {session_id: id_ for id_, session_id in id_rows.all()}
+    for db_trace in db_traces:
+        ps = db_trace.project_session
+        if ps is None:
+            continue
+        # detach in-memory ProjectSession to avoid cascading insert; use the
+        # resolved rowid from the upsert instead.
+        db_trace.project_session = None  # type: ignore[assignment]
+        db_trace.project_session_rowid = session_id_to_rowid[ps.session_id]
 
 
 def create_agents_router(authentication_enabled: bool) -> APIRouter:
@@ -403,7 +405,10 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                         )
                         db_traces = tracer.get_db_traces(project_id=project_id)
                         if db_traces:
-                            await _persist_db_traces_with_sessions(request.app.state.db, db_traces)
+                            async with request.app.state.db() as session:
+                                await _upsert_project_sessions(session, db_traces)
+                                session.add_all(db_traces)
+                                await session.flush()
                     tracer.tracer_provider.shutdown()
 
         return adapter.streaming_response(_stream_with_session())
@@ -457,7 +462,10 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     project_id = await _ensure_project_exists(request.app.state.db, project_name)
                     db_traces = tracer.get_db_traces(project_id=project_id)
                     if db_traces:
-                        await _persist_db_traces_with_sessions(request.app.state.db, db_traces)
+                        async with request.app.state.db() as session:
+                            await _upsert_project_sessions(session, db_traces)
+                            session.add_all(db_traces)
+                            await session.flush()
                 tracer.tracer_provider.shutdown()
         return _SummarizeResponse(summary=result.summary.strip())
 

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -298,6 +298,24 @@ async def _upsert_project_sessions(
     return {session_id: rowid for rowid, session_id in id_rows.all()}
 
 
+def _apply_project_session_rowids(
+    db_traces: list[models.Trace],
+    rowid_by_session_id: dict[str, int],
+) -> None:
+    """
+    For each trace with an attached in-memory ProjectSession, detach the
+    relationship and assign the resolved rowid as the foreign key. Mutates
+    ``db_traces`` in place. Detaching avoids a duplicate INSERT via the ORM's
+    save-update cascade when the trace is later added to a session.
+    """
+    for db_trace in db_traces:
+        project_session = db_trace.project_session
+        if project_session is None:
+            continue
+        db_trace.project_session = None  # type: ignore[assignment]
+        db_trace.project_session_rowid = rowid_by_session_id[project_session.session_id]
+
+
 def create_agents_router(authentication_enabled: bool) -> APIRouter:
     dependencies = [Depends(is_authenticated)] if authentication_enabled else []
     router = APIRouter(tags=["chat"], dependencies=dependencies)
@@ -403,16 +421,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                                 rowid_by_session_id = await _upsert_project_sessions(
                                     session, project_sessions
                                 )
-                                for db_trace in db_traces:
-                                    project_session = db_trace.project_session
-                                    if project_session is None:
-                                        continue
-                                    # detach in-memory ProjectSession to avoid cascading
-                                    # insert; use the resolved rowid from the upsert.
-                                    db_trace.project_session = None  # type: ignore[assignment]
-                                    db_trace.project_session_rowid = rowid_by_session_id[
-                                        project_session.session_id
-                                    ]
+                                _apply_project_session_rowids(db_traces, rowid_by_session_id)
                                 session.add_all(db_traces)
                                 await session.flush()
                     tracer.tracer_provider.shutdown()
@@ -477,16 +486,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                             rowid_by_session_id = await _upsert_project_sessions(
                                 session, project_sessions
                             )
-                            for db_trace in db_traces:
-                                project_session = db_trace.project_session
-                                if project_session is None:
-                                    continue
-                                # detach in-memory ProjectSession to avoid cascading
-                                # insert; use the resolved rowid from the upsert.
-                                db_trace.project_session = None  # type: ignore[assignment]
-                                db_trace.project_session_rowid = rowid_by_session_id[
-                                    project_session.session_id
-                                ]
+                            _apply_project_session_rowids(db_traces, rowid_by_session_id)
                             session.add_all(db_traces)
                             await session.flush()
                 tracer.tracer_provider.shutdown()

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -257,32 +257,32 @@ async def _upsert_project_sessions(
     then re-point each trace at the resolved rowid. Does NOT persist the traces
     themselves — the caller is responsible for adding them to the session.
     """
-    sessions_by_session_id: dict[str, models.ProjectSession] = {}
+    project_sessions_by_session_id: dict[str, models.ProjectSession] = {}
     for db_trace in db_traces:
-        ps = db_trace.project_session
-        if ps is None:
+        project_session = db_trace.project_session
+        if project_session is None:
             continue
-        existing = sessions_by_session_id.get(ps.session_id)
+        existing = project_sessions_by_session_id.get(project_session.session_id)
         if existing is None:
-            sessions_by_session_id[ps.session_id] = ps
+            project_sessions_by_session_id[project_session.session_id] = project_session
         else:
-            if ps.start_time < existing.start_time:
-                existing.start_time = ps.start_time
-            if existing.end_time < ps.end_time:
-                existing.end_time = ps.end_time
+            if project_session.start_time < existing.start_time:
+                existing.start_time = project_session.start_time
+            if existing.end_time < project_session.end_time:
+                existing.end_time = project_session.end_time
 
-    if not sessions_by_session_id:
+    if not project_sessions_by_session_id:
         return
 
     dialect = SupportedSQLDialect(session.bind.dialect.name)
     records = [
         {
-            "session_id": ps.session_id,
-            "project_id": ps.project_id,
-            "start_time": ps.start_time,
-            "end_time": ps.end_time,
+            "session_id": project_session.session_id,
+            "project_id": project_session.project_id,
+            "start_time": project_session.start_time,
+            "end_time": project_session.end_time,
         }
-        for ps in sessions_by_session_id.values()
+        for project_session in project_sessions_by_session_id.values()
     ]
     await session.execute(
         insert_on_conflict(
@@ -295,18 +295,18 @@ async def _upsert_project_sessions(
     )
     id_rows = await session.execute(
         select(models.ProjectSession.id, models.ProjectSession.session_id).where(
-            models.ProjectSession.session_id.in_(sessions_by_session_id.keys())
+            models.ProjectSession.session_id.in_(project_sessions_by_session_id.keys())
         )
     )
-    session_id_to_rowid = {session_id: id_ for id_, session_id in id_rows.all()}
+    rowid_by_session_id = {session_id: rowid for rowid, session_id in id_rows.all()}
     for db_trace in db_traces:
-        ps = db_trace.project_session
-        if ps is None:
+        project_session = db_trace.project_session
+        if project_session is None:
             continue
         # detach in-memory ProjectSession to avoid cascading insert; use the
         # resolved rowid from the upsert instead.
         db_trace.project_session = None  # type: ignore[assignment]
-        db_trace.project_session_rowid = session_id_to_rowid[ps.session_id]
+        db_trace.project_session_rowid = rowid_by_session_id[project_session.session_id]
 
 
 def create_agents_router(authentication_enabled: bool) -> APIRouter:

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -252,7 +252,6 @@ async def _persist_db_traces(
         # from the relationship and doesn't try to cascade-insert a duplicate.
         db_trace.project_session = persistent_by_session_id[project_session.session_id]
     session.add_all(db_traces)
-    await session.flush()
 
 
 async def _ensure_project_exists(db: DbSessionFactory, project_name: str) -> int:
@@ -439,6 +438,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                         if db_traces:
                             async with request.app.state.db() as session:
                                 await _persist_db_traces(session=session, db_traces=db_traces)
+                                await session.flush()
                     tracer.tracer_provider.shutdown()
 
         return adapter.streaming_response(_stream_with_session())
@@ -494,6 +494,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     if db_traces:
                         async with request.app.state.db() as session:
                             await _persist_db_traces(session=session, db_traces=db_traces)
+                            await session.flush()
                 tracer.tracer_provider.shutdown()
         return _SummarizeResponse(summary=result.summary.strip())
 

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -317,10 +317,6 @@ async def _persist_db_traces(
     session: AsyncSession,
     db_traces: list[models.Trace],
 ) -> None:
-    """
-    Upsert any ProjectSession rows attached to ``db_traces``, re-point each
-    trace at the resolved rowid, then add the traces to the session and flush.
-    """
     project_sessions = [
         db_trace.project_session for db_trace in db_traces if db_trace.project_session is not None
     ]

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -299,6 +299,7 @@ async def _upsert_project_sessions(
 
 
 def _apply_project_session_rowid(
+    *,
     db_trace: models.Trace,
     project_session_rowid: int,
 ) -> None:
@@ -421,8 +422,10 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                                     if project_session is None:
                                         continue
                                     _apply_project_session_rowid(
-                                        db_trace,
-                                        rowid_by_session_id[project_session.session_id],
+                                        db_trace=db_trace,
+                                        project_session_rowid=rowid_by_session_id[
+                                            project_session.session_id
+                                        ],
                                     )
                                 session.add_all(db_traces)
                                 await session.flush()
@@ -493,8 +496,10 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                                 if project_session is None:
                                     continue
                                 _apply_project_session_rowid(
-                                    db_trace,
-                                    rowid_by_session_id[project_session.session_id],
+                                    db_trace=db_trace,
+                                    project_session_rowid=rowid_by_session_id[
+                                        project_session.session_id
+                                    ],
                                 )
                             session.add_all(db_traces)
                             await session.flush()

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -238,20 +238,21 @@ async def _persist_db_traces(
 ) -> None:
     """
     Upsert any ProjectSession rows attached to ``db_traces``, re-point each
-    trace at the resolved rowid, then add the traces to the session and flush.
+    trace at the persistent ORM object, then add the traces to the session and
+    flush.
     """
     project_sessions = [
         db_trace.project_session for db_trace in db_traces if db_trace.project_session is not None
     ]
-    rowid_by_session_id = await _upsert_project_sessions(session, project_sessions)
+    persistent_by_session_id = await _upsert_project_sessions(session, project_sessions)
     for db_trace in db_traces:
         project_session = db_trace.project_session
         if project_session is None:
             continue
-        _apply_project_session_rowid(
-            db_trace=db_trace,
-            project_session_rowid=rowid_by_session_id[project_session.session_id],
-        )
+        # Replace the transient ProjectSession (built by Tracer) with the
+        # persistent one loaded from the upsert, so SQLAlchemy resolves the FK
+        # from the relationship and doesn't try to cascade-insert a duplicate.
+        db_trace.project_session = persistent_by_session_id[project_session.session_id]
     session.add_all(db_traces)
     await session.flush()
 
@@ -276,11 +277,12 @@ async def _ensure_project_exists(db: DbSessionFactory, project_name: str) -> int
 async def _upsert_project_sessions(
     session: AsyncSession,
     project_sessions: Iterable[models.ProjectSession],
-) -> dict[str, int]:
+) -> dict[str, models.ProjectSession]:
     """
-    Upsert ProjectSession rows keyed by session_id, returning a {session_id: rowid}
-    map. Duplicates in the input are merged by session_id, widening the start/end
-    time range across duplicates.
+    Upsert ProjectSession rows keyed by session_id, returning a
+    {session_id: ProjectSession} map of persistent ORM objects (loaded into the
+    session's identity map). Duplicates in the input are merged by session_id,
+    widening the start/end time range across duplicates.
     """
     project_sessions_by_session_id: dict[str, models.ProjectSession] = {}
     for project_session in project_sessions:
@@ -315,26 +317,12 @@ async def _upsert_project_sessions(
             on_conflict=OnConflict.DO_UPDATE,
         )
     )
-    id_rows = await session.execute(
-        select(models.ProjectSession.id, models.ProjectSession.session_id).where(
+    persistent_rows = await session.scalars(
+        select(models.ProjectSession).where(
             models.ProjectSession.session_id.in_(project_sessions_by_session_id.keys())
         )
     )
-    return {session_id: rowid for rowid, session_id in id_rows.all()}
-
-
-def _apply_project_session_rowid(
-    *,
-    db_trace: models.Trace,
-    project_session_rowid: int,
-) -> None:
-    """
-    Detach the in-memory ProjectSession from ``db_trace`` and assign the
-    resolved rowid as the foreign key. Detaching avoids a duplicate INSERT via
-    the ORM's save-update cascade when the trace is later added to a session.
-    """
-    db_trace.project_session = None  # type: ignore[assignment]
-    db_trace.project_session_rowid = project_session_rowid
+    return {row.session_id: row for row in persistent_rows}
 
 
 def create_agents_router(authentication_enabled: bool) -> APIRouter:

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterable
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -250,18 +250,15 @@ async def _ensure_project_exists(db: DbSessionFactory, project_name: str) -> int
 
 async def _upsert_project_sessions(
     session: AsyncSession,
-    db_traces: list[models.Trace],
-) -> None:
+    project_sessions: Iterable[models.ProjectSession],
+) -> dict[str, int]:
     """
-    Upsert any ProjectSession rows attached to ``db_traces`` (keyed by session_id),
-    then re-point each trace at the resolved rowid. Does NOT persist the traces
-    themselves — the caller is responsible for adding them to the session.
+    Upsert ProjectSession rows keyed by session_id, returning a {session_id: rowid}
+    map. Duplicates in the input are merged by session_id, widening the start/end
+    time range across duplicates.
     """
     project_sessions_by_session_id: dict[str, models.ProjectSession] = {}
-    for db_trace in db_traces:
-        project_session = db_trace.project_session
-        if project_session is None:
-            continue
+    for project_session in project_sessions:
         existing = project_sessions_by_session_id.get(project_session.session_id)
         if existing is None:
             project_sessions_by_session_id[project_session.session_id] = project_session
@@ -272,7 +269,7 @@ async def _upsert_project_sessions(
                 existing.end_time = project_session.end_time
 
     if not project_sessions_by_session_id:
-        return
+        return {}
 
     dialect = SupportedSQLDialect(session.bind.dialect.name)
     records = [
@@ -298,15 +295,7 @@ async def _upsert_project_sessions(
             models.ProjectSession.session_id.in_(project_sessions_by_session_id.keys())
         )
     )
-    rowid_by_session_id = {session_id: rowid for rowid, session_id in id_rows.all()}
-    for db_trace in db_traces:
-        project_session = db_trace.project_session
-        if project_session is None:
-            continue
-        # detach in-memory ProjectSession to avoid cascading insert; use the
-        # resolved rowid from the upsert instead.
-        db_trace.project_session = None  # type: ignore[assignment]
-        db_trace.project_session_rowid = rowid_by_session_id[project_session.session_id]
+    return {session_id: rowid for rowid, session_id in id_rows.all()}
 
 
 def create_agents_router(authentication_enabled: bool) -> APIRouter:
@@ -406,7 +395,24 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                         db_traces = tracer.get_db_traces(project_id=project_id)
                         if db_traces:
                             async with request.app.state.db() as session:
-                                await _upsert_project_sessions(session, db_traces)
+                                project_sessions = [
+                                    db_trace.project_session
+                                    for db_trace in db_traces
+                                    if db_trace.project_session is not None
+                                ]
+                                rowid_by_session_id = await _upsert_project_sessions(
+                                    session, project_sessions
+                                )
+                                for db_trace in db_traces:
+                                    project_session = db_trace.project_session
+                                    if project_session is None:
+                                        continue
+                                    # detach in-memory ProjectSession to avoid cascading
+                                    # insert; use the resolved rowid from the upsert.
+                                    db_trace.project_session = None  # type: ignore[assignment]
+                                    db_trace.project_session_rowid = rowid_by_session_id[
+                                        project_session.session_id
+                                    ]
                                 session.add_all(db_traces)
                                 await session.flush()
                     tracer.tracer_provider.shutdown()
@@ -463,7 +469,24 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     db_traces = tracer.get_db_traces(project_id=project_id)
                     if db_traces:
                         async with request.app.state.db() as session:
-                            await _upsert_project_sessions(session, db_traces)
+                            project_sessions = [
+                                db_trace.project_session
+                                for db_trace in db_traces
+                                if db_trace.project_session is not None
+                            ]
+                            rowid_by_session_id = await _upsert_project_sessions(
+                                session, project_sessions
+                            )
+                            for db_trace in db_traces:
+                                project_session = db_trace.project_session
+                                if project_session is None:
+                                    continue
+                                # detach in-memory ProjectSession to avoid cascading
+                                # insert; use the resolved rowid from the upsert.
+                                db_trace.project_session = None  # type: ignore[assignment]
+                                db_trace.project_session_rowid = rowid_by_session_id[
+                                    project_session.session_id
+                                ]
                             session.add_all(db_traces)
                             await session.flush()
                 tracer.tracer_provider.shutdown()

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -246,6 +246,67 @@ async def _ensure_project_exists(db: DbSessionFactory, project_name: str) -> int
         return project_id
 
 
+async def _persist_db_traces_with_sessions(
+    db: DbSessionFactory,
+    db_traces: list[models.Trace],
+) -> None:
+    """
+    Persist tracer-built traces, upserting any attached ProjectSession rows by
+    session_id so concurrent requests sharing a session don't collide on the
+    UNIQUE constraint.
+    """
+    sessions_by_session_id: dict[str, models.ProjectSession] = {}
+    for db_trace in db_traces:
+        ps = db_trace.project_session
+        if ps is None:
+            continue
+        existing = sessions_by_session_id.get(ps.session_id)
+        if existing is None:
+            sessions_by_session_id[ps.session_id] = ps
+        else:
+            if ps.start_time < existing.start_time:
+                existing.start_time = ps.start_time
+            if existing.end_time < ps.end_time:
+                existing.end_time = ps.end_time
+
+    async with db() as session:
+        if sessions_by_session_id:
+            records = [
+                {
+                    "session_id": ps.session_id,
+                    "project_id": ps.project_id,
+                    "start_time": ps.start_time,
+                    "end_time": ps.end_time,
+                }
+                for ps in sessions_by_session_id.values()
+            ]
+            await session.execute(
+                insert_on_conflict(
+                    *records,
+                    table=models.ProjectSession,
+                    dialect=db.dialect,
+                    unique_by=("session_id",),
+                    on_conflict=OnConflict.DO_UPDATE,
+                )
+            )
+            id_rows = await session.execute(
+                select(models.ProjectSession.id, models.ProjectSession.session_id).where(
+                    models.ProjectSession.session_id.in_(sessions_by_session_id.keys())
+                )
+            )
+            session_id_to_rowid = {session_id: id_ for id_, session_id in id_rows.all()}
+            for db_trace in db_traces:
+                ps = db_trace.project_session
+                if ps is None:
+                    continue
+                # detach in-memory ProjectSession to avoid cascading insert; use the
+                # resolved rowid from the upsert instead.
+                db_trace.project_session = None  # type: ignore[assignment]
+                db_trace.project_session_rowid = session_id_to_rowid[ps.session_id]
+        session.add_all(db_traces)
+        await session.flush()
+
+
 def create_agents_router(authentication_enabled: bool) -> APIRouter:
     dependencies = [Depends(is_authenticated)] if authentication_enabled else []
     router = APIRouter(tags=["chat"], dependencies=dependencies)
@@ -342,9 +403,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                         )
                         db_traces = tracer.get_db_traces(project_id=project_id)
                         if db_traces:
-                            async with request.app.state.db() as session:
-                                session.add_all(db_traces)
-                                await session.flush()
+                            await _persist_db_traces_with_sessions(request.app.state.db, db_traces)
                     tracer.tracer_provider.shutdown()
 
         return adapter.streaming_response(_stream_with_session())
@@ -398,9 +457,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     project_id = await _ensure_project_exists(request.app.state.db, project_name)
                     db_traces = tracer.get_db_traces(project_id=project_id)
                     if db_traces:
-                        async with request.app.state.db() as session:
-                            session.add_all(db_traces)
-                            await session.flush()
+                        await _persist_db_traces_with_sessions(request.app.state.db, db_traces)
                 tracer.tracer_provider.shutdown()
         return _SummarizeResponse(summary=result.summary.strip())
 

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -312,15 +312,14 @@ def _apply_project_session_rowid(
     db_trace.project_session_rowid = project_session_rowid
 
 
-async def _link_project_sessions_to_traces(
+async def _persist_db_traces(
     *,
     session: AsyncSession,
     db_traces: list[models.Trace],
 ) -> None:
     """
-    For any traces with an attached in-memory ProjectSession, upsert the
-    ProjectSession rows and re-point each trace at the resolved rowid. Mutates
-    ``db_traces`` in place. Does not add or flush the traces themselves.
+    Upsert any ProjectSession rows attached to ``db_traces``, re-point each
+    trace at the resolved rowid, then add the traces to the session and flush.
     """
     project_sessions = [
         db_trace.project_session for db_trace in db_traces if db_trace.project_session is not None
@@ -334,6 +333,8 @@ async def _link_project_sessions_to_traces(
             db_trace=db_trace,
             project_session_rowid=rowid_by_session_id[project_session.session_id],
         )
+    session.add_all(db_traces)
+    await session.flush()
 
 
 def create_agents_router(authentication_enabled: bool) -> APIRouter:
@@ -433,11 +434,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                         db_traces = tracer.get_db_traces(project_id=project_id)
                         if db_traces:
                             async with request.app.state.db() as session:
-                                await _link_project_sessions_to_traces(
-                                    session=session, db_traces=db_traces
-                                )
-                                session.add_all(db_traces)
-                                await session.flush()
+                                await _persist_db_traces(session=session, db_traces=db_traces)
                     tracer.tracer_provider.shutdown()
 
         return adapter.streaming_response(_stream_with_session())
@@ -492,11 +489,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     db_traces = tracer.get_db_traces(project_id=project_id)
                     if db_traces:
                         async with request.app.state.db() as session:
-                            await _link_project_sessions_to_traces(
-                                session=session, db_traces=db_traces
-                            )
-                            session.add_all(db_traces)
-                            await session.flush()
+                            await _persist_db_traces(session=session, db_traces=db_traces)
                 tracer.tracer_provider.shutdown()
         return _SummarizeResponse(summary=result.summary.strip())
 

--- a/src/phoenix/tracers.py
+++ b/src/phoenix/tracers.py
@@ -165,6 +165,7 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
 
         db_spans_by_trace_id: defaultdict[int, list[models.Span]] = defaultdict(list)
         db_span_costs_by_trace_id: defaultdict[int, list[models.SpanCost]] = defaultdict(list)
+        session_id_by_trace_id: dict[int, str] = {}
 
         for otel_span in otel_spans:
             trace_id = otel_span.get_span_context().trace_id  # type: ignore[no-untyped-call]
@@ -177,8 +178,16 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
             db_spans_by_trace_id[trace_id].append(db_span)
             if db_span_cost:
                 db_span_costs_by_trace_id[trace_id].append(db_span_cost)
+            if trace_id not in session_id_by_trace_id:
+                session_id_value = get_attribute_value(
+                    db_span.attributes, SpanAttributes.SESSION_ID
+                )
+                session_id = str(session_id_value).strip() if session_id_value is not None else ""
+                if session_id:
+                    session_id_by_trace_id[trace_id] = session_id
 
         db_traces = []
+        project_sessions_by_session_id: dict[str, models.ProjectSession] = {}
         for trace_id in db_spans_by_trace_id:
             db_spans = db_spans_by_trace_id[trace_id]
             db_span_costs = db_span_costs_by_trace_id[trace_id]
@@ -193,6 +202,23 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
             )
             db_trace.spans = db_spans  # explicitly set relationship to avoid lazy load
             db_trace.span_costs = db_span_costs  # explicitly set relationship to avoid lazy load
+            trace_session_id = session_id_by_trace_id.get(trace_id)
+            if trace_session_id is not None:
+                project_session = project_sessions_by_session_id.get(trace_session_id)
+                if project_session is None:
+                    project_session = models.ProjectSession(
+                        session_id=trace_session_id,
+                        project_id=project_id,
+                        start_time=db_trace.start_time,
+                        end_time=db_trace.end_time,
+                    )
+                    project_sessions_by_session_id[trace_session_id] = project_session
+                else:
+                    if db_trace.start_time < project_session.start_time:
+                        project_session.start_time = db_trace.start_time
+                    if project_session.end_time < db_trace.end_time:
+                        project_session.end_time = db_trace.end_time
+                db_trace.project_session = project_session
             db_traces.append(db_trace)
 
         return db_traces

--- a/tests/unit/test_tracers.py
+++ b/tests/unit/test_tracers.py
@@ -76,6 +76,45 @@ class TestTracer:
         return Tracer(span_cost_calculator=span_cost_calculator)
 
     @pytest.mark.asyncio
+    async def test_get_db_traces_attaches_project_session_when_session_id_present(
+        self, db: DbSessionFactory, project: models.Project, tracer: Tracer
+    ) -> None:
+        with tracer.start_as_current_span(
+            "parent",
+            attributes={OPENINFERENCE_SPAN_KIND: "CHAIN"},
+        ) as parent_span:
+            parent_span.set_attribute(SpanAttributes.SESSION_ID, "session-abc")
+            with tracer.start_as_current_span(
+                "child",
+                attributes={OPENINFERENCE_SPAN_KIND: "LLM"},
+            ) as child_span:
+                child_span.set_attribute(SpanAttributes.SESSION_ID, "session-abc")
+
+        returned_traces = tracer.get_db_traces(project_id=project.id)
+        assert len(returned_traces) == 1
+        returned_trace = returned_traces[0]
+        project_session = returned_trace.project_session
+        assert project_session is not None
+        assert project_session.session_id == "session-abc"
+        assert project_session.project_id == project.id
+        assert project_session.start_time == returned_trace.start_time
+        assert project_session.end_time == returned_trace.end_time
+
+    @pytest.mark.asyncio
+    async def test_get_db_traces_leaves_project_session_unset_without_session_id(
+        self, db: DbSessionFactory, project: models.Project, tracer: Tracer
+    ) -> None:
+        with tracer.start_as_current_span(
+            "parent",
+            attributes={OPENINFERENCE_SPAN_KIND: "CHAIN"},
+        ):
+            pass
+
+        returned_traces = tracer.get_db_traces(project_id=project.id)
+        assert len(returned_traces) == 1
+        assert returned_traces[0].project_session is None
+
+    @pytest.mark.asyncio
     async def test_save_db_traces_persists_nested_spans(
         self, db: DbSessionFactory, project: models.Project, tracer: Tracer
     ) -> None:


### PR DESCRIPTION
## Summary
- `Tracer.get_db_traces` (used by `/chat` and `/summary`) now attaches an in-memory `ProjectSession` to each `Trace` whenever its spans carry `SpanAttributes.SESSION_ID` (set via `using_session`).
- A new `_persist_db_traces_with_sessions` helper in `agents.py` upserts those `ProjectSession` rows with `insert_on_conflict` keyed by `session_id`, then re-points each `Trace` at the resolved row before flushing. This avoids `UNIQUE(session_id)` collisions when concurrent requests share a session.
- Without these changes, traces produced by `/chat` and `/summary` never appeared under a session in the UI even though they were tagged with `session.id`.

## Test plan
- [x] `uv run pytest tests/unit/test_tracers.py` — 17 passed
- [x] `uv run mypy --strict` on modified files
- [x] `uv run ruff check` + `ruff format --check` on modified files
- [ ] Manual: start Phoenix, exercise `/agents/{agent_id}/sessions/{session_id}/chat` with `ingestTraces=true`, confirm a `project_sessions` row with matching `session_id` exists and a second request with the same `session_id` widens its `end_time` rather than creating a duplicate row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)