### PR TITLE
ci: scope CLA workflow permissions to least privilege

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,17 +3,19 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [assigned, opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
 
-permissions:
-  actions: write
-  contents: write
-  pull-requests: write
-  statuses: write
+# Least-privilege default: the CLA job grants only the scopes it needs below.
+permissions: {}
 
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # re-run the workflow on "recheck"
+      contents: write # commit the signature file to the "cla" branch
+      pull-requests: write # comment on the PR
+      statuses: write # set the CLA commit status
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'


### PR DESCRIPTION
## Summary
The `CLA Assistant` workflow granted four `write` permissions (`actions`, `contents`, `pull-requests`, `statuses`) at the workflow level — i.e. to every job in the workflow, including on the `pull_request_target` trigger. This tightens it to least privilege.

## Changes
- Workflow-wide `permissions:` → `permissions: {}` (no default permissions)
- The four `write` scopes are now granted **only on the `CLAAssistant` job**, each with a comment explaining why it's needed:
  - `actions: write` — re-run the workflow on `recheck`
  - `contents: write` — commit the signature file to the `cla` branch
  - `pull-requests: write` — comment on the PR
  - `statuses: write` — set the CLA commit status
- Dropped `assigned` from the `pull_request_target` `types` — it re-triggered the privileged workflow on assignee changes for no benefit

## Notes
All four permissions are genuinely used by `contributor-assistant/github-action`, so they're kept but confined to the single job.