### PR TITLE
fix: prevent format-string injection in f-string template formatter

### DIFF
--- a/src/phoenix/utilities/template_formatters.py
+++ b/src/phoenix/utilities/template_formatters.py
@@ -235,6 +235,39 @@ class NoOpFormatter(TemplateFormatter):
         return template
 
 
+_FIELD_NAME_PART_RE = re.compile(r"\.([^.\[\]]+)|\[([^\[\]]+)\]")
+
+
+class _SafeFieldFormatter(Formatter):
+    """
+    A :class:`string.Formatter` that forbids access to "private" attributes.
+
+    Python's ``str.format`` resolves ``{x.attr}`` and ``{x[key]}`` expressions.
+    Without restrictions, a malicious template can walk from a user-supplied
+    value to ``__class__`` / ``__globals__`` / ``__builtins__`` and read process
+    state (environment variables, secrets, etc.). This subclass blocks any
+    attribute access whose name starts with an underscore, which is sufficient
+    to break the traversal chain while preserving normal usage like
+    ``{user.name}`` and ``{items[0].value}``.
+    """
+
+    def get_field(self, field_name: str, args: Any, kwargs: Any) -> Any:
+        first = re.match(r"^[^.\[\]]*", field_name).group(0)  # type: ignore[union-attr]
+        rest = field_name[len(first) :]
+        key: Any = int(first) if first.isdigit() else first
+        obj = self.get_value(key, args, kwargs)
+        for attr, index in _FIELD_NAME_PART_RE.findall(rest):
+            if attr:
+                if attr.startswith("_"):
+                    raise TemplateFormatterError(
+                        f"Access to attribute '{attr}' is not permitted in templates"
+                    )
+                obj = getattr(obj, attr)
+            else:
+                obj = obj[int(index) if index.lstrip("-").isdigit() else index]
+        return obj, first
+
+
 class FStringTemplateFormatter(TemplateFormatter):
     """
     Regular f-string template formatter.
@@ -266,10 +299,14 @@ class FStringTemplateFormatter(TemplateFormatter):
     def parse(self, template: str) -> set[str]:
         return set(field_name for _, field_name, _, _ in Formatter().parse(template) if field_name)
 
+    # Shared formatter that blocks traversal into "private"/dunder attributes,
+    # preventing format-string injection (e.g. {x.__class__.__init__.__globals__}).
+    _formatter = _SafeFieldFormatter()
+
     def _format(self, template: str, variable_names: Iterable[str], **variables: Any) -> str:
         # Wrap dict and list variables to support attribute access (e.g., {user.name})
         wrapped_variables = {key: _wrap_value(value) for key, value in variables.items()}
-        return template.format(**wrapped_variables)
+        return self._formatter.vformat(template, (), wrapped_variables)
 
 
 class MustacheTemplateFormatter(TemplateFormatter):

--- a/tests/unit/utilities/test_template_formatters.py
+++ b/tests/unit/utilities/test_template_formatters.py
@@ -187,6 +187,48 @@ def test_template_formatters_raise_expected_error_on_missing_variables(
         formatter.format(template)
 
 
+class TestFStringFormatStringInjection:
+    """Regression tests for the f-string format-string injection vulnerability."""
+
+    @pytest.mark.parametrize(
+        "template",
+        (
+            "{u.__class__}",
+            "{u.__class__.__bases__[0].__init__.__globals__}",
+            "{u.__init__.__globals__[os].environ}",
+            "{u[x].__class__}",
+        ),
+    )
+    def test_dunder_attribute_access_is_blocked(self, template: str) -> None:
+        formatter = FStringTemplateFormatter()
+        with pytest.raises(TemplateFormatterError, match=r"not permitted in templates"):
+            formatter.format(template, u={"x": 1})
+
+    def test_legitimate_attribute_and_index_access_still_works(self) -> None:
+        formatter = FStringTemplateFormatter()
+        assert formatter.format("{user.name}", user={"name": "Alice"}) == "Alice"
+        assert formatter.format("{items[0].value}", items=[{"value": "first"}]) == "first"
+
+    @pytest.mark.parametrize(
+        "template",
+        (
+            "{{u.__class__}}",
+            "{{u.__class__.__init__.__globals__}}",
+            "{{u.__init__.__globals__}}",
+            "{{u.upper}}",
+            "{{#u}}{{__class__}}{{/u}}",
+        ),
+    )
+    @pytest.mark.parametrize("value", ({"x": 1}, "hello", ["a", "b"]))
+    def test_mustache_does_not_traverse_dunder_or_python_attributes(
+        self, template: str, value: Any
+    ) -> None:
+        # pystache only does dict-style lookups and refuses getattr on builtin
+        # types, so these resolve to "" rather than leaking internals.
+        formatter = MustacheTemplateFormatter()
+        assert formatter.format(template, u=value) == ""
+
+
 class TestMustacheSections:
     """Tests for full Mustache syntax support including sections."""
 


### PR DESCRIPTION
## Summary

`FStringTemplateFormatter` rendered templates via `str.format()`, which resolves `{x.attr}` / `{x[key]}` traversal. A template could walk from a user-supplied variable through `__class__` → `__init__.__globals__` → `os.environ`, disclosing server environment variables and secrets via the `applyChatTemplate` GraphQL endpoint. The `DotDict.__getattr__` guard was ineffective because dunders like `__class__` are real attributes, so `__getattr__` was never invoked.

## Changes

- Add `_SafeFieldFormatter(string.Formatter)` that resolves field-name traversal itself and rejects any attribute access whose name starts with `_`. Normal usage (`{user.name}`, `{items[0].value}`) is unaffected.
- `FStringTemplateFormatter._format()` now renders via this formatter instead of `str.format()`.
- Add regression tests for the f-string injection payload and variants.
- Add regression tests confirming Mustache is not vulnerable to the same vector (pystache only does dict lookups and refuses `getattr` on builtin types).

## Test plan

- `tests/unit/utilities/test_template_formatters.py` — 129 passed
- ruff + mypy clean