### PR TITLE
chore: add data-testid attributes to key UI buttons for E2E tests

### DIFF
--- a/.agents/skills/phoenix-frontend/SKILL.md
+++ b/.agents/skills/phoenix-frontend/SKILL.md
@@ -18,6 +18,7 @@ Read the relevant file(s) based on the task:
 | `rules/components.md` | Creating, composing, or refactoring components |
 | `rules/relay.md` | Using Relay |
 | `rules/accessibility.md` | Any interactive element, form, overlay, or semantic markup |
+| `rules/test-ids.md` | Adding or changing `data-testid` attributes for E2E tests |
 | `rules/resize-svg-logo-assets.md` | Adding or updating provider/integration logo icons |
 
 ## Verification

--- a/.agents/skills/phoenix-frontend/rules/test-ids.md
+++ b/.agents/skills/phoenix-frontend/rules/test-ids.md
@@ -1,0 +1,64 @@
+# `data-testid` Naming Conventions
+
+`data-testid` is an escape hatch for E2E tests when role/label/text selectors are
+not stable or specific enough. When you add one, follow these rules so the IDs stay
+stable, unambiguous, and easy to grep.
+
+## Naming
+
+- **kebab-case**, ASCII only.
+- **No abbreviations.** Spell out the element role: `button`, `menu-item`, `link`,
+  `tab`, `dialog`, `input`, `option` — never `btn`, `mi`, etc.
+- **Be specific and scoped.** Prefix with the feature/page/component so the ID is
+  globally unique. Prefer `create-dataset-button` over `create-button`,
+  `dataset-form-submit-button` over `submit-button`.
+- **End with the element role.** Pattern: `<scope>-<subject>-<role>`.
+  - `create-dataset-button`
+  - `create-project-button`
+  - `playground-run-button`
+  - `dataset-form-submit-button`
+  - `run-dataset-experiment-button`
+  - `run-dataset-experiment-via-sdk-menu-item`
+  - `llm-evaluator-form-submit-button`
+- **A form's primary submit control gets `<form-name>-submit-button`**, not a verb
+  that changes with mode (avoid `create-...` / `update-...` on the same element —
+  see state below).
+
+## State belongs in `data-*` attributes, not in the `data-testid`
+
+The `data-testid` must be **constant for the life of the element**. Never compute it
+from props/state and never make it conditionally `undefined`. If the same element
+behaves differently depending on state, keep one `data-testid` and expose the state
+through a separate `data-*` attribute:
+
+```tsx
+// ❌ testid changes with state; absent in edit mode
+<Button data-testid={mode === "create" ? "create-eval-btn" : undefined} />
+
+// ✅ stable testid, state on a data attribute
+<Button data-testid="llm-evaluator-form-submit-button" data-mode={mode} />
+```
+
+Tests then select the stable ID and assert/filter on the attribute:
+
+```typescript
+page.getByTestId("llm-evaluator-form-submit-button"); // always resolves
+page.locator('[data-testid="llm-evaluator-form-submit-button"][data-mode="create"]');
+```
+
+Common state attributes: `data-mode` (`create` | `edit`), `data-state`
+(`open` | `closed` | `loading`), `data-selected`. Reuse an existing attribute name
+if one already conveys the state (some design-system components set `data-state` etc.
+themselves).
+
+## Placement
+
+Put `data-testid` (and any companion `data-*`) as the **first prop** on the element
+for consistency and easy scanning.
+
+## When to add one
+
+Don't reach for `data-testid` first. Prefer, in order: role selectors
+(`getByRole`), label selectors (`getByLabel`), text/placeholder selectors. Add a
+`data-testid` only when those are ambiguous, unstable, or absent — e.g. an icon-only
+button, a row action that repeats, or an element whose visible text changes.

