### PR TITLE
feat(server)!: add system settings with admin-managed assistant enablement and trace recording policy

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,17 @@
 # Migrations
 
+## v16.x to v17.0.0
+
+### Agent assistant (PXI)
+
+Phoenix v17 ships **PXI**, an in-app assistant that helps you investigate traces, iterate on prompts, and navigate Phoenix without leaving the page you're on.
+
+To turn PXI off for an entire deployment, set:
+
+```shell
+PHOENIX_DISABLE_AGENT_ASSISTANT=true
+```
+
 ## v15.x to v16.0.0
 
 ### Sandbox provider allowlist (`PHOENIX_ALLOWED_SANDBOX_PROVIDERS`)

--- a/app/.env.example
+++ b/app/.env.example
@@ -10,8 +10,6 @@ export CHROMATIC_PROJECT_TOKEN=XXXXXXX
 export PHOENIX_TELEMETRY_ENABLED=False
 # Optional: enable Relay retain/dispose debug logs in the browser console
 # export VITE_DEBUG_RELAY=True
-# Enable the agents feature (the /chat endpoint)
-export PHOENIX_DANGEROUSLY_ENABLE_AGENTS=True
 # Optional: mirror agent traces to a remote Phoenix collector
 export PHOENIX_AGENTS_COLLECTOR_ENDPOINT=
 export PHOENIX_AGENTS_COLLECTOR_API_KEY=

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "dev:server:offline": "python -m phoenix.server.main serve --dev --debug --dev-vite-port ${VITE_PORT:-5173}",
     "dev:server:test": "node ./tests/utils/testServer.mjs",
     "dev:ui": "source ./.env && pnpm run build:static && pnpm run build:relay && vite",
-    "ensure:env": "test -f .env || printf 'export PHOENIX_TELEMETRY_ENABLED=False\nexport PHOENIX_DANGEROUSLY_ENABLE_AGENTS=True\n' > .env",
+    "ensure:env": "test -f .env || printf 'export PHOENIX_TELEMETRY_ENABLED=False\n' > .env",
     "fmt": "oxfmt --config ../.oxfmtrc.jsonc",
     "fmt:check": "oxfmt --check --config ../.oxfmtrc.jsonc",
     "generate:generative-ui-catalog": "tsx scripts/generate-generative-ui-catalog.ts",

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -77,6 +77,15 @@ input AddSpansToDatasetInput {
   datasetVersionMetadata: JSON
 }
 
