### PR TITLE
feat: improve skill score for phoenix-client-development

### DIFF
--- a/js/packages/phoenix-client/.agents/skills/phoenix-client-development/SKILL.md
+++ b/js/packages/phoenix-client/.agents/skills/phoenix-client-development/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: phoenix-client-development
-description: >
-  Guide for the phoenix-client TypeScript package — experiment lifecycle,
-  tracer provider management, and test conventions.
+description: "Development guide for the @arizeai/phoenix-client TypeScript SDK — run and resume experiments, manage OpenTelemetry tracer providers with stack-based attach/detach, and write vitest unit and integration tests. Use when adding features to phoenix-client, debugging experiment lifecycle or provider cleanup, modifying dataset/prompt/session/span APIs, or writing tests for the js/packages/phoenix-client/ directory."
 license: Apache-2.0
 metadata:
   author: oss@arize.com


### PR DESCRIPTION
Hey @mikeldking 👋

ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| phoenix-client-development | 72% | 85% | +13% |

The `phoenix-client-development` skill had strong content (100%) but its frontmatter description was holding it back, no `Use when...` clause meant agents couldn't reliably select it.

<details>
<summary>Changes made</summary>

- Rewrote the frontmatter `description` from a vague 3-line summary to a specific, trigger-rich single line
- Added concrete action verbs: "run and resume experiments", "manage OpenTelemetry tracer providers", "write vitest unit and integration tests"
- Added natural trigger terms agents actually search for: `@arizeai/phoenix-client`, `OpenTelemetry`, `vitest`, `dataset/prompt/session/span`
- Added explicit `Use when...` clause with 4 trigger scenarios (adding features, debugging lifecycle, modifying APIs, writing tests)
- Fixed description format from YAML chevron (`>`) to quoted string for standard compatibility
- Zero changes to the skill body or rule files - the content was already excellent

</details>

---

also stress-tested your `phoenix-client-development` skill against [a few real-world task evals](https://tessl.io/registry/skills/github/Arize-ai/phoenix/phoenix-client-development/evals) and it held up really well on experiment provider cleanup across two-phase task/eval lifecycles. Kudos for that.

quick honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

If you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@yogesh-tessl](https://github.com/yogesh-tessl), if you hit any snags.