### PR TITLE
fix(sandbox): make per-execute timeouts real across backends

### DIFF
--- a/src/phoenix/server/sandbox/daytona_backend.py
+++ b/src/phoenix/server/sandbox/daytona_backend.py
@@ -200,7 +200,7 @@ class DaytonaSandboxBackend(SandboxBackend):
             workspace = self._sessions.get(session_key)
             if workspace is not None:
                 result = await workspace.process.code_run(
-                    code, params=CodeRunParams(env=self._user_env or None)
+                    code, params=CodeRunParams(env=self._user_env or None, timeout=timeout)
                 )
                 return _to_execution_result(result)
             else:
@@ -209,7 +209,7 @@ class DaytonaSandboxBackend(SandboxBackend):
                 try:
                     await self._install_packages(workspace)
                     result = await workspace.process.code_run(
-                        code, params=CodeRunParams(env=self._user_env or None)
+                        code, params=CodeRunParams(env=self._user_env or None, timeout=timeout)
                     )
                     return _to_execution_result(result)
                 finally:

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -177,14 +177,30 @@ class ModalSandboxBackend(SandboxBackend):
             await sandbox.terminate.aio()
             logger.debug(f"Stopped Modal session '{session_key}'")
 
-    async def _exec_code(self, sandbox: Sandbox, code: str) -> ExecutionResult:
+    async def _exec_code(
+        self,
+        sandbox: Sandbox,
+        code: str,
+        timeout: Optional[int] = None,
+    ) -> ExecutionResult:
         """Run code in a sandbox and collect stdout/stderr."""
         proc = await sandbox.exec.aio("python", "-c", code)
-        stdout, stderr = await asyncio.gather(
-            proc.stdout.read.aio(),
-            proc.stderr.read.aio(),
-        )
-        exit_code = await proc.wait.aio()
+        try:
+            stdout, stderr, exit_code = await asyncio.wait_for(
+                asyncio.gather(
+                    proc.stdout.read.aio(),
+                    proc.stderr.read.aio(),
+                    proc.wait.aio(),
+                ),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            try:
+                await proc.terminate.aio()
+            except Exception:
+                logger.debug("Error terminating Modal process after timeout", exc_info=True)
+            error = f"Modal sandbox execution timed out after {timeout} seconds"
+            return ExecutionResult(stdout="", stderr=error, error=error)
         error: Optional[str] = stderr if exit_code != 0 else None
         return ExecutionResult(stdout=stdout or "", stderr=stderr or "", error=error)
 
@@ -197,11 +213,11 @@ class ModalSandboxBackend(SandboxBackend):
         try:
             sandbox = self._sessions.get(session_key)
             if sandbox is not None:
-                return await self._exec_code(sandbox, code)
+                return await self._exec_code(sandbox, code, timeout=timeout)
             else:
                 sandbox = await self._create_sandbox()
                 try:
-                    return await self._exec_code(sandbox, code)
+                    return await self._exec_code(sandbox, code, timeout=timeout)
                 finally:
                     await sandbox.terminate.aio()
         except Exception as exc:

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -237,12 +237,16 @@ class VercelSandboxBackend(SandboxBackend):
         sandbox: AsyncSandbox,
         code: str,
         env: Optional[dict[str, str]] = None,
+        timeout: Optional[int] = None,
     ) -> ExecutionResult:
         """Run code in a sandbox and collect stdout/stderr."""
         lang_cfg = self._lang_cfg()
         cmd: str = lang_cfg["cmd"]
         args: list[str] = lang_cfg["args_prefix"] + [code]
-        result = await sandbox.run_command(cmd, args, env=env)
+        run_kwargs: dict[str, Any] = {"env": env}
+        if timeout is not None:
+            run_kwargs["timeout"] = timeout
+        result = await sandbox.run_command(cmd, args, **run_kwargs)
         stdout, stderr = await asyncio.gather(result.stdout(), result.stderr())
         exit_code = result.exit_code
         error: Optional[str] = stderr if exit_code != 0 else None
@@ -258,13 +262,13 @@ class VercelSandboxBackend(SandboxBackend):
             session_env: Optional[dict[str, str]] = self._user_env or None
             sandbox = self._sessions.get(session_key)
             if sandbox is not None:
-                return await self._exec_code(sandbox, code, env=session_env)
+                return await self._exec_code(sandbox, code, env=session_env, timeout=timeout)
             else:
                 # Ephemeral: create, install (if configured), exec, stop.
                 sandbox = await self._create_sandbox()
                 try:
                     await self._install_packages(sandbox)
