### PR TITLE
feat(examples): allow agent trajectory examples to run against remote phoenix

### DIFF
--- a/examples/agents/tau_bench_langgraph/phoenix_setup.py
+++ b/examples/agents/tau_bench_langgraph/phoenix_setup.py
@@ -7,6 +7,8 @@ to a local Phoenix instance for trace collection. Uses the LangChain
 instrumentor which auto-instruments both LangChain and LangGraph.
 """
 
+import os
+
 from openinference.instrumentation.langchain import LangChainInstrumentor
 from openinference.semconv.resource import ResourceAttributes
 from opentelemetry import trace as trace_api
@@ -15,13 +17,40 @@ from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
-# Phoenix default OTLP endpoint
+# Phoenix default OTLP endpoint (local). Override with PHOENIX_COLLECTOR_ENDPOINT
+# to send traces to Phoenix Cloud (e.g. https://app.phoenix.arize.com/s/<space>).
 PHOENIX_OTLP_ENDPOINT = "http://localhost:6006/v1/traces"
+PHOENIX_UI_URL_DEFAULT = "http://localhost:6006"
 PHOENIX_PROJECT_NAME = "tau-bench-langgraph"
 
 
+def _resolve_endpoint(default: str) -> str:
+    """Resolve OTLP traces endpoint, preferring PHOENIX_COLLECTOR_ENDPOINT env var.
+
+    Appends `/v1/traces` if the env var points at a base URL.
+    """
+    env_endpoint = os.environ.get("PHOENIX_COLLECTOR_ENDPOINT")
+    if not env_endpoint:
+        return default
+    env_endpoint = env_endpoint.rstrip("/")
+    if env_endpoint.endswith("/v1/traces"):
+        return env_endpoint
+    return f"{env_endpoint}/v1/traces"
+
+
+def phoenix_ui_url() -> str:
+    """Return the Phoenix UI base URL (without the OTLP `/v1/traces` suffix).
+
+    Uses PHOENIX_COLLECTOR_ENDPOINT if set, otherwise the local default.
+    """
+    base = os.environ.get("PHOENIX_COLLECTOR_ENDPOINT", PHOENIX_UI_URL_DEFAULT).rstrip("/")
+    if base.endswith("/v1/traces"):
+        base = base[: -len("/v1/traces")]
+    return base
+
+
 def setup_instrumentation(
-    endpoint: str = PHOENIX_OTLP_ENDPOINT,
+    endpoint: str | None = None,
     project_name: str = PHOENIX_PROJECT_NAME,
 ) -> trace_sdk.TracerProvider:
     """Set up OpenInference instrumentation for LangChain/LangGraph.
