### PR TITLE
fix: refresh span notes after create

### DIFF
--- a/app/src/pages/trace/SpanNotesEditor.tsx
+++ b/app/src/pages/trace/SpanNotesEditor.tsx
@@ -92,8 +92,10 @@ export function SpanNotesEditor(props: SpanNotesEditorProps) {
             spanId: props.spanNodeId,
           },
         },
+        onCompleted: () => {
+          setFetchKey((key) => key + 1);
+        },
       });
-      setFetchKey(fetchKey + 1);
     });
   };
 


### PR DESCRIPTION
## Summary
- refresh the span notes query only after `createSpanNote` completes
- use a functional `fetchKey` update so quick note submissions do not reuse a stale key

This makes the new note visible without relying on a manual page refresh.

Closes #13252.

## To verify
- `pnpm exec oxlint app/src/pages/trace/SpanNotesEditor.tsx`
- `pnpm exec oxfmt --check --config ../.oxfmtrc.jsonc ./src/pages/trace/SpanNotesEditor.tsx`
- `pnpm typecheck`
- `git diff --check`
