### PR TITLE
fix: stream PXI server tool ownership

### DIFF
--- a/app/src/agent/chat/__tests__/advertisedTools.test.ts
+++ b/app/src/agent/chat/__tests__/advertisedTools.test.ts
@@ -1,0 +1,41 @@
+import {
+  getServerExecutedToolNames,
+  parseAgentAdvertisedToolsData,
+} from "@phoenix/agent/chat/advertisedTools";
+
+describe("advertisedTools", () => {
+  it("parses advertised tool ownership data", () => {
+    const data = parseAgentAdvertisedToolsData({
+      tools: [
+        { name: "bash", execution: "browser", family: "external" },
+        {
+          name: "query_docs_filesystem_phoenix",
+          execution: "server",
+          family: "docs",
+        },
+      ],
+    });
+
+    expect(data).toEqual({
+      tools: [
+        { name: "bash", execution: "browser", family: "external" },
+        {
+          name: "query_docs_filesystem_phoenix",
+          execution: "server",
+          family: "docs",
+        },
+      ],
+    });
+    expect(getServerExecutedToolNames(data!)).toEqual(
+      new Set(["query_docs_filesystem_phoenix"])
+    );
+  });
+
+  it("rejects malformed advertised tool data", () => {
+    expect(
+      parseAgentAdvertisedToolsData({
+        tools: [{ name: "search_phoenix", execution: "elsewhere" }],
+      })
+    ).toBeNull();
+  });
+});

--- a/app/src/agent/chat/advertisedTools.ts
+++ b/app/src/agent/chat/advertisedTools.ts
@@ -1,0 +1,86 @@
+import type { DataUIPart } from "ai";
+
+export const AGENT_ADVERTISED_TOOLS_DATA_TYPE = "data-agent-advertised-tools";
+
+export type AgentAdvertisedTool = {
+  name: string;
+  execution: "browser" | "server";
+  family?: string | null;
+};
+
+export type AgentAdvertisedToolsData = {
+  tools: AgentAdvertisedTool[];
+};
+
+export type AgentChatDataParts = {
+  "agent-advertised-tools": AgentAdvertisedToolsData;
+};
+
+export function parseAgentAdvertisedToolsDataPart(
+  part: DataUIPart<AgentChatDataParts>
+): AgentAdvertisedToolsData | null {
+  if (part.type !== AGENT_ADVERTISED_TOOLS_DATA_TYPE) {
+    return null;
+  }
+  return parseAgentAdvertisedToolsData(part.data);
+}
+
+export function parseAgentAdvertisedToolsData(
+  data: unknown
+): AgentAdvertisedToolsData | null {
+  if (typeof data !== "object" || data === null || !("tools" in data)) {
+    return null;
+  }
+  const tools = (data as { tools?: unknown }).tools;
+  if (!Array.isArray(tools)) {
+    return null;
+  }
+  const parsedTools: AgentAdvertisedTool[] = [];
+  for (const tool of tools) {
+    const parsedTool = parseAgentAdvertisedTool(tool);
+    if (parsedTool == null) {
+      return null;
+    }
+    parsedTools.push(parsedTool);
+  }
+  return { tools: parsedTools };
+}
+
+export function getServerExecutedToolNames(
+  data: AgentAdvertisedToolsData
+): Set<string> {
+  return new Set(
+    data.tools
+      .filter((tool) => tool.execution === "server")
+      .map((tool) => tool.name)
+  );
+}
+
+function parseAgentAdvertisedTool(input: unknown): AgentAdvertisedTool | null {
+  if (typeof input !== "object" || input === null) {
+    return null;
+  }
+  const candidate = input as {
+    name?: unknown;
+    execution?: unknown;
+    family?: unknown;
+  };
+  if (typeof candidate.name !== "string") {
+    return null;
+  }
+  if (candidate.execution !== "browser" && candidate.execution !== "server") {
+    return null;
+  }
+  if (
+    candidate.family !== undefined &&
+    candidate.family !== null &&
+    typeof candidate.family !== "string"
+  ) {
+    return null;
+  }
+  return {
+    name: candidate.name,
+    execution: candidate.execution,
+    ...(candidate.family !== undefined ? { family: candidate.family } : {}),
+  };
+}

