### PR TITLE
fix(server): handle empty header values in custom provider config

### DIFF
--- a/src/phoenix/server/api/helpers/headers.py
+++ b/src/phoenix/server/api/helpers/headers.py
@@ -1,0 +1,9 @@
+from typing import Any, Optional
+
+
+def clean_headers(headers: Any) -> Optional[dict[str, str]]:
+    """Drop entries whose value is empty or whitespace-only."""
+    if not headers or not hasattr(headers, "items"):
+        return None
+    cleaned = {k: v for k, v in headers.items() if isinstance(v, str) and v.strip()}
+    return cleaned or None

--- a/src/phoenix/server/api/input_types/GenerativeModelCustomerProviderConfigInput.py
+++ b/src/phoenix/server/api/input_types/GenerativeModelCustomerProviderConfigInput.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Optional
 
 import strawberry
 from strawberry import UNSET
@@ -23,16 +23,9 @@ from phoenix.db.types.model_provider import (
     OpenAICustomProviderConfig,
 )
 from phoenix.server.api.exceptions import BadRequest
+from phoenix.server.api.helpers.headers import clean_headers
 from phoenix.server.api.input_types.ModelClientOptionsInput import OpenAIApiType
 from phoenix.server.api.types.RedactedString import RedactedString
-
-
-def _clean_headers(headers: Any) -> Optional[dict[str, str]]:
-    """Drop entries whose value is empty or whitespace-only."""
-    if not headers or not hasattr(headers, "items"):
-        return None
-    cleaned = {k: v for k, v in headers.items() if isinstance(v, str) and v.strip()}
-    return cleaned or None
 
 
 @strawberry.input
@@ -55,7 +48,7 @@ class OpenAIClientKwargsInput:
             base_url=self.base_url or None,
             organization=self.organization or None,
             project=self.project or None,
-            default_headers=_clean_headers(self.default_headers),
+            default_headers=clean_headers(self.default_headers),
         )
 
 
@@ -130,7 +123,7 @@ class AzureOpenAIClientKwargsInput:
     def to_orm(self) -> AzureOpenAIClientKwargs:
         return AzureOpenAIClientKwargs(
             azure_endpoint=self.azure_endpoint,
-            default_headers=_clean_headers(self.default_headers),
+            default_headers=clean_headers(self.default_headers),
         )
 
 
@@ -168,7 +161,7 @@ class AnthropicClientKwargsInput:
     def to_orm(self) -> AnthropicClientKwargs:
         return AnthropicClientKwargs(
             base_url=self.base_url or None,
-            default_headers=_clean_headers(self.default_headers),
+            default_headers=clean_headers(self.default_headers),
         )
 
 
@@ -201,7 +194,7 @@ class GoogleGenAIHttpOptionsInput:
     def to_orm(self) -> GoogleGenAIHttpOptions:
         return GoogleGenAIHttpOptions(
             base_url=self.base_url or None,
-            headers=_clean_headers(self.headers),
+            headers=clean_headers(self.headers),
         )
 
 

--- a/src/phoenix/server/api/input_types/GenerativeModelCustomerProviderConfigInput.py
+++ b/src/phoenix/server/api/input_types/GenerativeModelCustomerProviderConfigInput.py
@@ -27,6 +27,14 @@ from phoenix.server.api.input_types.ModelClientOptionsInput import OpenAIApiType
 from phoenix.server.api.types.RedactedString import RedactedString
 
 
+def _clean_headers(headers: JSON | None) -> dict[str, str] | None:
+    """Drop entries whose value is empty or whitespace-only."""
+    if not headers:
+        return None
+    cleaned = {k: v for k, v in headers.items() if isinstance(v, str) and v.strip()}
+    return cleaned or None
+
+
 @strawberry.input
 class OpenAIAuthenticationMethodInput:
     api_key: RedactedString
@@ -47,7 +55,7 @@ class OpenAIClientKwargsInput:
             base_url=self.base_url or None,
             organization=self.organization or None,
             project=self.project or None,
-            default_headers=self.default_headers or None,
+            default_headers=_clean_headers(self.default_headers),
         )
 
 
@@ -122,7 +130,7 @@ class AzureOpenAIClientKwargsInput:
     def to_orm(self) -> AzureOpenAIClientKwargs:
         return AzureOpenAIClientKwargs(
             azure_endpoint=self.azure_endpoint,
-            default_headers=self.default_headers or None,
+            default_headers=_clean_headers(self.default_headers),
         )
 
 
