### PR TITLE
feat(db): make span insertion conflict policy configurable via PHOENIX_SPAN_ON_CONFLICT

### DIFF
--- a/docs/phoenix/self-hosting/configuration.mdx
+++ b/docs/phoenix/self-hosting/configuration.mdx
@@ -85,6 +85,8 @@ The following environment variables will control how your phoenix server runs.
 
 * **PHOENIX\_ALLOWED\_PROVIDERS:** A comma-separated, case-insensitive list of model provider names to display in the playground UI. When unset, all providers are shown. Set to `NONE` to hide all providers. Unrecognized provider names will cause a startup error. Supported values: `OPENAI`, `ANTHROPIC`, `AZURE_OPENAI`, `GOOGLE`, `DEEPSEEK`, `XAI`, `OLLAMA`, `AWS`, `CEREBRAS`, `FIREWORKS`, `GROQ`, `MOONSHOT`, `PERPLEXITY`, `TOGETHER`. Example: `PHOENIX_ALLOWED_PROVIDERS=OPENAI,ANTHROPIC`. Available since version 13.13.0.
 
+* **PHOENIX\_SPAN\_ON\_CONFLICT:** Conflict policy when inserting a span with a duplicate `span_id`. Accepts `do_nothing` (default; first-write-wins, subsequent inserts are silently ignored) or `do_update` (overwrite mutable columns such as name, end\_time, attributes, events, and status while preserving cumulative token and error counts). Use `do_update` to allow long-running clients to re-emit the same `span_id` for realtime mid-run visibility in the Phoenix UI.
+
 ### Logging
 
 * **PHOENIX\_LOG\_SQL:** Whether to log all SQL statements to stdout. Useful for debugging database queries. Defaults to `false`. Available since version 13.4.0.

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -34,6 +34,7 @@ from phoenix.utilities.logging import log_a_list
 from phoenix.utilities.re import parse_env_headers
 
 if TYPE_CHECKING:
+    from phoenix.db.insertion.helpers import OnConflict
     from phoenix.server.oauth2 import OAuth2Clients
 
 # Assignable roles (SYSTEM is internal-only and not included)
@@ -285,6 +286,20 @@ of memory. Adjust this value based on your system's available memory and expecte
 throughput.
 
 Defaults to 20000.
+"""
+ENV_PHOENIX_SPAN_ON_CONFLICT = "PHOENIX_SPAN_ON_CONFLICT"
+"""
+Conflict policy when inserting a span with a duplicate span_id.
+
+Allowed values (case-insensitive):
+- "do_nothing" (default): keep the first-written row; subsequent inserts are silently ignored.
+- "do_update": overwrite mutable columns (name, end_time, attributes, events, status, etc.)
+  on re-insert. Cumulative fields (cumulative_error_count,
+  cumulative_llm_token_count_prompt/completion) are preserved.
+
+The "do_update" mode enables clients to re-emit the same span_id periodically to provide
+realtime mid-run visibility for long-running spans (e.g. streaming agents). Phoenix UI will
+reflect the latest emission. The default preserves the historical first-write-wins behavior.
 """
 ENV_LOGGING_MODE = "PHOENIX_LOGGING_MODE"
 """
@@ -3032,6 +3047,22 @@ def get_env_max_spans_queue_size() -> int:
     return max_size
 
 
