### PR TITLE
fix(app): prevent nested spans table scrolling

### DIFF
--- a/app/src/pages/project/SpansTableAside.tsx
+++ b/app/src/pages/project/SpansTableAside.tsx
@@ -96,7 +96,13 @@ export function SpansTableAside(props: { filterCondition?: string | null }) {
 
   return (
     <Group orientation="vertical">
-      <TitledPanel title="Project Info" panelProps={{ defaultSize: "0%" }}>
+      <TitledPanel
+        title="Project Info"
+        panelProps={{
+          defaultSize: "0%",
+          minSize: 240,
+        }}
+      >
         <View padding="size-200" overflow="auto" height="100%">
           <Flex direction="column" gap="size-100" minWidth="size-3400">
             <CopyField value={project?.name ?? ""}>

--- a/app/src/pages/project/styles.tsx
+++ b/app/src/pages/project/styles.tsx
@@ -4,6 +4,8 @@ export const spansTableCSS = css`
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
+  height: 100%;
+  min-height: 0;
   overflow: hidden;
   .span-filter-condition-field {
     flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- Constrain the project spans table root to the available panel height
- Prevent the resizable panel wrapper from becoming a second vertical scroll container


https://github.com/user-attachments/assets/92805b98-72c2-4ace-b714-843a5540ced1



## Testing
- Verified on `localhost:6006` that the spans table panel wrapper no longer has vertical overflow and the table scroller owns the overflow
- Checked traces and sessions tabs still expose only their intended table scroller

Related issue: N/A