### PR TITLE
fix: remove unused PHOENIX_SANDBOX_PROVIDER

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -779,12 +779,6 @@ ENV_PHOENIX_DEFAULT_RETENTION_POLICY_DAYS = "PHOENIX_DEFAULT_RETENTION_POLICY_DA
 The default retention policy for traces in days.
 """
 
-ENV_PHOENIX_SANDBOX_PROVIDER = "PHOENIX_SANDBOX_PROVIDER"
-"""
-The default sandbox backend type to use for code evaluator execution.
-Accepted values: WASM, E2B, DAYTONA, VERCEL, DENO, MODAL.
-When not set, the WASM (local WebAssembly) backend is used.
-"""
 ENV_PHOENIX_ALLOWED_SANDBOX_PROVIDERS = "PHOENIX_ALLOWED_SANDBOX_PROVIDERS"
 """
 A comma-separated list of sandbox providers to allow.


### PR DESCRIPTION
## Summary

`ENV_PHOENIX_SANDBOX_PROVIDER` was defined in `src/phoenix/config.py` but never referenced anywhere — not in Python code, not in docs. This removes the dead constant and its docstring.

The sibling constant `ENV_PHOENIX_ALLOWED_SANDBOX_PROVIDERS` is actually wired up and is left untouched.

## Verification

- `grep -rn "PHOENIX_SANDBOX_PROVIDER"` across the repo returns only the definition line being removed.
- Docs (`docs/`) reference only `PHOENIX_ALLOWED_SANDBOX_PROVIDERS`, so no docs changes were needed.