### PR TITLE
fix: validate projection expressions and sandbox eval globals

### DIFF
--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -188,6 +188,7 @@ class SpanFilter:
             eval(
                 self.compiled,
                 {
+                    "__builtins__": {},
                     **_NAMES,
                     **self._aliased_annotation_attributes,
                     "not_": sqlalchemy.not_,
@@ -246,6 +247,32 @@ class SpanFilter:
         return stmt
 
 
+_VALID_PROJECTION_NODE_TYPES: tuple[type, ...] = (
+    ast.Expression,
+    ast.Attribute,
+    ast.Subscript,
+    ast.Name,
+    ast.Constant,
+    ast.List,
+    ast.Tuple,
+    ast.Load,
+)
+
+
+def _validate_projection_expression(expression: ast.Expression) -> None:
+    """
+    Reject any AST construct that isn't a simple attribute/subscript lookup.
+    Projection keys are paths like ``name``, ``output.value``,
+    ``attributes['key']``, or ``attributes[['a','b']]`` — never function calls,
+    operators, comprehensions, lambdas, or f-strings.
+    """
+    if not isinstance(expression, ast.Expression):
+        raise SyntaxError(f"invalid projection: {ast.unparse(expression)}")
+    for node in ast.walk(expression.body):
+        if not isinstance(node, _VALID_PROJECTION_NODE_TYPES):
+            raise SyntaxError(f"invalid projection: {ast.unparse(node)}")
+
+
 @dataclass(frozen=True)
 class Projector:
     expression: str
@@ -256,6 +283,7 @@ class Projector:
         if not (source := self.expression):
             raise ValueError("missing expression")
         root = ast.parse(source, mode="eval")
+        _validate_projection_expression(root)
         translated = _ProjectionTranslator(source).visit(root)
         ast.fix_missing_locations(translated)
         compiled = compile(translated, filename="", mode="eval")
@@ -265,7 +293,7 @@ class Projector:
     def __call__(self) -> sqlalchemy.SQLColumnExpression[typing.Any]:
         return typing.cast(
             sqlalchemy.SQLColumnExpression[typing.Any],
-            eval(self.compiled, {**_NAMES}),
+            eval(self.compiled, {"__builtins__": {}, **_NAMES}),
         )
 
 

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -280,9 +280,9 @@ def test_apply_eval_aliasing(filter_condition: str, expected: str) -> None:
         assert aliased == expected
 
 
-class TestProjectorSecurityClaim:
+class TestProjectorValidationGap:
     """
-    Validates the security claim about ``Projector`` in
+    Pins the two structural defects in ``Projector`` in
     ``src/phoenix/trace/dsl/filter.py``:
 
     1. Unlike ``SpanFilter``, ``Projector`` does NOT call

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -314,24 +314,33 @@ class TestProjectorValidationGap:
         with pytest.raises(SyntaxError):
             Projector(dangerous_expression)
 
-    def test_projector_eval_namespace_has_no_builtins_access(self) -> None:
-        # ``Projector.__call__`` evaluates the compiled AST with
-        # ``eval(self.compiled, {**_NAMES})``. Because ``__builtins__`` is not
-        # explicitly set to ``{}``, Python injects the full builtins dict
-        # into the namespace, exposing ``__import__``, ``open``, ``exec``,
-        # ``eval``, etc. to anything that survives the AST translator.
-        projector = Projector("name")  # any valid expression to trigger compile
+    def test_projector_eval_namespace_has_no_builtins_access(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``Projector.__call__`` evaluates the compiled AST inside an ``eval``
+        # call. The eval namespace must pin ``__builtins__`` to ``{}``;
+        # otherwise CPython auto-populates the full builtins dict, exposing
+        # ``__import__``, ``open``, ``exec``, ``eval``, etc. to anything that
+        # survives the AST translator.
+        projector = Projector("name")
 
-        # Recreate the same namespace the projector uses at eval time and
-        # confirm that builtins leak in.
-        namespace = {**phoenix.trace.dsl.filter._NAMES}
-        eval(projector.compiled, namespace)
+        captured_globals: list[dict[str, Any]] = []
+        real_eval = eval
 
-        # This assertion FAILS on current code: ``__builtins__`` is present
-        # and exposes the entire CPython builtins dict.
-        builtins_obj: Any = namespace.get("__builtins__")
-        assert builtins_obj is None or builtins_obj == {}, (
+        def spy_eval(code: Any, globals_dict: dict[str, Any], locals_dict: Any = None) -> Any:
+            captured_globals.append(globals_dict)
+            return real_eval(code, globals_dict, locals_dict)
+
+        # Inject the spy into the module's namespace; Python looks up bare
+        # ``eval`` in module globals before falling back to builtins, so this
+        # intercepts the call inside ``Projector.__call__``.
+        monkeypatch.setattr("phoenix.trace.dsl.filter.eval", spy_eval, raising=False)
+        projector()
+
+        assert len(captured_globals) == 1
+        builtins_obj = captured_globals[0].get("__builtins__")
+        assert builtins_obj == {}, (
             "Projector eval namespace must pin __builtins__ to {} to prevent "
             "code-injection vectors; instead it exposes "
-            f"{len(builtins_obj)} builtins."
+            f"{len(builtins_obj) if builtins_obj else 0} builtins."
         )

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -11,7 +11,12 @@ from sqlalchemy import select
 import phoenix.trace.dsl.filter
 from phoenix.db import models
 from phoenix.server.types import DbSessionFactory
-from phoenix.trace.dsl.filter import SpanFilter, _apply_eval_aliasing, _get_attribute_keys_list
+from phoenix.trace.dsl.filter import (
+    Projector,
+    SpanFilter,
+    _apply_eval_aliasing,
+    _get_attribute_keys_list,
+)
 
 
 @pytest.mark.parametrize(
@@ -272,4 +277,61 @@ def test_apply_eval_aliasing(filter_condition: str, expected: str) -> None:
         return_value=UUID(hex="00000000000000000000000000000000"),
     ):
         aliased, _ = _apply_eval_aliasing(filter_condition)
-    assert aliased == expected
+        assert aliased == expected
+
+
+class TestProjectorSecurityClaim:
+    """
+    Validates the security claim about ``Projector`` in
+    ``src/phoenix/trace/dsl/filter.py``:
+
+    1. Unlike ``SpanFilter``, ``Projector`` does NOT call
+       ``_validate_expression``. It only runs ``_ProjectionTranslator.visit()``,
+       which leaves many AST constructs unchecked.
+    2. The ``eval()`` namespace is ``{**_NAMES}`` — it does not pin
+       ``__builtins__`` to ``{}``, so Python auto-populates the full
+       builtins dict into the namespace.
+
+    These tests assert that ``Projector`` rejects dangerous inputs the
+    same way ``SpanFilter`` does, and that the eval namespace is
+    sandboxed. They are expected to FAIL on the current code,
+    demonstrating the vulnerability.
+    """
+
+    def test_projector_rejects_what_spanfilter_rejects(self) -> None:
+        # ``SpanFilter`` rejects this via ``_validate_expression`` — but
+        # ``Projector`` accepts it because it has no equivalent validation.
+        # An attacker who reaches the projection code path (e.g. via the
+        # SpanQuery REST/GraphQL projection key) can submit arbitrary AST
+        # shapes that bypass the structural guardrails ``SpanFilter`` enforces.
+        dangerous_expression = "10 ** 100000000"
+
+        with pytest.raises(SyntaxError):
+            SpanFilter(dangerous_expression)
+
+        # This assertion FAILS on current code: ``Projector`` happily
+        # compiles the unbounded-exponent expression with no validation.
+        with pytest.raises(SyntaxError):
+            Projector(dangerous_expression)
+
+    def test_projector_eval_namespace_has_no_builtins_access(self) -> None:
+        # ``Projector.__call__`` evaluates the compiled AST with
+        # ``eval(self.compiled, {**_NAMES})``. Because ``__builtins__`` is not
+        # explicitly set to ``{}``, Python injects the full builtins dict
+        # into the namespace, exposing ``__import__``, ``open``, ``exec``,
+        # ``eval``, etc. to anything that survives the AST translator.
+        projector = Projector("name")  # any valid expression to trigger compile
+
+        # Recreate the same namespace the projector uses at eval time and
+        # confirm that builtins leak in.
+        namespace = {**phoenix.trace.dsl.filter._NAMES}
+        eval(projector.compiled, namespace)
+
+        # This assertion FAILS on current code: ``__builtins__`` is present
+        # and exposes the entire CPython builtins dict.
+        builtins_obj: Any = namespace.get("__builtins__")
+        assert builtins_obj is None or builtins_obj == {}, (
+            "Projector eval namespace must pin __builtins__ to {} to prevent "
+            "code-injection vectors; instead it exposes "
+            f"{len(builtins_obj)} builtins."
+        )


### PR DESCRIPTION
## Summary

`Projector` in `src/phoenix/trace/dsl/filter.py` previously accepted any Python expression as a projection key and ran it through `eval()` with an open namespace. This PR tightens both ends.

## What changed

- **AST allow-list for projection keys.** A new `_validate_projection_expression()` rejects anything that isn't a simple lookup path — only `Name`, `Attribute`, `Subscript`, `Constant`, `List`, `Tuple` are allowed. Valid keys like `name`, `output.value`, `attributes['k']`, and `attributes[['a','b']]` still work; operators, function calls, comprehensions, lambdas, and f-strings are rejected with a clear `SyntaxError`.
- **Locked-down eval globals.** `Projector.__call__` and `SpanFilter.__call__` now pin `__builtins__: {}` so the eval namespace only contains the SQLAlchemy column mappings the DSL is meant to expose.
- **Tests.** Two pytest cases pin these invariants. The namespace test spies on the real `eval` call inside the module via `monkeypatch`, so it exercises the production path rather than a reconstructed namespace.

## Test plan

- [x] `uv run pytest tests/unit/trace/dsl/test_filter.py::TestProjectorValidationGap -v` — both pass.
- [x] `uv run pytest tests/unit/trace/dsl/ -v` — 146 passed, no regressions in existing filter/projection behavior.