@@ -30,16 +59,27 @@ def setup_instrumentation(
     Instruments LangChain so all LLM calls, tool executions, and LangGraph
     node transitions produce spans automatically.
 
+    Reads PHOENIX_COLLECTOR_ENDPOINT and PHOENIX_API_KEY from the environment
+    when not explicitly overridden, so the same code targets local Phoenix or
+    Phoenix Cloud depending on configuration.
+
     Args:
-        endpoint: OTLP HTTP endpoint for Phoenix. Defaults to local Phoenix.
+        endpoint: OTLP HTTP endpoint for Phoenix. If None, resolves from
+                  PHOENIX_COLLECTOR_ENDPOINT env var or falls back to local.
         project_name: Phoenix project name to attach to emitted traces.
 
     Returns:
         The configured TracerProvider.
     """
+    resolved_endpoint = endpoint or _resolve_endpoint(PHOENIX_OTLP_ENDPOINT)
+    headers: dict[str, str] = {}
+    api_key = os.environ.get("PHOENIX_API_KEY")
+    if api_key:
+        headers["authorization"] = f"Bearer {api_key}"
+
     resource = Resource.create({ResourceAttributes.PROJECT_NAME: project_name})
     tracer_provider = trace_sdk.TracerProvider(resource=resource)
-    exporter = OTLPSpanExporter(endpoint=endpoint)
+    exporter = OTLPSpanExporter(endpoint=resolved_endpoint, headers=headers or None)
     tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
     # Share one provider for both auto-instrumented and manual spans.
     if type(trace_api.get_tracer_provider()).__name__ == "ProxyTracerProvider":

--- a/examples/agents/tau_bench_langgraph/run.py
+++ b/examples/agents/tau_bench_langgraph/run.py
@@ -94,12 +94,13 @@ def run_tasks(
         List of ConversationResult for each task.
     """
     if enable_phoenix:
-        from .phoenix_setup import setup_instrumentation
+        from .phoenix_setup import PHOENIX_PROJECT_NAME, phoenix_ui_url, setup_instrumentation
 
         tracer_provider = setup_instrumentation()
+        ui_url = phoenix_ui_url()
         print(
-            "Phoenix instrumentation enabled. Traces will be sent to "
-            "http://localhost:6006 (project: tau-bench-langgraph)"
+            f"Phoenix instrumentation enabled. Traces will be sent to "
+            f"{ui_url} (project: {PHOENIX_PROJECT_NAME})"
         )
     else:
         tracer_provider = None
@@ -155,9 +156,11 @@ def run_tasks(
         print(f"    Actual:   {actual_tools}")
 
     if tracer_provider is not None:
+        from .phoenix_setup import phoenix_ui_url
+
         print("\nFlushing traces...")
         tracer_provider.force_flush()
-        print("Traces exported to Phoenix. View at http://localhost:6006")
+        print(f"Traces exported to Phoenix. View at {phoenix_ui_url()}")
 
     return results
 

--- a/examples/agents/tau_bench_openai_agents/phoenix_setup.py
+++ b/examples/agents/tau_bench_openai_agents/phoenix_setup.py
@@ -6,6 +6,8 @@ Initializes OpenTelemetry tracing with OpenInference and connects
 to a local Phoenix instance for trace collection.
 """
 
+import os
+
 from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
 from openinference.semconv.resource import ResourceAttributes
 from opentelemetry import trace as trace_api
@@ -14,13 +16,40 @@ from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
-# Phoenix default OTLP endpoint
+# Phoenix default OTLP endpoint (local). Override with PHOENIX_COLLECTOR_ENDPOINT
+# to send traces to Phoenix Cloud (e.g. https://app.phoenix.arize.com/s/<space>).
 PHOENIX_OTLP_ENDPOINT = "http://localhost:6006/v1/traces"
+PHOENIX_UI_URL_DEFAULT = "http://localhost:6006"
 PHOENIX_PROJECT_NAME = "tau-bench-openai"
 
 
+def _resolve_endpoint(default: str) -> str:
+    """Resolve OTLP traces endpoint, preferring PHOENIX_COLLECTOR_ENDPOINT env var.
+
+    Appends `/v1/traces` if the env var points at a base URL.
+    """
+    env_endpoint = os.environ.get("PHOENIX_COLLECTOR_ENDPOINT")
+    if not env_endpoint:
+        return default
+    env_endpoint = env_endpoint.rstrip("/")
+    if env_endpoint.endswith("/v1/traces"):
+        return env_endpoint
+    return f"{env_endpoint}/v1/traces"
+
+
+def phoenix_ui_url() -> str:
+    """Return the Phoenix UI base URL (without the OTLP `/v1/traces` suffix).
+
+    Uses PHOENIX_COLLECTOR_ENDPOINT if set, otherwise the local default.
+    """
+    base = os.environ.get("PHOENIX_COLLECTOR_ENDPOINT", PHOENIX_UI_URL_DEFAULT).rstrip("/")
+    if base.endswith("/v1/traces"):
+        base = base[: -len("/v1/traces")]
+    return base
+
+
 def setup_instrumentation(
-    endpoint: str = PHOENIX_OTLP_ENDPOINT,
+    endpoint: str | None = None,
     project_name: str = PHOENIX_PROJECT_NAME,
 ) -> trace_sdk.TracerProvider:
     """Set up OpenInference instrumentation for OpenAI Agents SDK.
@@ -36,9 +65,15 @@ def setup_instrumentation(
     Returns:
         The configured TracerProvider.
     """
+    resolved_endpoint = endpoint or _resolve_endpoint(PHOENIX_OTLP_ENDPOINT)
+    headers: dict[str, str] = {}
+    api_key = os.environ.get("PHOENIX_API_KEY")
+    if api_key:
+        headers["authorization"] = f"Bearer {api_key}"
+
     resource = Resource.create({ResourceAttributes.PROJECT_NAME: project_name})
     tracer_provider = trace_sdk.TracerProvider(resource=resource)
-    exporter = OTLPSpanExporter(endpoint=endpoint)
+    exporter = OTLPSpanExporter(endpoint=resolved_endpoint, headers=headers or None)
     tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
     # Share one provider for both auto-instrumented and manual spans.
     if type(trace_api.get_tracer_provider()).__name__ == "ProxyTracerProvider":

--- a/examples/agents/tau_bench_openai_agents/run.py
+++ b/examples/agents/tau_bench_openai_agents/run.py
@@ -90,12 +90,13 @@ async def run_tasks(
         List of ConversationResult for each task.
     """
     if enable_phoenix:
-        from .phoenix_setup import setup_instrumentation
+        from .phoenix_setup import PHOENIX_PROJECT_NAME, phoenix_ui_url, setup_instrumentation
 
         tracer_provider = setup_instrumentation()
+        ui_url = phoenix_ui_url()
         print(
-            "Phoenix instrumentation enabled. Traces will be sent to "
-            "http://localhost:6006 (project: tau-bench-openai)"
+            f"Phoenix instrumentation enabled. Traces will be sent to "
+            f"{ui_url} (project: {PHOENIX_PROJECT_NAME})"
         )
     else:
         tracer_provider = None
@@ -151,9 +152,11 @@ async def run_tasks(
         print(f"    Actual:   {actual_tools}")
 
     if tracer_provider is not None:
+        from .phoenix_setup import phoenix_ui_url
+
         print("\nFlushing traces...")
         tracer_provider.force_flush()
-        print("Traces exported to Phoenix. View at http://localhost:6006")
+        print(f"Traces exported to Phoenix. View at {phoenix_ui_url()}")
 
     return results
 

--- a/examples/agents/traject_bench_langgraph/phoenix_setup.py
+++ b/examples/agents/traject_bench_langgraph/phoenix_setup.py
@@ -7,6 +7,8 @@ to a local Phoenix instance for trace collection. Uses the LangChain
 instrumentor which auto-instruments both LangChain and LangGraph.
 """
 
+import os
+
 from openinference.instrumentation.langchain import LangChainInstrumentor
 from openinference.semconv.resource import ResourceAttributes
 from opentelemetry import trace as trace_api
@@ -15,13 +17,40 @@ from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
-# Phoenix default OTLP endpoint
+# Phoenix default OTLP endpoint (local). Override with PHOENIX_COLLECTOR_ENDPOINT
+# to send traces to Phoenix Cloud (e.g. https://app.phoenix.arize.com/s/<space>).
 PHOENIX_OTLP_ENDPOINT = "http://localhost:6006/v1/traces"
+PHOENIX_UI_URL_DEFAULT = "http://localhost:6006"
 PHOENIX_PROJECT_NAME = "traject-bench-langgraph"
 
 
+def _resolve_endpoint(default: str) -> str:
+    """Resolve OTLP traces endpoint, preferring PHOENIX_COLLECTOR_ENDPOINT env var.
+
+    Appends `/v1/traces` if the env var points at a base URL.
+    """
+    env_endpoint = os.environ.get("PHOENIX_COLLECTOR_ENDPOINT")
+    if not env_endpoint:
+        return default
+    env_endpoint = env_endpoint.rstrip("/")
+    if env_endpoint.endswith("/v1/traces"):
+        return env_endpoint
+    return f"{env_endpoint}/v1/traces"
+
+
+def phoenix_ui_url() -> str:
+    """Return the Phoenix UI base URL (without the OTLP `/v1/traces` suffix).
+
+    Uses PHOENIX_COLLECTOR_ENDPOINT if set, otherwise the local default.
+    """
+    base = os.environ.get("PHOENIX_COLLECTOR_ENDPOINT", PHOENIX_UI_URL_DEFAULT).rstrip("/")
+    if base.endswith("/v1/traces"):
+        base = base[: -len("/v1/traces")]
+    return base
+
+
 def setup_instrumentation(
-    endpoint: str = PHOENIX_OTLP_ENDPOINT,
+    endpoint: str | None = None,
     project_name: str = PHOENIX_PROJECT_NAME,
 ) -> trace_sdk.TracerProvider:
     """Set up OpenInference instrumentation for LangChain/LangGraph.
@@ -37,9 +66,15 @@ def setup_instrumentation(
     Returns:
         The configured TracerProvider.
     """
+    resolved_endpoint = endpoint or _resolve_endpoint(PHOENIX_OTLP_ENDPOINT)
+    headers: dict[str, str] = {}
+    api_key = os.environ.get("PHOENIX_API_KEY")
+    if api_key:
+        headers["authorization"] = f"Bearer {api_key}"
+
     resource = Resource.create({ResourceAttributes.PROJECT_NAME: project_name})
     tracer_provider = trace_sdk.TracerProvider(resource=resource)
-    exporter = OTLPSpanExporter(endpoint=endpoint)
+    exporter = OTLPSpanExporter(endpoint=resolved_endpoint, headers=headers or None)
     tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
     # Share one provider for both auto-instrumented and manual spans.
     if type(trace_api.get_tracer_provider()).__name__ == "ProxyTracerProvider":

--- a/examples/agents/traject_bench_langgraph/run.py
+++ b/examples/agents/traject_bench_langgraph/run.py
@@ -103,12 +103,13 @@ def run_tasks(
         List of TaskResult for each task.
     """
     if enable_phoenix:
-        from .phoenix_setup import setup_instrumentation
+        from .phoenix_setup import PHOENIX_PROJECT_NAME, phoenix_ui_url, setup_instrumentation
 
         tracer_provider = setup_instrumentation()
+        ui_url = phoenix_ui_url()
         print(
-            "Phoenix instrumentation enabled. Traces will be sent to "
-            "http://localhost:6006 (project: traject-bench-langgraph)"
+            f"Phoenix instrumentation enabled. Traces will be sent to "
+            f"{ui_url} (project: {PHOENIX_PROJECT_NAME})"
         )
     else:
         tracer_provider = None
@@ -160,9 +161,11 @@ def run_tasks(
         print(f"    Actual:   {actual_names}")
 
     if tracer_provider is not None:
+        from .phoenix_setup import phoenix_ui_url
+
         print("\nFlushing traces...")
         tracer_provider.force_flush()
-        print("Traces exported to Phoenix. View at http://localhost:6006")
+        print(f"Traces exported to Phoenix. View at {phoenix_ui_url()}")
 
     return results
 


### PR DESCRIPTION
## Summary

- The agent trajectory examples (`examples/agents/{tau_bench_openai_agents,tau_bench_langgraph,traject_bench_langgraph}`) were hardcoded to send traces to `http://localhost:6006`. This makes them unusable against a remote Phoenix (Phoenix Cloud or any self-hosted deployment) without code edits.
- Each `phoenix_setup.py` now reads `PHOENIX_COLLECTOR_ENDPOINT` and `PHOENIX_API_KEY` from the environment, falling back to localhost when unset. When `PHOENIX_API_KEY` is set, the OTLP exporter sends an `authorization: Bearer ...` header.
- A new `phoenix_ui_url()` helper derives the UI base URL from the same env var, and the `run.py` scripts use it so the printed "View at <url>" line reflects the actual destination (Cloud or local) instead of always saying localhost.
