### PR TITLE
fix(sandbox): bound a WASM execution's host-memory footprint

### DIFF
--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -56,19 +56,15 @@ _EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="wasm-sandbox")
 # 1s tick: store epoch deadline (a tick count) maps directly to seconds.
 _EPOCH_INTERVAL_SECONDS = 1.0
 
-# Upper bound on a single guest's WebAssembly linear memory. memory.grow past
-# this fails inside the guest (a MemoryError in CPython-WASM) instead of
-# OOM-killing the Phoenix process. With _EXECUTOR's 4 workers the worst-case
-# host footprint is bounded at 4 × this. Generous enough for normal evaluator
-# code; bump this constant if a legitimate workload needs more.
+# Cap on a single guest's WebAssembly linear memory. An over-cap memory.grow
+# fails inside the guest (MemoryError in CPython-WASM) rather than OOM-killing
+# the Phoenix process. Worst-case host footprint is 4 × this — _EXECUTOR runs
+# 4 workers.
 _MAX_WASM_MEMORY_BYTES = 256 * 1024 * 1024
 
-# Per-stream sliding-window cap on guest stdout/stderr held in host memory. The
-# WASI output callbacks append every guest write to a host buffer, so without a
-# cap a guest that prints in a loop grows host RAM for the whole execution
-# window — a vector _MAX_WASM_MEMORY_BYTES (which bounds only the guest's own
-# memory) does not address. _BoundedOutputSink retains the most recent bytes up
-# to this cap and drops older output.
+# Per-stream cap on guest stdout/stderr retained in host memory. Distinct from
+# _MAX_WASM_MEMORY_BYTES: that bounds the guest's own memory, not what the host
+# accumulates from its output. See _BoundedOutputSink.
 _MAX_OUTPUT_BYTES = 1024 * 1024
 
 
