### PR TITLE
test(sandbox): fix dialog locator flakes in e2e tests

### DIFF
--- a/app/tests/code-evaluators.spec.ts
+++ b/app/tests/code-evaluators.spec.ts
@@ -455,8 +455,7 @@ test.describe.serial("Code Evaluators", () => {
 
     const dialog = page.getByRole("dialog");
     const nameInput = dialog.getByRole("textbox", {
-      name: "Name",
-      exact: true,
+      name: /^Name(\s*\*)?$/,
     });
     await expect(nameInput).toHaveValue(pythonEvaluatorName);
 
@@ -470,9 +469,7 @@ test.describe.serial("Code Evaluators", () => {
 
     await openEvaluatorEditor(page, updatedPythonEvaluatorName);
     await expect(
-      page
-        .getByRole("dialog")
-        .getByRole("textbox", { name: "Name", exact: true })
+      page.getByRole("dialog").getByRole("textbox", { name: /^Name(\s*\*)?$/ })
     ).toHaveValue(updatedPythonEvaluatorName);
     await page
       .getByRole("dialog")
@@ -629,7 +626,7 @@ test.describe.serial("Code Evaluators", () => {
     ).toBeVisible();
 
     await dialog
-      .getByRole("textbox", { name: "Name", exact: true })
+      .getByRole("textbox", { name: /^Name(\s*\*)?$/ })
       .fill("test-no-sandbox-eval");
 
     // Sandbox is intentionally left empty.
@@ -711,7 +708,7 @@ test.describe.serial("Code Evaluators", () => {
     ).toBeVisible();
 
     await dialog
-      .getByRole("textbox", { name: "Name", exact: true })
+      .getByRole("textbox", { name: /^Name(\s*\*)?$/ })
       .fill(categoricalEvaluatorName);
 
     await selectSandbox(page, dialog, pythonSandboxName);
@@ -788,7 +785,7 @@ test.describe.serial("Code Evaluators", () => {
     ).toBeVisible();
 
     await dialog
-      .getByRole("textbox", { name: "Name", exact: true })
+      .getByRole("textbox", { name: /^Name(\s*\*)?$/ })
       .fill(placeholderCategoricalName);
 
     await selectSandbox(page, dialog, pythonSandboxName);
@@ -833,7 +830,7 @@ test.describe.serial("Code Evaluators", () => {
     ).toBeVisible();
 
     await dialog
-      .getByRole("textbox", { name: "Name", exact: true })
+      .getByRole("textbox", { name: /^Name(\s*\*)?$/ })
       .fill(placeholderDefaultsName);
 
     await selectSandbox(page, dialog, pythonSandboxName);

--- a/app/tests/code-evaluators.spec.ts
+++ b/app/tests/code-evaluators.spec.ts
@@ -205,7 +205,7 @@ async function ensureSandboxConfig(
     dialog.getByRole("button", { name: "Create Config" }).click(),
   ]);
 
-  await expect(dialog).not.toBeVisible();
+  await expect(page.getByTestId("dialog")).not.toBeVisible();
   // The same configName text appears in both the Name cell and the actions
   // cell (via the Edit/Delete button aria-labels), so anchor on the first.
   await expect(
@@ -280,7 +280,7 @@ async function createCustomCodeEvaluator({
   ).toBeVisible();
 
   await dialog
-    .getByRole("textbox", { name: "Name", exact: true })
+    .getByRole("textbox", { name: /^Name(\s*\*)?$/ })
     .fill(evaluatorName);
 
   if (description) {
@@ -346,7 +346,7 @@ async function createE2BSandboxWithLiteralEnvVar(
     dialog.getByRole("button", { name: "Create Config" }).click(),
   ]);
 
-  await expect(dialog).not.toBeVisible();
+  await expect(page.getByTestId("dialog")).not.toBeVisible();
   await expect(
     page.getByRole("cell", { name: configName }).first()
   ).toBeVisible();

--- a/app/tests/code-evaluators.spec.ts
+++ b/app/tests/code-evaluators.spec.ts
@@ -25,7 +25,7 @@ function isGraphQLMutationResponse(response: Response, operationName: string) {
  */
 function selectTrigger(scope: Page | Locator, label: string): Locator {
   return scope.getByRole("button", {
-    name: new RegExp(`\\b${escapeRegex(label)}\\s*$`),
+    name: new RegExp(`\\b${escapeRegex(label)}(?:\\s*\\*)?\\s*$`),
   });
 }
 

--- a/app/tests/settings-sandboxes.spec.ts
+++ b/app/tests/settings-sandboxes.spec.ts
@@ -80,7 +80,7 @@ test.describe("Settings Sandboxes", () => {
 
       // Close dialog
       await dialog.getByRole("button", { name: /cancel/i }).click();
-      await expect(dialog).not.toBeVisible();
+      await expect(page.getByTestId("dialog")).not.toBeVisible();
     });
 
     test("E2B provider shows env vars editor", async ({ page }) => {
@@ -122,7 +122,7 @@ test.describe("Settings Sandboxes", () => {
         dialog.getByRole("button", { name: "Create Config" }).click(),
       ]);
 
-      await expect(dialog).not.toBeVisible();
+      await expect(page.getByTestId("dialog")).not.toBeVisible();
 
       // Verify the config appears in the table. The configName text is
       // exposed in two cells of the same row — the Name cell ("<name>
@@ -168,7 +168,7 @@ test.describe("Settings Sandboxes", () => {
 
       // Close without changes
       await dialog.getByRole("button", { name: /cancel/i }).click();
-      await expect(dialog).not.toBeVisible();
+      await expect(page.getByTestId("dialog")).not.toBeVisible();
     });
   });
 });


### PR DESCRIPTION
## Summary

Unblock the Playwright job on #12459. Two distinct failure modes both come from how the e2e tests locate the sandbox dialog:

1. **Hard failure** — `Code Evaluators › can create and render a Python code evaluator` was timing out on both Firefox and Chromium at `dialog.getByRole("textbox", { name: "Name", exact: true }).fill(...)`. The most recent commit on the feature branch added `isRequired` to `<EvaluatorNameInput>`, which appends `*` to the visible label and includes it in the textbox's accessible name (`"Name *"`). The `exact: true` lookup no longer matched. Switched to `{ name: /^Name(\s*\*)?$/ }` — tolerates the asterisk and is still anchored at `^Name` so it doesn't pick up `"Annotation name"` elsewhere in the dialog.

2. **Flaky** — `Code Evaluators › can create prerequisites...` and `Settings Sandboxes › WASM provider hides...` intermittently failed the dialog-dismissal assertion with `strict mode violation: getByRole('dialog') resolved to 2 elements`. React Aria's Select popover has `role="dialog"`, so during the popover's close animation (`data-exiting="true"`), `page.getByRole("dialog")` matches both the main dialog and the popover. Switched the affected `expect(dialog).not.toBeVisible()` assertions to `page.getByTestId("dialog")`, which is unique to the actual dialog.

Same defensive switch applied to two other identical-pattern dismissal assertions that hadn't yet failed.