### PR TITLE
fix(agents): persist agent turn as a root span

### DIFF
--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -434,14 +434,6 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
 
         async def _stream_with_session() -> AsyncIterator[BaseChunk]:
             try:
-                # `aclosing` guarantees the inner stream is fully closed (and the
-                # root agent span's context manager has exited) before the
-                # `finally` below flushes/drains the tracer — otherwise a client
-                # disconnect mid-stream can race the cleanup and drop the root
-                # span from the persisted trace.
-                # `detached_otel_context` hides the ambient ASGI/FastAPI server
-                # span so the agent turn becomes a root span in the Phoenix
-                # agents trace rather than a child of an unexported parent.
                 with detached_otel_context(), using_session(session_id=session_id):
                     async with aclosing(
                         adapter.run_stream(deps=deps, on_complete=_on_complete)

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1,7 +1,7 @@
 import logging
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncGenerator, AsyncIterator, Iterable
 from contextlib import aclosing
-from typing import Annotated, Any
+from typing import Annotated, Any, TypeVar
 
 from fastapi import APIRouter, Depends, HTTPException
 from openinference.instrumentation import using_metadata, using_session
@@ -26,7 +26,7 @@ from sqlalchemy.dialects.sqlite import insert as insert_sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 from starlette.responses import Response
-from typing_extensions import assert_never
+from typing_extensions import TypeIs, assert_never
 
 from phoenix.config import get_env_phoenix_agents_assistant_project_name
 from phoenix.db import models
@@ -178,6 +178,17 @@ def _log_run_complete(result: AgentRunResult[Any]) -> None:
     logger.info("agent run complete: %d messages", len(messages))
     for message in messages:
         logger.info("%s", message)
+
+
+_AsyncGeneratorType = TypeVar("_AsyncGeneratorType")
+
+
+def _is_async_generator(
+    obj: AsyncIterator[_AsyncGeneratorType],
+) -> TypeIs[AsyncGenerator[_AsyncGeneratorType, None]]:
+    return all(
+        hasattr(obj, name) for name in ("__aiter__", "__anext__", "asend", "athrow", "aclose")
+    )
 
 
 class _AgentSpanContextRecorder(SpanProcessor):
@@ -435,9 +446,9 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         async def _stream_with_session() -> AsyncIterator[BaseChunk]:
             try:
                 with detached_otel_context(), using_session(session_id=session_id):
-                    async with aclosing(
-                        adapter.run_stream(deps=deps, on_complete=_on_complete)
-                    ) as stream:
+                    raw_stream = adapter.run_stream(deps=deps, on_complete=_on_complete)
+                    assert _is_async_generator(raw_stream)
+                    async with aclosing(raw_stream) as stream:
                         async for chunk in stream:
                             yield chunk
             finally:

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -44,7 +44,7 @@ from phoenix.server.agents.summarization import summarize_messages
 from phoenix.server.agents.types import AgentDependencies, AgentOutput
 from phoenix.server.bearer_auth import is_authenticated
 from phoenix.server.types import DbSessionFactory
-from phoenix.tracers import Tracer
+from phoenix.tracers import Tracer, detached_otel_context
 
 
 class _CamelModel(BaseModel):
@@ -439,7 +439,10 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 # `finally` below flushes/drains the tracer — otherwise a client
                 # disconnect mid-stream can race the cleanup and drop the root
                 # span from the persisted trace.
-                with using_session(session_id=session_id):
+                # `detached_otel_context` hides the ambient ASGI/FastAPI server
+                # span so the agent turn becomes a root span in the Phoenix
+                # agents trace rather than a child of an unexported parent.
+                with detached_otel_context(), using_session(session_id=session_id):
                     async with aclosing(
                         adapter.run_stream(deps=deps, on_complete=_on_complete)
                     ) as stream:
@@ -498,7 +501,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
 
         history = VercelAIAdapter.load_messages(body.messages)
         try:
-            with using_metadata({"session_id": session_id}):
+            with detached_otel_context(), using_metadata({"session_id": session_id}):
                 result = await summarize_messages(messages=history, model=model)
         except SummarizationError as exc:
             raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import AsyncIterator, Iterable
+from contextlib import aclosing
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -433,9 +434,17 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
 
         async def _stream_with_session() -> AsyncIterator[BaseChunk]:
             try:
+                # `aclosing` guarantees the inner stream is fully closed (and the
+                # root agent span's context manager has exited) before the
+                # `finally` below flushes/drains the tracer — otherwise a client
+                # disconnect mid-stream can race the cleanup and drop the root
+                # span from the persisted trace.
                 with using_session(session_id=session_id):
-                    async for chunk in adapter.run_stream(deps=deps, on_complete=_on_complete):
-                        yield chunk
+                    async with aclosing(
+                        adapter.run_stream(deps=deps, on_complete=_on_complete)
+                    ) as stream:
+                        async for chunk in stream:
+                            yield chunk
             finally:
                 if tracer is not None:
                     tracer.tracer_provider.force_flush()

--- a/src/phoenix/tracers.py
+++ b/src/phoenix/tracers.py
@@ -1,5 +1,7 @@
 import logging
 from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from threading import Lock
@@ -8,6 +10,7 @@ from typing import Callable, Optional, Sequence
 import wrapt
 from openinference.semconv.resource import ResourceAttributes
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
+from opentelemetry import context as otel_context
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ReadableSpan, SpanLimits, TracerProvider
 from opentelemetry.sdk.trace.export import (
@@ -29,6 +32,19 @@ from phoenix.server.telemetry import normalize_http_collector_endpoint
 from phoenix.trace.attributes import get_attribute_value, load_json_strings, unflatten
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def detached_otel_context() -> Iterator[None]:
+    """Hide the ambient OpenTelemetry context so that spans started inside the
+    block become roots (i.e. they have no parent), rather than children of
+    whatever span happens to be current — typically an ASGI/FastAPI
+    server-request span that is not exported with the Phoenix-agents trace."""
+    token = otel_context.attach(otel_context.Context())
+    try:
+        yield
+    finally:
+        otel_context.detach(token)
 
 
 class _BufferedSpanExporter(SpanExporter):


### PR DESCRIPTION
## Summary

Two related fixes that make sure every `/chat` and `/summary` agent turn is persisted as a properly rooted, complete trace.

### 1. Detach the OpenTelemetry context so the agent turn becomes a root span

The agent turn span was being created as a child of the ambient ASGI/FastAPI server-request span. Phoenix doesn't export the server-request span as part of the agents trace, so the persisted trace had a dangling parent reference.

Wrap the `/chat` and `/summary` calls in a `detached_otel_context` helper that hides the ambient context for the scope of the call, so the agent turn span becomes a root span. Keeping this at the call site (rather than inside `OpenInferenceAgentWrapper`) lets the wrapper stay generic — only the Phoenix-agents endpoints opt into the detached-root policy.

### 2. Close the chat stream before flushing the tracer

On client disconnect mid-stream, the `finally` block in `_stream_with_session` could run `force_flush` / `get_db_traces` / `shutdown` before the inner `adapter.run_stream(...)` async generator was closed. The root AGENT span's context manager hadn't yet exited (Python doesn't auto-close abandoned async generators — it happens during GC), so the span wasn't in the buffered exporter when traces were drained.

Wrap the inner stream in `contextlib.aclosing` so it is guaranteed to be closed (and the root span ended) before the tracer is flushed. `/summary` is unaffected — it `await`s a non-streaming `summarize_messages(...)`, so spans are already ended when its `finally` runs.

## Test plan

- [ ] Send a normal `/chat` turn and confirm the persisted trace has a single root AGENT span (no orphan parent reference).
- [ ] Abort a `/chat` request mid-stream (e.g., navigate away in the assistant UI) and confirm the root AGENT span still lands in the persisted trace.
- [ ] Send a `/summary` request and confirm its trace is also rooted at the agent turn.
- [ ] CI: existing agents tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)