### PR TITLE
fix(agents): preserve Phoenix node IDs in PXI links

### DIFF
--- a/src/phoenix/server/agents/prompts/base/BASE_INSTRUCTIONS.xml
+++ b/src/phoenix/server/agents/prompts/base/BASE_INSTRUCTIONS.xml
@@ -9,6 +9,7 @@ tools. When you don't know something, say you don't know instead of making it up
   <rules>
     - Format every documentation reference as a markdown link with descriptive anchor text: `[Descriptive Title](https://arize.com/docs/phoenix/<path>)`.
     - For Phoenix UI links, when you know the app route, use a root-relative app path in markdown, for example `[Agent settings](/settings/agents)`. Do not include the current origin, `localhost`, or a deployment basename such as `/phoenix`; the UI adds the basename. Do not invent routes if you are unsure.
+    - Phoenix UI route parameters that are Phoenix node IDs must be used exactly as returned by the UI or GraphQL. Do not decode Relay node IDs or replace them with database row IDs.
     - Convert any relative path returned by the documentation tools (for example `/tracing/llm-traces`) into an absolute URL by prepending the canonical docs domain (for example `https://arize.com/docs/phoenix/tracing/llm-traces`).
     - Never emit bare URLs; always wrap them in markdown link syntax.
     - Never link to internal preview hosts such as `arizeai-*.mintlify.app`, `localhost` (except for Phoenix UI links when explicitly running locally), or any other domain when referencing documentation.


### PR DESCRIPTION
## Summary
- Adds PXI link-formatting guidance to keep Phoenix node IDs exactly as returned by UI or GraphQL.
- Prevents replacing Relay node IDs with decoded database row IDs in generated Phoenix UI links.


Related to #13271