### PR TITLE
docs(skills): weekly audit — 2026-05-13

### DIFF
--- a/.agents/skills/phoenix-tracing/references/production-python.md
+++ b/.agents/skills/phoenix-tracing/references/production-python.md
@@ -25,8 +25,11 @@ export OPENINFERENCE_HIDE_INPUT_MESSAGES=true  # Hide LLM input messages
 export OPENINFERENCE_HIDE_OUTPUT_MESSAGES=true # Hide LLM output messages
 export OPENINFERENCE_HIDE_INPUT_IMAGES=true    # Hide image content
 export OPENINFERENCE_HIDE_INPUT_TEXT=true      # Hide embedding text
+export OPENINFERENCE_HIDE_LLM_TOOLS=true       # Hide tool definitions sent to the LLM (llm.tools.*)
 export OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH=10000  # Limit image size
 ```
+
+> `OPENINFERENCE_HIDE_LLM_TOOLS` is also applied when `OPENINFERENCE_HIDE_INPUTS` is enabled, consistent with `OPENINFERENCE_HIDE_INPUT_MESSAGES` and `OPENINFERENCE_HIDE_LLM_PROMPTS`.
 
 **Python TraceConfig:**
 
@@ -37,7 +40,8 @@ from openinference.instrumentation import TraceConfig
 config = TraceConfig(
     hide_inputs=True,
     hide_outputs=True,
-    hide_input_messages=True
+    hide_input_messages=True,
+    hide_llm_tools=True,
 )
 register(trace_config=config)
 ```

--- a/.agents/skills/phoenix-tracing/references/production-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/production-typescript.md
@@ -74,8 +74,11 @@ export OPENINFERENCE_HIDE_INPUT_MESSAGES=true  # Hide LLM input messages
 export OPENINFERENCE_HIDE_OUTPUT_MESSAGES=true # Hide LLM output messages
 export OPENINFERENCE_HIDE_INPUT_IMAGES=true    # Hide image content
 export OPENINFERENCE_HIDE_INPUT_TEXT=true      # Hide embedding text
+export OPENINFERENCE_HIDE_LLM_TOOLS=true       # Hide tool definitions sent to the LLM (llm.tools.*)
 export OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH=10000  # Limit image size
 ```
+
+> `OPENINFERENCE_HIDE_LLM_TOOLS` is also applied when `OPENINFERENCE_HIDE_INPUTS` is enabled, consistent with `OPENINFERENCE_HIDE_INPUT_MESSAGES` and `OPENINFERENCE_HIDE_LLM_PROMPTS`.
 
 **TypeScript TraceConfig:**
 
@@ -86,7 +89,8 @@ import { OpenAIInstrumentation } from "@arizeai/openinference-instrumentation-op
 const traceConfig = {
   hideInputs: true,
   hideOutputs: true,
-  hideInputMessages: true
+  hideInputMessages: true,
+  hideLLMTools: true,
 };
 
 const instrumentation = new OpenAIInstrumentation({ traceConfig });

--- a/.agents/skills/phoenix-tracing/references/projects-python.md
+++ b/.agents/skills/phoenix-tracing/references/projects-python.md
@@ -57,6 +57,37 @@ register(project_name="my-app-v1")
 register(project_name="my-app-v2")
 ```
 
+## Via HTTP Header (OTEL Collector / config-based tools)
+
+If you cannot set resource attributes in code (e.g. when using an OTEL Collector or another configuration-driven pipeline), set the `x-project-name` HTTP header on OTLP HTTP exports. The header takes precedence over the `openinference.project.name` resource attribute; every span in the request is routed to that project.
+
+```bash
+# Via OTEL_EXPORTER_OTLP_HEADERS environment variable
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:6006"
+export OTEL_EXPORTER_OTLP_HEADERS="x-project-name=my-project"
+```
+
+```python
+# Using the raw OTLP HTTP exporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+exporter = OTLPSpanExporter(
+    endpoint="http://localhost:6006/v1/traces",
+    headers={"x-project-name": "my-project"},
+)
+```
+
+```yaml
+# OTEL Collector otlphttp exporter
+exporters:
+  otlphttp:
+    endpoint: "http://phoenix:6006"
+    headers:
+      x-project-name: "my-project"
+```
+
+> **Note:** `x-project-name` is only supported by the **HTTP** OTLP endpoint (`/v1/traces`). For gRPC, use the `openinference.project.name` resource attribute instead.
+
 ## Switching Projects (Python Notebooks Only)
 
 ```python

--- a/.agents/skills/phoenix-tracing/references/projects-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/projects-typescript.md
@@ -52,3 +52,24 @@ register({ projectName: "chatbot-claude" });
 register({ projectName: "my-app-v1" });
 register({ projectName: "my-app-v2" });
 ```
