### PR TITLE
feat(agents): documentation_questions eval suite and link-rendering rules

### DIFF
--- a/.agents/skills/phoenix-pxi/SKILL.md
+++ b/.agents/skills/phoenix-pxi/SKILL.md
@@ -31,6 +31,7 @@ Read the relevant file(s) based on the task:
 | `resources/extending-tool-registry.md`               | Adding, editing, or removing a PXI tool — server advertisement, browser execution, capability gating, request/dispatch flow  |
 | `resources/system-prompt-xml-conventions.md`         | Adding to, editing, or reviewing the PXI agent system prompt or any module that contributes lines to it                      |
 | `resources/per-turn-context-and-cache-management.md` | Injecting per-turn page or UI state into a chat request; sanitizing user-controlled values; preserving prompt-cache prefixes |
+| `resources/optimization-loop.md`                     | Tuning PXI behavior with the `tests/pxi/evals/` harness — collect tough examples, name failure modes, grade them, propose a change to the human, then re-run     |
 
 ## When To Add Which Tool Type
 

--- a/.agents/skills/phoenix-pxi/resources/optimization-loop.md
+++ b/.agents/skills/phoenix-pxi/resources/optimization-loop.md
@@ -43,12 +43,21 @@ The loop is human-in-the-loop on purpose. **Never** silently iterate on prompts 
 - **Label precedence.** When multiple failure modes could fire on the same example, document the precedence in the evaluator's docstring (most-actionable first) and short-circuit in that order. Mixed labels are unreadable in summaries.
 - **Metadata over prose.** Put URLs, tool names, and offending values into `metadata`. The `explanation` field is for humans skimming a failure; structured `metadata` is for filtering and trend analysis.
 
+## Dataset Curation: Evals Are Goals
+
+An eval suite is a **goal set**, not a regression corpus. Every example should either define behavior the agent must keep, or stretch the agent toward behavior it doesn't yet reliably produce. Examples that no longer do either job are noise — they inflate pass rates and hide real failures.
+
+- **Keep a thin baseline.** A small number of obviously-easy cases is fine to anchor the suite — they catch catastrophic regressions (model swap, prompt assembly bug). Beyond that baseline, easy examples should be flagged for removal.
+- **Flag rather than delete in-flight.** When you notice an example is trivially passing, surface it to the user in the proposal step (step 4) with a recommendation: remove, replace with a harder variant in the same category, or keep as baseline. Do not silently prune — the user may be using it to lock in behavior you don't know about.
+- **Promote, don't pad.** When the agent starts passing a hard case reliably, the right move is usually to replace it with a harder one in the same `metadata.category` — not to leave it in *and* add the harder one. Two examples that probe the same behavior at different difficulties dilute the signal from the suite-level pass rate.
+- **Heuristic for "too easy."** If an example passes across three consecutive runs *and* spans two prompt iterations *and* its category has no other failing cases, it's a candidate for removal. Categories that still have failing siblings should keep their easy cases as the floor.
+
 ## Anti-Patterns
 
 - **Don't** edit the prompt and re-run without first naming the failure modes you expect to move. You will end up chasing whichever case ran most recently.
 - **Don't** delete failing examples to make the experiment green. If an example no longer reflects desired behavior, change its `expected` — and call that out in the PR.
 - **Don't** reach for an LLM-as-judge evaluator when a regex or set membership check works. Code evaluators are reproducible across model versions; LLM judges aren't.
-- **Don't** add only easy cases. A dataset that the agent already passes 100% on the first try is not protecting against regressions — it's confirming the status quo.
+- **Don't** keep arbitrarily easy examples around to pad the pass rate. See **Dataset Curation** above — the suite is a goal set, not a regression corpus.
 
 ## Verification
 

