### PR TITLE
fix(evaluators): preserve user score when categorical config has no canonical score

### DIFF
--- a/src/phoenix/server/api/coerce_output.py
+++ b/src/phoenix/server/api/coerce_output.py
@@ -175,7 +175,8 @@ def _validate_triple_categorical(
                 f"Remove the 'score' key or use the canonical value {looked_up_score!r}."
             )
 
-    return Triple(label=label, score=looked_up_score, explanation=triple.explanation)
+    score = looked_up_score if looked_up_score is not None else triple.score
+    return Triple(label=label, score=score, explanation=triple.explanation)
 
 
 def _validate_triple_continuous(

--- a/tests/unit/server/api/test_coerce_output.py
+++ b/tests/unit/server/api/test_coerce_output.py
@@ -158,6 +158,17 @@ class TestCategoricalCoerce:
         assert label == "maybe"
         assert score is None
 
+    def test_none_canonical_score_falls_back_to_user_score(self) -> None:
+        cat = _cat([("maybe", None)])  # type: ignore[list-item]
+        label, score, explanation = _coerce_output({"label": "maybe", "score": 0.7}, cat)
+        assert label == "maybe"
+        assert score == pytest.approx(0.7)
+
+    def test_none_canonical_score_rejects_bool_user_score(self) -> None:
+        cat = _cat([("maybe", None)])  # type: ignore[list-item]
+        with pytest.raises(ValueError, match="must not be bool"):
+            _coerce_output({"label": "maybe", "score": True}, cat)
+
     def test_dict_with_label_key_accepted(self) -> None:
         label, score, explanation = _coerce_output({"label": "pass"}, _cat())
         assert label == "pass"


### PR DESCRIPTION
## Summary
- `_validate_triple_categorical` was always returning the canonical score from the `label → score` lookup, even when that lookup yielded `None` (since `CategoricalAnnotationValue.score` is `Optional[float]`). User-supplied scores were silently dropped for label entries without a canonical score.
- Fall back to `triple.score` when the canonical lookup is `None`, so the user's value round-trips into the annotation row. Bool exclusion still applies via the existing guard.

## Test plan
- [x] `uv run pytest tests/unit/server/api/test_coerce_output.py` — 57 passing (added 2 new cases)
- [x] New: `test_none_canonical_score_falls_back_to_user_score` — user supplies 0.7 for a label with `score=None` → preserved
- [x] New: `test_none_canonical_score_rejects_bool_user_score` — `score=True` still raises
- [x] Existing `test_label_score_can_be_none` still passes (no-score case still returns `score=None`)