### PR TITLE
fix(sandbox): make the WASM execution timeout enforceable via an epoch ticker

### DIFF
--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -5,7 +5,11 @@ Executes Python code locally via a CPython 3.12 WebAssembly binary using the
 ``wasmtime`` runtime. Stateless — inherits BaseNoSessionBackend.
 
 The WASM binary is downloaded on first use via _download.ensure_wasm_binary().
-Execution runs in a thread pool to avoid blocking the event loop.
+Execution runs in a thread pool to avoid blocking the event loop. The
+per-execution timeout is enforced through wasmtime epoch interruption: a
+daemon ticker thread advances the engine epoch (see _start_epoch_ticker) so a
+store's epoch deadline actually traps runaway guest code instead of letting it
+run forever and leak a worker thread.
 
 Requires the ``wasmtime`` package (optional extra). Runtime imports are lazy
 inside ``_run_wasm`` and ``_get_engine_and_module`` so the module remains
@@ -19,8 +23,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import os
 import tempfile
+import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -47,33 +54,79 @@ _DEFAULT_TIMEOUT_SECONDS = 30
 _EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="wasm-sandbox")
 
 
+# Wall-clock interval between engine epoch increments. A store's epoch
+# deadline is a tick count, so with a 1s tick it maps directly to seconds.
+_EPOCH_TICK_SECONDS = 1.0
+
 # Module-level cache: path → (engine, compiled module).
 # Engine and module must be paired — a module compiled with one engine
 # cannot be used with a store from a different engine.
 _MODULE_CACHE: dict[str, tuple[wasmtime.Engine, wasmtime.Module]] = {}
 
+# Serializes the check-compile-cache sequence in _get_engine_and_module so
+# concurrent _EXECUTOR worker threads cannot create duplicate engines — each
+# duplicate would also spawn its own (orphaned, never-stopping) ticker thread.
+_MODULE_CACHE_LOCK = threading.Lock()
+
+
+def _start_epoch_ticker(engine: wasmtime.Engine) -> None:
+    """Advance *engine*'s epoch on a daemon thread, once per _EPOCH_TICK_SECONDS.
+
+    wasmtime epoch interruption only traps a running guest once the engine's
+    epoch counter passes the store's deadline, and that counter advances ONLY
+    when increment_epoch() is called. Without this ticker the deadline set in
+    _run_wasm would never be reached, so guest code such as an infinite loop
+    would run forever and permanently consume an _EXECUTOR worker thread —
+    four such executions would wedge the WASM backend process-wide.
+
+    The thread is a daemon (never blocks interpreter shutdown) and keeps the
+    engine alive, which is fine: engines live in _MODULE_CACHE for the life of
+    the process anyway.
+    """
+
+    def _tick() -> None:
+        while True:
+            time.sleep(_EPOCH_TICK_SECONDS)
+            engine.increment_epoch()
+
+    threading.Thread(target=_tick, name="wasm-epoch-ticker", daemon=True).start()
+
 
 def _get_engine_and_module(binary_path: Path) -> tuple[wasmtime.Engine, wasmtime.Module]:
-    """Return a cached (engine, module) pair, compiling on first use."""
+    """Return a cached (engine, module) pair, compiling on first use.
+
+    The first call for a binary creates the engine and starts its epoch-ticker
+    thread (see _start_epoch_ticker) so per-store epoch deadlines fire. The
+    lock keeps that one-time setup atomic across worker threads.
+    """
     import wasmtime as _wasm
 
     cache_key = str(binary_path)
-    if cache_key not in _MODULE_CACHE:
-        engine_cfg = _wasm.Config()
-        engine_cfg.epoch_interruption = True
-        engine = _wasm.Engine(engine_cfg)
-        module = _wasm.Module.from_file(engine, str(binary_path))
-        _MODULE_CACHE[cache_key] = (engine, module)
-    return _MODULE_CACHE[cache_key]
+    with _MODULE_CACHE_LOCK:
+        if cache_key not in _MODULE_CACHE:
+            engine_cfg = _wasm.Config()
+            engine_cfg.epoch_interruption = True
+            engine = _wasm.Engine(engine_cfg)
+            module = _wasm.Module.from_file(engine, str(binary_path))
+            _start_epoch_ticker(engine)
+            _MODULE_CACHE[cache_key] = (engine, module)
+        return _MODULE_CACHE[cache_key]
 
 
 def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
