### PR TITLE
fix(app): hide zero PXI cache write usage

### DIFF
--- a/app/src/components/agent/ChatSessionUsage.tsx
+++ b/app/src/components/agent/ChatSessionUsage.tsx
@@ -26,9 +26,14 @@ type ChatSessionUsage = {
   sessionId: string;
 };
 
+type CachePromptDetails = {
+  "cache read": number;
+  "cache write"?: number;
+};
+
 type CacheUsageDisplay = {
   summaryText: string | null;
-  promptDetails: Record<string, number> | undefined;
+  promptDetails: CachePromptDetails | undefined;
 };
 
 function getLatestAssistantMessageUsage(
@@ -72,7 +77,7 @@ export function getCacheUsageDisplay({
       promptDetails: undefined,
     };
   }
-  const visiblePromptDetails: Record<string, number> = {
+  const visiblePromptDetails: CachePromptDetails = {
     "cache read": cacheRead,
   };
   const summaryParts = [`cache read ${cacheRead.toLocaleString()}`];

--- a/app/src/components/agent/ChatSessionUsage.tsx
+++ b/app/src/components/agent/ChatSessionUsage.tsx
@@ -26,6 +26,11 @@ type ChatSessionUsage = {
   sessionId: string;
 };
 
+type CacheUsageDisplay = {
+  summaryText: string | null;
+  promptDetails: Record<string, number> | undefined;
+};
+
 function getLatestAssistantMessageUsage(
   messages: AgentUIMessage[]
 ): AgentSessionUsage | null {
@@ -48,6 +53,42 @@ function getLatestAssistantMessageUsage(
   return null;
 }
 
+export function getCacheUsageDisplay({
+  promptDetails,
+}: {
+  promptDetails: AgentSessionUsage["tokenCount"]["promptDetails"];
+}): CacheUsageDisplay {
+  if (!promptDetails) {
+    return {
+      summaryText: null,
+      promptDetails: undefined,
+    };
+  }
+  const cacheRead = promptDetails?.cacheRead ?? 0;
+  const cacheWrite = promptDetails?.cacheWrite ?? 0;
+  if (cacheRead <= 0 && cacheWrite <= 0) {
+    return {
+      summaryText: null,
+      promptDetails: undefined,
+    };
+  }
+  const visiblePromptDetails: Record<string, number> = {
+    "cache read": cacheRead,
+  };
+  const summaryParts = [`cache read ${cacheRead.toLocaleString()}`];
+
+  // OpenAI does not report cache writes, so we omit this metric from the UI when it's zero.
+  if (cacheWrite > 0) {
+    visiblePromptDetails["cache write"] = cacheWrite;
+    summaryParts.push(`cache write ${cacheWrite.toLocaleString()}`);
+  }
+
+  return {
+    summaryText: `latest ${summaryParts.join(" / ")}`,
+    promptDetails: visiblePromptDetails,
+  };
+}
+
 export const ChatSessionUsage = ({ sessionId }: ChatSessionUsage) => {
   const usage = useAgentContext((state) => {
     const session = state.sessionMap[sessionId];
@@ -55,21 +96,14 @@ export const ChatSessionUsage = ({ sessionId }: ChatSessionUsage) => {
     return getLatestAssistantMessageUsage(session.messages) ?? session.usage;
   });
   if (!usage) return null;
-  const promptDetails = usage.tokenCount.promptDetails
-    ? {
-        "cache read": usage.tokenCount.promptDetails.cacheRead,
-        "cache write": usage.tokenCount.promptDetails.cacheWrite,
-      }
-    : undefined;
-  const cacheRead = usage.tokenCount.promptDetails?.cacheRead ?? 0;
-  const cacheWrite = usage.tokenCount.promptDetails?.cacheWrite ?? 0;
-  const hasCacheUsage = cacheRead > 0 || cacheWrite > 0;
+  const { summaryText, promptDetails } = getCacheUsageDisplay({
+    promptDetails: usage.tokenCount.promptDetails,
+  });
   return (
     <div css={chatSessionUsageCSS}>
-      {hasCacheUsage ? (
+      {summaryText ? (
         <Text size="XS" color="text-300" fontFamily="mono">
-          latest cache read {cacheRead.toLocaleString()} / write{" "}
-          {cacheWrite.toLocaleString()}
+          {summaryText}
         </Text>
       ) : null}
       <TooltipTrigger>

--- a/app/src/components/agent/__tests__/ChatSessionUsage.test.ts
+++ b/app/src/components/agent/__tests__/ChatSessionUsage.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { getCacheUsageDisplay } from "../ChatSessionUsage";
+
+describe("getCacheUsageDisplay", () => {
+  it("renders only cache read when cache write is zero", () => {
+    expect(
+      getCacheUsageDisplay({
+        promptDetails: {
+          cacheRead: 71168,
+          cacheWrite: 0,
+        },
+      })
+    ).toEqual({
+      summaryText: "latest cache read 71,168",
+      promptDetails: {
+        "cache read": 71168,
+      },
+    });
+  });
+
+  it("renders both cache read and write when both are positive", () => {
+    expect(
+      getCacheUsageDisplay({
+        promptDetails: {
+          cacheRead: 71168,
+          cacheWrite: 98229,
+        },
+      })
+    ).toEqual({
+      summaryText: "latest cache read 71,168 / cache write 98,229",
+      promptDetails: {
+        "cache read": 71168,
+        "cache write": 98229,
+      },
+    });
+  });
+
+  it("keeps cache read visible when it is zero", () => {
+    expect(
+      getCacheUsageDisplay({
+        promptDetails: {
+          cacheRead: 0,
+          cacheWrite: 98229,
+        },
+      })
+    ).toEqual({
+      summaryText: "latest cache read 0 / cache write 98,229",
+      promptDetails: {
+        "cache read": 0,
+        "cache write": 98229,
+      },
+    });
+  });
+
+  it("omits cache usage when both cache counts are zero", () => {
+    expect(
+      getCacheUsageDisplay({
+        promptDetails: {
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+      })
+    ).toEqual({
+      summaryText: null,
+      promptDetails: undefined,
+    });
+  });
+
+  it("omits cache usage when cache details are missing", () => {
+    expect(getCacheUsageDisplay({ promptDetails: undefined })).toEqual({
+      summaryText: null,
+      promptDetails: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Hide the PXI cache write metric when the reported value is zero
- Preserve the existing behavior that omits cache usage when both cache read and write are zero
- Add focused tests for PXI cache usage display formatting

## Rationale
OpenAI reports prompt-cache reads through cached token usage, but it does not provide a cache-write token metric. PXI receives usage through Pydantic AI, whose aggregate RunUsage fields normalize missing cache metrics to zero. 

## Test Plan
- pnpm --dir app test ChatSessionUsage
- pnpm --dir app typecheck