-                    return await self._exec_code(sandbox, code, env=session_env)
+                    return await self._exec_code(sandbox, code, env=session_env, timeout=timeout)
                 finally:
                     try:
                         await sandbox.stop()

--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -21,10 +21,12 @@ import asyncio
 import logging
 import os
 import tempfile
+import threading
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Mapping, Optional
+from typing import TYPE_CHECKING, Iterator, Mapping, Optional
 
 if TYPE_CHECKING:
     import wasmtime
@@ -45,12 +47,69 @@ _WASM_BINARY_PATH_ENV = "PHOENIX_WASM_BINARY_PATH"
 
 _DEFAULT_TIMEOUT_SECONDS = 30
 _EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="wasm-sandbox")
+_EPOCH_INTERVAL_SECONDS = 1.0
 
 
 # Module-level cache: path → (engine, compiled module).
 # Engine and module must be paired — a module compiled with one engine
 # cannot be used with a store from a different engine.
 _MODULE_CACHE: dict[str, tuple[wasmtime.Engine, wasmtime.Module]] = {}
+_EPOCH_TICKERS: dict[int, "_EngineEpochTicker"] = {}
+_EPOCH_TICKERS_LOCK = threading.Lock()
+
+
+class _EngineEpochTicker:
+    def __init__(self, engine: wasmtime.Engine) -> None:
+        self._engine = engine
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="wasm-sandbox-epoch",
+            daemon=True,
+        )
+        self._ref_count = 0
+
+    def acquire(self) -> None:
+        self._ref_count += 1
+        if not self._thread.is_alive():
+            self._thread.start()
+
+    def release(self) -> bool:
+        self._ref_count -= 1
+        return self._ref_count <= 0
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=_EPOCH_INTERVAL_SECONDS)
+
+    def _run(self) -> None:
+        while not self._stop.wait(_EPOCH_INTERVAL_SECONDS):
+            try:
+                self._engine.increment_epoch()
+            except Exception:
+                logger.debug("Error incrementing WASM engine epoch", exc_info=True)
+
+
+@contextmanager
+def _engine_epoch_ticker(engine: wasmtime.Engine) -> Iterator[None]:
+    """Drive wasmtime epoch deadlines while any store using this engine is active."""
+    engine_key = id(engine)
+    with _EPOCH_TICKERS_LOCK:
+        ticker = _EPOCH_TICKERS.get(engine_key)
+        if ticker is None:
+            ticker = _EngineEpochTicker(engine)
+            _EPOCH_TICKERS[engine_key] = ticker
+        ticker.acquire()
+    try:
+        yield
+    finally:
+        stop_ticker = False
+        with _EPOCH_TICKERS_LOCK:
+            stop_ticker = ticker.release()
+            if stop_ticker:
+                _EPOCH_TICKERS.pop(engine_key, None)
+        if stop_ticker:
+            ticker.stop()
 
 
 def _get_engine_and_module(binary_path: Path) -> tuple[wasmtime.Engine, wasmtime.Module]:
@@ -95,11 +154,12 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
         store.set_wasi(wasi)
         store.set_epoch_deadline(timeout)
 
-        instance = linker.instantiate(store, module)
-        exports = instance.exports(store)
-        start = exports.get("_start")
-        if isinstance(start, _wasm.Func):
-            start(store)
+        with _engine_epoch_ticker(engine):
+            instance = linker.instantiate(store, module)
+            exports = instance.exports(store)
+            start = exports.get("_start")
+            if isinstance(start, _wasm.Func):
+                start(store)
 
         return ExecutionResult(
             stdout=b"".join(stdout_chunks).decode("utf-8", errors="replace"),

--- a/tests/unit/server/api/test_wasm_backend.py
+++ b/tests/unit/server/api/test_wasm_backend.py
@@ -10,6 +10,7 @@ metadata, build_backend config plumbing).
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast  # noqa: F401
 
@@ -372,6 +373,79 @@ class TestRunWasmStdoutCapture:
         assert result.error is None
         assert len(stdin_path_holder) == 1
         assert stdin_path_holder[0].endswith(".py")
