### PR TITLE
fix(db): align sandbox config constraints

### DIFF
--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -1422,7 +1422,11 @@ CREATE TABLE public.sandbox_configs (
         FOREIGN KEY
         (backend_type)
         REFERENCES public.sandbox_providers (backend_type)
-        ON DELETE CASCADE,
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_sandbox_configs_language_languages FOREIGN KEY
+        (language)
+        REFERENCES public.languages (name)
+        ON DELETE RESTRICT,
     CONSTRAINT fk_sandbox_configs_user_id_users FOREIGN KEY
         (user_id)
         REFERENCES public.users (id)

--- a/src/phoenix/db/migrations/versions/0ff41b5b118f_add_sandbox_and_code_evaluator_support.py
+++ b/src/phoenix/db/migrations/versions/0ff41b5b118f_add_sandbox_and_code_evaluator_support.py
@@ -69,6 +69,7 @@ def upgrade() -> None:
             _Integer,
             sa.ForeignKey("users.id", ondelete="SET NULL"),
             nullable=True,
+            index=True,
         ),
         sa.Column(
             "updated_at",
@@ -77,7 +78,6 @@ def upgrade() -> None:
             server_default=sa.func.now(),
         ),
     )
-    op.create_index("ix_sandbox_providers_user_id", "sandbox_providers", ["user_id"])
 
     op.create_table(
         "sandbox_configs",
@@ -85,10 +85,15 @@ def upgrade() -> None:
         sa.Column(
             "backend_type",
             sa.String,
-            sa.ForeignKey("sandbox_providers.backend_type", ondelete="CASCADE"),
+            sa.ForeignKey("sandbox_providers.backend_type", ondelete="RESTRICT"),
             nullable=False,
         ),
-        sa.Column("language", sa.String, nullable=False),
+        sa.Column(
+            "language",
+            sa.String,
+            sa.ForeignKey("languages.name", ondelete="RESTRICT"),
+            nullable=False,
+        ),
         sa.Column("name", sa.String, nullable=False),
         sa.Column("description", sa.String, nullable=True),
         sa.Column("config", JSON_, nullable=False, server_default="{}"),
@@ -111,11 +116,11 @@ def upgrade() -> None:
             _Integer,
             sa.ForeignKey("users.id", ondelete="SET NULL"),
             nullable=True,
+            index=True,
         ),
         sa.UniqueConstraint("backend_type", "name"),
-        sa.UniqueConstraint("language", "id"),
+        sa.UniqueConstraint("language", "id"),  # needed for the composite FK
     )
-    op.create_index("ix_sandbox_configs_user_id", "sandbox_configs", ["user_id"])
 
     # code_evaluators: ADD COLUMN to a pre-existing table requires batch_alter_table on SQLite.
     # The composite FK fk_code_evaluators_sandbox_config_language is named explicitly because
@@ -132,7 +137,7 @@ def upgrade() -> None:
                 sa.String,
                 sa.ForeignKey("languages.name", ondelete="RESTRICT"),
                 nullable=False,
-                server_default="PYTHON",
+                server_default="PYTHON",  # removed below
             )
         )
         batch_op.add_column(
@@ -180,6 +185,7 @@ def upgrade() -> None:
             _Integer,
             sa.ForeignKey("users.id", ondelete="SET NULL"),
             nullable=True,
+            index=True,
         ),
         sa.Column("source_code", sa.String, nullable=False, server_default=""),
         sa.Column(
@@ -194,11 +200,6 @@ def upgrade() -> None:
         "ix_code_evaluator_code_versions_code_evaluator_id_id",
         "code_evaluator_code_versions",
         ["code_evaluator_id", "id"],
-    )
-    op.create_index(
-        "ix_code_evaluator_code_versions_user_id",
-        "code_evaluator_code_versions",
-        ["user_id"],
     )
 
 

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -2777,9 +2777,11 @@ class SandboxProvider(Base):
 class SandboxConfig(HasId):
     __tablename__ = "sandbox_configs"
     backend_type: Mapped[SandboxBackendType] = mapped_column(
-        ForeignKey("sandbox_providers.backend_type", ondelete="CASCADE"), nullable=False
+        ForeignKey("sandbox_providers.backend_type", ondelete="RESTRICT"), nullable=False
     )
-    language: Mapped[LanguageName] = mapped_column(nullable=False)
+    language: Mapped[LanguageName] = mapped_column(
+        ForeignKey("languages.name", ondelete="RESTRICT"), nullable=False
+    )
     name: Mapped[Identifier] = mapped_column(_Identifier, nullable=False)
     description: Mapped[Optional[str]] = mapped_column(nullable=True)
     config: Mapped[dict[str, Any]] = mapped_column(JSON_, nullable=False, server_default="{}")


### PR DESCRIPTION
## Summary
- Align `SandboxConfig` ORM constraints with the sandbox migration and generated PostgreSQL schema.
- Add the language foreign key for sandbox configs and restrict provider deletion while configs exist.
- Keep safe index cleanups for newly-created migration tables.

## Test plan
- `uvx tox r -e integration_tests -- -k test_up_and_down_migrations`