### PR TITLE
fix(playground): block custom base URL paired with env-var provider key

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -3177,6 +3177,41 @@ def _get_credential_from_input(
     )
 
 
+async def _resolve_provider_api_key(
+    *,
+    credentials: Sequence[GenerativeCredentialInput] | None,
+    session: AsyncSession,
+    decrypt: Callable[[bytes], bytes],
+    env_var_name: str,
+    client_base_url: str | None,
+    provider_label: str,
+) -> str | None:
+    """Resolve a provider API key and enforce the custom-base-URL guard.
+
+    Resolution priority: client-supplied credential -> DB-encrypted secret ->
+    process environment variable.
+
+    Security: a server-configured (environment variable) API key must never be
+    sent to a client-supplied base URL — doing so would leak that credential to
+    the client-controlled host (SSRF / credential exfiltration). When the key
+    would fall through to an environment variable and the caller also supplied a
+    custom ``base_url``, the request is rejected. A key from the request itself or
+    from a DB secret is allowed with a custom base URL.
+    """
+    if from_input := _get_credential_from_input(credentials, env_var_name):
+        return from_input
+    if from_secret := (await _resolve_secrets(session, decrypt, env_var_name)).get(env_var_name):
+        return from_secret
+    from_env = getenv(env_var_name)
+    if from_env and client_base_url:
+        raise BadRequest(
+            f"A custom base URL cannot be used with the server-configured "
+            f"{provider_label} API key. Provide an API key with the request, "
+            f"or store one as a Phoenix secret, to use a custom base URL."
+        )
+    return from_env
+
+
 def get_openai_client_class(
     provider_key: "GenerativeProviderKey",
     model_name: str,
@@ -3284,6 +3319,9 @@ async def _get_builtin_provider_client(
 
     sdk = _builtin_sdk_fields_from_connection(model_provider, connection)
     base_url = sdk.base_url
+    # The client-supplied base URL, captured before any environment-variable fallback.
+    # Used to reject pairing a server-owned env-var API key with a client-controlled URL.
+    client_base_url = sdk.base_url or None
     endpoint = sdk.endpoint
     region = sdk.region
     openai_api_type = sdk.openai_api_type
@@ -3294,10 +3332,13 @@ async def _get_builtin_provider_client(
         except ImportError:
             raise BadRequest("OpenAI package not installed. Run: pip install openai")
 
-        api_key = (
-            _get_credential_from_input(credentials, "OPENAI_API_KEY")
-            or (await _resolve_secrets(session, decrypt, "OPENAI_API_KEY")).get("OPENAI_API_KEY")
-            or getenv("OPENAI_API_KEY")
+        api_key = await _resolve_provider_api_key(
+            credentials=credentials,
+            session=session,
+            decrypt=decrypt,
+            env_var_name="OPENAI_API_KEY",
+            client_base_url=client_base_url,
+            provider_label="OpenAI",
         )
         base_url = base_url or getenv("OPENAI_BASE_URL")
 
@@ -3544,12 +3585,13 @@ async def _get_builtin_provider_client(
         except ImportError:
             raise BadRequest("OpenAI package not installed. Run: pip install openai")
 
-        api_key = (
-            _get_credential_from_input(credentials, "DEEPSEEK_API_KEY")
-            or (await _resolve_secrets(session, decrypt, "DEEPSEEK_API_KEY")).get(
-                "DEEPSEEK_API_KEY"
-            )
-            or getenv("DEEPSEEK_API_KEY")
+        api_key = await _resolve_provider_api_key(
+            credentials=credentials,
+            session=session,
+            decrypt=decrypt,
+            env_var_name="DEEPSEEK_API_KEY",
+            client_base_url=client_base_url,
+            provider_label="DeepSeek",
         )
         base_url = base_url or getenv("DEEPSEEK_BASE_URL") or "https://api.deepseek.com"
 
@@ -3584,10 +3626,13 @@ async def _get_builtin_provider_client(
         except ImportError:
             raise BadRequest("OpenAI package not installed. Run: pip install openai")
 
-        api_key = (
-            _get_credential_from_input(credentials, "XAI_API_KEY")
-            or (await _resolve_secrets(session, decrypt, "XAI_API_KEY")).get("XAI_API_KEY")
-            or getenv("XAI_API_KEY")
+        api_key = await _resolve_provider_api_key(
+            credentials=credentials,
+            session=session,
+            decrypt=decrypt,
+            env_var_name="XAI_API_KEY",
+            client_base_url=client_base_url,
+            provider_label="xAI",
         )
         base_url = base_url or getenv("XAI_BASE_URL") or "https://api.x.ai/v1"
 
@@ -3653,12 +3698,13 @@ async def _get_builtin_provider_client(
         except ImportError:
             raise BadRequest("OpenAI package not installed. Run: pip install openai")
 
-        api_key = (
-            _get_credential_from_input(credentials, "CEREBRAS_API_KEY")
-            or (await _resolve_secrets(session, decrypt, "CEREBRAS_API_KEY")).get(
-                "CEREBRAS_API_KEY"
-            )
-            or getenv("CEREBRAS_API_KEY")
+        api_key = await _resolve_provider_api_key(
+            credentials=credentials,
+            session=session,
+            decrypt=decrypt,
+            env_var_name="CEREBRAS_API_KEY",
+            client_base_url=client_base_url,
+            provider_label="Cerebras",
         )
         base_url = base_url or getenv("CEREBRAS_BASE_URL") or "https://api.cerebras.ai/v1"
 
@@ -3692,12 +3738,13 @@ async def _get_builtin_provider_client(
         except ImportError:
             raise BadRequest("OpenAI package not installed. Run: pip install openai")
 
-        api_key = (
-            _get_credential_from_input(credentials, "FIREWORKS_API_KEY")
-            or (await _resolve_secrets(session, decrypt, "FIREWORKS_API_KEY")).get(
-                "FIREWORKS_API_KEY"
-            )
-            or getenv("FIREWORKS_API_KEY")
+        api_key = await _resolve_provider_api_key(
+            credentials=credentials,
+            session=session,
+            decrypt=decrypt,
+            env_var_name="FIREWORKS_API_KEY",
+            client_base_url=client_base_url,
+            provider_label="Fireworks",
         )
         base_url = (
             base_url or getenv("FIREWORKS_BASE_URL") or "https://api.fireworks.ai/inference/v1"
@@ -3733,10 +3780,13 @@ async def _get_builtin_provider_client(
         except ImportError:
             raise BadRequest("OpenAI package not installed. Run: pip install openai")
 
-        api_key = (
-            _get_credential_from_input(credentials, "GROQ_API_KEY")
-            or (await _resolve_secrets(session, decrypt, "GROQ_API_KEY")).get("GROQ_API_KEY")
-            or getenv("GROQ_API_KEY")
+        api_key = await _resolve_provider_api_key(
+            credentials=credentials,
+            session=session,
+            decrypt=decrypt,
+            env_var_name="GROQ_API_KEY",
+            client_base_url=client_base_url,
+            provider_label="Groq",
         )
         base_url = base_url or getenv("GROQ_BASE_URL") or "https://api.groq.com/openai/v1"
 
@@ -3770,12 +3820,13 @@ async def _get_builtin_provider_client(
         except ImportError:
             raise BadRequest("OpenAI package not installed. Run: pip install openai")
 
-        api_key = (
-            _get_credential_from_input(credentials, "MOONSHOT_API_KEY")
-            or (await _resolve_secrets(session, decrypt, "MOONSHOT_API_KEY")).get(
-                "MOONSHOT_API_KEY"
-            )
-            or getenv("MOONSHOT_API_KEY")
+        api_key = await _resolve_provider_api_key(
+            credentials=credentials,
+            session=session,
+            decrypt=decrypt,
+            env_var_name="MOONSHOT_API_KEY",
+            client_base_url=client_base_url,
+            provider_label="Moonshot",
         )
         base_url = base_url or getenv("MOONSHOT_BASE_URL") or "https://api.moonshot.ai/v1"
 
@@ -3809,12 +3860,13 @@ async def _get_builtin_provider_client(
         except ImportError:
             raise BadRequest("OpenAI package not installed. Run: pip install openai")
 
-        api_key = (
-            _get_credential_from_input(credentials, "PERPLEXITY_API_KEY")
-            or (await _resolve_secrets(session, decrypt, "PERPLEXITY_API_KEY")).get(
-                "PERPLEXITY_API_KEY"
-            )
-            or getenv("PERPLEXITY_API_KEY")
+        api_key = await _resolve_provider_api_key(
+            credentials=credentials,
+            session=session,
+            decrypt=decrypt,
+            env_var_name="PERPLEXITY_API_KEY",
+            client_base_url=client_base_url,
+            provider_label="Perplexity",
         )
         base_url = base_url or getenv("PERPLEXITY_BASE_URL") or "https://api.perplexity.ai"
 
@@ -3848,12 +3900,13 @@ async def _get_builtin_provider_client(
         except ImportError:
             raise BadRequest("OpenAI package not installed. Run: pip install openai")
 
-        api_key = (
-            _get_credential_from_input(credentials, "TOGETHER_API_KEY")
-            or (await _resolve_secrets(session, decrypt, "TOGETHER_API_KEY")).get(
-                "TOGETHER_API_KEY"
-            )
-            or getenv("TOGETHER_API_KEY")
+        api_key = await _resolve_provider_api_key(
+            credentials=credentials,
+            session=session,
+            decrypt=decrypt,
+            env_var_name="TOGETHER_API_KEY",
+            client_base_url=client_base_url,
+            provider_label="Together",
         )
         base_url = base_url or getenv("TOGETHER_BASE_URL") or "https://api.together.xyz/v1"
 

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -18,7 +18,9 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import StatusCode, Tracer
 
-from phoenix.db.types.model_provider import LLMClientFactory
+from phoenix.db import models
+from phoenix.db.types.experiment_config import OpenAIConnectionConfig
+from phoenix.db.types.model_provider import LLMClientFactory, ModelProvider
 from phoenix.db.types.prompts import (
     PromptAnthropicInvocationParameters,
     PromptAnthropicInvocationParametersContent,
@@ -30,6 +32,7 @@ from phoenix.db.types.prompts import (
     PromptToolFunctionDefinition,
     PromptTools,
 )
+from phoenix.server.api.exceptions import BadRequest
 from phoenix.server.api.helpers.message_helpers import PlaygroundMessage, create_playground_message
 from phoenix.server.api.helpers.playground_clients import (
     AnthropicStreamingClient,
@@ -40,12 +43,17 @@ from phoenix.server.api.helpers.playground_clients import (
     OpenAIReasoningNonStreamingClient,
     OpenAIResponsesAPIStreamingClient,
     OpenAIStreamingClient,
+    _get_builtin_provider_client,
+    _resolve_provider_api_key,
     get_openai_client_class,
 )
+from phoenix.server.api.input_types.GenerativeCredentialInput import GenerativeCredentialInput
 from phoenix.server.api.input_types.ModelClientOptionsInput import OpenAIApiType
 from phoenix.server.api.types.ChatCompletionMessageRole import ChatCompletionMessageRole
 from phoenix.server.api.types.ChatCompletionSubscriptionPayload import TextChunk
 from phoenix.server.api.types.GenerativeProvider import GenerativeProviderKey
+from phoenix.server.api.types.SecretString import SecretString
+from phoenix.server.types import DbSessionFactory
 from tests.unit.vcr import CustomVCR
 
 
@@ -703,3 +711,153 @@ class TestGetOpenAIClientClass:
             None,
         )
         assert client_class is None
+
+
+def _identity_decrypt(value: bytes) -> bytes:
+    return value
+
+
+class TestResolveProviderApiKey:
+    """The custom-base-URL guard in ``_resolve_provider_api_key``.
+
+    A server-configured (environment variable) API key must never be sent to a
+    client-supplied base URL — that would leak the credential to the
+    client-controlled host. A key from the request itself or from a DB secret is
+    allowed with a custom base URL.
+    """
+
+    async def test_input_credential_with_base_url_is_allowed(
+        self, db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        credentials = [
+            GenerativeCredentialInput(
+                env_var_name="OPENAI_API_KEY", value=SecretString("sk-from-input")
+            )
+        ]
+        async with db() as session:
+            api_key = await _resolve_provider_api_key(
+                credentials=credentials,
+                session=session,
+                decrypt=_identity_decrypt,
+                env_var_name="OPENAI_API_KEY",
+                client_base_url="https://attacker.example",
+                provider_label="OpenAI",
+            )
+        assert api_key == "sk-from-input"
+
+    async def test_db_secret_with_base_url_is_allowed(
+        self, db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from phoenix.server.encryption import EncryptionService
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        encryption = EncryptionService()
+        async with db() as session:
+            session.add(
+                models.Secret(key="OPENAI_API_KEY", value=encryption.encrypt(b"sk-from-secret"))
+            )
+            await session.commit()
+        async with db() as session:
+            api_key = await _resolve_provider_api_key(
+                credentials=None,
+                session=session,
+                decrypt=encryption.decrypt,
+                env_var_name="OPENAI_API_KEY",
+                client_base_url="https://my-proxy.example",
+                provider_label="OpenAI",
+            )
+        assert api_key == "sk-from-secret"
+
+    async def test_env_var_key_with_base_url_is_rejected(
+        self, db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        async with db() as session:
+            with pytest.raises(BadRequest):
+                await _resolve_provider_api_key(
+                    credentials=None,
+                    session=session,
+                    decrypt=_identity_decrypt,
+                    env_var_name="OPENAI_API_KEY",
+                    client_base_url="https://attacker.example",
+                    provider_label="OpenAI",
+                )
+
+    async def test_env_var_key_without_base_url_is_allowed(
+        self, db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        async with db() as session:
+            api_key = await _resolve_provider_api_key(
+                credentials=None,
+                session=session,
+                decrypt=_identity_decrypt,
+                env_var_name="OPENAI_API_KEY",
+                client_base_url=None,
+                provider_label="OpenAI",
+            )
+        assert api_key == "sk-from-env"
+
+    async def test_no_key_with_base_url_returns_none(
+        self, db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        async with db() as session:
+            api_key = await _resolve_provider_api_key(
+                credentials=None,
+                session=session,
+                decrypt=_identity_decrypt,
+                env_var_name="OPENAI_API_KEY",
+                client_base_url="https://my-endpoint.example",
+                provider_label="OpenAI",
+            )
+        assert api_key is None
+
+    async def test_builtin_openai_client_rejects_base_url_with_env_key(
+        self, db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end: a custom base URL paired with an env-var-only key is rejected."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        connection = OpenAIConnectionConfig(
+            type="openai",
+            base_url="https://attacker.example",
+            openai_api_type="chat_completions",
+        )
+        async with db() as session:
+            with pytest.raises(BadRequest):
+                await _get_builtin_provider_client(
+                    ModelProvider.OPENAI,
+                    "gpt-4o",
+                    connection,
+                    None,
+                    session,
+                    _identity_decrypt,
+                )
+
+    async def test_builtin_openai_client_allows_base_url_with_request_key(
+        self, db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A custom base URL is allowed when the caller supplies their own key."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        connection = OpenAIConnectionConfig(
+            type="openai",
+            base_url="https://my-proxy.example",
+            openai_api_type="chat_completions",
+        )
+        credentials = [
+            GenerativeCredentialInput(
+                env_var_name="OPENAI_API_KEY", value=SecretString("sk-from-request")
+            )
+        ]
+        async with db() as session:
+            client = await _get_builtin_provider_client(
+                ModelProvider.OPENAI,
+                "gpt-4o",
+                connection,
+                None,
+                session,
+                _identity_decrypt,
+                credentials,
+            )
+        assert isinstance(client, OpenAIStreamingClient)


### PR DESCRIPTION
## Problem

The playground lets any client supply a custom `base_url` for builtin LLM providers via `ConnectionConfigInput`. The server then resolves a provider API key — priority: client-supplied credential → DB-encrypted secret → process **environment variable** — and dials the **client-controlled URL** with that key in the `Authorization` header.

On a deployment that configures provider keys through environment variables (e.g. a shared, multi-tenant host), any Member-or-above user can point `base_url` at an attacker host and exfiltrate the server's env-var API key — an SSRF + cross-tenant credential leak.

The dangerous combination is specifically **client-supplied `base_url` + server-owned env-var credential**. A client using their *own* key (or a DB secret) with their own URL leaks nothing.

## Fix

An **always-on guard**: a server-owned environment-variable API key is never paired with a client-supplied base URL.

- New helper `_resolve_provider_api_key` performs credential resolution (request credential → DB secret → env var) and raises `BadRequest` when the key would fall through to an env var **and** the caller supplied a custom `base_url`.
- A key from the request itself or from a DB-encrypted secret is still allowed with a custom base URL.
- Providers with no API key (Ollama) are unaffected.
- Folding the guard into the resolver means it cannot be forgotten when a new provider is added.

The 9 OpenAI-SDK-style providers that use `base_url` with an API key — OpenAI, DeepSeek, xAI, Cerebras, Fireworks, Groq, Moonshot, Perplexity, Together — route through the helper. This single chokepoint (`_get_builtin_provider_client`) covers both the live playground subscription and the dataset/experiment runner path.

## Scope / out of scope

- No GraphQL schema change, no DB migration, no frontend change. `base_url` still works for clients that bring their own key or a DB secret.
- **Untouched:** Azure (`azure_endpoint`) and AWS (`endpoint_url`/`region_name`) — not `base_url`. Anthropic/Google extract `base_url` but never pass it to their SDK client (dead code today) — flagged for future maintainers if that changes. Ollama has no API key, so nothing to leak.

## Tests

New `TestResolveProviderApiKey` (7 tests): request-credential + base URL allowed, DB-secret + base URL allowed, **env-var key + base URL rejected**, env-var key without base URL allowed, no key returns `None`, plus two end-to-end `_get_builtin_provider_client` tests verifying the OpenAI wiring.

- `uv run pytest tests/unit/server/api/helpers/test_playground_clients.py` → 24 passed
- `mypy` and `ruff` clean on changed files