### PR TITLE
fix: replay dangling Anthropic tool uses

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -2560,7 +2560,28 @@ class AnthropicStreamingClient(PlaygroundStreamingClient["AsyncAnthropic"]):
         from anthropic.types import MessageParam, ToolResultBlockParam
 
         anthropic_messages: list[MessageParam] = []
+        pending_tool_use_ids: list[str] = []
         system_prompt = ""
+
+        def flush_missing_tool_results() -> None:
+            nonlocal pending_tool_use_ids
+            if not pending_tool_use_ids:
+                return
+            anthropic_messages.append(
+                MessageParam(
+                    role="user",
+                    content=[
+                        ToolResultBlockParam(
+                            type="tool_result",
+                            tool_use_id=tool_use_id,
+                            content="Tool result unavailable in replayed trace.",
+                        )
+                        for tool_use_id in pending_tool_use_ids
+                    ],
+                )
+            )
+            pending_tool_use_ids = []
+
         for msg in messages:
             role = msg["role"]
             content = msg["content"]
@@ -2568,14 +2589,22 @@ class AnthropicStreamingClient(PlaygroundStreamingClient["AsyncAnthropic"]):
             tool_calls = msg.get("tool_calls")
             tool_aware_content = self._anthropic_message_content(content, tool_calls)
             if role == ChatCompletionMessageRole.USER:
+                flush_missing_tool_results()
                 anthropic_messages.append(MessageParam(role="user", content=tool_aware_content))
             elif role == ChatCompletionMessageRole.AI:
+                flush_missing_tool_results()
                 anthropic_messages.append(
                     MessageParam(role="assistant", content=tool_aware_content)
                 )
+                pending_tool_use_ids.extend(
+                    tool_call["id"] for tool_call in tool_calls or () if tool_call.get("id")
+                )
             elif role == ChatCompletionMessageRole.SYSTEM:
+                flush_missing_tool_results()
                 system_prompt += content + "\n"
             elif role == ChatCompletionMessageRole.TOOL:
+                if tool_call_id in pending_tool_use_ids:
+                    pending_tool_use_ids.remove(tool_call_id)
                 anthropic_messages.append(
                     MessageParam(
                         role="user",
@@ -2591,6 +2620,7 @@ class AnthropicStreamingClient(PlaygroundStreamingClient["AsyncAnthropic"]):
             else:
                 assert_never(role)
 
+        flush_missing_tool_results()
         return anthropic_messages, system_prompt
 
     def _anthropic_message_content(

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -458,6 +458,87 @@ class TestOpenAIBaseStreamingClient:
 
 
 class TestAnthropicStreamingClient:
+    def _client(self) -> AnthropicStreamingClient:
+        @asynccontextmanager
+        async def create_client() -> AsyncIterator[Any]:
+            yield None
+
+        return AnthropicStreamingClient(
+            client_factory=LLMClientFactory(create_client, ("anthropic", "test")),
+            model_name="claude-3-5-sonnet-latest",
+            provider="anthropic",
+        )
+
+    def test_dangling_tool_use_gets_placeholder_tool_result(self) -> None:
+        client = self._client()
+
+        messages = [
+            create_playground_message(
+                ChatCompletionMessageRole.AI,
+                "",
+                tool_calls=[
+                    {
+                        "id": "toolu_01memory",
+                        "function": {
+                            "name": "memory",
+                            "arguments": {"command": "view", "path": "/memories"},
+                        },
+                    }
+                ],
+            ),
+            create_playground_message(ChatCompletionMessageRole.USER, "continue"),
+        ]
+
+        anthropic_messages, _ = client._build_anthropic_messages(messages)
+
+        assert [message["role"] for message in anthropic_messages] == [
+            "assistant",
+            "user",
+            "user",
+        ]
+        assert anthropic_messages[1]["content"] == [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_01memory",
+                "content": "Tool result unavailable in replayed trace.",
+            }
+        ]
+
+    def test_existing_tool_result_prevents_placeholder_tool_result(self) -> None:
+        client = self._client()
+
+        messages = [
+            create_playground_message(
+                ChatCompletionMessageRole.AI,
+                "",
+                tool_calls=[
+                    {
+                        "id": "toolu_01memory",
+                        "function": {
+                            "name": "memory",
+                            "arguments": {"command": "view", "path": "/memories"},
+                        },
+                    }
+                ],
+            ),
+            create_playground_message(
+                ChatCompletionMessageRole.TOOL,
+                "memory contents",
+                tool_call_id="toolu_01memory",
+            ),
+        ]
+
+        anthropic_messages, _ = client._build_anthropic_messages(messages)
+
+        assert len(anthropic_messages) == 2
+        assert anthropic_messages[1]["content"] == [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_01memory",
+                "content": "memory contents",
+            }
+        ]
+
     def test_specific_tool_choice_includes_tool_definitions(self) -> None:
         @asynccontextmanager
         async def create_client() -> AsyncIterator[Any]:


### PR DESCRIPTION
﻿## Summary
- synthesize placeholder Anthropic `tool_result` blocks when replayed playground history contains assistant `tool_use` blocks without matching tool messages
- keep existing real tool result messages unchanged
- cover both missing-result and existing-result paths in unit tests

Closes #12975

## To verify
- `uv run pytest -o addopts="" tests\unit\server\api\helpers\test_playground_clients.py::TestAnthropicStreamingClient -q --basetemp .tmp\pytest -p no:cacheprovider`
- `uv run ruff check src\phoenix\server\api\helpers\playground_clients.py tests\unit\server\api\helpers\test_playground_clients.py`
- `uv run ruff format --check src\phoenix\server\api\helpers\playground_clients.py tests\unit\server\api\helpers\test_playground_clients.py`
- `uv run python -m py_compile src\phoenix\server\api\helpers\playground_clients.py tests\unit\server\api\helpers\test_playground_clients.py`
- `git diff --check`

Note: the default pytest addopts currently include `--new-first`; this local environment does not have that plugin installed, so I used `-o addopts=""` for the targeted unit test run.
