### PR TITLE
fix(sandbox): cap concurrent Deno subprocesses to bound host resource use

### DIFF
--- a/src/phoenix/server/sandbox/deno_backend.py
+++ b/src/phoenix/server/sandbox/deno_backend.py
@@ -5,6 +5,11 @@ Stateless (BaseNoSessionBackend) — each execute() call is independent.
 Executes code through the local ``deno`` CLI with a default-deny permission
 model. Deno sandboxes intentionally never receive any user-supplied
 environment variables.
+
+Each execute() spawns a ``deno`` child process on the Phoenix server host,
+consuming the server's own CPU/memory. A module-level semaphore caps the
+number of concurrent Deno subprocesses across every backend instance so an
+unbounded fan-out (e.g. a large experiment) cannot exhaust host resources.
 """
 
 from __future__ import annotations
@@ -26,6 +31,29 @@ from .types import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Upper bound on Deno subprocesses running concurrently on the Phoenix host,
+# shared across every DenoSandboxBackend instance (build_backend() mints a
+# fresh instance per call, so a per-instance cap would not bound global
+# concurrency).
+_MAX_CONCURRENT_DENO_EXECUTIONS = 4
+
+# Lazily created and rebound per running event loop. asyncio.Semaphore binds to
+# the loop on first use; constructing it at import time would fail tests that
+# each run on a fresh loop. Production has a single long-lived loop, so this
+# resolves to a process-wide singleton there.
+_execution_slots: asyncio.Semaphore | None = None
+_execution_slots_loop: asyncio.AbstractEventLoop | None = None
+
+
+def _get_execution_slots() -> asyncio.Semaphore:
+    """Return the concurrency-limiting semaphore bound to the running loop."""
+    global _execution_slots, _execution_slots_loop
+    loop = asyncio.get_running_loop()
+    if _execution_slots is None or _execution_slots_loop is not loop:
+        _execution_slots = asyncio.Semaphore(_MAX_CONCURRENT_DENO_EXECUTIONS)
+        _execution_slots_loop = loop
+    return _execution_slots
 
 
 class DenoSandboxBackend(BaseNoSessionBackend):
@@ -68,40 +96,45 @@ class DenoSandboxBackend(BaseNoSessionBackend):
         cmd = self._build_command()
         exec_timeout = timeout if timeout is not None else 30
 
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=self._build_subprocess_env(),
-            )
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                proc.communicate(code.encode("utf-8")),
-                timeout=exec_timeout,
-            )
-            stdout = stdout_bytes.decode("utf-8", errors="replace")
-            stderr = stderr_bytes.decode("utf-8", errors="replace")
-            if proc.returncode == 0:
-                return ExecutionResult(stdout=stdout, stderr=stderr)
-            error = stderr or f"Deno process exited with code {proc.returncode}"
-            return ExecutionResult(stdout=stdout, stderr=stderr, error=error)
-        except asyncio.TimeoutError:
-            if proc is not None:
-                proc.kill()
-                try:
-                    await proc.wait()
-                except Exception:
-                    logger.debug("Timed-out Deno process failed to exit cleanly", exc_info=True)
-            message = f"Execution timed out after {exec_timeout}s"
-            return ExecutionResult(stdout="", stderr=message, error=message)
-        except FileNotFoundError:
-            message = (
-                "Deno executable not found. Install Deno and ensure the `deno` binary is on PATH."
-            )
-            return ExecutionResult(stdout="", stderr=message, error=message)
-        except Exception as exc:
-            return ExecutionResult(stdout="", stderr=str(exc), error=str(exc))
+        # Hold a slot for the lifetime of the subprocess so concurrent Deno
+        # executions on the host stay bounded. Waiters queue here as cheap
+        # coroutines; the working timeout below guarantees slots free up.
+        async with _get_execution_slots():
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=self._build_subprocess_env(),
+                )
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(code.encode("utf-8")),
+                    timeout=exec_timeout,
+                )
+                stdout = stdout_bytes.decode("utf-8", errors="replace")
+                stderr = stderr_bytes.decode("utf-8", errors="replace")
+                if proc.returncode == 0:
+                    return ExecutionResult(stdout=stdout, stderr=stderr)
+                error = stderr or f"Deno process exited with code {proc.returncode}"
+                return ExecutionResult(stdout=stdout, stderr=stderr, error=error)
+            except asyncio.TimeoutError:
+                if proc is not None:
+                    proc.kill()
+                    try:
+                        await proc.wait()
+                    except Exception:
+                        logger.debug("Timed-out Deno process failed to exit cleanly", exc_info=True)
+                message = f"Execution timed out after {exec_timeout}s"
+                return ExecutionResult(stdout="", stderr=message, error=message)
+            except FileNotFoundError:
+                message = (
+                    "Deno executable not found. "
+                    "Install Deno and ensure the `deno` binary is on PATH."
+                )
+                return ExecutionResult(stdout="", stderr=message, error=message)
+            except Exception as exc:
+                return ExecutionResult(stdout="", stderr=str(exc), error=str(exc))
 
     async def close(self) -> None:
         pass

--- a/src/phoenix/server/sandbox/deno_backend.py
+++ b/src/phoenix/server/sandbox/deno_backend.py
@@ -92,7 +92,7 @@ class DenoSandboxBackend(BaseNoSessionBackend):
         session_key: str,
         timeout: Optional[int] = None,
     ) -> ExecutionResult:
-        proc: asyncio.subprocess.Process | None = None
+        process: asyncio.subprocess.Process | None = None
         cmd = self._build_command()
         exec_timeout = timeout if timeout is not None else 30
 
@@ -101,7 +101,7 @@ class DenoSandboxBackend(BaseNoSessionBackend):
         # coroutines; the working timeout below guarantees slots free up.
         async with _get_execution_slots():
             try:
-                proc = await asyncio.create_subprocess_exec(
+                process = await asyncio.create_subprocess_exec(
                     *cmd,
                     stdin=asyncio.subprocess.PIPE,
                     stdout=asyncio.subprocess.PIPE,
@@ -109,20 +109,20 @@ class DenoSandboxBackend(BaseNoSessionBackend):
                     env=self._build_subprocess_env(),
                 )
                 stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                    proc.communicate(code.encode("utf-8")),
+                    process.communicate(code.encode("utf-8")),
                     timeout=exec_timeout,
                 )
                 stdout = stdout_bytes.decode("utf-8", errors="replace")
                 stderr = stderr_bytes.decode("utf-8", errors="replace")
-                if proc.returncode == 0:
+                if process.returncode == 0:
                     return ExecutionResult(stdout=stdout, stderr=stderr)
-                error = stderr or f"Deno process exited with code {proc.returncode}"
+                error = stderr or f"Deno process exited with code {process.returncode}"
                 return ExecutionResult(stdout=stdout, stderr=stderr, error=error)
             except asyncio.TimeoutError:
-                if proc is not None:
-                    proc.kill()
+                if process is not None:
+                    process.kill()
                     try:
-                        await proc.wait()
+                        await process.wait()
                     except Exception:
                         logger.debug("Timed-out Deno process failed to exit cleanly", exc_info=True)
                 message = f"Execution timed out after {exec_timeout}s"
@@ -138,18 +138,18 @@ class DenoSandboxBackend(BaseNoSessionBackend):
             finally:
                 # Terminate the child on ANY exit from this block. An outer
                 # asyncio.wait_for (CodeEvaluatorRunner wraps execute()) can
-                # fire while proc.communicate() is in flight — its
+                # fire while process.communicate() is in flight — its
                 # CancelledError is a BaseException, so it is NOT caught by
                 # the handlers above and the asyncio.TimeoutError cleanup is
                 # skipped. Without this finally the Deno child would outlive
                 # its execute() call, and stop_session() is a no-op for this
-                # stateless backend. proc.kill() is a synchronous SIGKILL;
+                # stateless backend. process.kill() is a synchronous SIGKILL;
                 # asyncio's child watcher reaps the process once it exits.
                 # The returncode guard makes this a no-op on the success and
                 # asyncio.TimeoutError paths, where the process is already
                 # reaped.
-                if proc is not None and proc.returncode is None:
-                    proc.kill()
+                if process is not None and process.returncode is None:
+                    process.kill()
 
     async def close(self) -> None:
         pass

--- a/src/phoenix/server/sandbox/deno_backend.py
+++ b/src/phoenix/server/sandbox/deno_backend.py
@@ -135,6 +135,21 @@ class DenoSandboxBackend(BaseNoSessionBackend):
                 return ExecutionResult(stdout="", stderr=message, error=message)
             except Exception as exc:
                 return ExecutionResult(stdout="", stderr=str(exc), error=str(exc))
+            finally:
+                # Terminate the child on ANY exit from this block. An outer
+                # asyncio.wait_for (CodeEvaluatorRunner wraps execute()) can
+                # fire while proc.communicate() is in flight — its
+                # CancelledError is a BaseException, so it is NOT caught by
+                # the handlers above and the asyncio.TimeoutError cleanup is
+                # skipped. Without this finally the Deno child would outlive
+                # its execute() call, and stop_session() is a no-op for this
+                # stateless backend. proc.kill() is a synchronous SIGKILL;
+                # asyncio's child watcher reaps the process once it exits.
+                # The returncode guard makes this a no-op on the success and
+                # asyncio.TimeoutError paths, where the process is already
+                # reaped.
+                if proc is not None and proc.returncode is None:
+                    proc.kill()
 
     async def close(self) -> None:
         pass

--- a/tests/unit/server/sandbox/test_deno_backend.py
+++ b/tests/unit/server/sandbox/test_deno_backend.py
@@ -198,3 +198,54 @@ class TestDenoSandboxBackend:
         assert "Deno executable not found" in result.stderr
         assert result.error is not None
         assert "Deno executable not found" in result.error
+
+    @pytest.mark.asyncio
+    async def test_execute_caps_concurrent_subprocesses(self) -> None:
+        """No more than _MAX_CONCURRENT_DENO_EXECUTIONS Deno subprocesses run
+        at once, so a large fan-out cannot exhaust the Phoenix host."""
+        from phoenix.server.sandbox import deno_backend
+
+        cap = deno_backend._MAX_CONCURRENT_DENO_EXECUTIONS
+        live = 0
+        peak = 0
+        gate = asyncio.Event()
+        reached_cap = asyncio.Event()
+
+        async def _communicate(_input: bytes) -> tuple[bytes, bytes]:
+            nonlocal live, peak
+            live += 1
+            peak = max(peak, live)
+            if live >= cap:
+                reached_cap.set()
+            try:
+                await gate.wait()
+            finally:
+                live -= 1
+            return (b"ok\n", b"")
+
+        def _make_proc(*_args: object, **_kwargs: object) -> _StubProcess:
+            proc = _StubProcess(stdout=b"ok\n")
+            proc.communicate = _communicate  # type: ignore[assignment]
+            return proc
+
+        backend = DenoSandboxBackend(deno_executable="/usr/local/bin/deno")
+        with patch(
+            "phoenix.server.sandbox.deno_backend.asyncio.create_subprocess_exec",
+            AsyncMock(side_effect=_make_proc),
+        ):
+            tasks = [
+                asyncio.create_task(backend.execute("x", session_key="s", timeout=5))
+                for _ in range(cap * 3)
+            ]
+            # Once `cap` tasks are in-flight, give any tasks that a broken cap
+            # would let through a window to start before asserting.
+            await asyncio.wait_for(reached_cap.wait(), timeout=2)
+            await asyncio.sleep(0.05)
+            assert live == cap
+            assert peak == cap
+
+            gate.set()
+            results = await asyncio.gather(*tasks)
+
+        assert len(results) == cap * 3
+        assert all(r.stdout == "ok\n" and r.error is None for r in results)

--- a/tests/unit/server/sandbox/test_deno_backend.py
+++ b/tests/unit/server/sandbox/test_deno_backend.py
@@ -19,11 +19,11 @@ class _StubProcess:
         *,
         stdout: bytes = b"",
         stderr: bytes = b"",
-        returncode: int = 0,
+        returncode: int | None = 0,
     ) -> None:
         self._stdout = stdout
         self._stderr = stderr
-        self.returncode = returncode
+        self.returncode: int | None = returncode
         self.communicate = AsyncMock(return_value=(stdout, stderr))
         self.kill = MagicMock()
         self.wait = AsyncMock()
@@ -249,3 +249,37 @@ class TestDenoSandboxBackend:
 
         assert len(results) == cap * 3
         assert all(r.stdout == "ok\n" and r.error is None for r in results)
+
+    @pytest.mark.asyncio
+    async def test_execute_kills_subprocess_on_outer_cancellation(self) -> None:
+        """An outer cancellation (e.g. CodeEvaluatorRunner's asyncio.wait_for
+        firing while proc.communicate() is in flight) must still kill the Deno
+        child. CancelledError is a BaseException, so it bypasses the
+        asyncio.TimeoutError cleanup path — the finally block is what prevents
+        the subprocess from outliving its execute() call."""
+        backend = DenoSandboxBackend(deno_executable="/usr/local/bin/deno")
+        proc = _StubProcess()
+        # None = still running, so the finally's returncode guard fires.
+        proc.returncode = None
+        in_communicate = asyncio.Event()
+
+        async def _hang(_input: bytes) -> tuple[bytes, bytes]:
+            in_communicate.set()
+            await asyncio.Event().wait()  # never resolves
+            return (b"", b"")
+
+        proc.communicate = _hang  # type: ignore[assignment]
+
+        with patch(
+            "phoenix.server.sandbox.deno_backend.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ):
+            task = asyncio.create_task(
+                backend.execute("console.log('x')", session_key="test", timeout=30)
+            )
+            await asyncio.wait_for(in_communicate.wait(), timeout=2)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        proc.kill.assert_called_once_with()

--- a/tests/unit/server/sandbox/test_deno_backend.py
+++ b/tests/unit/server/sandbox/test_deno_backend.py
@@ -283,3 +283,85 @@ class TestDenoSandboxBackend:
                 await task
 
         proc.kill.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_execute_kills_subprocess_cancelled_after_queueing(self) -> None:
+        """The real trigger from CodeEvaluatorRunner: an execution waits for a
+        semaphore slot, then spawns its subprocess, then is externally
+        cancelled before its own internal timeout. The queued-then-started
+        path must still kill the Deno child.
+
+        Only proc.kill() is asserted: the cancellation-path finally issues a
+        synchronous SIGKILL and does not await proc.wait() — awaiting inside a
+        finally that runs during CancelledError unwinding gains no determinism,
+        and asyncio's child watcher reaps the killed process anyway."""
+        from phoenix.server.sandbox import deno_backend
+
+        cap = deno_backend._MAX_CONCURRENT_DENO_EXECUTIONS
+        backend = DenoSandboxBackend(deno_executable="/usr/local/bin/deno")
+
+        blocker_gate = asyncio.Event()
+        all_blockers_running = asyncio.Event()
+        victim_in_communicate = asyncio.Event()
+        blockers_started = 0
+
+        async def _blocker_communicate(_input: bytes) -> tuple[bytes, bytes]:
+            nonlocal blockers_started
+            blockers_started += 1
+            if blockers_started >= cap:
+                all_blockers_running.set()
+            await blocker_gate.wait()
+            return (b"", b"")
+
+        async def _victim_communicate(_input: bytes) -> tuple[bytes, bytes]:
+            victim_in_communicate.set()
+            await asyncio.Event().wait()  # hang until cancelled
+            return (b"", b"")
+
+        victim_proc = _StubProcess()
+        victim_proc.returncode = None  # still running when the finally runs
+        victim_proc.communicate = _victim_communicate  # type: ignore[assignment]
+        made = 0
+
+        def _make_proc(*_a: object, **_kw: object) -> _StubProcess:
+            # The first `cap` spawns saturate the semaphore; the next is the
+            # victim, which can only spawn once it dequeues a freed slot.
+            nonlocal made
+            made += 1
+            if made <= cap:
+                blocker = _StubProcess()
+                blocker.communicate = _blocker_communicate  # type: ignore[assignment]
+                return blocker
+            return victim_proc
+
+        with patch(
+            "phoenix.server.sandbox.deno_backend.asyncio.create_subprocess_exec",
+            AsyncMock(side_effect=_make_proc),
+        ):
+            blockers = [
+                asyncio.create_task(backend.execute("x", session_key="b", timeout=30))
+                for _ in range(cap)
+            ]
+            await asyncio.wait_for(all_blockers_running.wait(), timeout=2)
+
+            victim = asyncio.create_task(
+                backend.execute("console.log('x')", session_key="v", timeout=30)
+            )
+            # All slots are held, so the victim is parked on the semaphore and
+            # has not spawned its subprocess yet.
+            await asyncio.sleep(0.05)
+            assert not victim_in_communicate.is_set()
+
+            # Free the slots; the victim dequeues, spawns, reaches communicate().
+            blocker_gate.set()
+            await asyncio.wait_for(victim_in_communicate.wait(), timeout=2)
+
+            # External cancellation while the victim subprocess is in flight,
+            # well before its internal 30s timeout.
+            victim.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await victim
+
+            await asyncio.gather(*blockers)
+
+        victim_proc.kill.assert_called_once_with()


