### PR TITLE
ci: pin openapi-diff image and fix non-risky zizmor findings

### DIFF
--- a/.github/workflows/check-card-links.yml
+++ b/.github/workflows/check-card-links.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
@@ -64,10 +66,12 @@ jobs:
       - name: Comment on PR with summary
         if: ${{ github.event_name == 'pull_request' && always() }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          SUMMARY_PATH: ${{ steps.run-check.outputs.summary_path }}
         with:
           script: |
             const fs = require('fs');
-            const summaryPath = '${{ steps.run-check.outputs.summary_path }}';
+            const summaryPath = process.env.SUMMARY_PATH;
             const body = '<!-- card-links-check -->\n' + fs.readFileSync(summaryPath, 'utf8');
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -78,7 +82,9 @@ jobs:
 
       - name: Write to Job Summary
         if: always()
-        run: cat ${{ steps.run-check.outputs.summary_path }} >> $GITHUB_STEP_SUMMARY
+        env:
+          SUMMARY_PATH: ${{ steps.run-check.outputs.summary_path }}
+        run: cat "$SUMMARY_PATH" >> $GITHUB_STEP_SUMMARY
 
       - name: Fail if errors detected
         if: ${{ steps.run-check.outputs.exit_code != '' }}

--- a/.github/workflows/check-dependabot-uv-version.yml
+++ b/.github/workflows/check-dependabot-uv-version.yml
@@ -56,21 +56,24 @@ jobs:
         id: existing_pr
         env:
           GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          UV_VERSION: ${{ steps.dependabot.outputs.version }}
         run: |
           set -euo pipefail
           count=$(gh pr list \
-            --search "chore(deps): bump uv to ${{ steps.dependabot.outputs.version }} in:title" \
+            --search "chore(deps): bump uv to $UV_VERSION in:title" \
             --state open --json number --jq 'length')
           echo "count=$count" >> "$GITHUB_OUTPUT"
           if [ "$count" -gt 0 ]; then
-            echo "An open PR for uv ${{ steps.dependabot.outputs.version }} already exists; skipping."
+            echo "An open PR for uv $UV_VERSION already exists; skipping."
           fi
 
       - name: Create branch
         if: steps.dependabot.outputs.version != steps.repo.outputs.version && steps.existing_pr.outputs.count == '0'
+        env:
+          UV_VERSION: ${{ steps.dependabot.outputs.version }}
         run: |
           DATE=$(date -u +%Y-%m-%d)
-          BRANCH="claude/bump-uv-${{ steps.dependabot.outputs.version }}-$DATE"
+          BRANCH="claude/bump-uv-$UV_VERSION-$DATE"
           git checkout -b "$BRANCH"
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
 

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -23,11 +23,14 @@ jobs:
 
     steps:
       - name: Guard – check permissions and duplicates
+        env:
+          REPO: ${{ github.repository }}
+          SENDER: ${{ github.event.sender.login }}
         run: |
           # Verify sender has write access
-          PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission" -q '.permission')
+          PERMISSION=$(gh api "repos/$REPO/collaborators/$SENDER/permission" -q '.permission')
           if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "maintain" && "$PERMISSION" != "write" ]]; then
-            echo "Sender ${{ github.event.sender.login }} has '$PERMISSION' permission, skipping"
+            echo "Sender $SENDER has '$PERMISSION' permission, skipping"
             exit 0
           fi
 
@@ -121,8 +124,11 @@ jobs:
 
       - name: Cleanup
         if: always() && env.READY == 'true'
