### PR TITLE
fix(sandbox): enforce per-execute timeouts across backends

### DIFF
--- a/src/phoenix/server/sandbox/daytona_backend.py
+++ b/src/phoenix/server/sandbox/daytona_backend.py
@@ -263,7 +263,9 @@ class DaytonaSandboxBackend(SandboxBackend):
 
             sandbox: AsyncSandbox = handle  # type: ignore[assignment]
             result = await sandbox.process.code_run(
-                code, params=CodeRunParams(env=self._user_env or None)
+                code,
+                params=CodeRunParams(env=self._user_env or None),
+                timeout=timeout,
             )
             return _to_execution_result(result)
         except Exception as exc:
@@ -292,7 +294,9 @@ class DaytonaSandboxBackend(SandboxBackend):
             try:
                 await self._install_packages(workspace)
                 result = await workspace.process.code_run(
-                    code, params=CodeRunParams(env=self._user_env or None)
+                    code,
+                    params=CodeRunParams(env=self._user_env or None),
+                    timeout=timeout,
                 )
                 return _to_execution_result(result)
             finally:

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -223,6 +223,8 @@ class ModalSandboxBackend(SandboxBackend):
             return
 
     async def _exec_code(self, sandbox: Sandbox, code: str) -> ExecutionResult:
+        # No timeout= kwarg: ContainerProcess has no kill; cleanup is via
+        # outer wait_for + schedule_eviction -> sandbox.terminate.
         proc = await sandbox.exec.aio("python", "-c", code)
         stdout, stderr = await asyncio.gather(
             proc.stdout.read.aio(),

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import functools
 import logging
 from datetime import timedelta
@@ -246,7 +247,7 @@ class VercelSandboxBackend(SandboxBackend):
         sandbox: AsyncSandbox = handle  # type: ignore[assignment]
         try:
             session_env: Optional[dict[str, str]] = self._user_env or None
-            return await self._exec_code(sandbox, code, env=session_env)
+            return await self._exec_code(sandbox, code, env=session_env, timeout=timeout)
         except Exception as exc:
             if self.is_session_gone(exc):
                 raise
@@ -311,11 +312,31 @@ class VercelSandboxBackend(SandboxBackend):
         sandbox: AsyncSandbox,
         code: str,
         env: Optional[dict[str, str]] = None,
+        timeout: Optional[int] = None,
     ) -> ExecutionResult:
         lang_cfg = self._lang_cfg()
         cmd: str = lang_cfg["cmd"]
         args: list[str] = lang_cfg["args_prefix"] + [code]
-        result = await sandbox.run_command(cmd, args, env=env)
+
+        if timeout is None:
+            result = await sandbox.run_command(cmd, args, env=env)
+        else:
+            # run_command has no timeout kwarg; detached + finally-kill so
+            # cleanup runs on inner timeout AND outer cancellation.
+            command = await sandbox.run_command_detached(cmd, args, env=env)
+            completed = False
+            try:
+                try:
+                    result = await asyncio.wait_for(command.wait(), timeout=timeout)
+                    completed = True
+                except (TimeoutError, asyncio.TimeoutError):
+                    message = f"Execution timed out after {timeout}s"
+                    return ExecutionResult(stdout="", stderr=message, error=message)
+            finally:
+                if not completed:
+                    with contextlib.suppress(Exception):
+                        await command.kill()
+
         stdout, stderr = await asyncio.gather(result.stdout(), result.stderr())
         exit_code = result.exit_code
         error: Optional[str] = stderr if exit_code != 0 else None
@@ -338,7 +359,7 @@ class VercelSandboxBackend(SandboxBackend):
             sandbox = await self._create_sandbox()
             try:
                 await self._install_packages(sandbox)
-                return await self._exec_code(sandbox, code, env=session_env)
+                return await self._exec_code(sandbox, code, env=session_env, timeout=timeout)
             finally:
                 try:
                     await sandbox.stop()

