### PR TITLE
feat: add pydantic-ai-skills for SkillsCapability loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dependencies = [
   "orjson",
   "jmespath",
   "ldap3",
+  "pydantic-ai-skills>=0.10.0",
 ]
 dynamic = ["version"]
 

--- a/src/phoenix/server/agents/skills/trace-debugging/SKILL.md
+++ b/src/phoenix/server/agents/skills/trace-debugging/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: trace-debugging
+description: Systematically investigate failing or slow traces in a Phoenix project. Use when the user asks why a span errored, why latency is high, why a tool call produced the wrong result, or any variant of "what went wrong" / "where do I look" inside a project's traces. Walks through narrowing with set_time_range and set_spans_filter, then inspecting span attributes for the failure signature.
+---
+
+# Trace Debugging
+
+A repeatable loop for investigating failures inside a Phoenix project. The
+goal is to converge on a concrete failure signature — not just "it's slow" or
+"the LLM hallucinated" — so the user can decide what to fix or evaluate next.
+
+## When to Apply
+
+Trigger this workflow when the user is looking at a Phoenix project and asks
+any variant of:
+
+- "Why did this trace fail?"
+- "What's making latency high?"
+- "Which spans are erroring?"
+- "Where do I focus?"
+
+## Loop
+
+1. **Frame the question.** Get one concrete thing to look for: an error
+   substring, a latency threshold, a tool name, a model name, an output shape.
+   Vague intent ("look at failures") becomes a vague filter and a vague answer.
+
+2. **Narrow the window.** Use `set_time_range` to clamp to the smallest window
+   that still contains the behavior. A 24-hour view hides patterns that a
+   1-hour view exposes.
+
+3. **Narrow the spans.** Use `set_spans_filter` to keep only spans that match
+   the frame. Start broad (`status_code == 'ERROR'`), then layer constraints
+   (`span_kind == 'LLM'`, attribute predicates) as you learn what the failure
+   class actually is.
+
+4. **Read a few end-to-end.** Pick 3–5 surviving traces and read them top to
+   bottom. Patterns at the trace level (e.g. retriever returned empty, tool
+   args malformed, model retried 4×) only show up when you see the sequence.
+
+5. **Name the failure.** Write down the signature in one sentence:
+   *"Retriever returns zero docs when the query contains a date range, so the
+   LLM fabricates an answer."* If you can't write that sentence, you haven't
+   narrowed enough — return to step 3.
+
+6. **Decide the next move.** A named failure points at exactly one of:
+   instrument the gap, fix the code, write an eval that catches the class, or
+   collect a dataset. Don't skip naming — undirected fixes are how regressions
+   come back.
+
+## Anti-patterns
+
+- **Scrolling without a frame.** Looking at the trace list with no filter is
+  triage, not debugging. Always commit to one question before looking.
+- **One trace, one conclusion.** A single failing trace tells you a failure
+  exists. It does not tell you the class. Inspect a handful before naming.
+- **Filtering on output text.** Output strings are noisy and vary per call.
+  Filter on structural attributes (status, span kind, tool name, model name)
+  first; use output substrings only to confirm a hypothesis.

--- a/src/phoenix/server/agents/toolsets/__init__.py
+++ b/src/phoenix/server/agents/toolsets/__init__.py
@@ -6,6 +6,7 @@ from pydantic_ai.toolsets import AbstractToolset, CombinedToolset
 from phoenix.server.agents.dependencies import ChatDependencies
 from phoenix.server.agents.pydantic_ai import OpenInferenceToolsetWrapper
 from phoenix.server.agents.toolsets.external import build_external_toolset
+from phoenix.server.agents.toolsets.skills import build_skills_toolset
 
 
 def build_toolset(
@@ -16,6 +17,7 @@ def build_toolset(
     """Build the combined PXI toolset from request dependencies."""
     toolsets: list[AbstractToolset[ChatDependencies]] = [
         build_external_toolset(deps),
+        build_skills_toolset(),
     ]
     if deps.docs_mcp_toolset is not None:
         toolsets.append(deps.docs_mcp_toolset)

--- a/src/phoenix/server/agents/toolsets/skills.py
+++ b/src/phoenix/server/agents/toolsets/skills.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic_ai_skills import SkillsToolset
+
+_SKILLS_DIR = Path(__file__).resolve().parent.parent / "skills"
+assert _SKILLS_DIR.parts[-4:] == ("phoenix", "server", "agents", "skills")
+
+
+def build_skills_toolset() -> SkillsToolset:
+    return SkillsToolset(directories=[_SKILLS_DIR])

--- a/uv.lock
+++ b/uv.lock
@@ -437,6 +437,7 @@ dependencies = [
     { name = "psutil" },
     { name = "pyarrow" },
     { name = "pydantic" },
+    { name = "pydantic-ai-skills" },
     { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "google", "mcp", "openai", "ui"] },
     { name = "pystache" },
     { name = "python-dateutil" },
@@ -639,6 +640,7 @@ requires-dist = [
     { name = "py-grpc-prometheus", marker = "extra == 'container'" },
     { name = "pyarrow" },
     { name = "pydantic", specifier = ">=2.1.0" },
+    { name = "pydantic-ai-skills", specifier = ">=0.10.0" },
     { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "google", "mcp", "openai", "ui"], specifier = ">=1.87.0" },
     { name = "pystache" },
     { name = "python-dateutil" },
@@ -4911,6 +4913,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-ai-skills"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "pydantic-ai-slim" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/6a/52f74c1f954e383e0baa15f32b6320be03ac985231b75176863ac0f0cc3f/pydantic_ai_skills-0.10.0.tar.gz", hash = "sha256:28f2471957331ad8f4607b782e0e6d12fe294a50a19fd6d92d684082cc57dabc", size = 9015728, upload-time = "2026-05-09T00:21:05.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/4d/20e559cdf8748bce1794189de5a3a35fe3e339cd2e9198c8132bd41043b2/pydantic_ai_skills-0.10.0-py3-none-any.whl", hash = "sha256:327fbec03e915e674ce1b2b27f30dc8be26132bf626159e810853d95d21df377", size = 55353, upload-time = "2026-05-09T00:21:03.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `pydantic-ai-skills>=0.10.0` to `arize-phoenix` dependencies so agents can load Claude-skill-format directories (`SKILL.md` + `references/` + `scripts/`) via pydantic-ai's `capabilities=[...]` API.
- Enables wiring existing `.agents/skills/` (e.g. `phoenix-cli`, `phoenix-tracing`) into a pydantic-ai agent with `SkillsCapability(directories=[...])`.

## Test plan
- [ ] `uv sync` resolves cleanly
- [ ] `from pydantic_ai_skills import SkillsCapability, SkillsToolset` imports
- [ ] Build a minimal `Agent(capabilities=[SkillsCapability(directories=['./.agents/skills'])])` and confirm `list_skills` / `load_skill` tools appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)