### PR TITLE
fix(app): route PXI markdown links through router

### DIFF
--- a/app/src/components/markdown/__tests__/streamdownComponents.test.tsx
+++ b/app/src/components/markdown/__tests__/streamdownComponents.test.tsx
@@ -1,0 +1,66 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+
+import { MarkdownLink } from "../streamdownComponents";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function renderMarkdownLink({
+  href,
+  basename,
+}: {
+  href: string;
+  basename?: string;
+}) {
+  act(() => {
+    root.render(
+      <MemoryRouter basename={basename} initialEntries={[basename ?? "/"]}>
+        <MarkdownLink href={href} rel="noopener noreferrer" target="_blank">
+          Link
+        </MarkdownLink>
+      </MemoryRouter>
+    );
+  });
+}
+
+describe("MarkdownLink", () => {
+  it("delegates app link href generation to React Router", () => {
+    renderMarkdownLink({ href: "/settings/general", basename: "/phoenix" });
+
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("/phoenix/settings/general");
+  });
+
+  it("does not pass Streamdown's target attributes into React Router links", () => {
+    renderMarkdownLink({ href: "/settings/general" });
+
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("target")).toBeNull();
+    expect(link?.getAttribute("rel")).toBeNull();
+  });
+
+  it("keeps Streamdown's target attributes for external links", () => {
+    renderMarkdownLink({ href: "https://arize.com/docs/phoenix" });
+
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("https://arize.com/docs/phoenix");
+    expect(link?.getAttribute("target")).toBe("_blank");
+    expect(link?.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+});

--- a/app/src/components/markdown/streamdownComponents.tsx
+++ b/app/src/components/markdown/streamdownComponents.tsx
@@ -10,11 +10,13 @@ import {
   useState,
 } from "react";
 import { DialogTrigger } from "react-aria-components";
+import { Link as RouterLink } from "react-router";
 import {
   extractTableDataFromElement,
   tableDataToCSV,
   tableDataToMarkdown,
   type Components,
+  type ExtraProps,
 } from "streamdown";
 
 import { IconButton } from "../core/button";
@@ -109,6 +111,53 @@ const linkCSS = css`
 const strongCSS = css`
   font-weight: var(--global-font-weight-semibold);
 `;
+
+function shouldPreserveExternalLinkAttributes({
+  href,
+}: {
+  href: string | undefined;
+}) {
+  if (!href) {
+    return false;
+  }
+
+  try {
+    const url = new URL(href, window.location.href);
+
+    // Streamdown adds target/rel for links. Preserve those for external links
+    // so they keep opening in a new tab, but strip them from internal links so
+    // React Router can handle same-tab SPA navigation.
+    return url.origin !== window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+export function MarkdownLink({
+  children,
+  className,
+  href,
+  rel,
+  target,
+  node: _node,
+  ...rest
+}: ComponentPropsWithoutRef<"a"> & ExtraProps) {
+  const externalLinkAttributes = shouldPreserveExternalLinkAttributes({ href })
+    ? { rel, target }
+    : {};
+
+  return (
+    <RouterLink
+      css={linkCSS}
+      className={className}
+      to={href ?? ""}
+      {...externalLinkAttributes}
+      {...rest}
+    >
+      {children}
+    </RouterLink>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Lists
@@ -478,11 +527,7 @@ export const streamdownComponents: Components = {
       {children}
     </strong>
   ),
-  a: ({ children, className, href, ...rest }) => (
-    <a css={linkCSS} className={className} href={href} {...rest}>
-      {children}
-    </a>
-  ),
+  a: MarkdownLink,
   ul: ({ children, className, ...rest }) => (
     <ul css={listCSS} className={className} {...rest}>
       {children}

--- a/src/phoenix/server/agents/prompts/base/BASE_INSTRUCTIONS.xml
+++ b/src/phoenix/server/agents/prompts/base/BASE_INSTRUCTIONS.xml
@@ -8,6 +8,7 @@ tools. When you don't know something, say you don't know instead of making it up
   <canonical_docs_domain>https://arize.com/docs/phoenix</canonical_docs_domain>
   <rules>
     - Format every documentation reference as a markdown link with descriptive anchor text: `[Descriptive Title](https://arize.com/docs/phoenix/<path>)`.
+    - For Phoenix UI links, when you know the app route, use a root-relative app path in markdown, for example `[Agent settings](/settings/agents)`. Do not include the current origin, `localhost`, or a deployment basename such as `/phoenix`; the UI adds the basename. Do not invent routes if you are unsure.
     - Convert any relative path returned by the documentation tools (for example `/tracing/llm-traces`) into an absolute URL by prepending the canonical docs domain (for example `https://arize.com/docs/phoenix/tracing/llm-traces`).
     - Never emit bare URLs; always wrap them in markdown link syntax.
     - Never link to internal preview hosts such as `arizeai-*.mintlify.app`, `localhost` (except for Phoenix UI links when explicitly running locally), or any other domain when referencing documentation.

--- a/tests/pxi/evals/README.md
+++ b/tests/pxi/evals/README.md
@@ -11,6 +11,12 @@ Phoenix, then run:
 uv run python tests/pxi/evals/run_experiment.py --dataset set_spans_filter
 ```
 
+For the in-app link suite:
+
+```bash
+uv run python tests/pxi/evals/run_experiment.py --dataset in_app_links
+```
+
 The runner checks `/healthz` against whichever Phoenix URL is configured
 (default `http://localhost:6006`, or `PHOENIX_COLLECTOR_ENDPOINT` /
 `OTEL_EXPORTER_OTLP_ENDPOINT` if set) before uploading anything. To use a

--- a/tests/pxi/evals/datasets/in_app_links.yaml
+++ b/tests/pxi/evals/datasets/in_app_links.yaml
@@ -36,3 +36,18 @@ examples:
           - /settings/general
     metadata:
       category: settings
+  - id: dataset-resource-link
+    input:
+      query: Link me to where I can see experiments for my PXI link evals dataset.
+      resource:
+        type: dataset
+        name: PXI link evals
+        id: RGF0YXNldDox
+    expected:
+      tools:
+        required: []
+      links:
+        required_in_app:
+          - /datasets/RGF0YXNldDox/experiments
+    metadata:
+      category: dynamic-resource

--- a/tests/pxi/evals/datasets/in_app_links.yaml
+++ b/tests/pxi/evals/datasets/in_app_links.yaml
@@ -1,0 +1,38 @@
+dataset_name: in_app_links
+description: PXI server-side eval suite for root-relative Phoenix UI markdown links.
+evaluators:
+  - in_app_links_valid
+examples:
+  - id: agent-settings-link
+    input:
+      query: Link me to the Phoenix agent settings page.
+    expected:
+      tools:
+        required: []
+      links:
+        required_in_app:
+          - /settings/agents
+    metadata:
+      category: settings
+  - id: ai-provider-settings-link
+    input:
+      query: Where can I configure AI providers in Phoenix? Include a link.
+    expected:
+      tools:
+        required: []
+      links:
+        required_in_app:
+          - /settings/providers
+    metadata:
+      category: settings
+  - id: general-settings-link
+    input:
+      query: Link me to the Phoenix general settings page.
+    expected:
+      tools:
+        required: []
+      links:
+        required_in_app:
+          - /settings/general
+    metadata:
+      category: settings

--- a/tests/pxi/evals/evaluators/__init__.py
+++ b/tests/pxi/evals/evaluators/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from tests.pxi.evals.evaluators.links import in_app_links_valid
 from tests.pxi.evals.evaluators.tools import (
     correct_tools_called,
     set_spans_filter_args_match,
@@ -16,6 +17,7 @@ from tests.pxi.evals.evaluators.tools import (
 # ``@create_evaluator`` decorators in this package.
 EVALUATORS_BY_NAME: dict[str, Any] = {
     "correct_tools_called": correct_tools_called,
+    "in_app_links_valid": in_app_links_valid,
     "tool_call_args_match": tool_call_args_match,
     "set_spans_filter_args_match": set_spans_filter_args_match,
 }
@@ -23,6 +25,7 @@ EVALUATORS_BY_NAME: dict[str, Any] = {
 __all__ = [
     "EVALUATORS_BY_NAME",
     "correct_tools_called",
+    "in_app_links_valid",
     "set_spans_filter_args_match",
     "tool_call_args_match",
 ]

--- a/tests/pxi/evals/evaluators/links.py
+++ b/tests/pxi/evals/evaluators/links.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+from phoenix.evals import create_evaluator
+
+_MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)\s]+)\)")
+_BARE_URL_RE = re.compile(r"https?://[^\s)]+")
+_LOCAL_APP_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _assistant_text(output: Any) -> str | None:
+    text = _as_dict(output).get("assistant_text")
+    return text if isinstance(text, str) and text.strip() else None
+
+
+def _expected_links(expected: Any) -> dict[str, Any]:
+    return _as_dict(_as_dict(expected).get("links", {}))
+
+
+def _required_in_app_links(expected: Any) -> list[str]:
+    required = _expected_links(expected).get("required_in_app", [])
+    return [link for link in required if isinstance(link, str)]
+
+
+def _markdown_href_spans(text: str) -> tuple[list[str], list[tuple[int, int]]]:
+    hrefs: list[str] = []
+    spans: list[tuple[int, int]] = []
+    for match in _MARKDOWN_LINK_RE.finditer(text):
+        hrefs.append(match.group(1))
+        spans.append(match.span(1))
+    return hrefs, spans
+
+
+def _bare_urls(text: str, markdown_href_spans: list[tuple[int, int]]) -> list[str]:
+    urls: list[str] = []
+    for match in _BARE_URL_RE.finditer(text):
+        start, end = match.span()
+        if any(
+            span_start <= start and end <= span_end for span_start, span_end in markdown_href_spans
+        ):
+            continue
+        urls.append(match.group(0))
+    return urls
+
+
+def _absolute_app_link_reason(href: str, required_paths: list[str]) -> str | None:
+    parsed = urlparse(href)
+    if parsed.scheme not in {"http", "https"}:
+        return None
+    if parsed.hostname not in _LOCAL_APP_HOSTS:
+        return None
+    if parsed.path in required_paths:
+        return "absolute app link"
+    return None
+
+
+def _invalid_in_app_hrefs(hrefs: list[str], required_paths: list[str]) -> list[str]:
+    invalid: list[str] = []
+    for href in hrefs:
+        if _absolute_app_link_reason(href, required_paths):
+            invalid.append(href)
+    return invalid
+
+
+def _failure(explanation: str, metadata: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "score": 0.0,
+        "label": "fail",
+        "explanation": explanation,
+        "metadata": metadata,
+    }
+
+
+def evaluate_in_app_links(output: Any, expected: Any) -> dict[str, Any]:
+    """Evaluate PXI answer links against root-relative in-app link expectations."""
+    text = _assistant_text(output)
+    required = _required_in_app_links(expected)
+    if text is None:
+        return _failure(
+            "Assistant output did not include text.",
+            {
+                "required_in_app": required,
+                "observed_markdown_hrefs": [],
+            },
+        )
+
+    hrefs, href_spans = _markdown_href_spans(text)
+    bare_urls = _bare_urls(text, href_spans)
+    missing = [path for path in required if path not in hrefs]
+    invalid_in_app = _invalid_in_app_hrefs(hrefs, required)
+    metadata = {
+        "required_in_app": required,
+        "observed_markdown_hrefs": hrefs,
+        "missing_required_in_app": missing,
+        "invalid_in_app_hrefs": invalid_in_app,
+        "bare_urls": bare_urls,
+    }
+
+    if not hrefs:
+        return _failure("Assistant output did not include markdown links.", metadata)
+    if bare_urls:
+        return _failure("Assistant output included bare URLs.", metadata)
+    if missing:
+        return _failure("Assistant output missed required in-app links.", metadata)
+    if invalid_in_app:
+        return _failure("Assistant output included non-root-relative app links.", metadata)
+
+    return {
+        "score": 1.0,
+        "label": "pass",
+        "explanation": "All required in-app links were emitted as root-relative markdown links.",
+        "metadata": metadata,
+    }
+
+
+@create_evaluator(name="in_app_links_valid", kind="code")
+def in_app_links_valid(output: Any, expected: Any) -> dict[str, Any]:
+    return evaluate_in_app_links(output, expected)

--- a/tests/pxi/evals/test_datasets.py
+++ b/tests/pxi/evals/test_datasets.py
@@ -166,3 +166,9 @@ examples:
         assert dataset.dataset_name == "set_spans_filter"
         assert len(dataset.examples) >= 1
         assert "correct_tools_called" in dataset.evaluators
+
+    def test_loads_in_app_links_dataset(self) -> None:
+        dataset = load_dataset("in_app_links")
+        assert dataset.dataset_name == "in_app_links"
+        assert len(dataset.examples) == 3
+        assert "in_app_links_valid" in dataset.evaluators

--- a/tests/pxi/evals/test_datasets.py
+++ b/tests/pxi/evals/test_datasets.py
@@ -170,5 +170,6 @@ examples:
     def test_loads_in_app_links_dataset(self) -> None:
         dataset = load_dataset("in_app_links")
         assert dataset.dataset_name == "in_app_links"
-        assert len(dataset.examples) == 3
+        assert len(dataset.examples) == 4
         assert "in_app_links_valid" in dataset.evaluators
+        assert any(example["id"] == "dataset-resource-link" for example in dataset.examples)

--- a/tests/pxi/evals/test_evaluators.py
+++ b/tests/pxi/evals/test_evaluators.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pytest
 
+from tests.pxi.evals.evaluators.links import evaluate_in_app_links
 from tests.pxi.evals.evaluators.tools import (
     _normalize_arg_value,
     evaluate_set_spans_filter_args,
@@ -172,6 +173,51 @@ def _output_with_args(name: str, args: dict[str, Any]) -> dict[str, Any]:
             }
         ]
     }