@@ -153,19 +149,16 @@ def _get_engine_and_module(binary_path: Path) -> tuple[wasmtime.Engine, wasmtime
 
 
 class _BoundedOutputSink:
-    """Accumulates guest stdout/stderr, retaining a sliding window of the most
-    recent ``limit`` bytes.
-
-    The WASI ``stdout_custom`` / ``stderr_custom`` callbacks hand every guest
-    write to the host; appending without bound lets a guest that prints in a
-    loop grow host RAM for the whole execution window.
+    """Accumulates guest stdout/stderr into a sliding window of the most recent
+    ``limit`` bytes, so a guest that prints in a loop cannot grow host RAM
+    without bound.
 
     The window keeps the **tail**, not the head. This is deliberate: the
     code-evaluator harness prints its fenced result markers (parsed by
     ``_extract_fenced_result``) last, after the user's code, so head-truncation
-    would drop them and break result parsing. The retained tail always contains
-    that final marker block, which is tiny relative to ``limit``.
-    ``getvalue()`` prepends a notice when older output was dropped.
+    would drop them and break result parsing — the tiny trailing marker block
+    always fits the retained tail. ``getvalue()`` prepends a notice when older
+    output was dropped.
     """
 
     def __init__(self, limit: int) -> None:
@@ -174,11 +167,10 @@ class _BoundedOutputSink:
         self._dropped = 0
 
     def write(self, data: bytes) -> None:
-        # A single write at least as large as the window makes everything
-        # buffered so far — and all but the payload's own tail — unreachable.
-        # Slice it down instead of appending the whole payload: appending would
-        # transiently copy all of `data` into `_buf`, so the sink's footprint
-        # would track the largest callback payload rather than the window.
+        # A write at least as large as the window makes everything buffered so
+        # far unreachable. Slice to the tail rather than appending: `_buf +=`
+        # would copy the whole payload in, so the sink's transient footprint
+        # would track the largest callback payload, not the window.
         if len(data) >= self._limit:
             self._dropped += len(self._buf) + (len(data) - self._limit)
             self._buf = bytearray(data[-self._limit :])
@@ -232,11 +224,8 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
         store.set_wasi(wasi)
         # Deadline in engine ticks; with a 1s tick this is `timeout` seconds.
         store.set_epoch_deadline(timeout)
-        # Cap the guest's WebAssembly linear memory — one of the two host-RAM
-        # vectors for a single execution (captured output, bounded by the
-        # sinks above, is the other). Must be set before instantiate(), when
-        # the guest memory is created; an over-cap memory.grow then fails
-        # inside the guest rather than OOM-killing the Phoenix process.
+        # Must be set before instantiate(), where the guest memory is created.
+        # See _MAX_WASM_MEMORY_BYTES.
         store.set_limits(memory_size=_MAX_WASM_MEMORY_BYTES)
 
         with _engine_epoch_ticker(engine):

--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -5,9 +5,11 @@ Executes Python code locally via a CPython 3.12 WebAssembly binary using the
 ``wasmtime`` runtime. Stateless — inherits BaseNoSessionBackend.
 
 The WASM binary is downloaded on first use via _download.ensure_wasm_binary().
-Execution runs in a thread pool to avoid blocking the event loop. Each store
-caps the guest's WebAssembly linear memory (_MAX_WASM_MEMORY_BYTES) so a single
-execution cannot exhaust host RAM.
+Execution runs in a thread pool to avoid blocking the event loop. A single
+execution's host-memory footprint is bounded on two fronts: the guest's
+WebAssembly linear memory is capped (_MAX_WASM_MEMORY_BYTES), and captured
+stdout/stderr is capped (_MAX_OUTPUT_BYTES) so a guest that prints in a loop
+cannot grow host RAM through output alone.
 
 Requires the ``wasmtime`` package (optional extra). Runtime imports are lazy
 inside ``_run_wasm`` and ``_get_engine_and_module`` so the module remains
@@ -60,6 +62,13 @@ _EPOCH_INTERVAL_SECONDS = 1.0
 # host footprint is bounded at 4 × this. Generous enough for normal evaluator
 # code; bump this constant if a legitimate workload needs more.
 _MAX_WASM_MEMORY_BYTES = 256 * 1024 * 1024
+
+# Per-stream cap on guest stdout/stderr held in host memory. The WASI output
+# callbacks append every guest write to a host buffer, so without a cap a guest
+# that prints in a loop grows host RAM for the whole execution window — a vector
+# that _MAX_WASM_MEMORY_BYTES (which bounds only the guest's own memory) does
+# not address. Bytes past the cap are dropped (see _BoundedOutputSink).
+_MAX_OUTPUT_BYTES = 1024 * 1024
 
 
 # Engine and module must be paired: a module compiled with one engine cannot
@@ -142,12 +151,46 @@ def _get_engine_and_module(binary_path: Path) -> tuple[wasmtime.Engine, wasmtime
     return _MODULE_CACHE[cache_key]
 
 
+class _BoundedOutputSink:
+    """Accumulates guest stdout/stderr bytes up to a fixed cap.
+
+    The WASI ``stdout_custom`` / ``stderr_custom`` callbacks hand every guest
+    write to the host; appending unconditionally would let a guest that prints
+    in a loop grow host RAM for the whole execution window. Bytes past
+    ``limit`` are dropped, and ``getvalue()`` appends a truncation marker so the
+    caller can tell output was cut.
+    """
+
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        self._chunks: list[bytes] = []
+        self._size = 0
+        self._truncated = False
+
+    def write(self, data: bytes) -> None:
+        remaining = self._limit - self._size
+        if remaining <= 0:
+            self._truncated = True
+            return
+        if len(data) > remaining:
+            data = data[:remaining]
+            self._truncated = True
+        self._chunks.append(data)
+        self._size += len(data)
+
+    def getvalue(self) -> str:
+        text = b"".join(self._chunks).decode("utf-8", errors="replace")
+        if self._truncated:
+            text += f"\n[output truncated: exceeded {self._limit} bytes]"
+        return text
+
+
 def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
     """Execute *code* in a wasmtime WASI context. Runs in a thread."""
     import wasmtime as _wasm
 
-    stdout_chunks: list[bytes] = []
-    stderr_chunks: list[bytes] = []
+    stdout_sink = _BoundedOutputSink(_MAX_OUTPUT_BYTES)
+    stderr_sink = _BoundedOutputSink(_MAX_OUTPUT_BYTES)
     stdin_path: str | None = None
     started_at = time.monotonic()
 
@@ -158,8 +201,8 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
         linker.define_wasi()
 
         wasi = _wasm.WasiConfig()
-        wasi.stdout_custom = lambda data: stdout_chunks.append(data)
-        wasi.stderr_custom = lambda data: stderr_chunks.append(data)
+        wasi.stdout_custom = stdout_sink.write
+        wasi.stderr_custom = stderr_sink.write
 
         # Inject code via a temp stdin file
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
@@ -171,10 +214,11 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
         store.set_wasi(wasi)
         # Deadline in engine ticks; with a 1s tick this is `timeout` seconds.
         store.set_epoch_deadline(timeout)
-        # Cap the guest's linear memory so one execution cannot exhaust host
-        # RAM. Must be set before instantiate(), when the guest memory is
-        # created; an over-cap memory.grow then fails inside the guest rather
-        # than OOM-killing the Phoenix process.
+        # Cap the guest's WebAssembly linear memory — one of the two host-RAM
+        # vectors for a single execution (captured output, bounded by the
+        # sinks above, is the other). Must be set before instantiate(), when
+        # the guest memory is created; an over-cap memory.grow then fails
+        # inside the guest rather than OOM-killing the Phoenix process.
         store.set_limits(memory_size=_MAX_WASM_MEMORY_BYTES)
 
         with _engine_epoch_ticker(engine):
@@ -184,13 +228,10 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
             if isinstance(start, _wasm.Func):
                 start(store)
 
-        return ExecutionResult(
-            stdout=b"".join(stdout_chunks).decode("utf-8", errors="replace"),
-            stderr=b"".join(stderr_chunks).decode("utf-8", errors="replace"),
-        )
+        return ExecutionResult(stdout=stdout_sink.getvalue(), stderr=stderr_sink.getvalue())
     except Exception as exc:
-        stdout = b"".join(stdout_chunks).decode("utf-8", errors="replace")
-        stderr = b"".join(stderr_chunks).decode("utf-8", errors="replace")
+        stdout = stdout_sink.getvalue()
+        stderr = stderr_sink.getvalue()
         # Classify late traps as timeouts (raw wasmtime trap string is opaque).
         if time.monotonic() - started_at >= timeout:
             message = f"Execution timed out after {timeout}s"

--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -63,11 +63,12 @@ _EPOCH_INTERVAL_SECONDS = 1.0
 # code; bump this constant if a legitimate workload needs more.
 _MAX_WASM_MEMORY_BYTES = 256 * 1024 * 1024
 
-# Per-stream cap on guest stdout/stderr held in host memory. The WASI output
-# callbacks append every guest write to a host buffer, so without a cap a guest
-# that prints in a loop grows host RAM for the whole execution window — a vector
-# that _MAX_WASM_MEMORY_BYTES (which bounds only the guest's own memory) does
-# not address. Bytes past the cap are dropped (see _BoundedOutputSink).
+# Per-stream sliding-window cap on guest stdout/stderr held in host memory. The
+# WASI output callbacks append every guest write to a host buffer, so without a
+# cap a guest that prints in a loop grows host RAM for the whole execution
+# window — a vector _MAX_WASM_MEMORY_BYTES (which bounds only the guest's own
+# memory) does not address. _BoundedOutputSink retains the most recent bytes up
+# to this cap and drops older output.
 _MAX_OUTPUT_BYTES = 1024 * 1024
 
 
@@ -152,36 +153,44 @@ def _get_engine_and_module(binary_path: Path) -> tuple[wasmtime.Engine, wasmtime
 
 
 class _BoundedOutputSink:
-    """Accumulates guest stdout/stderr bytes up to a fixed cap.
+    """Accumulates guest stdout/stderr, retaining a sliding window of the most
+    recent ``limit`` bytes.
 
     The WASI ``stdout_custom`` / ``stderr_custom`` callbacks hand every guest
-    write to the host; appending unconditionally would let a guest that prints
-    in a loop grow host RAM for the whole execution window. Bytes past
-    ``limit`` are dropped, and ``getvalue()`` appends a truncation marker so the
-    caller can tell output was cut.
+    write to the host; appending without bound lets a guest that prints in a
+    loop grow host RAM for the whole execution window.
+
+    The window keeps the **tail**, not the head. This is deliberate: the
+    code-evaluator harness prints its fenced result markers (parsed by
+    ``_extract_fenced_result``) last, after the user's code, so head-truncation
+    would drop them and break result parsing. The retained tail always contains
+    that final marker block, which is tiny relative to ``limit``.
+    ``getvalue()`` prepends a notice when older output was dropped.
     """
 
     def __init__(self, limit: int) -> None:
         self._limit = limit
-        self._chunks: list[bytes] = []
-        self._size = 0
-        self._truncated = False
+        self._buf = bytearray()
+        self._dropped = 0
 
     def write(self, data: bytes) -> None:
-        remaining = self._limit - self._size
-        if remaining <= 0:
-            self._truncated = True
-            return
-        if len(data) > remaining:
-            data = data[:remaining]
-            self._truncated = True
-        self._chunks.append(data)
-        self._size += len(data)
+        self._buf += data
+        # Trim lazily — only once the buffer reaches twice the window — so the
+        # amortized cost is O(1) per byte rather than O(limit) per write.
+        if len(self._buf) > 2 * self._limit:
+            self._trim()
+
+    def _trim(self) -> None:
+        excess = len(self._buf) - self._limit
+        if excess > 0:
+            del self._buf[:excess]
+            self._dropped += excess
 
     def getvalue(self) -> str:
-        text = b"".join(self._chunks).decode("utf-8", errors="replace")
-        if self._truncated:
-            text += f"\n[output truncated: exceeded {self._limit} bytes]"
+        self._trim()
+        text = self._buf.decode("utf-8", errors="replace")
+        if self._dropped:
+            text = f"[output truncated: {self._dropped} earlier bytes dropped]\n{text}"
         return text
 
 

--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -58,9 +58,10 @@ _EPOCH_INTERVAL_SECONDS = 1.0
 
 # Cap on a single guest's WebAssembly linear memory. An over-cap memory.grow
 # fails inside the guest (MemoryError in CPython-WASM) rather than OOM-killing
-# the Phoenix process. Worst-case host footprint is 4 × this — _EXECUTOR runs
-# 4 workers.
-_MAX_WASM_MEMORY_BYTES = 256 * 1024 * 1024
+# the Phoenix process. 128 MiB is well above the interpreter's baseline and
+# leaves room for evaluator code, while keeping the aggregate a single user
+# can pin modest: _EXECUTOR runs 4 workers, so worst case is 4 × this.
+_MAX_WASM_MEMORY_BYTES = 128 * 1024 * 1024
 
 # Per-stream cap on guest stdout/stderr retained in host memory. Distinct from
 # _MAX_WASM_MEMORY_BYTES: that bounds the guest's own memory, not what the host

--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -1,4 +1,21 @@
-"""WASM sandbox backend executing Python via CPython-WASM under wasmtime."""
+"""
+WASM sandbox backend.
+
+Executes Python code locally via a CPython 3.12 WebAssembly binary using the
+``wasmtime`` runtime. Stateless — inherits BaseNoSessionBackend.
+
+The WASM binary is downloaded on first use via _download.ensure_wasm_binary().
+Execution runs in a thread pool to avoid blocking the event loop. Each store
+caps the guest's WebAssembly linear memory (_MAX_WASM_MEMORY_BYTES) so a single
+execution cannot exhaust host RAM.
+
+Requires the ``wasmtime`` package (optional extra). Runtime imports are lazy
+inside ``_run_wasm`` and ``_get_engine_and_module`` so the module remains
+importable when the extra is absent (test environments mock or skip). Adapter
+availability is gated by ``WASMAdapter.probe_dependencies`` at registration
+time, which surfaces a missing extra as ``status=NOT_INSTALLED`` instead of a
+runtime error during evaluation.
+"""
 
 from __future__ import annotations
 
@@ -36,6 +53,13 @@ _EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="wasm-sandbox")
 
 # 1s tick: store epoch deadline (a tick count) maps directly to seconds.
 _EPOCH_INTERVAL_SECONDS = 1.0