--- a/.agents/skills/phoenix-pxi/resources/optimization-loop.md
+++ b/.agents/skills/phoenix-pxi/resources/optimization-loop.md
@@ -1,0 +1,56 @@
+# PXI Optimization Loop
+
+Use this when changing PXI behavior that is judged on the **assistant's output** (which tool it picks, what its text says, how it formats links) rather than purely on schema/wiring. The harness lives at `tests/pxi/evals/`; this guide is the loop you run *around* it.
+
+## When To Use This Loop
+
+Trigger this loop when a change touches:
+
+- `src/phoenix/server/agents/prompts.py` (system-prompt rules or tool guidance).
+- Tool descriptions / `when_to_use` lines that steer model behavior.
+- Anything where "did this fix the failure or push it sideways?" is a real question.
+
+Pure schema or wiring changes (new tool registration, type fix, refactor) do **not** need this loop — the existing unit tests are enough.
+
+## The Loop
+
+The loop is human-in-the-loop on purpose. **Never** silently iterate on prompts and re-run; surface each step to the user and wait for acknowledgement before the next change.
+
+1. **Collect tough examples.** Write the prompts that *fail today* into a dataset YAML under `tests/pxi/evals/datasets/<topic>.yaml`. Cover adversarial cases, not just happy paths — ambiguous queries, queries that look like the wrong tool, queries that span multiple Phoenix areas. A dataset that only contains golden inputs proves nothing.
+2. **Characterize failure modes.** Run the dataset against the current agent. For each failing case, name *why* it failed (e.g. "bare URL", "called bash on a definitional question", "leaked internal preview host"). Group similar failures — these become evaluator labels.
+3. **Decide how to grade.** Pick an evaluator shape for each failure mode:
+   - **Code evaluator** (`kind="code"`) when the property is mechanically checkable — URL prefixes, tool names called, argument shapes, link syntax. Prefer these; they're deterministic and cheap.
+   - **LLM-as-judge** (`kind="llm"`) only when the property is genuinely linguistic (tone, helpfulness, hedging). Spell out the rubric in the prompt.
+   Each evaluator returns `{score, label, explanation, metadata}` — distinct `label` values per failure mode let you read the experiment summary and see the failure distribution at a glance.
+4. **Propose the change.** Write up: (a) the failure modes you observed, (b) the proposed prompt or tool change, (c) which evaluator labels it should move. **Stop here and surface this to the user.** Do not edit `prompts.py` until they acknowledge the diagnosis. The most expensive mistake is fixing the wrong failure mode.
+5. **Re-run after acknowledgement.** Apply the change, re-run `run_experiment.py --dataset <topic>`, and report the label distribution before/after. Flag any new failure modes introduced — a fix that resolves one label by creating another is not a fix.
+6. **Loop or land.** If failures remain and the diagnosis is unchanged, return to step 4 with a tightened proposal. If failures remain but the diagnosis has shifted, return to step 2 — don't keep proposing changes against a stale theory.
+
+## File Layout
+
+| File | Role |
+| --- | --- |
+| `tests/pxi/evals/datasets/<topic>.yaml` | Inputs + expectations. `dataset_name` matches the file stem. Examples have `input`, `expected`, and `metadata.category` for grouping. |
+| `tests/pxi/evals/evaluators/<property>.py` | One code evaluator per scored property. Export both `evaluate_<property>` (pure function, easy to unit-test) and a `@create_evaluator(name=..., kind="code")` wrapper. |
+| `tests/pxi/evals/evaluators/__init__.py` | Re-export the `@create_evaluator`-decorated function so `run_experiment.py` can import it. |
+| `tests/pxi/evals/run_experiment.py` | Wires evaluators into the evaluator list passed to `evaluate_experiment`. Run with `--dataset <stem>`. |
+| `tests/pxi/evals/test_evaluators.py` | Unit tests for the evaluator's labels — exercise every failure path you defined. |
+
+## Conventions
+
+- **Dataset name vs. evaluator name.** Datasets are named for the *inputs* (`documentation_questions`, `set_spans_filter`). Evaluators are named for the *property scored* (`documentation_links`, `correct_tools_called`, `tool_call_args_match`). They don't have to share a name and usually shouldn't — one dataset is often scored by several evaluators.
+- **`not_applicable` label.** When an evaluator is wired into the global evaluator list but a given dataset's `expected` block doesn't carry its inputs, return `{"score": 1.0, "label": "not_applicable"}`. This lets evaluators stack without polluting unrelated suites.
+- **Label precedence.** When multiple failure modes could fire on the same example, document the precedence in the evaluator's docstring (most-actionable first) and short-circuit in that order. Mixed labels are unreadable in summaries.
+- **Metadata over prose.** Put URLs, tool names, and offending values into `metadata`. The `explanation` field is for humans skimming a failure; structured `metadata` is for filtering and trend analysis.
+
+## Anti-Patterns
+
+- **Don't** edit the prompt and re-run without first naming the failure modes you expect to move. You will end up chasing whichever case ran most recently.
+- **Don't** delete failing examples to make the experiment green. If an example no longer reflects desired behavior, change its `expected` — and call that out in the PR.
+- **Don't** reach for an LLM-as-judge evaluator when a regex or set membership check works. Code evaluators are reproducible across model versions; LLM judges aren't.
+- **Don't** add only easy cases. A dataset that the agent already passes 100% on the first try is not protecting against regressions — it's confirming the status quo.
+
+## Verification
+
+- `uv run pytest tests/pxi/evals/test_evaluators.py` for evaluator unit tests.
+- `uv run python -m tests.pxi.evals.run_experiment --dataset <topic>` against a local Phoenix for the full loop.

