### PR TITLE
fix: adjust session turn output metadata layout

### DIFF
--- a/app/src/pages/trace/SessionDetails.tsx
+++ b/app/src/pages/trace/SessionDetails.tsx
@@ -18,7 +18,7 @@ import {
   TriggerWrap,
   View,
 } from "@phoenix/components";
-import { SessionAnnotationSummaryGroupTokens } from "@phoenix/components/annotation/SessionAnnotationSummaryGroup";
+import { SessionAnnotationSummaryGroupStacks } from "@phoenix/components/annotation/SessionAnnotationSummaryGroup";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SessionTokenCount } from "@phoenix/components/trace/SessionTokenCount";
 import { SESSION_VIEW_PARAM } from "@phoenix/constants/searchParams";
@@ -127,7 +127,7 @@ function SessionDetailsHeader({
           ) : null}
         </Flex>
         <Flex direction="row" justifyContent="end">
-          <SessionAnnotationSummaryGroupTokens
+          <SessionAnnotationSummaryGroupStacks
             session={session}
             renderEmptyState={() => null}
           />

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -134,9 +134,8 @@ function RootSpanMessage({ extra, label, role, value }: RootSpanMessageProps) {
     <Flex
       direction="column"
       gap="size-50"
-      alignSelf={isInput ? "start" : "end"}
       alignItems={isInput ? "start" : "end"}
-      css={messageWrapCSS}
+      width="100%"
     >
       <Flex
         direction="row"
@@ -188,6 +187,20 @@ function RootSpanStartTime({ rootSpan }: RootSpanProps) {
   );
 }
 