+
+# Upper bound on a single guest's WebAssembly linear memory. memory.grow past
+# this fails inside the guest (a MemoryError in CPython-WASM) instead of
+# OOM-killing the Phoenix process. With _EXECUTOR's 4 workers the worst-case
+# host footprint is bounded at 4 × this. Generous enough for normal evaluator
+# code; bump this constant if a legitimate workload needs more.
+_MAX_WASM_MEMORY_BYTES = 256 * 1024 * 1024
 
 
 # Engine and module must be paired: a module compiled with one engine cannot
@@ -147,6 +171,11 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
         store.set_wasi(wasi)
         # Deadline in engine ticks; with a 1s tick this is `timeout` seconds.
         store.set_epoch_deadline(timeout)
+        # Cap the guest's linear memory so one execution cannot exhaust host
+        # RAM. Must be set before instantiate(), when the guest memory is
+        # created; an over-cap memory.grow then fails inside the guest rather
+        # than OOM-killing the Phoenix process.
+        store.set_limits(memory_size=_MAX_WASM_MEMORY_BYTES)
 
         with _engine_epoch_ticker(engine):
             instance = linker.instantiate(store, module)

--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -174,6 +174,15 @@ class _BoundedOutputSink:
         self._dropped = 0
 
     def write(self, data: bytes) -> None:
+        # A single write at least as large as the window makes everything
+        # buffered so far — and all but the payload's own tail — unreachable.
+        # Slice it down instead of appending the whole payload: appending would
+        # transiently copy all of `data` into `_buf`, so the sink's footprint
+        # would track the largest callback payload rather than the window.
+        if len(data) >= self._limit:
+            self._dropped += len(self._buf) + (len(data) - self._limit)
+            self._buf = bytearray(data[-self._limit :])
+            return
         self._buf += data
         # Trim lazily — only once the buffer reaches twice the window — so the
         # amortized cost is O(1) per byte rather than O(limit) per write.

--- a/tests/unit/server/api/test_wasm_backend.py
+++ b/tests/unit/server/api/test_wasm_backend.py
@@ -775,16 +775,30 @@ class TestBoundedOutputSink:
 
         assert sink.getvalue() == "abcde"
 
-    def test_truncates_and_bounds_host_memory_past_limit(self) -> None:
+    def test_keeps_tail_so_trailing_result_markers_survive(self) -> None:
+        """The window must retain the tail: the code-evaluator harness prints
+        its fenced result markers last, so dropping the tail would break result
+        parsing for any evaluator that prints a lot before emitting them."""
         from phoenix.server.sandbox.wasm_backend import _BoundedOutputSink
 
