### PR TITLE
fix: enforce sandbox execute timeouts

### DIFF
--- a/src/phoenix/server/sandbox/daytona_backend.py
+++ b/src/phoenix/server/sandbox/daytona_backend.py
@@ -263,7 +263,7 @@ class DaytonaSandboxBackend(SandboxBackend):
 
             sandbox: AsyncSandbox = handle  # type: ignore[assignment]
             result = await sandbox.process.code_run(
-                code, params=CodeRunParams(env=self._user_env or None)
+                code, params=CodeRunParams(env=self._user_env or None), timeout=timeout
             )
             return _to_execution_result(result)
         except Exception as exc:
@@ -292,7 +292,7 @@ class DaytonaSandboxBackend(SandboxBackend):
             try:
                 await self._install_packages(workspace)
                 result = await workspace.process.code_run(
-                    code, params=CodeRunParams(env=self._user_env or None)
+                    code, params=CodeRunParams(env=self._user_env or None), timeout=timeout
                 )
                 return _to_execution_result(result)
             finally:

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -199,7 +199,7 @@ class ModalSandboxBackend(SandboxBackend):
     ) -> ExecutionResult:
         sandbox: Sandbox = handle  # type: ignore[assignment]
         try:
-            return await self._exec_code(sandbox, code)
+            return await self._exec_code(sandbox, code, timeout=timeout)
         except Exception as exc:
             if self.is_session_gone(exc):
                 raise
@@ -222,8 +222,13 @@ class ModalSandboxBackend(SandboxBackend):
         except NotFoundError:
             return
 
-    async def _exec_code(self, sandbox: Sandbox, code: str) -> ExecutionResult:
-        proc = await sandbox.exec.aio("python", "-c", code)
+    async def _exec_code(
+        self,
+        sandbox: Sandbox,
+        code: str,
+        timeout: Optional[int] = None,
+    ) -> ExecutionResult:
+        proc = await sandbox.exec.aio("python", "-c", code, timeout=timeout)
         stdout, stderr = await asyncio.gather(
             proc.stdout.read.aio(),
             proc.stderr.read.aio(),
@@ -243,7 +248,7 @@ class ModalSandboxBackend(SandboxBackend):
         try:
             sandbox = await self._create_sandbox()
             try:
-                return await self._exec_code(sandbox, code)
+                return await self._exec_code(sandbox, code, timeout=timeout)
             finally:
                 await sandbox.terminate.aio()
         except Exception as exc:

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -246,7 +246,7 @@ class VercelSandboxBackend(SandboxBackend):
         sandbox: AsyncSandbox = handle  # type: ignore[assignment]
         try:
             session_env: Optional[dict[str, str]] = self._user_env or None
-            return await self._exec_code(sandbox, code, env=session_env)
+            return await self._exec_code(sandbox, code, env=session_env, timeout=timeout)
         except Exception as exc:
             if self.is_session_gone(exc):
                 raise
@@ -311,11 +311,23 @@ class VercelSandboxBackend(SandboxBackend):
         sandbox: AsyncSandbox,
         code: str,
         env: Optional[dict[str, str]] = None,
+        timeout: Optional[int] = None,
     ) -> ExecutionResult:
         lang_cfg = self._lang_cfg()
         cmd: str = lang_cfg["cmd"]
         args: list[str] = lang_cfg["args_prefix"] + [code]
-        result = await sandbox.run_command(cmd, args, env=env)
+
+        if timeout is None:
+            result = await sandbox.run_command(cmd, args, env=env)
+        else:
+            command = await sandbox.run_command_detached(cmd, args, env=env)
+            try:
+                result = await asyncio.wait_for(command.wait(), timeout=timeout)
+            except (TimeoutError, asyncio.TimeoutError):
+                await command.kill()
+                message = f"Execution timed out after {timeout}s"
+                return ExecutionResult(stdout="", stderr=message, error=message)
+
         stdout, stderr = await asyncio.gather(result.stdout(), result.stderr())
         exit_code = result.exit_code
         error: Optional[str] = stderr if exit_code != 0 else None
