### PR TITLE
docs(skills): weekly audit — 2026-05-20

### DIFF
--- a/.agents/skills/phoenix-tracing/SKILL.md
+++ b/.agents/skills/phoenix-tracing/SKILL.md
@@ -44,10 +44,11 @@ Reference these guidelines when:
 
 ### 2. Instrumentation
 
-- [instrumentation-auto-python](references/instrumentation-auto-python.md) - Auto-instrument OpenAI, LangChain, etc.
+- [instrumentation-auto-python](references/instrumentation-auto-python.md) - Auto-instrument OpenAI, LangChain, etc. (also covers OTel GenAI native instrumentation)
 - [instrumentation-auto-typescript](references/instrumentation-auto-typescript.md) - Auto-instrument supported frameworks
 - [instrumentation-manual-python](references/instrumentation-manual-python.md) - Custom spans with decorators
 - [instrumentation-manual-typescript](references/instrumentation-manual-typescript.md) - Custom spans with wrappers
+- [instrumentation-atif-python](references/instrumentation-atif-python.md) - Import ATIF agent trajectories (Claude Code, OpenHands, Codex, etc.)
 
 ### 3. Span Types (with full attribute schemas)
 

--- a/.agents/skills/phoenix-tracing/references/instrumentation-atif-python.md
+++ b/.agents/skills/phoenix-tracing/references/instrumentation-atif-python.md
@@ -1,0 +1,135 @@
+# Phoenix Tracing: ATIF Trajectory Import (Python)
+
+**Import agent trajectories from ATIF-compatible frameworks into Phoenix as traces.**
+
+## Overview
+
+ATIF (Agent Trajectory Interchange Format) is an open schema for recording agent execution. Frameworks like **Claude Code**, **OpenHands**, **Gemini CLI**, and **Codex** export ATIF via [Harbor](https://www.harborframework.com/docs). The `phoenix-client` package converts ATIF JSON into OpenTelemetry span trees and uploads them to Phoenix.
+
+Supports ATIF schema versions v1.0 through v1.7.
+
+## Installation
+
+```bash
+pip install arize-phoenix-client
+```
+
+## Quick Start
+
+```python
+import json
+from phoenix.client import Client
+from phoenix.client.helpers.atif import upload_atif_trajectories_as_spans
+
+with open("trajectory.json") as f:
+    trajectory = json.load(f)
+
+client = Client()
+result = upload_atif_trajectories_as_spans(
+    client, [trajectory], project_name="my-agent-eval"
+)
+# {"total_received": 5, "total_queued": 5}
+```
+
+## Signature
+
+```python
+def upload_atif_trajectories_as_spans(
+    client: Client,
+    trajectories: Sequence[Mapping[str, Any]],
+    *,
+    project_name: str,
+    timeout: Optional[int] = 30,
+) -> v1.CreateSpansResponseBody:
+```
+
+- `client` — a `phoenix.client.Client` instance
+- `trajectories` — one or more ATIF trajectory dicts (v1.0–v1.7)
+- `project_name` — the Phoenix project to upload spans into
+- `timeout` — request timeout in seconds (default: 30)
+
+## Trace Hierarchy
+
+The converter builds a span tree matching what real-time instrumentors produce:
+
+**Single-turn:**
+```
+AGENT (root — input=user message, output=final agent reply)
+  LLM
+  TOOL
+  LLM
+```
+
+**Multi-turn:**
+```
+AGENT (root — input=first user message, output=final agent reply)
+  AGENT turn_1 (input=user msg 1, output=agent reply 1)
+    LLM
+    TOOL
+  AGENT turn_2 (input=user msg 2, output=agent reply 2)
+    LLM
+```
+
+## Multi-Agent / Subagent Linking
+
+Upload parent and child trajectories together for cross-references to resolve:
+
+```python
+with open("parent.json") as f:
+    parent = json.load(f)
+with open("child.json") as f:
+    child = json.load(f)
+
+upload_atif_trajectories_as_spans(
+    client, [parent, child], project_name="my-agent-eval"
+)
+```
+
+Resulting trace:
+```
+AGENT (parent)
+  LLM
+  TOOL (delegate_task)
+    AGENT (child agent)
+      LLM
+      TOOL
+```
+
+**ATIF v1.7**: embedded `subagent_trajectories` inside a single trajectory file are automatically flattened and linked. References resolve by `trajectory_id` — no separate upload needed.
+
+## Deterministic Dispatch (v1.7+)
+
+Agent steps with `llm_call_count: 0` represent non-LLM orchestration that issued tool calls. These steps do not produce a synthetic LLM span; their TOOL spans are still emitted under the AGENT/turn parent.
+
+## Continuation Merging
+
+When an agent's context window fills up, Harbor splits the session across multiple files. The converter detects continuation files (session IDs ending in `-cont-N`) and merges them into one trace. Continuation root spans are annotated with `metadata.is_continuation = True`.
+
+## Attribute Mapping
+
+| ATIF field | OpenInference attribute |
+|---|---|
+| `metrics.prompt_tokens` | `llm.token_count.prompt` |
+| `metrics.completion_tokens` | `llm.token_count.completion` |
+| `metrics.cached_tokens` | `llm.token_count.prompt_details.cache_read` |
+| `metrics.cost_usd` | `llm.cost.total` |
+| `agent.model_name` / step `model_name` | `llm.model_name` |
+| `agent.tool_definitions` | `llm.tools.{i}.tool.json_schema` |
+| `reasoning_content` | `metadata.reasoning_content` |
+| `session_id` | `session.id` |
+| `trajectory_id` | Root span `metadata.trajectory_id` |
+| Step messages | `llm.input_messages` / `llm.output_messages` |
+| Tool calls | `llm.output_messages.{i}.message.tool_calls` |
+| Observations | Tool span `output.value` |
+
+## Deterministic IDs
+
+Trace IDs are derived from the run-scoped `session_id` when present. Span IDs use document-scoped `trajectory_id` when available. ATIF v1.7 embedded subagents use the same `trajectory_id`-based seeding so they do not collide even when inheriting the same `session_id`. Re-uploading the same trajectory produces the same trace (idempotent).
+
+## Known Limitation
+
+Each LLM span includes the full conversation history as `llm.input_messages`. For very long sessions (~16+ turns with dense tool calls), this can exceed OTel attribute size limits and cause truncation.
+
+## API Reference
+
+- [API docs](https://arize-phoenix.readthedocs.io/en/latest/api/helpers.html#module-client.helpers.atif)

--- a/.agents/skills/phoenix-tracing/references/instrumentation-auto-python.md
+++ b/.agents/skills/phoenix-tracing/references/instrumentation-auto-python.md
@@ -56,6 +56,21 @@ tracer_provider = register(project_name="my-app")  # No auto_instrument
 OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
 ```
 
+## OTel GenAI Native Instrumentation
+
+Phoenix automatically converts [OTel GenAI semantic convention](https://opentelemetry.io/docs/specs/semconv/gen-ai/) attributes (`gen_ai.*`) to OpenInference when receiving OTLP spans. This means you can use **OTel-native AI instrumentation** — any library that emits `gen_ai.*` attributes — without installing OpenInference instrumentors, and Phoenix will display spans with proper LLM span kind, model names, token counts, and message content.
+
+If a span already has OpenInference attributes set (e.g. from a dual-emitting instrumentor), those values take precedence over the synthesized ones.
+
+No client-side changes required. Send OTLP to Phoenix as usual:
+
+```python
+from phoenix.otel import register
+
+# Works with any OTel-native AI instrumentor that emits gen_ai.* attributes
+register(project_name="my-app")
+```
+
 ## Limitations
 
 Auto-instrumentation does NOT capture:

--- a/.agents/skills/phoenix-tracing/references/instrumentation-auto-python.md
+++ b/.agents/skills/phoenix-tracing/references/instrumentation-auto-python.md
@@ -71,6 +71,36 @@ from phoenix.otel import register
 register(project_name="my-app")
 ```
 
+**OTel GenAI packages** (from [opentelemetry-python-genai](https://github.com/open-telemetry/opentelemetry-python-genai/tree/main/instrumentation)):
+
+- `opentelemetry-instrumentation-anthropic`
+- `opentelemetry-instrumentation-openai`
+
+```bash
+pip install opentelemetry-instrumentation-anthropic
+```
+
+```python
+from phoenix.otel import register
+from opentelemetry.instrumentation.anthropic import AnthropicInstrumentor
+import anthropic
+
+register(project_name="my-app")
+
+# Instrument Anthropic
+AnthropicInstrumentor().instrument()
+
+# Use Anthropic client as normal — spans are created automatically
+client = anthropic.Anthropic()
+response = client.messages.create(
+    model="claude-3-5-sonnet-20241022",
+    max_tokens=1024,
+    messages=[
+        {"role": "user", "content": "Hello, Claude!"}
+    ]
+)
+```
+
 ## Limitations
 
 Auto-instrumentation does NOT capture:


### PR DESCRIPTION
# Phoenix Skills Audit — 2026-05-13 to 2026-05-20

**Audited against:** `origin/main` at `af751b6bace50f84fc36f0b1160c50059884df4f`
**Commits analyzed:** 66 total (2 user-facing edits applied, 64 skipped)

## Edits applied

### phoenix-tracing

- `references/instrumentation-atif-python.md` — **new file** documenting
  `upload_atif_trajectories_as_spans` from `packages/phoenix-client/src/phoenix/client/helpers/atif/__init__.py`.
  Covers ATIF v1.0–v1.7, embedded subagent flattening (v1.7), deterministic dispatch
  (`llm_call_count: 0` steps), continuation merging, and attribute mapping table.
  Source: commit `17f2ec275` (`feat(client): support ATIF v1.7 trajectory upload`).
  Signature verified at `packages/phoenix-client/src/phoenix/client/helpers/atif/__init__.py:28`.

- `references/instrumentation-auto-python.md` — added **"OTel GenAI Native Instrumentation"**
  section explaining that Phoenix automatically converts `gen_ai.*` OTel semantic convention
  attributes to OpenInference on ingest (server-side, via `decode_otlp_span` in
  `src/phoenix/trace/otel.py:78`). OI attributes win on conflict; no client-side changes
  required. Source: commit `6248d2045` (`feat(trace): convert OTel GenAI semconv attrs to OpenInference`).

- `SKILL.md` — updated instrumentation section to link to the new
  `references/instrumentation-atif-python.md` file and annotated the auto-python entry
  with OTel GenAI coverage.

## Skipped commits

| SHA | Subject | Reason |
|---|---|---|
| `af751b6ba` | fix(app): prevent nested spans table scrolling | Frontend only |
| `b03ae9f91` | refactor(agents): render every PXI prompt as a Jinja template | PXI internal refactor |
| `eceff5589` | fix(cost): update built-in model token prices | Internal server data |
| `749025406` | fix(app): route PXI markdown links through router | Frontend + PXI tests |
| `ef421e5af` | feat(agents): stamp tool execution environment on tool-call provider metadata | `ToolCallProviderMetadata.tool_execution_environment` is PXI frontend-internal, not user-facing tracing/evals/CLI API |
| `e64e067be` | chore: update phoenix version in kustomize and helm | Devops bookkeeping |
| `c77596b95` | chore(main): release arize-phoenix 15.11.1 | Release-please |
| `93e2614e5` | refactor(agents): group agent prompt files into subdirectories | PXI internal file reorganization |
| `e2b672abd` | fix(agents): instrument PXI agent system prompt on LLM spans | PXI internal model wrapper; no user-facing API changes |
| `fdd4e0728` | chore(main): release arize-phoenix 15.11.0 | Release-please |
| `645d7a5c6` | feat(agents): Generative UI rendering within agent chats | PXI frontend feature; no user-facing SDK/CLI API |
| `6e8626bde` | chore(deps): bump strawberry-graphql | Dep bump |
| `a3299461a` | fix(server): handle empty header values in custom provider config | Internal server fix |
| `433225539` | fix(devops): tolerate missing pnpm-lock.yaml in oidc-server build | CI/devops |
| `c0ba83d85` | chore: update phoenix version in kustomize and helm | Devops bookkeeping |
| `e506c1a45` | chore(main): release arize-phoenix 15.10.1 | Release-please |
| `a800a48cc` | chore: add support for codex hooks | CI/devops |
| `fbf55a0e2` | chore: update sitemap.xml | Docs infra |
| `3436877de` | ci: restore pull-requests: write for triage labeler | CI |
| `91c0e19d9` | docs: remove dead nav entries from docs.json | Docs infra |
| `3e64b24ea` | fix(agents): persist agent turn as a root span | `detached_otel_context()` is an internal server utility added to `tracers.py`; not exported to users via any public package |
| `864562939` | refactor(agents): migrate from toolsets to capabilities | Internal PXI agent refactor; only OpenAPI addition is `session.storeSessions` (internal PXI capability flag) and `"GraphQL runtime state"` description |
| `3ab13bc62` | chore: gitignore pnpm-lock.yaml in vignettes | Repo hygiene |
| `7e4a0b1cd` | fix(app): hide zero PXI cache write usage | Frontend |
| `b9ebb69df` | chore: update phoenix version in kustomize and helm | Devops bookkeeping |
| `30735f2a4` | chore(main): release arize-phoenix 15.10.0 | Release-please |
| `5006911aa` | fix: simplify generative model store polling | Internal server |
| `65e7833b8` | fix(examples): guard against IndexError on empty LLM choices list | Examples only |
| `acd1626b7` | feat: border and divider cleanup with improved storybook support | Frontend design system |
| `e84331e59` | docs: Update info for Arconia Java integration | Docs only |
| `be80e90c4` | fix: refresh span notes after create | Frontend |
| `ce58ae28a` | refactor(agents): restructure system prompts | PXI internal refactor; generated API file changes are PXI-agent-internal only |
| `924117e8b` | ci: hardcode internal contributors for triage labeler | CI |
| `81c98505b` | chore(main): release arize-phoenix-client 2.7.0 | Release-please |
| `0b2185499` | feat(examples/agents): support Phoenix Cloud via env vars | Examples only |
| `95f4e9021` | chore: update sitemap.xml | Docs infra |
| `47662443c` | feat: pxi button styles and thinking glyph animation | Frontend |
| `1bd96b9a8` | feat: add trace feedback toolbar to session turns | Frontend + GraphQL; no new CLI commands or span attributes |
| `5ca9f470c` | ci: remove pnpm lock files from scripts | CI |
| `45ccf8465` | chore(claude): remove slow PostToolUse hooks | Claude Code settings |
| `de8c91579` | feat(agents): curate agent model menu | Frontend |
| `a2d8a5961` | test(playground): harden prompt-config E2E with stable test IDs | Tests |
| `1ab474d3b` | fix: adjust session turn output metadata layout | Frontend |
| `fa0e75577` | ci: use checkCollaborator API instead of author_association | CI |
| `122f23ff4` | feat(agents): eval harness improvements | Internal PXI test infra |
| `1c282498e` | feat: cap agent session retention | `session.storeSessions` is internal PXI capability flag; no user-facing SDK/CLI surface |
| `56faa023b` | fix(cost): update built-in model token prices | Internal server data |
| `bd1a474a5` | refactor(agents): make agent traces more readable | PXI internal |
| `44c3bfdef` | chore: update phoenix version in kustomize and helm | Devops bookkeeping |
| `a428b9cf0` | docs: Add Phoenix release notes for 05-08–05-13-2026 | Docs only |
| `f91c9b71e` | chore(skills): refresh agent-browser and add weekly update workflow | Other skill (agent-browser) |
| `56ab89b02` | chore(main): release arize-phoenix 15.9.0 | Release-please |
| `d58334315` | chore(js): update versions | JS package version bumps |
| `1c3899523` | ci: grant write permissions to @claude workflow | CI |
| `d638839e7` | docs: Audit and update llms.txt | Docs only |
| `cb6f7b2bf` | test: fix two e2e flakes | Tests |
| `266b5460a` | ci: pin openapi-diff image and fix non-risky zizmor findings | CI |
| `4b221b93c` | feat(agents): backfill TOOL spans for external tool returns in agent wrapper | Internal PXI agent wrapper; no user-facing instrumentation API changes |
| `35c8f3d3f` | fix: handle invalid GraphQL node ids | Internal server error handling |
| `ebfc2ff4e` | chore: update phoenix version in kustomize and helm | Devops bookkeeping |
| `f5da1140d` | fix(agent): clarify PXI remote trace sharing consent | Frontend |
| `8349361aa` | docs(skills): weekly audit — 2026-05-13 | Previous skills audit (already applied) |
| `017c5cc4c` | chore(main): release arize-phoenix 15.8.0 | Release-please |
| `9ca0a3ffb` | fix: validate projection expressions and sandbox eval globals | Internal server DSL filter |

## Out-of-scope findings

- `3e64b24ea` adds `detached_otel_context()` to `src/phoenix/tracers.py`. This is an
  internal server-side utility; it's not exported by any public package. No action needed.
- The Arconia Java integration docs update (`e84331e59`) belongs in a Java/Arconia-specific
  skill if one exists — not in any of the three skills owned here.
- `4b221b93c` documents that PXI external tools emit backfilled TOOL spans. This is a
  PXI-specific behavior note; if a `phoenix-pxi` skill exists, it may warrant mention there.

## Notes

- ATIF v1.7 had no TS mirror — the `upload_atif_trajectories_as_spans` helper is
  Python-only (`packages/phoenix-client`). No TypeScript equivalent exists in `js/packages/`.
  This is Python-only by design; calling it out here for awareness.
- The OTel GenAI → OpenInference conversion (`6248d2045`) is server-side Python only.
  There is no TypeScript equivalent because Phoenix receives OTLP from any language;
  the conversion happens on ingestion regardless of the sender's language.