--- a/src/phoenix/server/agents/prompts.py
+++ b/src/phoenix/server/agents/prompts.py
@@ -63,8 +63,11 @@ _BASH_TOOL_SYSTEM_PROMPT_LINES = (
         "refreshed on navigation, time-range changes, or a /refresh command."
     ),
     (
-        "    - To orient to the current page, first read /phoenix/agent-start.md. "
-        "Use other files in /phoenix as needed."
+        "    - Only read /phoenix/agent-start.md when the user's request depends on "
+        "the page they are currently viewing (for example filtering spans, acting on "
+        "the visible trace, or page-specific state). For general definitional "
+        '("what is X") or unanchored ("how do I…") questions, prefer search_phoenix '
+        "and answer from the docs without reading page context."
     ),
     "  </orientation>",
     "</tool>",
@@ -89,6 +92,11 @@ _ASK_USER_TOOL_SYSTEM_PROMPT_LINES = (
     "    - Set `allow_skip: true` for optional questions.",
     "    - Use `freeform` type only when the answer space is truly open-ended.",
     (
+        "    - Also use this when a user question is too broad to answer well "
+        '(for example "how do I get started?") and presenting 2-4 scoped options '
+        "would lead to a much better answer than guessing across multiple Phoenix areas."
+    ),
+    (
         "    - After receiving answers, summarize what you understood and proceed. "
         "Do not re-ask the same questions."
     ),
@@ -108,6 +116,36 @@ _STATIC_SYSTEM_PROMPT_LINES = (
     *_BASH_TOOL_SYSTEM_PROMPT_LINES,
     *_ASK_USER_TOOL_SYSTEM_PROMPT_LINES,
     "</tools>",
+    "",
+    "<tool_selection>",
+    "  <rule>",
+    (
+        '    For definitional questions about Phoenix concepts ("what is a span", '
+        '"what\'s an annotation"): call search_phoenix once and answer in prose '
+        "with a markdown link to the canonical docs page. Do not call bash — page "
+        "context does not help define a concept."
+    ),
+    "  </rule>",
+    "  <rule>",
+    (
+        '    For broad or ambiguous "how do I…" / "where do I start" questions that '
+        "could plausibly map to more than one Phoenix area (tracing vs. evals vs. "
+        "datasets vs. self-hosting), call ask_user first with 2-4 scoped options "
+        "before any other tool call. Exception: if the user explicitly names a "
+        'specific Phoenix area (for example "how do I get started with tracing", '
+        '"docs for self-hosting") or explicitly asks for a documentation link, skip '
+        "the elicitation and answer directly from search_phoenix."
+    ),
+    "  </rule>",
+    "  <rule>",
+    (
+        "    Use bash for operations tied to the current page or system data — "
+        "inspecting /phoenix context, running phoenix-gql, or executing built-in "
+        "utilities. Never call bash in parallel with search_phoenix on a "
+        "definitional question."
+    ),
+    "  </rule>",
+    "</tool_selection>",
     "",
     "<link_formatting>",
     "  <canonical_docs_domain>https://arize.com/docs/phoenix</canonical_docs_domain>",

--- a/tests/pxi/evals/datasets/documentation_questions.yaml
+++ b/tests/pxi/evals/datasets/documentation_questions.yaml
@@ -1,0 +1,240 @@
+dataset_name: documentation_questions
+description: >
+  PXI server-side eval suite verifying that the agent renders documentation
+  references as markdown links against the canonical Arize Phoenix docs
+  domain (https://arize.com/docs/phoenix/...) and never leaks internal
+  preview hosts (arizeai-*.mintlify.app), localhost, or bare URLs.
+examples:
+  - id: tracing-quickstart
+    input:
+      query: How do I get started with tracing my LLM app in Phoenix? Please link to the relevant docs.
+    expected:
+      tools:
+        required: [search_phoenix]
+      assistant_text:
+        required_url_prefix: https://arize.com/docs/phoenix/
+        markdown_link_required: true
+        forbidden_url_substrings:
+          - arizeai-
+          - .mintlify.app
+          - localhost
+        expected_url_path_substrings:
+          - tracing
+    metadata:
+      category: tracing
+  - id: openai-integration
+    input:
+      query: Where can I find documentation for instrumenting OpenAI calls with Phoenix?
+    expected:
+      tools:
+        required: [search_phoenix]
+      assistant_text:
+        required_url_prefix: https://arize.com/docs/phoenix/
+        markdown_link_required: true
+        forbidden_url_substrings:
+          - arizeai-
+          - .mintlify.app
+          - localhost
+        expected_url_path_substrings:
+          - openai
+    metadata:
+      category: integrations
+  - id: langchain-integration
+    input:
+      query: Point me at the Phoenix docs for tracing LangChain applications.
+    expected:
+      tools:
+        required: [search_phoenix]
+      assistant_text:
+        required_url_prefix: https://arize.com/docs/phoenix/
+        markdown_link_required: true
+        forbidden_url_substrings:
+          - arizeai-
+          - .mintlify.app
+          - localhost
+        expected_url_path_substrings:
+          - langchain
+    metadata:
+      category: integrations
+  - id: experiments-overview
+    input:
+      query: What are Phoenix experiments and where can I read more about them?
+    expected:
+      tools:
+        required: [search_phoenix]
+      assistant_text:
+        required_url_prefix: https://arize.com/docs/phoenix/
+        markdown_link_required: true
+        forbidden_url_substrings:
+          - arizeai-
+          - .mintlify.app
+          - localhost
+        expected_url_path_substrings:
+          - experiments
+    metadata:
+      category: experiments
+  - id: datasets-overview
+    input:
+      query: Share the Phoenix documentation page that explains datasets.
+    expected:
+      tools:
+        required: [search_phoenix]
+      assistant_text:
+        required_url_prefix: https://arize.com/docs/phoenix/
+        markdown_link_required: true
+        forbidden_url_substrings:
+          - arizeai-
+          - .mintlify.app
+          - localhost
+        expected_url_path_substrings:
+          - datasets
+    metadata:
+      category: datasets
+  - id: evaluators-builtin
+    input:
+      query: Which built-in evaluators ship with Phoenix? Include a link to the docs.
+    expected:
+      tools:
+        required: [search_phoenix]
+      assistant_text:
+        required_url_prefix: https://arize.com/docs/phoenix/
+        markdown_link_required: true
+        forbidden_url_substrings:
+          - arizeai-
+          - .mintlify.app
+          - localhost
+        expected_url_path_substrings:
+          - eval
+    metadata:
+      category: evaluation
+  - id: self-hosting
+    input:
+      query: How do I self-host Phoenix? Link to the deployment docs.
+    expected:
+      tools:
+        required: [search_phoenix]
+      assistant_text:
+        required_url_prefix: https://arize.com/docs/phoenix/
+        markdown_link_required: true
+        forbidden_url_substrings:
+          - arizeai-
+          - .mintlify.app
+          - localhost
+        expected_url_path_substrings:
+          - self-host
+    metadata:
+      category: deployment
+  - id: prompts-overview
+    input:
+      query: Where are the Phoenix prompts docs?
+    expected:
+      tools:
+        required: [search_phoenix]
+      assistant_text:
+        required_url_prefix: https://arize.com/docs/phoenix/
+        markdown_link_required: true
+        forbidden_url_substrings:
+          - arizeai-
+          - .mintlify.app
+          - localhost
+        expected_url_path_substrings:
+          - prompt
+    metadata:
+      category: prompts
+  - id: annotations-overview
+    input:
+      query: Send me the docs for span annotations in Phoenix.
+    expected:
+      tools:
+        required: [search_phoenix]
+      assistant_text:
+        required_url_prefix: https://arize.com/docs/phoenix/
+        markdown_link_required: true
+        forbidden_url_substrings:
+          - arizeai-
+          - .mintlify.app
+          - localhost
+        expected_url_path_substrings:
+          - annotation
+    metadata:
+      category: annotations
+  - id: docs-domain-grounding
+    input:
+      query: When you share a documentation link, what URL should it start with?
+    expected:
+      tools: {}
+      assistant_text:
+        required_url_prefix: https://arize.com/docs/phoenix
+        markdown_link_required: false
+        forbidden_url_substrings:
+          - arizeai-
+          - .mintlify.app
+          - localhost
+    metadata:
+      category: meta
+  - id: what-is-a-span
+    input:
+      query: What is a span?
+    expected:
+      tools:
+        required: [search_phoenix]
+        forbidden: [bash]
+      assistant_text:
+        required_url_prefix: https://arize.com/docs/phoenix/
+        markdown_link_required: true
+        forbidden_url_substrings:
+          - arizeai-
+          - .mintlify.app
+          - localhost
+    metadata:
+      category: ambiguous-definitional
+  - id: what-is-an-annotation
+    input:
+      query: What's an annotation?
+    expected:
+      tools:
+        required: [search_phoenix]
+        forbidden: [bash]
+      assistant_text:
+        required_url_prefix: https://arize.com/docs/phoenix/
+        markdown_link_required: true
+        forbidden_url_substrings:
+          - arizeai-
+          - .mintlify.app
+          - localhost
+    metadata:
+      category: ambiguous-definitional
+  - id: how-do-i-run-evals
+    input:
+      query: How do I run evals?
+    expected:
+      tools:
+        required: [ask_user]
+        forbidden: [bash]
+    metadata:
+      category: ambiguous-broad
+  - id: what-is-a-trace
+    input:
+      query: What is a trace?
+    expected:
+      tools:
+        required: [search_phoenix]
+        forbidden: [bash]
+      assistant_text:
+        required_url_prefix: https://arize.com/docs/phoenix/
+        markdown_link_required: true
+        forbidden_url_substrings:
+          - arizeai-
+          - .mintlify.app
+          - localhost
+    metadata:
+      category: ambiguous-definitional
+  - id: how-do-i-get-started
+    input:
+      query: How do I get started?
+    expected:
+      tools:
+        required: [ask_user]
+        forbidden: [bash]
+    metadata:
+      category: ambiguous-broad

--- a/tests/pxi/evals/evaluators/__init__.py
+++ b/tests/pxi/evals/evaluators/__init__.py
@@ -1,8 +1,10 @@
 """Code evaluators for PXI experiment suites."""
 
+from tests.pxi.evals.evaluators.documentation_links import documentation_links
 from tests.pxi.evals.evaluators.tools import correct_tools_called, tool_call_args_match
 
 __all__ = [
     "correct_tools_called",
+    "documentation_links",
     "tool_call_args_match",
 ]

--- a/tests/pxi/evals/evaluators/documentation_links.py
+++ b/tests/pxi/evals/evaluators/documentation_links.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from phoenix.evals import create_evaluator
+
+_MARKDOWN_LINK_RE = re.compile(r"\[(?P<text>[^\]]+)\]\((?P<url>[^)\s]+)\)")
+_URL_RE = re.compile(r"https?://[^\s)\]]+")
+_URL_TRAILING_PUNCT = ".,;:!?'\""
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _assistant_text(output: Any) -> str | None:
+    text = _as_dict(output).get("assistant_text")
+    return text if isinstance(text, str) else None
+
+
+def _assistant_text_expectations(expected: Any) -> dict[str, Any] | None:
+    expectations = _as_dict(expected).get("assistant_text")
+    return expectations if isinstance(expectations, dict) else None
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _extract_links(text: str) -> tuple[list[str], list[str]]:
+    """Return ``(linked_urls, bare_urls)`` found in ``text``.
+
+    Linked URLs are pulled from markdown link syntax ``[anchor](url)``. Bare
+    URLs are any remaining ``https?://`` substrings after the markdown link
+    occurrences are stripped. Trailing punctuation in
+    ``_URL_TRAILING_PUNCT`` is stripped from bare URLs because it almost
+    always belongs to the surrounding sentence rather than the URL.
+    """
+    linked = [match.group("url").strip() for match in _MARKDOWN_LINK_RE.finditer(text)]
+    stripped = _MARKDOWN_LINK_RE.sub("", text)
+    bare = [match.group(0).rstrip(_URL_TRAILING_PUNCT) for match in _URL_RE.finditer(stripped)]
+    return linked, bare
+
+
+def _failure(
+    label: str,
+    explanation: str,
+    *,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "score": 0.0,
+        "label": label,
+        "explanation": explanation,
+    }
+    if metadata:
+        payload["metadata"] = dict(metadata)
+    return payload
+
+
+def _success(label: str = "pass", *, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {"score": 1.0, "label": label}
+    if metadata:
+        payload["metadata"] = dict(metadata)
+    return payload
+
+
+def evaluate_documentation_links(output: Any, expected: Any) -> dict[str, Any]:
+    """Score documentation links in the assistant text against PXI link rules.
+
+    Reads constraints from ``expected.assistant_text``:
+
+    - ``required_url_prefix`` (str): at least one URL must start with this prefix.
+    - ``markdown_link_required`` (bool, default False): no bare ``https?://``
+      URLs allowed — every URL must appear inside markdown link syntax.
+    - ``forbidden_url_substrings`` (list[str]): no URL may contain any of these.
+    - ``expected_url_path_substrings`` (list[str]): at least one URL must
+      contain at least one of these substrings.
+
+    Returns one of the following labels:
+
+    - ``pass``: all configured checks passed.
+    - ``not_applicable``: ``expected.assistant_text`` was not provided, so
+      the evaluator has nothing to score — safe to wire alongside other
+      evaluators globally.
+    - ``missing_assistant_text``: the agent produced no text output.
+    - ``forbidden_url``: at least one URL contained a forbidden substring.
+    - ``bare_url``: ``markdown_link_required`` is true and at least one URL
+      appeared outside markdown link syntax.
+    - ``missing_required_prefix``: no URL started with
+      ``required_url_prefix``.
+    - ``missing_expected_path``: no URL contained any of the
+      ``expected_url_path_substrings``.
+
+    Precedence (most actionable first): ``forbidden_url`` > ``bare_url`` >
+    ``missing_required_prefix`` > ``missing_expected_path``.
+    """
+    expectations = _assistant_text_expectations(expected)
+    if expectations is None:
+        return _success(label="not_applicable")
+
+    text = _assistant_text(output)
+    if not text:
+        return _failure("missing_assistant_text", "Assistant produced no text output")
+
+    linked_urls, bare_urls = _extract_links(text)
+    all_urls = linked_urls + bare_urls
+
+    forbidden = _string_list(expectations.get("forbidden_url_substrings"))
+    forbidden_hits = [url for url in all_urls if any(substring in url for substring in forbidden)]
+    if forbidden_hits:
+        return _failure(
+            "forbidden_url",
+            f"URLs contained forbidden substrings: {forbidden_hits}",
+            metadata={"urls": all_urls, "forbidden": forbidden},
+        )
+
+    if bool(expectations.get("markdown_link_required", False)) and bare_urls:
+        return _failure(
+            "bare_url",
+            f"Bare URLs emitted outside markdown link syntax: {bare_urls}",
+            metadata={"linked_urls": linked_urls, "bare_urls": bare_urls},
+        )
+
+    required_prefix = expectations.get("required_url_prefix")
+    if isinstance(required_prefix, str) and required_prefix:
+        if not any(url.startswith(required_prefix) for url in all_urls):
+            return _failure(
+                "missing_required_prefix",
+                f"No URL started with required prefix {required_prefix!r}",
+                metadata={"urls": all_urls, "required_url_prefix": required_prefix},
+            )
+
+    path_substrings = _string_list(expectations.get("expected_url_path_substrings"))
+    if path_substrings:
+        if not any(substring in url for url in all_urls for substring in path_substrings):
+            return _failure(
+                "missing_expected_path",
+                f"No URL contained any of expected path substrings: {path_substrings}",
+                metadata={"urls": all_urls, "expected_url_path_substrings": path_substrings},
+            )
+
+    return _success(metadata={"urls": all_urls})
+
+
+@create_evaluator(name="documentation_links", kind="code")
+def documentation_links(output: Any, expected: Any) -> dict[str, Any]:
+    """Phoenix evaluator entrypoint for documentation link correctness.
+
+    Delegates to :func:`evaluate_documentation_links`; see that function for
+    label semantics and precedence. Datasets that don't define
+    ``expected.assistant_text`` receive a passing ``not_applicable`` result
+    so this evaluator can be wired globally without affecting other suites.
+    """
+    return evaluate_documentation_links(output, expected)

--- a/tests/pxi/evals/run_experiment.py
+++ b/tests/pxi/evals/run_experiment.py
@@ -30,7 +30,11 @@ from tests.pxi.evals.agent_task import (
     make_task,
 )
 from tests.pxi.evals.datasets import EvalDataset, load_dataset
-from tests.pxi.evals.evaluators import correct_tools_called, tool_call_args_match
+from tests.pxi.evals.evaluators import (
+    correct_tools_called,
+    documentation_links,
+    tool_call_args_match,
+)
 
 DEFAULT_BASE_URL = "http://localhost:6006"
 PASSING_SCORE = 1.0
@@ -197,7 +201,10 @@ async def _run_async(config: ExperimentConfig) -> int:
                     task_run["dataset_example_id"] = output["stable_example_id"]
             experiment = await client.experiments.evaluate_experiment(
                 experiment=experiment,
-                evaluators=cast(Any, [correct_tools_called, tool_call_args_match]),
+                evaluators=cast(
+                    Any,
+                    [correct_tools_called, tool_call_args_match, documentation_links],
+                ),
                 print_summary=False,
                 concurrency=3,
                 timeout=180,

--- a/tests/pxi/evals/test_evaluators.py
+++ b/tests/pxi/evals/test_evaluators.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pytest
 
+from tests.pxi.evals.evaluators.documentation_links import evaluate_documentation_links
 from tests.pxi.evals.evaluators.tools import (
     _normalize_arg_value,
     evaluate_tool_call_args,
@@ -299,5 +300,122 @@ class TestToolCallArgsMatch:
                 ]
             },
             expected=self._expected(set_spans_filter={"condition": "right"}),
+        )
+        assert result["label"] == "pass"
+
+
+class TestDocumentationLinks:
+    def _expected(self, **kwargs: Any) -> dict[str, Any]:
+        return {"assistant_text": kwargs}
+
+    def _output(self, text: str | None) -> dict[str, Any]:
+        return {"assistant_text": text}
+
+    def test_passes_with_markdown_link_to_canonical_domain(self) -> None:
+        result = evaluate_documentation_links(
+            output=self._output(
+                "See [Tracing](https://arize.com/docs/phoenix/tracing) for details."
+            ),
+            expected=self._expected(
+                required_url_prefix="https://arize.com/docs/phoenix/",
+                markdown_link_required=True,
+                expected_url_path_substrings=["tracing"],
+                forbidden_url_substrings=["arizeai-", ".mintlify.app", "localhost"],
+            ),
+        )
+        assert result["score"] == 1.0
+        assert result["label"] == "pass"
+
+    def test_fails_when_url_uses_preview_host(self) -> None:
+        result = evaluate_documentation_links(
+            output=self._output("See [docs](https://arizeai-433a7140.mintlify.app/tracing)."),
+            expected=self._expected(
+                required_url_prefix="https://arize.com/docs/phoenix/",
+                forbidden_url_substrings=["arizeai-", ".mintlify.app"],
+            ),
+        )
+        assert result["score"] == 0.0
+        assert result["label"] == "forbidden_url"
+
+    def test_fails_when_bare_url_emitted(self) -> None:
+        result = evaluate_documentation_links(
+            output=self._output("Visit https://arize.com/docs/phoenix/tracing for more info."),
+            expected=self._expected(
+                required_url_prefix="https://arize.com/docs/phoenix/",
+                markdown_link_required=True,
+            ),
+        )
+        assert result["label"] == "bare_url"
+
+    def test_passes_with_bare_url_when_not_required(self) -> None:
+        result = evaluate_documentation_links(
+            output=self._output("Visit https://arize.com/docs/phoenix/tracing for more info."),
+            expected=self._expected(
+                required_url_prefix="https://arize.com/docs/phoenix/",
+                markdown_link_required=False,
+            ),
+        )
+        assert result["label"] == "pass"
+
+    def test_fails_when_no_url_matches_required_prefix(self) -> None:
+        result = evaluate_documentation_links(
+            output=self._output("See [docs](https://example.com/whatever)."),
+            expected=self._expected(
+                required_url_prefix="https://arize.com/docs/phoenix/",
+            ),
+        )
+        assert result["label"] == "missing_required_prefix"
+
+    def test_fails_when_expected_path_substring_missing(self) -> None:
+        result = evaluate_documentation_links(
+            output=self._output(
+                "See the [Phoenix overview](https://arize.com/docs/phoenix/) page."
+            ),
+            expected=self._expected(
+                required_url_prefix="https://arize.com/docs/phoenix/",
+                expected_url_path_substrings=["tracing"],
+            ),
+        )
+        assert result["label"] == "missing_expected_path"
+
+    def test_not_applicable_when_expectation_missing(self) -> None:
+        result = evaluate_documentation_links(
+            output=self._output("anything"),
+            expected={"tools": {}},
+        )
+        assert result["score"] == 1.0
+        assert result["label"] == "not_applicable"
+
+    def test_fails_when_assistant_text_missing(self) -> None:
+        result = evaluate_documentation_links(
+            output=self._output(None),
+            expected=self._expected(
+                required_url_prefix="https://arize.com/docs/phoenix/",
+            ),
+        )
+        assert result["label"] == "missing_assistant_text"
+
+    def test_forbidden_precedence_over_bare_url(self) -> None:
+        # A bare URL containing a forbidden substring should be reported as
+        # ``forbidden_url`` because that is the more actionable failure.
+        result = evaluate_documentation_links(
+            output=self._output("Visit https://arizeai-433a7140.mintlify.app/tracing"),
+            expected=self._expected(
+                required_url_prefix="https://arize.com/docs/phoenix/",
+                markdown_link_required=True,
+                forbidden_url_substrings=["arizeai-"],
+            ),
+        )
+        assert result["label"] == "forbidden_url"
+
+    def test_trailing_punctuation_stripped_from_bare_url(self) -> None:
+        # The forbidden substring should still match even when the bare URL
+        # is followed by sentence punctuation.
+        result = evaluate_documentation_links(
+            output=self._output("See https://arize.com/docs/phoenix/tracing."),
+            expected=self._expected(
+                required_url_prefix="https://arize.com/docs/phoenix/",
+                expected_url_path_substrings=["tracing"],
+            ),
         )
         assert result["label"] == "pass"


### PR DESCRIPTION
## Summary
- Add PXI system-prompt tool-selection rules so the agent uses `search_phoenix` + canonical markdown links for definitional questions, `ask_user` for ambiguous "how do I..." prompts, and only reaches for `bash` when the page context actually matters.
- Ship a `documentation_links` code evaluator that checks assistant text for the canonical docs prefix, markdown-link rendering, forbidden internal hosts (`arizeai-`, `.mintlify.app`, `localhost`), and expected URL path substrings.
- Add a `documentation_questions` dataset covering tracing/integrations/experiments/datasets/evaluators/self-hosting/prompts/annotations and ambiguous definitional/broad queries, plus unit tests for the evaluator.
- Wire `documentation_links` into `run_experiment.py` alongside the existing tool evaluators.

## Test plan
- [ ] `uv run pytest tests/pxi/evals/test_evaluators.py`
- [ ] `uv run python -m tests.pxi.evals.run_experiment --dataset documentation_questions` against a local Phoenix
- [ ] Spot-check that the PXI agent links to `https://arize.com/docs/phoenix/...` (no `arizeai-*.mintlify.app` / `localhost`) and uses `ask_user` for broad "how do I get started?"–style prompts