### PR TITLE
refactor(agents): move Anthropic prompt cache flags from model to agent

### DIFF
--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -14,16 +14,6 @@ from phoenix.server.agents.toolsets import build_toolset_factory
 from phoenix.server.agents.types import AgentDependencies, AgentOutput
 
 
-def _underlying_model(model: Model) -> Model:
-    # ``build_model`` returns the production model wrapped in
-    # ``OpenInferenceModelWrapper``; unwrap so provider-type checks
-    # (e.g. ``isinstance(..., AnthropicModel)``) still match.
-    current = model
-    while isinstance(current, WrapperModel):
-        current = current.wrapped
-    return current
-
-
 def build_agent(
     *,
     model: Model,
@@ -40,7 +30,7 @@ def build_agent(
     )
 
     capabilities: list[AbstractCapability[AgentDependencies]] = []
-    if isinstance(_underlying_model(model), AnthropicModel):
+    if isinstance(_get_underlying_model(model), AnthropicModel):
         capabilities.append(AnthropicPromptCacheCapability())
 
     agent = Agent(
@@ -96,3 +86,10 @@ def build_agent(
         return graphql_context.render_instruction(resolved_instructions)
 
     return OpenInferenceAgentWrapper(agent, tracer_provider=provider)
+
+
+def _get_underlying_model(model: Model) -> Model:
+    current = model
+    while isinstance(current, WrapperModel):
+        current = current.wrapped
+    return current

--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -1,13 +1,27 @@
 from opentelemetry.trace import NoOpTracerProvider, TracerProvider
 from pydantic_ai import Agent, DeferredToolRequests, RunContext
+from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.mcp import MCPServerStreamableHTTP
 from pydantic_ai.models import Model
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.models.wrapper import WrapperModel
 
+from phoenix.server.agents.capabilities import AnthropicPromptCacheCapability
 from phoenix.server.agents.context import GraphQLContext
 from phoenix.server.agents.prompts import AgentInstructions
 from phoenix.server.agents.pydantic_ai import OpenInferenceAgentWrapper
 from phoenix.server.agents.toolsets import build_toolset_factory
 from phoenix.server.agents.types import AgentDependencies, AgentOutput
+
+
+def _underlying_model(model: Model) -> Model:
+    # ``build_model`` returns the production model wrapped in
+    # ``OpenInferenceModelWrapper``; unwrap so provider-type checks
+    # (e.g. ``isinstance(..., AnthropicModel)``) still match.
+    current = model
+    while isinstance(current, WrapperModel):
+        current = current.wrapped
+    return current
 
 
 def build_agent(
@@ -25,6 +39,10 @@ def build_agent(
         tracer_provider=provider,
     )
 
+    capabilities: list[AbstractCapability[AgentDependencies]] = []
+    if isinstance(_underlying_model(model), AnthropicModel):
+        capabilities.append(AnthropicPromptCacheCapability())
+
     agent = Agent(
         model,
         name="PXIAgent",
@@ -32,6 +50,7 @@ def build_agent(
         output_type=[str, DeferredToolRequests],
         instructions=[resolved_instructions.base],
         toolsets=[build_toolset],
+        capabilities=capabilities,
     )
 
     @agent.instructions

--- a/src/phoenix/server/agents/capabilities/__init__.py
+++ b/src/phoenix/server/agents/capabilities/__init__.py
@@ -1,0 +1,5 @@
+from phoenix.server.agents.capabilities.anthropic_prompt_cache import (
+    AnthropicPromptCacheCapability,
+)
+
+__all__ = ["AnthropicPromptCacheCapability"]

--- a/src/phoenix/server/agents/capabilities/anthropic_prompt_cache.py
+++ b/src/phoenix/server/agents/capabilities/anthropic_prompt_cache.py
@@ -10,23 +10,7 @@ from phoenix.server.agents.types import AgentDependencies
 
 @dataclass
 class AnthropicPromptCacheCapability(AbstractCapability[AgentDependencies]):
-    """Enable Anthropic prompt caching across the conversation prefix, tool
-    definitions, and the static→dynamic instruction boundary.
-
-    pydantic-ai sorts instruction parts static-before-dynamic regardless of
-    provider, so OpenAI's automatic prefix caching kicks in on the stable
-    static portion for free; Anthropic additionally needs explicit
-    ``cache_control`` markers, which this capability contributes via:
-
-    - ``anthropic_cache=True`` — top-level automatic breakpoint that
-      pydantic-ai moves forward as the conversation grows.
-    - ``anthropic_cache_tool_definitions=True`` — marker on the last tool
-      definition so the tools block joins the cached prefix.
-    - ``anthropic_cache_instructions=True`` — marker at the end of the
-      static system-prompt blocks.
-
-    Mount only when the underlying model is Anthropic.
-    """
+    """Enable Anthropic prompt caching."""
 
     def get_model_settings(self) -> AnthropicModelSettings:
         return AnthropicModelSettings(

--- a/src/phoenix/server/agents/capabilities/anthropic_prompt_cache.py
+++ b/src/phoenix/server/agents/capabilities/anthropic_prompt_cache.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.models.anthropic import AnthropicModelSettings
+
+from phoenix.server.agents.types import AgentDependencies
+
+
+@dataclass
+class AnthropicPromptCacheCapability(AbstractCapability[AgentDependencies]):
+    """Enable Anthropic prompt caching across the conversation prefix, tool
+    definitions, and the static→dynamic instruction boundary.
+
+    pydantic-ai sorts instruction parts static-before-dynamic regardless of
+    provider, so OpenAI's automatic prefix caching kicks in on the stable
+    static portion for free; Anthropic additionally needs explicit
+    ``cache_control`` markers, which this capability contributes via:
+
+    - ``anthropic_cache=True`` — top-level automatic breakpoint that
+      pydantic-ai moves forward as the conversation grows.
+    - ``anthropic_cache_tool_definitions=True`` — marker on the last tool
+      definition so the tools block joins the cached prefix.
+    - ``anthropic_cache_instructions=True`` — marker at the end of the
+      static system-prompt blocks.
+
+    Mount only when the underlying model is Anthropic.
+    """
+
+    def get_model_settings(self) -> AnthropicModelSettings:
+        return AnthropicModelSettings(
+            anthropic_cache=True,
+            anthropic_cache_tool_definitions=True,
+            anthropic_cache_instructions=True,
+        )

--- a/src/phoenix/server/agents/model_factory.py
+++ b/src/phoenix/server/agents/model_factory.py
@@ -22,7 +22,6 @@ from typing import Any, Callable, Literal, Protocol, cast
 from opentelemetry.trace import NoOpTracerProvider, TracerProvider
 from pydantic import ValidationError
 from pydantic_ai.models import Model as PydanticAIModel
-from pydantic_ai.models.anthropic import AnthropicModelSettings
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
 from typing_extensions import assert_never
@@ -53,20 +52,6 @@ from phoenix.utilities.env_vars import without_env_vars
 
 class _EncryptedProviderRecord(Protocol):
     config: bytes
-
-
-def _anthropic_cache_settings() -> "AnthropicModelSettings":
-    """Cache flags applied to every Anthropic model built for the chat endpoint.
-
-    Together they cover the conversation prefix, system instructions, and tool
-    definitions — the most expensive parts of each turn.
-    """
-
-    return AnthropicModelSettings(
-        anthropic_cache=True,
-        anthropic_cache_instructions=True,
-        anthropic_cache_tool_definitions=True,
-    )
 
 
 def _build_openai_model(
@@ -328,11 +313,7 @@ async def _get_pydantic_ai_model_from_generative_model_custom_provider(
                     max_retries=0,
                 )
             )
-        return AnthropicModel(
-            model_name,
-            provider=anthropic_provider,
-            settings=_anthropic_cache_settings(),
-        )
+        return AnthropicModel(model_name, provider=anthropic_provider)
     if config.type == "google_genai":
         google_kwargs = config.google_genai_client_kwargs
         http_options = google_kwargs.http_options if google_kwargs else None
@@ -448,11 +429,7 @@ async def _get_pydantic_ai_model_from_builtin_provider(
                 "Set the ANTHROPIC_API_KEY environment variable or store it in Phoenix secrets."
             )
         anthropic_provider = AnthropicProvider(anthropic_client=AsyncAnthropic(api_key=api_key))
-        return AnthropicModel(
-            params.model_name,
-            provider=anthropic_provider,
-            settings=_anthropic_cache_settings(),
-        )
+        return AnthropicModel(params.model_name, provider=anthropic_provider)
     if params.provider == ModelProvider.GOOGLE:
         api_key = await _resolve_secret_or_env(session, decrypt, "GEMINI_API_KEY", "GOOGLE_API_KEY")
         if not api_key:

--- a/tests/pxi/evals/agent_task.py
+++ b/tests/pxi/evals/agent_task.py
@@ -16,9 +16,6 @@ from phoenix.config import (
 from phoenix.server.agents.agent_factory import build_agent
 from phoenix.server.agents.context import ProjectContext, ResolvedContexts
 from phoenix.server.agents.model_factory import (
-    _anthropic_cache_settings as anthropic_cache_settings,
-)
-from phoenix.server.agents.model_factory import (
     _build_openai_model as build_openai_model,
 )
 from phoenix.server.agents.model_factory import (
@@ -111,7 +108,6 @@ async def _build_model() -> PydanticAIModel:
             provider=AnthropicProvider(
                 anthropic_client=AsyncAnthropic(api_key=api_key, max_retries=0)
             ),
-            settings=anthropic_cache_settings(),
         )
 
     raise RuntimeError(f"Unsupported {ENV_ASSISTANT_PROVIDER} for evals: {provider}")

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -104,10 +104,7 @@ def anthropic_model(
     captured_request: CapturedRequest,
 ) -> AnthropicModel:
     """An ``AnthropicModel`` whose underlying HTTP client is an
-    ``httpx.MockTransport``-backed stub. The cache breakpoints in the request
-    body come from ``AnthropicPromptCacheCapability``, which ``build_agent``
-    mounts when the underlying model is Anthropic — so the fixture itself
-    does not configure any model settings."""
+    ``httpx.MockTransport``-backed stub."""
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured_request.bodies.append(json.loads(request.read()))

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -17,7 +17,7 @@ from anthropic.types.beta import (
 )
 from anthropic.types.beta.message_create_params import MessageCreateParams
 from pydantic_ai import RunContext
-from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
+from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.providers.anthropic import AnthropicProvider
 from pydantic_ai.usage import RunUsage
@@ -104,9 +104,10 @@ def anthropic_model(
     captured_request: CapturedRequest,
 ) -> AnthropicModel:
     """An ``AnthropicModel`` whose underlying HTTP client is an
-    ``httpx.MockTransport``-backed stub. The settings mirror
-    ``model_factory._anthropic_cache_settings`` so the request body carries
-    the ``cache_control`` breakpoint the cache-boundary tests rely on."""
+    ``httpx.MockTransport``-backed stub. The cache breakpoints in the request
+    body come from ``AnthropicPromptCacheCapability``, which ``build_agent``
+    mounts when the underlying model is Anthropic — so the fixture itself
+    does not configure any model settings."""
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured_request.bodies.append(json.loads(request.read()))
@@ -124,12 +125,7 @@ def anthropic_model(
 
     http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     provider = AnthropicProvider(api_key=anthropic_api_key, http_client=http_client)
-    settings = AnthropicModelSettings(
-        anthropic_cache=True,
-        anthropic_cache_instructions=True,
-        anthropic_cache_tool_definitions=True,
-    )
-    return AnthropicModel("claude-haiku-4-5", provider=provider, settings=settings)
+    return AnthropicModel("claude-haiku-4-5", provider=provider)
 
 
 class _OfflineDocsMCPToolset(MintlifyDocsMCPServer):


### PR DESCRIPTION
## Summary

- Introduce `AnthropicPromptCacheCapability` (a `pydantic_ai.capabilities.AbstractCapability`) that contributes the three Anthropic cache flags via `get_model_settings()`.
- Mount it from `build_agent` whenever the underlying model is Anthropic — those cache breakpoints describe how *this agent* uses Anthropic, not properties of the model object itself — and drop the corresponding `settings=_anthropic_cache_settings()` arguments from every `AnthropicModel(...)` call in `model_factory`.
- Walk through `WrapperModel` layers (e.g. `OpenInferenceModelWrapper`) before the `isinstance(model, AnthropicModel)` check so the production path — where `build_model` always returns a wrapped model — still triggers the capability.

This is a small slice copied over from the larger capabilities refactor in `xander/capability-refactor` so it can land independently.

## Test plan

- [x] `uv run pytest tests/unit/server/agents/` — 43 passed, 3 skipped (Postgres-only)
- [x] `make typecheck-python` — clean
- [ ] Manual sanity: hit an Anthropic-backed chat turn and confirm `cache_control` markers still appear in the request body

🤖 Generated with [Claude Code](https://claude.com/claude-code)