--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -6,10 +6,13 @@ import asyncio
 import logging
 import os
 import tempfile
+import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Mapping, Optional
+from typing import TYPE_CHECKING, Iterator, Mapping, Optional
 
 if TYPE_CHECKING:
     import wasmtime
@@ -31,10 +34,74 @@ _WASM_BINARY_PATH_ENV = "PHOENIX_WASM_BINARY_PATH"
 _DEFAULT_TIMEOUT_SECONDS = 30
 _EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="wasm-sandbox")
 
+# 1s tick: store epoch deadline (a tick count) maps directly to seconds.
+_EPOCH_INTERVAL_SECONDS = 1.0
+
 
 # Engine and module must be paired: a module compiled with one engine cannot
 # be used with a store from a different engine.
 _MODULE_CACHE: dict[str, tuple[wasmtime.Engine, wasmtime.Module]] = {}
+
+_EPOCH_TICKERS: dict[int, "_EngineEpochTicker"] = {}
+_EPOCH_TICKERS_LOCK = threading.Lock()
+
+
+class _EngineEpochTicker:
+    """Drives ``engine.increment_epoch()`` so store epoch deadlines fire.
+
+    ``acquire``/``release`` mutate ``_ref_count`` under ``_EPOCH_TICKERS_LOCK``.
+    """
+
+    def __init__(self, engine: wasmtime.Engine) -> None:
+        self._engine = engine
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="wasm-sandbox-epoch",
+            daemon=True,
+        )
+        self._ref_count = 0
+
+    def acquire(self) -> None:
+        self._ref_count += 1
+        if not self._thread.is_alive():
+            self._thread.start()
+
+    def release(self) -> bool:
+        self._ref_count -= 1
+        return self._ref_count <= 0
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=_EPOCH_INTERVAL_SECONDS * 2)
+
+    def _run(self) -> None:
+        while not self._stop.wait(_EPOCH_INTERVAL_SECONDS):
+            try:
+                self._engine.increment_epoch()
+            except Exception:
+                logger.debug("Error incrementing WASM engine epoch", exc_info=True)
+
+
+@contextmanager
+def _engine_epoch_ticker(engine: wasmtime.Engine) -> Iterator[None]:
+    """Ref-counted lifetime guard for the per-engine epoch ticker."""
+    engine_key = id(engine)
+    with _EPOCH_TICKERS_LOCK:
+        ticker = _EPOCH_TICKERS.get(engine_key)
+        if ticker is None:
+            ticker = _EngineEpochTicker(engine)
+            _EPOCH_TICKERS[engine_key] = ticker
+        ticker.acquire()
+    try:
+        yield
+    finally:
+        with _EPOCH_TICKERS_LOCK:
+            stop_ticker = ticker.release()
+            if stop_ticker:
+                _EPOCH_TICKERS.pop(engine_key, None)
+        if stop_ticker:
+            ticker.stop()
 
 
 def _get_engine_and_module(binary_path: Path) -> tuple[wasmtime.Engine, wasmtime.Module]:
@@ -58,6 +125,7 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
     stdout_chunks: list[bytes] = []
     stderr_chunks: list[bytes] = []
     stdin_path: str | None = None
+    started_at = time.monotonic()
 
     try:
         engine, module = _get_engine_and_module(binary_path)
@@ -77,28 +145,30 @@ def _run_wasm(binary_path: Path, code: str, timeout: int) -> ExecutionResult:
 
         store = _wasm.Store(engine)
         store.set_wasi(wasi)
+        # Deadline in engine ticks; with a 1s tick this is `timeout` seconds.
         store.set_epoch_deadline(timeout)
 
