### PR TITLE
fix: handle invalid GraphQL node ids

### DIFF
--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -1000,7 +1000,10 @@ class Query:
                 dataset_example_rowid=dataset_example_rowid,
             )
 
-        global_id = GlobalID.from_id(id)
+        try:
+            global_id = GlobalID.from_id(id)
+        except ValueError:
+            raise NotFound(f"Unknown node: {id}") from None
         type_name = global_id.type_name
         if type_name == Secret.__name__:
             return Secret(id=global_id.node_id)

--- a/src/phoenix/server/api/types/node.py
+++ b/src/phoenix/server/api/types/node.py
@@ -1,5 +1,6 @@
 import re
 from base64 import b64decode
+from binascii import Error as BinasciiError
 
 from strawberry.relay import GlobalID
 
@@ -7,7 +8,10 @@ _COMPOSITE_GLOBAL_ID_PATTERN = re.compile(r"[^:]+:[^:]+(:[^:]+)+")
 
 
 def is_composite_global_id(node_id: str) -> bool:
-    decoded_node_id = b64decode(node_id).decode()
+    try:
+        decoded_node_id = b64decode(node_id).decode()
+    except (BinasciiError, UnicodeDecodeError):
+        return False
     return _COMPOSITE_GLOBAL_ID_PATTERN.match(decoded_node_id) is not None
 
 

--- a/tests/unit/server/api/types/test_node.py
+++ b/tests/unit/server/api/types/test_node.py
@@ -1,7 +1,11 @@
 import pytest
 from strawberry.relay import GlobalID
 
-from phoenix.server.api.types.node import from_global_id, from_global_id_with_expected_type
+from phoenix.server.api.types.node import (
+    from_global_id,
+    from_global_id_with_expected_type,
+    is_composite_global_id,
+)
 
 
 def test_from_global_id_returns_type_name_and_node_id() -> None:
@@ -21,3 +25,18 @@ def test_from_global_id_with_expected_type_raises_value_error_for_unexpected_typ
     global_id = GlobalID(type_name="EmbeddingDimension", node_id=str(1))
     with pytest.raises(ValueError):
         from_global_id_with_expected_type(global_id=global_id, expected_type_name="Dimension")
+
+
+@pytest.mark.parametrize("node_id", ["default", "not base64", "////"])
+def test_is_composite_global_id_returns_false_for_invalid_base64(node_id: str) -> None:
+    assert is_composite_global_id(node_id) is False
+
+
+def test_is_composite_global_id_returns_false_for_simple_global_id() -> None:
+    node_id = str(GlobalID(type_name="Project", node_id="1"))
+    assert is_composite_global_id(node_id) is False
+
+
+def test_is_composite_global_id_returns_true_for_composite_global_id() -> None:
+    node_id = str(GlobalID(type_name="ExperimentRepeatedRunGroup", node_id="1:2"))
+    assert is_composite_global_id(node_id) is True


### PR DESCRIPTION
﻿## Summary
- treat invalid base64 values as non-composite node IDs instead of letting the decoder exception escape
- convert invalid Relay node IDs in the `node` resolver into the normal `NotFound` path
- add unit coverage for literal project-name slugs and normal/composite IDs

Fixes #12908

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\unit\server\api\types\test_node.py -q`
- `.\.venv\Scripts\python.exe -m ruff check src\phoenix\server\api\types\node.py src\phoenix\server\api\queries.py tests\unit\server\api\types\test_node.py`
- `.\.venv\Scripts\python.exe -m ruff format --check src\phoenix\server\api\types\node.py src\phoenix\server\api\queries.py tests\unit\server\api\types\test_node.py`
- `git diff --check`

Note: pytest passes with existing local warning noise from dependency deprecations and a Windows `.pytest_cache` access warning.
