### PR TITLE
feat(agents): Enable provider native web search / fetch when available

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -87,6 +87,11 @@ type AgentsConfig {
   The project name used for assistant agent traces. Resolved from the PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME environment variable.
   """
   assistantProjectName: String!
+
+  """
+  Whether PXI can expose native web search and web fetch capabilities. False when external resources are disabled or PHOENIX_AGENTS_DISABLE_WEB_ACCESS is true.
+  """
+  webAccessEnabled: Boolean!
 }
 
 interface Annotation {

--- a/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
+++ b/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
@@ -20,6 +20,7 @@ describe("buildAgentChatRequestBody", () => {
         hasAcknowledgedConsent: false,
       },
       hasRemoteCollector: false,
+      isWebAccessEnabled: true,
       contexts: [],
       modelSelection: {
         providerType: "builtin",
@@ -43,5 +44,34 @@ describe("buildAgentChatRequestBody", () => {
       timeZone: expect.any(String),
     });
     expect(body).not.toHaveProperty("system");
+  });
+
+  it("only requests web access when both the user and server allow it", () => {
+    const capabilities = createDefaultAgentCapabilities();
+    capabilities["web.access"] = true;
+
+    const body = buildAgentChatRequestBody({
+      body: undefined,
+      id: "session-1",
+      messages: [] as AgentUIMessage[],
+      trigger: "submit-message",
+      messageId: undefined,
+      capabilities,
+      observability: {
+        storeLocalTraces: false,
+        exportRemoteTraces: false,
+        hasAcknowledgedConsent: false,
+      },
+      hasRemoteCollector: false,
+      isWebAccessEnabled: false,
+      contexts: [],
+      modelSelection: {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-4o-mini",
+      },
+    });
+
+    expect(body.capabilities).toEqual({ webAccess: false });
   });
 });

--- a/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
+++ b/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
@@ -20,7 +20,6 @@ describe("buildAgentChatRequestBody", () => {
         hasAcknowledgedConsent: false,
       },
       hasRemoteCollector: false,
-      isWebAccessEnabled: true,
       contexts: [],
       modelSelection: {
         providerType: "builtin",
@@ -46,7 +45,7 @@ describe("buildAgentChatRequestBody", () => {
     expect(body).not.toHaveProperty("system");
   });
 
-  it("only requests web access when both the user and server allow it", () => {
+  it("forwards the user's web access toggle as a context entry", () => {
     const capabilities = createDefaultAgentCapabilities();
     capabilities["web.access"] = true;
 
@@ -63,7 +62,6 @@ describe("buildAgentChatRequestBody", () => {
         hasAcknowledgedConsent: false,
       },
       hasRemoteCollector: false,
-      isWebAccessEnabled: false,
       contexts: [],
       modelSelection: {
         providerType: "builtin",
@@ -72,6 +70,9 @@ describe("buildAgentChatRequestBody", () => {
       },
     });
 
-    expect(body.capabilities).toEqual({ webAccess: false });
+    expect(body.contexts).toContainEqual({
+      type: "web_access",
+      enabled: true,
+    });
   });
 });

--- a/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -24,8 +24,6 @@ type BuildAgentChatRequestBodyOptions = {
   observability: AgentObservabilitySettings;
   /** Whether a remote collector is configured for this Phoenix instance. */
   hasRemoteCollector: boolean;
-  /** Whether this Phoenix instance allows PXI web search/fetch. */
-  isWebAccessEnabled: boolean;
   /** Typed page and mounted UI contexts for the current turn. */
   contexts: AgentContext[];
   /** Provider + model selection for this turn. */
@@ -65,6 +63,18 @@ function buildGraphQLContext(capabilities: AgentCapabilities): AgentContext {
 }
 
 /**
+ * Build web access context from the current capability snapshot.
+ *
+ * Forwards the user's web access toggle to the backend as a typed context.
+ */
+function buildWebAccessContext(capabilities: AgentCapabilities): AgentContext {
+  return {
+    type: "web_access",
+    enabled: capabilities["web.access"],
+  };
+}
+
+/**
  * Merges the AI SDK transport payload with PXI chat metadata. Tool definitions
  * are intentionally omitted because the server is the model-facing authority.
  */
@@ -77,13 +87,13 @@ export function buildAgentChatRequestBody({
   capabilities,
   observability,
   hasRemoteCollector,
-  isWebAccessEnabled,
   contexts,
   modelSelection,
 }: BuildAgentChatRequestBodyOptions): BuildAgentChatRequestBodyResult {
   const requestContexts = [
     buildCurrentAppContext(),
     buildGraphQLContext(capabilities),
+    buildWebAccessContext(capabilities),
     ...contexts,
   ];
   return {
@@ -94,9 +104,6 @@ export function buildAgentChatRequestBody({
     messageId,
     ingestTraces: observability.storeLocalTraces,
     exportRemoteTraces: observability.exportRemoteTraces && hasRemoteCollector,
-    capabilities: {
-      webAccess: capabilities["web.access"] && isWebAccessEnabled,
-    },
     contexts: requestContexts,
     model: modelSelection,
   };

--- a/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -24,6 +24,8 @@ type BuildAgentChatRequestBodyOptions = {
   observability: AgentObservabilitySettings;
   /** Whether a remote collector is configured for this Phoenix instance. */
   hasRemoteCollector: boolean;
+  /** Whether this Phoenix instance allows PXI web search/fetch. */
+  isWebAccessEnabled: boolean;
   /** Typed page and mounted UI contexts for the current turn. */
   contexts: AgentContext[];
   /** Provider + model selection for this turn. */
@@ -75,6 +77,7 @@ export function buildAgentChatRequestBody({
   capabilities,
   observability,
   hasRemoteCollector,
+  isWebAccessEnabled,
   contexts,
   modelSelection,
 }: BuildAgentChatRequestBodyOptions): BuildAgentChatRequestBodyResult {
@@ -91,6 +94,9 @@ export function buildAgentChatRequestBody({
     messageId,
     ingestTraces: observability.storeLocalTraces,
     exportRemoteTraces: observability.exportRemoteTraces && hasRemoteCollector,
+    capabilities: {
+      webAccess: capabilities["web.access"] && isWebAccessEnabled,
+    },
     contexts: requestContexts,
     model: modelSelection,
   };

--- a/app/src/agent/context/agentContextTypes.ts
+++ b/app/src/agent/context/agentContextTypes.ts
@@ -65,5 +65,7 @@ export function agentContextKey(context: AgentContext): string {
     }
     case "graphql":
       return "graphql";
+    case "web_access":
+      return "web_access";
   }
 }

--- a/app/src/agent/extensions/__tests__/capabilities.test.ts
+++ b/app/src/agent/extensions/__tests__/capabilities.test.ts
@@ -17,11 +17,16 @@ describe("agent capabilities", () => {
     const debugMenuCapabilities = getAgentCapabilitiesForControlSurface(
       "experimental-settings"
     );
+    const agentSettingsCapabilities =
+      getAgentCapabilitiesForControlSurface("agent-settings");
 
     expect(debugMenuCapabilities).toEqual(
       AGENT_CAPABILITY_DEFINITIONS.filter(
         (definition) => definition.controlSurface === "experimental-settings"
       )
     );
+    expect(
+      agentSettingsCapabilities.map((definition) => definition.key)
+    ).toEqual(["web.access"]);
   });
 });

--- a/app/src/agent/extensions/capabilities.ts
+++ b/app/src/agent/extensions/capabilities.ts
@@ -8,7 +8,8 @@
 export type AgentCapabilityKey =
   | "bash.retainInactiveSessions"
   | "graphql.mutations"
-  | "session.storeSessions";
+  | "session.storeSessions"
+  | "web.access";
 
 /** Describes one capability and how it should appear across the app. */
 export type AgentCapabilityDefinition = {
@@ -27,6 +28,7 @@ const DEFAULT_AGENT_CAPABILITIES: AgentCapabilities = {
   "bash.retainInactiveSessions": false,
   "graphql.mutations": false,
   "session.storeSessions": false,
+  "web.access": false,
 };
 
 /** Ordered capability catalog used by the UI and runtime. */
@@ -54,6 +56,15 @@ export const AGENT_CAPABILITY_DEFINITIONS: AgentCapabilityDefinition[] = [
     label: "Store recent sessions",
     description:
       "Keeps the three most recent chat sessions instead of replacing session history when starting a new chat.",
+    defaultValue: false,
+    scope: "global",
+    controlSurface: "experimental-settings",
+  },
+  {
+    key: "web.access",
+    label: "Allow web access",
+    description:
+      "Lets PXI use provider-native web search and URL fetching when the selected model supports it.",
     defaultValue: false,
     scope: "global",
     controlSurface: "experimental-settings",

--- a/app/src/agent/extensions/capabilities.ts
+++ b/app/src/agent/extensions/capabilities.ts
@@ -18,7 +18,7 @@ export type AgentCapabilityDefinition = {
   description: string;
   defaultValue: boolean;
   scope: "global" | "session";
-  controlSurface?: "experimental-settings";
+  controlSurface?: "agent-settings" | "experimental-settings";
 };
 
 /** Boolean runtime snapshot keyed by capability name. */
@@ -67,7 +67,7 @@ export const AGENT_CAPABILITY_DEFINITIONS: AgentCapabilityDefinition[] = [
       "Lets PXI use provider-native web search and URL fetching when the selected model supports it.",
     defaultValue: false,
     scope: "global",
-    controlSurface: "experimental-settings",
+    controlSurface: "agent-settings",
   },
 ];
 

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1641,6 +1641,7 @@ export interface components {
             contexts?: components["schemas"]["ChatContext"][];
             /** Model */
             model: components["schemas"]["CustomProviderModelSelection"] | components["schemas"]["BuiltInProviderModelSelection"];
+            capabilities?: components["schemas"]["_AgentRequestCapabilities"];
         } & {
             [key: string]: unknown;
         };
@@ -1677,6 +1678,7 @@ export interface components {
             contexts?: components["schemas"]["ChatContext"][];
             /** Model */
             model: components["schemas"]["CustomProviderModelSelection"] | components["schemas"]["BuiltInProviderModelSelection"];
+            capabilities?: components["schemas"]["_AgentRequestCapabilities"];
         } & {
             [key: string]: unknown;
         };
@@ -5017,6 +5019,17 @@ export interface components {
             input?: unknown;
             /** Context */
             ctx?: Record<string, unknown>;
+        };
+        /**
+         * _AgentRequestCapabilities
+         * @description Per-request PXI capabilities requested by the browser.
+         */
+        _AgentRequestCapabilities: {
+            /**
+             * Webaccess
+             * @default false
+             */
+            webAccess?: boolean;
         };
         /**
          * _SummarizeRequest

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1610,7 +1610,7 @@ export interface components {
          * ChatContext
          * @description Discriminated union of every UI-state context the agent understands.
          */
-        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["GraphQLContext"];
+        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"];
         /**
          * ChatRegenerateMessage
          * @description Regenerate message extended with Phoenix-specific fields.
@@ -1641,7 +1641,6 @@ export interface components {
             contexts?: components["schemas"]["ChatContext"][];
             /** Model */
             model: components["schemas"]["CustomProviderModelSelection"] | components["schemas"]["BuiltInProviderModelSelection"];
-            capabilities?: components["schemas"]["_AgentRequestCapabilities"];
         } & {
             [key: string]: unknown;
         };
@@ -1678,7 +1677,6 @@ export interface components {
             contexts?: components["schemas"]["ChatContext"][];
             /** Model */
             model: components["schemas"]["CustomProviderModelSelection"] | components["schemas"]["BuiltInProviderModelSelection"];
-            capabilities?: components["schemas"]["_AgentRequestCapabilities"];
         } & {
             [key: string]: unknown;
         };
@@ -5021,15 +5019,17 @@ export interface components {
             ctx?: Record<string, unknown>;
         };
         /**
-         * _AgentRequestCapabilities
-         * @description Per-request PXI capabilities requested by the browser.
+         * WebAccessContext
+         * @description User's per-turn request to expose web search / fetch tools.
          */
-        _AgentRequestCapabilities: {
+        WebAccessContext: {
             /**
-             * Webaccess
-             * @default false
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
              */
-            webAccess?: boolean;
+            type: "web_access";
+            /** Enabled */
+            enabled: boolean;
         };
         /**
          * _SummarizeRequest

--- a/app/src/components/agent/AgentContextPills.tsx
+++ b/app/src/components/agent/AgentContextPills.tsx
@@ -27,6 +27,7 @@ function contextLabel(context: AgentContext): string {
   switch (context.type) {
     case "app":
     case "graphql":
+    case "web_access":
       // Request-only runtime metadata, not user-visible page context, so it
       // should never render as a pill.
       return "";
@@ -92,7 +93,11 @@ export function AgentContextPills() {
   }
 
   const items = contexts.flatMap((context) => {
-    if (context.type === "app" || context.type === "graphql") {
+    if (
+      context.type === "app" ||
+      context.type === "graphql" ||
+      context.type === "web_access"
+    ) {
       return [];
     }
     const filterPill = spanFilterAttachmentData(context);

--- a/app/src/components/agent/AgentExperimentalSettings.tsx
+++ b/app/src/components/agent/AgentExperimentalSettings.tsx
@@ -4,10 +4,6 @@ import { getAgentCapabilitiesForControlSurface } from "@phoenix/agent/extensions
 import { Alert, Flex, Switch, Text, View } from "@phoenix/components";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 
-const experimentalCapabilities = getAgentCapabilitiesForControlSurface(
-  "experimental-settings"
-);
-
 const settingsCSS = css`
   display: flex;
   flex-direction: column;
@@ -47,6 +43,14 @@ const detailsCSS = css`
 export function AgentExperimentalSettings() {
   const store = useAgentStore();
   const capabilities = useAgentContext((state) => state.capabilities);
+  const isWebAccessEnabled = useAgentContext(
+    (state) => state.agentsConfig.webAccessEnabled
+  );
+  const experimentalCapabilities = getAgentCapabilitiesForControlSurface(
+    "experimental-settings"
+  ).filter(
+    (definition) => definition.key !== "web.access" || isWebAccessEnabled
+  );
 
   if (experimentalCapabilities.length === 0) {
     return null;

--- a/app/src/components/agent/AgentExperimentalSettings.tsx
+++ b/app/src/components/agent/AgentExperimentalSettings.tsx
@@ -1,6 +1,9 @@
 import { css } from "@emotion/react";
 
-import { getAgentCapabilitiesForControlSurface } from "@phoenix/agent/extensions/capabilities";
+import {
+  getAgentCapabilitiesForControlSurface,
+  getAgentCapabilityDefinition,
+} from "@phoenix/agent/extensions/capabilities";
 import { Alert, Flex, Switch, Text, View } from "@phoenix/components";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 
@@ -25,7 +28,7 @@ const settingSwitchCSS = css`
   padding: var(--global-dimension-size-150);
   gap: var(--global-dimension-size-200);
 
-  .agent-experimental__label {
+  .agent-settings__label {
     display: flex;
     flex: 1 1 auto;
     flex-direction: column;
@@ -43,13 +46,8 @@ const detailsCSS = css`
 export function AgentExperimentalSettings() {
   const store = useAgentStore();
   const capabilities = useAgentContext((state) => state.capabilities);
-  const isWebAccessEnabled = useAgentContext(
-    (state) => state.agentsConfig.webAccessEnabled
-  );
   const experimentalCapabilities = getAgentCapabilitiesForControlSurface(
     "experimental-settings"
-  ).filter(
-    (definition) => definition.key !== "web.access" || isWebAccessEnabled
   );
 
   if (experimentalCapabilities.length === 0) {
@@ -78,7 +76,7 @@ export function AgentExperimentalSettings() {
                   labelPlacement="start"
                   css={settingSwitchCSS}
                 >
-                  <span className="agent-experimental__label">
+                  <span className="agent-settings__label">
                     <Text weight="heavy" size="M">
                       {definition.label}
                     </Text>
@@ -91,5 +89,40 @@ export function AgentExperimentalSettings() {
         </Flex>
       </View>
     </details>
+  );
+}
+
+export function AgentWebAccessSettings() {
+  const store = useAgentStore();
+  const capabilities = useAgentContext((state) => state.capabilities);
+  const isWebAccessEnabled = useAgentContext(
+    (state) => state.agentsConfig.webAccessEnabled
+  );
+  const definition = getAgentCapabilityDefinition("web.access");
+
+  if (!isWebAccessEnabled) {
+    return null;
+  }
+
+  return (
+    <div css={settingsCSS}>
+      <div css={settingRowCSS}>
+        <Switch
+          isSelected={capabilities[definition.key]}
+          onChange={(enabled) => {
+            store.getState().setCapability({ key: definition.key, enabled });
+          }}
+          labelPlacement="start"
+          css={settingSwitchCSS}
+        >
+          <span className="agent-settings__label">
+            <Text weight="heavy" size="M">
+              {definition.label}
+            </Text>
+            <Text color="text-500">{definition.description}</Text>
+          </span>
+        </Switch>
+      </div>
+    </div>
   );
 }

--- a/app/src/components/agent/AgentModelMenu.tsx
+++ b/app/src/components/agent/AgentModelMenu.tsx
@@ -58,6 +58,8 @@ const AGENT_CURATED_BUILT_IN_MODELS: readonly AgentBuiltInModelSelection[] = [
   { provider: "OPENAI", modelName: "gpt-5.4" },
   { provider: "OPENAI", modelName: "gpt-5.4-mini" },
   { provider: "OPENAI", modelName: "gpt-5.5" },
+  { provider: "GOOGLE", modelName: "gemini-3.1-pro-preview" },
+  { provider: "GOOGLE", modelName: "gemini-3.5-flash" },
 ];
 
 type CustomProviderInfo = {

--- a/app/src/components/agent/AgentSettingsForm.tsx
+++ b/app/src/components/agent/AgentSettingsForm.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import type { ReactNode } from "react";
 import { Controller, useForm } from "react-hook-form";
 
 import { Button, Flex, Label } from "@phoenix/components";
@@ -23,7 +24,7 @@ export type AgentSettingsFormValues = {
   model: ModelMenuValue;
 };
 
-export function AgentSettingsForm() {
+export function AgentSettingsForm({ children }: { children?: ReactNode }) {
   const store = useAgentStore();
   const defaultModelConfig = useAgentContext(
     (state) => state.defaultModelConfig
@@ -69,6 +70,7 @@ export function AgentSettingsForm() {
           )}
         />
       </div>
+      {children}
       <Flex direction="row" gap="size-100" justifyContent="end" width="100%">
         <Button type="submit" variant="primary" isDisabled={!formState.isDirty}>
           Save

--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -452,6 +452,30 @@ function getFirstStringField(
 }
 
 /**
+ * Provider-native web tools use different input field names for target URLs.
+ * Check the known URL aliases in priority order when building collapsed previews.
+ */
+const NATIVE_WEB_URL_FIELDS = ["url", "uri", "href"];
+
+/**
+ * Provider-native web search tools use different input field names for search
+ * text. Check the known query aliases in priority order for preview text.
+ */
+const NATIVE_WEB_SEARCH_QUERY_FIELDS = ["query", "q", "search_query"];
+
+/**
+ * Pydantic AI's provider-native web search tool name as it appears in AI SDK
+ * tool invocation parts.
+ */
+const NATIVE_WEB_SEARCH_TOOL_NAME = "web_search";
+
+/**
+ * Pydantic AI's provider-native web fetch tool name as it appears in AI SDK
+ * tool invocation parts.
+ */
+const NATIVE_WEB_FETCH_TOOL_NAME = "web_fetch";
+
+/**
  * Formats native web-search action types for display in the collapsed tool row.
  */
 function formatNativeWebSearchType(type: string): string {
@@ -478,20 +502,19 @@ function getNativeWebToolPreview(
     return "";
   }
   const inputRecord = input as Record<string, unknown>;
-  if (toolName === "web_search") {
+  if (toolName === NATIVE_WEB_SEARCH_TOOL_NAME) {
     const type = getStringField(inputRecord, "type");
     if (type && type !== "search") {
       const value =
-        getFirstStringField(inputRecord, ["url", "uri", "href"]) ||
-        getFirstStringField(inputRecord, ["query", "q", "search_query"]);
+        getFirstStringField(inputRecord, NATIVE_WEB_URL_FIELDS) ||
+        getFirstStringField(inputRecord, NATIVE_WEB_SEARCH_QUERY_FIELDS);
       const label = formatNativeWebSearchType(type);
       return value ? `${label}: ${value}` : label;
     }
-    const query = getFirstStringField(inputRecord, [
-      "query",
-      "q",
-      "search_query",
-    ]);
+    const query = getFirstStringField(
+      inputRecord,
+      NATIVE_WEB_SEARCH_QUERY_FIELDS
+    );
     if (query) {
       return query;
     }
@@ -505,8 +528,8 @@ function getNativeWebToolPreview(
       );
     }
   }
-  if (toolName === "web_fetch") {
-    return getFirstStringField(inputRecord, ["url", "uri", "href"]);
+  if (toolName === NATIVE_WEB_FETCH_TOOL_NAME) {
+    return getFirstStringField(inputRecord, NATIVE_WEB_URL_FIELDS);
   }
   return "";
 }
@@ -546,8 +569,8 @@ function getToolPresentation(
         statusVariant,
         details: <EditPromptToolDetails part={part} />,
       };
-    case "web_search":
-    case "web_fetch": {
+    case NATIVE_WEB_SEARCH_TOOL_NAME:
+    case NATIVE_WEB_FETCH_TOOL_NAME: {
       const inputStr = JSON.stringify(part.input, null, 2);
       const outputStr =
         part.state === "output-available"

--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -423,6 +423,94 @@ function getStatusVariant(
   }
 }
 
+/**
+ * Returns a string field from arbitrary tool input records, or an empty string
+ * when the field is absent or not textual.
+ */
+function getStringField(
+  record: Record<string, unknown>,
+  field: string
+): string {
+  const value = record[field];
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * Returns the first non-empty string from a list of possible field names.
+ */
+function getFirstStringField(
+  record: Record<string, unknown>,
+  fields: string[]
+): string {
+  for (const field of fields) {
+    const value = getStringField(record, field);
+    if (value) {
+      return value;
+    }
+  }
+  return "";
+}
+
+/**
+ * Formats native web-search action types for display in the collapsed tool row.
+ */
+function formatNativeWebSearchType(type: string): string {
+  return type
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+/**
+ * Derives a compact preview for native web-search and web-fetch tool calls from
+ * provider-specific input shapes.
+ */
+function getNativeWebToolPreview(
+  toolName: string,
+  part: ToolInvocationPart
+): string {
+  const input = part.input;
+  if (typeof input === "string") {
+    return input;
+  }
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return "";
+  }
+  const inputRecord = input as Record<string, unknown>;
+  if (toolName === "web_search") {
+    const type = getStringField(inputRecord, "type");
+    if (type && type !== "search") {
+      const value =
+        getFirstStringField(inputRecord, ["url", "uri", "href"]) ||
+        getFirstStringField(inputRecord, ["query", "q", "search_query"]);
+      const label = formatNativeWebSearchType(type);
+      return value ? `${label}: ${value}` : label;
+    }
+    const query = getFirstStringField(inputRecord, [
+      "query",
+      "q",
+      "search_query",
+    ]);
+    if (query) {
+      return query;
+    }
+    const queries = inputRecord.queries;
+    if (Array.isArray(queries)) {
+      return (
+        queries.find(
+          (value): value is string =>
+            typeof value === "string" && value.length > 0
+        ) ?? ""
+      );
+    }
+  }
+  if (toolName === "web_fetch") {
+    return getFirstStringField(inputRecord, ["url", "uri", "href"]);
+  }
+  return "";
+}
+
 function getToolPresentation(
   toolName: string,
   part: ToolInvocationPart
@@ -458,6 +546,37 @@ function getToolPresentation(
         statusVariant,
         details: <EditPromptToolDetails part={part} />,
       };
+    case "web_search":
+    case "web_fetch": {
+      const inputStr = JSON.stringify(part.input, null, 2);
+      const outputStr =
+        part.state === "output-available"
+          ? JSON.stringify(part.output, null, 2)
+          : "";
+      return {
+        preview: getNativeWebToolPreview(toolName, part),
+        stateLabel: formatToolState(part.state),
+        statusVariant,
+        details: (
+          <div className="tool-part__body">
+            <ToolPartLabel>Input</ToolPartLabel>
+            <ToolPartCodeBlock>{inputStr}</ToolPartCodeBlock>
+            {part.state === "output-available" ? (
+              <>
+                <ToolPartLabel>Output</ToolPartLabel>
+                <ToolPartCodeBlock>{outputStr}</ToolPartCodeBlock>
+              </>
+            ) : null}
+            {part.state === "output-error" ? (
+              <>
+                <ToolPartLabel variant="danger">Error</ToolPartLabel>
+                <ToolPartCodeBlock>{part.errorText ?? ""}</ToolPartCodeBlock>
+              </>
+            ) : null}
+          </div>
+        ),
+      };
+    }
     default: {
       if (isDocsToolName(toolName)) {
         return {

--- a/app/src/components/agent/__tests__/ToolPartDisclosure.test.tsx
+++ b/app/src/components/agent/__tests__/ToolPartDisclosure.test.tsx
@@ -8,7 +8,7 @@ import {
 } from "@phoenix/agent/tools/playgroundPrompt";
 import { AgentProvider } from "@phoenix/contexts/AgentContext";
 
-import { ToolPart } from "../ToolPart";
+import { getToolPartPreview, ToolPart } from "../ToolPart";
 import { ToolPartGroup } from "../ToolPartGroup";
 import type { ToolInvocationPart } from "../toolPartTypes";
 
@@ -105,6 +105,53 @@ describe("tool disclosure controls", () => {
 
     click(summary);
     expect(details?.hasAttribute("open")).toBe(false);
+  });
+
+  it("previews native web search queries", () => {
+    expect(
+      getToolPartPreview(
+        createToolPart({
+          type: "dynamic-tool",
+          toolName: "web_search",
+          input: { query: "phoenix pxi web search" },
+        } as Partial<ToolInvocationPart>)
+      )
+    ).toBe("phoenix pxi web search");
+
+    expect(
+      getToolPartPreview(
+        createToolPart({
+          type: "dynamic-tool",
+          toolName: "web_search",
+          input: { queries: ["first query", "second query"] },
+        } as Partial<ToolInvocationPart>)
+      )
+    ).toBe("first query");
+
+    expect(
+      getToolPartPreview(
+        createToolPart({
+          type: "dynamic-tool",
+          toolName: "web_search",
+          input: {
+            type: "open_page",
+            url: "https://ai.google.dev/gemini-api/docs/models",
+          },
+        } as Partial<ToolInvocationPart>)
+      )
+    ).toBe("Open Page: https://ai.google.dev/gemini-api/docs/models");
+  });
+
+  it("previews native web fetch urls", () => {
+    expect(
+      getToolPartPreview(
+        createToolPart({
+          type: "dynamic-tool",
+          toolName: "web_fetch",
+          input: { url: "https://example.com/docs" },
+        } as Partial<ToolInvocationPart>)
+      )
+    ).toBe("https://example.com/docs");
   });
 
   it("allows manually collapsing and expanding an auto-open solo tool part", () => {

--- a/app/src/components/agent/index.tsx
+++ b/app/src/components/agent/index.tsx
@@ -1,7 +1,10 @@
 export { AgentSettingsForm } from "./AgentSettingsForm";
 export type { AgentSettingsFormValues } from "./AgentSettingsForm";
 export { AgentObservabilitySettings } from "./AgentObservabilitySettings";
-export { AgentExperimentalSettings } from "./AgentExperimentalSettings";
+export {
+  AgentExperimentalSettings,
+  AgentWebAccessSettings,
+} from "./AgentExperimentalSettings";
 export { AgentChatPanel } from "./AgentChatPanel";
 export { AgentChatWidget } from "./AgentChatWidget";
 export { useAssistantAgentEnabled } from "./useAssistantAgentEnabled";

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -105,6 +105,8 @@ export function useAgentChat({
                     hasRemoteCollector: Boolean(
                       store.getState().agentsConfig.collectorEndpoint
                     ),
+                    isWebAccessEnabled:
+                      store.getState().agentsConfig.webAccessEnabled,
                     contexts: selectActiveContexts(store.getState()),
                     modelSelection: modelSelectionRef.current,
                   }),

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -105,8 +105,6 @@ export function useAgentChat({
                     hasRemoteCollector: Boolean(
                       store.getState().agentsConfig.collectorEndpoint
                     ),
-                    isWebAccessEnabled:
-                      store.getState().agentsConfig.webAccessEnabled,
                     contexts: selectActiveContexts(store.getState()),
                     modelSelection: modelSelectionRef.current,
                   }),

--- a/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
+++ b/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fb805084442992d96b65cee34f0627eb>>
+ * @generated SignedSource<<2ff1269407f67843a752cbadbf64b270>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type authenticatedRootLoaderQuery$data = {
   readonly agentsConfig: {
     readonly assistantProjectName: string;
     readonly collectorEndpoint: string | null;
+    readonly webAccessEnabled: boolean;
   };
   readonly viewer: {
     readonly email: string | null;
@@ -50,6 +51,13 @@ var v0 = {
       "args": null,
       "kind": "ScalarField",
       "name": "assistantProjectName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "webAccessEnabled",
       "storageKey": null
     }
   ],
@@ -215,16 +223,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5e92607362ede89ee7c069c98c00d4aa",
+    "cacheID": "65fe4e55ba0417d1568b44ea99419aac",
     "id": null,
     "metadata": {},
     "name": "authenticatedRootLoaderQuery",
     "operationKind": "query",
-    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  agentsConfig {\n    collectorEndpoint\n    assistantProjectName\n  }\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    isManagementUser\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
+    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  agentsConfig {\n    collectorEndpoint\n    assistantProjectName\n    webAccessEnabled\n  }\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    isManagementUser\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d5380bc11973727ed3df98eb7bdaa3f9";
+(node as any).hash = "5b0fabbed4b99fa6de423a58b4e81f52";
 
 export default node;

--- a/app/src/pages/authenticatedRootLoader.ts
+++ b/app/src/pages/authenticatedRootLoader.ts
@@ -12,6 +12,7 @@ export const authenticatedRootLoaderQueryNode = graphql`
     agentsConfig {
       collectorEndpoint
       assistantProjectName
+      webAccessEnabled
     }
     viewer {
       id

--- a/app/src/pages/settings/SettingsAgentsPage.tsx
+++ b/app/src/pages/settings/SettingsAgentsPage.tsx
@@ -15,6 +15,7 @@ import {
   AgentExperimentalSettings,
   AgentObservabilitySettings,
   AgentSettingsForm,
+  AgentWebAccessSettings,
 } from "@phoenix/components/agent";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
@@ -128,8 +129,10 @@ export function SettingsAgentsPage() {
           `}
         >
           <AssistantTraceCollectionInfo />
-          <AgentSettingsForm />
-          <AgentExperimentalSettings />
+          <AgentSettingsForm>
+            <AgentWebAccessSettings />
+            <AgentExperimentalSettings />
+          </AgentSettingsForm>
         </Flex>
       </View>
     </Card>

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -248,6 +248,7 @@ describe("agentStore", () => {
         "bash.retainInactiveSessions": true,
         "graphql.mutations": true,
         "session.storeSessions": false,
+        "web.access": false,
       });
       expect(store.getState().observability).toEqual({
         storeLocalTraces: true,

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -44,6 +44,8 @@ export type AgentServerConfig = {
   collectorEndpoint: string | null;
   /** Local Phoenix project used for PXI trace persistence. */
   assistantProjectName: string;
+  /** Whether this Phoenix instance allows PXI web search/fetch. */
+  webAccessEnabled: boolean;
 };
 
 /**
@@ -108,6 +110,7 @@ const DEFAULT_MODEL_CONFIG: ModelConfig = {
 const DEFAULT_AGENT_SERVER_CONFIG: AgentServerConfig = {
   collectorEndpoint: null,
   assistantProjectName: "assistant_agent",
+  webAccessEnabled: false,
 };
 
 const DEFAULT_AGENT_OBSERVABILITY_SETTINGS: AgentObservabilitySettings = {

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1641,6 +1641,7 @@ export interface components {
             contexts?: components["schemas"]["ChatContext"][];
             /** Model */
             model: components["schemas"]["CustomProviderModelSelection"] | components["schemas"]["BuiltInProviderModelSelection"];
+            capabilities?: components["schemas"]["_AgentRequestCapabilities"];
         } & {
             [key: string]: unknown;
         };
@@ -1677,6 +1678,7 @@ export interface components {
             contexts?: components["schemas"]["ChatContext"][];
             /** Model */
             model: components["schemas"]["CustomProviderModelSelection"] | components["schemas"]["BuiltInProviderModelSelection"];
+            capabilities?: components["schemas"]["_AgentRequestCapabilities"];
         } & {
             [key: string]: unknown;
         };
@@ -5017,6 +5019,17 @@ export interface components {
             input?: unknown;
             /** Context */
             ctx?: Record<string, unknown>;
+        };
+        /**
+         * _AgentRequestCapabilities
+         * @description Per-request PXI capabilities requested by the browser.
+         */
+        _AgentRequestCapabilities: {
+            /**
+             * Webaccess
+             * @default false
+             */
+            webAccess?: boolean;
         };
         /**
          * _SummarizeRequest

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1610,7 +1610,7 @@ export interface components {
          * ChatContext
          * @description Discriminated union of every UI-state context the agent understands.
          */
-        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["GraphQLContext"];
+        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"];
         /**
          * ChatRegenerateMessage
          * @description Regenerate message extended with Phoenix-specific fields.
@@ -1641,7 +1641,6 @@ export interface components {
             contexts?: components["schemas"]["ChatContext"][];
             /** Model */
             model: components["schemas"]["CustomProviderModelSelection"] | components["schemas"]["BuiltInProviderModelSelection"];
-            capabilities?: components["schemas"]["_AgentRequestCapabilities"];
         } & {
             [key: string]: unknown;
         };
@@ -1678,7 +1677,6 @@ export interface components {
             contexts?: components["schemas"]["ChatContext"][];
             /** Model */
             model: components["schemas"]["CustomProviderModelSelection"] | components["schemas"]["BuiltInProviderModelSelection"];
-            capabilities?: components["schemas"]["_AgentRequestCapabilities"];
         } & {
             [key: string]: unknown;
         };
@@ -5021,15 +5019,17 @@ export interface components {
             ctx?: Record<string, unknown>;
         };
         /**
-         * _AgentRequestCapabilities
-         * @description Per-request PXI capabilities requested by the browser.
+         * WebAccessContext
+         * @description User's per-turn request to expose web search / fetch tools.
          */
-        _AgentRequestCapabilities: {
+        WebAccessContext: {
             /**
-             * Webaccess
-             * @default false
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
              */
-            webAccess?: boolean;
+            type: "web_access";
+            /** Enabled */
+            enabled: boolean;
         };
         /**
          * _SummarizeRequest

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -315,10 +315,6 @@ class OtlpStatus(TypedDict):
     message: NotRequired[str]
 
 
-class PhoenixToolCallProviderMetadata(TypedDict):
-    tool_execution_environment: Literal["client", "server"]
-
-
 class PlaygroundContext(TypedDict):
     type: Literal["playground"]
     instanceIds: Sequence[int]
@@ -900,12 +896,17 @@ class ValidationError(TypedDict):
     ctx: NotRequired[Mapping[str, Any]]
 
 
-class FieldAgentRequestCapabilities(TypedDict):
-    webAccess: NotRequired[bool]
+class WebAccessContext(TypedDict):
+    type: Literal["web_access"]
+    enabled: bool
 
 
 class FieldSummarizeResponse(TypedDict):
     summary: str
+
+
+class ToolCallProviderMetadata(TypedDict):
+    tool_execution_environment: Literal["client", "server"]
 
 
 class AnnotateSessionsRequestBody(TypedDict):
@@ -1456,10 +1457,10 @@ class ChatRegenerateMessage(TypedDict):
                 AgentSpanContext,
                 PlaygroundContext,
                 GraphQLContext,
+                WebAccessContext,
             ]
         ]
     ]
-    capabilities: NotRequired[FieldAgentRequestCapabilities]
 
 
 class ChatSubmitMessage(TypedDict):
@@ -1478,10 +1479,10 @@ class ChatSubmitMessage(TypedDict):
                 AgentSpanContext,
                 PlaygroundContext,
                 GraphQLContext,
+                WebAccessContext,
             ]
         ]
     ]
-    capabilities: NotRequired[FieldAgentRequestCapabilities]
 
 
 class CreateSpansRequestBody(TypedDict):

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -900,6 +900,10 @@ class ValidationError(TypedDict):
     ctx: NotRequired[Mapping[str, Any]]
 
 
+class FieldAgentRequestCapabilities(TypedDict):
+    webAccess: NotRequired[bool]
+
+
 class FieldSummarizeResponse(TypedDict):
     summary: str
 
@@ -1455,6 +1459,7 @@ class ChatRegenerateMessage(TypedDict):
             ]
         ]
     ]
+    capabilities: NotRequired[FieldAgentRequestCapabilities]
 
 
 class ChatSubmitMessage(TypedDict):
@@ -1476,6 +1481,7 @@ class ChatSubmitMessage(TypedDict):
             ]
         ]
     ]
+    capabilities: NotRequired[FieldAgentRequestCapabilities]
 
 
 class CreateSpansRequestBody(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -7306,6 +7306,9 @@
           },
           {
             "$ref": "#/components/schemas/GraphQLContext"
+          },
+          {
+            "$ref": "#/components/schemas/WebAccessContext"
           }
         ],
         "title": "ChatContext",
@@ -7318,7 +7321,8 @@
             "playground": "#/components/schemas/PlaygroundContext",
             "project": "#/components/schemas/ProjectContext",
             "span": "#/components/schemas/AgentSpanContext",
-            "trace": "#/components/schemas/TraceContext"
+            "trace": "#/components/schemas/TraceContext",
+            "web_access": "#/components/schemas/WebAccessContext"
           }
         }
       },
@@ -7385,9 +7389,6 @@
                 "custom": "#/components/schemas/CustomProviderModelSelection"
               }
             }
-          },
-          "capabilities": {
-            "$ref": "#/components/schemas/_AgentRequestCapabilities"
           }
         },
         "additionalProperties": true,
@@ -7473,9 +7474,6 @@
                 "custom": "#/components/schemas/CustomProviderModelSelection"
               }
             }
-          },
-          "capabilities": {
-            "$ref": "#/components/schemas/_AgentRequestCapabilities"
           }
         },
         "additionalProperties": true,
@@ -15384,17 +15382,25 @@
         ],
         "title": "ValidationError"
       },
-      "_AgentRequestCapabilities": {
+      "WebAccessContext": {
         "properties": {
-          "webAccess": {
+          "type": {
+            "type": "string",
+            "const": "web_access",
+            "title": "Type"
+          },
+          "enabled": {
             "type": "boolean",
-            "title": "Webaccess",
-            "default": false
+            "title": "Enabled"
           }
         },
         "type": "object",
-        "title": "_AgentRequestCapabilities",
-        "description": "Per-request PXI capabilities requested by the browser."
+        "required": [
+          "type",
+          "enabled"
+        ],
+        "title": "WebAccessContext",
+        "description": "User's per-turn request to expose web search / fetch tools."
       },
       "_SummarizeRequest": {
         "properties": {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -7385,6 +7385,9 @@
                 "custom": "#/components/schemas/CustomProviderModelSelection"
               }
             }
+          },
+          "capabilities": {
+            "$ref": "#/components/schemas/_AgentRequestCapabilities"
           }
         },
         "additionalProperties": true,
@@ -7470,6 +7473,9 @@
                 "custom": "#/components/schemas/CustomProviderModelSelection"
               }
             }
+          },
+          "capabilities": {
+            "$ref": "#/components/schemas/_AgentRequestCapabilities"
           }
         },
         "additionalProperties": true,
@@ -15377,6 +15383,18 @@
           "type"
         ],
         "title": "ValidationError"
+      },
+      "_AgentRequestCapabilities": {
+        "properties": {
+          "webAccess": {
+            "type": "boolean",
+            "title": "Webaccess",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "_AgentRequestCapabilities",
+        "description": "Per-request PXI capabilities requested by the browser."
       },
       "_SummarizeRequest": {
         "properties": {

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -78,6 +78,11 @@ ENV_PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME = "PHOENIX_AGENTS_ASSISTANT_PROJECT_NA
 """
 Project name used for assistant agent traces.
 """
+ENV_PHOENIX_AGENTS_DISABLE_WEB_ACCESS = "PHOENIX_AGENTS_DISABLE_WEB_ACCESS"
+"""
+Disables PXI native web search and web fetch capabilities even when external
+resources are otherwise allowed.
+"""
 ENV_PHOENIX_WORKING_DIR = "PHOENIX_WORKING_DIR"
 """
 The directory in which to save, load, and export datasets. This directory must
@@ -1275,6 +1280,14 @@ def get_env_phoenix_agents_collector_api_key() -> Optional[str]:
 
 def get_env_phoenix_agents_assistant_project_name() -> str:
     return getenv(ENV_PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME, "assistant_agent")
+
+
+def get_env_phoenix_agents_disable_web_access() -> bool:
+    return _bool_val(ENV_PHOENIX_AGENTS_DISABLE_WEB_ACCESS, False)
+
+
+def get_env_phoenix_agents_web_access_enabled() -> bool:
+    return get_env_allow_external_resources() and not get_env_phoenix_agents_disable_web_access()
 
 
 class AuthSettings(NamedTuple):

--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -7,6 +7,8 @@ from pydantic_ai.capabilities import (
     AbstractCapability,
     CombinedCapability,
     DynamicCapability,
+    WebFetch,
+    WebSearch,
 )
 from pydantic_ai.mcp import MCPServerStreamableHTTP
 from pydantic_ai.models import Model
@@ -33,6 +35,7 @@ def build_agent(
     model: Model,
     instructions: AgentInstructions | None = None,
     docs_mcp_server: MCPServerStreamableHTTP | None = None,
+    enable_web_access: bool = False,
     tracer_provider: TracerProvider | None = None,
 ) -> OpenInferenceAgentWrapper[AgentDependencies, AgentOutput]:
     resolved_instructions = instructions or AgentInstructions()
@@ -59,6 +62,15 @@ def build_agent(
                 mcp_server=docs_mcp_server,
                 instructions=resolved_instructions.docs_tool,
             )
+        )
+    if enable_web_access:
+        # If model provider supports web access natively, the agent will have access to the web
+        # via these capabilities
+        capabilities.extend(
+            [
+                WebSearch(native=True, local=False),
+                WebFetch(native=True, local=False),
+            ]
         )
 
     traced_capability = OpenInferenceCapabilityWrapper(

--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -13,6 +13,7 @@ from pydantic_ai.capabilities import (
 from pydantic_ai.mcp import MCPServerStreamableHTTP
 from pydantic_ai.models import Model
 from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.native_tools import WebFetchTool, WebSearchTool
 
 from phoenix.server.agents.capabilities import (
     AnthropicPromptCacheCapability,
@@ -64,14 +65,7 @@ def build_agent(
             )
         )
     if enable_web_access:
-        # If model provider supports web access natively, the agent will have access to the web
-        # via these capabilities
-        capabilities.extend(
-            [
-                WebSearch(native=True, local=False),
-                WebFetch(native=True, local=False),
-            ]
-        )
+        capabilities.extend(_get_native_web_access_capabilities(model))
 
     traced_capability = OpenInferenceCapabilityWrapper(
         wrapped=CombinedCapability(capabilities=capabilities),
@@ -87,3 +81,15 @@ def build_agent(
         capabilities=[traced_capability],
     )
     return OpenInferenceAgentWrapper(agent, tracer=tracer)
+
+
+def _get_native_web_access_capabilities(
+    model: Model,
+) -> list[AbstractCapability[AgentDependencies]]:
+    supported_native_tools = model.profile.supported_native_tools
+    capabilities: list[AbstractCapability[AgentDependencies]] = []
+    if WebSearchTool in supported_native_tools:
+        capabilities.append(WebSearch(native=True, local=False))
+    if WebFetchTool in supported_native_tools:
+        capabilities.append(WebFetch(native=True, local=False))
+    return capabilities

--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -7,13 +7,10 @@ from pydantic_ai.capabilities import (
     AbstractCapability,
     CombinedCapability,
     DynamicCapability,
-    WebFetch,
-    WebSearch,
 )
 from pydantic_ai.mcp import MCPServerStreamableHTTP
 from pydantic_ai.models import Model
 from pydantic_ai.models.anthropic import AnthropicModel
-from pydantic_ai.native_tools import WebFetchTool, WebSearchTool
 
 from phoenix.server.agents.capabilities import (
     AnthropicPromptCacheCapability,
@@ -29,6 +26,10 @@ from phoenix.server.agents.pydantic_ai import (
     OpenInferenceCapabilityWrapper,
 )
 from phoenix.server.agents.types import AgentDependencies, AgentOutput
+from phoenix.server.agents.web_access import (
+    build_web_fetch_capability,
+    build_web_search_capability,
+)
 
 
 def build_agent(
@@ -65,7 +66,10 @@ def build_agent(
             )
         )
     if enable_web_access:
-        capabilities.extend(_get_native_web_access_capabilities(model))
+        if (web_search := build_web_search_capability(model)) is not None:
+            capabilities.append(web_search)
+        if (web_fetch := build_web_fetch_capability(model)) is not None:
+            capabilities.append(web_fetch)
 
     traced_capability = OpenInferenceCapabilityWrapper(
         wrapped=CombinedCapability(capabilities=capabilities),
@@ -81,20 +85,3 @@ def build_agent(
         capabilities=[traced_capability],
     )
     return OpenInferenceAgentWrapper(agent, tracer=tracer)
-
-
-def _get_native_web_access_capabilities(
-    model: Model,
-) -> list[AbstractCapability[AgentDependencies]]:
-    """Return native web capabilities supported by the selected model.
-
-    Provider-native web search and fetch are only registered when the model's
-    profile advertises support for the corresponding Pydantic AI native tool.
-    """
-    supported_native_tools = model.profile.supported_native_tools
-    capabilities: list[AbstractCapability[AgentDependencies]] = []
-    if WebSearchTool in supported_native_tools:
-        capabilities.append(WebSearch(native=True, local=False))
-    if WebFetchTool in supported_native_tools:
-        capabilities.append(WebFetch(native=True, local=False))
-    return capabilities

--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -86,6 +86,11 @@ def build_agent(
 def _get_native_web_access_capabilities(
     model: Model,
 ) -> list[AbstractCapability[AgentDependencies]]:
+    """Return native web capabilities supported by the selected model.
+
+    Provider-native web search and fetch are only registered when the model's
+    profile advertises support for the corresponding Pydantic AI native tool.
+    """
     supported_native_tools = model.profile.supported_native_tools
     capabilities: list[AbstractCapability[AgentDependencies]] = []
     if WebSearchTool in supported_native_tools:

--- a/src/phoenix/server/agents/context.py
+++ b/src/phoenix/server/agents/context.py
@@ -97,6 +97,13 @@ class GraphQLContext(_ChatContextBase):
     mutations_enabled: bool = Field(alias="mutationsEnabled")
 
 
+class WebAccessContext(_ChatContextBase):
+    """User's per-turn request to expose web search / fetch tools."""
+
+    type: Literal["web_access"]
+    enabled: bool
+
+
 class ChatContext(
     RootModel[
         Annotated[
@@ -105,7 +112,8 @@ class ChatContext(
             | TraceContext
             | AgentSpanContext
             | PlaygroundContext
-            | GraphQLContext,
+            | GraphQLContext
+            | WebAccessContext,
             Field(discriminator="type"),
         ]
     ]
@@ -121,6 +129,7 @@ class ResolvedContexts:
     span: AgentSpanContext | None = None
     playground: PlaygroundContext | None = None
     graphql: GraphQLContext | None = None
+    web_access: WebAccessContext | None = None
 
 
 def resolve_contexts(contexts: list[ChatContext]) -> ResolvedContexts:
@@ -139,6 +148,8 @@ def resolve_contexts(contexts: list[ChatContext]) -> ResolvedContexts:
             resolved.span = context_value
         elif isinstance(context_value, GraphQLContext):
             resolved.graphql = context_value
+        elif isinstance(context_value, WebAccessContext):
+            resolved.web_access = context_value
         else:
             assert_never(context_value)
     return resolved

--- a/src/phoenix/server/agents/pydantic_ai/openinference_model_wrapper.py
+++ b/src/phoenix/server/agents/pydantic_ai/openinference_model_wrapper.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Callable, Union
 
 from openinference.instrumentation import (
@@ -10,6 +11,7 @@ from openinference.instrumentation import (
     TokenCount,
     get_input_attributes,
     get_llm_attributes,
+    get_metadata_attributes,
     get_output_attributes,
     get_span_kind_attributes,
     safe_json_dumps,
@@ -19,7 +21,10 @@ from openinference.semconv.trace import (
     OpenInferenceLLMProviderValues,
     OpenInferenceLLMSystemValues,
     OpenInferenceMimeTypeValues,
+    SpanAttributes,
+    ToolCallAttributes,
 )
+from opentelemetry import context as context_api
 from opentelemetry.trace import Status, StatusCode, Tracer
 from pydantic_ai import RunContext
 from pydantic_ai._instrumentation import get_instructions
@@ -27,6 +32,8 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    NativeToolCallPart,
+    NativeToolReturnPart,
     RetryPromptPart,
     SystemPromptPart,
     TextPart,
@@ -127,6 +134,7 @@ class OpenInferenceModelWrapper(WrapperModel):
             "model_settings": model_settings,
             "model_request_parameters": model_request_parameters,
         }
+        parent_context = context_api.get_current()
         attributes = {
             **get_span_kind_attributes("llm"),
             **get_llm_attributes(
@@ -148,6 +156,10 @@ class OpenInferenceModelWrapper(WrapperModel):
         ) as span:
 
             def set_response(response: ModelResponse) -> None:
+                self._emit_native_tool_spans(
+                    response=response,
+                    parent_context=parent_context,
+                )
                 span.set_attributes(
                     {
                         **get_llm_attributes(
@@ -160,6 +172,84 @@ class OpenInferenceModelWrapper(WrapperModel):
 
             yield set_response
             span.set_status(Status(StatusCode.OK))
+
+    def _emit_native_tool_spans(
+        self,
+        *,
+        response: ModelResponse,
+        parent_context: context_api.Context,
+    ) -> None:
+        """Emit TOOL spans for provider-executed native tools.
+
+        Native tools, such as provider-side web search, do not flow through the
+        local toolset wrapper. Pydantic AI records them as model response parts,
+        so synthesize TOOL spans as soon as each model response is observed.
+        """
+        calls_by_id: dict[str, NativeToolCallPart] = {}
+        returns_by_id: dict[str, NativeToolReturnPart] = {}
+        for part in response.parts:
+            if isinstance(part, NativeToolCallPart):
+                calls_by_id[part.tool_call_id] = part
+            elif isinstance(part, NativeToolReturnPart):
+                returns_by_id[part.tool_call_id] = part
+
+        for tool_call_id, call_part in calls_by_id.items():
+            self._emit_native_tool_span(
+                call_part=call_part,
+                return_part=returns_by_id.get(tool_call_id),
+                parent_context=parent_context,
+                fallback_timestamp=response.timestamp,
+            )
+
+    def _emit_native_tool_span(
+        self,
+        *,
+        call_part: NativeToolCallPart,
+        return_part: NativeToolReturnPart | None,
+        parent_context: context_api.Context,
+        fallback_timestamp: datetime,
+    ) -> None:
+        metadata = {
+            "native_tool": {
+                "provider_name": call_part.provider_name,
+                "provider_details": call_part.provider_details,
+                "tool_kind": call_part.tool_kind,
+            }
+        }
+        attributes: dict[str, Any] = {
+            **get_span_kind_attributes("tool"),
+            SpanAttributes.TOOL_NAME: call_part.tool_name,
+            **get_input_attributes(
+                call_part.args_as_dict(),
+                mime_type=OpenInferenceMimeTypeValues.JSON,
+            ),
+            **get_metadata_attributes(metadata=metadata),
+            ToolCallAttributes.TOOL_CALL_ID: call_part.tool_call_id,
+        }
+        if return_part is not None:
+            attributes.update(get_output_attributes(return_part.content))
+        span_timestamp = _to_unix_nano(
+            return_part.timestamp if return_part is not None else fallback_timestamp
+        )
+        span = self.tracer.start_span(
+            name=call_part.tool_name,
+            context=parent_context,
+            attributes=attributes,
+            start_time=span_timestamp,
+        )
+        try:
+            if return_part is None or return_part.outcome == "success":
+                span.set_status(Status(StatusCode.OK))
+                return
+            error_message = (
+                str(return_part.content) if return_part.content is not None else return_part.outcome
+            )
+            span.record_exception(Exception(error_message))
+            span.set_status(
+                Status(StatusCode.ERROR, f"native tool {return_part.outcome}: {error_message}")
+            )
+        finally:
+            span.end(end_time=span_timestamp)
 
 
 def _to_oi_provider(
@@ -176,6 +266,10 @@ def _to_oi_system(
     if pydantic_system is None:
         return None
     return _SYSTEMS_BY_VALUE.get(pydantic_system.lower(), pydantic_system)
+
+
+def _to_unix_nano(timestamp: datetime) -> int:
+    return int(timestamp.timestamp() * 1_000_000_000)
 
 
 def _to_oi_messages(messages: list[ModelMessage]) -> list[Message]:
@@ -232,7 +326,7 @@ def _response_to_oi_message(msg: ModelResponse) -> Message:
     for part in msg.parts:
         if isinstance(part, TextPart):
             text_chunks.append(part.content)
-        elif isinstance(part, ToolCallPart):
+        elif isinstance(part, (ToolCallPart, NativeToolCallPart)):
             arguments: Union[str, dict[str, Any]]
             if isinstance(part.args, dict):
                 arguments = part.args

--- a/src/phoenix/server/agents/web_access.py
+++ b/src/phoenix/server/agents/web_access.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pydantic_ai.capabilities import WebFetch, WebSearch
+from pydantic_ai.models import Model
+from pydantic_ai.native_tools import WebFetchTool, WebSearchTool
+
+from phoenix.server.agents.types import AgentDependencies
+
+
+def build_web_search_capability(model: Model) -> WebSearch[AgentDependencies] | None:
+    """Return a provider-native web search capability if the model supports it."""
+    if WebSearchTool not in model.profile.supported_native_tools:
+        return None
+    return WebSearch(native=True, local=False)
+
+
+def build_web_fetch_capability(model: Model) -> WebFetch[AgentDependencies] | None:
+    """Return a provider-native web fetch capability if the model supports it."""
+    if WebFetchTool not in model.profile.supported_native_tools:
+        return None
+    return WebFetch(native=True, local=False)

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -2994,6 +2994,7 @@ class Gemini25GoogleStreamingClient(GoogleStreamingClient):
 GEMINI_3_MODELS = [
     "gemini-3.5-flash",
     "gemini-3.1-pro-preview",
+    "gemini-3-pro-preview",
     "gemini-3-flash-preview",
 ]
 

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -20,6 +20,7 @@ from phoenix.config import (
     get_env_database_allocated_storage_capacity_gibibytes,
     get_env_phoenix_agents_assistant_project_name,
     get_env_phoenix_agents_collector_endpoint,
+    get_env_phoenix_agents_web_access_enabled,
     getenv,
 )
 from phoenix.db import models
@@ -1470,6 +1471,7 @@ class Query:
         return AgentsConfig(
             collector_endpoint=get_env_phoenix_agents_collector_endpoint(),
             assistant_project_name=get_env_phoenix_agents_assistant_project_name(),
+            web_access_enabled=get_env_phoenix_agents_web_access_enabled(),
         )
 
     @strawberry.field

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -153,12 +153,6 @@ class _ObservabilityMixin(BaseModel):
     export_remote_traces: bool = Field(default=False, alias="exportRemoteTraces")
 
 
-class _AgentRequestCapabilities(_CamelModel):
-    """Per-request PXI capabilities requested by the browser."""
-
-    web_access: bool = False
-
-
 class _ChatMessageMixin(_ObservabilityMixin):
     """Phoenix-specific extensions added to Vercel AI request messages."""
 
@@ -169,7 +163,6 @@ class _ChatMessageMixin(_ObservabilityMixin):
     contexts: list[ChatContext] = Field(default_factory=list)
     messages: list[AssistantMetadataUIMessage]
     model: AgentModelSelection
-    capabilities: _AgentRequestCapabilities = Field(default_factory=_AgentRequestCapabilities)
 
 
 class ChatSubmitMessage(_ChatMessageMixin, SubmitMessage):
@@ -471,11 +464,16 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             getattr(model, "settings", None),
         )
 
+        resolved_contexts = resolve_contexts(body.contexts)
+        web_access_enabled = (
+            resolved_contexts.web_access is not None
+            and resolved_contexts.web_access.enabled
+            and get_env_phoenix_agents_web_access_enabled()
+        )
         agent = build_agent(
             model=model,
             docs_mcp_server=request.app.state.docs_mcp_server,
-            enable_web_access=body.capabilities.web_access
-            and get_env_phoenix_agents_web_access_enabled(),
+            enable_web_access=web_access_enabled,
             tracer_provider=tracer_provider,
         )
         adapter: VercelAIAdapter[AgentDependencies, AgentOutput] = VercelAIAdapter(
@@ -483,9 +481,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             run_input=body,
             accept=request.headers.get("accept"),
         )
-        deps = AgentDependencies(
-            contexts=resolve_contexts(body.contexts),
-        )
+        deps = AgentDependencies(contexts=resolved_contexts)
 
         async def _on_complete(result: AgentRunResult[Any]) -> AsyncIterator[BaseChunk]:
             yield _build_message_metadata_chunk(

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -34,7 +34,10 @@ from starlette.requests import Request
 from starlette.responses import Response
 from typing_extensions import TypeIs, assert_never
 
-from phoenix.config import get_env_phoenix_agents_assistant_project_name
+from phoenix.config import (
+    get_env_phoenix_agents_assistant_project_name,
+    get_env_phoenix_agents_web_access_enabled,
+)
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
@@ -150,6 +153,12 @@ class _ObservabilityMixin(BaseModel):
     export_remote_traces: bool = Field(default=False, alias="exportRemoteTraces")
 
 
+class _AgentRequestCapabilities(_CamelModel):
+    """Per-request PXI capabilities requested by the browser."""
+
+    web_access: bool = False
+
+
 class _ChatMessageMixin(_ObservabilityMixin):
     """Phoenix-specific extensions added to Vercel AI request messages."""
 
@@ -160,6 +169,7 @@ class _ChatMessageMixin(_ObservabilityMixin):
     contexts: list[ChatContext] = Field(default_factory=list)
     messages: list[AssistantMetadataUIMessage]
     model: AgentModelSelection
+    capabilities: _AgentRequestCapabilities = Field(default_factory=_AgentRequestCapabilities)
 
 
 class ChatSubmitMessage(_ChatMessageMixin, SubmitMessage):
@@ -464,6 +474,8 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         agent = build_agent(
             model=model,
             docs_mcp_server=request.app.state.docs_mcp_server,
+            enable_web_access=body.capabilities.web_access
+            and get_env_phoenix_agents_web_access_enabled(),
             tracer_provider=tracer_provider,
         )
         adapter: VercelAIAdapter[AgentDependencies, AgentOutput] = VercelAIAdapter(

--- a/src/phoenix/server/api/types/AgentsConfig.py
+++ b/src/phoenix/server/api/types/AgentsConfig.py
@@ -17,3 +17,10 @@ class AgentsConfig:
             "Resolved from the PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME environment variable."
         ),
     )
+    web_access_enabled: bool = strawberry.field(
+        description=(
+            "Whether PXI can expose native web search and web fetch capabilities. "
+            "False when external resources are disabled or PHOENIX_AGENTS_DISABLE_WEB_ACCESS "
+            "is true."
+        ),
+    )

--- a/tests/unit/server/agents/pydantic_ai/test_openinference_agent_wrapper.py
+++ b/tests/unit/server/agents/pydantic_ai/test_openinference_agent_wrapper.py
@@ -661,7 +661,9 @@ async def test_emits_tool_span_for_provider_native_tool(
     assert isinstance(output_value, str)
     assert json.loads(output_value) == {"results": [{"title": "Phoenix"}]}
     assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
-    metadata = json.loads(attributes.pop(METADATA))
+    metadata_value = attributes.pop(METADATA)
+    assert isinstance(metadata_value, str)
+    metadata = json.loads(metadata_value)
     assert metadata == {
         "native_tool": {
             "provider_name": "openai",

--- a/tests/unit/server/agents/pydantic_ai/test_openinference_agent_wrapper.py
+++ b/tests/unit/server/agents/pydantic_ai/test_openinference_agent_wrapper.py
@@ -22,6 +22,8 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    NativeToolCallPart,
+    NativeToolReturnPart,
     TextPart,
     ToolCallPart,
     ToolReturnPart,
@@ -113,6 +115,54 @@ def raising_model() -> WrapperModel:
             yield  # pragma: no cover
 
     return _RaisingWrapperModel(TestModel())
+
+
+@pytest.fixture
+def native_tool_agent(tracer: Tracer) -> OpenInferenceAgentWrapper:
+    class _NativeToolModel(WrapperModel):
+        async def request(
+            self,
+            messages: list[ModelMessage],
+            model_settings: ModelSettings | None,
+            model_request_parameters: ModelRequestParameters,
+        ) -> ModelResponse:
+            return ModelResponse(
+                parts=[
+                    NativeToolCallPart(
+                        tool_name="web_search",
+                        args={"query": "phoenix tracing"},
+                        tool_call_id="native-call-1",
+                        provider_name="openai",
+                        provider_details={"type": "web_search_call"},
+                    ),
+                    NativeToolReturnPart(
+                        tool_name="web_search",
+                        content={"results": [{"title": "Phoenix"}]},
+                        tool_call_id="native-call-1",
+                        provider_name="openai",
+                        provider_details={"status": "completed"},
+                    ),
+                    TextPart(content="I found Phoenix tracing documentation."),
+                ]
+            )
+
+        @asynccontextmanager
+        async def request_stream(
+            self,
+            messages: list[ModelMessage],
+            model_settings: ModelSettings | None,
+            model_request_parameters: ModelRequestParameters,
+            run_context: Any = None,
+        ) -> AsyncIterator[StreamedResponse]:
+            raise RuntimeError("streaming is not used")
+            yield  # pragma: no cover
+
+    inner: Agent[None, str] = Agent(
+        OpenInferenceModelWrapper(_NativeToolModel(TestModel()), tracer=tracer),
+        name="NativeToolAgent",
+        deps_type=type(None),
+    )
+    return OpenInferenceAgentWrapper(inner, tracer=tracer)
 
 
 @pytest.fixture
@@ -578,6 +628,47 @@ async def test_tool_span_args_come_from_prior_tool_call_part(
     assert json.loads(tool_parameters) == dict(
         SET_TIME_RANGE_TOOL_DEFINITION.parameters_json_schema
     )
+    assert not attributes
+
+
+async def test_emits_tool_span_for_provider_native_tool(
+    native_tool_agent: OpenInferenceAgentWrapper,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    result = await native_tool_agent.run("search the web")
+    assert result.output == "I found Phoenix tracing documentation."
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    agent_span = _get_agent_span(spans)
+    tool_spans = _get_tool_spans(spans)
+    assert len(tool_spans) == 1
+    tool_span = tool_spans[0]
+    assert tool_span.name == "web_search"
+    assert tool_span.parent is not None
+    assert tool_span.parent.span_id == agent_span.context.span_id
+    assert tool_span.context.trace_id == agent_span.context.trace_id
+    assert tool_span.status.status_code == StatusCode.OK
+
+    attributes = dict(tool_span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == TOOL
+    assert attributes.pop(TOOL_NAME) == "web_search"
+    assert attributes.pop(TOOL_CALL_ID) == "native-call-1"
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert json.loads(input_value) == {"query": "phoenix tracing"}
+    assert attributes.pop(INPUT_MIME_TYPE) == JSON
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    assert json.loads(output_value) == {"results": [{"title": "Phoenix"}]}
+    assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
+    metadata = json.loads(attributes.pop(METADATA))
+    assert metadata == {
+        "native_tool": {
+            "provider_name": "openai",
+            "provider_details": {"type": "web_search_call"},
+            "tool_kind": None,
+        }
+    }
     assert not attributes
 
 

--- a/tests/unit/server/agents/pydantic_ai/test_openinference_model_wrapper.py
+++ b/tests/unit/server/agents/pydantic_ai/test_openinference_model_wrapper.py
@@ -365,8 +365,11 @@ async def test_request_emits_llm_span_for_native_tool_call_response(
     )
 
     spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    attributes = dict(spans[0].attributes or {})
+    llm_spans = [
+        span for span in spans if (span.attributes or {}).get(OPENINFERENCE_SPAN_KIND) == LLM
+    ]
+    assert len(llm_spans) == 1
+    attributes = dict(llm_spans[0].attributes or {})
 
     assert attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "assistant"
     assert (

--- a/tests/unit/server/agents/pydantic_ai/test_openinference_model_wrapper.py
+++ b/tests/unit/server/agents/pydantic_ai/test_openinference_model_wrapper.py
@@ -26,6 +26,7 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    NativeToolCallPart,
     PartDeltaEvent,
     PartStartEvent,
     SystemPromptPart,
@@ -100,6 +101,39 @@ def raising_model(tracer: Tracer) -> OpenInferenceModelWrapper:
             yield  # pragma: no cover
 
     return OpenInferenceModelWrapper(_RaisingModel(TestModel()), tracer=tracer)
+
+
+@pytest.fixture
+def native_tool_model(tracer: Tracer) -> OpenInferenceModelWrapper:
+    class _NativeToolModel(WrapperModel):
+        async def request(
+            self,
+            messages: list[ModelMessage],
+            model_settings: ModelSettings | None,
+            model_request_parameters: ModelRequestParameters,
+        ) -> ModelResponse:
+            return ModelResponse(
+                parts=[
+                    NativeToolCallPart(
+                        tool_name="web_search",
+                        args={"query": "phoenix tracing"},
+                        tool_call_id="native-call-1",
+                    )
+                ]
+            )
+
+        @asynccontextmanager
+        async def request_stream(
+            self,
+            messages: list[ModelMessage],
+            model_settings: ModelSettings | None,
+            model_request_parameters: ModelRequestParameters,
+            run_context: Any = None,
+        ) -> AsyncIterator[StreamedResponse]:
+            raise RuntimeError("streaming is not used")
+            yield  # pragma: no cover
+
+    return OpenInferenceModelWrapper(_NativeToolModel(TestModel()), tracer=tracer)
 
 
 async def test_request_emits_llm_span_for_text_response(
@@ -256,8 +290,11 @@ async def test_request_emits_llm_span_for_tool_call_response(
     assert tool_call_part.tool_call_id
 
     spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    attributes = dict(spans[0].attributes or {})
+    llm_spans = [
+        span for span in spans if (span.attributes or {}).get(OPENINFERENCE_SPAN_KIND) == LLM
+    ]
+    assert len(llm_spans) == 1
+    attributes = dict(llm_spans[0].attributes or {})
 
     assert attributes.pop(OPENINFERENCE_SPAN_KIND) == LLM
     assert attributes.pop(LLM_PROVIDER) == PROVIDER_ANTHROPIC
@@ -313,6 +350,45 @@ async def test_request_emits_llm_span_for_tool_call_response(
     assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
     assert not attributes
+
+
+async def test_request_emits_llm_span_for_native_tool_call_response(
+    native_tool_model: OpenInferenceModelWrapper,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    await native_tool_model.request(
+        messages=[ModelRequest(parts=[UserPromptPart(content="search the web")])],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(
+            function_tools=[], native_tools=[], output_tools=[]
+        ),
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+
+    assert attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "assistant"
+    assert (
+        attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_ID}")
+        == "native-call-1"
+    )
+    assert (
+        attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_NAME}")
+        == "web_search"
+    )
+    args_attr = attributes.pop(
+        f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_ARGUMENTS_JSON}"
+    )
+    assert isinstance(args_attr, str)
+    assert json.loads(args_attr) == {"query": "phoenix tracing"}
+
+    tool_spans = [
+        span for span in spans if (span.attributes or {}).get(OPENINFERENCE_SPAN_KIND) == TOOL
+    ]
+    assert len(tool_spans) == 1
+    tool_attributes = dict(tool_spans[0].attributes or {})
+    assert tool_attributes.pop(TOOL_NAME) == "web_search"
 
 
 async def test_request_stream_emits_llm_span(
@@ -659,6 +735,7 @@ LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
 LLM_TOOLS = SpanAttributes.LLM_TOOLS
 TOOL_JSON_SCHEMA = ToolAttributes.TOOL_JSON_SCHEMA
+TOOL_NAME = SpanAttributes.TOOL_NAME
 MESSAGE_ROLE = MessageAttributes.MESSAGE_ROLE
 MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT
 MESSAGE_TOOL_CALLS = MessageAttributes.MESSAGE_TOOL_CALLS
@@ -672,6 +749,7 @@ OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
 OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
 
 LLM = OpenInferenceSpanKindValues.LLM.value
+TOOL = OpenInferenceSpanKindValues.TOOL.value
 PROVIDER_ANTHROPIC = OpenInferenceLLMProviderValues.ANTHROPIC.value
 SYSTEM_ANTHROPIC = OpenInferenceLLMSystemValues.ANTHROPIC.value
 JSON = OpenInferenceMimeTypeValues.JSON.value

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -462,6 +462,13 @@ class TestCapabilityInstructionsOverride:
 
 
 class TestWebAccessCapabilities:
+    @staticmethod
+    def _get_native_tool_types(model: TestModel) -> set[type]:
+        """Native tool types the agent advertised on the last ``TestModel`` request."""
+        params = model.last_model_request_parameters
+        assert params is not None
+        return {type(tool) for tool in params.native_tools}
+
     async def test_web_tools_advertised_when_enabled(
         self,
         model_with_web_access: TestModel,
@@ -475,7 +482,7 @@ class TestWebAccessCapabilities:
         with pytest.raises(UserError):
             await agent.run("hello", deps=deps)
 
-        native_tool_types = _get_native_tool_types(model_with_web_access)
+        native_tool_types = self._get_native_tool_types(model_with_web_access)
         assert WebSearchTool in native_tool_types
         assert WebFetchTool in native_tool_types
 
@@ -488,7 +495,7 @@ class TestWebAccessCapabilities:
 
         await agent.run("hello", deps=deps)
 
-        native_tool_types = _get_native_tool_types(model_with_web_access)
+        native_tool_types = self._get_native_tool_types(model_with_web_access)
         assert WebSearchTool not in native_tool_types
         assert WebFetchTool not in native_tool_types
 
@@ -501,13 +508,6 @@ class TestWebAccessCapabilities:
 
         await agent.run("hello", deps=deps)
 
-        native_tool_types = _get_native_tool_types(model_without_web_access)
+        native_tool_types = self._get_native_tool_types(model_without_web_access)
         assert WebSearchTool not in native_tool_types
         assert WebFetchTool not in native_tool_types
-
-
-def _get_native_tool_types(model: TestModel) -> set[type]:
-    """Native tool types the agent advertised on the last ``TestModel`` request."""
-    params = model.last_model_request_parameters
-    assert params is not None
-    return {type(tool) for tool in params.native_tools}

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -17,16 +17,15 @@ from anthropic.types.beta import (
 )
 from anthropic.types.beta.message_create_params import MessageCreateParams
 from jinja2 import Template
-from pydantic_ai import RunContext
-from pydantic_ai.capabilities import WebFetch, WebSearch
+from pydantic_ai import RunContext, UserError
 from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.native_tools import WebSearchTool
+from pydantic_ai.native_tools import WebFetchTool, WebSearchTool
 from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.providers.anthropic import AnthropicProvider
 from typing_extensions import TypeIs, assert_never
 
-from phoenix.server.agents.agent_factory import _get_native_web_access_capabilities, build_agent
+from phoenix.server.agents.agent_factory import build_agent
 from phoenix.server.agents.capabilities import (
     MintlifyDocsMCPServer,
 )
@@ -133,6 +132,22 @@ class _OfflineDocsMCPToolset(MintlifyDocsMCPServer):
 @pytest.fixture
 def docs_mcp_server() -> _OfflineDocsMCPToolset:
     return _OfflineDocsMCPToolset()
+
+
+@pytest.fixture
+def model_with_web_access() -> TestModel:
+    """Model whose profile advertises both native web tools."""
+    return TestModel(
+        profile=ModelProfile(
+            supported_native_tools=frozenset({WebSearchTool, WebFetchTool}),
+        )
+    )
+
+
+@pytest.fixture
+def model_without_web_access() -> TestModel:
+    """Model whose profile advertises no native web tools."""
+    return TestModel(profile=ModelProfile(supported_native_tools=frozenset()))
 
 
 def _get_system_text_blocks(body: MessageCreateParams) -> list[BetaTextBlockParam]:
@@ -446,30 +461,53 @@ class TestCapabilityInstructionsOverride:
         assert _DEFAULT_INSTRUCTIONS.bash_tool.render() not in joined_system
 
 
-class TestNativeWebAccessCapabilities:
-    def test_only_adds_supported_native_web_tools(self) -> None:
-        model = TestModel(
-            profile=ModelProfile(
-                supported_native_tools=frozenset({WebSearchTool}),
-            )
-        )
+class TestWebAccessCapabilities:
+    async def test_web_tools_advertised_when_enabled(
+        self,
+        model_with_web_access: TestModel,
+    ) -> None:
+        agent = build_agent(model=model_with_web_access, enable_web_access=True)
+        deps = AgentDependencies(contexts=ResolvedContexts())
 
-        capabilities = _get_native_web_access_capabilities(model)
+        # ``TestModel`` refuses to respond when native tools are advertised on
+        # the request, but ``last_model_request_parameters`` is recorded before
+        # the error is raised — sufficient to verify ``build_agent``'s wiring.
+        with pytest.raises(UserError):
+            await agent.run("hello", deps=deps)
 
-        assert [type(capability) for capability in capabilities] == [WebSearch]
+        native_tool_types = _get_native_tool_types(model_with_web_access)
+        assert WebSearchTool in native_tool_types
+        assert WebFetchTool in native_tool_types
 
-    def test_adds_no_web_tools_when_model_supports_none(self) -> None:
-        model = TestModel(
-            profile=ModelProfile(
-                supported_native_tools=frozenset(),
-            )
-        )
+    async def test_web_tools_absent_when_disabled(
+        self,
+        model_with_web_access: TestModel,
+    ) -> None:
+        agent = build_agent(model=model_with_web_access, enable_web_access=False)
+        deps = AgentDependencies(contexts=ResolvedContexts())
 
-        assert _get_native_web_access_capabilities(model) == []
+        await agent.run("hello", deps=deps)
 
-    def test_adds_fetch_when_supported(self) -> None:
-        model = TestModel()
+        native_tool_types = _get_native_tool_types(model_with_web_access)
+        assert WebSearchTool not in native_tool_types
+        assert WebFetchTool not in native_tool_types
 
-        capabilities = _get_native_web_access_capabilities(model)
+    async def test_web_tools_absent_when_model_does_not_support_them(
+        self,
+        model_without_web_access: TestModel,
+    ) -> None:
+        agent = build_agent(model=model_without_web_access, enable_web_access=True)
+        deps = AgentDependencies(contexts=ResolvedContexts())
 
-        assert WebFetch in [type(capability) for capability in capabilities]
+        await agent.run("hello", deps=deps)
+
+        native_tool_types = _get_native_tool_types(model_without_web_access)
+        assert WebSearchTool not in native_tool_types
+        assert WebFetchTool not in native_tool_types
+
+
+def _get_native_tool_types(model: TestModel) -> set[type]:
+    """Native tool types the agent advertised on the last ``TestModel`` request."""
+    params = model.last_model_request_parameters
+    assert params is not None
+    return {type(tool) for tool in params.native_tools}

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -18,11 +18,15 @@ from anthropic.types.beta import (
 from anthropic.types.beta.message_create_params import MessageCreateParams
 from jinja2 import Template
 from pydantic_ai import RunContext
+from pydantic_ai.capabilities import WebFetch, WebSearch
 from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.native_tools import WebSearchTool
+from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.providers.anthropic import AnthropicProvider
 from typing_extensions import TypeIs, assert_never
 
-from phoenix.server.agents.agent_factory import build_agent
+from phoenix.server.agents.agent_factory import _get_native_web_access_capabilities, build_agent
 from phoenix.server.agents.capabilities import (
     MintlifyDocsMCPServer,
 )
@@ -440,3 +444,32 @@ class TestCapabilityInstructionsOverride:
         joined_system = "\n".join(_get_system_texts(captured_request.body))
         assert "CUSTOM_BASH_SENTINEL" in joined_system
         assert _DEFAULT_INSTRUCTIONS.bash_tool.render() not in joined_system
+
+
+class TestNativeWebAccessCapabilities:
+    def test_only_adds_supported_native_web_tools(self) -> None:
+        model = TestModel(
+            profile=ModelProfile(
+                supported_native_tools=frozenset({WebSearchTool}),
+            )
+        )
+
+        capabilities = _get_native_web_access_capabilities(model)
+
+        assert [type(capability) for capability in capabilities] == [WebSearch]
+
+    def test_adds_no_web_tools_when_model_supports_none(self) -> None:
+        model = TestModel(
+            profile=ModelProfile(
+                supported_native_tools=frozenset(),
+            )
+        )
+
+        assert _get_native_web_access_capabilities(model) == []
+
+    def test_adds_fetch_when_supported(self) -> None:
+        model = TestModel()
+
+        capabilities = _get_native_web_access_capabilities(model)
+
+        assert WebFetch in [type(capability) for capability in capabilities]

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -477,11 +477,14 @@ async def test_agents_config_returns_env_values(
 ) -> None:
     monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", "http://collector.example:4318")
     monkeypatch.setenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", "custom_assistant")
+    monkeypatch.setenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "true")
+    monkeypatch.setenv("PHOENIX_AGENTS_DISABLE_WEB_ACCESS", "false")
     query = """
       query {
         agentsConfig {
           collectorEndpoint
           assistantProjectName
+          webAccessEnabled
         }
       }
     """
@@ -491,6 +494,7 @@ async def test_agents_config_returns_env_values(
     assert data["agentsConfig"] == {
         "collectorEndpoint": "http://collector.example:4318",
         "assistantProjectName": "custom_assistant",
+        "webAccessEnabled": True,
     }
 
 
@@ -500,11 +504,14 @@ async def test_agents_config_defaults_when_env_unset(
 ) -> None:
     monkeypatch.delenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", raising=False)
     monkeypatch.delenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", raising=False)
+    monkeypatch.delenv("PHOENIX_AGENTS_DISABLE_WEB_ACCESS", raising=False)
+    monkeypatch.delenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", raising=False)
     query = """
       query {
         agentsConfig {
           collectorEndpoint
           assistantProjectName
+          webAccessEnabled
         }
       }
     """
@@ -514,7 +521,38 @@ async def test_agents_config_defaults_when_env_unset(
     assert data["agentsConfig"] == {
         "collectorEndpoint": None,
         "assistantProjectName": "assistant_agent",
+        "webAccessEnabled": True,
     }
+
+
+@pytest.mark.parametrize(
+    ("allow_external_resources", "disable_web_access", "expected"),
+    [
+        ("true", "false", True),
+        ("false", "false", False),
+        ("true", "true", False),
+    ],
+)
+async def test_agents_config_web_access_respects_env_flags(
+    gql_client: AsyncGraphQLClient,
+    monkeypatch: pytest.MonkeyPatch,
+    allow_external_resources: str,
+    disable_web_access: str,
+    expected: bool,
+) -> None:
+    monkeypatch.setenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", allow_external_resources)
+    monkeypatch.setenv("PHOENIX_AGENTS_DISABLE_WEB_ACCESS", disable_web_access)
+    query = """
+      query {
+        agentsConfig {
+          webAccessEnabled
+        }
+      }
+    """
+    response = await gql_client.execute(query=query)
+    assert not response.errors
+    assert (data := response.data) is not None
+    assert data["agentsConfig"] == {"webAccessEnabled": expected}
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- Adds a server-advertised PXI web access capability, gated by `PHOENIX_ALLOW_EXTERNAL_RESOURCES` and `PHOENIX_AGENTS_DISABLE_WEB_ACCESS`.
- Wires the agent settings UI and request body so users can opt into provider-native web search/fetch when the selected model supports it.
- Emits OpenInference TOOL spans for provider-executed native tools and previews native web search/fetch calls in agent chat.
- Adds Gemini model menu entries and regenerates GraphQL/OpenAPI client artifacts.

## Testing

- `make typecheck-python`
- `tox run -q -e unit_tests -- tests/unit/server/agents/test_agent_factory.py tests/unit/server/agents/pydantic_ai/test_openinference_model_wrapper.py tests/unit/server/agents/pydantic_ai/test_openinference_agent_wrapper.py -n auto`