-    """Execute *code* in a wasmtime WASI context. Runs in a thread."""
+    """Execute *code* in a wasmtime WASI context. Runs in a thread.
+
+    The *timeout* (seconds) is enforced via the store's epoch deadline, which
+    the engine ticker thread advances; runaway guest code traps after roughly
+    *timeout* seconds and is reported as a timeout rather than running forever
+    and leaking this worker thread.
+    """
     import wasmtime as _wasm
 
     stdout_chunks: list[bytes] = []
     stderr_chunks: list[bytes] = []
     stdin_path: str | None = None
+    started_at = time.monotonic()
 
     try:
         engine, module = _get_engine_and_module(binary_path)
@@ -93,7 +146,11 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
 
         store = _wasm.Store(engine)
         store.set_wasi(wasi)
-        store.set_epoch_deadline(timeout)
+        # Epoch deadline, expressed in engine ticks. The ticker advances one
+        # tick every _EPOCH_TICK_SECONDS, so ceil(timeout / tick) ticks is
+        # roughly `timeout` seconds; at least one tick so a deadline always
+        # exists.
+        store.set_epoch_deadline(max(1, math.ceil(timeout / _EPOCH_TICK_SECONDS)))
 
         instance = linker.instantiate(store, module)
         exports = instance.exports(store)
@@ -106,15 +163,17 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
             stderr=b"".join(stderr_chunks).decode("utf-8", errors="replace"),
         )
     except Exception as exc:
-        return ExecutionResult(
-            stdout=b"".join(stdout_chunks).decode("utf-8", errors="replace"),
-            stderr=b"".join(stderr_chunks).decode("utf-8", errors="replace"),
-            error=str(exc),
-        )
+        stdout = b"".join(stdout_chunks).decode("utf-8", errors="replace")
+        stderr = b"".join(stderr_chunks).decode("utf-8", errors="replace")
+        # An epoch-deadline trap fires ~timeout seconds in. wasmtime surfaces
+        # it as a generic trap, so identify it by elapsed wall time and report
+        # an actionable timeout message instead of a raw trap string.
+        if time.monotonic() - started_at >= timeout:
+            message = f"Execution timed out after {timeout}s"
+            return ExecutionResult(stdout=stdout, stderr=stderr, error=message)
+        return ExecutionResult(stdout=stdout, stderr=stderr, error=str(exc))
     finally:
         if stdin_path is not None:
-            import os
-
             try:
                 os.unlink(stdin_path)
             except OSError:

--- a/tests/unit/server/api/test_wasm_backend.py
+++ b/tests/unit/server/api/test_wasm_backend.py
@@ -729,8 +729,6 @@ class TestRunWasmTimeout:
     def test_reports_timeout_when_trap_fires_after_deadline(self) -> None:
         import wasmtime
 
-        from phoenix.server.sandbox import wasm_backend
-
         class _TrappingStart:
             def __call__(self, store: object) -> None:
                 del store
@@ -751,9 +749,7 @@ class TestRunWasmTimeout:
                 with patch("wasmtime.Store", return_value=fake_store):
                     with patch.object(wasmtime, "Func", _TrappingStart):
                         # started_at, then the except branch reads 30s later.
-                        with patch.object(
-                            wasm_backend.time, "monotonic", side_effect=[100.0, 130.0]
-                        ):
+                        with patch("time.monotonic", side_effect=[100.0, 130.0]):
                             result = _run_wasm(
                                 Path("/fake/cpython.wasm"), "while True: pass", timeout=30
                             )
@@ -764,8 +760,6 @@ class TestRunWasmTimeout:
 
     def test_preserves_generic_error_raised_before_timeout(self) -> None:
         import wasmtime
-
-        from phoenix.server.sandbox import wasm_backend
 
         class _FailingStart:
             def __call__(self, store: object) -> None:
@@ -787,9 +781,7 @@ class TestRunWasmTimeout:
                     with patch.object(wasmtime, "Func", _FailingStart):
                         # Only 0.5s elapsed — far under the 30s timeout, so the
                         # error is a genuine guest fault, not a deadline trap.
-                        with patch.object(
-                            wasm_backend.time, "monotonic", side_effect=[100.0, 100.5]
-                        ):
+                        with patch("time.monotonic", side_effect=[100.0, 100.5]):
                             result = _run_wasm(Path("/fake/cpython.wasm"), "1/0", timeout=30)
 
         assert result.error == "integer division by zero"

--- a/tests/unit/server/api/test_wasm_backend.py
+++ b/tests/unit/server/api/test_wasm_backend.py
@@ -10,6 +10,7 @@ metadata, build_backend config plumbing).
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast  # noqa: F401
 
@@ -678,3 +679,144 @@ class TestSandboxBackendsResolverWASMStatus:
                         secrets=_empty_secrets_context(),
                     )
         mock_retrieve.assert_not_called()