-        sink = _BoundedOutputSink(limit=10)
-        # Simulate a guest printing in a loop far past the cap.
-        for _ in range(1000):
-            sink.write(b"xxxxxxxxxx")
+        sink = _BoundedOutputSink(limit=64)
+        sink.write(b"NOISE" * 1000)  # chatty user code, far past the cap
+        sink.write(b"===PHOENIX_RESULT_BEGIN===\n{}\n===PHOENIX_RESULT_END===")
 
         value = sink.getvalue()
-        captured = value.split("\n[output truncated", 1)[0]
-        # Only the first `limit` bytes are kept, regardless of total written.
-        assert captured == "x" * 10
-        assert "[output truncated: exceeded 10 bytes]" in value
+        assert value.endswith("===PHOENIX_RESULT_END===")
+        assert "===PHOENIX_RESULT_BEGIN===" in value
+        assert "[output truncated" in value
+
+    def test_retained_output_stays_bounded(self) -> None:
+        from phoenix.server.sandbox.wasm_backend import _BoundedOutputSink
+
+        sink = _BoundedOutputSink(limit=100)
+        for _ in range(100_000):  # 5 MB written in 50-byte chunks
+            sink.write(b"x" * 50)
+
+        notice, _, retained = sink.getvalue().partition("\n")
+        # A truncation notice plus at most `limit` bytes of retained output —
+        # the host buffer never grows with total bytes written.
+        assert notice.startswith("[output truncated")
+        assert len(retained.encode("utf-8")) <= 100

