### PR TITLE
feat: cap agent session retention

### DIFF
--- a/app/src/agent/extensions/capabilities.ts
+++ b/app/src/agent/extensions/capabilities.ts
@@ -30,7 +30,7 @@ export type AgentCapabilities = Record<AgentCapabilityKey, boolean>;
 const DEFAULT_AGENT_CAPABILITIES: AgentCapabilities = {
   "bash.retainInactiveSessions": false,
   "graphql.mutations": false,
-  "session.storeRecentSessions": false,
+  "session.storeSessions": false,
 };
 
 /** Ordered capability catalog used by the UI and runtime. */
@@ -54,7 +54,7 @@ export const AGENT_CAPABILITY_DEFINITIONS: AgentCapabilityDefinition[] = [
     controlSurface: "experimental-settings",
   },
   {
-    key: "session.storeRecentSessions",
+    key: "session.storeSessions",
     label: "Store recent sessions",
     description:
       "Keeps the three most recent chat sessions instead of replacing session history when starting a new chat.",

--- a/app/src/agent/extensions/capabilities.ts
+++ b/app/src/agent/extensions/capabilities.ts
@@ -30,6 +30,7 @@ export type AgentCapabilities = Record<AgentCapabilityKey, boolean>;
 const DEFAULT_AGENT_CAPABILITIES: AgentCapabilities = {
   "bash.retainInactiveSessions": false,
   "graphql.mutations": false,
+  "session.storeRecentSessions": false,
 };
 
 /** Ordered capability catalog used by the UI and runtime. */
@@ -48,6 +49,15 @@ export const AGENT_CAPABILITY_DEFINITIONS: AgentCapabilityDefinition[] = [
     label: "Dangerously enable mutations",
     description:
       "Allows the phoenix-gql bash command to execute GraphQL mutations in addition to queries.",
+    defaultValue: false,
+    scope: "global",
+    controlSurface: "experimental-settings",
+  },
+  {
+    key: "session.storeRecentSessions",
+    label: "Store recent sessions",
+    description:
+      "Keeps the three most recent chat sessions instead of replacing session history when starting a new chat.",
     defaultValue: false,
     scope: "global",
     controlSurface: "experimental-settings",

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1399,10 +1399,10 @@ export interface components {
              */
             "graphql.mutations"?: boolean;
             /**
-             * Session.Storerecentsessions
+             * Session.Storesessions
              * @default false
              */
-            "session.storeRecentSessions"?: boolean;
+            "session.storeSessions"?: boolean;
         };
         /**
          * AgentSpanContext

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1398,6 +1398,11 @@ export interface components {
              * @default false
              */
             "graphql.mutations"?: boolean;
+            /**
+             * Session.Storerecentsessions
+             * @default false
+             */
+            "session.storeRecentSessions"?: boolean;
         };
         /**
          * AgentSpanContext

--- a/app/src/components/agent/AgentChatPanel.tsx
+++ b/app/src/components/agent/AgentChatPanel.tsx
@@ -25,6 +25,7 @@ export function AgentChatPanel() {
     isOpen,
     activeSessionId,
     orderedSessions,
+    showSessionHistory,
     chatApiUrl,
     modelSelection,
     menuValue,
@@ -52,6 +53,7 @@ export function AgentChatPanel() {
       isOpen={isOpen}
       activeSessionId={activeSessionId}
       orderedSessions={orderedSessions}
+      showSessionHistory={showSessionHistory}
       sessionDisplayName={sessionDisplayName}
       chatApiUrl={chatApiUrl}
       modelSelection={modelSelection}
@@ -69,6 +71,7 @@ function AgentChatController({
   isOpen,
   activeSessionId,
   orderedSessions,
+  showSessionHistory,
   sessionDisplayName,
   chatApiUrl,
   modelSelection,
@@ -82,6 +85,9 @@ function AgentChatController({
   isOpen: boolean;
   activeSessionId: string | null;
   orderedSessions: ReturnType<typeof useAgentChatPanelState>["orderedSessions"];
+  showSessionHistory: ReturnType<
+    typeof useAgentChatPanelState
+  >["showSessionHistory"];
   sessionDisplayName: string;
   chatApiUrl: string;
   modelSelection: AgentModelSelection;
@@ -121,6 +127,7 @@ function AgentChatController({
         sessionDisplayName={sessionDisplayName}
         orderedSessions={orderedSessions}
         activeSessionId={activeSessionId}
+        showSessionHistory={showSessionHistory}
         onSelectSession={setActiveSession}
         onDeleteSession={deleteSession}
         onCreateSession={createSession}

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -55,6 +55,7 @@ export function AgentChatHeader({
   sessionDisplayName,
   orderedSessions,
   activeSessionId,
+  showSessionHistory,
   onSelectSession,
   onDeleteSession,
   onCreateSession,
@@ -63,6 +64,7 @@ export function AgentChatHeader({
   sessionDisplayName: string;
   orderedSessions: AgentSession[];
   activeSessionId: string | null;
+  showSessionHistory: boolean;
   onSelectSession: (sessionId: string | null) => void;
   onDeleteSession: (sessionId: string) => void;
   onCreateSession: () => void;
@@ -87,12 +89,14 @@ export function AgentChatHeader({
         gap="size-50"
         css={panelHeaderActionsCSS}
       >
-        <SessionListMenu
-          sessions={orderedSessions}
-          activeSessionId={activeSessionId}
-          onSelectSession={onSelectSession}
-          onDeleteSession={onDeleteSession}
-        />
+        {showSessionHistory ? (
+          <SessionListMenu
+            sessions={orderedSessions}
+            activeSessionId={activeSessionId}
+            onSelectSession={onSelectSession}
+            onDeleteSession={onDeleteSession}
+          />
+        ) : null}
         <Button
           variant="quiet"
           size="S"

--- a/app/src/components/agent/SessionListMenu.tsx
+++ b/app/src/components/agent/SessionListMenu.tsx
@@ -86,7 +86,7 @@ export function SessionListMenu({
         aria-label="Sessions"
         leadingVisual={<Icon svg={<Icons.HistoryOutline />} />}
       />
-      <MenuContainer placement="bottom end" maxHeight={400}>
+      <MenuContainer placement="bottom end" minHeight="auto" maxHeight={400}>
         <Menu
           selectionMode="single"
           selectedKeys={selectedKeys}

--- a/app/src/components/agent/TraceAgentChatPanel.tsx
+++ b/app/src/components/agent/TraceAgentChatPanel.tsx
@@ -38,6 +38,7 @@ function TraceAgentChatController() {
   const {
     activeSessionId,
     orderedSessions,
+    showSessionHistory,
     chatApiUrl,
     modelSelection,
     menuValue,
@@ -76,6 +77,7 @@ function TraceAgentChatController() {
         sessionDisplayName={sessionDisplayName}
         orderedSessions={orderedSessions}
         activeSessionId={activeSessionId}
+        showSessionHistory={showSessionHistory}
         onSelectSession={setActiveSession}
         onDeleteSession={deleteSession}
         onCreateSession={createSession}

--- a/app/src/components/agent/useAgentChatPanelState.ts
+++ b/app/src/components/agent/useAgentChatPanelState.ts
@@ -96,7 +96,7 @@ export function useAgentChatPanelState() {
   const sessionIds = useAgentContext((state) => state.sessions);
   const sessionMap = useAgentContext((state) => state.sessionMap);
   const showSessionHistory = useAgentContext(
-    (state) => state.capabilities["session.storeRecentSessions"]
+    (state) => state.capabilities["session.storeSessions"]
   );
   const defaultModelConfig = useAgentContext(
     (state) => state.defaultModelConfig

--- a/app/src/components/agent/useAgentChatPanelState.ts
+++ b/app/src/components/agent/useAgentChatPanelState.ts
@@ -95,6 +95,9 @@ export function useAgentChatPanelState() {
   const deleteSession = useAgentContext((state) => state.deleteSession);
   const sessionIds = useAgentContext((state) => state.sessions);
   const sessionMap = useAgentContext((state) => state.sessionMap);
+  const showSessionHistory = useAgentContext(
+    (state) => state.capabilities["session.storeRecentSessions"]
+  );
   const defaultModelConfig = useAgentContext(
     (state) => state.defaultModelConfig
   );
@@ -264,6 +267,7 @@ export function useAgentChatPanelState() {
     isOpen,
     activeSessionId,
     orderedSessions,
+    showSessionHistory,
     chatApiUrl,
     modelSelection,
     menuValue,

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -32,7 +32,7 @@ describe("agentStore", () => {
     it("falls back activeSessionId to last remaining session when active is deleted", () => {
       const store = createAgentStore();
       store.getState().setCapability({
-        key: "session.storeRecentSessions",
+        key: "session.storeSessions",
         enabled: true,
       });
       const sessionId1 = store.getState().createSession();
@@ -93,7 +93,7 @@ describe("agentStore", () => {
     it("keeps the three newest sessions when recent session storage is enabled", () => {
       const store = createAgentStore();
       store.getState().setCapability({
-        key: "session.storeRecentSessions",
+        key: "session.storeSessions",
         enabled: true,
       });
       const firstSessionId = store.getState().createSession();
@@ -116,7 +116,7 @@ describe("agentStore", () => {
     it("prunes to the active session when recent session storage is disabled", () => {
       const store = createAgentStore();
       store.getState().setCapability({
-        key: "session.storeRecentSessions",
+        key: "session.storeSessions",
         enabled: true,
       });
       const firstSessionId = store.getState().createSession();
@@ -128,7 +128,7 @@ describe("agentStore", () => {
       store.getState().setSessionChatStatus(firstSessionId, "streaming");
 
       store.getState().setCapability({
-        key: "session.storeRecentSessions",
+        key: "session.storeSessions",
         enabled: false,
       });
 
@@ -247,7 +247,7 @@ describe("agentStore", () => {
         ...createDefaultAgentCapabilities(),
         "bash.retainInactiveSessions": true,
         "graphql.mutations": true,
-        "session.storeRecentSessions": false,
+        "session.storeSessions": false,
       });
       expect(store.getState().observability).toEqual({
         storeLocalTraces: true,

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -31,6 +31,10 @@ describe("agentStore", () => {
 
     it("falls back activeSessionId to last remaining session when active is deleted", () => {
       const store = createAgentStore();
+      store.getState().setCapability({
+        key: "session.storeRecentSessions",
+        enabled: true,
+      });
       const sessionId1 = store.getState().createSession();
       const sessionId2 = store.getState().createSession();
       // active is sessionId2
@@ -60,6 +64,83 @@ describe("agentStore", () => {
       const before = store.getState();
       store.getState().setSessionMessages("nonexistent", []);
       expect(store.getState().sessionMap).toBe(before.sessionMap);
+    });
+  });
+
+  describe("session retention", () => {
+    it("replaces prior sessions by default when creating a session", () => {
+      const store = createAgentStore();
+      const firstSessionId = store.getState().createSession();
+      store.getState().setPendingElicitation(firstSessionId, {
+        toolCallId: "tool-call-1",
+        questions: [],
+      });
+      store.getState().setSessionChatStatus(firstSessionId, "streaming");
+
+      const secondSessionId = store.getState().createSession();
+
+      expect(store.getState().sessions).toEqual([secondSessionId]);
+      expect(store.getState().activeSessionId).toBe(secondSessionId);
+      expect(store.getState().sessionMap[firstSessionId]).toBeUndefined();
+      expect(
+        store.getState().pendingElicitationBySessionId[firstSessionId]
+      ).toBeUndefined();
+      expect(
+        store.getState().chatStatusBySessionId[firstSessionId]
+      ).toBeUndefined();
+    });
+
+    it("keeps the three newest sessions when recent session storage is enabled", () => {
+      const store = createAgentStore();
+      store.getState().setCapability({
+        key: "session.storeRecentSessions",
+        enabled: true,
+      });
+      const firstSessionId = store.getState().createSession();
+      const secondSessionId = store.getState().createSession();
+      const thirdSessionId = store.getState().createSession();
+      const fourthSessionId = store.getState().createSession();
+
+      expect(store.getState().sessions).toEqual([
+        secondSessionId,
+        thirdSessionId,
+        fourthSessionId,
+      ]);
+      expect(store.getState().activeSessionId).toBe(fourthSessionId);
+      expect(store.getState().sessionMap[firstSessionId]).toBeUndefined();
+      expect(store.getState().sessionMap[secondSessionId]).toBeDefined();
+      expect(store.getState().sessionMap[thirdSessionId]).toBeDefined();
+      expect(store.getState().sessionMap[fourthSessionId]).toBeDefined();
+    });
+
+    it("prunes to the active session when recent session storage is disabled", () => {
+      const store = createAgentStore();
+      store.getState().setCapability({
+        key: "session.storeRecentSessions",
+        enabled: true,
+      });
+      const firstSessionId = store.getState().createSession();
+      const secondSessionId = store.getState().createSession();
+      store.getState().setPendingElicitation(firstSessionId, {
+        toolCallId: "tool-call-1",
+        questions: [],
+      });
+      store.getState().setSessionChatStatus(firstSessionId, "streaming");
+
+      store.getState().setCapability({
+        key: "session.storeRecentSessions",
+        enabled: false,
+      });
+
+      expect(store.getState().sessions).toEqual([secondSessionId]);
+      expect(store.getState().activeSessionId).toBe(secondSessionId);
+      expect(store.getState().sessionMap[firstSessionId]).toBeUndefined();
+      expect(
+        store.getState().pendingElicitationBySessionId[firstSessionId]
+      ).toBeUndefined();
+      expect(
+        store.getState().chatStatusBySessionId[firstSessionId]
+      ).toBeUndefined();
     });
   });
 
@@ -166,6 +247,7 @@ describe("agentStore", () => {
         ...createDefaultAgentCapabilities(),
         "bash.retainInactiveSessions": true,
         "graphql.mutations": true,
+        "session.storeRecentSessions": false,
       });
       expect(store.getState().observability).toEqual({
         storeLocalTraces: true,

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -369,11 +369,14 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
             modelConfig: { ...state.defaultModelConfig },
             createdAt: Date.now(),
           };
-          const nextSessionIds = state.capabilities[
-            "session.storeRecentSessions"
-          ]
-            ? [...state.sessions, sessionId].slice(-MAX_STORED_AGENT_SESSIONS)
-            : [sessionId];
+          let nextSessionIds: string[];
+          if (state.capabilities["session.storeSessions"]) {
+            nextSessionIds = [...state.sessions, sessionId].slice(
+              -MAX_STORED_AGENT_SESSIONS
+            );
+          } else {
+            nextSessionIds = [sessionId];
+          }
 
           return {
             ...buildSessionRetentionPatch({
@@ -556,7 +559,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
       set(
         (state) => {
           const capabilities = { ...state.capabilities, [key]: enabled };
-          if (key !== "session.storeRecentSessions" || enabled) {
+          if (key !== "session.storeSessions" || enabled) {
             return { capabilities };
           }
           return {

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -116,6 +116,8 @@ const DEFAULT_AGENT_OBSERVABILITY_SETTINGS: AgentObservabilitySettings = {
   hasAcknowledgedConsent: false,
 };
 
+const MAX_STORED_AGENT_SESSIONS = 3;
+
 /**
  * Serializable properties that define the agent's state.
  * These are the values persisted to local storage.
@@ -257,6 +259,62 @@ export type AgentClientAction = (
 ) => Promise<AgentClientActionResult>;
 
 /**
+ * Removes entries keyed by sessions that are no longer retained.
+ */
+function pruneSessionScopedRecord<T>({
+  record,
+  retainedSessionIds,
+}: {
+  record: Record<string, T>;
+  retainedSessionIds: Set<string>;
+}): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(record).filter(([sessionId]) =>
+      retainedSessionIds.has(sessionId)
+    )
+  );
+}
+
+/**
+ * Builds the persisted session-state patch after creating, pruning, or clearing
+ * retained sessions, keeping sessionMap and related per-session UI state aligned.
+ */
+function buildSessionRetentionPatch({
+  state,
+  retainedSessionIds,
+  activeSessionId,
+}: {
+  state: AgentState;
+  retainedSessionIds: string[];
+  activeSessionId: string | null;
+}): Pick<
+  AgentState,
+  | "sessions"
+  | "activeSessionId"
+  | "sessionMap"
+  | "pendingElicitationBySessionId"
+  | "chatStatusBySessionId"
+> {
+  const retainedSessionIdSet = new Set(retainedSessionIds);
+  return {
+    sessions: retainedSessionIds,
+    activeSessionId,
+    sessionMap: pruneSessionScopedRecord({
+      record: state.sessionMap,
+      retainedSessionIds: retainedSessionIdSet,
+    }),
+    pendingElicitationBySessionId: pruneSessionScopedRecord({
+      record: state.pendingElicitationBySessionId,
+      retainedSessionIds: retainedSessionIdSet,
+    }),
+    chatStatusBySessionId: pruneSessionScopedRecord({
+      record: state.chatStatusBySessionId,
+      retainedSessionIds: retainedSessionIdSet,
+    }),
+  };
+}
+
+/**
  * Creates a Zustand store for managing agent UI state and conversation sessions.
  *
  * The store is wrapped with devtools (for Redux DevTools inspection) and
@@ -311,10 +369,21 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
             modelConfig: { ...state.defaultModelConfig },
             createdAt: Date.now(),
           };
+          const nextSessionIds = state.capabilities[
+            "session.storeRecentSessions"
+          ]
+            ? [...state.sessions, sessionId].slice(-MAX_STORED_AGENT_SESSIONS)
+            : [sessionId];
+
           return {
-            sessions: [...state.sessions, sessionId],
-            sessionMap: { ...state.sessionMap, [sessionId]: session },
-            activeSessionId: sessionId,
+            ...buildSessionRetentionPatch({
+              state: {
+                ...state,
+                sessionMap: { ...state.sessionMap, [sessionId]: session },
+              },
+              retainedSessionIds: nextSessionIds,
+              activeSessionId: sessionId,
+            }),
           };
         },
         false,
@@ -485,9 +554,22 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
     },
     setCapability: ({ key, enabled }) => {
       set(
-        (state) => ({
-          capabilities: { ...state.capabilities, [key]: enabled },
-        }),
+        (state) => {
+          const capabilities = { ...state.capabilities, [key]: enabled };
+          if (key !== "session.storeRecentSessions" || enabled) {
+            return { capabilities };
+          }
+          return {
+            capabilities,
+            ...buildSessionRetentionPatch({
+              state,
+              retainedSessionIds: state.activeSessionId
+                ? [state.activeSessionId]
+                : [],
+              activeSessionId: state.activeSessionId,
+            }),
+          };
+        },
         false,
         { type: "setCapability" }
       );

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1399,10 +1399,10 @@ export interface components {
              */
             "graphql.mutations"?: boolean;
             /**
-             * Session.Storerecentsessions
+             * Session.Storesessions
              * @default false
              */
