### PR TITLE
chore(claude): remove slow PostToolUse hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,26 +14,6 @@
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path | select(endswith(\".py\"))' | xargs -r uv run mypy --strict >&2 || { [ $? -eq 1 ] && exit 2; }"
-          },
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.file_path | select(endswith(\".ts\") or endswith(\".tsx\"))' | xargs -r sh -c 'cd app && pnpm run build:relay >&2' || { [ $? -eq 1 ] && exit 2; }"
-          },
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.file_path | select(endswith(\".ts\") or endswith(\".tsx\"))' | xargs -r sh -c 'cd app && pnpm run fmt -- \"$@\" >&2' _ || { [ $? -eq 1 ] && exit 2; }"
-          },
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.file_path | select(endswith(\".ts\") or endswith(\".tsx\"))' | xargs -r sh -c 'cd app && pnpm run lint:fix >&2' _ || { [ $? -eq 1 ] && exit 2; }"
-          },
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.file_path | select(endswith(\".ts\") or endswith(\".tsx\"))' | xargs -r sh -c 'cd app && pnpm run typecheck >&2' || { [ $? -eq 1 ] && exit 2; }"
-          },
-          {
-            "type": "command",
             "command": "jq -r '.tool_input.file_path | select(contains(\"src/phoenix/db/migrations/versions\"))' | xargs -r sh -c 'make schema-ddl >&2' || { [ $? -eq 1 ] && exit 2; }"
           },
           {


### PR DESCRIPTION
## Summary
- Drop `mypy --strict`, relay build, `pnpm fmt`, `pnpm lint:fix`, and `pnpm typecheck` PostToolUse hooks from `.claude/settings.json`.
- The TS hooks duplicate what pre-commit already runs.
- Running these on every Claude edit slows iteration and makes rebases / multi-file refactors painful.

## Test plan
- [ ] Confirm `.claude/settings.json` still parses (used by Claude Code on next session).
- [ ] Pre-commit still catches TS fmt/lint/typecheck issues at commit time.