### PR TITLE
feat(agents): eval harness improvements

### DIFF
--- a/tests/pxi/__init__.py
+++ b/tests/pxi/__init__.py
@@ -1,0 +1,1 @@
+"""PXI test helpers and standalone eval suites."""

--- a/tests/pxi/evals/datasets.py
+++ b/tests/pxi/evals/datasets.py
@@ -14,6 +14,7 @@ class EvalDataset(BaseModel):
 
     dataset_name: str
     description: str | None = None
+    evaluators: list[str]
     examples: list[dict[str, Any]]
 
     @field_validator("dataset_name")
@@ -21,6 +22,22 @@ class EvalDataset(BaseModel):
     def _dataset_name_not_empty(cls, value: str) -> str:
         if not value.strip():
             raise ValueError("dataset_name cannot be empty")
+        return value
+
+    @field_validator("evaluators")
+    @classmethod
+    def _evaluators_non_empty(cls, value: list[str]) -> list[str]:
+        if not value:
+            raise ValueError(
+                "evaluators must be a non-empty list of evaluator names "
+                "(see tests/pxi/evals/evaluators/__init__.py for valid names)"
+            )
+        for name in value:
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError("evaluators entries must be non-empty strings")
+        duplicates = sorted({n for n in value if value.count(n) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate evaluator names: {', '.join(duplicates)}")
         return value
 
     @model_validator(mode="after")

--- a/tests/pxi/evals/datasets/set_spans_filter.yaml
+++ b/tests/pxi/evals/datasets/set_spans_filter.yaml
@@ -1,5 +1,8 @@
 dataset_name: set_spans_filter
 description: PXI server-side eval suite for deferred set_spans_filter tool calls.
+evaluators:
+  - correct_tools_called
+  - set_spans_filter_args_match
 examples:
   - id: llm-spans
     input:

--- a/tests/pxi/evals/evaluators/__init__.py
+++ b/tests/pxi/evals/evaluators/__init__.py
@@ -1,8 +1,28 @@
 """Code evaluators for PXI experiment suites."""
 
-from tests.pxi.evals.evaluators.tools import correct_tools_called, tool_call_args_match
+from typing import Any
+
+from tests.pxi.evals.evaluators.tools import (
+    correct_tools_called,
+    set_spans_filter_args_match,
+    tool_call_args_match,
+)
+
+# Registry of evaluators by name. The runner uses this to look up the
+# concrete ``@create_evaluator`` objects for the names a dataset declares
+# in its ``evaluators:`` field. Values are ``phoenix.evals.Evaluator``
+# instances, typed as ``Any`` here to match how the runner forwards them
+# into ``client.experiments.run_experiment``. Keep in sync with the
+# ``@create_evaluator`` decorators in this package.
+EVALUATORS_BY_NAME: dict[str, Any] = {
+    "correct_tools_called": correct_tools_called,
+    "tool_call_args_match": tool_call_args_match,
+    "set_spans_filter_args_match": set_spans_filter_args_match,
+}
 
 __all__ = [
+    "EVALUATORS_BY_NAME",
     "correct_tools_called",
+    "set_spans_filter_args_match",
     "tool_call_args_match",
 ]

--- a/tests/pxi/evals/evaluators/tools.py
+++ b/tests/pxi/evals/evaluators/tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from phoenix.evals import create_evaluator
@@ -35,7 +36,17 @@ def _tool_name(call: dict[str, Any]) -> str | None:
 
 def _tool_args(call: dict[str, Any]) -> dict[str, Any]:
     args = call.get("args", {})
-    return args if isinstance(args, dict) else {}
+    if isinstance(args, dict):
+        return args
+    if isinstance(args, str):
+        # Pydantic AI serializes tool-call args as a JSON string in some
+        # transports. Decode so subset/any-of matching can see the keys.
+        try:
+            decoded = json.loads(args)
+        except (json.JSONDecodeError, ValueError):
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
+    return {}
 
 
 def _expected_tools(expected: Any) -> dict[str, Any]:
@@ -129,49 +140,131 @@ def correct_tools_called(output: Any, expected: Any) -> dict[str, Any]:
 
 
 def _normalize_arg_value(value: Any) -> Any:
-    """Make string values that look like ``and``-joined SQL conjunctions
-    invariant to clause ordering.
+    """Make string values that look like SQL boolean conjunctions or
+    disjunctions invariant to clause ordering.
 
     Phoenix tool arg values like ``"span_kind == 'LLM' and latency_ms >= 5000"``
-    are semantically equivalent regardless of clause order. The evaluator
-    compares strings exactly otherwise, so without normalization a model that
-    emits the clauses in the opposite order from the dataset would silently
-    fail. The normalization is intentionally narrow: only string values that
-    contain `` and `` are split, trimmed, and returned as a frozenset.
+    are semantically equivalent regardless of clause order; the same holds for
+    ``"span_kind == 'TOOL' or span_kind == 'CHAIN'"``. The evaluator compares
+    strings exactly otherwise, so without normalization a model that emits
+    clauses in a different order from the dataset (or, in OR's case, picks an
+    equivalent membership rewrite) would silently fail.
+
+    Normalization rules:
+
+    - Pure ``and``-joined: split on `` and ``, return ``("AND", frozenset(...))``.
+    - Pure ``or``-joined: split on `` or ``, return ``("OR", frozenset(...))``.
+    - Mixed (both ``and`` and ``or`` appear): return the raw string. Splitting
+      naively would lose precedence; dataset authors who care about a specific
+      mixed-operator form should pin it exactly.
+    - Everything else: return the value unchanged.
+
+    The tagged tuples guarantee an AND-set never compares equal to an OR-set
+    over the same clauses — those expressions are not semantically equivalent.
     """
-    if not isinstance(value, str) or " and " not in value:
+    if not isinstance(value, str):
         return value
-    return frozenset(clause.strip() for clause in value.split(" and ") if clause.strip())
+    has_and = " and " in value
+    has_or = " or " in value
+    if has_and and has_or:
+        return value
+    if has_and:
+        clauses = frozenset(clause.strip() for clause in value.split(" and ") if clause.strip())
+        return ("AND", clauses)
+    if has_or:
+        clauses = frozenset(clause.strip() for clause in value.split(" or ") if clause.strip())
+        return ("OR", clauses)
+    return value
 
 
-def evaluate_tool_call_args(output: Any, expected: Any) -> dict[str, Any]:
-    """Pure-Python implementation of :func:`tool_call_args_match`.
+# Tools that have their own specialized arg-match evaluator with
+# tool-specific value semantics. The generic ``tool_call_args_match``
+# evaluator skips these so we don't double-score (and so a tool whose
+# args have semantic equivalences -- like the Phoenix span-filter DSL
+# -- isn't held to a stricter exact-string standard by the generic eval).
+_TOOLS_WITH_SPECIALIZED_ARG_EVALUATORS: frozenset[str] = frozenset({"set_spans_filter"})
 
-    Exists separately so unit tests can call it without going through the
-    :class:`phoenix.evals.Evaluator` wrapper produced by
-    ``@create_evaluator``.
+
+def _values_match_exact(observed: Any, expected_value: Any) -> bool:
+    return bool(observed == expected_value)
+
+
+def _values_match_with_dsl_normalization(observed: Any, expected_value: Any) -> bool:
+    return bool(_normalize_arg_value(observed) == _normalize_arg_value(expected_value))
+
+
+def _expected_arg_variants(expected_for_tool: Any) -> list[dict[str, Any]]:
+    """Return the list of acceptable arg dicts for one tool.
+
+    The dataset schema for ``expected.tool_call_args[<tool>]`` accepts either:
+
+    - a single dict ``{key: value, ...}`` (the default form), OR
+    - a list of dicts -- each entry is an independently-acceptable
+      arg shape; the observed call passes if it satisfies ANY variant.
+
+    Variants exist for genuinely-ambiguous queries where more than one
+    set of arguments is a reasonable agent choice (e.g. "show me recent
+    traces" could resolve to ``1h``, ``1d``, ``7d``, etc.). Invalid
+    entries (non-dict members of a list) are silently dropped.
+    """
+    if isinstance(expected_for_tool, dict):
+        return [expected_for_tool]
+    if isinstance(expected_for_tool, list):
+        return [item for item in expected_for_tool if isinstance(item, dict)]
+    return []
+
+
+def _evaluate_args_for_tools(
+    output: Any,
+    expected: Any,
+    *,
+    tool_predicate: Any,
+    value_comparator: Any,
+) -> dict[str, Any]:
+    """Shared subset/any-of arg matcher used by both arg evaluators.
+
+    ``tool_predicate`` filters which tool names from ``expected.tool_call_args``
+    this evaluator is responsible for. ``value_comparator`` decides whether
+    an observed value matches an expected value for a single ``(key, value)``
+    pair -- exact equality for the generic evaluator, DSL-normalized
+    equality for the ``set_spans_filter``-specific evaluator.
+
+    Matching is permissive in three ways:
+
+    1. **Subset match per call.** Extra observed arg keys are ignored.
+    2. **Any-of match across multiple calls.** If a tool fires multiple
+       times in one turn, ANY call may satisfy the expectation.
+    3. **Variant match across expected shapes.** If the dataset declares a
+       list of acceptable arg dicts for a tool, ANY variant passing is
+       enough. See :func:`_expected_arg_variants`.
     """
     expected_args_by_tool = _expected_tool_call_args(expected)
     observed_calls = tool_calls_from_output(output)
     failures: dict[str, Any] = {}
 
-    for tool_name, expected_args in expected_args_by_tool.items():
-        if not isinstance(tool_name, str) or not isinstance(expected_args, dict):
+    for tool_name, expected_for_tool in expected_args_by_tool.items():
+        if not isinstance(tool_name, str):
+            continue
+        if not tool_predicate(tool_name):
+            continue
+        variants = _expected_arg_variants(expected_for_tool)
+        if not variants:
             continue
         matching_calls = [call for call in observed_calls if _tool_name(call) == tool_name]
         if not matching_calls:
             failures[tool_name] = {"reason": "tool was not called"}
             continue
+        # Pass if ANY (variant, call) pair satisfies the subset check.
         if any(
             all(
-                _normalize_arg_value(_tool_args(call).get(key)) == _normalize_arg_value(value)
-                for key, value in expected_args.items()
+                value_comparator(_tool_args(call).get(key), value) for key, value in variant.items()
             )
+            for variant in variants
             for call in matching_calls
         ):
             continue
         failures[tool_name] = {
-            "expected": dict(expected_args),
+            "expected": ([dict(v) for v in variants] if len(variants) > 1 else dict(variants[0])),
             "observed": [dict(_tool_args(call)) for call in matching_calls],
         }
 
@@ -180,26 +273,78 @@ def evaluate_tool_call_args(output: Any, expected: Any) -> dict[str, Any]:
     return _success()
 
 
+def evaluate_tool_call_args(output: Any, expected: Any) -> dict[str, Any]:
+    """Pure-Python implementation of :func:`tool_call_args_match`.
+
+    Scoped to tools that do NOT have a specialized arg-match evaluator
+    (see ``_TOOLS_WITH_SPECIALIZED_ARG_EVALUATORS``). Uses exact value
+    comparison.
+    """
+    return _evaluate_args_for_tools(
+        output,
+        expected,
+        tool_predicate=lambda name: name not in _TOOLS_WITH_SPECIALIZED_ARG_EVALUATORS,
+        value_comparator=_values_match_exact,
+    )
+
+
+def evaluate_set_spans_filter_args(output: Any, expected: Any) -> dict[str, Any]:
+    """Pure-Python implementation of :func:`set_spans_filter_args_match`.
+
+    Scoped to the ``set_spans_filter`` tool only. Applies Phoenix span-filter
+    DSL normalization to string values so semantically-equivalent
+    ``condition`` rewrites (clause reordering under ``and`` or ``or``) match.
+    """
+    return _evaluate_args_for_tools(
+        output,
+        expected,
+        tool_predicate=lambda name: name == "set_spans_filter",
+        value_comparator=_values_match_with_dsl_normalization,
+    )
+
+
 @create_evaluator(name="tool_call_args_match", kind="code")
 def tool_call_args_match(output: Any, expected: Any) -> dict[str, Any]:
-    """Check that observed tool-call arguments match the dataset's expectations.
+    """Generic tool-call arg matcher with exact value comparison.
 
-    The expected shape is ``expected.tool_call_args[tool_name] -> {key: value}``
-    — at most one expected arg map per tool name. The match has two
-    intentional permissive properties documented here so future readers and
-    dataset authors aren't surprised:
+    The expected shape is
+    ``expected.tool_call_args[tool_name] -> {key: value}`` (a single
+    acceptable arg dict) OR ``... -> [{key: value}, ...]`` (a list of
+    independently-acceptable variants). Three intentional permissive
+    properties:
 
     - **Subset match.** A call passes the per-tool check when *all* expected
       ``(key, value)`` pairs are present; the observed call may carry extra
       arg keys that the dataset doesn't mention.
     - **Any-of match across multiple calls.** When a tool is called more
       than once in a single turn, the check passes if *any* of those calls
-      satisfies the expected arg pairs. The schema cannot express
-      "expectation N for the Nth call to this tool"; if you need that,
-      widen the schema before relying on multi-call ordering.
+      satisfies the expected arg pairs.
+    - **Variant match across expected shapes.** When the dataset declares a
+      list of variants, ANY variant matching ANY observed call passes.
 
-    String values are compared with :func:`_normalize_arg_value`, which
-    treats `` and ``-joined conjunctions as order-independent. Other types
-    are compared with ``==``.
+    Values are compared with ``==``. This evaluator skips tools that have
+    their own specialized arg-match evaluator (e.g. ``set_spans_filter``)
+    so that tool-specific semantic equivalence isn't undercut by a stricter
+    exact-string check.
     """
     return evaluate_tool_call_args(output, expected)
+
+
+@create_evaluator(name="set_spans_filter_args_match", kind="code")
+def set_spans_filter_args_match(output: Any, expected: Any) -> dict[str, Any]:
+    """Arg matcher specialized for the ``set_spans_filter`` tool.
+
+    The Phoenix span-filter DSL has commutative boolean operators: clauses
+    joined by ``and`` (or ``or``) are semantically equivalent regardless of
+    order, and a model run can plausibly emit either order. This evaluator
+    applies :func:`_normalize_arg_value` to both expected and observed
+    values so clause reordering under a pure-``and`` or pure-``or``
+    expression does not produce a spurious failure. Mixed ``and``/``or``
+    expressions fall back to exact-string comparison because precedence
+    matters and we don't parse the DSL here.
+
+    Subset / any-of / variant semantics are identical to
+    ``tool_call_args_match`` -- see that docstring for details. Scoped to
+    the ``set_spans_filter`` tool only.
+    """
+    return evaluate_set_spans_filter_args(output, expected)

--- a/tests/pxi/evals/evaluators/tools.py
+++ b/tests/pxi/evals/evaluators/tools.py
@@ -204,14 +204,29 @@ def _expected_arg_variants(expected_for_tool: Any) -> list[dict[str, Any]]:
 
     Variants exist for genuinely-ambiguous queries where more than one
     set of arguments is a reasonable agent choice (e.g. "show me recent
-    traces" could resolve to ``1h``, ``1d``, ``7d``, etc.). Invalid
-    entries (non-dict members of a list) are silently dropped.
+    traces" could resolve to ``1h``, ``1d``, ``7d``, etc.).
     """
     if isinstance(expected_for_tool, dict):
         return [expected_for_tool]
     if isinstance(expected_for_tool, list):
-        return [item for item in expected_for_tool if isinstance(item, dict)]
+        return expected_for_tool
     return []
+
+
+def _invalid_arg_expectation_reason(expected_for_tool: Any) -> str | None:
+    """Return a schema error for malformed per-tool arg expectations."""
+    if isinstance(expected_for_tool, dict):
+        return None
+    if isinstance(expected_for_tool, list):
+        if not expected_for_tool:
+            return "expected arg variants must be a non-empty list of objects"
+        invalid_indices = [
+            str(index) for index, item in enumerate(expected_for_tool) if not isinstance(item, dict)
+        ]
+        if invalid_indices:
+            return f"expected arg variants must all be objects; invalid indices: {', '.join(invalid_indices)}"
+        return None
+    return "expected tool arguments must be an object or a non-empty list of objects"
 
 
 def _evaluate_args_for_tools(
@@ -247,9 +262,14 @@ def _evaluate_args_for_tools(
             continue
         if not tool_predicate(tool_name):
             continue
-        variants = _expected_arg_variants(expected_for_tool)
-        if not variants:
+        invalid_reason = _invalid_arg_expectation_reason(expected_for_tool)
+        if invalid_reason:
+            failures[tool_name] = {
+                "reason": invalid_reason,
+                "expected": expected_for_tool,
+            }
             continue
+        variants = _expected_arg_variants(expected_for_tool)
         matching_calls = [call for call in observed_calls if _tool_name(call) == tool_name]
         if not matching_calls:
             failures[tool_name] = {"reason": "tool was not called"}

--- a/tests/pxi/evals/run_experiment.py
+++ b/tests/pxi/evals/run_experiment.py
@@ -137,6 +137,20 @@ def _result_field(evaluation_run: ExperimentEvaluationRun, key: str) -> str:
     return "" if value is None else _truncate_cell(value)
 
 
+def _task_error_rows(experiment: RanExperiment) -> list[tuple[str, str]]:
+    rows: list[tuple[str, str]] = []
+    for task_run in experiment.get("task_runs", []):
+        output = task_run.get("output")
+        output_error = output.get("error") if isinstance(output, dict) else None
+        error = task_run.get("error") or output_error
+        if not error:
+            continue
+        stable_example_id = output.get("stable_example_id") if isinstance(output, dict) else None
+        example_id = stable_example_id or task_run["dataset_example_id"]
+        rows.append((_truncate_cell(example_id), _truncate_cell(error)))
+    return rows
+
+
 def _failed_evaluation_rows(
     experiment: RanExperiment,
     evaluation_runs: Sequence[ExperimentEvaluationRun],
@@ -205,6 +219,10 @@ def _print_score_summary(dataset: EvalDataset, experiment: RanExperiment) -> boo
             has_regressions = True
 
     print(f"Dataset: {dataset.dataset_name} ({len(dataset.examples)} examples)")
+    task_error_rows = _task_error_rows(experiment)
+    if task_error_rows:
+        print(f"Task errors: {len(task_error_rows)}/{len(experiment.get('task_runs', []))}")
+        print(_format_table(("Example", "Error"), task_error_rows))
     if by_evaluator:
         rows = []
         for name, summary in sorted(by_evaluator.items()):

--- a/tests/pxi/evals/run_experiment.py
+++ b/tests/pxi/evals/run_experiment.py
@@ -269,14 +269,22 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Exit non-zero if any evaluator fails (use in CI gating)",
     )
+    # The dataset YAML's ``evaluators:`` field is the source of truth for
+    # what gets scored in normal use. This flag is a transient per-run
+    # override -- useful for iterating on a single evaluator (halves eval
+    # cost while debugging), trying a new evaluator across existing
+    # datasets without committing a YAML change, or skipping a slow or
+    # noisy evaluator during a quick check. If you want a different
+    # combination permanently, edit the dataset YAML instead.
     parser.add_argument(
         "--evaluator",
         action="append",
         dest="evaluators",
         metavar="NAME",
         help=(
-            "Override the evaluators declared in the dataset YAML. Repeatable. "
-            f"Valid names: {', '.join(sorted(EVALUATORS_BY_NAME))}."
+            "Override the evaluators declared in the dataset YAML for this "
+            "run only. Repeatable. Use for ad-hoc iteration; edit the YAML "
+            f"for permanent changes. Valid names: {', '.join(sorted(EVALUATORS_BY_NAME))}."
         ),
     )
     return parser

--- a/tests/pxi/evals/run_experiment.py
+++ b/tests/pxi/evals/run_experiment.py
@@ -11,7 +11,7 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Sequence, cast
 from urllib.parse import urljoin
 
 if __package__ in {None, ""}:
@@ -29,7 +29,7 @@ from tests.pxi.evals.agent_task import (
     build_shared_docs_mcp_toolset,
     make_task,
 )
-from tests.pxi.evals.datasets import (  # type: ignore[attr-defined, unused-ignore]
+from tests.pxi.evals.datasets import (
     EvalDataset,
     load_dataset,
 )
@@ -37,6 +37,7 @@ from tests.pxi.evals.evaluators import EVALUATORS_BY_NAME
 
 DEFAULT_BASE_URL = "http://localhost:6006"
 PASSING_SCORE = 1.0
+MAX_TABLE_CELL_WIDTH = 80
 
 
 @dataclass(frozen=True)
@@ -105,9 +106,67 @@ def _experiment_name(dataset: EvalDataset, config: ExperimentConfig) -> str:
     return "-".join(parts)
 
 
-def _experiment_url(base_url: str, experiment: RanExperiment) -> str:
-    experiment_id = experiment.get("experiment_id")
-    return f"{base_url.rstrip('/')}/experiments/{experiment_id}" if experiment_id else base_url
+def _format_table(headers: tuple[str, ...], rows: Sequence[tuple[str, ...]]) -> str:
+    widths = [
+        max(len(header), *(len(row[index]) for row in rows)) for index, header in enumerate(headers)
+    ]
+    rule = "+" + "+".join("-" * (width + 2) for width in widths) + "+"
+
+    def format_row(row: tuple[str, ...]) -> str:
+        cells = [value.ljust(widths[index]) for index, value in enumerate(row)]
+        return "| " + " | ".join(cells) + " |"
+
+    lines = [rule, format_row(headers), rule]
+    lines.extend(format_row(row) for row in rows)
+    lines.append(rule)
+    return "\n".join(lines)
+
+
+def _truncate_cell(value: Any) -> str:
+    text = str(value)
+    if len(text) <= MAX_TABLE_CELL_WIDTH:
+        return text
+    return text[: MAX_TABLE_CELL_WIDTH - 3] + "..."
+
+
+def _result_field(evaluation_run: ExperimentEvaluationRun, key: str) -> str:
+    result = evaluation_run.result
+    if not isinstance(result, dict):
+        return ""
+    value = result.get(key)
+    return "" if value is None else _truncate_cell(value)
+
+
+def _failed_evaluation_rows(
+    experiment: RanExperiment,
+    evaluation_runs: Sequence[ExperimentEvaluationRun],
+) -> list[tuple[str, str, str, str, str]]:
+    task_runs_by_id = {
+        str(task_run["id"]): task_run for task_run in experiment.get("task_runs", []) if "id" in task_run
+    }
+    rows: list[tuple[str, str, str, str, str]] = []
+    for evaluation_run in evaluation_runs:
+        score = _score(evaluation_run)
+        if evaluation_run.error is None and score is not None and score >= PASSING_SCORE:
+            continue
+        task_run = task_runs_by_id.get(str(evaluation_run.experiment_run_id))
+        example_id = task_run["dataset_example_id"] if task_run else str(evaluation_run.experiment_run_id)
+        rows.append(
+            (
+                _truncate_cell(example_id),
+                _truncate_cell(evaluation_run.name or "unknown"),
+                (
+                    "error"
+                    if evaluation_run.error is not None
+                    else "missing"
+                    if score is None
+                    else f"{score:g}"
+                ),
+                _result_field(evaluation_run, "label"),
+                _truncate_cell(evaluation_run.error or _result_field(evaluation_run, "explanation")),
+            )
+        )
+    return rows
 
 
 def _score(evaluation_run: ExperimentEvaluationRun) -> float | None:
@@ -118,7 +177,7 @@ def _score(evaluation_run: ExperimentEvaluationRun) -> float | None:
     return float(value) if isinstance(value, (int, float)) else None
 
 
-def _print_score_summary(dataset: EvalDataset, experiment: RanExperiment, base_url: str) -> bool:
+def _print_score_summary(dataset: EvalDataset, experiment: RanExperiment) -> bool:
     evaluation_runs = list(experiment.get("evaluation_runs") or [])
     by_evaluator: dict[str, dict[str, Any]] = {}
     has_regressions = False
@@ -146,16 +205,34 @@ def _print_score_summary(dataset: EvalDataset, experiment: RanExperiment, base_u
             has_regressions = True
 
     print(f"Dataset: {dataset.dataset_name} ({len(dataset.examples)} examples)")
-    print(f"Experiment URL: {_experiment_url(base_url, experiment)}")
     if by_evaluator:
-        print(f"Evaluator score summary (passing score >= {PASSING_SCORE:g}):")
+        rows = []
         for name, summary in sorted(by_evaluator.items()):
-            detail = f"{summary['passing']}/{summary['total']} passed, {summary['failing']} failed"
-            if summary["errors"]:
-                detail += f", {summary['errors']} errors"
-            if summary["missing_score"]:
-                detail += f", {summary['missing_score']} missing scores"
-            print(f"  {name}: {detail}")
+            total = int(summary["total"])
+            passing = int(summary["passing"])
+            pass_rate = f"{passing / total:.0%}" if total else "n/a"
+            rows.append(
+                (
+                    name,
+                    str(total),
+                    str(passing),
+                    str(summary["failing"]),
+                    str(summary["errors"]),
+                    str(summary["missing_score"]),
+                    pass_rate,
+                )
+            )
+        print(f"Evaluator results (passing score >= {PASSING_SCORE:g}):")
+        print(
+            _format_table(
+                ("Evaluator", "Total", "Passed", "Failed", "Errors", "Missing", "Pass Rate"),
+                rows,
+            )
+        )
+        failed_rows = _failed_evaluation_rows(experiment, evaluation_runs)
+        if failed_rows:
+            print("Failed evaluations:")
+            print(_format_table(("Example", "Evaluator", "Score", "Label", "Details"), failed_rows))
     return has_regressions
 
 
@@ -210,7 +287,7 @@ async def _run_async(config: ExperimentConfig) -> int:
                 experiment_name=name,
                 experiment_description=dataset.description,
                 experiment_metadata=metadata,
-                print_summary=False,
+                print_summary=True,
                 concurrency=3,
                 timeout=180,
                 retries=0,
@@ -222,7 +299,7 @@ async def _run_async(config: ExperimentConfig) -> int:
             experiment = await client.experiments.evaluate_experiment(
                 experiment=experiment,
                 evaluators=cast(Any, evaluators),
-                print_summary=False,
+                print_summary=True,
                 concurrency=3,
                 timeout=180,
                 retries=0,
@@ -241,7 +318,7 @@ async def _run_async(config: ExperimentConfig) -> int:
                         f"warning: AsyncClient cleanup failed: {cleanup_exc}",
                         file=sys.stderr,
                     )
-    has_regressions = _print_score_summary(dataset, experiment, config.base_url)
+    has_regressions = _print_score_summary(dataset, experiment)
     return 1 if has_regressions and config.fail_on_regression else 0
 
 

--- a/tests/pxi/evals/run_experiment.py
+++ b/tests/pxi/evals/run_experiment.py
@@ -156,7 +156,9 @@ def _failed_evaluation_rows(
     evaluation_runs: Sequence[ExperimentEvaluationRun],
 ) -> list[tuple[str, str, str, str, str]]:
     task_runs_by_id = {
-        str(task_run["id"]): task_run for task_run in experiment.get("task_runs", []) if "id" in task_run
+        str(task_run["id"]): task_run
+        for task_run in experiment.get("task_runs", [])
+        if "id" in task_run
     }
     rows: list[tuple[str, str, str, str, str]] = []
     for evaluation_run in evaluation_runs:
@@ -164,7 +166,9 @@ def _failed_evaluation_rows(
         if evaluation_run.error is None and score is not None and score >= PASSING_SCORE:
             continue
         task_run = task_runs_by_id.get(str(evaluation_run.experiment_run_id))
-        example_id = task_run["dataset_example_id"] if task_run else str(evaluation_run.experiment_run_id)
+        example_id = (
+            task_run["dataset_example_id"] if task_run else str(evaluation_run.experiment_run_id)
+        )
         rows.append(
             (
                 _truncate_cell(example_id),
@@ -177,7 +181,9 @@ def _failed_evaluation_rows(
                     else f"{score:g}"
                 ),
                 _result_field(evaluation_run, "label"),
-                _truncate_cell(evaluation_run.error or _result_field(evaluation_run, "explanation")),
+                _truncate_cell(
+                    evaluation_run.error or _result_field(evaluation_run, "explanation")
+                ),
             )
         )
     return rows

--- a/tests/pxi/evals/run_experiment.py
+++ b/tests/pxi/evals/run_experiment.py
@@ -20,6 +20,7 @@ if __package__ in {None, ""}:
 from phoenix.client import AsyncClient
 from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
 from phoenix.client.utils.config import get_base_url, get_env_phoenix_api_key
+
 from tests.pxi.evals.agent_task import (
     DEFAULT_ASSISTANT_MODEL,
     DEFAULT_ASSISTANT_PROVIDER,
@@ -28,7 +29,10 @@ from tests.pxi.evals.agent_task import (
     build_shared_docs_mcp_toolset,
     make_task,
 )
-from tests.pxi.evals.datasets import EvalDataset, load_dataset  # type: ignore[attr-defined]
+from tests.pxi.evals.datasets import (  # type: ignore[attr-defined, unused-ignore]
+    EvalDataset,
+    load_dataset,
+)
 from tests.pxi.evals.evaluators import EVALUATORS_BY_NAME
 
 DEFAULT_BASE_URL = "http://localhost:6006"

--- a/tests/pxi/evals/run_experiment.py
+++ b/tests/pxi/evals/run_experiment.py
@@ -20,7 +20,6 @@ if __package__ in {None, ""}:
 from phoenix.client import AsyncClient
 from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
 from phoenix.client.utils.config import get_base_url, get_env_phoenix_api_key
-
 from tests.pxi.evals.agent_task import (
     DEFAULT_ASSISTANT_MODEL,
     DEFAULT_ASSISTANT_PROVIDER,
@@ -29,8 +28,8 @@ from tests.pxi.evals.agent_task import (
     build_shared_docs_mcp_toolset,
     make_task,
 )
-from tests.pxi.evals.datasets import EvalDataset, load_dataset
-from tests.pxi.evals.evaluators import correct_tools_called, tool_call_args_match
+from tests.pxi.evals.datasets import EvalDataset, load_dataset  # type: ignore[attr-defined]
+from tests.pxi.evals.evaluators import EVALUATORS_BY_NAME
 
 DEFAULT_BASE_URL = "http://localhost:6006"
 PASSING_SCORE = 1.0
@@ -46,6 +45,23 @@ class ExperimentConfig:
     experiment_name: str | None
     experiment_name_suffix: str | None
     fail_on_regression: bool
+    evaluator_override: tuple[str, ...] | None
+
+
+def _resolve_evaluators(dataset: EvalDataset, override: tuple[str, ...] | None) -> list[Any]:
+    """Resolve evaluator names (from CLI override or dataset YAML) to
+    concrete ``@create_evaluator`` objects, failing fast on unknown names.
+    """
+    requested = list(override) if override else list(dataset.evaluators)
+    if not requested:
+        raise ValueError(
+            "no evaluators selected: pass --evaluator or set `evaluators:` in the dataset YAML"
+        )
+    unknown = [name for name in requested if name not in EVALUATORS_BY_NAME]
+    if unknown:
+        available = ", ".join(sorted(EVALUATORS_BY_NAME))
+        raise ValueError(f"unknown evaluator name(s): {', '.join(unknown)}. Available: {available}")
+    return [EVALUATORS_BY_NAME[name] for name in requested]
 
 
 def _configured_base_url() -> tuple[str, bool]:
@@ -154,6 +170,10 @@ def _phoenix_examples(dataset: EvalDataset) -> list[dict[str, Any]]:
 async def _run_async(config: ExperimentConfig) -> int:
     _check_phoenix_healthz(config.base_url)
     dataset = load_dataset(config.dataset)
+    evaluators = _resolve_evaluators(dataset, config.evaluator_override)
+    print(
+        f"Evaluators: {', '.join(name for name in (config.evaluator_override or dataset.evaluators))}"
+    )
     client = AsyncClient(base_url=config.base_url, api_key=config.bearer_token)
     # Build the docs MCP toolset once and enter its async context manager for
     # the duration of the run, mirroring the production server's FastAPI
@@ -197,7 +217,7 @@ async def _run_async(config: ExperimentConfig) -> int:
                     task_run["dataset_example_id"] = output["stable_example_id"]
             experiment = await client.experiments.evaluate_experiment(
                 experiment=experiment,
-                evaluators=cast(Any, [correct_tools_called, tool_call_args_match]),
+                evaluators=cast(Any, evaluators),
                 print_summary=False,
                 concurrency=3,
                 timeout=180,
@@ -249,6 +269,16 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Exit non-zero if any evaluator fails (use in CI gating)",
     )
+    parser.add_argument(
+        "--evaluator",
+        action="append",
+        dest="evaluators",
+        metavar="NAME",
+        help=(
+            "Override the evaluators declared in the dataset YAML. Repeatable. "
+            f"Valid names: {', '.join(sorted(EVALUATORS_BY_NAME))}."
+        ),
+    )
     return parser
 
 
@@ -263,6 +293,7 @@ def main(argv: list[str] | None = None) -> int:
         experiment_name=args.experiment_name,
         experiment_name_suffix=args.experiment_name_suffix,
         fail_on_regression=args.fail_on_regression,
+        evaluator_override=tuple(args.evaluators) if args.evaluators else None,
     )
     try:
         return run(config)

--- a/tests/pxi/evals/test_datasets.py
+++ b/tests/pxi/evals/test_datasets.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.pxi.evals.datasets import (
+from tests.pxi.evals.datasets import (  # type: ignore[attr-defined]
     DatasetValidationError,
     EvalDataset,
     dataset_path,
@@ -21,6 +21,9 @@ from tests.pxi.evals.datasets import (
 _VALID_YAML = """\
 dataset_name: example_suite
 description: Tiny suite for tests
+evaluators:
+  - correct_tools_called
+  - tool_call_args_match
 examples:
   - id: ex-1
     input:
@@ -77,6 +80,7 @@ class TestLoadDataset:
             tmp_path / "dupes.yaml",
             """\
 dataset_name: dupes
+evaluators: [correct_tools_called]
 examples:
   - id: b
     input: {query: x}
@@ -100,11 +104,60 @@ examples:
     def test_empty_examples_raises_validation_error(self, tmp_path: Path) -> None:
         path = _write(
             tmp_path / "no_examples.yaml",
-            "dataset_name: empty\nexamples: []\n",
+            "dataset_name: empty\nevaluators: [correct_tools_called]\nexamples: []\n",
         )
         with pytest.raises(DatasetValidationError) as exc_info:
             load_dataset(path)
         assert "at least one example" in str(exc_info.value)
+
+    def test_missing_evaluators_field_raises_validation_error(self, tmp_path: Path) -> None:
+        # Datasets must declare which evaluators to run; there is no
+        # implicit default.
+        path = _write(
+            tmp_path / "no_evaluators.yaml",
+            """\
+dataset_name: missing_evaluators
+examples:
+  - id: ex-1
+    input: {query: x}
+    expected: {tools: {required: []}}
+""",
+        )
+        with pytest.raises(DatasetValidationError) as exc_info:
+            load_dataset(path)
+        assert "evaluators" in str(exc_info.value).lower()
+
+    def test_empty_evaluators_field_raises_validation_error(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "empty_evaluators.yaml",
+            """\
+dataset_name: empty_evaluators
+evaluators: []
+examples:
+  - id: ex-1
+    input: {query: x}
+    expected: {tools: {required: []}}
+""",
+        )
+        with pytest.raises(DatasetValidationError) as exc_info:
+            load_dataset(path)
+        assert "evaluators must be a non-empty list" in str(exc_info.value)
+
+    def test_duplicate_evaluator_names_raises_validation_error(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "dupe_evaluators.yaml",
+            """\
+dataset_name: dupe_evaluators
+evaluators: [correct_tools_called, correct_tools_called]
+examples:
+  - id: ex-1
+    input: {query: x}
+    expected: {tools: {required: []}}
+""",
+        )
+        with pytest.raises(DatasetValidationError) as exc_info:
+            load_dataset(path)
+        assert "duplicate evaluator names" in str(exc_info.value)
 
     def test_load_by_stem_uses_repo_datasets_dir(self) -> None:
         # The shipped ``set_spans_filter`` dataset must round-trip cleanly so
@@ -112,3 +165,4 @@ examples:
         dataset = load_dataset("set_spans_filter")
         assert dataset.dataset_name == "set_spans_filter"
         assert len(dataset.examples) >= 1
+        assert "correct_tools_called" in dataset.evaluators

--- a/tests/pxi/evals/test_datasets.py
+++ b/tests/pxi/evals/test_datasets.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.pxi.evals.datasets import (  # type: ignore[attr-defined]
+from tests.pxi.evals.datasets import (  # type: ignore[attr-defined, unused-ignore]
     DatasetValidationError,
     EvalDataset,
     dataset_path,

--- a/tests/pxi/evals/test_datasets.py
+++ b/tests/pxi/evals/test_datasets.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.pxi.evals.datasets import (  # type: ignore[attr-defined, unused-ignore]
+from tests.pxi.evals.datasets import (
     DatasetValidationError,
     EvalDataset,
     dataset_path,

--- a/tests/pxi/evals/test_evaluators.py
+++ b/tests/pxi/evals/test_evaluators.py
@@ -530,6 +530,74 @@ class TestSetSpansFilterArgsMatch:
         )
         assert result["label"] == "pass"
 
+    # ---------------- Variant-list pattern ----------------
+
+    def test_variant_list_passes_when_any_variant_matches(self) -> None:
+        # The set_spans_filter-specific evaluator uses the shared variant
+        # matcher, while still applying DSL normalization within each variant.
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {
+                    "condition": "latency_ms >= 5000 and span_kind == 'LLM'",
+                    "rootSpansOnly": False,
+                },
+            ),
+            expected=self._expected(
+                set_spans_filter=[
+                    {"condition": "status_code == 'ERROR'", "rootSpansOnly": False},
+                    {
+                        "condition": "span_kind == 'LLM' and latency_ms >= 5000",
+                        "rootSpansOnly": False,
+                    },
+                ],
+            ),
+        )
+        assert result["label"] == "pass"
+
+    def test_variant_list_fails_when_no_variant_matches(self) -> None:
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {"condition": "span_kind == 'TOOL'", "rootSpansOnly": False},
+            ),
+            expected=self._expected(
+                set_spans_filter=[
+                    {"condition": "span_kind == 'LLM'", "rootSpansOnly": False},
+                    {"condition": "status_code == 'ERROR'", "rootSpansOnly": False},
+                ],
+            ),
+        )
+        assert result["label"] == "fail"
+        assert isinstance(result["metadata"]["set_spans_filter"]["expected"], list)
+
+    def test_empty_variant_list_fails(self) -> None:
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {"condition": "span_kind == 'LLM'", "rootSpansOnly": False},
+            ),
+            expected=self._expected(set_spans_filter=[]),
+        )
+        assert result["label"] == "fail"
+        assert "non-empty list" in result["metadata"]["set_spans_filter"]["reason"]
+
+    def test_malformed_variant_list_fails(self) -> None:
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {"condition": "span_kind == 'LLM'", "rootSpansOnly": False},
+            ),
+            expected=self._expected(
+                set_spans_filter=[
+                    {"condition": "span_kind == 'LLM'", "rootSpansOnly": False},
+                    "not-a-dict",  # type: ignore[list-item]
+                ],
+            ),
+        )
+        assert result["label"] == "fail"
+        assert "invalid indices: 1" in result["metadata"]["set_spans_filter"]["reason"]
+
 
 class TestToolCallArgsMatch:
     """Tests for the generic ``tool_call_args_match`` evaluator.
@@ -674,12 +742,31 @@ class TestToolCallArgsMatch:
         )
         assert result["label"] == "pass"
 
-    def test_variant_list_with_empty_list_is_a_no_op(self) -> None:
-        # A defensive case: an empty variant list means "no expectation
-        # for this tool"; the evaluator returns success without checking
-        # observed calls for that tool.
+    def test_variant_list_with_empty_list_fails(self) -> None:
         result = evaluate_tool_call_args(
             output=_output_with_args("set_time_range", {"timeRangeKey": "1h"}),
             expected=self._expected(set_time_range=[]),
         )
-        assert result["label"] == "pass"
+        assert result["label"] == "fail"
+        assert "non-empty list" in result["metadata"]["set_time_range"]["reason"]
+
+    def test_variant_list_with_malformed_entry_fails(self) -> None:
+        result = evaluate_tool_call_args(
+            output=_output_with_args("set_time_range", {"timeRangeKey": "1h"}),
+            expected=self._expected(
+                set_time_range=[
+                    {"timeRangeKey": "1h"},
+                    "not-a-dict",  # type: ignore[list-item]
+                ],
+            ),
+        )
+        assert result["label"] == "fail"
+        assert "invalid indices: 1" in result["metadata"]["set_time_range"]["reason"]
+
+    def test_non_dict_arg_expectation_fails(self) -> None:
+        result = evaluate_tool_call_args(
+            output=_output_with_args("set_time_range", {"timeRangeKey": "1h"}),
+            expected={"tool_call_args": {"set_time_range": "not-a-dict"}},
+        )
+        assert result["label"] == "fail"
+        assert "must be an object" in result["metadata"]["set_time_range"]["reason"]

--- a/tests/pxi/evals/test_evaluators.py
+++ b/tests/pxi/evals/test_evaluators.py
@@ -14,6 +14,7 @@ import pytest
 
 from tests.pxi.evals.evaluators.tools import (
     _normalize_arg_value,
+    evaluate_set_spans_filter_args,
     evaluate_tool_call_args,
     evaluate_tools_called,
 )
@@ -183,22 +184,52 @@ class TestNormalizeArgValue:
         assert _normalize_arg_value("span_kind == 'LLM'") == "span_kind == 'LLM'"
         assert _normalize_arg_value("") == ""
 
-    def test_normalizes_and_conjunction_to_set(self) -> None:
+    def test_normalizes_and_conjunction_to_tagged_set(self) -> None:
         result = _normalize_arg_value("span_kind == 'LLM' and latency_ms >= 5000")
-        assert result == frozenset({"span_kind == 'LLM'", "latency_ms >= 5000"})
+        assert result == ("AND", frozenset({"span_kind == 'LLM'", "latency_ms >= 5000"}))
 
     def test_conjunction_order_does_not_matter(self) -> None:
         a = _normalize_arg_value("span_kind == 'LLM' and latency_ms >= 5000")
         b = _normalize_arg_value("latency_ms >= 5000 and span_kind == 'LLM'")
         assert a == b
 
+    def test_normalizes_or_conjunction_to_tagged_set(self) -> None:
+        result = _normalize_arg_value("span_kind == 'TOOL' or span_kind == 'CHAIN'")
+        assert result == ("OR", frozenset({"span_kind == 'TOOL'", "span_kind == 'CHAIN'"}))
 
-class TestToolCallArgsMatch:
-    def _expected(self, **per_tool: dict[str, Any]) -> dict[str, Any]:
+    def test_or_clause_order_does_not_matter(self) -> None:
+        a = _normalize_arg_value("span_kind == 'TOOL' or span_kind == 'CHAIN'")
+        b = _normalize_arg_value("span_kind == 'CHAIN' or span_kind == 'TOOL'")
+        assert a == b
+
+    def test_and_and_or_do_not_compare_equal_for_same_clauses(self) -> None:
+        # AND and OR over the same set of clauses are NOT semantically
+        # equivalent. The tagged-tuple form prevents accidental equality.
+        a = _normalize_arg_value("x == 1 and y == 2")
+        o = _normalize_arg_value("x == 1 or y == 2")
+        assert a != o
+
+    def test_mixed_and_or_returns_raw_string(self) -> None:
+        # Splitting a mixed-operator expression without parsing would lose
+        # precedence; treat it as opaque.
+        raw = "a == 1 and b == 2 or c == 3"
+        assert _normalize_arg_value(raw) == raw
+
+
+class TestSetSpansFilterArgsMatch:
+    """Tests for the specialized ``set_spans_filter`` arg evaluator.
+
+    Covers the DSL semantic equivalences (clause reordering under pure
+    ``and`` or pure ``or``) that this evaluator owns, alongside the same
+    subset / any-of / JSON-string-decoding behavior as the generic
+    evaluator.
+    """
+
+    def _expected(self, **per_tool: dict[str, Any] | list[dict[str, Any]]) -> dict[str, Any]:
         return {"tool_call_args": per_tool}
 
     def test_passes_when_all_expected_keys_match(self) -> None:
-        result = evaluate_tool_call_args(
+        result = evaluate_set_spans_filter_args(
             output=_output_with_args(
                 "set_spans_filter", {"condition": "span_kind == 'LLM'", "rootSpansOnly": False}
             ),
@@ -210,7 +241,7 @@ class TestToolCallArgsMatch:
         assert result["label"] == "pass"
 
     def test_reads_args_from_pydantic_ai_messages(self) -> None:
-        result = evaluate_tool_call_args(
+        result = evaluate_set_spans_filter_args(
             output=_output_with_args(
                 "set_spans_filter", {"condition": "span_kind == 'LLM'", "rootSpansOnly": False}
             ),
@@ -220,10 +251,40 @@ class TestToolCallArgsMatch:
         )
         assert result["label"] == "pass"
 
+    def test_decodes_args_when_serialized_as_json_string(self) -> None:
+        # Pydantic AI emits tool-call args as a JSON string over some
+        # transports. The evaluator must decode the string before matching;
+        # otherwise every arg-pin example silently fails with observed={}.
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                '{"condition": "span_kind == \'LLM\'", "rootSpansOnly": false}',  # type: ignore[arg-type]
+            ),
+            expected=self._expected(
+                set_spans_filter={"condition": "span_kind == 'LLM'", "rootSpansOnly": False},
+            ),
+        )
+        assert result["score"] == 1.0
+        assert result["label"] == "pass"
+
+    def test_treats_malformed_json_string_args_as_empty(self) -> None:
+        # If the string isn't valid JSON, fall back to {} rather than raising.
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                "not-json-at-all",  # type: ignore[arg-type]
+            ),
+            expected=self._expected(
+                set_spans_filter={"condition": "span_kind == 'LLM'"},
+            ),
+        )
+        assert result["score"] == 0.0
+        assert result["label"] == "fail"
+
     def test_subset_match_allows_extra_observed_keys(self) -> None:
         # Observed call carries an extra arg the dataset doesn't mention.
         # Documented behavior: subset match passes.
-        result = evaluate_tool_call_args(
+        result = evaluate_set_spans_filter_args(
             output=_output_with_args(
                 "set_spans_filter",
                 {"condition": "span_kind == 'LLM'", "rootSpansOnly": False, "limit": 100},
@@ -235,7 +296,7 @@ class TestToolCallArgsMatch:
         assert result["label"] == "pass"
 
     def test_fails_when_value_differs(self) -> None:
-        result = evaluate_tool_call_args(
+        result = evaluate_set_spans_filter_args(
             output=_output_with_args(
                 "set_spans_filter", {"condition": "span_kind == 'LLM'", "rootSpansOnly": True}
             ),
@@ -247,7 +308,7 @@ class TestToolCallArgsMatch:
         assert "set_spans_filter" in result["metadata"]
 
     def test_fails_when_tool_not_called(self) -> None:
-        result = evaluate_tool_call_args(
+        result = evaluate_set_spans_filter_args(
             output=_output(),
             expected=self._expected(set_spans_filter={"condition": ""}),
         )
@@ -258,7 +319,7 @@ class TestToolCallArgsMatch:
         # Composite condition emitted in opposite order from the dataset
         # should still pass — this is exactly the ``slow-llm-spans``
         # scenario flagged in review.
-        result = evaluate_tool_call_args(
+        result = evaluate_set_spans_filter_args(
             output=_output_with_args(
                 "set_spans_filter",
                 {
@@ -278,7 +339,7 @@ class TestToolCallArgsMatch:
     def test_any_of_match_across_multiple_calls(self) -> None:
         # When a tool is called twice, the check passes if ANY call
         # satisfies the expected pairs.
-        result = evaluate_tool_call_args(
+        result = evaluate_set_spans_filter_args(
             output={
                 "messages": [
                     {
@@ -299,5 +360,326 @@ class TestToolCallArgsMatch:
                 ]
             },
             expected=self._expected(set_spans_filter={"condition": "right"}),
+        )
+        assert result["label"] == "pass"
+
+    # ---------------- DSL equivalence: what IS considered equivalent ----------------
+
+    def test_and_clause_reorder_passes(self) -> None:
+        # Pure AND: clause order does not change semantics.
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {"condition": "latency_ms >= 5000 and span_kind == 'LLM'", "rootSpansOnly": False},
+            ),
+            expected=self._expected(
+                set_spans_filter={
+                    "condition": "span_kind == 'LLM' and latency_ms >= 5000",
+                    "rootSpansOnly": False,
+                }
+            ),
+        )
+        assert result["label"] == "pass"
+
+    def test_or_clause_reorder_passes(self) -> None:
+        # Pure OR: clause order does not change semantics.
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {
+                    "condition": "span_kind == 'CHAIN' or span_kind == 'TOOL'",
+                    "rootSpansOnly": False,
+                },
+            ),
+            expected=self._expected(
+                set_spans_filter={
+                    "condition": "span_kind == 'TOOL' or span_kind == 'CHAIN'",
+                    "rootSpansOnly": False,
+                }
+            ),
+        )
+        assert result["label"] == "pass"
+
+    def test_three_clause_and_reorder_passes(self) -> None:
+        # Reordering still passes when there are more than two clauses.
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {
+                    "condition": (
+                        "latency_ms >= 5000 and status_code == 'ERROR' and span_kind == 'LLM'"
+                    ),
+                    "rootSpansOnly": False,
+                },
+            ),
+            expected=self._expected(
+                set_spans_filter={
+                    "condition": (
+                        "span_kind == 'LLM' and latency_ms >= 5000 and status_code == 'ERROR'"
+                    ),
+                    "rootSpansOnly": False,
+                }
+            ),
+        )
+        assert result["label"] == "pass"
+
+    # ---------------- DSL equivalence: what is NOT considered equivalent ----------------
+
+    def test_and_does_not_match_or_with_same_clauses(self) -> None:
+        # AND and OR over the same clauses are different semantics.
+        # The tagged-tuple normalization keeps them disjoint.
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {
+                    "condition": "span_kind == 'LLM' or latency_ms >= 5000",
+                    "rootSpansOnly": False,
+                },
+            ),
+            expected=self._expected(
+                set_spans_filter={
+                    "condition": "span_kind == 'LLM' and latency_ms >= 5000",
+                    "rootSpansOnly": False,
+                }
+            ),
+        )
+        assert result["label"] == "fail"
+
+    def test_or_does_not_match_and_with_same_clauses(self) -> None:
+        # Symmetric: expecting OR does not accept AND.
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {
+                    "condition": "span_kind == 'LLM' and latency_ms >= 5000",
+                    "rootSpansOnly": False,
+                },
+            ),
+            expected=self._expected(
+                set_spans_filter={
+                    "condition": "span_kind == 'LLM' or latency_ms >= 5000",
+                    "rootSpansOnly": False,
+                }
+            ),
+        )
+        assert result["label"] == "fail"
+
+    def test_missing_clause_fails(self) -> None:
+        # Same operator, but observed is missing one of the expected clauses.
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {"condition": "span_kind == 'LLM'", "rootSpansOnly": False},
+            ),
+            expected=self._expected(
+                set_spans_filter={
+                    "condition": "span_kind == 'LLM' and latency_ms >= 5000",
+                    "rootSpansOnly": False,
+                }
+            ),
+        )
+        assert result["label"] == "fail"
+
+    def test_extra_clause_fails(self) -> None:
+        # Same operator, but observed adds an unexpected clause.
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {
+                    "condition": "span_kind == 'LLM' and latency_ms >= 5000",
+                    "rootSpansOnly": False,
+                },
+            ),
+            expected=self._expected(
+                set_spans_filter={"condition": "span_kind == 'LLM'", "rootSpansOnly": False},
+            ),
+        )
+        assert result["label"] == "fail"
+
+    def test_mixed_and_or_requires_exact_match(self) -> None:
+        # Mixed-operator expressions are not normalized (precedence matters).
+        # Matching is exact, so a different ordering does NOT pass.
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {
+                    "condition": "b == 2 and a == 1 or c == 3",
+                    "rootSpansOnly": False,
+                },
+            ),
+            expected=self._expected(
+                set_spans_filter={
+                    "condition": "a == 1 and b == 2 or c == 3",
+                    "rootSpansOnly": False,
+                }
+            ),
+        )
+        assert result["label"] == "fail"
+
+    def test_mixed_and_or_passes_when_exact(self) -> None:
+        # Same mixed expression exactly: passes via the raw-string fallback.
+        condition = "a == 1 and b == 2 or c == 3"
+        result = evaluate_set_spans_filter_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {"condition": condition, "rootSpansOnly": False},
+            ),
+            expected=self._expected(
+                set_spans_filter={"condition": condition, "rootSpansOnly": False}
+            ),
+        )
+        assert result["label"] == "pass"
+
+
+class TestToolCallArgsMatch:
+    """Tests for the generic ``tool_call_args_match`` evaluator.
+
+    The generic evaluator uses exact value comparison (no DSL semantic
+    normalization) and skips tools that have a specialized arg-match
+    evaluator (currently just ``set_spans_filter``). These tests use
+    ``set_time_range`` to cover the generic path.
+    """
+
+    def _expected(self, **per_tool: dict[str, Any] | list[dict[str, Any]]) -> dict[str, Any]:
+        return {"tool_call_args": per_tool}
+
+    def test_passes_when_all_expected_keys_match(self) -> None:
+        result = evaluate_tool_call_args(
+            output=_output_with_args("set_time_range", {"timeRangeKey": "1h"}),
+            expected=self._expected(set_time_range={"timeRangeKey": "1h"}),
+        )
+        assert result["score"] == 1.0
+        assert result["label"] == "pass"
+
+    def test_subset_match_allows_extra_observed_keys(self) -> None:
+        result = evaluate_tool_call_args(
+            output=_output_with_args(
+                "set_time_range", {"timeRangeKey": "1h", "startTime": "2025-01-01T00:00:00Z"}
+            ),
+            expected=self._expected(set_time_range={"timeRangeKey": "1h"}),
+        )
+        assert result["label"] == "pass"
+
+    def test_fails_when_value_differs(self) -> None:
+        result = evaluate_tool_call_args(
+            output=_output_with_args("set_time_range", {"timeRangeKey": "7d"}),
+            expected=self._expected(set_time_range={"timeRangeKey": "1h"}),
+        )
+        assert result["label"] == "fail"
+
+    def test_fails_when_tool_not_called(self) -> None:
+        result = evaluate_tool_call_args(
+            output=_output(),
+            expected=self._expected(set_time_range={"timeRangeKey": "1h"}),
+        )
+        assert result["label"] == "fail"
+
+    def test_decodes_args_when_serialized_as_json_string(self) -> None:
+        result = evaluate_tool_call_args(
+            output=_output_with_args(
+                "set_time_range",
+                '{"timeRangeKey": "1h"}',  # type: ignore[arg-type]
+            ),
+            expected=self._expected(set_time_range={"timeRangeKey": "1h"}),
+        )
+        assert result["label"] == "pass"
+
+    def test_skips_set_spans_filter(self) -> None:
+        # set_spans_filter has its own specialized evaluator; the generic
+        # one must not score it, even when the observed call would mismatch
+        # under exact comparison. With set_spans_filter as the only pinned
+        # tool, the generic evaluator has nothing to score and returns pass.
+        result = evaluate_tool_call_args(
+            output=_output_with_args(
+                "set_spans_filter",
+                {"condition": "completely wrong", "rootSpansOnly": False},
+            ),
+            expected=self._expected(
+                set_spans_filter={"condition": "span_kind == 'LLM'", "rootSpansOnly": False},
+            ),
+        )
+        assert result["label"] == "pass"
+
+    def test_does_not_normalize_and_reorder_for_generic_tools(self) -> None:
+        # The generic evaluator does NOT apply DSL normalization. If a
+        # future generic tool happens to have an arg containing ``and``,
+        # clause reordering is treated as a real difference.
+        result = evaluate_tool_call_args(
+            output=_output_with_args("set_time_range", {"note": "b and a"}),
+            expected=self._expected(set_time_range={"note": "a and b"}),
+        )
+        assert result["label"] == "fail"
+
+    # ---------------- Variant-list pattern ----------------
+
+    def test_variant_list_passes_when_first_variant_matches(self) -> None:
+        # A list of acceptable arg dicts. Observed call matches the first.
+        result = evaluate_tool_call_args(
+            output=_output_with_args("set_time_range", {"timeRangeKey": "1h"}),
+            expected=self._expected(
+                set_time_range=[
+                    {"timeRangeKey": "1h"},
+                    {"timeRangeKey": "1d"},
+                    {"timeRangeKey": "7d"},
+                ],
+            ),
+        )
+        assert result["label"] == "pass"
+
+    def test_variant_list_passes_when_any_later_variant_matches(self) -> None:
+        # Matching a non-first variant still passes.
+        result = evaluate_tool_call_args(
+            output=_output_with_args("set_time_range", {"timeRangeKey": "7d"}),
+            expected=self._expected(
+                set_time_range=[
+                    {"timeRangeKey": "1h"},
+                    {"timeRangeKey": "1d"},
+                    {"timeRangeKey": "7d"},
+                ],
+            ),
+        )
+        assert result["label"] == "pass"
+
+    def test_variant_list_fails_when_no_variant_matches(self) -> None:
+        # Observed call satisfies none of the variants -> fail. The
+        # failure metadata lists all variants.
+        result = evaluate_tool_call_args(
+            output=_output_with_args("set_time_range", {"timeRangeKey": "30d"}),
+            expected=self._expected(
+                set_time_range=[
+                    {"timeRangeKey": "1h"},
+                    {"timeRangeKey": "1d"},
+                ],
+            ),
+        )
+        assert result["label"] == "fail"
+        assert isinstance(result["metadata"]["set_time_range"]["expected"], list)
+        assert len(result["metadata"]["set_time_range"]["expected"]) == 2
+
+    def test_variant_list_applies_subset_match_per_variant(self) -> None:
+        # Each variant uses subset matching: observed may carry extra keys.
+        # Here the agent picks custom with a startTime; one variant accepts
+        # just timeRangeKey: custom, which is a subset of the observed call.
+        result = evaluate_tool_call_args(
+            output=_output_with_args(
+                "set_time_range",
+                {"timeRangeKey": "custom", "startTime": "2025-01-15T00:00:00Z"},
+            ),
+            expected=self._expected(
+                set_time_range=[
+                    {"timeRangeKey": "1d"},
+                    {"timeRangeKey": "custom"},
+                ],
+            ),
+        )
+        assert result["label"] == "pass"
+
+    def test_variant_list_with_empty_list_is_a_no_op(self) -> None:
+        # A defensive case: an empty variant list means "no expectation
+        # for this tool"; the evaluator returns success without checking
+        # observed calls for that tool.
+        result = evaluate_tool_call_args(
+            output=_output_with_args("set_time_range", {"timeRangeKey": "1h"}),
+            expected=self._expected(set_time_range=[]),
         )
         assert result["label"] == "pass"

--- a/tests/pxi/evals/test_run_experiment.py
+++ b/tests/pxi/evals/test_run_experiment.py
@@ -1,0 +1,71 @@
+"""Unit tests for the standalone PXI eval experiment runner.
+
+Run directly:
+
+    uv run pytest tests/pxi/evals/test_run_experiment.py
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
+
+from tests.pxi.evals.run_experiment import _failed_evaluation_rows, _format_table
+
+
+def _ran_experiment(*, dataset_id: str = "dataset-1", experiment_id: str = "experiment-1") -> RanExperiment:
+    return {
+        "experiment_id": experiment_id,
+        "dataset_id": dataset_id,
+        "dataset_version_id": "dataset-version-1",
+        "task_runs": [],
+        "evaluation_runs": [],
+        "experiment_metadata": {},
+        "project_name": None,
+    }
+
+
+def test_format_table_aligns_headers_and_rows() -> None:
+    table = _format_table(
+        ("Evaluator", "Passed", "Failed"),
+        [("correct_tools_called", "10", "0"), ("tool_call_args_match", "9", "1")],
+    )
+    assert table == "\n".join(
+        [
+            "+----------------------+--------+--------+",
+            "| Evaluator            | Passed | Failed |",
+            "+----------------------+--------+--------+",
+            "| correct_tools_called | 10     | 0      |",
+            "| tool_call_args_match | 9      | 1      |",
+            "+----------------------+--------+--------+",
+        ]
+    )
+
+
+def test_failed_evaluation_rows_include_stable_example_id_and_details() -> None:
+    now = datetime.now(timezone.utc)
+    experiment = _ran_experiment()
+    experiment["task_runs"] = [
+        {
+            "id": "run-1",
+            "dataset_example_id": "example-1",
+            "output": {},
+            "repetition_number": 1,
+            "start_time": now.isoformat(),
+            "end_time": now.isoformat(),
+            "experiment_id": "experiment-1",
+        }
+    ]
+    evaluation_run = ExperimentEvaluationRun(
+        experiment_run_id="run-1",
+        start_time=now,
+        end_time=now,
+        name="tool_call_args_match",
+        annotator_kind="CODE",
+        result={"score": 0.0, "label": "fail", "explanation": "wrong filter"},
+    )
+
+    assert _failed_evaluation_rows(experiment, [evaluation_run]) == [
+        ("example-1", "tool_call_args_match", "0", "fail", "wrong filter")
+    ]

--- a/tests/pxi/evals/test_run_experiment.py
+++ b/tests/pxi/evals/test_run_experiment.py
@@ -14,7 +14,9 @@ from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, 
 from tests.pxi.evals.run_experiment import _failed_evaluation_rows, _format_table, _task_error_rows
 
 
-def _ran_experiment(*, dataset_id: str = "dataset-1", experiment_id: str = "experiment-1") -> RanExperiment:
+def _ran_experiment(
+    *, dataset_id: str = "dataset-1", experiment_id: str = "experiment-1"
+) -> RanExperiment:
     return {
         "experiment_id": experiment_id,
         "dataset_id": dataset_id,

--- a/tests/pxi/evals/test_run_experiment.py
+++ b/tests/pxi/evals/test_run_experiment.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 
 from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
 
-from tests.pxi.evals.run_experiment import _failed_evaluation_rows, _format_table
+from tests.pxi.evals.run_experiment import _failed_evaluation_rows, _format_table, _task_error_rows
 
 
 def _ran_experiment(*, dataset_id: str = "dataset-1", experiment_id: str = "experiment-1") -> RanExperiment:
@@ -69,3 +69,45 @@ def test_failed_evaluation_rows_include_stable_example_id_and_details() -> None:
     assert _failed_evaluation_rows(experiment, [evaluation_run]) == [
         ("example-1", "tool_call_args_match", "0", "fail", "wrong filter")
     ]
+
+
+def test_task_error_rows_include_output_errors_with_stable_example_id() -> None:
+    now = datetime.now(timezone.utc)
+    experiment = _ran_experiment()
+    experiment["task_runs"] = [
+        {
+            "id": "run-1",
+            "dataset_example_id": "opaque-example-id",
+            "output": {
+                "stable_example_id": "example-1",
+                "error": "RuntimeError: model credentials missing",
+            },
+            "repetition_number": 1,
+            "start_time": now.isoformat(),
+            "end_time": now.isoformat(),
+            "experiment_id": "experiment-1",
+        }
+    ]
+
+    assert _task_error_rows(experiment) == [
+        ("example-1", "RuntimeError: model credentials missing")
+    ]
+
+
+def test_task_error_rows_include_task_run_errors() -> None:
+    now = datetime.now(timezone.utc)
+    experiment = _ran_experiment()
+    experiment["task_runs"] = [
+        {
+            "id": "run-1",
+            "dataset_example_id": "example-1",
+            "output": {},
+            "repetition_number": 1,
+            "start_time": now.isoformat(),
+            "end_time": now.isoformat(),
+            "experiment_id": "experiment-1",
+            "error": "TimeoutError: task timed out",
+        }
+    ]
+
+    assert _task_error_rows(experiment) == [("example-1", "TimeoutError: task timed out")]


### PR DESCRIPTION
## Summary

Four improvements to the PXI eval harness, no dataset content changes.

- **Split the args evaluator by tool.** `tool_call_args_match` is now strictly generic (exact value comparison, skips tools listed in `_TOOLS_WITH_SPECIALIZED_ARG_EVALUATORS`). A new `set_spans_filter_args_match` owns the Phoenix span-filter DSL semantics — clause reordering under pure `and` or pure `or` no longer produces spurious failures, while AND-set and OR-set over the same clauses remain disjoint.
- **Per-dataset evaluator selection.** Datasets now declare a required `evaluators:` list in the YAML; the runner looks each name up through a new `EVALUATORS_BY_NAME` registry and fails fast on unknowns. A new `--evaluator NAME` (repeatable) CLI flag overrides the YAML for ad-hoc runs (debugging a single evaluator, trying a new one across existing datasets). Eliminates the misleading vacuous-pass lines in the dashboard from evaluators whose tool predicate filtered everything out of scope.
- **Bug fix: JSON-string tool-call args.** Pydantic AI serializes tool-call args as a JSON-encoded string over some transports; `_tool_args` previously coerced strings to `{}`, so every arg-pin example was silently failing without metadata. Now decodes via `json.loads`, falling back to `{}` only on parse failure.
- Variant-list arg matching is also included: `tool_call_args[<tool>]` accepts either a single dict or a list of dicts, with any-of semantics. Useful for genuinely-ambiguous queries where multiple arg shapes are equally correct.

Includes a one-line bump to the shipped `set_spans_filter.yaml` so the existing dataset satisfies the new required `evaluators:` field. No example content changes.