### PR TITLE
docs(evaluation): add intro videos to code evaluator pages

### DIFF
--- a/docs/phoenix/evaluation/how-to-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/how-to-evals/code-evaluators.mdx
@@ -2,6 +2,8 @@
 title: "Code Evaluators"
 ---
 
+<video src="https://storage.googleapis.com/arize-phoenix-assets/assets/videos/sandboxes/code_evaluators_intro.mp4" width="100%" height="100%" style={{ display: 'block', objectFit: 'fill', backgroundColor: 'transparent' }} controls autoPlay muted loop />
+
 Evaluations do not all require LLMs, and often it's useful to create Evaluators that perform basic checks or calculations on datasets that, in concert with LLM evaluations, can help provide useful signal to improve an application.
 
 These evaluations that don't use an LLM are indicated by a `kind="code"` flag on the scores.

--- a/docs/phoenix/evaluation/how-to-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/how-to-evals/code-evaluators.mdx
@@ -2,8 +2,6 @@
 title: "Code Evaluators"
 ---
 
-<video src="https://storage.googleapis.com/arize-phoenix-assets/assets/videos/sandboxes/code_evaluators_intro.mp4" width="100%" height="100%" style={{ display: 'block', objectFit: 'fill', backgroundColor: 'transparent' }} controls autoPlay muted loop />
-
 Evaluations do not all require LLMs, and often it's useful to create Evaluators that perform basic checks or calculations on datasets that, in concert with LLM evaluations, can help provide useful signal to improve an application.
 
 These evaluations that don't use an LLM are indicated by a `kind="code"` flag on the scores.

--- a/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
@@ -3,6 +3,8 @@ title: "Code Evaluators"
 description: "Write Python or TypeScript evaluators directly in Phoenix and run them in a managed sandbox — no SDK, local runtime, or deploy step required."
 ---
 
+<video src="https://storage.googleapis.com/arize-phoenix-assets/assets/videos/sandboxes/code_evaluators_intro.mp4" width="100%" height="100%" style={{ display: 'block', objectFit: 'fill', backgroundColor: 'transparent' }} controls autoPlay muted loop />
+
 Code evaluators let you author a custom evaluation function in **Python** or **TypeScript** and attach it directly to a dataset. Phoenix stores the source, executes it server-side in a sandbox, and records labels and scores as annotations on each experiment run — the same way LLM evaluators do, but with deterministic code instead of a judge model.
 
 Reach for a code evaluator when:

--- a/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
@@ -102,12 +102,10 @@ The function returns an object with three optional fields:
 
 ### Output configuration
 
-Each evaluator declares one of two **output shapes**:
+An evaluator's output config is descriptive — it tells Phoenix how to interpret whatever your function returns, not what shape it must produce.
 
-- **Continuous score** — A numeric value within a configurable range (default `0.0`–`1.0`). Use for similarity scores, distances, or any graded metric.
-- **Categorical label** — A fixed set of labels, each mapped to a numeric score. The label your function returns must be one of the configured values.
-
-You also pick an **optimization direction** (maximize vs. minimize) so Phoenix can render trends correctly in experiment comparisons.
+- **Optimization direction** — `maximize` or `minimize`, used to render trends correctly in experiment comparisons.
+- **Threshold** *(optional)* — A numeric cutoff that splits scores into pass/fail for threshold-pivoted coloring in result views. Leave it unset if pass/fail isn't meaningful for your metric.
 
 ## Sandbox Runtimes
 

--- a/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
@@ -126,6 +126,10 @@ The available backends are:
 If your evaluator needs to install a package or call an external API, pick a hosted backend. The local runtimes are intentionally restricted.
 </Tip>
 
+The walkthrough below shows creating a Python code evaluator that runs on a Daytona sandbox — from picking the hosted backend through testing the evaluator against a dataset example.
+
+<video src="https://storage.googleapis.com/arize-phoenix-assets/assets/videos/sandboxes/code_evaluator_on_daytona.mp4" width="100%" height="100%" style={{ display: 'block', objectFit: 'fill', backgroundColor: 'transparent' }} controls autoPlay muted loop />
+
 ## Versioning
 
 Every time you save an evaluator's source, Phoenix creates a new **evaluator version** that executes for subsequent experiment runs. Older versions are retained so you can audit which code produced any historical score.

