### PR TITLE
ci: use checkCollaborator API instead of author_association

### DIFF
--- a/.github/workflows/auto-label-external-issues.yaml
+++ b/.github/workflows/auto-label-external-issues.yaml
@@ -34,21 +34,28 @@ jobs:
               return;
             }
 
-            // Treat MEMBER / OWNER / COLLABORATOR as internal. Everything
-            // else (CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE)
-            // is external and gets routed to triage.
-            const internal = ["MEMBER", "OWNER", "COLLABORATOR"];
-            const association = payload.author_association;
-            if (internal.includes(association)) {
-              core.info(
-                `Skipping internal contributor (author_association=${association})`
-              );
+            // The webhook's `author_association` is unreliable: it returns
+            // CONTRIBUTOR for org members whose membership is private and who
+            // aren't direct repo collaborators. Check collaborator status
+            // directly via the API — 204 means internal, 404 means external.
+            const username = payload.user.login;
+            let isCollaborator = false;
+            try {
+              await github.rest.repos.checkCollaborator({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username,
+              });
+              isCollaborator = true;
+            } catch (err) {
+              if (err.status !== 404) throw err;
+            }
+            if (isCollaborator) {
+              core.info(`Skipping internal collaborator: ${username}`);
               return;
             }
 
-            core.info(
-              `External contributor (author_association=${association}); applying triage label`
-            );
+            core.info(`External contributor (${username}); applying triage label`);
 
             const label = "triage";
             await github.rest.issues.addLabels({


### PR DESCRIPTION
## Summary
- The `auto-label-external-issues` workflow was mislabeling internal PRs as `triage` (e.g. #13238). Empirically, the webhook payload's `author_association` returns `CONTRIBUTOR` for org members whose org membership is **private** and who aren't direct repo collaborators — the REST API later reports `MEMBER` for the same user, but the webhook doesn't see private memberships.
- Replace the `author_association` check with `github.rest.repos.checkCollaborator(...)` — 204 means internal, 404 means external. This works for private org members with implicit repo access.

## Verification (via `gh api`)
| user | webhook said | `/collaborators/{user}` | correct? |
| --- | --- | --- | --- |
| RogerHYang (private MEMBER) | `CONTRIBUTOR` (mislabeled) | 204 | internal |
| mikeldking (private MEMBER, also repo admin) | `COLLABORATOR` | 204 | internal |
| qizwiz (true external) | `FIRST_TIME_CONTRIBUTOR` | 404 | external |
| octocat (random) | — | 404 | external |

## Test plan
- [ ] On next external PR/issue: confirm `triage` is applied.
- [ ] On next internal PR (especially from a private org member): confirm `triage` is NOT applied.