### PR DESCRIPTION
## Summary

`DenoSandboxBackend.execute()` spawns a `deno` child process **on the Phoenix server host**, consuming the server's own CPU and memory. Because `DenoAdapter.build_backend()` mints a fresh `DenoSandboxBackend` per call, nothing bounded how many Deno subprocesses could run at once. A large experiment fan-out (an N-row dataset, or repeated evaluator-test mutations) could spawn an unbounded number of `deno` processes and exhaust host resources — a denial-of-service against the Phoenix server itself.

This was discovered during a security review of the sandbox subsystem with all providers enabled. It is reachable by any **MEMBER**-level user: the mutation that triggers code-evaluator execution is gated only by `IsNotReadOnly, IsNotViewer, IsLocked`, so the sandbox is the sole boundary between a member and the host.

## Fix

Add a module-level `asyncio.Semaphore` (cap **4**) shared across every `DenoSandboxBackend` instance. `execute()` holds a slot for the lifetime of each subprocess.

- **Module-level, not per-instance** — `build_backend()` creates a fresh backend per call, so a per-instance cap would not bound *global* concurrency.
- **Cap of 4** mirrors the WASM backend's `ThreadPoolExecutor(max_workers=4)`. Both backends execute locally and contend for the same host CPU/memory, so they get the same budget.
- **Lazily bound per running event loop** — `asyncio.Semaphore` binds to the loop on first use; constructing it at import time would break tests that each run on a fresh loop. Production has a single long-lived loop, so it resolves to a process-wide singleton there.
- Excess callers queue as cheap coroutines on the semaphore. Deno's already-working `asyncio.wait_for` timeout + `proc.kill()` guarantees slots free up, so the queue drains at a steady rate.