+
+
+def _link_output(assistant_text: str | None) -> dict[str, Any]:
+    return {"assistant_text": assistant_text}
+
+
+def _link_expected(*required: str) -> dict[str, Any]:
+    return {"tools": {"required": []}, "links": {"required_in_app": list(required)}}
+
+
+class TestInAppLinksValid:
+    def test_required_root_relative_markdown_link_passes(self) -> None:
+        result = evaluate_in_app_links(
+            output=_link_output("Open [Agent settings](/settings/agents)."),
+            expected=_link_expected("/settings/agents"),
+        )
+        assert result["score"] == 1.0
+        assert result["label"] == "pass"
+
+    def test_missing_required_path_fails(self) -> None:
+        result = evaluate_in_app_links(
+            output=_link_output("Open [General settings](/settings/general)."),
+            expected=_link_expected("/settings/agents"),
+        )
+        assert result["score"] == 0.0
+        assert result["label"] == "fail"
+        assert result["metadata"]["missing_required_in_app"] == ["/settings/agents"]
+
+    def test_absolute_local_app_link_fails(self) -> None:
+        result = evaluate_in_app_links(
+            output=_link_output("Open [Agent settings](http://localhost:6006/settings/agents)."),
+            expected=_link_expected("/settings/agents"),
+        )
+        assert result["label"] == "fail"
+        assert result["metadata"]["invalid_in_app_hrefs"] == [
+            "http://localhost:6006/settings/agents"
+        ]
+
+    def test_bare_url_fails(self) -> None:
+        result = evaluate_in_app_links(
+            output=_link_output("Open http://localhost:6006/settings/agents."),
+            expected=_link_expected("/settings/agents"),
+        )
+        assert result["label"] == "fail"
+        assert result["metadata"]["bare_urls"] == ["http://localhost:6006/settings/agents."]
 
 
 class TestNormalizeArgValue:

--- a/tests/pxi/evals/test_evaluators.py
+++ b/tests/pxi/evals/test_evaluators.py
@@ -192,6 +192,19 @@ class TestInAppLinksValid:
         assert result["score"] == 1.0
         assert result["label"] == "pass"
 
+    def test_dynamic_resource_markdown_link_passes(self) -> None:
+        result = evaluate_in_app_links(
+            output=_link_output(
+                "Open the [PXI link evals dataset](/datasets/RGF0YXNldDox/experiments)."
+            ),
+            expected=_link_expected("/datasets/RGF0YXNldDox/experiments"),
+        )
+        assert result["score"] == 1.0
+        assert result["label"] == "pass"
+        assert result["metadata"]["observed_markdown_hrefs"] == [
+            "/datasets/RGF0YXNldDox/experiments"
+        ]
+
     def test_missing_required_path_fails(self) -> None:
         result = evaluate_in_app_links(
             output=_link_output("Open [General settings](/settings/general)."),


### PR DESCRIPTION
## Summary
- render PXI markdown links through React Router so in-app links navigate client-side
- preserve external-link behavior for off-app URLs
- add PXI guidance and a minimal in-app link eval suite

## Testing
- pnpm --dir app test -- --run app/src/components/markdown/__tests__/streamdownComponents.test.tsx
- uv run ruff format --check tests/pxi/evals/evaluators/links.py tests/pxi/evals/evaluators/__init__.py tests/pxi/evals/test_datasets.py tests/pxi/evals/test_evaluators.py
- uv run ruff check tests/pxi/evals/evaluators/links.py tests/pxi/evals/evaluators/__init__.py tests/pxi/evals/test_datasets.py tests/pxi/evals/test_evaluators.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest tests/pxi/evals/test_datasets.py tests/pxi/evals/test_evaluators.py tests/pxi/evals/test_run_experiment.py
- Browser validated PXI link generation and click-through under PHOENIX_HOST_ROOT_PATH=/phoenix

Related to #13271