### PR TITLE
fix(agent): clarify PXI remote trace sharing consent

### DIFF
--- a/app/src/components/agent/AgentConsentGate.tsx
+++ b/app/src/components/agent/AgentConsentGate.tsx
@@ -45,6 +45,9 @@ export function AgentConsentGate() {
   const acknowledgeConsent = useAgentContext(
     (state) => state.acknowledgeConsent
   );
+  const hasRemoteCollector = useAgentContext((state) =>
+    Boolean(state.agentsConfig.collectorEndpoint)
+  );
 
   return (
     <div css={consentCSS}>
@@ -60,8 +63,9 @@ export function AgentConsentGate() {
       </div>
       <ul css={consentListCSS}>
         <li>
-          Review how your PXI session traces are saved and shared before you
-          continue.
+          {hasRemoteCollector
+            ? "Review how your PXI session traces are saved and shared before you continue."
+            : "Review how your PXI session traces are saved before you continue."}
         </li>
         <li>You can change these settings later from Agent Settings.</li>
       </ul>

--- a/app/src/components/agent/AgentObservabilitySettings.tsx
+++ b/app/src/components/agent/AgentObservabilitySettings.tsx
@@ -76,36 +76,31 @@ export function AgentObservabilitySettings() {
           </span>
         </Switch>
       </div>
-      <div css={settingRowCSS}>
-        <Switch
-          isSelected={
-            isRemoteCollectorConfigured && observability.exportRemoteTraces
-          }
-          isDisabled={!isRemoteCollectorConfigured}
-          onChange={(exportRemoteTraces) => {
-            setObservability({ exportRemoteTraces });
-          }}
-          labelPlacement="start"
-          css={settingSwitchCSS}
-        >
-          <span className="agent-observability__label">
-            <Text weight="heavy" size="M">
-              Share PXI session traces with the team improving PXI
-            </Text>
-            <Text color="text-500">
-              {agentsConfig.collectorEndpoint ? (
-                <>
-                  Transmits the same unredacted traces to{" "}
-                  <code css={codeCSS}>{agentsConfig.collectorEndpoint}</code>.
-                  Browser-only setting.
-                </>
-              ) : (
-                "Sharing to the PXI improvement team is not configured for this Phoenix app."
-              )}
-            </Text>
-          </span>
-        </Switch>
-      </div>
+      {isRemoteCollectorConfigured ? (
+        <div css={settingRowCSS}>
+          <Switch
+            isSelected={
+              isRemoteCollectorConfigured && observability.exportRemoteTraces
+            }
+            onChange={(exportRemoteTraces) => {
+              setObservability({ exportRemoteTraces });
+            }}
+            labelPlacement="start"
+            css={settingSwitchCSS}
+          >
+            <span className="agent-observability__label">
+              <Text weight="heavy" size="M">
+                Share PXI session traces with the team improving PXI
+              </Text>
+              <Text color="text-500">
+                Transmits the same unredacted traces to{" "}
+                <code css={codeCSS}>{agentsConfig.collectorEndpoint}</code>.
+                Browser-only setting.
+              </Text>
+            </span>
+          </Switch>
+        </div>
+      ) : null}
       <Text css={footerNoteCSS} size="S">
         Trace links and feedback buttons only work when traces are saved in this
         Phoenix app.


### PR DESCRIPTION
## Summary

- hide the PXI remote trace sharing switch when no agent collector is configured
- keep the consent gate copy specific to whether traces can be shared remotely
- leave local PXI trace persistence defaults and request behavior unchanged

remote collector configured:
<img width="1384" height="1512" alt="image" src="https://github.com/user-attachments/assets/52af7919-d7bb-4070-9da4-ccf0d0911c29" />

no remote collector configured:
<img width="1384" height="1246" alt="image" src="https://github.com/user-attachments/assets/74e831fe-7650-4fba-8f6b-a628e20b6918" />


## Testing

- make typecheck-frontend
- pnpm --dir app exec oxfmt --check --config ../.oxfmtrc.jsonc src/components/agent/AgentConsentGate.tsx src/components/agent/AgentObservabilitySettings.tsx
- pnpm --dir app exec oxlint src/components/agent/AgentConsentGate.tsx src/components/agent/AgentObservabilitySettings.tsx

Resolves #13150