@@ -338,7 +350,7 @@ class VercelSandboxBackend(SandboxBackend):
             sandbox = await self._create_sandbox()
             try:
                 await self._install_packages(sandbox)
-                return await self._exec_code(sandbox, code, env=session_env)
+                return await self._exec_code(sandbox, code, env=session_env, timeout=timeout)
             finally:
                 try:
                     await sandbox.stop()

--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import tempfile
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -58,6 +59,7 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
     stdout_chunks: list[bytes] = []
     stderr_chunks: list[bytes] = []
     stdin_path: str | None = None
+    timer: threading.Timer | None = None
 
     try:
         engine, module = _get_engine_and_module(binary_path)
@@ -77,7 +79,10 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
 
         store = _wasm.Store(engine)
         store.set_wasi(wasi)
-        store.set_epoch_deadline(timeout)
+        store.set_epoch_deadline(1)
+        timer = threading.Timer(timeout, engine.increment_epoch)
+        timer.daemon = True
+        timer.start()
 
         instance = linker.instantiate(store, module)
         exports = instance.exports(store)
@@ -96,6 +101,8 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
             error=str(exc),
         )
     finally:
+        if timer is not None:
+            timer.cancel()
         if stdin_path is not None:
             import os
 

--- a/tests/unit/server/api/test_wasm_backend.py
+++ b/tests/unit/server/api/test_wasm_backend.py
@@ -328,6 +328,94 @@ class TestRunWasmStdoutCapture:
         assert len(stdin_path_holder) == 1
         assert stdin_path_holder[0].endswith(".py")
 
