### PR TITLE
fix: prevent prototype pollution in DatasetPreviewTable

### DIFF
--- a/app/src/pages/datasets/DatasetPreview/DatasetPreviewTable.tsx
+++ b/app/src/pages/datasets/DatasetPreview/DatasetPreviewTable.tsx
@@ -106,8 +106,12 @@ export type DatasetPreviewTableProps = {
   exampleIdColumn?: string | null;
 };
 
-/** Keys that must never be written to, to prevent prototype pollution. */
-const UNSAFE_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+/**
+ * Creates a prototype-less object for accumulating user-supplied keys. Because
+ * it has no prototype, writing keys like `__proto__` or `constructor` just adds
+ * plain own properties instead of polluting `Object.prototype`.
+ */
+const emptyBucket = (): Record<string, unknown> => Object.create(null);
 
 /**
  * Preview table showing how data will look in the final dataset.
@@ -144,20 +148,11 @@ export function DatasetPreviewTable({
       value: unknown
     ) => {
       const parts = key.split(".");
-      // Guard against prototype pollution via crafted column names like
-      // "__proto__.polluted" or "constructor.prototype.polluted".
-      if (parts.some((part) => UNSAFE_KEYS.has(part))) {
-        return;
-      }
       let current = obj;
       for (let i = 0; i < parts.length - 1; i++) {
         const part = parts[i];
-        if (
-          !Object.prototype.hasOwnProperty.call(current, part) ||
-          typeof current[part] !== "object" ||
-          current[part] === null
-        ) {
-          current[part] = {};
+        if (typeof current[part] !== "object" || current[part] === null) {
+          current[part] = emptyBucket();
         }
         current = current[part] as Record<string, unknown>;
       }
@@ -214,9 +209,9 @@ export function DatasetPreviewTable({
     };
 
     return rows.map((row): DatasetPreviewRow => {
-      const input: Record<string, unknown> = {};
-      const output: Record<string, unknown> = {};
-      const metadata: Record<string, unknown> = {};
+      const input = emptyBucket();
+      const output = emptyBucket();
+      const metadata = emptyBucket();
       let splits: string[] = [];
       let exampleId: string | null = null;
 

--- a/app/src/pages/datasets/DatasetPreview/DatasetPreviewTable.tsx
+++ b/app/src/pages/datasets/DatasetPreview/DatasetPreviewTable.tsx
@@ -111,7 +111,8 @@ export type DatasetPreviewTableProps = {
  * it has no prototype, writing keys like `__proto__` or `constructor` just adds
  * plain own properties instead of polluting `Object.prototype`.
  */