-        instance = linker.instantiate(store, module)
-        exports = instance.exports(store)
-        start = exports.get("_start")
-        if isinstance(start, _wasm.Func):
-            start(store)
+        with _engine_epoch_ticker(engine):
+            instance = linker.instantiate(store, module)
+            exports = instance.exports(store)
+            start = exports.get("_start")
+            if isinstance(start, _wasm.Func):
+                start(store)
 
         return ExecutionResult(
             stdout=b"".join(stdout_chunks).decode("utf-8", errors="replace"),
             stderr=b"".join(stderr_chunks).decode("utf-8", errors="replace"),
         )
     except Exception as exc:
-        return ExecutionResult(
-            stdout=b"".join(stdout_chunks).decode("utf-8", errors="replace"),
-            stderr=b"".join(stderr_chunks).decode("utf-8", errors="replace"),
-            error=str(exc),
-        )
+        stdout = b"".join(stdout_chunks).decode("utf-8", errors="replace")
+        stderr = b"".join(stderr_chunks).decode("utf-8", errors="replace")
+        # Classify late traps as timeouts (raw wasmtime trap string is opaque).
+        if time.monotonic() - started_at >= timeout:
+            message = f"Execution timed out after {timeout}s"
+            return ExecutionResult(stdout=stdout, stderr=stderr, error=message)
+        return ExecutionResult(stdout=stdout, stderr=stderr, error=str(exc))
     finally:
         if stdin_path is not None:
-            import os
-
             try:
                 os.unlink(stdin_path)
             except OSError:

--- a/tests/unit/server/api/test_wasm_backend.py
+++ b/tests/unit/server/api/test_wasm_backend.py
@@ -329,6 +329,126 @@ class TestRunWasmStdoutCapture:
         assert stdin_path_holder[0].endswith(".py")
 
 