+function RootSpanEndTime({ rootSpan }: RootSpanProps) {
+  const { fullTimeFormatter } = useTimeFormatters();
+  if (rootSpan.endTime == null) {
+    return null;
+  }
+  const endDate = new Date(rootSpan.endTime);
+
+  return (
+    <Text color="text-700" size="XS">
+      {fullTimeFormatter(endDate)}
+    </Text>
+  );
+}
+
 function RootSpanTraceLink({
   traceId,
   rootSpan,
@@ -213,15 +226,22 @@ function RootSpanTraceLink({
 
 function RootSpanOutputMetadata({ rootSpan }: RootSpanProps) {
   return (
-    <Flex direction="column" gap="size-100">
-      <Flex
-        direction="row"
-        justifyContent="space-between"
-        alignItems="center"
-        gap="size-200"
-        wrap
-      >
-        <Flex direction="row" alignItems="center" gap="size-100" wrap>
+    <Flex
+      direction="row"
+      justifyContent="space-between"
+      alignItems="start"
+      gap="size-200"
+      width="100%"
+    >
+      <RootSpanEndTime rootSpan={rootSpan} />
+      <Flex direction="column" alignItems="end" gap="size-100" minWidth={0}>
+        <Flex
+          direction="row"
+          justifyContent="end"
+          alignItems="center"
+          gap="size-100"
+          wrap
+        >
           <SpanCumulativeTokenCount
             tokenCountTotal={rootSpan.cumulativeTokenCountTotal || 0}
             nodeId={rootSpan.id}
@@ -244,11 +264,11 @@ function RootSpanOutputMetadata({ rootSpan }: RootSpanProps) {
             buttonText="Annotate"
           />
         </span>
+        <AnnotationSummaryGroupTokens
+          span={rootSpan}
+          renderEmptyState={() => null}
+        />
       </Flex>
-      <AnnotationSummaryGroupTokens
-        span={rootSpan}
-        renderEmptyState={() => null}
-      />
     </Flex>
   );
 }
@@ -262,7 +282,13 @@ function SessionTurnDetail({
 
   return (
     <Flex direction="column" gap="size-200">
-      <Flex direction="column" gap="size-100" alignItems="start">
+      <Flex
+        direction="column"
+        gap="size-100"
+        alignSelf="start"
+        alignItems="start"
+        css={messageWrapCSS}
+      >
         <RootSpanMessage
           label={inputLabel}
           role="INPUT"
@@ -270,7 +296,13 @@ function SessionTurnDetail({
         />
         <RootSpanStartTime rootSpan={rootSpan} />
       </Flex>
-      <Flex direction="column" gap="size-100">
+      <Flex
+        direction="column"
+        gap="size-100"
+        alignSelf="end"
+        alignItems="end"
+        css={messageWrapCSS}
+      >
         <RootSpanMessage
           extra={<RootSpanTraceLink traceId={traceId} rootSpan={rootSpan} />}
           role="OUTPUT"
@@ -520,6 +552,7 @@ export function SessionDetailsTraceList({
                 cumulativeTokenCountTotal
                 latencyMs
                 startTime
+                endTime
                 spanId
                 ...AnnotationSummaryGroup
               }

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -108,6 +108,20 @@ const messageWrapCSS = css`
   max-width: 70%;
 `;
 
+const outputMetadataMutedCSS = css`
+  .latency-text,
+  .token-count-item,
+  .token-costs-item,
+  .text,
+  .icon-wrap,
+  svg,
+  .token__text {
+    color: var(--global-text-color-700);
+    font-size: var(--global-font-size-xs);
+    line-height: var(--global-line-height-xs);
+  }
+`;
+
 const SESSION_TURN_MESSAGE_MAX_HEIGHT = 280;
 
 type RootSpanMessageRole = "INPUT" | "OUTPUT";
@@ -226,50 +240,59 @@ function RootSpanTraceLink({
 
 function RootSpanOutputMetadata({ rootSpan }: RootSpanProps) {
   return (
-    <Flex
-      direction="row"
-      justifyContent="space-between"
-      alignItems="start"
-      gap="size-200"
-      width="100%"
-    >
-      <RootSpanEndTime rootSpan={rootSpan} />
-      <Flex direction="column" alignItems="end" gap="size-100" minWidth={0}>
-        <Flex
-          direction="row"
-          justifyContent="end"
-          alignItems="center"
-          gap="size-100"
-          wrap
-        >
-          <SpanCumulativeTokenCount
-            tokenCountTotal={rootSpan.cumulativeTokenCountTotal || 0}
-            nodeId={rootSpan.id}
-          />
-          {rootSpan.trace.costSummary?.total?.cost != null && (
-            <TraceTokenCosts
-              totalCost={rootSpan.trace.costSummary.total.cost}
-              nodeId={rootSpan.trace.id}
+    <>
+      <Flex
+        direction="row"
+        justifyContent="space-between"
+        alignItems="start"
+        gap="size-200"
+        width="100%"
+      >
+        <RootSpanEndTime rootSpan={rootSpan} />
+        <Flex direction="column" alignItems="end" gap="size-100" minWidth={0}>
+          <Flex
+            direction="row"
+            justifyContent="end"
+            alignItems="center"
+            gap="size-100"
+            wrap
+            css={outputMetadataMutedCSS}
+          >
+            <SpanCumulativeTokenCount
+              tokenCountTotal={rootSpan.cumulativeTokenCountTotal || 0}
+              nodeId={rootSpan.id}
             />
-          )}
-          {rootSpan.latencyMs != null ? (
-            <LatencyText latencyMs={rootSpan.latencyMs} />
-          ) : null}
+            {rootSpan.trace.costSummary?.total?.cost != null && (
+              <TraceTokenCosts
+                totalCost={rootSpan.trace.costSummary.total.cost}
+                nodeId={rootSpan.trace.id}
+              />
+            )}
+            {rootSpan.latencyMs != null ? (
+              <LatencyText latencyMs={rootSpan.latencyMs} />
+            ) : null}
+          </Flex>
+          <span>
+            <EditSpanAnnotationsButton
+              size="S"
+              spanNodeId={rootSpan.id}
+              projectId={rootSpan.project.id}
+              buttonText="Annotate"
+            />
+          </span>
         </Flex>
-        <span>
-          <EditSpanAnnotationsButton
-            size="S"
-            spanNodeId={rootSpan.id}
-            projectId={rootSpan.project.id}
-            buttonText="Annotate"
-          />
-        </span>
+      </Flex>
+      <div
+        css={css`
+          align-self: start;
+        `}
+      >
         <AnnotationSummaryGroupTokens
           span={rootSpan}
           renderEmptyState={() => null}
         />
-      </Flex>
-    </Flex>
+      </div>
+    </>
   );
 }
 

--- a/app/src/pages/trace/__generated__/SessionDetailsTraceListQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsTraceListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<de1b9fef1c78275cf587a5e96be0a898>>
+ * @generated SignedSource<<6bfa0b657830633a2c24248664a3de3f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -405,6 +405,13 @@ return {
                                 "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
+                                "name": "endTime",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
                                 "name": "spanId",
                                 "storageKey": null
                               },
@@ -577,12 +584,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9f82284161ce916a8334bfbe7eea414a",
+    "cacheID": "daf04dc452b4e0aa030364a9e7c4e319",
     "id": null,
     "metadata": {},
     "name": "SessionDetailsTraceListQuery",
     "operationKind": "query",
-    "text": "query SessionDetailsTraceListQuery(\n  $id: ID!\n  $first: Int!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      ...SessionDetailsTraceList_traces_3ASum4\n    }\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_3ASum4 on ProjectSession {\n  numTraces\n  traces(first: $first) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          trace {\n            id\n            costSummary {\n              total {\n                cost\n              }\n            }\n          }\n          id\n          name\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            truncatedValue\n            mimeType\n          }\n          output {\n            value\n            truncatedValue\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query SessionDetailsTraceListQuery(\n  $id: ID!\n  $first: Int!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      ...SessionDetailsTraceList_traces_3ASum4\n    }\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_3ASum4 on ProjectSession {\n  numTraces\n  traces(first: $first) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          trace {\n            id\n            costSummary {\n              total {\n                cost\n              }\n            }\n          }\n          id\n          name\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            truncatedValue\n            mimeType\n          }\n          output {\n            value\n            truncatedValue\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          latencyMs\n          startTime\n          endTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/app/src/pages/trace/__generated__/SessionDetailsTraceListRefetchQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsTraceListRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<236de2b9fab524db77027c1051be9a04>>
+ * @generated SignedSource<<72f05dd847bebe4031ccd792b3e7eb04>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -405,6 +405,13 @@ return {
                                 "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
+                                "name": "endTime",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
                                 "name": "spanId",
                                 "storageKey": null
                               },
@@ -577,16 +584,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "86ce0cadcd8157074d1732fd836ebadf",
+    "cacheID": "a798c61231216cf1922ed16a375c0fcf",
     "id": null,
     "metadata": {},
     "name": "SessionDetailsTraceListRefetchQuery",
     "operationKind": "query",
-    "text": "query SessionDetailsTraceListRefetchQuery(\n  $after: String = null\n  $first: Int = 50\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionDetailsTraceList_traces_2HEEH6\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_2HEEH6 on ProjectSession {\n  numTraces\n  traces(first: $first, after: $after) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          trace {\n            id\n            costSummary {\n              total {\n                cost\n              }\n            }\n          }\n          id\n          name\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            truncatedValue\n            mimeType\n          }\n          output {\n            value\n            truncatedValue\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query SessionDetailsTraceListRefetchQuery(\n  $after: String = null\n  $first: Int = 50\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionDetailsTraceList_traces_2HEEH6\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_2HEEH6 on ProjectSession {\n  numTraces\n  traces(first: $first, after: $after) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          trace {\n            id\n            costSummary {\n              total {\n                cost\n              }\n            }\n          }\n          id\n          name\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            truncatedValue\n            mimeType\n          }\n          output {\n            value\n            truncatedValue\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          latencyMs\n          startTime\n          endTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "78d860d4c19b7111632899f55e7da5fc";
+(node as any).hash = "c465f9a1ea6cf2748901dbc8583c4a17";
 
 export default node;

--- a/app/src/pages/trace/__generated__/SessionDetailsTraceList_traces.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsTraceList_traces.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<34f653fb4eae908a5000f3e5a49cac71>>
+ * @generated SignedSource<<b2251451b1d896ce98e2932fc46b6802>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,6 +21,7 @@ export type SessionDetailsTraceList_traces$data = {
         readonly rootSpan: {
           readonly attributes: string;
           readonly cumulativeTokenCountTotal: number | null;
+          readonly endTime: string | null;
           readonly id: string;
           readonly input: {
             readonly mimeType: MimeType;
@@ -300,6 +301,13 @@ return {
                       "alias": null,
                       "args": null,
                       "kind": "ScalarField",
+                      "name": "endTime",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
                       "name": "spanId",
                       "storageKey": null
                     },
@@ -377,6 +385,6 @@ return {
 };
 })();
 
-(node as any).hash = "78d860d4c19b7111632899f55e7da5fc";
+(node as any).hash = "c465f9a1ea6cf2748901dbc8583c4a17";
 
 export default node;


### PR DESCRIPTION
## Summary
- move session turn output end time below the output message on the left
- right-align output metrics and place the Annotate action beneath them
- include root span endTime in the session turn Relay fragment

<img width="768" height="387" alt="image" src="https://github.com/user-attachments/assets/d4afbdb2-55e8-4e37-bdbb-21e6f3312c32" />


## Testing
- make relay-build
- make typecheck-frontend
- Playwright smoke test against local session details view

Related issue: N/A