### PR TITLE
docs(evals): add guide for writing a judge prompt template

### DIFF
--- a/docs/phoenix/evaluation/how-to-evals/prompt-formats.mdx
+++ b/docs/phoenix/evaluation/how-to-evals/prompt-formats.mdx
@@ -152,11 +152,11 @@ All formats support variable substitution. Python supports both f-string (`{vari
 
 # Writing a prompt template
 
-A successful judge prompt template has five elements:
+A successful judge prompt template has four elements:
 
 ## Define the judge's role
 
-In the first part of your prompt, define the judge's role. This consists of giving it domain context: tell it what kind of inputs you're expecting and what the output it will be judging is supposed to accomplish. Framing like "you are an expert evaluator" is common but not critical; instead focus on saying what the inputs and outputs are.
+In the first part of your prompt, define the judge's role. Avoid framing like "you are an expert evaluator": it rarely helps and can sometimes make results worse. Instead, focus on giving the judge context — what type of system it is evaluating, what industry or domain that system operates in, and what the judge's task is. For example, telling the judge "you are identifying issues with the relevance of an agent's responses so we can improve the experience for our users" establishes the system under evaluation, the quality dimension you care about, and the goal of the evaluation.
 
 ## Explicit criteria
 
@@ -164,29 +164,25 @@ Avoid ambiguous or aspirational instructions like "a good response" or "a helpfu
 
 Also include criteria for failure: what would make the response **not helpful**? This is often drawn from inspecting traces.
 
+Be careful not to over-specify. Modern LLMs follow instructions very closely, so a long list of rigid rules can constrain the judge in ways you don't intend. A criterion like "must contain a specific buy/sell/hold recommendation" may be too strict compared to a more open-ended goal like "consider whether the response provides an appropriate next step when the user asks for advice on whether to buy, sell, or hold an asset" — especially when the judge already has the context that it is evaluating a system inside a financial institution.
+
 ## Include labeled data
 
-Include variable names that will be expanded at runtime, e.g. `{input}` and `{output}` or `{question}` and `{answer}` (see above). In your template, surround these variables with clear labels to the LLM so that it understands where your instructions end and inputs and outputs begin and end. You can use labels like
+Include variable names that will be expanded at runtime, e.g. `{input}` and `{output}` or `{question}` and `{answer}` (see above). In your template, surround these variables with clear labels to the LLM so that it understands where your instructions end and inputs and outputs begin and end. XML tags are a clear way to mark where each block begins and ends:
 
 ```
-[BEGIN DATA]
-************
-User query: {input}
-************
-Financial Report: {output}
-************
-[END DATA]
+<user_query>
+{input}
+</user_query>
+
+<financial_report>
+{output}
+</financial_report>
 ```
 
-XML tags are also a clear way to mark beginning and ending blocks.
+## Don't specify the output format
 
-## Add examples
-
-LLMs are often better at matching the pattern of an example than they are at following instructions which can be interpreted multiple ways. Include specific examples of what a passing or failing output might look like. Again, be careful to label these with XML or other tags so that the LLM does not mistake examples for the real output it should be judging.
-
-## Constrain the output
-
-Finally, you should tell the LLM what it should output. This should usually be a simple one-word response, which will get mapped to the `choices` and scores that you supply (see above).
+You don't need to tell the LLM what labels to output or describe a response format in your prompt. You define the possible responses externally, as the evaluator's `choices` (see above), and Phoenix builds an output schema from those choices so that responses are easy to parse. Phoenix uses the model's structured output mode where it is available (not all models have one), or otherwise defines a single tool and requires the model to call it. Even without either mechanism, an LLM given one tool with a clear description will use it consistently without extra instruction. In all cases Phoenix ensures the LLM responds with one of your `choices`, so your prompt can focus on the evaluation criteria rather than the output format.
 
 # Using Phoenix Prompt Versions as Eval Templates (Python)
 

--- a/docs/phoenix/evaluation/how-to-evals/prompt-formats.mdx
+++ b/docs/phoenix/evaluation/how-to-evals/prompt-formats.mdx
@@ -156,7 +156,7 @@ A successful judge prompt template has four elements:
 
 ## Define the judge's role
 
-In the first part of your prompt, define the judge's role. Avoid framing like "you are an expert evaluator": it rarely helps and can sometimes make results worse. Instead, focus on giving the judge context — what type of system it is evaluating, what industry or domain that system operates in, and what the judge's task is. For example, telling the judge "you are identifying issues with the relevance of an agent's responses so we can improve the experience for our users" establishes the system under evaluation, the quality dimension you care about, and the goal of the evaluation.
+In the first part of your prompt, define the judge's role. Avoid framing like "you are an expert evaluator": it rarely helps and can sometimes make results worse. Instead, focus on giving the judge context: what type of system it is evaluating, what industry or domain that system operates in, and what the judge's task is. For example, telling the judge "you are identifying issues with the relevance of an agent's responses so we can improve the experience for our users" establishes the system under evaluation, the quality dimension you care about, and the goal of the evaluation.
 
 ## Explicit criteria
 
@@ -182,7 +182,7 @@ Include variable names that will be expanded at runtime, e.g. `{input}` and `{ou
 
 ## Don't specify the output format
 
-You don't need to tell the LLM what labels to output or describe a response format in your prompt. You define the possible responses externally, as the evaluator's `choices` (see above), and Phoenix builds an output schema from those choices so that responses are easy to parse. Phoenix uses the model's structured output mode where it is available (not all models have one), or otherwise defines a single tool and requires the model to call it. Even without either mechanism, an LLM given one tool with a clear description will use it consistently without extra instruction. In all cases Phoenix ensures the LLM responds with one of your `choices`, so your prompt can focus on the evaluation criteria rather than the output format.
+You don't need to tell the LLM what labels to output or describe a response format in your prompt. You define the possible responses externally, as the evaluator's `choices` (see above), and Phoenix builds an output schema from those choices so that responses are easy to parse. Phoenix uses the model's structured output mode where it is available, or otherwise defines a single tool and requires the model to call it. In all cases Phoenix ensures the LLM responds with one of your `choices`, so your prompt can focus on the evaluation criteria rather than the output format.
 
 # Using Phoenix Prompt Versions as Eval Templates (Python)
 

--- a/docs/phoenix/evaluation/how-to-evals/prompt-formats.mdx
+++ b/docs/phoenix/evaluation/how-to-evals/prompt-formats.mdx
@@ -150,6 +150,44 @@ All formats support variable substitution. Python supports both f-string (`{vari
   </Tab>
 </Tabs>
 
+# Writing a prompt template
+
+A successful judge prompt template has five elements:
+
+## Define the judge's role
+
+In the first part of your prompt, define the judge's role. This consists of giving it domain context: tell it what kind of inputs you're expecting and what the output it will be judging is supposed to accomplish. Framing like "you are an expert evaluator" is common but not critical; instead focus on saying what the inputs and outputs are.
+
+## Explicit criteria
+
+Avoid ambiguous or aspirational instructions like "a good response" or "a helpful answer". Focus on explicit instructions: what specific elements of a response would make it helpful? For example, for a financial agent, one criterion might be "Contains a specific buy/sell/hold recommendation", or for a customer service agent it might be "mentions specific actions to take in the UI to resolve the issue".
+
+Also include criteria for failure: what would make the response **not helpful**? This is often drawn from inspecting traces.
+
+## Include labeled data
+
+Include variable names that will be expanded at runtime, e.g. `{input}` and `{output}` or `{question}` and `{answer}` (see above). In your template, surround these variables with clear labels to the LLM so that it understands where your instructions end and inputs and outputs begin and end. You can use labels like
+
+```
+[BEGIN DATA]
+************
+User query: {input}
+************
+Financial Report: {output}
+************
+[END DATA]
+```
+
+XML tags are also a clear way to mark beginning and ending blocks.
+
+## Add examples
+
+LLMs are often better at matching the pattern of an example than they are at following instructions which can be interpreted multiple ways. Include specific examples of what a passing or failing output might look like. Again, be careful to label these with XML or other tags so that the LLM does not mistake examples for the real output it should be judging.
+
+## Constrain the output
+
+Finally, you should tell the LLM what it should output. This should usually be a simple one-word response, which will get mapped to the `choices` and scores that you supply (see above).
+
 # Using Phoenix Prompt Versions as Eval Templates (Python)
 
 If your prompt is already stored in Phoenix Prompt Management, you can convert it directly into an evals `PromptTemplate` with `phoenix_prompt_to_prompt_template`.


### PR DESCRIPTION
## Summary

Adds a **"Writing a prompt template"** section to the evals [prompt-formats](docs/phoenix/evaluation/how-to-evals/prompt-formats.mdx) page. It walks through the five elements of an effective judge prompt:

- **Define the judge's role** — give domain context about expected inputs and outputs
- **Explicit criteria** — concrete pass/fail criteria instead of aspirational language
- **Include labeled data** — clearly delimit runtime variables (e.g. `[BEGIN DATA]` blocks or XML tags)
- **Add examples** — pattern-match passing/failing outputs, labeled to avoid confusion
- **Constrain the output** — a simple one-word response mapped to `choices`/scores

## Test plan

- [ ] Docs-only change; verify rendering in the Mintlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)