+    def test_epoch_timer_is_started_and_cancelled(self) -> None:
+        import wasmtime
+
+        class _CapturingWasiConfig:
+            @property
+            def stdout_custom(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stdout_custom.setter
+            def stdout_custom(self, cb: object) -> None:
+                del cb
+
+            @property
+            def stderr_custom(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stderr_custom.setter
+            def stderr_custom(self, cb: object) -> None:
+                del cb
+
+            @property
+            def stdin_file(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stdin_file.setter
+            def stdin_file(self, path: object) -> None:
+                del path
+
+        class _StartFunc:
+            def __call__(self, store: object) -> None:
+                del store
+
+        class _FakeTimer:
+            def __init__(self, interval: float, function: object) -> None:
+                self.interval = interval
+                self.function = function
+                self.daemon = False
+                self.started = False
+                self.cancelled = False
+
+            def start(self) -> None:
+                self.started = True
+
+            def cancel(self) -> None:
+                self.cancelled = True
+
+        timers: list[_FakeTimer] = []
+
+        def _make_timer(interval: float, function: object) -> _FakeTimer:
+            timer = _FakeTimer(interval, function)
+            timers.append(timer)
+            return timer
+
+        engine = MagicMock()
+        fake_store = MagicMock()
+        mock_exports = MagicMock()
+        mock_exports.get.return_value = _StartFunc()
+        mock_instance = MagicMock()
+        mock_instance.exports.return_value = mock_exports
+
+        with patch(
+            "phoenix.server.sandbox.wasm_backend._get_engine_and_module",
+            return_value=(engine, MagicMock()),
+        ):
+            with patch("wasmtime.WasiConfig", _CapturingWasiConfig):
+                with patch("wasmtime.Linker") as mock_linker_cls:
+                    mock_linker = MagicMock()
+                    mock_linker_cls.return_value = mock_linker
+                    mock_linker.instantiate.return_value = mock_instance
+                    with patch("wasmtime.Store", return_value=fake_store):
+                        with patch.object(wasmtime, "Func", _StartFunc):
+                            with patch(
+                                "phoenix.server.sandbox.wasm_backend.threading.Timer",
+                                side_effect=_make_timer,
+                            ):
+                                result = _run_wasm(
+                                    Path("/fake/cpython.wasm"), "print(1)", timeout=5
+                                )
+
+        assert result.error is None
+        fake_store.set_epoch_deadline.assert_called_once_with(1)
+        assert len(timers) == 1
+        assert timers[0].interval == 5
+        assert timers[0].function is engine.increment_epoch
+        assert timers[0].daemon is True
+        assert timers[0].started is True
+        assert timers[0].cancelled is True
+
 
 class TestTempFileCleanup:
     def test_stdin_temp_file_is_deleted_after_run(self, tmp_path: Path) -> None:

--- a/tests/unit/server/sandbox/test_daytona_backend.py
+++ b/tests/unit/server/sandbox/test_daytona_backend.py
@@ -144,6 +144,49 @@ class TestCodeRunParamsKwarg:
             f"Expected params.env=None for empty user_env, got {params.env!r}"
         )
 
+    @pytest.mark.asyncio
+    async def test_execute_forwards_timeout_to_code_run(self) -> None:
+        daytona_mod, process_mod = _make_daytona_mocks()
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            backend = DaytonaSandboxBackend(api_key=_API_KEY, language="PYTHON")
+            await backend.execute("1+1", session_key="s1", timeout=12)
+
+        workspace = daytona_mod.AsyncDaytona.return_value.create.return_value
+        call_kwargs = workspace.process.code_run.call_args.kwargs
+        params = call_kwargs["params"]
+        assert isinstance(params, _CodeRunParams)
+        assert call_kwargs["timeout"] == 12
+
+    @pytest.mark.asyncio
+    async def test_execute_in_session_forwards_timeout_to_code_run(self) -> None:
+        daytona_mod, process_mod = _make_daytona_mocks()
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            sandbox = MagicMock()
+            sandbox.process.code_run = AsyncMock(return_value=MagicMock(result="ok", exit_code=0))
+            backend = DaytonaSandboxBackend(api_key=_API_KEY, language="PYTHON")
+            await backend.execute_in_session(sandbox, "1+1", timeout=9)
+
+        call_kwargs = sandbox.process.code_run.call_args.kwargs
+        params = call_kwargs["params"]
+        assert isinstance(params, _CodeRunParams)
+        assert call_kwargs["timeout"] == 9
+
 
 class TestNetworkBlockAll:
     @pytest.mark.asyncio

--- a/tests/unit/server/sandbox/test_modal_backend.py
+++ b/tests/unit/server/sandbox/test_modal_backend.py
@@ -264,6 +264,27 @@ async def test_exec_code_strips_ansi_from_all_three_fields() -> None:
 
 
 @pytest.mark.asyncio
+async def test_exec_code_forwards_per_execute_timeout() -> None:
+    modal_mock = _make_modal_mock()
+    with patch.dict(sys.modules, {"modal": modal_mock}):
+        from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+        backend = ModalSandboxBackend(token_id=_TOKEN_ID, token_secret=_TOKEN_SECRET)
+
+        sandbox = MagicMock()
+        proc = MagicMock()
+        proc.stdout.read.aio = AsyncMock(return_value="")
+        proc.stderr.read.aio = AsyncMock(return_value="")
+        proc.wait.aio = AsyncMock(return_value=0)
+        sandbox.exec.aio = AsyncMock(return_value=proc)
+
+        result = await backend._exec_code(sandbox, "noop", timeout=11)
+
+    sandbox.exec.aio.assert_awaited_once_with("python", "-c", "noop", timeout=11)
+    assert result.error is None
+
+
+@pytest.mark.asyncio
 async def test_execute_strips_ansi_in_raised_exception_path() -> None:
     modal_mock = _make_modal_mock()
     modal_mock.Sandbox.create.aio = AsyncMock(

--- a/tests/unit/server/sandbox/test_vercel_backend.py
+++ b/tests/unit/server/sandbox/test_vercel_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import sys
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -405,6 +406,56 @@ async def test_execute_strips_ansi_from_all_three_fields(
     assert result.stdout == "ok\n"
     assert result.stderr == "boom: failed\n"
     assert result.error == "boom: failed\n"
+
+
+@pytest.mark.asyncio
+async def test_exec_code_uses_detached_command_when_timeout_is_set() -> None:
+    command_result = MagicMock()
+    command_result.exit_code = 0
+    command_result.stdout = AsyncMock(return_value="done\n")
+    command_result.stderr = AsyncMock(return_value="")
+
+    command = MagicMock()
+    command.wait = AsyncMock(return_value=command_result)
+    command.kill = AsyncMock()
+
+    sandbox = MagicMock()
+    sandbox.run_command = AsyncMock(side_effect=AssertionError("should use detached command"))
+    sandbox.run_command_detached = AsyncMock(return_value=command)
+
+    backend = VercelSandboxBackend(
+        token=_TOKEN, project_id=_PROJECT, team_id=_TEAM, language="PYTHON"
+    )
+    result = await backend._exec_code(sandbox, "print('done')", timeout=5)
+
+    sandbox.run_command_detached.assert_awaited_once()
+    command.kill.assert_not_awaited()
+    assert result.stdout == "done\n"
+    assert result.error is None
+
+
+@pytest.mark.asyncio
+async def test_exec_code_kills_detached_command_on_timeout() -> None:
+    async def _hang() -> Any:
+        await asyncio.sleep(10)
+
+    command = MagicMock()
+    command.wait = AsyncMock(side_effect=_hang)
+    command.kill = AsyncMock()
+
+    sandbox = MagicMock()
+    sandbox.run_command = AsyncMock(side_effect=AssertionError("should use detached command"))
+    sandbox.run_command_detached = AsyncMock(return_value=command)
+
+    backend = VercelSandboxBackend(
+        token=_TOKEN, project_id=_PROJECT, team_id=_TEAM, language="PYTHON"
+    )
+    result = await backend._exec_code(sandbox, "while True: pass", timeout=1)
+
+    command.kill.assert_awaited_once()
+    assert result.stdout == ""
+    assert result.stderr == "Execution timed out after 1s"
+    assert result.error == "Execution timed out after 1s"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
﻿## Summary
- forward per-execute timeouts to Daytona and Modal provider APIs
- enforce Vercel command timeouts with detached commands plus kill on timeout
- drive WASM epoch interruption with a timer so runaway local executions stop

## Why
`SandboxBackend.execute(..., timeout=...)` is part of the sandbox protocol, but several backends accepted the value and then dropped it. The outer evaluator timeout protects the caller, but it can leave provider commands or WASM executor threads running after Phoenix has returned.

## Notes
- Daytona SDK 0.173.0 exposes timeout as a direct `process.code_run(..., timeout=...)` argument, so this PR uses that instead of adding it to `CodeRunParams`.
- Vercel SDK 0.5.8 does not expose a timeout kwarg on `run_command(...)`; the detached command API exposes `wait()` and `kill()`, so timeout cleanup is explicit.

## To verify
- `uv run ruff check src/phoenix/server/sandbox/daytona_backend.py src/phoenix/server/sandbox/vercel_backend.py src/phoenix/server/sandbox/modal_backend.py src/phoenix/server/sandbox/wasm_backend.py tests/unit/server/sandbox/test_daytona_backend.py tests/unit/server/sandbox/test_vercel_backend.py tests/unit/server/sandbox/test_modal_backend.py tests/unit/server/api/test_wasm_backend.py`
- `git diff --check`
- `uv run pytest tests/unit/server/sandbox/test_daytona_backend.py tests/unit/server/sandbox/test_vercel_backend.py tests/unit/server/sandbox/test_modal_backend.py tests/unit/server/api/test_wasm_backend.py -q -k "not is_session_gone and not execute_in_session_propagates_session_gone_exception"`

Full targeted pytest on Windows still hits existing Vercel SDK import failures because `vercel.sandbox.pty.shell` imports `termios`; the new timeout tests pass, and the excluded run above passed with 64 passed, 1 skipped, 5 deselected.

Fixes #13313
