### PR TITLE
fix(playground): show View Trace on errored runs when a span exists

### DIFF
--- a/app/src/pages/playground/PlaygroundOutput.tsx
+++ b/app/src/pages/playground/PlaygroundOutput.tsx
@@ -405,11 +405,18 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
             );
           case selectedRepetitionError != null:
             return (
-              <View padding="size-200">
-                <PlaygroundErrorWrap>
-                  {selectedRepetitionError.message}
-                </PlaygroundErrorWrap>
-              </View>
+              <>
+                <View padding="size-200">
+                  <PlaygroundErrorWrap>
+                    {selectedRepetitionError.message}
+                  </PlaygroundErrorWrap>
+                </View>
+                <Suspense>
+                  {selectedRepetitionSpanId ? (
+                    <RunMetadataFooter spanId={selectedRepetitionSpanId} />
+                  ) : null}
+                </Suspense>
+              </>
             );
           default:
             return (


### PR DESCRIPTION
## Summary

- When a chat completion fails after the backend has already created a span (e.g. LLM-side failure), `ChatCompletionSubscriptionError` is yielded first, followed by `ChatCompletionSubscriptionResult` carrying the `spanId`.
- Previously the error branch in `PlaygroundOutput.tsx` only rendered `PlaygroundErrorWrap`, so the **View Trace** affordance in `RunMetadataFooter` was hidden even when a `spanId` was available.
- This PR wraps the error branch in a fragment and adds the same `RunMetadataFooter` (guarded by `selectedRepetitionSpanId`) that already exists in the success branch, so "View Trace" appears below the error message whenever a span was recorded.

## Changed files

- `app/src/pages/playground/PlaygroundOutput.tsx` — error case now also renders `RunMetadataFooter` when `selectedRepetitionSpanId` is set

## How to verify

1. Open Prompt Playground and configure a model call that produces an LLM-side error (e.g. bad API key or invalid parameters that the model rejects after span creation).
2. Hit **Run**.
3. The error message appears as before.
4. If the backend created a span before the failure, a **View Trace** link is now visible below the error — click it to inspect the span attributes and exception details.

Closes arize-ai/phoenix#13130

Generated with [Claude Code](https://claude.com/claude-code)