+
+
+class TestEpochTicker:
+    """The epoch ticker is what makes the WASM execution timeout fire at all:
+    wasmtime traps a runaway guest only once the engine epoch passes the
+    store's deadline, and that epoch advances solely via increment_epoch()."""
+
+    def test_start_epoch_ticker_advances_engine_epoch(self) -> None:
+        from phoenix.server.sandbox import wasm_backend
+
+        increments = 0
+
+        class _FakeEngine:
+            def increment_epoch(self) -> None:
+                nonlocal increments
+                increments += 1
+
+        with patch.object(wasm_backend, "_EPOCH_TICK_SECONDS", 0.01):
+            wasm_backend._start_epoch_ticker(cast(Any, _FakeEngine()))
+            time.sleep(0.1)
+
+        assert increments >= 3, "ticker must keep advancing the engine epoch"
+
+    def test_get_engine_and_module_starts_one_ticker_per_engine(self) -> None:
+        import wasmtime
+
+        from phoenix.server.sandbox import wasm_backend
+        from phoenix.server.sandbox.wasm_backend import _MODULE_CACHE, _get_engine_and_module
+
+        fake_path = Path("/fake/ticker-per-engine.wasm")
+        _MODULE_CACHE.pop(str(fake_path), None)
+
+        with patch.object(wasm_backend, "_start_epoch_ticker") as mock_ticker:
+            with patch.object(wasmtime.Module, "from_file", return_value="fake_module"):
+                engine1, _ = _get_engine_and_module(fake_path)
+                engine2, _ = _get_engine_and_module(fake_path)
+
+        assert engine1 is engine2
+        # One engine → one ticker; the cached second call must not start another.
+        mock_ticker.assert_called_once_with(engine1)
+        _MODULE_CACHE.pop(str(fake_path), None)
+
+
+class TestRunWasmTimeout:
+    """_run_wasm enforces the per-execution timeout via the store's epoch
+    deadline and classifies a deadline trap as a timeout."""
+
+    def test_reports_timeout_when_trap_fires_after_deadline(self) -> None:
+        import wasmtime
+
+        from phoenix.server.sandbox import wasm_backend
+
+        class _TrappingStart:
+            def __call__(self, store: object) -> None:
+                del store
+                raise RuntimeError("wasm trap: interrupt")
+
+        mock_exports = MagicMock()
+        mock_exports.get.return_value = _TrappingStart()
+        mock_instance = MagicMock()
+        mock_instance.exports.return_value = mock_exports
+        fake_store = MagicMock()
+
+        with patch(
+            "phoenix.server.sandbox.wasm_backend._get_engine_and_module",
+            return_value=(MagicMock(), MagicMock()),
+        ):
+            with patch("wasmtime.Linker") as mock_linker_cls:
+                mock_linker_cls.return_value.instantiate.return_value = mock_instance
+                with patch("wasmtime.Store", return_value=fake_store):
+                    with patch.object(wasmtime, "Func", _TrappingStart):
+                        # started_at, then the except branch reads 30s later.
+                        with patch.object(
+                            wasm_backend.time, "monotonic", side_effect=[100.0, 130.0]
+                        ):
+                            result = _run_wasm(
+                                Path("/fake/cpython.wasm"), "while True: pass", timeout=30
+                            )
+
+        # 30s timeout / 1s tick → a 30-tick epoch deadline.
+        fake_store.set_epoch_deadline.assert_called_once_with(30)
+        assert result.error == "Execution timed out after 30s"
+
+    def test_preserves_generic_error_raised_before_timeout(self) -> None:
+        import wasmtime
+
+        from phoenix.server.sandbox import wasm_backend
+
+        class _FailingStart:
+            def __call__(self, store: object) -> None:
+                del store
+                raise RuntimeError("integer division by zero")
+
+        mock_exports = MagicMock()
+        mock_exports.get.return_value = _FailingStart()
+        mock_instance = MagicMock()
+        mock_instance.exports.return_value = mock_exports
+
+        with patch(
+            "phoenix.server.sandbox.wasm_backend._get_engine_and_module",
+            return_value=(MagicMock(), MagicMock()),
+        ):
+            with patch("wasmtime.Linker") as mock_linker_cls:
+                mock_linker_cls.return_value.instantiate.return_value = mock_instance
+                with patch("wasmtime.Store", return_value=MagicMock()):
+                    with patch.object(wasmtime, "Func", _FailingStart):
+                        # Only 0.5s elapsed — far under the 30s timeout, so the
+                        # error is a genuine guest fault, not a deadline trap.
+                        with patch.object(
+                            wasm_backend.time, "monotonic", side_effect=[100.0, 100.5]
+                        ):
+                            result = _run_wasm(Path("/fake/cpython.wasm"), "1/0", timeout=30)
+
+        assert result.error == "integer division by zero"
+
+    def test_epoch_deadline_is_at_least_one_tick(self) -> None:
+        import wasmtime
+
+        class _NoopStart:
+            def __call__(self, store: object) -> None:
+                del store
+
+        mock_exports = MagicMock()
+        mock_exports.get.return_value = _NoopStart()
+        mock_instance = MagicMock()
+        mock_instance.exports.return_value = mock_exports
+        fake_store = MagicMock()
+
+        with patch(
+            "phoenix.server.sandbox.wasm_backend._get_engine_and_module",
+            return_value=(MagicMock(), MagicMock()),
+        ):
+            with patch("wasmtime.Linker") as mock_linker_cls:
+                mock_linker_cls.return_value.instantiate.return_value = mock_instance
+                with patch("wasmtime.Store", return_value=fake_store):
+                    with patch.object(wasmtime, "Func", _NoopStart):
+                        result = _run_wasm(Path("/fake/cpython.wasm"), "x=1", timeout=0)
+
+        # ceil(0 / 1.0) is 0, floored to a minimum of one tick.
+        fake_store.set_epoch_deadline.assert_called_once_with(1)
+        assert result.error is None