--- a/app/src/agent/chat/handleAgentToolCall.ts
+++ b/app/src/agent/chat/handleAgentToolCall.ts
@@ -18,6 +18,7 @@ type HandleAgentToolCallOptions = {
   toolCall: AgentToolCall;
   sessionId: string | null;
   addToolOutput: AddToolOutput;
+  serverExecutedToolNames?: ReadonlySet<string>;
   /**
    * The agent store instance, needed by tools that interact with shared UI
    * state (e.g. the elicit tool sets a pending elicitation).
@@ -32,12 +33,14 @@ export async function handleAgentToolCall({
   toolCall,
   sessionId,
   addToolOutput,
+  serverExecutedToolNames,
   agentStore,
 }: HandleAgentToolCallOptions) {
   await handleRegisteredAgentToolCall({
     toolCall,
     sessionId,
     addToolOutput,
+    serverExecutedToolNames,
     agentStore,
   });
 }

--- a/app/src/agent/chat/types.ts
+++ b/app/src/agent/chat/types.ts
@@ -1,5 +1,6 @@
 import type { UIMessage } from "ai";
 
+import type { AgentChatDataParts } from "@phoenix/agent/chat/advertisedTools";
 import type { components } from "@phoenix/api/__generated__/v1";
 
 /**
@@ -7,5 +8,6 @@ import type { components } from "@phoenix/api/__generated__/v1";
  * metadata shape, sourced from the generated OpenAPI types.
  */
 export type AgentUIMessage = UIMessage<
-  components["schemas"]["AssistantMessageMetadata"]
+  components["schemas"]["AssistantMessageMetadata"],
+  AgentChatDataParts
 >;

--- a/app/src/agent/extensions/__tests__/toolRegistry.test.ts
+++ b/app/src/agent/extensions/__tests__/toolRegistry.test.ts
@@ -40,6 +40,25 @@ describe("toolRegistry", () => {
     );
   });
 