This brings Deno in line with WASM, which was already bounded — Deno was the odd one out.

### Scope

This PR addresses the **host-resource-bounding gap only**. Deno's guest capability isolation (`--no-prompt --no-config --no-remote --no-npm`, empty subprocess env) was already correct and is untouched.

## Test

`test_execute_caps_concurrent_subprocesses` launches `4 × 3` concurrent `execute()` calls against a gated stub process and asserts in-flight subprocesses never exceed — and do saturate — the cap of 4.

## Follow-up

The cap interacts with the experiment runner's seat model (`MAX_CONCURRENT = 1000`): a queued Deno work item holds a runner seat while blocked on the Deno semaphore, and the work-item `fail_after` timeout covers that queue wait. This is a pre-existing property of the local-backend design (WASM has the same shape) and is **not made worse** by this PR — but the holistic solution is a runner-scheduling change. Tracked in #13365.


## Update — subprocess leak on outer cancellation (commit 1cfe0d5)

Review surfaced a leak that this PR's semaphore would otherwise *trigger*: `CodeEvaluatorRunner` wraps `execute()` in `asyncio.wait_for(timeout=self._timeout)` and passes the same timeout into `execute()`. The queue wait delays subprocess spawn past the start of the outer timer, so the outer `wait_for` fires while `proc.communicate()` is in flight and raises `CancelledError` into `execute()`. `CancelledError` is a `BaseException` — caught by neither the `asyncio.TimeoutError` handler (which kills the child) nor the broad `except Exception`. The `deno` child was orphaned (`stop_session()` is a no-op for this stateless backend), and leaked processes recreate the very host-resource exhaustion the semaphore exists to prevent.

Fixed by a `finally` block that kills the child whenever it is still running on exit (`returncode is None`) — covering cancellation and unexpected errors. The guard makes it a no-op on the success and `TimeoutError` paths. New test: `test_execute_kills_subprocess_on_outer_cancellation`.
