### PR TITLE
test(playground): harden prompt-config E2E with stable test IDs

### DIFF
--- a/app/src/components/code/LazyEditorWrapper.tsx
+++ b/app/src/components/code/LazyEditorWrapper.tsx
@@ -1,6 +1,16 @@
 import { css } from "@emotion/react";
-import type { ReactNode } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+type LazyEditorWrapperProps = {
+  /**
+   * The minimum height of the container for the JSON editor prior to initialization.
+   * After initialization, the height will be set to auto and grow to fit the editor.
+   * This allows for the editor to properly get its dimensions when it is rendered outside of the viewport.
+   */
+  preInitializationMinHeight: number;
+  children: ReactNode;
+} & ComponentPropsWithoutRef<"div">;
 
 /**
  * A wrapper for code mirror editors that lazily initializes the editor when it is scrolled into view.
@@ -10,21 +20,9 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
  */
 export function LazyEditorWrapper({
   preInitializationMinHeight,
-  testId,
   children,
-}: {
-  /**
-   * The minimum height of the container for the JSON editor prior to initialization.
-   * After initialization, the height will be set to auto and grow to fit the editor.
-   * This allows for the editor to properly get its dimensions when it is rendered outside of the viewport.
-   */
-  preInitializationMinHeight: number;
-  /**
-   * Forwarded to the wrapper element as `data-testid`.
-   */
-  testId?: string;
-  children: ReactNode;
-}) {
+  ...rest
+}: LazyEditorWrapperProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -63,7 +61,7 @@ export function LazyEditorWrapper({
   return (
     <div
       ref={wrapperRef}
-      data-testid={testId}
+      {...rest}
       css={css`
         min-height: ${
           !isInitialized ? `${preInitializationMinHeight}px` : "auto"

--- a/app/src/components/code/LazyEditorWrapper.tsx
+++ b/app/src/components/code/LazyEditorWrapper.tsx
@@ -10,6 +10,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
  */
 export function LazyEditorWrapper({
   preInitializationMinHeight,
+  testId,
   children,
 }: {
   /**
@@ -18,6 +19,10 @@ export function LazyEditorWrapper({
    * This allows for the editor to properly get its dimensions when it is rendered outside of the viewport.
    */
   preInitializationMinHeight: number;
+  /**
+   * Forwarded to the wrapper element as `data-testid`.
+   */
+  testId?: string;
   children: ReactNode;
 }) {
   const [isVisible, setIsVisible] = useState(false);
@@ -58,6 +63,7 @@ export function LazyEditorWrapper({
   return (
     <div
       ref={wrapperRef}
+      data-testid={testId}
       css={css`
         min-height: ${
           !isInitialized ? `${preInitializationMinHeight}px` : "auto"

--- a/app/src/components/core/card/Card.tsx
+++ b/app/src/components/core/card/Card.tsx
@@ -19,6 +19,7 @@ function Card({
   scrollBody = false,
   extra,
   onCollapseChange,
+  testId,
   ...otherProps
 }: CardProps & { ref?: Ref<HTMLElement> }) {
   const { styleProps } = useStyleProps(otherProps, viewStyleProps);
@@ -60,6 +61,7 @@ function Card({
       data-collapsible={collapsible}
       data-collapsed={isCollapsed}
       data-title-separator={titleSeparator}
+      data-testid={testId}
       style={styleProps.style}
     >
       <header id={headerId}>

--- a/app/src/components/core/card/types.ts
+++ b/app/src/components/core/card/types.ts
@@ -43,4 +43,8 @@ export interface CardProps extends PropsWithChildren<ViewStyleProps> {
    * Callback fired when the card is collapsed or expanded. Only applicable if `collapsible` is `true`.
    */
   onCollapseChange?: (isCollapsed: boolean) => void;
+  /**
+   * Forwarded to the root `<section>` element as `data-testid`.
+   */
+  testId?: string;
 }

--- a/app/src/components/playground/model/InvocationParametersFormFields.tsx
+++ b/app/src/components/playground/model/InvocationParametersFormFields.tsx
@@ -202,7 +202,7 @@ const InvocationParameterFormField = ({
           aria-label={spec.label}
         >
           <Label>{spec.label}</Label>
-          <Button>
+          <Button data-testid={`invocation-param-${spec.name}`}>
             <SelectValue />
             <SelectChevronUpDownIcon />
           </Button>

--- a/app/src/components/playground/model/OpenAIApiTypeConfigFormField.tsx
+++ b/app/src/components/playground/model/OpenAIApiTypeConfigFormField.tsx
@@ -74,7 +74,7 @@ export function OpenAIApiTypeConfigFormField({
       }}
     >
       <Label>API Type</Label>
-      <Button>
+      <Button data-testid="invocation-param-apiType">
         <SelectValue />
         <SelectChevronUpDownIcon />
       </Button>

--- a/app/src/pages/playground/PlaygroundChatTemplateFooter.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplateFooter.tsx
@@ -66,6 +66,7 @@ export function PlaygroundChatTemplateFooter({
         <Button
           size="S"
           aria-label="response format"
+          data-testid="add-response-format"
           leadingVisual={<Icon svg={<Icons.PlusOutline />} />}
           isDisabled={hasResponseFormat}
           onPress={() => {

--- a/app/src/pages/playground/PlaygroundResponseFormat.tsx
+++ b/app/src/pages/playground/PlaygroundResponseFormat.tsx
@@ -126,7 +126,7 @@ export function PlaygroundResponseFormat({
     >
       <LazyEditorWrapper
         preInitializationMinHeight={RESPONSE_FORMAT_EDITOR_PRE_INIT_HEIGHT}
-        testId="playground-response-format-editor"
+        data-testid="playground-response-format-editor"
       >
         <JSONEditor
           value={initialResponseFormatDefinition}

--- a/app/src/pages/playground/PlaygroundResponseFormat.tsx
+++ b/app/src/pages/playground/PlaygroundResponseFormat.tsx
@@ -126,6 +126,7 @@ export function PlaygroundResponseFormat({
     >
       <LazyEditorWrapper
         preInitializationMinHeight={RESPONSE_FORMAT_EDITOR_PRE_INIT_HEIGHT}
+        testId="playground-response-format-editor"
       >
         <JSONEditor
           value={initialResponseFormatDefinition}

--- a/app/src/pages/playground/PlaygroundTool.tsx
+++ b/app/src/pages/playground/PlaygroundTool.tsx
@@ -141,6 +141,7 @@ export function PlaygroundTool({
   return (
     <Card
       collapsible
+      testId={`playground-tool-card-${toolName ?? "Tool"}`}
       backgroundColor={"yellow-100"}
       borderColor={"yellow-700"}
       title={

--- a/app/src/pages/playground/PlaygroundToolType/JSONToolEditor.tsx
+++ b/app/src/pages/playground/PlaygroundToolType/JSONToolEditor.tsx
@@ -73,7 +73,7 @@ export const JSONToolEditor = ({
   return (
     <LazyEditorWrapper
       preInitializationMinHeight={TOOL_EDITOR_PRE_INIT_HEIGHT}
-      testId="playground-tool-editor"
+      data-testid="playground-tool-editor"
     >
       <JSONEditor
         value={initialEditorValue}

--- a/app/src/pages/playground/PlaygroundToolType/JSONToolEditor.tsx
+++ b/app/src/pages/playground/PlaygroundToolType/JSONToolEditor.tsx
@@ -71,7 +71,10 @@ export const JSONToolEditor = ({
     [updateTool]
   );
   return (
-    <LazyEditorWrapper preInitializationMinHeight={TOOL_EDITOR_PRE_INIT_HEIGHT}>
+    <LazyEditorWrapper
+      preInitializationMinHeight={TOOL_EDITOR_PRE_INIT_HEIGHT}
+      testId="playground-tool-editor"
+    >
       <JSONEditor
         value={initialEditorValue}
         onChange={onChange}

--- a/app/tests/playground-prompt-configuration.spec.ts
+++ b/app/tests/playground-prompt-configuration.spec.ts
@@ -222,7 +222,7 @@ async function selectOpenAIApiType(
   page: Page,
   apiTypeLabel: "Chat Completions" | "Responses"
 ): Promise<void> {
-  await popover.getByLabel("API Type").click();
+  await popover.getByTestId("invocation-param-apiType").click();
   await page.getByRole("option", { name: apiTypeLabel, exact: true }).click();
 }
 
@@ -256,6 +256,12 @@ async function setCodeMirrorValue(
   await page.keyboard.insertText(editorValue);
 }
 
+const TOOL_CARD_TESTID_PREFIX = /^playground-tool-card-/;
+
+function toolCard(page: Page, toolName: string): Locator {
+  return page.getByTestId(`playground-tool-card-${toolName}`);
+}
+
 async function addTool({
   page,
   value,
@@ -265,17 +271,16 @@ async function addTool({
   value: unknown;
   expectedTitle: string;
 }): Promise<void> {
-  const toolCards = page.getByRole("button", { name: /^tool / });
+  const toolCards = page.getByTestId(TOOL_CARD_TESTID_PREFIX);
   const previousCount = await toolCards.count();
   await page.getByRole("button", { name: "add tool" }).click();
   await expect(toolCards).toHaveCount(previousCount + 1);
-  const toolEditors = page
-    .locator(".cm-content")
-    .filter({ hasText: /new_function_\d+/ });
-  await setCodeMirrorValue(page, toolEditors.last(), value);
-  await expect(
-    page.getByRole("button", { name: new RegExp(`^tool ${expectedTitle}$`) })
-  ).toBeVisible();
+  const newToolEditor = toolCards
+    .last()
+    .getByTestId("playground-tool-editor")
+    .locator(".cm-content");
+  await setCodeMirrorValue(page, newToolEditor, value);
+  await expect(toolCard(page, expectedTitle)).toBeVisible();
 }
 
 async function addFunctionAndRawTools({
@@ -336,16 +341,13 @@ async function addResponseFormat({
   label: "Response Format" | "Response Schema";
   value: unknown;
 }): Promise<void> {
-  await page
-    .getByRole("button", { name: "response format", exact: true })
-    .click();
+  await page.getByTestId("add-response-format").click();
   await expect(
     page.getByRole("button", { name: label, exact: true })
   ).toBeVisible();
   const responseFormatEditor = page
-    .locator(".cm-content")
-    .filter({ hasText: "additionalProperties" })
-    .last();
+    .getByTestId("playground-response-format-editor")
+    .locator(".cm-content");
   await setCodeMirrorValue(page, responseFormatEditor, value);
 }
 
@@ -372,12 +374,8 @@ async function expectFunctionAndRawTools({
   rawToolTitle: string;
   rawToolText: string;
 }): Promise<void> {
-  await expect(
-    page.getByRole("button", { name: /^tool get_weather$/ })
-  ).toBeVisible();
-  await expect(
-    page.getByRole("button", { name: new RegExp(`^tool ${rawToolTitle}$`) })
-  ).toBeVisible();
+  await expect(toolCard(page, "get_weather")).toBeVisible();
+  await expect(toolCard(page, rawToolTitle)).toBeVisible();
   await expect(page.getByText(rawToolText).first()).toBeVisible();
 }
 
@@ -437,7 +435,7 @@ test.describe("Playground prompt configuration round-trip", () => {
         .getByRole("textbox", { name: "Max Completion Tokens" })
         .fill(expectedMaxCompletionTokens);
 
-      await popover.getByRole("button", { name: /Reasoning Effort/ }).click();
+      await popover.getByTestId("invocation-param-reasoningEffort").click();
       await page
         .getByRole("option", { name: expectedReasoningEffort, exact: true })
         .click();
@@ -472,10 +470,10 @@ test.describe("Playground prompt configuration round-trip", () => {
         reopened.getByRole("textbox", { name: "Max Completion Tokens" })
       ).toHaveValue(expectedMaxCompletionTokens);
       await expect(
-        reopened.getByRole("button", { name: /API Type/ })
+        reopened.getByTestId("invocation-param-apiType")
       ).toContainText(apiTypeLabel);
       await expect(
-        reopened.getByRole("button", { name: /Reasoning Effort/ })
+        reopened.getByTestId("invocation-param-reasoningEffort")
       ).toContainText(expectedReasoningEffort);
       await expectResponseFormat({ page, label: "Response Format" });
       if (apiTypeLabel === "Responses") {
@@ -525,20 +523,19 @@ test.describe("Playground prompt configuration round-trip", () => {
       .fill(expectedMaxTokens);
 
     // Switch Thinking to "Enabled" so the budget path is exercised. The Budget
-    // Tokens NumberField only renders in Enabled mode. The negative lookahead
-    // disambiguates the Thinking-mode Select from the Thinking-Display Select.
-    await popover.getByRole("button", { name: /Thinking(?! Display)/ }).click();
+    // Tokens NumberField only renders in Enabled mode.
+    await popover.getByTestId("invocation-param-thinkingType").click();
     await page.getByRole("option", { name: "enabled", exact: true }).click();
     await popover
       .getByRole("textbox", { name: "Budget Tokens" })
       .fill(expectedBudgetTokens);
 
-    await popover.getByRole("button", { name: /Thinking Display/ }).click();
+    await popover.getByTestId("invocation-param-thinkingDisplay").click();
     await page
       .getByRole("option", { name: expectedThinkingDisplay, exact: true })
       .click();
 
-    await popover.getByRole("button", { name: /Effort/ }).click();
+    await popover.getByTestId("invocation-param-effort").click();
     await page
       .getByRole("option", { name: expectedEffort, exact: true })
       .click();
@@ -565,17 +562,17 @@ test.describe("Playground prompt configuration round-trip", () => {
       reopened.getByRole("textbox", { name: "Max Tokens" })
     ).toHaveValue(expectedMaxTokens);
     await expect(
-      reopened.getByRole("button", { name: /Thinking(?! Display)/ })
+      reopened.getByTestId("invocation-param-thinkingType")
     ).toContainText("enabled");
     await expect(
       reopened.getByRole("textbox", { name: "Budget Tokens" })
     ).toHaveValue(expectedBudgetTokens);
     await expect(
-      reopened.getByRole("button", { name: /Thinking Display/ })
+      reopened.getByTestId("invocation-param-thinkingDisplay")
     ).toContainText(expectedThinkingDisplay);
-    await expect(
-      reopened.getByRole("button", { name: /Effort/ })
-    ).toContainText(expectedEffort);
+    await expect(reopened.getByTestId("invocation-param-effort")).toContainText(
+      expectedEffort
+    );
     await expectResponseFormat({ page, label: "Response Format" });
     await expectFunctionAndRawTools({
       page,
@@ -602,12 +599,12 @@ test.describe("Playground prompt configuration round-trip", () => {
       .getByRole("textbox", { name: "Max Output Tokens" })
       .fill(expectedMaxOutputTokens);
     await expect(
-      popover.getByRole("button", { name: /Thinking Level/ })
+      popover.getByTestId("invocation-param-thinkingLevel")
     ).toContainText("medium");
     await expect(
       popover.getByRole("switch", { name: "Include Thoughts" })
     ).toBeChecked();
-    await popover.getByRole("button", { name: /Thinking Level/ }).click();
+    await popover.getByTestId("invocation-param-thinkingLevel").click();
     await page
       .getByRole("option", { name: expectedThinkingLevel, exact: true })
       .click();
@@ -639,7 +636,7 @@ test.describe("Playground prompt configuration round-trip", () => {
       reopened.getByRole("textbox", { name: "Max Output Tokens" })
     ).toHaveValue(expectedMaxOutputTokens);
     await expect(
-      reopened.getByRole("button", { name: /Thinking Level/ })
+      reopened.getByTestId("invocation-param-thinkingLevel")
     ).toContainText(expectedThinkingLevel);
     await expect(
       reopened.getByRole("switch", { name: "Include Thoughts" })


### PR DESCRIPTION
## Summary

The playground prompt-configuration spec leaned on brittle locators — role+name regex (with a negative-lookahead trick to disambiguate "Thinking" from "Thinking Display"), CSS class internals (`.cm-content`, `.card__title`), and seed-text `hasText` filters. These were fragile to upstream renames and to any new "Tool"-prefixed button or shared label appearing in the same view.

This PR exposes `data-testid` on the controls that previously required those tricks — tool cards, JSON editors, the response-format toggle, and invocation-parameter select triggers — and switches the spec to `getByTestId` for them. Stable role+name lookups (Save Prompt, Configure model parameters, Add Tool) are left alone.

## Test plan

- [x] `pnpm exec playwright test tests/playground-prompt-configuration.spec.ts --project=chromium` — all 5 round-trip tests pass (OpenAI Chat Completions, OpenAI Responses, Anthropic, Google, AWS Bedrock)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm run lint` clean