### PR TITLE
feat(sandbox): show allowlist status in banner and Sandboxes settings

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3376,6 +3376,7 @@ enum SandboxBackendStatus {
   MISSING_CREDENTIALS
   UNAVAILABLE
   NOT_INSTALLED
+  DISABLED
 }
 
 enum SandboxBackendType {

--- a/app/src/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideoverQuery.graphql.ts
+++ b/app/src/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideoverQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5a644a0bc5cc2e07b315913979cae18e>>
+ * @generated SignedSource<<18f468bcb4196b93256217886590e55b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,7 +12,7 @@ import { ConcreteRequest } from 'relay-runtime';
 export type InternetAccessChoice = "ALLOW" | "DENY";
 export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
-export type SandboxBackendStatus = "AVAILABLE" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
+export type SandboxBackendStatus = "AVAILABLE" | "DISABLED" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
 export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";
 export type CreateCodeDatasetEvaluatorSlideoverQuery$variables = Record<PropertyKey, never>;
 export type CreateCodeDatasetEvaluatorSlideoverQuery$data = {

--- a/app/src/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery.graphql.ts
+++ b/app/src/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<14de446cb1cbdfe90f7c4b0b5680412a>>
+ * @generated SignedSource<<17ff36e3b325f879d3cec9dd4b928d5a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,7 +14,7 @@ export type InternetAccessChoice = "ALLOW" | "DENY";
 export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
-export type SandboxBackendStatus = "AVAILABLE" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
+export type SandboxBackendStatus = "AVAILABLE" | "DISABLED" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
 export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";
 export type EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery$variables = {
   datasetEvaluatorId: string;

--- a/app/src/components/sandbox/__generated__/SandboxProviderSelectQuery.graphql.ts
+++ b/app/src/components/sandbox/__generated__/SandboxProviderSelectQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2d727a8bfc9a2bc3037491d5b67a8a27>>
+ * @generated SignedSource<<eeec0b8456a4a78c6cb8a9e391946f2b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 export type Language = "PYTHON" | "TYPESCRIPT";
-export type SandboxBackendStatus = "AVAILABLE" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
+export type SandboxBackendStatus = "AVAILABLE" | "DISABLED" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
 export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";
 export type SandboxHostingType = "HOSTED" | "LOCAL";
 export type SandboxProviderSelectQuery$variables = Record<PropertyKey, never>;

--- a/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e4f22eb06e6905b59d4eacae3ae62b48>>
+ * @generated SignedSource<<09387a4534ce7e7309c5f4cc9ee2fdb1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,7 +12,7 @@ import { ReaderFragment } from 'relay-runtime';
 export type InternetAccessChoice = "ALLOW" | "DENY";
 export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
-export type SandboxBackendStatus = "AVAILABLE" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
+export type SandboxBackendStatus = "AVAILABLE" | "DISABLED" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
 export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";
 export type SandboxHostingType = "HOSTED" | "LOCAL";
 import { FragmentRefs } from "relay-runtime";

--- a/app/src/pages/settings/sandboxes/utils.tsx
+++ b/app/src/pages/settings/sandboxes/utils.tsx
@@ -45,7 +45,9 @@ export function StatusText({
   }
 
   const textColor =
-    status === "NOT_INSTALLED" || status === "DISABLED" ? "text-700" : "warning";
+    status === "NOT_INSTALLED" || status === "DISABLED"
+      ? "text-700"
+      : "warning";
 
   return (
     <TooltipTrigger delay={100}>

--- a/app/src/pages/settings/sandboxes/utils.tsx
+++ b/app/src/pages/settings/sandboxes/utils.tsx
@@ -44,11 +44,14 @@ export function StatusText({
     return <span style={{ color }}>{label}</span>;
   }
 
+  const textColor =
+    status === "NOT_INSTALLED" || status === "DISABLED" ? "text-700" : "warning";
+
   return (
     <TooltipTrigger delay={100}>
       <TriggerWrap>
         <Text
-          color={status === "NOT_INSTALLED" ? "text-700" : "warning"}
+          color={textColor}
           css={css`
             text-decoration: underline dotted;
             text-underline-offset: 2px;
@@ -130,6 +133,8 @@ export function statusLabel(status: BackendInfo["status"]) {
       return "Unavailable";
     case "NOT_INSTALLED":
       return "Not installed";
+    case "DISABLED":
+      return "Disabled";
     default:
       assertUnreachable(status);
   }

--- a/docs/phoenix/self-hosting/configuration.mdx
+++ b/docs/phoenix/self-hosting/configuration.mdx
@@ -85,6 +85,8 @@ The following environment variables will control how your phoenix server runs.
 
 * **PHOENIX\_ALLOWED\_PROVIDERS:** A comma-separated, case-insensitive list of model provider names to display in the playground UI. When unset, all providers are shown. Set to `NONE` to hide all providers. Unrecognized provider names will cause a startup error. Supported values: `OPENAI`, `ANTHROPIC`, `AZURE_OPENAI`, `GOOGLE`, `DEEPSEEK`, `XAI`, `OLLAMA`, `AWS`, `CEREBRAS`, `FIREWORKS`, `GROQ`, `MOONSHOT`, `PERPLEXITY`, `TOGETHER`. Example: `PHOENIX_ALLOWED_PROVIDERS=OPENAI,ANTHROPIC`. Available since version 13.13.0.
 
+* **PHOENIX\_ALLOWED\_SANDBOX\_PROVIDERS:** A comma-separated, case-insensitive list of code-execution sandbox providers that Phoenix is permitted to use. When unset, all providers are allowed. Set to `NONE` to disable every sandbox provider. Unrecognized provider names will cause a startup error. Supported values: `WASM`, `DENO`, `E2B`, `DAYTONA`, `VERCEL`, `MODAL`. Example: `PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO`. See [Sandbox Backends](self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) for details.
+
 ### Logging
 
 * **PHOENIX\_LOG\_SQL:** Whether to log all SQL statements to stdout. Useful for debugging database queries. Defaults to `false`. Available since version 13.4.0.

--- a/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
+++ b/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
@@ -5,17 +5,23 @@ description: How Phoenix's code-execution sandbox backends are wired in self-hos
 
 Phoenix supports multiple code-execution sandbox providers for evaluators and other LLM-driven workflows. This page describes which providers are ready to use in the official `arizephoenix/phoenix` container and what extra setup the others need.
 
-<Info>
-The provider list, their advertised capabilities, and the status reported under **Settings → Sandboxes** are all driven by the static registry in `src/phoenix/server/sandbox/__init__.py` (`SANDBOX_ADAPTER_METADATA`). When a provider's optional Python extra is missing the adapter is dropped from the runtime registry and shows as `NOT_INSTALLED`; when its credentials are missing it shows as `MISSING_CREDENTIALS`; runtime-asset gates (Deno binary on `PATH`, CPython WASM binary file present) surface as `UNAVAILABLE` with a `statusDetail` string you can act on. Providers excluded by `PHOENIX_ALLOWED_SANDBOX_PROVIDERS` show as `DISABLED` and take precedence over the capability states above.
-</Info>
+## Provider status
+
+Under **Settings → Sandboxes**, each provider shows a status that tells you whether it's ready to run code:
+
+- **Available** — the provider is installed, configured, and ready to use.
+- **Not installed** — the provider's optional Python package isn't installed. Install the matching Phoenix extra to enable it.
+- **Missing credentials** — the provider is installed but its required credentials (API keys, service account, etc.) haven't been set.
+- **Unavailable** — a runtime prerequisite is missing on the host (for example, the Deno binary isn't on `PATH`, or the bundled CPython WebAssembly runtime can't be found). The status detail next to the provider tells you what's missing so you can fix it.
+- **Disabled** — the provider has been excluded by your allowlist (see [Restricting which providers are allowed](#restricting-which-providers-are-allowed)). This takes precedence: a fully installed and configured provider will still show as disabled if it's not on the list.
 
 ## Overview
 
 After deploying the official Phoenix container, the following sandbox providers are usable out of the box:
 
-- **Deno (local)** — TypeScript runtime, runs in-process. The `deno` binary is bundled in the container.
-- **WebAssembly (local)** — Python via CPython compiled to WASM, runs in-process. The CPython WASM binary is bundled in the container.
-- **External-API providers** (E2B, Modal, Daytona, Vercel) — the Python SDKs ship inside the container; they need only credentials to become `AVAILABLE`.
+- **Deno (local)** — TypeScript runtime, runs in-process. The Deno binary is bundled in the container.
+- **WebAssembly (local)** — Python via CPython compiled to WebAssembly, runs in-process. The CPython WASM binary is bundled in the container.
+- **External-API providers** (E2B, Modal, Daytona, Vercel) — the Python SDKs ship inside the container; they need only credentials to become available.
 
 Outside the official container — for example, when running `pip install arize-phoenix` directly on a host or a custom image — local providers require runtime binaries on the host and external providers require their optional pip extras to be installed alongside their credentials.
 
@@ -25,24 +31,22 @@ The official `arizephoenix/phoenix` image bundles both local sandbox backends so
 
 ### Deno
 
-The `deno` binary is copied into the final image at `/usr/local/bin/deno` from the pinned `denoland/deno:bin-2.1.4` base. `/usr/local/bin` is on the distroless image's default `PATH`, so `shutil.which("deno")` in `phoenix.server.sandbox.deno_backend` resolves to the bundled binary at runtime.
-
-No environment variables are required.
+The `deno` binary is installed into the container image at `/usr/local/bin/deno`, which is on the default `PATH`. Phoenix picks it up automatically — no environment variables or extra setup required.
 
 ### WebAssembly (CPython WASM)
 
-The CPython WASM binary (`python-3.12.0.wasm`) is pre-downloaded at image-build time and copied into the final image at `/opt/phoenix/wasm/python-3.12.0.wasm`. The container ships with:
+The CPython WebAssembly binary (`python-3.12.0.wasm`) is pre-downloaded at image-build time and copied into the container at `/opt/phoenix/wasm/python-3.12.0.wasm`. The container also presets the corresponding environment variable:
 
 ```
-ENV PHOENIX_WASM_BINARY_PATH=/opt/phoenix/wasm/python-3.12.0.wasm
+PHOENIX_WASM_BINARY_PATH=/opt/phoenix/wasm/python-3.12.0.wasm
 ```
 
-`PHOENIX_WASM_BINARY_PATH` is the authoritative resolver hook used by both the execution path (`ensure_wasm_binary()`) and the capability-probe path (`resolve_wasm_binary_if_present()` / `WASMAdapter.probe_binary()`):
+When `PHOENIX_WASM_BINARY_PATH` is set:
 
-- When the env var is set and the file exists, the binary is used as-is — no network egress, no cache write.
-- When the env var is set but the file is missing, the WASM provider reports `UNAVAILABLE` instead of silently falling back to a download.
+- If the file exists, Phoenix uses it directly — no network egress, no cache write.
+- If the file is missing, the WASM provider reports **Unavailable** rather than silently falling back to a download.
 
-This makes the WASM provider work immediately in the distroless container — which has a read-only rootfs and no shell — without any first-run penalty or operator-supplied cache volume.
+This makes the WASM provider work immediately in the distroless container — which has a read-only root filesystem and no shell — without any first-run penalty or operator-supplied cache volume.
 
 ## Non-container deployments
 
@@ -50,20 +54,17 @@ If you are running Phoenix outside the official container (e.g. `pip install ari
 
 ### Deno
 
-Install the Deno runtime so that the `deno` binary is on `PATH` for the Phoenix process:
-
-- See the [official Deno install guide](https://deno.land/install) for platform-specific instructions.
-- Phoenix locates Deno via `shutil.which("deno")`, so any directory on the process `PATH` works.
+Install the Deno runtime so that the `deno` binary is on `PATH` for the Phoenix process. See the [official Deno install guide](https://deno.land/install) for platform-specific instructions. Any directory on the process `PATH` works.
 
 ### WebAssembly (CPython WASM)
 
-Install Phoenix with the `wasm` extra so the `wasmtime` Python package is available:
+Install Phoenix with the `wasm` extra so the WebAssembly runtime is available:
 
 ```bash
 pip install 'arize-phoenix[wasm]'
 ```
 
-Without `wasmtime`, the WASM adapter is not registered and the provider shows as `NOT_INSTALLED`.
+Without this extra, the WASM provider shows as **Not installed**.
 
 By default Phoenix lazy-downloads the CPython WASM binary on first use into a local cache (sha256-verified). To opt out of the download — for example, in air-gapped or read-only environments — pre-provision the binary and point Phoenix at it:
 
@@ -99,7 +100,7 @@ export PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO   # local only
 export PHOENIX_ALLOWED_SANDBOX_PROVIDERS=NONE        # disable all
 ```
 
-Disallowed providers show as `DISABLED` under **Settings → Sandboxes** with the tooltip "Disabled on the server.", and the startup banner prints a per-provider summary:
+Disallowed providers show as **Disabled** under **Settings → Sandboxes** with the tooltip "Disabled on the server.", and the startup banner prints a per-provider summary:
 
 ```
 |  📦 Code Sandbox Providers 📦
@@ -108,11 +109,11 @@ Disallowed providers show as `DISABLED` under **Settings → Sandboxes** with th
 |  - WASM: ✅ Allowed
 ```
 
-The allowlist gates execution only; stored `SandboxConfig` rows for disallowed providers are preserved and reactivate when the provider is re-allowed.
+The allowlist gates execution only; existing sandbox configurations for disallowed providers are preserved and reactivate when the provider is re-allowed.
 
 ## Compatibility matrix
 
-The rows below correspond exactly to the entries in `SANDBOX_ADAPTER_METADATA`. The container-ready column reflects the post-install state of `arizephoenix/phoenix`.
+The container-ready column reflects the post-install state of the `arizephoenix/phoenix` image.
 
 | Provider (kind) | Languages | Container-ready | Extra setup outside container | Credentials | Runtime location |
 | :-- | :-- | :-- | :-- | :-- | :-- |
@@ -124,7 +125,7 @@ The rows below correspond exactly to the entries in `SANDBOX_ADAPTER_METADATA`. 
 | **Modal** (`MODAL`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[modal]'` | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` | External API |
 
 <Info>
-"Container-ready" means the SDK or binary is present in `arizephoenix/phoenix`. External providers still need their credentials configured before the GraphQL `status` flips from `MISSING_CREDENTIALS` to `AVAILABLE`. Local providers (Deno, WASM) become `AVAILABLE` immediately after the container starts.
+"Container-ready" means the SDK or binary is present in `arizephoenix/phoenix`. External providers still need their credentials configured before they move from **Missing credentials** to **Available**. Local providers (Deno, WASM) become **Available** immediately after the container starts.
 </Info>
 
 <Info>
@@ -133,7 +134,7 @@ The rows below correspond exactly to the entries in `SANDBOX_ADAPTER_METADATA`. 
 
 ## Troubleshooting
 
-The **Settings → Sandboxes** page surfaces a `status` and an optional `statusDetail` for each registered backend. Map the detail strings below to the recommended remediation.
+The **Settings → Sandboxes** page shows a status and an optional status detail for each provider. Map the detail strings below to the recommended remediation.
 
 ### `PHOENIX_WASM_BINARY_PATH=<path> is set but the file does not exist.`
 
@@ -151,12 +152,12 @@ The `PHOENIX_WASM_BINARY_PATH` environment variable is set, but no file lives at
 
 **Remediation:**
 
-- Expected on non-container installs that have not yet exercised the WASM provider. Confirm the host has network egress to `github.com` (the binary is fetched from `vmware-labs/webassembly-language-runtimes`).
+- Expected on non-container installs that have not yet exercised the WASM provider. Confirm the host has network egress to `github.com`.
 - For air-gapped or read-only-rootfs environments, pre-provision the binary and set `PHOENIX_WASM_BINARY_PATH` (see [Non-container deployments](#non-container-deployments) above).
 
 ### `Deno executable not found. Install Deno and ensure the `deno` binary is on PATH.`
 
-Phoenix called `deno` as a subprocess and the OS could not find it on `PATH`.
+Phoenix tried to run `deno` and the operating system could not find it on `PATH`.
 
 **Remediation:**
 
@@ -164,5 +165,5 @@ Phoenix called `deno` as a subprocess and the OS could not find it on `PATH`.
 - In the official `arizephoenix/phoenix` container the binary is pre-installed at `/usr/local/bin/deno`. If you see this error inside the official container, check that you have not overridden `PATH` to exclude `/usr/local/bin` or replaced the entrypoint in a way that strips it.
 
 <Info>
-The local Deno provider also surfaces a one-time trust warning in the UI when the deployment is self-hosted (no `managementUrl`) and the backend reports `AVAILABLE`. The warning is suppressed for managed deployments and for any non-`AVAILABLE` status because the provider cannot be selected from the UI in those cases.
+The local Deno provider also surfaces a one-time trust warning in the UI on self-hosted deployments when the provider is available. The warning does not appear on managed deployments or when the provider is in any non-available state, because it cannot be selected in those cases.
 </Info>

--- a/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
+++ b/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
@@ -91,7 +91,7 @@ pip install 'arize-phoenix[daytona]'  # Daytona
 pip install 'arize-phoenix[vercel]'   # Vercel Sandbox (Python and TypeScript)
 ```
 
-Provider credentials are configured under **Settings → Sandboxes** or via the Phoenix sandbox environment variables listed in the matrix below.
+Add the credentials each hosted provider needs — for example, `E2B_API_KEY`, `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`, or the Vercel token / project / team triple. You can either set them as environment variables on the Phoenix server or paste them directly into the provider's row in **Settings → Sandboxes**. The full list of credential variables for each provider is in the [compatibility matrix](#compatibility-matrix) below.
 
 ## Restricting which providers are allowed
 
@@ -99,7 +99,7 @@ To restrict which sandbox providers your deployment can use, set the `PHOENIX_AL
 
 - **Leave it unset** to allow every supported provider (the default).
 - **Set it to `NONE`** to disable every sandbox provider.
-- **Set it to one or more provider names** to allow only those. Valid names are `WASM`, `DENO`, `E2B`, `DAYTONA`, `VERCEL`, and `MODAL`. An unknown name will stop Phoenix from starting.
+- **Set it to one or more provider names** to allow only those. Valid names are `WASM`, `DENO`, `E2B`, `DAYTONA`, `VERCEL`, and `MODAL` (lowercase works too — the variable is case-insensitive). An unknown name will stop Phoenix from starting so a typo can't silently disable a provider.
 
 ```bash
 export PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO   # allow local sandboxes only
@@ -123,12 +123,12 @@ The container-ready column reflects the post-install state of the `arizephoenix/
 
 | Provider (kind) | Languages | Container-ready | Extra setup outside container | Credentials | Runtime location |
 | :-- | :-- | :-- | :-- | :-- | :-- |
-| **Deno (local)** (`DENO`) | TypeScript | Yes — `deno` bundled at `/usr/local/bin/deno` | Install Deno on `PATH` | None | In-process (subprocess) |
-| **WebAssembly (local)** (`WASM`) | Python | Yes — CPython WASM bundled at `$PHOENIX_WASM_BINARY_PATH` | `pip install 'arize-phoenix[wasm]'`; optionally set `PHOENIX_WASM_BINARY_PATH` | None | In-process (`wasmtime`) |
-| **E2B** (`E2B`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[e2b]'` | `E2B_API_KEY` | External API |
-| **Daytona** (`DAYTONA`) | Python, TypeScript | Ready with credentials — SDK in container | `pip install 'arize-phoenix[daytona]'` | `DAYTONA_API_KEY` | External API |
-| **Vercel Sandbox** (`VERCEL`) | Python, TypeScript | Ready with credentials — SDK in container | `pip install 'arize-phoenix[vercel]'` | `VERCEL_TOKEN` + `VERCEL_PROJECT_ID` + `VERCEL_TEAM_ID` ([auth docs](https://vercel.com/docs/vercel-sandbox/concepts/authentication)) | External API |
-| **Modal** (`MODAL`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[modal]'` | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` | External API |
+| **Deno (local)** (`DENO`) | TypeScript | Yes — `deno` bundled at `/usr/local/bin/deno` | Install Deno on `PATH` | None | On the Phoenix server |
+| **WebAssembly (local)** (`WASM`) | Python | Yes — Python WebAssembly runtime bundled at `$PHOENIX_WASM_BINARY_PATH` | `pip install 'arize-phoenix[wasm]'`; optionally set `PHOENIX_WASM_BINARY_PATH` | None | On the Phoenix server |
+| **E2B** (`E2B`) | Python | Ready with credentials — already in container | `pip install 'arize-phoenix[e2b]'` | `E2B_API_KEY` | E2B cloud |
+| **Daytona** (`DAYTONA`) | Python, TypeScript | Ready with credentials — already in container | `pip install 'arize-phoenix[daytona]'` | `DAYTONA_API_KEY` | Daytona cloud |
+| **Vercel Sandbox** (`VERCEL`) | Python, TypeScript | Ready with credentials — already in container | `pip install 'arize-phoenix[vercel]'` | `VERCEL_TOKEN` + `VERCEL_PROJECT_ID` + `VERCEL_TEAM_ID` ([auth docs](https://vercel.com/docs/vercel-sandbox/concepts/authentication)) | Vercel cloud |
+| **Modal** (`MODAL`) | Python | Ready with credentials — already in container | `pip install 'arize-phoenix[modal]'` | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` | Modal cloud |
 
 <Info>
 "Container-ready" means the necessary code or binary is already inside the official `arizephoenix/phoenix` image. For hosted providers you still need to enter credentials before the status changes from **Missing credentials** to **Available**. The two local providers (Deno and WebAssembly) become **Available** the moment the container starts.
@@ -168,7 +168,3 @@ How to fix it:
 
 - **Non-container hosts:** install Deno (see the [Deno install guide](https://deno.land/install)) and make sure the user running Phoenix can find it on their `PATH`.
 - **Official `arizephoenix/phoenix` container:** Deno is pre-installed at `/usr/local/bin/deno`. If you're still seeing this error inside the container, your deployment is overriding `PATH` or replacing the entrypoint in a way that hides the bundled binary — restore the defaults or add `/usr/local/bin` back to `PATH`.
-
-<Info>
-The first time you select the local Deno sandbox on a self-hosted deployment, Phoenix shows a one-time warning about the trust model for running code locally. This warning only appears when Deno is ready to use — if Deno is unavailable or disabled, you can't pick it anyway, so the warning is suppressed.
-</Info>

--- a/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
+++ b/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
@@ -6,7 +6,7 @@ description: How Phoenix's code-execution sandbox backends are wired in self-hos
 Phoenix supports multiple code-execution sandbox providers for evaluators and other LLM-driven workflows. This page describes which providers are ready to use in the official `arizephoenix/phoenix` container and what extra setup the others need.
 
 <Info>
-The provider list, their advertised capabilities, and the status reported under **Settings → Sandboxes** are all driven by the static registry in `src/phoenix/server/sandbox/__init__.py` (`SANDBOX_ADAPTER_METADATA`). When a provider's optional Python extra is missing the adapter is dropped from the runtime registry and shows as `NOT_INSTALLED`; when its credentials are missing it shows as `MISSING_CREDENTIALS`; runtime-asset gates (Deno binary on `PATH`, CPython WASM binary file present) surface as `UNAVAILABLE` with a `statusDetail` string you can act on.
+The provider list, their advertised capabilities, and the status reported under **Settings → Sandboxes** are all driven by the static registry in `src/phoenix/server/sandbox/__init__.py` (`SANDBOX_ADAPTER_METADATA`). When a provider's optional Python extra is missing the adapter is dropped from the runtime registry and shows as `NOT_INSTALLED`; when its credentials are missing it shows as `MISSING_CREDENTIALS`; runtime-asset gates (Deno binary on `PATH`, CPython WASM binary file present) surface as `UNAVAILABLE` with a `statusDetail` string you can act on. Providers excluded by `PHOENIX_ALLOWED_SANDBOX_PROVIDERS` show as `DISABLED` and take precedence over the capability states above.
 </Info>
 
 ## Overview
@@ -89,6 +89,26 @@ pip install 'arize-phoenix[vercel]'   # Vercel Sandbox (Python and TypeScript)
 ```
 
 Provider credentials are configured under **Settings → Sandboxes** or via the Phoenix sandbox environment variables listed in the matrix below.
+
+## Restricting which providers are allowed
+
+Set `PHOENIX_ALLOWED_SANDBOX_PROVIDERS` to a comma-separated allowlist (case-insensitive). Unset means all providers are allowed; `NONE` disables every provider. Unknown names fail at startup.
+
+```bash
+export PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO   # local only
+export PHOENIX_ALLOWED_SANDBOX_PROVIDERS=NONE        # disable all
+```
+
+Disallowed providers show as `DISABLED` under **Settings → Sandboxes** with the tooltip "Disabled on the server.", and the startup banner prints a per-provider summary:
+
+```
+|  📦 Code Sandbox Providers 📦
+|  - DAYTONA: ❌ Disabled
+|  - DENO: ✅ Allowed
+|  - WASM: ✅ Allowed
+```
+
+The allowlist gates execution only; stored `SandboxConfig` rows for disallowed providers are preserved and reactivate when the provider is re-allowed.
 
 ## Compatibility matrix
 

--- a/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
+++ b/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
@@ -1,29 +1,29 @@
 ---
 title: "Sandbox Backends"
-description: How Phoenix's code-execution sandbox backends are wired in self-hosted deployments
+description: Set up the sandbox providers that run code evaluators on your self-hosted Phoenix.
 ---
 
-Phoenix supports multiple code-execution sandbox providers for evaluators and other LLM-driven workflows. This page describes which providers are ready to use in the official `arizephoenix/phoenix` container and what extra setup the others need.
+Phoenix runs code evaluators (and other LLM-driven workloads that need to execute code) inside sandboxes. This page tells you which sandbox providers are ready to use in the official `arizephoenix/phoenix` container, what extra setup the others need, and how to read the status badges shown on **Settings → Sandboxes**.
 
-## Provider status
+## Reading the status on Settings → Sandboxes
 
-Under **Settings → Sandboxes**, each provider shows a status that tells you whether it's ready to run code:
+Each provider on the **Settings → Sandboxes** page shows a status that tells you whether it's ready to run code:
 
 - **Available** — the provider is installed, configured, and ready to use.
-- **Not installed** — the provider's optional Python package isn't installed. Install the matching Phoenix extra to enable it.
-- **Missing credentials** — the provider is installed but its required credentials (API keys, service account, etc.) haven't been set.
-- **Unavailable** — a runtime prerequisite is missing on the host (for example, the Deno binary isn't on `PATH`, or the bundled CPython WebAssembly runtime can't be found). The status detail next to the provider tells you what's missing so you can fix it.
-- **Disabled** — the provider has been excluded by your allowlist (see [Restricting which providers are allowed](#restricting-which-providers-are-allowed)). This takes precedence: a fully installed and configured provider will still show as disabled if it's not on the list.
+- **Not installed** — the provider's optional Python package isn't installed. Install the matching Phoenix extra (e.g. `pip install 'arize-phoenix[e2b]'`) to enable it.
+- **Missing credentials** — the provider is installed but you still need to enter its credentials (API key, token, etc.) before it can be used.
+- **Unavailable** — something on the host is missing — for example, the Deno binary isn't installed, or the Python WebAssembly runtime can't be found. The text next to the status tells you exactly what's missing.
+- **Disabled** — an administrator has excluded this provider via the [allowlist](#restricting-which-providers-are-allowed). This overrides everything else: a fully working provider will still show as disabled if it isn't on the allowlist.
 
-## Overview
+## What works out of the box
 
-After deploying the official Phoenix container, the following sandbox providers are usable out of the box:
+If you deploy the official `arizephoenix/phoenix` container, these providers are usable immediately:
 
-- **Deno (local)** — TypeScript runtime, runs in-process. The Deno binary is bundled in the container.
-- **WebAssembly (local)** — Python via CPython compiled to WebAssembly, runs in-process. The CPython WASM binary is bundled in the container.
-- **External-API providers** (E2B, Modal, Daytona, Vercel) — the Python SDKs ship inside the container; they need only credentials to become available.
+- **Deno (local)** — runs TypeScript inside Phoenix. The Deno binary is bundled in the container.
+- **WebAssembly (local)** — runs Python inside Phoenix using a WebAssembly Python interpreter. The interpreter is bundled in the container.
+- **Hosted providers (E2B, Modal, Daytona, Vercel)** — the integration code ships inside the container, so you only need to add your credentials before each becomes **Available**.
 
-Outside the official container — for example, when running `pip install arize-phoenix` directly on a host or a custom image — local providers require runtime binaries on the host and external providers require their optional pip extras to be installed alongside their credentials.
+If you're not using the official container — for example, you installed Phoenix with `pip install arize-phoenix` on your own host, or you're building a custom image — you'll need to install the runtime tooling for local sandboxes and the relevant Phoenix extras for hosted ones. See [Non-container deployments](#non-container-deployments) below.
 
 ## Container-bundled backends
 
@@ -35,18 +35,18 @@ The `deno` binary is installed into the container image at `/usr/local/bin/deno`
 
 ### WebAssembly (CPython WASM)
 
-The CPython WebAssembly binary (`python-3.12.0.wasm`) is pre-downloaded at image-build time and copied into the container at `/opt/phoenix/wasm/python-3.12.0.wasm`. The container also presets the corresponding environment variable:
+The Python WebAssembly binary (`python-3.12.0.wasm`) is downloaded when the image is built and shipped inside the container at `/opt/phoenix/wasm/python-3.12.0.wasm`. The container also sets:
 
 ```
 PHOENIX_WASM_BINARY_PATH=/opt/phoenix/wasm/python-3.12.0.wasm
 ```
 
-When `PHOENIX_WASM_BINARY_PATH` is set:
+When `PHOENIX_WASM_BINARY_PATH` is set, Phoenix uses only the file at that path:
 
-- If the file exists, Phoenix uses it directly — no network egress, no cache write.
-- If the file is missing, the WASM provider reports **Unavailable** rather than silently falling back to a download.
+- If the file is present, the WebAssembly sandbox is ready to run immediately — no download, no first-run delay.
+- If the file is missing, the WebAssembly sandbox shows as **Unavailable** in **Settings → Sandboxes** rather than silently downloading a replacement.
 
-This makes the WASM provider work immediately in the distroless container — which has a read-only root filesystem and no shell — without any first-run penalty or operator-supplied cache volume.
+This means the WebAssembly sandbox works out of the box in the container — even in air-gapped environments — without needing a writable cache directory or network access.
 
 ## Non-container deployments
 
@@ -66,13 +66,15 @@ pip install 'arize-phoenix[wasm]'
 
 Without this extra, the WASM provider shows as **Not installed**.
 
-By default Phoenix lazy-downloads the CPython WASM binary on first use into a local cache (sha256-verified). To opt out of the download — for example, in air-gapped or read-only environments — pre-provision the binary and point Phoenix at it:
+By default, the first time you run a Python evaluator, Phoenix downloads the Python WebAssembly binary into a local cache and verifies its checksum. After that it's reused for every subsequent run.
+
+If you can't allow that download — for example, on an air-gapped server or a read-only filesystem — provide the binary yourself and tell Phoenix where to find it:
 
 ```bash
 export PHOENIX_WASM_BINARY_PATH=/path/to/python-3.12.0.wasm
 ```
 
-When `PHOENIX_WASM_BINARY_PATH` is set, Phoenix treats it as authoritative: the file at that path is used, and if it does not exist Phoenix surfaces an error rather than falling back to a network download.
+Once `PHOENIX_WASM_BINARY_PATH` is set, Phoenix will only use that file. If the file is missing, the sandbox reports an error instead of falling back to the download.
 
 <Tip>
 You can copy `python-3.12.0.wasm` out of an `arizephoenix/phoenix` container (`/opt/phoenix/wasm/python-3.12.0.wasm`) to seed an air-gapped host without re-fetching from upstream.
@@ -93,14 +95,18 @@ Provider credentials are configured under **Settings → Sandboxes** or via the 
 
 ## Restricting which providers are allowed
 
-Set `PHOENIX_ALLOWED_SANDBOX_PROVIDERS` to a comma-separated allowlist (case-insensitive). Unset means all providers are allowed; `NONE` disables every provider. Unknown names fail at startup.
+To restrict which sandbox providers your deployment can use, set the `PHOENIX_ALLOWED_SANDBOX_PROVIDERS` environment variable to a comma-separated list of the providers you want to allow. The variable is case-insensitive.
+
+- **Leave it unset** to allow every supported provider (the default).
+- **Set it to `NONE`** to disable every sandbox provider.
+- **Set it to one or more provider names** to allow only those. Valid names are `WASM`, `DENO`, `E2B`, `DAYTONA`, `VERCEL`, and `MODAL`. An unknown name will stop Phoenix from starting.
 
 ```bash
-export PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO   # local only
-export PHOENIX_ALLOWED_SANDBOX_PROVIDERS=NONE        # disable all
+export PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO   # allow local sandboxes only
+export PHOENIX_ALLOWED_SANDBOX_PROVIDERS=NONE        # disable every sandbox
 ```
 
-Disallowed providers show as **Disabled** under **Settings → Sandboxes** with the tooltip "Disabled on the server.", and the startup banner prints a per-provider summary:
+Providers that aren't on the allowlist appear under **Settings → Sandboxes** with the status **Disabled** and the tooltip "Disabled on the server." When Phoenix starts, you'll also see a per-provider summary in the startup logs:
 
 ```
 |  📦 Code Sandbox Providers 📦
@@ -109,7 +115,7 @@ Disallowed providers show as **Disabled** under **Settings → Sandboxes** with 
 |  - WASM: ✅ Allowed
 ```
 
-The allowlist gates execution only; existing sandbox configurations for disallowed providers are preserved and reactivate when the provider is re-allowed.
+The allowlist controls only whether sandboxes can run code — it doesn't delete anything. Any sandbox configurations you've already saved for a disallowed provider are kept and become usable again the moment you allow that provider.
 
 ## Compatibility matrix
 
@@ -125,7 +131,7 @@ The container-ready column reflects the post-install state of the `arizephoenix/
 | **Modal** (`MODAL`) | Python | Ready with credentials — SDK in container | `pip install 'arize-phoenix[modal]'` | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` | External API |
 
 <Info>
-"Container-ready" means the SDK or binary is present in `arizephoenix/phoenix`. External providers still need their credentials configured before they move from **Missing credentials** to **Available**. Local providers (Deno, WASM) become **Available** immediately after the container starts.
+"Container-ready" means the necessary code or binary is already inside the official `arizephoenix/phoenix` image. For hosted providers you still need to enter credentials before the status changes from **Missing credentials** to **Available**. The two local providers (Deno and WebAssembly) become **Available** the moment the container starts.
 </Info>
 
 <Info>
@@ -134,36 +140,35 @@ The container-ready column reflects the post-install state of the `arizephoenix/
 
 ## Troubleshooting
 
-The **Settings → Sandboxes** page shows a status and an optional status detail for each provider. Map the detail strings below to the recommended remediation.
+Each provider on **Settings → Sandboxes** shows a status and, when something's wrong, a short message explaining what's missing. The three most common messages are below.
 
-### `PHOENIX_WASM_BINARY_PATH=<path> is set but the file does not exist.`
+### "WebAssembly binary not found at the configured path"
 
-The `PHOENIX_WASM_BINARY_PATH` environment variable is set, but no file lives at the path it points to. Phoenix treats the env var as authoritative, so it does not fall back to a download.
+You'll see this when `PHOENIX_WASM_BINARY_PATH` is set but the file at that path doesn't exist. Phoenix uses the configured path exclusively — it won't fall back to a download.
 
-**Remediation:**
+How to fix it:
 
-- Verify the path: `ls "$PHOENIX_WASM_BINARY_PATH"`. If you mounted the binary into the container, confirm the volume mount is correct.
-- If you intend to use the bundled binary in `arizephoenix/phoenix`, leave `PHOENIX_WASM_BINARY_PATH` unchanged — it is preset to `/opt/phoenix/wasm/python-3.12.0.wasm`.
-- If you want lazy download instead, unset `PHOENIX_WASM_BINARY_PATH` so Phoenix falls back to its sha256-verified cache + download path.
+- Check the file is where you expect it. If you're mounting it into a container, confirm the volume mount is correct.
+- If you're using the official `arizephoenix/phoenix` image, leave `PHOENIX_WASM_BINARY_PATH` unset (or at its default value of `/opt/phoenix/wasm/python-3.12.0.wasm`) — the binary is already in the right place.
+- If you'd rather let Phoenix download the binary, unset `PHOENIX_WASM_BINARY_PATH` and Phoenix will fetch and cache it on first use.
 
-### `WASM binary not present locally; will download on first use.`
+### "WebAssembly binary will be downloaded on first use"
 
-`PHOENIX_WASM_BINARY_PATH` is unset and the local cache directory has no resolved binary. The provider will function on first request, but the first execution will block on a download (and requires network egress to GitHub).
+You'll see this on a non-container install before the WebAssembly sandbox has been used. The first Python evaluation will pause briefly to download the binary, after which it's cached locally. The download requires outbound network access to GitHub.
 
-**Remediation:**
+How to fix it (if you can't allow the download):
 
-- Expected on non-container installs that have not yet exercised the WASM provider. Confirm the host has network egress to `github.com`.
-- For air-gapped or read-only-rootfs environments, pre-provision the binary and set `PHOENIX_WASM_BINARY_PATH` (see [Non-container deployments](#non-container-deployments) above).
+- Pre-provision the binary and set `PHOENIX_WASM_BINARY_PATH` to point at it. See [Non-container deployments](#non-container-deployments) above for the full steps.
 
-### `Deno executable not found. Install Deno and ensure the `deno` binary is on PATH.`
+### "Deno not found"
 
-Phoenix tried to run `deno` and the operating system could not find it on `PATH`.
+You'll see this when Phoenix tries to run the Deno binary but can't find it on your system's `PATH`.
 
-**Remediation:**
+How to fix it:
 
-- On non-container hosts: install Deno (see [`https://deno.land/install`](https://deno.land/install)) and confirm `which deno` resolves under the same user/PATH that runs the Phoenix process.
-- In the official `arizephoenix/phoenix` container the binary is pre-installed at `/usr/local/bin/deno`. If you see this error inside the official container, check that you have not overridden `PATH` to exclude `/usr/local/bin` or replaced the entrypoint in a way that strips it.
+- **Non-container hosts:** install Deno (see the [Deno install guide](https://deno.land/install)) and make sure the user running Phoenix can find it on their `PATH`.
+- **Official `arizephoenix/phoenix` container:** Deno is pre-installed at `/usr/local/bin/deno`. If you're still seeing this error inside the container, your deployment is overriding `PATH` or replacing the entrypoint in a way that hides the bundled binary — restore the defaults or add `/usr/local/bin` back to `PATH`.
 
 <Info>
-The local Deno provider also surfaces a one-time trust warning in the UI on self-hosted deployments when the provider is available. The warning does not appear on managed deployments or when the provider is in any non-available state, because it cannot be selected in those cases.
+The first time you select the local Deno sandbox on a self-hosted deployment, Phoenix shows a one-time warning about the trust model for running code locally. This warning only appears when Deno is ready to use — if Deno is unavailable or disabled, you can't pick it anyway, so the warning is suppressed.
 </Info>

--- a/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
+++ b/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
@@ -31,22 +31,13 @@ The official `arizephoenix/phoenix` image bundles both local sandbox backends so
 
 ### Deno
 
-The `deno` binary is installed into the container image at `/usr/local/bin/deno`, which is on the default `PATH`. Phoenix picks it up automatically — no environment variables or extra setup required.
+The `deno` binary is bundled in the container image and on the default `PATH`. Phoenix picks it up automatically — no environment variables or extra setup required.
 
 ### WebAssembly (CPython WASM)
 
-The Python WebAssembly binary (`python-3.12.0.wasm`) is fetched during the Docker image build and baked into the container at `/opt/phoenix/wasm/python-3.12.0.wasm`, so running the container needs no extra download. The container also sets:
+The container ships with the Python WebAssembly runtime already in place and the `PHOENIX_WASM_BINARY_PATH` environment variable pre-set to point at it. The WebAssembly sandbox works out of the box — no download on first use, no writable cache directory, and no network access required (it runs even in air-gapped deployments).
 
-```
-PHOENIX_WASM_BINARY_PATH=/opt/phoenix/wasm/python-3.12.0.wasm
-```
-
-When `PHOENIX_WASM_BINARY_PATH` is set, Phoenix uses only the file at that path:
-
-- If the file is present, the WebAssembly sandbox is ready to run immediately — no download, no first-run delay.
-- If the file is missing, the WebAssembly sandbox shows as **Unavailable** in **Settings → Sandboxes** rather than silently downloading a replacement.
-
-This means the WebAssembly sandbox works out of the box in the container — even in air-gapped environments — without needing a writable cache directory or network access.
+If you ever override `PHOENIX_WASM_BINARY_PATH` yourself, Phoenix will use only the file at that path. If the file isn't there, the WebAssembly sandbox shows as **Unavailable** in **Settings → Sandboxes** rather than silently falling back to a download.
 
 ## Non-container deployments
 
@@ -76,9 +67,6 @@ export PHOENIX_WASM_BINARY_PATH=/path/to/python-3.12.0.wasm
 
 Once `PHOENIX_WASM_BINARY_PATH` is set, Phoenix will only use that file. If the file is missing, the sandbox reports an error instead of falling back to the download.
 
-<Tip>
-You can copy `python-3.12.0.wasm` out of an `arizephoenix/phoenix` container (`/opt/phoenix/wasm/python-3.12.0.wasm`) to seed an air-gapped host without re-fetching from upstream.
-</Tip>
 
 ### Hosted providers
 
@@ -123,8 +111,8 @@ The container-ready column reflects the post-install state of the `arizephoenix/
 
 | Provider (kind) | Languages | Container-ready | Extra setup outside container | Credentials | Runtime location |
 | :-- | :-- | :-- | :-- | :-- | :-- |
-| **Deno (local)** (`DENO`) | TypeScript | Yes — `deno` bundled at `/usr/local/bin/deno` | Install Deno on `PATH` | None | On the Phoenix server |
-| **WebAssembly (local)** (`WASM`) | Python | Yes — Python WebAssembly runtime bundled at `$PHOENIX_WASM_BINARY_PATH` | `pip install 'arize-phoenix[wasm]'`; optionally set `PHOENIX_WASM_BINARY_PATH` | None | On the Phoenix server |
+| **Deno (local)** (`DENO`) | TypeScript | Yes — `deno` bundled in the image | Install Deno on `PATH` | None | On the Phoenix server |
+| **WebAssembly (local)** (`WASM`) | Python | Yes — Python WebAssembly runtime bundled in the image | `pip install 'arize-phoenix[wasm]'`; optionally set `PHOENIX_WASM_BINARY_PATH` | None | On the Phoenix server |
 | **E2B** (`E2B`) | Python | Ready with credentials — already in container | `pip install 'arize-phoenix[e2b]'` | `E2B_API_KEY` | E2B cloud |
 | **Daytona** (`DAYTONA`) | Python, TypeScript | Ready with credentials — already in container | `pip install 'arize-phoenix[daytona]'` | `DAYTONA_API_KEY` | Daytona cloud |
 | **Vercel Sandbox** (`VERCEL`) | Python, TypeScript | Ready with credentials — already in container | `pip install 'arize-phoenix[vercel]'` | `VERCEL_TOKEN` + `VERCEL_PROJECT_ID` + `VERCEL_TEAM_ID` ([auth docs](https://vercel.com/docs/vercel-sandbox/concepts/authentication)) | Vercel cloud |
@@ -149,7 +137,7 @@ You'll see this when `PHOENIX_WASM_BINARY_PATH` is set but the file at that path
 How to fix it:
 
 - Check the file is where you expect it. If you're mounting it into a container, confirm the volume mount is correct.
-- If you're using the official `arizephoenix/phoenix` image, leave `PHOENIX_WASM_BINARY_PATH` unset (or at its default value of `/opt/phoenix/wasm/python-3.12.0.wasm`) — the binary is already in the right place.
+- If you're using the official `arizephoenix/phoenix` image, leave `PHOENIX_WASM_BINARY_PATH` at its default — the binary is already in the right place.
 - If you'd rather let Phoenix download the binary, unset `PHOENIX_WASM_BINARY_PATH` and Phoenix will fetch and cache it on first use.
 
 ### "WebAssembly binary will be downloaded on first use"
@@ -167,4 +155,4 @@ You'll see this when Phoenix tries to run the Deno binary but can't find it on y
 How to fix it:
 
 - **Non-container hosts:** install Deno (see the [Deno install guide](https://deno.land/install)) and make sure the user running Phoenix can find it on their `PATH`.
-- **Official `arizephoenix/phoenix` container:** Deno is pre-installed at `/usr/local/bin/deno`. If you're still seeing this error inside the container, your deployment is overriding `PATH` or replacing the entrypoint in a way that hides the bundled binary — restore the defaults or add `/usr/local/bin` back to `PATH`.
+- **Official `arizephoenix/phoenix` container:** Deno is pre-installed and on the default `PATH`. If you're still seeing this error inside the container, your deployment is overriding `PATH` or replacing the entrypoint in a way that hides the bundled binary — restore the defaults.

--- a/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
+++ b/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
@@ -35,7 +35,7 @@ The `deno` binary is installed into the container image at `/usr/local/bin/deno`
 
 ### WebAssembly (CPython WASM)
 
-The Python WebAssembly binary (`python-3.12.0.wasm`) is downloaded when the image is built and shipped inside the container at `/opt/phoenix/wasm/python-3.12.0.wasm`. The container also sets:
+The Python WebAssembly binary (`python-3.12.0.wasm`) is fetched during the Docker image build and baked into the container at `/opt/phoenix/wasm/python-3.12.0.wasm`, so running the container needs no extra download. The container also sets:
 
 ```
 PHOENIX_WASM_BINARY_PATH=/opt/phoenix/wasm/python-3.12.0.wasm
@@ -80,9 +80,9 @@ Once `PHOENIX_WASM_BINARY_PATH` is set, Phoenix will only use that file. If the 
 You can copy `python-3.12.0.wasm` out of an `arizephoenix/phoenix` container (`/opt/phoenix/wasm/python-3.12.0.wasm`) to seed an air-gapped host without re-fetching from upstream.
 </Tip>
 
-### External-API providers
+### Hosted providers
 
-Each external provider has its own optional pip extra and credential requirements:
+Each hosted provider ships as a separate Phoenix extra and has its own credentials. The official `arizephoenix/phoenix` container already includes all four extras — you only need to install one of these when you're running on a custom image or a plain `pip install arize-phoenix`:
 
 ```bash
 pip install 'arize-phoenix[e2b]'      # E2B

--- a/docs/phoenix/settings/sandboxes.mdx
+++ b/docs/phoenix/settings/sandboxes.mdx
@@ -79,7 +79,7 @@ flowchart LR
   </Accordion>
 </AccordionGroup>
 
-A common pattern is to enable a local sandbox for the everyday case (pure-logic checks, regex, JSON diffs) and one hosted sandbox for the cases that need extra horsepower (dependencies, network calls, longer runtimes). See [Sandbox Backends](/docs/phoenix/self-hosting/features/sandbox-runtimes) for the full capability matrix and self-hosting setup.
+A common pattern is to enable a local sandbox for the everyday case (pure-logic checks, regex, JSON diffs) and one hosted sandbox for the cases that need extra horsepower (dependencies, network calls, longer runtimes). Each provider page above has the setup steps for that provider; if you're self-hosting and need the platform-level details (which providers are bundled in the container, how to install extras, how the allowlist works), see [Sandbox Backends](/docs/phoenix/self-hosting/features/sandbox-runtimes).
 
 ## Sandbox Providers
 

--- a/docs/phoenix/settings/sandboxes.mdx
+++ b/docs/phoenix/settings/sandboxes.mdx
@@ -5,12 +5,12 @@ description: "Configure the sandbox backends that execute code evaluators and ot
 
 ![Sandboxes](https://storage.googleapis.com/arize-phoenix-assets/assets/images/sandboxes_banner.png)
 
-A **sandbox** is an isolated runtime that executes a snippet of code on demand. It's fast enough to run on every evaluation, but locked down enough that the code can't read the host filesystem, exfiltrate secrets, or make arbitrary network calls. Phoenix uses sandboxes to run [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators) — an author writes a Python or TypeScript function and Phoenix runs it server-side without exposing the rest of your deployment.
+A **sandbox** is an isolated runtime that executes a snippet of code on demand. It's fast enough to run on every evaluation, but locked down enough that the code can't read the host filesystem, exfiltrate secrets, or make arbitrary network calls. Phoenix uses sandboxes to run [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluators) — short Python or TypeScript functions that you write to score or judge your LLM outputs server-side, without exposing the rest of your deployment.
 
-The **Settings → Sandboxes** page is where an administrator picks which sandbox backends are available and bundles them into reusable configurations that evaluator authors choose from. It has two cards:
+The **Settings → Sandboxes** page is where administrators pick which sandbox providers are available and bundle them into named, reusable configurations that anyone writing a code evaluator can pick from. The page has two cards:
 
-- **Sandbox Providers** — One row per backend. Set credentials, enable a provider, see runtime status.
-- **Sandbox Configurations** — Reusable named configs (timeout, environment variables, internet access, dependencies) that evaluators select from.
+- **Sandbox Providers** — one row per provider. Each row lets you set the provider's credentials, enable or disable it for your deployment, and see whether it's currently ready to run code.
+- **Sandbox Configurations** — named runtime profiles you create once and re-use. Each one bundles a provider with a timeout, environment variables, optional internet access, and any dependencies that should be pre-installed.
 
 <Note>
 Only users with the **Admin** role can view or edit this page. Non-admin users are routed away from the tab.
@@ -18,7 +18,7 @@ Only users with the **Admin** role can view or edit this page. Non-admin users a
 
 ## Local vs. hosted sandboxes
 
-Phoenix supports two flavors of sandbox, distinguished by where the code actually runs. The **hosting type** badge on each provider row tells you which kind you're looking at.
+Phoenix supports two kinds of sandbox, distinguished by where the code actually runs. The badge on each row in **Sandbox Providers** (labeled either **Local** or **Hosted**) tells you which kind it is.
 
 ```mermaid
 flowchart LR
@@ -83,7 +83,7 @@ A common pattern is to enable a local sandbox for the everyday case (pure-logic 
 
 ## Sandbox Providers
 
-A **provider** is a sandbox backend account/runtime — for example, *Vercel Sandbox* or *Daytona*. Each row shows the backend's display name, supported languages, current runtime status, and a gear icon to configure credentials. The **Enabled** switch appears once the runtime is reachable; flipping it off hides the provider's configurations from evaluator authors without deleting them.
+A **provider** is a sandbox runtime that Phoenix can run code on — for example, *Vercel Sandbox* or *Daytona*. Each row in this card shows the provider's name, the languages it supports, its current status, and a gear icon for entering credentials. Once the provider is ready to run code, an **Enabled** switch appears. Turning it off hides every configuration tied to that provider from the people writing evaluators, but doesn't delete anything — flip it back on and the configurations reappear.
 
 ### Configuring credentials
 
@@ -98,7 +98,7 @@ Values are stored encrypted at rest using the server's `PHOENIX_SECRET`. The dia
 
 ## Sandbox Configurations
 
-A **sandbox configuration** is a named, reusable bundle of runtime settings — timeout, environment variables, internet access, and any pre-installed dependencies — bound to a specific provider. Code evaluators don't pick a provider directly; they pick a configuration. This lets you maintain a small set of curated runtimes (for example, a "default Python with `requests` and `numpy`" config and an "internet-enabled Node.js" config) that evaluator authors choose from.
+A **sandbox configuration** is a named, reusable runtime profile — a provider plus its timeout, environment variables, internet-access setting, and any pre-installed dependencies. Code evaluators don't pick a provider directly; they pick a configuration. This means administrators can set up a small set of vetted profiles — for example, "Python with `requests` and `numpy`" or "Node.js with internet access" — and the people writing evaluators just pick the profile that fits their script.
 
 <Warning>
 Environment-variable values — including the values resolved from secret references — are visible to any code that runs in the sandbox (for example, `os.environ` in Python). Treat them as readable by anyone authorized to author or run an evaluator against the config.

--- a/docs/phoenix/settings/sandboxes.mdx
+++ b/docs/phoenix/settings/sandboxes.mdx
@@ -51,10 +51,10 @@ flowchart LR
 
     <CardGroup cols={2}>
       <Card title="WebAssembly" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/wasm.svg" href="/docs/phoenix/settings/sandboxes/wasm">
-        Python in CPython-on-Wasm via `wasmtime`. Isolation at the Wasm boundary.
+        Runs Python in an isolated WebAssembly runtime with no access to your filesystem or network.
       </Card>
       <Card title="Deno" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/deno.svg" href="/docs/phoenix/settings/sandboxes/deno">
-        TypeScript in a `deno run` subprocess with no `--allow-*` permissions.
+        Runs TypeScript in a locked-down Deno process — no filesystem, network, or third-party package access.
       </Card>
     </CardGroup>
   </Accordion>
@@ -106,7 +106,7 @@ Environment-variable values — including the values resolved from secret refere
 
 ### Creating a configuration
 
-Click **New Sandbox** in the Sandbox Configurations card. Only providers whose backend is `AVAILABLE` *and* whose admin toggle is enabled appear in the picker.
+Click **New Sandbox** in the Sandbox Configurations card. Only providers that are currently available *and* enabled by an administrator appear in the picker.
 
 The dialog exposes the following fields. Fields that aren't supported by the selected backend are shown as **Not supported by the selected backend**.
 

--- a/docs/phoenix/settings/sandboxes/daytona.mdx
+++ b/docs/phoenix/settings/sandboxes/daytona.mdx
@@ -7,9 +7,36 @@ description: "Run code evaluators in Daytona's managed development sandboxes."
 <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/daytona.svg" alt="Daytona" className="invert-on-dark" style={{ height: '112px', flexShrink: 0 }} />
 <div>
 
-[**Daytona**](https://www.daytona.io/) provides managed development sandboxes with fast, snapshot-based startup. Phoenix uses it as a hosted backend for both Python and TypeScript code evaluators that need stronger isolation than the local sandboxes, longer maximum timeouts, or runtime dependency installation.
+[**Daytona**](https://www.daytona.io/) runs each evaluation in a managed development sandbox on its own cloud. Sandboxes start from snapshots, which keeps startup fast, and Daytona supports both Python and TypeScript evaluators.
 
 </div>
 </div>
 
-To use Daytona, sign up at [daytona.io](https://www.daytona.io/) and generate an API key, then add it as `DAYTONA_API_KEY` from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).
+## When to choose Daytona
+
+Pick Daytona when you want a single hosted provider that handles both **Python and TypeScript** evaluators, or when you need any of the following:
+
+- **Stronger isolation than the local sandboxes.** Every run gets its own sandbox with no access to your Phoenix server.
+- **Third-party packages at runtime.** Install Python or npm packages on the configuration and Daytona has them ready before each run.
+- **Outbound network access** for evaluators that call out to APIs.
+- **Longer timeouts** for slower evaluators.
+
+If your team writes only one language, a single-language hosted provider (E2B for Python, Vercel for TypeScript) may be a closer fit. If you don't need packages or network access, the local [WebAssembly](/docs/phoenix/settings/sandboxes/wasm) or [Deno](/docs/phoenix/settings/sandboxes/deno) sandboxes will be cheaper and faster.
+
+## Setup
+
+1. **Create a Daytona account** at [daytona.io](https://www.daytona.io/) if you don't already have one.
+2. **Generate an API key** in the Daytona dashboard.
+3. **Add the key to Phoenix.** Open [Settings → Sandboxes](/docs/phoenix/settings/sandboxes), find the **Daytona** row, click the gear icon, and paste the key as `DAYTONA_API_KEY`. You can also set it as an environment variable on the Phoenix server instead.
+4. **Create a configuration.** In **Sandbox Configurations**, click **New Sandbox**, pick **Daytona**, choose the language (Python or TypeScript), set the timeout and any environment variables or dependencies, and save.
+
+## Pricing and quotas
+
+See [daytona.io/pricing](https://www.daytona.io/pricing) for current rates and free-tier limits. Phoenix doesn't add a markup.
+
+## Troubleshooting
+
+- **The row says "Missing credentials"** — Phoenix hasn't received your API key. Open the gear icon on the Daytona row and paste it in.
+- **The row says "Not installed"** — the Daytona integration isn't installed. On a non-container Phoenix install, run `pip install 'arize-phoenix[daytona]'` and restart Phoenix. The official `arizephoenix/phoenix` container already has it.
+- **The row says "Disabled"** — an administrator has excluded Daytona via the [`PHOENIX_ALLOWED_SANDBOX_PROVIDERS`](/docs/phoenix/self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) allowlist. Either add `DAYTONA` to the allowlist or remove the variable.
+- **Evaluations fail with an authentication error** — your API key is wrong, expired, or revoked. Regenerate it in the Daytona dashboard and update it in Phoenix.

--- a/docs/phoenix/settings/sandboxes/daytona.mdx
+++ b/docs/phoenix/settings/sandboxes/daytona.mdx
@@ -12,27 +12,12 @@ description: "Run code evaluators in Daytona's managed development sandboxes."
 </div>
 </div>
 
-## When to choose Daytona
-
-Pick Daytona when you want a single hosted provider that handles both **Python and TypeScript** evaluators, or when you need any of the following:
-
-- **Stronger isolation than the local sandboxes.** Every run gets its own sandbox with no access to your Phoenix server.
-- **Third-party packages at runtime.** Install Python or npm packages on the configuration and Daytona has them ready before each run.
-- **Outbound network access** for evaluators that call out to APIs.
-- **Longer timeouts** for slower evaluators.
-
-If your team writes only one language, a single-language hosted provider (E2B for Python, Vercel for TypeScript) may be a closer fit. If you don't need packages or network access, the local [WebAssembly](/docs/phoenix/settings/sandboxes/wasm) or [Deno](/docs/phoenix/settings/sandboxes/deno) sandboxes will be cheaper and faster.
-
 ## Setup
 
 1. **Create a Daytona account** at [daytona.io](https://www.daytona.io/) if you don't already have one.
 2. **Generate an API key** in the Daytona dashboard.
 3. **Add the key to Phoenix.** Open [Settings → Sandboxes](/docs/phoenix/settings/sandboxes), find the **Daytona** row, click the gear icon, and paste the key as `DAYTONA_API_KEY`. You can also set it as an environment variable on the Phoenix server instead.
 4. **Create a configuration.** In **Sandbox Configurations**, click **New Sandbox**, pick **Daytona**, choose the language (Python or TypeScript), set the timeout and any environment variables or dependencies, and save.
-
-## Pricing and quotas
-
-See [daytona.io/pricing](https://www.daytona.io/pricing) for current rates and free-tier limits. Phoenix doesn't add a markup.
 
 ## Troubleshooting
 

--- a/docs/phoenix/settings/sandboxes/daytona.mdx
+++ b/docs/phoenix/settings/sandboxes/daytona.mdx
@@ -18,10 +18,3 @@ description: "Run code evaluators in Daytona's managed development sandboxes."
 2. **Generate an API key** in the Daytona dashboard.
 3. **Add the key to Phoenix.** Open [Settings → Sandboxes](/docs/phoenix/settings/sandboxes), find the **Daytona** row, click the gear icon, and paste the key as `DAYTONA_API_KEY`. You can also set it as an environment variable on the Phoenix server instead.
 4. **Create a configuration.** In **Sandbox Configurations**, click **New Sandbox**, pick **Daytona**, choose the language (Python or TypeScript), set the timeout and any environment variables or dependencies, and save.
-
-## Troubleshooting
-
-- **The row says "Missing credentials"** — Phoenix hasn't received your API key. Open the gear icon on the Daytona row and paste it in.
-- **The row says "Not installed"** — the Daytona integration isn't installed. On a non-container Phoenix install, run `pip install 'arize-phoenix[daytona]'` and restart Phoenix. The official `arizephoenix/phoenix` container already has it.
-- **The row says "Disabled"** — an administrator has excluded Daytona via the [`PHOENIX_ALLOWED_SANDBOX_PROVIDERS`](/docs/phoenix/self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) allowlist. Either add `DAYTONA` to the allowlist or remove the variable.
-- **Evaluations fail with an authentication error** — your API key is wrong, expired, or revoked. Regenerate it in the Daytona dashboard and update it in Phoenix.

--- a/docs/phoenix/settings/sandboxes/deno.mdx
+++ b/docs/phoenix/settings/sandboxes/deno.mdx
@@ -1,27 +1,25 @@
 ---
 title: "Deno"
-description: "Run TypeScript code evaluators inside the Phoenix server using a sandboxed Deno subprocess."
+description: "Run TypeScript code evaluators inside the Phoenix server using a sandboxed Deno process."
 ---
 
 <div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem', marginTop: '1.5rem', marginBottom: '1.5rem' }}>
 <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/deno.svg" alt="Deno" className="invert-on-dark" style={{ height: '112px', flexShrink: 0 }} />
 <div>
 
-The **Deno** sandbox runs TypeScript code in a `deno run` subprocess locked down with `--no-prompt --no-config --no-remote --no-npm` and no `--allow-*` flags beyond a scoped `--allow-env` for declared environment variables. The script can't read files, open sockets, spawn processes, fetch remote modules, or import `npm:` packages — these flags aren't user-configurable. Like the WebAssembly sandbox, it runs locally inside the Phoenix server, starts in milliseconds, and requires no credentials, making it the default choice for TypeScript code evaluators that don't need outbound network access or third-party packages.
+The **Deno** sandbox runs TypeScript code evaluators inside a locked-down Deno process on the Phoenix server. Scripts cannot read your files, open network connections, run other programs, or pull in third-party packages — the only things they can read are the environment variables you explicitly add to the sandbox configuration. Because Deno runs locally inside Phoenix, it starts in milliseconds and needs no credentials, which makes it the default choice for TypeScript evaluators that don't need outbound network access or third-party libraries.
 
 </div>
 </div>
 
-Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes). Learn more about Deno's permission model at [deno.land](https://deno.land/).
+Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes). For background on how Deno enforces these restrictions, see [deno.land](https://deno.land/).
 
 ## Risks of running untrusted code
 
-Phoenix runs evaluator scripts through `deno run` with no `--allow-*` flags beyond a scoped `--allow-env` for the environment variables declared on the sandbox configuration. That removes filesystem, network, subprocess, and remote-module access — but it does **not** make running untrusted code safe in general. Deno itself calls this out in [Executing untrusted code](https://docs.deno.com/runtime/fundamentals/security/#executing-untrusted-code): permission flags reduce blast radius, they don't eliminate it.
+The Deno sandbox is tightly restricted, but it is **not a substitute for running untrusted code on isolated infrastructure**. Deno itself makes this point in [Executing untrusted code](https://docs.deno.com/runtime/fundamentals/security/#executing-untrusted-code): restricting permissions limits what an attacker can do, but it does not eliminate the risk. Before using the Deno sandbox for code you do not control, understand the three caveats below.
 
-Specifically:
+- **Anything you put in the sandbox's environment variables is visible to the script.** This includes values pulled from secret references in your configuration. A malicious script can read these and pass them back out through its return value or an error message. Only expose the credentials the evaluator actually needs.
+- **The script shares CPU and memory with the Phoenix server.** A script that runs an infinite loop or allocates too much memory will keep doing so until the configured timeout expires. Keep timeouts short for evaluators that handle untrusted input.
+- **The security boundary depends on Deno itself.** Phoenix relies on Deno to enforce the restrictions. A bug in Deno would weaken the protection.
 
-- **Declared environment variables are readable by the script.** Anything you expose through the configuration's env vars (including values resolved from secret references) can be read by `Deno.env.get` and exfiltrated through whatever side channels the script has — including its return value or thrown errors. Only put credentials in the sandbox env that the evaluator legitimately needs.
-- **The sandbox shares the Phoenix host's CPU and memory.** A pathological script can still consume resources up to the configured timeout. Keep timeouts tight for evaluators that run on untrusted inputs.
-- **Deno's permission model is the security boundary.** Phoenix relies on the upstream `deno` binary enforcing `--no-prompt --no-config --no-remote --no-npm` and the absence of `--allow-read`, `--allow-write`, `--allow-net`, `--allow-run`, etc. A bug or misconfiguration in `deno` itself would weaken that boundary.
-
-If you are not comfortable with this trust model — for example, you need to run code from sources you don't control and cannot accept the residual risks above — **do not use the Deno sandbox**. Use a [hosted sandbox](/docs/phoenix/settings/sandboxes#hosted-sandboxes) (E2B, Daytona, Vercel, Modal) instead, which executes the code on a remote VM or micro-VM isolated from the Phoenix host.
+If these trade-offs are not acceptable for your use case — for example, you need to evaluate code from sources you cannot verify — **use a hosted sandbox instead**. [E2B, Daytona, Vercel, and Modal](/docs/phoenix/settings/sandboxes#hosted-sandboxes) run each evaluation on a remote virtual machine isolated from your Phoenix server.

--- a/docs/phoenix/settings/sandboxes/e2b.mdx
+++ b/docs/phoenix/settings/sandboxes/e2b.mdx
@@ -12,17 +12,6 @@ description: "Run code evaluators in E2B's hosted micro-VM sandboxes."
 </div>
 </div>
 
-## When to choose E2B
-
-Pick E2B when you need any of the following from your Python evaluators:
-
-- **Stronger isolation than the local WebAssembly sandbox.** Every run gets its own micro-VM, so an evaluator can't see anything from your Phoenix server or from other runs.
-- **Third-party Python packages at runtime.** Add packages like `pandas`, `requests`, or anything else to the sandbox configuration and E2B installs them before each run.
-- **Outbound network access.** Enable internet on the configuration if your evaluator needs to call an API.
-- **Longer timeouts** for evaluators that need more than a few seconds to run.
-
-If your evaluators are quick, pure-logic Python (regex, JSON parsing, scoring functions) and don't need third-party packages or network access, the local [WebAssembly sandbox](/docs/phoenix/settings/sandboxes/wasm) will be faster and free.
-
 ## Setup
 
 1. **Create an E2B account** at [e2b.dev](https://e2b.dev/) if you don't already have one.
@@ -31,10 +20,6 @@ If your evaluators are quick, pure-logic Python (regex, JSON parsing, scoring fu
 4. **Create a configuration.** In the **Sandbox Configurations** card, click **New Sandbox**, pick **E2B**, set the timeout and any environment variables or dependencies the evaluator needs, and save.
 
 Once the configuration exists, code evaluators can select it from their settings.
-
-## Pricing and quotas
-
-E2B charges per second of sandbox runtime. See [e2b.dev/pricing](https://e2b.dev/pricing) for current rates and free-tier limits. Phoenix doesn't add any markup — you pay E2B directly.
 
 ## Troubleshooting
 

--- a/docs/phoenix/settings/sandboxes/e2b.mdx
+++ b/docs/phoenix/settings/sandboxes/e2b.mdx
@@ -20,10 +20,3 @@ description: "Run code evaluators in E2B's hosted micro-VM sandboxes."
 4. **Create a configuration.** In the **Sandbox Configurations** card, click **New Sandbox**, pick **E2B**, set the timeout and any environment variables or dependencies the evaluator needs, and save.
 
 Once the configuration exists, code evaluators can select it from their settings.
-
-## Troubleshooting
-
-- **The row says "Missing credentials"** — Phoenix hasn't received your API key. Open the gear icon on the E2B row and paste it in.
-- **The row says "Not installed"** — the E2B integration isn't installed. On a non-container Phoenix install, run `pip install 'arize-phoenix[e2b]'` and restart Phoenix. The official `arizephoenix/phoenix` container already has it.
-- **The row says "Disabled"** — an administrator has excluded E2B via the [`PHOENIX_ALLOWED_SANDBOX_PROVIDERS`](/docs/phoenix/self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) allowlist. Either add `E2B` to the allowlist or remove the variable.
-- **Evaluations fail with an authentication error** — your API key is likely wrong or revoked. Regenerate it in the E2B dashboard and update the credential in Phoenix.

--- a/docs/phoenix/settings/sandboxes/e2b.mdx
+++ b/docs/phoenix/settings/sandboxes/e2b.mdx
@@ -7,9 +7,38 @@ description: "Run code evaluators in E2B's hosted micro-VM sandboxes."
 <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/e2b.svg" alt="E2B" className="invert-on-dark" style={{ height: '112px', flexShrink: 0 }} />
 <div>
 
-[**E2B**](https://e2b.dev/) provides hosted micro-VM sandboxes purpose-built for executing AI-generated code. Each invocation spins up a fresh VM on E2B's infrastructure, so Phoenix can run untrusted Python with kernel-level isolation, install dependencies at execution time, and opt in to outbound network access — without exposing the rest of your deployment.
+[**E2B**](https://e2b.dev/) runs each evaluation inside a fresh micro-VM on its own infrastructure. That gives you kernel-level isolation — much stronger than the local sandboxes — plus the ability to install Python packages on the fly and reach the public internet when the configuration allows it. The trade-off is per-call network latency and the need to manage an E2B account.
 
 </div>
 </div>
 
-To use E2B, sign up at [e2b.dev](https://e2b.dev/) and create an API key, then add it as `E2B_API_KEY` from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).
+## When to choose E2B
+
+Pick E2B when you need any of the following from your Python evaluators:
+
+- **Stronger isolation than the local WebAssembly sandbox.** Every run gets its own micro-VM, so an evaluator can't see anything from your Phoenix server or from other runs.
+- **Third-party Python packages at runtime.** Add packages like `pandas`, `requests`, or anything else to the sandbox configuration and E2B installs them before each run.
+- **Outbound network access.** Enable internet on the configuration if your evaluator needs to call an API.
+- **Longer timeouts** for evaluators that need more than a few seconds to run.
+
+If your evaluators are quick, pure-logic Python (regex, JSON parsing, scoring functions) and don't need third-party packages or network access, the local [WebAssembly sandbox](/docs/phoenix/settings/sandboxes/wasm) will be faster and free.
+
+## Setup
+
+1. **Create an E2B account** at [e2b.dev](https://e2b.dev/) if you don't already have one.
+2. **Generate an API key** in the E2B dashboard.
+3. **Add the key to Phoenix.** Open [Settings → Sandboxes](/docs/phoenix/settings/sandboxes), find the **E2B** row, click the gear icon, and paste your key as `E2B_API_KEY`. You can also set it as an environment variable on the Phoenix server instead.
+4. **Create a configuration.** In the **Sandbox Configurations** card, click **New Sandbox**, pick **E2B**, set the timeout and any environment variables or dependencies the evaluator needs, and save.
+
+Once the configuration exists, code evaluators can select it from their settings.
+
+## Pricing and quotas
+
+E2B charges per second of sandbox runtime. See [e2b.dev/pricing](https://e2b.dev/pricing) for current rates and free-tier limits. Phoenix doesn't add any markup — you pay E2B directly.
+
+## Troubleshooting
+
+- **The row says "Missing credentials"** — Phoenix hasn't received your API key. Open the gear icon on the E2B row and paste it in.
+- **The row says "Not installed"** — the E2B integration isn't installed. On a non-container Phoenix install, run `pip install 'arize-phoenix[e2b]'` and restart Phoenix. The official `arizephoenix/phoenix` container already has it.
+- **The row says "Disabled"** — an administrator has excluded E2B via the [`PHOENIX_ALLOWED_SANDBOX_PROVIDERS`](/docs/phoenix/self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) allowlist. Either add `E2B` to the allowlist or remove the variable.
+- **Evaluations fail with an authentication error** — your API key is likely wrong or revoked. Regenerate it in the E2B dashboard and update the credential in Phoenix.

--- a/docs/phoenix/settings/sandboxes/modal.mdx
+++ b/docs/phoenix/settings/sandboxes/modal.mdx
@@ -18,10 +18,3 @@ description: "Run code evaluators in Modal's serverless container platform."
 2. **Create a token pair** in the Modal dashboard. Modal authenticates with two values — a token ID and a token secret — and gives you both when you create the pair.
 3. **Add the credentials to Phoenix.** Open [Settings → Sandboxes](/docs/phoenix/settings/sandboxes), find the **Modal** row, click the gear icon, and paste the values as `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`. You can also set them as environment variables on the Phoenix server instead.
 4. **Create a configuration.** In **Sandbox Configurations**, click **New Sandbox**, pick **Modal**, set the timeout and any environment variables or dependencies, and save.
-
-## Troubleshooting
-
-- **The row says "Missing credentials"** — at least one of `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` is unset. Re-open the gear icon and confirm both fields are filled in.
-- **The row says "Not installed"** — the Modal integration isn't installed. On a non-container Phoenix install, run `pip install 'arize-phoenix[modal]'` and restart Phoenix. The official `arizephoenix/phoenix` container already has it.
-- **The row says "Disabled"** — an administrator has excluded Modal via the [`PHOENIX_ALLOWED_SANDBOX_PROVIDERS`](/docs/phoenix/self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) allowlist. Either add `MODAL` to the allowlist or remove the variable.
-- **Evaluations fail with an authentication error** — your token pair is wrong, expired, or has been revoked. Regenerate it in the Modal dashboard and update both values in Phoenix.

--- a/docs/phoenix/settings/sandboxes/modal.mdx
+++ b/docs/phoenix/settings/sandboxes/modal.mdx
@@ -7,9 +7,35 @@ description: "Run code evaluators in Modal's serverless container platform."
 <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/modal.svg" alt="Modal" style={{ height: '112px', flexShrink: 0 }} />
 <div>
 
-[**Modal**](https://modal.com/) is a serverless container platform with sub-second cold starts and Python-first ergonomics. Phoenix uses it as a hosted backend for code evaluators that benefit from Modal's fast container scheduling, generous timeouts, and pay-per-execution pricing.
+[**Modal**](https://modal.com/) runs each Python evaluation in a fresh, serverless container on its own cloud. Cold starts are typically under a second, timeouts can be generous, and you pay only for the seconds your code actually runs.
 
 </div>
 </div>
 
-To use Modal, sign up at [modal.com](https://modal.com/) and create a token pair, then add `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).
+## When to choose Modal
+
+Pick Modal when you want a hosted Python sandbox that's:
+
+- **Fast to start.** Modal containers spin up in under a second, so latency feels close to a local sandbox.
+- **Strongly isolated.** Every run gets its own container with no access to your Phoenix server or other runs.
+- **Flexible on dependencies and runtime.** Install Python packages in the configuration and Modal makes them available before each run.
+
+If your evaluators don't need third-party packages or network access, the local [WebAssembly sandbox](/docs/phoenix/settings/sandboxes/wasm) will be cheaper and even faster. If your team is already on a different platform (E2B, Daytona, Vercel) it usually makes sense to consolidate there.
+
+## Setup
+
+1. **Create a Modal account** at [modal.com](https://modal.com/) if you don't already have one.
+2. **Create a token pair** in the Modal dashboard. Modal authenticates with two values — a token ID and a token secret — and gives you both when you create the pair.
+3. **Add the credentials to Phoenix.** Open [Settings → Sandboxes](/docs/phoenix/settings/sandboxes), find the **Modal** row, click the gear icon, and paste the values as `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`. You can also set them as environment variables on the Phoenix server instead.
+4. **Create a configuration.** In **Sandbox Configurations**, click **New Sandbox**, pick **Modal**, set the timeout and any environment variables or dependencies, and save.
+
+## Pricing and quotas
+
+Modal charges per second of container runtime. See [modal.com/pricing](https://modal.com/pricing) for current rates and free-tier limits. Phoenix doesn't add a markup.
+
+## Troubleshooting
+
+- **The row says "Missing credentials"** — at least one of `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` is unset. Re-open the gear icon and confirm both fields are filled in.
+- **The row says "Not installed"** — the Modal integration isn't installed. On a non-container Phoenix install, run `pip install 'arize-phoenix[modal]'` and restart Phoenix. The official `arizephoenix/phoenix` container already has it.
+- **The row says "Disabled"** — an administrator has excluded Modal via the [`PHOENIX_ALLOWED_SANDBOX_PROVIDERS`](/docs/phoenix/self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) allowlist. Either add `MODAL` to the allowlist or remove the variable.
+- **Evaluations fail with an authentication error** — your token pair is wrong, expired, or has been revoked. Regenerate it in the Modal dashboard and update both values in Phoenix.

--- a/docs/phoenix/settings/sandboxes/modal.mdx
+++ b/docs/phoenix/settings/sandboxes/modal.mdx
@@ -7,20 +7,10 @@ description: "Run code evaluators in Modal's serverless container platform."
 <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/modal.svg" alt="Modal" style={{ height: '112px', flexShrink: 0 }} />
 <div>
 
-[**Modal**](https://modal.com/) runs each Python evaluation in a fresh, serverless container on its own cloud. Cold starts are typically under a second, timeouts can be generous, and you pay only for the seconds your code actually runs.
+[**Modal**](https://modal.com/) runs each Python evaluation in a fresh, serverless container on its own cloud. Cold starts are typically under a second, and timeouts can be generous.
 
 </div>
 </div>
-
-## When to choose Modal
-
-Pick Modal when you want a hosted Python sandbox that's:
-
-- **Fast to start.** Modal containers spin up in under a second, so latency feels close to a local sandbox.
-- **Strongly isolated.** Every run gets its own container with no access to your Phoenix server or other runs.
-- **Flexible on dependencies and runtime.** Install Python packages in the configuration and Modal makes them available before each run.
-
-If your evaluators don't need third-party packages or network access, the local [WebAssembly sandbox](/docs/phoenix/settings/sandboxes/wasm) will be cheaper and even faster. If your team is already on a different platform (E2B, Daytona, Vercel) it usually makes sense to consolidate there.
 
 ## Setup
 
@@ -28,10 +18,6 @@ If your evaluators don't need third-party packages or network access, the local 
 2. **Create a token pair** in the Modal dashboard. Modal authenticates with two values — a token ID and a token secret — and gives you both when you create the pair.
 3. **Add the credentials to Phoenix.** Open [Settings → Sandboxes](/docs/phoenix/settings/sandboxes), find the **Modal** row, click the gear icon, and paste the values as `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`. You can also set them as environment variables on the Phoenix server instead.
 4. **Create a configuration.** In **Sandbox Configurations**, click **New Sandbox**, pick **Modal**, set the timeout and any environment variables or dependencies, and save.
-
-## Pricing and quotas
-
-Modal charges per second of container runtime. See [modal.com/pricing](https://modal.com/pricing) for current rates and free-tier limits. Phoenix doesn't add a markup.
 
 ## Troubleshooting
 

--- a/docs/phoenix/settings/sandboxes/vercel.mdx
+++ b/docs/phoenix/settings/sandboxes/vercel.mdx
@@ -28,10 +28,3 @@ Then:
 2. **Create a configuration.** In **Sandbox Configurations**, click **New Sandbox**, pick **Vercel Sandbox**, choose the language (Python or TypeScript), set the timeout and any environment variables or dependencies, and save.
 
 For Vercel's full authentication walkthrough, see [Vercel Sandbox authentication](https://vercel.com/docs/vercel-sandbox/concepts/authentication).
-
-## Troubleshooting
-
-- **The row says "Missing credentials"** — at least one of the three values is missing. Re-open the gear icon and check each field.
-- **The row says "Not installed"** — the Vercel Sandbox integration isn't installed. On a non-container Phoenix install, run `pip install 'arize-phoenix[vercel]'` and restart Phoenix. The official `arizephoenix/phoenix` container already has it.
-- **The row says "Disabled"** — an administrator has excluded Vercel via the [`PHOENIX_ALLOWED_SANDBOX_PROVIDERS`](/docs/phoenix/self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) allowlist. Either add `VERCEL` to the allowlist or remove the variable.
-- **Evaluations fail with an authentication or permission error** — the token may not have access to the configured team/project. Confirm the token, team ID, and project ID belong together, then update them in Phoenix.

--- a/docs/phoenix/settings/sandboxes/vercel.mdx
+++ b/docs/phoenix/settings/sandboxes/vercel.mdx
@@ -12,16 +12,6 @@ description: "Run code evaluators in ephemeral compute on Vercel's infrastructur
 </div>
 </div>
 
-## When to choose Vercel Sandbox
-
-Pick Vercel Sandbox when:
-
-- **Your team is already on Vercel.** Sandbox usage rolls up under the same Vercel billing, access controls, and team boundaries you already manage. No new vendor relationship needed.
-- **You want both Python and TypeScript** evaluators under one provider.
-- **You need stronger isolation than the local sandboxes** plus optional outbound internet access and runtime package installation.
-
-If you're not already a Vercel customer, E2B (Python) or Daytona (Python + TypeScript) are usually simpler starting points.
-
 ## Setup
 
 Vercel Sandbox needs three values:
@@ -38,10 +28,6 @@ Then:
 2. **Create a configuration.** In **Sandbox Configurations**, click **New Sandbox**, pick **Vercel Sandbox**, choose the language (Python or TypeScript), set the timeout and any environment variables or dependencies, and save.
 
 For Vercel's full authentication walkthrough, see [Vercel Sandbox authentication](https://vercel.com/docs/vercel-sandbox/concepts/authentication).
-
-## Pricing and quotas
-
-Sandbox usage is billed to the Vercel team that owns the project. See [vercel.com/pricing](https://vercel.com/pricing) and the [Vercel Sandbox docs](https://vercel.com/docs/vercel-sandbox) for current rates. Phoenix doesn't add a markup.
 
 ## Troubleshooting
 

--- a/docs/phoenix/settings/sandboxes/vercel.mdx
+++ b/docs/phoenix/settings/sandboxes/vercel.mdx
@@ -7,9 +7,45 @@ description: "Run code evaluators in ephemeral compute on Vercel's infrastructur
 <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/vercel.svg" alt="Vercel Sandbox" className="invert-on-dark" style={{ height: '112px', flexShrink: 0 }} />
 <div>
 
-[**Vercel Sandbox**](https://vercel.com/docs/vercel-sandbox) runs code in ephemeral compute on Vercel's infrastructure, scoped to a Vercel team and project. It's a good fit when your team is already on Vercel and you'd like sandbox usage to roll up under the same billing and access controls.
+[**Vercel Sandbox**](https://vercel.com/docs/vercel-sandbox) runs each evaluation in ephemeral compute on Vercel's infrastructure, scoped to a specific Vercel team and project. It supports both Python and TypeScript evaluators.
 
 </div>
 </div>
 
-To use Vercel Sandbox, create a token and note your team and project IDs in the Vercel dashboard, then add `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID` from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).
+## When to choose Vercel Sandbox
+
+Pick Vercel Sandbox when:
+
+- **Your team is already on Vercel.** Sandbox usage rolls up under the same Vercel billing, access controls, and team boundaries you already manage. No new vendor relationship needed.
+- **You want both Python and TypeScript** evaluators under one provider.
+- **You need stronger isolation than the local sandboxes** plus optional outbound internet access and runtime package installation.
+
+If you're not already a Vercel customer, E2B (Python) or Daytona (Python + TypeScript) are usually simpler starting points.
+
+## Setup
+
+Vercel Sandbox needs three values:
+
+| Value | What it is | Where to find it |
+| :-- | :-- | :-- |
+| `VERCEL_TOKEN` | A personal access token | [Account Settings → Tokens](https://vercel.com/account/tokens) |
+| `VERCEL_PROJECT_ID` | The project's resource ID | Project Settings → General |
+| `VERCEL_TEAM_ID` | The team's resource ID | `https://vercel.com/teams/<your-team>/settings#team-id` |
+
+Then:
+
+1. **Add the credentials to Phoenix.** Open [Settings → Sandboxes](/docs/phoenix/settings/sandboxes), find the **Vercel Sandbox** row, click the gear icon, and paste each value into the matching field. You can also set them as environment variables on the Phoenix server.
+2. **Create a configuration.** In **Sandbox Configurations**, click **New Sandbox**, pick **Vercel Sandbox**, choose the language (Python or TypeScript), set the timeout and any environment variables or dependencies, and save.
+
+For Vercel's full authentication walkthrough, see [Vercel Sandbox authentication](https://vercel.com/docs/vercel-sandbox/concepts/authentication).
+
+## Pricing and quotas
+
+Sandbox usage is billed to the Vercel team that owns the project. See [vercel.com/pricing](https://vercel.com/pricing) and the [Vercel Sandbox docs](https://vercel.com/docs/vercel-sandbox) for current rates. Phoenix doesn't add a markup.
+
+## Troubleshooting
+
+- **The row says "Missing credentials"** — at least one of the three values is missing. Re-open the gear icon and check each field.
+- **The row says "Not installed"** — the Vercel Sandbox integration isn't installed. On a non-container Phoenix install, run `pip install 'arize-phoenix[vercel]'` and restart Phoenix. The official `arizephoenix/phoenix` container already has it.
+- **The row says "Disabled"** — an administrator has excluded Vercel via the [`PHOENIX_ALLOWED_SANDBOX_PROVIDERS`](/docs/phoenix/self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) allowlist. Either add `VERCEL` to the allowlist or remove the variable.
+- **Evaluations fail with an authentication or permission error** — the token may not have access to the configured team/project. Confirm the token, team ID, and project ID belong together, then update them in Phoenix.

--- a/docs/phoenix/settings/sandboxes/wasm.mdx
+++ b/docs/phoenix/settings/sandboxes/wasm.mdx
@@ -1,21 +1,21 @@
 ---
 title: "WebAssembly"
-description: "Run Python code evaluators inside the Phoenix server using a CPython-on-Wasm interpreter."
+description: "Run Python code evaluators inside the Phoenix server using a sandboxed Python interpreter."
 ---
 
 <div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem', marginTop: '1.5rem', marginBottom: '1.5rem' }}>
 <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/wasm.svg" alt="WebAssembly" style={{ height: '112px', flexShrink: 0 }} />
 <div>
 
-The **WebAssembly** sandbox runs Python code in a CPython interpreter compiled to WebAssembly and executed via [`wasmtime`](https://wasmtime.dev/), in-process inside the Phoenix server. Isolation is enforced at the Wasm boundary: the guest has no filesystem, no network, and no syscalls except those Phoenix explicitly grants. It starts in milliseconds and requires no credentials, which makes it the default choice for fast, pure-logic Python evaluators.
+The **WebAssembly** sandbox runs Python code evaluators inside an isolated [WebAssembly](https://webassembly.org/) runtime on the Phoenix server. Scripts cannot read your files, open network connections, or access anything else on the host — Phoenix controls exactly which operations the Python code is allowed to perform. It runs locally inside Phoenix, starts in milliseconds, and needs no credentials, which makes it the default choice for fast Python evaluators that handle pure logic (regex, JSON parsing, scoring functions, etc.).
 
 </div>
 </div>
 
-Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes). Learn more about WebAssembly at [webassembly.org](https://webassembly.org/).
+Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes). For background on the underlying technology, see [webassembly.org](https://webassembly.org/).
 
 ## Security model
 
-WebAssembly enforces isolation through **memory-safe, sandboxed execution**: the guest can only read and write inside its own linear memory, cannot forge pointers into the host's address space, and has no ambient access to syscalls, the filesystem, or the network. Phoenix relies on this boundary plus `wasmtime`'s capability-based host interface to keep evaluator code contained inside the Phoenix process.
+WebAssembly runs the Python interpreter inside a strictly isolated environment. Memory is partitioned so the script can only touch its own data, and the script has no built-in access to the filesystem, network, or operating system. Phoenix decides explicitly which operations to allow, and everything else is denied by default.
 
-For the full threat model — including memory-safety guarantees, control-flow integrity, and the side-channel caveats that apply to any in-process sandbox — see WebAssembly's [Security](https://webassembly.org/docs/security/) documentation.
+For the full security model — including memory safety, control-flow integrity, and the side-channel limitations that apply to any in-process sandbox — see WebAssembly's [Security](https://webassembly.org/docs/security/) documentation.

--- a/src/phoenix/server/api/types/SandboxConfig.py
+++ b/src/phoenix/server/api/types/SandboxConfig.py
@@ -18,6 +18,7 @@ from strawberry import lazy
 from strawberry.relay import Node, NodeID
 from strawberry.types import Info
 
+from phoenix.config import get_env_allowed_sandbox_providers
 from phoenix.db import models
 from phoenix.db.types.identifier import Identifier
 from phoenix.server.api.context import Context
@@ -89,6 +90,8 @@ class SandboxBackendStatus(Enum):
     """Adapter is installed but backend creation failed (e.g. bad credentials)."""
     NOT_INSTALLED = "NOT_INSTALLED"
     """Optional dependency for this backend is not installed."""
+    DISABLED = "DISABLED"
+    """Backend is excluded from PHOENIX_ALLOWED_SANDBOX_PROVIDERS on the server."""
 
 
 @strawberry.enum
@@ -511,11 +514,15 @@ async def get_sandbox_backend_info(
     """
     from phoenix.server.sandbox import SANDBOX_ADAPTERS
 
+    allowed_backend_types = get_env_allowed_sandbox_providers()
     infos: list[SandboxBackendInfo] = []
     for backend_type, meta in SANDBOX_ADAPTER_METADATA.items():
         probe_language: models.LanguageName = sorted(meta.supported_languages)[0]
         status_detail: Optional[str] = None
-        if backend_type not in SANDBOX_ADAPTERS:
+        if backend_type not in allowed_backend_types:
+            status = SandboxBackendStatus.DISABLED
+            status_detail = "Disabled on the server."
+        elif backend_type not in SANDBOX_ADAPTERS:
             status = SandboxBackendStatus.NOT_INSTALLED
         else:
             missing_auth_detail = await secrets.missing_auth_detail(backend_type)

--- a/src/phoenix/server/cli/commands/serve.py
+++ b/src/phoenix/server/cli/commands/serve.py
@@ -21,6 +21,7 @@ from phoenix.config import (
     TLSConfigVerifyClient,
     get_env_access_token_expiry,
     get_env_allowed_origins,
+    get_env_allowed_sandbox_providers,
     get_env_auth_settings,
     get_env_dangerously_enable_agents,
     get_env_database_connection_str,
@@ -125,12 +126,25 @@ _WELCOME_MESSAGE = Environment(loader=BaseLoader()).from_string("""
 {%- if schema %}
 |    - Schema: {{ schema }}
 {%- endif %}
+|
+|  📦 Code Sandbox Providers 📦
+{%- for provider in sandbox_providers %}
+|  - {{ provider.name }}: {{ "✅ Allowed" if provider.enabled else "❌ Disabled" }}
+{%- endfor %}
 {%- if agents_enabled %}
 |
 |  🧪 Experimental Features 🧪
 |  Agents: Enabled
 {%- endif %}
 """)
+
+
+def _get_sandbox_provider_statuses() -> list[dict[str, object]]:
+    """Return per-provider enabled/disabled status for the launch banner."""
+    from phoenix.server.sandbox.types import SANDBOX_BACKEND_TYPES
+
+    allowed = get_env_allowed_sandbox_providers()
+    return [{"name": name, "enabled": name in allowed} for name in sorted(SANDBOX_BACKEND_TYPES)]
 
 
 def _add_server_args(parser: ArgumentParser) -> None:
@@ -292,6 +306,7 @@ def run(args: Namespace) -> None:
         tls_verify_client=tls_verify_client,
         allowed_origins=allowed_origins,
         agents_enabled=get_env_dangerously_enable_agents(),
+        sandbox_providers=_get_sandbox_provider_statuses(),
     )
 
     msg = no_emojis_on_windows(msg)

--- a/tests/unit/server/api/test_wasm_backend.py
+++ b/tests/unit/server/api/test_wasm_backend.py
@@ -590,6 +590,24 @@ class TestSandboxBackendsResolverWASMStatus:
         assert wasm.status == SandboxBackendStatus.UNAVAILABLE
         assert wasm.status_detail == detail
 
+    async def test_wasm_reports_disabled_when_excluded_by_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from phoenix.server.api.types.SandboxConfig import (
+            SandboxBackendStatus,
+            get_sandbox_backend_info,
+        )
+        from phoenix.server.sandbox import _SANDBOX_ADAPTERS
+
+        monkeypatch.setenv("PHOENIX_ALLOWED_SANDBOX_PROVIDERS", "DENO")
+        with patch.dict(_SANDBOX_ADAPTERS, {"WASM": WASMAdapter()}, clear=False):
+            infos = await get_sandbox_backend_info(
+                secrets=_empty_secrets_context(),
+            )
+        wasm = next(info for info in infos if info.backend_type.value == "WASM")
+        assert wasm.status == SandboxBackendStatus.DISABLED
+        assert wasm.status_detail == "Disabled on the server."
+
     async def test_wasm_status_path_does_not_invoke_network(self) -> None:
         """Resolver-level guarantee: even when the probe is exercised end-to-end,
         ``urllib.request.urlretrieve`` is never called.


### PR DESCRIPTION
## Summary

- Add a `DISABLED` `SandboxBackendStatus` that wins over `NOT_INSTALLED` / `MISSING_CREDENTIALS` / `UNAVAILABLE` when a backend is excluded by `PHOENIX_ALLOWED_SANDBOX_PROVIDERS`, so the **Settings → Sandboxes** page renders "Disabled" with the tooltip "Disabled on the server." instead of misleading capability states.
- Print a `📦 Code Sandbox Providers` section on the server startup banner with `✅ Allowed` / `❌ Disabled` per provider so operators can confirm the env var was read as expected.
- Document `PHOENIX_ALLOWED_SANDBOX_PROVIDERS` in `self-hosting/configuration.mdx` and add a "Restricting which providers are allowed" section to `self-hosting/features/sandbox-runtimes.mdx`.

## Test plan

- [x] `uv run pytest tests/unit/server/api/test_wasm_backend.py::TestSandboxBackendsResolverWASMStatus` — including the new `test_wasm_reports_disabled_when_excluded_by_env`
- [x] `uv run pytest tests/unit/server/sandbox tests/unit/test_config.py`
- [x] `make graphql` regenerates schema + Relay types with `DISABLED` in `SandboxBackendStatus`
- [x] `pnpm tsc --noEmit` (app)
- [ ] Manually verify banner renders `✅ Allowed` / `❌ Disabled` with `PHOENIX_ALLOWED_SANDBOX_PROVIDERS` set, and **Settings → Sandboxes** shows "Disabled" status with the tooltip