### PR DESCRIPTION
## Summary

The WASM sandbox backend's per-execution timeout was **inert** — it never fired. `_get_engine_and_module` enabled `epoch_interruption` on the engine and `_run_wasm` called `store.set_epoch_deadline(timeout)`, but **nothing ever advanced the engine epoch**. wasmtime epoch interruption only traps a running guest once the engine's epoch counter passes the store's deadline, and that counter advances *solely* when `engine.increment_epoch()` is called — which nothing did.

Consequence: guest code such as `while True: pass` ran forever, permanently consuming one of the four `_EXECUTOR` worker threads. Because the timeout never recovered the thread, **four such executions wedge the WASM backend process-wide** — every subsequent WASM evaluation hangs. WASM is the default sandbox provider, and the path is reachable by any MEMBER-level user, so this is a denial-of-service against the Phoenix server.

Found during a security review of the sandbox subsystem.

## Fix

- **`_start_epoch_ticker(engine)`** — a daemon thread per engine that calls `engine.increment_epoch()` once per `_EPOCH_TICK_SECONDS` (1s). This is the missing piece that makes any epoch deadline reachable.
- **`_run_wasm`** sets the deadline as `ceil(timeout / _EPOCH_TICK_SECONDS)` ticks (floored to at least 1), so a 30s timeout maps to a 30-tick deadline ≈ 30s. A deadline trap is classified by elapsed wall time and surfaced as `Execution timed out after Ns` instead of a raw wasmtime trap string.
- **`_get_engine_and_module`** is now guarded by a lock so concurrent `_EXECUTOR` worker threads racing on first use cannot create duplicate engines — each duplicate would also spawn its own orphaned, never-stopping ticker thread.

The ticker thread is a daemon (never blocks interpreter shutdown) and holds the engine alive — fine, since engines live in `_MODULE_CACHE` for the process lifetime regardless.

### Scope

This PR fixes the **timeout / thread-leak** only. Two related WASM issues are intentionally out of scope:
- **No memory cap** — a WASM guest can still grow linear memory toward the module max; needs `StoreLimits`. Worth a follow-up PR.
- **Cancellation** — an outer `asyncio.wait_for` cancellation still cannot interrupt the worker thread mid-execution; but with a *working* epoch deadline the thread is now bounded (it frees within `timeout`), so the unbounded leak is closed.

## Tests

`test_wasm_backend.py` (runs in CI; the module is `importorskip`-gated on the `wasmtime` extra):
- `test_start_epoch_ticker_advances_engine_epoch` — the ticker keeps calling `increment_epoch()`.
- `test_get_engine_and_module_starts_one_ticker_per_engine` — one ticker per engine; the cached second call starts none.
- `test_reports_timeout_when_trap_fires_after_deadline` — deadline set to 30 ticks; a post-deadline trap → `Execution timed out after 30s`.
- `test_preserves_generic_error_raised_before_timeout` — a fault well under the timeout keeps its original message (guards the elapsed-time heuristic).
- `test_epoch_deadline_is_at_least_one_tick` — `timeout=0` floors to a 1-tick deadline.

The ticker mechanism and deadline arithmetic were also verified locally against a fake engine (the `wasmtime` extra is not installed in the local env, so the gated suite is exercised by CI).

