### PR TITLE
ci: hardcode internal contributors for triage labeler

### DIFF
--- a/.github/workflows/auto-label-external-issues.yaml
+++ b/.github/workflows/auto-label-external-issues.yaml
@@ -14,9 +14,9 @@ jobs:
   label:
     name: Label external issues and PRs
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - name: Add triage label for non-team contributors
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
@@ -34,24 +34,30 @@ jobs:
               return;
             }
 
-            // The webhook's `author_association` is unreliable: it returns
-            // CONTRIBUTOR for org members whose membership is private and who
-            // aren't direct repo collaborators. Check collaborator status
-            // directly via the API — 204 means internal, 404 means external.
+            // Hardcoded list of active internal contributors. Avoids the
+            // GITHUB_TOKEN/PAT scope issues with `checkCollaborator` and
+            // `author_association`, both of which misclassify org members
+            // depending on private membership and team-mediated repo access.
+            // New joiners get one false-positive triage label on their first
+            // PR — add them here and the next PR is correctly skipped.
+            const internalContributors = new Set([
+              "anticorrelator",
+              "axiomofjoy",
+              "cephalization",
+              "ehutt",
+              "jimbobbennett",
+              "mikeldking",
+              "Nancy-Chauhan",
+              "PatriciaArnedo",
+              "rickarize",
+              "RogerHYang",
+              "seldo",
+              "yfrigui2",
+            ]);
+
             const username = payload.user.login;
-            let isCollaborator = false;
-            try {
-              await github.rest.repos.checkCollaborator({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                username,
-              });
-              isCollaborator = true;
-            } catch (err) {
-              if (err.status !== 404) throw err;
-            }
-            if (isCollaborator) {
-              core.info(`Skipping internal collaborator: ${username}`);
+            if (internalContributors.has(username)) {
+              core.info(`Skipping internal contributor: ${username}`);
               return;
             }
 


### PR DESCRIPTION
## Summary

The auto-triage labeler keeps misclassifying internal contributors because neither available signal is authoritative under `GITHUB_TOKEN`:

- `payload.author_association` returns `CONTRIBUTOR` for org members whose membership is private and who haven't yet been linked to the repo (mislabeled @axiomofjoy on #13205, fixed in #13239).
- `github.rest.repos.checkCollaborator` returns `404` for org members whose repo access is via team membership rather than direct collaborator entry — `GITHUB_TOKEN` is a per-repo installation token and can't enumerate team-mediated access (mislabeled me on #13254 after #13239 merged).

The only authoritative answer (`orgs/{org}/members/{user}`) requires org-level read, which `GITHUB_TOKEN` structurally cannot have. Adding a PAT works but expands blast radius on a `pull_request_target` workflow.

This PR replaces the API call with a hardcoded set of active internal contributors (sourced from the last 90 days of merged PRs). New joiners get one false-positive triage label on their first PR — add them to the list and the next PR is correctly skipped.

Also tightens the workflow:
- Drops `pull-requests: write` (unused — `issues.addLabels` works for PRs under `issues: write`).
- Adds `timeout-minutes: 5`.
- Removes the `GITHUB_TOKEN` API dependency entirely.

## Test plan

- [ ] After merge, open a test PR from an internal contributor account and confirm no `triage` label is applied.
- [ ] Open a test PR from an external account (or wait for an organic one) and confirm `triage` is applied.