### PR TITLE
docs: add Go LLM provider integration docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -455,14 +455,16 @@
                 "pages": [
                   "docs/phoenix/integrations/llm-providers/anthropic",
                   "docs/phoenix/integrations/llm-providers/anthropic/anthropic-tracing",
-                  "docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-typescript"
+                  "docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-typescript",
+                  "docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go"
                 ]
               },
               {
                 "group": "Google",
                 "pages": [
                   "docs/phoenix/integrations/llm-providers/google-gen-ai",
-                  "docs/phoenix/integrations/llm-providers/google-gen-ai/google-genai-tracing"
+                  "docs/phoenix/integrations/llm-providers/google-gen-ai/google-genai-tracing",
+                  "docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk"
                 ]
               },
               {
@@ -492,7 +494,8 @@
                   "docs/phoenix/integrations/llm-providers/openai",
                   "docs/phoenix/integrations/llm-providers/openai/openai-tracing",
                   "docs/phoenix/integrations/llm-providers/openai/openai-agents-sdk-tracing",
-                  "docs/phoenix/integrations/llm-providers/openai/openai-node-js-sdk"
+                  "docs/phoenix/integrations/llm-providers/openai/openai-node-js-sdk",
+                  "docs/phoenix/integrations/llm-providers/openai/openai-go-sdk"
                 ]
               },
               {

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -103,6 +103,13 @@ Phoenix captures detailed traces from your AI applications, giving you visibilit
       <Card title="Arconia" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-tracing.jpeg" href="/docs/phoenix/integrations/java/arconia" />
     </CardGroup>
   </Tab>
+  <Tab title="Go" icon="golang">
+    <CardGroup cols={4}>
+      <Card title="OpenAI Go SDK" href="/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk" icon="robot" description="OpenInference Go for sashabaranov/go-openai"/>
+      <Card title="Anthropic SDK Go" href="/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go" icon="robot" description="OpenInference Go for anthropic-sdk-go"/>
+      <Card title="Gemini Go SDK" href="/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk" icon="robot" description="OTel GenAI conventions for google.golang.org/genai"/>
+    </CardGroup>
+  </Tab>
 </Tabs>
 
 ### LLM Providers

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -105,7 +105,7 @@ Phoenix captures detailed traces from your AI applications, giving you visibilit
   </Tab>
   <Tab title="Go" icon="golang">
     <CardGroup cols={4}>
-      <Card title="OpenAI Go SDK" href="/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk" icon="robot" description="OpenInference Go for sashabaranov/go-openai"/>
+      <Card title="OpenAI Go SDK" href="/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk" icon="robot" description="OpenInference Go for openai/openai-go"/>
       <Card title="Anthropic SDK Go" href="/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go" icon="robot" description="OpenInference Go for anthropic-sdk-go"/>
       <Card title="Gemini Go SDK" href="/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk" icon="robot" description="OTel GenAI conventions for google.golang.org/genai"/>
     </CardGroup>

--- a/docs/phoenix/integrations/llm-providers/anthropic.mdx
+++ b/docs/phoenix/integrations/llm-providers/anthropic.mdx
@@ -13,6 +13,7 @@ description: Anthropic is an AI research company that develops LLMs, including C
 <Columns cols={2}>
   <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/5d0ed01c-image.avif" href="/docs/phoenix/integrations/llm-providers/anthropic/anthropic-tracing" title="Anthropic Tracing (Python)"/>
   <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/5d0ed01c-image.avif" href="/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-typescript" title="Anthropic Tracing (TypeScript)"/>
+  <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/5d0ed01c-image.avif" href="/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go" title="Anthropic Tracing (Go)"/>
   <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/5d0ed01c-image.avif" href="/docs/phoenix/integrations/llm-providers/anthropic/anthropic-evals" title="Anthropic Evals"/>
 </Columns>
 

--- a/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go.mdx
+++ b/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go.mdx
@@ -26,6 +26,7 @@ package main
 import (
 	"context"
 	"os"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -33,6 +34,14 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
+
+func phoenixTraceEndpoint(endpoint string) string {
+	endpoint = strings.TrimRight(endpoint, "/")
+	if strings.HasSuffix(endpoint, "/v1/traces") {
+		return endpoint
+	}
+	return endpoint + "/v1/traces"
+}
 
 func initTracer(ctx context.Context) (*sdktrace.TracerProvider, error) {
 	// Default: self-hosted Phoenix on localhost.
@@ -44,8 +53,7 @@ func initTracer(ctx context.Context) (*sdktrace.TracerProvider, error) {
 	}
 	if endpoint := os.Getenv("PHOENIX_COLLECTOR_ENDPOINT"); endpoint != "" {
 		opts = []otlptracehttp.Option{
-			otlptracehttp.WithEndpoint(endpoint),
-			otlptracehttp.WithURLPath("/v1/traces"),
+			otlptracehttp.WithEndpointURL(phoenixTraceEndpoint(endpoint)),
 			otlptracehttp.WithHeaders(map[string]string{
 				"Authorization": "Bearer " + os.Getenv("PHOENIX_API_KEY"),
 			}),
@@ -100,7 +108,7 @@ func main() {
 	ctx = instrumentation.WithUser(ctx, "user-xyz")
 
 	resp, _ := client.Messages.New(ctx, anthropic.MessageNewParams{
-		Model:     "claude-3-5-sonnet-latest",
+		Model:     anthropic.ModelClaudeHaiku4_5,
 		MaxTokens: 1024,
 		Messages: []anthropic.MessageParam{
 			anthropic.NewUserMessage(anthropic.NewTextBlock("Write a haiku about recursion.")),

--- a/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go.mdx
+++ b/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go.mdx
@@ -1,0 +1,125 @@
+---
+title: "Anthropic SDK Go"
+description: Instrument and observe Anthropic calls in Go
+---
+
+This module provides instrumentation for the [Anthropic Go SDK (`anthropics/anthropic-sdk-go`)](https://github.com/anthropics/anthropic-sdk-go) using the [`openinference-instrumentation-anthropic`](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation/anthropic) Go package, exporting OpenInference LLM spans to Phoenix. Requires `anthropic-sdk-go` v1.43+ (which introduced `option.Middleware`).
+
+## Install
+
+```bash
+go get github.com/anthropics/anthropic-sdk-go
+go get github.com/Arize-ai/openinference/go/instrumentation
+go get github.com/Arize-ai/openinference/go/instrumentation/anthropic
+go get go.opentelemetry.io/otel
+go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
+go get go.opentelemetry.io/otel/sdk
+```
+
+## Setup
+
+Configure an OTLP/HTTP exporter pointed at Phoenix. Create `tracing.go`:
+
+```go expandable
+package main
+
+import (
+	"context"
+	"os"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+func initTracer(ctx context.Context) (*sdktrace.TracerProvider, error) {
+	// Default: self-hosted Phoenix on localhost.
+	// For Phoenix Cloud, set PHOENIX_COLLECTOR_ENDPOINT and PHOENIX_API_KEY.
+	opts := []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint("localhost:6006"),
+		otlptracehttp.WithURLPath("/v1/traces"),
+		otlptracehttp.WithInsecure(),
+	}
+	if endpoint := os.Getenv("PHOENIX_COLLECTOR_ENDPOINT"); endpoint != "" {
+		opts = []otlptracehttp.Option{
+			otlptracehttp.WithEndpoint(endpoint),
+			otlptracehttp.WithURLPath("/v1/traces"),
+			otlptracehttp.WithHeaders(map[string]string{
+				"Authorization": "Bearer " + os.Getenv("PHOENIX_API_KEY"),
+			}),
+		}
+	}
+
+	exporter, err := otlptracehttp.New(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res, _ := resource.New(ctx, resource.WithAttributes(
+		semconv.ServiceName("anthropic-go-app"),
+	))
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+	return tp, nil
+}
+```
+
+## Run Anthropic
+
+Pass `anthropicotel.Middleware` to the client via `option.WithMiddleware`. Session and user identifiers propagate via baggage to every LLM span descended from the context.
+
+```go expandable
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"go.opentelemetry.io/otel"
+
+	"github.com/Arize-ai/openinference/go/instrumentation"
+	anthropicotel "github.com/Arize-ai/openinference/go/instrumentation/anthropic"
+)
+
+func main() {
+	ctx := context.Background()
+	tp, _ := initTracer(ctx)
+	defer tp.Shutdown(ctx)
+
+	client := anthropic.NewClient(
+		option.WithMiddleware(anthropicotel.Middleware(otel.Tracer("anthropic-go-app"))),
+	)
+
+	ctx = instrumentation.WithSession(ctx, "session-abc")
+	ctx = instrumentation.WithUser(ctx, "user-xyz")
+
+	resp, _ := client.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:     "claude-3-5-sonnet-latest",
+		MaxTokens: 1024,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("Write a haiku about recursion.")),
+		},
+	})
+	for _, block := range resp.Content {
+		fmt.Println(block)
+	}
+}
+```
+
+To redact sensitive data, set `OPENINFERENCE_HIDE_INPUTS=true` or `OPENINFERENCE_HIDE_OUTPUTS=true`. See the [openinference Go README](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation/anthropic) for the full env-var matrix and the in-code `WithTraceConfig` override.
+
+## Observe
+
+After setting up instrumentation and running your Anthropic application, traces will appear in the Phoenix UI for visualization and analysis.
+
+## Resources
+
+* [OpenInference Go package for Anthropic](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation/anthropic)
+
+* [Anthropic Go SDK](https://github.com/anthropics/anthropic-sdk-go)

--- a/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go.mdx
+++ b/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go.mdx
@@ -3,14 +3,14 @@ title: "Anthropic SDK Go"
 description: Instrument and observe Anthropic calls in Go
 ---
 
-This module provides instrumentation for the [Anthropic Go SDK (`anthropics/anthropic-sdk-go`)](https://github.com/anthropics/anthropic-sdk-go) using the [`openinference-instrumentation-anthropic`](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation/anthropic) Go package, exporting OpenInference LLM spans to Phoenix. Requires `anthropic-sdk-go` v1.43+ (which introduced `option.Middleware`).
+This module provides instrumentation for the [Anthropic Go SDK (`anthropics/anthropic-sdk-go`)](https://github.com/anthropics/anthropic-sdk-go) using the [`openinference-instrumentation-anthropic`](https://github.com/Arize-ai/openinference/tree/main/go/openinference-instrumentation-anthropic-sdk-go) Go package, exporting OpenInference LLM spans to Phoenix. Requires `anthropic-sdk-go` v1.43+ (which introduced `option.Middleware`).
 
 ## Install
 
 ```bash
 go get github.com/anthropics/anthropic-sdk-go
-go get github.com/Arize-ai/openinference/go/instrumentation
-go get github.com/Arize-ai/openinference/go/instrumentation/anthropic
+go get github.com/Arize-ai/openinference/go/openinference-instrumentation
+go get github.com/Arize-ai/openinference/go/openinference-instrumentation-anthropic-sdk-go
 go get go.opentelemetry.io/otel
 go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
 go get go.opentelemetry.io/otel/sdk
@@ -70,7 +70,7 @@ func initTracer(ctx context.Context) (*sdktrace.TracerProvider, error) {
 
 ## Run Anthropic
 
-Pass `anthropicotel.Middleware` to the client via `option.WithMiddleware`. Session and user identifiers propagate via baggage to every LLM span descended from the context.
+Pass `anthropicotel.Middleware` to the client via `option.WithMiddleware`. Session and user identifiers are stored on the Go context and applied to every LLM span descended from it.
 
 ```go expandable
 package main
@@ -83,8 +83,8 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/option"
 	"go.opentelemetry.io/otel"
 
-	"github.com/Arize-ai/openinference/go/instrumentation"
-	anthropicotel "github.com/Arize-ai/openinference/go/instrumentation/anthropic"
+	"github.com/Arize-ai/openinference/go/openinference-instrumentation"
+	anthropicotel "github.com/Arize-ai/openinference/go/openinference-instrumentation-anthropic-sdk-go"
 )
 
 func main() {
@@ -112,7 +112,7 @@ func main() {
 }
 ```
 
-To redact sensitive data, set `OPENINFERENCE_HIDE_INPUTS=true` or `OPENINFERENCE_HIDE_OUTPUTS=true`. See the [openinference Go README](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation/anthropic) for the full env-var matrix and the in-code `WithTraceConfig` override.
+To redact sensitive data, set `OPENINFERENCE_HIDE_INPUTS=true` or `OPENINFERENCE_HIDE_OUTPUTS=true`. See the [openinference Go README](https://github.com/Arize-ai/openinference/tree/main/go/openinference-instrumentation-anthropic-sdk-go) for the full env-var matrix and the in-code `WithTraceConfig` override.
 
 ## Observe
 
@@ -120,6 +120,6 @@ After setting up instrumentation and running your Anthropic application, traces 
 
 ## Resources
 
-* [OpenInference Go package for Anthropic](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation/anthropic)
+* [OpenInference Go package for Anthropic](https://github.com/Arize-ai/openinference/tree/main/go/openinference-instrumentation-anthropic-sdk-go)
 
 * [Anthropic Go SDK](https://github.com/anthropics/anthropic-sdk-go)

--- a/docs/phoenix/integrations/llm-providers/google-gen-ai.mdx
+++ b/docs/phoenix/integrations/llm-providers/google-gen-ai.mdx
@@ -18,6 +18,10 @@ description: Google GenAI is a suite of AI tools and models from Google Cloud, d
   <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/7b413cbf-image.jpeg" href="/docs/phoenix/integrations/llm-providers/google-gen-ai/google-gen-ai-evals" title="Google Gen AI Evals"/>
 </Columns>
 
+<Columns cols={2}>
+  <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/7b413cbf-image.jpeg" href="/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk" title="Gemini Go SDK"/>
+</Columns>
+
 ### Featured Tutorials
 
 <Columns cols={2}>

--- a/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk.mdx
+++ b/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk.mdx
@@ -69,7 +69,7 @@ func initTracer(ctx context.Context) (*sdktrace.TracerProvider, error) {
 
 ## Run Gemini
 
-Wrap each Gemini call in a span and set `gen_ai.*` attributes from `go.opentelemetry.io/otel/semconv/v1.32.0`.
+Wrap each Gemini call in a span and set `gen_ai.*` attributes using OpenTelemetry semantic-convention helpers where available.
 
 ```go expandable
 package main
@@ -80,6 +80,7 @@ import (
 	"os"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
 	"go.opentelemetry.io/otel/trace"
@@ -104,9 +105,9 @@ func main() {
 
 	ctx, span := tracer.Start(ctx, "gemini.generate_content",
 		trace.WithAttributes(
-			semconv.GenAISystemKey.String("gemini"),
-			semconv.GenAIOperationNameKey.String("chat"),
-			semconv.GenAIRequestModelKey.String(modelName),
+			attribute.String("gen_ai.system", "gemini"),
+			attribute.String("gen_ai.operation.name", "chat"),
+			semconv.GenAIRequestModel(modelName),
 		),
 	)
 	defer span.End()
@@ -118,11 +119,11 @@ func main() {
 		return
 	}
 
-	span.SetAttributes(semconv.GenAIResponseModelKey.String(modelName))
+	span.SetAttributes(semconv.GenAIResponseModel(modelName))
 	if usage := resp.UsageMetadata; usage != nil {
 		span.SetAttributes(
-			semconv.GenAIUsageInputTokensKey.Int(int(usage.PromptTokenCount)),
-			semconv.GenAIUsageOutputTokensKey.Int(int(usage.CandidatesTokenCount)),
+			semconv.GenAIUsageInputTokens(int(usage.PromptTokenCount)),
+			semconv.GenAIUsageOutputTokens(int(usage.CandidatesTokenCount)),
 		)
 	}
 	fmt.Println(resp.Text())

--- a/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk.mdx
+++ b/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk.mdx
@@ -1,0 +1,142 @@
+---
+title: "Gemini Go SDK"
+description: Instrument Gemini calls in Go using OpenTelemetry GenAI conventions
+---
+
+The [Google GenAI Go SDK (`google.golang.org/genai`)](https://github.com/googleapis/go-genai) does not emit OpenTelemetry spans natively, and there is no OpenInference Go instrumentor for it today. The pattern below wraps each Gemini call in a manual span and sets [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) attributes. Phoenix ingests these spans directly — see [Translating Semantic Conventions](/docs/phoenix/tracing/concepts-tracing/translating-conventions) for context.
+
+## Install
+
+```bash
+go get google.golang.org/genai
+go get go.opentelemetry.io/otel
+go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
+go get go.opentelemetry.io/otel/sdk
+go get go.opentelemetry.io/otel/semconv/v1.32.0
+```
+
+## Setup
+
+Configure an OTLP/HTTP exporter pointed at Phoenix. Create `tracing.go`:
+
+```go expandable
+package main
+
+import (
+	"context"
+	"os"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
+)
+
+func initTracer(ctx context.Context) (*sdktrace.TracerProvider, error) {
+	// Default: self-hosted Phoenix on localhost.
+	// For Phoenix Cloud, set PHOENIX_COLLECTOR_ENDPOINT and PHOENIX_API_KEY.
+	opts := []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint("localhost:6006"),
+		otlptracehttp.WithURLPath("/v1/traces"),
+		otlptracehttp.WithInsecure(),
+	}
+	if endpoint := os.Getenv("PHOENIX_COLLECTOR_ENDPOINT"); endpoint != "" {
+		opts = []otlptracehttp.Option{
+			otlptracehttp.WithEndpoint(endpoint),
+			otlptracehttp.WithURLPath("/v1/traces"),
+			otlptracehttp.WithHeaders(map[string]string{
+				"Authorization": "Bearer " + os.Getenv("PHOENIX_API_KEY"),
+			}),
+		}
+	}
+
+	exporter, err := otlptracehttp.New(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res, _ := resource.New(ctx, resource.WithAttributes(
+		semconv.ServiceName("gemini-go-app"),
+	))
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+	return tp, nil
+}
+```
+
+## Run Gemini
+
+Wrap each Gemini call in a span and set `gen_ai.*` attributes from `go.opentelemetry.io/otel/semconv/v1.32.0`.
+
+```go expandable
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
+	"go.opentelemetry.io/otel/trace"
+
+	"google.golang.org/genai"
+)
+
+const modelName = "gemini-2.0-flash"
+
+func main() {
+	ctx := context.Background()
+	tp, _ := initTracer(ctx)
+	defer tp.Shutdown(ctx)
+
+	client, _ := genai.NewClient(ctx, &genai.ClientConfig{
+		APIKey:  os.Getenv("GEMINI_API_KEY"),
+		Backend: genai.BackendGeminiAPI,
+	})
+	tracer := otel.Tracer("gemini-go-app")
+
+	prompt := "Write a haiku about recursion."
+
+	ctx, span := tracer.Start(ctx, "gemini.generate_content",
+		trace.WithAttributes(
+			semconv.GenAISystemKey.String("gemini"),
+			semconv.GenAIOperationNameKey.String("chat"),
+			semconv.GenAIRequestModelKey.String(modelName),
+		),
+	)
+	defer span.End()
+
+	resp, err := client.Models.GenerateContent(ctx, modelName, genai.Text(prompt), nil)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return
+	}
+
+	span.SetAttributes(semconv.GenAIResponseModelKey.String(modelName))
+	if usage := resp.UsageMetadata; usage != nil {
+		span.SetAttributes(
+			semconv.GenAIUsageInputTokensKey.Int(int(usage.PromptTokenCount)),
+			semconv.GenAIUsageOutputTokensKey.Int(int(usage.CandidatesTokenCount)),
+		)
+	}
+	fmt.Println(resp.Text())
+}
+```
+
+## Observe
+
+After running your application, Gemini calls will appear in the Phoenix UI for visualization and analysis. Spans are queryable by `gen_ai.*` attributes; Phoenix UI features that key off OpenInference attributes are reduced, since this flow emits GenAI conventions rather than OpenInference. For Go SDKs with native OpenInference instrumentation, see [OpenAI Go SDK](/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk) and [Anthropic SDK Go](/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go).
+
+## Resources
+
+* [Google GenAI Go SDK](https://github.com/googleapis/go-genai)
+
+* [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+
+* [Translating Semantic Conventions](/docs/phoenix/tracing/concepts-tracing/translating-conventions)

--- a/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk.mdx
+++ b/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk.mdx
@@ -25,6 +25,7 @@ package main
 import (
 	"context"
 	"os"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -32,6 +33,14 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
 )
+
+func phoenixTraceEndpoint(endpoint string) string {
+	endpoint = strings.TrimRight(endpoint, "/")
+	if strings.HasSuffix(endpoint, "/v1/traces") {
+		return endpoint
+	}
+	return endpoint + "/v1/traces"
+}
 
 func initTracer(ctx context.Context) (*sdktrace.TracerProvider, error) {
 	// Default: self-hosted Phoenix on localhost.
@@ -43,8 +52,7 @@ func initTracer(ctx context.Context) (*sdktrace.TracerProvider, error) {
 	}
 	if endpoint := os.Getenv("PHOENIX_COLLECTOR_ENDPOINT"); endpoint != "" {
 		opts = []otlptracehttp.Option{
-			otlptracehttp.WithEndpoint(endpoint),
-			otlptracehttp.WithURLPath("/v1/traces"),
+			otlptracehttp.WithEndpointURL(phoenixTraceEndpoint(endpoint)),
 			otlptracehttp.WithHeaders(map[string]string{
 				"Authorization": "Bearer " + os.Getenv("PHOENIX_API_KEY"),
 			}),

--- a/docs/phoenix/integrations/llm-providers/openai.mdx
+++ b/docs/phoenix/integrations/llm-providers/openai.mdx
@@ -21,6 +21,10 @@ description: OpenAI provides state-of-the-art LLMs for natural language understa
   <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/ae376d63-image.avif" href="/docs/phoenix/integrations/llm-providers/openai/openai-node-js-sdk" title="OpenAI Node.js SDK"/>
 </Columns>
 
+<Columns cols={2}>
+  <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/ae376d63-image.avif" href="/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk" title="OpenAI Go SDK"/>
+</Columns>
+
 ### Featured Tutorials
 
 <Columns cols={3}>

--- a/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk.mdx
+++ b/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk.mdx
@@ -1,0 +1,125 @@
+---
+title: "OpenAI Go SDK"
+description: Instrument and observe OpenAI calls in Go
+---
+
+This module provides instrumentation for the [OpenAI Go SDK (`sashabaranov/go-openai`)](https://github.com/sashabaranov/go-openai) using the [`openinference-instrumentation-openai`](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation/openai) Go package, exporting OpenInference LLM spans to Phoenix.
+
+## Install
+
+```bash
+go get github.com/sashabaranov/go-openai
+go get github.com/Arize-ai/openinference/go/instrumentation
+go get github.com/Arize-ai/openinference/go/instrumentation/openai
+go get go.opentelemetry.io/otel
+go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
+go get go.opentelemetry.io/otel/sdk
+```
+
+## Setup
+
+Configure an OTLP/HTTP exporter pointed at Phoenix. Create `tracing.go`:
+
+```go expandable
+package main
+
+import (
+	"context"
+	"os"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+func initTracer(ctx context.Context) (*sdktrace.TracerProvider, error) {
+	// Default: self-hosted Phoenix on localhost.
+	// For Phoenix Cloud, set PHOENIX_COLLECTOR_ENDPOINT and PHOENIX_API_KEY.
+	opts := []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint("localhost:6006"),
+		otlptracehttp.WithURLPath("/v1/traces"),
+		otlptracehttp.WithInsecure(),
+	}
+	if endpoint := os.Getenv("PHOENIX_COLLECTOR_ENDPOINT"); endpoint != "" {
+		opts = []otlptracehttp.Option{
+			otlptracehttp.WithEndpoint(endpoint),
+			otlptracehttp.WithURLPath("/v1/traces"),
+			otlptracehttp.WithHeaders(map[string]string{
+				"Authorization": "Bearer " + os.Getenv("PHOENIX_API_KEY"),
+			}),
+		}
+	}
+
+	exporter, err := otlptracehttp.New(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res, _ := resource.New(ctx, resource.WithAttributes(
+		semconv.ServiceName("openai-go-app"),
+	))
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+	return tp, nil
+}
+```
+
+## Run OpenAI
+
+Wire `openaiotel.NewTransport` into the OpenAI client's HTTP transport. Session and user identifiers propagate via baggage to every LLM span descended from the context.
+
+```go expandable
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/sashabaranov/go-openai"
+	"go.opentelemetry.io/otel"
+
+	"github.com/Arize-ai/openinference/go/instrumentation"
+	openaiotel "github.com/Arize-ai/openinference/go/instrumentation/openai"
+)
+
+func main() {
+	ctx := context.Background()
+	tp, _ := initTracer(ctx)
+	defer tp.Shutdown(ctx)
+
+	cfg := openai.DefaultConfig(os.Getenv("OPENAI_API_KEY"))
+	cfg.HTTPClient = &http.Client{
+		Transport: openaiotel.NewTransport(http.DefaultTransport, otel.Tracer("openai-go-app")),
+	}
+	client := openai.NewClientWithConfig(cfg)
+
+	ctx = instrumentation.WithSession(ctx, "session-abc")
+	ctx = instrumentation.WithUser(ctx, "user-xyz")
+
+	resp, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT4o,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "Write a haiku."},
+		},
+	})
+	fmt.Println(resp.Choices[0].Message.Content)
+}
+```
+
+To redact sensitive data, set `OPENINFERENCE_HIDE_INPUTS=true` or `OPENINFERENCE_HIDE_OUTPUTS=true`. See the [openinference Go README](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation/openai) for the full env-var matrix and the in-code `WithTraceConfig` override.
+
+## Observe
+
+After setting up instrumentation and running your OpenAI application, traces will appear in the Phoenix UI for visualization and analysis.
+
+## Resources
+
+* [OpenInference Go package for OpenAI](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation/openai)
+
+* [OpenAI Go SDK](https://github.com/sashabaranov/go-openai)

--- a/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk.mdx
+++ b/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk.mdx
@@ -26,6 +26,7 @@ package main
 import (
 	"context"
 	"os"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -33,6 +34,14 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
+
+func phoenixTraceEndpoint(endpoint string) string {
+	endpoint = strings.TrimRight(endpoint, "/")
+	if strings.HasSuffix(endpoint, "/v1/traces") {
+		return endpoint
+	}
+	return endpoint + "/v1/traces"
+}
 
 func initTracer(ctx context.Context) (*sdktrace.TracerProvider, error) {
 	// Default: self-hosted Phoenix on localhost.
@@ -44,8 +53,7 @@ func initTracer(ctx context.Context) (*sdktrace.TracerProvider, error) {
 	}
 	if endpoint := os.Getenv("PHOENIX_COLLECTOR_ENDPOINT"); endpoint != "" {
 		opts = []otlptracehttp.Option{
-			otlptracehttp.WithEndpoint(endpoint),
-			otlptracehttp.WithURLPath("/v1/traces"),
+			otlptracehttp.WithEndpointURL(phoenixTraceEndpoint(endpoint)),
 			otlptracehttp.WithHeaders(map[string]string{
 				"Authorization": "Bearer " + os.Getenv("PHOENIX_API_KEY"),
 			}),

--- a/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk.mdx
+++ b/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk.mdx
@@ -3,14 +3,14 @@ title: "OpenAI Go SDK"
 description: Instrument and observe OpenAI calls in Go
 ---
 
-This module provides instrumentation for the [OpenAI Go SDK (`sashabaranov/go-openai`)](https://github.com/sashabaranov/go-openai) using the [`openinference-instrumentation-openai`](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation/openai) Go package, exporting OpenInference LLM spans to Phoenix.
+This module provides instrumentation for the [OpenAI Go SDK (`openai/openai-go`)](https://github.com/openai/openai-go) using the [`openinference-instrumentation-openai-go`](https://github.com/Arize-ai/openinference/tree/main/go/openinference-instrumentation-openai-go) Go package, exporting OpenInference LLM spans to Phoenix.
 
 ## Install
 
 ```bash
-go get github.com/sashabaranov/go-openai
-go get github.com/Arize-ai/openinference/go/instrumentation
-go get github.com/Arize-ai/openinference/go/instrumentation/openai
+go get github.com/openai/openai-go
+go get github.com/Arize-ai/openinference/go/openinference-instrumentation
+go get github.com/Arize-ai/openinference/go/openinference-instrumentation-openai-go
 go get go.opentelemetry.io/otel
 go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
 go get go.opentelemetry.io/otel/sdk
@@ -70,7 +70,7 @@ func initTracer(ctx context.Context) (*sdktrace.TracerProvider, error) {
 
 ## Run OpenAI
 
-Wire `openaiotel.NewTransport` into the OpenAI client's HTTP transport. Session and user identifiers propagate via baggage to every LLM span descended from the context.
+Pass `openaiotel.Middleware` to the client via `option.WithMiddleware`. Session and user identifiers are stored on the Go context and applied to every LLM span descended from it.
 
 ```go expandable
 package main
@@ -78,14 +78,15 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 
-	"github.com/sashabaranov/go-openai"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/shared"
 	"go.opentelemetry.io/otel"
 
-	"github.com/Arize-ai/openinference/go/instrumentation"
-	openaiotel "github.com/Arize-ai/openinference/go/instrumentation/openai"
+	"github.com/Arize-ai/openinference/go/openinference-instrumentation"
+	openaiotel "github.com/Arize-ai/openinference/go/openinference-instrumentation-openai-go"
 )
 
 func main() {
@@ -93,26 +94,25 @@ func main() {
 	tp, _ := initTracer(ctx)
 	defer tp.Shutdown(ctx)
 
-	cfg := openai.DefaultConfig(os.Getenv("OPENAI_API_KEY"))
-	cfg.HTTPClient = &http.Client{
-		Transport: openaiotel.NewTransport(http.DefaultTransport, otel.Tracer("openai-go-app")),
-	}
-	client := openai.NewClientWithConfig(cfg)
+	client := openai.NewClient(
+		option.WithAPIKey(os.Getenv("OPENAI_API_KEY")),
+		option.WithMiddleware(openaiotel.Middleware(otel.Tracer("openai-go-app"))),
+	)
 
 	ctx = instrumentation.WithSession(ctx, "session-abc")
 	ctx = instrumentation.WithUser(ctx, "user-xyz")
 
-	resp, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
-		Model: openai.GPT4o,
-		Messages: []openai.ChatCompletionMessage{
-			{Role: openai.ChatMessageRoleUser, Content: "Write a haiku."},
+	resp, _ := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+		Model: shared.ChatModelGPT4o,
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("Write a haiku."),
 		},
 	})
 	fmt.Println(resp.Choices[0].Message.Content)
 }
 ```
 
-To redact sensitive data, set `OPENINFERENCE_HIDE_INPUTS=true` or `OPENINFERENCE_HIDE_OUTPUTS=true`. See the [openinference Go README](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation/openai) for the full env-var matrix and the in-code `WithTraceConfig` override.
+To redact sensitive data, set `OPENINFERENCE_HIDE_INPUTS=true` or `OPENINFERENCE_HIDE_OUTPUTS=true`. See the [openinference Go README](https://github.com/Arize-ai/openinference/tree/main/go/openinference-instrumentation-openai-go) for the full env-var matrix and the in-code `WithTraceConfig` override.
 
 ## Observe
 
@@ -120,6 +120,6 @@ After setting up instrumentation and running your OpenAI application, traces wil
 
 ## Resources
 
-* [OpenInference Go package for OpenAI](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation/openai)
+* [OpenInference Go package for OpenAI](https://github.com/Arize-ai/openinference/tree/main/go/openinference-instrumentation-openai-go)
 
-* [OpenAI Go SDK](https://github.com/sashabaranov/go-openai)
+* [OpenAI Go SDK](https://github.com/openai/openai-go)

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -213,13 +213,16 @@
 - [OpenAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/openai/openai-tracing): Auto-instrument OpenAI Python SDK with openinference-instrumentation-openai
 - [OpenAI Agents SDK Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/openai/openai-agents-sdk-tracing): Trace OpenAI Agents SDK workflows including tool calls and handoffs
 - [OpenAI Node.js SDK](https://arize.com/docs/phoenix/integrations/llm-providers/openai/openai-node-js-sdk): Instrument OpenAI calls in TypeScript/Node.js
+- [OpenAI Go SDK](https://arize.com/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk): Instrument openai/openai-go with openinference-instrumentation-openai-go middleware
 - [Anthropic Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/anthropic/anthropic-tracing): Auto-instrument Anthropic Python SDK
 - [Anthropic TypeScript SDK](https://arize.com/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-typescript): Instrument Anthropic calls in TypeScript
+- [Anthropic SDK Go](https://arize.com/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go): Instrument anthropics/anthropic-sdk-go with openinference-instrumentation-anthropic-sdk-go middleware
 - [Amazon Bedrock Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock/amazon-bedrock-tracing): Auto-instrument Bedrock SDK with openinference-instrumentation-bedrock
 - [Amazon Bedrock Agents Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock/amazon-bedrock-agents-tracing): Trace Bedrock agent orchestration workflows
 - [Amazon Bedrock Agent Runtime JS](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock/amazon-bedrock-agent-runtime-js): Instrument Bedrock Agent Runtime in TypeScript
 - [Amazon Bedrock SDK JS](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock/amazon-bedrock-sdk-js): Instrument Bedrock SDK in TypeScript
 - [Google GenAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai/google-genai-tracing): Auto-instrument Google GenAI SDK
+- [Gemini Go SDK](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk): Instrument google.golang.org/genai using OTel GenAI semantic conventions (Phoenix ingests gen_ai.* attributes)
 - [Groq Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/groq/groq-tracing): Auto-instrument Groq SDK
 - [LiteLLM Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/litellm/litellm-tracing): Auto-instrument LiteLLM unified API calls
 - [MistralAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/mistralai/mistralai-tracing): Auto-instrument MistralAI SDK

--- a/docs/phoenix/tracing/concepts-tracing/translating-conventions.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/translating-conventions.mdx
@@ -334,6 +334,8 @@ Spans emitted this way do not carry `openinference.span.kind` or structured `llm
     ```go
     import (
         "context"
+        "os"
+        "strings"
 
         "go.opentelemetry.io/otel"
         "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -342,11 +344,29 @@ Spans emitted this way do not carry `openinference.span.kind` or structured `llm
         semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
     )
 
-    exporter, _ := otlptracehttp.New(ctx,
+    func phoenixTraceEndpoint(endpoint string) string {
+        endpoint = strings.TrimRight(endpoint, "/")
+        if strings.HasSuffix(endpoint, "/v1/traces") {
+            return endpoint
+        }
+        return endpoint + "/v1/traces"
+    }
+
+    opts := []otlptracehttp.Option{
         otlptracehttp.WithEndpoint("localhost:6006"),
         otlptracehttp.WithURLPath("/v1/traces"),
         otlptracehttp.WithInsecure(),
-    )
+    }
+    if endpoint := os.Getenv("PHOENIX_COLLECTOR_ENDPOINT"); endpoint != "" {
+        opts = []otlptracehttp.Option{
+            otlptracehttp.WithEndpointURL(phoenixTraceEndpoint(endpoint)),
+            otlptracehttp.WithHeaders(map[string]string{
+                "Authorization": "Bearer " + os.Getenv("PHOENIX_API_KEY"),
+            }),
+        }
+    }
+
+    exporter, _ := otlptracehttp.New(ctx, opts...)
     res, _ := resource.New(ctx, resource.WithAttributes(
         semconv.ServiceName("my-go-app"),
     ))

--- a/docs/phoenix/tracing/concepts-tracing/translating-conventions.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/translating-conventions.mdx
@@ -358,11 +358,12 @@ Spans emitted this way do not carry `openinference.span.kind` or structured `llm
     ```
   </Step>
   <Step title={<span className="step-title">Emit a GenAI-Convention Span</span>}>
-    Wrap each LLM call in a span and set the canonical `gen_ai.*` attributes from `go.opentelemetry.io/otel/semconv/v1.32.0`.
+    Wrap each LLM call in a span and set the canonical `gen_ai.*` attributes using OpenTelemetry semantic-convention helpers where available.
 
     ```go
     import (
         "go.opentelemetry.io/otel"
+        "go.opentelemetry.io/otel/attribute"
         semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
         "go.opentelemetry.io/otel/trace"
     )
@@ -370,9 +371,9 @@ Spans emitted this way do not carry `openinference.span.kind` or structured `llm
     tracer := otel.Tracer("my-go-app")
     ctx, span := tracer.Start(ctx, "llm.generate",
         trace.WithAttributes(
-            semconv.GenAISystemKey.String("gemini"),
-            semconv.GenAIOperationNameKey.String("chat"),
-            semconv.GenAIRequestModelKey.String("gemini-2.0-flash"),
+            attribute.String("gen_ai.system", "gemini"),
+            attribute.String("gen_ai.operation.name", "chat"),
+            semconv.GenAIRequestModel("gemini-2.0-flash"),
         ),
     )
     defer span.End()
@@ -380,9 +381,9 @@ Spans emitted this way do not carry `openinference.span.kind` or structured `llm
     // ... make the LLM call ...
 
     span.SetAttributes(
-        semconv.GenAIResponseModelKey.String("gemini-2.0-flash"),
-        semconv.GenAIUsageInputTokensKey.Int(promptTokens),
-        semconv.GenAIUsageOutputTokensKey.Int(completionTokens),
+        semconv.GenAIResponseModel("gemini-2.0-flash"),
+        semconv.GenAIUsageInputTokens(promptTokens),
+        semconv.GenAIUsageOutputTokens(completionTokens),
     )
     ```
 

--- a/docs/phoenix/tracing/concepts-tracing/translating-conventions.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/translating-conventions.mdx
@@ -311,6 +311,85 @@ View on npm
   </Step>
 </Steps>
 
+## View OpenTelemetry GenAI Traces from Go in Phoenix
+
+There is no Go equivalent of `@arizeai/openinference-genai` today, so the Go flow does not convert GenAI attributes to OpenInference in-process. Instead, emit GenAI-convention spans directly with the standard OpenTelemetry Go SDK; Phoenix ingests them as-is.
+
+<Info>
+Spans emitted this way do not carry `openinference.span.kind` or structured `llm.input_messages.*` / `llm.output_messages.*` indexing. They appear in Phoenix and remain queryable by `gen_ai.*` attributes, but Phoenix UI features that key off OpenInference attributes will be reduced. For Go SDKs with dedicated OpenInference instrumentation (OpenAI, Anthropic), prefer those instead.
+</Info>
+
+<Steps>
+  <Step title={<span className="step-title">Install Required Packages</span>}>
+    ```bash
+    go get go.opentelemetry.io/otel
+    go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
+    go get go.opentelemetry.io/otel/sdk
+    go get go.opentelemetry.io/otel/semconv/v1.32.0
+    ```
+  </Step>
+  <Step title={<span className="step-title">Configure the Tracer Provider</span>}>
+    Point an OTLP/HTTP exporter at Phoenix. For Phoenix Cloud, set `PHOENIX_COLLECTOR_ENDPOINT` and `PHOENIX_API_KEY`.
+
+    ```go
+    import (
+        "context"
+
+        "go.opentelemetry.io/otel"
+        "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+        "go.opentelemetry.io/otel/sdk/resource"
+        sdktrace "go.opentelemetry.io/otel/sdk/trace"
+        semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
+    )
+
+    exporter, _ := otlptracehttp.New(ctx,
+        otlptracehttp.WithEndpoint("localhost:6006"),
+        otlptracehttp.WithURLPath("/v1/traces"),
+        otlptracehttp.WithInsecure(),
+    )
+    res, _ := resource.New(ctx, resource.WithAttributes(
+        semconv.ServiceName("my-go-app"),
+    ))
+    tp := sdktrace.NewTracerProvider(
+        sdktrace.WithBatcher(exporter),
+        sdktrace.WithResource(res),
+    )
+    otel.SetTracerProvider(tp)
+    ```
+  </Step>
+  <Step title={<span className="step-title">Emit a GenAI-Convention Span</span>}>
+    Wrap each LLM call in a span and set the canonical `gen_ai.*` attributes from `go.opentelemetry.io/otel/semconv/v1.32.0`.
+
+    ```go
+    import (
+        "go.opentelemetry.io/otel"
+        semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
+        "go.opentelemetry.io/otel/trace"
+    )
+
+    tracer := otel.Tracer("my-go-app")
+    ctx, span := tracer.Start(ctx, "llm.generate",
+        trace.WithAttributes(
+            semconv.GenAISystemKey.String("gemini"),
+            semconv.GenAIOperationNameKey.String("chat"),
+            semconv.GenAIRequestModelKey.String("gemini-2.0-flash"),
+        ),
+    )
+    defer span.End()
+
+    // ... make the LLM call ...
+
+    span.SetAttributes(
+        semconv.GenAIResponseModelKey.String("gemini-2.0-flash"),
+        semconv.GenAIUsageInputTokensKey.Int(promptTokens),
+        semconv.GenAIUsageOutputTokensKey.Int(completionTokens),
+    )
+    ```
+
+    For a worked end-to-end example using `google.golang.org/genai`, see [Gemini Go SDK](/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk).
+  </Step>
+</Steps>
+
 ## Learn More
 
 - [OpenInference Semantic Conventions](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md)

--- a/docs/phoenix/tracing/how-to-tracing/add-metadata/customize-spans.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/add-metadata/customize-spans.mdx
@@ -51,11 +51,11 @@ Supported Context Attributes include:
   <Tab title="Go" icon="golang">
 
     ```bash
-    go get github.com/Arize-ai/openinference/go/instrumentation
+    go get github.com/Arize-ai/openinference/go/openinference-instrumentation
     ```
 
     <Note>
-    Phoenix does not ship a `phoenix-otel-go` wrapper. Use the OpenInference Go `instrumentation` package directly to propagate context attributes via OTel baggage. See [Go integrations](/docs/phoenix/integrations) for tracer-provider setup.
+    Phoenix does not ship a `phoenix-otel-go` wrapper. Use the OpenInference Go `instrumentation` package directly to store context attributes on `context.Context`. See [Go integrations](/docs/phoenix/integrations) for tracer-provider setup.
     </Note>
 
   </Tab>
@@ -111,10 +111,10 @@ Supported Context Attributes include:
 
   <Tab title="Go" icon="golang">
 
-    Use `instrumentation.WithSession` to attach a session ID to the context. OpenInference Go auto-instrumentors (OpenAI Go, Anthropic Go) automatically read this from baggage and add `session.id` to every LLM span descended from the context.
+    Use `instrumentation.WithSession` to attach a session ID to the context. OpenInference Go auto-instrumentors (OpenAI Go, Anthropic Go) automatically read this from `context.Context` and add `session.id` to every LLM span descended from it.
 
     ```go
-    import "github.com/Arize-ai/openinference/go/instrumentation"
+    import "github.com/Arize-ai/openinference/go/openinference-instrumentation"
 
     ctx = instrumentation.WithSession(ctx, "my-session-id")
     // Calls within this context will generate spans with the attributes:
@@ -173,10 +173,10 @@ Supported Context Attributes include:
 
   <Tab title="Go" icon="golang">
 
-    Use `instrumentation.WithUser` to attach a user ID to the context. OpenInference Go auto-instrumentors automatically read this from baggage and add `user.id` to every LLM span descended from the context.
+    Use `instrumentation.WithUser` to attach a user ID to the context. OpenInference Go auto-instrumentors automatically read this from `context.Context` and add `user.id` to every LLM span descended from it.
 
     ```go
-    import "github.com/Arize-ai/openinference/go/instrumentation"
+    import "github.com/Arize-ai/openinference/go/openinference-instrumentation"
 
     ctx = instrumentation.WithUser(ctx, "my-user-id")
     // Calls within this context will generate spans with the attributes:
@@ -240,13 +240,13 @@ Supported Context Attributes include:
 
   <Tab title="Go" icon="golang">
 
-    Use `instrumentation.WithMetadata` to attach a JSON-encoded metadata string to the context. OpenInference Go auto-instrumentors automatically read this from baggage and add `metadata` to every LLM span descended from the context.
+    Use `instrumentation.WithMetadata` to attach a JSON-encoded metadata string to the context. OpenInference Go auto-instrumentors automatically read this from `context.Context` and add `metadata` to every LLM span descended from it.
 
     ```go
     import (
         "encoding/json"
 
-        "github.com/Arize-ai/openinference/go/instrumentation"
+        "github.com/Arize-ai/openinference/go/openinference-instrumentation"
     )
 
     metadata := map[string]any{"key1": "value1", "key2": "value2"}
@@ -310,10 +310,10 @@ Supported Context Attributes include:
 
   <Tab title="Go" icon="golang">
 
-    Use `instrumentation.WithTags` (variadic strings) to attach a list of tags to the context. OpenInference Go auto-instrumentors automatically read this from baggage and add `tag.tags` to every LLM span descended from the context.
+    Use `instrumentation.WithTags` (variadic strings) to attach a list of tags to the context. OpenInference Go auto-instrumentors automatically read this from `context.Context` and add `tag.tags` to every LLM span descended from it.
 
     ```go
-    import "github.com/Arize-ai/openinference/go/instrumentation"
+    import "github.com/Arize-ai/openinference/go/openinference-instrumentation"
 
     ctx = instrumentation.WithTags(ctx, "tag_1", "tag_2")
     // Calls within this context will generate spans with the attributes:
@@ -468,13 +468,13 @@ Supported Context Attributes include:
 
   <Tab title="Go" icon="golang">
 
-    Go has no single-shot equivalent of `using_attributes` — compose the `With*` helpers instead. Each returns a new context; chain them to attach session, user, metadata, and tags together. Auto-instrumentors pick up all four from baggage.
+    Go has no single-shot equivalent of `using_attributes` — compose the `With*` helpers instead. Each returns a new context; chain them to attach session, user, metadata, and tags together. Auto-instrumentors pick up all four from `context.Context`.
 
     ```go
     import (
         "encoding/json"
 
-        "github.com/Arize-ai/openinference/go/instrumentation"
+        "github.com/Arize-ai/openinference/go/openinference-instrumentation"
     )
 
     metadata := map[string]any{"key-1": "value_1", "key-2": "value_2"}
@@ -491,7 +491,7 @@ Supported Context Attributes include:
     // "tag.tags"    = '["tag_1","tag_2"]'
     ```
 
-    For prompt-template attributes (`llm.prompt_template.*`), set them directly on the LLM span using `semconv.LLMPromptTemplate` / `LLMPromptTemplateVersion` / `LLMPromptTemplateVariables` from `github.com/Arize-ai/openinference/go/semconv` — see [Prompt Templates](/docs/phoenix/tracing/how-to-tracing/add-metadata/instrumenting-prompt-templates-and-prompt-variables).
+    For prompt-template attributes (`llm.prompt_template.*`), set them directly on the LLM span using `semconv.LLMPromptTemplate` / `LLMPromptTemplateVersion` / `LLMPromptTemplateVariables` from `github.com/Arize-ai/openinference/go/openinference-semantic-conventions` — see [Prompt Templates](/docs/phoenix/tracing/how-to-tracing/add-metadata/instrumenting-prompt-templates-and-prompt-variables).
 
   </Tab>
 

--- a/docs/phoenix/tracing/how-to-tracing/add-metadata/customize-spans.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/add-metadata/customize-spans.mdx
@@ -48,6 +48,18 @@ Supported Context Attributes include:
 
   </Tab>
 
+  <Tab title="Go" icon="golang">
+
+    ```bash
+    go get github.com/Arize-ai/openinference/go/instrumentation
+    ```
+
+    <Note>
+    Phoenix does not ship a `phoenix-otel-go` wrapper. Use the OpenInference Go `instrumentation` package directly to propagate context attributes via OTel baggage. See [Go integrations](/docs/phoenix/integrations) for tracer-provider setup.
+    </Note>
+
+  </Tab>
+
 </Tabs>
 
 ### Specifying a session
@@ -97,6 +109,20 @@ Supported Context Attributes include:
 
   </Tab>
 
+  <Tab title="Go" icon="golang">
+
+    Use `instrumentation.WithSession` to attach a session ID to the context. OpenInference Go auto-instrumentors (OpenAI Go, Anthropic Go) automatically read this from baggage and add `session.id` to every LLM span descended from the context.
+
+    ```go
+    import "github.com/Arize-ai/openinference/go/instrumentation"
+
+    ctx = instrumentation.WithSession(ctx, "my-session-id")
+    // Calls within this context will generate spans with the attributes:
+    // "session.id" = "my-session-id"
+    ```
+
+  </Tab>
+
 </Tabs>
 
 ### Specifying users
@@ -141,6 +167,20 @@ Supported Context Attributes include:
         // "user.id" = "user-id"
       }
     )
+    ```
+
+  </Tab>
+
+  <Tab title="Go" icon="golang">
+
+    Use `instrumentation.WithUser` to attach a user ID to the context. OpenInference Go auto-instrumentors automatically read this from baggage and add `user.id` to every LLM span descended from the context.
+
+    ```go
+    import "github.com/Arize-ai/openinference/go/instrumentation"
+
+    ctx = instrumentation.WithUser(ctx, "my-user-id")
+    // Calls within this context will generate spans with the attributes:
+    // "user.id" = "my-user-id"
     ```
 
   </Tab>
@@ -198,6 +238,27 @@ Supported Context Attributes include:
 
   </Tab>
 
+  <Tab title="Go" icon="golang">
+
+    Use `instrumentation.WithMetadata` to attach a JSON-encoded metadata string to the context. OpenInference Go auto-instrumentors automatically read this from baggage and add `metadata` to every LLM span descended from the context.
+
+    ```go
+    import (
+        "encoding/json"
+
+        "github.com/Arize-ai/openinference/go/instrumentation"
+    )
+
+    metadata := map[string]any{"key1": "value1", "key2": "value2"}
+    metadataJSON, _ := json.Marshal(metadata)
+
+    ctx = instrumentation.WithMetadata(ctx, string(metadataJSON))
+    // Calls within this context will generate spans with the attributes:
+    // "metadata" = '{"key1": "value1", "key2": "value2"}'
+    ```
+
+  </Tab>
+
 </Tabs>
 
 ### Specifying Tags
@@ -243,6 +304,20 @@ Supported Context Attributes include:
         // "tag.tags" = '["value1", "value2"]'
       }
     )
+    ```
+
+  </Tab>
+
+  <Tab title="Go" icon="golang">
+
+    Use `instrumentation.WithTags` (variadic strings) to attach a list of tags to the context. OpenInference Go auto-instrumentors automatically read this from baggage and add `tag.tags` to every LLM span descended from the context.
+
+    ```go
+    import "github.com/Arize-ai/openinference/go/instrumentation"
+
+    ctx = instrumentation.WithTags(ctx, "tag_1", "tag_2")
+    // Calls within this context will generate spans with the attributes:
+    // "tag.tags" = '["tag_1","tag_2"]'
     ```
 
   </Tab>
@@ -388,6 +463,35 @@ Supported Context Attributes include:
       }
     )
     ```
+
+  </Tab>
+
+  <Tab title="Go" icon="golang">
+
+    Go has no single-shot equivalent of `using_attributes` — compose the `With*` helpers instead. Each returns a new context; chain them to attach session, user, metadata, and tags together. Auto-instrumentors pick up all four from baggage.
+
+    ```go
+    import (
+        "encoding/json"
+
+        "github.com/Arize-ai/openinference/go/instrumentation"
+    )
+
+    metadata := map[string]any{"key-1": "value_1", "key-2": "value_2"}
+    metadataJSON, _ := json.Marshal(metadata)
+
+    ctx = instrumentation.WithSession(ctx, "my-session-id")
+    ctx = instrumentation.WithUser(ctx, "my-user-id")
+    ctx = instrumentation.WithMetadata(ctx, string(metadataJSON))
+    ctx = instrumentation.WithTags(ctx, "tag_1", "tag_2")
+    // Calls within this context will generate spans with the attributes:
+    // "session.id"  = "my-session-id"
+    // "user.id"     = "my-user-id"
+    // "metadata"    = '{"key-1":"value_1","key-2":"value_2"}'
+    // "tag.tags"    = '["tag_1","tag_2"]'
+    ```
+
+    For prompt-template attributes (`llm.prompt_template.*`), set them directly on the LLM span using `semconv.LLMPromptTemplate` / `LLMPromptTemplateVersion` / `LLMPromptTemplateVariables` from `github.com/Arize-ai/openinference/go/semconv` — see [Prompt Templates](/docs/phoenix/tracing/how-to-tracing/add-metadata/instrumenting-prompt-templates-and-prompt-variables).
 
   </Tab>
 

--- a/docs/phoenix/tracing/how-to-tracing/add-metadata/instrumenting-prompt-templates-and-prompt-variables.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/add-metadata/instrumenting-prompt-templates-and-prompt-variables.mdx
@@ -88,6 +88,31 @@ Instrumenting prompt templates and variables allows you to track and visualize p
     
   </Tab>
 
+  <Tab title="Go" icon="golang">
+
+    Go has no prompt-template context helper today. Set the prompt-template attributes directly on the LLM span using the typed constants in [`github.com/Arize-ai/openinference/go/semconv`](https://github.com/Arize-ai/openinference/tree/main/go/semconv):
+
+    ```go
+    import (
+        "encoding/json"
+
+        "go.opentelemetry.io/otel/attribute"
+
+        "github.com/Arize-ai/openinference/go/semconv"
+    )
+
+    variables := map[string]string{"city": "Johannesburg", "date": "July 11"}
+    varsJSON, _ := json.Marshal(variables)
+
+    span.SetAttributes(
+        attribute.String(semconv.LLMPromptTemplate, "Please describe the weather forecast for {city} on {date}"),
+        attribute.String(semconv.LLMPromptTemplateVersion, "v1.0"),
+        attribute.String(semconv.LLMPromptTemplateVariables, string(varsJSON)),
+    )
+    ```
+
+  </Tab>
+
 </Tabs>
 
 

--- a/docs/phoenix/tracing/how-to-tracing/add-metadata/instrumenting-prompt-templates-and-prompt-variables.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/add-metadata/instrumenting-prompt-templates-and-prompt-variables.mdx
@@ -90,7 +90,7 @@ Instrumenting prompt templates and variables allows you to track and visualize p
 
   <Tab title="Go" icon="golang">
 
-    Go has no prompt-template context helper today. Set the prompt-template attributes directly on the LLM span using the typed constants in [`github.com/Arize-ai/openinference/go/semconv`](https://github.com/Arize-ai/openinference/tree/main/go/semconv):
+    Go has no prompt-template context helper today. Set the prompt-template attributes directly on the LLM span using the typed constants in [`github.com/Arize-ai/openinference/go/openinference-semantic-conventions`](https://github.com/Arize-ai/openinference/tree/main/go/openinference-semantic-conventions):
 
     ```go
     import (
@@ -98,7 +98,7 @@ Instrumenting prompt templates and variables allows you to track and visualize p
 
         "go.opentelemetry.io/otel/attribute"
 
-        "github.com/Arize-ai/openinference/go/semconv"
+        "github.com/Arize-ai/openinference/go/openinference-semantic-conventions"
     )
 
     variables := map[string]string{"city": "Johannesburg", "date": "July 11"}

--- a/docs/phoenix/tracing/how-to-tracing/advanced/masking-span-attributes.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/advanced/masking-span-attributes.mdx
@@ -90,27 +90,26 @@ Below is an example of how to set these values in code using our OpenAI Python a
 
     ```go
     import (
-        "net/http"
-
+        "github.com/openai/openai-go"
+        "github.com/openai/openai-go/option"
         "go.opentelemetry.io/otel"
 
-        "github.com/Arize-ai/openinference/go/instrumentation"
-        openaiotel "github.com/Arize-ai/openinference/go/instrumentation/openai"
+        "github.com/Arize-ai/openinference/go/openinference-instrumentation"
+        openaiotel "github.com/Arize-ai/openinference/go/openinference-instrumentation-openai-go"
     )
 
-    cfg := openai.DefaultConfig(apiKey)
-    cfg.HTTPClient = &http.Client{
-        Transport: openaiotel.NewTransport(
-            http.DefaultTransport,
+    client := openai.NewClient(
+        option.WithAPIKey(apiKey),
+        option.WithMiddleware(openaiotel.Middleware(
             otel.Tracer("my-app"),
             openaiotel.WithTraceConfig(instrumentation.TraceConfig{
                 HideInputs: true,
             }),
-        ),
-    }
+        )),
+    )
     ```
 
-    For the Anthropic Go instrumentor, the equivalent is `anthropicotel.Middleware(otel.Tracer(...), anthropicotel.WithTraceConfig(instrumentation.TraceConfig{...}))`. See [OpenAI Go SDK](/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk) and [Anthropic SDK Go](/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go) for full setup.
+    The Anthropic Go instrumentor uses the same shape: `option.WithMiddleware(anthropicotel.Middleware(otel.Tracer(...), anthropicotel.WithTraceConfig(instrumentation.TraceConfig{...})))`. See [OpenAI Go SDK](/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk) and [Anthropic SDK Go](/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go) for full setup.
 
   </Tab>
 

--- a/docs/phoenix/tracing/how-to-tracing/advanced/masking-span-attributes.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/advanced/masking-span-attributes.mdx
@@ -84,4 +84,34 @@ Below is an example of how to set these values in code using our OpenAI Python a
 
   </Tab>
 
+  <Tab title="Go" icon="golang">
+
+    Use `instrumentation.TraceConfig` and pass it to the provider instrumentor via `WithTraceConfig`. Setting a value in code fully replaces the env-derived config for that instrumentor — matching the Python and JS precedence rules.
+
+    ```go
+    import (
+        "net/http"
+
+        "go.opentelemetry.io/otel"
+
+        "github.com/Arize-ai/openinference/go/instrumentation"
+        openaiotel "github.com/Arize-ai/openinference/go/instrumentation/openai"
+    )
+
+    cfg := openai.DefaultConfig(apiKey)
+    cfg.HTTPClient = &http.Client{
+        Transport: openaiotel.NewTransport(
+            http.DefaultTransport,
+            otel.Tracer("my-app"),
+            openaiotel.WithTraceConfig(instrumentation.TraceConfig{
+                HideInputs: true,
+            }),
+        ),
+    }
+    ```
+
+    For the Anthropic Go instrumentor, the equivalent is `anthropicotel.Middleware(otel.Tracer(...), anthropicotel.WithTraceConfig(instrumentation.TraceConfig{...}))`. See [OpenAI Go SDK](/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk) and [Anthropic SDK Go](/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go) for full setup.
+
+  </Tab>
+
 </Tabs>

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument.mdx
@@ -84,6 +84,8 @@ Configure the OpenTelemetry Go SDK with an OTLP/HTTP exporter pointed at Phoenix
 ```go
 import (
     "context"
+    "os"
+    "strings"
 
     "go.opentelemetry.io/otel"
     "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -92,12 +94,30 @@ import (
     semconvotel "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
+func phoenixTraceEndpoint(endpoint string) string {
+    endpoint = strings.TrimRight(endpoint, "/")
+    if strings.HasSuffix(endpoint, "/v1/traces") {
+        return endpoint
+    }
+    return endpoint + "/v1/traces"
+}
+
 ctx := context.Background()
-exporter, _ := otlptracehttp.New(ctx,
+opts := []otlptracehttp.Option{
     otlptracehttp.WithEndpoint("localhost:6006"),
     otlptracehttp.WithURLPath("/v1/traces"),
     otlptracehttp.WithInsecure(),
-)
+}
+if endpoint := os.Getenv("PHOENIX_COLLECTOR_ENDPOINT"); endpoint != "" {
+    opts = []otlptracehttp.Option{
+        otlptracehttp.WithEndpointURL(phoenixTraceEndpoint(endpoint)),
+        otlptracehttp.WithHeaders(map[string]string{
+            "Authorization": "Bearer " + os.Getenv("PHOENIX_API_KEY"),
+        }),
+    }
+}
+
+exporter, _ := otlptracehttp.New(ctx, opts...)
 res, _ := resource.New(ctx, resource.WithAttributes(
     semconvotel.ServiceName("your project name"),
 ))

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument.mdx
@@ -38,6 +38,20 @@ For detailed API documentation, consult the respective documentation sites.
 <Card title="Phoenix TypeScript API" href="https://arize-ai.github.io/phoenix" icon="js" description="TypeScript API docs"/>
 <Card title="OpenInference JavaScript API" href="https://arize-ai.github.io/openinference/js/" icon="brackets-curly" description="OpenInference JS docs"/>
 </Tab>
+
+<Tab title="Go" icon="golang">
+Phoenix does not ship a `phoenix-otel-go` wrapper. Install the OpenInference Go semconv + instrumentation packages plus the stock OpenTelemetry Go SDK:
+
+```bash
+go get github.com/Arize-ai/openinference/go/semconv
+go get github.com/Arize-ai/openinference/go/instrumentation
+go get go.opentelemetry.io/otel
+go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
+go get go.opentelemetry.io/otel/sdk
+```
+
+The `semconv` package provides typed constants for the wire-format-stable attribute keys; `instrumentation` provides context-attribute helpers (session, user, metadata, tags, suppression).
+</Tab>
 </Tabs>
 
 ## Setting Up Tracing
@@ -61,6 +75,39 @@ const tracerProvider = register({
   url: "https://your-phoenix.com",
   apiKey: process.env.PHOENIX_API_KEY,
 });
+```
+</Tab>
+
+<Tab title="Go" icon="golang">
+Configure the OpenTelemetry Go SDK with an OTLP/HTTP exporter pointed at Phoenix, then obtain a tracer. For Phoenix Cloud, set `PHOENIX_COLLECTOR_ENDPOINT` and `PHOENIX_API_KEY`.
+
+```go
+import (
+    "context"
+
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+    "go.opentelemetry.io/otel/sdk/resource"
+    sdktrace "go.opentelemetry.io/otel/sdk/trace"
+    semconvotel "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+ctx := context.Background()
+exporter, _ := otlptracehttp.New(ctx,
+    otlptracehttp.WithEndpoint("localhost:6006"),
+    otlptracehttp.WithURLPath("/v1/traces"),
+    otlptracehttp.WithInsecure(),
+)
+res, _ := resource.New(ctx, resource.WithAttributes(
+    semconvotel.ServiceName("your project name"),
+))
+tp := sdktrace.NewTracerProvider(
+    sdktrace.WithBatcher(exporter),
+    sdktrace.WithResource(res),
+)
+otel.SetTracerProvider(tp)
+
+tracer := otel.Tracer("your project name")
 ```
 </Tab>
 </Tabs>
@@ -93,6 +140,39 @@ const myFunc = (input: string): string => {
 const tracedFunc = traceChain(myFunc, { name: "my-func" });
 
 tracedFunc("input");
+```
+</Tab>
+
+<Tab title="Go" icon="golang">
+Go has no decorator syntax. Wrap the function body in a `tracer.Start` span and set input / output / span-kind attributes manually using the OpenInference Go semconv constants:
+
+```go
+import (
+    "context"
+
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/attribute"
+    "go.opentelemetry.io/otel/codes"
+    "go.opentelemetry.io/otel/trace"
+
+    "github.com/Arize-ai/openinference/go/semconv"
+)
+
+func myFunc(ctx context.Context, input string) (string, error) {
+    tracer := otel.Tracer("my-app")
+    ctx, span := tracer.Start(ctx, "my-func",
+        trace.WithAttributes(
+            attribute.String(semconv.OpenInferenceSpanKind, semconv.SpanKindChain),
+            attribute.String(semconv.InputValue, input),
+        ),
+    )
+    defer span.End()
+
+    output := "output"
+    span.SetAttributes(attribute.String(semconv.OutputValue, output))
+    span.SetStatus(codes.Ok, "")
+    return output, nil
+}
 ```
 </Tab>
 </Tabs>
@@ -134,6 +214,35 @@ await withSpan(
     kind: "CHAIN",
   }
 );
+```
+</Tab>
+
+<Tab title="Go" icon="golang">
+Go does not have a `with` statement; use `tracer.Start` + `defer span.End()` to scope a span to a block:
+
+```go
+import (
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/attribute"
+    "go.opentelemetry.io/otel/codes"
+    "go.opentelemetry.io/otel/trace"
+
+    "github.com/Arize-ai/openinference/go/semconv"
+)
+
+tracer := otel.Tracer("my-app")
+ctx, span := tracer.Start(ctx, "my-span-name",
+    trace.WithAttributes(
+        attribute.String(semconv.OpenInferenceSpanKind, semconv.SpanKindChain),
+    ),
+)
+defer span.End()
+
+span.SetAttributes(
+    attribute.String(semconv.InputValue, "input"),
+    attribute.String(semconv.OutputValue, "output"),
+)
+span.SetStatus(codes.Ok, "")
 ```
 </Tab>
 </Tabs>
@@ -276,6 +385,33 @@ const thisNameShouldBeOverridden = traceChain(
 thisNameShouldBeOverridden("input");
 ```
 </Tab>
+
+<Tab title="Go" icon="golang">
+Set the OpenInference span kind to `CHAIN` on any span that represents a step or glue point in your application. Inputs and outputs go on the same span via the semconv constants:
+
+```go
+import (
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/attribute"
+    "go.opentelemetry.io/otel/trace"
+
+    "github.com/Arize-ai/openinference/go/semconv"
+)
+
+tracer := otel.Tracer("my-app")
+ctx, span := tracer.Start(ctx, "my-chain",
+    trace.WithAttributes(
+        attribute.String(semconv.OpenInferenceSpanKind, semconv.SpanKindChain),
+        attribute.String(semconv.InputValue, "input"),
+    ),
+)
+defer span.End()
+
+// ... do work ...
+
+span.SetAttributes(attribute.String(semconv.OutputValue, "output"))
+```
+</Tab>
 </Tabs>
 
 ***
@@ -344,6 +480,34 @@ const decoratedAgent = traceAgent(
 );
 
 decoratedAgent("input");
+```
+</Tab>
+
+<Tab title="Go" icon="golang">
+Use the `AGENT` span kind for spans that wrap an LLM-driven reasoning loop. Set `agent.name` to identify the agent across calls:
+
+```go
+import (
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/attribute"
+    "go.opentelemetry.io/otel/trace"
+
+    "github.com/Arize-ai/openinference/go/semconv"
+)
+
+tracer := otel.Tracer("my-app")
+ctx, span := tracer.Start(ctx, "my-agent",
+    trace.WithAttributes(
+        attribute.String(semconv.OpenInferenceSpanKind, semconv.SpanKindAgent),
+        attribute.String(semconv.AgentName, "research-agent"),
+        attribute.String(semconv.InputValue, userQuery),
+    ),
+)
+defer span.End()
+
+// ... run agent loop, calling tools and LLMs (those produce child spans) ...
+
+span.SetAttributes(attribute.String(semconv.OutputValue, finalAnswer))
 ```
 </Tab>
 </Tabs>
@@ -437,6 +601,38 @@ const thisToolNameShouldBeOverridden = traceTool(
 );
 
 thisToolNameShouldBeOverridden("input1", 1);
+```
+</Tab>
+
+<Tab title="Go" icon="golang">
+Use the `TOOL` span kind for spans that wrap calls to external functions, APIs, or any tool the agent invokes. The tool name and inputs are conventionally attached to the same span:
+
+```go
+import (
+    "encoding/json"
+
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/attribute"
+    "go.opentelemetry.io/otel/trace"
+
+    "github.com/Arize-ai/openinference/go/semconv"
+)
+
+tracer := otel.Tracer("my-app")
+toolArgs := map[string]any{"city": "Johannesburg"}
+toolArgsJSON, _ := json.Marshal(toolArgs)
+
+ctx, span := tracer.Start(ctx, "lookup_weather",
+    trace.WithAttributes(
+        attribute.String(semconv.OpenInferenceSpanKind, semconv.SpanKindTool),
+        attribute.String(semconv.InputValue, string(toolArgsJSON)),
+        attribute.String(semconv.InputMimeType, semconv.MimeTypeJSON),
+    ),
+)
+defer span.End()
+
+result := lookupWeather(toolArgs["city"].(string))
+span.SetAttributes(attribute.String(semconv.OutputValue, result))
 ```
 </Tab>
 </Tabs>
@@ -1102,6 +1298,41 @@ const invokeLLM = withSpan(
 await invokeLLM([{ role: "user", content: "Hello, world!" }], "gpt-4", 0.5);
 ```
 </Tab>
+
+<Tab title="Go" icon="golang">
+For SDKs with OpenInference Go auto-instrumentation, see [OpenAI Go SDK](/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk) and [Anthropic SDK Go](/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go) — no manual span code required. For SDKs without auto-instrumentation, attach model and token attributes directly using `semconv`:
+
+```go
+import (
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/attribute"
+    "go.opentelemetry.io/otel/trace"
+
+    "github.com/Arize-ai/openinference/go/semconv"
+)
+
+tracer := otel.Tracer("my-app")
+ctx, span := tracer.Start(ctx, "invoke_llm",
+    trace.WithAttributes(
+        attribute.String(semconv.OpenInferenceSpanKind, semconv.SpanKindLLM),
+        attribute.String(semconv.LLMProvider, semconv.LLMProviderOpenAI),
+        attribute.String(semconv.LLMSystem, semconv.LLMSystemOpenAI),
+        attribute.String(semconv.LLMModelName, "gpt-4"),
+        attribute.String(semconv.InputValue, "Hello, world!"),
+    ),
+)
+defer span.End()
+
+// ... make the LLM call ...
+
+span.SetAttributes(
+    attribute.String(semconv.OutputValue, completionText),
+    attribute.Int(semconv.LLMTokenCountPrompt, promptTokens),
+    attribute.Int(semconv.LLMTokenCountCompletion, completionTokens),
+    attribute.Int(semconv.LLMTokenCountTotal, totalTokens),
+)
+```
+</Tab>
 </Tabs>
 
 
@@ -1153,6 +1384,21 @@ await context.with(suppressTracing(context.active()), async () => {
 });
 ```
 </Tab>
+
+<Tab title="Go" icon="golang">
+Use `instrumentation.WithSuppression` to mark a context such that any OpenInference-aware Go instrumentor (e.g. the OpenAI and Anthropic Go transports / middlewares) skips span emission for calls descended from it. Typical use: evaluator or grader code that itself calls an LLM but should not appear in the customer's product trace.
+
+```go
+import (
+    "github.com/Arize-ai/openinference/go/instrumentation"
+)
+
+ctx := instrumentation.WithSuppression(ctx)
+resp, _ := client.CreateChatCompletion(ctx, req)  // no LLM span emitted
+```
+
+For manual spans you author yourself, check the context before calling `tracer.Start` if you want to honor suppression in your own code.
+</Tab>
 </Tabs>
 
 ### Using Context Attributes
@@ -1203,6 +1449,32 @@ await context.with(
   }
 );
 ```
+</Tab>
+
+<Tab title="Go" icon="golang">
+Use the helpers in [`github.com/Arize-ai/openinference/go/instrumentation`](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation) to propagate session, user, metadata, and tags via OTel baggage. Auto-instrumentors (OpenAI Go, Anthropic Go) automatically apply these to every LLM span descended from the context:
+
+```go
+import (
+    "encoding/json"
+
+    "github.com/Arize-ai/openinference/go/instrumentation"
+)
+
+metadata := map[string]any{"key-1": "value_1", "key-2": "value_2"}
+metadataJSON, _ := json.Marshal(metadata)
+
+ctx = instrumentation.WithSession(ctx, "my-session-id")
+ctx = instrumentation.WithUser(ctx, "my-user-id")
+ctx = instrumentation.WithMetadata(ctx, string(metadataJSON))
+ctx = instrumentation.WithTags(ctx, "tag_1", "tag_2")
+
+// All LLM spans descended from ctx now carry session.id, user.id,
+// metadata, and tag.tags — no per-span code needed.
+resp, _ := client.CreateChatCompletion(ctx, req)
+```
+
+For manual spans you author yourself, set the same attributes directly via the `semconv` keys (`SessionID`, `UserID`, `Metadata`, `TagTags`) after `tracer.Start`.
 </Tab>
 </Tabs>
 
@@ -1310,6 +1582,12 @@ await withSpan(
   }
 );
 ```
+</Tab>
+
+<Tab title="Go" icon="golang">
+For SDKs with OpenInference Go auto-instrumentation (OpenAI Go, Anthropic Go), multimodal content is captured automatically when you call the SDK with image-containing messages — no per-span code required.
+
+For manual spans, attach image content using the indexed `llm.input_messages.{i}.message.contents.{j}.*` attributes from `github.com/Arize-ai/openinference/go/semconv`. The Python `openinference.instrumentation` message-builder helpers do not yet have a Go equivalent — refer to the [OpenInference spec](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md) for the full multimodal attribute taxonomy.
 </Tab>
 </Tabs>
 

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument.mdx
@@ -43,8 +43,8 @@ For detailed API documentation, consult the respective documentation sites.
 Phoenix does not ship a `phoenix-otel-go` wrapper. Install the OpenInference Go semconv + instrumentation packages plus the stock OpenTelemetry Go SDK:
 
 ```bash
-go get github.com/Arize-ai/openinference/go/semconv
-go get github.com/Arize-ai/openinference/go/instrumentation
+go get github.com/Arize-ai/openinference/go/openinference-semantic-conventions
+go get github.com/Arize-ai/openinference/go/openinference-instrumentation
 go get go.opentelemetry.io/otel
 go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
 go get go.opentelemetry.io/otel/sdk
@@ -155,7 +155,7 @@ import (
     "go.opentelemetry.io/otel/codes"
     "go.opentelemetry.io/otel/trace"
 
-    "github.com/Arize-ai/openinference/go/semconv"
+    "github.com/Arize-ai/openinference/go/openinference-semantic-conventions"
 )
 
 func myFunc(ctx context.Context, input string) (string, error) {
@@ -227,7 +227,7 @@ import (
     "go.opentelemetry.io/otel/codes"
     "go.opentelemetry.io/otel/trace"
 
-    "github.com/Arize-ai/openinference/go/semconv"
+    "github.com/Arize-ai/openinference/go/openinference-semantic-conventions"
 )
 
 tracer := otel.Tracer("my-app")
@@ -395,7 +395,7 @@ import (
     "go.opentelemetry.io/otel/attribute"
     "go.opentelemetry.io/otel/trace"
 
-    "github.com/Arize-ai/openinference/go/semconv"
+    "github.com/Arize-ai/openinference/go/openinference-semantic-conventions"
 )
 
 tracer := otel.Tracer("my-app")
@@ -492,7 +492,7 @@ import (
     "go.opentelemetry.io/otel/attribute"
     "go.opentelemetry.io/otel/trace"
 
-    "github.com/Arize-ai/openinference/go/semconv"
+    "github.com/Arize-ai/openinference/go/openinference-semantic-conventions"
 )
 
 tracer := otel.Tracer("my-app")
@@ -615,7 +615,7 @@ import (
     "go.opentelemetry.io/otel/attribute"
     "go.opentelemetry.io/otel/trace"
 
-    "github.com/Arize-ai/openinference/go/semconv"
+    "github.com/Arize-ai/openinference/go/openinference-semantic-conventions"
 )
 
 tracer := otel.Tracer("my-app")
@@ -1308,7 +1308,7 @@ import (
     "go.opentelemetry.io/otel/attribute"
     "go.opentelemetry.io/otel/trace"
 
-    "github.com/Arize-ai/openinference/go/semconv"
+    "github.com/Arize-ai/openinference/go/openinference-semantic-conventions"
 )
 
 tracer := otel.Tracer("my-app")
@@ -1390,7 +1390,7 @@ Use `instrumentation.WithSuppression` to mark a context such that any OpenInfere
 
 ```go
 import (
-    "github.com/Arize-ai/openinference/go/instrumentation"
+    "github.com/Arize-ai/openinference/go/openinference-instrumentation"
 )
 
 ctx := instrumentation.WithSuppression(ctx)
@@ -1452,13 +1452,13 @@ await context.with(
 </Tab>
 
 <Tab title="Go" icon="golang">
-Use the helpers in [`github.com/Arize-ai/openinference/go/instrumentation`](https://github.com/Arize-ai/openinference/tree/main/go/instrumentation) to propagate session, user, metadata, and tags via OTel baggage. Auto-instrumentors (OpenAI Go, Anthropic Go) automatically apply these to every LLM span descended from the context:
+Use the helpers in [`github.com/Arize-ai/openinference/go/openinference-instrumentation`](https://github.com/Arize-ai/openinference/tree/main/go/openinference-instrumentation) to store session, user, metadata, and tags on `context.Context`. Auto-instrumentors (OpenAI Go, Anthropic Go) automatically apply these to every LLM span descended from the context:
 
 ```go
 import (
     "encoding/json"
 
-    "github.com/Arize-ai/openinference/go/instrumentation"
+    "github.com/Arize-ai/openinference/go/openinference-instrumentation"
 )
 
 metadata := map[string]any{"key-1": "value_1", "key-2": "value_2"}
@@ -1587,7 +1587,6 @@ await withSpan(
 <Tab title="Go" icon="golang">
 For SDKs with OpenInference Go auto-instrumentation (OpenAI Go, Anthropic Go), multimodal content is captured automatically when you call the SDK with image-containing messages — no per-span code required.
 
-For manual spans, attach image content using the indexed `llm.input_messages.{i}.message.contents.{j}.*` attributes from `github.com/Arize-ai/openinference/go/semconv`. The Python `openinference.instrumentation` message-builder helpers do not yet have a Go equivalent — refer to the [OpenInference spec](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md) for the full multimodal attribute taxonomy.
+For manual spans, attach image content using the indexed `llm.input_messages.{i}.message.contents.{j}.*` attributes from `github.com/Arize-ai/openinference/go/openinference-semantic-conventions`. The Python `openinference.instrumentation` message-builder helpers do not yet have a Go equivalent — refer to the [OpenInference spec](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md) for the full multimodal attribute taxonomy.
 </Tab>
 </Tabs>
-

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
@@ -42,6 +42,10 @@ REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST as
 
 The Phoenix OTEL SDK provides a lightweight wrapper around OpenTelemetry with sensible defaults for Phoenix.
 
+<Note>
+**Go users:** Phoenix does not ship a branded `phoenix-otel` SDK wrapper for Go. Configure the standard [OpenTelemetry Go SDK](https://opentelemetry.io/docs/languages/go/) directly and point an OTLP/HTTP exporter at Phoenix. End-to-end examples live in the Go integration pages — [OpenAI Go SDK](/docs/phoenix/integrations/llm-providers/openai/openai-go-sdk), [Anthropic SDK Go](/docs/phoenix/integrations/llm-providers/anthropic/anthropic-sdk-go), and [Gemini Go SDK](/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk).
+</Note>
+
 ## Install
 
 <Tabs>


### PR DESCRIPTION
###  Summary

- Add Go tracing docs for OpenAI and Anthropic SDK instrumentation.
- Add Gemini Go tracing docs using manual OpenTelemetry GenAI semantic conventions.
- Wire the new Go pages into docs navigation, provider pages, integration cards, and `llms.txt`.
- Update shared Go tracing setup examples to handle Phoenix Cloud collector hostnames correctly.