--- a/tests/unit/server/api/test_wasm_backend.py
+++ b/tests/unit/server/api/test_wasm_backend.py
@@ -751,3 +751,40 @@ class TestRunWasmMemoryLimit:
 
         fake_store.set_limits.assert_called_once_with(memory_size=_MAX_WASM_MEMORY_BYTES)
         assert result.error is None
+
+
+class TestBoundedOutputSink:
+    """_BoundedOutputSink caps host-side stdout/stderr capture so a guest that
+    prints in a loop cannot grow host RAM without bound — a vector the WASM
+    linear-memory limit does not cover."""
+
+    def test_passes_through_output_under_limit(self) -> None:
+        from phoenix.server.sandbox.wasm_backend import _BoundedOutputSink
+
+        sink = _BoundedOutputSink(limit=1024)
+        sink.write(b"hello ")
+        sink.write(b"world")
+
+        assert sink.getvalue() == "hello world"
+
+    def test_output_exactly_at_limit_is_not_truncated(self) -> None:
+        from phoenix.server.sandbox.wasm_backend import _BoundedOutputSink
+
+        sink = _BoundedOutputSink(limit=5)
+        sink.write(b"abcde")
+
+        assert sink.getvalue() == "abcde"
+
+    def test_truncates_and_bounds_host_memory_past_limit(self) -> None:
+        from phoenix.server.sandbox.wasm_backend import _BoundedOutputSink
+
+        sink = _BoundedOutputSink(limit=10)
+        # Simulate a guest printing in a loop far past the cap.
+        for _ in range(1000):
+            sink.write(b"xxxxxxxxxx")
+
+        value = sink.getvalue()
+        captured = value.split("\n[output truncated", 1)[0]
+        # Only the first `limit` bytes are kept, regardless of total written.
+        assert captured == "x" * 10
+        assert "[output truncated: exceeded 10 bytes]" in value

--- a/tests/unit/server/api/test_wasm_backend.py
+++ b/tests/unit/server/api/test_wasm_backend.py
@@ -802,3 +802,19 @@ class TestBoundedOutputSink:
         # the host buffer never grows with total bytes written.
         assert notice.startswith("[output truncated")
         assert len(retained.encode("utf-8")) <= 100
+
+    def test_single_oversized_write_is_not_fully_buffered(self) -> None:
+        """A single callback payload larger than the window must be sliced
+        down on arrival — not appended whole — so the sink's footprint tracks
+        the window, not the largest payload a guest can hand it in one write."""
+        from phoenix.server.sandbox.wasm_backend import _BoundedOutputSink
+
+        sink = _BoundedOutputSink(limit=100)
+        sink.write(b"H" * 10_000 + b"T" * 100)  # one 10100-byte payload
+
+        # The buffer holds only the window immediately — the 10 KB head was
+        # never retained, not merely trimmed away afterwards.
+        assert len(sink._buf) == 100
+        value = sink.getvalue()
+        assert value.endswith("T" * 100)
+        assert "H" not in value.partition("\n")[2]