+
+## Via HTTP Header (OTEL Collector / config-based tools)
+
+If you cannot set resource attributes in code (e.g. when using an OTEL Collector or another configuration-driven pipeline), set the `x-project-name` HTTP header on OTLP HTTP exports. The header takes precedence over the `openinference.project.name` resource attribute; every span in the request is routed to that project.
+
+```bash
+# Via OTEL_EXPORTER_OTLP_HEADERS environment variable
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:6006"
+export OTEL_EXPORTER_OTLP_HEADERS="x-project-name=my-project"
+```
+
+```yaml
+# OTEL Collector otlphttp exporter
+exporters:
+  otlphttp:
+    endpoint: "http://phoenix:6006"
+    headers:
+      x-project-name: "my-project"
+```
+
+> **Note:** `x-project-name` is only supported by the **HTTP** OTLP endpoint (`/v1/traces`). For gRPC, use the `openinference.project.name` resource attribute instead.


### PR DESCRIPTION
# Phoenix Skills Audit — 2026-05-06 to 2026-05-13

**Audited against:** `origin/main` at `f0a2f9e9d9c8be02db120e407447ba4a79e7ea2f`
**Commits analyzed:** 45 (10 user-facing candidates, 2 applied as edits, 8 already reflected or skipped with documented rationale)

## Edits applied

### phoenix-tracing

- `references/production-python.md` — added `OPENINFERENCE_HIDE_LLM_TOOLS=true` to the env-var table and `hide_llm_tools=True` to the `TraceConfig` code example; added note that this flag is also applied when `OPENINFERENCE_HIDE_INPUTS` is enabled (commit `559acf830`, source: `docs/phoenix/tracing/how-to-tracing/advanced/masking-span-attributes.mdx` and `js/packages/phoenix-otel/README.md`).

- `references/production-typescript.md` — same additions for the TypeScript surface: `OPENINFERENCE_HIDE_LLM_TOOLS=true` env var and `hideLLMTools: true` in the `traceConfig` object (commit `559acf830`, source: same as above; grounded against `js/packages/phoenix-otel/README.md` line showing `hideLLMTools: true` in the `OITracer` config block).

- `references/projects-python.md` — added new section "Via HTTP Header (OTEL Collector / config-based tools)" documenting the `x-project-name` HTTP header that can be set on OTLP HTTP exports to override the project for all spans in the request; includes env-var, raw-exporter-headers, and OTEL-Collector YAML examples; notes HTTP-only restriction (commit `7d1038660`, source: `src/phoenix/server/api/routers/v1/traces.py` `x_project_name: Optional[str] = Header(default=None)` and `docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-projects.mdx`).

- `references/projects-typescript.md` — same `x-project-name` HTTP header section added (same server-side feature; no TS-SDK change needed — header is set at the OTLP exporter / infra level, not in the TS SDK).

## Skipped commits

