### PR TITLE
docs(sandbox): document PHOENIX_ALLOWED_SANDBOX_PROVIDERS on Sandboxes settings page

### DIFF
--- a/docs/phoenix/settings/sandboxes.mdx
+++ b/docs/phoenix/settings/sandboxes.mdx
@@ -87,6 +87,16 @@ A common pattern is to enable a local sandbox for the everyday case (pure-logic 
 
 A **provider** is a sandbox runtime that Phoenix can run code on — for example, *Vercel Sandbox* or *Daytona*. Each row in this card shows the provider's name, the languages it supports, its current status, and a gear icon for entering credentials. Once the provider is ready to run code, an **Enabled** switch appears. Turning it off hides every configuration tied to that provider from the people writing evaluators, but doesn't delete anything — flip it back on and the configurations reappear.
 
+### Restricting providers at the server level
+
+The **Enabled** switch above is a per-deployment, admin-facing control. Self-hosted deployments can also restrict providers at the *server* level with the `PHOENIX_ALLOWED_SANDBOX_PROVIDERS` environment variable, which is set before Phoenix starts and cannot be overridden from this page.
+
+- **Leave it unset** to allow every supported provider (the default).
+- **Set it to a comma-separated list** — e.g. `PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO` — to allow only those providers. Accepted values are `WASM`, `DENO`, `E2B`, `DAYTONA`, `VERCEL`, and `MODAL` (case-insensitive).
+- **Set it to `NONE`** to disable every sandbox provider.
+
+A provider that isn't on the allowlist shows the status **Disabled** with the tooltip "Disabled on the server," and its **Enabled** switch is unavailable. See [Sandbox Backends](/docs/phoenix/self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) for the full details.
+
 ### Configuring credentials
 
 Click the gear icon next to a provider to open the credentials dialog. The dialog lists the credential fields the backend declares — for example:


### PR DESCRIPTION
## Summary

Adds documentation for the `PHOENIX_ALLOWED_SANDBOX_PROVIDERS` server-level allowlist to the **Settings → Sandboxes** page.

The `NONE` sentinel (and the env var generally) was already documented in `MIGRATION.md`, `self-hosting/configuration.mdx`, and `self-hosting/features/sandbox-runtimes.mdx`, but the user-facing **Settings → Sandboxes** page only referenced it via a link. This adds a dedicated **"Restricting providers at the server level"** subsection there.

## Changes

- New subsection under **Sandbox Providers** covering the three modes:
  - unset → all providers allowed (default)
  - comma-separated list → only those providers
  - `NONE` → disables every sandbox provider
- Distinguishes the server-level env var from the per-deployment **Enabled** UI switch
- Notes the resulting **Disabled** ("Disabled on the server") status
- Links to the deeper [Sandbox Backends](https://arize.com/docs/phoenix/self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) page

## Notes

The `NONE` kill-switch code (`get_env_allowed_sandbox_providers` / `validate_env_allowed_sandbox_providers` in `config.py`) and its tests already exist on `version-sandboxes` — this PR is docs-only.