+type AgentAssistantEnabled {
+  enabled: Boolean!
+}
+
+type AgentTraceRecording {
+  allowLocalTraces: Boolean!
+  allowRemoteExport: Boolean!
+}
+
 type AgentsConfig {
   """
   The collector endpoint used by the server-side agents to export traces. Resolved from the PHOENIX_AGENTS_COLLECTOR_ENDPOINT environment variable.
@@ -92,6 +101,21 @@ type AgentsConfig {
   Whether PXI can expose native web search and web fetch capabilities. False when external resources are disabled or PHOENIX_AGENTS_DISABLE_WEB_ACCESS is true.
   """
   webAccessEnabled: Boolean!
+
+  """
+  Admin ceiling for the agent assistant feature. Sourced from the `agent.assistant.enabled` system setting. When False, agent chat is disabled for the entire workspace regardless of individual user preferences.
+  """
+  assistantEnabled: Boolean!
+
+  """
+  Admin ceiling for persisting PXI traces in this Phoenix instance. Sourced from the `agent.assistant.trace_recording` system setting. When False, users cannot turn on local trace recording for themselves.
+  """
+  allowLocalTraces: Boolean!
+
+  """
+  Admin ceiling for exporting PXI traces to the remote collector. Sourced from the `agent.assistant.trace_recording` system setting. When False, users cannot turn on remote trace export for themselves.
+  """
+  allowRemoteExport: Boolean!
 }
 
 interface Annotation {
@@ -2334,6 +2358,8 @@ type Mutation {
   createSpanNote(annotationInput: CreateSpanNoteInput!): SpanAnnotationMutationPayload!
   patchSpanAnnotations(input: [PatchAnnotationInput!]!): SpanAnnotationMutationPayload!
   deleteSpanAnnotations(input: DeleteAnnotationsInput!): SpanAnnotationMutationPayload!
+  setAgentAssistantEnabled(input: SetAgentAssistantEnabledInput!): AgentAssistantEnabled!
+  setAgentTraceRecording(input: SetAgentTraceRecordingInput!): AgentTraceRecording!
   createProjectSessionAnnotations(input: CreateProjectSessionAnnotationInput!): ProjectSessionAnnotationMutationPayload!
   updateProjectSessionAnnotations(input: UpdateAnnotationInput!): ProjectSessionAnnotationMutationPayload!
   deleteProjectSessionAnnotation(id: ID!): ProjectSessionAnnotationMutationPayload!
@@ -3515,6 +3541,15 @@ scalar SecretString
 
 type ServerStatus {
   insufficientStorage: Boolean!
+}
+
+input SetAgentAssistantEnabledInput {
+  enabled: Boolean!
+}
+
+input SetAgentTraceRecordingInput {
+  allowLocalTraces: Boolean!
+  allowRemoteExport: Boolean!
 }
 
 input SetDatasetExampleSplitsInput {

--- a/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
+++ b/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
@@ -5,6 +5,15 @@ import { createDefaultAgentCapabilities } from "@phoenix/agent/extensions/capabi
 import { buildAgentChatRequestBody } from "../buildAgentChatRequestBody";
 import type { AgentUIMessage } from "../types";
 
+const agentsConfig = {
+  collectorEndpoint: null,
+  assistantProjectName: "assistant_agent",
+  webAccessEnabled: false,
+  assistantEnabled: true,
+  allowLocalTraces: false,
+  allowRemoteExport: false,
+};
+
 describe("buildAgentChatRequestBody", () => {
   it("merges the transport body with PXI chat metadata and omits client-supplied prompt overrides", () => {
     const body = buildAgentChatRequestBody({
@@ -17,10 +26,10 @@ describe("buildAgentChatRequestBody", () => {
       observability: {
         storeLocalTraces: true,
         exportRemoteTraces: false,
-        hasAcknowledgedConsent: false,
+        acknowledgedTraceConsent: null,
       },
+      agentsConfig,
       permissions: { edits: "manual" },
-      hasRemoteCollector: false,
       contexts: [],
       modelSelection: {
         providerType: "builtin",
@@ -62,10 +71,10 @@ describe("buildAgentChatRequestBody", () => {
       observability: {
         storeLocalTraces: false,
         exportRemoteTraces: false,
-        hasAcknowledgedConsent: false,
+        acknowledgedTraceConsent: null,
       },
+      agentsConfig,
       permissions: { edits: "bypass" },
-      hasRemoteCollector: false,
       contexts: [],
       modelSelection: {
         providerType: "builtin",
@@ -78,5 +87,40 @@ describe("buildAgentChatRequestBody", () => {
       type: "web_access",
       enabled: true,
     });
+  });
+
+  it("applies server trace ceilings to trace request flags", () => {
+    const body = buildAgentChatRequestBody({
+      body: undefined,
+      id: "session-1",
+      messages: [] as AgentUIMessage[],
+      trigger: "submit-message",
+      messageId: undefined,
+      capabilities: createDefaultAgentCapabilities(),
+      observability: {
+        storeLocalTraces: true,
+        exportRemoteTraces: true,
+        acknowledgedTraceConsent: {
+          allowLocalTraces: true,
+          allowRemoteExport: true,
+        },
+      },
+      agentsConfig: {
+        ...agentsConfig,
+        collectorEndpoint: "https://collector.example.com",
+        allowLocalTraces: false,
+        allowRemoteExport: true,
+      },
+      permissions: { edits: "manual" },
+      contexts: [],
+      modelSelection: {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-4o-mini",
+      },
+    });
+
+    expect(body.ingestTraces).toBe(false);
+    expect(body.exportRemoteTraces).toBe(true);
   });
 });

--- a/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -2,9 +2,11 @@ import type { AgentContext } from "@phoenix/agent/context/agentContextTypes";
 import type { AgentCapabilities } from "@phoenix/agent/extensions/capabilities";
 import type { components } from "@phoenix/api/__generated__/v1";
 import type { AgentModelSelection } from "@phoenix/components/agent/useGenerateSessionSummary";
-import type {
-  AgentObservabilitySettings,
-  AgentPermissions,
+import {
+  getEffectiveTraceRecordingSettings,
+  type AgentObservabilitySettings,
+  type AgentPermissions,
+  type AgentServerConfig,
 } from "@phoenix/store/agentStore";
 import { getTimeZone, toLocalISOWithOffset } from "@phoenix/utils/timeUtils";
 
@@ -25,10 +27,10 @@ type BuildAgentChatRequestBodyOptions = {
   capabilities: AgentCapabilities;
   /** Per-user PXI observability settings for this request. */
   observability: AgentObservabilitySettings;
+  /** Server PXI configuration for this request. */
+  agentsConfig: AgentServerConfig;
   /** Per-user PXI approval permission settings for this request. */
   permissions: AgentPermissions;
-  /** Whether a remote collector is configured for this Phoenix instance. */
-  hasRemoteCollector: boolean;
   /** Typed page and mounted UI contexts for the current turn. */
   contexts: AgentContext[];
   /** Provider + model selection for this turn. */
@@ -91,11 +93,15 @@ export function buildAgentChatRequestBody({
   messageId,
   capabilities,
   observability,
+  agentsConfig,
   permissions,
-  hasRemoteCollector,
   contexts,
   modelSelection,
 }: BuildAgentChatRequestBodyOptions): BuildAgentChatRequestBodyResult {
+  const traceRecording = getEffectiveTraceRecordingSettings({
+    agentsConfig,
+    observability,
+  });
   const requestContexts = [
     buildCurrentAppContext(),
     buildGraphQLContext(capabilities),
@@ -108,8 +114,8 @@ export function buildAgentChatRequestBody({
     messages,
     trigger,
     messageId,
-    ingestTraces: observability.storeLocalTraces,
-    exportRemoteTraces: observability.exportRemoteTraces && hasRemoteCollector,
+    ingestTraces: traceRecording.ingestTraces,
+    exportRemoteTraces: traceRecording.exportRemoteTraces,
     editPermission: permissions.edits,
     contexts: requestContexts,
     model: modelSelection,

--- a/app/src/agent/extensions/capabilities.ts
+++ b/app/src/agent/extensions/capabilities.ts
@@ -64,7 +64,7 @@ export const AGENT_CAPABILITY_DEFINITIONS: AgentCapabilityDefinition[] = [
     key: "web.access",
     label: "Web search",
     description:
-      "Lets PXI use provider-native web search and URL fetching when the selected model supports it.",
+      "Lets the assistant use provider-native web search and URL fetching when the selected model supports it.",
     defaultValue: false,
     scope: "global",
   },

--- a/app/src/components/agent/AgentChatPanel.tsx
+++ b/app/src/components/agent/AgentChatPanel.tsx
@@ -18,6 +18,7 @@ import {
 } from "./sessionSummaryUtils";
 import { useAgentChat } from "./useAgentChat";
 import { useAgentChatPanelState } from "./useAgentChatPanelState";
+import { useAssistantAgentEnabled } from "./useAssistantAgentEnabled";
 import type { AgentModelSelection } from "./useGenerateSessionSummary";
 
 type AgentChatPanelLayer = "content" | "modal";
@@ -113,7 +114,7 @@ function AgentChatSurface({
   positionOverride,
   isPositionChangeDisabled = false,
 }: AgentChatSurfaceProps) {
-  const isAgentAssistantEnabled = !window.Config.agentAssistantDisabled;
+  const isAgentAssistantEnabled = useAssistantAgentEnabled();
   const {
     isOpen,
     position,

--- a/app/src/components/agent/AgentChatPanel.tsx
+++ b/app/src/components/agent/AgentChatPanel.tsx
@@ -3,7 +3,6 @@ import { Suspense, useState, type ReactNode, type RefObject } from "react";
 import { ChatSessionUsage } from "@phoenix/components/agent/ChatSessionUsage";
 import { Loading } from "@phoenix/components/core";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
-import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import type { AgentPosition } from "@phoenix/store/agentStore";
 
 import {
@@ -114,7 +113,7 @@ function AgentChatSurface({
   positionOverride,
   isPositionChangeDisabled = false,
 }: AgentChatSurfaceProps) {
-  const isAgentsEnabled = useFeatureFlag("agents");
+  const isAgentAssistantEnabled = !window.Config.agentAssistantDisabled;
   const {
     isOpen,
     position,
@@ -139,7 +138,7 @@ function AgentChatSurface({
     ? getSessionDisplayName(activeSession)
     : EMPTY_SESSION_DISPLAY_NAME;
 
-  if (!isAgentsEnabled) {
+  if (!isAgentAssistantEnabled) {
     return null;
   }
 

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -182,7 +182,7 @@ export function AgentChatHeader({
           variant="quiet"
           size="S"
           to="/settings/agents"
-          aria-label="Agent settings"
+          aria-label="Assistant settings"
           leadingVisual={<Icon svg={<Icons.OptionsOutline />} />}
         />
         {position != null && onPositionChange != null ? (
@@ -213,7 +213,7 @@ export function AgentChatHeader({
         <Button
           variant="quiet"
           size="S"
-          aria-label="Close agent chat"
+          aria-label="Close assistant"
           onPress={onClose}
           leadingVisual={<Icon svg={<Icons.CloseOutline />} />}
         />

--- a/app/src/components/agent/AgentChatWidget.tsx
+++ b/app/src/components/agent/AgentChatWidget.tsx
@@ -378,7 +378,7 @@ export interface AgentChatWidgetButtonProps extends Omit<
 export function AgentChatWidgetButton({
   ref,
   isStreaming = false,
-  ariaLabel = "Open agent chat",
+  ariaLabel = "Open assistant",
   isDragHandle = false,
   glyphAnimation = "wave-reveal",
   ...buttonProps

--- a/app/src/components/agent/AgentConsentGate.tsx
+++ b/app/src/components/agent/AgentConsentGate.tsx
@@ -53,21 +53,21 @@ export function AgentConsentGate() {
     <div css={consentCSS}>
       <div css={consentHeaderCSS}>
         <Text elementType="h3" size="L" weight="heavy">
-          Before you use PXI
+          Before you use the assistant
         </Text>
         <Text color="text-700">
-          PXI can and will make mistakes. What it can do may vary a lot
-          depending on the task and the context it has, so it should be used
+          The assistant can and will make mistakes. What it can do may vary a
+          lot depending on the task and the context it has, so it should be used
           with care.
         </Text>
       </div>
       <ul css={consentListCSS}>
         <li>
           {hasRemoteCollector
-            ? "Review how your PXI session traces are saved and shared before you continue."
-            : "Review how your PXI session traces are saved before you continue."}
+            ? "Review how your assistant session traces are saved and shared before you continue."
+            : "Review how your assistant session traces are saved before you continue."}
         </li>
-        <li>You can change these settings later from Agent Settings.</li>
+        <li>You can change these settings later in Assistant settings.</li>
       </ul>
       <div css={consentSectionCSS}>
         <Text elementType="h4" size="M" weight="heavy">
@@ -77,7 +77,7 @@ export function AgentConsentGate() {
       <AgentObservabilitySettings />
       <Flex direction="row" css={consentActionsCSS}>
         <LinkButton to="/settings/agents" variant="default">
-          Agent Settings
+          Assistant settings
         </LinkButton>
         <Button
           variant="primary"

--- a/app/src/components/agent/AgentExperimentalSettings.tsx
+++ b/app/src/components/agent/AgentExperimentalSettings.tsx
@@ -1,13 +1,21 @@
 import { css } from "@emotion/react";
 
-import { getAgentCapabilitiesForControlSurface } from "@phoenix/agent/extensions/capabilities";
-import { Alert, Flex, Switch, Text, View } from "@phoenix/components";
+import {
+  getAgentCapabilitiesForControlSurface,
+  getAgentCapabilityDefinition,
+} from "@phoenix/agent/extensions/capabilities";
+import { Flex, Switch, Text } from "@phoenix/components";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 
-const settingsCSS = css`
+import { SystemSettingsWarning } from "./SystemSettingsWarning";
+
+const settingsListCSS = css`
   display: flex;
   flex-direction: column;
   gap: var(--global-dimension-size-150);
+  list-style: none;
+  margin: 0;
+  padding: 0;
 `;
 
 const settingRowCSS = css`
@@ -34,12 +42,6 @@ const settingSwitchCSS = css`
   }
 `;
 
-const detailsCSS = css`
-  summary {
-    cursor: pointer;
-  }
-`;
-
 export function AgentExperimentalSettings() {
   const store = useAgentStore();
   const capabilities = useAgentContext((state) => state.capabilities);
@@ -52,39 +54,61 @@ export function AgentExperimentalSettings() {
   }
 
   return (
-    <details css={detailsCSS}>
-      <summary>Experimental Features</summary>
-      <View paddingTop="size-150">
-        <Flex direction="column" gap="size-200">
-          <Alert variant="warning" title="Experimental">
-            These features are under active development and may change or be
-            removed at any time.
-          </Alert>
-          <div css={settingsCSS}>
-            {experimentalCapabilities.map((definition) => (
-              <div key={definition.key} css={settingRowCSS}>
-                <Switch
-                  isSelected={capabilities[definition.key]}
-                  onChange={(enabled) => {
-                    store
-                      .getState()
-                      .setCapability({ key: definition.key, enabled });
-                  }}
-                  labelPlacement="start"
-                  css={settingSwitchCSS}
-                >
-                  <span className="agent-settings__label">
-                    <Text weight="heavy" size="M">
-                      {definition.label}
-                    </Text>
-                    <Text color="text-500">{definition.description}</Text>
-                  </span>
-                </Switch>
-              </div>
-            ))}
-          </div>
-        </Flex>
-      </View>
-    </details>
+    <Flex direction="column" gap="size-200">
+      <ul css={settingsListCSS}>
+        {experimentalCapabilities.map((definition) => (
+          <li key={definition.key} css={settingRowCSS}>
+            <Switch
+              isSelected={capabilities[definition.key]}
+              onChange={(enabled) => {
+                store.getState().setCapability({ key: definition.key, enabled });
+              }}
+              labelPlacement="start"
+              css={settingSwitchCSS}
+            >
+              <span className="agent-settings__label">
+                <Text weight="heavy" size="M">
+                  {definition.label}
+                </Text>
+                <Text color="text-500">{definition.description}</Text>
+              </span>
+            </Switch>
+          </li>
+        ))}
+      </ul>
+    </Flex>
+  );
+}
+
+export function AgentWebAccessSettings() {
+  const store = useAgentStore();
+  const capabilities = useAgentContext((state) => state.capabilities);
+  const isWebAccessEnabled = useAgentContext(
+    (state) => state.agentsConfig.webAccessEnabled
+  );
+  const definition = getAgentCapabilityDefinition("web.access");
+
+  return (
+    <ul css={settingsListCSS}>
+      <li css={settingRowCSS}>
+        <Switch
+          isSelected={isWebAccessEnabled && capabilities[definition.key]}
+          isDisabled={!isWebAccessEnabled}
+          onChange={(enabled) => {
+            store.getState().setCapability({ key: definition.key, enabled });
+          }}
+          labelPlacement="start"
+          css={settingSwitchCSS}
+        >
+          <span className="agent-settings__label">
+            <Text weight="heavy" size="M">
+              {definition.label}
+            </Text>
+            <Text color="text-500">{definition.description}</Text>
+          </span>
+        </Switch>
+        {!isWebAccessEnabled ? <SystemSettingsWarning /> : null}
+      </li>
+    </ul>
   );
 }

--- a/app/src/components/agent/AgentExperimentalSettings.tsx
+++ b/app/src/components/agent/AgentExperimentalSettings.tsx
@@ -61,7 +61,9 @@ export function AgentExperimentalSettings() {
             <Switch
               isSelected={capabilities[definition.key]}
               onChange={(enabled) => {
-                store.getState().setCapability({ key: definition.key, enabled });
+                store
+                  .getState()
+                  .setCapability({ key: definition.key, enabled });
               }}
               labelPlacement="start"
               css={settingSwitchCSS}

--- a/app/src/components/agent/AgentModelCredentialForm.tsx
+++ b/app/src/components/agent/AgentModelCredentialForm.tsx
@@ -98,7 +98,7 @@ export function AgentModelCredentialForm({
           <>
             <Text size="XS" color="text-700">
               Add server-side credentials for {modelName} to use this model with
-              PXI.
+              the assistant.
             </Text>
             <ProviderServerCredentialsPanel
               provider={provider}
@@ -108,7 +108,7 @@ export function AgentModelCredentialForm({
         ) : (
           <Text size="XS" color="text-700">
             Contact an administrator to configure {provider.name} credentials
-            before using {modelName} with PXI.
+            before using {modelName} with the assistant.
           </Text>
         )}
       </Flex>

--- a/app/src/components/agent/AgentObservabilitySettings.tsx
+++ b/app/src/components/agent/AgentObservabilitySettings.tsx
@@ -1,12 +1,23 @@
 import { css } from "@emotion/react";
 
-import { Switch, Text } from "@phoenix/components";
+import { ContextualHelp, Switch, Text } from "@phoenix/components";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
 
-const settingsCSS = css`
+import { SystemSettingsWarning } from "./SystemSettingsWarning";
+
+const settingsContainerCSS = css`
   display: flex;
   flex-direction: column;
   gap: var(--global-dimension-size-150);
+`;
+
+const settingsListCSS = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-size-150);
+  list-style: none;
+  margin: 0;
+  padding: 0;
 `;
 
 const settingRowCSS = css`
@@ -31,11 +42,18 @@ const settingSwitchCSS = css`
     gap: var(--global-dimension-size-75);
     min-width: 0;
   }
-`;
 
-const footerNoteCSS = css`
-  display: block;
-  color: var(--global-text-color-500);
+  .agent-observability__title {
+    display: flex;
+    align-items: center;
+    gap: var(--global-dimension-size-50);
+    min-width: 0;
+  }
+
+  .agent-observability__help {
+    display: inline-flex;
+    flex: 0 0 auto;
+  }
 `;
 
 const codeCSS = css`
@@ -45,7 +63,37 @@ const codeCSS = css`
   font-size: 0.95em;
 `;
 
-const DISABLED_BY_ADMIN_NOTE = "Disabled by your workspace admin.";
+const traceDetailsTooltipCSS = css`
+  max-width: 320px;
+`;
+
+function TraceExportInfoTip({
+  collectorEndpoint,
+}: {
+  collectorEndpoint: string;
+}) {
+  return (
+    <span
+      className="agent-observability__help"
+      onClick={(event) => {
+        event.stopPropagation();
+      }}
+      onPointerDown={(event) => {
+        event.stopPropagation();
+      }}
+    >
+      <ContextualHelp
+        variant="info"
+        placement="top"
+        css={traceDetailsTooltipCSS}
+      >
+        Exported traces are unredacted and include prompts, replies, tool calls,
+        tool results, and any Phoenix data the assistant read. They are sent to{" "}
+        <code css={codeCSS}>{collectorEndpoint}</code>.
+      </ContextualHelp>
+    </span>
+  );
+}
 
 export function AgentObservabilitySettings() {
   const agentsConfig = useAgentContext((state) => state.agentsConfig);
@@ -60,69 +108,70 @@ export function AgentObservabilitySettings() {
   const remoteExportDisabledByAdmin = !agentsConfig.allowRemoteExport;
 
   return (
-    <div css={settingsCSS}>
-      <div css={settingRowCSS}>
-        <Switch
-          isSelected={
-            !localTracesDisabledByAdmin && observability.storeLocalTraces
-          }
-          isDisabled={localTracesDisabledByAdmin}
-          onChange={(storeLocalTraces) => {
-            setObservability({ storeLocalTraces });
-          }}
-          labelPlacement="start"
-          css={settingSwitchCSS}
-        >
-          <span className="agent-observability__label">
-            <Text weight="heavy" size="M">
-              Save PXI session traces in this Phoenix app
-            </Text>
-            <Text color="text-500">
-              Stores full, unredacted session recordings (prompts, replies, tool
-              calls, tool results, and any Phoenix data PXI read) in the{" "}
-              <code css={codeCSS}>{agentsConfig.assistantProjectName}</code>{" "}
-              project, visible to anyone with project access. Browser-only
-              setting.
-              {localTracesDisabledByAdmin ? ` ${DISABLED_BY_ADMIN_NOTE}` : ""}
-            </Text>
-          </span>
-        </Switch>
-      </div>
-      {isRemoteCollectorConfigured ? (
-        <div css={settingRowCSS}>
+    <div css={settingsContainerCSS}>
+      <ul css={settingsListCSS}>
+        <li css={settingRowCSS}>
           <Switch
             isSelected={
-              isRemoteCollectorConfigured &&
-              !remoteExportDisabledByAdmin &&
-              observability.exportRemoteTraces
+              !localTracesDisabledByAdmin && observability.storeLocalTraces
             }
-            isDisabled={remoteExportDisabledByAdmin}
-            onChange={(exportRemoteTraces) => {
-              setObservability({ exportRemoteTraces });
+            isDisabled={localTracesDisabledByAdmin}
+            onChange={(storeLocalTraces) => {
+              setObservability({ storeLocalTraces });
             }}
             labelPlacement="start"
             css={settingSwitchCSS}
           >
             <span className="agent-observability__label">
               <Text weight="heavy" size="M">
-                Share PXI session traces with the team improving PXI
+                Save assistant session traces in this Phoenix instance
               </Text>
               <Text color="text-500">
-                Transmits the same unredacted traces to{" "}
-                <code css={codeCSS}>{agentsConfig.collectorEndpoint}</code>.
-                Browser-only setting.
-                {remoteExportDisabledByAdmin
-                  ? ` ${DISABLED_BY_ADMIN_NOTE}`
-                  : ""}
+                Stores full, unredacted traces (prompts, replies, tool calls,
+                tool results, and any Phoenix data the assistant read) in the{" "}
+                <code css={codeCSS}>{agentsConfig.assistantProjectName}</code>{" "}
+                project. Anyone with access to that project can view them. This
+                setting applies only to this browser.
               </Text>
             </span>
           </Switch>
-        </div>
-      ) : null}
-      <Text css={footerNoteCSS} size="S">
-        Trace links and feedback buttons only work when traces are saved in this
-        Phoenix app.
-      </Text>
+          {localTracesDisabledByAdmin ? <SystemSettingsWarning /> : null}
+        </li>
+        {isRemoteCollectorConfigured ? (
+          <li css={settingRowCSS}>
+            <Switch
+              isSelected={
+                isRemoteCollectorConfigured &&
+                !remoteExportDisabledByAdmin &&
+                observability.exportRemoteTraces
+              }
+              isDisabled={remoteExportDisabledByAdmin}
+              onChange={(exportRemoteTraces) => {
+                setObservability({ exportRemoteTraces });
+              }}
+              labelPlacement="start"
+              css={settingSwitchCSS}
+            >
+              <span className="agent-observability__label">
+                <span className="agent-observability__title">
+                  <Text weight="heavy" size="M">
+                    Exporting traces
+                  </Text>
+                  <TraceExportInfoTip
+                    collectorEndpoint={agentsConfig.collectorEndpoint ?? ""}
+                  />
+                </span>
+                <Text color="text-500">
+                  Exports assistant session traces to{" "}
+                  <code css={codeCSS}>{agentsConfig.collectorEndpoint}</code>.
+                  This setting applies only to this browser.
+                </Text>
+              </span>
+            </Switch>
+            {remoteExportDisabledByAdmin ? <SystemSettingsWarning /> : null}
+          </li>
+        ) : null}
+      </ul>
     </div>
   );
 }

--- a/app/src/components/agent/AgentObservabilitySettings.tsx
+++ b/app/src/components/agent/AgentObservabilitySettings.tsx
@@ -45,17 +45,28 @@ const codeCSS = css`
   font-size: 0.95em;
 `;
 
+const DISABLED_BY_ADMIN_NOTE = "Disabled by your workspace admin.";
+
 export function AgentObservabilitySettings() {
   const agentsConfig = useAgentContext((state) => state.agentsConfig);
   const observability = useAgentContext((state) => state.observability);
   const setObservability = useAgentContext((state) => state.setObservability);
   const isRemoteCollectorConfigured = Boolean(agentsConfig.collectorEndpoint);
 
+  // User-side preference is effectively off whenever the admin ceiling is off,
+  // regardless of stored value. We don't reset the stored preference so the
+  // user's prior opt-in returns if the admin re-enables.
+  const localTracesDisabledByAdmin = !agentsConfig.allowLocalTraces;
+  const remoteExportDisabledByAdmin = !agentsConfig.allowRemoteExport;
+
   return (
     <div css={settingsCSS}>
       <div css={settingRowCSS}>
         <Switch
-          isSelected={observability.storeLocalTraces}
+          isSelected={
+            !localTracesDisabledByAdmin && observability.storeLocalTraces
+          }
+          isDisabled={localTracesDisabledByAdmin}
           onChange={(storeLocalTraces) => {
             setObservability({ storeLocalTraces });
           }}
@@ -72,6 +83,7 @@ export function AgentObservabilitySettings() {
               <code css={codeCSS}>{agentsConfig.assistantProjectName}</code>{" "}
               project, visible to anyone with project access. Browser-only
               setting.
+              {localTracesDisabledByAdmin ? ` ${DISABLED_BY_ADMIN_NOTE}` : ""}
             </Text>
           </span>
         </Switch>
@@ -80,8 +92,11 @@ export function AgentObservabilitySettings() {
         <div css={settingRowCSS}>
           <Switch
             isSelected={
-              isRemoteCollectorConfigured && observability.exportRemoteTraces
+              isRemoteCollectorConfigured &&
+              !remoteExportDisabledByAdmin &&
+              observability.exportRemoteTraces
             }
+            isDisabled={remoteExportDisabledByAdmin}
             onChange={(exportRemoteTraces) => {
               setObservability({ exportRemoteTraces });
             }}
@@ -96,6 +111,9 @@ export function AgentObservabilitySettings() {
                 Transmits the same unredacted traces to{" "}
                 <code css={codeCSS}>{agentsConfig.collectorEndpoint}</code>.
                 Browser-only setting.
+                {remoteExportDisabledByAdmin
+                  ? ` ${DISABLED_BY_ADMIN_NOTE}`
+                  : ""}
               </Text>
             </span>
           </Switch>

--- a/app/src/components/agent/AgentSettingsForm.tsx
+++ b/app/src/components/agent/AgentSettingsForm.tsx
@@ -64,7 +64,7 @@ export function AgentSettingsForm({ children }: { children?: ReactNode }) {
       `}
     >
       <div css={fieldBaseCSS}>
-        <Label>Agent Model</Label>
+        <Label>Assistant model</Label>
         <Controller
           name="model"
           control={control}
@@ -83,8 +83,8 @@ export function AgentSettingsForm({ children }: { children?: ReactNode }) {
               margin-top: var(--global-dimension-size-100);
             `}
           >
-            This model has not been verified with PXI and may fail or behave
-            poorly.
+            This model has not been verified with the assistant and may fail or
+            behave poorly.
           </Alert>
         )}
       </div>

--- a/app/src/components/agent/AgentSettingsForm.tsx
+++ b/app/src/components/agent/AgentSettingsForm.tsx
@@ -1,8 +1,7 @@
 import { css } from "@emotion/react";
 import type { ReactNode } from "react";
-import { Controller, useForm, useWatch } from "react-hook-form";
 
-import { Alert, Button, Flex, Label } from "@phoenix/components";
+import { Alert, Label } from "@phoenix/components";
 import { fieldBaseCSS } from "@phoenix/components/core/field/styles";
 import type { ModelMenuValue } from "@phoenix/components/generative/ModelMenu";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
@@ -21,10 +20,6 @@ function defaultModelConfigToMenuValue(config: ModelConfig): ModelMenuValue {
   };
 }
 
-export type AgentSettingsFormValues = {
-  model: ModelMenuValue;
-};
-
 export function AgentSettingsForm({ children }: { children?: ReactNode }) {
   const store = useAgentStore();
   const defaultModelConfig = useAgentContext(
@@ -34,29 +29,21 @@ export function AgentSettingsForm({ children }: { children?: ReactNode }) {
     (state) => state.setDefaultModelConfig
   );
 
-  const { control, handleSubmit, formState, reset } =
-    useForm<AgentSettingsFormValues>({
-      defaultValues: {
-        model: defaultModelConfigToMenuValue(defaultModelConfig),
-      },
-    });
-  const selectedModel = useWatch({ control, name: "model" });
+  const selectedModel = defaultModelConfigToMenuValue(defaultModelConfig);
   const isRecommendedModel = isAgentCuratedModelSelection(selectedModel);
 
-  const onSubmit = (data: AgentSettingsFormValues) => {
+  const handleModelChange = (model: ModelMenuValue) => {
     const { defaultModelConfig: current } = store.getState();
     setDefaultModelConfig({
       ...current,
-      provider: data.model.provider,
-      modelName: data.model.modelName,
-      customProvider: data.model.customProvider ?? null,
+      provider: model.provider,
+      modelName: model.modelName,
+      customProvider: model.customProvider ?? null,
     });
-    reset(data);
   };
 
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
+    <div
       css={css`
         display: flex;
         flex-direction: column;
@@ -65,16 +52,10 @@ export function AgentSettingsForm({ children }: { children?: ReactNode }) {
     >
       <div css={fieldBaseCSS}>
         <Label>Assistant model</Label>
-        <Controller
-          name="model"
-          control={control}
-          render={({ field }) => (
-            <AgentModelMenu
-              value={field.value}
-              onChange={field.onChange}
-              limitToCuratedModels={false}
-            />
-          )}
+        <AgentModelMenu
+          value={selectedModel}
+          onChange={handleModelChange}
+          limitToCuratedModels={false}
         />
         {!isRecommendedModel && (
           <Alert
@@ -89,11 +70,6 @@ export function AgentSettingsForm({ children }: { children?: ReactNode }) {
         )}
       </div>
       {children}
-      <Flex direction="row" gap="size-100" justifyContent="end" width="100%">
-        <Button type="submit" variant="primary" isDisabled={!formState.isDirty}>
-          Save
-        </Button>
-      </Flex>
-    </form>
+    </div>
   );
 }

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -32,6 +32,7 @@ import { Shimmer } from "@phoenix/components/ai/shimmer";
 import type { ModelMenuValue } from "@phoenix/components/generative/ModelMenu";
 import { useTheme } from "@phoenix/contexts";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
+import { hasAcknowledgedCurrentTraceConsent } from "@phoenix/store/agentStore";
 
 import { AgentConsentGate } from "./AgentConsentGate";
 import { AgentContextPills } from "./AgentContextPills";
@@ -376,8 +377,11 @@ export function ChatView({
 
   const [elicitationDraft, setElicitationDraft] =
     useState<PendingElicitationDraft | null>(null);
-  const hasAcknowledgedConsent = useAgentContext(
-    (state) => state.observability.hasAcknowledgedConsent
+  const hasAcknowledgedConsent = useAgentContext((state) =>
+    hasAcknowledgedCurrentTraceConsent({
+      agentsConfig: state.agentsConfig,
+      observability: state.observability,
+    })
   );
   const editPermissionMode = useAgentContext(
     (state) => state.permissions.edits

--- a/app/src/components/agent/SystemSettingsWarning.tsx
+++ b/app/src/components/agent/SystemSettingsWarning.tsx
@@ -1,0 +1,25 @@
+import { css } from "@emotion/react";
+
+import { Flex, Icon, Icons, Text } from "@phoenix/components";
+
+const warningCSS = css`
+  margin: 0 var(--global-dimension-size-150)
+    var(--global-dimension-size-150);
+  color: var(--global-color-warning);
+`;
+
+export function SystemSettingsWarning() {
+  return (
+    <Flex
+      direction="row"
+      gap="size-75"
+      alignItems="center"
+      css={warningCSS}
+    >
+      <Icon svg={<Icons.LockOutline />} />
+      <Text color="inherit" size="S">
+        Disabled by system settings. An administrator needs to turn this on.
+      </Text>
+    </Flex>
+  );
+}

--- a/app/src/components/agent/SystemSettingsWarning.tsx
+++ b/app/src/components/agent/SystemSettingsWarning.tsx
@@ -3,19 +3,13 @@ import { css } from "@emotion/react";
 import { Flex, Icon, Icons, Text } from "@phoenix/components";
 
 const warningCSS = css`
-  margin: 0 var(--global-dimension-size-150)
-    var(--global-dimension-size-150);
+  margin: 0 var(--global-dimension-size-150) var(--global-dimension-size-150);
   color: var(--global-color-warning);
 `;
 
 export function SystemSettingsWarning() {
   return (
-    <Flex
-      direction="row"
-      gap="size-75"
-      alignItems="center"
-      css={warningCSS}
-    >
+    <Flex direction="row" gap="size-75" alignItems="center" css={warningCSS}>
       <Icon svg={<Icons.LockOutline />} />
       <Text color="inherit" size="S">
         Disabled by system settings. An administrator needs to turn this on.

--- a/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
@@ -8,7 +8,6 @@ import {
   MODAL_PORTAL_CONTAINER_ATTR,
 } from "@phoenix/components/core/overlay/constants";
 import { AgentProvider, useAgentContext } from "@phoenix/contexts/AgentContext";
-import { FeatureFlagsContext } from "@phoenix/contexts/FeatureFlagsContext";
 import { PreferencesProvider } from "@phoenix/contexts/PreferencesContext";
 import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
 
@@ -126,21 +125,23 @@ describe("AgentChatWidget", () => {
     act(() => {
       root.render(
         <ThemeProvider themeMode="light" disableBodyTheme>
-          <FeatureFlagsContext.Provider
-            value={{
-              featureFlags: { agents: true },
-              setFeatureFlags: vi.fn(),
-            }}
+          <PreferencesProvider
+            isAssistantAgentEnabled={isAssistantAgentEnabled}
           >
-            <PreferencesProvider
-              isAssistantAgentEnabled={isAssistantAgentEnabled}
+            <AgentProvider
+              agentsConfig={{
+                collectorEndpoint: null,
+                assistantProjectName: "assistant_agent",
+                webAccessEnabled: false,
+                assistantEnabled: true,
+                allowLocalTraces: true,
+                allowRemoteExport: false,
+              }}
             >
-              <AgentProvider>
-                <AgentChatWidget />
-                <AgentOpenState />
-              </AgentProvider>
-            </PreferencesProvider>
-          </FeatureFlagsContext.Provider>
+              <AgentChatWidget />
+              <AgentOpenState />
+            </AgentProvider>
+          </PreferencesProvider>
         </ThemeProvider>
       );
     });
@@ -386,18 +387,20 @@ describe("AgentChatWidget", () => {
     act(() => {
       root.render(
         <ThemeProvider themeMode="light" disableBodyTheme>
-          <FeatureFlagsContext.Provider
-            value={{
-              featureFlags: { agents: true },
-              setFeatureFlags: vi.fn(),
-            }}
-          >
-            <PreferencesProvider isAssistantAgentEnabled>
-              <AgentProvider>
-                <AgentWidgetWithBoundary />
-              </AgentProvider>
-            </PreferencesProvider>
-          </FeatureFlagsContext.Provider>
+          <PreferencesProvider isAssistantAgentEnabled>
+            <AgentProvider
+              agentsConfig={{
+                collectorEndpoint: null,
+                assistantProjectName: "assistant_agent",
+                webAccessEnabled: false,
+                assistantEnabled: true,
+                allowLocalTraces: true,
+                allowRemoteExport: false,
+              }}
+            >
+              <AgentWidgetWithBoundary />
+            </AgentProvider>
+          </PreferencesProvider>
         </ThemeProvider>
       );
     });

--- a/app/src/components/agent/index.tsx
+++ b/app/src/components/agent/index.tsx
@@ -1,5 +1,4 @@
 export { AgentSettingsForm } from "./AgentSettingsForm";
-export type { AgentSettingsFormValues } from "./AgentSettingsForm";
 export { AgentObservabilitySettings } from "./AgentObservabilitySettings";
 export {
   AgentExperimentalSettings,

--- a/app/src/components/agent/index.tsx
+++ b/app/src/components/agent/index.tsx
@@ -1,7 +1,11 @@
 export { AgentSettingsForm } from "./AgentSettingsForm";
 export type { AgentSettingsFormValues } from "./AgentSettingsForm";
 export { AgentObservabilitySettings } from "./AgentObservabilitySettings";
-export { AgentExperimentalSettings } from "./AgentExperimentalSettings";
+export {
+  AgentExperimentalSettings,
+  AgentWebAccessSettings,
+} from "./AgentExperimentalSettings";
+export { SystemSettingsWarning } from "./SystemSettingsWarning";
 export { AgentChatPanel, FloatingAgentChatPanel } from "./AgentChatPanel";
 export { AgentChatWidget } from "./AgentChatWidget";
 export { useAssistantAgentEnabled } from "./useAssistantAgentEnabled";

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -106,10 +106,8 @@ export function useAgentChat({
                     messageId,
                     capabilities: store.getState().capabilities,
                     observability: store.getState().observability,
+                    agentsConfig: store.getState().agentsConfig,
                     permissions: store.getState().permissions,
-                    hasRemoteCollector: Boolean(
-                      store.getState().agentsConfig.collectorEndpoint
-                    ),
                     contexts: selectActiveContexts(store.getState()),
                     modelSelection: modelSelectionRef.current,
                   }),

--- a/app/src/components/agent/useAssistantAgentEnabled.ts
+++ b/app/src/components/agent/useAssistantAgentEnabled.ts
@@ -1,10 +1,20 @@
-import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
+import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 
+/**
+ * Three layered gates: deploy ceiling (env var) → admin ceiling (system_settings.agent.assistant.enabled)
+ * → user preference (LocalStorage). All three must be on for the agent UI to render.
+ */
 export function useAssistantAgentEnabled() {
-  const isAgentsFeatureEnabled = useFeatureFlag("agents");
+  const adminAgentEnabled = useAgentContext(
+    (state) => state.agentsConfig.assistantEnabled
+  );
   const isAssistantAgentEnabled = usePreferencesContext(
     (state) => state.isAssistantAgentEnabled
   );
-  return isAgentsFeatureEnabled && isAssistantAgentEnabled;
+  return (
+    !window.Config.agentAssistantDisabled &&
+    adminAgentEnabled &&
+    isAssistantAgentEnabled
+  );
 }

--- a/app/src/components/agent/useGenerateSessionSummary.ts
+++ b/app/src/components/agent/useGenerateSessionSummary.ts
@@ -4,6 +4,7 @@ import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import type { components, paths } from "@phoenix/api/__generated__/v1";
 import { authApiFetch } from "@phoenix/api/authApiFetch";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
+import { getEffectiveTraceRecordingSettings } from "@phoenix/store/agentStore";
 
 const SUMMARIZE_PATH =
   "/agents/{agent_id}/sessions/{session_id}/summary" as const satisfies keyof paths;
@@ -69,15 +70,17 @@ export function useGenerateSessionSummary() {
 
       requestedSessionsRef.current.add(sessionId);
 
-      const hasRemoteCollector = Boolean(state.agentsConfig.collectorEndpoint);
+      const traceRecording = getEffectiveTraceRecordingSettings({
+        agentsConfig: state.agentsConfig,
+        observability: state.observability,
+      });
 
       void fetchSummary({
         sessionId,
         modelSelection,
         messages: session.messages,
-        ingestTraces: state.observability.storeLocalTraces,
-        exportRemoteTraces:
-          state.observability.exportRemoteTraces && hasRemoteCollector,
+        ingestTraces: traceRecording.ingestTraces,
+        exportRemoteTraces: traceRecording.exportRemoteTraces,
       })
         .then((summary) => {
           if (summary) {

--- a/app/src/components/core/icon/Icons.tsx
+++ b/app/src/components/core/icon/Icons.tsx
@@ -815,6 +815,18 @@ export const ClockOutline = () => (
   </svg>
 );
 
+export const LockOutline = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <g data-name="Layer 2">
+      <g data-name="lock">
+        <rect width="24" height="24" opacity="0" />
+        <path d="M17 8h-1V6.11a4 4 0 1 0-8 0V8H7a3 3 0 0 0-3 3v8a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3v-8a3 3 0 0 0-3-3zm-7-1.89A2.06 2.06 0 0 1 12 4a2.06 2.06 0 0 1 2 2.11V8h-4zM18 19a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-8a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1z" />
+        <path d="M12 12a3 3 0 1 0 3 3 3 3 0 0 0-3-3zm0 4a1 1 0 1 1 1-1 1 1 0 0 1-1 1z" />
+      </g>
+    </g>
+  </svg>
+);
+
 export const Checkmark = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g data-name="Layer 2">

--- a/app/src/contexts/FeatureFlagsContext.tsx
+++ b/app/src/contexts/FeatureFlagsContext.tsx
@@ -11,7 +11,9 @@ import {
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
 
-type FeatureFlag = "agents";
+// Add a new flag by extending the union, then add a default below.
+type FeatureFlag = "agent-experimental-settings";
+
 export type FeatureFlagsContextType = {
   featureFlags: Record<FeatureFlag, boolean>;
   setFeatureFlags: (featureFlags: Record<FeatureFlag, boolean>) => void;
@@ -20,8 +22,7 @@ export type FeatureFlagsContextType = {
 export const LOCAL_STORAGE_FEATURE_FLAGS_KEY = "arize-phoenix-feature-flags";
 
 const DEFAULT_FEATURE_FLAGS: Record<FeatureFlag, boolean> = {
-  // TODO: when this flag is removed, update agentStore.ts by resetting / removing the persistence migration
-  agents: false,
+  "agent-experimental-settings": false,
 };
 
 function getFeatureFlags(): Record<FeatureFlag, boolean> {
@@ -43,7 +44,7 @@ function getFeatureFlags(): Record<FeatureFlag, boolean> {
     for (const key of Object.keys(DEFAULT_FEATURE_FLAGS) as FeatureFlag[]) {
       const v = parsedFeatureFlags[key];
       if (typeof v === "boolean") {
-        next[key] = v;
+        (next as Record<string, boolean>)[key] = v;
       }
     }
     if (hasUnknownFeatureFlags) {

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -8,6 +8,7 @@ import {
   AgentChatPanel,
   AgentChatWidget,
   FloatingAgentChatPanel,
+  useAssistantAgentEnabled,
 } from "@phoenix/components/agent";
 import {
   Brand,
@@ -91,7 +92,7 @@ const sideLinksCSS = css`
 
 export function Layout() {
   const contentRef = useRef<HTMLDivElement>(null);
-  const isAgentAssistantEnabled = !window.Config.agentAssistantDisabled;
+  const isAgentAssistantEnabled = useAssistantAgentEnabled();
   const isAgentPanelOpen = useAgentContext((state) => state.isOpen);
   const agentPosition = useAgentContext((state) => state.position);
   const hasOpenModal = useHasOpenModal();

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -26,7 +26,6 @@ import {
   TopNavbar,
 } from "@phoenix/components/nav";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
-import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 import {
@@ -92,19 +91,19 @@ const sideLinksCSS = css`
 
 export function Layout() {
   const contentRef = useRef<HTMLDivElement>(null);
-  const isAgentsEnabled = useFeatureFlag("agents");
+  const isAgentAssistantEnabled = !window.Config.agentAssistantDisabled;
   const isAgentPanelOpen = useAgentContext((state) => state.isOpen);
   const agentPosition = useAgentContext((state) => state.position);
   const hasOpenModal = useHasOpenModal();
   const hasOpenDrawer = useHasOpenDrawer();
   const shouldForceFloatingAgentPanel = hasOpenModal || hasOpenDrawer;
   const shouldShowDockedAgentPanel =
-    isAgentsEnabled &&
+    isAgentAssistantEnabled &&
     isAgentPanelOpen &&
     agentPosition === "pinned" &&
     !shouldForceFloatingAgentPanel;
   const shouldShowFloatingAgentPanel =
-    isAgentsEnabled &&
+    isAgentAssistantEnabled &&
     isAgentPanelOpen &&
     (agentPosition === "detached" || shouldForceFloatingAgentPanel);
   const panelIds = shouldShowDockedAgentPanel

--- a/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
+++ b/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2ff1269407f67843a752cbadbf64b270>>
+ * @generated SignedSource<<b2dc46bcc3064ee53938f5dfab5873fe>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,9 @@ import { FragmentRefs } from "relay-runtime";
 export type authenticatedRootLoaderQuery$variables = Record<PropertyKey, never>;
 export type authenticatedRootLoaderQuery$data = {
   readonly agentsConfig: {
+    readonly allowLocalTraces: boolean;
+    readonly allowRemoteExport: boolean;
+    readonly assistantEnabled: boolean;
     readonly assistantProjectName: string;
     readonly collectorEndpoint: string | null;
     readonly webAccessEnabled: boolean;
@@ -58,6 +61,27 @@ var v0 = {
       "args": null,
       "kind": "ScalarField",
       "name": "webAccessEnabled",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "assistantEnabled",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "allowLocalTraces",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "allowRemoteExport",
       "storageKey": null
     }
   ],
@@ -223,16 +247,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "65fe4e55ba0417d1568b44ea99419aac",
+    "cacheID": "c4d76dc1d6016faf2d55d3694b970ece",
     "id": null,
     "metadata": {},
     "name": "authenticatedRootLoaderQuery",
     "operationKind": "query",
-    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  agentsConfig {\n    collectorEndpoint\n    assistantProjectName\n    webAccessEnabled\n  }\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    isManagementUser\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
+    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  agentsConfig {\n    collectorEndpoint\n    assistantProjectName\n    webAccessEnabled\n    assistantEnabled\n    allowLocalTraces\n    allowRemoteExport\n  }\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    isManagementUser\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "5b0fabbed4b99fa6de423a58b4e81f52";
+(node as any).hash = "e66d05013f311a15863e40c44d7bb33f";
 
 export default node;

--- a/app/src/pages/authenticatedRootLoader.ts
+++ b/app/src/pages/authenticatedRootLoader.ts
@@ -13,6 +13,9 @@ export const authenticatedRootLoaderQueryNode = graphql`
       collectorEndpoint
       assistantProjectName
       webAccessEnabled
+      assistantEnabled
+      allowLocalTraces
+      allowRemoteExport
     }
     viewer {
       id

--- a/app/src/pages/settings/SettingsAgentsPage.tsx
+++ b/app/src/pages/settings/SettingsAgentsPage.tsx
@@ -15,9 +15,13 @@ import {
   AgentExperimentalSettings,
   AgentObservabilitySettings,
   AgentSettingsForm,
+  AgentWebAccessSettings,
 } from "@phoenix/components/agent";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
+import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
+
+import { SettingsAgentsWorkspaceCard } from "./SettingsAgentsWorkspaceCard";
 
 const traceDetailsCSS = css`
   summary {
@@ -112,27 +116,36 @@ export function SettingsAgentsPage() {
   const isAssistantAgentEnabled = usePreferencesContext(
     (state) => state.isAssistantAgentEnabled
   );
+  const isExperimentalSettingsEnabled = useFeatureFlag(
+    "agent-experimental-settings"
+  );
   return (
-    <Card
-      title="Assistant"
-      collapsible
-      defaultOpen={isAssistantAgentEnabled}
-      extra={<AssistantAgentEnabledSwitch />}
-    >
-      <View padding="size-200">
-        <Flex
-          direction="column"
-          gap="size-300"
-          css={css`
-            width: 100%;
-          `}
-        >
-          <AssistantTraceCollectionInfo />
-          <AgentSettingsForm>
-            <AgentExperimentalSettings />
-          </AgentSettingsForm>
-        </Flex>
-      </View>
-    </Card>
+    <Flex direction="column" gap="size-200">
+      <SettingsAgentsWorkspaceCard />
+      <Card
+        title="Assistant"
+        collapsible
+        defaultOpen={isAssistantAgentEnabled}
+        extra={<AssistantAgentEnabledSwitch />}
+      >
+        <View padding="size-200">
+          <Flex
+            direction="column"
+            gap="size-300"
+            css={css`
+              width: 100%;
+            `}
+          >
+            <AssistantTraceCollectionInfo />
+            <AgentSettingsForm>
+              <AgentWebAccessSettings />
+              {isExperimentalSettingsEnabled ? (
+                <AgentExperimentalSettings />
+              ) : null}
+            </AgentSettingsForm>
+          </Flex>
+        </View>
+      </Card>
+    </Flex>
   );
 }

--- a/app/src/pages/settings/SettingsAgentsPage.tsx
+++ b/app/src/pages/settings/SettingsAgentsPage.tsx
@@ -2,52 +2,79 @@ import { css } from "@emotion/react";
 
 import {
   Card,
-  CopyField,
-  CopyInput,
-  ExternalLink,
+  Disclosure,
+  DisclosureGroup,
+  DisclosurePanel,
+  DisclosureTrigger,
   Flex,
-  Label,
   Switch,
   Text,
-  View,
 } from "@phoenix/components";
 import {
   AgentExperimentalSettings,
   AgentObservabilitySettings,
   AgentSettingsForm,
   AgentWebAccessSettings,
+  SystemSettingsWarning,
 } from "@phoenix/components/agent";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
+import { useViewer } from "@phoenix/contexts/ViewerContext";
 
-import { SettingsAgentsWorkspaceCard } from "./SettingsAgentsWorkspaceCard";
+import { SettingsAgentsAdminSettingsSection } from "./SettingsAgentsWorkspaceCard";
 
-const traceDetailsCSS = css`
-  summary {
-    cursor: pointer;
+const ADMIN_SECTION_ID = "admin-settings";
+const PERSONAL_SECTION_ID = "personal-settings";
+const EXPERIMENTAL_SECTION_ID = "experimental-settings";
+
+const sectionPanelCSS = css`
+  padding: var(--global-dimension-size-200);
+`;
+
+const settingsListCSS = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-size-150);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+const settingRowCSS = css`
+  border: 1px solid var(--global-border-color-default);
+  border-radius: var(--global-rounding-medium);
+  background: var(--global-background-color-primary);
+`;
+
+const settingSwitchCSS = css`
+  width: 100%;
+  box-sizing: border-box;
+  white-space: normal;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: var(--global-dimension-size-150);
+  gap: var(--global-dimension-size-200);
+
+  .assistant-personal-settings__label {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: var(--global-dimension-size-75);
+    min-width: 0;
   }
 `;
 
-function getProjectRedirectUrl(
-  collectorEndpoint: string,
-  projectName: string
-): string | null {
-  try {
-    const url = new URL(collectorEndpoint);
-    url.pathname = url.pathname
-      .replace(/\/v1\/traces\/?$/, "")
-      .replace(/\/$/, "");
-    url.pathname = `${url.pathname}/redirects/projects/${encodeURIComponent(projectName)}`;
-    url.search = "";
-    url.hash = "";
-    return url.toString();
-  } catch {
-    return null;
-  }
+function useIsAdmin() {
+  const { viewer } = useViewer();
+  // Match IsAdminIfAuthEnabled server-side: no viewer => auth disabled => treat as admin
+  return !viewer || viewer.role?.name === "ADMIN";
 }
 
-function AssistantAgentEnabledSwitch() {
+function AssistantAgentEnabledSetting() {
+  const adminAssistantEnabled = useAgentContext(
+    (state) => state.agentsConfig.assistantEnabled
+  );
   const isAssistantAgentEnabled = usePreferencesContext(
     (state) => state.isAssistantAgentEnabled
   );
@@ -55,96 +82,110 @@ function AssistantAgentEnabledSwitch() {
     (state) => state.setIsAssistantAgentEnabled
   );
   return (
-    <Switch
-      labelPlacement="start"
-      isSelected={isAssistantAgentEnabled}
-      onChange={setIsAssistantAgentEnabled}
-    >
-      Enabled
-    </Switch>
+    <ul css={settingsListCSS}>
+      <li css={settingRowCSS}>
+        <Switch
+          labelPlacement="start"
+          isSelected={adminAssistantEnabled && isAssistantAgentEnabled}
+          isDisabled={!adminAssistantEnabled}
+          onChange={setIsAssistantAgentEnabled}
+          css={settingSwitchCSS}
+        >
+          <span className="assistant-personal-settings__label">
+            <Text weight="heavy">Use assistant</Text>
+            <Text color="text-500" size="S">
+              Shows the assistant in this browser.
+            </Text>
+          </span>
+        </Switch>
+        {!adminAssistantEnabled ? <SystemSettingsWarning /> : null}
+      </li>
+    </ul>
   );
 }
 
-function AssistantTraceCollectionInfo() {
-  const { collectorEndpoint, assistantProjectName } = useAgentContext(
-    (state) => state.agentsConfig
+function AssistantSettingsSectionTrigger({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <DisclosureTrigger direction="column" alignItems="start">
+      <Text weight="heavy" size="S">
+        {title}
+      </Text>
+      <Text color="text-500" size="XS">
+        {description}
+      </Text>
+    </DisclosureTrigger>
   );
-  const projectRedirectUrl = collectorEndpoint
-    ? getProjectRedirectUrl(collectorEndpoint, assistantProjectName)
-    : null;
+}
 
+function PersonalSettingsSection() {
   return (
     <Flex direction="column" gap="size-200">
-      <AgentObservabilitySettings />
-      <details css={traceDetailsCSS}>
-        <summary>Tracing Details</summary>
-        <View paddingTop="size-150">
-          <Flex direction="column" gap="size-200">
-            <CopyField value={assistantProjectName}>
-              <Label>Assistant Project Name</Label>
-              <CopyInput />
-              <Text slot="description">
-                {projectRedirectUrl ? (
-                  <>
-                    View traces in{" "}
-                    <ExternalLink href={projectRedirectUrl}>
-                      {assistantProjectName}
-                    </ExternalLink>
-                  </>
-                ) : (
-                  "The project where assistant agent traces are recorded"
-                )}
-              </Text>
-            </CopyField>
-            <CopyField value={collectorEndpoint ?? ""}>
-              <Label>Collector Endpoint</Label>
-              <CopyInput />
-              <Text slot="description">
-                {collectorEndpoint
-                  ? "This is the sharing destination used when trace sharing is turned on."
-                  : "Trace sharing is not configured for this Phoenix app."}
-              </Text>
-            </CopyField>
-          </Flex>
-        </View>
-      </details>
+      <Text color="text-500">
+        These settings apply only to this browser. System settings control which
+        options are available.
+      </Text>
+      <AssistantAgentEnabledSetting />
+      <AgentSettingsForm>
+        <AgentWebAccessSettings />
+        <AgentObservabilitySettings />
+      </AgentSettingsForm>
     </Flex>
   );
 }
 
 export function SettingsAgentsPage() {
-  const isAssistantAgentEnabled = usePreferencesContext(
-    (state) => state.isAssistantAgentEnabled
-  );
+  const isAdmin = useIsAdmin();
   const isExperimentalSettingsEnabled = useFeatureFlag(
     "agent-experimental-settings"
   );
   return (
     <Flex direction="column" gap="size-200">
-      <SettingsAgentsWorkspaceCard />
-      <Card
-        title="Assistant"
-        collapsible
-        defaultOpen={isAssistantAgentEnabled}
-        extra={<AssistantAgentEnabledSwitch />}
-      >
-        <View padding="size-200">
-          <Flex
-            direction="column"
-            gap="size-300"
-            css={css`
-              width: 100%;
-            `}
-          >
-            <AssistantTraceCollectionInfo />
-            <AgentSettingsForm>
-              <AgentWebAccessSettings />
-              {isExperimentalSettingsEnabled ? (
-                <AgentExperimentalSettings />
-              ) : null}
-            </AgentSettingsForm>
-          </Flex>
-        </View>
+      <Card title="Assistant settings - PXI">
+        <DisclosureGroup defaultExpandedKeys={[PERSONAL_SECTION_ID]}>
+          {isAdmin ? (
+            <Disclosure id={ADMIN_SECTION_ID}>
+              <AssistantSettingsSectionTrigger
+                title="System settings"
+                description="Settings that apply to everyone using this Phoenix instance."
+              />
+              <DisclosurePanel>
+                <div css={sectionPanelCSS}>
+                  <SettingsAgentsAdminSettingsSection />
+                </div>
+              </DisclosurePanel>
+            </Disclosure>
+          ) : null}
+          <Disclosure id={PERSONAL_SECTION_ID}>
+            <AssistantSettingsSectionTrigger
+              title="Personal settings"
+              description="Your assistant preferences for this browser."
+            />
+            <DisclosurePanel>
+              <div css={sectionPanelCSS}>
+                <PersonalSettingsSection />
+              </div>
+            </DisclosurePanel>
+          </Disclosure>
+          {isExperimentalSettingsEnabled ? (
+            <Disclosure id={EXPERIMENTAL_SECTION_ID}>
+              <AssistantSettingsSectionTrigger
+                title="Experimental settings"
+                description="Early assistant capabilities that may change."
+              />
+              <DisclosurePanel>
+                <div css={sectionPanelCSS}>
+                  <AgentExperimentalSettings />
+                </div>
+              </DisclosurePanel>
+            </Disclosure>
+          ) : null}
+        </DisclosureGroup>
       </Card>
     </Flex>
   );

--- a/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
+++ b/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useState } from "react";
+import { graphql, useMutation } from "react-relay";
+
+import {
+  Card,
+  Flex,
+  Switch,
+  Text,
+  Tooltip,
+  TooltipArrow,
+  TooltipTrigger,
+  View,
+} from "@phoenix/components";
+import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
+import { useViewer } from "@phoenix/contexts/ViewerContext";
+
+import type { SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation } from "./__generated__/SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation.graphql";
+import type { SettingsAgentsWorkspaceCardSetTraceRecordingMutation } from "./__generated__/SettingsAgentsWorkspaceCardSetTraceRecordingMutation.graphql";
+
+const ADMIN_ONLY_TOOLTIP = "Only workspace admins can change this setting";
+
+export function SettingsAgentsWorkspaceCard() {
+  const { viewer } = useViewer();
+  // Match IsAdminIfAuthEnabled server-side: no viewer ⇒ auth disabled ⇒ treat as admin
+  const isAdmin = !viewer || viewer.role?.name === "ADMIN";
+
+  const isRemoteCollectorConfigured = useAgentContext((state) =>
+    Boolean(state.agentsConfig.collectorEndpoint)
+  );
+  const assistantEnabled = useAgentContext(
+    (state) => state.agentsConfig.assistantEnabled
+  );
+  const allowLocalTraces = useAgentContext(
+    (state) => state.agentsConfig.allowLocalTraces
+  );
+  const allowRemoteExport = useAgentContext(
+    (state) => state.agentsConfig.allowRemoteExport
+  );
+  const store = useAgentStore();
+
+  const [setAgentAssistantEnabled, isUpdatingEnabled] =
+    useMutation<SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation>(graphql`
+      mutation SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation(
+        $input: SetAgentAssistantEnabledInput!
+      ) {
+        setAgentAssistantEnabled(input: $input) {
+          enabled
+        }
+      }
+    `);
+
+  const [setTraceRecording, isUpdatingTraceRecording] =
+    useMutation<SettingsAgentsWorkspaceCardSetTraceRecordingMutation>(graphql`
+      mutation SettingsAgentsWorkspaceCardSetTraceRecordingMutation(
+        $input: SetAgentTraceRecordingInput!
+      ) {
+        setAgentTraceRecording(input: $input) {
+          allowLocalTraces
+          allowRemoteExport
+        }
+      }
+    `);
+
+  const isBusy = isUpdatingEnabled || isUpdatingTraceRecording;
+  const switchesDisabled = !isAdmin || isBusy;
+
+  const handleEnabledChange = useCallback(
+    (next: boolean) => {
+      setAgentAssistantEnabled({
+        variables: { input: { enabled: next } },
+        onCompleted: (response) => {
+          store.getState().setAgentsConfig({
+            assistantEnabled: response.setAgentAssistantEnabled.enabled,
+          });
+        },
+      });
+    },
+    [setAgentAssistantEnabled, store]
+  );
+
+  const handleTraceRecordingChange = useCallback(
+    (patch: { allowLocalTraces?: boolean; allowRemoteExport?: boolean }) => {
+      const nextLocal = patch.allowLocalTraces ?? allowLocalTraces;
+      const nextRemote = patch.allowRemoteExport ?? allowRemoteExport;
+      setTraceRecording({
+        variables: {
+          input: {
+            allowLocalTraces: nextLocal,
+            allowRemoteExport: nextRemote,
+          },
+        },
+        onCompleted: (response) => {
+          store.getState().setAgentsConfig({
+            allowLocalTraces: response.setAgentTraceRecording.allowLocalTraces,
+            allowRemoteExport:
+              response.setAgentTraceRecording.allowRemoteExport,
+          });
+        },
+      });
+    },
+    [allowLocalTraces, allowRemoteExport, setTraceRecording, store]
+  );
+
+  return (
+    <Card title="Workspace">
+      <View padding="size-200">
+        <Flex direction="column" gap="size-150">
+          <Text color="text-500">
+            {isAdmin
+              ? "Configures defaults for all users in this workspace. Individual users may turn these off for themselves, but cannot turn them on if you disable them here."
+              : "Set by your workspace admin. Your personal preferences below cannot exceed these."}
+          </Text>
+          <WorkspaceSwitch
+            label="Available to this workspace"
+            description="Master switch for the agent feature. When off, no user in this workspace can access agent chat."
+            isSelected={assistantEnabled}
+            onChange={handleEnabledChange}
+            isDisabled={switchesDisabled}
+            isAdmin={isAdmin}
+          />
+          <WorkspaceSwitch
+            label="Allow saving PXI traces in this app"
+            description="Permits users to store PXI session traces (prompts, replies, tool calls) in this Phoenix instance."
+            isSelected={allowLocalTraces}
+            onChange={(allowLocalTraces) =>
+              handleTraceRecordingChange({ allowLocalTraces })
+            }
+            isDisabled={switchesDisabled}
+            isAdmin={isAdmin}
+          />
+          {isRemoteCollectorConfigured ? (
+            <WorkspaceSwitch
+              label="Allow sharing PXI traces with the PXI team"
+              description="Permits users to export PXI session traces to the remote collector configured for this Phoenix instance."
+              isSelected={allowRemoteExport}
+              onChange={(allowRemoteExport) =>
+                handleTraceRecordingChange({ allowRemoteExport })
+              }
+              isDisabled={switchesDisabled}
+              isAdmin={isAdmin}
+            />
+          ) : null}
+        </Flex>
+      </View>
+    </Card>
+  );
+}
+
+function WorkspaceSwitch({
+  label,
+  description,
+  isSelected,
+  onChange,
+  isDisabled,
+  isAdmin,
+}: {
+  label: string;
+  description: string;
+  isSelected: boolean;
+  onChange: (next: boolean) => void;
+  isDisabled: boolean;
+  isAdmin: boolean;
+}) {
+  const switchEl = (
+    <Switch
+      isSelected={isSelected}
+      onChange={onChange}
+      isDisabled={isDisabled}
+      labelPlacement="start"
+    >
+      <Flex direction="column" gap="size-50">
+        <Text weight="heavy">{label}</Text>
+        <Text color="text-500" size="S">
+          {description}
+        </Text>
+      </Flex>
+    </Switch>
+  );
+
+  if (isAdmin) {
+    return switchEl;
+  }
+  // Non-admins see the read-only switch with an "admin only" tooltip on hover.
+  return (
+    <ReadOnlyTooltip>
+      <div>{switchEl}</div>
+    </ReadOnlyTooltip>
+  );
+}
+
+function ReadOnlyTooltip({ children }: { children: React.ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <TooltipTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
+      {children}
+      <Tooltip>
+        <TooltipArrow />
+        {ADMIN_ONLY_TOOLTIP}
+      </Tooltip>
+    </TooltipTrigger>
+  );
+}

--- a/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
+++ b/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
@@ -1,27 +1,49 @@
-import { useCallback, useState } from "react";
+import { css } from "@emotion/react";
 import { graphql, useMutation } from "react-relay";
 
-import {
-  Card,
-  Flex,
-  Switch,
-  Text,
-  Tooltip,
-  TooltipArrow,
-  TooltipTrigger,
-  View,
-} from "@phoenix/components";
+import { Flex, Switch, Text } from "@phoenix/components";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 import { useViewer } from "@phoenix/contexts/ViewerContext";
 
 import type { SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation } from "./__generated__/SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation.graphql";
 import type { SettingsAgentsWorkspaceCardSetTraceRecordingMutation } from "./__generated__/SettingsAgentsWorkspaceCardSetTraceRecordingMutation.graphql";
 
-const ADMIN_ONLY_TOOLTIP = "Only workspace admins can change this setting";
+const settingsListCSS = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-size-150);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
 
-export function SettingsAgentsWorkspaceCard() {
+const settingRowCSS = css`
+  border: 1px solid var(--global-border-color-default);
+  border-radius: var(--global-rounding-medium);
+  background: var(--global-background-color-primary);
+`;
+
+const settingSwitchCSS = css`
+  width: 100%;
+  box-sizing: border-box;
+  white-space: normal;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: var(--global-dimension-size-150);
+  gap: var(--global-dimension-size-200);
+
+  .assistant-admin-settings__label {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: var(--global-dimension-size-75);
+    min-width: 0;
+  }
+`;
+
+export function SettingsAgentsAdminSettingsSection() {
   const { viewer } = useViewer();
-  // Match IsAdminIfAuthEnabled server-side: no viewer ⇒ auth disabled ⇒ treat as admin
+  // Match IsAdminIfAuthEnabled server-side: no viewer => auth disabled => treat as admin
   const isAdmin = !viewer || viewer.role?.name === "ADMIN";
 
   const isRemoteCollectorConfigured = useAgentContext((state) =>
@@ -62,141 +84,116 @@ export function SettingsAgentsWorkspaceCard() {
     `);
 
   const isBusy = isUpdatingEnabled || isUpdatingTraceRecording;
-  const switchesDisabled = !isAdmin || isBusy;
 
-  const handleEnabledChange = useCallback(
-    (next: boolean) => {
-      setAgentAssistantEnabled({
-        variables: { input: { enabled: next } },
-        onCompleted: (response) => {
-          store.getState().setAgentsConfig({
-            assistantEnabled: response.setAgentAssistantEnabled.enabled,
-          });
-        },
-      });
-    },
-    [setAgentAssistantEnabled, store]
-  );
+  const handleEnabledChange = (next: boolean) => {
+    setAgentAssistantEnabled({
+      variables: { input: { enabled: next } },
+      onCompleted: (response) => {
+        store.getState().setAgentsConfig({
+          assistantEnabled: response.setAgentAssistantEnabled.enabled,
+        });
+      },
+    });
+  };
 
-  const handleTraceRecordingChange = useCallback(
-    (patch: { allowLocalTraces?: boolean; allowRemoteExport?: boolean }) => {
-      const nextLocal = patch.allowLocalTraces ?? allowLocalTraces;
-      const nextRemote = patch.allowRemoteExport ?? allowRemoteExport;
-      setTraceRecording({
-        variables: {
-          input: {
-            allowLocalTraces: nextLocal,
-            allowRemoteExport: nextRemote,
-          },
+  const handleTraceRecordingChange = (patch: {
+    allowLocalTraces?: boolean;
+    allowRemoteExport?: boolean;
+  }) => {
+    const nextLocal = patch.allowLocalTraces ?? allowLocalTraces;
+    const nextRemote = patch.allowRemoteExport ?? allowRemoteExport;
+    setTraceRecording({
+      variables: {
+        input: {
+          allowLocalTraces: nextLocal,
+          allowRemoteExport: nextRemote,
         },
-        onCompleted: (response) => {
-          store.getState().setAgentsConfig({
-            allowLocalTraces: response.setAgentTraceRecording.allowLocalTraces,
-            allowRemoteExport:
-              response.setAgentTraceRecording.allowRemoteExport,
-          });
-        },
-      });
-    },
-    [allowLocalTraces, allowRemoteExport, setTraceRecording, store]
-  );
+      },
+      onCompleted: (response) => {
+        store.getState().setAgentsConfig({
+          allowLocalTraces: response.setAgentTraceRecording.allowLocalTraces,
+          allowRemoteExport: response.setAgentTraceRecording.allowRemoteExport,
+        });
+      },
+    });
+  };
+
+  if (!isAdmin) {
+    return null;
+  }
 
   return (
-    <Card title="Workspace">
-      <View padding="size-200">
-        <Flex direction="column" gap="size-150">
-          <Text color="text-500">
-            {isAdmin
-              ? "Configures defaults for all users in this workspace. Individual users may turn these off for themselves, but cannot turn them on if you disable them here."
-              : "Set by your workspace admin. Your personal preferences below cannot exceed these."}
-          </Text>
-          <WorkspaceSwitch
-            label="Available to this workspace"
-            description="Master switch for the agent feature. When off, no user in this workspace can access agent chat."
+    <Flex direction="column" gap="size-150">
+      <Text color="text-500">
+        Applies to all users. When a system setting is off, the matching
+        personal setting is unavailable.
+      </Text>
+      <ul css={settingsListCSS}>
+        <li css={settingRowCSS}>
+          <AdminSettingsSwitch
+            label="Assistant access"
+            description="Controls whether users can open the assistant."
             isSelected={assistantEnabled}
             onChange={handleEnabledChange}
-            isDisabled={switchesDisabled}
-            isAdmin={isAdmin}
+            isDisabled={isBusy}
           />
-          <WorkspaceSwitch
-            label="Allow saving PXI traces in this app"
-            description="Permits users to store PXI session traces (prompts, replies, tool calls) in this Phoenix instance."
+        </li>
+        <li css={settingRowCSS}>
+          <AdminSettingsSwitch
+            label="Save traces in this Phoenix instance"
+            description="Allows users to store assistant session traces in this Phoenix instance."
             isSelected={allowLocalTraces}
             onChange={(allowLocalTraces) =>
               handleTraceRecordingChange({ allowLocalTraces })
             }
-            isDisabled={switchesDisabled}
-            isAdmin={isAdmin}
+            isDisabled={isBusy}
           />
-          {isRemoteCollectorConfigured ? (
-            <WorkspaceSwitch
-              label="Allow sharing PXI traces with the PXI team"
-              description="Permits users to export PXI session traces to the remote collector configured for this Phoenix instance."
+        </li>
+        {isRemoteCollectorConfigured ? (
+          <li css={settingRowCSS}>
+            <AdminSettingsSwitch
+              label="Exporting traces"
+              description="Allows users to export assistant session traces to the configured remote collector."
               isSelected={allowRemoteExport}
               onChange={(allowRemoteExport) =>
                 handleTraceRecordingChange({ allowRemoteExport })
               }
-              isDisabled={switchesDisabled}
-              isAdmin={isAdmin}
+              isDisabled={isBusy}
             />
-          ) : null}
-        </Flex>
-      </View>
-    </Card>
+          </li>
+        ) : null}
+      </ul>
+    </Flex>
   );
 }
 
-function WorkspaceSwitch({
+function AdminSettingsSwitch({
   label,
   description,
   isSelected,
   onChange,
   isDisabled,
-  isAdmin,
 }: {
   label: string;
   description: string;
   isSelected: boolean;
   onChange: (next: boolean) => void;
   isDisabled: boolean;
-  isAdmin: boolean;
 }) {
-  const switchEl = (
+  return (
     <Switch
       isSelected={isSelected}
       onChange={onChange}
       isDisabled={isDisabled}
       labelPlacement="start"
+      css={settingSwitchCSS}
     >
-      <Flex direction="column" gap="size-50">
+      <span className="assistant-admin-settings__label">
         <Text weight="heavy">{label}</Text>
         <Text color="text-500" size="S">
           {description}
         </Text>
-      </Flex>
+      </span>
     </Switch>
-  );
-
-  if (isAdmin) {
-    return switchEl;
-  }
-  // Non-admins see the read-only switch with an "admin only" tooltip on hover.
-  return (
-    <ReadOnlyTooltip>
-      <div>{switchEl}</div>
-    </ReadOnlyTooltip>
-  );
-}
-
-function ReadOnlyTooltip({ children }: { children: React.ReactNode }) {
-  const [isOpen, setIsOpen] = useState(false);
-  return (
-    <TooltipTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
-      {children}
-      <Tooltip>
-        <TooltipArrow />
-        {ADMIN_ONLY_TOOLTIP}
-      </Tooltip>
-    </TooltipTrigger>
   );
 }

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -32,7 +32,7 @@ const TABS: { id: string; label: string }[] = [
   { id: "annotations", label: "Annotations" },
   { id: "prompts", label: "Prompts" },
   { id: "data", label: "Data Retention" },
-  { id: "agents", label: "Agents" },
+  { id: "agents", label: "Assistant" },
 ];
 
 export function SettingsPage() {

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -6,7 +6,6 @@ import { Navigate, Outlet, useLocation, useNavigate } from "react-router";
 
 import { Loading, Tab, TabList, TabPanel, Tabs } from "@phoenix/components";
 import { useViewerCanManageSandboxes } from "@phoenix/contexts";
-import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 
 const settingsPageCSS = css`
   overflow-y: auto;
@@ -48,11 +47,11 @@ export function SettingsPage() {
     },
     [navigate]
   );
-  const isAgentsEnabled = useFeatureFlag("agents");
+  const isAgentAssistantEnabled = !window.Config.agentAssistantDisabled;
   const canManageSecrets = useViewerCanManageSandboxes();
   const canManageSandboxes = useViewerCanManageSandboxes();
   const tabs = TABS.filter((tab) => {
-    if (tab.id === "agents" && !isAgentsEnabled) {
+    if (tab.id === "agents" && !isAgentAssistantEnabled) {
       return false;
     }
     if (tab.id === "secrets" && !canManageSecrets) {

--- a/app/src/pages/settings/__generated__/SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation.graphql.ts
@@ -1,0 +1,92 @@
+/**
+ * @generated SignedSource<<2632773ed6f093f16dedc3d89c3fe5ee>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type SetAgentAssistantEnabledInput = {
+  enabled: boolean;
+};
+export type SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation$variables = {
+  input: SetAgentAssistantEnabledInput;
+};
+export type SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation$data = {
+  readonly setAgentAssistantEnabled: {
+    readonly enabled: boolean;
+  };
+};
+export type SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation = {
+  response: SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation$data;
+  variables: SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "AgentAssistantEnabled",
+    "kind": "LinkedField",
+    "name": "setAgentAssistantEnabled",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "enabled",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "ec85b24f77e8ee6a2ccda1ed49454972",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation",
+    "operationKind": "mutation",
+    "text": "mutation SettingsAgentsWorkspaceCardSetAgentAssistantEnabledMutation(\n  $input: SetAgentAssistantEnabledInput!\n) {\n  setAgentAssistantEnabled(input: $input) {\n    enabled\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "f30d583cd02b8e97af398d3dc3e6e88b";
+
+export default node;

--- a/app/src/pages/settings/__generated__/SettingsAgentsWorkspaceCardSetTraceRecordingMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsAgentsWorkspaceCardSetTraceRecordingMutation.graphql.ts
@@ -1,0 +1,101 @@
+/**
+ * @generated SignedSource<<5e155e051951988e5a2266db3ab6f01a>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type SetAgentTraceRecordingInput = {
+  allowLocalTraces: boolean;
+  allowRemoteExport: boolean;
+};
+export type SettingsAgentsWorkspaceCardSetTraceRecordingMutation$variables = {
+  input: SetAgentTraceRecordingInput;
+};
+export type SettingsAgentsWorkspaceCardSetTraceRecordingMutation$data = {
+  readonly setAgentTraceRecording: {
+    readonly allowLocalTraces: boolean;
+    readonly allowRemoteExport: boolean;
+  };
+};
+export type SettingsAgentsWorkspaceCardSetTraceRecordingMutation = {
+  response: SettingsAgentsWorkspaceCardSetTraceRecordingMutation$data;
+  variables: SettingsAgentsWorkspaceCardSetTraceRecordingMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "AgentTraceRecording",
+    "kind": "LinkedField",
+    "name": "setAgentTraceRecording",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "allowLocalTraces",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "allowRemoteExport",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsAgentsWorkspaceCardSetTraceRecordingMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SettingsAgentsWorkspaceCardSetTraceRecordingMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "12d8e45409795fa51183e2733cb0cb94",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsAgentsWorkspaceCardSetTraceRecordingMutation",
+    "operationKind": "mutation",
+    "text": "mutation SettingsAgentsWorkspaceCardSetTraceRecordingMutation(\n  $input: SetAgentTraceRecordingInput!\n) {\n  setAgentTraceRecording(input: $input) {\n    allowLocalTraces\n    allowRemoteExport\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "a3d1ce0f69b4d309a16e1d06100506dc";
+
+export default node;

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -1,7 +1,10 @@
 import { installTestStorage } from "@phoenix/__tests__/installTestStorage";
 import { createDefaultAgentCapabilities } from "@phoenix/agent/extensions/capabilities";
 
-import { createAgentStore } from "../agentStore";
+import {
+  createAgentStore,
+  hasAcknowledgedCurrentTraceConsent,
+} from "../agentStore";
 
 installTestStorage();
 
@@ -345,13 +348,22 @@ describe("agentStore", () => {
       expect(store.getState().observability).toEqual({
         storeLocalTraces: true,
         exportRemoteTraces: false,
-        hasAcknowledgedConsent: false,
+        acknowledgedTraceConsent: null,
       });
       expect(store.getState().fabPlacement).toBe("bottom-end");
     });
 
-    it("acknowledges consent without changing trace toggles", () => {
-      const store = createAgentStore();
+    it("acknowledges consent for the current server trace settings", () => {
+      const store = createAgentStore({
+        agentsConfig: {
+          collectorEndpoint: "https://collector.example.com",
+          assistantProjectName: "assistant_agent",
+          webAccessEnabled: false,
+          assistantEnabled: true,
+          allowLocalTraces: true,
+          allowRemoteExport: true,
+        },
+      });
 
       store.getState().setObservability({
         storeLocalTraces: false,
@@ -362,8 +374,32 @@ describe("agentStore", () => {
       expect(store.getState().observability).toEqual({
         storeLocalTraces: false,
         exportRemoteTraces: true,
-        hasAcknowledgedConsent: true,
+        acknowledgedTraceConsent: {
+          allowLocalTraces: true,
+          allowRemoteExport: true,
+        },
       });
+    });
+
+    it("requires renewed consent when server trace settings broaden", () => {
+      const store = createAgentStore();
+
+      store.getState().acknowledgeConsent();
+      expect(
+        hasAcknowledgedCurrentTraceConsent({
+          agentsConfig: store.getState().agentsConfig,
+          observability: store.getState().observability,
+        })
+      ).toBe(true);
+
+      store.getState().setAgentsConfig({ allowLocalTraces: true });
+
+      expect(
+        hasAcknowledgedCurrentTraceConsent({
+          agentsConfig: store.getState().agentsConfig,
+          observability: store.getState().observability,
+        })
+      ).toBe(false);
     });
   });
 

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -190,10 +190,12 @@ function buildForkSummary(source: AgentSession): string {
 }
 
 /**
- * The trace-recording ceilings the user is asked to consent to. Remote export
- * is only on offer when a collector is actually configured. This is the shape
- * snapshotted at acknowledgement so we can later detect when the server
- * broadens recording beyond what the user agreed to.
+ * The trace-recording capabilities the user is asked to consent to. Consent is
+ * about whether local persistence and/or remote export are allowed, not the
+ * current destination names/endpoints. Remote export is only on offer when a
+ * collector is actually configured. This is the shape snapshotted at
+ * acknowledgement so we can later detect when the server broadens recording
+ * beyond what the user agreed to.
  */
 export function getCurrentTraceConsentSettings(
   agentsConfig: AgentServerConfig

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -53,19 +53,32 @@ export type AgentServerConfig = {
   allowRemoteExport: boolean;
 };
 
+export type AgentTraceConsentSettings = Pick<
+  AgentServerConfig,
+  "allowLocalTraces" | "allowRemoteExport"
+>;
+
+/** The resolved trace flags sent on an agent request. */
+export type AgentTraceRecordingSettings = {
+  /** Whether traces should be ingested by this Phoenix instance. */
+  ingestTraces: boolean;
+  /** Whether traces should also be exported to the remote collector. */
+  exportRemoteTraces: boolean;
+};
+
 /**
  * Per-user PXI observability preferences persisted in local storage.
  *
  * These settings control where PXI traces are sent for the current browser
- * user and whether the one-time consent gate has been acknowledged.
+ * user and which server trace settings the consent gate has acknowledged.
  */
 export type AgentObservabilitySettings = {
   /** Whether PXI traces should be persisted in the current Phoenix instance. */
   storeLocalTraces: boolean;
   /** Whether PXI traces should also be exported to a remote collector. */
   exportRemoteTraces: boolean;
-  /** Whether the user has acknowledged the PXI consent gate. */
-  hasAcknowledgedConsent: boolean;
+  /** Trace recording ceilings visible when consent was acknowledged; null means unacknowledged. */
+  acknowledgedTraceConsent: AgentTraceConsentSettings | null;
 };
 
 export type AgentEditPermissionMode = "manual" | "bypass";
@@ -131,7 +144,7 @@ const DEFAULT_AGENT_SERVER_CONFIG: AgentServerConfig = {
 const DEFAULT_AGENT_OBSERVABILITY_SETTINGS: AgentObservabilitySettings = {
   storeLocalTraces: true,
   exportRemoteTraces: false,
-  hasAcknowledgedConsent: false,
+  acknowledgedTraceConsent: null,
 };
 
 const DEFAULT_AGENT_PERMISSIONS: AgentPermissions = {
@@ -174,6 +187,68 @@ function buildForkSummary(source: AgentSession): string {
     return base;
   }
   return base ? `${FORK_SUMMARY_PREFIX}${base}` : FORK_SUMMARY_PREFIX.trim();
+}
+
+/**
+ * The trace-recording ceilings the user is asked to consent to. Remote export
+ * is only on offer when a collector is actually configured. This is the shape
+ * snapshotted at acknowledgement so we can later detect when the server
+ * broadens recording beyond what the user agreed to.
+ */
+export function getCurrentTraceConsentSettings(
+  agentsConfig: AgentServerConfig
+): AgentTraceConsentSettings {
+  return {
+    allowLocalTraces: agentsConfig.allowLocalTraces,
+    allowRemoteExport:
+      Boolean(agentsConfig.collectorEndpoint) && agentsConfig.allowRemoteExport,
+  };
+}
+
+/**
+ * Whether the consent the user previously acknowledged still covers the current
+ * server ceilings. Re-consent is required only when the server *broadens*
+ * recording (enables a dimension the user never agreed to); narrowing leaves
+ * prior consent intact.
+ */
+export function hasAcknowledgedCurrentTraceConsent({
+  agentsConfig,
+  observability,
+}: {
+  agentsConfig: AgentServerConfig;
+  observability: AgentObservabilitySettings;
+}): boolean {
+  const acknowledgedTraceConsent = observability.acknowledgedTraceConsent;
+  if (!acknowledgedTraceConsent) {
+    return false;
+  }
+  const currentTraceConsent = getCurrentTraceConsentSettings(agentsConfig);
+  return (
+    (!currentTraceConsent.allowLocalTraces ||
+      acknowledgedTraceConsent.allowLocalTraces) &&
+    (!currentTraceConsent.allowRemoteExport ||
+      acknowledgedTraceConsent.allowRemoteExport)
+  );
+}
+
+/**
+ * The trace flags actually sent on a request: the server ceiling AND the user's
+ * preference must both allow a dimension for it to be recorded. Keeps the
+ * "remote requires a collector" rule in sync with {@link getCurrentTraceConsentSettings}.
+ */
+export function getEffectiveTraceRecordingSettings({
+  agentsConfig,
+  observability,
+}: {
+  agentsConfig: AgentServerConfig;
+  observability: AgentObservabilitySettings;
+}): AgentTraceRecordingSettings {
+  const ceiling = getCurrentTraceConsentSettings(agentsConfig);
+  return {
+    ingestTraces: ceiling.allowLocalTraces && observability.storeLocalTraces,
+    exportRemoteTraces:
+      ceiling.allowRemoteExport && observability.exportRemoteTraces,
+  };
 }
 
 /**
@@ -715,7 +790,9 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         (state) => ({
           observability: {
             ...state.observability,
-            hasAcknowledgedConsent: true,
+            acknowledgedTraceConsent: getCurrentTraceConsentSettings(
+              state.agentsConfig
+            ),
           },
         }),
         false,

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -45,6 +45,12 @@ export type AgentServerConfig = {
   assistantProjectName: string;
   /** Whether this Phoenix instance allows PXI web search/fetch. */
   webAccessEnabled: boolean;
+  /** Admin ceiling: whether the agent assistant feature is enabled for this workspace. */
+  assistantEnabled: boolean;
+  /** Admin ceiling: whether users may persist PXI traces locally. */
+  allowLocalTraces: boolean;
+  /** Admin ceiling: whether users may export PXI traces to the remote collector. */
+  allowRemoteExport: boolean;
 };
 
 /**
@@ -117,6 +123,9 @@ const DEFAULT_AGENT_SERVER_CONFIG: AgentServerConfig = {
   collectorEndpoint: null,
   assistantProjectName: "assistant_agent",
   webAccessEnabled: false,
+  assistantEnabled: false,
+  allowLocalTraces: false,
+  allowRemoteExport: false,
 };
 
 const DEFAULT_AGENT_OBSERVABILITY_SETTINGS: AgentObservabilitySettings = {
@@ -224,6 +233,20 @@ export interface AgentState extends AgentProps {
   setDefaultModelConfig: (config: ModelConfig) => void;
   setObservability: (patch: Partial<AgentObservabilitySettings>) => void;
   setPermissions: (patch: Partial<AgentPermissions>) => void;
+  /**
+   * Updates the admin-controlled fields of {@link AgentServerConfig} after a
+   * successful workspace-settings mutation. Only the admin ceiling slots are
+   * patchable; env-derived fields (collectorEndpoint, assistantProjectName,
+   * webAccessEnabled) stay sourced from the initial loader query.
+   */
+  setAgentsConfig: (
+    patch: Partial<
+      Pick<
+        AgentServerConfig,
+        "assistantEnabled" | "allowLocalTraces" | "allowRemoteExport"
+      >
+    >
+  ) => void;
   acknowledgeConsent: () => void;
   clearAllSessions: () => void;
   setCapability: (params: {
@@ -676,6 +699,15 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         }),
         false,
         { type: "setPermissions" }
+      );
+    },
+    setAgentsConfig: (patch) => {
+      set(
+        (state) => ({
+          agentsConfig: { ...state.agentsConfig, ...patch },
+        }),
+        false,
+        { type: "setAgentsConfig" }
       );
     },
     acknowledgeConsent: () => {

--- a/app/src/window.d.ts
+++ b/app/src/window.d.ts
@@ -25,6 +25,10 @@ declare global {
       supportEmail?: string | null;
       hasDbThreshold: boolean;
       /**
+       * Whether the agent assistant feature is disabled at the deployment level.
+       */
+      agentAssistantDisabled: boolean;
+      /**
        * Mapping of auth error codes to user-friendly messages.
        * Passed from the backend to ensure single source of truth.
        */

--- a/app/tests/utils/testServer.mjs
+++ b/app/tests/utils/testServer.mjs
@@ -50,6 +50,12 @@ if (!fs.existsSync(wasmCachedBinary)) {
 
 if (process.env["PXI_E2E"] === "true") {
   process.env["PHOENIX_ALLOW_EXTERNAL_RESOURCES"] = "True";
+} else {
+  // The PXI assistant is enabled by default, which renders a floating action
+  // button that overlaps and intercepts clicks in unrelated specs. Disable it
+  // for the standard e2e suite; PXI specs run with PXI_E2E=true and rely on the
+  // assistant being enabled.
+  process.env["PHOENIX_DISABLE_AGENT_ASSISTANT"] = "True";
 }
 
 console.log("Phoenix test server starting...");

--- a/app/tests/utils/testServer.mjs
+++ b/app/tests/utils/testServer.mjs
@@ -49,7 +49,6 @@ if (!fs.existsSync(wasmCachedBinary)) {
 }
 
 if (process.env["PXI_E2E"] === "true") {
-  process.env["PHOENIX_DANGEROUSLY_ENABLE_AGENTS"] = "True";
   process.env["PHOENIX_ALLOW_EXTERNAL_RESOURCES"] = "True";
 }
 

--- a/app/vitest.setup.ts
+++ b/app/vitest.setup.ts
@@ -8,6 +8,7 @@ export const baseWindowConfig = {
   authenticationEnabled: true,
   basename: "/",
   platformVersion: "1.0.0",
+  agentAssistantDisabled: false,
   authErrorMessages: {},
 };
 Object.defineProperty(window, "Config", {

--- a/docs/phoenix/pxi.mdx
+++ b/docs/phoenix/pxi.mdx
@@ -52,20 +52,31 @@ capabilities in the prompt playground.
 PXI accelerates the loop you already run. Evals, experiments, and human
 review still belong at the end of it — PXI just gets you there faster.
 
-## Disabling PXI
+## Access and settings
 
-PXI is **on by default**. To turn it off, set the following environment
-variable on the Phoenix server and restart:
+PXI is **on by default**. Access is controlled in three layers:
 
-```bash
-PHOENIX_DISABLE_AGENT_ASSISTANT=true
-```
+- **Deployment setting.** To turn PXI off for the whole deployment, set the
+  following environment variable on the Phoenix server and restart:
+
+  ```bash
+  PHOENIX_DISABLE_AGENT_ASSISTANT=true
+  ```
+
+- **System settings.** Administrators can open **Settings → Assistant →
+  System settings** and turn **Assistant access** off for everyone using the
+  Phoenix instance. This does not require a restart.
+- **Personal settings.** Each user can open **Settings → Assistant →
+  Personal settings** and turn **Use assistant** off for their browser.
 
 <Note>
 PXI gives an LLM the ability to read Phoenix data the signed-in user can
 already see, and to call tools that modify UI state. If that trade-off is
-not acceptable for your deployment, disable PXI with the variable above.
+not acceptable for your deployment, disable PXI with
+`PHOENIX_DISABLE_AGENT_ASSISTANT=true`.
 </Note>
+
+The old `PHOENIX_DANGEROUSLY_ENABLE_AGENTS` opt-in flag is no longer used.
 
 PXI needs a model to talk to. Configure credentials for at least one provider
 via environment variables or Phoenix secrets:
@@ -94,9 +105,10 @@ Other built-in or custom-provider models can be selected from the model menu,
 but they are untested with PXI and may fail to invoke tools correctly. If you
 swap in a non-curated model, expect rougher behavior.
 
-The first time a user opens PXI they are shown a consent gate that explains
-what gets recorded and where it is sent. Acknowledging the gate enables the
-chat surface for that user.
+The first time a user opens PXI, they are shown a consent gate that asks them
+to review the available assistant session trace settings. Acknowledging the
+gate enables the chat surface for that browser; it does not override system
+settings.
 
 ## How it works
 
@@ -106,10 +118,10 @@ Cursor, or Codex — but pointed at Phoenix instead of a code editor. It has:
 - A **harness of tools** for taking action in the product (set the time range,
   apply a spans filter, read a span, edit a playground prompt, render
   generative UI, ask the user a question).
-- An **MCP server** that exposes the Phoenix docs to the agent — served by
-  Mintlify, the same provider that hosts the public Phoenix documentation —
-  so PXI can look up product behavior the same way a coding agent looks up
-  library docs.
+- An **MCP server** that exposes the Phoenix docs to the agent when external
+  resources are allowed — served by Mintlify, the same provider that hosts the
+  public Phoenix documentation — so PXI can look up product behavior the same
+  way a coding agent looks up library docs.
 - **Skills** — reusable, multi-step playbooks for common investigations. The
   first built-in skill is `debug_trace`, which walks a failing trace and
   proposes root causes.
@@ -174,8 +186,8 @@ sandbox, PXI uses the **phoenix-gql** CLI to query the Phoenix **GraphQL API**
 on the server, the same authenticated endpoint a logged-in user hits from the
 UI. The server hosts the PXI agent along with its model-facing surface —
 **tools**, **skills**, and an **MCP** client — and calls your LLM provider
-with your API key. The only external dependency is the Mintlify-hosted
-Phoenix docs MCP, reached through the server's MCP client.
+with your API key. When external resources are allowed, the server also reaches
+the Mintlify-hosted Phoenix docs MCP through its MCP client.
 
 ### Runs entirely on your Phoenix
 
@@ -186,29 +198,49 @@ PXI runs **inside the Phoenix process you are already running**. Concretely:
 - The LLM behind PXI is **your model provider**, called with **your API key**
   (OpenAI, Anthropic, Google, Bedrock, or a custom provider you configured).
   Arize is not in the request path.
-- Documentation lookups go to the **Mintlify-hosted Phoenix docs MCP server**,
-  the same public docs surface you can read in a browser. It serves docs only.
-- Arize receives PXI session traces **only if you explicitly opt in** under
-  **Settings → Agents** ("Share PXI session traces with the team improving
-  PXI"), and that opt-in is only available when a remote collector has been
-  configured for your instance. If you never enable it, Arize never sees your
-  traces, prompts, or tool outputs.
+- Documentation lookups go to the **Mintlify-hosted Phoenix docs MCP server**
+  when external resources are allowed. It is the same public docs surface you
+  can read in a browser, and it serves docs only. Set
+  `PHOENIX_ALLOW_EXTERNAL_RESOURCES=false` to disable external docs lookups and
+  web access, or set `PHOENIX_AGENTS_DISABLE_WEB_ACCESS=true` to disable PXI's
+  native web search and fetch tools while leaving other external resources
+  available.
+- Remote trace export happens **only if all required gates are enabled**: a
+  remote collector is configured for the instance, an administrator allows
+  trace export in **Settings → Assistant → System settings**, and the user
+  enables trace export in **Settings → Assistant → Personal settings**. If any
+  gate is off, PXI traces, prompts, and tool outputs are not exported.
+  Configure the collector with `PHOENIX_AGENTS_COLLECTOR_ENDPOINT` and,
+  if needed, `PHOENIX_AGENTS_COLLECTOR_API_KEY`.
 
 ## Privacy and observability
 
-Every PXI conversation is captured as a Phoenix trace. By default these traces
-are written to a dedicated PXI project in the Phoenix instance you are using —
-no data leaves your deployment.
+PXI can capture conversations as Phoenix traces. Trace recording is controlled
+by both system settings and per-browser user preferences.
 
-From **Settings → Agents** you can:
+From **Settings → Assistant**, administrators can:
 
-- Turn local PXI tracing on or off.
-- Opt into sharing PXI session traces with the team building PXI (only
-  available when a remote collector is configured).
+- Turn **Assistant access** on or off for everyone.
+- Allow users to save assistant session traces in this Phoenix instance.
+- Allow users to export assistant session traces to the configured remote
+  collector, when one is configured.
 
-Tool inputs and outputs are recorded on the corresponding spans, which makes it
-easy to audit what PXI did during a session and to evaluate PXI the same way
-you evaluate any other agent in Phoenix.
+From **Settings → Assistant**, each user can:
+
+- Show or hide the assistant in their browser.
+- Save assistant session traces in this Phoenix instance when an administrator
+  allows local trace recording.
+- Export assistant session traces to the configured remote collector when an
+  administrator allows remote export.
+
+By default, the system trace-recording settings do not allow local persistence
+or remote export. Local traces are written to the
+`assistant_agent` project unless `PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME` is set
+to a different project name.
+
+When trace recording is enabled, tool inputs and outputs are recorded on the
+corresponding spans. This makes it easy to audit what PXI did during a session
+and to evaluate PXI the same way you evaluate any other agent in Phoenix.
 
 ## Safety
 

--- a/docs/phoenix/pxi.mdx
+++ b/docs/phoenix/pxi.mdx
@@ -52,20 +52,19 @@ capabilities in the prompt playground.
 PXI accelerates the loop you already run. Evals, experiments, and human
 review still belong at the end of it — PXI just gets you there faster.
 
-## Enabling PXI
+## Disabling PXI
 
-PXI is **off by default**. To turn it on, set the following environment
+PXI is **on by default**. To turn it off, set the following environment
 variable on the Phoenix server and restart:
 
 ```bash
-PHOENIX_DANGEROUSLY_ENABLE_AGENTS=true
+PHOENIX_DISABLE_AGENT_ASSISTANT=true
 ```
 
 <Note>
-The `DANGEROUSLY_` prefix is intentional. Enabling PXI gives an LLM the ability
-to read Phoenix data the signed-in user can already see, and to call tools that
-modify UI state. Only enable it in environments where that trade-off is
-acceptable.
+PXI gives an LLM the ability to read Phoenix data the signed-in user can
+already see, and to call tools that modify UI state. If that trade-off is
+not acceptable for your deployment, disable PXI with the variable above.
 </Note>
 
 PXI needs a model to talk to. Configure credentials for at least one provider

--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -77,8 +77,6 @@ allowed. The assistant is on by default; external resources must be opted in:
 
 ```bash
 export PHOENIX_ALLOW_EXTERNAL_RESOURCES=true
-# Optionally disable the assistant entirely:
-# export PHOENIX_DISABLE_AGENT_ASSISTANT=true
 ```
 
 If either gate fails, the experiment still runs but the agent does not

--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -72,13 +72,16 @@ Provider credentials are read from the normal provider env vars, such as
 `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`.
 
 The docs MCP toolset follows the same production gates as the Phoenix server:
+the agent assistant must not be disabled, and external resources must be
+allowed. The assistant is on by default; external resources must be opted in:
 
 ```bash
-export PHOENIX_DANGEROUSLY_ENABLE_AGENTS=true
 export PHOENIX_ALLOW_EXTERNAL_RESOURCES=true
+# Optionally disable the assistant entirely:
+# export PHOENIX_DISABLE_AGENT_ASSISTANT=true
 ```
 
-If either gate is disabled, the experiment still runs but the agent does not
+If either gate fails, the experiment still runs but the agent does not
 receive docs MCP tools.
 
 ## Datasets

--- a/evals/pxi/harness/agent_task.py
+++ b/evals/pxi/harness/agent_task.py
@@ -21,7 +21,7 @@ from pydantic_ai.models import Model as PydanticAIModel
 
 from phoenix.config import (
     get_env_allow_external_resources,
-    get_env_dangerously_enable_agents,
+    get_env_disable_agent_assistant,
 )
 from phoenix.server.agents.agent_factory import build_agent
 from phoenix.server.agents.capabilities import MintlifyDocsMCPServer
@@ -131,10 +131,10 @@ async def _build_model() -> PydanticAIModel:
 def should_build_docs_mcp_server() -> bool:
     """Mirror the production gate so callers know whether to build the toolset.
 
-    See ``phoenix.server.app:1191-1195`` — the real server only constructs
-    the docs MCP toolset when both env toggles are true.
+    The real server only constructs the docs MCP toolset when the agent
+    assistant is not disabled and external resources are allowed.
     """
-    return get_env_dangerously_enable_agents() and get_env_allow_external_resources()
+    return not get_env_disable_agent_assistant() and get_env_allow_external_resources()
 
 
 def build_shared_docs_mcp_server() -> MCPServerStreamableHTTP | None:

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -37,6 +37,8 @@ CREATE UNIQUE INDEX ix_generative_models_match_criteria ON public.generative_mod
     USING btree (name_pattern, provider, is_built_in) WHERE (deleted_at IS NULL);
 CREATE UNIQUE INDEX ix_generative_models_name_is_built_in ON public.generative_models
     USING btree (name, is_built_in) WHERE (deleted_at IS NULL);
+CREATE INDEX ix_generative_models_updated_at ON public.generative_models
+    USING btree (updated_at);
 
 
 -- Table: languages
@@ -1554,6 +1556,24 @@ CREATE TABLE public.span_annotations (
 
 CREATE INDEX ix_span_annotations_span_rowid ON public.span_annotations
     USING btree (span_rowid);
+
+
+-- Table: system_settings
+-- ----------------------
+CREATE TABLE public.system_settings (
+    key VARCHAR NOT NULL,
+    value JSONB NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_by BIGINT,
+    CONSTRAINT pk_system_settings PRIMARY KEY (key),
+    CONSTRAINT fk_system_settings_updated_by_users FOREIGN KEY
+        (updated_by)
+        REFERENCES public.users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_system_settings_updated_at ON public.system_settings
+    USING btree (updated_at);
 
 
 -- Table: trace_annotations

--- a/scripts/docker/devops/docker-compose.yml
+++ b/scripts/docker/devops/docker-compose.yml
@@ -53,7 +53,6 @@ services:
       - PHOENIX_LOG_LEVEL=DEBUG
       - PHOENIX_HOST_ROOT_PATH=/phoenix
       - PHOENIX_ROOT_URL=http://localhost:18273/phoenix
-      - PHOENIX_DANGEROUSLY_ENABLE_AGENTS=true
       - PYTHONDONTWRITEBYTECODE=1
       - PYTHONUNBUFFERED=1
       # OIDC Authentication

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -85,6 +85,12 @@ ENV_PHOENIX_AGENTS_DISABLE_WEB_ACCESS = "PHOENIX_AGENTS_DISABLE_WEB_ACCESS"
 Disables PXI native web search and web fetch capabilities even when external
 resources are otherwise allowed.
 """
+ENV_PHOENIX_DISABLE_AGENT_ASSISTANT = "PHOENIX_DISABLE_AGENT_ASSISTANT"
+"""
+Whether to disable the agent assistant feature (the /chat endpoint). Defaults to False,
+meaning the assistant is enabled by default. Set to True on the Phoenix server to turn
+it off for the whole deployment.
+"""
 ENV_PHOENIX_WORKING_DIR = "PHOENIX_WORKING_DIR"
 """
 The directory in which to save, load, and export datasets. This directory must
@@ -313,13 +319,6 @@ Whether or not to log migrations. Defaults to true.
 """
 
 ENV_PHOENIX_DANGEROUSLY_DISABLE_MIGRATIONS = "PHOENIX_DANGEROUSLY_DISABLE_MIGRATIONS"
-
-ENV_PHOENIX_DANGEROUSLY_ENABLE_AGENTS = "PHOENIX_DANGEROUSLY_ENABLE_AGENTS"
-"""
-Whether or not to enable the agents feature (the /chat endpoint). Defaults to False.
-
-This is an unreleased feature and should only be enabled for development or testing.
-"""
 """
 Whether or not to disable migrations. Defaults to None / False.
 
@@ -3308,8 +3307,8 @@ def get_env_disable_migrations() -> bool:
     return _bool_val(ENV_PHOENIX_DANGEROUSLY_DISABLE_MIGRATIONS, False)
 
 
-def get_env_dangerously_enable_agents() -> bool:
-    return _bool_val(ENV_PHOENIX_DANGEROUSLY_ENABLE_AGENTS, False)
+def get_env_disable_agent_assistant() -> bool:
+    return _bool_val(ENV_PHOENIX_DISABLE_AGENT_ASSISTANT, False)
 
 
 def get_env_mask_internal_server_errors() -> bool:

--- a/src/phoenix/db/migrations/versions/d4e5f6a7b8c9_add_system_settings_table.py
+++ b/src/phoenix/db/migrations/versions/d4e5f6a7b8c9_add_system_settings_table.py
@@ -1,0 +1,79 @@
+"""add system_settings table and index on generative_models.updated_at
+
+Revision ID: d4e5f6a7b8c9
+Revises: 0ff41b5b118f
+Create Date: 2026-05-14 12:00:00.000000
+
+"""
+
+from typing import Any, Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import JSON
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.compiler import compiles
+
+
+class JSONB(JSON):
+    __visit_name__ = "JSONB"
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_sqlite(*args: Any, **kwargs: Any) -> str:
+    return "JSONB"
+
+
+JSON_ = (
+    JSON()
+    .with_variant(
+        postgresql.JSONB(),
+        "postgresql",
+    )
+    .with_variant(
+        JSONB(),
+        "sqlite",
+    )
+)
+
+_Integer = sa.Integer().with_variant(
+    sa.BigInteger(),
+    "postgresql",
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, None] = "0ff41b5b118f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "system_settings",
+        sa.Column("key", sa.String(), nullable=False, primary_key=True),
+        sa.Column("value", JSON_, nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "updated_by",
+            _Integer,
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_generative_models_updated_at",
+        "generative_models",
+        ["updated_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_generative_models_updated_at", table_name="generative_models")
+    op.drop_table("system_settings")

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -184,6 +184,10 @@ GenerativeModelSDK: TypeAlias = Literal[
 ExperimentStatus: TypeAlias = Literal["RUNNING", "COMPLETED", "STOPPED", "ERROR"]
 ExperimentLogCategory: TypeAlias = Literal["TASK", "EVAL", "EXPERIMENT"]
 ExperimentLogLevel: TypeAlias = Literal["ERROR", "WARN", "INFO"]
+SystemSettingKey: TypeAlias = Literal[
+    "agent.assistant.trace_recording",
+    "agent.assistant.enabled",
+]
 
 
 class JSONB(JSON):
@@ -2098,6 +2102,25 @@ class User(HasId):
     )
 
 
+class SystemSetting(Base):
+    """Server-wide key/value settings (JSON object per key)."""
+
+    __tablename__ = "system_settings"
+
+    key: Mapped[SystemSettingKey] = mapped_column(primary_key=True)
+    value: Mapped[dict[str, Any]] = mapped_column(JsonDict, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        UtcTimeStamp,
+        server_default=func.now(),
+        onupdate=func.now(),
+        index=True,
+    )
+    updated_by: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+
 class LocalUser(User):
     __mapper_args__ = {
         "polymorphic_identity": "LOCAL",
@@ -2266,6 +2289,7 @@ class GenerativeModel(HasId):
         UtcTimeStamp,
         server_default=func.now(),
         onupdate=func.now(),
+        index=True,
     )
     deleted_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
 

--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -105,6 +105,7 @@ if TYPE_CHECKING:
     from phoenix.server.api.dataloaders.dataset_labels import DatasetLabelsDataLoader
     from phoenix.server.daemons.experiment_runner import ExperimentRunner
     from phoenix.server.daemons.span_cost_calculator import SpanCostCalculator
+    from phoenix.server.daemons.system_settings import SystemSettings
     from phoenix.server.dml_event import DmlEvent
     from phoenix.server.email.types import EmailSender
     from phoenix.server.sandbox.session_manager import SandboxSessionManager
@@ -256,6 +257,7 @@ class _NoOp:
 class Context(BaseContext):
     db: DbSessionFactory
     data_loaders: DataLoaders
+    settings: SystemSettings
     cache_for_dataloaders: Optional[CacheForDataLoaders]
     span_cost_calculator: SpanCostCalculator
     experiment_runner: ExperimentRunner

--- a/src/phoenix/server/api/mutations/__init__.py
+++ b/src/phoenix/server/api/mutations/__init__.py
@@ -30,6 +30,7 @@ from phoenix.server.api.mutations.prompt_version_tag_mutations import PromptVers
 from phoenix.server.api.mutations.sandbox_config_mutations import SandboxConfigMutationMixin
 from phoenix.server.api.mutations.secret_mutations import SecretMutationMixin
 from phoenix.server.api.mutations.span_annotations_mutations import SpanAnnotationMutationMixin
+from phoenix.server.api.mutations.system_settings_mutations import SystemSettingsMutationMixin
 from phoenix.server.api.mutations.trace_annotations_mutations import TraceAnnotationMutationMixin
 from phoenix.server.api.mutations.trace_mutations import TraceMutationMixin
 from phoenix.server.api.mutations.user_mutations import UserMutationMixin
@@ -56,6 +57,7 @@ class Mutation(
     SandboxConfigMutationMixin,
     SecretMutationMixin,
     SpanAnnotationMutationMixin,
+    SystemSettingsMutationMixin,
     ProjectSessionAnnotationMutationMixin,
     TraceAnnotationMutationMixin,
     TraceMutationMixin,

--- a/src/phoenix/server/api/mutations/system_settings_mutations.py
+++ b/src/phoenix/server/api/mutations/system_settings_mutations.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import strawberry
+from starlette.requests import Request
+from strawberry.types import Info
+
+from phoenix.server.api.auth import (
+    IsAdminIfAuthEnabled,
+    IsLocked,
+    IsNotReadOnly,
+    IsNotViewer,
+)
+from phoenix.server.api.context import Context
+from phoenix.server.api.queries import AgentAssistantEnabled, AgentTraceRecording
+from phoenix.server.bearer_auth import PhoenixUser
+from phoenix.server.settings.registry import (
+    AgentAssistantEnabledSetting,
+    AgentTraceRecordingSetting,
+)
+
+
+def _viewer_user_id(info: Info[Context, None]) -> int | None:
+    assert isinstance(request := info.context.request, Request)
+    if "user" in request.scope and isinstance((user := info.context.user), PhoenixUser):
+        return int(user.identity)
+    return None
+
+
+@strawberry.input
+class SetAgentAssistantEnabledInput:
+    enabled: bool
+
+
+@strawberry.input
+class SetAgentTraceRecordingInput:
+    allow_local_traces: bool
+    allow_remote_export: bool
+
+
+@strawberry.type
+class SystemSettingsMutationMixin:
+    @strawberry.mutation(
+        permission_classes=[IsAdminIfAuthEnabled, IsNotReadOnly, IsNotViewer, IsLocked]
+    )  # type: ignore
+    async def set_agent_assistant_enabled(
+        self,
+        info: Info[Context, None],
+        input: SetAgentAssistantEnabledInput,
+    ) -> AgentAssistantEnabled:
+        await info.context.settings.update_agent_assistant_enabled(
+            AgentAssistantEnabledSetting(enabled=input.enabled),
+            user_id=_viewer_user_id(info),
+        )
+        s = info.context.settings.agent_assistant_enabled
+        return AgentAssistantEnabled(enabled=s.enabled)
+
+    @strawberry.mutation(
+        permission_classes=[IsAdminIfAuthEnabled, IsNotReadOnly, IsNotViewer, IsLocked]
+    )  # type: ignore
+    async def set_agent_trace_recording(
+        self,
+        info: Info[Context, None],
+        input: SetAgentTraceRecordingInput,
+    ) -> AgentTraceRecording:
+        await info.context.settings.update_agent_trace_recording(
+            AgentTraceRecordingSetting(
+                allow_local_traces=input.allow_local_traces,
+                allow_remote_export=input.allow_remote_export,
+            ),
+            user_id=_viewer_user_id(info),
+        )
+        recording = info.context.settings.agent_trace_recording
+        return AgentTraceRecording(
+            allow_local_traces=recording.allow_local_traces,
+            allow_remote_export=recording.allow_remote_export,
+        )

--- a/src/phoenix/server/api/mutations/system_settings_mutations.py
+++ b/src/phoenix/server/api/mutations/system_settings_mutations.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import strawberry
-from starlette.requests import Request
 from strawberry.types import Info
 
 from phoenix.server.api.auth import (
@@ -11,19 +10,21 @@ from phoenix.server.api.auth import (
     IsNotViewer,
 )
 from phoenix.server.api.context import Context
-from phoenix.server.api.queries import AgentAssistantEnabled, AgentTraceRecording
-from phoenix.server.bearer_auth import PhoenixUser
 from phoenix.server.settings.registry import (
     AgentAssistantEnabledSetting,
     AgentTraceRecordingSetting,
 )
 
 
-def _viewer_user_id(info: Info[Context, None]) -> int | None:
-    assert isinstance(request := info.context.request, Request)
-    if "user" in request.scope and isinstance((user := info.context.user), PhoenixUser):
-        return int(user.identity)
-    return None
+@strawberry.type
+class AgentTraceRecording:
+    allow_local_traces: bool
+    allow_remote_export: bool
+
+
+@strawberry.type
+class AgentAssistantEnabled:
+    enabled: bool
 
 
 @strawberry.input
@@ -49,10 +50,10 @@ class SystemSettingsMutationMixin:
     ) -> AgentAssistantEnabled:
         await info.context.settings.update_agent_assistant_enabled(
             AgentAssistantEnabledSetting(enabled=input.enabled),
-            user_id=_viewer_user_id(info),
+            user_id=info.context.user_id,
         )
-        s = info.context.settings.agent_assistant_enabled
-        return AgentAssistantEnabled(enabled=s.enabled)
+        setting = info.context.settings.agent_assistant_enabled
+        return AgentAssistantEnabled(enabled=setting.enabled)
 
     @strawberry.mutation(
         permission_classes=[IsAdminIfAuthEnabled, IsNotReadOnly, IsNotViewer, IsLocked]
@@ -67,7 +68,7 @@ class SystemSettingsMutationMixin:
                 allow_local_traces=input.allow_local_traces,
                 allow_remote_export=input.allow_remote_export,
             ),
-            user_id=_viewer_user_id(info),
+            user_id=info.context.user_id,
         )
         recording = info.context.settings.agent_trace_recording
         return AgentTraceRecording(

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -213,17 +213,6 @@ class ExperimentRunMetricComparisons:
 
 
 @strawberry.type
-class AgentTraceRecording:
-    allow_local_traces: bool
-    allow_remote_export: bool
-
-
-@strawberry.type
-class AgentAssistantEnabled:
-    enabled: bool
-
-
-@strawberry.type
 class Query:
     @strawberry.field
     async def model_providers(self, info: Info[Context, None]) -> list[GenerativeProvider]:

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -213,6 +213,17 @@ class ExperimentRunMetricComparisons:
 
 
 @strawberry.type
+class AgentTraceRecording:
+    allow_local_traces: bool
+    allow_remote_export: bool
+
+
+@strawberry.type
+class AgentAssistantEnabled:
+    enabled: bool
+
+
+@strawberry.type
 class Query:
     @strawberry.field
     async def model_providers(self, info: Info[Context, None]) -> list[GenerativeProvider]:
@@ -1481,11 +1492,16 @@ class Query:
         )
 
     @strawberry.field
-    def agents_config(self) -> AgentsConfig:
+    def agents_config(self, info: Info[Context, None]) -> AgentsConfig:
+        agent_assistant_enabled = info.context.settings.agent_assistant_enabled
+        trace_recording = info.context.settings.agent_trace_recording
         return AgentsConfig(
             collector_endpoint=get_env_phoenix_agents_collector_endpoint(),
             assistant_project_name=get_env_phoenix_agents_assistant_project_name(),
             web_access_enabled=get_env_phoenix_agents_web_access_enabled(),
+            assistant_enabled=agent_assistant_enabled.enabled,
+            allow_local_traces=trace_recording.allow_local_traces,
+            allow_remote_export=trace_recording.allow_remote_export,
         )
 
     @strawberry.field

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -501,15 +501,20 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
     ) -> Response:
         if agent_id != _ASSISTANT_AGENT_ID:
             raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
+        if not request.app.state.system_settings.agent_assistant_enabled.enabled:
+            raise HTTPException(status_code=403, detail="Agents are disabled")
         body = request_body.root
+        recording = request.app.state.system_settings.agent_trace_recording
+        ingest_traces = bool(body.ingest_traces and recording.allow_local_traces)
+        export_remote_traces = bool(body.export_remote_traces and recording.allow_remote_export)
         project_name = get_env_phoenix_agents_assistant_project_name()
         tracer = (
             Tracer(
                 span_cost_calculator=request.app.state.span_cost_calculator,
-                enable_remote_export=body.export_remote_traces,
+                enable_remote_export=export_remote_traces,
                 project_name=project_name,
             )
-            if (body.ingest_traces or body.export_remote_traces)
+            if (ingest_traces or export_remote_traces)
             else None
         )
         tracer_provider = tracer.tracer_provider if tracer is not None else None
@@ -599,7 +604,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             finally:
                 if tracer is not None:
                     tracer.tracer_provider.force_flush()
-                    if body.ingest_traces:
+                    if ingest_traces:
                         project_id = await _ensure_project_exists(
                             request.app.state.db, project_name
                         )
@@ -624,14 +629,19 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
     ) -> _SummarizeResponse:
         if agent_id != _ASSISTANT_AGENT_ID:
             raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
+        if not request.app.state.system_settings.agent_assistant_enabled.enabled:
+            raise HTTPException(status_code=403, detail="Agents are disabled")
+        recording = request.app.state.system_settings.agent_trace_recording
+        ingest_traces = bool(body.ingest_traces and recording.allow_local_traces)
+        export_remote_traces = bool(body.export_remote_traces and recording.allow_remote_export)
         project_name = get_env_phoenix_agents_assistant_project_name()
         tracer = (
             Tracer(
                 span_cost_calculator=request.app.state.span_cost_calculator,
-                enable_remote_export=body.export_remote_traces,
+                enable_remote_export=export_remote_traces,
                 project_name=project_name,
             )
-            if (body.ingest_traces or body.export_remote_traces)
+            if (ingest_traces or export_remote_traces)
             else None
         )
         tracer_provider = tracer.tracer_provider if tracer is not None else None
@@ -656,7 +666,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         finally:
             if tracer is not None:
                 tracer.tracer_provider.force_flush()
-                if body.ingest_traces:
+                if ingest_traces:
                     project_id = await _ensure_project_exists(request.app.state.db, project_name)
                     db_traces = tracer.get_db_traces(project_id=project_id)
                     if db_traces:

--- a/src/phoenix/server/api/types/AgentsConfig.py
+++ b/src/phoenix/server/api/types/AgentsConfig.py
@@ -24,3 +24,24 @@ class AgentsConfig:
             "is true."
         ),
     )
+    assistant_enabled: bool = strawberry.field(
+        description=(
+            "Admin ceiling for the agent assistant feature. Sourced from the "
+            "`agent.assistant.enabled` system setting. When False, agent chat is "
+            "disabled for the entire workspace regardless of individual user preferences."
+        ),
+    )
+    allow_local_traces: bool = strawberry.field(
+        description=(
+            "Admin ceiling for persisting PXI traces in this Phoenix instance. "
+            "Sourced from the `agent.assistant.trace_recording` system setting. When False, "
+            "users cannot turn on local trace recording for themselves."
+        ),
+    )
+    allow_remote_export: bool = strawberry.field(
+        description=(
+            "Admin ceiling for exporting PXI traces to the remote collector. "
+            "Sourced from the `agent.assistant.trace_recording` system setting. When False, "
+            "users cannot turn on remote trace export for themselves."
+        ),
+    )

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -63,9 +63,9 @@ from phoenix.config import (
     get_env_allow_external_resources,
     get_env_allowed_providers,
     get_env_csrf_trusted_origins,
-    get_env_dangerously_enable_agents,
     get_env_database_allocated_storage_capacity_gibibytes,
     get_env_database_usage_insertion_blocking_threshold_percentage,
+    get_env_disable_agent_assistant,
     get_env_fastapi_middleware_paths,
     get_env_gql_extension_paths,
     get_env_grpc_interceptor_paths,
@@ -186,6 +186,7 @@ from phoenix.server.daemons.experiment_runner import ExperimentRunner
 from phoenix.server.daemons.experiment_sweeper import ExperimentSweeper
 from phoenix.server.daemons.generative_model_store import GenerativeModelStore
 from phoenix.server.daemons.span_cost_calculator import SpanCostCalculator
+from phoenix.server.daemons.system_settings import SystemSettings
 from phoenix.server.dml_event import DmlEvent
 from phoenix.server.dml_event_handler import DmlEventHandler
 from phoenix.server.email.types import EmailSender
@@ -199,6 +200,7 @@ from phoenix.server.redaction import Redactor, current_redactor
 from phoenix.server.retention import TraceDataSweeper
 from phoenix.server.sandbox._download import prefetch_wasm_binary_if_needed
 from phoenix.server.sandbox.session_manager import SandboxSessionManager
+from phoenix.server.settings.registry import SETTINGS_REGISTRY
 from phoenix.server.telemetry import initialize_opentelemetry_tracer_provider
 from phoenix.server.types import (
     CanGetLastUpdatedAt,
@@ -308,6 +310,8 @@ class AppConfig(NamedTuple):
     """ Whether the database has a threshold for usage """
     allow_external_resources: bool = True
     """ Whether to allow external resources like Google Fonts in the web interface """
+    agent_assistant_disabled: bool = False
+    """ Whether the agent assistant feature is disabled at the deployment level"""
     dev_vite_port: int = 5173
     """ Port the Vite dev server runs on. Only used in development mode. """
 
@@ -372,6 +376,7 @@ class Static(StaticFiles):
                     "support_email": self._app_config.support_email,
                     "has_db_threshold": self._app_config.has_db_threshold,
                     "allow_external_resources": self._app_config.allow_external_resources,
+                    "agent_assistant_disabled": self._app_config.agent_assistant_disabled,
                     "auth_error_messages": self._app_config.auth_error_messages,
                 },
             )
@@ -650,6 +655,7 @@ def _lifespan(
     experiment_sweeper: ExperimentSweeper,
     span_cost_calculator: SpanCostCalculator,
     generative_model_store: GenerativeModelStore,
+    system_settings: SystemSettings,
     db_disk_usage_monitor: DbDiskUsageMonitor,
     experiment_runner: ExperimentRunner,
     sandbox_session_manager: SandboxSessionManager,
@@ -673,6 +679,7 @@ def _lifespan(
             if isinstance((res := callback()), Awaitable):
                 await res
         db.lock = asyncio.Lock() if db.dialect is SupportedSQLDialect.SQLITE else None
+        await system_settings.bootstrap()
         async with AsyncExitStack() as stack:
             (
                 enqueue_annotations,
@@ -702,6 +709,7 @@ def _lifespan(
             await stack.enter_async_context(experiment_sweeper)
             await stack.enter_async_context(span_cost_calculator)
             await stack.enter_async_context(generative_model_store)
+            await stack.enter_async_context(system_settings)
             await stack.enter_async_context(db_disk_usage_monitor)
             # ``sandbox_session_manager`` must enter before ``experiment_runner``
             # so ``AsyncExitStack`` tears them down in reverse and the runner
@@ -758,6 +766,7 @@ def create_graphql_router(
     *,
     graphql_schema: strawberry.Schema,
     db: DbSessionFactory,
+    system_settings: SystemSettings,
     last_updated_at: CanGetLastUpdatedAt,
     authentication_enabled: bool,
     span_cost_calculator: SpanCostCalculator,
@@ -796,6 +805,7 @@ def create_graphql_router(
     def get_context() -> Context:
         return Context(
             db=db,
+            settings=system_settings,
             allowed_provider_names=allowed_provider_names,
             last_updated_at=last_updated_at,
             event_queue=event_queue,
@@ -1156,6 +1166,7 @@ def create_app(
     )
     experiment_sweeper = ExperimentSweeper(db)
     generative_model_store = GenerativeModelStore(db)
+    system_settings = SystemSettings(db=db, registry=SETTINGS_REGISTRY)
     span_cost_calculator = SpanCostCalculator(db, generative_model_store)
     bulk_inserter = bulk_inserter_factory(
         db,
@@ -1200,6 +1211,7 @@ def create_app(
     )
     graphql_router = create_graphql_router(
         db=db,
+        system_settings=system_settings,
         graphql_schema=build_graphql_schema(graphql_schema_extensions),
         authentication_enabled=authentication_enabled,
         last_updated_at=last_updated_at,
@@ -1223,7 +1235,7 @@ def create_app(
     grpc_interceptors.append(DbDiskUsageInterceptor(db))
     docs_mcp_server = (
         MintlifyDocsMCPServer()
-        if get_env_dangerously_enable_agents() and get_env_allow_external_resources()
+        if not get_env_disable_agent_assistant() and get_env_allow_external_resources()
         else None
     )
     app = FastAPI(
@@ -1240,6 +1252,7 @@ def create_app(
             experiment_sweeper=experiment_sweeper,
             span_cost_calculator=span_cost_calculator,
             generative_model_store=generative_model_store,
+            system_settings=system_settings,
             db_disk_usage_monitor=DbDiskUsageMonitor(db, email_sender),
             experiment_runner=experiment_runner,
             sandbox_session_manager=sandbox_session_manager,
@@ -1263,7 +1276,7 @@ def create_app(
         },
     )
     app.include_router(create_v1_router(authentication_enabled))
-    if get_env_dangerously_enable_agents():
+    if not get_env_disable_agent_assistant():
         app.include_router(create_agents_router(authentication_enabled))
     app.include_router(router)
     app.include_router(graphql_router)
@@ -1336,6 +1349,7 @@ def create_app(
                         and get_env_database_usage_insertion_blocking_threshold_percentage()
                     ),
                     allow_external_resources=get_env_allow_external_resources(),
+                    agent_assistant_disabled=get_env_disable_agent_assistant(),
                     auth_error_messages=dict(AUTH_ERROR_MESSAGES) if authentication_enabled else {},
                     dev_vite_port=dev_vite_port,
                 ),
@@ -1354,6 +1368,7 @@ def create_app(
 
         app.state.ldap_authenticator = LDAPAuthenticator(ldap_config)
     app.state.db = db
+    app.state.system_settings = system_settings
     app.state.email_sender = email_sender
     app.state.span_cost_calculator = span_cost_calculator
     app.state.encrypt = encryption_service.encrypt

--- a/src/phoenix/server/cli/commands/serve.py
+++ b/src/phoenix/server/cli/commands/serve.py
@@ -23,9 +23,9 @@ from phoenix.config import (
     get_env_allowed_origins,
     get_env_allowed_sandbox_providers,
     get_env_auth_settings,
-    get_env_dangerously_enable_agents,
     get_env_database_connection_str,
     get_env_database_schema,
+    get_env_disable_agent_assistant,
     get_env_enable_prometheus,
     get_env_grpc_port,
     get_env_host,
@@ -131,10 +131,9 @@ _WELCOME_MESSAGE = Environment(loader=BaseLoader()).from_string("""
 {%- for provider in sandbox_providers %}
 |  - {{ provider.name }}: {{ "✅ Allowed" if provider.enabled else "❌ Disabled" }}
 {%- endfor %}
-{%- if agents_enabled %}
+{%- if agent_assistant_disabled %}
 |
-|  🧪 Experimental Features 🧪
-|  Agents: Enabled
+|  Agent Assistant: Disabled
 {%- endif %}
 """)
 
@@ -305,7 +304,7 @@ def run(args: Namespace) -> None:
         tls_enabled_for_grpc=tls_enabled_for_grpc,
         tls_verify_client=tls_verify_client,
         allowed_origins=allowed_origins,
-        agents_enabled=get_env_dangerously_enable_agents(),
+        agent_assistant_disabled=get_env_disable_agent_assistant(),
         sandbox_providers=_get_sandbox_provider_statuses(),
     )
 

--- a/src/phoenix/server/daemons/system_settings.py
+++ b/src/phoenix/server/daemons/system_settings.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import logging
+from asyncio import sleep
+from datetime import datetime, timedelta, timezone
+from typing import Literal, Mapping, Optional, overload
+
+import sqlalchemy as sa
+from pydantic import BaseModel, ValidationError
+
+from phoenix.db import models
+from phoenix.db.insertion.helpers import insert_on_conflict
+from phoenix.db.models import SystemSettingKey
+from phoenix.server.api.exceptions import BadRequest
+from phoenix.server.settings.registry import (
+    SETTINGS_REGISTRY,
+    AgentAssistantEnabledSetting,
+    AgentTraceRecordingSetting,
+)
+from phoenix.server.types import DaemonTask, DbSessionFactory
+
+logger = logging.getLogger(__name__)
+
+
+class _SettingsCache:
+    """Typed in-memory store for system_settings.
+
+    Each ``SystemSettingKey`` is bound to a concrete model class by
+    ``SETTINGS_REGISTRY``; the ``get`` overloads encode that mapping so
+    callers don't need ``cast``.
+    """
+
+    def __init__(self) -> None:
+        self._data: dict[SystemSettingKey, BaseModel] = {}
+
+    @overload
+    def get(
+        self, key: Literal["agent.assistant.trace_recording"]
+    ) -> Optional[AgentTraceRecordingSetting]: ...
+    @overload
+    def get(
+        self, key: Literal["agent.assistant.enabled"]
+    ) -> Optional[AgentAssistantEnabledSetting]: ...
+    def get(self, key: SystemSettingKey) -> Optional[BaseModel]:
+        return self._data.get(key)
+
+    def __setitem__(self, key: SystemSettingKey, value: BaseModel) -> None:
+        self._data[key] = value
+
+
+class SystemSettings(DaemonTask):
+    """In-memory cache of system_settings — kept fresh by polling and write-through."""
+
+    _DEFAULT_OVERLAP = timedelta(seconds=10)
+
+    def __init__(
+        self,
+        db: DbSessionFactory,
+        *,
+        registry: Mapping[SystemSettingKey, type[BaseModel]] = SETTINGS_REGISTRY,
+        refresh_interval_seconds: int = 30,
+        overlap_window: timedelta = _DEFAULT_OVERLAP,
+    ) -> None:
+        super().__init__()
+        self._db = db
+        self._registry = registry
+        self._cache = _SettingsCache()
+        self._last_poll_at: Optional[datetime] = None
+        self._refresh_interval_seconds = refresh_interval_seconds
+        self._overlap_window = overlap_window
+
+    @property
+    def agent_trace_recording(self) -> AgentTraceRecordingSetting:
+        return self._cache.get("agent.assistant.trace_recording") or AgentTraceRecordingSetting()
+
+    async def update_agent_trace_recording(
+        self,
+        value: AgentTraceRecordingSetting,
+        *,
+        user_id: Optional[int] = None,
+    ) -> None:
+        await self._set("agent.assistant.trace_recording", value, user_id=user_id)
+
+    @property
+    def agent_assistant_enabled(self) -> AgentAssistantEnabledSetting:
+        return self._cache.get("agent.assistant.enabled") or AgentAssistantEnabledSetting()
+
+    async def update_agent_assistant_enabled(
+        self,
+        value: AgentAssistantEnabledSetting,
+        *,
+        user_id: Optional[int] = None,
+    ) -> None:
+        await self._set("agent.assistant.enabled", value, user_id=user_id)
+
+    async def _set(
+        self,
+        key: SystemSettingKey,
+        value: BaseModel,
+        *,
+        user_id: Optional[int] = None,
+    ) -> BaseModel:
+        model_cls = self._registry.get(key)
+        if model_cls is None:
+            raise BadRequest(f"Unknown setting: {key}")
+        try:
+            parsed = model_cls.model_validate(value)
+        except ValidationError as e:
+            raise BadRequest(str(e)) from e
+        payload = parsed.model_dump(mode="json")
+        stmt = insert_on_conflict(
+            {"key": key, "value": payload, "updated_by": user_id},
+            table=models.SystemSetting,
+            dialect=self._db.dialect,
+            unique_by=("key",),
+            constraint_name="pk_system_settings",
+            set_={
+                "value": payload,
+                "updated_by": user_id,
+                "updated_at": sa.func.now(),
+            },
+        )
+        async with self._db() as session:
+            await session.execute(stmt)
+        self._cache[key] = parsed
+        return parsed
+
+    async def bootstrap(self) -> None:
+        await self._fetch()
+
+    async def _run(self) -> None:
+        while self._running:
+            try:
+                await self._fetch()
+            except Exception:
+                logger.exception("Failed to refresh system_settings")
+            await sleep(self._refresh_interval_seconds)
+
+    async def _fetch(self) -> None:
+        now = datetime.now(timezone.utc)
+        cursor: Optional[datetime] = None
+        if self._last_poll_at is not None:
+            cursor = self._last_poll_at - self._overlap_window
+
+        stmt = sa.select(models.SystemSetting)
+        if cursor is not None:
+            stmt = stmt.where(models.SystemSetting.updated_at >= cursor)
+        async with self._db() as session:
+            rows = (await session.scalars(stmt)).all()
+
+        for row in rows:
+            model_cls = self._registry.get(row.key)
+            if model_cls is None:
+                logger.warning("Unknown setting key in DB: %s — ignoring", row.key)
+                continue
+            try:
+                self._cache[row.key] = model_cls.model_validate(row.value)
+            except ValidationError as e:
+                logger.error(
+                    "Invalid value for setting %s: %s — keeping last-known-good",
+                    row.key,
+                    e,
+                )
+        self._last_poll_at = now

--- a/src/phoenix/server/settings/__init__.py
+++ b/src/phoenix/server/settings/__init__.py
@@ -1,0 +1,11 @@
+from phoenix.server.settings.registry import (
+    SETTINGS_REGISTRY,
+    AgentAssistantEnabledSetting,
+    AgentTraceRecordingSetting,
+)
+
+__all__ = [
+    "AgentAssistantEnabledSetting",
+    "AgentTraceRecordingSetting",
+    "SETTINGS_REGISTRY",
+]

--- a/src/phoenix/server/settings/registry.py
+++ b/src/phoenix/server/settings/registry.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from phoenix.db.models import SystemSettingKey
+
+
+class AgentTraceRecordingSetting(BaseModel):
+    """Server-side ceiling for assistant trace recording flags."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, validate_assignment=True)
+
+    allow_local_traces: bool = Field(default=False)
+    allow_remote_export: bool = Field(default=False)
+
+
+class AgentAssistantEnabledSetting(BaseModel):
+    """Whether the agent assistant feature (the /chat endpoint) is enabled at runtime.
+
+    Defaults to ``True`` so deployments without PHOENIX_DISABLE_AGENT_ASSISTANT
+    set get a working assistant out of the box. The env var is the deploy-time
+    ceiling; this setting is the admin-runtime knob below it. Admins can flip
+    it to ``False`` from the UI to kill the feature for the whole workspace
+    without redeploying.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, validate_assignment=True)
+
+    enabled: bool = Field(default=True)
+
+
+SETTINGS_REGISTRY: Mapping[SystemSettingKey, type[BaseModel]] = MappingProxyType(
+    {
+        "agent.assistant.trace_recording": AgentTraceRecordingSetting,
+        "agent.assistant.enabled": AgentAssistantEnabledSetting,
+    }
+)

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -108,6 +108,7 @@
               supportEmail: {{support_email | tojson}},
               hasDbThreshold: Boolean("{{has_db_threshold}}" == "True"),
               allowExternalResources: Boolean("{{allow_external_resources}}" == "True"),
+              agentAssistantDisabled: Boolean("{{agent_assistant_disabled}}" == "True"),
               authErrorMessages: {{auth_error_messages | tojson}},
           }),
           writable: false

--- a/tests/integration/auth/conftest.py
+++ b/tests/integration/auth/conftest.py
@@ -434,7 +434,6 @@ def _env_agents() -> dict[str, str]:
     provide a fake key to keep those requests on the authenticated code path.
     """
     return {
-        "PHOENIX_DANGEROUSLY_ENABLE_AGENTS": "true",
         "ANTHROPIC_API_KEY": "sk-fake-anthropic-key",
     }
 

--- a/tests/unit/server/api/mutations/test_agent_trace_recording_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_trace_recording_mutations.py
@@ -1,0 +1,65 @@
+"""GraphQL tests for agent trace recording mutations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from phoenix.server.settings.registry import AgentTraceRecordingSetting
+from tests.unit.graphql import AsyncGraphQLClient
+
+_AGENT_TRACE_QUERY = """
+query AgentTraceRecordingQ {
+  agentsConfig {
+    allowLocalTraces
+    allowRemoteExport
+  }
+}
+"""
+
+_SET_AGENT_TRACE_MUTATION = """
+mutation SetCap($input: SetAgentTraceRecordingInput!) {
+  setAgentTraceRecording(input: $input) {
+    allowLocalTraces
+    allowRemoteExport
+  }
+}
+"""
+
+
+@pytest.mark.asyncio
+async def test_mutation_persists_and_query_reflects_write(
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    """Full GraphQL round-trip: mutation -> _set UPSERT -> cache -> query.
+
+    Uses (False, True), which flips both flags from their defaults
+    (True, False) so a swapped-field bug surfaces as an assertion failure
+    instead of slipping through with (True, True) on both sides.
+    """
+    default = AgentTraceRecordingSetting()
+
+    # Flip the flags to test the update
+    allow_local = not default.allow_local_traces
+    allow_remote = not default.allow_remote_export
+
+    variables: dict[str, Any] = {
+        "input": {
+            "allowLocalTraces": allow_local,
+            "allowRemoteExport": allow_remote,
+        },
+    }
+    result = await gql_client.execute(_SET_AGENT_TRACE_MUTATION, variables)
+    assert not result.errors
+    assert result.data is not None
+    out = result.data["setAgentTraceRecording"]
+    assert out["allowLocalTraces"] is allow_local
+    assert out["allowRemoteExport"] is allow_remote
+
+    q = await gql_client.execute(_AGENT_TRACE_QUERY, {})
+    assert not q.errors
+    assert q.data is not None
+    atr = q.data["agentsConfig"]
+    assert atr["allowLocalTraces"] is allow_local
+    assert atr["allowRemoteExport"] is allow_remote

--- a/tests/unit/server/daemons/test_system_settings.py
+++ b/tests/unit/server/daemons/test_system_settings.py
@@ -1,0 +1,40 @@
+"""Tests for system-wide settings store and agent trace recording policy."""
+
+from __future__ import annotations
+
+import pytest
+
+from phoenix.db import models
+from phoenix.server.daemons.system_settings import SystemSettings
+from phoenix.server.settings.registry import SETTINGS_REGISTRY, AgentTraceRecordingSetting
+from phoenix.server.types import DbSessionFactory
+
+
+@pytest.mark.asyncio
+async def test_update_agent_trace_recording_persists_and_updates_cache(
+    db: DbSessionFactory,
+) -> None:
+    ss = SystemSettings(db=db, registry=SETTINGS_REGISTRY)
+    await ss.bootstrap()
+    default = AgentTraceRecordingSetting()
+
+    # Flip the flags to test the update
+    allow_local = not default.allow_local_traces
+    allow_remote = not default.allow_remote_export
+    await ss.update_agent_trace_recording(
+        AgentTraceRecordingSetting(
+            allow_local_traces=allow_local, allow_remote_export=allow_remote
+        ),
+        user_id=None,
+    )
+    assert ss.agent_trace_recording.allow_local_traces is allow_local
+    assert ss.agent_trace_recording.allow_remote_export is allow_remote
+
+    expected = {
+        "allow_local_traces": allow_local,
+        "allow_remote_export": allow_remote,
+    }
+    async with db() as session:
+        row = await session.get(models.SystemSetting, "agent.assistant.trace_recording")
+        assert row is not None
+        assert row.value == expected


### PR DESCRIPTION
## Summary

Introduces a general **`system_settings`** store for admin-managed, server-enforced policy, and uses it to (1) graduate the PXI assistant from a client feature flag to an admin-managed setting and (2) add a server-side **trace recording policy** that acts as a ceiling over per-user preferences.

## System settings infrastructure

- Adds a `system_settings` table (PK `key`, JSON `value`, indexed `updated_at`, nullable updater FK) and a polled, write-through-cached `SystemSettings` daemon that hydrates a per-process cache from the table.
- Adds a typed settings registry; settings are defined once and surfaced through GraphQL and the loader query.
- Adds an index on `generative_models.updated_at` (used by the existing `generative_model_store` cursor scan, which today does a sequential scan every poll).

## Agent trace recording policy

- Wires the first concrete setting — agent trace recording — through GraphQL (`agentTraceRecording` query, `setAgentTraceRecording` mutation) and through the agent REST router, which intersects per-request flags with the server policy. **The server policy is a ceiling, not an override**: a request can only record traces the admin allows.
- Frontend resolves effective flags as `server ceiling ∧ user preference` in one place (`getEffectiveTraceRecordingSettings`), shared by the chat request builder and session summary.

## Assistant enablement (feature flag → system setting)

- Replaces the client `agents` feature flag with an admin-managed `agent.assistant.enabled` system setting (defaults to enabled). The agent UI now renders only when all three gates pass: deploy env (`PHOENIX_DISABLE_AGENT_ASSISTANT`) → admin system setting → per-user preference (`useAssistantAgentEnabled`).
- Adds an admin workspace card to toggle assistant enablement and trace recording, plus a `SystemSettingsWarning` surface.

## Consent & trace UX

- Replaces the one-shot `hasAcknowledgedConsent` boolean with an `acknowledgedTraceConsent` snapshot of the server trace ceilings at acknowledgement time. Consent is re-requested only when the server **broadens** recording (enables a channel the user never agreed to); narrowing leaves prior consent intact. Returning users from before this change are re-prompted once.
- Refreshes the consent gate and observability settings to reflect local vs. remote trace destinations.

## Tests

- Unit coverage for the system settings daemon, the trace recording mutation, and the consent snapshot / effective-flag logic.
- Disables the assistant in the standard Playwright suite via `PHOENIX_DISABLE_AGENT_ASSISTANT` (it is now default-on, and its floating action button otherwise intercepts clicks in unrelated specs); PXI specs run with `PXI_E2E=true` and keep it enabled.

## Breaking / migration notes

- Adds a DB migration for `system_settings` (see `MIGRATION.md`).
- Removes the `agents` feature flag; assistant availability is now governed by the system setting + user preference.