--- a/.agents/skills/phoenix-playwright-tests/SKILL.md
+++ b/.agents/skills/phoenix-playwright-tests/SKILL.md
@@ -77,8 +77,17 @@ test.describe("Feature Name", () => {
 4. **Test IDs** (when available):
 
    ```typescript
-   page.getByTestId("modal");
+   page.getByTestId("create-dataset-button");
+   // element with state — select the stable id, filter on the data attribute
+   page.locator('[data-testid="llm-evaluator-form-submit-button"][data-mode="create"]');
    ```
+
+   `data-testid`s are scoped, fully spelled out (`...-button`, never `...-btn`), and
+   **constant regardless of state** — state is exposed via a sibling `data-*`
+   attribute (`data-mode`, `data-state`, …), so never key a `getByTestId` off a value
+   that only exists in one mode. If you need a `data-testid` that doesn't exist yet,
+   add it following `rules/test-ids.md` in the `phoenix-frontend` skill (pattern:
+   `<scope>-<subject>-<role>`).
 
 5. **CSS locators** (last resort):
    ```typescript

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ helm/charts/*.tgz
 # mypy
 .mypy_cache
 .hypothesis
+.claude/worktrees/

--- a/app/src/components/dataset/DatasetForm.tsx
+++ b/app/src/components/dataset/DatasetForm.tsx
@@ -165,9 +165,8 @@ export function DatasetForm({
           </Button>
         )}
         <Button
-          data-testid={
-            formMode === "create" ? "submit-create-dataset-btn" : undefined
-          }
+          data-testid="dataset-form-submit-button"
+          data-mode={formMode}
           isDisabled={(formMode === "edit" ? !isDirty : false) || isSubmitting}
           variant={isDirty ? "primary" : "default"}
           size="M"

--- a/app/src/components/dataset/DatasetForm.tsx
+++ b/app/src/components/dataset/DatasetForm.tsx
@@ -169,6 +169,9 @@ export function DatasetForm({
           variant={isDirty ? "primary" : "default"}
           size="M"
           type="submit"
+          data-testid={
+            formMode === "create" ? "submit-create-dataset-btn" : undefined
+          }
         >
           {submitButtonText}
         </Button>

--- a/app/src/components/dataset/DatasetForm.tsx
+++ b/app/src/components/dataset/DatasetForm.tsx
@@ -165,13 +165,13 @@ export function DatasetForm({
           </Button>
         )}
         <Button
+          data-testid={
+            formMode === "create" ? "submit-create-dataset-btn" : undefined
+          }
           isDisabled={(formMode === "edit" ? !isDirty : false) || isSubmitting}
           variant={isDirty ? "primary" : "default"}
           size="M"
           type="submit"
-          data-testid={
-            formMode === "create" ? "submit-create-dataset-btn" : undefined
-          }
         >
           {submitButtonText}
         </Button>

--- a/app/src/components/evaluators/EditBuiltInEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditBuiltInEvaluatorDialogContent.tsx
@@ -49,7 +49,8 @@ export const EditBuiltInEvaluatorDialogContent = ({
             Cancel
           </Button>
           <Button
-            data-testid={mode === "create" ? "create-eval-btn" : undefined}
+            data-testid="builtin-evaluator-form-submit-button"
+            data-mode={mode}
             variant="primary"
             isDisabled={isSubmitting}
             isPending={isSubmitting}

--- a/app/src/components/evaluators/EditBuiltInEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditBuiltInEvaluatorDialogContent.tsx
@@ -49,6 +49,7 @@ export const EditBuiltInEvaluatorDialogContent = ({
             Cancel
           </Button>
           <Button
+            data-testid={mode === "create" ? "create-eval-btn" : undefined}
             variant="primary"
             isDisabled={isSubmitting}
             isPending={isSubmitting}

--- a/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
@@ -55,6 +55,7 @@ export const EditLLMEvaluatorDialogContent = ({
             isDisabled={isSubmitting}
             isPending={isSubmitting}
             onPress={handleSubmit}
+            data-testid="create-eval-btn"
           >
             {mode === "create" ? "Create" : "Update"}
           </Button>

--- a/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
@@ -51,11 +51,11 @@ export const EditLLMEvaluatorDialogContent = ({
             Cancel
           </Button>
           <Button
+            data-testid="create-eval-btn"
             variant="primary"
             isDisabled={isSubmitting}
             isPending={isSubmitting}
             onPress={handleSubmit}
-            data-testid="create-eval-btn"
           >
             {mode === "create" ? "Create" : "Update"}
           </Button>

--- a/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
@@ -51,7 +51,8 @@ export const EditLLMEvaluatorDialogContent = ({
             Cancel
           </Button>
           <Button
-            data-testid={mode === "create" ? "create-eval-btn" : undefined}
+            data-testid="llm-evaluator-form-submit-button"
+            data-mode={mode}
             variant="primary"
             isDisabled={isSubmitting}
             isPending={isSubmitting}

--- a/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
@@ -51,7 +51,7 @@ export const EditLLMEvaluatorDialogContent = ({
             Cancel
           </Button>
           <Button
-            data-testid="create-eval-btn"
+            data-testid={mode === "create" ? "create-eval-btn" : undefined}
             variant="primary"
             isDisabled={isSubmitting}
             isPending={isSubmitting}

--- a/app/src/pages/dataset/RunDatasetExperimentButton.tsx
+++ b/app/src/pages/dataset/RunDatasetExperimentButton.tsx
@@ -50,6 +50,7 @@ export function RunDatasetExperimentButton(
           size={size}
           variant={variant}
           leadingVisual={<Icon svg={<Icons.PlusOutline />} />}
+          data-testid="new-experiment-btn"
         >
           Experiment
         </Button>
@@ -69,13 +70,19 @@ export function RunDatasetExperimentButton(
               }
             }}
           >
-            <MenuItem id={ExperimentAction.RUN_VIA_SDK}>
+            <MenuItem
+              id={ExperimentAction.RUN_VIA_SDK}
+              data-testid="run-via-sdk-btn"
+            >
               <Flex direction="row" gap="size-100" alignItems="center">
                 <Icon svg={<Icons.Code />} />
                 <Text>Run via SDK</Text>
               </Flex>
             </MenuItem>
-            <MenuItem id={ExperimentAction.RUN_IN_PLAYGROUND}>
+            <MenuItem
+              id={ExperimentAction.RUN_IN_PLAYGROUND}
+              data-testid="run-in-playground-btn"
+            >
               <Flex direction="row" gap="size-100" alignItems="center">
                 <Icon svg={<Icons.PlayCircleOutline />} />
                 <Text>Run in Playground</Text>

--- a/app/src/pages/dataset/RunDatasetExperimentButton.tsx
+++ b/app/src/pages/dataset/RunDatasetExperimentButton.tsx
@@ -47,10 +47,10 @@ export function RunDatasetExperimentButton(
     <>
       <MenuTrigger>
         <Button
+          data-testid="new-experiment-btn"
           size={size}
           variant={variant}
           leadingVisual={<Icon svg={<Icons.PlusOutline />} />}
-          data-testid="new-experiment-btn"
         >
           Experiment
         </Button>
@@ -71,8 +71,8 @@ export function RunDatasetExperimentButton(
             }}
           >
             <MenuItem
-              id={ExperimentAction.RUN_VIA_SDK}
               data-testid="run-via-sdk-btn"
+              id={ExperimentAction.RUN_VIA_SDK}
             >
               <Flex direction="row" gap="size-100" alignItems="center">
                 <Icon svg={<Icons.Code />} />
@@ -80,8 +80,8 @@ export function RunDatasetExperimentButton(
               </Flex>
             </MenuItem>
             <MenuItem
-              id={ExperimentAction.RUN_IN_PLAYGROUND}
               data-testid="run-in-playground-btn"
+              id={ExperimentAction.RUN_IN_PLAYGROUND}
             >
               <Flex direction="row" gap="size-100" alignItems="center">
                 <Icon svg={<Icons.PlayCircleOutline />} />

--- a/app/src/pages/dataset/RunDatasetExperimentButton.tsx
+++ b/app/src/pages/dataset/RunDatasetExperimentButton.tsx
@@ -47,7 +47,7 @@ export function RunDatasetExperimentButton(
     <>
       <MenuTrigger>
         <Button
-          data-testid="new-experiment-btn"
+          data-testid="run-dataset-experiment-button"
           size={size}
           variant={variant}
           leadingVisual={<Icon svg={<Icons.PlusOutline />} />}
@@ -71,7 +71,7 @@ export function RunDatasetExperimentButton(
             }}
           >
             <MenuItem
-              data-testid="run-via-sdk-btn"
+              data-testid="run-dataset-experiment-via-sdk-menu-item"
               id={ExperimentAction.RUN_VIA_SDK}
             >
               <Flex direction="row" gap="size-100" alignItems="center">
@@ -80,7 +80,7 @@ export function RunDatasetExperimentButton(
               </Flex>
             </MenuItem>
             <MenuItem
-              data-testid="run-in-playground-btn"
+              data-testid="run-dataset-experiment-in-playground-menu-item"
               id={ExperimentAction.RUN_IN_PLAYGROUND}
             >
               <Flex direction="row" gap="size-100" alignItems="center">

--- a/app/src/pages/datasets/CreateDatasetButton.tsx
+++ b/app/src/pages/datasets/CreateDatasetButton.tsx
@@ -110,12 +110,12 @@ export function CreateDatasetButton({
   return (
     <DialogTrigger onOpenChange={setIsOpen} isOpen={isOpen}>
       <Button
+        data-testid="create-dataset-btn"
         variant="primary"
         size="M"
         leadingVisual={<Icon svg={<Icons.DatabaseOutline />} />}
         onPress={() => setIsOpen(true)}
         aria-label="Create a new dataset"
-        data-testid="create-dataset-btn"
       >
         New Dataset
       </Button>

--- a/app/src/pages/datasets/CreateDatasetButton.tsx
+++ b/app/src/pages/datasets/CreateDatasetButton.tsx
@@ -110,7 +110,7 @@ export function CreateDatasetButton({
   return (
     <DialogTrigger onOpenChange={setIsOpen} isOpen={isOpen}>
       <Button
-        data-testid="create-dataset-btn"
+        data-testid="create-dataset-button"
         variant="primary"
         size="M"
         leadingVisual={<Icon svg={<Icons.DatabaseOutline />} />}

--- a/app/src/pages/datasets/CreateDatasetButton.tsx
+++ b/app/src/pages/datasets/CreateDatasetButton.tsx
@@ -115,6 +115,7 @@ export function CreateDatasetButton({
         leadingVisual={<Icon svg={<Icons.DatabaseOutline />} />}
         onPress={() => setIsOpen(true)}
         aria-label="Create a new dataset"
+        data-testid="create-dataset-btn"
       >
         New Dataset
       </Button>

--- a/app/src/pages/datasets/DatasetFromFileForm.tsx
+++ b/app/src/pages/datasets/DatasetFromFileForm.tsx
@@ -979,6 +979,7 @@ export function DatasetFromFileForm(props: DatasetFromFileFormProps) {
                 <Icon svg={<Icons.LoadingOutline />} />
               ) : undefined
             }
+            data-testid="submit-create-dataset-btn"
           >
             {pendingAction === "create" ? "Creating..." : "Create Dataset"}
           </Button>

--- a/app/src/pages/datasets/DatasetFromFileForm.tsx
+++ b/app/src/pages/datasets/DatasetFromFileForm.tsx
@@ -969,6 +969,7 @@ export function DatasetFromFileForm(props: DatasetFromFileFormProps) {
           </>
         ) : (
           <Button
+            data-testid="submit-create-dataset-btn"
             variant="primary"
             size="S"
             type="button"
@@ -979,7 +980,6 @@ export function DatasetFromFileForm(props: DatasetFromFileFormProps) {
                 <Icon svg={<Icons.LoadingOutline />} />
               ) : undefined
             }
-            data-testid="submit-create-dataset-btn"
           >
             {pendingAction === "create" ? "Creating..." : "Create Dataset"}
           </Button>

--- a/app/src/pages/datasets/DatasetFromFileForm.tsx
+++ b/app/src/pages/datasets/DatasetFromFileForm.tsx
@@ -969,7 +969,7 @@ export function DatasetFromFileForm(props: DatasetFromFileFormProps) {
           </>
         ) : (
           <Button
-            data-testid="submit-create-dataset-btn"
+            data-testid="dataset-from-file-form-submit-button"
             variant="primary"
             size="S"
             type="button"

--- a/app/src/pages/playground/PlaygroundRunButton.tsx
+++ b/app/src/pages/playground/PlaygroundRunButton.tsx
@@ -100,6 +100,7 @@ export function PlaygroundRunButton() {
       onPress={() => {
         toggleRunning();
       }}
+      data-testid="run-btn"
       trailingVisual={
         <Keyboard>
           <VisuallyHidden>{modifierKey}</VisuallyHidden>

--- a/app/src/pages/playground/PlaygroundRunButton.tsx
+++ b/app/src/pages/playground/PlaygroundRunButton.tsx
@@ -88,7 +88,7 @@ export function PlaygroundRunButton() {
   );
   return (
     <Button
-      data-testid="run-btn"
+      data-testid="playground-run-button"
       variant="primary"
       leadingVisual={
         <Icon

--- a/app/src/pages/playground/PlaygroundRunButton.tsx
+++ b/app/src/pages/playground/PlaygroundRunButton.tsx
@@ -88,6 +88,7 @@ export function PlaygroundRunButton() {
   );
   return (
     <Button
+      data-testid="run-btn"
       variant="primary"
       leadingVisual={
         <Icon
@@ -100,7 +101,6 @@ export function PlaygroundRunButton() {
       onPress={() => {
         toggleRunning();
       }}
-      data-testid="run-btn"
       trailingVisual={
         <Keyboard>
           <VisuallyHidden>{modifierKey}</VisuallyHidden>

--- a/app/src/pages/projects/NewProjectButton.tsx
+++ b/app/src/pages/projects/NewProjectButton.tsx
@@ -59,6 +59,7 @@ export function NewProjectButton({
           leadingVisual={<Icon svg={<Icons.GridOutline />} />}
           size="M"
           variant={variant}
+          data-testid="new-project-btn"
         >
           New Project
         </Button>

--- a/app/src/pages/projects/NewProjectButton.tsx
+++ b/app/src/pages/projects/NewProjectButton.tsx
@@ -56,10 +56,10 @@ export function NewProjectButton({
     <div>
       <DialogTrigger>
         <Button
+          data-testid="new-project-btn"
           leadingVisual={<Icon svg={<Icons.GridOutline />} />}
           size="M"
           variant={variant}
-          data-testid="new-project-btn"
         >
           New Project
         </Button>

--- a/app/src/pages/projects/NewProjectButton.tsx
+++ b/app/src/pages/projects/NewProjectButton.tsx
@@ -56,7 +56,7 @@ export function NewProjectButton({
     <div>
       <DialogTrigger>
         <Button
-          data-testid="new-project-btn"
+          data-testid="create-project-button"
           leadingVisual={<Icon svg={<Icons.GridOutline />} />}
           size="M"
           variant={variant}


### PR DESCRIPTION
## Summary
Adds stable `data-testid` hooks to key user-facing buttons so Playwright / E2E selectors don't depend on visible text or DOM structure.

`data-testid` values follow a convention: kebab-case, no abbreviations (`button`, not `btn`), scoped as `<scope>-<subject>-<role>`, and **constant regardless of state** — state (e.g. create vs. edit) is exposed through a sibling `data-*` attribute rather than baked into / conditionally removed from the `data-testid`. This is codified in `.agents/skills/phoenix-frontend/rules/test-ids.md` and referenced from the `phoenix-playwright-tests` skill.

| File | `data-testid` | State attr | Element |
|---|---|---|---|
| `app/src/pages/projects/NewProjectButton.tsx` | `create-project-button` | — | "New Project" button |
| `app/src/pages/datasets/CreateDatasetButton.tsx` | `create-dataset-button` | — | "New Dataset" trigger (opens "Create Dataset" slideover) |
| `app/src/components/dataset/DatasetForm.tsx` | `dataset-form-submit-button` | `data-mode` (`create`\|`edit`) | Submit button in the "From scratch" tab |
| `app/src/pages/datasets/DatasetFromFileForm.tsx` | `dataset-from-file-form-submit-button` | — | "Create Dataset" submit button in the "From file" tab |
| `app/src/pages/dataset/RunDatasetExperimentButton.tsx` | `run-dataset-experiment-button` | — | "+ Experiment" button |
| `app/src/pages/dataset/RunDatasetExperimentButton.tsx` | `run-dataset-experiment-via-sdk-menu-item` | — | "Run via SDK" menu item |
| `app/src/pages/dataset/RunDatasetExperimentButton.tsx` | `run-dataset-experiment-in-playground-menu-item` | — | "Run in Playground" menu item |
| `app/src/pages/playground/PlaygroundRunButton.tsx` | `playground-run-button` | — | Playground Run / Stop button |
| `app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx` | `llm-evaluator-form-submit-button` | `data-mode` (`create`\|`edit`) | Primary submit on the LLM eval dialog (custom + built-in LLM evaluators) |
| `app/src/components/evaluators/EditBuiltInEvaluatorDialogContent.tsx` | `builtin-evaluator-form-submit-button` | `data-mode` (`create`\|`edit`) | Primary submit on the built-in code eval dialog (Levenshtein, Exact Match, Regex, etc.) |

## Notes
- Eval and dataset create/edit dialogs share components. Rather than conditionally rendering the `data-testid` only in create mode, the id is now constant and `data-mode` carries the mode — tests select `[data-testid="..."][data-mode="create"]` when they need a specific flow.
- `create-dataset-button` is on the outer trigger that opens the slideover; `dataset-form-submit-button` / `dataset-from-file-form-submit-button` are on the submit buttons inside it — so E2E tests can target either step distinctly.

## Test plan
- [ ] `pnpm install` + `pnpm run typecheck` in `app/` passes
- [ ] `pnpm run lint:fix` clean
- [ ] Inspect each button in devtools and confirm the `data-testid` (and `data-mode` where applicable) appears on the rendered element
- [ ] "+ Experiment" menu items render their testids when the popover is open
- [ ] LLM eval dialog: `data-mode="create"` in create flow, `data-mode="edit"` in edit flow
- [ ] Built-in code eval dialog (e.g. Levenshtein): `data-mode` matches the flow
- [ ] Dataset create slideover: submit testids present in both tabs; dataset edit form: `data-mode="edit"`
