### PR TITLE
fix(agents): instrument PXI agent system prompt on LLM spans

### DIFF
--- a/src/phoenix/server/agents/pydantic_ai/openinference_model_wrapper.py
+++ b/src/phoenix/server/agents/pydantic_ai/openinference_model_wrapper.py
@@ -22,6 +22,7 @@ from openinference.semconv.trace import (
 )
 from opentelemetry.trace import Status, StatusCode, Tracer
 from pydantic_ai import RunContext
+from pydantic_ai._instrumentation import get_instructions
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -111,6 +112,9 @@ class OpenInferenceModelWrapper(WrapperModel):
         model_request_parameters: ModelRequestParameters,
     ) -> Iterator[Callable[[ModelResponse], None]]:
         input_messages: list[Message] = []
+        instructions = get_instructions(messages, model_request_parameters)
+        if instructions:
+            input_messages.append(Message(role="system", content=instructions))
         for msg in messages:
             if isinstance(msg, ModelRequest):
                 input_messages.extend(_request_to_oi_messages(msg))

--- a/tests/unit/server/agents/pydantic_ai/test_openinference_model_wrapper.py
+++ b/tests/unit/server/agents/pydantic_ai/test_openinference_model_wrapper.py
@@ -22,6 +22,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import StatusCode, Tracer
 from pydantic_ai.messages import (
+    InstructionPart,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -547,6 +548,44 @@ async def test_request_emits_tool_return_message_in_history(
     assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
     assert not attributes
+
+
+async def test_request_emits_system_message_from_instructions(
+    tracer: Tracer,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    wrapped = OpenInferenceModelWrapper(TestModel(), tracer=tracer)
+    static_text = "You are a helpful assistant."
+    dynamic_text = "Current time: 2026-05-19."
+    joined = f"{static_text}\n\n{dynamic_text}"
+    messages: list[ModelMessage] = [
+        ModelRequest(
+            parts=[UserPromptPart(content="Hi.")],
+            instructions=joined,
+        )
+    ]
+
+    await wrapped.request(
+        messages=messages,
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(
+            function_tools=[],
+            native_tools=[],
+            output_tools=[],
+            instruction_parts=[
+                InstructionPart(content=static_text),
+                InstructionPart(content=dynamic_text, dynamic=True),
+            ],
+        ),
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    assert attributes[f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}"] == "system"
+    assert attributes[f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}"] == joined
+    assert attributes[f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_ROLE}"] == "user"
+    assert attributes[f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_CONTENT}"] == "Hi."
 
 
 async def test_request_raises_expected_exception_events(


### PR DESCRIPTION
## Summary

- The PXI model wrapper only emitted a `system` input message when the legacy `SystemPromptPart` was used, but the PXI agent is built with `Agent(instructions=...)` — so the system prompt landed on `ModelRequest.instructions` and was never surfaced on the LLM span.
- Reads the rendered system prompt via pydantic-ai's `get_instructions(messages, model_request_parameters)` helper (which prefers `model_request_parameters.instruction_parts` and falls back to the most recent `ModelRequest.instructions`) and prepends it as a `system` message on the LLM span's `llm.input_messages.*`.
- Adds one unit test exercising the production path: `instruction_parts` set on `ModelRequestParameters` with both static and dynamic parts, asserting the joined string appears as the index-0 system message.

## Test plan

- [ ] `uvx tox run -e unit_tests -- unit/server/agents/pydantic_ai/test_openinference_model_wrapper.py` passes
- [ ] Manual check in the PXI playground: open an agent turn span and confirm the system prompt shows up as the first input message

🤖 Generated with [Claude Code](https://claude.com/claude-code)