### PR TITLE
ci: restore pull-requests: write for triage labeler

### DIFF
--- a/.github/workflows/auto-label-external-issues.yaml
+++ b/.github/workflows/auto-label-external-issues.yaml
@@ -17,6 +17,11 @@ jobs:
     timeout-minutes: 5
     permissions:
       issues: write
+      # Required to label PRs from forks. Although the labels endpoint
+      # is under /issues, GitHub's permission check for fork-PR tokens
+      # (via pull_request_target) rejects the call without
+      # pull-requests: write even when issues: write is granted.
+      pull-requests: write
     steps:
       - name: Add triage label for non-team contributors
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0


### PR DESCRIPTION
## Summary
- `POST /repos/{owner}/{repo}/issues/{n}/labels` returns **403 Resource not accessible by integration** for fork PRs when only `issues: write` is granted, even though the endpoint sits under `/issues`. The token issued by `pull_request_target` on a fork PR needs `pull-requests: write` to label the PR.
- This reverses the permission drop from #13257, whose premise — "labels go through the issues API, so `issues: write` is sufficient" — holds for issues and same-repo PRs, but not for fork PRs.
- Observed failure: [run 25924976700](https://github.com/Arize-ai/phoenix/actions/runs/25924976700/job/76203675777) on #13264 (fork PR from `Adversarial-Risk-Management/phoenix`). The 403 response header `x-accepted-github-permissions: issues=write; pull_requests=write` nominally reads as "either suffices," but GitHub's actual enforcement for fork-PR tokens requires `pull-requests: write` for this call.

## Test plan
- [ ] Merge, then verify the next external fork PR is auto-labeled with `triage` (manually label #13264 since its `opened` event already fired).