### PR TITLE
fix(sandbox): revalidate secrets list in sandbox config secret picker

### DIFF
--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -863,7 +863,13 @@ function SecretKeyComboBox({
         }
       }
     `,
-    {}
+    {},
+    // This query is not part of a managed Relay connection, so secrets added
+    // elsewhere (e.g. the Secrets settings page mutation) don't get appended to
+    // this list in the store. Revalidate against the network on every mount so
+    // the combobox always reflects the current set of secrets, while still
+    // rendering cached data immediately.
+    { fetchPolicy: "store-and-network" }
   );
 
   const secretKeys = data.secrets.edges.map((e) => ({


### PR DESCRIPTION
## Problem

When a user adds a secret on the **Secrets** settings page and then navigates to **Sandbox configurations**, the new secret does not appear in the sandbox config form's secret picker. A full page refresh is required to see it.

## Root cause

The `upsertOrDeleteSecrets` mutation updates secrets via `@appendNode`, which only mutates the one Relay connection it is given — `SettingsSecretsPage_secrets`, keyed to the Secrets settings page.

The sandbox config secret picker (`SecretKeyComboBox`) runs a *separate*, standalone query with no `@connection` directive:

```graphql
query SandboxConfigDialogSecretsQuery {
  secrets(first: 200) { edges { node { key } } }
}
```

Because this `secrets(first: 200)` field is not part of a managed connection, the mutation's `@appendNode` never touches it. With `useLazyLoadQuery`'s default `store-or-network` fetch policy, once that field is in the Relay store it is served stale — hence the refresh requirement.

## Fix

Set `fetchPolicy: "store-and-network"` on the picker query. The combobox now renders cached data immediately (no Suspense flash) and revalidates against the server on every mount, so the list always reflects the current set of secrets.

`store-and-network` was chosen over wiring the picker into a shared `@connection` because:
- The mutation is committed from `NewSecretButton` on the Secrets page, which has no knowledge of the picker's connection ID — sharing would require cross-page connection-key plumbing.
- `store-and-network` also covers deletions, edits, and secrets created by other users/sessions, not just this one mutation path.
- The picker does not paginate (`first: 200` fixed), so it gains nothing from connection management.

## Testing

Manual: open a sandbox config with a secret env var, add a new secret on the Secrets page, then reopen the sandbox config — the new key appears without a refresh.