### PR TITLE
docs: Add Phoenix release notes for 05-13-2026 through 05-15-2026

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1177,6 +1177,9 @@
               {
                 "group": "05.2026",
                 "pages": [
+                  "docs/phoenix/release-notes/05-2026/05-15-2026-otel-semconv-conversion",
+                  "docs/phoenix/release-notes/05-2026/05-15-2026-session-feedback-and-atif",
+                  "docs/phoenix/release-notes/05-2026/05-13-2026-playground-thinking-controls",
                   "docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations",
                   "docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences",
                   "docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header",

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -7,6 +7,35 @@ description: The latest from the Phoenix team.
 GitHub
 </Card>
 
+<Update label="05.15.2026">
+## [05.15.2026: OTel GenAI Semantic Convention Auto-Conversion](/docs/phoenix/release-notes/05-2026/05-15-2026-otel-semconv-conversion)
+**Available in arize-phoenix 15.10.0+**
+
+Phoenix now automatically converts OTel GenAI semantic convention attributes (`gen_ai.*`) to OpenInference at ingest time. Traces from OpenTelemetry-native instrumentations — OpenAI, Anthropic, and Google GenAI contrib packages — now render with full message I/O, tool calls, retrieval documents, and token counts without code changes.
+
+- **Zero-config** — point any OTel-native instrumentation at Phoenix's OTLP endpoint; conversion happens server-side
+- **OpenInference wins** — spans that already carry OpenInference attributes are untouched; conversion only fills in what's missing
+- **Full coverage** — input/output messages, tool definitions and results, system instructions, retrieval documents, usage tokens, provider, and model name
+</Update>
+
+<Update label="05.15.2026">
+## [05.15.2026: Session Trace Feedback and ATIF v1.7](/docs/phoenix/release-notes/05-2026/05-15-2026-session-feedback-and-atif)
+**Available in arize-phoenix 15.10.0+ (server), arize-phoenix-client 2.7.0+ (Python)**
+
+- **Session feedback toolbar** — thumbs-up/down and annotate buttons appear on each turn in Session Details; clicking creates a `user_feedback` trace annotation with toggle behavior
+- **ATIF v1.7 trajectory upload** — `upload_atif_trajectories_as_spans` now supports embedded subagent trajectories via `subagent_trajectories`, `trajectory_id`-based deterministic span IDs for idempotent re-uploads, `session_id` in trajectory headers, and deterministic dispatch steps (`llm_call_count: 0`)
+</Update>
+
+<Update label="05.13.2026">
+## [05.13.2026: Playground Thinking Controls](/docs/phoenix/release-notes/05-2026/05-13-2026-playground-thinking-controls)
+**Available in arize-phoenix 15.8.0+**
+
+The Playground now exposes first-class extended thinking controls for Anthropic and Google models, persisted with saved prompts.
+
+- **Anthropic** — Thinking mode (adaptive/enabled/off), token budget (min 1,024), thinking display toggle, and output effort level
+- **Google** — Thinking budget and thinking level (LOW / MEDIUM / HIGH)
+</Update>
+
 <Update label="05.13.2026">
 ## [05.13.2026: Session Enhancements and Annotation Identifiers](/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations)
 **Available in arize-phoenix 15.7.0+**

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -7,6 +7,10 @@ description: The latest from the Phoenix team.
 GitHub
 </Card>
 
+<Info>
+**We want to hear from you!** The DevRel team wants to hear from the Phoenix community. If you're building with Phoenix and want to tell us what's working, what's painful, or what you wish existed, [grab 25 minutes with us](https://cal.com/team/arize-devrel/user-interview).
+</Info>
+
 <Update label="05.15.2026">
 ## [05.15.2026: OTel GenAI Semantic Convention Auto-Conversion](/docs/phoenix/release-notes/05-2026/05-15-2026-otel-semconv-conversion)
 **Available in arize-phoenix 15.10.0+**

--- a/docs/phoenix/release-notes/05-2026/05-13-2026-playground-thinking-controls.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-13-2026-playground-thinking-controls.mdx
@@ -1,0 +1,27 @@
+---
+title: "05.13.2026: Playground Thinking Controls for Anthropic and Google"
+description: "The Phoenix Playground now exposes first-class thinking controls for Anthropic extended thinking and Google thinking — token budgets, effort levels, and display toggles."
+---
+
+**Available in arize-phoenix 15.8.0+**
+
+The Phoenix Playground now surfaces dedicated controls for extended thinking on Anthropic and Google models. Thinking parameters are persisted with saved prompts and restored correctly on reload or provider switch.
+
+## Anthropic Extended Thinking
+
+Three controls appear when an Anthropic model is selected:
+
+- **Thinking** — choose between **Adaptive** (model decides when to think), **Enabled** (always think), or disabled. Adaptive mode is the default for new instances.
+- **Thinking Budget** — token budget allocated for the thinking block. Minimum is 1,024 tokens; maximum is capped by the `max_tokens` setting. Defaults to 5,000.
+- **Thinking Display** — toggle whether the thinking block is shown inline in the Playground response panel.
+
+Anthropic also exposes an **Effort** control (low / medium / high) for models that support output-confidence effort levels independently of extended thinking.
+
+## Google Thinking
+
+For Google Gemini models:
+
+- **Thinking Budget** — maximum tokens the model may spend on internal reasoning before emitting the response.
+- **Thinking Level** — preset effort level (`LOW`, `MEDIUM`, `HIGH`). Overrides the budget when set.
+
+Thinking parameters are saved as part of the prompt version and round-tripped through storage and the SDK export format. Switching to a provider that does not support thinking drops the thinking config automatically; switching back restores it.

--- a/docs/phoenix/release-notes/05-2026/05-15-2026-otel-semconv-conversion.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-15-2026-otel-semconv-conversion.mdx
@@ -1,0 +1,44 @@
+---
+title: "05.15.2026: OTel GenAI Semantic Convention Auto-Conversion"
+description: "Phoenix now automatically converts OpenTelemetry GenAI semantic convention attributes to OpenInference, so traces from OTel-native instrumentations render with full message I/O, tool calls, and token counts."
+---
+
+**Available in arize-phoenix 15.10.0+**
+
+Phoenix now automatically converts [OpenTelemetry GenAI semantic convention](https://opentelemetry.io/docs/specs/semconv/gen-ai/) attributes (`gen_ai.*`) to OpenInference format when spans arrive. Traces produced by OTel-native instrumentations — such as the OpenAI, Anthropic, and Google GenAI contrib packages — now render in Phoenix with full message I/O, tool definitions, retrieval documents, and token counts without any code changes.
+
+## What gets converted
+
+| OTel GenAI attribute | OpenInference output |
+|---|---|
+| `gen_ai.input.messages` | `llm.input_messages.*` (role, content, tool calls) |
+| `gen_ai.output.message` | `llm.output_messages.*` |
+| `gen_ai.system_instructions` | Synthetic `system` message prepended to inputs |
+| Tool definitions and call results | `llm.tools.*`, `tool.*` |
+| Retrieval documents | `retrieval.documents.*` |
+| `gen_ai.usage.*` | `llm.token_count.prompt`, `llm.token_count.completion` |
+| `gen_ai.system` / `gen_ai.request.model` | `llm.provider`, `llm.model_name` |
+| `gen_ai.operation.name` | `llm.invocation_parameters` |
+
+If a span already has OpenInference attributes (e.g., from `openinference-instrumentation-*`), those values take precedence — conversion only fills in what's missing.
+
+## No code changes required
+
+Send OTel-native traces directly to Phoenix and the conversion happens at ingest time. Install any OTel GenAI contrib package, point it at Phoenix's OTLP endpoint, and spans appear with the full Phoenix trace detail view.
+
+```python
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from openai.contrib.instrumentation import OpenAIInstrumentor  # example
+
+provider = TracerProvider()
+provider.add_span_processor(
+    SimpleSpanProcessor(
+        OTLPSpanExporter(endpoint="http://localhost:6006/v1/traces")
+    )
+)
+OpenAIInstrumentor().instrument(tracer_provider=provider)
+```
+
+Spans emitted this way now show message I/O, tool calls, and token counts in the Phoenix UI exactly as they would from OpenInference-native instrumentation.

--- a/docs/phoenix/release-notes/05-2026/05-15-2026-session-feedback-and-atif.mdx
+++ b/docs/phoenix/release-notes/05-2026/05-15-2026-session-feedback-and-atif.mdx
@@ -1,0 +1,81 @@
+---
+title: "05.15.2026: Session Trace Feedback and ATIF v1.7 Support"
+---
+
+# Trace Feedback in Session Turn View
+
+May 15, 2026
+
+**Available in arize-phoenix 15.10.0+**
+
+The Session Details view now includes a feedback toolbar on each turn. Click the thumbs-up or thumbs-down icon to create a `user_feedback` trace annotation on the underlying trace. Click the annotate icon to open the full annotation panel for label and score entry.
+
+Feedback is keyed per-viewer using a client-managed identifier, so clicking the same icon a second time removes it (toggle behavior). The annotation summary in the turn footer updates immediately to reflect the new annotation count.
+
+# ATIF v1.7 Trajectory Upload
+
+May 15, 2026
+
+**Available in arize-phoenix-client 2.7.0+**
+
+`upload_atif_trajectories_as_spans` now supports [ATIF v1.7](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md), which introduces embedded subagent trajectories, `trajectory_id`-based linking, and deterministic dispatch steps.
+
+## Embedded subagents
+
+Pass a parent trajectory with `subagent_trajectories` inline and the full multi-agent span tree is built automatically. No separate upload call is needed:
+
+```python
+from phoenix.client import Client
+from phoenix.client.helpers.atif import upload_atif_trajectories_as_spans
+
+client = Client()
+
+parent = {
+    "schema_version": "v1.7",
+    "trajectory_id": "parent-traj-abc",
+    "agent": {"model_name": "claude-opus-4"},
+    "steps": [
+        {
+            "role": "agent",
+            "content": "Delegating to search subagent.",
+            "tool_calls": [{"id": "tc1", "name": "search_agent", "arguments": {"query": "latest results"}}],
+        }
+    ],
+    "subagent_trajectories": [
+        {
+            "schema_version": "v1.7",
+            "trajectory_id": "child-traj-xyz",
+            "agent": {"model_name": "gpt-4o"},
+            "steps": [
+                {"role": "agent", "content": "Found 5 results.", "tool_calls": []}
+            ],
+        }
+    ],
+}
+
+upload_atif_trajectories_as_spans(client, [parent], project_name="my-project")
+```
+
+The resulting trace nests the child agent's spans under the parent's tool span, preserving the delegation hierarchy in the Phoenix UI.
+
+## Trajectory IDs and deterministic span IDs
+
+Trajectories that include a `trajectory_id` field use it as the canonical span identity key. Re-uploading the same trajectory produces the same span IDs, making uploads idempotent. Trajectories without a `trajectory_id` fall back to a stable document hash.
+
+## Deterministic dispatch steps
+
+Steps with `llm_call_count: 0` represent orchestration that issued tool calls without an LLM invocation (rule-based routing, hard-coded delegation). Phoenix emits TOOL spans for these steps but does not create a synthetic LLM span, matching the actual execution structure.
+
+## Session ID support
+
+Trajectories can now include an optional `session_id` in the header. When present, Phoenix groups all spans from that trajectory under the specified session, linking them to related traces in the Sessions view.
+
+```python
+trajectory = {
+    "schema_version": "v1.7",
+    "trajectory_id": "traj-001",
+    "session_id": "session-abc123",
+    "agent": {"model_name": "gpt-4o"},
+    "steps": [...],
+}
+```

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,9 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/05-2026/05-15-2026-otel-semconv-conversion" arrow="true" title="05.15.2026" icon="calendar" description="OTel GenAI semantic convention attributes auto-converted to OpenInference at ingest — full message I/O, tool calls, and token counts from OTel-native instrumentations"/>
+    <Card href="/docs/phoenix/release-notes/05-2026/05-15-2026-session-feedback-and-atif" arrow="true" title="05.15.2026" icon="calendar" description="Session turn feedback toolbar (thumbs up/down, annotate); ATIF v1.7 support with embedded subagents, trajectory_id, session_id, and deterministic dispatch steps"/>
+    <Card href="/docs/phoenix/release-notes/05-2026/05-13-2026-playground-thinking-controls" arrow="true" title="05.13.2026" icon="calendar" description="Playground thinking controls for Anthropic (adaptive/enabled, budget, effort) and Google (budget, level)"/>
     <Card href="/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations" arrow="true" title="05.13.2026" icon="calendar" description="Expandable session turn messages; note identifier upsert on notes REST endpoints; new CLI annotation bulk-delete and project-get commands"/>
     <Card href="/docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences" arrow="true" title="05.10.2026" icon="calendar" description="Save a default Playground provider and model; span metrics aside now always visible"/>
     <Card href="/docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header" arrow="true" title="05.08.2026" icon="calendar" description="Route OTLP traces to a named project via x-project-name HTTP header"/>


### PR DESCRIPTION
## Summary

- **05.13.2026** — Playground extended thinking controls for Anthropic (adaptive/enabled, budget tokens, effort, display) and Google (budget, level) — arize-phoenix 15.8.0
- **05.15.2026** — OTel GenAI semantic convention auto-conversion: `gen_ai.*` attributes are now converted to OpenInference at ingest, so OTel-native instrumentations render with full message I/O, tool calls, and token counts — arize-phoenix 15.10.0
- **05.15.2026** — Session turn trace feedback toolbar (thumbs up/down + annotate creates `user_feedback` annotations) — arize-phoenix 15.10.0
- **05.15.2026** — ATIF v1.7 trajectory upload: embedded subagents via `subagent_trajectories`, `trajectory_id`-based deterministic span IDs, `session_id` in trajectory headers, and deterministic dispatch steps — arize-phoenix-client 2.7.0

## Test plan

- [ ] Verify new MDX files render correctly on docs site
- [ ] Confirm aggregate `release-notes.mdx` dates are monotonically non-increasing
- [ ] Confirm `docs.json` paths match actual file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)