--- a/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
@@ -46,7 +46,7 @@ From authoring to results, you'll work through five steps:
 
 1. **Create the evaluator** — From a dataset's **Evaluators** tab, choose **Add evaluator → Create new code evaluator**. Pick a language (Python or TypeScript) and a sandbox configuration.
 2. **Write `evaluate(...)`** — The editor opens pre-populated with an `evaluate(...)` function. Its parameters become the evaluator's inputs.
-3. **Configure output** — Declare whether the evaluator returns a continuous score (e.g. `0.0`–`1.0`) or a categorical label (e.g. `pass` / `fail`).
+3. **Configure the annotation** — Pick an optimization direction (maximize vs. minimize) and, optionally, a threshold for pass/fail coloring.
 4. **Map inputs** — Bind each parameter to a path on the [evaluation parameters](/docs/phoenix/evaluation/server-evals/input-mapping#evaluation-parameters) (`input`, `output`, `reference`, `metadata`) or to a literal value.
 5. **Test, save, run** — Dry-run the evaluator against a dataset example in the test panel, save it, then run an experiment. Scores land on every new run automatically.
 
@@ -100,9 +100,9 @@ The function returns an object with three optional fields:
 | `score` | number | A numeric score. Required for continuous evaluators. Categorical evaluators can omit it — Phoenix fills it in from the configured label-to-score mapping. |
 | `explanation` | string | Free-form text shown alongside the score. Useful for debugging surprising results. |
 
-### Output configuration
+### Annotation configuration
 
-An evaluator's output config is descriptive — it tells Phoenix how to interpret whatever your function returns, not what shape it must produce.
+An evaluator's annotation config is descriptive — it tells Phoenix how to interpret whatever your function returns, not what shape it must produce.
 
 - **Optimization direction** — `maximize` or `minimize`, used to render trends correctly in experiment comparisons.
 - **Threshold** *(optional)* — A numeric cutoff that splits scores into pass/fail for threshold-pivoted coloring in result views. Leave it unset if pass/fail isn't meaningful for your metric.
@@ -132,7 +132,7 @@ The walkthrough below shows creating a Python code evaluator that runs on a Dayt
 
 Every time you save an evaluator's source, Phoenix creates a new **evaluator version** that executes for subsequent experiment runs. Older versions are retained so you can audit which code produced any historical score.
 
-The evaluator's **name**, **description**, **output configuration**, **input mapping**, and **sandbox binding** live on the evaluator itself rather than on a version — editing those updates the evaluator in place without creating a new version.
+The evaluator's **name**, **description**, **annotation configuration**, **input mapping**, and **sandbox binding** live on the evaluator itself rather than on a version — editing those updates the evaluator in place without creating a new version.
 
 ## Testing Before You Save
 

--- a/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
@@ -105,6 +105,7 @@ The function returns an object with three optional fields:
 An evaluator's annotation config is descriptive — it tells Phoenix how to interpret whatever your function returns, not what shape it must produce.
 
 - **Optimization direction** — `maximize` or `minimize`, used to render trends correctly in experiment comparisons.
+- **Lower / upper bound** *(optional)* — The expected numeric range for scores. Used to normalize values for visualization.
 - **Threshold** *(optional)* — A numeric cutoff that splits scores into pass/fail for threshold-pivoted coloring in result views. Leave it unset if pass/fail isn't meaningful for your metric.
 
 ## Sandbox Runtimes


### PR DESCRIPTION
## Summary
- Embed the regex-based intro walkthrough video on the local (SDK) code evaluators page
- Embed the Daytona hosted-sandbox walkthrough in the Sandbox Runtimes section of the hosted code evaluators page

## Test plan
- [ ] Run `mintlify dev` and visit `/docs/phoenix/evaluation/how-to-evals/code-evaluators` — intro video renders at top
- [ ] Visit `/docs/phoenix/evaluation/server-evals/code-evaluators` — Daytona walkthrough renders in Sandbox Runtimes section