### PR TITLE
docs(sandbox): improve logo layout on sandbox docs pages

### DIFF
--- a/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
@@ -117,60 +117,14 @@ The available backends are:
 
 | Language | Backends |
 |----------|----------|
-| Python | WebAssembly (in-process), E2B, Daytona, Vercel Sandbox, Modal |
-| TypeScript | Deno (in-process), Daytona, Vercel Sandbox |
+| Python | WebAssembly (local), E2B, Daytona, Vercel Sandbox, Modal |
+| TypeScript | Deno (local), Daytona, Vercel Sandbox |
 
-**In-process** backends (WebAssembly, Deno) ship with Phoenix and need no credentials, so they're available immediately on self-hosted deployments. **Hosted** backends (E2B, Daytona, Vercel, Modal) run each invocation on a third-party provider's infrastructure, which buys stronger isolation, longer timeouts, package installation, and outbound network access. See [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for the full capability matrix.
+**Local** backends (WebAssembly, Deno) ship with Phoenix and need no credentials, so they're available immediately on self-hosted deployments. **Hosted** backends (E2B, Daytona, Vercel, Modal) run each invocation on a third-party provider's infrastructure, which buys stronger isolation, longer timeouts, package installation, and outbound network access. See [Sandbox Runtimes](/docs/phoenix/self-hosting/features/sandbox-runtimes) for the full capability matrix.
 
 <Tip>
-If your evaluator needs to install a package or call an external API, pick a hosted backend. The in-process runtimes are intentionally restricted.
+If your evaluator needs to install a package or call an external API, pick a hosted backend. The local runtimes are intentionally restricted.
 </Tip>
-
-## Examples
-
-The pages below are copy-paste starting points for common evaluator patterns, grouped by how much infrastructure they need. Each one spells out the exact **sandbox configuration** — backend, dependencies, internet access, environment variables — to provision under **Settings → Sandboxes** before you save.
-
-### Simple — pure code, in-process sandbox
-
-No dependencies, no network. Runs in the bundled WebAssembly (Python) or Deno (TypeScript) sandboxes.
-
-<CardGroup cols={2}>
-  <Card title="JSON Match" icon="brackets-curly" href="/docs/phoenix/evaluation/server-evals/code-evaluators/json-match">
-    Pass when the output and reference parse to the same JSON structure.
-  </Card>
-  <Card title="Regex Match" icon="asterisk" href="/docs/phoenix/evaluation/server-evals/code-evaluators/regex-match">
-    Pass when the output matches a regular expression pattern.
-  </Card>
-</CardGroup>
-
-### Medium — third-party library, hosted sandbox
-
-Needs a third-party library — pip or npm — and sometimes outbound network access. Pick a hosted backend matching your language: Python on E2B / Daytona / Vercel / Modal, TypeScript on Daytona or Vercel.
-
-<CardGroup cols={2}>
-  <Card title="Embedding Distance" icon="vector-square" href="/docs/phoenix/evaluation/server-evals/code-evaluators/embedding-distance">
-    Cosine similarity over OpenAI embeddings. Needs the `openai` package, internet access, and `OPENAI_API_KEY`.
-  </Card>
-  <Card title="scikit-learn" icon="flask" href="/docs/phoenix/evaluation/server-evals/code-evaluators/scikit-learn">
-    Token-overlap similarity via `HashingVectorizer` and cosine. Offline — no network at run time.
-  </Card>
-</CardGroup>
-
-### Advanced — multi-judgment evaluators
-
-Patterns that combine multiple judgments — across axes, across LLM jurors, or across candidates.
-
-<CardGroup cols={2}>
-  <Card title="Pairwise Evaluator" icon="scale-balanced" href="/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise">
-    Blind LLM-judge `output` vs `reference` head-to-head, with randomized presentation order to mitigate position bias.
-  </Card>
-  <Card title="Composite Evaluator" icon="layer-group" href="/docs/phoenix/evaluation/server-evals/code-evaluators/composite">
-    Blend several sub-scores (LLM judgments + code rules) into one weighted average, with a per-axis breakdown in the explanation.
-  </Card>
-  <Card title="LLM Jury" icon="gavel" href="/docs/phoenix/evaluation/server-evals/code-evaluators/llm-jury">
-    Poll multiple LLMs (OpenAI, Anthropic, Google) on the same judgment and combine their verdicts with a weighted average.
-  </Card>
-</CardGroup>
 
 ## Versioning
 
@@ -182,6 +136,30 @@ The evaluator's **name**, **description**, **output configuration**, **input map
 
 The editor includes a **Test** panel that runs the current draft against a chosen dataset example. It shows the inputs Phoenix will pass to `evaluate(...)` after input mapping, the raw return value, and the parsed label/score/explanation. Use it to catch errors before saving — for example, to confirm that a path mapping resolves to a string rather than `None`, or that your function handles missing fields gracefully.
 
-## Traceability
+## Examples
 
-Like LLM evaluators, every code-evaluator execution emits an OpenTelemetry trace into a dedicated project. The trace captures the resolved inputs, the return value, any exception, and the sandbox call's latency — so when an annotation looks wrong, you can navigate from it directly to the execution that produced it.
+Copy-paste starting points for common evaluator patterns. Each page spells out the exact **sandbox configuration** — backend, dependencies, internet access, environment variables — to provision under **Settings → Sandboxes** before you save.
+
+<CardGroup cols={3}>
+  <Card title="JSON Match" icon="brackets-curly" href="/docs/phoenix/evaluation/server-evals/code-evaluators/json-match">
+    Pass when output and reference parse to the same JSON structure. Local sandbox.
+  </Card>
+  <Card title="Regex Match" icon="asterisk" href="/docs/phoenix/evaluation/server-evals/code-evaluators/regex-match">
+    Pass when output matches a regular expression. Local sandbox.
+  </Card>
+  <Card title="Embedding Distance" icon="vector-square" href="/docs/phoenix/evaluation/server-evals/code-evaluators/embedding-distance">
+    Cosine similarity over OpenAI embeddings. Needs `openai`, network, and `OPENAI_API_KEY`.
+  </Card>
+  <Card title="scikit-learn" icon="flask" href="/docs/phoenix/evaluation/server-evals/code-evaluators/scikit-learn">
+    Token-overlap similarity via `HashingVectorizer` and cosine. Offline.
+  </Card>
+  <Card title="Pairwise Evaluator" icon="scale-balanced" href="/docs/phoenix/evaluation/server-evals/code-evaluators/pairwise">
+    Blind LLM-judge `output` vs `reference` head-to-head with randomized order.
+  </Card>
+  <Card title="Composite Evaluator" icon="layer-group" href="/docs/phoenix/evaluation/server-evals/code-evaluators/composite">
+    Blend sub-scores (LLM + code rules) into one weighted average with per-axis breakdown.
+  </Card>
+  <Card title="LLM Jury" icon="gavel" href="/docs/phoenix/evaluation/server-evals/code-evaluators/llm-jury">
+    Poll multiple LLMs (OpenAI, Anthropic, Google) and combine verdicts with a weighted average.
+  </Card>
+</CardGroup>

--- a/docs/phoenix/settings/sandboxes/daytona.mdx
+++ b/docs/phoenix/settings/sandboxes/daytona.mdx
@@ -3,8 +3,13 @@ title: "Daytona"
 description: "Run code evaluators in Daytona's managed development sandboxes."
 ---
 
-<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/daytona.svg" alt="Daytona" style={{ height: '64px' }} />
+<div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem', marginTop: '1.5rem', marginBottom: '1.5rem' }}>
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/daytona.svg" alt="Daytona" className="invert-on-dark" style={{ height: '112px', flexShrink: 0 }} />
+<div>
 
 [**Daytona**](https://www.daytona.io/) provides managed development sandboxes with fast, snapshot-based startup. Phoenix uses it as a hosted backend for both Python and TypeScript code evaluators that need stronger isolation than the local sandboxes, longer maximum timeouts, or runtime dependency installation.
+
+</div>
+</div>
 
 To use Daytona, sign up at [daytona.io](https://www.daytona.io/) and generate an API key, then add it as `PHOENIX_SANDBOX_DAYTONA_API_KEY` from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).

--- a/docs/phoenix/settings/sandboxes/deno.mdx
+++ b/docs/phoenix/settings/sandboxes/deno.mdx
@@ -3,8 +3,13 @@ title: "Deno"
 description: "Run TypeScript code evaluators inside the Phoenix server using a sandboxed Deno subprocess."
 ---
 
-<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/deno.svg" alt="Deno" style={{ height: '64px' }} />
+<div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem', marginTop: '1.5rem', marginBottom: '1.5rem' }}>
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/deno.svg" alt="Deno" className="invert-on-dark" style={{ height: '112px', flexShrink: 0 }} />
+<div>
 
 The **Deno** sandbox runs TypeScript code in a `deno run` subprocess locked down with `--no-prompt --no-config --no-remote --no-npm` and no `--allow-*` flags beyond a scoped `--allow-env` for declared environment variables. The script can't read files, open sockets, spawn processes, fetch remote modules, or import `npm:` packages — these flags aren't user-configurable. Like the WebAssembly sandbox, it runs locally inside the Phoenix server, starts in milliseconds, and requires no credentials, making it the default choice for TypeScript code evaluators that don't need outbound network access or third-party packages.
+
+</div>
+</div>
 
 Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes). Learn more about Deno's permission model at [deno.land](https://deno.land/).

--- a/docs/phoenix/settings/sandboxes/e2b.mdx
+++ b/docs/phoenix/settings/sandboxes/e2b.mdx
@@ -3,8 +3,13 @@ title: "E2B"
 description: "Run code evaluators in E2B's hosted micro-VM sandboxes."
 ---
 
-<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/e2b.svg" alt="E2B" style={{ height: '64px' }} />
+<div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem', marginTop: '1.5rem', marginBottom: '1.5rem' }}>
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/e2b.svg" alt="E2B" className="invert-on-dark" style={{ height: '112px', flexShrink: 0 }} />
+<div>
 
 [**E2B**](https://e2b.dev/) provides hosted micro-VM sandboxes purpose-built for executing AI-generated code. Each invocation spins up a fresh VM on E2B's infrastructure, so Phoenix can run untrusted Python with kernel-level isolation, install dependencies at execution time, and opt in to outbound network access — without exposing the rest of your deployment.
+
+</div>
+</div>
 
 To use E2B, sign up at [e2b.dev](https://e2b.dev/) and create an API key, then add it as `E2B_API_KEY` from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).

--- a/docs/phoenix/settings/sandboxes/modal.mdx
+++ b/docs/phoenix/settings/sandboxes/modal.mdx
@@ -3,8 +3,13 @@ title: "Modal"
 description: "Run code evaluators in Modal's serverless container platform."
 ---
 
-<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/modal.svg" alt="Modal" style={{ height: '64px' }} />
+<div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem', marginTop: '1.5rem', marginBottom: '1.5rem' }}>
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/modal.svg" alt="Modal" style={{ height: '112px', flexShrink: 0 }} />
+<div>
 
 [**Modal**](https://modal.com/) is a serverless container platform with sub-second cold starts and Python-first ergonomics. Phoenix uses it as a hosted backend for code evaluators that benefit from Modal's fast container scheduling, generous timeouts, and pay-per-execution pricing.
+
+</div>
+</div>
 
 To use Modal, sign up at [modal.com](https://modal.com/) and create a token pair, then add `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).

--- a/docs/phoenix/settings/sandboxes/vercel.mdx
+++ b/docs/phoenix/settings/sandboxes/vercel.mdx
@@ -3,8 +3,13 @@ title: "Vercel Sandbox"
 description: "Run code evaluators in ephemeral compute on Vercel's infrastructure."
 ---
 
-<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/vercel.svg" alt="Vercel Sandbox" style={{ height: '64px' }} />
+<div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem', marginTop: '1.5rem', marginBottom: '1.5rem' }}>
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/vercel.svg" alt="Vercel Sandbox" className="invert-on-dark" style={{ height: '112px', flexShrink: 0 }} />
+<div>
 
 [**Vercel Sandbox**](https://vercel.com/docs/vercel-sandbox) runs code in ephemeral compute on Vercel's infrastructure, scoped to a Vercel team and project. It's a good fit when your team is already on Vercel and you'd like sandbox usage to roll up under the same billing and access controls.
+
+</div>
+</div>
 
 To use Vercel Sandbox, create a token and note your team and project IDs in the Vercel dashboard, then add `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID` from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).

--- a/docs/phoenix/settings/sandboxes/wasm.mdx
+++ b/docs/phoenix/settings/sandboxes/wasm.mdx
@@ -3,8 +3,13 @@ title: "WebAssembly"
 description: "Run Python code evaluators inside the Phoenix server using a CPython-on-Wasm interpreter."
 ---
 
-<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/wasm.svg" alt="WebAssembly" style={{ height: '64px' }} />
+<div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem', marginTop: '1.5rem', marginBottom: '1.5rem' }}>
+<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/wasm.svg" alt="WebAssembly" style={{ height: '112px', flexShrink: 0 }} />
+<div>
 
 The **WebAssembly** sandbox runs Python code in a CPython interpreter compiled to WebAssembly and executed via [`wasmtime`](https://wasmtime.dev/), in-process inside the Phoenix server. Isolation is enforced at the Wasm boundary: the guest has no filesystem, no network, and no syscalls except those Phoenix explicitly grants. It starts in milliseconds and requires no credentials, which makes it the default choice for fast, pure-logic Python evaluators.
+
+</div>
+</div>
 
 Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes). Learn more about WebAssembly at [webassembly.org](https://webassembly.org/).

--- a/docs/style.css
+++ b/docs/style.css
@@ -31,3 +31,8 @@ table {
 .step-title {
   font-size: 1.5rem !important;
 }
+
+/* Invert monochrome-black logos in dark mode (e.g. vendor SVGs with hardcoded fill="#000"). */
+.dark .invert-on-dark {
+  filter: invert(1);
+}


### PR DESCRIPTION
## Summary
- Wrap each sandbox page's vendor logo + intro paragraph in a side-by-side flex layout (logo vertically centered, 112px) so the logo no longer floats alone in a stripe of empty space.
- Add an `.invert-on-dark` helper in `docs/style.css` and apply it to the monochrome-black logos (Deno, Daytona, E2B, Vercel) so they remain visible in dark mode. Modal and Wasm are colored and unchanged.

## Test plan
- [ ] Run docs locally and load each sandbox page (`/docs/phoenix/settings/sandboxes/{deno,daytona,e2b,vercel,modal,wasm}`); confirm the logo sits to the left of the intro paragraph and is vertically centered.
- [ ] Toggle dark mode and confirm the four black logos invert to white while the colored Modal/Wasm logos stay as-is.