-const emptyBucket = (): Record<string, unknown> => Object.create(null);
+const createPollutionSafeRecord = (): Record<string, unknown> =>
+  Object.create(null);
 
 /**
  * Preview table showing how data will look in the final dataset.
@@ -152,7 +153,7 @@ export function DatasetPreviewTable({
       for (let i = 0; i < parts.length - 1; i++) {
         const part = parts[i];
         if (typeof current[part] !== "object" || current[part] === null) {
-          current[part] = emptyBucket();
+          current[part] = createPollutionSafeRecord();
         }
         current = current[part] as Record<string, unknown>;
       }
@@ -209,9 +210,9 @@ export function DatasetPreviewTable({
     };
 
     return rows.map((row): DatasetPreviewRow => {
-      const input = emptyBucket();
-      const output = emptyBucket();
-      const metadata = emptyBucket();
+      const input = createPollutionSafeRecord();
+      const output = createPollutionSafeRecord();
+      const metadata = createPollutionSafeRecord();
       let splits: string[] = [];
       let exampleId: string | null = null;
 

--- a/app/src/pages/datasets/DatasetPreview/DatasetPreviewTable.tsx
+++ b/app/src/pages/datasets/DatasetPreview/DatasetPreviewTable.tsx
@@ -106,6 +106,9 @@ export type DatasetPreviewTableProps = {
   exampleIdColumn?: string | null;
 };
 
+/** Keys that must never be written to, to prevent prototype pollution. */
+const UNSAFE_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
 /**
  * Preview table showing how data will look in the final dataset.
  * Each row shows input/output/metadata as JSON objects.
@@ -141,11 +144,16 @@ export function DatasetPreviewTable({
       value: unknown
     ) => {
       const parts = key.split(".");
+      // Guard against prototype pollution via crafted column names like
+      // "__proto__.polluted" or "constructor.prototype.polluted".
+      if (parts.some((part) => UNSAFE_KEYS.has(part))) {
+        return;
+      }
       let current = obj;
       for (let i = 0; i < parts.length - 1; i++) {
         const part = parts[i];
         if (
-          !(part in current) ||
+          !Object.prototype.hasOwnProperty.call(current, part) ||
           typeof current[part] !== "object" ||
           current[part] === null
         ) {

--- a/app/src/pages/datasets/DatasetPreview/DatasetPreviewTable.tsx
+++ b/app/src/pages/datasets/DatasetPreview/DatasetPreviewTable.tsx
@@ -114,6 +114,21 @@ export type DatasetPreviewTableProps = {
 const createPollutionSafeRecord = (): Record<string, unknown> =>
   Object.create(null);
 
+const isPollutionSafeRecord = (
+  value: unknown
+): value is Record<string, unknown> =>
+  typeof value === "object" &&
+  value !== null &&
+  Object.getPrototypeOf(value) === null;
+
+const toPollutionSafeRecord = (value: unknown): Record<string, unknown> => {
+  const record = createPollutionSafeRecord();
+  if (typeof value === "object" && value !== null) {
+    Object.assign(record, value);
+  }
+  return record;
+};
+
 /**
  * Preview table showing how data will look in the final dataset.
  * Each row shows input/output/metadata as JSON objects.
@@ -152,8 +167,8 @@ export function DatasetPreviewTable({
       let current = obj;
       for (let i = 0; i < parts.length - 1; i++) {
         const part = parts[i];
-        if (typeof current[part] !== "object" || current[part] === null) {
-          current[part] = createPollutionSafeRecord();
+        if (!isPollutionSafeRecord(current[part])) {
+          current[part] = toPollutionSafeRecord(current[part]);
         }
         current = current[part] as Record<string, unknown>;
       }

--- a/app/src/pages/datasets/DatasetPreview/__tests__/DatasetPreviewTable.test.tsx
+++ b/app/src/pages/datasets/DatasetPreview/__tests__/DatasetPreviewTable.test.tsx
@@ -1,0 +1,107 @@
+import { act } from "react";
+import type { ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DatasetPreviewTable } from "../DatasetPreviewTable";
+
+const getPollutedValue = () =>
+  (Object.prototype as Record<string, unknown>).polluted;
+
+const deletePollutedValue = () => {
+  delete (Object.prototype as Record<string, unknown>).polluted;
+};
+
+vi.mock("@phoenix/components", () => ({
+  Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@phoenix/components/core/counter", () => ({
+  Counter: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@phoenix/components/table", () => ({
+  CompactJSONCell: ({ getValue }: { getValue: () => unknown }) => (
+    <span>{JSON.stringify(getValue())}</span>
+  ),
+}));
+
+describe("DatasetPreviewTable", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    deletePollutedValue();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    deletePollutedValue();
+    vi.restoreAllMocks();
+  });
+
+  it("renders assigned dotted columns as nested preview buckets", () => {
+    act(() => {
+      root.render(
+        <DatasetPreviewTable
+          columns={["input.user.name", "output.answer", "metadata.source"]}
+          rows={[["Ada", "42", "csv"]]}
+          inputColumns={["input.user.name"]}
+          outputColumns={["output.answer"]}
+          metadataColumns={["metadata.source"]}
+        />
+      );
+    });
+
+    expect(container.textContent).toContain('{"user":{"name":"Ada"}}');
+    expect(container.textContent).toContain('{"answer":"42"}');
+    expect(container.textContent).toContain('{"source":"csv"}');
+  });
+
+  it("does not pollute Object.prototype for a direct __proto__ path", () => {
+    act(() => {
+      root.render(
+        <DatasetPreviewTable
+          columns={["input.__proto__.polluted", "output.answer"]}
+          rows={[["yes", "ok"]]}
+          inputColumns={["input.__proto__.polluted"]}
+          outputColumns={["output.answer"]}
+          metadataColumns={[]}
+        />
+      );
+    });
+
+    expect(getPollutedValue()).toBeUndefined();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.hasOwn(Object.prototype, "polluted")).toBe(false);
+    expect(container.textContent).toContain('{"__proto__":{"polluted":"yes"}}');
+  });
+
+  it("does not pollute Object.prototype when a nested key traverses through a parsed object", () => {
+    act(() => {
+      root.render(
+        <DatasetPreviewTable
+          columns={[
+            "input.payload",
+            "input.payload.__proto__.polluted",
+            "output.answer",
+          ]}
+          rows={[["{}", "yes", "ok"]]}
+          inputColumns={["input.payload", "input.payload.__proto__.polluted"]}
+          outputColumns={["output.answer"]}
+          metadataColumns={[]}
+        />
+      );
+    });
+
+    expect(getPollutedValue()).toBeUndefined();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.hasOwn(Object.prototype, "polluted")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
`setNestedValue` in `DatasetPreviewTable.tsx` builds nested objects from dot-separated column names supplied by user data (e.g. uploaded CSV headers). A crafted column name like `__proto__.polluted` or `constructor.prototype.polluted` could walk into `Object.prototype` and pollute it.

## Changes
- Added a `createPollutionSafeRecord()` helper (`Object.create(null)`) and used it for the `input` / `output` / `metadata` accumulators and for any nested objects `setNestedValue` creates. Because these objects have no prototype, writing a key like `__proto__` just adds a plain own property instead of mutating `Object.prototype` — no key blocklist or special-casing needed.

## Test plan
- `pnpm run typecheck` and `pnpm run lint` pass (also enforced by pre-commit hook).