--- a/tests/unit/server/api/test_wasm_backend.py
+++ b/tests/unit/server/api/test_wasm_backend.py
@@ -710,3 +710,44 @@ class TestSandboxBackendsResolverWASMStatus:
                         secrets=_empty_secrets_context(),
                     )
         mock_retrieve.assert_not_called()
+
+
+class TestRunWasmMemoryLimit:
+    """_run_wasm caps the guest's linear memory so one execution cannot
+    exhaust host RAM."""
+
+    def test_sets_store_memory_limit_before_instantiate(self) -> None:
+        import wasmtime
+
+        from phoenix.server.sandbox.wasm_backend import _MAX_WASM_MEMORY_BYTES
+
+        class _NoopStart:
+            def __call__(self, store: object) -> None:
+                del store
+
+        mock_exports = MagicMock()
+        mock_exports.get.return_value = _NoopStart()
+        mock_instance = MagicMock()
+        mock_instance.exports.return_value = mock_exports
+        fake_store = MagicMock()
+
+        # The cap must be installed before instantiate() creates the guest
+        # memory — assert that ordering from inside the instantiate stub.
+        def _instantiate(*_args: object, **_kwargs: object) -> object:
+            assert fake_store.set_limits.called, (
+                "memory limit must be set before linker.instantiate()"
+            )
+            return mock_instance
+
+        with patch(
+            "phoenix.server.sandbox.wasm_backend._get_engine_and_module",
+            return_value=(MagicMock(), MagicMock()),
+        ):
+            with patch("wasmtime.Linker") as mock_linker_cls:
+                mock_linker_cls.return_value.instantiate.side_effect = _instantiate
+                with patch("wasmtime.Store", return_value=fake_store):
+                    with patch.object(wasmtime, "Func", _NoopStart):
+                        result = _run_wasm(Path("/fake/cpython.wasm"), "x=1", timeout=5)
+
+        fake_store.set_limits.assert_called_once_with(memory_size=_MAX_WASM_MEMORY_BYTES)
+        assert result.error is None


### PR DESCRIPTION
## Summary

A single WASM sandbox execution could exhaust the Phoenix host's RAM via two unbounded vectors:

1. **Guest linear memory** — nothing bounded the guest's WebAssembly linear memory, so it could `memory.grow` toward the wasm32 maximum (up to 4 GiB).
2. **Host-side output capture** — the WASI `stdout_custom` / `stderr_custom` callbacks appended every guest write to unbounded Python lists, so a guest printing in a loop grew the host's RAM for the whole execution window.

Either is an OOM-kill of the Phoenix server process, reachable by any MEMBER-level user since WASM is the default sandbox provider.

## Fix

- **Guest linear memory** — `store.set_limits(memory_size=_MAX_WASM_MEMORY_BYTES)` (256 MiB), set before `instantiate()` when the guest memory is created. An over-cap `memory.grow` then fails inside the guest (a `MemoryError` in CPython-WASM) instead of OOM-killing the host.
- **Captured output** — `_BoundedOutputSink` is a sliding window that retains the most recent `_MAX_OUTPUT_BYTES` (1 MiB per stream) and drops older output, prepending a notice. `set_limits` bounds only the guest's *own* memory, not what the host accumulates from it — this closes the second vector. The window keeps the **tail**, not the head: the code-evaluator harness prints its `===PHOENIX_RESULT_*===` markers last, so head-truncation would drop them and break result parsing.

With `_EXECUTOR`'s 4 worker threads the worst-case host footprint is bounded: ~4 × 256 MiB of guest memory and ~4 × 2 × 1 MiB of captured output.

## Tests

`test_wasm_backend.py` (runs in CI; the module is `importorskip`-gated on the `wasmtime` extra):
- `TestRunWasmMemoryLimit` — `_run_wasm` calls `store.set_limits(...)` with the cap, and the `instantiate` stub asserts the limit was already set when it runs (before-instantiate ordering).
- `TestBoundedOutputSink` — output under/at the limit passes through unchanged; a chatty write followed by trailing result markers keeps the **tail** so the markers survive; retained output stays bounded after 5 MB is written in small chunks.
