### PR TITLE
docs: Update info for Arconia Java integration

### DIFF
--- a/.github/.scripts/check-card-links.js
+++ b/.github/.scripts/check-card-links.js
@@ -183,7 +183,7 @@ async function checkExternal(href, timeoutMs, maxRetries = 5, backoffBaseMs = 50
     return [true, "Arize NPM package"];
   }
 
-  if (href === "https://arconia.io/docs/arconia/latest/observability/generative-ai/") {
+  if (href === "https://docs.arconia.io/arconia/latest/observability/semantic-conventions/openinference/") {
     return [true, "Arconia returns 404 from actions, but is valid"];
   }
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Normalize and convert data across other instrumentation libraries by adding span
 |:---:|---|---|---|
 | <img src="https://unpkg.com/@lobehub/icons-static-png@latest/dark/langchain-color.png" height="14"> | [LangChain4j](https://github.com/Arize-ai/openinference/tree/main/java/instrumentation/openinference-instrumentation-langchain4j) | `openinference-instrumentation-langchain4j` | [![Maven Central](https://img.shields.io/maven-central/v/com.arize/openinference-instrumentation-langchain4j.svg)](https://central.sonatype.com/artifact/com.arize/openinference-instrumentation-langchain4j) |
 | | SpringAI | `openinference-instrumentation-springAI` | [![Maven Central](https://img.shields.io/maven-central/v/com.arize/openinference-instrumentation-springAI.svg)](https://central.sonatype.com/artifact/com.arize/openinference-instrumentation-springAI) |
-| | [Arconia](https://arconia.io/docs/arconia/latest/observability/generative-ai/) | `openinference-instrumentation-springAI` | [![Maven Central](https://img.shields.io/maven-central/v/com.arize/openinference-instrumentation-springAI.svg)](https://central.sonatype.com/artifact/com.arize/openinference-instrumentation-springAI) |
+| <img src="https://avatars.githubusercontent.com/u/151681568" height="16"> | [Arconia](https://docs.arconia.io/arconia/latest/observability/semantic-conventions/openinference/) for Spring AI | `io.arconia:arconia-openinference-semantic-conventions` | [![Maven Central](https://img.shields.io/maven-central/v/io.arconia/arconia-openinference-ai-semantic-conventions.svg)](https://central.sonatype.com/artifact/io.arconia/arconia-openinference-ai-semantic-conventions) |
 
 ### Platforms
 

--- a/docs/PROMPT.md
+++ b/docs/PROMPT.md
@@ -120,7 +120,7 @@ This is the **canonical list** of supported integrations. Use these tables to ma
 |---|---|---|
 | `langchain4j` (in `pom.xml` or `build.gradle`) | LangChain4j | https://arize.com/docs/phoenix/integrations/java/langchain4j |
 | `spring-ai` (in `pom.xml` or `build.gradle`) | Spring AI | https://arize.com/docs/phoenix/integrations/java/springai |
-| `arconia` (in `pom.xml` or `build.gradle`) | Arconia | https://arize.com/docs/phoenix/integrations/java/arconia |
+| `arconia` or `spring-ai` (in `pom.xml` or `build.gradle`) | Arconia for Spring AI | https://arize.com/docs/phoenix/integrations/java/arconia |
 
 ### Platforms
 
@@ -253,8 +253,8 @@ For framework-specific setups (Mastra, Vercel AI SDK, LangChain), the doc pages 
 
 Java integrations use the OpenTelemetry Java SDK. The level of automation varies by framework:
 
-**Arconia** (zero-code — recommended for Spring Boot projects):
-Add dependencies and Arconia auto-configures tracing via its Spring Boot starter. No explicit OTel setup code needed — just set environment variables.
+**Arconia** (zero-code — recommended for Spring Boot and Spring AI projects):
+Add dependencies and Arconia auto-configures OpenTelemetry tracing via its Spring Boot starter and semantic conventions via its OpenInference library. No explicit OTel setup code needed — just set environment variables.
 
 **LangChain4j** (one-liner):
 

--- a/docs/phoenix/integrations/java/arconia.mdx
+++ b/docs/phoenix/integrations/java/arconia.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Arconia"
-description: "Arconia is an open-source framework and set of tools for building modern, cloud-native enterprise applications using Java and the Spring Boot framework"
+description: "Arconia is an open-source framework that you can add to an existing Spring Boot application to boost developer experience, reduce boilerplate, and seamlessly adopt cloud native patterns."
 sidebarTitle: "Overview"
 ---
 
-<Card title="Arconia" href="https://arconia.io/docs/arconia/latest/observability/generative-ai/" icon="globe" horizontal>
-[](https://arconia.io/docs/arconia/latest/observability/generative-ai/)
+<Card title="Arconia" href="https://docs.arconia.io/arconia/latest/observability/semantic-conventions/openinference/" icon="globe" horizontal>
+[](https://docs.arconia.io/arconia/latest/observability/semantic-conventions/openinference/)
 </Card>
 
 <Columns cols={2}>

--- a/docs/phoenix/integrations/java/arconia/arconia-tracing.mdx
+++ b/docs/phoenix/integrations/java/arconia/arconia-tracing.mdx
@@ -1,38 +1,89 @@
 ---
 title: "Arconia Tracing"
-description: "How to use OpenInference instrumentation with Arconia and export traces to Arize Phoenix."
+description: "How to use OpenInference instrumentation for Spring AI with Arconia and export traces to Arize Phoenix."
 ---
 
 ## Prerequisites
 
-* Java 11 or higher
-* (Optional) Phoenix API key if using auth
+* Java 21 or higher
+* (Optional) Phoenix API key if using Phoenix Cloud
+* (Optional) Docker or Podman if using the Arconia Phoenix Dev Service
 
 ### Add Dependencies
 
-#### **1. Gradle**
+
+<Tabs>
+<Tab title="Gradle">
 
 Add the dependencies to your `build.gradle`:
 
 ```groovy expandable
 dependencies {
-    implementation 'io.arconia:arconia-openinference-semantic-conventions'
+    implementation 'io.arconia:arconia-openinference-ai-semantic-conventions'
     implementation 'io.arconia:arconia-opentelemetry-spring-boot-starter'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.ai:spring-ai-starter-model-mistral-ai'
 
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testAndDevelopmentOnly 'io.arconia:arconia-dev-services-phoenix'
-
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 ```
+</Tab>
 
-## **Setup Phoenix Tracing**
+<Tab title="Maven">
+
+Add the dependencies to your `pom.xml`:
+
+```xml expandable
+<dependencies>
+  <dependency>
+      <groupId>io.arconia</groupId>
+      <artifactId>arconia-openinference-ai-semantic-conventions</artifactId>
+  </dependency>
+  <dependency>
+      <groupId>io.arconia</groupId>
+      <artifactId>arconia-opentelemetry-spring-boot-starter</artifactId>
+  </dependency>
+  <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>spring-ai-starter-model-mistral-ai</artifactId>
+  </dependency>
+  <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webmvc</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>io.arconia</groupId>
+    <artifactId>arconia-dev-services-phoenix</artifactId>
+    <scope>runtime</scope>
+    <optional>true</optional>
+  </dependency>
+</dependencies>
+```
+</Tab>
+</Tabs>
+
+## **Setup Phoenix**
 
 <Tabs>
+<Tab title="Phoenix Dev Service">
+
+If you included the Arconia Phoenix Dev Service dependency as instructed in the previous step,
+your Spring Boot application will automatically provision a Phoenix service at startup time
+and connect to it. No extra code or configuration needed.
+
+The application logs will show you the URL where you can access the Phoenix AI observability platform
+in your development environment.
+
+```logs
+...Phoenix UI: http://localhost:<port>
+```
+
+By default, traces are exported via OTLP using the HTTP/Protobuf format.
+
+For more info on using Phoenix with Arconia, see [Phoenix Dev Service](https://docs.arconia.io/arconia/latest/dev-services/phoenix/).
+</Tab>
+
 <Tab title="Docker">
 
 **Pull latest Phoenix image from** [**Docker Hub**](https://hub.docker.com/r/arizephoenix/phoenix)**:**
@@ -94,12 +145,12 @@ Having trouble finding your endpoint? Check out [Finding your Phoenix Endpoint](
 </Tabs>
 
 <Warning>
-If you are using Phoenix Cloud, adjust the endpoint in the code as needed.
+If you are using Phoenix Cloud or a self-hosted Phoenix, adjust the endpoint in the code as needed via the `arconia.otel.exporter.otlp.endpoint=${PHOENIX_COLLECTOR_ENDPOINT}` and `arconia.otel.exporter.otlp.headers=Authorization=Bearer ${PHOENIX_API_KEY}` properties. Alternatively, you can use the canonical OpenTelemetry Environment Variables: `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS`.
 </Warning>
 
-## Run Arconia
+## Run Spring AI with Arconia
 
-By instrumenting your  application with Arconia, spans are automatically created whenever your AI models (e.g., via Spring AI) are invoked and sent to the Phoenix server for collection. Arconia plugs into Spring Boot and Spring AI with minimal code changes.
+By instrumenting your application with Arconia, spans are automatically created whenever your AI models via Spring AI are invoked and sent to the Phoenix server for collection. Arconia plugs into Spring Boot and Spring AI without any code or configuration changes.
 
 ```java expandable
 package io.arconia.demo;
@@ -157,5 +208,5 @@ Once configured, your OpenInference traces will be automatically sent to Phoenix
 
 <CardGroup>
   <Card title="Full Example" href="https://github.com/arconia-io/arconia-examples/tree/main/arconia-openinference" icon="github" horizontal description="Complete tracing example"/>
-  <Card title="OpenInference package" href="https://central.sonatype.com/artifact/com.arize/openinference-instrumentation-langchain4j" icon="box" horizontal description="OpenInference Java package"/>
+  <Card title="Arconia OpenInference Semantic Conventions (docs)" href="https://docs.arconia.io/arconia/latest/observability/semantic-conventions/openinference/" icon="box" horizontal description="Arconia OpenInference Semantic Conventions (docs)"/>
 </CardGroup>

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -267,7 +267,7 @@
 
 ### Java Frameworks
 
-- [Arconia Tracing](https://arize.com/docs/phoenix/integrations/java/arconia/arconia-tracing): Auto-instrument Arconia Java applications
+- [Arconia Tracing](https://arize.com/docs/phoenix/integrations/java/arconia/arconia-tracing): Auto-instrument Spring Boot and Spring AI applications
 - [LangChain4j Tracing](https://arize.com/docs/phoenix/integrations/java/langchain4j/langchain4j-tracing): Auto-instrument LangChain4j chains and agents
 - [Spring AI Tracing](https://arize.com/docs/phoenix/integrations/java/springai/springai-tracing): Auto-instrument Spring AI applications
 


### PR DESCRIPTION
* Use correct package name for the Arconia OpenInference support.
* Update the Arconia/Phoenix integration example with current configuration.
* Extend example with instruction for Maven, similar to existing Gradle instructions.