### PR TITLE
fix(devops): tolerate missing pnpm-lock.yaml in oidc-server build and dev-mock-llm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,7 +387,7 @@ dev-docker: ## Run Docker devops environment (use ARGS= to pass arguments, defau
 
 dev-mock-llm: ## Start the mock LLM server
 	@echo -e "$(CYAN)Starting mock LLM server...$(NC)"
-	cd scripts/mock-llm-server && $(PNPM) install --frozen-lockfile && $(PNPM) run build:all && $(PNPM) start
+	cd scripts/mock-llm-server && $(PNPM) install && $(PNPM) run build:all && $(PNPM) start
 
 #=============================================================================
 # Cleanup

--- a/scripts/docker/devops/oidc-server/Dockerfile
+++ b/scripts/docker/devops/oidc-server/Dockerfile
@@ -7,9 +7,12 @@ RUN corepack enable
 # Set working directory
 WORKDIR /app
 
-# Copy package files
-COPY package*.json pnpm-lock.yaml ./
-COPY frontend/package*.json ./frontend/
+# Copy package files. ``pnpm-lock.yaml*`` (with trailing glob) tolerates the
+# lockfile being absent — lock files under ``scripts/docker/devops/`` are
+# untracked per the SBOM-scanner directive, and pnpm install falls back to a
+# fresh resolve when no lockfile is present.
+COPY package*.json pnpm-lock.yaml* ./
+COPY frontend/package*.json frontend/pnpm-lock.yaml* ./frontend/
 
 # Install dependencies
 RUN pnpm install


### PR DESCRIPTION
## Summary

Make the four `scripts/` lockfile call sites tolerate the lockfiles being absent, so the build paths don't break once [#13248](https://github.com/Arize-ai/phoenix/pull/13248) removes them per the SBOM-scanner directive.

Two call sites currently hard-require a soon-to-be-removed lockfile:

1. **`scripts/docker/devops/oidc-server/Dockerfile:11`** — `COPY package*.json pnpm-lock.yaml ./` fails the build with:
   ```
   target oidc-dev: failed to solve: failed to compute cache key:
     failed to calculate checksum of ref ...: "/pnpm-lock.yaml": not found
   ```
2. **`Makefile:390` (`dev-mock-llm`)** — `pnpm install --frozen-lockfile` errors out with `ERR_PNPM_NO_LOCKFILE` when the lockfile is absent.

## Changes

- **`scripts/docker/devops/oidc-server/Dockerfile`** — switch both COPY lines to the glob-tolerant `pnpm-lock.yaml*` pattern that `smtp-server/Dockerfile` already uses. The trailing `*` matches the lockfile when present and matches nothing when absent.
- **`Makefile`** — drop `--frozen-lockfile` from `dev-mock-llm`. `pnpm install` does a fresh resolve when no lockfile is present.

## Behavior

- **Lockfile present** (current state): the glob matches / `pnpm install` reads the lockfile. No change.
- **Lockfile absent** (post-SBOM-removal): the glob matches nothing / `pnpm install` does a fresh resolve from `package.json`.

## Why the other Dockerfiles don't need this

- **`scripts/docker/devops/smtp-server/Dockerfile`** already uses `COPY package.json pnpm-lock.yaml* ./`.
- **`scripts/docker/devops/Dockerfile`** and **`scripts/docker/devops/vite-dev/Dockerfile`** reference `./app/pnpm-lock.yaml` (the main app's lockfile), which remains tracked.
- **`.github/workflows/typescript-CI.yml`** and **`.github/workflows/playwright.yaml`** cache against `./app/pnpm-lock.yaml`, same.
