### PR TITLE
feat(sandbox): disallow environment variables for Deno sandboxes

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1300,7 +1300,6 @@ type DeleteUsersPayload {
 
 input DenoConfigInput {
   language: Language!
-  envVars: [EnvVarInput!]! = []
 }
 
 input DependenciesInput {

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogCreateSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogCreateSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2ffdcb94b7f1375575c0bad36169260c>>
+ * @generated SignedSource<<db419a279335b279387c0e2d880ad5ed>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -50,7 +50,6 @@ export type DaytonaConfigInput = {
   language: Language;
 };
 export type DenoConfigInput = {
-  envVars?: ReadonlyArray<EnvVarInput>;
   language: Language;
 };
 export type VercelConfigInput = {

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<805c6e60f2d5004b267dfaf8109fd296>>
+ * @generated SignedSource<<0c734f09681b53406a880165aa829ae2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -51,7 +51,6 @@ export type DaytonaConfigInput = {
   language: Language;
 };
 export type DenoConfigInput = {
-  envVars?: ReadonlyArray<EnvVarInput>;
   language: Language;
 };
 export type VercelConfigInput = {

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<acd61e65dba636ec0229ce00aec8168c>>
+ * @generated SignedSource<<beab48459ba481163a985a16f80adc0e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -51,7 +51,6 @@ export type DaytonaConfigInput = {
   language: Language;
 };
 export type DenoConfigInput = {
-  envVars?: ReadonlyArray<EnvVarInput>;
   language: Language;
 };
 export type VercelConfigInput = {

--- a/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
@@ -144,10 +144,10 @@ flowchart LR
     Server -. HTTPS .-> hostedBox
 ```
 
-**Local** backends (WebAssembly, Deno) ship with Phoenix and need no credentials, so they're available immediately on self-hosted deployments. **Hosted** backends (E2B, Daytona, Vercel, Modal) run each invocation on a third-party provider's infrastructure, which buys stronger isolation, longer timeouts, package installation, and outbound network access. See [Sandbox Backends](/docs/phoenix/self-hosting/features/sandbox-runtimes) for the full capability matrix.
+**Local** backends (WebAssembly, Deno) ship with Phoenix and need no credentials, so they're available immediately on self-hosted deployments — but they only run **simple, self-contained code**: no environment variables, no network access, no installed packages. **Hosted** backends (E2B, Daytona, Vercel, Modal) run each invocation on a third-party provider's infrastructure, and are the only backends that support environment variables, outbound network access, and third-party dependencies. See [Sandbox Backends](/docs/phoenix/self-hosting/features/sandbox-runtimes) for the full capability matrix.
 
 <Tip>
-If your evaluator needs to install a package or call an external API, pick a hosted backend. The local backends are intentionally restricted.
+If your evaluator needs to read an environment variable, install a package, or call an external API, pick a hosted backend. The local backends are intentionally restricted to simple code evaluation.
 </Tip>
 
 The walkthrough below shows creating a Python code evaluator that runs on a Daytona sandbox — from picking the hosted backend through testing the evaluator against a dataset example.

--- a/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
+++ b/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
@@ -5,6 +5,10 @@ description: Set up the sandbox providers that run code evaluators on your self-
 
 Phoenix runs code evaluators (and other LLM-driven workloads that need to execute code) inside sandboxes. This page tells you which sandbox providers are ready to use in the official `arizephoenix/phoenix` container, what extra setup the others need, and how to read the status badges shown on **Settings → Sandboxes**.
 
+<Warning>
+**Local sandboxes (Deno, WebAssembly) are for simple code evaluation only.** Environment variables, network access, and third-party dependencies are supported **only** in hosted sandboxes (E2B, Daytona, Vercel, Modal).
+</Warning>
+
 ## Reading the status on Settings → Sandboxes
 
 Each provider on the **Settings → Sandboxes** page shows a status that tells you whether it's ready to run code:

--- a/docs/phoenix/settings/sandboxes.mdx
+++ b/docs/phoenix/settings/sandboxes.mdx
@@ -10,7 +10,7 @@ A **sandbox** is an isolated runtime that executes a snippet of code on demand. 
 The **Settings → Sandboxes** page is where administrators pick which sandbox providers are available and bundle them into named, reusable configurations that anyone writing a code evaluator can pick from. The page has two cards:
 
 - **Sandbox Providers** — one row per provider. Each row lets you set the provider's credentials, enable or disable it for your deployment, and see whether it's currently ready to run code.
-- **Sandbox Configurations** — named runtime profiles you create once and re-use. Each one bundles a provider with a timeout, environment variables, optional internet access, and any dependencies that should be pre-installed.
+- **Sandbox Configurations** — named runtime profiles you create once and re-use. Each one bundles a provider with a timeout and, for hosted providers, environment variables, optional internet access, and any dependencies that should be pre-installed.
 
 <Note>
 Only users with the **Admin** role can view or edit this page. Non-admin users are routed away from the tab.
@@ -19,6 +19,10 @@ Only users with the **Admin** role can view or edit this page. Non-admin users a
 ## Local vs. hosted sandboxes
 
 Phoenix supports two kinds of sandbox, distinguished by where the code actually runs. The badge on each row in **Sandbox Providers** (labeled either **Local** or **Hosted**) tells you which kind it is.
+
+<Warning>
+**Environment variables, network access, and third-party dependencies are only supported in hosted sandboxes.** Local sandboxes (Deno and WebAssembly) are for **simple, self-contained code evaluation** — pure-logic checks like regex matches, JSON parsing, and scoring functions. If your evaluator needs to read a secret, call an API, or import a package, you must use a hosted sandbox.
+</Warning>
 
 ```mermaid
 flowchart LR
@@ -41,26 +45,24 @@ flowchart LR
     Server -. HTTPS .-> hostedBox
 ```
 
-<Info>
-**Local sandboxes** run on the Phoenix machine itself — fully isolated, no credentials needed, but they share the Phoenix process's CPU and memory and can't reach the internet or install packages. **Hosted sandboxes** run on a remote machine operated by a third-party provider, so they support third-party libraries, outbound web access, and isolation from Phoenix's own resources — at the cost of per-call network latency and provider credentials.
-</Info>
-
 <AccordionGroup>
-  <Accordion title="Local sandboxes" icon="server">
-    **Local sandboxes** run inside the Phoenix server process itself. They start in milliseconds and require no external credentials, which makes them the fastest and cheapest option. The trade-off is narrower isolation than a full VM and a smaller capability surface — they can't install arbitrary packages, and they can't reach the public internet.
+  <Accordion title="Local sandboxes — simple code evaluation only" icon="server">
+    **Local sandboxes** run inside the Phoenix server process itself. They start in milliseconds and require no external credentials, which makes them the fastest and cheapest option for **simple, self-contained evaluators** — regex matches, JSON parsing, scoring functions, and other pure logic.
+
+    They **do not** support environment variables, network access, or third-party dependencies. If your evaluator needs any of those, use a hosted sandbox.
 
     <CardGroup cols={2}>
       <Card title="WebAssembly" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/wasm.svg" href="/docs/phoenix/settings/sandboxes/wasm">
-        Runs Python in an isolated WebAssembly runtime with no access to your filesystem or network.
+        Runs simple Python evaluators in an isolated WebAssembly runtime. No env vars, network, or packages.
       </Card>
       <Card title="Deno" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/deno.svg" href="/docs/phoenix/settings/sandboxes/deno">
-        Runs TypeScript in a locked-down Deno process — no filesystem, network, or third-party package access.
+        Runs simple TypeScript evaluators in a locked-down Deno process. No env vars, network, or packages.
       </Card>
     </CardGroup>
   </Accordion>
 
-  <Accordion title="Hosted sandboxes" icon="cloud">
-    **Hosted sandboxes** run on a third-party provider's infrastructure. Each invocation spins up a fresh sandbox there — a VM, micro-VM, or container, depending on the provider. The upside: kernel-level isolation, longer maximum timeouts, the ability to install Python or npm packages at execution time, and opt-in outbound network access. The cost: per-call round-trip latency and the need to configure credentials for the upstream service.
+  <Accordion title="Hosted sandboxes — full capability" icon="cloud">
+    **Hosted sandboxes** run on a third-party provider's infrastructure. Each invocation spins up a fresh sandbox there — a VM, micro-VM, or container, depending on the provider. They are the **only** sandboxes that support environment variables, outbound network access, and third-party dependencies, plus kernel-level isolation and longer maximum timeouts. The cost: per-call round-trip latency and the need to configure credentials for the upstream service.
 
     <CardGroup cols={2}>
       <Card title="E2B" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/e2b.svg" href="/docs/phoenix/settings/sandboxes/e2b">
@@ -98,7 +100,11 @@ Values are stored encrypted at rest using the server's `PHOENIX_SECRET`. The dia
 
 ## Sandbox Configurations
 
-A **sandbox configuration** is a named, reusable runtime profile — a provider plus its timeout, environment variables, internet-access setting, and any pre-installed dependencies. Code evaluators don't pick a provider directly; they pick a configuration. This means administrators can set up a small set of vetted profiles — for example, "Python with `requests` and `numpy`" or "Node.js with internet access" — and the people writing evaluators just pick the profile that fits their script.
+A **sandbox configuration** is a named, reusable runtime profile. For a **local** provider it's just a provider and a timeout. For a **hosted** provider it can also carry environment variables, an internet-access setting, and pre-installed dependencies. Code evaluators don't pick a provider directly; they pick a configuration. This means administrators can set up a small set of vetted profiles — for example, "Python with `requests` and `numpy`" or "Node.js with internet access" — and the people writing evaluators just pick the profile that fits their script.
+
+<Warning>
+Environment variables, internet access, and dependencies are **hosted-sandbox-only**. A local-sandbox configuration (Deno or WebAssembly) is just a provider and a timeout — those fields are hidden in the dialog when a local provider is selected.
+</Warning>
 
 <Warning>
 Environment-variable values — including the values resolved from secret references — are visible to any code that runs in the sandbox (for example, `os.environ` in Python). Treat them as readable by anyone authorized to author or run an evaluator against the config.
@@ -108,18 +114,18 @@ Environment-variable values — including the values resolved from secret refere
 
 Click **New Sandbox** in the Sandbox Configurations card. Only providers that are currently available *and* enabled by an administrator appear in the picker.
 
-The dialog exposes the following fields. Fields that aren't supported by the selected backend are shown as **Not supported by the selected backend**.
+The dialog exposes the following fields. The last three are **hosted-sandbox-only** — when a local provider (Deno or WebAssembly) is selected they are hidden entirely.
 
-| Field | Notes |
-|-------|-------|
-| **Provider** | Required. The sandbox provider this config targets. Provider credentials and deployment routing are shared across that provider's supported languages. |
-| **Language** | Required. Auto-filled for single-language providers; selected explicitly for multi-language providers. Configs are language-scoped — a Python config can only be selected by Python evaluators. |
-| **Name** | Required. Lowercase letters, digits, dashes, and underscores. Must start and end with a letter or digit. Used to identify the config in the evaluator UI. |
-| **Description** | Optional free-form text shown next to the config name. |
-| **Timeout (seconds)** | Required. Total time allowed for sandbox setup and execution. Defaults to **300s**. |
-| **Environment Variables** | One row per variable. Each row is either a **literal value** typed inline, or a **secret reference** to a key from [Settings → Secrets](/docs/phoenix/settings/secrets). Available only for backends that support env vars; the Deno sandbox does not accept any user-supplied env vars and the field is hidden when Deno is selected. |
-| **Allow Internet Access** | Toggle for backends that gate outbound networking. When off, the sandbox runs with no network egress. |
-| **Dependencies** | One package per line. The dialog shows whether the backend takes Python packages (e.g. `requests`, `numpy==1.26.0`) or npm packages (e.g. `@types/node`, `lodash`). Phoenix installs these before each execution. |
+| Field | Availability | Notes |
+|-------|-------------|-------|
+| **Provider** | All | Required. The sandbox provider this config targets. Provider credentials and deployment routing are shared across that provider's supported languages. |
+| **Language** | All | Required. Auto-filled for single-language providers; selected explicitly for multi-language providers. Configs are language-scoped — a Python config can only be selected by Python evaluators. |
+| **Name** | All | Required. Lowercase letters, digits, dashes, and underscores. Must start and end with a letter or digit. Used to identify the config in the evaluator UI. |
+| **Description** | All | Optional free-form text shown next to the config name. |
+| **Timeout (seconds)** | All | Required. Total time allowed for sandbox setup and execution. Defaults to **300s**. |
+| **Environment Variables** | Hosted only | One row per variable. Each row is either a **literal value** typed inline, or a **secret reference** to a key from [Settings → Secrets](/docs/phoenix/settings/secrets). |
+| **Allow Internet Access** | Hosted only | Toggle for outbound networking. When off, the sandbox runs with no network egress. |
+| **Dependencies** | Hosted only | One package per line — Python packages (e.g. `requests`, `numpy==1.26.0`) or npm packages (e.g. `@types/node`, `lodash`). Phoenix installs these before each execution. |
 
 ## Next steps
 

--- a/docs/phoenix/settings/sandboxes.mdx
+++ b/docs/phoenix/settings/sandboxes.mdx
@@ -117,7 +117,7 @@ The dialog exposes the following fields. Fields that aren't supported by the sel
 | **Name** | Required. Lowercase letters, digits, dashes, and underscores. Must start and end with a letter or digit. Used to identify the config in the evaluator UI. |
 | **Description** | Optional free-form text shown next to the config name. |
 | **Timeout (seconds)** | Required. Total time allowed for sandbox setup and execution. Defaults to **300s**. |
-| **Environment Variables** | One row per variable. Each row is either a **literal value** typed inline, or a **secret reference** to a key from [Settings → Secrets](/docs/phoenix/settings/secrets). Available only for backends that support env vars. |
+| **Environment Variables** | One row per variable. Each row is either a **literal value** typed inline, or a **secret reference** to a key from [Settings → Secrets](/docs/phoenix/settings/secrets). Available only for backends that support env vars; the Deno sandbox does not accept any user-supplied env vars and the field is hidden when Deno is selected. |
 | **Allow Internet Access** | Toggle for backends that gate outbound networking. When off, the sandbox runs with no network egress. |
 | **Dependencies** | One package per line. The dialog shows whether the backend takes Python packages (e.g. `requests`, `numpy==1.26.0`) or npm packages (e.g. `@types/node`, `lodash`). Phoenix installs these before each execution. |
 

--- a/docs/phoenix/settings/sandboxes/deno.mdx
+++ b/docs/phoenix/settings/sandboxes/deno.mdx
@@ -7,7 +7,7 @@ description: "Run TypeScript code evaluators inside the Phoenix server using a s
 <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/deno.svg" alt="Deno" className="invert-on-dark" style={{ height: '112px', flexShrink: 0 }} />
 <div>
 
-The **Deno** sandbox runs TypeScript code evaluators inside a locked-down Deno process on the Phoenix server. Scripts cannot read your files, open network connections, run other programs, or pull in third-party packages — the only things they can read are the environment variables you explicitly add to the sandbox configuration. Because Deno runs locally inside Phoenix, it starts in milliseconds and needs no credentials, which makes it the default choice for TypeScript evaluators that don't need outbound network access or third-party libraries.
+The **Deno** sandbox runs TypeScript code evaluators inside a locked-down Deno process on the Phoenix server. Scripts cannot read your files, open network connections, run other programs, pull in third-party packages, or read any environment variables — the Deno sandbox is intentionally configured with no env-var passthrough at all. Because Deno runs locally inside Phoenix, it starts in milliseconds and needs no credentials, which makes it the default choice for TypeScript evaluators that don't need outbound network access or third-party libraries.
 
 </div>
 </div>
@@ -18,7 +18,7 @@ Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes). Fo
 
 The Deno sandbox is tightly restricted, but it is **not a substitute for running untrusted code on isolated infrastructure**. Deno itself makes this point in [Executing untrusted code](https://docs.deno.com/runtime/fundamentals/security/#executing-untrusted-code): restricting permissions limits what an attacker can do, but it does not eliminate the risk. Before using the Deno sandbox for code you do not control, understand the three caveats below.
 
-- **Anything you put in the sandbox's environment variables is visible to the script.** This includes values pulled from secret references in your configuration. A malicious script can read these and pass them back out through its return value or an error message. Only expose the credentials the evaluator actually needs.
+- **Environment variables are intentionally unavailable to Deno sandboxes.** The Deno sandbox does not accept user-supplied env vars and the child process runs with an empty environment, so the script cannot read either configuration-time secrets or the Phoenix server's ambient process env. If your TypeScript evaluator needs to read a secret, use a hosted sandbox instead.
 - **The script shares CPU and memory with the Phoenix server.** A script that runs an infinite loop or allocates too much memory will keep doing so until the configured timeout expires. Keep timeouts short for evaluators that handle untrusted input.
 - **The security boundary depends on Deno itself.** Phoenix relies on Deno to enforce the restrictions. A bug in Deno would weaken the protection.
 

--- a/docs/phoenix/settings/sandboxes/deno.mdx
+++ b/docs/phoenix/settings/sandboxes/deno.mdx
@@ -1,25 +1,31 @@
 ---
 title: "Deno"
-description: "Run TypeScript code evaluators inside the Phoenix server using a sandboxed Deno process."
+description: "Run simple TypeScript code evaluators locally inside the Phoenix server."
 ---
 
 <div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem', marginTop: '1.5rem', marginBottom: '1.5rem' }}>
 <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/deno.svg" alt="Deno" className="invert-on-dark" style={{ height: '112px', flexShrink: 0 }} />
 <div>
 
-The **Deno** sandbox runs TypeScript code evaluators inside a locked-down Deno process on the Phoenix server. Scripts cannot read your files, open network connections, run other programs, pull in third-party packages, or read any environment variables — the Deno sandbox is intentionally configured with no env-var passthrough at all. Because Deno runs locally inside Phoenix, it starts in milliseconds and needs no credentials, which makes it the default choice for TypeScript evaluators that don't need outbound network access or third-party libraries.
+The **Deno** sandbox is a **local sandbox** for **simple TypeScript evaluators** — pure-logic checks like regex matches, JSON parsing, and scoring functions. It runs locally inside the Phoenix server, starts in milliseconds, and needs no credentials.
 
 </div>
 </div>
 
-Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes). For background on how Deno enforces these restrictions, see [deno.land](https://deno.land/).
+Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).
 
-## Risks of running untrusted code
+## What it supports
 
-The Deno sandbox is tightly restricted, but it is **not a substitute for running untrusted code on isolated infrastructure**. Deno itself makes this point in [Executing untrusted code](https://docs.deno.com/runtime/fundamentals/security/#executing-untrusted-code): restricting permissions limits what an attacker can do, but it does not eliminate the risk. Before using the Deno sandbox for code you do not control, understand the three caveats below.
+The Deno sandbox runs your TypeScript in a locked-down local process. It is intentionally limited to **self-contained code**:
 
-- **Environment variables are intentionally unavailable to Deno sandboxes.** The Deno sandbox does not accept user-supplied env vars and the child process runs with an empty environment, so the script cannot read either configuration-time secrets or the Phoenix server's ambient process env. If your TypeScript evaluator needs to read a secret, use a hosted sandbox instead.
-- **The script shares CPU and memory with the Phoenix server.** A script that runs an infinite loop or allocates too much memory will keep doing so until the configured timeout expires. Keep timeouts short for evaluators that handle untrusted input.
-- **The security boundary depends on Deno itself.** Phoenix relies on Deno to enforce the restrictions. A bug in Deno would weaken the protection.
+| Capability | Supported? |
+| :-- | :-- |
+| Environment variables | ❌ Not supported — use a hosted sandbox |
+| Network access | ❌ Not supported — use a hosted sandbox |
+| Third-party dependencies | ❌ Not supported — use a hosted sandbox |
 
-If these trade-offs are not acceptable for your use case — for example, you need to evaluate code from sources you cannot verify — **use a hosted sandbox instead**. [E2B, Daytona, Vercel, and Modal](/docs/phoenix/settings/sandboxes#hosted-sandboxes) run each evaluation on a remote virtual machine isolated from your Phoenix server.
+If your evaluator needs **any** of the above, it cannot run on Deno. Use a [hosted sandbox](/docs/phoenix/settings/sandboxes#local-vs-hosted-sandboxes) (E2B, Daytona, Vercel, or Modal) instead — those run each evaluation on an isolated remote VM with full support for environment variables, outbound network access, and installed packages.
+
+## Running untrusted code
+
+The Deno sandbox is tightly restricted, but it runs in the Phoenix server process, so it is **not a substitute for running untrusted code on isolated infrastructure**. The script shares CPU and memory with Phoenix, and the security boundary depends on Deno itself. If you need to evaluate code from sources you cannot verify, use a [hosted sandbox](/docs/phoenix/settings/sandboxes#local-vs-hosted-sandboxes).

--- a/docs/phoenix/settings/sandboxes/wasm.mdx
+++ b/docs/phoenix/settings/sandboxes/wasm.mdx
@@ -1,21 +1,31 @@
 ---
 title: "WebAssembly"
-description: "Run Python code evaluators inside the Phoenix server using a sandboxed Python interpreter."
+description: "Run simple Python code evaluators locally inside the Phoenix server."
 ---
 
 <div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem', marginTop: '1.5rem', marginBottom: '1.5rem' }}>
 <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/wasm.svg" alt="WebAssembly" style={{ height: '112px', flexShrink: 0 }} />
 <div>
 
-The **WebAssembly** sandbox runs Python code evaluators inside an isolated [WebAssembly](https://webassembly.org/) runtime on the Phoenix server. Scripts cannot read your files, open network connections, or access anything else on the host — Phoenix controls exactly which operations the Python code is allowed to perform. It runs locally inside Phoenix, starts in milliseconds, and needs no credentials, which makes it the default choice for fast Python evaluators that handle pure logic (regex, JSON parsing, scoring functions, etc.).
+The **WebAssembly** sandbox is a **local sandbox** for **simple Python evaluators** — pure-logic checks like regex matches, JSON parsing, and scoring functions. It runs locally inside the Phoenix server, starts in milliseconds, and needs no credentials.
 
 </div>
 </div>
 
-Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes). For background on the underlying technology, see [webassembly.org](https://webassembly.org/).
+Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).
 
-## Security model
+## What it supports
 
-WebAssembly runs the Python interpreter inside a strictly isolated environment. Memory is partitioned so the script can only touch its own data, and the script has no built-in access to the filesystem, network, or operating system. Phoenix decides explicitly which operations to allow, and everything else is denied by default.
+The WebAssembly sandbox runs your Python in an isolated [WebAssembly](https://webassembly.org/) runtime on the Phoenix server. It is intentionally limited to **self-contained code**:
 
-For the full security model — including memory safety, control-flow integrity, and the side-channel limitations that apply to any in-process sandbox — see WebAssembly's [Security](https://webassembly.org/docs/security/) documentation.
+| Capability | Supported? |
+| :-- | :-- |
+| Environment variables | ❌ Not supported — use a hosted sandbox |
+| Network access | ❌ Not supported — use a hosted sandbox |
+| Third-party dependencies | ❌ Not supported — use a hosted sandbox |
+
+If your evaluator needs **any** of the above, it cannot run on WebAssembly. Use a [hosted sandbox](/docs/phoenix/settings/sandboxes#local-vs-hosted-sandboxes) (E2B, Daytona, Vercel, or Modal) instead — those run each evaluation on an isolated remote VM with full support for environment variables, outbound network access, and installed packages.
+
+## Running untrusted code
+
+WebAssembly runs the Python interpreter inside a strictly isolated environment — memory is partitioned and the script has no built-in access to the filesystem, network, or operating system. The sandbox still runs in the Phoenix server process, so the script shares CPU and memory with Phoenix. For the full security model, see WebAssembly's [Security](https://webassembly.org/docs/security/) documentation.

--- a/src/phoenix/server/api/mutations/sandbox_config_mutations.py
+++ b/src/phoenix/server/api/mutations/sandbox_config_mutations.py
@@ -154,20 +154,15 @@ class DaytonaConfigInput:
 
 @strawberry.input
 class DenoConfigInput:
-    """Deno runs as a local subprocess with no network policy hook, so it
-    doesn't carry an ``internet_access`` field. Env vars are still supported."""
+    """Deno runs as a local subprocess with no network policy hook and no
+    env-var passthrough. Deno sandboxes intentionally cannot receive any
+    user-supplied environment variables, so this input carries only
+    ``language``."""
 
     language: Language
-    env_vars: list[EnvVarInput] = strawberry.field(default_factory=list)
-
-    def __post_init__(self) -> None:
-        _names_are_unique(self.env_vars)
 
     def to_orm(self) -> DenoConfig:
-        fields: dict[str, Any] = {"language": self.language.to_orm()}
-        if self.env_vars:
-            fields["env_vars"] = {ev.name: ev.to_orm() for ev in self.env_vars}
-        return DenoConfig.model_validate(fields)
+        return DenoConfig.model_validate({"language": self.language.to_orm()})
 
 
 @strawberry.input

--- a/src/phoenix/server/sandbox/deno_backend.py
+++ b/src/phoenix/server/sandbox/deno_backend.py
@@ -3,7 +3,8 @@ Local Deno sandbox backend.
 
 Stateless (BaseNoSessionBackend) — each execute() call is independent.
 Executes code through the local ``deno`` CLI with a default-deny permission
-model, granting only exact env-var access for server-injected variables.
+model. Deno sandboxes intentionally never receive any user-supplied
+environment variables.
 """
 
 from __future__ import annotations
@@ -30,14 +31,9 @@ logger = logging.getLogger(__name__)
 class DenoSandboxBackend(BaseNoSessionBackend):
     """Sandbox backend executing TypeScript code in a local Deno runtime."""
 
-    def __init__(
-        self,
-        deno_executable: str,
-        user_env: Optional[Mapping[str, str]] = None,
-    ) -> None:
+    def __init__(self, deno_executable: str) -> None:
         self._deno_executable = deno_executable
-        self._user_env: dict[str, str] = dict(user_env or {})
-        self.secret_values = compose_secret_values(user_env)
+        self.secret_values = compose_secret_values(None)
 
     def _build_command(self) -> list[str]:
         # Deno security docs: permissions are denied by default, but config
@@ -46,24 +42,21 @@ class DenoSandboxBackend(BaseNoSessionBackend):
         # Docs:
         # - https://docs.deno.com/runtime/fundamentals/security/
         # - https://docs.deno.com/runtime/reference/cli/run/
-        cmd = [
+        return [
             self._deno_executable,
             "run",
             "--no-prompt",
             "--no-config",
             "--no-remote",
             "--no-npm",
+            "-",
         ]
-        if self._user_env:
-            allowed_env_names = ",".join(sorted(self._user_env))
-            cmd.append(f"--allow-env={allowed_env_names}")
-        cmd.append("-")
-        return cmd
 
     def _build_subprocess_env(self) -> dict[str, str]:
-        # Pass only caller-resolved variables through to the child so Deno code
-        # cannot observe the Phoenix server's ambient environment.
-        return dict(self._user_env)
+        # Deno child runs with an empty environment so it cannot observe the
+        # Phoenix server's ambient process env. User-supplied env vars are
+        # intentionally not supported for Deno sandboxes.
+        return {}
 
     async def execute(
         self,
@@ -133,9 +126,15 @@ class DenoAdapter(SandboxAdapter[DenoConfig, NoCredentials, DenoDeployment]):
         deployment: DenoDeployment,
         user_env: Optional[Mapping[str, str]] = None,
     ) -> SandboxBackend:
+        # Deno sandboxes do not accept user-supplied environment variables.
+        # DenoConfig does not compose SupportsEnvVars, so SecretsContext should
+        # already resolve an empty mapping here; reject anything else as
+        # defense-in-depth.
+        if user_env:
+            raise ValueError("Deno sandboxes do not support user-supplied environment variables.")
         deno_executable = shutil.which("deno")
         if deno_executable is None:
             raise ValueError(
                 "Deno is not installed. Install Deno and ensure the `deno` binary is on PATH."
             )
-        return DenoSandboxBackend(deno_executable=deno_executable, user_env=user_env)
+        return DenoSandboxBackend(deno_executable=deno_executable)

--- a/src/phoenix/server/sandbox/types.py
+++ b/src/phoenix/server/sandbox/types.py
@@ -319,7 +319,11 @@ class DaytonaConfig(
     language: Literal["PYTHON", "TYPESCRIPT"]
 
 
-class DenoConfig(_Config, SupportsEnvVars):
+class DenoConfig(_Config):
+    # Deno runs untrusted TypeScript locally; we deliberately do not compose
+    # SupportsEnvVars so no user-supplied env vars can ever reach the
+    # subprocess. The adapter metadata's ``supports_env_vars`` derives from the
+    # mixin, so this also hides env-var UI in the frontend.
     backend_type: Literal["DENO"] = "DENO"
     language: Literal["TYPESCRIPT"] = "TYPESCRIPT"
 

--- a/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
+++ b/tests/unit/server/api/mutations/test_sandbox_config_mutations.py
@@ -182,6 +182,35 @@ class TestCapabilityGates:
         assert result.errors
         assert result.data is None
 
+    async def test_env_vars_field_absent_from_deno_input_returns_error(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        """Deno sandboxes intentionally don't accept env vars — ``DenoConfigInput``
+        has no ``envVars`` field, so the GraphQL parser rejects it outright."""
+        provider = await _get_provider(db, "DENO")
+        config = await _create_config_for_provider(db, provider)
+
+        with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"DENO": _deno_adapter}):
+            result = await gql_client.execute(
+                _UPDATE,
+                variables={
+                    "input": {
+                        "id": _config_global_id(config.id),
+                        "config": {
+                            "deno": {
+                                "language": "TYPESCRIPT",
+                                "envVars": [{"name": "FOO", "secretKey": "k"}],
+                            }
+                        },
+                    }
+                },
+            )
+        assert result.errors
+        assert result.data is None
+
     async def test_dependencies_packages_on_unsupported_adapter_returns_error(
         self,
         gql_client: AsyncGraphQLClient,

--- a/tests/unit/server/sandbox/test_deno_backend.py
+++ b/tests/unit/server/sandbox/test_deno_backend.py
@@ -52,7 +52,6 @@ class TestDenoAdapter:
                 _DENO_CFG,
                 credentials=_DENO_CREDS,
                 deployment=_DENO_DEPLOY,
-                user_env={"TOKEN": "value"},
             )
 
         assert isinstance(backend, DenoSandboxBackend)
@@ -63,17 +62,33 @@ class TestDenoAdapter:
             "--no-config",
             "--no-remote",
             "--no-npm",
-            "--allow-env=TOKEN",
             "-",
         ]
 
+    def test_build_backend_rejects_user_env(self) -> None:
+        """Defense-in-depth: even if a caller passes user_env, the Deno adapter
+        refuses to construct a backend that could leak env vars to the
+        subprocess."""
+        adapter = DenoAdapter()
+
+        with patch(
+            "phoenix.server.sandbox.deno_backend.shutil.which",
+            return_value="/opt/homebrew/bin/deno",
+        ):
+            with pytest.raises(
+                ValueError, match="do not support user-supplied environment variables"
+            ):
+                adapter.build_backend(
+                    _DENO_CFG,
+                    credentials=_DENO_CREDS,
+                    deployment=_DENO_DEPLOY,
+                    user_env={"TOKEN": "value"},
+                )
+
 
 class TestDenoSandboxBackend:
-    def test_build_command_scopes_env_permissions_exactly(self) -> None:
-        backend = DenoSandboxBackend(
-            deno_executable="/usr/local/bin/deno",
-            user_env={"B": "2", "A": "1"},
-        )
+    def test_build_command_has_no_allow_env(self) -> None:
+        backend = DenoSandboxBackend(deno_executable="/usr/local/bin/deno")
 
         assert backend._build_command() == [
             "/usr/local/bin/deno",
@@ -82,24 +97,20 @@ class TestDenoSandboxBackend:
             "--no-config",
             "--no-remote",
             "--no-npm",
-            "--allow-env=A,B",
             "-",
         ]
 
-    def test_build_subprocess_env_includes_only_user_env(self) -> None:
-        backend = DenoSandboxBackend(
-            deno_executable="/usr/local/bin/deno",
-            user_env={"SECRET": "value"},
-        )
+    def test_build_subprocess_env_is_empty(self) -> None:
+        """Deno sandboxes never receive any environment variables — the child
+        process runs with an empty env so it cannot read the Phoenix server's
+        ambient process env either."""
+        backend = DenoSandboxBackend(deno_executable="/usr/local/bin/deno")
 
-        assert backend._build_subprocess_env() == {"SECRET": "value"}
+        assert backend._build_subprocess_env() == {}
 
     @pytest.mark.asyncio
     async def test_execute_successfully_runs_deno_process(self) -> None:
-        backend = DenoSandboxBackend(
-            deno_executable="/usr/local/bin/deno",
-            user_env={"TOKEN": "secret", "FOO": "bar"},
-        )
+        backend = DenoSandboxBackend(deno_executable="/usr/local/bin/deno")
         proc = _StubProcess(stdout=b"ok\n", stderr=b"", returncode=0)
 
         with patch(
@@ -113,10 +124,7 @@ class TestDenoSandboxBackend:
         assert result.error is None
         proc.communicate.assert_awaited_once_with(b"console.log('ok')")
         assert create_subprocess_exec.await_args is not None
-        assert create_subprocess_exec.await_args.kwargs["env"] == {
-            "TOKEN": "secret",
-            "FOO": "bar",
-        }
+        assert create_subprocess_exec.await_args.kwargs["env"] == {}
         assert create_subprocess_exec.await_args.args == (
             "/usr/local/bin/deno",
             "run",
@@ -124,7 +132,6 @@ class TestDenoSandboxBackend:
             "--no-config",
             "--no-remote",
             "--no-npm",
-            "--allow-env=FOO,TOKEN",
             "-",
         )
 


### PR DESCRIPTION
## Summary

Deno sandboxes run untrusted TypeScript locally inside the Phoenix server process and have no legitimate use for user-supplied environment variables. This change completely disallows inserting env vars into Deno sandboxes, on both the backend and frontend.

- **Backend types** — `DenoConfig` no longer composes the `SupportsEnvVars` mixin, so the adapter metadata reports `supports_env_vars: false` for Deno.
- **GraphQL** — `DenoConfigInput` drops the `envVars` field (and its uniqueness check); the GraphQL parser now rejects any `envVars` payload for the `deno` variant outright.
- **Deno backend** — `DenoSandboxBackend` no longer accepts `user_env`; the subprocess runs with an empty environment and without the `--allow-env` flag, so Deno code cannot read configuration secrets or the Phoenix server's ambient process env. `DenoAdapter.build_backend` rejects a non-empty `user_env` as defense-in-depth.
- **Frontend** — no hand-written changes needed: the config dialog already gates the env-var section on `supportsEnvVars`, and `formValuesToConfigPatch` already gates the `envVars` payload on the same flag. With the backend now reporting `false`, the UI shows the "Not supported by the selected backend" placeholder for Deno. `schema.graphql` and the Relay artifacts were regenerated.
- **Docs** — updated the Deno sandbox page and the Sandboxes settings page to reflect that Deno accepts no env vars.
