### PR TITLE
docs: remove dead nav entries from docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -782,19 +782,6 @@
               "docs/phoenix/integrations/evaluation-integrations/ragas",
               "docs/phoenix/integrations/evaluation-integrations/uqlm"
             ]
-          },
-          {
-            "group": "Vector Databases",
-            "icon": "database",
-            "pages": [
-              "docs/phoenix/integrations/vector-databases/mongodb",
-              "docs/phoenix/integrations/vector-databases/opensearch",
-              "docs/phoenix/integrations/vector-databases/pinecone",
-              "docs/phoenix/integrations/vector-databases/qdrant",
-              "docs/phoenix/integrations/vector-databases/weaviate",
-              "docs/phoenix/integrations/vector-databases/zilliz-milvus",
-              "docs/phoenix/integrations/vector-databases/couchbase"
-            ]
           }
         ]
       },
@@ -1171,7 +1158,6 @@
             "pages": [
               "docs/phoenix/cookbook/datasets-and-experiments/analyzing-customer-review-evals-with-repetition-experiments",
               "docs/phoenix/cookbook/datasets-and-experiments/experiment-with-a-customer-support-agent",
-              "docs/phoenix/cookbook/datasets-and-experiments/model-comparison-for-an-email-text-extraction-service",
               "docs/phoenix/cookbook/datasets-and-experiments/comparing-llamaindex-query-engines-with-a-pairwise-evaluator",
               "docs/phoenix/cookbook/datasets-and-experiments/summarization",
               "docs/phoenix/cookbook/datasets-and-experiments/text2sql",


### PR DESCRIPTION
## Summary

`docs.json` referenced documentation pages that do not exist in the repo, producing broken entries in the published Mintlify navigation. This PR removes the dead references; no content is added.

## What was removed (-14 lines)

- **Vector Databases group** (entire group, ~13 lines): listed 7 pages (mongodb, opensearch, pinecone, qdrant, weaviate, zilliz-milvus, couchbase), but `docs/phoenix/integrations/vector-databases/` does not exist on disk, so the group rendered empty.
- **Cookbook orphan** (1 line): `docs/phoenix/cookbook/datasets-and-experiments/model-comparison-for-an-email-text-extraction-service`, which has no `.mdx` file.

## What was intentionally left alone

`docs/phoenix/evaluation/pre-built-metrics/hallucination` is also missing on disk, but a redirect in `docs.json` targets it, suggesting the page is intended to ship. Flagging here for maintainer triage rather than removing it unilaterally.

## How the dead references were found

```python
import json, os
data = json.load(open('docs.json'))
def walk(n):
    if isinstance(n, dict): [walk(v) for v in n.values()]
    elif isinstance(n, list): [walk(x) for x in n]
    elif isinstance(n, str) and n.startswith('docs/') and not n.startswith('http'):
        if not (os.path.exists(n+'.mdx') or os.path.exists(n+'.md') or os.path.isdir(n)):
            print('MISSING:', n)
walk(data)
```

Before this PR: 9 missing references. After this PR: 1 (the hallucination page, left intentionally).

## Test plan

- [x] `python3 -c "import json; json.load(open('docs.json'))"` — JSON still parses.
- [x] Re-ran the script above — only the intentional `hallucination` ref remains.
- [x] Spot-checked that the remaining cookbook and integration pages still resolve.

I have read the CLA Document and I hereby sign the CLA.