### PR TITLE
docs(evaluation): add tutorial video to code evaluators page

### DIFF
--- a/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
@@ -63,6 +63,10 @@ From authoring to results, you'll work through five steps:
 4. **Map inputs** — Bind each parameter to a path on the [evaluation parameters](/docs/phoenix/evaluation/server-evals/input-mapping#evaluation-parameters) (`input`, `output`, `reference`, `metadata`) or to a literal value.
 5. **Test, save, run** — Dry-run the evaluator against a dataset example in the test panel, save it, then run an experiment. Scores land on every new run automatically.
 
+Watch a full walkthrough of these steps end to end:
+
+<video src="https://storage.googleapis.com/arize-assets/phoenix/assets/videos/code_evaluators.mp4" width="100%" height="100%" style={{ display: 'block', objectFit: 'fill', backgroundColor: 'transparent' }} controls />
+
 ## Authoring an Evaluator
 
 ### Function signature


### PR DESCRIPTION
## Summary

Embeds a full walkthrough video in the **How It Works** section of the server-side Code Evaluators page (`docs/phoenix/evaluation/server-evals/code-evaluators.mdx`), placed right after the five-step overview.

The video uses `controls` only (no `autoPlay`/`muted`/`loop`) — unlike the page's two short silent demo clips — since a narrated tutorial should play on user intent.

Source: `https://storage.googleapis.com/arize-assets/phoenix/assets/videos/code_evaluators.mp4`

## Notes

- Base branch is `version-sandboxes` (the sandbox feature integration branch), not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)