### PR TITLE
refactor(sandbox): Unify sandbox credential env vars

### DIFF
--- a/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
+++ b/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
@@ -88,7 +88,7 @@ pip install 'arize-phoenix[daytona]'  # Daytona
 pip install 'arize-phoenix[vercel]'   # Vercel Sandbox (Python and TypeScript)
 ```
 
-Provider credentials are configured under **Settings → Sandboxes** or via the provider-specific environment variables listed in the matrix below.
+Provider credentials are configured under **Settings → Sandboxes** or via the Phoenix sandbox environment variables listed in the matrix below.
 
 ## Compatibility matrix
 
@@ -99,7 +99,7 @@ The rows below correspond exactly to the entries in `SANDBOX_ADAPTER_METADATA`. 
 | **Deno (local)** (`DENO`) | TypeScript | Yes — `deno` bundled at `/usr/local/bin/deno` | Install Deno on `PATH` | None | In-process (subprocess) |
 | **WebAssembly (local)** (`WASM`) | Python | Yes — CPython WASM bundled at `$PHOENIX_WASM_BINARY_PATH` | `pip install 'arize-phoenix[wasm]'`; optionally set `PHOENIX_WASM_BINARY_PATH` | None | In-process (`wasmtime`) |
 | **E2B** (`E2B`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[e2b]'` | `E2B_API_KEY` | External API |