| SHA | Subject | Reason |
|-----|---------|--------|
| `f0a2f9e9d` | fix: prevent prototype pollution in DatasetPreviewTable | frontend-only (`app/src/`) |
| `d8d5322ea` | feat: pxi tool layout rebalancing | frontend-only |
| `c132f0c13` | feat(playground): Add Anthropic and Google thinking controls | frontend-only |
| `af881d396` | refactor: reorganize agent tools under toolsets package | internal server refactor, no public surface change |
| `dde26f67b` | fix(cost): update built-in model token prices | internal cost manifest, no SDK surface |
| `11275b48d` | feat(agents): populate project_sessions for /chat traces | internal ORM fix; `tracers.py` change is server-internal, not a user-facing API |
| `04a830ce2` | ci: harden GitHub Actions workflows | CI only |
| `3a4fcff66` | ci: scope CLA workflow permissions | CI only |
| `97974ed65` | chore: update phoenix version in kustomize and helm | helm/kustomize bookkeeping |
| `f840b5c63` | chore(main): release arize-phoenix 15.7.0 | release-please bookkeeping |
| `e7224a685` | fix: prevent format-string injection in f-string template formatter | internal utility, no public API |
| `30ccbe6b3` | chore: add data-testid attributes to key UI buttons | frontend + playwright skill (not in scope) |
| `f3a2beaed` + `724f45a3b` | chore: Rename llms.txt / Restore llms.txt | net-zero: the URL was renamed then restored; no user-facing change survives |
| `0700201d8` | refactor(agents): move chat model selection from query params to request body | PXI internal `/agents/chat` endpoint; not exposed through CLI, tracing, or evals skill surfaces |
| `73b0d6262` | fix: keep PXI send button in stop mode while streaming | frontend-only |
| `6dceb101b` | feat: session-tagged identifiers for open/axial coding workflows | already applied — this commit itself modified `.agents/skills/phoenix-cli/SKILL.md`, `references/open-coding.md`, `references/axial-coding.md` |
| `9499fdf19` | chore: Improve vite dev server boot times | frontend build tooling |
| `1cc1ce7b8` | feat(ui): move toasts to top-center | frontend-only |
| `91e465389` | chore(js): update versions | JS version bumps |
| `3797110fe` | feat: add trace user feedback annotations | server-side GraphQL mutation; no corresponding CLI/SDK surface change observed |
| `44b07acf6` | fix: surface playground validation errors | server subscriptions, internal |
| `66f1dca70` | chore(deps): drop unused vertexai shim from phoenix-evals | unused transitive dep removed; no documented public dependency |
| `af05e2d96` | chore(deps): swap pydantic-ai for pydantic-ai-slim | dep reorganization, no API change |
| `0a400ae5a` | feat(agents): server-side eval harness for pxi | internal test harness under `tests/pxi/` |
| `4c30b7d30` | chore(deps): bump urllib3 | dep bump |
| `f9fad4db1` | chore(agents): drop unused user and db fields from ChatDependencies | internal |
| `71ceeb3fa` | feat(agents): rip v1 /chat route | removes internal PXI-only `/chat` v1 route; CLI does not wrap this endpoint |
| `f898dc089` | feat: make session turn messages expandable | frontend-only |
| `a5c27f8be` | chore: auto-label external issues and PRs | CI/GitHub automation |
| `e80b93da7` | chore: update phoenix version in helm | helm bookkeeping |
| `1f4a098ed` | chore(main): release arize-phoenix 15.6.0 | release-please bookkeeping |
| `5682d82e6` | chore: update sitemap.xml | docs infrastructure |
| `0883fa7c8` | docs: fill 6 documentation gaps from weekly audit | docs update, not skill files |
| `448774042` | feat(playground): default provider/model as a user preference | frontend-only |
| `37dc417f8` | feat(agents): Playground manipulation tools w/ confirmation | PXI frontend |
| `ea3d7e7b0` | feat(tracing): always show metrics aside | frontend UI change |
| `419c3a069` | feat(agents): add /agents/{agent_id}/sessions/{session_id}/summary endpoint | PXI-internal REST endpoint |
| `d37dfa0f5` | fix(pxi): resolve interrupted tool calls | PXI frontend |
| `a4b65920d` | chore(main): release arize-phoenix 15.5.1 | release-please bookkeeping |
| `9c8068b59` | fix(evaluators): preserve built-in evaluator on dataset evaluator delete | server-side GraphQL mutation fix |
| `054b88bc3` | chore(deps): bump python-dotenv in examples | example dependency |
| `f76c6670d` | refactor: normalize graphql prompt invocation parameters | server-side GraphQL refactor; `toOpenAI.ts` gains new provider branches (see out-of-scope) |
| `49aa7528f` | docs: fix typo in docker.mdx | docs typo |
| `61afbc2c7` + `e80b93da7` | chore: update phoenix version in helm | helm bookkeeping |
| `a4b4e528c` | chore(main): release arize-phoenix 15.5.0 | release-please bookkeeping |
| `0e2c175e9` | fix: add types-aiobotocore-bedrock-runtime in extras | dep fix |
| `68e1ca294` + `3f6eb2336` | chore(js): fix lockfile / bump npm deps | security dep bumps |
| `01146efae` | ci: trigger CI on version-* branches | CI |
| `a1be82022` | feat: Update session details turns layout | frontend-only |
| `33901f5ef` | chore: remove deprecated manually-instrumented-chatbot example | example removal |
| `590669d1a` | feat(app): type frontend REST calls against the OpenAPI schema | frontend codegen tooling |
| `1ef5793fe` + `4c30b7d30` + `7cd1f0dbd` + `1255f201a` | dep bumps | dep bumps |
| `85a0ceeeb` | chore(js): update versions | JS version bumps |
| `ccf1880cf` | fix(deps): bump litellm floor | security dep fix |
| `44e50f084` | chore: update sitemap.xml | docs infrastructure |
| `a5d970b49` | docs(skills): weekly audit — 2026-05-06 | previous audit run, already applied |
| `1791ecb6c` | docs: add px profile commands to CLI reference page | `px profile` commands already fully documented in CLI skill SKILL.md |
| `e8c3b13a6` | docs: add REST API pages for annotation DELETE endpoints | docs-only update (annotation DELETE commands already in CLI skill via `6dceb101b`) |

## Out-of-scope findings

- **`f76c6670d` — `toOpenAI.ts` extended to handle new OpenAI-family provider types** (`azure_openai`, `deepseek`, `xai`, `ollama`, `cerebras`, `fireworks`, `groq`, `moonshot`, `perplexity`, `together`): the `toOpenAI` function in `@arizeai/phoenix-client` (TypeScript) now converts prompts from all these providers to OpenAI-compatible `ChatCompletionCreateParams`, not just `openai`-typed prompts. This is user-facing for anyone using the prompt SDK, but it belongs in a `phoenix-client` or `phoenix-prompts` skill that does not currently exist. Source: `js/packages/phoenix-client/src/prompts/sdks/toOpenAI.ts`.

- **`71ceeb3fa` — removal of v1 `/chat` route**: The `/chat` v1 route was a PXI-internal endpoint, not documented in any of the three audited skills. Belongs to the `phoenix-server` skill (already updated in that commit).

- **`11275b48d` — session linking for `/chat` and `/summary` traces**: The `Tracer` now correctly creates `ProjectSession` rows for agent traces that carry `session.id`. This is a behavior fix that makes sessions visible in the Phoenix UI for PXI users. Belongs to `phoenix-server` skill.