+  it("ignores server-executed tools advertised by the chat stream", async () => {
+    const store = createAgentStore();
+    const addToolOutput = vi.fn().mockResolvedValue(undefined);
+
+    await handleRegisteredAgentToolCall({
+      toolCall: {
+        toolCallId: "tool-call-server",
+        toolName: "query_docs_filesystem_phoenix",
+        input: { command: 'rg -il "datasets" /' },
+      },
+      sessionId: "session-1",
+      addToolOutput,
+      agentStore: store,
+      serverExecutedToolNames: new Set(["query_docs_filesystem_phoenix"]),
+    });
+
+    expect(addToolOutput).not.toHaveBeenCalled();
+  });
+
   it("returns an error output for invalid tool input", async () => {
     const store = createAgentStore();
     const addToolOutput = vi.fn().mockResolvedValue(undefined);

--- a/app/src/agent/extensions/toolRegistry.ts
+++ b/app/src/agent/extensions/toolRegistry.ts
@@ -473,15 +473,20 @@ export async function handleRegisteredAgentToolCall({
   sessionId,
   addToolOutput,
   agentStore,
+  serverExecutedToolNames,
 }: {
   toolCall: AgentToolCall;
   sessionId: string | null;
   addToolOutput: AddToolOutput;
   agentStore: AgentStore;
+  serverExecutedToolNames?: ReadonlySet<string>;
 }) {
   const registeredTool = agentToolRegistryByName.get(toolCall.toolName);
 
   if (!registeredTool) {
+    if (serverExecutedToolNames?.has(toolCall.toolName)) {
+      return;
+    }
     await addToolOutput({
       state: "output-error",
       tool: toolCall.toolName,

--- a/app/src/agent/tools/docs/docsToolTypes.ts
+++ b/app/src/agent/tools/docs/docsToolTypes.ts
@@ -13,6 +13,13 @@ export type DocsGetPageInput = {
 };
 
 /**
+ * Input shape for the query_docs_filesystem_phoenix tool.
+ */
+export type DocsFilesystemQueryInput = {
+  command: string;
+};
+
+/**
  * Output from docs tools is a string (the search results or page content).
  * The MCP server returns text content.
  */
@@ -21,7 +28,11 @@ export type DocsToolOutput = string;
 /**
  * Names of backend docs tools. Used for rendering dispatch.
  */
-export const DOCS_TOOL_NAMES = ["search_phoenix", "get_page_phoenix"] as const;
+export const DOCS_TOOL_NAMES = [
+  "search_phoenix",
+  "get_page_phoenix",
+  "query_docs_filesystem_phoenix",
+] as const;
 export type DocsToolName = (typeof DOCS_TOOL_NAMES)[number];
 
 export function isDocsToolName(name: string): name is DocsToolName {
@@ -54,6 +65,23 @@ export function parseDocsGetPageInput(input: unknown): DocsGetPageInput | null {
     typeof (input as Record<string, unknown>).page === "string"
   ) {
     return input as DocsGetPageInput;
+  }
+  return null;
+}
+
+/**
+ * Parse the query_docs_filesystem_phoenix tool input from the raw AI SDK part input.
+ */
+export function parseDocsFilesystemQueryInput(
+  input: unknown
+): DocsFilesystemQueryInput | null {
+  if (
+    typeof input === "object" &&
+    input !== null &&
+    "command" in input &&
+    typeof (input as Record<string, unknown>).command === "string"
+  ) {
+    return input as DocsFilesystemQueryInput;
   }
   return null;
 }

--- a/app/src/agent/tools/docs/index.ts
+++ b/app/src/agent/tools/docs/index.ts
@@ -1,10 +1,12 @@
 export {
   DOCS_TOOL_NAMES,
   isDocsToolName,
+  parseDocsFilesystemQueryInput,
   parseDocsGetPageInput,
   parseDocsSearchInput,
 } from "./docsToolTypes";
 export type {
+  DocsFilesystemQueryInput,
   DocsGetPageInput,
   DocsSearchInput,
   DocsToolName,

--- a/app/src/components/agent/DocsToolDetails.tsx
+++ b/app/src/components/agent/DocsToolDetails.tsx
@@ -2,6 +2,7 @@ import { getToolName } from "ai";
 
 import {
   isDocsToolName,
+  parseDocsFilesystemQueryInput,
   parseDocsGetPageInput,
   parseDocsSearchInput,
 } from "@phoenix/agent/tools/docs";
@@ -24,6 +25,10 @@ export function getDocsToolPreview(part: ToolInvocationPart): string {
     const input = parseDocsSearchInput(part.input);
     return input ? `Searching: ${input.query}` : "";
   }
+  if (toolName === "query_docs_filesystem_phoenix") {
+    const input = parseDocsFilesystemQueryInput(part.input);
+    return input ? `Querying: ${input.command}` : "";
+  }
   if (toolName === "get_page_phoenix") {
     const input = parseDocsGetPageInput(part.input);
     return input ? `Fetching: ${input.page}` : "";
@@ -41,6 +46,9 @@ export function formatDocsToolState(
   const toolName = getToolName(part);
   switch (state) {
     case "input-streaming":
+      if (toolName === "query_docs_filesystem_phoenix") {
+        return "Querying…";
+      }
       return toolName === "get_page_phoenix" ? "Fetching…" : "Searching…";
     case "input-available":
       return "Running…";
@@ -60,9 +68,14 @@ export function formatDocsToolState(
 export function DocsToolDetails({ part }: { part: ToolInvocationPart }) {
   const toolName = getToolName(part);
   const isSearch = toolName === "search_phoenix";
+  const isFilesystemQuery = toolName === "query_docs_filesystem_phoenix";
 
-  const inputLabel = isSearch ? "Query" : "Page";
-  const inputText = getInputText(part, isSearch);
+  const inputLabel = isSearch
+    ? "Query"
+    : isFilesystemQuery
+      ? "Command"
+      : "Page";
+  const inputText = getInputText(part, toolName);
   const outputText = getOutputText(part);
 
   return (
@@ -71,7 +84,9 @@ export function DocsToolDetails({ part }: { part: ToolInvocationPart }) {
       <ToolPartCodeBlock>{inputText}</ToolPartCodeBlock>
       {part.state === "output-available" ? (
         <>
-          <ToolPartLabel>{isSearch ? "Results" : "Content"}</ToolPartLabel>
+          <ToolPartLabel>
+            {isSearch ? "Results" : isFilesystemQuery ? "Output" : "Content"}
+          </ToolPartLabel>
           <ToolPartCodeBlock>{outputText || "(no output)"}</ToolPartCodeBlock>
         </>
       ) : null}
@@ -95,10 +110,14 @@ export { isDocsToolName };
 // Helpers
 // ---------------------------------------------------------------------------
 
-function getInputText(part: ToolInvocationPart, isSearch: boolean): string {
-  if (isSearch) {
+function getInputText(part: ToolInvocationPart, toolName: string): string {
+  if (toolName === "search_phoenix") {
     const input = parseDocsSearchInput(part.input);
     return input?.query ?? stringifyToolValue(part.input);
+  }
+  if (toolName === "query_docs_filesystem_phoenix") {
+    const input = parseDocsFilesystemQueryInput(part.input);
+    return input?.command ?? stringifyToolValue(part.input);
   }
   const input = parseDocsGetPageInput(part.input);
   return input?.page ?? stringifyToolValue(part.input);

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -3,6 +3,10 @@ import type { ChatStatus } from "ai";
 import { DefaultChatTransport, isToolUIPart } from "ai";
 import { useEffect, useRef } from "react";
 
+import {
+  getServerExecutedToolNames,
+  parseAgentAdvertisedToolsDataPart,
+} from "@phoenix/agent/chat/advertisedTools";
 import { buildAgentChatRequestBody } from "@phoenix/agent/chat/buildAgentChatRequestBody";
 import { handleAgentToolCall } from "@phoenix/agent/chat/handleAgentToolCall";
 import { getUnresolvedToolCalls } from "@phoenix/agent/chat/interruptToolCalls";
@@ -66,6 +70,7 @@ export function useAgentChat({
   // next send/summary without rebuilding the Chat.
   const modelSelectionRef = useRef(modelSelection);
   modelSelectionRef.current = modelSelection;
+  const serverExecutedToolNamesRef = useRef<ReadonlySet<string>>(new Set());
 
   // Resolve the imperative runtime instance for this session/model pair. The
   // runtime owns replacement semantics when the transport changes, while the
@@ -93,22 +98,25 @@ export function useAgentChat({
                   messages,
                   trigger,
                   messageId,
-                }) => ({
-                  body: buildAgentChatRequestBody({
-                    body,
-                    id,
-                    messages,
-                    trigger,
-                    messageId,
-                    capabilities: store.getState().capabilities,
-                    observability: store.getState().observability,
-                    hasRemoteCollector: Boolean(
-                      store.getState().agentsConfig.collectorEndpoint
-                    ),
-                    contexts: selectActiveContexts(store.getState()),
-                    modelSelection: modelSelectionRef.current,
-                  }),
-                }),
+                }) => {
+                  serverExecutedToolNamesRef.current = new Set();
+                  return {
+                    body: buildAgentChatRequestBody({
+                      body,
+                      id,
+                      messages,
+                      trigger,
+                      messageId,
+                      capabilities: store.getState().capabilities,
+                      observability: store.getState().observability,
+                      hasRemoteCollector: Boolean(
+                        store.getState().agentsConfig.collectorEndpoint
+                      ),
+                      contexts: selectActiveContexts(store.getState()),
+                      modelSelection: modelSelectionRef.current,
+                    }),
+                  };
+                },
               }),
               // Tool execution must target the runtime-owned chat instance so
               // tool outputs continue to attach to the correct conversation
@@ -118,8 +126,17 @@ export function useAgentChat({
                   toolCall,
                   sessionId,
                   addToolOutput: chat.addToolOutput,
+                  serverExecutedToolNames: serverExecutedToolNamesRef.current,
                   agentStore: store,
                 });
+              },
+              onData: (part) => {
+                const advertisedTools = parseAgentAdvertisedToolsDataPart(part);
+                if (advertisedTools == null) {
+                  return;
+                }
+                serverExecutedToolNamesRef.current =
+                  getServerExecutedToolNames(advertisedTools);
               },
               sendAutomaticallyWhen: shouldSendAutomaticallyAfterToolOutput,
               onFinish: ({ messages: finalMessages, message }) => {

--- a/src/phoenix/server/agents/advertised_tools.py
+++ b/src/phoenix/server/agents/advertised_tools.py
@@ -1,0 +1,51 @@
+"""Resolve the PXI tools advertised for a chat turn."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from phoenix.server.agents.dependencies import ChatDependencies
+from phoenix.server.agents.toolsets.external import build_external_tool_definitions
+
+
+class AgentAdvertisedTool(BaseModel):
+    """Tool name and execution owner advertised to the browser."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str
+    execution: Literal["browser", "server"]
+    family: str | None = None
+
+
+class AgentAdvertisedToolsData(BaseModel):
+    """Data chunk payload sent before PXI tool calls stream."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    tools: list[AgentAdvertisedTool]
+
+
+async def resolve_advertised_tools(deps: ChatDependencies) -> list[AgentAdvertisedTool]:
+    """Resolve the tool ownership manifest for one chat request."""
+    tools = [
+        AgentAdvertisedTool(
+            name=tool_definition.name,
+            execution="browser",
+            family="external",
+        )
+        for tool_definition in build_external_tool_definitions(deps)
+    ]
+    if deps.docs_mcp_toolset is not None:
+        tool_prefix = deps.docs_mcp_toolset.tool_prefix
+        tools.extend(
+            AgentAdvertisedTool(
+                name=f"{tool_prefix}_{tool.name}" if tool_prefix else tool.name,
+                execution="server",
+                family="docs",
+            )
+            for tool in await deps.docs_mcp_toolset.list_tools()
+        )
+    return tools

--- a/src/phoenix/server/agents/prompts.py
+++ b/src/phoenix/server/agents/prompts.py
@@ -20,11 +20,21 @@ _DOCS_TOOL_SYSTEM_PROMPT_LINES = (
     ),
     "  <when_to_use>You need detailed information from a known docs page.</when_to_use>",
     "</tool>",
+    '<tool name="query_docs_filesystem_phoenix">',
+    (
+        "  <description>Run a read-only shell-like query against the Phoenix "
+        "documentation filesystem.</description>"
+    ),
+    (
+        "  <when_to_use>You need to inspect docs files or OpenAPI specs with "
+        "commands such as `rg`, `tree`, or `head`.</when_to_use>"
+    ),
+    "</tool>",
     "<documentation_usage>",
     (
         "  Use the documentation tools proactively when answering questions about Phoenix. "
-        "Search first, then fetch specific pages if needed for deeper detail. Always cite "
-        "the documentation when providing answers based on search results."
+        "Search first, then fetch specific pages or query docs files if needed for deeper "
+        "detail. Always cite the documentation when providing answers based on search results."
     ),
     "</documentation_usage>",
 )

--- a/src/phoenix/server/agents/toolsets/external/__init__.py
+++ b/src/phoenix/server/agents/toolsets/external/__init__.py
@@ -17,6 +17,11 @@ from phoenix.server.agents.toolsets.external.tools import (
 
 def build_external_toolset(deps: ChatDependencies) -> ExternalToolset[ChatDependencies]:
     """Build the browser-deferred external toolset gated on request context."""
+    return ExternalToolset(build_external_tool_definitions(deps))
+
+
+def build_external_tool_definitions(deps: ChatDependencies) -> list[ToolDefinition]:
+    """Build the browser-deferred external tool definitions for this request."""
     tools: list[ToolDefinition] = [
         BASH_TOOL_DEFINITION,
         ASK_USER_TOOL_DEFINITION,
@@ -34,7 +39,7 @@ def build_external_toolset(deps: ChatDependencies) -> ExternalToolset[ChatDepend
                 EDIT_PROMPT_TOOL_DEFINITION,
             ]
         )
-    return ExternalToolset(tools)
+    return tools
 
 
-__all__ = ["build_external_toolset"]
+__all__ = ["build_external_tool_definitions", "build_external_toolset"]

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -18,7 +18,7 @@ from pydantic_ai.ui.vercel_ai.request_types import (
     SubmitMessage,
     UIMessage,
 )
-from pydantic_ai.ui.vercel_ai.response_types import BaseChunk, MessageMetadataChunk
+from pydantic_ai.ui.vercel_ai.response_types import BaseChunk, DataChunk, MessageMetadataChunk
 from sqlalchemy import Insert, func, select
 from sqlalchemy.dialects.postgresql import insert as insert_postgresql
 from sqlalchemy.dialects.sqlite import insert as insert_sqlite
@@ -31,6 +31,10 @@ from phoenix.config import get_env_phoenix_agents_assistant_project_name
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
+from phoenix.server.agents.advertised_tools import (
+    AgentAdvertisedToolsData,
+    resolve_advertised_tools,
+)
 from phoenix.server.agents.agent_factory import build_agent
 from phoenix.server.agents.capabilities import AgentCapabilities
 from phoenix.server.agents.context import (
@@ -171,6 +175,7 @@ class _SummarizeResponse(BaseModel):
 logger = logging.getLogger(__name__)
 
 _ASSISTANT_AGENT_ID = "assistant"
+_ADVERTISED_TOOLS_DATA_CHUNK_TYPE = "data-agent-advertised-tools"
 
 
 def _log_run_complete(result: AgentRunResult[Any]) -> None:
@@ -179,6 +184,17 @@ def _log_run_complete(result: AgentRunResult[Any]) -> None:
     logger.info("agent run complete: %d messages", len(messages))
     for message in messages:
         logger.info("%s", message)
+
+
+async def _build_advertised_tools_chunk(deps: ChatDependencies) -> DataChunk:
+    """Build the first stream chunk that tells the browser which tools are server-owned."""
+    return DataChunk(
+        type=_ADVERTISED_TOOLS_DATA_CHUNK_TYPE,
+        data=AgentAdvertisedToolsData(tools=await resolve_advertised_tools(deps)).model_dump(
+            mode="json", by_alias=True
+        ),
+        transient=True,
+    )
 
 
 class _AgentSpanContextRecorder(SpanProcessor):
@@ -434,6 +450,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         async def _stream_with_session() -> AsyncIterator[BaseChunk]:
             try:
                 with using_session(session_id=session_id):
+                    yield await _build_advertised_tools_chunk(deps)
                     async for chunk in adapter.run_stream(deps=deps, on_complete=_on_complete):
                         yield chunk
             finally:

--- a/tests/unit/server/agents/test_advertised_tools.py
+++ b/tests/unit/server/agents/test_advertised_tools.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+
+from phoenix.server.agents.advertised_tools import resolve_advertised_tools
+from phoenix.server.agents.capabilities import AgentCapabilities
+from phoenix.server.agents.context import ProjectContext, ResolvedContexts
+from phoenix.server.agents.dependencies import ChatDependencies
+
+
+class _DocsToolset:
+    tool_prefix = ""
+
+    async def list_tools(self) -> list[SimpleNamespace]:
+        return [
+            SimpleNamespace(name="search_phoenix"),
+            SimpleNamespace(name="query_docs_filesystem_phoenix"),
+        ]
+
+
+def test_resolve_advertised_tools_marks_docs_tools_as_server_executed() -> None:
+    deps = ChatDependencies(
+        contexts=ResolvedContexts(
+            project=ProjectContext(
+                type="project",
+                projectNodeId="UHJvamVjdDox",
+                spanFilter="",
+                rootSpansOnly=False,
+            )
+        ),
+        capabilities=AgentCapabilities(),
+        docs_mcp_toolset=cast(Any, _DocsToolset()),
+    )
+
+    tools = asyncio.run(resolve_advertised_tools(deps))
+
+    tools_by_name = {tool.name: tool for tool in tools}
+    assert tools_by_name["bash"].execution == "browser"
+    assert tools_by_name["set_spans_filter"].execution == "browser"
+    assert tools_by_name["search_phoenix"].execution == "server"
+    assert tools_by_name["query_docs_filesystem_phoenix"].execution == "server"
+    assert tools_by_name["query_docs_filesystem_phoenix"].family == "docs"


### PR DESCRIPTION
## Summary
- stream a transient advertised-tool ownership manifest before PXI tool chunks
- use the server-provided manifest to no-op browser dispatch for server-executed tools
- add docs filesystem tool rendering/prompt support while keeping get_page rendering compatibility

## Validation
- pnpm --dir app test src/agent/extensions/__tests__/toolRegistry.test.ts src/agent/chat/__tests__/advertisedTools.test.ts
- make typecheck-frontend
- uv run ruff check src/phoenix/server/agents/advertised_tools.py src/phoenix/server/agents/toolsets/external/__init__.py src/phoenix/server/api/routers/agents.py src/phoenix/server/agents/prompts.py tests/unit/server/agents/test_advertised_tools.py
- uv run python -m py_compile src/phoenix/server/agents/advertised_tools.py src/phoenix/server/agents/toolsets/external/__init__.py src/phoenix/server/api/routers/agents.py src/phoenix/server/agents/prompts.py tests/unit/server/agents/test_advertised_tools.py
- git diff --check
- live Mintlify manifest check resolved search_phoenix and query_docs_filesystem_phoenix as server-executed

## Notes
- `uv run pytest tests/unit/server/agents/test_advertised_tools.py -q` could not collect locally because the repo test conftest imports psycopg and local libpq is unavailable. The advertised-tools helper was checked directly with the same assertions.

Related issue: N/A