### PR TITLE
fix(examples): guard against IndexError on empty LLM choices list

### DIFF
--- a/examples/agent_framework_comparison/code_based_agent/router.py
+++ b/examples/agent_framework_comparison/code_based_agent/router.py
@@ -43,6 +43,10 @@ def router(messages, parent_context):
                 tools=skill_map.get_combined_function_description_for_openai(),
             )
 
+        if not response.choices:
+            span.set_attribute(SpanAttributes.OUTPUT_VALUE, "")
+            return None
+
         messages.append(response.choices[0].message)
         tool_calls = response.choices[0].message.tool_calls
         if tool_calls:

--- a/examples/agent_framework_comparison/skills/analyze_data.py
+++ b/examples/agent_framework_comparison/skills/analyze_data.py
@@ -87,6 +87,9 @@ class AnalyzeData(Skill):
                         },
                     ],
                 )
+            if not response.choices:
+                span.set_attribute(SpanAttributes.OUTPUT_VALUE, "")
+                return "No response from the model."
             analysis_result = response.choices[0].message.content
             span.set_attribute(SpanAttributes.OUTPUT_VALUE, analysis_result)
             return analysis_result

--- a/examples/agent_framework_comparison/skills/generate_sql_query.py
+++ b/examples/agent_framework_comparison/skills/generate_sql_query.py
@@ -90,6 +90,8 @@ class GenerateSQLQuery(Skill):
                 ],
             )
 
+        if not response.choices:
+            return "No response from the model."
         sql_query = response.choices[0].message.content
 
         tracer = trace.get_tracer(__name__)


### PR DESCRIPTION
## Summary

Three files in `examples/agent_framework_comparison` call `response.choices[0]` without checking whether the API returned any choices. This raises a bare `IndexError` when the LLM applies a content-policy filter or returns a truncated streaming response.

### Changes

Inline guard at each call site — no new files, no monkey-patching:

| File | Fix |
|------|-----|
| `code_based_agent/router.py` | `if not response.choices: return None` after the API call, before all `choices[0]` accesses |
| `skills/analyze_data.py` | `if not response.choices: return "No response from the model."` before `choices[0]` |
| `skills/generate_sql_query.py` | `if not response.choices: return "No response from the model."` before `choices[0]` |