### PR TITLE
docs(evaluation): add Code Evaluators page under server-side evaluators

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -236,7 +236,24 @@
                 "pages": [
                   "docs/phoenix/evaluation/server-evals/overview",
                   "docs/phoenix/evaluation/server-evals/llm-evaluators",
-                  "docs/phoenix/evaluation/server-evals/code-evaluators",
+                  {
+                    "group": "Code Evaluators",
+                    "pages": [
+                      "docs/phoenix/evaluation/server-evals/code-evaluators",
+                      {
+                        "group": "Examples",
+                        "pages": [
+                          "docs/phoenix/evaluation/server-evals/code-evaluators/json-match",
+                          "docs/phoenix/evaluation/server-evals/code-evaluators/regex-match",
+                          "docs/phoenix/evaluation/server-evals/code-evaluators/embedding-distance",
+                          "docs/phoenix/evaluation/server-evals/code-evaluators/scikit-learn",
+                          "docs/phoenix/evaluation/server-evals/code-evaluators/pairwise",
+                          "docs/phoenix/evaluation/server-evals/code-evaluators/composite",
+                          "docs/phoenix/evaluation/server-evals/code-evaluators/llm-jury"
+                        ]
+                      }
+                    ]
+                  },
                   "docs/phoenix/evaluation/server-evals/input-mapping",
                   {
                     "group": "Pre-Built Metrics",
@@ -352,7 +369,18 @@
               "docs/phoenix/settings/secrets",
               "docs/phoenix/settings/data-retention",
               "docs/phoenix/settings/custom-ai-providers",
-              "docs/phoenix/settings/sandboxes"
+              {
+                "group": "Sandboxes",
+                "pages": [
+                  "docs/phoenix/settings/sandboxes",
+                  "docs/phoenix/settings/sandboxes/wasm",
+                  "docs/phoenix/settings/sandboxes/deno",
+                  "docs/phoenix/settings/sandboxes/e2b",
+                  "docs/phoenix/settings/sandboxes/daytona",
+                  "docs/phoenix/settings/sandboxes/vercel",
+                  "docs/phoenix/settings/sandboxes/modal"
+                ]
+              }
             ]
           },
           {
@@ -774,6 +802,16 @@
                   "docs/phoenix/integrations/platforms/prompt-flow/prompt-flow-tracing"
                 ]
               }
