### PR TITLE
fix(agents): align PXI docs tool dispatch

### DIFF
--- a/app/src/agent/chat/__tests__/handleAgentToolCall.test.ts
+++ b/app/src/agent/chat/__tests__/handleAgentToolCall.test.ts
@@ -1,0 +1,26 @@
+import { handleAgentToolCall } from "@phoenix/agent/chat/handleAgentToolCall";
+import { createAgentStore } from "@phoenix/store/agentStore";
+
+describe("handleAgentToolCall", () => {
+  beforeEach(() => {
+    localStorage.removeItem("arize-phoenix-agent");
+  });
+
+  it("does not dispatch server-executed tools through the frontend registry", async () => {
+    const agentStore = createAgentStore();
+    const addToolOutput = vi.fn().mockResolvedValue(undefined);
+
+    await handleAgentToolCall({
+      toolCall: {
+        toolCallId: "tool-call-1",
+        toolName: "search_phoenix",
+        input: { query: "traces" },
+      },
+      sessionId: "session-1",
+      addToolOutput,
+      agentStore,
+    });
+
+    expect(addToolOutput).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/agent/chat/handleAgentToolCall.ts
+++ b/app/src/agent/chat/handleAgentToolCall.ts
@@ -9,6 +9,7 @@ import {
   handleRegisteredAgentToolCall,
   type AgentToolCall,
 } from "@phoenix/agent/extensions/toolRegistry";
+import { isServerExecutedAgentToolName } from "@phoenix/agent/tools/serverToolTypes";
 import type { AgentStore } from "@phoenix/store/agentStore";
 
 type AddToolOutput = Chat<UIMessage>["addToolOutput"];
@@ -34,6 +35,9 @@ export async function handleAgentToolCall({
   addToolOutput,
   agentStore,
 }: HandleAgentToolCallOptions) {
+  if (isServerExecutedAgentToolName(toolCall.toolName)) {
+    return;
+  }
   await handleRegisteredAgentToolCall({
     toolCall,
     sessionId,

--- a/app/src/agent/tools/docs/docsToolTypes.ts
+++ b/app/src/agent/tools/docs/docsToolTypes.ts
@@ -6,10 +6,10 @@ export type DocsSearchInput = {
 };
 
 /**
- * Input shape for the get_page_phoenix tool.
+ * Input shape for the query_docs_filesystem_phoenix tool.
  */
-export type DocsGetPageInput = {
-  page: string;
+export type DocsFilesystemQueryInput = {
+  command: string;
 };
 
 /**
@@ -21,7 +21,10 @@ export type DocsToolOutput = string;
 /**
  * Names of backend docs tools. Used for rendering dispatch.
  */
-export const DOCS_TOOL_NAMES = ["search_phoenix", "get_page_phoenix"] as const;
+export const DOCS_TOOL_NAMES = [
+  "search_phoenix",
+  "query_docs_filesystem_phoenix",
+] as const;
 export type DocsToolName = (typeof DOCS_TOOL_NAMES)[number];
 
 export function isDocsToolName(name: string): name is DocsToolName {
@@ -44,16 +47,18 @@ export function parseDocsSearchInput(input: unknown): DocsSearchInput | null {
 }
 
 /**
- * Parse the get_page_phoenix tool input from the raw AI SDK part input.
+ * Parse the query_docs_filesystem_phoenix tool input from the raw AI SDK part input.
  */
-export function parseDocsGetPageInput(input: unknown): DocsGetPageInput | null {
+export function parseDocsFilesystemQueryInput(
+  input: unknown
+): DocsFilesystemQueryInput | null {
   if (
     typeof input === "object" &&
     input !== null &&
-    "page" in input &&
-    typeof (input as Record<string, unknown>).page === "string"
+    "command" in input &&
+    typeof (input as Record<string, unknown>).command === "string"
   ) {
-    return input as DocsGetPageInput;
+    return input as DocsFilesystemQueryInput;
   }
   return null;
 }

--- a/app/src/agent/tools/docs/index.ts
+++ b/app/src/agent/tools/docs/index.ts
@@ -1,11 +1,11 @@
 export {
   DOCS_TOOL_NAMES,
   isDocsToolName,
-  parseDocsGetPageInput,
+  parseDocsFilesystemQueryInput,
   parseDocsSearchInput,
 } from "./docsToolTypes";
 export type {
-  DocsGetPageInput,
+  DocsFilesystemQueryInput,
   DocsSearchInput,
   DocsToolName,
   DocsToolOutput,

--- a/app/src/agent/tools/serverToolTypes.ts
+++ b/app/src/agent/tools/serverToolTypes.ts
@@ -1,0 +1,16 @@
+import { DOCS_TOOL_NAMES } from "@phoenix/agent/tools/docs";
+
+/**
+ * Server-executed tools are model-facing tools that the frontend may render,
+ * but must not dispatch through the browser-owned tool registry.
+ */
+export const SERVER_EXECUTED_AGENT_TOOL_NAMES = [...DOCS_TOOL_NAMES] as const;
+
+export type ServerExecutedAgentToolName =
+  (typeof SERVER_EXECUTED_AGENT_TOOL_NAMES)[number];
+
+export function isServerExecutedAgentToolName(
+  name: string
+): name is ServerExecutedAgentToolName {
+  return (SERVER_EXECUTED_AGENT_TOOL_NAMES as readonly string[]).includes(name);
+}

--- a/app/src/components/agent/DocsToolDetails.tsx
+++ b/app/src/components/agent/DocsToolDetails.tsx
@@ -2,7 +2,7 @@ import { getToolName } from "ai";
 
 import {
   isDocsToolName,
-  parseDocsGetPageInput,
+  parseDocsFilesystemQueryInput,
   parseDocsSearchInput,
 } from "@phoenix/agent/tools/docs";
 
@@ -24,9 +24,9 @@ export function getDocsToolPreview(part: ToolInvocationPart): string {
     const input = parseDocsSearchInput(part.input);
     return input ? `Searching: ${input.query}` : "";
   }
-  if (toolName === "get_page_phoenix") {
-    const input = parseDocsGetPageInput(part.input);
-    return input ? `Fetching: ${input.page}` : "";
+  if (toolName === "query_docs_filesystem_phoenix") {
+    const input = parseDocsFilesystemQueryInput(part.input);
+    return input ? `Running: ${input.command}` : "";
   }
   return "";
 }
@@ -41,7 +41,9 @@ export function formatDocsToolState(
   const toolName = getToolName(part);
   switch (state) {
     case "input-streaming":
-      return toolName === "get_page_phoenix" ? "Fetching…" : "Searching…";
+      return toolName === "query_docs_filesystem_phoenix"
+        ? "Querying…"
+        : "Searching…";
     case "input-available":
       return "Running…";
     case "output-available":
@@ -61,7 +63,7 @@ export function DocsToolDetails({ part }: { part: ToolInvocationPart }) {
   const toolName = getToolName(part);
   const isSearch = toolName === "search_phoenix";
 
-  const inputLabel = isSearch ? "Query" : "Page";
+  const inputLabel = isSearch ? "Query" : "Command";
   const inputText = getInputText(part, isSearch);
   const outputText = getOutputText(part);
 
@@ -71,7 +73,7 @@ export function DocsToolDetails({ part }: { part: ToolInvocationPart }) {
       <ToolPartCodeBlock>{inputText}</ToolPartCodeBlock>
       {part.state === "output-available" ? (
         <>
-          <ToolPartLabel>{isSearch ? "Results" : "Content"}</ToolPartLabel>
+          <ToolPartLabel>{isSearch ? "Results" : "Output"}</ToolPartLabel>
           <ToolPartCodeBlock>{outputText || "(no output)"}</ToolPartCodeBlock>
         </>
       ) : null}
@@ -100,8 +102,8 @@ function getInputText(part: ToolInvocationPart, isSearch: boolean): string {
     const input = parseDocsSearchInput(part.input);
     return input?.query ?? stringifyToolValue(part.input);
   }
-  const input = parseDocsGetPageInput(part.input);
-  return input?.page ?? stringifyToolValue(part.input);
+  const input = parseDocsFilesystemQueryInput(part.input);
+  return input?.command ?? stringifyToolValue(part.input);
 }
 
 function getOutputText(part: ToolInvocationPart): string {

--- a/app/stories/ToolPart.stories.tsx
+++ b/app/stories/ToolPart.stories.tsx
@@ -432,17 +432,17 @@ const docsSearchRunningPart = makePart({
 });
 
 const docsGetPagePart = makePart({
-  toolName: "get_page_phoenix",
+  toolName: "query_docs_filesystem_phoenix",
   state: "output-available",
-  input: { page: "/docs/tracing/quickstart" },
+  input: { command: "head -80 /docs/tracing/quickstart.mdx" },
   output:
     "# Getting Started with Tracing\n\nPhoenix tracing helps you understand your LLM application's behavior...\n\n## Installation\n\n```bash\npip install arize-phoenix\n```\n\n## Quick Start\n\nImport and initialize the tracer:\n\n```python\nimport phoenix as px\npx.launch_app()\n```",
 });
 
 const docsGetPageRunningPart = makePart({
-  toolName: "get_page_phoenix",
+  toolName: "query_docs_filesystem_phoenix",
   state: "input-available",
-  input: { page: "/docs/evaluation/overview" },
+  input: { command: "head -80 /docs/evaluation/overview.mdx" },
 });
 
 // ---------------------------------------------------------------------------

--- a/app/tests/pxi/fixtures.ts
+++ b/app/tests/pxi/fixtures.ts
@@ -210,11 +210,7 @@ export class PxiDriver {
   expectDocsToolCalled(turn: PxiTurn) {
     // These names intentionally match Phoenix's docs tool prompt contract.
     // If the docs tool names change, update this assertion with the prompt.
-    const docsToolNames = [
-      "search_phoenix",
-      "get_page_phoenix",
-      "query_docs_filesystem_phoenix",
-    ];
+    const docsToolNames = ["search_phoenix", "query_docs_filesystem_phoenix"];
     const hasCalledDocsTool = turn.calledTools.some((toolName) =>
       docsToolNames.includes(toolName)
     );

--- a/src/phoenix/server/agents/prompts/DOCS_TOOL_INSTRUCTIONS.xml
+++ b/src/phoenix/server/agents/prompts/DOCS_TOOL_INSTRUCTIONS.xml
@@ -2,10 +2,10 @@
   <description>Search the Phoenix documentation for relevant information.</description>
   <when_to_use>The user asks about Phoenix features, setup, APIs, configuration, or troubleshooting.</when_to_use>
 </tool>
-<tool name="get_page_phoenix">
-  <description>Retrieve the full content of a specific documentation page by path.</description>
-  <when_to_use>You need detailed information from a known docs page.</when_to_use>
+<tool name="query_docs_filesystem_phoenix">
+  <description>Query the Phoenix documentation filesystem for exact matches, docs structure, page content, or OpenAPI details.</description>
+  <when_to_use>You need detailed information from known docs paths, using `head` or `cat` with `.mdx` page paths.</when_to_use>
 </tool>
 <documentation_usage>
-  Use the documentation tools proactively when answering questions about Phoenix. Search first, then fetch specific pages if needed for deeper detail. Always cite the documentation when providing answers based on search results.
+  Use the documentation tools proactively when answering questions about Phoenix. Search first, then query specific docs paths or exact matches if needed for deeper detail. Always cite the documentation when providing answers based on search results.
 </documentation_usage>


### PR DESCRIPTION
## Summary
- update PXI docs tool prompt and frontend docs tool types for `query_docs_filesystem_phoenix`
- add a server-executed tool predicate so frontend dispatch skips server-owned tools without hardcoding docs names in the chat handler
- update docs tool rendering, Storybook fixtures, and PXI test fixtures for the filesystem query tool

## Test Plan
- `pnpm --dir app test src/agent/chat/__tests__/handleAgentToolCall.test.ts`
- `pnpm --dir app typecheck`

Related issue: None