+class TestEpochTicker:
+    """The store's epoch deadline is inert unless the engine epoch is
+    actively incremented; the ref-counted ticker is what makes
+    ``set_epoch_deadline`` enforce the per-execute timeout. These tests
+    pin the contract so a future "simplification" can't silently regress
+    back to a wedged-thread bug.
+    """
+
+    def test_run_wasm_enters_and_exits_engine_ticker(self) -> None:
+        """``_run_wasm`` must wrap execution in ``_engine_epoch_ticker``."""
+        from contextlib import contextmanager
+
+        import wasmtime
+
+        ticker_events: list[tuple[str, object]] = []
+
+        @contextmanager
+        def _fake_ticker(engine: object) -> Any:
+            ticker_events.append(("enter", engine))
+            try:
+                yield
+            finally:
+                ticker_events.append(("exit", engine))
+
+        class _CapturingWasiConfig:
+            @property
+            def stdout_custom(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stdout_custom.setter
+            def stdout_custom(self, cb: object) -> None:
+                del cb
+
+            @property
+            def stderr_custom(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stderr_custom.setter
+            def stderr_custom(self, cb: object) -> None:
+                del cb
+
+            @property
+            def stdin_file(self) -> None:
+                raise AttributeError("unreadable attribute")
+
+            @stdin_file.setter
+            def stdin_file(self, path: object) -> None:
+                del path
+
+        class _StartFunc:
+            def __call__(self, store: object) -> None:
+                del store
+
+        engine = MagicMock(name="engine")
+        module = MagicMock(name="module")
+        fake_store = MagicMock()
+        mock_exports = MagicMock()
+        mock_exports.get.return_value = _StartFunc()
+        mock_instance = MagicMock()
+        mock_instance.exports.return_value = mock_exports
+
+        with patch(
+            "phoenix.server.sandbox.wasm_backend._get_engine_and_module",
+            return_value=(engine, module),
+        ):
+            with patch(
+                "phoenix.server.sandbox.wasm_backend._engine_epoch_ticker",
+                _fake_ticker,
+            ):
+                with patch("wasmtime.WasiConfig", _CapturingWasiConfig):
+                    with patch("wasmtime.Linker") as mock_linker_cls:
+                        mock_linker = MagicMock()
+                        mock_linker_cls.return_value = mock_linker
+                        mock_linker.instantiate.return_value = mock_instance
+                        with patch("wasmtime.Store", return_value=fake_store):
+                            with patch.object(wasmtime, "Func", _StartFunc):
+                                result = _run_wasm(Path("/fake/cpython.wasm"), "x=1", timeout=7)
+
+        assert result.error is None
+        fake_store.set_epoch_deadline.assert_called_once_with(7)
+        assert ticker_events == [("enter", engine), ("exit", engine)]
+
+    def test_run_wasm_classifies_late_trap_as_timeout(self) -> None:
+        """A wasmtime trap after >= timeout seconds reports as a timeout
+        message rather than the raw trap string."""
+        import wasmtime
+
+        elapsed = [0.0]
+
+        class _MonotonicStub:
+            def __call__(self) -> float:
+                return elapsed[0]
+
+        monotonic_stub = _MonotonicStub()
+
+        class _Linker:
+            def __init__(self, engine: object) -> None:
+                del engine
+
+            def define_wasi(self) -> None:
+                return None
+
+            def instantiate(self, store: object, module: object) -> object:
+                # Advance the clock past the timeout, then trap.
+                elapsed[0] = 10.0
+                raise RuntimeError("wasm trap: interrupt")
+
+        with patch(
+            "phoenix.server.sandbox.wasm_backend._get_engine_and_module",
+            return_value=(MagicMock(), MagicMock()),
+        ):
+            with patch("phoenix.server.sandbox.wasm_backend.time.monotonic", monotonic_stub):
+                with patch.object(wasmtime, "WasiConfig", return_value=MagicMock()):
+                    with patch.object(wasmtime, "Store", return_value=MagicMock()):
+                        with patch.object(wasmtime, "Linker", _Linker):
+                            result = _run_wasm(Path("/fake.wasm"), "x=1", timeout=5)
+
+        assert result.error == "Execution timed out after 5s"
+
+
 class TestTempFileCleanup:
     def test_stdin_temp_file_is_deleted_after_run(self, tmp_path: Path) -> None:
         import wasmtime

--- a/tests/unit/server/sandbox/test_daytona_backend.py
+++ b/tests/unit/server/sandbox/test_daytona_backend.py
@@ -145,6 +145,78 @@ class TestCodeRunParamsKwarg:
         )
 
 
+class TestPerExecuteTimeout:
+    """Per-execute timeout is plumbed through to Daytona's ``code_run``.
+
+    Regression guard: the SDK accepts ``timeout`` as a top-level kwarg on
+    ``process.code_run``, NOT as a ``CodeRunParams`` field. Passing it via
+    ``CodeRunParams(timeout=...)`` would silently drop the value (and raise
+    TypeError against a real strict-dataclass ``CodeRunParams``).
+    """
+
+    @pytest.mark.asyncio
+    async def test_ephemeral_execute_passes_timeout_to_code_run_kwarg(self) -> None:
+        daytona_mod, process_mod = _make_daytona_mocks()
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            backend = DaytonaSandboxBackend(api_key=_API_KEY, user_env={}, language="PYTHON")
+            await backend.execute("1+1", session_key="s1", timeout=7)
+
+        workspace = daytona_mod.AsyncDaytona.return_value.create.return_value
+        call_args = workspace.process.code_run.call_args
+        assert call_args.kwargs.get("timeout") == 7, (
+            f"code_run kwargs should include timeout=7 as top-level kwarg; got: {call_args.kwargs}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_session_execute_passes_timeout_to_code_run_kwarg(self) -> None:
+        daytona_mod, process_mod = _make_daytona_mocks()
+
+        modules = {
+            "daytona_sdk": daytona_mod,
+            "daytona_sdk.common": MagicMock(),
+            "daytona_sdk.common.process": process_mod,
+        }
+        with patch.dict(sys.modules, modules):
+            from phoenix.server.sandbox.daytona_backend import DaytonaSandboxBackend
+
+            sandbox = MagicMock()
+            sandbox.process.code_run = AsyncMock(return_value=MagicMock(result="ok", exit_code=0))
+            backend = DaytonaSandboxBackend(api_key=_API_KEY, user_env={}, language="PYTHON")
+            await backend.execute_in_session(sandbox, "1+1", timeout=11)
+
+        call_args = sandbox.process.code_run.call_args
+        assert call_args.kwargs.get("timeout") == 11, (
+            f"execute_in_session should forward timeout=11 to code_run; got: {call_args.kwargs}"
+        )
+
+
+def test_code_run_accepts_top_level_timeout_kwarg() -> None:
+    """SDK shape guard: ``code_run(..., timeout=N)`` is the supported surface.
+
+    Catches the failure mode in PR #13321 — passing ``timeout`` via
+    ``CodeRunParams(timeout=...)`` raises TypeError against the real
+    strict-dataclass ``CodeRunParams``.
+    """
+    import inspect
+
+    pytest.importorskip("daytona_sdk")
+    from daytona_sdk._async.process import AsyncProcess
+
+    sig = inspect.signature(AsyncProcess.code_run)
+    assert "timeout" in sig.parameters, (
+        "daytona_sdk's AsyncProcess.code_run no longer accepts a top-level "
+        f"`timeout` kwarg; got params: {list(sig.parameters)}"
+    )
+
+
 class TestNetworkBlockAll:
     @pytest.mark.asyncio
     async def test_deny_mode_passes_network_block_all_true(self) -> None:

--- a/tests/unit/server/sandbox/test_modal_backend.py
+++ b/tests/unit/server/sandbox/test_modal_backend.py
@@ -349,6 +349,42 @@ async def test_execute_in_session_wraps_non_session_gone_exception() -> None:
     assert result.stderr == "user oops"
 
 
+@pytest.mark.asyncio
+async def test_exec_code_does_not_pass_timeout_to_sdk_exec() -> None:
+    """``sandbox.exec(timeout=N)`` is client-side polling only — there is
+    no per-process kill RPC (``ContainerProcess`` has no ``terminate``).
+    A timeout kwarg here would suppress the outer ``asyncio.wait_for``
+    without delivering server-side cleanup, growing the leaked-subprocess
+    window from "immediate eviction" to "idle-TTL eviction" (~300s).
+
+    Cleanup is intentionally routed through the outer wait_for +
+    ``schedule_eviction`` -> ``close_session`` -> ``sandbox.terminate``.
+    This test pins that decision so a future contributor can't quietly
+    re-add the kwarg.
+    """
+    modal_mock = _make_modal_mock()
+    with patch.dict(sys.modules, {"modal": modal_mock}):
+        from phoenix.server.sandbox.modal_backend import ModalSandboxBackend
+
+        backend = ModalSandboxBackend(token_id=_TOKEN_ID, token_secret=_TOKEN_SECRET)
+        sandbox = MagicMock()
+        proc = MagicMock()
+        proc.stdout.read.aio = AsyncMock(return_value="")
+        proc.stderr.read.aio = AsyncMock(return_value="")
+        proc.wait.aio = AsyncMock(return_value=0)
+        sandbox.exec.aio = AsyncMock(return_value=proc)
+
+        await backend._exec_code(sandbox, "noop")
+
+    call_args = sandbox.exec.aio.call_args
+    assert "timeout" not in call_args.kwargs, (
+        "Modal exec must NOT receive a timeout kwarg from Phoenix — "
+        "ContainerProcess has no per-process kill, so a timeout here is "
+        "a no-op for cleanup and suppresses the outer wait_for path. "
+        f"Got kwargs: {call_args.kwargs}"
+    )
+
+
 def test_adapter_build_backend_wires_packages_to_image() -> None:
     from phoenix.server.sandbox.types import ModalConfig, ModalCredentials, ModalDeployment
 

--- a/tests/unit/server/sandbox/test_vercel_backend.py
+++ b/tests/unit/server/sandbox/test_vercel_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import sys
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -423,6 +424,96 @@ async def test_execute_strips_ansi_in_raised_exception_path(
 
     assert result.error == "provider error"
     assert result.stderr == "provider error"
+
+
+# ---------------------------------------------------------------------------
+# Per-execute timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exec_code_with_timeout_uses_detached_command() -> None:
+    """Happy path: with a timeout, ``_exec_code`` uses
+    ``run_command_detached`` (the only Vercel primitive that supports
+    bounded waits) and returns the command's output on completion."""
+    command_result = MagicMock()
+    command_result.exit_code = 0
+    command_result.stdout = AsyncMock(return_value="done\n")
+    command_result.stderr = AsyncMock(return_value="")
+
+    command = MagicMock()
+    command.wait = AsyncMock(return_value=command_result)
+    command.kill = AsyncMock()
+
+    sandbox = MagicMock()
+    sandbox.run_command_detached = AsyncMock(return_value=command)
+
+    backend = VercelSandboxBackend(
+        token=_TOKEN, project_id=_PROJECT, team_id=_TEAM, language="PYTHON"
+    )
+    result = await backend._exec_code(sandbox, "print('done')", env=None, timeout=5)
+
+    sandbox.run_command_detached.assert_awaited_once()
+    command.kill.assert_not_awaited()
+    assert result.stdout == "done\n"
+    assert result.error is None
+
+
+@pytest.mark.asyncio
+async def test_exec_code_kills_detached_command_on_outer_cancellation() -> None:
+    """Regression guard for PR #13378's missed cancellation: when the
+    outer ``asyncio.wait_for`` cancels this coroutine, the inner
+    ``command.wait()`` raises ``CancelledError`` — which is NOT
+    ``TimeoutError``. ``command.kill()`` must still run via the
+    ``finally``-with-sentinel pattern, otherwise the detached subprocess
+    survives until the whole sandbox is stopped.
+    """
+
+    async def _hang() -> Any:
+        await asyncio.sleep(10)
+
+    command = MagicMock()
+    command.wait = AsyncMock(side_effect=_hang)
+    command.kill = AsyncMock()
+
+    sandbox = MagicMock()
+    sandbox.run_command_detached = AsyncMock(return_value=command)
+
+    backend = VercelSandboxBackend(
+        token=_TOKEN, project_id=_PROJECT, team_id=_TEAM, language="PYTHON"
+    )
+
+    async def _drive() -> Any:
+        return await backend._exec_code(sandbox, "while True: pass", env=None, timeout=100)
+
+    task = asyncio.create_task(_drive())
+    await asyncio.sleep(0.05)  # let the task enter ``command.wait()``
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    command.kill.assert_awaited_once()
+
+
+def test_run_command_has_no_timeout_kwarg() -> None:
+    """SDK shape guard: bounding a Vercel command requires
+    ``run_command_detached`` + explicit ``kill``. If the SDK ever adds
+    ``timeout`` directly to ``run_command`` we should simplify.
+
+    Catches the failure mode in PR #13321 — ``run_command(..., timeout=...)``
+    raises TypeError because the real SDK accepts only ``cwd``, ``env``,
+    ``sudo``.
+    """
+    import inspect
+
+    pytest.importorskip("vercel")
+    from vercel.sandbox.sandbox import AsyncSandbox
+
+    sig = inspect.signature(AsyncSandbox.run_command)
+    assert "timeout" not in sig.parameters, (
+        f"Vercel SDK now accepts ``timeout`` on ``run_command`` ({list(sig.parameters)}). "
+        "Consider simplifying the backend to use it directly instead of detached + kill."
+    )
 
 
 @pytest.mark.parametrize("language", _LANGUAGES)


### PR DESCRIPTION
resolves #13313

Implements per-execute timeouts for each sandbox provider. Uses work from both #13321 and #13378.