### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22.12.0

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -27,6 +27,8 @@ jobs:
       e2e: ${{ steps.filter.outputs.e2e }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
@@ -57,6 +59,8 @@ jobs:
         os: [oss-4-core-runner] # re-add macos-latest-large once billing is set
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install PNPM
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -171,8 +171,9 @@ jobs:
             os: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: |
             Makefile
             scripts/ci/json-canonicalization-schema/
@@ -180,14 +181,14 @@ jobs:
             packages/
             .jcs-test-data/
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.11.8"
       - name: Install make (Windows)
         if: runner.os == 'Windows'
         run: choco install make --no-progress -y
       - name: Cache test data
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: .jcs-test-data
           key: jcs-test-data

--- a/.github/workflows/typescript-CI.yml
+++ b/.github/workflows/typescript-CI.yml
@@ -23,6 +23,8 @@ jobs:
       app: ${{ steps.filter.outputs.app }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
@@ -42,6 +44,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install PNPM
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:

--- a/.github/workflows/typescript-packages-CI.yml
+++ b/.github/workflows/typescript-packages-CI.yml
@@ -22,6 +22,8 @@ jobs:
       packages: ${{ steps.filter.outputs.packages }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
@@ -41,6 +43,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Nodejs
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:


### PR DESCRIPTION
## Summary

Defense-in-depth hardening of the GitHub Actions workflows, prompted by the TanStack `pull_request_target` → cache-poisoning → OIDC-extraction supply-chain incident. Phoenix is **not** vulnerable to that chain (the only `pull_request_target` workflows — `cla.yml`, `auto-label-external-issues.yaml` — never check out fork code; cache-using workflows run on `pull_request`, whose caches are PR-scoped and can't poison `main`; publish workflows restore no caches), but these changes tighten the surface it abused.

## Changes

- **Pin floating action refs in `python-CI.yml`** — the `test-json-canonicalization-schema` job used `actions/checkout@v4`, `astral-sh/setup-uv@v7`, and `actions/cache@v4` (mutable tags). Pinned to the same commit SHAs the rest of the repo already uses (`checkout` v6.0.2, `setup-uv` v7.6.0, `cache` v5.0.4). A floating tag is exactly how a compromised upstream action gets pulled in.
- **`persist-credentials: false`** on the `actions/checkout` steps in PR-triggered build/test workflows (`chromatic.yml`, `claude-code-review.yml`, `playwright.yaml`, `python-CI.yml`, `typescript-CI.yml`, `typescript-packages-CI.yml`), so the `GITHUB_TOKEN` isn't left in `.git/config` for a later third-party step to read. These jobs only run tests / `git diff --exit-code`, so they don't need the token.

## Not changed (intentionally)

- `publish.yaml` already sets `persist-credentials: false` and restores no caches.
- `cla.yml` / `auto-label-external-issues.yaml` — `pull_request_target` but never check out fork code.
- Remaining CI checkouts keep credentials; those workflows already declare `permissions: contents: read`, so the persisted token is read-only on a public repo.

## Test plan

- [ ] CI green on this PR (validates the SHA pins resolve and the `with:` blocks parse)