### PR TITLE
fix: keep PXI send button in stop mode while streaming

### DIFF
--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -196,7 +196,7 @@ export function useAgentChat({
 
   const handleSendMessage = async (...args: Parameters<typeof sendMessage>) => {
     if (chatInstance && isRequestActive(chatInstance.status)) {
-      await stop();
+      return;
     }
 
     setMessages(removeInterruptedToolInputParts);

--- a/app/src/components/ai/prompt-input/PromptInput.tsx
+++ b/app/src/components/ai/prompt-input/PromptInput.tsx
@@ -60,6 +60,10 @@ export function PromptInput({
   valueRef.current = value;
 
   const handleSubmit = () => {
+    if (status === "submitted" || status === "streaming") {
+      return;
+    }
+
     const trimmed = valueRef.current.trim();
     if (trimmed) {
       onSubmit?.(trimmed);

--- a/app/src/components/ai/prompt-input/PromptInputSubmit.tsx
+++ b/app/src/components/ai/prompt-input/PromptInputSubmit.tsx
@@ -9,9 +9,7 @@ import type { PromptInputSubmitProps } from "./types";
  * Submit / stop button that adapts its icon and behavior to the current status.
  *
  * - **ready / error** — arrow icon; pressing sends the message.
- * - **streaming, empty input** — stop icon; pressing stops generation.
- * - **streaming, user has typed** — arrow icon; pressing stops generation
- *   then sends the message.
+ * - **submitted / streaming** — stop icon; pressing stops generation.
  *
  * Automatically disables when `status` is `"ready"` and the textarea is empty.
  */
@@ -30,8 +28,7 @@ export function PromptInputSubmit({
   const computedDisabled =
     isDisabledProp ?? (context.status === "ready" && isEmpty);
 
-  // Send icon overrides the stop icon when user input is entered during streaming.
-  const showSend = !isStreaming || !isEmpty;
+  const showSend = !isStreaming;
 
   const computedAriaLabel =
     ariaLabel ?? (showSend ? "Send message" : "Stop generation");
@@ -39,10 +36,9 @@ export function PromptInputSubmit({
   const handlePress = () => {
     if (isStreaming) {
       onStop?.();
+      return;
     }
-    if (!isEmpty) {
-      context.onSubmit();
-    }
+    context.onSubmit();
   };
 
   return (

--- a/app/src/components/ai/prompt-input/types.ts
+++ b/app/src/components/ai/prompt-input/types.ts
@@ -25,7 +25,7 @@ export interface PromptInputContextValue {
   status: PromptInputStatus;
   /** Whether the entire prompt input tree is disabled. */
   isDisabled: boolean;
-  /** Trigger a submit. Called by PromptInputTextarea (Enter) and PromptInputSubmit. */
+  /** Trigger a submit when the input is idle. Called by PromptInputTextarea (Enter) and PromptInputSubmit. */
   onSubmit: () => void;
   /** The current text content of the textarea. */
   value: string;


### PR DESCRIPTION
## Summary
- keep the prompt input submit button in stop mode while PXI is submitted or streaming
- ignore Enter submissions and programmatic sends while a PXI request is active

## Tests
- make typecheck-frontend
- make lint-frontend

Resolves #13151 