### PR TITLE
fix(evaluators): make sandbox warnings banners with a link button

### DIFF
--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -17,7 +17,7 @@ import {
   Icons,
   Input,
   Label,
-  Link,
+  LinkButton,
   List,
   ListItem,
   NumberField,
@@ -309,15 +309,22 @@ export const EditCodeEvaluatorDialogContent = ({
           </Alert>
         )}
         {hasNoSandboxConfigs ? (
-          <Alert variant="warning" title="No sandboxes configured">
-            You can still draft and save this evaluator now.{" "}
-            <Link to="/settings/sandboxes">Configure a sandbox</Link> later to
-            test or execute it.
+          <Alert
+            variant="warning"
+            banner
+            extra={
+              <LinkButton size="S" to="/settings/sandboxes">
+                Configure a sandbox
+              </LinkButton>
+            }
+          >
+            No sandboxes configured. You can still draft and save this
+            evaluator now. Configure a sandbox later to test or execute it.
           </Alert>
         ) : null}
 
         {unavailableSandboxSelectionMessage ? (
-          <Alert variant="warning" title="Sandbox unavailable">
+          <Alert variant="warning" banner>
             {unavailableSandboxSelectionMessage}
           </Alert>
         ) : null}

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -318,8 +318,8 @@ export const EditCodeEvaluatorDialogContent = ({
               </LinkButton>
             }
           >
-            No sandboxes configured. You can still draft and save this
-            evaluator now. Configure a sandbox later to test or execute it.
+            No sandboxes configured. You can still draft and save this evaluator
+            now. Configure a sandbox later to test or execute it.
           </Alert>
         ) : null}
 


### PR DESCRIPTION
## Summary

Cleans up the sandbox warning alerts on the Edit Code Evaluator page:

- Both warning alerts (`No sandboxes configured` and `Sandbox unavailable`) now render as full-width `banner`s and dropped their titles.
- The "Configure a sandbox" link is now a `LinkButton` placed in the alert's `extra` slot, rendering as a button on the right side of the banner.
- The descriptive copy moved into the alert body now that the titles are gone.

## Test plan

- Open the Edit Code Evaluator dialog with no sandboxes configured → banner shows with a "Configure a sandbox" link button.
- Open it with a previously selected but now-unavailable sandbox → banner shows the unavailable message.