### PR TITLE
fix(sandbox): normalize and validate dependency package specs

### DIFF
--- a/app/src/components/dataset/CreateCodeDatasetEvaluatorSlideover.tsx
+++ b/app/src/components/dataset/CreateCodeDatasetEvaluatorSlideover.tsx
@@ -12,7 +12,7 @@ import type { CreateCodeDatasetEvaluatorSlideoverQuery } from "@phoenix/componen
 import { mapSandboxConfigOptions } from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
 import { getDefaultCodeEvaluatorSource } from "@phoenix/components/evaluators/codeEvaluatorUtils";
 import {
-  createDefaultContinuousOutputConfig,
+  createDefaultCategoricalOutputConfig,
   EditCodeEvaluatorDialogContent,
 } from "@phoenix/components/evaluators/EditCodeEvaluatorDialogContent";
 import { buildOutputConfigsInput } from "@phoenix/components/evaluators/utils";
@@ -173,7 +173,7 @@ const CreateCodeEvaluatorDialog = ({
       isBuiltin: false,
       includeExplanation: false,
     },
-    outputConfigs: [createDefaultContinuousOutputConfig("")],
+    outputConfigs: [createDefaultCategoricalOutputConfig("")],
     dataset: {
       readonly: true,
       id: datasetId,
@@ -271,8 +271,8 @@ const CreateCodeEvaluatorDialog = ({
           initialLanguage="PYTHON"
           initialSourceCode={getDefaultCodeEvaluatorSource(
             "PYTHON",
-            "continuous",
-            createDefaultContinuousOutputConfig("")
+            "categorical",
+            createDefaultCategoricalOutputConfig("")
           )}
           sandboxConfigs={sandboxConfigs}
           initialSandboxConfigId={null}

--- a/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
+++ b/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
@@ -37,6 +37,7 @@ export type CodeEvaluatorLanguageFieldProps = {
   /** Callback when language changes */
   onChange: (language: CodeEvaluatorLanguage) => void;
   isDisabled?: boolean;
+  isRequired?: boolean;
 };
 
 /**
@@ -46,11 +47,13 @@ export const CodeEvaluatorLanguageField = ({
   language,
   onChange,
   isDisabled,
+  isRequired,
 }: CodeEvaluatorLanguageFieldProps) => {
   return (
     <Select
       value={language}
       isDisabled={isDisabled}
+      isRequired={isRequired}
       onChange={(value) => onChange(value as CodeEvaluatorLanguage)}
     >
       <Label>Language</Label>
@@ -89,6 +92,8 @@ export type CodeEvaluatorSandboxFieldProps = {
   onSelectionChange: (sandboxConfigId: string | null) => void;
   /** Optional size variant */
   size?: "M" | "L";
+  /** Whether the selection is required for form submission. */
+  isRequired?: boolean;
 };
 
 /**
@@ -101,6 +106,7 @@ export const CodeEvaluatorSandboxField = ({
   selectedSandboxConfigId,
   onSelectionChange,
   size = "M",
+  isRequired,
 }: CodeEvaluatorSandboxFieldProps) => {
   // Filter configs to only show those matching the current language
   const compatibleConfigs = useMemo(
@@ -122,6 +128,7 @@ export const CodeEvaluatorSandboxField = ({
   return (
     <Select
       size={size}
+      isRequired={isRequired}
       selectedKey={validSelectedId != null ? String(validSelectedId) : null}
       onSelectionChange={(key) => {
         onSelectionChange(typeof key === "string" ? key : null);

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -65,7 +65,10 @@ import { EvaluatorInputMapping } from "@phoenix/components/evaluators/EvaluatorI
 import { EvaluatorInputPreview } from "@phoenix/components/evaluators/EvaluatorInputPreview";
 import { CodeEvaluatorInputVariablesProvider } from "@phoenix/components/evaluators/EvaluatorInputVariablesContext/CodeEvaluatorInputVariablesProvider";
 import { EvaluatorNameInput } from "@phoenix/components/evaluators/EvaluatorNameInput";
-import { OptimizationDirectionField } from "@phoenix/components/evaluators/OptimizationDirectionField";
+import {
+  DEFAULT_OPTIMIZATION_DIRECTION,
+  OptimizationDirectionField,
+} from "@phoenix/components/evaluators/OptimizationDirectionField";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
 import { useTheme } from "@phoenix/contexts";
 import {
@@ -75,6 +78,7 @@ import {
 import type { AnnotationConfig } from "@phoenix/store/evaluatorStore";
 import type {
   ClassificationChoice,
+  ClassificationEvaluatorAnnotationConfig,
   CodeEvaluatorLanguage,
   ContinuousEvaluatorAnnotationConfig,
 } from "@phoenix/types";
@@ -88,9 +92,20 @@ export const createDefaultContinuousOutputConfig = (
   name: string
 ): ContinuousEvaluatorAnnotationConfig => ({
   name,
-  optimizationDirection: "NONE",
+  optimizationDirection: DEFAULT_OPTIMIZATION_DIRECTION,
   lowerBound: 0,
   upperBound: 1,
+});
+
+export const createDefaultCategoricalOutputConfig = (
+  name: string
+): ClassificationEvaluatorAnnotationConfig => ({
+  name,
+  optimizationDirection: DEFAULT_OPTIMIZATION_DIRECTION,
+  values: [
+    { label: "pass", score: 1 },
+    { label: "fail", score: 0 },
+  ],
 });
 
 export const EditCodeEvaluatorDialogContent = ({
@@ -389,6 +404,7 @@ export const EditCodeEvaluatorDialogContent = ({
                   selectedSandboxConfigId={selectedSandboxConfigId}
                   onSandboxChange={setSandboxConfigId}
                   isLanguageEditable={mode === "create"}
+                  isSandboxRequired={mode === "create"}
                 />
                 <CodeEditor
                   language={language}
@@ -433,6 +449,7 @@ const EvaluatorMetadataForm = ({
   selectedSandboxConfigId,
   onSandboxChange,
   isLanguageEditable,
+  isSandboxRequired,
 }: {
   language: CodeEvaluatorLanguage;
   onLanguageChange: (language: CodeEvaluatorLanguage) => void;
@@ -440,17 +457,19 @@ const EvaluatorMetadataForm = ({
   selectedSandboxConfigId: string | null;
   onSandboxChange: (sandboxConfigId: string | null) => void;
   isLanguageEditable?: boolean;
+  isSandboxRequired?: boolean;
 }) => {
   return (
     <div css={metadataFormCSS}>
       <div style={{ flex: "0 0 260px" }}>
-        <EvaluatorNameInput />
+        <EvaluatorNameInput isRequired />
       </div>
       <div style={{ flex: "0 0 260px" }}>
         <CodeEvaluatorLanguageField
           language={language}
           onChange={onLanguageChange}
           isDisabled={!isLanguageEditable}
+          isRequired
         />
       </div>
       <div style={{ flex: "0 0 260px" }}>
@@ -459,6 +478,7 @@ const EvaluatorMetadataForm = ({
           language={language}
           selectedSandboxConfigId={selectedSandboxConfigId}
           onSelectionChange={onSandboxChange}
+          isRequired={isSandboxRequired}
         />
       </div>
       <div style={{ flex: "1 1 240px", minWidth: 180 }}>
@@ -907,11 +927,11 @@ const OutputConfigSection = () => {
 
   useEffect(() => {
     if (!outputConfig) {
-      store
-        .getState()
-        .setOutputConfigs([createDefaultContinuousOutputConfig(evaluatorName)]);
+      const state = store.getState();
+      const name = state.evaluator.name || state.evaluator.globalName;
+      state.setOutputConfigs([createDefaultCategoricalOutputConfig(name)]);
     }
-  }, [evaluatorName, outputConfig, store]);
+  }, [outputConfig, store]);
 
   if (!outputConfig) {
     return null;
@@ -932,21 +952,17 @@ const OutputConfigSection = () => {
         <div css={fillCSS}>
           <Select
             value={outputType}
+            disabledKeys={["continuous"]}
             onChange={(value) => {
               const nextType =
                 value as (typeof outputTypeOptions)[number]["id"];
-              store.getState().setOutputConfigs([
-                nextType === "categorical"
-                  ? {
-                      name: evaluatorName,
-                      optimizationDirection: "NONE",
-                      values: [
-                        { label: "pass", score: 1 },
-                        { label: "fail", score: 0 },
-                      ],
-                    }
-                  : createDefaultContinuousOutputConfig(evaluatorName),
-              ]);
+              store
+                .getState()
+                .setOutputConfigs([
+                  nextType === "categorical"
+                    ? createDefaultCategoricalOutputConfig(evaluatorName)
+                    : createDefaultContinuousOutputConfig(evaluatorName),
+                ]);
             }}
           >
             <Label>Output type</Label>
@@ -1005,7 +1021,7 @@ const CategoricalChoicesEditor = ({
         Choices
       </Text>
       {values.map((choice, index) => (
-        <div key={`${index}-${choice.label}`} css={choiceGridCSS}>
+        <div key={index} css={choiceGridCSS}>
           <TextField
             value={choice.label}
             onChange={(label) => {

--- a/app/src/components/evaluators/OptimizationDirectionField.tsx
+++ b/app/src/components/evaluators/OptimizationDirectionField.tsx
@@ -16,6 +16,9 @@ import {
 import { useEvaluatorStore } from "@phoenix/contexts/EvaluatorContext";
 import type { EvaluatorOptimizationDirection } from "@phoenix/types";
 
+export const DEFAULT_OPTIMIZATION_DIRECTION: EvaluatorOptimizationDirection =
+  "MAXIMIZE";
+
 export const optimizationDirectionOptions: {
   value: EvaluatorOptimizationDirection;
   label: string;

--- a/app/src/components/evaluators/codeEvaluatorTemplates.ts
+++ b/app/src/components/evaluators/codeEvaluatorTemplates.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_OPTIMIZATION_DIRECTION } from "@phoenix/components/evaluators/OptimizationDirectionField";
 import type {
   ClassificationEvaluatorAnnotationConfig,
   CodeEvaluatorLanguage,
@@ -37,7 +38,7 @@ export type CodeEvaluatorTemplate = {
 const getCategoricalConfigFromChoices = (
   choices: Record<string, number>
 ): TemplateOutputConfig => ({
-  optimizationDirection: "NONE",
+  optimizationDirection: DEFAULT_OPTIMIZATION_DIRECTION,
   values: Object.entries(choices).map(([label, score]) => ({ label, score })),
 });
 

--- a/app/src/components/evaluators/codeEvaluatorUtils.ts
+++ b/app/src/components/evaluators/codeEvaluatorUtils.ts
@@ -24,28 +24,28 @@ export function getStaticFallbackSource(
   if (language === "PYTHON") {
     if (shape === "categorical") {
       return `def evaluate(output, reference=None, input=None, metadata=None):
-${PYTHON_INDENT}# return {"label": "pass", "score": 1, "explanation": "..."}  # also set score and explanation
-${PYTHON_INDENT}return "pass"  # label only
+${PYTHON_INDENT}# You can also return only the label, e.g. return "pass"
+${PYTHON_INDENT}return {"label": "pass", "score": 1, "explanation": "..."}
 `;
     }
     // continuous
     return `def evaluate(output, reference=None, input=None, metadata=None):
-${PYTHON_INDENT}# return {"score": 0.5, "explanation": "..."}  # also set explanation
-${PYTHON_INDENT}return 0.5  # score only
+${PYTHON_INDENT}# You can also return only the score, e.g. return 0.5
+${PYTHON_INDENT}return {"score": 0.5, "explanation": "..."}
 `;
   }
   // TYPESCRIPT
   if (shape === "categorical") {
     return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-${TYPESCRIPT_INDENT}// return { label: "pass", score: 1, explanation: "..." };  // also set score and explanation
-${TYPESCRIPT_INDENT}return "pass";  // label only
+${TYPESCRIPT_INDENT}// You can also return only the label, e.g. return "pass";
+${TYPESCRIPT_INDENT}return { label: "pass", score: 1, explanation: "..." };
 }
 `;
   }
   // continuous
   return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-${TYPESCRIPT_INDENT}// return { score: 0.5, explanation: "..." };  // also set explanation
-${TYPESCRIPT_INDENT}return 0.5;  // score only
+${TYPESCRIPT_INDENT}// You can also return only the score, e.g. return 0.5;
+${TYPESCRIPT_INDENT}return { score: 0.5, explanation: "..." };
 }
 `;
 }
@@ -93,14 +93,14 @@ export function getDefaultCodeEvaluatorSource(
       const labelLiteral = JSON.stringify(label);
       if (language === "PYTHON") {
         return `def evaluate(output, reference=None, input=None, metadata=None):
-${PYTHON_INDENT}# return {"label": ${labelLiteral}, "score": 1, "explanation": "..."}  # also set score and explanation
-${PYTHON_INDENT}return ${labelLiteral}  # label only
+${PYTHON_INDENT}# You can also return only the label, e.g. return ${labelLiteral}
+${PYTHON_INDENT}return {"label": ${labelLiteral}, "score": 1, "explanation": "..."}
 `;
       }
       // TYPESCRIPT
       return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-${TYPESCRIPT_INDENT}// return { label: ${labelLiteral}, score: 1, explanation: "..." };  // also set score and explanation
-${TYPESCRIPT_INDENT}return ${labelLiteral};  // label only
+${TYPESCRIPT_INDENT}// You can also return only the label, e.g. return ${labelLiteral};
+${TYPESCRIPT_INDENT}return { label: ${labelLiteral}, score: 1, explanation: "..." };
 }
 `;
     }
@@ -123,14 +123,14 @@ ${TYPESCRIPT_INDENT}return ${labelLiteral};  // label only
       const rangeComment = `${lower.toFixed(1)} - ${upper.toFixed(1)}`;
       if (language === "PYTHON") {
         return `def evaluate(output, reference=None, input=None, metadata=None):
-${PYTHON_INDENT}# return {"score": ${midpoint.toFixed(1)}, "explanation": "..."}  # also set explanation
-${PYTHON_INDENT}return ${midpoint.toFixed(1)}  # score only (expected range: ${rangeComment})
+${PYTHON_INDENT}# You can also return only the score (expected range: ${rangeComment}), e.g. return ${midpoint.toFixed(1)}
+${PYTHON_INDENT}return {"score": ${midpoint.toFixed(1)}, "explanation": "..."}
 `;
       }
       // TYPESCRIPT
       return `function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
-${TYPESCRIPT_INDENT}// return { score: ${midpoint.toFixed(1)}, explanation: "..." };  // also set explanation
-${TYPESCRIPT_INDENT}return ${midpoint.toFixed(1)};  // score only (expected range: ${rangeComment})
+${TYPESCRIPT_INDENT}// You can also return only the score (expected range: ${rangeComment}), e.g. return ${midpoint.toFixed(1)};
+${TYPESCRIPT_INDENT}return { score: ${midpoint.toFixed(1)}, explanation: "..." };
 }
 `;
     }

--- a/app/src/components/sandbox/SandboxProviderSelect.tsx
+++ b/app/src/components/sandbox/SandboxProviderSelect.tsx
@@ -1,0 +1,191 @@
+import { useMemo } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+
+import {
+  Button,
+  FieldError,
+  Flex,
+  Label,
+  ListBox,
+  Popover,
+  Select,
+  SelectChevronUpDownIcon,
+  SelectItem,
+  SelectValue,
+  type SelectProps,
+  Text,
+} from "@phoenix/components";
+import { SandboxProviderIcon } from "@phoenix/components/sandbox/SandboxProviderIcon";
+import { languageLabel } from "@phoenix/pages/settings/sandboxes/utils";
+
+import type {
+  SandboxProviderSelectQuery,
+  SandboxProviderSelectQuery$data,
+} from "./__generated__/SandboxProviderSelectQuery.graphql";
+
+type SandboxBackend =
+  SandboxProviderSelectQuery$data["sandboxBackends"][number];
+type SandboxProvider =
+  SandboxProviderSelectQuery$data["sandboxProviders"][number];
+
+/**
+ * A single selectable sandbox provider, joined with its backend so the option
+ * can render the backend's display name + icon.
+ */
+export type SandboxProviderOption = {
+  provider: SandboxProvider;
+  backend: SandboxBackend;
+};
+
+type SandboxProviderSelectProps = Pick<
+  SelectProps,
+  "selectedKey" | "onBlur" | "isDisabled" | "isInvalid"
+> & {
+  onChange?: (sandboxProviderId: string) => void;
+  errorMessage?: string;
+  /**
+   * Optional predicate to narrow which providers are offered (e.g. only those
+   * whose backend is available and whose admin toggle is enabled). When
+   * omitted, every sandbox provider is listed. The currently `selectedKey` is
+   * always kept in the list so a controlled value never disappears.
+   */
+  filter?: (option: SandboxProviderOption) => boolean;
+};
+
+function SandboxProviderOptionContent({
+  option,
+}: {
+  option: SandboxProviderOption;
+}) {
+  return (
+    <Flex direction="row" gap="size-100" alignItems="center">
+      <SandboxProviderIcon
+        backendType={option.backend.backendType}
+        height={18}
+      />
+      <Text>{option.backend.displayName}</Text>
+      <Text color="text-500">{languageLabel(option.provider.language)}</Text>
+    </Flex>
+  );
+}
+
+/**
+ * Self-contained sandbox provider `<Select>`. Fetches the available sandbox
+ * providers (and their backends) itself, so it can be dropped into any form
+ * without the parent wiring up provider data. Wrap in `<Suspense>`.
+ */
+export function SandboxProviderSelect({
+  selectedKey,
+  onChange,
+  onBlur,
+  isDisabled,
+  isInvalid,
+  errorMessage,
+  filter,
+}: SandboxProviderSelectProps) {
+  const data = useLazyLoadQuery<SandboxProviderSelectQuery>(
+    graphql`
+      query SandboxProviderSelectQuery {
+        sandboxBackends {
+          backendType
+          displayName
+          hostingType
+          status
+        }
+        sandboxProviders {
+          id
+          backendType
+          language
+          enabled
+        }
+      }
+    `,
+    {}
+  );
+
+  const options = useMemo(() => {
+    const backendByType = new Map(
+      data.sandboxBackends.map((backend) => [backend.backendType, backend])
+    );
+    return data.sandboxProviders
+      .map((provider) => ({
+        provider,
+        backend: backendByType.get(provider.backendType),
+      }))
+      .filter(
+        (option): option is SandboxProviderOption => option.backend != null
+      )
+      .filter(
+        (option) =>
+          option.provider.id === selectedKey || filter == null || filter(option)
+      )
+      .sort((a, b) => {
+        // Local providers first, then alphabetical by display name, then by
+        // language for stable ordering when two providers share a name.
+        const aLocal = a.backend.hostingType === "LOCAL" ? 0 : 1;
+        const bLocal = b.backend.hostingType === "LOCAL" ? 0 : 1;
+        if (aLocal !== bLocal) return aLocal - bLocal;
+        const nameCmp = a.backend.displayName.localeCompare(
+          b.backend.displayName
+        );
+        if (nameCmp !== 0) return nameCmp;
+        return a.provider.language.localeCompare(b.provider.language);
+      });
+  }, [data.sandboxBackends, data.sandboxProviders, selectedKey, filter]);
+
+  return (
+    <Select
+      size="M"
+      selectedKey={selectedKey}
+      isDisabled={isDisabled}
+      isInvalid={isInvalid}
+      placeholder="Select a sandbox provider"
+      onSelectionChange={(key) => {
+        if (typeof key === "string") {
+          onChange?.(key);
+        }
+      }}
+      onBlur={onBlur}
+    >
+      <Label>Sandbox Provider</Label>
+      <Button>
+        <SelectValue />
+        <SelectChevronUpDownIcon />
+      </Button>
+      <Popover>
+        <ListBox>
+          {options.map((option) => (
+            <SelectItem
+              key={option.provider.id}
+              id={option.provider.id}
+              textValue={option.backend.displayName}
+            >
+              <SandboxProviderOptionContent option={option} />
+            </SelectItem>
+          ))}
+        </ListBox>
+      </Popover>
+      <FieldError>{errorMessage}</FieldError>
+    </Select>
+  );
+}
+
+/**
+ * Fallback to render inside `<Suspense>` while {@link SandboxProviderSelect}
+ * loads its provider list — a disabled, empty select that matches the real
+ * control's footprint so the form doesn't jump.
+ */
+export function SandboxProviderSelectFallback() {
+  return (
+    <Select size="M" isDisabled placeholder="Loading…">
+      <Label>Sandbox Provider</Label>
+      <Button>
+        <SelectValue />
+        <SelectChevronUpDownIcon />
+      </Button>
+      <Popover>
+        <ListBox />
+      </Popover>
+    </Select>
+  );
+}

--- a/app/src/components/sandbox/__generated__/SandboxProviderSelectQuery.graphql.ts
+++ b/app/src/components/sandbox/__generated__/SandboxProviderSelectQuery.graphql.ts
@@ -1,0 +1,141 @@
+/**
+ * @generated SignedSource<<c1d30166ac70f52a6e0c511e3ba90f98>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type Language = "PYTHON" | "TYPESCRIPT";
+export type SandboxBackendStatus = "AVAILABLE" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
+export type SandboxHostingType = "HOSTED" | "LOCAL";
+export type SandboxProviderSelectQuery$variables = Record<PropertyKey, never>;
+export type SandboxProviderSelectQuery$data = {
+  readonly sandboxBackends: ReadonlyArray<{
+    readonly backendType: string;
+    readonly displayName: string;
+    readonly hostingType: SandboxHostingType;
+    readonly status: SandboxBackendStatus;
+  }>;
+  readonly sandboxProviders: ReadonlyArray<{
+    readonly backendType: string;
+    readonly enabled: boolean;
+    readonly id: string;
+    readonly language: Language;
+  }>;
+};
+export type SandboxProviderSelectQuery = {
+  response: SandboxProviderSelectQuery$data;
+  variables: SandboxProviderSelectQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "backendType",
+  "storageKey": null
+},
+v1 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "SandboxBackendInfo",
+    "kind": "LinkedField",
+    "name": "sandboxBackends",
+    "plural": true,
+    "selections": [
+      (v0/*: any*/),
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "displayName",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "hostingType",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "status",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "SandboxProvider",
+    "kind": "LinkedField",
+    "name": "sandboxProviders",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      (v0/*: any*/),
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "language",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "enabled",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SandboxProviderSelectQuery",
+    "selections": (v1/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "SandboxProviderSelectQuery",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "891c5ebc9db29c0b106fe39945f2756b",
+    "id": null,
+    "metadata": {},
+    "name": "SandboxProviderSelectQuery",
+    "operationKind": "query",
+    "text": "query SandboxProviderSelectQuery {\n  sandboxBackends {\n    backendType\n    displayName\n    hostingType\n    status\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "8d20fa72d4cba405e430d26cc8a08dec";
+
+export default node;

--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -37,7 +37,10 @@ import {
   TextField,
   View,
 } from "@phoenix/components";
-import { SandboxProviderIcon } from "@phoenix/components/sandbox/SandboxProviderIcon";
+import {
+  SandboxProviderSelect,
+  SandboxProviderSelectFallback,
+} from "@phoenix/components/sandbox/SandboxProviderSelect";
 import { useNotifySuccess } from "@phoenix/contexts";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 import {
@@ -45,6 +48,7 @@ import {
   transformIdentifierInput,
   validateIdentifier,
 } from "@phoenix/utils/identifierUtils";
+import { validateDependencyPackages } from "@phoenix/utils/packageSpecUtils";
 
 import type { SandboxConfigDialogCreateSandboxConfigMutation } from "./__generated__/SandboxConfigDialogCreateSandboxConfigMutation.graphql";
 import type { SandboxConfigDialogSecretsQuery } from "./__generated__/SandboxConfigDialogSecretsQuery.graphql";
@@ -61,7 +65,6 @@ import { DEFAULT_SANDBOX_TIMEOUT_SECONDS } from "./types";
 import {
   formValuesToConfigPatch,
   getDependencyPreview,
-  LanguageWithIcon,
   shouldShowLocalDenoTrustWarning,
 } from "./utils";
 
@@ -104,7 +107,7 @@ export function SandboxConfigDialogTrigger(
                 <DialogTitle>
                   {props.mode === "create"
                     ? "New Sandbox Config"
-                    : `Edit "${props.config.name}" config`}
+                    : `Edit Sandbox Config: ${props.config.name}`}
                 </DialogTitle>
                 <DialogTitleExtra>
                   <DialogCloseButton slot="close" />
@@ -159,6 +162,15 @@ const envVarFieldFillCSS = css`
 // different lengths). Sized to fit the longer label plus dropdown chevron.
 const envVarKindFieldCSS = css`
   min-width: 7rem;
+`;
+
+// The env-var row controls are top-aligned (see `alignItems="start"` below) so
+// a field-level error (e.g. "Name is required") only grows its own column
+// downward instead of knocking the rest of the row out of alignment. The
+// label-less remove button needs to be nudged down by the height of a field
+// label so it lines up with the inputs rather than the labels.
+const envVarRemoveButtonOffsetCSS = css`
+  padding-top: var(--global-dimension-static-size-300);
 `;
 
 function defaultConfigName(provider: ProviderRow): string {
@@ -374,19 +386,22 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
                 execution.
               </Alert>
             ) : null}
-            {mode === "create" ? (
-              <Controller
-                name="sandboxProviderId"
-                control={form.control}
-                rules={{ required: "Provider is required" }}
-                render={({ field, fieldState }) => (
-                  <ComboBox
-                    label="Provider"
-                    placeholder="Search providers"
-                    size="L"
-                    selectedKey={field.value || null}
-                    onSelectionChange={(key) => {
-                      if (typeof key === "string") {
+            <Suspense fallback={<SandboxProviderSelectFallback />}>
+              {mode === "create" ? (
+                <Controller
+                  name="sandboxProviderId"
+                  control={form.control}
+                  rules={{ required: "Provider is required" }}
+                  render={({ field, fieldState }) => (
+                    <SandboxProviderSelect
+                      selectedKey={field.value || null}
+                      onBlur={field.onBlur}
+                      isInvalid={fieldState.invalid}
+                      errorMessage={fieldState.error?.message}
+                      filter={({ backend, provider }) =>
+                        backend.status === "AVAILABLE" && provider.enabled
+                      }
+                      onChange={(key) => {
                         field.onChange(key);
                         const currentName = form.getValues("name");
                         const isDefaultName =
@@ -402,50 +417,17 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
                             form.setValue("name", defaultConfigName(selected));
                           }
                         }
-                      }
-                    }}
-                    onBlur={field.onBlur}
-                    isInvalid={fieldState.invalid}
-                    errorMessage={fieldState.error?.message}
-                    menuTrigger="focus"
-                    defaultItems={providers ?? []}
-                    renderEmptyState={() => <div>No providers found</div>}
-                  >
-                    {(item) => (
-                      <ComboBoxItem
-                        id={item.provider.id}
-                        key={item.provider.id}
-                        textValue={`${item.backend.displayName}`}
-                      >
-                        <Flex
-                          direction="row"
-                          gap="size-100"
-                          alignItems="center"
-                          width="100%"
-                        >
-                          <SandboxProviderIcon
-                            backendType={item.backend.backendType}
-                            height={18}
-                          />
-                          <Text>{item.backend.displayName}</Text>
-                          <Text
-                            color="text-700"
-                            size="S"
-                            css={css`
-                              margin-inline-start: auto;
-                            `}
-                          >
-                            <LanguageWithIcon
-                              language={item.provider.language}
-                            />
-                          </Text>
-                        </Flex>
-                      </ComboBoxItem>
-                    )}
-                  </ComboBox>
-                )}
-              />
-            ) : null}
+                      }}
+                    />
+                  )}
+                />
+              ) : (
+                <SandboxProviderSelect
+                  selectedKey={props.provider.id}
+                  isDisabled
+                />
+              )}
+            </Suspense>
             {mode === "create" && (
               <Controller
                 name="name"
@@ -516,20 +498,25 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
             {activeBackend?.supportsEnvVars ? (
               <Flex direction="column" gap="size-100">
                 <Text>Environment Variables</Text>
+                <Alert variant="warning">
+                  Anyone who can run code in this sandbox can read these values
+                  (e.g. via <code>os.environ</code>). Don&apos;t store secrets
+                  you wouldn&apos;t share with everyone who has access to this
+                  config.
+                </Alert>
                 {envVarFields.length === 0 ? (
                   <Text color="text-700" size="S">
                     No environment variables configured.
                   </Text>
-                ) : (
-                  envVarFields.map((fieldItem, index) => (
-                    <EnvVarRow
-                      key={fieldItem.id}
-                      index={index}
-                      form={form}
-                      onRemove={() => removeEnvVar(index)}
-                    />
-                  ))
-                )}
+                ) : null}
+                {envVarFields.map((fieldItem, index) => (
+                  <EnvVarRow
+                    key={fieldItem.id}
+                    index={index}
+                    form={form}
+                    onRemove={() => removeEnvVar(index)}
+                  />
+                ))}
                 <Button
                   size="S"
                   variant="default"
@@ -575,7 +562,18 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
               <Controller
                 name="dependenciesText"
                 control={form.control}
-                render={({ field }) => {
+                rules={{
+                  validate: (value) => {
+                    const language = activeBackend?.dependenciesLanguage;
+                    if (language == null) return true;
+                    const result = validateDependencyPackages({
+                      packagesText: value,
+                      language,
+                    });
+                    return result.valid ? true : result.message;
+                  },
+                }}
+                render={({ field, fieldState }) => {
                   const preview = getDependencyPreview({
                     packagesText: field.value,
                     dependenciesLanguage: activeBackend.dependenciesLanguage,
@@ -583,7 +581,7 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
                   });
                   return (
                     <Flex direction="column" gap="size-50">
-                      <TextField {...field}>
+                      <TextField {...field} isInvalid={fieldState.invalid}>
                         <Label>
                           {activeBackend.dependenciesLanguage === "PYTHON"
                             ? "Python Packages"
@@ -596,9 +594,14 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
                               : "@types/node\nlodash"
                           }
                         />
-                        <Text slot="description" size="S" color="text-700">
-                          One package per line. Installed before code execution.
-                        </Text>
+                        {fieldState.error ? (
+                          <FieldError>{fieldState.error.message}</FieldError>
+                        ) : (
+                          <Text slot="description" size="S" color="text-700">
+                            One package per line. Installed before code
+                            execution.
+                          </Text>
+                        )}
                       </TextField>
                       {preview ? (
                         <Text size="S" color="text-700">
@@ -712,13 +715,15 @@ function EnvVarRow({
     </div>
   );
   const removeButton = (
-    <Button
-      size="M"
-      variant="quiet"
-      aria-label="Remove variable"
-      leadingVisual={<Icon svg={<Icons.TrashOutline />} />}
-      onPress={onRemove}
-    />
+    <div css={envVarRemoveButtonOffsetCSS}>
+      <Button
+        size="M"
+        variant="quiet"
+        aria-label="Remove variable"
+        leadingVisual={<Icon svg={<Icons.TrashOutline />} />}
+        onPress={onRemove}
+      />
+    </div>
   );
 
   if (kind === "secret_ref") {
@@ -735,7 +740,7 @@ function EnvVarRow({
       }
     };
     return (
-      <Flex gap="size-100" alignItems="end">
+      <Flex gap="size-100" alignItems="start">
         {kindField}
         {nameField}
         <div css={envVarFieldFillCSS}>
@@ -755,7 +760,7 @@ function EnvVarRow({
   }
 
   return (
-    <Flex gap="size-100" alignItems="end">
+    <Flex gap="size-100" alignItems="start">
       {kindField}
       {nameField}
       <div css={envVarFieldFillCSS}>

--- a/app/src/pages/settings/sandboxes/__tests__/formValuesToConfigPatch.test.ts
+++ b/app/src/pages/settings/sandboxes/__tests__/formValuesToConfigPatch.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import type { BackendInfo, SandboxConfigFormValues } from "../types";
 import {
   formValuesToConfigPatch,
-  getDependencyPackages,
   getDependencyPreview,
   getDisplaySandboxConfig,
 } from "../utils";
@@ -124,20 +123,6 @@ describe("formValuesToConfigPatch — capability-only output", () => {
   });
 });
 
-describe("getDependencyPackages", () => {
-  it("trims whitespace and drops empty lines", () => {
-    expect(getDependencyPackages("  numpy  \n\n pandas\n")).toEqual([
-      "numpy",
-      "pandas",
-    ]);
-  });
-
-  it("returns empty array for empty input", () => {
-    expect(getDependencyPackages("")).toEqual([]);
-    expect(getDependencyPackages("   \n  ")).toEqual([]);
-  });
-});
-
 describe("getDependencyPreview", () => {
   it("returns null when no language is advertised", () => {
     expect(
@@ -203,14 +188,14 @@ describe("getDependencyPreview", () => {
     ).toBe('image.pip_install("numpy", "pandas==2.0")');
   });
 
-  it("renders unavailable for TypeScript", () => {
+  it("renders npm install for TypeScript", () => {
     expect(
       getDependencyPreview({
-        packagesText: "lodash",
+        packagesText: "lodash\n@scope/pkg@1.2.3",
         dependenciesLanguage: "TYPESCRIPT",
         backendType: "DENO",
       })
-    ).toBe("preview unavailable for typescript");
+    ).toBe("npm install lodash @scope/pkg@1.2.3");
   });
 });
 

--- a/app/src/pages/settings/sandboxes/utils.tsx
+++ b/app/src/pages/settings/sandboxes/utils.tsx
@@ -11,6 +11,7 @@ import {
 import { PythonSVG, TypeScriptSVG } from "@phoenix/components/core/icon/Icons";
 import { assertUnreachable } from "@phoenix/typeUtils";
 import { isPlainObject } from "@phoenix/utils/jsonUtils";
+import { getDependencyPackages } from "@phoenix/utils/packageSpecUtils";
 
 import type {
   BackendInfo,
@@ -238,17 +239,6 @@ export function getDisplaySandboxConfig(config: unknown): unknown {
 }
 
 /**
- * Splits the user-edited "one package per line" textarea into a normalized
- * list of package specifiers.
- */
-export function getDependencyPackages(packagesText: string): string[] {
-  return packagesText
-    .split("\n")
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
-
-/**
  * Produces a one-line install-command preview for the dependency textarea.
  * Returns null when there is nothing to display (no language advertised, no
  * packages typed) so the caller can hide the preview entirely.
@@ -269,11 +259,11 @@ export function getDependencyPreview({
   if (packages.length === 0) {
     return null;
   }
+  const joined = packages.join(" ");
   if (dependenciesLanguage === "TYPESCRIPT") {
-    return "preview unavailable for typescript";
+    return `npm install ${joined}`;
   }
   // Python branch: shape the preview after the install path the backend uses.
-  const joined = packages.join(" ");
   if (backendType === "MODAL") {
     const args = packages.map((p) => `"${p}"`).join(", ");
     return `image.pip_install(${args})`;

--- a/app/src/utils/__tests__/packageSpecUtils.test.ts
+++ b/app/src/utils/__tests__/packageSpecUtils.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getDependencyPackages,
+  validateDependencyPackages,
+} from "../packageSpecUtils";
+
+describe("getDependencyPackages", () => {
+  it("returns an empty list for empty/whitespace input", () => {
+    expect(getDependencyPackages("")).toEqual([]);
+    expect(getDependencyPackages("\n  \n\t\n")).toEqual([]);
+  });
+
+  it("splits on newlines and trims each line", () => {
+    expect(getDependencyPackages("requests\n  numpy==1.26.0  \nhttpx")).toEqual(
+      ["requests", "numpy==1.26.0", "httpx"]
+    );
+  });
+
+  it("drops blank lines between packages", () => {
+    expect(getDependencyPackages("requests\n\n\nnumpy")).toEqual([
+      "requests",
+      "numpy",
+    ]);
+  });
+});
+
+describe("validateDependencyPackages", () => {
+  describe("empty input", () => {
+    it("returns valid for empty text in either ecosystem", () => {
+      expect(
+        validateDependencyPackages({ packagesText: "", language: "PYTHON" })
+      ).toEqual({ valid: true });
+      expect(
+        validateDependencyPackages({
+          packagesText: "\n  \n",
+          language: "TYPESCRIPT",
+        })
+      ).toEqual({ valid: true });
+    });
+  });
+
+  describe("PYTHON", () => {
+    it.each([
+      ["bare name", "requests"],
+      ["exact version", "numpy==1.26.0"],
+      ["compound version clause", "httpx>=0.27,<1"],
+      ["extras list", "httpx[http2]"],
+      ["extras + version", "httpx[http2,brotli]>=0.27,<1"],
+      ["tilde-equal", "openai~=2.0"],
+      ["wildcard version", "django==4.*"],
+    ])("accepts %s", (_label, spec) => {
+      expect(
+        validateDependencyPackages({ packagesText: spec, language: "PYTHON" })
+      ).toEqual({ valid: true });
+    });
+
+    it("accepts multi-line valid input", () => {
+      expect(
+        validateDependencyPackages({
+          packagesText: "requests\nnumpy==1.26.0\nhttpx[http2]>=0.27,<1",
+          language: "PYTHON",
+        })
+      ).toEqual({ valid: true });
+    });
+
+    it.each([
+      ["whitespace in name", "not a package!"],
+      ["npm-style @version", "lodash@^4.17"],
+      ["leading dot", ".invalid"],
+    ])("rejects %s with a Python-spec error", (_label, spec) => {
+      const result = validateDependencyPackages({
+        packagesText: spec,
+        language: "PYTHON",
+      });
+      expect(result).toMatchObject({ valid: false });
+      if (result.valid) throw new Error("expected invalid result");
+      expect(result.message).toMatch(/Invalid Python package spec/);
+      expect(result.message).toContain(spec);
+    });
+
+    it("reports the first offending line when multiple lines are invalid", () => {
+      const result = validateDependencyPackages({
+        packagesText: "requests\nbad spec!\nanother bad!",
+        language: "PYTHON",
+      });
+      expect(result).toMatchObject({ valid: false });
+      if (result.valid) throw new Error("expected invalid result");
+      expect(result.message).toContain("bad spec!");
+      expect(result.message).not.toContain("another bad!");
+    });
+  });
+
+  describe("TYPESCRIPT", () => {
+    it.each([
+      ["bare name", "lodash"],
+      ["caret range", "lodash@^4.17"],
+      ["scoped package", "@scope/pkg@1.2.3"],
+      ["scoped package without version", "@types/node"],
+      ["tilde range", "react@~18.2"],
+    ])("accepts %s", (_label, spec) => {
+      expect(
+        validateDependencyPackages({
+          packagesText: spec,
+          language: "TYPESCRIPT",
+        })
+      ).toEqual({ valid: true });
+    });
+
+    it("accepts multi-line valid input", () => {
+      expect(
+        validateDependencyPackages({
+          packagesText: "lodash\nlodash@^4.17\n@scope/pkg@1.2.3",
+          language: "TYPESCRIPT",
+        })
+      ).toEqual({ valid: true });
+    });
+
+    it.each([
+      ["whitespace in name", "has spaces"],
+      ["Python-style version", "openai>=6.37.0"],
+      ["double @ in spec", "pkg@@1.0"],
+    ])("rejects %s with an npm-spec error", (_label, spec) => {
+      const result = validateDependencyPackages({
+        packagesText: spec,
+        language: "TYPESCRIPT",
+      });
+      expect(result).toMatchObject({ valid: false });
+      if (result.valid) throw new Error("expected invalid result");
+      expect(result.message).toMatch(/Invalid npm package spec/);
+      expect(result.message).toContain(spec);
+    });
+
+    it("reports the first offending line when multiple lines are invalid", () => {
+      const result = validateDependencyPackages({
+        packagesText: "lodash\nbad spec!\nalso bad!",
+        language: "TYPESCRIPT",
+      });
+      expect(result).toMatchObject({ valid: false });
+      if (result.valid) throw new Error("expected invalid result");
+      expect(result.message).toContain("bad spec!");
+      expect(result.message).not.toContain("also bad!");
+    });
+  });
+});

--- a/app/src/utils/packageSpecUtils.ts
+++ b/app/src/utils/packageSpecUtils.ts
@@ -1,0 +1,77 @@
+/**
+ * Validators for the package specifiers users type into "one package per
+ * line" textareas (e.g. the sandbox dependencies editor). Grammar mirrors
+ * the server-side pydantic validators in
+ * `src/phoenix/server/sandbox/types.py` — keep the two in sync.
+ *
+ * npm and Python requirements are validated independently. No
+ * cross-conversion: a Python-style spec is invalid as npm, and vice
+ * versa.
+ */
+
+/** The package ecosystems this module knows how to validate. */
+export type PackageEcosystem = "PYTHON" | "TYPESCRIPT";
+
+/** One identifier segment: starts/ends alphanumeric, allows `.`/`_`/`-`/`~` inside. */
+const IDENT = `[A-Za-z0-9](?:[A-Za-z0-9._~-]*[A-Za-z0-9])?`;
+
+/** An npm requirement: `name` or `name@version` (incl. `@scope/name`). */
+const NPM_REQUIREMENT_RE = new RegExp(
+  `^(?:@${IDENT}/)?${IDENT}(?:@[^@\\s]+)?$`
+);
+
+/** PEP 508 extras list, e.g. `[socks,brotli]`. */
+const PY_EXTRAS = `(?:\\[\\s*[A-Za-z0-9._-]+(?:\\s*,\\s*[A-Za-z0-9._-]+)*\\s*\\])?`;
+
+/** One PEP 440 version clause, e.g. `>=1.2`, `==1.*`, `~=2.0`. */
+const PY_VERSION_CLAUSE = `(?:===|==|!=|~=|<=|>=|<|>)\\s*[A-Za-z0-9*][A-Za-z0-9.*+!_-]*`;
+
+const PYTHON_REQUIREMENT_RE = new RegExp(
+  `^${IDENT}\\s*${PY_EXTRAS}\\s*(?:${PY_VERSION_CLAUSE}(?:\\s*,\\s*${PY_VERSION_CLAUSE})*)?\\s*$`
+);
+
+/**
+ * Splits the user-edited "one package per line" textarea into a normalized
+ * list of package specifiers. Lines are trimmed and blank lines dropped.
+ */
+export function getDependencyPackages(packagesText: string): string[] {
+  return packagesText
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export type DependencyPackagesValidationResult =
+  | { valid: true }
+  | { valid: false; message: string };
+
+/**
+ * Validate a "one package per line" textarea against the grammar for the
+ * given package ecosystem. Returns `{ valid: true }` for an empty list, or
+ * `{ valid: false, message }` naming the first offending line.
+ */
+export function validateDependencyPackages({
+  packagesText,
+  language,
+}: {
+  packagesText: string;
+  language: PackageEcosystem;
+}): DependencyPackagesValidationResult {
+  const isPython = language === "PYTHON";
+  for (const pkg of getDependencyPackages(packagesText)) {
+    if (isPython) {
+      if (!PYTHON_REQUIREMENT_RE.test(pkg)) {
+        return {
+          valid: false,
+          message: `Invalid Python package spec: "${pkg}" (e.g. "requests", "numpy==1.26.0", "httpx[http2]>=0.27,<1")`,
+        };
+      }
+    } else if (!NPM_REQUIREMENT_RE.test(pkg)) {
+      return {
+        valid: false,
+        message: `Invalid npm package spec: "${pkg}" (e.g. "lodash", "lodash@^4.17", "@scope/pkg@1.2.3")`,
+      };
+    }
+  }
+  return { valid: true };
+}

--- a/app/tests/code-evaluators.spec.ts
+++ b/app/tests/code-evaluators.spec.ts
@@ -192,7 +192,7 @@ async function ensureSandboxConfig(
     dialog.getByRole("heading", { name: "New Sandbox Config" })
   ).toBeVisible();
 
-  await selectFromCombobox(page, dialog, "Provider", providerName);
+  await selectFromSelect(page, dialog, "Sandbox Provider", providerName);
   await dialog.getByRole("textbox", { name: "Name" }).fill(configName);
 
   await Promise.all([
@@ -325,7 +325,7 @@ async function createE2BSandboxWithLiteralEnvVar(
   const dialog = page.getByRole("dialog");
   await expect(dialog).toBeVisible();
 
-  await selectFromCombobox(page, dialog, "Provider", "E2B");
+  await selectFromSelect(page, dialog, "Sandbox Provider", "E2B");
 
   await expect(
     dialog.getByText("Environment Variables", { exact: true })
@@ -1086,7 +1086,7 @@ test.describe
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
 
-    await selectFromCombobox(page, dialog, "Provider", "E2B");
+    await selectFromSelect(page, dialog, "Sandbox Provider", "E2B");
 
     await expect(
       dialog.getByText("Environment Variables", { exact: true })

--- a/app/tests/code-evaluators.spec.ts
+++ b/app/tests/code-evaluators.spec.ts
@@ -770,7 +770,7 @@ test.describe.serial("Code Evaluators", () => {
   // Phase 4: Config-aware placeholder assertions
 
   const placeholderCategoricalName = `placeholder-cat-${randomUUID().slice(0, 8)}`;
-  const placeholderContinuousName = `placeholder-cont-${randomUUID().slice(0, 8)}`;
+  const placeholderDefaultsName = `placeholder-defaults-${randomUUID().slice(0, 8)}`;
 
   test("categorical placeholder shows substituted label from config", async ({
     page,
@@ -817,7 +817,7 @@ test.describe.serial("Code Evaluators", () => {
     ).toBeVisible();
   });
 
-  test("continuous placeholder shows midpoint and bounds-range comment", async ({
+  test("categorical placeholder shows default pass/fail labels for a new evaluator", async ({
     page,
   }) => {
     await gotoDatasetEvaluators(page, datasetName);
@@ -834,21 +834,17 @@ test.describe.serial("Code Evaluators", () => {
 
     await dialog
       .getByRole("textbox", { name: "Name", exact: true })
-      .fill(placeholderContinuousName);
+      .fill(placeholderDefaultsName);
 
     await selectSandbox(page, dialog, pythonSandboxName);
 
-    // Set explicit bounds and Reset so the placeholder regenerates with the
-    // new midpoint/range.
-    await dialog.getByLabel("Lower bound").fill("0");
-    await dialog.getByLabel("Upper bound").fill("10");
-
+    // New evaluators default to a categorical output config with "pass" /
+    // "fail" choices, so Reset regenerates the placeholder with the first
+    // label substituted in.
     await dialog.getByRole("button", { name: "Reset" }).click();
 
-    await expect.poll(() => getEditorContent(dialog)).toContain("5.0");
+    await expect.poll(() => getEditorContent(dialog)).toContain('"pass"');
     const content = await getEditorContent(dialog);
-    // Bounds range comment.
-    expect(content).toContain("0.0 - 10.0");
     // Dict-form comment with explanation key.
     expect(content).toContain("explanation");
 
@@ -949,15 +945,13 @@ test.describe.serial("Code Evaluators", () => {
     await expect(page.getByTestId("dialog")).not.toBeVisible();
   });
 
-  test("shape change from continuous to categorical auto-swaps placeholder", async ({
+  test("categorical placeholder regenerates from Reset after user edits source", async ({
     page,
   }) => {
     await gotoDatasetEvaluators(page, datasetName);
 
-    // Open a fresh create dialog. Initial source is the substituted
-    // continuous template (with the bounds-range comment), which the
-    // shape-change guard cannot recognize as a default once the new config
-    // is categorical (no bounds → continuous falls back to static).
+    // Open a fresh create dialog. New evaluators default to a categorical
+    // output config with "pass" / "fail" choices.
     await page.getByRole("button", { name: "Add evaluator" }).click();
     await page
       .getByRole("menuitem", { name: "Create new code evaluator" })
@@ -968,26 +962,28 @@ test.describe.serial("Code Evaluators", () => {
       dialog.getByRole("heading", { name: "Create Code Evaluator" })
     ).toBeVisible();
 
-    // Pin the editor to the static continuous fallback by clearing the
-    // bounds and Resetting — `getDefaultCodeEvaluatorSource` falls back to
-    // the static template when bounds are null. The static template is the
-    // one form the shape-change guard *can* recognize across configs.
-    await dialog.getByLabel("Lower bound").fill("");
-    await dialog.getByLabel("Upper bound").fill("");
+    // Customize the categorical choices and Reset so the placeholder is
+    // pinned to the substituted "approved"/"rejected" form.
+    const choiceInputs = dialog.locator('input[placeholder^="Choice"]');
+    await choiceInputs.first().fill("approved");
+    await choiceInputs.nth(1).fill("rejected");
     await dialog.getByRole("button", { name: "Reset" }).click();
-    await expect.poll(() => getEditorContent(dialog)).toContain("return 0.5");
+    await expect.poll(() => getEditorContent(dialog)).toContain('"approved"');
+
+    // Overwrite the editor body with custom code.
+    const editor = dialog.locator(".cm-content").first();
+    await editor.click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.insertText("# custom user code");
     await expect
       .poll(() => getEditorContent(dialog))
-      .not.toMatch(/expected range/);
+      .toContain("custom user code");
 
-    // Now switch output type to categorical — the shape-change guard
-    // regenerates the placeholder against the new categorical config
-    // (default values "pass" / "fail"), so the editor body now reads
-    // `return "pass"`.
-    await selectFromSelect(page, dialog, "Output type", "Categorical label");
-
-    await expect.poll(() => getEditorContent(dialog)).toContain('"pass"');
+    // Reset restores the substituted categorical placeholder.
+    await dialog.getByRole("button", { name: "Reset" }).click();
+    await expect.poll(() => getEditorContent(dialog)).toContain('"approved"');
     const content = await getEditorContent(dialog);
+    expect(content).not.toContain("custom user code");
     expect(content).toContain("explanation");
 
     await dialog.getByRole("button", { name: "Cancel" }).click();

--- a/app/tests/settings-sandboxes.spec.ts
+++ b/app/tests/settings-sandboxes.spec.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { expect, test, type Response } from "@playwright/test";
+import { expect, test, type Locator, type Response } from "@playwright/test";
 
 function isGraphQLMutationResponse(response: Response, operationName: string) {
   if (!response.url().includes("/graphql") || response.status() !== 200) {
@@ -7,6 +7,30 @@ function isGraphQLMutationResponse(response: Response, operationName: string) {
   }
   const postData = response.request().postData();
   return postData?.includes(operationName) ?? false;
+}
+
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Pick the provider from the `<Select>` in the New/Edit Sandbox dialog. The
+ * trigger is a `<button>` whose accessible name ends with the field label
+ * "Sandbox Provider"; the option content is a provider icon plus its display
+ * name, so match the option on a substring regex.
+ */
+async function selectProvider(dialog: Locator, providerName: string | RegExp) {
+  await dialog.getByRole("button", { name: /\bSandbox Provider\s*$/ }).click();
+  await dialog
+    .page()
+    .getByRole("option", {
+      name:
+        typeof providerName === "string"
+          ? new RegExp(escapeRegex(providerName))
+          : providerName,
+    })
+    .first()
+    .click();
 }
 
 test.describe("Settings Sandboxes", () => {
@@ -23,15 +47,8 @@ test.describe("Settings Sandboxes", () => {
       const dialog = page.getByRole("dialog");
       await expect(dialog).toBeVisible();
 
-      // Select WASM provider. Two elements expose the "Provider" name (the
-      // ComboBox input and the disclosure button), so anchor on role.
-      await dialog
-        .getByRole("combobox", { name: "Provider" })
-        .fill("WebAssembly");
-      await page
-        .getByRole("option", { name: /WebAssembly/i })
-        .first()
-        .click();
+      // Select WASM provider.
+      await selectProvider(dialog, /WebAssembly/i);
 
       // For unsupported capabilities, the dialog renders the section
       // heading plus a "Not supported by the selected backend." copy
@@ -75,8 +92,7 @@ test.describe("Settings Sandboxes", () => {
       await expect(dialog).toBeVisible();
 
       // Select E2B provider
-      await dialog.getByRole("combobox", { name: "Provider" }).fill("E2B");
-      await page.getByRole("option", { name: /E2B/i }).first().click();
+      await selectProvider(dialog, /E2B/i);
 
       // E2B supports env vars — section heading must be visible. Use
       // exact match so the empty-state copy "No environment variables

--- a/src/phoenix/server/sandbox/types.py
+++ b/src/phoenix/server/sandbox/types.py
@@ -7,7 +7,9 @@ import unconditionally regardless of optional sandbox extras.
 
 from __future__ import annotations
 
+import re
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import (
     Annotated,
@@ -20,12 +22,81 @@ from typing import (
     get_args,
 )
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from starlette.datastructures import Secret
 
 
 class UnsupportedOperation(Exception):
     """Raised when a sandbox backend does not support a requested operation."""
+
+
+# ---------------------------------------------------------------------------
+# Dependency-spec grammar. npm and Python requirement strings are validated
+# independently — there is intentionally no cross-conversion: a TypeScript
+# sandbox takes npm syntax (`lodash@^4.17`), a Python sandbox takes pip
+# syntax (`numpy==1.26.0`), and a spec in the wrong dialect is rejected with
+# a hint rather than silently translated. The frontend mirrors these in
+# app/src/pages/settings/sandboxes/utils.tsx; keep the two in sync.
+# ---------------------------------------------------------------------------
+
+#: One identifier segment: starts/ends alphanumeric, allows ``.``/``_``/``-``/``~`` inside.
+_IDENT = r"[A-Za-z0-9](?:[A-Za-z0-9._~-]*[A-Za-z0-9])?"
+
+#: npm package name — optional ``@scope/`` prefix, then a name segment.
+_NPM_NAME = rf"(?:@{_IDENT}/)?{_IDENT}"
+#: npm version selector — anything non-empty without whitespace or ``@`` (covers
+#: ranges like ``^1.2.0``, ``>=6.37.0``, ``1.2.3``, dist-tags, git refs).
+_NPM_VERSION = r"[^@\s]+"
+#: An npm requirement: ``name`` or ``name@version`` (incl. ``@scope/name``).
+_NPM_REQUIREMENT_RE = re.compile(rf"^(?:{_NPM_NAME})(?:@{_NPM_VERSION})?$")
+
+#: PEP 508 extras list, e.g. ``[socks,brotli]``.
+_PY_EXTRAS = r"(?:\[\s*[A-Za-z0-9._-]+(?:\s*,\s*[A-Za-z0-9._-]+)*\s*\])?"
+#: One PEP 440 version clause, e.g. ``>=1.2``, ``==1.*``, ``~=2.0``.
+_PY_VERSION_CLAUSE = r"(?:===|==|!=|~=|<=|>=|<|>)\s*[A-Za-z0-9*][A-Za-z0-9.*+!_-]*"
+#: A Python requirement: ``name[extras] <clause>[, <clause>...]`` (markers/URLs
+#: are intentionally out of scope for the dependency-list UI).
+_PYTHON_REQUIREMENT_RE = re.compile(
+    rf"^{_IDENT}\s*{_PY_EXTRAS}\s*"
+    rf"(?:{_PY_VERSION_CLAUSE}(?:\s*,\s*{_PY_VERSION_CLAUSE})*)?\s*$"
+)
+
+
+def validate_npm_package_spec(spec: str) -> str:
+    """Strip and validate a single npm install spec; raise ValueError if invalid."""
+    stripped = spec.strip()
+    if not stripped or not _NPM_REQUIREMENT_RE.match(stripped):
+        raise ValueError(
+            f"invalid npm package spec {spec!r} "
+            "(expected e.g. 'lodash', 'lodash@^4.17', '@scope/pkg@1.2.3')"
+        )
+    return stripped
+
+
+def validate_python_package_spec(spec: str) -> str:
+    """Strip and validate a single Python package spec; raise ValueError if invalid."""
+    stripped = spec.strip()
+    if not stripped or not _PYTHON_REQUIREMENT_RE.match(stripped):
+        raise ValueError(
+            f"invalid Python package spec {spec!r} "
+            "(expected e.g. 'requests', 'numpy==1.26.0', 'httpx[http2]>=0.27,<1')"
+        )
+    return stripped
+
+
+def _validated_package_list(packages: list[str], validate_one: Callable[[str], str]) -> list[str]:
+    """Apply a per-entry validator across a package list.
+
+    Re-raises the first failure with the offending index so the pydantic
+    ValidationError points at the bad line.
+    """
+    out: list[str] = []
+    for i, pkg in enumerate(packages):
+        try:
+            out.append(validate_one(pkg))
+        except ValueError as exc:
+            raise ValueError(f"packages[{i}]: {exc}") from exc
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -87,12 +158,22 @@ class PythonDependenciesConfig(BaseModel):
     packages: list[str] = Field(default_factory=list)
     lockfile: Optional[str] = None
 
+    @field_validator("packages", mode="after")
+    @classmethod
+    def _validate_python_specs(cls, packages: list[str]) -> list[str]:
+        return _validated_package_list(packages, validate_python_package_spec)
+
 
 class TypescriptDependenciesConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     packages: list[str] = Field(default_factory=list)
     lockfile: Optional[str] = None
+
+    @field_validator("packages", mode="after")
+    @classmethod
+    def _validate_npm_specs(cls, packages: list[str]) -> list[str]:
+        return _validated_package_list(packages, validate_npm_package_spec)
 
 
 @dataclass

--- a/tests/unit/server/sandbox/test_sandbox_config_validation.py
+++ b/tests/unit/server/sandbox/test_sandbox_config_validation.py
@@ -35,6 +35,8 @@ from phoenix.server.sandbox.types import (
     _env_vars_equal,
     _internet_access_equal,
     _packages_equal,
+    validate_npm_package_spec,
+    validate_python_package_spec,
 )
 
 # ---------------------------------------------------------------------------
@@ -271,3 +273,97 @@ class TestPackagesEqual:
             {"packages": same_pkgs, "lockfile": None},
             {"packages": same_pkgs, "lockfile": "req.txt"},
         )
+
+
+class TestTypescriptDependenciesValidation:
+    def test_strips_and_accepts_valid(self) -> None:
+        cfg = TypescriptDependenciesConfig(
+            packages=["  lodash  ", "lodash@^4.17", "@scope/pkg@1.2.3"],
+        )
+        assert cfg.packages == ["lodash", "lodash@^4.17", "@scope/pkg@1.2.3"]
+
+    def test_rejects_invalid_with_index(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match=r"packages\[1\]"):
+            TypescriptDependenciesConfig(packages=["lodash", "has spaces"])
+
+    def test_rejects_python_style_spec(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="invalid npm package spec"):
+            TypescriptDependenciesConfig(packages=["openai>=6.37.0"])
+
+
+class TestValidateNpmPackageSpec:
+    @pytest.mark.parametrize(
+        "spec, expected",
+        [
+            ("lodash", "lodash"),
+            ("lodash@^4.17", "lodash@^4.17"),
+            ("@scope/pkg@1.2.3", "@scope/pkg@1.2.3"),
+            ("@scope/pkg", "@scope/pkg"),
+            ("  react  ", "react"),
+        ],
+    )
+    def test_valid(self, spec: str, expected: str) -> None:
+        assert validate_npm_package_spec(spec) == expected
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "",
+            "   ",
+            "has spaces",
+            "bad name!!",
+            "@scope/",
+            "/x",
+            "openai>=6.37.0",  # pip-style, not npm
+        ],
+    )
+    def test_invalid(self, spec: str) -> None:
+        with pytest.raises(ValueError, match="invalid npm package spec"):
+            validate_npm_package_spec(spec)
+
+
+class TestValidatePythonPackageSpec:
+    @pytest.mark.parametrize(
+        "req, expected",
+        [
+            ("requests", "requests"),
+            ("numpy==1.26.0", "numpy==1.26.0"),
+            ("httpx[http2]>=0.27,<1", "httpx[http2]>=0.27,<1"),
+            ("scikit-learn", "scikit-learn"),
+            ("  pandas>=1.0  ", "pandas>=1.0"),
+            ("pkg==1.*", "pkg==1.*"),
+        ],
+    )
+    def test_valid(self, req: str, expected: str) -> None:
+        assert validate_python_package_spec(req) == expected
+
+    @pytest.mark.parametrize(
+        "req",
+        [
+            "",
+            "   ",
+            "not a package!",
+            "openai@>=6.37.0",  # npm-style, not pip
+            "requests==",
+            "package; python_version<'3.8'",  # markers out of scope
+        ],
+    )
+    def test_invalid(self, req: str) -> None:
+        with pytest.raises(ValueError, match="invalid Python package spec"):
+            validate_python_package_spec(req)
+
+
+class TestPythonDependenciesValidation:
+    def test_strips_and_accepts_valid(self) -> None:
+        cfg = PythonDependenciesConfig(packages=["  requests  ", "numpy==1.26.0"])
+        assert cfg.packages == ["requests", "numpy==1.26.0"]
+
+    def test_rejects_invalid_with_index(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match=r"packages\[1\]"):
+            PythonDependenciesConfig(packages=["requests", "bad name!"])


### PR DESCRIPTION
## Problem

The Vercel TypeScript backend passed dependency strings straight to `npm install`, so a pip-style spec such as `openai>=6.37.0` failed at install time:

```
npm error code EINVALIDTAGNAME
npm error Invalid tag name "openai>=6.37.0" ...
```

## Approach

npm package specs and Python requirements are validated **independently** — no cross-conversion. A TypeScript sandbox takes npm syntax (`lodash@^4.17`), a Python sandbox takes pip syntax (`numpy==1.26.0`), and a spec in the wrong dialect is rejected with a hint rather than silently translated.

## Changes

- **`sandbox/types.py`**: reusable regex fragments (`_IDENT`, `_NPM_REQUIREMENT_RE`, `_PYTHON_REQUIREMENT_RE`) feeding `validate_npm_package_spec` / `validate_python_requirement`, plus a generic `_validated_package_list` that reports the offending `packages[i]`.
- **Server-side validation on mutations**: `field_validator("packages")` on `PythonDependenciesConfig` and `TypescriptDependenciesConfig`. Create/update sandbox-config mutations already route config through `validate_config`, so invalid specs surface as `BadRequest`.
- **Frontend**: mirrors the grammar in `sandboxes/utils.tsx` (`validateDependencyPackages`), wires a react-hook-form `validate` rule + `FieldError` into the dependencies textarea.

## Additional dogfooding fixes on this branch

- **fix(evaluators): keep focus when typing in categorical choice labels** — the choice row's `key` included `choice.label`, so each keystroke changed the key and remounted the `TextField`, stealing focus mid-edit.
- **feat(evaluators): default new code evaluators to categorical output**
- **refactor(sandbox): extract self-contained SandboxProviderSelect**

## Tests

- Python: helper functions, `PythonDependenciesConfig` / `TypescriptDependenciesConfig` validators (incl. wrong-dialect rejection).
- Vitest: `validateDependencyPackages` for both languages.

All green: `tests/unit/server/sandbox/` (198), app vitest (37), mypy --strict + oxlint + tsc.