+def get_env_span_on_conflict() -> OnConflict:
+    """Resolve PHOENIX_SPAN_ON_CONFLICT env var to an OnConflict enum value."""
+    # Imported lazily to avoid a circular import (phoenix.db.helpers imports phoenix.config).
+    from phoenix.db.insertion.helpers import OnConflict
+
+    raw = os.environ.get(ENV_PHOENIX_SPAN_ON_CONFLICT, "do_nothing").strip().lower()
+    if raw == "do_nothing":
+        return OnConflict.DO_NOTHING
+    if raw == "do_update":
+        return OnConflict.DO_UPDATE
+    raise ValueError(
+        f"Invalid value for {ENV_PHOENIX_SPAN_ON_CONFLICT}: {raw!r}. "
+        "Expected 'do_nothing' or 'do_update'."
+    )
+
+
 def get_env_client_headers() -> dict[str, str]:
     headers = parse_env_headers(getenv(ENV_PHOENIX_CLIENT_HEADERS))
     if (api_key := get_env_phoenix_api_key()) and "authorization" not in [
@@ -3332,6 +3363,7 @@ def verify_server_environment_variables() -> None:
     get_env_database_usage_email_warning_threshold_percentage()
     get_env_database_usage_insertion_blocking_threshold_percentage()
     get_env_max_spans_queue_size()
+    get_env_span_on_conflict()
     validate_env_support_email()
     validate_env_allowed_providers()
 

--- a/src/phoenix/db/insertion/helpers.py
+++ b/src/phoenix/db/insertion/helpers.py
@@ -39,9 +39,15 @@ def insert_on_conflict(
     on_conflict: OnConflict = OnConflict.DO_UPDATE,
     set_: Optional[Mapping[str, Any]] = None,
     constraint_name: Optional[str] = None,
+    exclude_from_update: tuple[str, ...] = (),
 ) -> Insert:
     """
     Dialect specific insertion statement using ON CONFLICT DO syntax.
+
+    ``exclude_from_update`` lists additional column names that should be omitted from the SET
+    clause when ``on_conflict`` is :class:`OnConflict.DO_UPDATE`. Primary key columns and
+    ``created_at`` are always excluded; this parameter lets callers also protect cumulative or
+    otherwise non-overwritable fields. Ignored when ``set_`` is provided explicitly.
     """
     if on_conflict is OnConflict.DO_UPDATE:
         # postegresql rejects duplicate updates for the same record
@@ -61,7 +67,9 @@ def insert_on_conflict(
         if on_conflict is OnConflict.DO_UPDATE:
             return stmt_postgresql.on_conflict_do_update(
                 constraint=constraint,
-                set_=set_ if set_ else dict(_clean(stmt_postgresql.excluded.items())),
+                set_=set_
+                if set_
+                else dict(_clean(stmt_postgresql.excluded.items(), exclude_from_update)),
             )
         assert_never(on_conflict)
     if dialect is SupportedSQLDialect.SQLITE:
@@ -71,7 +79,9 @@ def insert_on_conflict(
         if on_conflict is OnConflict.DO_UPDATE:
             return stmt_sqlite.on_conflict_do_update(
                 unique_by,
-                set_=set_ if set_ else dict(_clean(stmt_sqlite.excluded.items())),
+                set_=set_
+                if set_
+                else dict(_clean(stmt_sqlite.excluded.items(), exclude_from_update)),
             )
         assert_never(on_conflict)
     assert_never(dialect)
@@ -79,9 +89,10 @@ def insert_on_conflict(
 
 def _clean(
     kv: Iterable[tuple[str, KeyedColumnElement[Any]]],
+    exclude: tuple[str, ...] = (),
 ) -> Iterator[tuple[str, KeyedColumnElement[Any]]]:
     for k, v in kv:
-        if v.primary_key or k == "created_at":
+        if v.primary_key or k == "created_at" or k in exclude:
             continue
         if k == "metadata_":
             yield "metadata", v

--- a/src/phoenix/db/insertion/span.py
+++ b/src/phoenix/db/insertion/span.py
@@ -5,6 +5,7 @@ from openinference.semconv.trace import SpanAttributes
 from sqlalchemy import func, insert, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from phoenix.config import get_env_span_on_conflict
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
@@ -140,6 +141,15 @@ async def insert_span(
         cumulative_error_count += cast(int, accumulation[0] or 0)
         cumulative_llm_token_count_prompt += cast(int, accumulation[1] or 0)
         cumulative_llm_token_count_completion += cast(int, accumulation[2] or 0)
+    on_conflict_policy = get_env_span_on_conflict()
+    # Under DO_UPDATE, a returned rowid does not distinguish between a fresh insert and an
+    # overwrite of an existing row. We therefore probe for the row up front so we can skip the
+    # ancestor cumulative propagation below on re-emits and avoid double-counting.
+    preexisting_span_rowid: Optional[int] = None
+    if on_conflict_policy is OnConflict.DO_UPDATE:
+        preexisting_span_rowid = await session.scalar(
+            select(models.Span.id).where(models.Span.span_id == span.context.span_id)
+        )
     span_rowid = await session.scalar(
         insert_on_conflict(
             dict(
@@ -163,11 +173,20 @@ async def insert_span(
             dialect=dialect,
             table=models.Span,
             unique_by=("span_id",),
-            on_conflict=OnConflict.DO_NOTHING,
+            on_conflict=on_conflict_policy,
+            exclude_from_update=(
+                "cumulative_error_count",
+                "cumulative_llm_token_count_prompt",
+                "cumulative_llm_token_count_completion",
+            ),
         ).returning(models.Span.id)
     )
     if span_rowid is None:
         return None
+    if preexisting_span_rowid is not None:
+        # Span already existed (DO_UPDATE re-emit). Cumulative ancestor propagation has already
+        # been applied on the original insert; running it again would double-count.
+        return SpanInsertionEvent(project_rowid, span_rowid, trace.id)
     # Propagate cumulative values to ancestors. This is usually a no-op, since
     # the parent usually arrives after the child. But in the event that a
     # child arrives after its parent, we need to make sure that all the

--- a/tests/unit/db/insertion/test_span.py
+++ b/tests/unit/db/insertion/test_span.py
@@ -1,0 +1,187 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from phoenix.db import models
+from phoenix.db.insertion.span import insert_span
+from phoenix.server.types import DbSessionFactory
+from phoenix.trace.schemas import (
+    Span,
+    SpanContext,
+    SpanKind,
+    SpanStatusCode,
+)
+
+
+def _make_span(
+    *,
+    trace_id: str,
+    span_id: str,
+    name: str = "span-name",
+    parent_id: str | None = None,
+    end_offset_seconds: float = 1.0,
+    status_code: SpanStatusCode = SpanStatusCode.OK,
+    attributes: dict | None = None,
+) -> Span:
+    start_time = datetime.now(timezone.utc)
+    return Span(
+        name=name,
+        context=SpanContext(trace_id=trace_id, span_id=span_id),
+        span_kind=SpanKind.CHAIN,
+        parent_id=parent_id,
+        start_time=start_time,
+        end_time=start_time + timedelta(seconds=end_offset_seconds),
+        status_code=status_code,
+        status_message="",
+        attributes=attributes if attributes is not None else {},
+        events=[],
+        conversation=None,
+    )
+
+
+class TestInsertSpanOnConflict:
+    async def test_first_insert_succeeds_under_do_nothing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db: DbSessionFactory,
+    ) -> None:
+        monkeypatch.setenv("PHOENIX_SPAN_ON_CONFLICT", "do_nothing")
+        span_a = _make_span(trace_id="trace-a", span_id="span-a", name="first")
+        span_b = _make_span(trace_id="trace-a", span_id="span-b", name="second")
+        async with db() as session:
+            event_a = await insert_span(session, span_a, project_name="default")
+            event_b = await insert_span(session, span_b, project_name="default")
+        assert event_a is not None
+        assert event_b is not None
+        async with db() as session:
+            rows = (
+                await session.scalars(
+                    select(models.Span).order_by(models.Span.span_id)
+                )
+            ).all()
+        assert [row.span_id for row in rows] == ["span-a", "span-b"]
+        assert [row.name for row in rows] == ["first", "second"]
+
+    async def test_duplicate_dropped_under_do_nothing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db: DbSessionFactory,
+    ) -> None:
+        monkeypatch.setenv("PHOENIX_SPAN_ON_CONFLICT", "do_nothing")
+        original = _make_span(
+            trace_id="trace-a",
+            span_id="span-x",
+            name="original",
+            attributes={"k": "original"},
+        )
+        async with db() as session:
+            first_event = await insert_span(session, original, project_name="default")
+        assert first_event is not None
+
+        duplicate = _make_span(
+            trace_id="trace-a",
+            span_id="span-x",
+            name="updated",
+            end_offset_seconds=5.0,
+            attributes={"k": "updated"},
+        )
+        async with db() as session:
+            second_event = await insert_span(session, duplicate, project_name="default")
+        # Under DO_NOTHING the duplicate insert is silently ignored; insert_span returns None.
+        assert second_event is None
+
+        async with db() as session:
+            row = (
+                await session.scalars(
+                    select(models.Span).where(models.Span.span_id == "span-x")
+                )
+            ).one()
+        assert row.name == "original"
+        assert row.attributes == {"k": "original"}
+        assert row.end_time == original.end_time
+
+    async def test_duplicate_overwrites_under_do_update(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db: DbSessionFactory,
+    ) -> None:
+        monkeypatch.setenv("PHOENIX_SPAN_ON_CONFLICT", "do_update")
+        original = _make_span(
+            trace_id="trace-a",
+            span_id="span-x",
+            name="original",
+            attributes={"k": "original"},
+        )
+        async with db() as session:
+            first_event = await insert_span(session, original, project_name="default")
+        assert first_event is not None
+
+        duplicate = _make_span(
+            trace_id="trace-a",
+            span_id="span-x",
+            name="updated",
+            end_offset_seconds=5.0,
+            attributes={"k": "updated"},
+        )
+        async with db() as session:
+            second_event = await insert_span(session, duplicate, project_name="default")
+        # Under DO_UPDATE the existing row's id is returned, so the event is non-None.
+        assert second_event is not None
+        assert second_event.span_rowid == first_event.span_rowid
+
+        async with db() as session:
+            row = (
+                await session.scalars(
+                    select(models.Span).where(models.Span.span_id == "span-x")
+                )
+            ).one()
+        assert row.name == "updated"
+        assert row.attributes == {"k": "updated"}
+        assert row.end_time == duplicate.end_time
+
+    async def test_cumulative_fields_preserved_under_do_update(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db: DbSessionFactory,
+    ) -> None:
+        monkeypatch.setenv("PHOENIX_SPAN_ON_CONFLICT", "do_update")
+        # Original span is in ERROR status so cumulative_error_count is seeded to 1.
+        original = _make_span(
+            trace_id="trace-a",
+            span_id="span-x",
+            name="original",
+            status_code=SpanStatusCode.ERROR,
+        )
+        async with db() as session:
+            assert await insert_span(session, original, project_name="default") is not None
+
+        async with db() as session:
+            row = (
+                await session.scalars(
+                    select(models.Span).where(models.Span.span_id == "span-x")
+                )
+            ).one()
+        original_cumulative_error_count = row.cumulative_error_count
+        assert original_cumulative_error_count == 1
+
+        # Re-emit with status_code=OK. The mutable status_code column must be overwritten, but
+        # cumulative_error_count must remain preserved at its earlier value.
+        updated = _make_span(
+            trace_id="trace-a",
+            span_id="span-x",
+            name="updated",
+            status_code=SpanStatusCode.OK,
+        )
+        async with db() as session:
+            assert await insert_span(session, updated, project_name="default") is not None
+
+        async with db() as session:
+            row = (
+                await session.scalars(
+                    select(models.Span).where(models.Span.span_id == "span-x")
+                )
+            ).one()
+        assert row.status_code == SpanStatusCode.OK.value
+        assert row.name == "updated"
+        assert row.cumulative_error_count == original_cumulative_error_count


### PR DESCRIPTION
## Summary

Currently `src/phoenix/db/insertion/span.py:166` hardcodes `on_conflict=OnConflict.DO_NOTHING`, so any retransmission of a span with the same `span_id` is silently dropped. This PR adds an opt-in env var `PHOENIX_SPAN_ON_CONFLICT=do_update` that switches the policy to upsert (the already-implemented `OnConflict.DO_UPDATE` path in `helpers.py`). Default remains `do_nothing` — zero behavior change for existing users.

## Motivation

Long-running streaming/agent spans (e.g. an async generator that yields chunks for tens of seconds) are not visible in Phoenix UI until they end, because the root span is exported only on `.end()`. We want clients to be able to re-emit the same `span_id` periodically with an updated `end_time`/`attributes`/`status` so the UI reflects in-flight progress.

Pattern in client code (separate, not part of this PR):

```python
class SnapshotSpanProcessor(SpanProcessor):
    # on_start: register live span
    # on_end:   pop from registry
    # tick():   for each live span, build a ReadableSpan with the same span_id
    #           and end_time=now_ns(), then exporter.export([snapshot])
```

This is meaningless without backend upsert. The PR enables that backend option.

## What changes

| File | Change |
|---|---|
| `src/phoenix/config.py` | New `ENV_PHOENIX_SPAN_ON_CONFLICT` constant + `get_env_span_on_conflict()` accessor (function-local import to avoid circular). Called in `verify_server_environment_variables()` for fail-fast validation. |
| `src/phoenix/db/insertion/helpers.py` | New `exclude_from_update: tuple[str, ...] = ()` kwarg on `insert_on_conflict()` and `exclude` on `_clean()`. Lets callers protect specific columns from being overwritten under `DO_UPDATE`. Backward-compatible (default is empty). |
| `src/phoenix/db/insertion/span.py` | Calls `get_env_span_on_conflict()` instead of hardcoded value. Passes `exclude_from_update=("cumulative_error_count", "cumulative_llm_token_count_prompt", "cumulative_llm_token_count_completion")` so re-emits do not overwrite values that the server-side accumulates from child spans. Also adds a pre-insert existence check gated to `DO_UPDATE` mode so ancestor cumulative propagation does not double-count on re-emit. |
| `tests/unit/db/insertion/test_span.py` (new) | 4 cases: first-insert under do_nothing, duplicate dropped under do_nothing, duplicate overwrites under do_update, cumulative fields preserved under do_update. |
| `docs/phoenix/self-hosting/configuration.mdx` | Bullet for the new env var. |

## Safety

- **Default value is `do_nothing`** — no user sees a behavior change unless they explicitly set `PHOENIX_SPAN_ON_CONFLICT=do_update`.
- **Cumulative fields are protected** from re-emit clobber via `exclude_from_update`. A naive "just flip to DO_UPDATE" would silently regress these aggregates if a snapshot arrives after a final BSP export.
- **Ancestor propagation guarded** — the existing code at `insert_span` propagates this span's cumulative counters to ancestors on a fresh insert. Under DO_UPDATE without a guard, that block would run on every re-emit and double-count. A pre-insert SELECT detects pre-existence and skips the propagation in that case.
- **Validation at startup** — `verify_server_environment_variables()` calls the accessor, so a typo in the env var (e.g. `do_updte`) fails immediately at boot instead of at first span insert.

## Tests

```bash
tox run -e unit_tests
# or for postgres:
tox run -e unit_tests -- --run-postgres
```

The new tests use `monkeypatch.setenv("PHOENIX_SPAN_ON_CONFLICT", "do_update")` to flip the mode per-test.

## Out of scope (follow-up)

- Per-table (not just spans) conflict policy. This PR scopes to spans only.
- gRPC-side hint to clients (e.g. response header) indicating server supports upsert.
- A parent+child cumulative test variant — covered by the protection logic but not exhaustively asserted; happy to add if reviewer requests.

## Issue / discussion

I did not open an issue first per `CONTRIBUTING.md`. If maintainers prefer that workflow, I can mark this PR as draft, open a feature-request issue with the same content above, and link back. Happy to do whichever you prefer.

## Reference implementation (client side)

We have a `SnapshotSpanProcessor` running against a forked Phoenix with this patch applied. Verified end-to-end against a 30s streaming agent span: latency value in Phoenix UI grew 3s -> 6s -> ... -> 30s mid-run, then settled at the real end_time after final BSP export. Same `(trace_id, span_id)` throughout, no duplicate rows.
