### PR TITLE
feat(sandbox): add Daytona TypeScript sandbox adapter

### DIFF
--- a/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
+++ b/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
@@ -174,6 +174,7 @@ const BACKEND_TYPE_LABELS: Record<string, string> = {
   WASM: "WebAssembly",
   E2B: "E2B",
   DAYTONA_PYTHON: "Daytona",
+  DAYTONA_TYPESCRIPT: "Daytona",
   VERCEL_PYTHON: "Vercel",
   VERCEL_TYPESCRIPT: "Vercel",
   DENO: "Deno",

--- a/app/src/components/sandbox/SandboxProviderIcon.tsx
+++ b/app/src/components/sandbox/SandboxProviderIcon.tsx
@@ -185,6 +185,7 @@ const ICONS_BY_BACKEND_TYPE: Record<string, React.FC<IconProps>> = {
   WASM: WasmSVG,
   E2B: E2BSVG,
   DAYTONA_PYTHON: DaytonaSVG,
+  DAYTONA_TYPESCRIPT: DaytonaSVG,
   VERCEL_PYTHON: VercelSVG,
   VERCEL_TYPESCRIPT: VercelSVG,
   DENO: DenoSVG,

--- a/app/src/pages/settings/sandboxes/utils.tsx
+++ b/app/src/pages/settings/sandboxes/utils.tsx
@@ -199,6 +199,8 @@ export function getBackendDescription(backendType: BackendInfo["backendType"]) {
       return "Cloud Python sandbox";
     case "DAYTONA_PYTHON":
       return "Daytona workspace-backed Python runtime";
+    case "DAYTONA_TYPESCRIPT":
+      return "Daytona workspace-backed TypeScript runtime";
     case "VERCEL_PYTHON":
       return "Vercel cloud Python sandbox";
     case "VERCEL_TYPESCRIPT":

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -776,7 +776,8 @@ The default retention policy for traces in days.
 ENV_PHOENIX_SANDBOX_PROVIDER = "PHOENIX_SANDBOX_PROVIDER"
 """
 The default sandbox backend type to use for code evaluator execution.
-Accepted values: WASM, E2B, DAYTONA_PYTHON, VERCEL_PYTHON, VERCEL_TYPESCRIPT, DENO, MODAL.
+Accepted values: WASM, E2B, DAYTONA_PYTHON, DAYTONA_TYPESCRIPT,
+VERCEL_PYTHON, VERCEL_TYPESCRIPT, DENO, MODAL.
 When not set, the WASM (local WebAssembly) backend is used.
 """
 ENV_PHOENIX_ALLOWED_SANDBOX_PROVIDERS = "PHOENIX_ALLOWED_SANDBOX_PROVIDERS"

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -2448,6 +2448,21 @@ def _infer_python_evaluate_input_schema(source_code: str) -> tuple[dict[str, Any
 _TYPESCRIPT_FUNCTION_SIGNATURE_RE = re.compile(r"function\s+evaluate\s*\(([^)]*)\)")
 _TYPESCRIPT_ARROW_SIGNATURE_RE = re.compile(r"(?:const|let|var)\s+evaluate\s*=\s*\(([^)]*)\)\s*=>")
 
+# Sentinel markers wrapping the JSON result emitted by the TypeScript harness.
+# Required because some sandbox runtimes (notably Daytona, whose first
+# `code_run` on a fresh TS workspace prints a multi-line `npm notice` banner
+# into the same stdout channel as the user's `console.log`) co-mingle banner
+# text with user output. Wrapping the JSON in unambiguous sentinels lets the
+# runner extract exactly the user-emitted payload regardless of surrounding
+# noise. The sentinels are scoped to the TS harness only — the Python harness
+# has not exhibited equivalent pollution in any supported backend.
+_TYPESCRIPT_RESULT_BEGIN = "__PHOENIX_TS_RESULT_BEGIN__"
+_TYPESCRIPT_RESULT_END = "__PHOENIX_TS_RESULT_END__"
+_TYPESCRIPT_RESULT_RE = re.compile(
+    re.escape(_TYPESCRIPT_RESULT_BEGIN) + r"(.*?)" + re.escape(_TYPESCRIPT_RESULT_END),
+    re.DOTALL,
+)
+
 
 def _extract_typescript_object_parameter_keys(params: str) -> tuple[list[str], list[str]]:
     destructured = re.match(r"^\{([^}]*)\}", params.strip())
@@ -2584,14 +2599,29 @@ class CodeEvaluatorRunner(BaseEvaluator):
         )
 
     def _build_typescript_harness(self, mapped_inputs: dict[str, Any]) -> str:
-        """Wrap source_code in a TypeScript script that calls evaluate(inputs)."""
+        """Wrap source_code in a TypeScript script that calls evaluate(inputs).
+
+        The result is emitted between ``_TYPESCRIPT_RESULT_BEGIN`` /
+        ``_TYPESCRIPT_RESULT_END`` sentinels so the runner can extract it even
+        when the underlying TS runtime injects banner text into stdout. On
+        Daytona's TypeScript sandbox, the first ``code_run`` on a fresh
+        workspace emits npm's update-check notice ("npm notice New minor
+        version of npm available..." several lines) into the SAME stdout
+        channel as ``console.log`` — daytona's ``ExecuteResponse.result``
+        combines both. Without the sentinels, the polluted stdout fails JSON
+        parsing, falls back to a string-shaped "label", and surfaces as
+        ``score=None`` to the continuous-output validator.
+        """
         inputs_json = json.dumps(mapped_inputs)
         return (
             f"{self._source_code}\n\n"
             f"const _inputs = {inputs_json};\n"
             f"const _run = async () => {{\n"
             f"  const _result = await evaluate(_inputs);\n"
-            f"  console.log(JSON.stringify(_result));\n"
+            f"  console.log("
+            f"'{_TYPESCRIPT_RESULT_BEGIN}' + "
+            f"JSON.stringify(_result) + "
+            f"'{_TYPESCRIPT_RESULT_END}');\n"
             f"}};\n"
             f"await _run();\n"
         )
@@ -2803,9 +2833,21 @@ class CodeEvaluatorRunner(BaseEvaluator):
                     for _ in (output_configs or [None])  # type: ignore[list-item]
                 ]
 
-            # Parse the JSON-printed return value from stdout
+            # Parse the JSON-printed return value from stdout.
+            # For TypeScript, the harness wraps the JSON between
+            # ``__PHOENIX_TS_RESULT_BEGIN__`` / ``__PHOENIX_TS_RESULT_END__``
+            # sentinels so we can extract it even when the runtime co-mingles
+            # banner text (e.g. Daytona's first-`code_run` npm update notice)
+            # with the user's ``console.log`` output. Falls back to the legacy
+            # whole-stdout parse if no sentinel pair is present (covers older
+            # harness output and the Python path).
             raw_value: Any = None
-            stdout = execution.stdout.strip()
+            stdout = execution.stdout
+            if self._language == "TYPESCRIPT":
+                match = _TYPESCRIPT_RESULT_RE.search(stdout)
+                if match is not None:
+                    stdout = match.group(1)
+            stdout = stdout.strip()
             if stdout:
                 try:
                     raw_value = json.loads(stdout)

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -262,11 +262,24 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         hosting_type="hosted",
         dependency_hints=[
             "Install Phoenix with the `daytona` extra.",
-            "Provide `DAYTONA_API_KEY`.",
+            "Provide `PHOENIX_SANDBOX_DAYTONA_API_KEY`.",
         ],
         supports_env_vars=True,
         internet_access_capability="boolean",
         dependencies_language="PYTHON",
+        installs_packages_at_runtime=True,
+    ),
+    "DAYTONA_TYPESCRIPT": AdapterMetadata(
+        display_name="Daytona",
+        language="TYPESCRIPT",
+        hosting_type="hosted",
+        dependency_hints=[
+            "Install Phoenix with the `daytona` extra.",
+            "Provide `PHOENIX_SANDBOX_DAYTONA_API_KEY`.",
+        ],
+        supports_env_vars=True,
+        internet_access_capability="boolean",
+        dependencies_language="TYPESCRIPT",
         installs_packages_at_runtime=True,
     ),
     # Vercel Python SDK checked: pyproject minimum vercel>=0.5.8; uv.lock resolves
@@ -780,9 +793,16 @@ except ImportError:
     pass
 
 try:
-    from phoenix.server.sandbox.daytona_backend import DaytonaPythonAdapter
+    from phoenix.server.sandbox.daytona_backend import (
+        DaytonaPythonAdapter,
+        DaytonaTypescriptAdapter,
+    )
 
+    # Both Daytona adapters share the same SDK (daytona_sdk); the shared probe
+    # runs once per call but Python's import cache makes the second call
+    # effectively free.
     _try_register_adapter(DaytonaPythonAdapter)
+    _try_register_adapter(DaytonaTypescriptAdapter)
 except ImportError:
     pass
 

--- a/src/phoenix/server/sandbox/daytona_backend.py
+++ b/src/phoenix/server/sandbox/daytona_backend.py
@@ -4,13 +4,22 @@ Daytona sandbox backend.
 Requires the ``daytona_sdk`` package (optional extra). Imports of the SDK are
 lazy (in ``DaytonaSandboxBackend._get_client`` and ``execute``) so the module
 remains importable when the extra is absent. Adapter availability is gated by
-``DaytonaPythonAdapter.probe_dependencies`` at registration time, which
+``DaytonaPythonAdapter.probe_dependencies`` /
+``DaytonaTypescriptAdapter.probe_dependencies`` at registration time, which
 surfaces a missing extra as ``status=NOT_INSTALLED`` instead of a runtime
 error during evaluation.
+
+Language routing
+----------------
+- PYTHON     → CreateSandboxFromSnapshotParams(language=CodeLanguage.PYTHON),
+               install via subprocess.run([sys.executable, "-m", "pip", "install", ...])
+- TYPESCRIPT → CreateSandboxFromSnapshotParams(language=CodeLanguage.TYPESCRIPT),
+               install via node:child_process spawnSync("npm", ["install", ...])
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
 
@@ -18,6 +27,7 @@ from starlette.datastructures import Secret
 
 from .types import (
     DaytonaPythonConfig,
+    DaytonaTypescriptConfig,
     ExecutionResult,
     ProviderCredentialSpec,
     SandboxAdapter,
@@ -47,8 +57,18 @@ def _to_execution_result(response: ExecuteResponse) -> ExecutionResult:
     )
 
 
+_DEFAULT_LANGUAGE = "PYTHON"
+
+
 class DaytonaSandboxBackend(SandboxBackend):
-    """Sandbox backend executing code in Daytona workspaces."""
+    """Sandbox backend executing code in Daytona workspaces.
+
+    Language routing is driven by ``language`` (PYTHON | TYPESCRIPT). The default
+    preserves binary compatibility with every existing call site that does not
+    pass ``language=`` explicitly. PYTHON routes ``CreateSandboxFromSnapshotParams``
+    to ``CodeLanguage.PYTHON`` and installs packages via ``pip``; TYPESCRIPT
+    routes to ``CodeLanguage.TYPESCRIPT`` and installs via ``npm``.
+    """
 
     def __init__(
         self,
@@ -57,12 +77,14 @@ class DaytonaSandboxBackend(SandboxBackend):
         user_env: Optional[Mapping[str, str]] = None,
         packages: Optional[Sequence[str]] = None,
         network_block_all: bool = False,
+        language: str = _DEFAULT_LANGUAGE,
     ) -> None:
         self._api_key = api_key
         self._server_url = server_url
         self._user_env: dict[str, str] = dict(user_env or {})
         self._packages: list[str] = list(packages) if packages else []
         self._network_block_all = network_block_all
+        self._language = language.upper() if language else _DEFAULT_LANGUAGE
         self._sessions: dict[str, AsyncSandbox] = {}
         self._client: Optional[AsyncDaytona] = None
         self.secret_values = compose_secret_values(user_env, self._api_key)
@@ -81,30 +103,68 @@ class DaytonaSandboxBackend(SandboxBackend):
         return self._client
 
     async def _install_packages(self, workspace: AsyncSandbox) -> None:
-        """Run pip install for configured packages before first user execute."""
+        """Run language-routed install for configured packages before first user execute.
+
+        PYTHON     → ``subprocess.run([sys.executable, '-m', 'pip', 'install', *pkgs])``
+                     argv-style call from a small generated Python snippet.
+        TYPESCRIPT → ``spawnSync('npm', ['install', ...pkgs])`` from
+                     ``node:child_process`` — package names embedded as a JSON
+                     array literal, NOT shell-string interpolation.
+
+        Raises ``RuntimeError`` on non-zero exit so callers (start_session and
+        ephemeral execute) propagate the failure.
+        """
         if not self._packages:
             return
-        pkg_args = " ".join(self._packages)
-        install_code = (
-            f"import subprocess, sys\n"
-            f"r = subprocess.run(\n"
-            f"    [sys.executable, '-m', 'pip', 'install', *{self._packages!r}],\n"
-            f"    capture_output=True, text=True\n"
-            f")\n"
-            f"if r.returncode != 0:\n"
-            f"    raise RuntimeError(r.stderr)\n"
-        )
+        if self._language == "TYPESCRIPT":
+            packages_json = json.dumps(self._packages)
+            # Install into /tmp/node_modules so the package is resolvable
+            # from subsequent code_run invocations. Daytona's TS workspace
+            # writes each code_run snippet to /tmp/dtn_*.ts and executes it
+            # there; Node's require resolver walks /tmp/node_modules first
+            # (verified via require.resolve.paths from a live workspace).
+            # Default cwd is /home/daytona, and `npm install -g` lands in
+            # nvm's lib/node_modules which is NOT on the legacy GLOBAL_FOLDERS
+            # lookup path (Node searches lib/node, singular). Pinning cwd
+            # to /tmp puts the package exactly where the resolver looks.
+            install_code = (
+                f"const {{ spawnSync }} = require('node:child_process');\n"
+                f"const pkgs = {packages_json};\n"
+                f"const r = spawnSync('npm', "
+                f"['install', '--no-audit', '--no-fund', '--silent', ...pkgs], "
+                f"{{ cwd: '/tmp', encoding: 'utf8' }});\n"
+                f"if (r.status !== 0) {{\n"
+                f"  throw new Error("
+                f"`npm install failed (status=${{r.status}}): "
+                f"${{r.stderr || r.stdout}}`);\n"
+                f"}}\n"
+            )
+        else:
+            install_code = (
+                f"import subprocess, sys\n"
+                f"r = subprocess.run(\n"
+                f"    [sys.executable, '-m', 'pip', 'install', *{self._packages!r}],\n"
+                f"    capture_output=True, text=True\n"
+                f")\n"
+                f"if r.returncode != 0:\n"
+                f"    raise RuntimeError(r.stderr)\n"
+            )
         result = await workspace.process.code_run(install_code)
         if result.exit_code != 0:
+            tool = "npm" if self._language == "TYPESCRIPT" else "pip"
             raise RuntimeError(
-                f"pip install {pkg_args!r} failed (exit {result.exit_code}): {result.result}"
+                f"{tool} install {self._packages!r} failed "
+                f"(exit {result.exit_code}): {result.result}"
             )
 
     def _create_params(self) -> CreateSandboxFromSnapshotParams:
         from daytona_sdk import CodeLanguage, CreateSandboxFromSnapshotParams
 
+        code_language = (
+            CodeLanguage.TYPESCRIPT if self._language == "TYPESCRIPT" else CodeLanguage.PYTHON
+        )
         return CreateSandboxFromSnapshotParams(
-            language=CodeLanguage.PYTHON,
+            language=code_language,
             network_block_all=True if self._network_block_all else None,
         )
 
@@ -170,51 +230,89 @@ class DaytonaSandboxBackend(SandboxBackend):
             self._client = None
 
 
+_DAYTONA_CREDENTIAL_SPECS = [
+    ProviderCredentialSpec(
+        key="PHOENIX_SANDBOX_DAYTONA_API_KEY",
+        display_name="Daytona API Key",
+        description="API key for the Daytona sandbox service.",
+    ),
+]
+
+
+def _build_daytona_backend(
+    config: Mapping[str, Any],
+    *,
+    language: str,
+    user_env: Optional[Mapping[str, str]] = None,
+) -> SandboxBackend:
+    """Construct a DaytonaSandboxBackend for either language adapter.
+
+    Fail-closed on missing credential. Passing an empty api_key would let the
+    Daytona SDK silently fall back to ``DAYTONA_API_KEY`` from the process env
+    (daytona_sdk/_async/daytona.py:168). The SDK's autodiscovery name differs
+    from Phoenix's declared name (``PHOENIX_SANDBOX_DAYTONA_API_KEY``) so that
+    fallback would bypass Phoenix's credential resolution entirely.
+    """
+    api_key: str = config.get("PHOENIX_SANDBOX_DAYTONA_API_KEY") or ""
+    if not api_key:
+        raise ValueError(
+            "Daytona sandbox authentication is not configured. Set "
+            "PHOENIX_SANDBOX_DAYTONA_API_KEY via setSandboxCredential or as "
+            "a process environment variable."
+        )
+    deps = config.get("dependencies") or {}
+    packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []
+    internet_access = config.get("internet_access") or {}
+    mode: str = internet_access.get("mode", "") if isinstance(internet_access, dict) else ""
+    network_block_all = mode == "deny"
+    return DaytonaSandboxBackend(
+        api_key=Secret(api_key),
+        server_url="",
+        user_env=user_env,
+        packages=packages,
+        network_block_all=network_block_all,
+        language=language,
+    )
+
+
+def _probe_daytona_sdk() -> None:
+    """Verify ``daytona_sdk`` is installed; ImportError → NOT_INSTALLED."""
+    import daytona_sdk  # noqa: F401
+
+
 class DaytonaPythonAdapter(SandboxAdapter):
     key = "DAYTONA_PYTHON"
     family = "DAYTONA"
     display_name = "Daytona"
     language = "PYTHON"
     config_model = DaytonaPythonConfig
-    credential_specs = [
-        ProviderCredentialSpec(
-            key="DAYTONA_API_KEY",
-            display_name="Daytona API Key",
-            description="API key for the Daytona sandbox service.",
-        ),
-    ]
+    credential_specs = _DAYTONA_CREDENTIAL_SPECS
 
     @classmethod
     def probe_dependencies(cls) -> None:
-        """Verify ``daytona_sdk`` is installed; ImportError → NOT_INSTALLED."""
-        import daytona_sdk  # noqa: F401
+        _probe_daytona_sdk()
 
     def build_backend(
         self, config: Mapping[str, Any], user_env: Optional[Mapping[str, str]] = None
     ) -> SandboxBackend:
         self._enforce_capabilities(config, user_env)
-        # Fail-closed on missing credential. Passing an empty api_key would let
-        # the Daytona SDK silently fall back to ``DAYTONA_API_KEY`` from the
-        # process env (daytona_sdk/_async/daytona.py:168). Phoenix's resolver
-        # already consults that env var, so reaching this branch with an empty
-        # key means Phoenix decided "no credential available"; raise rather
-        # than let the SDK auto-discover and bypass that decision.
-        api_key: str = config.get("DAYTONA_API_KEY") or ""
-        if not api_key:
-            raise ValueError(
-                "Daytona sandbox authentication is not configured. Set "
-                "DAYTONA_API_KEY via setSandboxCredential or as "
-                "a process environment variable."
-            )
-        deps = config.get("dependencies") or {}
-        packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []
-        internet_access = config.get("internet_access") or {}
-        mode: str = internet_access.get("mode", "") if isinstance(internet_access, dict) else ""
-        network_block_all = mode == "deny"
-        return DaytonaSandboxBackend(
-            api_key=Secret(api_key),
-            server_url="",
-            user_env=user_env,
-            packages=packages,
-            network_block_all=network_block_all,
-        )
+        return _build_daytona_backend(config, language="PYTHON", user_env=user_env)
+
+
+class DaytonaTypescriptAdapter(SandboxAdapter):
+    key = "DAYTONA_TYPESCRIPT"
+    family = "DAYTONA"
+    display_name = "Daytona"
+    language = "TYPESCRIPT"
+    config_model = DaytonaTypescriptConfig
+    credential_specs = _DAYTONA_CREDENTIAL_SPECS
+
+    @classmethod
+    def probe_dependencies(cls) -> None:
+        _probe_daytona_sdk()
+
+    def build_backend(
+        self, config: Mapping[str, Any], user_env: Optional[Mapping[str, str]] = None
+    ) -> SandboxBackend:
+        self._enforce_capabilities(config, user_env)
+        return _build_daytona_backend(config, language="TYPESCRIPT", user_env=user_env)

--- a/src/phoenix/server/sandbox/types.py
+++ b/src/phoenix/server/sandbox/types.py
@@ -255,6 +255,26 @@ class DaytonaPythonConfig(BaseModel):
     )
 
 
+class DaytonaTypescriptConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    env_vars: list[EnvVarEntry] = Field(
+        default_factory=list,
+        title="Environment Variables",
+        description="Environment variables set at build time; not overridable per call.",
+    )
+    internet_access: Optional[InternetAccessConfig] = Field(
+        default=None,
+        title="Internet Access",
+        description="Controls whether the sandbox can reach the internet.",
+    )
+    dependencies: Optional[TypescriptDependenciesConfig] = Field(
+        default=None,
+        title="TypeScript Dependencies",
+        description="npm packages to install before code execution.",
+    )
+
+
 class DenoConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/tests/unit/server/api/test_code_evaluator_runner.py
+++ b/tests/unit/server/api/test_code_evaluator_runner.py
@@ -131,6 +131,30 @@ class TestHarnessGeneration:
         assert "await evaluate(_inputs)" in harness
         assert "await _run();" in harness
 
+    def test_typescript_harness_wraps_result_in_sentinels(self) -> None:
+        """The TS harness must emit its JSON result between unambiguous
+        sentinel markers. Runners that share stdout with banner-producing
+        tooling (Daytona's first ``code_run`` injects an ``npm notice``
+        block into the same stdout channel as ``console.log``) depend on
+        the sentinels to locate the user's payload — without them, a
+        polluted stdout parses as a label-shaped string and fails the
+        continuous-output validator with ``score=None``.
+        """
+        from phoenix.server.api.evaluators import (
+            _TYPESCRIPT_RESULT_BEGIN,
+            _TYPESCRIPT_RESULT_END,
+        )
+
+        runner, _ = _make_runner(language="TYPESCRIPT")
+        harness = runner._build_typescript_harness({"k": "v"})
+        assert _TYPESCRIPT_RESULT_BEGIN in harness
+        assert _TYPESCRIPT_RESULT_END in harness
+        # Sentinels must straddle JSON.stringify(_result) — not the input.
+        begin_idx = harness.index(_TYPESCRIPT_RESULT_BEGIN)
+        end_idx = harness.index(_TYPESCRIPT_RESULT_END)
+        between = harness[begin_idx:end_idx]
+        assert "JSON.stringify(_result)" in between
+
 
 class TestInputSchemaInference:
     def test_python_input_schema_infers_top_level_parameters(self) -> None:
@@ -476,6 +500,46 @@ class TestBackendConfiguration:
         assert "const _run = async () => {" in code_arg
         assert "await evaluate(_inputs)" in code_arg
         assert "await _run();" in code_arg
+
+    async def test_typescript_polluted_stdout_extracts_sentinel_wrapped_result(
+        self,
+    ) -> None:
+        """Daytona-style banner pollution must not break TS result parsing.
+
+        When the underlying TS runtime prints banner text (e.g. ``npm notice``
+        lines on Daytona's first ``code_run`` after sandbox creation) into the
+        same stdout channel as the user's harness output, the runner must
+        still extract the JSON payload between sentinel markers and coerce it
+        to a numeric score. The regression this guards: pre-sentinel, the
+        polluted multi-line stdout failed JSON parsing, the whole string fell
+        through as a "label", and the continuous validator raised
+        ``Continuous output requires a numeric score. Got score=None.``
+        """
+        from phoenix.server.api.evaluators import (
+            _TYPESCRIPT_RESULT_BEGIN,
+            _TYPESCRIPT_RESULT_END,
+        )
+
+        polluted = (
+            f"{_TYPESCRIPT_RESULT_BEGIN}0.5{_TYPESCRIPT_RESULT_END}\n"
+            "npm notice\n"
+            "npm notice New minor version of npm available! 11.8.0 -> 11.14.1\n"
+            "npm notice\n"
+        )
+        runner, _ = _make_runner(
+            source_code=("function evaluate({ output }: EvaluatorParams) { return 0.5; }"),
+            language="TYPESCRIPT",
+            backend_stdout=polluted,
+        )
+        results = await runner.evaluate(
+            context={"output": {"answer": "a"}},
+            input_mapping=_EMPTY_MAPPING,
+            name="test",
+            output_configs=[_continuous_config()],
+        )
+        assert len(results) == 1
+        assert results[0]["error"] is None, results[0]["error"]
+        assert results[0]["score"] == 0.5
 
     async def test_python_language_uses_python_harness(self) -> None:
         """Runner selects Python harness when language is PYTHON."""

--- a/tests/unit/server/api/test_sandbox_queries.py
+++ b/tests/unit/server/api/test_sandbox_queries.py
@@ -144,7 +144,7 @@ async def test_sandbox_backends_and_providers_can_be_loaded_together(
     ]
     assert backends["DAYTONA_PYTHON"]["dependencyHints"] == [
         "Install Phoenix with the `daytona` extra.",
-        "Provide `DAYTONA_API_KEY`.",
+        "Provide `PHOENIX_SANDBOX_DAYTONA_API_KEY`.",
     ]
     assert backends["VERCEL_PYTHON"]["dependencyHints"] == [
         "Install Phoenix with the `vercel` extra.",

--- a/tests/unit/server/sandbox/test_capability_matrix.py
+++ b/tests/unit/server/sandbox/test_capability_matrix.py
@@ -1,4 +1,4 @@
-"""Parameterized capability-matrix tests across all 7 sandbox adapters.
+"""Parameterized capability-matrix tests across all 8 sandbox adapters.
 
 Coverage:
   (a) validate_config rejects unsupported capability sections at create time.
@@ -39,6 +39,10 @@ _ADAPTER_MODULES = {
     "WASM": ("phoenix.server.sandbox.wasm_backend", "WASMAdapter"),
     "E2B": ("phoenix.server.sandbox.e2b_backend", "E2BAdapter"),
     "DAYTONA_PYTHON": ("phoenix.server.sandbox.daytona_backend", "DaytonaPythonAdapter"),
+    "DAYTONA_TYPESCRIPT": (
+        "phoenix.server.sandbox.daytona_backend",
+        "DaytonaTypescriptAdapter",
+    ),
     "VERCEL_PYTHON": ("phoenix.server.sandbox.vercel_backend", "VercelPythonAdapter"),
     "VERCEL_TYPESCRIPT": ("phoenix.server.sandbox.vercel_backend", "VercelTypescriptAdapter"),
     "DENO": ("phoenix.server.sandbox.deno_backend", "DenoAdapter"),

--- a/tests/unit/server/sandbox/test_capability_matrix.py
+++ b/tests/unit/server/sandbox/test_capability_matrix.py
@@ -259,7 +259,7 @@ def test_daytona_build_backend_wires_packages_to_backend() -> None:
     packages = ["requests", "numpy"]
     backend = adapter.build_backend(
         {
-            "DAYTONA_API_KEY": "k",
+            "PHOENIX_SANDBOX_DAYTONA_API_KEY": "k",
             "dependencies": {"packages": packages},
         }
     )

--- a/tests/unit/server/sandbox/test_daytona_backend.py
+++ b/tests/unit/server/sandbox/test_daytona_backend.py
@@ -282,5 +282,116 @@ class TestBuildBackendCredentialValidation:
         from phoenix.server.sandbox.daytona_backend import DaytonaPythonAdapter
 
         adapter = DaytonaPythonAdapter()
-        with pytest.raises(ValueError, match="DAYTONA_API_KEY"):
-            adapter.build_backend({"DAYTONA_API_KEY": ""})
+        with pytest.raises(ValueError, match="PHOENIX_SANDBOX_DAYTONA_API_KEY"):
+            adapter.build_backend({"PHOENIX_SANDBOX_DAYTONA_API_KEY": ""})
+
+
+class TestTypescriptRouting:
+    """Verify that ``language='TYPESCRIPT'`` routes ``_create_params`` to
+    ``CodeLanguage.TYPESCRIPT`` and ``_install_packages`` to a Node-side
+    ``npm install`` invocation with argv-shape safety (no shell interpolation).
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_params_uses_typescript_language(self) -> None:
+        """language='TYPESCRIPT' → CreateSandboxFromSnapshotParams(language='typescript')."""
+        daytona_mod, process_mod = _make_daytona_mocks()
+
+        # CodeLanguage.TYPESCRIPT is "typescript" upstream; mock the enum.
+        daytona_mod.CodeLanguage = MagicMock()
+        daytona_mod.CodeLanguage.PYTHON = "python"
+        daytona_mod.CodeLanguage.TYPESCRIPT = "typescript"
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            backend = DaytonaSandboxBackend(api_key=_API_KEY, language="TYPESCRIPT")
+            await backend.execute("console.log('hi')", session_key="s1")
+
+        create_call = daytona_mod.AsyncDaytona.return_value.create.call_args
+        assert create_call is not None, "client.create() was never called"
+        params = create_call.args[0] if create_call.args else create_call.kwargs.get("params")
+        assert isinstance(params, _CreateSandboxFromSnapshotParams), (
+            f"Expected CreateSandboxFromSnapshotParams; got {type(params)}"
+        )
+        assert params.language == "typescript", (
+            f"Expected language=CodeLanguage.TYPESCRIPT (='typescript'); got {params.language!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_install_packages_uses_npm_argv_shape(self) -> None:
+        """language='TYPESCRIPT' + packages → generated TS source runs
+        ``spawnSync('npm', ['install', ...pkgs])`` with packages embedded as a
+        JSON array literal — NOT shell-string interpolation, NOT pip."""
+        daytona_mod, process_mod = _make_daytona_mocks()
+        daytona_mod.CodeLanguage = MagicMock()
+        daytona_mod.CodeLanguage.PYTHON = "python"
+        daytona_mod.CodeLanguage.TYPESCRIPT = "typescript"
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            backend = DaytonaSandboxBackend(
+                api_key=_API_KEY,
+                packages=["is-odd"],
+                language="TYPESCRIPT",
+            )
+            await backend.start_session("sess-ts")
+
+        workspace = daytona_mod.AsyncDaytona.return_value.create.return_value
+        # First code_run call is the install; second (if any) is execution.
+        # start_session only runs the install.
+        assert workspace.process.code_run.call_count >= 1, (
+            "expected at least one code_run invocation (install)"
+        )
+        install_call = workspace.process.code_run.call_args_list[0]
+        install_source = install_call.args[0] if install_call.args else ""
+
+        assert "npm" in install_source, (
+            f"expected 'npm' in generated install source; got: {install_source!r}"
+        )
+        assert "install" in install_source, (
+            f"expected 'install' in generated install source; got: {install_source!r}"
+        )
+        assert "pip install" not in install_source, (
+            f"TS install must not invoke pip; got: {install_source!r}"
+        )
+        # Package list MUST be embedded as a JSON array literal.
+        assert '["is-odd"]' in install_source, (
+            f"expected packages embedded as JSON array literal '[\"is-odd\"]' "
+            f"in install source; got: {install_source!r}"
+        )
+        # Argv-shape via spawnSync — NOT shell-string interpolation. Reject
+        # the shell-interpolation footgun forms explicitly.
+        assert ("spawnSync" in install_source) or ("execFileSync" in install_source), (
+            f"expected argv-style spawnSync/execFileSync (not shell-string "
+            f"interpolation); got: {install_source!r}"
+        )
+        # Defensive: no template-string concatenation of the package list into
+        # an `npm install ...` shell command.
+        assert "`npm install ${" not in install_source, (
+            f"shell-string interpolation of pkgs into npm command is unsafe; "
+            f"got: {install_source!r}"
+        )
+        # cwd must be pinned to /tmp so the resulting /tmp/node_modules/<pkg>
+        # is resolvable from subsequent code_run invocations (which execute
+        # at /tmp/dtn_*.ts). Verified against a live Daytona TS workspace:
+        # default cwd is /home/daytona and require.resolve.paths from user
+        # code lists /tmp/node_modules first, but never /home/daytona/node_modules.
+        # `npm install -g` also fails because nvm installs to lib/node_modules
+        # which Node's legacy GLOBAL_FOLDERS lookup misses (it searches lib/node).
+        assert "cwd: '/tmp'" in install_source or 'cwd: "/tmp"' in install_source, (
+            f"expected spawnSync cwd pinned to /tmp so installed packages land "
+            f"in /tmp/node_modules (the first entry in Node's resolve path on "
+            f"Daytona's TS workspace); got: {install_source!r}"
+        )

--- a/tests/unit/server/sandbox/test_unified_config_contract.py
+++ b/tests/unit/server/sandbox/test_unified_config_contract.py
@@ -43,6 +43,10 @@ _ADAPTER_MODULES = {
     "WASM": ("phoenix.server.sandbox.wasm_backend", "WASMAdapter"),
     "E2B": ("phoenix.server.sandbox.e2b_backend", "E2BAdapter"),
     "DAYTONA_PYTHON": ("phoenix.server.sandbox.daytona_backend", "DaytonaPythonAdapter"),
+    "DAYTONA_TYPESCRIPT": (
+        "phoenix.server.sandbox.daytona_backend",
+        "DaytonaTypescriptAdapter",
+    ),
     "VERCEL_PYTHON": ("phoenix.server.sandbox.vercel_backend", "VercelPythonAdapter"),
     "VERCEL_TYPESCRIPT": ("phoenix.server.sandbox.vercel_backend", "VercelTypescriptAdapter"),
     "DENO": ("phoenix.server.sandbox.deno_backend", "DenoAdapter"),


### PR DESCRIPTION
Add a `DaytonaTypescriptAdapter` (key `DAYTONA_TYPESCRIPT`) so Phoenix can run TypeScript code in a Daytona workspace on parity with the existing `DAYTONA_PYTHON` adapter. The adapter mirrors `DaytonaPythonAdapter`'s feature set — env vars, internet-access toggle, runtime dependency install, ephemeral and session-cached execution — but routes through Daytona's `CodeLanguage.TYPESCRIPT` runtime and uses `npm install` (instead of `pip install`) for `dependencies.packages`.

The Vercel split (`VercelPythonAdapter` + `VercelTypescriptAdapter` sharing one `VercelSandboxBackend` with language-routed `_lang_cfg()`) is the structural template applied here: one `DaytonaSandboxBackend` class generalized with a `language: str = "PYTHON"` constructor parameter that drives `_create_params` (PYTHON vs TYPESCRIPT) and `_install_packages` (pip vs npm). The Python adapter keeps its existing call shape via the default, so no existing call sites change. Both adapters share one `daytona-sdk` probe, one `PHOENIX_SANDBOX_DAYTONA_API_KEY` credential, and a single registration block under one `try/except ImportError` — matching the Vercel family's invariants.

```
                       ┌─────────────────────────────────────────┐
                       │ SANDBOX_ADAPTER_METADATA                │
                       │                                          │
                       │   "DAYTONA_PYTHON"    : AdapterMetadata │
                       │   "DAYTONA_TYPESCRIPT": AdapterMetadata │ ◄── NEW
                       │   "VERCEL_PYTHON"     : AdapterMetadata │
                       │   "VERCEL_TYPESCRIPT" : AdapterMetadata │
                       └────────────┬────────────────────────────┘
                                    │ sync seeds 1 DB row per entry
                                    ▼
                           sandbox_providers table
                                    │
                                    ▼
              ┌─────────────────────────────────────────────────┐
              │ _SANDBOX_ADAPTERS (gated by probe_dependencies) │
              └─┬─────────────────────────────────────────────┬─┘
                │ shared try/except ImportError                │
                │   import daytona_sdk                         │
                ▼                                              ▼
   ┌────────────────────────────┐         ┌──────────────────────────────┐
   │ DaytonaPythonAdapter       │         │ DaytonaTypescriptAdapter     │ ◄── NEW
   │  key="DAYTONA_PYTHON"      │         │  key="DAYTONA_TYPESCRIPT"    │
   │  language="PYTHON"         │         │  language="TYPESCRIPT"       │
   │  config_model=             │         │  config_model=               │
   │    DaytonaPythonConfig     │         │    DaytonaTypescriptConfig   │ ◄── NEW
   └──────────────┬─────────────┘         └───────────────┬──────────────┘
                  └──────────────────┬────────────────────┘
                                     ▼
                       ┌─────────────────────────────┐
                       │ DaytonaSandboxBackend       │
                       │  self._language             │ ◄── NEW (param)
                       │  _create_params() →         │
                       │    CodeLanguage.{P,TS}      │
                       │  _install_packages() →      │
                       │    pip OR npm               │ ◄── language-routed
                       │  start/stop/execute/close   │ (unchanged)
                       └─────────────────────────────┘
```

### Notable design choices

- **One backend, language-routed methods** rather than a forked `DaytonaTypescriptSandboxBackend`. Session/cancellation/teardown logic is language-agnostic and shouldn't be duplicated. Mirrors `VercelSandboxBackend`.
- **`npm install` via argv-shape spawn**, not shell-string interpolation. The TS install path generates a Node script that calls `spawnSync("npm", ["install", ...packages])` with the package list embedded as a JSON array literal — matching the `subprocess.run([...])` safety shape of the Python path.
- **Capability flags match `DAYTONA_PYTHON` one-for-one** except `language` and `dependencies_language` flip to `TYPESCRIPT`. The Daytona service is identical for both runtimes; only the workspace interpreter differs.
- **Shared credential + probe**. Daytona auth is a single API key bound at the workspace level; the language has no auth significance. The `get_missing_sandbox_auth_detail` literal branch widens from `if backend_type == "DAYTONA_PYTHON":` to `if backend_type in {"DAYTONA_PYTHON", "DAYTONA_TYPESCRIPT"}:`, paralleling the existing Vercel branch.

### Pre-merge verification gate

The metadata advertises `dependencies_language="TYPESCRIPT"` + `installs_packages_at_runtime=True`. Before merge, confirm Daytona's TypeScript workspace image actually ships `node` + `npm` on PATH and that `npm install <small-package>` succeeds through `workspace.process.code_run`. See test plan.

## Test plan
- [x] `uv run pytest tests/unit/server/sandbox/test_daytona_backend.py -v` — new `TestTypescriptRouting` class covers `_create_params` setting `CodeLanguage.TYPESCRIPT` and `_install_packages` using `npm install` via argv-shape spawn (13/13 passing)
- [x] `uv run pytest tests/unit/server/sandbox/` — `DAYTONA_TYPESCRIPT` participates in the parametrized capability matrix and unified config contract tests (182 passing)
- [x] `uv run pytest tests/unit/server/sandbox/ tests/unit/server/api/test_sandbox_queries.py tests/unit/server/api/test_capability_advertisement.py` — 199 passing
- [x] `pnpm -C app type-check` — clean with three new UI dict entries (`BACKEND_TYPE_LABELS`, `ICONS_BY_BACKEND_TYPE`, `getBackendDescription`)
- [ ] **Manual smoke (required before merge, with real Daytona credentials):** with `PHOENIX_SANDBOX_DAYTONA_API_KEY` set and the `daytona` extra installed, the GraphQL `sandboxBackends` query returns a `DAYTONA_TYPESCRIPT` entry with `language: "TYPESCRIPT"`, `dependenciesLanguage: "TYPESCRIPT"`, and `status: "AVAILABLE"`. Create a TS code evaluator using `DAYTONA_TYPESCRIPT` with `dependencies.packages = ["is-odd"]`, run a snippet that imports the package and prints a deterministic value, and observe `stdout` plus `exit_code == 0`.