-            "session.storeRecentSessions"?: boolean;
+            "session.storeSessions"?: boolean;
         };
         /**
          * AgentSpanContext

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1398,6 +1398,11 @@ export interface components {
              * @default false
              */
             "graphql.mutations"?: boolean;
+            /**
+             * Session.Storerecentsessions
+             * @default false
+             */
+            "session.storeRecentSessions"?: boolean;
         };
         /**
          * AgentSpanContext

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -11,7 +11,7 @@ from typing_extensions import NotRequired
 class AgentCapabilities(TypedDict):
     bash_retainInactiveSessions: NotRequired[bool]
     graphql_mutations: NotRequired[bool]
-    session_storeRecentSessions: NotRequired[bool]
+    session_storeSessions: NotRequired[bool]
 
 
 class AgentSpanContext(TypedDict):

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -11,6 +11,7 @@ from typing_extensions import NotRequired
 class AgentCapabilities(TypedDict):
     bash_retainInactiveSessions: NotRequired[bool]
     graphql_mutations: NotRequired[bool]
+    session_storeRecentSessions: NotRequired[bool]
 
 
 class AgentSpanContext(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -6674,6 +6674,11 @@
             "type": "boolean",
             "title": "Graphql.Mutations",
             "default": false
+          },
+          "session.storeRecentSessions": {
+            "type": "boolean",
+            "title": "Session.Storerecentsessions",
+            "default": false
           }
         },
         "type": "object",

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -6675,9 +6675,9 @@
             "title": "Graphql.Mutations",
             "default": false
           },
-          "session.storeRecentSessions": {
+          "session.storeSessions": {
             "type": "boolean",
-            "title": "Session.Storerecentsessions",
+            "title": "Session.Storesessions",
             "default": false
           }
         },

--- a/src/phoenix/server/agents/capabilities.py
+++ b/src/phoenix/server/agents/capabilities.py
@@ -16,9 +16,9 @@ class AgentCapabilities(BaseModel):
         alias="bash.retainInactiveSessions",
     )
     graphql_mutations: bool = Field(default=False, alias="graphql.mutations")
-    session_store_recent_sessions: bool = Field(
+    session_store_sessions: bool = Field(
         default=False,
-        alias="session.storeRecentSessions",
+        alias="session.storeSessions",
     )
 
 
@@ -53,7 +53,7 @@ _CAPABILITY_PROMPT_RULES = (
         build_line=_graphql_mutations_prompt_line,
     ),
     _CapabilityPromptRule(
-        field_name="session_store_recent_sessions",
+        field_name="session_store_sessions",
         # Browser-only session retention policy; no model guidance needed.
         build_line=lambda _: None,
     ),

--- a/src/phoenix/server/agents/capabilities.py
+++ b/src/phoenix/server/agents/capabilities.py
@@ -16,6 +16,10 @@ class AgentCapabilities(BaseModel):
         alias="bash.retainInactiveSessions",
     )
     graphql_mutations: bool = Field(default=False, alias="graphql.mutations")
+    session_store_recent_sessions: bool = Field(
+        default=False,
+        alias="session.storeRecentSessions",
+    )
 
 
 @dataclass(frozen=True)
@@ -47,6 +51,11 @@ _CAPABILITY_PROMPT_RULES = (
     _CapabilityPromptRule(
         field_name="graphql_mutations",
         build_line=_graphql_mutations_prompt_line,
+    ),
+    _CapabilityPromptRule(
+        field_name="session_store_recent_sessions",
+        # Browser-only session retention policy; no model guidance needed.
+        build_line=lambda _: None,
     ),
 )
 

--- a/tests/unit/server/agents/test_capabilities.py
+++ b/tests/unit/server/agents/test_capabilities.py
@@ -11,11 +11,13 @@ class TestAgentCapabilities:
             {
                 "bash.retainInactiveSessions": True,
                 "graphql.mutations": True,
+                "session.storeRecentSessions": True,
             }
         )
 
         assert capabilities.bash_retain_inactive_sessions is True
         assert capabilities.graphql_mutations is True
+        assert capabilities.session_store_recent_sessions is True
 
     def test_builds_graphql_mutation_guidance(self) -> None:
         disabled = build_capability_system_prompt(AgentCapabilities(graphql_mutations=False))
@@ -35,6 +37,16 @@ class TestAgentCapabilities:
         )
         enabled = build_capability_system_prompt(
             AgentCapabilities(bash_retain_inactive_sessions=True)
+        )
+
+        assert enabled == disabled
+
+    def test_session_store_recent_sessions_is_prompt_noop(self) -> None:
+        disabled = build_capability_system_prompt(
+            AgentCapabilities(session_store_recent_sessions=False)
+        )
+        enabled = build_capability_system_prompt(
+            AgentCapabilities(session_store_recent_sessions=True)
         )
 
         assert enabled == disabled

--- a/tests/unit/server/agents/test_capabilities.py
+++ b/tests/unit/server/agents/test_capabilities.py
@@ -11,13 +11,13 @@ class TestAgentCapabilities:
             {
                 "bash.retainInactiveSessions": True,
                 "graphql.mutations": True,
-                "session.storeRecentSessions": True,
+                "session.storeSessions": True,
             }
         )
 
         assert capabilities.bash_retain_inactive_sessions is True
         assert capabilities.graphql_mutations is True
-        assert capabilities.session_store_recent_sessions is True
+        assert capabilities.session_store_sessions is True
 
     def test_builds_graphql_mutation_guidance(self) -> None:
         disabled = build_capability_system_prompt(AgentCapabilities(graphql_mutations=False))
@@ -41,12 +41,8 @@ class TestAgentCapabilities:
 
         assert enabled == disabled
 
-    def test_session_store_recent_sessions_is_prompt_noop(self) -> None:
-        disabled = build_capability_system_prompt(
-            AgentCapabilities(session_store_recent_sessions=False)
-        )
-        enabled = build_capability_system_prompt(
-            AgentCapabilities(session_store_recent_sessions=True)
-        )
+    def test_session_store_sessions_is_prompt_noop(self) -> None:
+        disabled = build_capability_system_prompt(AgentCapabilities(session_store_sessions=False))
+        enabled = build_capability_system_prompt(AgentCapabilities(session_store_sessions=True))
 
         assert enabled == disabled


### PR DESCRIPTION
## Summary
- add the `session.storeRecentSessions` experimental agent capability
- replace chat sessions by default and retain only the newest 3 when enabled
- hide the chat history control while recent-session retention is off and size the history popover to its contents

## Testing
- `make schema-openapi codegen-ts-app`
- `make codegen-python-client`
- `make format-frontend format-python`
- `pnpm vitest run src/store/__tests__/agentStore.test.ts src/agent/extensions/__tests__/capabilities.test.ts`
- `DYLD_LIBRARY_PATH=/opt/homebrew/Cellar/libpq/17.6/lib uv run pytest tests/unit/server/agents/test_capabilities.py`
- `pnpm typecheck`
- targeted `pnpm oxlint` for changed agent panel files
- Playwright smoke against local Phoenix for hidden history button, visible retained-session history, and compact popover height

Resolves #13149