@@ -160,7 +168,7 @@ class AnthropicClientKwargsInput:
     def to_orm(self) -> AnthropicClientKwargs:
         return AnthropicClientKwargs(
             base_url=self.base_url or None,
-            default_headers=self.default_headers or None,
+            default_headers=_clean_headers(self.default_headers),
         )
 
 
@@ -193,7 +201,7 @@ class GoogleGenAIHttpOptionsInput:
     def to_orm(self) -> GoogleGenAIHttpOptions:
         return GoogleGenAIHttpOptions(
             base_url=self.base_url or None,
-            headers=self.headers or None,
+            headers=_clean_headers(self.headers),
         )
 
 

--- a/src/phoenix/server/api/input_types/GenerativeModelCustomerProviderConfigInput.py
+++ b/src/phoenix/server/api/input_types/GenerativeModelCustomerProviderConfigInput.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 import strawberry
 from strawberry import UNSET
@@ -27,9 +27,9 @@ from phoenix.server.api.input_types.ModelClientOptionsInput import OpenAIApiType
 from phoenix.server.api.types.RedactedString import RedactedString
 
 
-def _clean_headers(headers: JSON | None) -> dict[str, str] | None:
+def _clean_headers(headers: Any) -> Optional[dict[str, str]]:
     """Drop entries whose value is empty or whitespace-only."""
-    if not headers:
+    if not headers or not hasattr(headers, "items"):
         return None
     cleaned = {k: v for k, v in headers.items() if isinstance(v, str) and v.strip()}
     return cleaned or None

--- a/src/phoenix/server/api/mutations/generative_model_custom_provider_mutations.py
+++ b/src/phoenix/server/api/mutations/generative_model_custom_provider_mutations.py
@@ -342,7 +342,10 @@ class GenerativeModelCustomProviderMutationMixin:
         Uses models.list() where available, or a dummy model name where
         non-auth errors indicate valid credentials.
         """
-        config = input.to_orm()
+        try:
+            config = input.to_orm()
+        except ValidationError as e:
+            raise BadRequest(f"Invalid client config: {e}") from e
 
         if config.root.type == "openai":
             try:

--- a/tests/unit/server/api/helpers/test_headers.py
+++ b/tests/unit/server/api/helpers/test_headers.py
@@ -1,0 +1,33 @@
+from phoenix.server.api.helpers.headers import clean_headers
+
+
+class TestCleanHeaders:
+    def test_returns_none_for_none(self) -> None:
+        assert clean_headers(None) is None
+
+    def test_returns_none_for_empty_dict(self) -> None:
+        assert clean_headers({}) is None
+
+    def test_returns_none_for_non_mapping(self) -> None:
+        assert clean_headers("not a dict") is None
+        assert clean_headers(42) is None
+        assert clean_headers(["a", "b"]) is None
+
+    def test_drops_empty_string_values(self) -> None:
+        assert clean_headers({"X-Foo": "", "X-Bar": "bar"}) == {"X-Bar": "bar"}
+
+    def test_drops_whitespace_only_values(self) -> None:
+        assert clean_headers({"X-Foo": "   ", "X-Bar": "\t\n", "X-Baz": "baz"}) == {"X-Baz": "baz"}
+
+    def test_drops_non_string_values(self) -> None:
+        assert clean_headers({"X-Num": 1, "X-None": None, "X-Bar": "bar"}) == {"X-Bar": "bar"}
+
+    def test_returns_none_when_all_values_dropped(self) -> None:
+        assert clean_headers({"X-Foo": "", "X-Bar": "  "}) is None
+
+    def test_preserves_valid_entries(self) -> None:
+        headers = {"X-Foo": "foo", "X-Bar": "bar"}
+        assert clean_headers(headers) == {"X-Foo": "foo", "X-Bar": "bar"}
+
+    def test_preserves_values_with_internal_whitespace(self) -> None:
+        assert clean_headers({"X-Foo": "  hello world  "}) == {"X-Foo": "  hello world  "}


### PR DESCRIPTION
## Summary
- Wrap `input.to_orm()` in `test_generative_model_custom_provider_credentials` with `try/except ValidationError → BadRequest`, matching the sibling create/patch mutations so config errors surface as user-facing GraphQL errors instead of raw Pydantic tracebacks.
- Drop empty / whitespace-only header values inside `default_headers` (and Google's `headers`) before constructing the ORM model. The Pydantic `*ClientKwargs` models use `ConfigDict(str_min_length=1, str_strip_whitespace=True)`, which applies to every string in the model — including each value inside `Mapping[str, str]` — so e.g. `{"api_key": ""}` previously failed validation even though the frontend header schema allows empty values.