+        env:
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           gh issue edit "$ISSUE_NUMBER" --remove-assignee "mikeldking" --remove-label "agent-in-progress"
-          if [ "${{ job.status }}" = "failure" ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "Agent implementation failed. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          if [ "$JOB_STATUS" = "failure" ]; then
+            gh issue comment "$ISSUE_NUMBER" --body "Agent implementation failed. See [workflow run]($RUN_URL) for details."
           fi

--- a/.github/workflows/claude-skills-audit.yml
+++ b/.github/workflows/claude-skills-audit.yml
@@ -104,10 +104,13 @@ jobs:
 
       - name: Commit and push
         if: steps.changes.outputs.has_changes == 'true'
+        env:
+          AUDIT_DATE: ${{ steps.branch.outputs.date }}
+          AUDIT_BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
           git add .agents/skills/phoenix-tracing .agents/skills/phoenix-cli .agents/skills/phoenix-evals
-          git commit -m "docs(skills): weekly audit — ${{ steps.branch.outputs.date }}"
-          git push origin "${{ steps.branch.outputs.branch }}"
+          git commit -m "docs(skills): weekly audit — $AUDIT_DATE"
+          git push origin "$AUDIT_BRANCH"
 
       - name: Open pull request
         if: steps.changes.outputs.has_changes == 'true'

--- a/.github/workflows/openapi-schema.yaml
+++ b/.github/workflows/openapi-schema.yaml
@@ -28,6 +28,6 @@ jobs:
         run: |
           jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \
             schemas/openapi.json > base.json
-      - uses: docker://openapitools/openapi-diff
+      - uses: docker://openapitools/openapi-diff@sha256:82291446e5554742d9c0725d7b315d18e93958c5526f9a663e8885227bdd6cb6 # latest
         with:
           args: --fail-on-incompatible base.json head.json

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -22,11 +22,14 @@ jobs:
         id: branches
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.ref_name }}" != "main" ]; then
-            branches=$(jq -cn --arg b "${{ github.ref_name }}" '[$b]')
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$REF_NAME" != "main" ]; then
+            branches=$(jq -cn --arg b "$REF_NAME" '[$b]')
           else
-            branches=$(gh api repos/${{ github.repository }}/branches --paginate | jq -c -s '[.[][] | select(.name == "main" or (.name | startswith("version-"))) | .name]')
+            branches=$(gh api "repos/$REPO/branches" --paginate | jq -c -s '[.[][] | select(.name == "main" or (.name | startswith("version-"))) | .name]')
           fi
           echo "branches=$branches" >> $GITHUB_OUTPUT
 
@@ -64,6 +67,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.branch }}
+          persist-credentials: false
           sparse-checkout: |
             requirements/
             src/phoenix/
@@ -137,6 +141,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.branch }}
+          persist-credentials: false
           sparse-checkout: |
             requirements/
             src/phoenix/
@@ -171,6 +176,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.branch }}
+          persist-credentials: false
           sparse-checkout: |
             requirements/
             packages/phoenix-client/
@@ -197,6 +203,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.branch }}
+          persist-credentials: false
           sparse-checkout: |
             requirements/
             packages/phoenix-evals/
@@ -222,6 +229,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.branch }}
+          persist-credentials: false
           sparse-checkout: |
             requirements/
             packages/phoenix-otel/

--- a/.github/workflows/typescript-packages-publish-experimental.yml
+++ b/.github/workflows/typescript-packages-publish-experimental.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # workaround for broken corepack https://github.com/nodejs/corepack/issues/612
       - run: |


### PR DESCRIPTION
## Summary

- Pin `docker://openapitools/openapi-diff` in `.github/workflows/openapi-schema.yaml` to the `latest` manifest list digest (`sha256:8229...6cb6`) so the action runs against a fixed image.
- Apply the low-risk subset of zizmor's auto-fixable findings across `.github/workflows/`:
  - **template-injection**: move trusted contexts (`github.ref_name`, `github.event_name`, `github.repository`, `github.event.sender.login`, `job.status`, step outputs) into `env:` blocks and reference them as shell vars.
  - **artipacked**: add `persist-credentials: false` to checkouts that don't pass a `token:` and don't push (sparse read-only checkouts in `python-all-platforms.yml`, `check-card-links.yml`, `typescript-packages-publish-experimental.yml`).

Net zizmor delta: 295 → 270 findings; high 13 → 9, medium 44 → 37. Remaining findings are token-bearing checkouts, excessive-permissions, `pull_request_target` triggers, and cache-poisoning — left untouched as they need workflow-level reasoning.

## Test plan

- [ ] `openapi-schema` workflow still runs on a schema-changing PR
- [ ] `python-all-platforms` scheduled run still completes (sparse checkouts + ref input still work)
- [ ] `check-card-links` still posts/updates the PR comment and step summary
- [ ] `check-dependabot-uv-version` next dependabot bump still opens its PR
- [ ] `claude-implement-issue` and `claude-skills-audit` still claim/comment/push as expected