### PR TITLE
chore: release arize-phoenix-client 2.8.0

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__init__.py
@@ -5,6 +5,6 @@ from .client import AsyncClient, Client
 __version__ = version("arize-phoenix-client")
 
 __all__ = [
-    "Client",
     "AsyncClient",
+    "Client",
 ]


### PR DESCRIPTION
Force release-please to propose `arize-phoenix-client` **2.8.0** on its next run (current manifest version: `2.7.0`).

The path-touching edit sorts `__all__` in the client package `__init__.py` alphabetically to match the import statement ordering.

Release-As: 2.8.0