### PR TITLE
docs: Add Phoenix release notes for 05-08-2026 through 05-13-2026

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1191,6 +1191,9 @@
               {
                 "group": "05.2026",
                 "pages": [
+                  "docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations",
+                  "docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences",
+                  "docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header",
                   "docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools",
                   "docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates",
                   "docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing"

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -12,7 +12,7 @@ GitHub
 **Available in arize-phoenix 15.7.0+**
 
 - **Expandable session turns** — long messages in Session Details are now collapsed by default with an expand/collapse toggle
-- **Note identifier field** — `POST /v1/{traces,spans,sessions}_notes` accepts an optional `identifier` for upsert semantics; repeated calls with the same identifier overwrite the existing note
+- **Note identifier field** — `POST /v1/{trace,span,session}_notes` accepts an optional `identifier` for upsert semantics; repeated calls with the same identifier overwrite the existing note
 - **New CLI annotation commands** — `px {trace,span,session}-annotations delete` for bulk-remove by identifier or time range, `px project get <name>` to fetch project metadata; `--identifier` flag on `annotate` and `add-note`
 - **Security** — f-string template formatter now blocks dunder/private attribute traversal, preventing format-string injection through user-supplied variables
 </Update>

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -7,6 +7,34 @@ description: The latest from the Phoenix team.
 GitHub
 </Card>
 
+<Update label="05.13.2026">
+## [05.13.2026: Session Enhancements and Annotation Identifiers](/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations)
+**Available in arize-phoenix 15.7.0+**
+
+- **Expandable session turns** — long messages in Session Details are now collapsed by default with an expand/collapse toggle
+- **Note identifier field** — `POST /v1/{traces,spans,sessions}_notes` accepts an optional `identifier` for upsert semantics; repeated calls with the same identifier overwrite the existing note
+- **New CLI annotation commands** — `px {trace,span,session}-annotations delete` for bulk-remove by identifier or time range, `px project get <name>` to fetch project metadata; `--identifier` flag on `annotate` and `add-note`
+- **Security** — f-string template formatter now blocks dunder/private attribute traversal, preventing format-string injection through user-supplied variables
+</Update>
+
+<Update label="05.10.2026">
+## [05.10.2026: Playground Preferences](/docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences)
+**Available in arize-phoenix 15.6.0+**
+
+- **Default provider and model** — save a personal Playground default on the AI Providers settings page; Phoenix stores it in your browser and applies it to every new session
+- **Metrics aside always on** — the latency/token/error metrics panel on the right side of the spans table is now visible by default, no longer gated behind a feature flag
+</Update>
+
+<Update label="05.08.2026">
+## [05.08.2026: OTLP Project Routing via HTTP Header](/docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header)
+**Available in arize-phoenix 15.5.0+**
+
+Set the `x-project-name` HTTP header on OTLP exports to route all spans in the request to a named Phoenix project. The header takes precedence over the `openinference.project.name` resource attribute, so tools like the OpenTelemetry Collector can route traces without modifying the instrumented application.
+
+- **Works with any OTLP sender** — SDK header option, Collector `headers` config, or `OTEL_EXPORTER_OTLP_HEADERS` env var
+- **Bug fix** — deleting a dataset evaluator link no longer removes the shared evaluator row (arize-phoenix 15.5.1+)
+</Update>
+
 <Update label="05.05.2026">
 ## [05.05.2026: Provider Tools in Playground and Prompts](/docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools)
 **Available in arize-phoenix 15.4.0+**

--- a/docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header.mdx
@@ -1,0 +1,54 @@
+---
+title: "05.08.2026: OTLP Project Routing via HTTP Header"
+description: "Route OTLP traces to a named Phoenix project by setting the x-project-name HTTP header — no resource attribute required."
+---
+
+**Available in arize-phoenix 15.5.0+**
+
+Phoenix now reads the `x-project-name` HTTP header on incoming OTLP trace exports and routes all spans in the request to that project. The header takes precedence over the `openinference.project.name` resource attribute, so configuration-based tools like the OpenTelemetry Collector can route traces without touching the instrumented application.
+
+## Setting the header
+
+**OpenTelemetry SDK (Python)**
+
+```python
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+exporter = OTLPSpanExporter(
+    endpoint="http://localhost:6006/v1/traces",
+    headers={"x-project-name": "my-project"},
+)
+```
+
+**OpenTelemetry Collector**
+
+```yaml
+exporters:
+  otlphttp:
+    endpoint: http://localhost:6006
+    headers:
+      x-project-name: my-project
+```
+
+**Environment variable**
+
+```bash
+OTEL_EXPORTER_OTLP_HEADERS="x-project-name=my-project"
+```
+
+## Precedence rules
+
+| Source | Priority |
+|--------|----------|
+| `x-project-name` HTTP header | Highest |
+| `openinference.project.name` resource attribute | Second |
+| Server default project | Fallback |
+
+Every span in the request goes to the same project when the header is set, regardless of what individual spans report in their resource attributes.
+
+## Bug fix: built-in evaluator preserved on dataset evaluator delete
+
+**Available in arize-phoenix 15.5.1+**
+
+Deleting a dataset evaluator link no longer removes the underlying evaluator. Previously, `deleteDatasetEvaluators` deleted the shared `Evaluator` row, which cascaded to remove every dataset's link to that evaluator — including the global built-in evaluator entry. The mutation now deletes only the link, leaving the evaluator available for other datasets.

--- a/docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header.mdx
@@ -5,21 +5,9 @@ description: "Route OTLP traces to a named Phoenix project by setting the x-proj
 
 **Available in arize-phoenix 15.5.0+**
 
-Phoenix now reads the `x-project-name` HTTP header on incoming OTLP trace exports and routes all spans in the request to that project. The header takes precedence over the `openinference.project.name` resource attribute, so configuration-based tools like the OpenTelemetry Collector can route traces without touching the instrumented application.
+Phoenix now reads the `x-project-name` HTTP header on incoming OTLP trace exports and routes all spans in the request to that project. The header takes precedence over the `openinference.project.name` resource attribute, so tools like the OpenTelemetry Collector, Openclaw, and Daytona can route traces to the right project without modifying the instrumented application.
 
 ## Setting the header
-
-**OpenTelemetry SDK (Python)**
-
-```python
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-
-exporter = OTLPSpanExporter(
-    endpoint="http://localhost:6006/v1/traces",
-    headers={"x-project-name": "my-project"},
-)
-```
 
 **OpenTelemetry Collector**
 
@@ -51,4 +39,4 @@ Every span in the request goes to the same project when the header is set, regar
 
 **Available in arize-phoenix 15.5.1+**
 
-Deleting a dataset evaluator link no longer removes the underlying evaluator. Previously, `deleteDatasetEvaluators` deleted the shared `Evaluator` row, which cascaded to remove every dataset's link to that evaluator — including the global built-in evaluator entry. The mutation now deletes only the link, leaving the evaluator available for other datasets.
+Deleting a dataset evaluator link no longer removes the underlying evaluator — it stays available for other datasets.

--- a/docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences.mdx
@@ -1,0 +1,22 @@
+---
+title: "05.10.2026: Playground Preferences"
+description: "Save a default provider and model for the Playground, and the metrics aside is now always visible on the project page."
+---
+
+# Default Playground Provider and Model
+
+May 10, 2026
+
+**Available in arize-phoenix 15.6.0+**
+
+You can now save a personal default provider and model for the Playground from the **AI Providers** settings page. Phoenix stores the preference in your browser and uses it whenever you open a new Playground session. When no preference is set, Playground falls back to the existing default (OpenAI / gpt-4o).
+
+If you've previously configured per-provider invocation parameters (model, temperature, max tokens), those saved settings still take precedence for your preferred provider — the preference acts as a starting point, not an override.
+
+# Span Metrics Always Visible
+
+May 10, 2026
+
+**Available in arize-phoenix 15.6.0+**
+
+The metrics aside — showing latency percentiles, token counts, and error rates — is now always visible on the right side of the spans table on the project page. Previously this panel was gated behind the `tracing_ux` feature flag. The flag now only controls the sparkline at the top of the page; the metrics panel is on by default for everyone.

--- a/docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences.mdx
@@ -5,8 +5,6 @@ description: "Save a default provider and model for the Playground, and the metr
 
 # Default Playground Provider and Model
 
-May 10, 2026
-
 **Available in arize-phoenix 15.6.0+**
 
 You can now save a personal default provider and model for the Playground from the **AI Providers** settings page. Phoenix stores the preference in your browser and uses it whenever you open a new Playground session. When no preference is set, Playground falls back to the existing default (OpenAI / gpt-4o).
@@ -15,8 +13,6 @@ If you've previously configured per-provider invocation parameters (model, tempe
 
 # Span Metrics Always Visible
 
-May 10, 2026
-
 **Available in arize-phoenix 15.6.0+**
 
-The metrics aside — showing latency percentiles, token counts, and error rates — is now always visible on the right side of the spans table on the project page. Previously this panel was gated behind the `tracing_ux` feature flag. The flag now only controls the sparkline at the top of the page; the metrics panel is on by default for everyone.
+The metrics aside — showing latency percentiles, token counts, and error rates — is now always visible on the right side of the spans table on the project page.

--- a/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations.mdx
@@ -17,10 +17,10 @@ May 13, 2026
 
 **Available in arize-phoenix 15.7.0+**
 
-The `POST /v1/{traces,spans,sessions}_notes` endpoints now accept an optional `identifier` field on the request body. When provided, the note is upserted on `(entity_id, name='note', identifier)` — matching the semantics of structured annotations. Repeated calls with the same identifier overwrite the existing note. When omitted, the server stamps a unique `px-<kind>-note:<uuid>` identifier, preserving the existing append behavior.
+The `POST /v1/{trace,span,session}_notes` endpoints now accept an optional `identifier` field on the request body. When provided, the note is upserted on `(entity_id, name='note', identifier)` — matching the semantics of structured annotations. Repeated calls with the same identifier overwrite the existing note. When omitted, the server stamps a unique `px-<kind>-note:<uuid>` identifier, preserving the existing append behavior.
 
 ```http
-POST /v1/traces_notes
+POST /v1/trace_notes
 Content-Type: application/json
 
 {
@@ -33,7 +33,7 @@ Content-Type: application/json
 The same `identifier` field is available on span and session notes:
 
 ```http
-POST /v1/spans_notes
+POST /v1/span_notes
 {
   "span_id": "def456",
   "note": "Retrieval step returned stale document",

--- a/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations.mdx
@@ -5,15 +5,11 @@ description: "Session turn messages are now expandable, notes accept caller-supp
 
 # Expandable Session Turn Messages
 
-May 13, 2026
-
 **Available in arize-phoenix 15.7.0+**
 
 Long messages in the Session Details view are now collapsed by default with an expand button. This keeps the turn list scannable without losing any content — click to expand a message, click again to collapse it. The change applies to both user turns and model responses.
 
 # Note Identifier Support
-
-May 13, 2026
 
 **Available in arize-phoenix 15.7.0+**
 
@@ -50,8 +46,6 @@ curl -X DELETE \
 ```
 
 # New CLI Annotation Commands
-
-May 13, 2026
 
 **Available in arize-phoenix 15.7.0+ (server), @arizeai/phoenix-cli (next minor release)**
 
@@ -94,8 +88,6 @@ px trace add-note <trace-id> \
 The TypeScript client's `addTraceNote`, `addSpanNote`, and `addSessionNote` functions also accept an `identifier` parameter in the same upcoming release.
 
 # Security: Format-String Injection Prevention
-
-May 13, 2026
 
 **Available in arize-phoenix 15.7.0+**
 

--- a/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations.mdx
@@ -1,0 +1,102 @@
+---
+title: "05.13.2026: Session Enhancements and Annotation Identifiers"
+description: "Session turn messages are now expandable, notes accept caller-supplied identifiers for upsert semantics, and new CLI commands manage annotation bulk-delete."
+---
+
+# Expandable Session Turn Messages
+
+May 13, 2026
+
+**Available in arize-phoenix 15.7.0+**
+
+Long messages in the Session Details view are now collapsed by default with an expand button. This keeps the turn list scannable without losing any content — click to expand a message, click again to collapse it. The change applies to both user turns and model responses.
+
+# Note Identifier Support
+
+May 13, 2026
+
+**Available in arize-phoenix 15.7.0+**
+
+The `POST /v1/{traces,spans,sessions}_notes` endpoints now accept an optional `identifier` field on the request body. When provided, the note is upserted on `(entity_id, name='note', identifier)` — matching the semantics of structured annotations. Repeated calls with the same identifier overwrite the existing note. When omitted, the server stamps a unique `px-<kind>-note:<uuid>` identifier, preserving the existing append behavior.
+
+```http
+POST /v1/traces_notes
+Content-Type: application/json
+
+{
+  "trace_id": "abc123",
+  "note": "Reviewed — context loss detected at turn 3",
+  "identifier": "coding-session:chatbot-analysis-2026-05-13"
+}
+```
+
+The same `identifier` field is available on span and session notes:
+
+```http
+POST /v1/spans_notes
+{
+  "span_id": "def456",
+  "note": "Retrieval step returned stale document",
+  "identifier": "coding-session:chatbot-analysis-2026-05-13"
+}
+```
+
+Combined with the existing filter-based DELETE endpoints, this lets you tag every note in a coding session with a shared identifier and remove them all in one call:
+
+```bash
+curl -X DELETE \
+  "https://your-phoenix/v1/projects/my-project/trace_annotations?identifier=coding-session:chatbot-analysis-2026-05-13&delete_all=true" \
+  -H "Authorization: Bearer $PHOENIX_API_KEY"
+```
+
+# New CLI Annotation Commands
+
+May 13, 2026
+
+**Available in arize-phoenix 15.7.0+ (server), @arizeai/phoenix-cli (next minor release)**
+
+New `px` commands let you manage annotations without needing curl or GraphQL.
+
+**Bulk delete annotations by identifier or time range**
+
+```bash
+# Delete all annotations tagged with a coding session identifier
+px trace-annotations delete --identifier "coding-session:chatbot-analysis-2026-05-13" --all -y
+px span-annotations delete  --identifier "coding-session:chatbot-analysis-2026-05-13" --all -y
+px session-annotations delete --identifier "coding-session:chatbot-analysis-2026-05-13" --all -y
+
+# Delete by time range
+px trace-annotations delete --start-time 2026-05-01T00:00:00Z --end-time 2026-05-13T00:00:00Z -y
+```
+
+**Get a project by name**
+
+```bash
+px project get my-project
+px project get my-project --format raw --no-progress | jq -r '.id'
+```
+
+**`--identifier` flag on annotate and add-note**
+
+```bash
+# Annotate with a reusable identifier (upserts on repeated calls)
+px trace annotate <trace-id> \
+  --name quality \
+  --label pass \
+  --identifier "coding-session:chatbot-analysis-2026-05-13"
+
+# Add a note with a reusable identifier
+px trace add-note <trace-id> \
+  --text "Context loss detected at turn 3" \
+  --identifier "coding-session:chatbot-analysis-2026-05-13"
+```
+
+The TypeScript client's `addTraceNote`, `addSpanNote`, and `addSessionNote` functions also accept an `identifier` parameter in the same upcoming release.
+
+# Security: Format-String Injection Prevention
+
+May 13, 2026
+
+**Available in arize-phoenix 15.7.0+**
+
+The f-string template formatter now blocks access to private and dunder attributes in template expressions. Templates like `{user.__class__.__globals__}` raised an error instead of resolving, preventing a format-string injection path that could expose process state (environment variables, module globals) through user-supplied template variables. Normal attribute access (`{user.name}`, `{items[0].value}`) is unaffected.

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,9 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations" arrow="true" title="05.13.2026" icon="calendar" description="Expandable session turn messages; note identifier upsert on notes REST endpoints; new CLI annotation bulk-delete and project-get commands"/>
+    <Card href="/docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences" arrow="true" title="05.10.2026" icon="calendar" description="Save a default Playground provider and model; span metrics aside now always visible"/>
+    <Card href="/docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header" arrow="true" title="05.08.2026" icon="calendar" description="Route OTLP traces to a named project via x-project-name HTTP header"/>
     <Card href="/docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools" arrow="true" title="05.05.2026" icon="calendar" description="Vendor-native tools (web search, code execution, computer use, grounding) in Playground and Prompts"/>
     <Card href="/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates" arrow="true" title="05.05.2026" icon="calendar" description="Filter-based annotation DELETE; token counts in trace/session REST payloads; evals runtime model detection"/>
     <Card href="/docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing" arrow="true" title="05.01.2026" icon="calendar" description="OpenInference middleware for TanStack AI — AGENT, LLM, and TOOL spans for chat() calls"/>


### PR DESCRIPTION
## Summary

- **05.08.2026** — OTLP project routing via `x-project-name` HTTP header (v15.5.0); evaluator preservation bug fix (v15.5.1)
- **05.10.2026** — Playground default provider/model preference; span metrics aside always visible (v15.6.0)
- **05.13.2026** — Expandable session turn messages; note identifier upsert semantics on REST notes endpoints; new CLI annotation bulk-delete and `px project get` commands; f-string template injection security fix (v15.7.0)

## Test plan

- [ ] Verify all three new MDX files render correctly on the docs site
- [ ] Confirm aggregate `release-notes.mdx` entries are in reverse-chronological order (05.13 → 05.10 → 05.08 → 05.05 → ...)
- [ ] Confirm `docs.json` navigation links resolve to the correct pages
- [ ] Confirm year overview `2026.mdx` cards point to the correct paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)