+
+    def test_run_wasm_arms_epoch_ticker_for_timeout_deadline(self) -> None:
+        """WASM timeout requires both a store deadline and an engine epoch driver."""
+        import wasmtime
+
+        ticker_events: list[tuple[str, object]] = []
+
+        @contextmanager
+        def _fake_epoch_ticker(engine: object) -> Any:
+            ticker_events.append(("enter", engine))
+            try:
+                yield
+            finally:
+                ticker_events.append(("exit", engine))
+
+        class _CapturingWasiConfig:
+            @property
+            def stdout_custom(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stdout_custom.setter
+            def stdout_custom(self, cb: object) -> None:
+                del cb
+
+            @property
+            def stderr_custom(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stderr_custom.setter
+            def stderr_custom(self, cb: object) -> None:
+                del cb
+
+            @property
+            def stdin_file(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stdin_file.setter
+            def stdin_file(self, path: object) -> None:
+                del path
+
+        class _StartFunc:
+            def __call__(self, store: object) -> None:
+                del store
+
+        engine = MagicMock(name="engine")
+        module = MagicMock(name="module")
+        fake_store = MagicMock()
+        mock_exports = MagicMock()
+        mock_exports.get.return_value = _StartFunc()
+        mock_instance = MagicMock()
+        mock_instance.exports.return_value = mock_exports
+
+        with patch(
+            "phoenix.server.sandbox.wasm_backend._get_engine_and_module",
+            return_value=(engine, module),
+        ):
+            with patch(
+                "phoenix.server.sandbox.wasm_backend._engine_epoch_ticker",
+                _fake_epoch_ticker,
+                create=True,
+            ):
+                with patch("wasmtime.WasiConfig", _CapturingWasiConfig):
+                    with patch("wasmtime.Linker") as mock_linker_cls:
+                        mock_linker = MagicMock()
+                        mock_linker_cls.return_value = mock_linker
+                        mock_linker.instantiate.return_value = mock_instance
+                        with patch("wasmtime.Store", return_value=fake_store):
+                            with patch.object(wasmtime, "Func", _StartFunc):
+                                result = _run_wasm(Path("/fake/cpython.wasm"), "x=1", timeout=7)
+
+        assert result.error is None
+        fake_store.set_epoch_deadline.assert_called_once_with(7)
+        assert ticker_events == [("enter", engine), ("exit", engine)]
 
 
 class TestTempFileCleanup:

--- a/tests/unit/server/sandbox/test_daytona_backend.py
+++ b/tests/unit/server/sandbox/test_daytona_backend.py
@@ -44,9 +44,11 @@ class _CodeRunParams:
         self,
         argv: list[str] | None = None,
         env: dict[str, str] | None = None,
+        timeout: int | None = None,
     ) -> None:
         self.argv = argv
         self.env = env
+        self.timeout = timeout
 
 
 class _CreateSandboxFromSnapshotParams:
@@ -155,6 +157,51 @@ class TestCodeRunParamsKwarg:
         assert params.env is None, (
             f"Expected params.env=None for empty user_env, got {params.env!r}"
         )
+
+    @pytest.mark.asyncio
+    async def test_ephemeral_execute_passes_timeout_to_code_run_params(self) -> None:
+        """Per-execute timeout must reach Daytona's code_run params on ephemeral runs."""
+        daytona_mod, process_mod = _make_daytona_mocks()
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            backend = DaytonaSandboxBackend(api_key=_API_KEY, user_env={}, language="PYTHON")
+            await backend.execute("1+1", session_key="s1", timeout=7)
+
+        workspace = daytona_mod.AsyncDaytona.return_value.create.return_value
+        call_args = workspace.process.code_run.call_args
+        params = call_args.kwargs["params"]
+        assert isinstance(params, _CodeRunParams)
+        assert params.timeout == 7
+
+    @pytest.mark.asyncio
+    async def test_session_execute_passes_timeout_to_code_run_params(self) -> None:
+        """Per-execute timeout must also reach Daytona when reusing a named session."""
+        daytona_mod, process_mod = _make_daytona_mocks()
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            backend = DaytonaSandboxBackend(api_key=_API_KEY, user_env={}, language="PYTHON")
+            await backend.start_session("s1")
+            await backend.execute("1+1", session_key="s1", timeout=11)
+
+        workspace = daytona_mod.AsyncDaytona.return_value.create.return_value
+        call_args = workspace.process.code_run.call_args
+        params = call_args.kwargs["params"]
+        assert isinstance(params, _CodeRunParams)
+        assert params.timeout == 11
 
 
 class TestNetworkBlockAll:

--- a/tests/unit/server/sandbox/test_modal_backend.py
+++ b/tests/unit/server/sandbox/test_modal_backend.py
@@ -9,6 +9,7 @@ test_unified_config_contract.py.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import sys
 from typing import Any, Mapping
@@ -266,6 +267,75 @@ async def test_client_construction_is_memoized_across_sandbox_creates() -> None:
     assert modal_mock.Client.from_credentials.aio.await_count == 1
     assert modal_mock.App.lookup.aio.await_count == 1
     assert modal_mock.Sandbox.create.aio.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_exec_code_terminates_proc_when_timeout_expires() -> None:
+    """Per-execute timeout must terminate the Modal process, not just return locally."""
+    modal_mock = _make_modal_mock()
+    with patch.dict(sys.modules, {"modal": modal_mock}):
+        from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+        backend = ModalSandboxBackend(token_id=_TOKEN_ID, token_secret=_TOKEN_SECRET)
+
+        never = asyncio.Event()
+        proc = MagicMock()
+        proc.stdout.read.aio = AsyncMock(side_effect=never.wait)
+        proc.stderr.read.aio = AsyncMock(side_effect=never.wait)
+        proc.wait.aio = AsyncMock(side_effect=never.wait)
+        proc.terminate.aio = AsyncMock()
+        sandbox = MagicMock()
+        sandbox.exec.aio = AsyncMock(return_value=proc)
+
+        result = await backend._exec_code(sandbox, "while True: pass", timeout=0.01)
+
+    assert result.stdout == ""
+    assert result.error is not None
+    assert "timed out" in result.error.lower()
+    proc.terminate.aio.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_forwards_timeout_to_cached_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Session reuse path must not drop the per-execute timeout."""
+    modal_mock = _make_modal_mock()
+    with patch.dict(sys.modules, {"modal": modal_mock}):
+        from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+        backend = ModalSandboxBackend(token_id=_TOKEN_ID, token_secret=_TOKEN_SECRET)
+        sandbox = MagicMock()
+        backend._sessions["s1"] = sandbox
+        mock_exec = AsyncMock(return_value=MagicMock(error=None))
+        monkeypatch.setattr(backend, "_exec_code", mock_exec)
+
+        await backend.execute("print('ok')", session_key="s1", timeout=23)
+
+    mock_exec.assert_awaited_once_with(sandbox, "print('ok')", timeout=23)
+
+
+@pytest.mark.asyncio
+async def test_execute_forwards_timeout_to_ephemeral_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ephemeral Modal executions must enforce the same per-execute timeout."""
+    modal_mock = _make_modal_mock()
+    with patch.dict(sys.modules, {"modal": modal_mock}):
+        from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+        backend = ModalSandboxBackend(token_id=_TOKEN_ID, token_secret=_TOKEN_SECRET)
+        sandbox = MagicMock()
+        sandbox.terminate.aio = AsyncMock()
+        mock_create = AsyncMock(return_value=sandbox)
+        mock_exec = AsyncMock(return_value=MagicMock(error=None))
+        monkeypatch.setattr(backend, "_create_sandbox", mock_create)
+        monkeypatch.setattr(backend, "_exec_code", mock_exec)
+
+        await backend.execute("print('ok')", session_key="ephemeral", timeout=29)
+
+    mock_exec.assert_awaited_once_with(sandbox, "print('ok')", timeout=29)
+    sandbox.terminate.aio.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/sandbox/test_vercel_backend.py
+++ b/tests/unit/server/sandbox/test_vercel_backend.py
@@ -417,6 +417,75 @@ def test_adapter_build_backend_fails_closed_on_missing_triple(language: Language
 
 
 @pytest.mark.asyncio
+async def test_exec_code_forwards_timeout_to_run_command() -> None:
+    """Per-execute timeout must reach the Vercel run_command call."""
+    captured_kwargs: list[dict[str, Any]] = []
+
+    async def _run_command(cmd: str, args: list[str], **kwargs: Any) -> Any:
+        captured_kwargs.append(dict(kwargs))
+        result = MagicMock()
+        result.exit_code = 0
+        result.stdout = AsyncMock(return_value="ok\n")
+        result.stderr = AsyncMock(return_value="")
+        return result
+
+    sandbox = MagicMock()
+    sandbox.run_command = _run_command
+    backend = VercelSandboxBackend(
+        token=_TOKEN, project_id=_PROJECT, team_id=_TEAM, language="PYTHON"
+    )
+
+    result = await backend._exec_code(sandbox, "print('ok')", env={"A": "B"}, timeout=13)
+
+    assert result.error is None
+    assert captured_kwargs == [{"env": {"A": "B"}, "timeout": 13}]
+
+
+@pytest.mark.asyncio
+async def test_execute_forwards_timeout_to_cached_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Session reuse path must not drop the per-execute timeout."""
+    sandbox = MagicMock()
+    backend = VercelSandboxBackend(
+        token=_TOKEN, project_id=_PROJECT, team_id=_TEAM, language="PYTHON"
+    )
+    backend._sessions["s1"] = sandbox
+    mock_exec = AsyncMock(return_value=MagicMock(error=None))
+    monkeypatch.setattr(backend, "_exec_code", mock_exec)
+
+    await backend.execute("print('ok')", session_key="s1", timeout=17)
+
+    mock_exec.assert_awaited_once_with(sandbox, "print('ok')", env=None, timeout=17)
+
+
+@pytest.mark.asyncio
+async def test_execute_forwards_timeout_to_ephemeral_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ephemeral Vercel executions must enforce the same per-execute timeout."""
+    sandbox = MagicMock()
+    sandbox.stop = AsyncMock()
+    sandbox.client = MagicMock()
+    sandbox.client.aclose = AsyncMock()
+    backend = VercelSandboxBackend(
+        token=_TOKEN, project_id=_PROJECT, team_id=_TEAM, language="PYTHON"
+    )
+    mock_create = AsyncMock(return_value=sandbox)
+    mock_install = AsyncMock()
+    mock_exec = AsyncMock(return_value=MagicMock(error=None))
+    monkeypatch.setattr(backend, "_create_sandbox", mock_create)
+    monkeypatch.setattr(backend, "_install_packages", mock_install)
+    monkeypatch.setattr(backend, "_exec_code", mock_exec)
+
+    await backend.execute("print('ok')", session_key="ephemeral", timeout=19)
+
+    mock_exec.assert_awaited_once_with(sandbox, "print('ok')", env=None, timeout=19)
+    sandbox.stop.assert_awaited_once()
+    sandbox.client.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_execute_strips_ansi_from_all_three_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #13313

## Summary

This makes `SandboxConfig.timeout` effective at the per-execute boundary for the sandbox backends that were still dropping or not driving it:

- Daytona now passes `timeout` through `CodeRunParams`.
- Vercel now forwards `timeout` to `run_command`.
- Modal now enforces `timeout` locally around process output/wait collection and terminates the process on expiry.
- WASM now drives wasmtime epoch deadlines with a ref-counted per-engine ticker, so `store.set_epoch_deadline(...)` is no longer inert.

## Root Cause

The config model accepted a timeout, and some backends exposed execution paths that looked timeout-aware, but the value stopped before reaching the provider SDK execution call in Daytona/Vercel/Modal. WASM set an epoch deadline on the store, but never incremented the engine epoch, so there was no clock for the deadline to observe.

## Changes

- Threaded `timeout` through cached-session and ephemeral execution paths for Daytona, Vercel, and Modal.
- Added Modal timeout handling that terminates the running process before returning a timeout error.
- Added a small WASM epoch ticker shared per cached engine instead of starting one independent ticker per execution.
- Added regression coverage for session reuse, ephemeral execution, process termination, and WASM epoch deadline activation.

## Test Plan

```bash
PHOENIX_WORKING_DIR=/tmp/phoenix-test-working .venv/bin/pytest \
  tests/unit/server/sandbox/test_daytona_backend.py \
  tests/unit/server/sandbox/test_vercel_backend.py \
  tests/unit/server/sandbox/test_modal_backend.py \
  tests/unit/server/api/test_wasm_backend.py -q
```

Result: `84 passed, 50 warnings`

```bash
.venv/bin/ruff check \
  src/phoenix/server/sandbox/daytona_backend.py \
  src/phoenix/server/sandbox/vercel_backend.py \
  src/phoenix/server/sandbox/modal_backend.py \
  src/phoenix/server/sandbox/wasm_backend.py \
  tests/unit/server/sandbox/test_daytona_backend.py \
  tests/unit/server/sandbox/test_vercel_backend.py \
  tests/unit/server/sandbox/test_modal_backend.py \
  tests/unit/server/api/test_wasm_backend.py
```

Result: `All checks passed!`

```bash
.venv/bin/ruff format --check \
  src/phoenix/server/sandbox/daytona_backend.py \
  src/phoenix/server/sandbox/vercel_backend.py \
  src/phoenix/server/sandbox/modal_backend.py \
  src/phoenix/server/sandbox/wasm_backend.py \
  tests/unit/server/sandbox/test_daytona_backend.py \
  tests/unit/server/sandbox/test_vercel_backend.py \
  tests/unit/server/sandbox/test_modal_backend.py \
  tests/unit/server/api/test_wasm_backend.py
```

Result: `8 files already formatted`

```bash
git diff --check
```

Result: no whitespace errors.

## Risk

Low to moderate. The Daytona and Vercel changes only forward a timeout value that the issue notes those SDK paths already accept. Modal adds local enforcement and process cleanup on timeout. The WASM ticker is intentionally scoped per cached engine and ref-counted so overlapping executions do not multiply epoch increments for the same engine.