-| **Daytona** (`DAYTONA_PYTHON`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[daytona]'` | `PHOENIX_SANDBOX_DAYTONA_API_KEY` | External API |
+| **Daytona** (`DAYTONA_PYTHON`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[daytona]'` | `DAYTONA_API_KEY` | External API |
 | **Vercel Sandbox — Python** (`VERCEL_PYTHON`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[vercel]'` | `VERCEL_TOKEN` + `VERCEL_PROJECT_ID` + `VERCEL_TEAM_ID` ([auth docs](https://vercel.com/docs/vercel-sandbox/concepts/authentication)) | External API |
 | **Vercel Sandbox — TypeScript** (`VERCEL_TYPESCRIPT`) | TypeScript | Ready with credentials — SDK in container | `pip install 'arize-phoenix[vercel]'` | Same as `VERCEL_PYTHON` ([auth docs](https://vercel.com/docs/vercel-sandbox/concepts/authentication)) | External API |
 | **Modal** (`MODAL`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[modal]'` | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` | External API |
@@ -109,7 +109,7 @@ The rows below correspond exactly to the entries in `SANDBOX_ADAPTER_METADATA`. 
 </Info>
 
 <Info>
-**Where to find Vercel credentials.** `VERCEL_TOKEN` is a personal access token created at [Account Settings → Tokens](https://vercel.com/account/tokens). `VERCEL_PROJECT_ID` is the project's resource ID under Project Settings → General. `VERCEL_TEAM_ID` is the team's resource ID at `https://vercel.com/teams/<your-team>/settings#team-id`. Full provisioning steps: [Vercel Sandbox authentication](https://vercel.com/docs/vercel-sandbox/concepts/authentication).
+**Where to find Vercel credentials.** Store the personal access token as `VERCEL_TOKEN`; create it at [Account Settings → Tokens](https://vercel.com/account/tokens). Store the project's resource ID as `VERCEL_PROJECT_ID`; find it under Project Settings → General. Store the team's resource ID as `VERCEL_TEAM_ID`; find it at `https://vercel.com/teams/<your-team>/settings#team-id`. Full provisioning steps: [Vercel Sandbox authentication](https://vercel.com/docs/vercel-sandbox/concepts/authentication).
 </Info>
 
 ## Troubleshooting

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -34,6 +34,7 @@ from typing import (
     Mapping,
     MutableMapping,
     Optional,
+    Sequence,
 )
 
 from phoenix.config import get_env_allowed_sandbox_providers
@@ -261,7 +262,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         hosting_type="hosted",
         dependency_hints=[
             "Install Phoenix with the `daytona` extra.",
-            "Provide `PHOENIX_SANDBOX_DAYTONA_API_KEY`.",
+            "Provide `DAYTONA_API_KEY`.",
         ],
         supports_env_vars=True,
         internet_access_capability="boolean",
@@ -283,8 +284,10 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         dependency_hints=[
             "Install Phoenix with the `vercel` extra.",
             (
-                "Set all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`. "
-                "See https://vercel.com/docs/vercel-sandbox/concepts/authentication"
+                "Set all of `VERCEL_TOKEN`, "
+                "`VERCEL_PROJECT_ID`, and "
+                "`VERCEL_TEAM_ID`. See "
+                "https://vercel.com/docs/vercel-sandbox/concepts/authentication"
             ),
         ],
         supports_env_vars=True,
@@ -299,8 +302,10 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         dependency_hints=[
             "Install Phoenix with the `vercel` extra.",
             (
-                "Set all of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`. "
-                "See https://vercel.com/docs/vercel-sandbox/concepts/authentication"
+                "Set all of `VERCEL_TOKEN`, "
+                "`VERCEL_PROJECT_ID`, and "
+                "`VERCEL_TEAM_ID`. See "
+                "https://vercel.com/docs/vercel-sandbox/concepts/authentication"
             ),
         ],
         supports_env_vars=True,
@@ -325,7 +330,7 @@ SANDBOX_ADAPTER_METADATA: dict[str, AdapterMetadata] = {
         hosting_type="hosted",
         dependency_hints=[
             "Install Phoenix with the `modal` extra.",
-            "Provide `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` environment variables.",
+            ("Provide `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` environment variables."),
         ],
         supports_env_vars=True,
         internet_access_capability="boolean",
@@ -558,13 +563,20 @@ async def _resolve_user_env(
 async def _resolve_named_credentials(
     session: Optional[AsyncSession],
     decrypt: Optional[Callable[[bytes], bytes]],
-    keys: list[str],
+    keys: Sequence[str | ProviderCredentialSpec],
 ) -> dict[str, str]:
-    """Resolve arbitrary credential keys via DB secret lookup + env fallback."""
+    """Resolve credential specs via DB then process env."""
     if not keys:
         return {}
 
-    deduped_keys = list(dict.fromkeys(keys))
+    credential_specs = [
+        key
+        if isinstance(key, ProviderCredentialSpec)
+        else ProviderCredentialSpec(key=key, display_name=key)
+        for key in keys
+    ]
+    deduped_specs = list({spec.key: spec for spec in credential_specs}.values())
+    lookup_keys = [spec.key for spec in deduped_specs]
     db_secrets: dict[str, str] = {}
 
     if session is not None and decrypt is not None:
@@ -574,7 +586,7 @@ async def _resolve_named_credentials(
 
         rows = (
             await session.scalars(
-                sa.select(models.Secret).where(models.Secret.key.in_(deduped_keys))
+                sa.select(models.Secret).where(models.Secret.key.in_(lookup_keys))
             )
         ).all()
         for row in rows:
@@ -584,13 +596,13 @@ async def _resolve_named_credentials(
                 logger.warning(f"Failed to decrypt sandbox credential {row.key!r}", exc_info=True)
 
     result: dict[str, str] = {}
-    for key in deduped_keys:
-        if key in db_secrets:
-            result[key] = db_secrets[key]
-        else:
-            env_val = os.getenv(key)
-            if env_val:
-                result[key] = env_val
+    for spec in deduped_specs:
+        if spec.key in db_secrets:
+            result[spec.key] = db_secrets[spec.key]
+            continue
+        env_val = os.getenv(spec.key)
+        if env_val:
+            result[spec.key] = env_val
     return result
 
 
@@ -612,40 +624,6 @@ async def get_missing_sandbox_auth_detail(
     adapter = _SANDBOX_ADAPTERS.get(backend_type)
     if adapter is None:
         return None
-
-    if backend_type == "E2B":
-        resolved = await _resolve_named_credentials(session, decrypt, ["E2B_API_KEY"])
-        if "E2B_API_KEY" in resolved:
-            return None
-        return "Set `E2B_API_KEY`."
-
-    if backend_type == "DAYTONA_PYTHON":
-        resolved = await _resolve_named_credentials(
-            session, decrypt, ["PHOENIX_SANDBOX_DAYTONA_API_KEY"]
-        )
-        if "PHOENIX_SANDBOX_DAYTONA_API_KEY" in resolved:
-            return None
-        return "Set `PHOENIX_SANDBOX_DAYTONA_API_KEY`."
-
-    if backend_type in {"VERCEL_PYTHON", "VERCEL_TYPESCRIPT"}:
-        access_keys = [
-            "VERCEL_TOKEN",
-            "VERCEL_PROJECT_ID",
-            "VERCEL_TEAM_ID",
-        ]
-        resolved = await _resolve_named_credentials(session, decrypt, access_keys)
-        missing_access_keys = [key for key in access_keys if key not in resolved]
-        if not missing_access_keys:
-            return None
-        return f"Set {_format_required_keys(missing_access_keys)}."
-
-    if backend_type == "MODAL":
-        modal_keys = ["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"]
-        resolved = await _resolve_named_credentials(session, decrypt, modal_keys)
-        missing_modal_keys = [key for key in modal_keys if key not in resolved]
-        if not missing_modal_keys:
-            return None
-        return f"Set {_format_required_keys(missing_modal_keys)}."
 
     if not adapter.credential_specs:
         return None
@@ -671,7 +649,7 @@ async def _resolve_sandbox_credentials(
     return await _resolve_named_credentials(
         session=session,
         decrypt=decrypt,
-        keys=[spec.key for spec in credential_specs],
+        keys=credential_specs,
     )
 
 
@@ -762,11 +740,10 @@ async def get_or_create_backend(
 # _KNOWN_ADAPTER_CLASSES tracks every adapter class whose module imports
 # successfully — *regardless* of whether its SDK probe passes. The
 # reserved-credential-name set is derived from this list (not from
-# _SANDBOX_ADAPTERS), so adapter-declared credential keys (e.g.
-# VERCEL_TOKEN) remain reserved on installs that don't have
-# the optional SDK. Without this, a missing optional extra would silently
-# narrow the reserved set and let a user-supplied env_var or secret_ref
-# shadow a provider credential name.
+# _SANDBOX_ADAPTERS), so adapter-declared credential keys remain reserved on
+# installs that don't have the optional SDK. Without this, a missing optional
+# extra would silently narrow the reserved set and let a user-supplied
+# env_var or secret_ref shadow a provider credential name.
 # ---------------------------------------------------------------------------
 
 _KNOWN_ADAPTER_CLASSES: list[type[SandboxAdapter]] = []
@@ -857,12 +834,11 @@ def _build_reserved_credential_names() -> frozenset[str]:
 
     Walks ``_KNOWN_ADAPTER_CLASSES`` (every adapter whose module imports),
     NOT ``_SANDBOX_ADAPTERS`` (only adapters whose SDK probe passed). The
-    distinction matters: an installation without the ``vercel`` extra has
-    ``VercelPythonAdapter`` in _KNOWN_ADAPTER_CLASSES but not in
-    _SANDBOX_ADAPTERS, and ``VERCEL_TOKEN`` MUST remain
-    reserved regardless of whether the SDK is installed — otherwise a
-    user-supplied env_var or secret_ref on that name could shadow the
-    provider credential the moment the SDK is later installed.
+    distinction matters: an installation without an optional sandbox extra
+    still has its adapter class in _KNOWN_ADAPTER_CLASSES, so the adapter's
+    declared credential keys remain reserved regardless of whether the SDK is
+    installed — otherwise a user-supplied env_var or secret_ref on that name
+    could shadow the provider credential the moment the SDK is later installed.
     """
     names: set[str] = set()
     for adapter_cls in _KNOWN_ADAPTER_CLASSES:
@@ -874,7 +850,7 @@ def _build_reserved_credential_names() -> frozenset[str]:
 def is_reserved_credential_name(name: str) -> bool:
     """Return True if `name` collides with a reserved provider-credential key.
 
-    Comparison is case-insensitive: `VERCEL_TOKEN`, `Vercel_Token`, and
-    `vercel_token` are all reserved.
+    Comparison is case-insensitive: `VERCEL_TOKEN`,
+    `Vercel_Token`, and `vercel_token` are all reserved.
     """
     return name.lower() in _build_reserved_credential_names()

--- a/src/phoenix/server/sandbox/daytona_backend.py
+++ b/src/phoenix/server/sandbox/daytona_backend.py
@@ -178,7 +178,7 @@ class DaytonaPythonAdapter(SandboxAdapter):
     config_model = DaytonaPythonConfig
     credential_specs = [
         ProviderCredentialSpec(
-            key="PHOENIX_SANDBOX_DAYTONA_API_KEY",
+            key="DAYTONA_API_KEY",
             display_name="Daytona API Key",
             description="API key for the Daytona sandbox service.",
         ),
@@ -195,15 +195,15 @@ class DaytonaPythonAdapter(SandboxAdapter):
         self._enforce_capabilities(config, user_env)
         # Fail-closed on missing credential. Passing an empty api_key would let
         # the Daytona SDK silently fall back to ``DAYTONA_API_KEY`` from the
-        # process env (daytona_sdk/_async/daytona.py:168). The SDK's autodiscovery
-        # name differs from Phoenix's declared name
-        # (``PHOENIX_SANDBOX_DAYTONA_API_KEY``) so that fallback would bypass
-        # Phoenix's credential resolution entirely.
-        api_key: str = config.get("PHOENIX_SANDBOX_DAYTONA_API_KEY") or ""
+        # process env (daytona_sdk/_async/daytona.py:168). Phoenix's resolver
+        # already consults that env var, so reaching this branch with an empty
+        # key means Phoenix decided "no credential available"; raise rather
+        # than let the SDK auto-discover and bypass that decision.
+        api_key: str = config.get("DAYTONA_API_KEY") or ""
         if not api_key:
             raise ValueError(
                 "Daytona sandbox authentication is not configured. Set "
-                "PHOENIX_SANDBOX_DAYTONA_API_KEY via setSandboxCredential or as "
+                "DAYTONA_API_KEY via setSandboxCredential or as "
                 "a process environment variable."
             )
         deps = config.get("dependencies") or {}

--- a/src/phoenix/server/sandbox/e2b_backend.py
+++ b/src/phoenix/server/sandbox/e2b_backend.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+ENV_E2B_API_KEY = "E2B_API_KEY"
+
 
 class E2BSandboxBackend(SandboxBackend):
     """Sandbox backend executing code in E2B cloud sandboxes.
@@ -186,7 +188,7 @@ class E2BAdapter(SandboxAdapter):
     config_model = E2BConfig
     credential_specs = [
         ProviderCredentialSpec(
-            key="E2B_API_KEY",
+            key=ENV_E2B_API_KEY,
             display_name="E2B API Key",
             description="API key for the E2B sandbox service.",
         ),
@@ -205,13 +207,16 @@ class E2BAdapter(SandboxAdapter):
         self._enforce_capabilities(config, user_env)
         # Fail-closed on missing credential. Passing an empty api_key would let
         # the E2B SDK silently fall back to ``os.getenv("E2B_API_KEY")``
-        # (e2b.connection_config:94), running the sandbox with a process-env
-        # credential Phoenix never resolved or surfaced to the UI.
-        api_key: str = config.get("E2B_API_KEY") or ""
+        # (e2b.connection_config:94). Phoenix's resolver already consults that
+        # env var, so reaching this branch with an empty key means Phoenix
+        # decided "no credential available"; raise rather than let the SDK
+        # auto-discover and bypass that decision.
+        api_key: str = config.get(ENV_E2B_API_KEY) or ""
         if not api_key:
             raise ValueError(
-                "E2B sandbox authentication is not configured. Set E2B_API_KEY "
-                "via setSandboxCredential or as a process environment variable."
+                "E2B sandbox authentication is not configured. Set "
+                "E2B_API_KEY via setSandboxCredential or as a "
+                "process environment variable."
             )
         internet_access = config.get("internet_access")
         if internet_access is not None:

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -52,6 +52,8 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 600
 _DEFAULT_IDLE_TIMEOUT = 300
+ENV_MODAL_TOKEN_ID = "MODAL_TOKEN_ID"
+ENV_MODAL_TOKEN_SECRET = "MODAL_TOKEN_SECRET"
 
 
 class ModalSandboxBackend(SandboxBackend):
@@ -81,8 +83,9 @@ class ModalSandboxBackend(SandboxBackend):
     ) -> None:
         if not token_id or not token_secret:
             raise ValueError(
-                "Modal sandbox requires both MODAL_TOKEN_ID and MODAL_TOKEN_SECRET. "
-                "Set them via setSandboxCredential or as process environment variables."
+                "Modal sandbox requires both MODAL_TOKEN_ID and "
+                "MODAL_TOKEN_SECRET. Set them via setSandboxCredential "
+                "or as process environment variables."
             )
 
         import modal
@@ -220,12 +223,12 @@ class ModalAdapter(SandboxAdapter):
     config_model = ModalConfig
     credential_specs = [
         ProviderCredentialSpec(
-            key="MODAL_TOKEN_ID",
+            key=ENV_MODAL_TOKEN_ID,
             display_name="Modal Token ID",
             description="Token ID issued by `modal token new`.",
         ),
         ProviderCredentialSpec(
-            key="MODAL_TOKEN_SECRET",
+            key=ENV_MODAL_TOKEN_SECRET,
             display_name="Modal Token Secret",
             description="Token secret issued by `modal token new`.",
         ),
@@ -242,13 +245,13 @@ class ModalAdapter(SandboxAdapter):
         user_env: Optional[Mapping[str, str]] = None,
     ) -> SandboxBackend:
         self._enforce_capabilities(config, user_env)
-        token_id = config.get("MODAL_TOKEN_ID") or ""
-        token_secret = config.get("MODAL_TOKEN_SECRET") or ""
+        token_id = config.get(ENV_MODAL_TOKEN_ID) or ""
+        token_secret = config.get(ENV_MODAL_TOKEN_SECRET) or ""
         if not token_id or not token_secret:
             raise ValueError(
                 "Modal sandbox authentication is not configured. Set both "
-                "MODAL_TOKEN_ID and MODAL_TOKEN_SECRET via setSandboxCredential "
-                "or as process environment variables."
+                "MODAL_TOKEN_ID and MODAL_TOKEN_SECRET "
+                "via setSandboxCredential or as process environment variables."
             )
         deps = config.get("dependencies") or {}
         packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -13,12 +13,13 @@ when the extra is absent. Adapter availability is gated by
 surfaces a missing extra as ``status=NOT_INSTALLED`` instead of a runtime
 error during evaluation.
 
-Authentication uses the Vercel Sandbox access-token triple: ``VERCEL_TOKEN``,
-``VERCEL_PROJECT_ID``, and ``VERCEL_TEAM_ID``, forwarded as explicit kwargs to
-``AsyncSandbox.create``. The SDK's alternative OIDC path is not supported —
-it relied on ``os.environ`` mutation since the SDK has no ``oidc_token=``
-kwarg, and Phoenix's deployment model (self-hosted server, not a Vercel
-runtime context) has no documented OIDC workflow. See
+Authentication uses the Vercel Sandbox access-token triple, forwarded as
+explicit kwargs to ``AsyncSandbox.create``. Phoenix resolves those credentials
+from the SDK-native ``VERCEL_TOKEN`` / ``VERCEL_PROJECT_ID`` / ``VERCEL_TEAM_ID``
+keys. The SDK's alternative OIDC path is not supported — it relied on
+``os.environ`` mutation since the SDK has no ``oidc_token=`` kwarg, and
+Phoenix's deployment model (self-hosted server, not a Vercel runtime context)
+has no documented OIDC workflow. See
 https://vercel.com/docs/vercel-sandbox/concepts/authentication
 
 Language routing
@@ -55,9 +56,7 @@ class _LanguageConfig(TypedDict):
     args_prefix: list[str]
 
 
-# Vercel SDK credential env-var names. Phoenix uses these names verbatim for
-# its DB-stored credentials so an operator who already exports them in the
-# process env gets the same value Phoenix would resolve from the DB.
+# Canonical Phoenix credential keys.
 ENV_VERCEL_TOKEN = "VERCEL_TOKEN"
 ENV_VERCEL_PROJECT_ID = "VERCEL_PROJECT_ID"
 ENV_VERCEL_TEAM_ID = "VERCEL_TEAM_ID"
@@ -353,8 +352,9 @@ def _build_vercel_backend(
     if not (token and project_id and team_id):
         raise ValueError(
             "Vercel sandbox authentication is not configured. Set "
-            "VERCEL_TOKEN, VERCEL_PROJECT_ID, and VERCEL_TEAM_ID via "
-            f"setSandboxCredential. See {_VERCEL_AUTH_DOCS_URL}"
+            "VERCEL_TOKEN, VERCEL_PROJECT_ID, "
+            "and VERCEL_TEAM_ID via setSandboxCredential. "
+            f"See {_VERCEL_AUTH_DOCS_URL}"
         )
     deps = config.get("dependencies") or {}
     packages: list[str] = deps.get("packages", []) if isinstance(deps, dict) else []

--- a/tests/unit/server/api/mutations/test_reserved_credential_names.py
+++ b/tests/unit/server/api/mutations/test_reserved_credential_names.py
@@ -28,9 +28,10 @@ from tests.unit.graphql import AsyncGraphQLClient
 
 _e2b_adapter = E2BAdapter()
 
-# Reserved names exposed by the MODAL and VERCEL adapters (case-preserved for
-# readability; the mutation check is case-insensitive).
+# Reserved names exposed by the E2B, MODAL, and VERCEL adapters. The mutation
+# check is case-insensitive.
 _RESERVED_NAMES = [
+    "E2B_API_KEY",
     "MODAL_TOKEN_SECRET",
     "MODAL_TOKEN_ID",
     "VERCEL_TOKEN",

--- a/tests/unit/server/api/mutations/test_sandbox_credential_mutations.py
+++ b/tests/unit/server/api/mutations/test_sandbox_credential_mutations.py
@@ -10,6 +10,7 @@ import sqlalchemy as sa
 
 from phoenix.db import models
 from phoenix.server.sandbox import _BACKEND_CACHE, _SANDBOX_ADAPTERS
+from phoenix.server.sandbox.modal_backend import ModalAdapter
 from phoenix.server.sandbox.types import (
     ProviderCredentialSpec,
     SandboxAdapter,
@@ -38,6 +39,8 @@ _DELETE_MUTATION = """
 
 _TEST_BACKEND = "TEST_CRED_BACKEND"
 _TEST_KEY = "TEST_CRED_KEY"
+_MODAL_BACKEND = "MODAL"
+_MODAL_CANONICAL_TOKEN_ID = "MODAL_TOKEN_ID"
 
 
 class _TestCredAdapter(SandboxAdapter):
@@ -140,6 +143,40 @@ class TestSetSandboxCredential:
             operation_name="SetSandboxCredential",
         )
         assert result.errors
+
+    async def test_modal_canonical_key_succeeds(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        previous = _SANDBOX_ADAPTERS.get(_MODAL_BACKEND)
+        _SANDBOX_ADAPTERS[_MODAL_BACKEND] = ModalAdapter()
+        try:
+            result = await gql_client.execute(
+                query=_SET_MUTATION,
+                variables={
+                    "input": {
+                        "backendType": _MODAL_BACKEND,
+                        "key": _MODAL_CANONICAL_TOKEN_ID,
+                        "value": "canonical-token-id",
+                    }
+                },
+                operation_name="SetSandboxCredential",
+            )
+        finally:
+            if previous is None:
+                _SANDBOX_ADAPTERS.pop(_MODAL_BACKEND, None)
+            else:
+                _SANDBOX_ADAPTERS[_MODAL_BACKEND] = previous
+
+        assert not result.errors
+        assert result.data is not None
+        assert result.data["setSandboxCredential"]["key"] == _MODAL_CANONICAL_TOKEN_ID
+        async with db() as session:
+            row = await session.scalar(
+                sa.select(models.Secret).where(models.Secret.key == _MODAL_CANONICAL_TOKEN_ID)
+            )
+        assert row is not None
 
     async def test_empty_value_raises(
         self,

--- a/tests/unit/server/api/test_sandbox_queries.py
+++ b/tests/unit/server/api/test_sandbox_queries.py
@@ -144,7 +144,7 @@ async def test_sandbox_backends_and_providers_can_be_loaded_together(
     ]
     assert backends["DAYTONA_PYTHON"]["dependencyHints"] == [
         "Install Phoenix with the `daytona` extra.",
-        "Provide `PHOENIX_SANDBOX_DAYTONA_API_KEY`.",
+        "Provide `DAYTONA_API_KEY`.",
     ]
     assert backends["VERCEL_PYTHON"]["dependencyHints"] == [
         "Install Phoenix with the `vercel` extra.",

--- a/tests/unit/server/sandbox/test_capability_matrix.py
+++ b/tests/unit/server/sandbox/test_capability_matrix.py
@@ -255,7 +255,7 @@ def test_daytona_build_backend_wires_packages_to_backend() -> None:
     packages = ["requests", "numpy"]
     backend = adapter.build_backend(
         {
-            "PHOENIX_SANDBOX_DAYTONA_API_KEY": "k",
+            "DAYTONA_API_KEY": "k",
             "dependencies": {"packages": packages},
         }
     )

--- a/tests/unit/server/sandbox/test_daytona_backend.py
+++ b/tests/unit/server/sandbox/test_daytona_backend.py
@@ -268,19 +268,19 @@ class TestBuildBackendCredentialValidation:
     """``DaytonaPythonAdapter.build_backend`` must fail closed when api_key
     is missing, instead of letting the SDK fall back to ``DAYTONA_API_KEY``
     autodiscovery from process env (which differs from Phoenix's declared
-    ``PHOENIX_SANDBOX_DAYTONA_API_KEY`` and would bypass Phoenix's resolution).
+    ``DAYTONA_API_KEY`` and would bypass Phoenix's resolution).
     """
 
     def test_missing_api_key_raises_value_error(self) -> None:
         from phoenix.server.sandbox.daytona_backend import DaytonaPythonAdapter
 
         adapter = DaytonaPythonAdapter()
-        with pytest.raises(ValueError, match="PHOENIX_SANDBOX_DAYTONA_API_KEY"):
+        with pytest.raises(ValueError, match="DAYTONA_API_KEY"):
             adapter.build_backend({})
 
     def test_empty_api_key_raises_value_error(self) -> None:
         from phoenix.server.sandbox.daytona_backend import DaytonaPythonAdapter
 
         adapter = DaytonaPythonAdapter()
-        with pytest.raises(ValueError, match="PHOENIX_SANDBOX_DAYTONA_API_KEY"):
-            adapter.build_backend({"PHOENIX_SANDBOX_DAYTONA_API_KEY": ""})
+        with pytest.raises(ValueError, match="DAYTONA_API_KEY"):
+            adapter.build_backend({"DAYTONA_API_KEY": ""})

--- a/tests/unit/server/sandbox/test_e2b_backend.py
+++ b/tests/unit/server/sandbox/test_e2b_backend.py
@@ -15,6 +15,7 @@ from starlette.datastructures import Secret
 from phoenix.server.sandbox.e2b_backend import E2BAdapter, E2BSandboxBackend
 
 _API_KEY = Secret("k")
+_CANONICAL_API_KEY = "E2B_API_KEY"
 
 
 def _make_mock_sandbox_cls(create_result: Any = None) -> MagicMock:
@@ -54,7 +55,7 @@ def test_build_backend_translates_internet_access_to_allow_flag(
     """E2BAdapter.build_backend translates internet_access.mode → allow_internet_access kwarg."""
     adapter = E2BAdapter()
     backend: E2BSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
-        {"E2B_API_KEY": "k", **config}
+        {_CANONICAL_API_KEY: "k", **config}
     )
     assert backend._create_kwargs()["allow_internet_access"] is expected
 
@@ -170,7 +171,7 @@ async def test_ephemeral_execute_installs_packages_before_run_code() -> None:
 def test_build_backend_wires_packages(config: dict[str, Any], expected_packages: list[str]) -> None:
     adapter = E2BAdapter()
     backend: E2BSandboxBackend = adapter.build_backend(  # type: ignore[assignment]
-        {"E2B_API_KEY": "k", **config}
+        {_CANONICAL_API_KEY: "k", **config}
     )
     assert backend._packages == expected_packages
 
@@ -181,7 +182,7 @@ def test_build_backend_requires_api_key() -> None:
     path. See e2b/connection_config.py:94.
     """
     adapter = E2BAdapter()
-    with pytest.raises(ValueError, match="E2B_API_KEY"):
+    with pytest.raises(ValueError, match=_CANONICAL_API_KEY):
         adapter.build_backend({})
-    with pytest.raises(ValueError, match="E2B_API_KEY"):
-        adapter.build_backend({"E2B_API_KEY": ""})
+    with pytest.raises(ValueError, match=_CANONICAL_API_KEY):
+        adapter.build_backend({_CANONICAL_API_KEY: ""})

--- a/tests/unit/server/sandbox/test_env_var_resolution.py
+++ b/tests/unit/server/sandbox/test_env_var_resolution.py
@@ -69,7 +69,13 @@ class TestResolveUserEnvReservedSecretKey:
         """secret_ref whose `secret_key` matches a reserved provider-credential
         name raises MissingSecretError before any DB query — fail-closed
         defense-in-depth for rows persisted before the mutation-layer guard."""
-        raw = [{"kind": "secret_ref", "name": "MY_TOKEN", "secret_key": "VERCEL_TOKEN"}]
+        raw = [
+            {
+                "kind": "secret_ref",
+                "name": "MY_TOKEN",
+                "secret_key": "VERCEL_TOKEN",
+            }
+        ]
         session = _make_session({"VERCEL_TOKEN": b"should-not-reach-here"})
         with pytest.raises(MissingSecretError, match="VERCEL_TOKEN"):
             await _resolve_user_env(raw, session, _identity_decrypt)
@@ -89,7 +95,13 @@ class TestResolveUserEnvReservedSecretKey:
     @pytest.mark.asyncio
     async def test_reserved_check_is_case_insensitive(self) -> None:
         """Reserved-name comparison is case-insensitive in both positions."""
-        raw = [{"kind": "secret_ref", "name": "MY_TOKEN", "secret_key": "vercel_token"}]
+        raw = [
+            {
+                "kind": "secret_ref",
+                "name": "MY_TOKEN",
+                "secret_key": "vercel_token",
+            }
+        ]
         session = _make_session({"vercel_token": b"should-not-reach-here"})
         with pytest.raises(MissingSecretError):
             await _resolve_user_env(raw, session, _identity_decrypt)

--- a/tests/unit/server/sandbox/test_modal_backend.py
+++ b/tests/unit/server/sandbox/test_modal_backend.py
@@ -40,6 +40,8 @@ _TOKEN_ID_RAW = "ak-test-id"
 _TOKEN_SECRET_RAW = "as-test-secret"
 _TOKEN_ID = Secret(_TOKEN_ID_RAW)
 _TOKEN_SECRET = Secret(_TOKEN_SECRET_RAW)
+_CANONICAL_TOKEN_ID = "MODAL_TOKEN_ID"
+_CANONICAL_TOKEN_SECRET = "MODAL_TOKEN_SECRET"
 
 
 @pytest.mark.asyncio
@@ -85,8 +87,8 @@ def test_pip_install_invoked_only_when_packages_present() -> None:
         with_pkgs: Any = adapter.build_backend(
             {
                 "dependencies": {"packages": ["cowsay"]},
-                "MODAL_TOKEN_ID": _TOKEN_ID_RAW,
-                "MODAL_TOKEN_SECRET": _TOKEN_SECRET_RAW,
+                _CANONICAL_TOKEN_ID: _TOKEN_ID_RAW,
+                _CANONICAL_TOKEN_SECRET: _TOKEN_SECRET_RAW,
             }
         )
         slim_image.pip_install.assert_called_once_with(["cowsay"])
@@ -96,8 +98,8 @@ def test_pip_install_invoked_only_when_packages_present() -> None:
         without_pkgs: Any = adapter.build_backend(
             {
                 "dependencies": {"packages": []},
-                "MODAL_TOKEN_ID": _TOKEN_ID_RAW,
-                "MODAL_TOKEN_SECRET": _TOKEN_SECRET_RAW,
+                _CANONICAL_TOKEN_ID: _TOKEN_ID_RAW,
+                _CANONICAL_TOKEN_SECRET: _TOKEN_SECRET_RAW,
             }
         )
         slim_image.pip_install.assert_not_called()
@@ -135,23 +137,23 @@ async def test_block_network_kwarg_forwarding(
         (
             {
                 "internet_access": {"mode": "deny"},
-                "MODAL_TOKEN_ID": _TOKEN_ID_RAW,
-                "MODAL_TOKEN_SECRET": _TOKEN_SECRET_RAW,
+                _CANONICAL_TOKEN_ID: _TOKEN_ID_RAW,
+                _CANONICAL_TOKEN_SECRET: _TOKEN_SECRET_RAW,
             },
             True,
         ),
         (
             {
                 "internet_access": {"mode": "allow"},
-                "MODAL_TOKEN_ID": _TOKEN_ID_RAW,
-                "MODAL_TOKEN_SECRET": _TOKEN_SECRET_RAW,
+                _CANONICAL_TOKEN_ID: _TOKEN_ID_RAW,
+                _CANONICAL_TOKEN_SECRET: _TOKEN_SECRET_RAW,
             },
             False,
         ),
         (
             {
-                "MODAL_TOKEN_ID": _TOKEN_ID_RAW,
-                "MODAL_TOKEN_SECRET": _TOKEN_SECRET_RAW,
+                _CANONICAL_TOKEN_ID: _TOKEN_ID_RAW,
+                _CANONICAL_TOKEN_SECRET: _TOKEN_SECRET_RAW,
             },
             False,
         ),
@@ -177,10 +179,10 @@ def test_build_backend_requires_both_tokens() -> None:
         from phoenix.server.sandbox.modal_backend import ModalAdapter
 
         adapter = ModalAdapter()
-        with pytest.raises(ValueError, match="MODAL_TOKEN_ID"):
-            adapter.build_backend({"MODAL_TOKEN_SECRET": _TOKEN_SECRET_RAW})
-        with pytest.raises(ValueError, match="MODAL_TOKEN_ID"):
-            adapter.build_backend({"MODAL_TOKEN_ID": _TOKEN_ID_RAW})
+        with pytest.raises(ValueError, match=_CANONICAL_TOKEN_ID):
+            adapter.build_backend({_CANONICAL_TOKEN_SECRET: _TOKEN_SECRET_RAW})
+        with pytest.raises(ValueError, match=_CANONICAL_TOKEN_ID):
+            adapter.build_backend({_CANONICAL_TOKEN_ID: _TOKEN_ID_RAW})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Resolves #13070

Closes the last gap in the SDK-native credential-naming convention by renaming Daytona's canonical credential key from `PHOENIX_SANDBOX_DAYTONA_API_KEY` to `DAYTONA_API_KEY`. E2B, Vercel, and Modal already used SDK-native names on `version-sandboxes`; only Daytona was Phoenix-prefixed. After this PR, every external provider's canonical key matches what its upstream SDK reads from `os.environ`, so operators have a single mental model across the four providers.

The substantive change beyond the rename is in `get_missing_sandbox_auth_detail`. Each external backend (`E2B`, `DAYTONA_PYTHON`, `VERCEL_PYTHON`/`VERCEL_TYPESCRIPT`, `MODAL`) previously had a hardcoded branch that enumerated its credential keys and called `_resolve_named_credentials` against that literal list. Those four branches collapse into a single generic walk of `adapter.credential_specs`, with the spec-driven `_format_required_keys` producing the user-facing remediation string. To support that, `_resolve_named_credentials` widens its signature from `list[str]` to `Sequence[str | ProviderCredentialSpec]` and auto-promotes bare strings to specs internally — preserving the existing string-keyed call sites while letting the auth-detail path pass `adapter.credential_specs` through directly.

| Provider | Canonical key(s) | Source |
| :-- | :-- | :-- |
| E2B | `E2B_API_KEY` | unchanged (already SDK-native) |
| Daytona | `DAYTONA_API_KEY` | renamed from `PHOENIX_SANDBOX_DAYTONA_API_KEY` |
| Vercel | `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, `VERCEL_TEAM_ID` | unchanged (already SDK-native) |
| Modal | `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET` | unchanged (already SDK-native) |

Resolution per credential key stays simple: `secrets` table first, then process env. Because the sandbox subsystem still lives on the `version-sandboxes` long-running branch and has not shipped to main, there's no install base for the Daytona rename to break — no legacy-alias fallback or data migration is needed. Adapter SDKs are kwarg-passed the resolved credentials; each `build_backend` fail-closes (raises `ValueError`) when Phoenix's resolver returned no credential, so the SDK's autodiscovery from `os.environ` cannot silently bypass that decision. The reserved-credential-name set covers the canonical keys (case-insensitive) so user-supplied `env_vars` and `secret_refs` cannot shadow them.

Two adapter docstrings/comments — E2B's and Daytona's — that previously framed the fail-closed guard as protection against an SDK-autodiscovery name mismatch are reworded: with canonical = SDK-native, the resolver and the SDK consult the same env var, so the fail-closed branch is now defense-in-depth against bypassing Phoenix's resolution decision (e.g., a code path that constructs the backend without going through `_resolve_named_credentials`).

## Test plan
- [x] `tests/unit/server/sandbox/test_env_var_resolution.py` — DB-first / env-fallback resolution; reserved-name case-insensitivity on the renamed Daytona key
- [x] `tests/unit/server/sandbox/test_capability_matrix.py` — every adapter resolves credentials end-to-end with its canonical keys
- [x] `tests/unit/server/sandbox/test_daytona_backend.py` — Daytona fail-closed message and config lookup use the new `DAYTONA_API_KEY` name
- [x] `tests/unit/server/sandbox/test_{e2b,vercel,modal}_backend.py` — adapter tests unchanged in scope; minor refactor to use named constants for the canonical keys
- [x] `tests/unit/server/api/mutations/test_sandbox_credential_mutations.py` — `setSandboxCredential` accepts `MODAL_TOKEN_ID` via the real `ModalAdapter` registered into the resolver
- [x] `tests/unit/server/api/mutations/test_reserved_credential_names.py` — user-supplied `env_var` named `vercel_token` (any case) is rejected by `_check_env_var_collision`
- [x] `tests/unit/server/api/test_sandbox_queries.py` — `statusDetail` strings render the canonical key names
- [ ] Manual: deploy with `DAYTONA_API_KEY` exported in process env on an install that previously used `PHOENIX_SANDBOX_DAYTONA_API_KEY` — confirm Daytona shows `AVAILABLE` after the env var is renamed
- [ ] Manual: set a Daytona credential via Settings → Sandboxes UI and confirm `setSandboxCredential` writes the secret under `DAYTONA_API_KEY`