+            ]
+          },
+          {
+            "group": "Sandboxes",
+            "icon": "cube",
+            "pages": [
+              "docs/phoenix/integrations/sandboxes/e2b",
+              "docs/phoenix/integrations/sandboxes/daytona",
+              "docs/phoenix/integrations/sandboxes/vercel",
+              "docs/phoenix/integrations/sandboxes/modal"
             ]
           },
           {

--- a/docs.json
+++ b/docs.json
@@ -236,13 +236,14 @@
                 "pages": [
                   "docs/phoenix/evaluation/server-evals/overview",
                   "docs/phoenix/evaluation/server-evals/llm-evaluators",
+                  "docs/phoenix/evaluation/server-evals/code-evaluators",
                   "docs/phoenix/evaluation/server-evals/input-mapping",
                   {
                     "group": "Pre-Built Metrics",
                     "pages": [
                       "docs/phoenix/evaluation/server-evals/pre-built-metrics",
                       {
-                        "group": "Code Evaluators",
+                        "group": "Pre-built Code Evaluators",
                         "pages": [
                           "docs/phoenix/evaluation/server-evals/pre-built-metrics/contains",
                           "docs/phoenix/evaluation/server-evals/pre-built-metrics/exact-match",

--- a/docs.json
+++ b/docs.json
@@ -351,7 +351,8 @@
               "docs/phoenix/settings/api-keys",
               "docs/phoenix/settings/secrets",
               "docs/phoenix/settings/data-retention",
-              "docs/phoenix/settings/custom-ai-providers"
+              "docs/phoenix/settings/custom-ai-providers",
+              "docs/phoenix/settings/sandboxes"
             ]
           },
           {

--- a/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
@@ -161,8 +161,8 @@ Needs a third-party library — pip or npm — and sometimes outbound network ac
 Patterns that combine multiple judgments — across axes, across LLM jurors, or across candidates.
 
 <CardGroup cols={2}>
-  <Card title="Pairwise Comparison" icon="scale-balanced" href="/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise">
-    Blind LLM-judge "A vs. B" with randomized presentation order to mitigate position bias.
+  <Card title="Pairwise Evaluator" icon="scale-balanced" href="/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise">
+    Blind LLM-judge `output` vs `reference` head-to-head, with randomized presentation order to mitigate position bias.
   </Card>
   <Card title="Composite Evaluator" icon="layer-group" href="/docs/phoenix/evaluation/server-evals/code-evaluators/composite">
     Blend several sub-scores (LLM judgments + code rules) into one weighted average, with a per-axis breakdown in the explanation.

--- a/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
@@ -88,7 +88,7 @@ function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
 </Tab>
 </Tabs>
 
-`output`, `reference`, `input`, and `metadata` mirror the four [evaluation parameters](/docs/phoenix/evaluation/server-evals/input-mapping#evaluation-parameters), but the names aren't required. Rename them, drop the ones you don't use, or add new ones — the signature is the source of truth for what shows up in the input-mapping panel.
+`output`, `reference`, `input`, and `metadata` mirror the four [evaluation parameters](/docs/phoenix/evaluation/server-evals/input-mapping#evaluation-parameters), but the names aren't required. Rename them, drop the ones you don't use, or add new ones — the signature is the source of truth for what shows up in the input-mapping panel. When a parameter shares a name with one of the four evaluation parameters, Phoenix auto-binds it; otherwise you bind it explicitly in the panel to a path on the evaluation parameters or to a literal value.
 
 ### Return shape
 

--- a/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
@@ -5,11 +5,11 @@ description: "Write Python or TypeScript evaluators directly in Phoenix and run 
 
 Code evaluators let you author a custom evaluation function in **Python** or **TypeScript** and attach it directly to a dataset. Phoenix stores the source, executes it server-side in a sandbox, and records labels and scores as annotations on each experiment run — the same way LLM evaluators do, but with deterministic code instead of a judge model.
 
-Code evaluators are useful when:
+Reach for a code evaluator when:
 
-- Your check is a rule, a parser, or a calculation — not a judgment that needs an LLM.
-- You want a fast, repeatable evaluator with no per-call model cost.
-- You need logic that an LLM judge would be overkill for — exact-match comparisons, regex checks, structural diffs, custom scoring formulas.
+- The check is a rule, a parser, or a calculation — exact-match comparisons, regex checks, structural diffs, custom scoring formulas.
+- You want a deterministic, repeatable score with no per-call model cost.
+- An LLM judge would be slower, more expensive, or less reliable than just running the code.
 
 <Info>
 This page covers code evaluators authored **in the Phoenix UI** and run by Phoenix's sandbox runtimes. If you'd rather write evaluators locally and report scores with the `arize-phoenix-evals` SDK, see the [client-side code evaluators](/docs/phoenix/evaluation/how-to-evals/code-evaluators) guide.
@@ -17,17 +17,44 @@ This page covers code evaluators authored **in the Phoenix UI** and run by Phoen
 
 ## How It Works
 
-1. **Create the evaluator** — From a dataset's **Evaluators** tab, choose **Add evaluator → Create new code evaluator**. Pick a language (Python or TypeScript) and a sandbox.
-2. **Write `evaluate(...)`** — Phoenix gives you an editor pre-populated with an `evaluate(...)` function. The function's parameters become the evaluator's inputs.
+```mermaid
+flowchart LR
+    subgraph dataset [Dataset]
+        Example[Example]
+        Evaluator[Code Evaluator]
+    end
+
+    Task[Playground/UI Task]
+
+    subgraph sandbox [Sandbox Runtime]
+        Evaluate["evaluate(...)"]
+    end
+
+    subgraph results [Results]
+        Annotation[Label / Score]
+        Trace[Evaluator Trace]
+    end
+
+    Example --> Task
+    Task -- "input, output, reference, metadata" --> Evaluator
+    Evaluator -- "mapped inputs" --> Evaluate
+    Evaluate --> Annotation
+    Evaluate --> Trace
+```
+
+From authoring to results, you'll work through five steps:
+
+1. **Create the evaluator** — From a dataset's **Evaluators** tab, choose **Add evaluator → Create new code evaluator**. Pick a language (Python or TypeScript) and a sandbox configuration.
+2. **Write `evaluate(...)`** — The editor opens pre-populated with an `evaluate(...)` function. Its parameters become the evaluator's inputs.
 3. **Configure output** — Declare whether the evaluator returns a continuous score (e.g. `0.0`–`1.0`) or a categorical label (e.g. `pass` / `fail`).
-4. **Map inputs** — Connect each parameter to a path on the [evaluation parameters](/docs/phoenix/evaluation/server-evals/input-mapping#evaluation-parameters) (`input`, `output`, `reference`, `metadata`) or a literal value.
-5. **Test, save, run** — Try the evaluator against a dataset example in the test panel, save it, and run an experiment from the Playground. Scores appear automatically on each run.
+4. **Map inputs** — Bind each parameter to a path on the [evaluation parameters](/docs/phoenix/evaluation/server-evals/input-mapping#evaluation-parameters) (`input`, `output`, `reference`, `metadata`) or to a literal value.
+5. **Test, save, run** — Dry-run the evaluator against a dataset example in the test panel, save it, then run an experiment. Scores land on every new run automatically.
 
 ## Authoring an Evaluator
 
 ### Function signature
 
-The function name must be `evaluate`. Its parameters are the evaluator's inputs — any name you reference shows up in the input-mapping panel for you to bind.
+The function name must be `evaluate`. Each parameter becomes a row in the input-mapping panel — you bind it to a path on the evaluation parameters or to a literal value.
 
 <Tabs>
 <Tab title="Python" icon="python">
@@ -61,7 +88,7 @@ function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
 </Tab>
 </Tabs>
 
-`output`, `reference`, `input`, and `metadata` are conventional names that match the four [evaluation parameters](/docs/phoenix/evaluation/server-evals/input-mapping#evaluation-parameters), but they aren't required — you can rename them, add new ones, or drop the ones you don't need. Whatever parameter names appear in your `evaluate` signature become the rows in the input-mapping panel.
+`output`, `reference`, `input`, and `metadata` mirror the four [evaluation parameters](/docs/phoenix/evaluation/server-evals/input-mapping#evaluation-parameters), but the names aren't required. Rename them, drop the ones you don't use, or add new ones — the signature is the source of truth for what shows up in the input-mapping panel.
 
 ### Return shape
 
@@ -69,8 +96,8 @@ The function returns an object with three optional fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `label` | string | A label for categorical evaluators (e.g. `"correct"`, `"fail"`). Required for categorical output. |
-| `score` | number | A numeric score. Required for continuous output. For categorical output, derived from the label's score mapping if omitted. |
+| `label` | string | The category (e.g. `"correct"`, `"fail"`). Required for categorical evaluators. |
+| `score` | number | A numeric score. Required for continuous evaluators. Categorical evaluators can omit it — Phoenix fills it in from the configured label-to-score mapping. |
 | `explanation` | string | Free-form text shown alongside the score. Useful for debugging surprising results. |
 
 ### Output configuration
@@ -84,7 +111,7 @@ You also pick an **optimization direction** (maximize vs. minimize) so Phoenix c
 
 ## Sandbox Runtimes
 
-Code evaluators always run inside a sandbox. When you create an evaluator, you select one of the sandbox configurations that an administrator has provisioned under **Settings → Sandboxes**. Phoenix filters the list to sandboxes that match the language you chose.
+Code evaluators always run inside a sandbox. When you create one, you pick from the sandbox configurations an administrator has provisioned under **Settings → Sandboxes** — Phoenix filters the list to configurations that match the language you chose.
 
 The available backends are:
 
@@ -93,34 +120,68 @@ The available backends are:
 | Python | WebAssembly (in-process), E2B, Daytona, Vercel Sandbox, Modal |
 | TypeScript | Deno (in-process), Daytona, Vercel Sandbox |
 
-WebAssembly and Deno run inside the Phoenix process and require no external credentials, so they work immediately in self-hosted deployments. The remote backends (E2B, Daytona, Vercel, Modal) provide stronger isolation and support features like longer timeouts, package installation, and outbound network access — see the individual backend rows in [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for capability differences.
+**In-process** backends (WebAssembly, Deno) ship with Phoenix and need no credentials, so they're available immediately on self-hosted deployments. **Hosted** backends (E2B, Daytona, Vercel, Modal) run each invocation on a third-party provider's infrastructure, which buys stronger isolation, longer timeouts, package installation, and outbound network access. See [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for the full capability matrix.
 
 <Tip>
-If you need to install a Python package or call an external API from your evaluator, pick a remote backend (E2B, Daytona, Vercel, or Modal). The in-process runtimes are intentionally restricted.
+If your evaluator needs to install a package or call an external API, pick a hosted backend. The in-process runtimes are intentionally restricted.
 </Tip>
 
-## Templates
+## Examples
 
-When you open the **Add evaluator** menu, **Use built-in code evaluator** shows a submenu of starter templates that you can apply as a starting point and then customize:
+The pages below are copy-paste starting points for common evaluator patterns, grouped by how much infrastructure they need. Each one spells out the exact **sandbox configuration** — backend, dependencies, internet access, environment variables — to provision under **Settings → Sandboxes** before you save.
 
-- **Exact match** — Match/mismatch when output equals reference.
-- **Contains** — Whether the output contains the reference text.
-- **Regex** — Whether the output matches a regular expression.
-- **Levenshtein distance** — Normalized edit-distance similarity.
-- **JSON distance** — Equality after parsing both sides as JSON.
+### Simple — pure code, in-process sandbox
 
-Each template ships with source code (in both Python and TypeScript) and a matching output configuration, so you can apply one and immediately edit the logic to fit your use case.
+No dependencies, no network. Runs in the bundled WebAssembly (Python) or Deno (TypeScript) sandboxes.
+
+<CardGroup cols={2}>
+  <Card title="JSON Match" icon="brackets-curly" href="/docs/phoenix/evaluation/server-evals/code-evaluators/json-match">
+    Pass when the output and reference parse to the same JSON structure.
+  </Card>
+  <Card title="Regex Match" icon="asterisk" href="/docs/phoenix/evaluation/server-evals/code-evaluators/regex-match">
+    Pass when the output matches a regular expression pattern.
+  </Card>
+</CardGroup>
+
+### Medium — third-party library, hosted sandbox
+
+Needs a third-party library — pip or npm — and sometimes outbound network access. Pick a hosted backend matching your language: Python on E2B / Daytona / Vercel / Modal, TypeScript on Daytona or Vercel.
+
+<CardGroup cols={2}>
+  <Card title="Embedding Distance" icon="vector-square" href="/docs/phoenix/evaluation/server-evals/code-evaluators/embedding-distance">
+    Cosine similarity over OpenAI embeddings. Needs the `openai` package, internet access, and `OPENAI_API_KEY`.
+  </Card>
+  <Card title="scikit-learn" icon="flask" href="/docs/phoenix/evaluation/server-evals/code-evaluators/scikit-learn">
+    Token-overlap similarity via `HashingVectorizer` and cosine. Offline — no network at run time.
+  </Card>
+</CardGroup>
+
+### Advanced — multi-judgment evaluators
+
+Patterns that combine multiple judgments — across axes, across LLM jurors, or across candidates.
+
+<CardGroup cols={2}>
+  <Card title="Pairwise Comparison" icon="scale-balanced" href="/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise">
+    Blind LLM-judge "A vs. B" with randomized presentation order to mitigate position bias.
+  </Card>
+  <Card title="Composite Evaluator" icon="layer-group" href="/docs/phoenix/evaluation/server-evals/code-evaluators/composite">
+    Blend several sub-scores (LLM judgments + code rules) into one weighted average, with a per-axis breakdown in the explanation.
+  </Card>
+  <Card title="LLM Jury" icon="gavel" href="/docs/phoenix/evaluation/server-evals/code-evaluators/llm-jury">
+    Poll multiple LLMs (OpenAI, Anthropic, Google) on the same judgment and combine their verdicts with a weighted average.
+  </Card>
+</CardGroup>
 
 ## Versioning
 
-Every time you save a code evaluator's source, Phoenix creates a new **evaluator version**. The version stores the source code and is what executes for subsequent experiment runs. Older versions are retained so you can audit which code produced any historical score.
+Every time you save an evaluator's source, Phoenix creates a new **evaluator version** that executes for subsequent experiment runs. Older versions are retained so you can audit which code produced any historical score.
 
-The evaluator's **name**, **description**, **output configuration**, **input mapping**, and **sandbox binding** are stored on the evaluator itself rather than on a version — editing those updates the evaluator in place without creating a new version.
+The evaluator's **name**, **description**, **output configuration**, **input mapping**, and **sandbox binding** live on the evaluator itself rather than on a version — editing those updates the evaluator in place without creating a new version.
 
 ## Testing Before You Save
 
-The editor includes a **Test** panel that runs the current draft against a chosen dataset example. The panel shows the inputs as they would be passed to `evaluate(...)` after input mapping, the raw return value, and the parsed label/score/explanation. Use it to catch errors before saving — for example, to verify that a path mapping resolves to a string rather than `None`, or that your function handles missing fields gracefully.
+The editor includes a **Test** panel that runs the current draft against a chosen dataset example. It shows the inputs Phoenix will pass to `evaluate(...)` after input mapping, the raw return value, and the parsed label/score/explanation. Use it to catch errors before saving — for example, to confirm that a path mapping resolves to a string rather than `None`, or that your function handles missing fields gracefully.
 
 ## Traceability
 
-Like LLM evaluators, every code evaluator execution emits an OpenTelemetry trace into a dedicated project. The trace captures the resolved inputs, the function's return value, any exceptions, and the latency of the sandbox call — so when an annotation looks wrong you can navigate from the score directly to the execution that produced it.
+Like LLM evaluators, every code-evaluator execution emits an OpenTelemetry trace into a dedicated project. The trace captures the resolved inputs, the return value, any exception, and the sandbox call's latency — so when an annotation looks wrong, you can navigate from it directly to the execution that produced it.

--- a/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
@@ -1,0 +1,126 @@
+---
+title: "Code Evaluators"
+description: "Write Python or TypeScript evaluators directly in Phoenix and run them in a managed sandbox — no SDK, local runtime, or deploy step required."
+---
+
+Code evaluators let you author a custom evaluation function in **Python** or **TypeScript** and attach it directly to a dataset. Phoenix stores the source, executes it server-side in a sandbox, and records labels and scores as annotations on each experiment run — the same way LLM evaluators do, but with deterministic code instead of a judge model.
+
+Code evaluators are useful when:
+
+- Your check is a rule, a parser, or a calculation — not a judgment that needs an LLM.
+- You want a fast, repeatable evaluator with no per-call model cost.
+- You need logic that an LLM judge would be overkill for — exact-match comparisons, regex checks, structural diffs, custom scoring formulas.
+
+<Info>
+This page covers code evaluators authored **in the Phoenix UI** and run by Phoenix's sandbox runtimes. If you'd rather write evaluators locally and report scores with the `arize-phoenix-evals` SDK, see the [client-side code evaluators](/docs/phoenix/evaluation/how-to-evals/code-evaluators) guide.
+</Info>
+
+## How It Works
+
+1. **Create the evaluator** — From a dataset's **Evaluators** tab, choose **Add evaluator → Create new code evaluator**. Pick a language (Python or TypeScript) and a sandbox.
+2. **Write `evaluate(...)`** — Phoenix gives you an editor pre-populated with an `evaluate(...)` function. The function's parameters become the evaluator's inputs.
+3. **Configure output** — Declare whether the evaluator returns a continuous score (e.g. `0.0`–`1.0`) or a categorical label (e.g. `pass` / `fail`).
+4. **Map inputs** — Connect each parameter to a path on the [evaluation parameters](/docs/phoenix/evaluation/server-evals/input-mapping#evaluation-parameters) (`input`, `output`, `reference`, `metadata`) or a literal value.
+5. **Test, save, run** — Try the evaluator against a dataset example in the test panel, save it, and run an experiment from the Playground. Scores appear automatically on each run.
+
+## Authoring an Evaluator
+
+### Function signature
+
+The function name must be `evaluate`. Its parameters are the evaluator's inputs — any name you reference shows up in the input-mapping panel for you to bind.
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+def evaluate(output, reference=None, input=None, metadata=None):
+    matched = str(output).strip() == str(reference).strip()
+    return {
+        "label": "match" if matched else "mismatch",
+        "score": 1.0 if matched else 0.0,
+        "explanation": (
+            "Output matches the reference."
+            if matched
+            else "Output does not match the reference."
+        ),
+    }
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+function evaluate({ output, reference, input, metadata }: EvaluatorParams) {
+  const matched = String(output).trim() === String(reference).trim();
+  return {
+    label: matched ? "match" : "mismatch",
+    score: matched ? 1 : 0,
+    explanation: matched
+      ? "Output matches the reference."
+      : "Output does not match the reference.",
+  };
+}
+```
+</Tab>
+</Tabs>
+
+`output`, `reference`, `input`, and `metadata` are conventional names that match the four [evaluation parameters](/docs/phoenix/evaluation/server-evals/input-mapping#evaluation-parameters), but they aren't required — you can rename them, add new ones, or drop the ones you don't need. Whatever parameter names appear in your `evaluate` signature become the rows in the input-mapping panel.
+
+### Return shape
+
+The function returns an object with three optional fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `label` | string | A label for categorical evaluators (e.g. `"correct"`, `"fail"`). Required for categorical output. |
+| `score` | number | A numeric score. Required for continuous output. For categorical output, derived from the label's score mapping if omitted. |
+| `explanation` | string | Free-form text shown alongside the score. Useful for debugging surprising results. |
+
+### Output configuration
+
+Each evaluator declares one of two **output shapes**:
+
+- **Continuous score** — A numeric value within a configurable range (default `0.0`–`1.0`). Use for similarity scores, distances, or any graded metric.
+- **Categorical label** — A fixed set of labels, each mapped to a numeric score. The label your function returns must be one of the configured values.
+
+You also pick an **optimization direction** (maximize vs. minimize) so Phoenix can render trends correctly in experiment comparisons.
+
+## Sandbox Runtimes
+
+Code evaluators always run inside a sandbox. When you create an evaluator, you select one of the sandbox configurations that an administrator has provisioned under **Settings → Sandboxes**. Phoenix filters the list to sandboxes that match the language you chose.
+
+The available backends are:
+
+| Language | Backends |
+|----------|----------|
+| Python | WebAssembly (in-process), E2B, Daytona, Vercel Sandbox, Modal |
+| TypeScript | Deno (in-process), Daytona, Vercel Sandbox |
+
+WebAssembly and Deno run inside the Phoenix process and require no external credentials, so they work immediately in self-hosted deployments. The remote backends (E2B, Daytona, Vercel, Modal) provide stronger isolation and support features like longer timeouts, package installation, and outbound network access — see the individual backend rows in [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for capability differences.
+
+<Tip>
+If you need to install a Python package or call an external API from your evaluator, pick a remote backend (E2B, Daytona, Vercel, or Modal). The in-process runtimes are intentionally restricted.
+</Tip>
+
+## Templates
+
+When you open the **Add evaluator** menu, **Use built-in code evaluator** shows a submenu of starter templates that you can apply as a starting point and then customize:
+
+- **Exact match** — Match/mismatch when output equals reference.
+- **Contains** — Whether the output contains the reference text.
+- **Regex** — Whether the output matches a regular expression.
+- **Levenshtein distance** — Normalized edit-distance similarity.
+- **JSON distance** — Equality after parsing both sides as JSON.
+
+Each template ships with source code (in both Python and TypeScript) and a matching output configuration, so you can apply one and immediately edit the logic to fit your use case.
+
+## Versioning
+
+Every time you save a code evaluator's source, Phoenix creates a new **evaluator version**. The version stores the source code and is what executes for subsequent experiment runs. Older versions are retained so you can audit which code produced any historical score.
+
+The evaluator's **name**, **description**, **output configuration**, **input mapping**, and **sandbox binding** are stored on the evaluator itself rather than on a version — editing those updates the evaluator in place without creating a new version.
+
+## Testing Before You Save
+
+The editor includes a **Test** panel that runs the current draft against a chosen dataset example. The panel shows the inputs as they would be passed to `evaluate(...)` after input mapping, the raw return value, and the parsed label/score/explanation. Use it to catch errors before saving — for example, to verify that a path mapping resolves to a string rather than `None`, or that your function handles missing fields gracefully.
+
+## Traceability
+
+Like LLM evaluators, every code evaluator execution emits an OpenTelemetry trace into a dedicated project. The trace captures the resolved inputs, the function's return value, any exceptions, and the latency of the sandbox call — so when an annotation looks wrong you can navigate from the score directly to the execution that produced it.

--- a/docs/phoenix/evaluation/server-evals/code-evaluators/composite.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators/composite.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Composite Evaluator"
-sidebarTitle: "Composite"
+sidebarTitle: "Composite Evaluator"
 description: "Blend multiple sub-scores into a single weighted-average score with a per-axis breakdown."
 ---
 
@@ -12,6 +12,28 @@ The example below mixes:
 - A **deterministic code check** for format — a regex for a citation tag at the end of the answer.
 
 The score is the weighted average; every sub-score and the LLM's reasoning land in the `explanation` so you can audit how the final number was built.
+
+```mermaid
+flowchart LR
+    Inputs["output<br/>reference"]
+
+    subgraph axes [Sub-evaluators]
+        direction TB
+        E1["Correctness<br/>LLM judge"]
+        E2["Format<br/>regex check"]
+    end
+
+    Combine["Weighted average<br/>0.7 × correctness<br/>+ 0.3 × format"]
+    Final["Composite score<br/>+ per-axis breakdown"]
+
+    Inputs --> E1
+    Inputs --> E2
+    E1 -- "0.0 – 1.0" --> Combine
+    E2 -- "0 or 1" --> Combine
+    Combine --> Final
+```
+
+Each axis runs independently — some can be LLM-judged, others pure code — and their scores blend into one number you can rank runs by.
 
 ## Code
 
@@ -73,6 +95,13 @@ def evaluate(output, reference):
             f"Correctness reason: {correctness.explanation or 'n/a'}"
         ),
     }
+```
+
+**Sandbox dependencies** — paste into the sandbox configuration's Dependencies field, one package per line:
+
+```
+arize-phoenix-evals
+openai
 ```
 </Tab>
 <Tab title="TypeScript" icon="js">
@@ -137,6 +166,14 @@ async function evaluate({ output, reference }: EvaluatorParams) {
 ```
 
 The Python prompt template uses f-string-style `{variable}` placeholders; the TypeScript variant uses Mustache-style `{{ variable }}` — that difference is in `arize-phoenix-evals` / `@arizeai/phoenix-evals` themselves, not in your evaluator.
+
+**Sandbox dependencies** — paste into the sandbox configuration's Dependencies field, one package per line:
+
+```
+@arizeai/phoenix-evals
+ai
+@ai-sdk/openai
+```
 </Tab>
 </Tabs>
 

--- a/docs/phoenix/evaluation/server-evals/code-evaluators/composite.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators/composite.mdx
@@ -1,0 +1,185 @@
+---
+title: "Composite Evaluator"
+sidebarTitle: "Composite"
+description: "Blend multiple sub-scores into a single weighted-average score with a per-axis breakdown."
+---
+
+A **composite evaluator** runs several sub-checks against the same example and combines their scores into one number. Reach for it when "quality" depends on multiple aspects — correctness, format, conciseness, citations — and you want a single value to compare runs by, plus a breakdown to debug them.
+
+The example below mixes:
+
+- An **LLM judgment** for correctness, built with `arize-phoenix-evals` `ClassificationEvaluator`.
+- A **deterministic code check** for format — a regex for a citation tag at the end of the answer.
+
+The score is the weighted average; every sub-score and the LLM's reasoning land in the `explanation` so you can audit how the final number was built.
+
+## Code
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+import re
+
+from phoenix.evals import LLM, ClassificationEvaluator
+
+_llm = LLM(provider="openai", model="gpt-4o-mini")
+
+_correctness = ClassificationEvaluator(
+    name="correctness",
+    llm=_llm,
+    prompt_template=(
+        "Is the answer factually correct given the reference?\n\n"
+        "Reference: {reference}\n\nAnswer: {output}"
+    ),
+    choices={"correct": 1.0, "partially_correct": 0.5, "incorrect": 0.0},
+)
+
+# Format check: the answer should end with a citation tag like [src:1].
+_CITATION = re.compile(r"\[src:\d+\]\s*$")
+
+WEIGHTS = {"correctness": 0.7, "format": 0.3}
+
+
+def evaluate(output, reference):
+    if not output or not reference:
+        return {
+            "label": "missing",
+            "score": 0.0,
+            "explanation": "Missing output or reference.",
+        }
+
+    text = str(output)
+
+    # Sub-score 1: LLM-judged correctness (one API call).
+    correctness = _correctness.evaluate(
+        {"output": text, "reference": str(reference)}
+    )[0]
+    correctness_score = correctness.score if correctness.score is not None else 0.0
+
+    # Sub-score 2: deterministic format check (no API call).
+    format_score = 1.0 if _CITATION.search(text) else 0.0
+
+    sub_scores = {"correctness": correctness_score, "format": format_score}
+    total_weight = sum(WEIGHTS.values())
+    combined = sum(WEIGHTS[k] * sub_scores[k] for k in WEIGHTS) / total_weight
+
+    breakdown = ", ".join(
+        f"{k}={sub_scores[k]:.2f}×{WEIGHTS[k]:.2f}" for k in WEIGHTS
+    )
+    return {
+        "score": combined,
+        "explanation": (
+            f"Composite={combined:.4f}; {breakdown}. "
+            f"Correctness reason: {correctness.explanation or 'n/a'}"
+        ),
+    }
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+import { openai } from "@ai-sdk/openai";
+import { createClassificationEvaluator } from "@arizeai/phoenix-evals";
+
+const correctnessEval = createClassificationEvaluator({
+  name: "correctness",
+  model: openai("gpt-4o-mini"),
+  promptTemplate:
+    "Is the answer factually correct given the reference?\n\n" +
+    "Reference: {{ reference }}\n\nAnswer: {{ output }}",
+  choices: { correct: 1, partially_correct: 0.5, incorrect: 0 },
+});
+
+const CITATION = /\[src:\d+\]\s*$/;
+const WEIGHTS: Record<string, number> = { correctness: 0.7, format: 0.3 };
+
+async function evaluate({ output, reference }: EvaluatorParams) {
+  if (!output || !reference) {
+    return {
+      label: "missing",
+      score: 0,
+      explanation: "Missing output or reference.",
+    };
+  }
+
+  const text = String(output);
+
+  // Sub-score 1: LLM-judged correctness (one API call).
+  const correctness = await correctnessEval.evaluate({
+    output: text,
+    reference: String(reference),
+  });
+  const correctnessScore = correctness.score ?? 0;
+
+  // Sub-score 2: deterministic format check (no API call).
+  const formatScore = CITATION.test(text) ? 1 : 0;
+
+  const subScores: Record<string, number> = {
+    correctness: correctnessScore,
+    format: formatScore,
+  };
+  const totalWeight = Object.values(WEIGHTS).reduce((a, b) => a + b, 0);
+  const combined =
+    Object.entries(WEIGHTS).reduce(
+      (sum, [k, w]) => sum + w * (subScores[k] ?? 0),
+      0
+    ) / totalWeight;
+
+  const breakdown = Object.entries(WEIGHTS)
+    .map(([k, w]) => `${k}=${subScores[k].toFixed(2)}×${w.toFixed(2)}`)
+    .join(", ");
+  return {
+    score: combined,
+    explanation:
+      `Composite=${combined.toFixed(4)}; ${breakdown}. ` +
+      `Correctness reason: ${correctness.explanation ?? "n/a"}`,
+  };
+}
+```
+
+The Python prompt template uses f-string-style `{variable}` placeholders; the TypeScript variant uses Mustache-style `{{ variable }}` — that difference is in `arize-phoenix-evals` / `@arizeai/phoenix-evals` themselves, not in your evaluator.
+</Tab>
+</Tabs>
+
+## Input mapping
+
+| Parameter | Bind to |
+|-----------|---------|
+| `output` | The model output to grade, usually `output`. |
+| `reference` | The ground-truth answer, usually `reference`. |
+
+If you add more sub-scores (e.g. a conciseness check that needs the original `input`), expose them as new parameters here.
+
+## Output configuration
+
+Continuous score in the range `0.0` to `1.0` (matches the choice scores you configured on each sub-evaluator). Optimization direction: **maximize**.
+
+## Runtime requirements
+
+| Setting | Value |
+|---------|-------|
+| Sandbox | A **hosted** backend that matches your language. Python: **E2B**, **Daytona — Python**, **Vercel Sandbox — Python**, or **Modal**. TypeScript: **Daytona — TypeScript** or **Vercel Sandbox — TypeScript** (the local Deno sandbox is `--no-npm` and cannot install the npm packages). |
+| Dependencies | Python: `arize-phoenix-evals`, `openai`. TypeScript: `@arizeai/phoenix-evals`, `@ai-sdk/openai`, `ai`. |
+| Internet access | **Required** — the LLM sub-score calls `api.openai.com`. |
+| Environment variables | `OPENAI_API_KEY` — set as a **secret reference** to a key in [Settings → Secrets](/docs/phoenix/settings/secrets). |
+
+<Warning>
+`arize-phoenix-evals` pulls in `pydantic`, `httpx`, and the LLM provider SDKs you use. Cold-installing it can take 20–60s on a hosted sandbox — bump the configuration's **Timeout** accordingly, and re-use the same configuration across runs so the provider can warm-cache the environment.
+</Warning>
+
+## Variants
+
+### Tune the weights or add more axes
+
+The `WEIGHTS` dict is the only knob — push correctness toward `1.0` for a near-pure correctness signal, or add a third axis (e.g. `tone`, `length`, `safety`) by appending a new `ClassificationEvaluator` and another entry in the dict. Each new LLM-judged sub-score adds one more API call per example, so weigh latency and cost when stacking too many axes.
+
+### All-code composite (no LLM)
+
+If every sub-check is deterministic, drop `phoenix.evals` entirely — the evaluator runs in the in-process WebAssembly or Deno sandbox with no dependencies, no network, and no API key. Useful for cheap multi-rule checks: "has citation tag", "ends with period", "under 500 tokens".
+
+### All-LLM composite (no code rules)
+
+Replace the format regex with a second `ClassificationEvaluator` for `conciseness`, `tone`, or whatever other axis you care about. Every sub-score becomes a judge call, so latency and cost scale linearly with the number of axes.
+
+## Related
+
+- [LLM Jury](/docs/phoenix/evaluation/server-evals/code-evaluators/llm-jury) — instead of combining different *axes* of one judgment, combine the *same* judgment from multiple LLMs.

--- a/docs/phoenix/evaluation/server-evals/code-evaluators/embedding-distance.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators/embedding-distance.mdx
@@ -52,6 +52,12 @@ def evaluate(output, reference):
         ),
     }
 ```
+
+**Sandbox dependencies** — paste into the sandbox configuration's Dependencies field, one package per line:
+
+```
+openai
+```
 </Tab>
 <Tab title="TypeScript" icon="js">
 ```typescript
@@ -103,6 +109,12 @@ async function evaluate({ output, reference }: EvaluatorParams) {
 ```
 
 The TypeScript runtime supports `async` — Phoenix `await`s the returned promise. The two embedding requests run in parallel via `Promise.all`, so wall-clock latency is roughly one request, not two.
+
+**Sandbox dependencies** — paste into the sandbox configuration's Dependencies field, one package per line:
+
+```
+openai
+```
 </Tab>
 </Tabs>
 
@@ -138,5 +150,5 @@ Each `evaluate(...)` call makes **two** embedding requests (one for `output`, on
 
 ## Related
 
-- [Pairwise Comparison](/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise) — apply embedding distance to two candidate outputs and pick a winner.
+- [Pairwise Evaluator](/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise) — apply embedding distance to two candidate outputs and pick a winner.
 - [scikit-learn TF-IDF](/docs/phoenix/evaluation/server-evals/code-evaluators/scikit-learn) — a cheaper, offline alternative when embeddings are overkill.

--- a/docs/phoenix/evaluation/server-evals/code-evaluators/embedding-distance.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators/embedding-distance.mdx
@@ -1,0 +1,142 @@
+---
+title: "Embedding Distance"
+sidebarTitle: "Embedding Distance"
+description: "Score semantic similarity between two strings using an embeddings API."
+---
+
+Embed the model output and the reference with an embeddings model, then report their cosine similarity. This is the standard fuzzy-match check for free-text outputs — wording differences shouldn't count as failures as long as the meaning matches.
+
+The example uses **OpenAI**'s `text-embedding-3-small`. The same shape works for any HTTP embeddings endpoint; swap the client and model name to switch providers.
+
+## Code
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+import math
+import os
+
+from openai import OpenAI
+
+_MODEL = "text-embedding-3-small"
+_client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+
+def _embed(text):
+    response = _client.embeddings.create(model=_MODEL, input=text)
+    return response.data[0].embedding
+
+
+def _cosine(a, b):
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def evaluate(output, reference):
+    if not output or not reference:
+        return {
+            "label": "missing",
+            "score": 0.0,
+            "explanation": "Missing output or reference.",
+        }
+
+    similarity = _cosine(_embed(str(output)), _embed(str(reference)))
+    return {
+        "score": similarity,
+        "explanation": (
+            f"Cosine similarity {similarity:.4f} (model={_MODEL})."
+        ),
+    }
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+import OpenAI from "openai";
+
+const MODEL = "text-embedding-3-small";
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function embed(text: string): Promise<number[]> {
+  const response = await client.embeddings.create({
+    model: MODEL,
+    input: text,
+  });
+  return response.data[0].embedding;
+}
+
+function cosine(a: number[], b: number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+async function evaluate({ output, reference }: EvaluatorParams) {
+  if (!output || !reference) {
+    return {
+      label: "missing",
+      score: 0,
+      explanation: "Missing output or reference.",
+    };
+  }
+
+  const [vecOut, vecRef] = await Promise.all([
+    embed(String(output)),
+    embed(String(reference)),
+  ]);
+  const similarity = cosine(vecOut, vecRef);
+  return {
+    score: similarity,
+    explanation: `Cosine similarity ${similarity.toFixed(4)} (model=${MODEL}).`,
+  };
+}
+```
+
+The TypeScript runtime supports `async` — Phoenix `await`s the returned promise. The two embedding requests run in parallel via `Promise.all`, so wall-clock latency is roughly one request, not two.
+</Tab>
+</Tabs>
+
+## Input mapping
+
+| Parameter | Bind to |
+|-----------|---------|
+| `output` | The model output to score, usually `output`. |
+| `reference` | The ground-truth string, usually `reference`. |
+
+## Output configuration
+
+Continuous score in the range `-1.0` to `1.0` (cosine similarity). Optimization direction: **maximize**.
+
+In practice, OpenAI's text-embedding-3 models produce non-negative similarities on natural-language pairs, so a `0.0` – `1.0` range with a low-end threshold (e.g. `0.7` for "close enough") is also reasonable.
+
+## Runtime requirements
+
+| Setting | Value |
+|---------|-------|
+| Sandbox | A **hosted** backend that matches your language. Python: **E2B**, **Daytona — Python**, **Vercel Sandbox — Python**, or **Modal**. TypeScript: **Daytona — TypeScript** or **Vercel Sandbox — TypeScript** (the local Deno sandbox is started with `--no-npm` and cannot install the `openai` package). |
+| Dependencies | Python: `openai`. TypeScript: `openai` (npm). Add it under **Dependencies** when creating the sandbox configuration. |
+| Internet access | **Required** — toggle **Allow Internet Access** on for the configuration. The sandbox must reach `api.openai.com`. |
+| Environment variables | `OPENAI_API_KEY` — preferably set as a **secret reference** to a key in [Settings → Secrets](/docs/phoenix/settings/secrets), not a literal value. |
+
+<Warning>
+Each `evaluate(...)` call makes **two** embedding requests (one for `output`, one for `reference`). When running this across a large dataset:
+
+- Raise the sandbox configuration's **Timeout** if the default is too tight for a cold-start install plus two API calls.
+- Watch the upstream provider's rate limits and per-token cost — at production volume this adds up fast.
+- If `reference` is fixed across many examples (e.g. a shared gold answer), pre-compute its embedding once and store it on the example. The evaluator then needs only one API call per row, or none at all if you also pre-embed the output.
+</Warning>
+
+## Related
+
+- [Pairwise Comparison](/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise) — apply embedding distance to two candidate outputs and pick a winner.
+- [scikit-learn TF-IDF](/docs/phoenix/evaluation/server-evals/code-evaluators/scikit-learn) — a cheaper, offline alternative when embeddings are overkill.

--- a/docs/phoenix/evaluation/server-evals/code-evaluators/json-match.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators/json-match.mdx
@@ -1,0 +1,125 @@
+---
+title: "JSON Match"
+sidebarTitle: "JSON Match"
+description: "Pass when the output and the reference parse to the same JSON structure."
+---
+
+Parses both sides as JSON and reports a binary `match` / `mismatch`. Key order and whitespace don't affect the result — only structural equality does.
+
+Reach for this when:
+
+- A model is meant to return structured JSON and you want a strict pass/fail on the whole document.
+- Field-level scoring like the pre-built [JSON Distance](/docs/phoenix/evaluation/server-evals/pre-built-metrics/json-distance) metric is more nuance than you need.
+
+## Code
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+import json
+
+
+def evaluate(output, reference):
+    try:
+        actual = json.loads(output) if isinstance(output, str) else output
+        expected = (
+            json.loads(reference) if isinstance(reference, str) else reference
+        )
+    except (TypeError, ValueError) as exc:
+        return {
+            "label": "invalid",
+            "score": 0.0,
+            "explanation": f"Failed to parse JSON: {exc}",
+        }
+
+    matched = actual == expected
+    return {
+        "label": "match" if matched else "mismatch",
+        "score": 1.0 if matched else 0.0,
+        "explanation": (
+            "Outputs are structurally equal."
+            if matched
+            else f"Expected {expected!r}, got {actual!r}."
+        ),
+    }
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+function evaluate({ output, reference }: EvaluatorParams) {
+  function canonical(value: unknown): string {
+    if (value === null || typeof value !== "object") {
+      return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+      return "[" + value.map(canonical).join(",") + "]";
+    }
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    return (
+      "{" +
+      keys
+        .map((k) => `${JSON.stringify(k)}:${canonical(obj[k])}`)
+        .join(",") +
+      "}"
+    );
+  }
+
+  const parse = (v: unknown) =>
+    typeof v === "string" ? JSON.parse(v) : v;
+
+  let actual: unknown;
+  let expected: unknown;
+  try {
+    actual = parse(output);
+    expected = parse(reference);
+  } catch (err) {
+    return {
+      label: "invalid",
+      score: 0,
+      explanation: `Failed to parse JSON: ${(err as Error).message}`,
+    };
+  }
+
+  const matched = canonical(actual) === canonical(expected);
+  return {
+    label: matched ? "match" : "mismatch",
+    score: matched ? 1 : 0,
+    explanation: matched
+      ? "Outputs are structurally equal."
+      : `Expected ${canonical(expected)}, got ${canonical(actual)}.`,
+  };
+}
+```
+</Tab>
+</Tabs>
+
+The TypeScript version canonicalizes objects by sorting keys before stringifying — without that step, `{a: 1, b: 2}` and `{b: 2, a: 1}` would compare unequal. Python's `==` already handles structural equality across key orderings.
+
+## Input mapping
+
+| Parameter | Bind to |
+|-----------|---------|
+| `output` | The model output — usually `output`, or a nested path like `output.tool_calls[0].arguments` if the JSON lives inside a larger blob. |
+| `reference` | The ground-truth JSON value from the dataset — typically `reference`. |
+
+## Output configuration
+
+Categorical labels:
+
+| Label | Score |
+|-------|-------|
+| `match` | `1.0` |
+| `mismatch` | `0.0` |
+| `invalid` | `0.0` |
+
+Optimization direction: **maximize**.
+
+## Runtime requirements
+
+| Setting | Value |
+|---------|-------|
+| Sandbox | Any — works in the in-process **WebAssembly** (Python) or **Deno** (TypeScript) backends. |
+| Dependencies | None — uses `json` / built-in `JSON`. |
+| Internet access | Not required. |
+| Environment variables | None. |

--- a/docs/phoenix/evaluation/server-evals/code-evaluators/llm-jury.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators/llm-jury.mdx
@@ -1,0 +1,251 @@
+---
+title: "LLM Jury"
+sidebarTitle: "LLM Jury"
+description: "Poll multiple LLMs as judges and combine their verdicts with a weighted average to reduce single-model bias."
+---
+
+An **LLM jury** runs the same judgment through several LLMs — typically from different providers — and combines their verdicts. Each juror has a trust weight, the final score is the weighted average of the per-juror scores, and the per-juror labels (plus any errors) land in the `explanation` so you can audit who voted what.
+
+Reach for this when:
+
+- One judge's biases or self-preference are skewing your scores and you want a more robust verdict.
+- The output is high-stakes and the extra cost of N model calls is worth a more reliable score.
+- You're benchmarking judge models against each other — the per-juror breakdown shows their agreement rate over the dataset.
+
+The implementation uses `arize-phoenix-evals` / `@arizeai/phoenix-evals` to put every provider behind a uniform `ClassificationEvaluator` interface, so adding a juror is a one-liner.
+
+## Code
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+from phoenix.evals import LLM, ClassificationEvaluator
+
+_PROMPT = (
+    "Is the answer factually correct given the reference?\n\n"
+    "Reference: {reference}\n\nAnswer: {output}"
+)
+_CHOICES = {"correct": 1.0, "partially_correct": 0.5, "incorrect": 0.0}
+
+
+# Each juror: (LLM, weight). Weights reflect how much you trust each model.
+_JURORS = [
+    (LLM(provider="openai", model="gpt-4o-mini"), 1.0),
+    (LLM(provider="anthropic", model="claude-haiku-4-5"), 1.0),
+    (LLM(provider="google", model="gemini-2.5-flash"), 0.8),
+]
+
+_EVALUATORS = [
+    (
+        ClassificationEvaluator(
+            name=f"jury_{llm.provider}",
+            llm=llm,
+            prompt_template=_PROMPT,
+            choices=_CHOICES,
+        ),
+        weight,
+    )
+    for llm, weight in _JURORS
+]
+
+
+def evaluate(output, reference):
+    if not output or not reference:
+        return {
+            "label": "missing",
+            "score": 0.0,
+            "explanation": "Missing output or reference.",
+        }
+
+    inputs = {"output": str(output), "reference": str(reference)}
+    weighted_sum = 0.0
+    weight_total = 0.0
+    parts = []
+
+    for evaluator, weight in _EVALUATORS:
+        try:
+            result = evaluator.evaluate(inputs)[0]
+        except Exception as exc:
+            parts.append(f"{evaluator.name}=error:{exc.__class__.__name__}")
+            continue
+
+        score = result.score if result.score is not None else 0.0
+        weighted_sum += weight * score
+        weight_total += weight
+        parts.append(
+            f"{evaluator.name}({result.label or '?'})={score:.2f}×{weight:.1f}"
+        )
+
+    if weight_total == 0.0:
+        return {
+            "label": "invalid",
+            "score": 0.0,
+            "explanation": "All jurors errored. " + "; ".join(parts),
+        }
+
+    final_score = weighted_sum / weight_total
+    return {
+        "score": final_score,
+        "explanation": f"Jury={final_score:.4f}; " + ", ".join(parts),
+    }
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+import { anthropic } from "@ai-sdk/anthropic";
+import { google } from "@ai-sdk/google";
+import { openai } from "@ai-sdk/openai";
+import {
+  ClassificationEvaluator,
+  createClassificationEvaluator,
+} from "@arizeai/phoenix-evals";
+
+const PROMPT =
+  "Is the answer factually correct given the reference?\n\n" +
+  "Reference: {{ reference }}\n\nAnswer: {{ output }}";
+const CHOICES = { correct: 1, partially_correct: 0.5, incorrect: 0 };
+
+// Each juror: an evaluator + a trust weight.
+const JURORS: Array<{
+  evaluator: ClassificationEvaluator<{ output: string; reference: string }>;
+  weight: number;
+  name: string;
+}> = [
+  {
+    name: "openai",
+    weight: 1.0,
+    evaluator: createClassificationEvaluator({
+      name: "jury_openai",
+      model: openai("gpt-4o-mini"),
+      promptTemplate: PROMPT,
+      choices: CHOICES,
+    }),
+  },
+  {
+    name: "anthropic",
+    weight: 1.0,
+    evaluator: createClassificationEvaluator({
+      name: "jury_anthropic",
+      model: anthropic("claude-haiku-4-5"),
+      promptTemplate: PROMPT,
+      choices: CHOICES,
+    }),
+  },
+  {
+    name: "google",
+    weight: 0.8,
+    evaluator: createClassificationEvaluator({
+      name: "jury_google",
+      model: google("gemini-2.5-flash"),
+      promptTemplate: PROMPT,
+      choices: CHOICES,
+    }),
+  },
+];
+
+async function evaluate({ output, reference }: EvaluatorParams) {
+  if (!output || !reference) {
+    return {
+      label: "missing",
+      score: 0,
+      explanation: "Missing output or reference.",
+    };
+  }
+
+  const inputs = { output: String(output), reference: String(reference) };
+
+  // Fan out to all jurors in parallel — independent API calls.
+  const settled = await Promise.allSettled(
+    JURORS.map(({ evaluator }) => evaluator.evaluate(inputs))
+  );
+
+  let weightedSum = 0;
+  let weightTotal = 0;
+  const parts: string[] = [];
+
+  settled.forEach((res, i) => {
+    const { name, weight } = JURORS[i];
+    if (res.status === "rejected") {
+      parts.push(`${name}=error:${(res.reason as Error).name}`);
+      return;
+    }
+    const score = res.value.score ?? 0;
+    weightedSum += weight * score;
+    weightTotal += weight;
+    parts.push(
+      `${name}(${res.value.label ?? "?"})=${score.toFixed(2)}×${weight.toFixed(1)}`
+    );
+  });
+
+  if (weightTotal === 0) {
+    return {
+      label: "invalid",
+      score: 0,
+      explanation: `All jurors errored. ${parts.join("; ")}`,
+    };
+  }
+
+  const finalScore = weightedSum / weightTotal;
+  return {
+    score: finalScore,
+    explanation: `Jury=${finalScore.toFixed(4)}; ${parts.join(", ")}`,
+  };
+}
+```
+
+The TypeScript version fans out to all jurors in parallel with `Promise.allSettled`, so wall-clock latency is roughly the slowest single juror's call — not the sum. The Python version dispatches sequentially; if latency matters, submit each `evaluator.evaluate(...)` call to a `concurrent.futures.ThreadPoolExecutor` and gather the results.
+</Tab>
+</Tabs>
+
+## Input mapping
+
+| Parameter | Bind to |
+|-----------|---------|
+| `output` | The model output to grade, usually `output`. |
+| `reference` | The ground-truth answer the jurors compare against, usually `reference`. |
+
+## Output configuration
+
+Continuous score in the range `0.0` to `1.0` (matches the weighted average of the configured choice scores). Optimization direction: **maximize**.
+
+## Runtime requirements
+
+| Setting | Value |
+|---------|-------|
+| Sandbox | A **hosted** backend that matches your language. Python: **E2B**, **Daytona — Python**, **Vercel Sandbox — Python**, or **Modal**. TypeScript: **Daytona — TypeScript** or **Vercel Sandbox — TypeScript** (the local Deno sandbox is `--no-npm` and cannot install npm packages). |
+| Dependencies | Python: `arize-phoenix-evals`, `openai`, `anthropic`, `google-genai`. TypeScript: `@arizeai/phoenix-evals`, `ai`, `@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/google`. |
+| Internet access | **Required** — the sandbox must reach `api.openai.com`, `api.anthropic.com`, and `generativelanguage.googleapis.com`. |
+| Environment variables | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY` — set each as a **secret reference** to a key in [Settings → Secrets](/docs/phoenix/settings/secrets). Drop a juror entirely if you don't want to provision that provider's key. |
+
+<Warning>
+The jury makes **N API calls per example** — one per juror — and pays the full install cost for every provider SDK on cold start. `arize-phoenix-evals` alone pulls `pydantic` and `httpx`; each provider SDK adds another 10–40 MB. Bump the sandbox configuration's **Timeout** to comfortably cover N round-trips plus the install, and reuse the same configuration across runs so the provider can warm-cache it.
+
+The model IDs above (`gpt-4o-mini`, `claude-haiku-4-5`, `gemini-2.5-flash`) are reasonable defaults at the time of writing — swap them for the latest stable IDs from the provider's docs.
+</Warning>
+
+## Variants
+
+### Weighted majority vote (categorical jury)
+
+Instead of averaging numeric scores, count votes per label and return whichever label wins by weight. Use this when downstream consumers want a discrete verdict (`correct` / `incorrect`) rather than a continuous score. The sketch below replaces the score-averaging block; the per-juror collection loop stays the same:
+
+```python
+votes: dict[str, float] = {}
+for label, weight in juror_results:  # collected the same way as above
+    votes[label] = votes.get(label, 0.0) + weight
+winner = max(votes, key=votes.get) if votes else "invalid"
+return {
+    "label": winner,
+    "score": _CHOICES.get(winner, 0.0),
+    "explanation": f"Votes: {votes}",
+}
+```
+
+### Agreement filter (high-confidence subset)
+
+For training-data filtering, return a non-zero score only when **all** jurors agree — otherwise drop the example. Score collapses to `0` or `1`; label becomes `agreement` / `disagreement`.
+
+## Related
+
+- [Pairwise Comparison](/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise) — single LLM judging two candidate outputs against each other (blinded to avoid position bias).
+- [Composite Evaluator](/docs/phoenix/evaluation/server-evals/code-evaluators/composite) — combine different *axes* of judgment (from possibly different judges) into one score.

--- a/docs/phoenix/evaluation/server-evals/code-evaluators/llm-jury.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators/llm-jury.mdx
@@ -14,6 +14,29 @@ Reach for this when:
 
 The implementation uses `arize-phoenix-evals` / `@arizeai/phoenix-evals` to put every provider behind a uniform `ClassificationEvaluator` interface, so adding a juror is a one-liner.
 
+```mermaid
+flowchart LR
+    Inputs["output<br/>reference"]
+    subgraph jury [Jury]
+        direction TB
+        J1["Juror A<br/>weight 1.0"]
+        J2["Juror B<br/>weight 1.0"]
+        J3["Juror C<br/>weight 0.8"]
+    end
+    Combine["Weighted<br/>average"]
+    Final["Final score<br/>+ per-juror trace"]
+
+    Inputs --> J1
+    Inputs --> J2
+    Inputs --> J3
+    J1 -- "label × weight" --> Combine
+    J2 -- "label × weight" --> Combine
+    J3 -- "label × weight" --> Combine
+    Combine --> Final
+```
+
+Every juror sees the same prompt; their verdicts and weights combine into one score, and the per-juror labels (plus any errors) land in the explanation.
+
 ## Code
 
 <Tabs>
@@ -88,6 +111,15 @@ def evaluate(output, reference):
         "score": final_score,
         "explanation": f"Jury={final_score:.4f}; " + ", ".join(parts),
     }
+```
+
+**Sandbox dependencies** — paste into the sandbox configuration's Dependencies field, one package per line:
+
+```
+arize-phoenix-evals
+openai
+anthropic
+google-genai
 ```
 </Tab>
 <Tab title="TypeScript" icon="js">
@@ -194,6 +226,16 @@ async function evaluate({ output, reference }: EvaluatorParams) {
 ```
 
 The TypeScript version fans out to all jurors in parallel with `Promise.allSettled`, so wall-clock latency is roughly the slowest single juror's call — not the sum. The Python version dispatches sequentially; if latency matters, submit each `evaluator.evaluate(...)` call to a `concurrent.futures.ThreadPoolExecutor` and gather the results.
+
+**Sandbox dependencies** — paste into the sandbox configuration's Dependencies field, one package per line:
+
+```
+@arizeai/phoenix-evals
+ai
+@ai-sdk/openai
+@ai-sdk/anthropic
+@ai-sdk/google
+```
 </Tab>
 </Tabs>
 
@@ -247,5 +289,5 @@ For training-data filtering, return a non-zero score only when **all** jurors ag
 
 ## Related
 
-- [Pairwise Comparison](/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise) — single LLM judging two candidate outputs against each other (blinded to avoid position bias).
+- [Pairwise Evaluator](/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise) — single LLM judging `output` head-to-head against a `reference` baseline (blinded to avoid position bias).
 - [Composite Evaluator](/docs/phoenix/evaluation/server-evals/code-evaluators/composite) — combine different *axes* of judgment (from possibly different judges) into one score.

--- a/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise.mdx
@@ -1,12 +1,41 @@
 ---
-title: "Pairwise Comparison"
-sidebarTitle: "Pairwise"
-description: "Blind LLM-judge pairwise comparison between two candidate outputs against a reference."
+title: "Pairwise Evaluator"
+sidebarTitle: "Pairwise Evaluator"
+description: "Blind LLM-judge head-to-head comparison of the model output against a reference answer."
 ---
 
-A **pairwise evaluator** scores two candidate outputs side-by-side and returns the winner (or a tie). This is the classic "A vs. B" test for benchmarking two prompts, two models, or two prompt versions against the same dataset.
+A **pairwise evaluator** puts the model `output` head-to-head against a `reference` answer and returns a winner (or a tie). Use it to benchmark a new prompt or model against a known-good baseline that's already in the dataset row.
 
-The example below asks an LLM judge to pick the better candidate — but **blinds** the judge so it never sees which side is A and which is B. The presentation order is randomized per example using a seed derived from the inputs (so runs stay reproducible), and the judge's positional choice is decoded back to the original A/B labels after the call. This mitigates LLM position bias — the tendency of judges to systematically prefer whichever response they see first.
+The example below asks an LLM judge to pick the better candidate — but **blinds** the judge so it never sees which side is the model output and which is the reference. The presentation order is randomized per example using a seed derived from the inputs (so runs stay reproducible), and the judge's positional choice is decoded back to the original labels after the call. This mitigates LLM position bias — the tendency of judges to systematically prefer whichever response they see first.
+
+```mermaid
+flowchart LR
+    Out[Output]
+    Ref[Reference]
+
+    Shuffle{"Seeded<br/>shuffle"}
+
+    subgraph blinded [What the judge sees]
+        direction TB
+        C1[Candidate 1]
+        C2[Candidate 2]
+    end
+
+    Judge[LLM Judge]
+    Decode["Decode position<br/>using same seed"]
+    Final["Winner:<br/>output · reference · tie"]
+
+    Out --> Shuffle
+    Ref --> Shuffle
+    Shuffle --> C1
+    Shuffle --> C2
+    C1 --> Judge
+    C2 --> Judge
+    Judge -- "picks 1, 2,<br/>or tie" --> Decode
+    Decode --> Final
+```
+
+The judge never sees which side is the model output and which is the reference — only "Candidate 1" and "Candidate 2". The seeded shuffle is deterministic per example, so the same inputs always produce the same presentation order.
 
 ## Code
 
@@ -23,16 +52,13 @@ _MODEL = "gpt-4o-mini"
 _client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
 
 _SYSTEM_PROMPT = (
-    "You are an impartial judge comparing two candidate responses to a "
-    "reference answer. Decide which candidate is closer to the reference. "
+    "You are an impartial judge comparing two candidate responses. "
+    "Decide which candidate is the better answer. "
     "Reply with strict JSON: "
     '{"winner": "1" | "2" | "tie", "reason": "<one-sentence justification>"}.'
 )
 
-_USER_TEMPLATE = """Reference answer:
-{reference}
-
-Candidate 1:
+_USER_TEMPLATE = """Candidate 1:
 {first}
 
 Candidate 2:
@@ -40,7 +66,7 @@ Candidate 2:
 
 
 def _seeded_flip(*parts):
-    """Return True if A and B should be swapped before showing to the judge.
+    """Return True if output and reference should be swapped before showing to the judge.
 
     Seed is derived deterministically from the inputs so two runs on the same
     example produce the same presentation order — important for reproducibility
@@ -50,18 +76,16 @@ def _seeded_flip(*parts):
     return int(digest[:8], 16) % 2 == 1
 
 
-def evaluate(output_a, output_b, reference):
-    if not output_a or not output_b or not reference:
+def evaluate(output, reference):
+    if not output or not reference:
         return {
             "label": "missing",
             "score": 0.0,
-            "explanation": (
-                "Missing one or more of output_a, output_b, reference."
-            ),
+            "explanation": "Missing output or reference.",
         }
 
-    flip = _seeded_flip(str(output_a), str(output_b), str(reference))
-    first, second = (output_b, output_a) if flip else (output_a, output_b)
+    flip = _seeded_flip(str(output), str(reference))
+    first, second = (reference, output) if flip else (output, reference)
 
     response = _client.chat.completions.create(
         model=_MODEL,
@@ -71,9 +95,7 @@ def evaluate(output_a, output_b, reference):
             {"role": "system", "content": _SYSTEM_PROMPT},
             {
                 "role": "user",
-                "content": _USER_TEMPLATE.format(
-                    reference=reference, first=first, second=second
-                ),
+                "content": _USER_TEMPLATE.format(first=first, second=second),
             },
         ],
     )
@@ -90,13 +112,13 @@ def evaluate(output_a, output_b, reference):
     winner_position = str(parsed.get("winner", "")).strip()
     reason = str(parsed.get("reason", ""))[:300]
 
-    # Decode position back to A / B using the flip we applied.
+    # Decode position back to output / reference using the flip we applied.
     if winner_position == "tie":
         label = "tie"
     elif winner_position == "1":
-        label = "b" if flip else "a"
+        label = "reference" if flip else "output"
     elif winner_position == "2":
-        label = "a" if flip else "b"
+        label = "output" if flip else "reference"
     else:
         return {
             "label": "invalid",
@@ -107,16 +129,22 @@ def evaluate(output_a, output_b, reference):
             ),
         }
 
-    score = {"a": 1.0, "b": -1.0, "tie": 0.0}[label]
-    a_position = "2" if flip else "1"
+    score = {"output": 1.0, "reference": -1.0, "tie": 0.0}[label]
+    output_position = "2" if flip else "1"
     return {
         "label": label,
         "score": score,
         "explanation": (
             f"Judge chose position {winner_position} "
-            f"(A was shown as position {a_position}). {reason}"
+            f"(output was shown as position {output_position}). {reason}"
         ),
     }
+```
+
+**Sandbox dependencies** — paste into the sandbox configuration's Dependencies field, one package per line:
+
+```
+openai
 ```
 </Tab>
 <Tab title="TypeScript" icon="js">
@@ -127,17 +155,13 @@ const MODEL = "gpt-4o-mini";
 const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 const SYSTEM_PROMPT =
-  "You are an impartial judge comparing two candidate responses to a " +
-  "reference answer. Decide which candidate is closer to the reference. " +
+  "You are an impartial judge comparing two candidate responses. " +
+  "Decide which candidate is the better answer. " +
   "Reply with strict JSON: " +
   '{"winner": "1" | "2" | "tie", "reason": "<one-sentence justification>"}.';
 
-function userPrompt(reference: string, first: string, second: string): string {
-  return (
-    `Reference answer:\n${reference}\n\n` +
-    `Candidate 1:\n${first}\n\n` +
-    `Candidate 2:\n${second}`
-  );
+function userPrompt(first: string, second: string): string {
+  return `Candidate 1:\n${first}\n\nCandidate 2:\n${second}`;
 }
 
 // Deterministic per-example flip without external deps. Not cryptographically
@@ -151,23 +175,19 @@ function seededFlip(...parts: string[]): boolean {
   return (hash & 1) === 1;
 }
 
-async function evaluate({
-  output_a,
-  output_b,
-  reference,
-}: EvaluatorParams) {
-  if (!output_a || !output_b || !reference) {
+async function evaluate({ output, reference }: EvaluatorParams) {
+  if (!output || !reference) {
     return {
       label: "missing",
       score: 0,
-      explanation: "Missing one or more of output_a, output_b, reference.",
+      explanation: "Missing output or reference.",
     };
   }
 
-  const flip = seededFlip(String(output_a), String(output_b), String(reference));
+  const flip = seededFlip(String(output), String(reference));
   const [first, second] = flip
-    ? [String(output_b), String(output_a)]
-    : [String(output_a), String(output_b)];
+    ? [String(reference), String(output)]
+    : [String(output), String(reference)];
 
   const response = await client.chat.completions.create({
     model: MODEL,
@@ -175,7 +195,7 @@ async function evaluate({
     response_format: { type: "json_object" },
     messages: [
       { role: "system", content: SYSTEM_PROMPT },
-      { role: "user", content: userPrompt(String(reference), first, second) },
+      { role: "user", content: userPrompt(first, second) },
     ],
   });
 
@@ -193,13 +213,13 @@ async function evaluate({
   const winnerPosition = String(parsed.winner ?? "").trim();
   const reason = String(parsed.reason ?? "").slice(0, 300);
 
-  let label: "a" | "b" | "tie";
+  let label: "output" | "reference" | "tie";
   if (winnerPosition === "tie") {
     label = "tie";
   } else if (winnerPosition === "1") {
-    label = flip ? "b" : "a";
+    label = flip ? "reference" : "output";
   } else if (winnerPosition === "2") {
-    label = flip ? "a" : "b";
+    label = flip ? "output" : "reference";
   } else {
     return {
       label: "invalid",
@@ -210,35 +230,40 @@ async function evaluate({
     };
   }
 
-  const scoreMap: Record<typeof label, number> = { a: 1, b: -1, tie: 0 };
-  const aPosition = flip ? "2" : "1";
+  const scoreMap: Record<typeof label, number> = {
+    output: 1,
+    reference: -1,
+    tie: 0,
+  };
+  const outputPosition = flip ? "2" : "1";
   return {
     label,
     score: scoreMap[label],
     explanation:
       `Judge chose position ${winnerPosition} ` +
-      `(A was shown as position ${aPosition}). ${reason}`,
+      `(output was shown as position ${outputPosition}). ${reason}`,
   };
 }
 ```
 
 The TypeScript version uses a small djb2-style string hash instead of SHA-256 to avoid a `node:crypto` import that may not resolve in every TS sandbox. It's not cryptographically strong — it doesn't need to be — but it's deterministic and well-distributed enough to balance presentation orders across the dataset.
+
+**Sandbox dependencies** — paste into the sandbox configuration's Dependencies field, one package per line:
+
+```
+openai
+```
 </Tab>
 </Tabs>
 
-The judge never sees the strings "A" or "B" — only "Candidate 1" and "Candidate 2". The `flip` decision is recorded in the explanation so you can audit the decoding from the trace.
+The `flip` decision is recorded in the explanation so you can audit the decoding from the trace.
 
 ## Input mapping
 
 | Parameter | Bind to |
 |-----------|---------|
-| `output_a` | The first candidate output. Typical paths: `output.candidate_a`, `metadata.run_a.output`, or a column you populated by joining two experiment runs. |
-| `output_b` | The second candidate output. Mirror of `output_a`. |
-| `reference` | The ground-truth answer the judge compares against, usually `reference`. |
-
-<Info>
-Phoenix's code evaluators read all parameters off a single evaluation context, so both candidates must live on the same example row. If your candidates come from separate experiment runs, join them into a single column before pointing the evaluator at the dataset.
-</Info>
+| `output` | The model output you want to evaluate, usually `output`. |
+| `reference` | The competing answer to compare against — typically the baseline or known-good response stored on the example, usually `reference`. |
 
 ## Output configuration
 
@@ -246,13 +271,13 @@ Categorical. The function returns its own numeric score along with the label, so
 
 | Label | Score | Meaning |
 |-------|-------|---------|
-| `a` | `1.0` | Candidate A wins. |
-| `b` | `-1.0` | Candidate B wins. |
+| `output` | `1.0` | The model output beats the reference. |
+| `reference` | `-1.0` | The reference beats the model output. |
 | `tie` | `0.0` | Judge could not separate them. |
 | `missing` | `0.0` | One of the inputs was empty. |
 | `invalid` | `0.0` | Judge returned malformed output. |
 
-Optimization direction: **maximize** if `output_a` is the candidate you want to win (e.g. the new prompt, the challenger model). If `output_a` is your baseline and `output_b` is the challenger, set the direction to **minimize** instead.
+Optimization direction: **maximize** — you want `output` to win against the reference baseline.
 
 ## Runtime requirements
 
@@ -267,7 +292,7 @@ Optimization direction: **maximize** if `output_a` is the candidate you want to 
 Each `evaluate(...)` call makes **one** chat-completion request against `gpt-4o-mini`. At scale:
 
 - Raise the sandbox configuration's **Timeout** to comfortably cover the LLM round-trip plus a cold-start package install.
-- Watch the judge's per-token cost — every pairwise prompt includes the reference plus both candidates, so token counts grow with output length.
+- Watch the judge's per-token cost — every pairwise prompt includes both the output and the reference, so token counts grow with output length.
 - For high-stakes evaluations, see the **Swap-and-confirm** variant below. It doubles the cost but removes position bias on every example, instead of relying on randomized order to cancel it out in aggregate.
 </Warning>
 
@@ -278,8 +303,8 @@ Each `evaluate(...)` call makes **one** chat-completion request against `gpt-4o-
 The blinding above randomizes order per example, so position bias cancels out in expectation — but any single example can still be biased. To remove it per-example, call the judge twice (once in each order) and only return a winner when both calls agree:
 
 ```python
-def evaluate(output_a, output_b, reference):
-    if not output_a or not output_b or not reference:
+def evaluate(output, reference):
+    if not output or not reference:
         return {"label": "missing", "score": 0.0, "explanation": "Missing input."}
 
     def _ask(first, second):
@@ -291,32 +316,31 @@ def evaluate(output_a, output_b, reference):
                 {"role": "system", "content": _SYSTEM_PROMPT},
                 {
                     "role": "user",
-                    "content": _USER_TEMPLATE.format(
-                        reference=reference, first=first, second=second
-                    ),
+                    "content": _USER_TEMPLATE.format(first=first, second=second),
                 },
             ],
         )
         return json.loads(response.choices[0].message.content).get("winner")
 
-    pick_ab = _ask(output_a, output_b)  # "1" = A, "2" = B, "tie"
-    pick_ba = _ask(output_b, output_a)  # "1" = B, "2" = A, "tie"
+    pick_or = _ask(output, reference)  # "1" = output, "2" = reference, "tie"
+    pick_ro = _ask(reference, output)  # "1" = reference, "2" = output, "tie"
 
-    # Translate both picks into A / B / tie.
-    vote_ab = {"1": "a", "2": "b", "tie": "tie"}.get(pick_ab, "invalid")
-    vote_ba = {"1": "b", "2": "a", "tie": "tie"}.get(pick_ba, "invalid")
+    # Translate both picks into output / reference / tie.
+    vote_or = {"1": "output", "2": "reference", "tie": "tie"}.get(pick_or, "invalid")
+    vote_ro = {"1": "reference", "2": "output", "tie": "tie"}.get(pick_ro, "invalid")
 
-    if vote_ab == vote_ba and vote_ab in {"a", "b", "tie"}:
-        label = vote_ab
+    if vote_or == vote_ro and vote_or in {"output", "reference", "tie"}:
+        label = vote_or
     else:
         label = "tie"  # disagreement → call it a tie
 
-    score = {"a": 1.0, "b": -1.0, "tie": 0.0, "invalid": 0.0}[label]
+    score = {"output": 1.0, "reference": -1.0, "tie": 0.0, "invalid": 0.0}[label]
     return {
         "label": label,
         "score": score,
         "explanation": (
-            f"Order A,B → {pick_ab}; order B,A → {pick_ba}; final = {label}."
+            f"Order output,reference → {pick_or}; "
+            f"order reference,output → {pick_ro}; final = {label}."
         ),
     }
 ```
@@ -326,4 +350,4 @@ Costs 2× the API calls, but each example's verdict is independent of the underl
 ### Other directions
 
 - **Multi-criterion judging** — ask the judge to score on several axes (correctness, conciseness, format) and combine the per-axis verdicts. Return a structured `explanation` so the trace shows the breakdown.
-- **Embedding-based pairwise** — replace the LLM call with cosine similarity to the reference using OpenAI embeddings or [scikit-learn](/docs/phoenix/evaluation/server-evals/code-evaluators/scikit-learn). Cheaper and deterministic, but it won't catch semantic equivalence the way an LLM judge can on free-text answers.
+- **Embedding-based pairwise** — replace the LLM call with cosine similarity between `output` and `reference` using OpenAI embeddings or [scikit-learn](/docs/phoenix/evaluation/server-evals/code-evaluators/scikit-learn). Cheaper and deterministic, but it won't catch semantic equivalence the way an LLM judge can on free-text answers.

--- a/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise.mdx
@@ -1,0 +1,329 @@
+---
+title: "Pairwise Comparison"
+sidebarTitle: "Pairwise"
+description: "Blind LLM-judge pairwise comparison between two candidate outputs against a reference."
+---
+
+A **pairwise evaluator** scores two candidate outputs side-by-side and returns the winner (or a tie). This is the classic "A vs. B" test for benchmarking two prompts, two models, or two prompt versions against the same dataset.
+
+The example below asks an LLM judge to pick the better candidate — but **blinds** the judge so it never sees which side is A and which is B. The presentation order is randomized per example using a seed derived from the inputs (so runs stay reproducible), and the judge's positional choice is decoded back to the original A/B labels after the call. This mitigates LLM position bias — the tendency of judges to systematically prefer whichever response they see first.
+
+## Code
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+import hashlib
+import json
+import os
+
+from openai import OpenAI
+
+_MODEL = "gpt-4o-mini"
+_client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+_SYSTEM_PROMPT = (
+    "You are an impartial judge comparing two candidate responses to a "
+    "reference answer. Decide which candidate is closer to the reference. "
+    "Reply with strict JSON: "
+    '{"winner": "1" | "2" | "tie", "reason": "<one-sentence justification>"}.'
+)
+
+_USER_TEMPLATE = """Reference answer:
+{reference}
+
+Candidate 1:
+{first}
+
+Candidate 2:
+{second}"""
+
+
+def _seeded_flip(*parts):
+    """Return True if A and B should be swapped before showing to the judge.
+
+    Seed is derived deterministically from the inputs so two runs on the same
+    example produce the same presentation order — important for reproducibility
+    and for caching at the LLM layer.
+    """
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) % 2 == 1
+
+
+def evaluate(output_a, output_b, reference):
+    if not output_a or not output_b or not reference:
+        return {
+            "label": "missing",
+            "score": 0.0,
+            "explanation": (
+                "Missing one or more of output_a, output_b, reference."
+            ),
+        }
+
+    flip = _seeded_flip(str(output_a), str(output_b), str(reference))
+    first, second = (output_b, output_a) if flip else (output_a, output_b)
+
+    response = _client.chat.completions.create(
+        model=_MODEL,
+        temperature=0,
+        response_format={"type": "json_object"},
+        messages=[
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": _USER_TEMPLATE.format(
+                    reference=reference, first=first, second=second
+                ),
+            },
+        ],
+    )
+
+    try:
+        parsed = json.loads(response.choices[0].message.content)
+    except (json.JSONDecodeError, AttributeError, TypeError) as exc:
+        return {
+            "label": "invalid",
+            "score": 0.0,
+            "explanation": f"Failed to parse judge response: {exc}",
+        }
+
+    winner_position = str(parsed.get("winner", "")).strip()
+    reason = str(parsed.get("reason", ""))[:300]
+
+    # Decode position back to A / B using the flip we applied.
+    if winner_position == "tie":
+        label = "tie"
+    elif winner_position == "1":
+        label = "b" if flip else "a"
+    elif winner_position == "2":
+        label = "a" if flip else "b"
+    else:
+        return {
+            "label": "invalid",
+            "score": 0.0,
+            "explanation": (
+                f"Judge returned unexpected winner {winner_position!r}; "
+                f"expected '1', '2', or 'tie'."
+            ),
+        }
+
+    score = {"a": 1.0, "b": -1.0, "tie": 0.0}[label]
+    a_position = "2" if flip else "1"
+    return {
+        "label": label,
+        "score": score,
+        "explanation": (
+            f"Judge chose position {winner_position} "
+            f"(A was shown as position {a_position}). {reason}"
+        ),
+    }
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+import OpenAI from "openai";
+
+const MODEL = "gpt-4o-mini";
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const SYSTEM_PROMPT =
+  "You are an impartial judge comparing two candidate responses to a " +
+  "reference answer. Decide which candidate is closer to the reference. " +
+  "Reply with strict JSON: " +
+  '{"winner": "1" | "2" | "tie", "reason": "<one-sentence justification>"}.';
+
+function userPrompt(reference: string, first: string, second: string): string {
+  return (
+    `Reference answer:\n${reference}\n\n` +
+    `Candidate 1:\n${first}\n\n` +
+    `Candidate 2:\n${second}`
+  );
+}
+
+// Deterministic per-example flip without external deps. Not cryptographically
+// strong — just a stable, well-distributed seed so the order is reproducible.
+function seededFlip(...parts: string[]): boolean {
+  let hash = 5381;
+  const input = parts.join("|");
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) + hash + input.charCodeAt(i)) | 0;
+  }
+  return (hash & 1) === 1;
+}
+
+async function evaluate({
+  output_a,
+  output_b,
+  reference,
+}: EvaluatorParams) {
+  if (!output_a || !output_b || !reference) {
+    return {
+      label: "missing",
+      score: 0,
+      explanation: "Missing one or more of output_a, output_b, reference.",
+    };
+  }
+
+  const flip = seededFlip(String(output_a), String(output_b), String(reference));
+  const [first, second] = flip
+    ? [String(output_b), String(output_a)]
+    : [String(output_a), String(output_b)];
+
+  const response = await client.chat.completions.create({
+    model: MODEL,
+    temperature: 0,
+    response_format: { type: "json_object" },
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userPrompt(String(reference), first, second) },
+    ],
+  });
+
+  let parsed: { winner?: unknown; reason?: unknown };
+  try {
+    parsed = JSON.parse(response.choices[0].message.content ?? "{}");
+  } catch (err) {
+    return {
+      label: "invalid",
+      score: 0,
+      explanation: `Failed to parse judge response: ${(err as Error).message}`,
+    };
+  }
+
+  const winnerPosition = String(parsed.winner ?? "").trim();
+  const reason = String(parsed.reason ?? "").slice(0, 300);
+
+  let label: "a" | "b" | "tie";
+  if (winnerPosition === "tie") {
+    label = "tie";
+  } else if (winnerPosition === "1") {
+    label = flip ? "b" : "a";
+  } else if (winnerPosition === "2") {
+    label = flip ? "a" : "b";
+  } else {
+    return {
+      label: "invalid",
+      score: 0,
+      explanation: `Judge returned unexpected winner ${JSON.stringify(
+        winnerPosition
+      )}; expected "1", "2", or "tie".`,
+    };
+  }
+
+  const scoreMap: Record<typeof label, number> = { a: 1, b: -1, tie: 0 };
+  const aPosition = flip ? "2" : "1";
+  return {
+    label,
+    score: scoreMap[label],
+    explanation:
+      `Judge chose position ${winnerPosition} ` +
+      `(A was shown as position ${aPosition}). ${reason}`,
+  };
+}
+```
+
+The TypeScript version uses a small djb2-style string hash instead of SHA-256 to avoid a `node:crypto` import that may not resolve in every TS sandbox. It's not cryptographically strong — it doesn't need to be — but it's deterministic and well-distributed enough to balance presentation orders across the dataset.
+</Tab>
+</Tabs>
+
+The judge never sees the strings "A" or "B" — only "Candidate 1" and "Candidate 2". The `flip` decision is recorded in the explanation so you can audit the decoding from the trace.
+
+## Input mapping
+
+| Parameter | Bind to |
+|-----------|---------|
+| `output_a` | The first candidate output. Typical paths: `output.candidate_a`, `metadata.run_a.output`, or a column you populated by joining two experiment runs. |
+| `output_b` | The second candidate output. Mirror of `output_a`. |
+| `reference` | The ground-truth answer the judge compares against, usually `reference`. |
+
+<Info>
+Phoenix's code evaluators read all parameters off a single evaluation context, so both candidates must live on the same example row. If your candidates come from separate experiment runs, join them into a single column before pointing the evaluator at the dataset.
+</Info>
+
+## Output configuration
+
+Categorical. The function returns its own numeric score along with the label, so configure these label-to-score mappings to match what it produces:
+
+| Label | Score | Meaning |
+|-------|-------|---------|
+| `a` | `1.0` | Candidate A wins. |
+| `b` | `-1.0` | Candidate B wins. |
+| `tie` | `0.0` | Judge could not separate them. |
+| `missing` | `0.0` | One of the inputs was empty. |
+| `invalid` | `0.0` | Judge returned malformed output. |
+
+Optimization direction: **maximize** if `output_a` is the candidate you want to win (e.g. the new prompt, the challenger model). If `output_a` is your baseline and `output_b` is the challenger, set the direction to **minimize** instead.
+
+## Runtime requirements
+
+| Setting | Value |
+|---------|-------|
+| Sandbox | A **hosted** backend that matches your language. Python: **E2B**, **Daytona — Python**, **Vercel Sandbox — Python**, or **Modal**. TypeScript: **Daytona — TypeScript** or **Vercel Sandbox — TypeScript** (the local Deno sandbox is started with `--no-npm` and cannot install the `openai` package). |
+| Dependencies | Python: `openai`. TypeScript: `openai` (npm). |
+| Internet access | **Required** — toggle **Allow Internet Access** on. The sandbox must reach `api.openai.com`. |
+| Environment variables | `OPENAI_API_KEY` — preferably set as a **secret reference** to a key in [Settings → Secrets](/docs/phoenix/settings/secrets). |
+
+<Warning>
+Each `evaluate(...)` call makes **one** chat-completion request against `gpt-4o-mini`. At scale:
+
+- Raise the sandbox configuration's **Timeout** to comfortably cover the LLM round-trip plus a cold-start package install.
+- Watch the judge's per-token cost — every pairwise prompt includes the reference plus both candidates, so token counts grow with output length.
+- For high-stakes evaluations, see the **Swap-and-confirm** variant below. It doubles the cost but removes position bias on every example, instead of relying on randomized order to cancel it out in aggregate.
+</Warning>
+
+## Variants
+
+### Swap-and-confirm (position-bias-free)
+
+The blinding above randomizes order per example, so position bias cancels out in expectation — but any single example can still be biased. To remove it per-example, call the judge twice (once in each order) and only return a winner when both calls agree:
+
+```python
+def evaluate(output_a, output_b, reference):
+    if not output_a or not output_b or not reference:
+        return {"label": "missing", "score": 0.0, "explanation": "Missing input."}
+
+    def _ask(first, second):
+        response = _client.chat.completions.create(
+            model=_MODEL,
+            temperature=0,
+            response_format={"type": "json_object"},
+            messages=[
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": _USER_TEMPLATE.format(
+                        reference=reference, first=first, second=second
+                    ),
+                },
+            ],
+        )
+        return json.loads(response.choices[0].message.content).get("winner")
+
+    pick_ab = _ask(output_a, output_b)  # "1" = A, "2" = B, "tie"
+    pick_ba = _ask(output_b, output_a)  # "1" = B, "2" = A, "tie"
+
+    # Translate both picks into A / B / tie.
+    vote_ab = {"1": "a", "2": "b", "tie": "tie"}.get(pick_ab, "invalid")
+    vote_ba = {"1": "b", "2": "a", "tie": "tie"}.get(pick_ba, "invalid")
+
+    if vote_ab == vote_ba and vote_ab in {"a", "b", "tie"}:
+        label = vote_ab
+    else:
+        label = "tie"  # disagreement → call it a tie
+
+    score = {"a": 1.0, "b": -1.0, "tie": 0.0, "invalid": 0.0}[label]
+    return {
+        "label": label,
+        "score": score,
+        "explanation": (
+            f"Order A,B → {pick_ab}; order B,A → {pick_ba}; final = {label}."
+        ),
+    }
+```
+
+Costs 2× the API calls, but each example's verdict is independent of the underlying model's position bias.
+
+### Other directions
+
+- **Multi-criterion judging** — ask the judge to score on several axes (correctness, conciseness, format) and combine the per-axis verdicts. Return a structured `explanation` so the trace shows the breakdown.
+- **Embedding-based pairwise** — replace the LLM call with cosine similarity to the reference using OpenAI embeddings or [scikit-learn](/docs/phoenix/evaluation/server-evals/code-evaluators/scikit-learn). Cheaper and deterministic, but it won't catch semantic equivalence the way an LLM judge can on free-text answers.

--- a/docs/phoenix/evaluation/server-evals/code-evaluators/regex-match.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators/regex-match.mdx
@@ -1,0 +1,125 @@
+---
+title: "Regex Match"
+sidebarTitle: "Regex Match"
+description: "Pass when the output matches a regular expression pattern."
+---
+
+Compiles a regex and reports a binary `match` / `mismatch` against the model's output — handy for asserting format invariants like phone numbers, currency strings, UUIDs, or identifier prefixes without paying for a model call.
+
+For a zero-code option, see the pre-built [Regex Match](/docs/phoenix/evaluation/server-evals/pre-built-metrics/regex) metric. Use the version below when you want to extend the logic — capture groups, multiple alternative patterns, richer explanations.
+
+## Code
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+import re
+
+
+def evaluate(output, pattern):
+    if output is None:
+        return {
+            "label": "missing",
+            "score": 0.0,
+            "explanation": "Output is missing.",
+        }
+
+    try:
+        compiled = re.compile(pattern)
+    except re.error as exc:
+        return {
+            "label": "invalid_pattern",
+            "score": 0.0,
+            "explanation": f"Failed to compile regex {pattern!r}: {exc}",
+        }
+
+    match = compiled.search(str(output))
+    if match is None:
+        return {
+            "label": "mismatch",
+            "score": 0.0,
+            "explanation": f"Output does not match /{pattern}/.",
+        }
+    return {
+        "label": "match",
+        "score": 1.0,
+        "explanation": f"Matched substring: {match.group(0)!r}",
+    }
+```
+</Tab>
+<Tab title="TypeScript" icon="js">
+```typescript
+function evaluate({ output, pattern }: EvaluatorParams) {
+  if (output == null) {
+    return {
+      label: "missing",
+      score: 0,
+      explanation: "Output is missing.",
+    };
+  }
+
+  let regex: RegExp;
+  try {
+    regex = new RegExp(pattern as string);
+  } catch (err) {
+    return {
+      label: "invalid_pattern",
+      score: 0,
+      explanation: `Failed to compile regex ${JSON.stringify(pattern)}: ${
+        (err as Error).message
+      }`,
+    };
+  }
+
+  const match = String(output).match(regex);
+  if (match === null) {
+    return {
+      label: "mismatch",
+      score: 0,
+      explanation: `Output does not match /${pattern}/.`,
+    };
+  }
+  return {
+    label: "match",
+    score: 1,
+    explanation: `Matched substring: ${JSON.stringify(match[0])}`,
+  };
+}
+```
+</Tab>
+</Tabs>
+
+Both `re.search` and `String.match` find a match anywhere in the string. If you need the *entire* output to match, switch to `re.fullmatch` in Python, or anchor the pattern with `^...$` in TypeScript.
+
+## Input mapping
+
+| Parameter | Bind to |
+|-----------|---------|
+| `output` | The model output, usually `output`. |
+| `pattern` | Use a **literal** regex string (e.g. `^[A-Z]{3}-\d{4}$`) when every example shares the same pattern, or a dataset path (e.g. `metadata.expected_pattern`) when patterns vary per example. |
+
+## Output configuration
+
+Categorical labels:
+
+| Label | Score |
+|-------|-------|
+| `match` | `1.0` |
+| `mismatch` | `0.0` |
+| `missing` | `0.0` |
+| `invalid_pattern` | `0.0` |
+
+Optimization direction: **maximize**.
+
+## Runtime requirements
+
+| Setting | Value |
+|---------|-------|
+| Sandbox | Any — works in the in-process **WebAssembly** (Python) or **Deno** (TypeScript) backends. |
+| Dependencies | None — uses `re` / built-in `RegExp`. |
+| Internet access | Not required. |
+| Environment variables | None. |
+
+<Warning>
+Untrusted regex patterns can be vulnerable to catastrophic backtracking (ReDoS). If `pattern` is sourced from per-example dataset values rather than a fixed literal, prefer patterns from a trusted column you control.
+</Warning>

--- a/docs/phoenix/evaluation/server-evals/code-evaluators/scikit-learn.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators/scikit-learn.mdx
@@ -1,0 +1,134 @@
+---
+title: "scikit-learn Text Similarity"
+sidebarTitle: "scikit-learn"
+description: "Score text similarity offline with scikit-learn's HashingVectorizer and cosine similarity — no API calls."
+---
+
+An offline alternative to embedding-based similarity. `HashingVectorizer` hashes tokens directly into a fixed-size feature space — no fitted vocabulary, no model download, no network — so each `evaluate(...)` call is self-contained. After L2 normalization, cosine similarity measures how much the two texts share the same tokens.
+
+Use this when:
+
+- You want a cheap, deterministic fuzzy match between two short texts.
+- An external embeddings API is too slow, too expensive, or unavailable (air-gapped sandbox).
+- Exact or regex match is too brittle, but full semantic embeddings are overkill.
+
+This is a token-overlap score, not a true semantic embedding — synonyms and paraphrases will look dissimilar. For semantic matching, see [Embedding Distance](/docs/phoenix/evaluation/server-evals/code-evaluators/embedding-distance).
+
+## Code
+
+<Tabs>
+<Tab title="Python" icon="python">
+```python
+from sklearn.feature_extraction.text import HashingVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+_vectorizer = HashingVectorizer(
+    n_features=2**18,
+    analyzer="word",
+    norm="l2",
+    alternate_sign=False,
+)
+
+
+def evaluate(output, reference):
+    if not output or not reference:
+        return {
+            "label": "missing",
+            "score": 0.0,
+            "explanation": "Missing output or reference.",
+        }
+
+    vectors = _vectorizer.transform([str(output), str(reference)])
+    similarity = float(cosine_similarity(vectors[0], vectors[1])[0, 0])
+    return {
+        "score": similarity,
+        "explanation": f"Token-overlap cosine similarity {similarity:.4f}.",
+    }
+```
+
+Notes on the vectorizer configuration:
+
+- **`alternate_sign=False`** — disables sklearn's signed-hashing trick. The default (`True`) helps classifier features but adds noise to cosine similarity; turning it off keeps each cell a non-negative count of hashed tokens.
+- **`norm="l2"`** — L2-normalizes each vector so cosine similarity falls naturally in `[0.0, 1.0]`.
+- **`n_features=2**18`** — 262,144 hash buckets. Big enough that collisions on short texts are negligible, small enough to stay cheap.
+</Tab>
+<Tab title="TypeScript" icon="js">
+There's no scikit-learn for JavaScript, but the underlying recipe — tokenize, count, cosine — is a few lines of stdlib code and runs in the **local Deno sandbox** with no dependencies and no network.
+
+```typescript
+function tokenCounts(text: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  const tokens = text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+  for (const token of tokens) {
+    counts.set(token, (counts.get(token) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function cosine(a: Map<string, number>, b: Map<string, number>): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (const value of a.values()) normA += value * value;
+  for (const value of b.values()) normB += value * value;
+  for (const [token, va] of a) {
+    const vb = b.get(token);
+    if (vb !== undefined) dot += va * vb;
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+function evaluate({ output, reference }: EvaluatorParams) {
+  if (!output || !reference) {
+    return {
+      label: "missing",
+      score: 0,
+      explanation: "Missing output or reference.",
+    };
+  }
+
+  const similarity = cosine(
+    tokenCounts(String(output)),
+    tokenCounts(String(reference))
+  );
+  return {
+    score: similarity,
+    explanation: `Token-overlap cosine similarity ${similarity.toFixed(4)}.`,
+  };
+}
+```
+
+Mathematically equivalent to the Python version with `analyzer="word"`. Word boundaries are detected with `\p{L}\p{N}` (Unicode letters and digits), so non-ASCII text tokenizes correctly. The hashing step is dropped — the vocabulary is implicit in the `Map` keys — which is fine since the cost only scales with the two inputs' token counts.
+</Tab>
+</Tabs>
+
+## Input mapping
+
+| Parameter | Bind to |
+|-----------|---------|
+| `output` | The model output to score, usually `output`. |
+| `reference` | The ground-truth string, usually `reference`. |
+
+## Output configuration
+
+Continuous score in the range `0.0` to `1.0`. Optimization direction: **maximize**.
+
+## Runtime requirements
+
+| Setting | Value |
+|---------|-------|
+| Sandbox | **Python (scikit-learn version)**: a hosted backend — **E2B**, **Daytona — Python**, **Vercel Sandbox — Python**, or **Modal**. The in-process WebAssembly sandbox cannot install `scikit-learn` (it pulls in `scipy` and `numpy`, which are not available there). **TypeScript (stdlib version)**: any TS backend, including the in-process **Deno** sandbox. |
+| Dependencies | Python: `scikit-learn` (pulls `scipy` and `numpy` transitively). TypeScript: none — stdlib only. |
+| Internet access | Python: not required at execution time, but the sandbox fetches wheels from PyPI on cold install. TypeScript: not required. |
+| Environment variables | None. |
+
+<Warning>
+The Python `scikit-learn` install is a large dependency — 30–60s and ~150 MB on a cold start. To avoid paying that cost on every cold run, reuse the same sandbox configuration across experiments so the provider can warm-cache it, or pick a backend that supports snapshotting (Daytona) or persistent base images. The TypeScript variant has no cold-start cost — there's nothing to install.
+</Warning>
+
+## Variants
+
+- **Character n-grams** — for code, identifiers, or short fragments, `HashingVectorizer(analyzer="char_wb", ngram_range=(2, 4))` is usually more robust than word tokens.
+- **TF-IDF** — with a representative corpus to fit on (e.g. every example in the dataset), `TfidfVectorizer` weights rare tokens more heavily. `fit` on a corpus is awkward inside a per-call evaluator, so load a pickled pre-fit vectorizer from disk if you go this route.
+- **Classification metrics** — when `output` and `reference` are class labels rather than free text, swap the body for `sklearn.metrics.f1_score` or `accuracy_score`.

--- a/docs/phoenix/evaluation/server-evals/code-evaluators/scikit-learn.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators/scikit-learn.mdx
@@ -51,6 +51,12 @@ Notes on the vectorizer configuration:
 - **`alternate_sign=False`** — disables sklearn's signed-hashing trick. The default (`True`) helps classifier features but adds noise to cosine similarity; turning it off keeps each cell a non-negative count of hashed tokens.
 - **`norm="l2"`** — L2-normalizes each vector so cosine similarity falls naturally in `[0.0, 1.0]`.
 - **`n_features=2**18`** — 262,144 hash buckets. Big enough that collisions on short texts are negligible, small enough to stay cheap.
+
+**Sandbox dependencies** — paste into the sandbox configuration's Dependencies field, one package per line:
+
+```
+scikit-learn
+```
 </Tab>
 <Tab title="TypeScript" icon="js">
 There's no scikit-learn for JavaScript, but the underlying recipe — tokenize, count, cosine — is a few lines of stdlib code and runs in the **local Deno sandbox** with no dependencies and no network.
@@ -100,6 +106,8 @@ function evaluate({ output, reference }: EvaluatorParams) {
 ```
 
 Mathematically equivalent to the Python version with `analyzer="word"`. Word boundaries are detected with `\p{L}\p{N}` (Unicode letters and digits), so non-ASCII text tokenizes correctly. The hashing step is dropped — the vocabulary is implicit in the `Map` keys — which is fine since the cost only scales with the two inputs' token counts.
+
+**Sandbox dependencies** — none. The TypeScript variant uses stdlib only, so leave the sandbox configuration's Dependencies field empty.
 </Tab>
 </Tabs>
 

--- a/docs/phoenix/evaluation/server-evals/overview.mdx
+++ b/docs/phoenix/evaluation/server-evals/overview.mdx
@@ -15,11 +15,14 @@ Dataset evaluators let you attach an evaluation suite directly to a dataset. Eva
 ## Evaluator Types
 
 <CardGroup cols={2}>
-  <Card title="Built-in Code Evaluators" icon="cube" href="/docs/phoenix/evaluation/server-evals/pre-built-metrics">
-    Deterministic evaluators that run without an LLM — Contains, Exact Match, Regex, Levenshtein Distance, and JSON Distance.
-  </Card>
   <Card title="LLM Evaluators" icon="gavel" href="/docs/phoenix/evaluation/server-evals/llm-evaluators">
     LLM-as-a-judge evaluators backed by Phoenix-managed prompts. Use pre-built templates for common tasks like correctness and tool response handling, or write your own.
+  </Card>
+  <Card title="Code Evaluators" icon="code" href="/docs/phoenix/evaluation/server-evals/code-evaluators">
+    Custom Python or TypeScript evaluators that run in a managed sandbox. Use them when you need deterministic logic that the pre-built evaluators don't cover.
+  </Card>
+  <Card title="Pre-built Code Evaluators" icon="cube" href="/docs/phoenix/evaluation/server-evals/pre-built-metrics">
+    Deterministic evaluators that run without an LLM — Contains, Exact Match, Regex, Levenshtein Distance, and JSON Distance.
   </Card>
 </CardGroup>
 

--- a/docs/phoenix/evaluation/server-evals/pre-built-metrics.mdx
+++ b/docs/phoenix/evaluation/server-evals/pre-built-metrics.mdx
@@ -8,12 +8,12 @@ Server-side evaluators run entirely in the Phoenix UI — no local code or API k
 
 There are two types of pre-built server-side evaluators:
 
-- **Code evaluators** are deterministic. They apply a rule or algorithm to your data and return a result without calling any model.
+- **Pre-built code evaluators** are deterministic. They apply a rule or algorithm to your data and return a result without calling any model. For custom logic you author yourself, see [Code Evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators).
 - **LLM evaluators** use a judge model via a managed prompt template. Phoenix handles model configuration and API access — you only need to configure the input column mappings.
 
 ---
 
-## Code Evaluators
+## Pre-built Code Evaluators
 
 <CardGroup cols={2}>
   <Card title="Contains" href="/docs/phoenix/evaluation/server-evals/pre-built-metrics/contains">

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -35,6 +35,9 @@ Phoenix offers several types of integrations to support your AI development work
   <Card title="Span Processors" icon="arrows-rotate" href="#span-processors">
     Convert traces from other instrumentation libraries to the OpenInference format.
   </Card>
+  <Card title="Sandboxes" icon="cube" href="#sandboxes">
+    Run code evaluators in hosted sandbox providers with kernel-level isolation.
+  </Card>
 </CardGroup>
 
 ---
@@ -172,5 +175,18 @@ Normalize and convert data from other instrumentation libraries by adding span p
 <CardGroup cols={3}>
   <Card title="OpenLIT" href="https://pypi.org/project/openinference-instrumentation-openlit/" icon="arrows-rotate" description="OpenLIT span processor"/>
   <Card title="OpenLLMetry (Traceloop)" href="https://pypi.org/project/openinference-instrumentation-openllmetry/" icon="arrows-rotate" description="OpenLLMetry span processor"/>
+</CardGroup>
+
+---
+
+## Sandboxes
+
+Run Phoenix [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators) in hosted sandbox providers for kernel-level isolation, runtime dependency installation, and opt-in outbound network access. Configure providers from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).
+
+<CardGroup cols={4}>
+  <Card title="E2B" href="/docs/phoenix/integrations/sandboxes/e2b" icon="cube" description="Hosted micro-VMs for AI-generated code"/>
+  <Card title="Daytona" href="/docs/phoenix/integrations/sandboxes/daytona" icon="cube" description="Managed dev sandboxes with snapshot startup"/>
+  <Card title="Vercel Sandbox" href="/docs/phoenix/integrations/sandboxes/vercel" icon="cube" description="Ephemeral compute on Vercel infrastructure"/>
+  <Card title="Modal" href="/docs/phoenix/integrations/sandboxes/modal" icon="cube" description="Serverless containers, Python-first"/>
 </CardGroup>
 

--- a/docs/phoenix/integrations/sandboxes/daytona.mdx
+++ b/docs/phoenix/integrations/sandboxes/daytona.mdx
@@ -1,0 +1,15 @@
+---
+title: "Daytona"
+description: "Run Phoenix code evaluators in Daytona's managed development sandboxes."
+---
+
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/daytona.svg" alt="Daytona" style={{ height: '64px' }} />
+
+[**Daytona**](https://www.daytona.io/) provides managed development sandboxes with fast, snapshot-based startup. Phoenix uses Daytona as a hosted backend for both Python and TypeScript [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators) that need stronger isolation than the local sandboxes, longer maximum timeouts, or runtime dependency installation.
+
+## Configure
+
+1. Sign up at [daytona.io](https://www.daytona.io/) and generate an API key.
+2. Add it as `PHOENIX_SANDBOX_DAYTONA_API_KEY` from **Settings → Sandboxes**.
+
+See [Settings → Sandboxes → Daytona](/docs/phoenix/settings/sandboxes/daytona) for full configuration details and [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for self-hosting setup.

--- a/docs/phoenix/integrations/sandboxes/e2b.mdx
+++ b/docs/phoenix/integrations/sandboxes/e2b.mdx
@@ -1,0 +1,15 @@
+---
+title: "E2B"
+description: "Run Phoenix code evaluators in E2B's hosted micro-VM sandboxes."
+---
+
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/e2b.svg" alt="E2B" style={{ height: '64px' }} />
+
+[**E2B**](https://e2b.dev/) provides hosted micro-VM sandboxes purpose-built for executing AI-generated code. Phoenix uses E2B as a hosted backend for Python [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators), giving each invocation a fresh VM with kernel-level isolation, runtime dependency installation, and opt-in outbound network access — without exposing the rest of your deployment.
+
+## Configure
+
+1. Sign up at [e2b.dev](https://e2b.dev/) and create an API key.
+2. Add it as `E2B_API_KEY` from **Settings → Sandboxes**.
+
+See [Settings → Sandboxes → E2B](/docs/phoenix/settings/sandboxes/e2b) for full configuration details and [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for self-hosting setup.

--- a/docs/phoenix/integrations/sandboxes/modal.mdx
+++ b/docs/phoenix/integrations/sandboxes/modal.mdx
@@ -1,0 +1,15 @@
+---
+title: "Modal"
+description: "Run Phoenix code evaluators in Modal's serverless container platform."
+---
+
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/modal.svg" alt="Modal" style={{ height: '64px' }} />
+
+[**Modal**](https://modal.com/) is a serverless container platform with sub-second cold starts and Python-first ergonomics. Phoenix uses Modal as a hosted backend for Python [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators) that benefit from Modal's fast container scheduling, generous timeouts, and pay-per-execution pricing.
+
+## Configure
+
+1. Sign up at [modal.com](https://modal.com/) and create a token pair.
+2. Add `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` from **Settings → Sandboxes**.
+
+See [Settings → Sandboxes → Modal](/docs/phoenix/settings/sandboxes/modal) for full configuration details and [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for self-hosting setup.

--- a/docs/phoenix/integrations/sandboxes/vercel.mdx
+++ b/docs/phoenix/integrations/sandboxes/vercel.mdx
@@ -1,0 +1,15 @@
+---
+title: "Vercel Sandbox"
+description: "Run Phoenix code evaluators in ephemeral compute on Vercel's infrastructure."
+---
+
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/vercel.svg" alt="Vercel Sandbox" style={{ height: '64px' }} />
+
+[**Vercel Sandbox**](https://vercel.com/docs/vercel-sandbox) runs code in ephemeral compute on Vercel's infrastructure, scoped to a Vercel team and project. Phoenix uses it as a hosted backend for both Python and TypeScript [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators). It's a good fit when your team is already on Vercel and you'd like sandbox usage to roll up under the same billing and access controls.
+
+## Configure
+
+1. Create a token in the [Vercel dashboard](https://vercel.com/account/tokens) and note your team and project IDs.
+2. Add `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID` from **Settings → Sandboxes**.
+
+See [Settings → Sandboxes → Vercel Sandbox](/docs/phoenix/settings/sandboxes/vercel) for full configuration details and [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for self-hosting setup.

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -110,6 +110,7 @@
 
 - [Server Evals Overview](https://arize.com/docs/phoenix/evaluation/server-evals/overview): Attach evaluators to datasets so they run server-side on every Playground experiment
 - [LLM Evaluators](https://arize.com/docs/phoenix/evaluation/server-evals/llm-evaluators): Configure LLM-as-judge evaluators server-side
+- [Code Evaluators](https://arize.com/docs/phoenix/evaluation/server-evals/code-evaluators): Write custom Python or TypeScript evaluators that Phoenix runs in a managed sandbox
 - [Server Eval Input Mapping](https://arize.com/docs/phoenix/evaluation/server-evals/input-mapping): Map span attributes to server-side evaluator input variables
 - [Server Pre-Built Metrics](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics): All server-side code metrics — contains, exact match, regex, JSON distance, Levenshtein, tool
 

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -354,6 +354,7 @@
 - [Secrets](https://arize.com/docs/phoenix/settings/secrets): Store and manage encrypted API keys and credentials
 - [Data Retention](https://arize.com/docs/phoenix/settings/data-retention): Configure data retention policies
 - [Custom AI Providers](https://arize.com/docs/phoenix/settings/custom-ai-providers): Server-managed AI provider credentials for Playground and evals
+- [Sandboxes](https://arize.com/docs/phoenix/settings/sandboxes): Configure sandbox runtimes and reusable configurations for code evaluators
 
 ## Concepts
 

--- a/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
+++ b/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
@@ -99,7 +99,8 @@ The rows below correspond exactly to the entries in `SANDBOX_ADAPTER_METADATA`. 
 | **Deno (local)** (`DENO`) | TypeScript | Yes — `deno` bundled at `/usr/local/bin/deno` | Install Deno on `PATH` | None | In-process (subprocess) |
 | **WebAssembly (local)** (`WASM`) | Python | Yes — CPython WASM bundled at `$PHOENIX_WASM_BINARY_PATH` | `pip install 'arize-phoenix[wasm]'`; optionally set `PHOENIX_WASM_BINARY_PATH` | None | In-process (`wasmtime`) |
 | **E2B** (`E2B`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[e2b]'` | `E2B_API_KEY` | External API |
-| **Daytona** (`DAYTONA_PYTHON`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[daytona]'` | `DAYTONA_API_KEY` | External API |
+| **Daytona — Python** (`DAYTONA_PYTHON`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[daytona]'` | `PHOENIX_SANDBOX_DAYTONA_API_KEY` | External API |
+| **Daytona — TypeScript** (`DAYTONA_TYPESCRIPT`) | TypeScript | Ready with credentials — SDK in container | `pip install 'arize-phoenix[daytona]'` | Same as `DAYTONA_PYTHON` | External API |
 | **Vercel Sandbox — Python** (`VERCEL_PYTHON`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[vercel]'` | `VERCEL_TOKEN` + `VERCEL_PROJECT_ID` + `VERCEL_TEAM_ID` ([auth docs](https://vercel.com/docs/vercel-sandbox/concepts/authentication)) | External API |
 | **Vercel Sandbox — TypeScript** (`VERCEL_TYPESCRIPT`) | TypeScript | Ready with credentials — SDK in container | `pip install 'arize-phoenix[vercel]'` | Same as `VERCEL_PYTHON` ([auth docs](https://vercel.com/docs/vercel-sandbox/concepts/authentication)) | External API |
 | **Modal** (`MODAL`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[modal]'` | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` | External API |

--- a/docs/phoenix/settings/sandboxes.mdx
+++ b/docs/phoenix/settings/sandboxes.mdx
@@ -78,12 +78,3 @@ The dialog exposes the following fields. Fields that aren't supported by the sel
 Environment-variable values — including the values resolved from secret references — are visible to any code that runs in the sandbox (for example, `os.environ` in Python). Treat them as readable by anyone authorized to author or run an evaluator against the config.
 </Warning>
 
-### Managing configurations
-
-The configurations table shows one row per config with its provider, language, settings summary (timeout, dependency count, internet access), and an enable switch. From each row you can:
-
-- **Toggle Enabled** — A disabled config is hidden from evaluator authors but retained. Useful for retiring a config without deleting evaluators that reference it.
-- **Edit** — Change description, timeout, env vars, internet access, and dependencies. The provider and name are immutable after creation.
-- **Delete** — Permanently remove the config. Evaluators that reference it will need to be rebound to a different config before they run again.
-
-If a provider's admin toggle is off, all of its configurations are automatically considered disabled — flipping the provider back on restores them.

--- a/docs/phoenix/settings/sandboxes.mdx
+++ b/docs/phoenix/settings/sandboxes.mdx
@@ -1,0 +1,88 @@
+---
+title: "Sandboxes"
+description: "Configure the sandbox runtimes that execute code evaluators and other server-side code workloads."
+---
+
+The **Settings → Sandboxes** page is where an administrator wires up the runtimes that Phoenix uses to execute [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators) and other server-side code workloads. It has two cards:
+
+- **Sandbox Providers** — One row per backend. Set credentials, enable a provider, see runtime status.
+- **Sandbox Configurations** — Reusable named configs (timeout, environment variables, internet access, dependencies) that evaluators select from.
+
+<Note>
+Only users with the **Admin** role can view or edit this page. Non-admin users are routed away from the tab.
+</Note>
+
+## Sandbox Providers
+
+A **provider** is a (backend, language) pair — for example, *Vercel Sandbox — Python* or *Daytona — TypeScript*. Each row shows the backend's display name, the language, when the provider was last updated, its current runtime status, and a gear icon to configure credentials.
+
+### Runtime status
+
+The **Status** column reflects what Phoenix observed when it last probed the backend:
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `AVAILABLE` | The runtime is reachable and the provider is ready to enable. | Toggle the **Enabled** switch to make the provider selectable in evaluator creation. |
+| `MISSING_CREDENTIALS` | The backend requires API keys or tokens that haven't been set yet. | Click the gear icon and fill in the credential fields. |
+| `NOT_INSTALLED` | The optional Python extra for this backend isn't installed in the Phoenix environment. | Install the matching extra (e.g. `pip install 'arize-phoenix[e2b]'`). See [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for the full matrix. |
+| `UNAVAILABLE` | A runtime asset is missing (e.g. the `deno` binary isn't on `PATH`, or the configured WASM binary path doesn't exist). The row shows a `statusDetail` message describing what to fix. | Follow the remediation in [Sandbox Runtimes → Troubleshooting](/docs/phoenix/self-hosting/features/sandbox-runtimes#troubleshooting). |
+
+The **Enabled** switch only appears when status is `AVAILABLE`. Disabling a provider hides its configs from evaluator authors without deleting them — flipping the switch back makes the existing configs available again.
+
+### Configuring credentials
+
+Click the gear icon next to a provider to open the credentials dialog. The dialog lists the credential fields the backend declares — for example:
+
+- **E2B** — `E2B_API_KEY`
+- **Daytona** — `DAYTONA_API_KEY`
+- **Modal** — `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`
+- **Vercel Sandbox** — `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, `VERCEL_TEAM_ID`
+
+Values are stored encrypted at rest using the server's `PHOENIX_SECRET`. The dialog shows each field's environment-variable name and a short description; required fields are marked. Local backends (Deno, WebAssembly) have no credentials, and the gear button is disabled for them.
+
+<Tip>
+Credentials configured here override the corresponding environment variables on the Phoenix process. You can mix the two — set production credentials via env vars at deploy time, and override them per-instance in the UI when needed.
+</Tip>
+
+## Sandbox Configurations
+
+A **sandbox configuration** is a named, reusable bundle of runtime settings — timeout, environment variables, internet access, and any pre-installed dependencies — bound to a specific provider. Code evaluators don't pick a provider directly; they pick a configuration. This lets you maintain a small set of curated runtimes (for example, a "default Python with `requests` and `numpy`" config and a "internet-enabled Node.js" config) that evaluator authors choose from.
+
+### Creating a configuration
+
+Click **New Sandbox** in the Sandbox Configurations card. Only providers whose backend is `AVAILABLE` *and* whose admin toggle is enabled appear in the picker.
+
+The dialog exposes the following fields. Fields that aren't supported by the selected backend are shown as **Not supported by the selected backend**.
+
+| Field | Notes |
+|-------|-------|
+| **Provider** | Required. The backend + language pair this config targets. Configs are language-scoped — a Python config can only be selected by Python evaluators. |
+| **Name** | Required. Lowercase letters, digits, dashes, and underscores. Must start and end with a letter or digit. Used to identify the config in the evaluator UI. |
+| **Description** | Optional free-form text shown next to the config name. |
+| **Timeout (seconds)** | Required. Total time allowed for sandbox setup and execution. Defaults to **300s**. |
+| **Environment Variables** | One row per variable. Each row is either a **literal value** typed inline, or a **secret reference** to a key from [Settings → Secrets](/docs/phoenix/settings/secrets). Available only for backends that support env vars. |
+| **Allow Internet Access** | Toggle for backends that gate outbound networking. When off, the sandbox runs with no network egress. |
+| **Dependencies** | One package per line. The dialog shows whether the backend takes Python packages (e.g. `requests`, `numpy==1.26.0`) or npm packages (e.g. `@types/node`, `lodash`). Phoenix installs these before each execution. |
+
+<Warning>
+Environment-variable values — including the values resolved from secret references — are visible to any code that runs in the sandbox (for example, `os.environ` in Python). Treat them as readable by anyone authorized to author or run an evaluator against the config.
+</Warning>
+
+### Managing configurations
+
+The configurations table shows one row per config with its provider, language, settings summary (timeout, dependency count, internet access), and an enable switch. From each row you can:
+
+- **Toggle Enabled** — A disabled config is hidden from evaluator authors but retained. Useful for retiring a config without deleting evaluators that reference it.
+- **Edit** — Change description, timeout, env vars, internet access, and dependencies. The provider and name are immutable after creation.
+- **Delete** — Permanently remove the config. Evaluators that reference it will need to be rebound to a different config before they run again.
+
+If a provider's admin toggle is off, all of its configurations are automatically considered disabled — flipping the provider back on restores them.
+
+## Local vs. remote backends
+
+The **hosting type** badge next to each provider distinguishes:
+
+- **Local backends** — Deno and WebAssembly run inside the Phoenix process. They have no per-execution startup cost but offer narrower isolation. WebAssembly is sandboxed at the Wasm boundary; Deno relies on its permission system, which Phoenix surfaces with a one-time trust warning on self-hosted deployments.
+- **Remote backends** — E2B, Daytona, Vercel Sandbox, and Modal run code in their own infrastructure. Each execution spins up a fresh VM-level sandbox, with stronger isolation, longer maximum timeouts, configurable package install, and outbound network access — at the cost of credentials and per-call latency.
+
+Pick a local backend when the evaluator is fast, deterministic, and self-contained; pick a remote backend when you need package installation, external API calls, or stronger isolation guarantees. See [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for the full capability matrix and self-hosting setup.

--- a/docs/phoenix/settings/sandboxes.mdx
+++ b/docs/phoenix/settings/sandboxes.mdx
@@ -3,6 +3,8 @@ title: "Sandboxes"
 description: "Configure the sandbox runtimes that execute code evaluators and other server-side code workloads."
 ---
 
+![Sandboxes](https://storage.googleapis.com/arize-phoenix-assets/assets/images/sandboxes_banner.png)
+
 The **Settings → Sandboxes** page is where an administrator wires up the runtimes that Phoenix uses to execute [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators) and other server-side code workloads. It has two cards:
 
 - **Sandbox Providers** — One row per backend. Set credentials, enable a provider, see runtime status.

--- a/docs/phoenix/settings/sandboxes.mdx
+++ b/docs/phoenix/settings/sandboxes.mdx
@@ -5,7 +5,7 @@ description: "Configure the sandbox runtimes that execute code evaluators and ot
 
 ![Sandboxes](https://storage.googleapis.com/arize-phoenix-assets/assets/images/sandboxes_banner.png)
 
-A **sandbox** is an isolated runtime that executes a snippet of code on demand — fast enough to run on every evaluation, and locked down enough that the code can't read the host filesystem, exfiltrate secrets, or make arbitrary network calls. Phoenix uses sandboxes to run [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators), so an evaluator author can write a Python or TypeScript function and Phoenix can run it server-side without exposing the rest of your deployment.
+A **sandbox** is an isolated runtime that executes a snippet of code on demand. It's fast enough to run on every evaluation, but locked down enough that the code can't read the host filesystem, exfiltrate secrets, or make arbitrary network calls. Phoenix uses sandboxes to run [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators) — an author writes a Python or TypeScript function and Phoenix runs it server-side without exposing the rest of your deployment.
 
 The **Settings → Sandboxes** page is where an administrator picks which sandbox runtimes are available and bundles them into reusable configurations that evaluator authors choose from. It has two cards:
 
@@ -20,43 +20,64 @@ Only users with the **Admin** role can view or edit this page. Non-admin users a
 
 Phoenix supports two flavors of sandbox, distinguished by where the code actually runs. The **hosting type** badge on each provider row tells you which kind you're looking at.
 
-**Local sandboxes** run inside the Phoenix server process itself:
+<AccordionGroup>
+  <Accordion title="Local sandboxes" icon="server">
+    **Local sandboxes** run inside the Phoenix server process itself. They start in milliseconds and require no external credentials, which makes them the fastest and cheapest option. The trade-off is narrower isolation than a full VM and a smaller capability surface — they can't install arbitrary packages, and they can't reach the public internet.
 
-- **WebAssembly** (Python) — CPython compiled to WebAssembly, executed via `wasmtime`. Isolation is enforced at the Wasm boundary: the guest has no filesystem, no network, and no syscalls except those Phoenix explicitly grants.
-- **Deno** (TypeScript) — Deno's `deno run` subprocess with its permission model (no `--allow-*` flags), so the script can't read files, open sockets, or spawn processes by default.
+    <CardGroup cols={2}>
+      <Card title="WebAssembly" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/wasm.svg" href="/docs/phoenix/settings/sandboxes/wasm">
+        Python in CPython-on-Wasm via `wasmtime`. Isolation at the Wasm boundary.
+      </Card>
+      <Card title="Deno" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/deno.svg" href="/docs/phoenix/settings/sandboxes/deno">
+        TypeScript in a `deno run` subprocess with no `--allow-*` permissions.
+      </Card>
+    </CardGroup>
+  </Accordion>
 
-Local sandboxes start in milliseconds and require no external credentials, which makes them the fastest and cheapest option. The trade-off is narrower isolation than a full VM and a smaller capability surface — they can't install arbitrary packages, and they can't reach the public internet.
+  <Accordion title="Hosted sandboxes" icon="cloud">
+    **Hosted sandboxes** run on a third-party provider's infrastructure. Each invocation spins up a fresh sandbox there — a VM, micro-VM, or container, depending on the provider. The upside: kernel-level isolation, longer maximum timeouts, the ability to install Python or npm packages at execution time, and opt-in outbound network access. The cost: per-call round-trip latency and the need to configure credentials for the upstream service.
 
-**Hosted sandboxes** run on a third-party provider's infrastructure:
-
-- **E2B**, **Daytona**, **Vercel Sandbox**, **Modal** — Each invocation spins up a fresh sandbox (a VM, micro-VM, or container, depending on the provider) on the provider's side. Phoenix ships your code over the network, the provider executes it, and the result comes back as if it ran in-process.
-
-Hosted sandboxes give you stronger isolation (kernel-level, not language-level), longer maximum timeouts, the ability to install Python or npm packages at execution time, and outbound network access when you opt in. The cost is per-call latency for the round-trip and the need to configure credentials for the upstream service.
+    <CardGroup cols={2}>
+      <Card title="E2B" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/e2b.svg" href="/docs/phoenix/settings/sandboxes/e2b">
+        Cloud micro-VMs purpose-built for AI-generated code execution.
+      </Card>
+      <Card title="Daytona" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/daytona.svg" href="/docs/phoenix/settings/sandboxes/daytona">
+        Managed development sandboxes with fast snapshot-based startup.
+      </Card>
+      <Card title="Vercel Sandbox" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/vercel.svg" href="/docs/phoenix/settings/sandboxes/vercel">
+        Ephemeral compute on Vercel's infrastructure with team-scoped credentials.
+      </Card>
+      <Card title="Modal" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/modal.svg" href="/docs/phoenix/settings/sandboxes/modal">
+        Serverless containers with sub-second cold starts and Python-first ergonomics.
+      </Card>
+    </CardGroup>
+  </Accordion>
+</AccordionGroup>
 
 A common pattern is to enable a local sandbox for the everyday case (pure-logic checks, regex, JSON diffs) and one hosted sandbox for the cases that need extra horsepower (dependencies, network calls, longer runtimes). See [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for the full capability matrix and self-hosting setup.
 
 ## Sandbox Providers
 
-A **provider** is a (backend, language) pair — for example, *Vercel Sandbox — Python* or *Daytona — TypeScript*. Each row shows the backend's display name, the language, when the provider was last updated, its current runtime status, and a gear icon to configure credentials. The **Enabled** switch appears once the runtime is reachable; flipping it off hides the provider's configurations from evaluator authors without deleting them.
+A **provider** is a backend + language pair — for example, *Vercel Sandbox — Python* or *Daytona — TypeScript*. Each row shows the backend's display name, the language, when the provider was last updated, its current runtime status, and a gear icon to configure credentials. The **Enabled** switch appears once the runtime is reachable; flipping it off hides the provider's configurations from evaluator authors without deleting them.
 
 ### Configuring credentials
 
 Click the gear icon next to a provider to open the credentials dialog. The dialog lists the credential fields the backend declares — for example:
 
 - **E2B** — `E2B_API_KEY`
-- **Daytona** — `DAYTONA_API_KEY`
+- **Daytona** — `PHOENIX_SANDBOX_DAYTONA_API_KEY`
 - **Modal** — `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`
 - **Vercel Sandbox** — `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, `VERCEL_TEAM_ID`
 
 Values are stored encrypted at rest using the server's `PHOENIX_SECRET`. The dialog shows each field's environment-variable name and a short description; required fields are marked. Local backends (Deno, WebAssembly) have no credentials, and the gear button is disabled for them.
 
-<Tip>
-Credentials configured here override the corresponding environment variables on the Phoenix process. You can mix the two — set production credentials via env vars at deploy time, and override them per-instance in the UI when needed.
-</Tip>
-
 ## Sandbox Configurations
 
-A **sandbox configuration** is a named, reusable bundle of runtime settings — timeout, environment variables, internet access, and any pre-installed dependencies — bound to a specific provider. Code evaluators don't pick a provider directly; they pick a configuration. This lets you maintain a small set of curated runtimes (for example, a "default Python with `requests` and `numpy`" config and a "internet-enabled Node.js" config) that evaluator authors choose from.
+A **sandbox configuration** is a named, reusable bundle of runtime settings — timeout, environment variables, internet access, and any pre-installed dependencies — bound to a specific provider. Code evaluators don't pick a provider directly; they pick a configuration. This lets you maintain a small set of curated runtimes (for example, a "default Python with `requests` and `numpy`" config and an "internet-enabled Node.js" config) that evaluator authors choose from.
+
+<Warning>
+Environment-variable values — including the values resolved from secret references — are visible to any code that runs in the sandbox (for example, `os.environ` in Python). Treat them as readable by anyone authorized to author or run an evaluator against the config.
+</Warning>
 
 ### Creating a configuration
 
@@ -74,7 +95,12 @@ The dialog exposes the following fields. Fields that aren't supported by the sel
 | **Allow Internet Access** | Toggle for backends that gate outbound networking. When off, the sandbox runs with no network egress. |
 | **Dependencies** | One package per line. The dialog shows whether the backend takes Python packages (e.g. `requests`, `numpy==1.26.0`) or npm packages (e.g. `@types/node`, `lodash`). Phoenix installs these before each execution. |
 
-<Warning>
-Environment-variable values — including the values resolved from secret references — are visible to any code that runs in the sandbox (for example, `os.environ` in Python). Treat them as readable by anyone authorized to author or run an evaluator against the config.
-</Warning>
+## Next steps
 
+Once a configuration is in place, point an evaluator at it.
+
+<CardGroup cols={1}>
+  <Card title="Code Evaluators" icon="code" href="/docs/phoenix/evaluation/server-evals/code-evaluators">
+    Configure a server-side code evaluator that runs against a sandbox configuration.
+  </Card>
+</CardGroup>

--- a/docs/phoenix/settings/sandboxes.mdx
+++ b/docs/phoenix/settings/sandboxes.mdx
@@ -5,7 +5,9 @@ description: "Configure the sandbox runtimes that execute code evaluators and ot
 
 ![Sandboxes](https://storage.googleapis.com/arize-phoenix-assets/assets/images/sandboxes_banner.png)
 
-The **Settings → Sandboxes** page is where an administrator wires up the runtimes that Phoenix uses to execute [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators) and other server-side code workloads. It has two cards:
+A **sandbox** is an isolated runtime that executes a snippet of code on demand — fast enough to run on every evaluation, and locked down enough that the code can't read the host filesystem, exfiltrate secrets, or make arbitrary network calls. Phoenix uses sandboxes to run [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators), so an evaluator author can write a Python or TypeScript function and Phoenix can run it server-side without exposing the rest of your deployment.
+
+The **Settings → Sandboxes** page is where an administrator picks which sandbox runtimes are available and bundles them into reusable configurations that evaluator authors choose from. It has two cards:
 
 - **Sandbox Providers** — One row per backend. Set credentials, enable a provider, see runtime status.
 - **Sandbox Configurations** — Reusable named configs (timeout, environment variables, internet access, dependencies) that evaluators select from.
@@ -14,22 +16,28 @@ The **Settings → Sandboxes** page is where an administrator wires up the runti
 Only users with the **Admin** role can view or edit this page. Non-admin users are routed away from the tab.
 </Note>
 
+## Local vs. hosted sandboxes
+
+Phoenix supports two flavors of sandbox, distinguished by where the code actually runs. The **hosting type** badge on each provider row tells you which kind you're looking at.
+
+**Local sandboxes** run inside the Phoenix server process itself:
+
+- **WebAssembly** (Python) — CPython compiled to WebAssembly, executed via `wasmtime`. Isolation is enforced at the Wasm boundary: the guest has no filesystem, no network, and no syscalls except those Phoenix explicitly grants.
+- **Deno** (TypeScript) — Deno's `deno run` subprocess with its permission model (no `--allow-*` flags), so the script can't read files, open sockets, or spawn processes by default.
+
+Local sandboxes start in milliseconds and require no external credentials, which makes them the fastest and cheapest option. The trade-off is narrower isolation than a full VM and a smaller capability surface — they can't install arbitrary packages, and they can't reach the public internet.
+
+**Hosted sandboxes** run on a third-party provider's infrastructure:
+
+- **E2B**, **Daytona**, **Vercel Sandbox**, **Modal** — Each invocation spins up a fresh sandbox (a VM, micro-VM, or container, depending on the provider) on the provider's side. Phoenix ships your code over the network, the provider executes it, and the result comes back as if it ran in-process.
+
+Hosted sandboxes give you stronger isolation (kernel-level, not language-level), longer maximum timeouts, the ability to install Python or npm packages at execution time, and outbound network access when you opt in. The cost is per-call latency for the round-trip and the need to configure credentials for the upstream service.
+
+A common pattern is to enable a local sandbox for the everyday case (pure-logic checks, regex, JSON diffs) and one hosted sandbox for the cases that need extra horsepower (dependencies, network calls, longer runtimes). See [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for the full capability matrix and self-hosting setup.
+
 ## Sandbox Providers
 
-A **provider** is a (backend, language) pair — for example, *Vercel Sandbox — Python* or *Daytona — TypeScript*. Each row shows the backend's display name, the language, when the provider was last updated, its current runtime status, and a gear icon to configure credentials.
-
-### Runtime status
-
-The **Status** column reflects what Phoenix observed when it last probed the backend:
-
-| Status | Meaning | Action |
-|--------|---------|--------|
-| `AVAILABLE` | The runtime is reachable and the provider is ready to enable. | Toggle the **Enabled** switch to make the provider selectable in evaluator creation. |
-| `MISSING_CREDENTIALS` | The backend requires API keys or tokens that haven't been set yet. | Click the gear icon and fill in the credential fields. |
-| `NOT_INSTALLED` | The optional Python extra for this backend isn't installed in the Phoenix environment. | Install the matching extra (e.g. `pip install 'arize-phoenix[e2b]'`). See [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for the full matrix. |
-| `UNAVAILABLE` | A runtime asset is missing (e.g. the `deno` binary isn't on `PATH`, or the configured WASM binary path doesn't exist). The row shows a `statusDetail` message describing what to fix. | Follow the remediation in [Sandbox Runtimes → Troubleshooting](/docs/phoenix/self-hosting/features/sandbox-runtimes#troubleshooting). |
-
-The **Enabled** switch only appears when status is `AVAILABLE`. Disabling a provider hides its configs from evaluator authors without deleting them — flipping the switch back makes the existing configs available again.
+A **provider** is a (backend, language) pair — for example, *Vercel Sandbox — Python* or *Daytona — TypeScript*. Each row shows the backend's display name, the language, when the provider was last updated, its current runtime status, and a gear icon to configure credentials. The **Enabled** switch appears once the runtime is reachable; flipping it off hides the provider's configurations from evaluator authors without deleting them.
 
 ### Configuring credentials
 
@@ -79,12 +87,3 @@ The configurations table shows one row per config with its provider, language, s
 - **Delete** — Permanently remove the config. Evaluators that reference it will need to be rebound to a different config before they run again.
 
 If a provider's admin toggle is off, all of its configurations are automatically considered disabled — flipping the provider back on restores them.
-
-## Local vs. remote backends
-
-The **hosting type** badge next to each provider distinguishes:
-
-- **Local backends** — Deno and WebAssembly run inside the Phoenix process. They have no per-execution startup cost but offer narrower isolation. WebAssembly is sandboxed at the Wasm boundary; Deno relies on its permission system, which Phoenix surfaces with a one-time trust warning on self-hosted deployments.
-- **Remote backends** — E2B, Daytona, Vercel Sandbox, and Modal run code in their own infrastructure. Each execution spins up a fresh VM-level sandbox, with stronger isolation, longer maximum timeouts, configurable package install, and outbound network access — at the cost of credentials and per-call latency.
-
-Pick a local backend when the evaluator is fast, deterministic, and self-contained; pick a remote backend when you need package installation, external API calls, or stronger isolation guarantees. See [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for the full capability matrix and self-hosting setup.

--- a/docs/phoenix/settings/sandboxes/daytona.mdx
+++ b/docs/phoenix/settings/sandboxes/daytona.mdx
@@ -1,0 +1,10 @@
+---
+title: "Daytona"
+description: "Run code evaluators in Daytona's managed development sandboxes."
+---
+
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/daytona.svg" alt="Daytona" style={{ height: '64px' }} />
+
+[**Daytona**](https://www.daytona.io/) provides managed development sandboxes with fast, snapshot-based startup. Phoenix uses it as a hosted backend for both Python and TypeScript code evaluators that need stronger isolation than the local sandboxes, longer maximum timeouts, or runtime dependency installation.
+
+To use Daytona, sign up at [daytona.io](https://www.daytona.io/) and generate an API key, then add it as `PHOENIX_SANDBOX_DAYTONA_API_KEY` from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).

--- a/docs/phoenix/settings/sandboxes/deno.mdx
+++ b/docs/phoenix/settings/sandboxes/deno.mdx
@@ -5,6 +5,6 @@ description: "Run TypeScript code evaluators inside the Phoenix server using a s
 
 <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/deno.svg" alt="Deno" style={{ height: '64px' }} />
 
-The **Deno** sandbox runs TypeScript code in a `deno run` subprocess with no `--allow-*` permission flags, so the script can't read files, open sockets, or spawn processes by default. Like the WebAssembly sandbox, it runs locally inside the Phoenix server, starts in milliseconds, and requires no credentials — making it the default choice for TypeScript code evaluators that don't need outbound network access or npm packages installed at runtime.
+The **Deno** sandbox runs TypeScript code in a `deno run` subprocess locked down with `--no-prompt --no-config --no-remote --no-npm` and no `--allow-*` flags beyond a scoped `--allow-env` for declared environment variables. The script can't read files, open sockets, spawn processes, fetch remote modules, or import `npm:` packages — these flags aren't user-configurable. Like the WebAssembly sandbox, it runs locally inside the Phoenix server, starts in milliseconds, and requires no credentials, making it the default choice for TypeScript code evaluators that don't need outbound network access or third-party packages.
 
 Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes). Learn more about Deno's permission model at [deno.land](https://deno.land/).

--- a/docs/phoenix/settings/sandboxes/deno.mdx
+++ b/docs/phoenix/settings/sandboxes/deno.mdx
@@ -1,0 +1,10 @@
+---
+title: "Deno"
+description: "Run TypeScript code evaluators inside the Phoenix server using a sandboxed Deno subprocess."
+---
+
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/deno.svg" alt="Deno" style={{ height: '64px' }} />
+
+The **Deno** sandbox runs TypeScript code in a `deno run` subprocess with no `--allow-*` permission flags, so the script can't read files, open sockets, or spawn processes by default. Like the WebAssembly sandbox, it runs locally inside the Phoenix server, starts in milliseconds, and requires no credentials — making it the default choice for TypeScript code evaluators that don't need outbound network access or npm packages installed at runtime.
+
+Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes). Learn more about Deno's permission model at [deno.land](https://deno.land/).

--- a/docs/phoenix/settings/sandboxes/e2b.mdx
+++ b/docs/phoenix/settings/sandboxes/e2b.mdx
@@ -1,0 +1,10 @@
+---
+title: "E2B"
+description: "Run code evaluators in E2B's hosted micro-VM sandboxes."
+---
+
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/e2b.svg" alt="E2B" style={{ height: '64px' }} />
+
+[**E2B**](https://e2b.dev/) provides hosted micro-VM sandboxes purpose-built for executing AI-generated code. Each invocation spins up a fresh VM on E2B's infrastructure, so Phoenix can run untrusted Python with kernel-level isolation, install dependencies at execution time, and opt in to outbound network access — without exposing the rest of your deployment.
+
+To use E2B, sign up at [e2b.dev](https://e2b.dev/) and create an API key, then add it as `E2B_API_KEY` from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).

--- a/docs/phoenix/settings/sandboxes/modal.mdx
+++ b/docs/phoenix/settings/sandboxes/modal.mdx
@@ -1,0 +1,10 @@
+---
+title: "Modal"
+description: "Run code evaluators in Modal's serverless container platform."
+---
+
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/modal.svg" alt="Modal" style={{ height: '64px' }} />
+
+[**Modal**](https://modal.com/) is a serverless container platform with sub-second cold starts and Python-first ergonomics. Phoenix uses it as a hosted backend for code evaluators that benefit from Modal's fast container scheduling, generous timeouts, and pay-per-execution pricing.
+
+To use Modal, sign up at [modal.com](https://modal.com/) and create a token pair, then add `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).

--- a/docs/phoenix/settings/sandboxes/vercel.mdx
+++ b/docs/phoenix/settings/sandboxes/vercel.mdx
@@ -1,0 +1,10 @@
+---
+title: "Vercel Sandbox"
+description: "Run code evaluators in ephemeral compute on Vercel's infrastructure."
+---
+
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/vercel.svg" alt="Vercel Sandbox" style={{ height: '64px' }} />
+
+[**Vercel Sandbox**](https://vercel.com/docs/vercel-sandbox) runs code in ephemeral compute on Vercel's infrastructure, scoped to a Vercel team and project. It's a good fit when your team is already on Vercel and you'd like sandbox usage to roll up under the same billing and access controls.
+
+To use Vercel Sandbox, create a token and note your team and project IDs in the Vercel dashboard, then add `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID` from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).

--- a/docs/phoenix/settings/sandboxes/wasm.mdx
+++ b/docs/phoenix/settings/sandboxes/wasm.mdx
@@ -1,0 +1,10 @@
+---
+title: "WebAssembly"
+description: "Run Python code evaluators inside the Phoenix server using a CPython-on-Wasm interpreter."
+---
+
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/wasm.svg" alt="WebAssembly" style={{ height: '64px' }} />
+
+The **WebAssembly** sandbox runs Python code in a CPython interpreter compiled to WebAssembly and executed via [`wasmtime`](https://wasmtime.dev/), in-process inside the Phoenix server. Isolation is enforced at the Wasm boundary: the guest has no filesystem, no network, and no syscalls except those Phoenix explicitly grants. It starts in milliseconds and requires no credentials, which makes it the default choice for fast, pure-logic Python evaluators.
+
+Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes). Learn more about WebAssembly at [webassembly.org](https://webassembly.org/).


### PR DESCRIPTION
## Summary

- Adds a new docs page at `docs/phoenix/evaluation/server-evals/code-evaluators.mdx` describing user-authored Python/TypeScript code evaluators that run in Phoenix's managed sandbox (signature, return shape, output config, sandbox runtimes, templates, versioning, testing, traceability).
- Wires the new page into the Server-Side Evals (UI) section in `docs.json` and `llms.txt`, and adds it as a Card on the server-evals overview.
- Renames the existing "Code Evaluators" subgroup under Pre-Built Metrics to "Pre-built Code Evaluators" (and updates the matching heading/intro on `pre-built-metrics.mdx`) to disambiguate from the new custom code evaluator feature.
