### PR TITLE
feat(agents): make agent FAB movable

### DIFF
--- a/app/src/components/agent/AgentChatWidget.tsx
+++ b/app/src/components/agent/AgentChatWidget.tsx
@@ -1,11 +1,17 @@
 import { css, keyframes } from "@emotion/react";
 import { AnimatePresence, motion } from "motion/react";
+import type { RefObject } from "react";
 import { createPortal } from "react-dom";
 
 import { useTheme } from "@phoenix/contexts";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { useHasOpenModal } from "@phoenix/hooks/useHasOpenModal";
 
+import { AgentFabPositioner } from "./AgentFabPositioner";
+import {
+  AGENT_FAB_RESTING_SIZE,
+  AGENT_FAB_STREAMING_SIZE,
+} from "./agentFabPositioning";
 import { PxiGlyph, type PxiGlyphAnimation } from "./PxiGlyph";
 import { useAssistantAgentEnabled } from "./useAssistantAgentEnabled";
 
@@ -85,6 +91,11 @@ const floatingButtonCSS = css`
 
 const inlineButtonCSS = css`
   position: relative;
+`;
+
+const draggableButtonCSS = css`
+  cursor: inherit;
+  touch-action: none;
 `;
 
 const darkThemeGlyphThemeCSS = css`
@@ -307,6 +318,7 @@ export interface AgentChatWidgetButtonProps {
   onClick?: () => void;
   ariaLabel?: string;
   isFloating?: boolean;
+  isDragHandle?: boolean;
   glyphAnimation?: PxiGlyphAnimation;
 }
 
@@ -315,6 +327,7 @@ export function AgentChatWidgetButton({
   onClick,
   ariaLabel = "Open agent chat",
   isFloating = false,
+  isDragHandle = false,
   glyphAnimation = "wave-reveal",
 }: AgentChatWidgetButtonProps) {
   const { theme } = useTheme();
@@ -323,8 +336,16 @@ export function AgentChatWidgetButton({
       type="button"
       css={
         isFloating
-          ? [buttonCSS, floatingButtonCSS]
-          : [buttonCSS, inlineButtonCSS]
+          ? [
+              buttonCSS,
+              floatingButtonCSS,
+              isDragHandle ? draggableButtonCSS : undefined,
+            ]
+          : [
+              buttonCSS,
+              inlineButtonCSS,
+              isDragHandle ? draggableButtonCSS : undefined,
+            ]
       }
       onClick={onClick}
       aria-label={ariaLabel}
@@ -396,10 +417,16 @@ export function AgentChatWidgetButton({
   );
 }
 
-export function AgentChatWidget() {
+export type AgentChatWidgetProps = {
+  boundaryRef?: RefObject<HTMLElement | null>;
+};
+
+export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
   const isAssistantAgentEnabled = useAssistantAgentEnabled();
   const isOpen = useAgentContext((state) => state.isOpen);
   const toggleOpen = useAgentContext((state) => state.toggleOpen);
+  const fabPlacement = useAgentContext((state) => state.fabPlacement);
+  const setFabPlacement = useAgentContext((state) => state.setFabPlacement);
   const activeSessionId = useAgentContext((state) => state.activeSessionId);
   const hasOpenModal = useHasOpenModal();
   const isStreaming = useAgentContext((state) =>
@@ -415,11 +442,19 @@ export function AgentChatWidget() {
   }
 
   return createPortal(
-    <AgentChatWidgetButton
-      isStreaming={isStreaming}
-      onClick={toggleOpen}
-      isFloating
-    />,
+    <AgentFabPositioner
+      boundaryRef={boundaryRef}
+      placement={fabPlacement}
+      size={isStreaming ? AGENT_FAB_STREAMING_SIZE : AGENT_FAB_RESTING_SIZE}
+      onPlacementChange={setFabPlacement}
+    >
+      <AgentChatWidgetButton
+        ariaLabel="Open PXI chat"
+        isDragHandle
+        isStreaming={isStreaming}
+        onClick={toggleOpen}
+      />
+    </AgentFabPositioner>,
     document.body
   );
 }

--- a/app/src/components/agent/AgentChatWidget.tsx
+++ b/app/src/components/agent/AgentChatWidget.tsx
@@ -8,10 +8,7 @@ import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { useHasOpenModal } from "@phoenix/hooks/useHasOpenModal";
 
 import { AgentFabPositioner } from "./AgentFabPositioner";
-import {
-  FAB_RESTING_SIZE,
-  FAB_STREAMING_SIZE,
-} from "./agentFabPositioning";
+import { FAB_RESTING_SIZE, FAB_STREAMING_SIZE } from "./agentFabPositioning";
 import { PxiGlyph, type PxiGlyphAnimation } from "./PxiGlyph";
 import { useAssistantAgentEnabled } from "./useAssistantAgentEnabled";
 

--- a/app/src/components/agent/AgentChatWidget.tsx
+++ b/app/src/components/agent/AgentChatWidget.tsx
@@ -9,8 +9,8 @@ import { useHasOpenModal } from "@phoenix/hooks/useHasOpenModal";
 
 import { AgentFabPositioner } from "./AgentFabPositioner";
 import {
-  AGENT_FAB_RESTING_SIZE,
-  AGENT_FAB_STREAMING_SIZE,
+  FAB_RESTING_SIZE,
+  FAB_STREAMING_SIZE,
 } from "./agentFabPositioning";
 import { PxiGlyph, type PxiGlyphAnimation } from "./PxiGlyph";
 import { useAssistantAgentEnabled } from "./useAssistantAgentEnabled";
@@ -82,17 +82,13 @@ const buttonCSS = css`
   justify-content: flex-end;
 `;
 
-const floatingButtonCSS = css`
-  position: fixed;
-  bottom: 24px;
-  right: 36px;
-  z-index: 1000;
-`;
-
 const inlineButtonCSS = css`
   position: relative;
 `;
 
+// Applied when the button is used as a drag handle inside the FAB positioner.
+// The positioner owns the cursor (pointer / grabbing) and consumes touch
+// gestures itself, so the button only needs to opt out of both.
 const draggableButtonCSS = css`
   cursor: inherit;
   touch-action: none;
@@ -317,7 +313,6 @@ export interface AgentChatWidgetButtonProps {
   isStreaming?: boolean;
   onClick?: () => void;
   ariaLabel?: string;
-  isFloating?: boolean;
   isDragHandle?: boolean;
   glyphAnimation?: PxiGlyphAnimation;
 }
@@ -326,7 +321,6 @@ export function AgentChatWidgetButton({
   isStreaming = false,
   onClick,
   ariaLabel = "Open agent chat",
-  isFloating = false,
   isDragHandle = false,
   glyphAnimation = "wave-reveal",
 }: AgentChatWidgetButtonProps) {
@@ -334,19 +328,11 @@ export function AgentChatWidgetButton({
   return (
     <button
       type="button"
-      css={
-        isFloating
-          ? [
-              buttonCSS,
-              floatingButtonCSS,
-              isDragHandle ? draggableButtonCSS : undefined,
-            ]
-          : [
-              buttonCSS,
-              inlineButtonCSS,
-              isDragHandle ? draggableButtonCSS : undefined,
-            ]
-      }
+      css={[
+        buttonCSS,
+        inlineButtonCSS,
+        isDragHandle ? draggableButtonCSS : undefined,
+      ]}
       onClick={onClick}
       aria-label={ariaLabel}
     >
@@ -445,11 +431,10 @@ export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
     <AgentFabPositioner
       boundaryRef={boundaryRef}
       placement={fabPlacement}
-      size={isStreaming ? AGENT_FAB_STREAMING_SIZE : AGENT_FAB_RESTING_SIZE}
+      size={isStreaming ? FAB_STREAMING_SIZE : FAB_RESTING_SIZE}
       onPlacementChange={setFabPlacement}
     >
       <AgentChatWidgetButton
-        ariaLabel="Open PXI chat"
         isDragHandle
         isStreaming={isStreaming}
         onClick={toggleOpen}

--- a/app/src/components/agent/AgentFabPositioner.tsx
+++ b/app/src/components/agent/AgentFabPositioner.tsx
@@ -1,0 +1,485 @@
+import { css } from "@emotion/react";
+import type {
+  MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
+  ReactNode,
+  RefObject,
+  TransitionEvent as ReactTransitionEvent,
+} from "react";
+import { useLayoutEffect, useRef, useState } from "react";
+
+import type { AgentFabPlacement } from "@phoenix/store/agentStore";
+
+import {
+  AGENT_FAB_INSET,
+  AGENT_FAB_RESTING_SIZE,
+  clampAgentFabPosition,
+  getAgentFabPinnedPosition,
+  getNearestAgentFabPlacement,
+  type AgentFabBounds,
+  type AgentFabPoint,
+  type AgentFabSize,
+} from "./agentFabPositioning";
+
+const DRAG_START_THRESHOLD_PX = 4;
+const SNAP_TRANSITION = "transform 180ms cubic-bezier(0.2, 0.9, 0.2, 1)";
+
+const positionerCSS = css`
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  cursor: pointer;
+  touch-action: none;
+  transform: translate3d(0, 0, 0);
+  visibility: hidden;
+  will-change: transform;
+
+  &[data-ready="true"] {
+    visibility: visible;
+  }
+
+  &[data-dragging="true"],
+  &[data-dragging="true"] * {
+    cursor: grabbing;
+  }
+`;
+
+type DragSession = {
+  bounds: AgentFabBounds;
+  hasPointerCapture: boolean;
+  offset: AgentFabPoint;
+  pointerId: number;
+  size: AgentFabSize;
+  startPointer: AgentFabPoint;
+};
+
+export type AgentFabPositionerProps = {
+  boundaryRef?: RefObject<HTMLElement | null>;
+  children: ReactNode;
+  placement: AgentFabPlacement;
+  size?: AgentFabSize;
+  onPlacementChange: (placement: AgentFabPlacement) => void;
+};
+
+function getViewportBounds(): AgentFabBounds {
+  const visualViewport = window.visualViewport;
+  if (visualViewport) {
+    return {
+      left: visualViewport.offsetLeft,
+      top: visualViewport.offsetTop,
+      width: visualViewport.width,
+      height: visualViewport.height,
+    };
+  }
+
+  return {
+    left: 0,
+    top: 0,
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+}
+
+function getRectBounds(rect: DOMRect): AgentFabBounds {
+  return {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function requestFrame(callback: FrameRequestCallback): number {
+  if (typeof window.requestAnimationFrame === "function") {
+    return window.requestAnimationFrame(callback);
+  }
+  return window.setTimeout(() => callback(performance.now()), 16);
+}
+
+function cancelFrame(frameId: number) {
+  if (typeof window.cancelAnimationFrame === "function") {
+    window.cancelAnimationFrame(frameId);
+    return;
+  }
+  window.clearTimeout(frameId);
+}
+
+function getBoundaryBounds(boundary: HTMLElement | null | undefined) {
+  if (boundary) {
+    const rect = boundary.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      return getRectBounds(rect);
+    }
+  }
+  return null;
+}
+
+function getPositioningBounds({
+  boundary,
+  requiresBoundary,
+}: {
+  boundary: HTMLElement | null | undefined;
+  requiresBoundary: boolean;
+}) {
+  return (
+    getBoundaryBounds(boundary) ??
+    (requiresBoundary ? null : getViewportBounds())
+  );
+}
+
+function getElementSize({
+  element,
+  size,
+}: {
+  element: HTMLElement | null;
+  size?: AgentFabSize;
+}): AgentFabSize {
+  if (size) {
+    return size;
+  }
+
+  const rect = element?.getBoundingClientRect();
+  if (rect && rect.width > 0 && rect.height > 0) {
+    return {
+      width: rect.width,
+      height: rect.height,
+    };
+  }
+
+  return AGENT_FAB_RESTING_SIZE;
+}
+
+function applyElementPosition({
+  element,
+  point,
+}: {
+  element: HTMLElement | null;
+  point: AgentFabPoint;
+}) {
+  if (!element) return;
+  element.style.transform = `translate3d(${point.x}px, ${point.y}px, 0)`;
+  element.dataset.ready = "true";
+}
+
+function applyElementPinnedPosition({
+  boundary,
+  element,
+  placement,
+  requiresBoundary,
+  size,
+}: {
+  boundary: HTMLElement | null | undefined;
+  element: HTMLElement | null;
+  placement: AgentFabPlacement;
+  requiresBoundary: boolean;
+  size?: AgentFabSize;
+}): boolean {
+  const bounds = getPositioningBounds({ boundary, requiresBoundary });
+  if (!bounds) {
+    delete element?.dataset.ready;
+    return false;
+  }
+
+  applyElementPosition({
+    element,
+    point: getAgentFabPinnedPosition({
+      placement,
+      bounds,
+      size: getElementSize({ element, size }),
+      inset: AGENT_FAB_INSET,
+    }),
+  });
+  return true;
+}
+
+export function AgentFabPositioner({
+  boundaryRef,
+  children,
+  placement,
+  size,
+  onPlacementChange,
+}: AgentFabPositionerProps) {
+  const positionerRef = useRef<HTMLDivElement>(null);
+  const dragSessionRef = useRef<DragSession | null>(null);
+  const frameIdRef = useRef<number | null>(null);
+  const pendingPointerRef = useRef<AgentFabPoint | null>(null);
+  const latestDragPositionRef = useRef<AgentFabPoint | null>(null);
+  const hasDraggedRef = useRef(false);
+  const suppressClickRef = useRef(false);
+  const suppressClickResetIdRef = useRef<number | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const requiresBoundary = Boolean(boundaryRef);
+
+  const scheduleSuppressClickReset = () => {
+    if (suppressClickResetIdRef.current != null) {
+      window.clearTimeout(suppressClickResetIdRef.current);
+    }
+    suppressClickResetIdRef.current = window.setTimeout(() => {
+      suppressClickRef.current = false;
+      suppressClickResetIdRef.current = null;
+    }, 0);
+  };
+
+  const getBounds = (): AgentFabBounds => {
+    return (
+      getPositioningBounds({
+        boundary: boundaryRef?.current,
+        requiresBoundary,
+      }) ?? getViewportBounds()
+    );
+  };
+
+  const getSize = (): AgentFabSize => {
+    return getElementSize({ element: positionerRef.current, size });
+  };
+
+  const applyPosition = (point: AgentFabPoint) => {
+    applyElementPosition({ element: positionerRef.current, point });
+  };
+
+  const getDragPosition = ({
+    pointer,
+    session,
+  }: {
+    pointer: AgentFabPoint;
+    session: DragSession;
+  }): AgentFabPoint =>
+    clampAgentFabPosition({
+      point: {
+        x: pointer.x - session.offset.x,
+        y: pointer.y - session.offset.y,
+      },
+      bounds: session.bounds,
+      size: session.size,
+      inset: AGENT_FAB_INSET,
+    });
+
+  const flushPendingDragPosition = () => {
+    frameIdRef.current = null;
+    const session = dragSessionRef.current;
+    const pointer = pendingPointerRef.current;
+    if (!session || !pointer) return;
+    pendingPointerRef.current = null;
+    const nextPosition = getDragPosition({ pointer, session });
+    latestDragPositionRef.current = nextPosition;
+    applyPosition(nextPosition);
+  };
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+
+    const positioner = positionerRef.current;
+    if (!positioner) return;
+
+    const rect = positioner.getBoundingClientRect();
+    const nextSize =
+      rect.width > 0 && rect.height > 0
+        ? { width: rect.width, height: rect.height }
+        : getSize();
+    const pointer = { x: event.clientX, y: event.clientY };
+
+    dragSessionRef.current = {
+      bounds: getBounds(),
+      hasPointerCapture: false,
+      offset: {
+        x: pointer.x - rect.left,
+        y: pointer.y - rect.top,
+      },
+      pointerId: event.pointerId,
+      size: nextSize,
+      startPointer: pointer,
+    };
+    latestDragPositionRef.current = null;
+    pendingPointerRef.current = null;
+    hasDraggedRef.current = false;
+  };
+
+  const handlePointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const session = dragSessionRef.current;
+    if (!session) return;
+
+    const pointer = { x: event.clientX, y: event.clientY };
+    const distance =
+      (pointer.x - session.startPointer.x) ** 2 +
+      (pointer.y - session.startPointer.y) ** 2;
+
+    if (!hasDraggedRef.current) {
+      if (distance < DRAG_START_THRESHOLD_PX ** 2) {
+        return;
+      }
+      hasDraggedRef.current = true;
+      session.hasPointerCapture = true;
+      event.currentTarget.setPointerCapture(session.pointerId);
+      positionerRef.current?.style.setProperty("transition", "none");
+      setIsDragging(true);
+    }
+
+    event.preventDefault();
+    pendingPointerRef.current = pointer;
+
+    if (frameIdRef.current == null) {
+      frameIdRef.current = requestFrame(flushPendingDragPosition);
+    }
+  };
+
+  const finishDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const session = dragSessionRef.current;
+    if (!session) return;
+
+    if (frameIdRef.current != null) {
+      cancelFrame(frameIdRef.current);
+      frameIdRef.current = null;
+    }
+
+    if (pendingPointerRef.current) {
+      const nextPosition = getDragPosition({
+        pointer: pendingPointerRef.current,
+        session,
+      });
+      pendingPointerRef.current = null;
+      latestDragPositionRef.current = nextPosition;
+      applyPosition(nextPosition);
+    }
+
+    dragSessionRef.current = null;
+    setIsDragging(false);
+
+    if (
+      session.hasPointerCapture &&
+      event.currentTarget.hasPointerCapture(session.pointerId)
+    ) {
+      event.currentTarget.releasePointerCapture(session.pointerId);
+    }
+
+    if (!hasDraggedRef.current) {
+      positionerRef.current?.style.removeProperty("transition");
+      return;
+    }
+
+    suppressClickRef.current = true;
+    scheduleSuppressClickReset();
+    const droppedPosition =
+      latestDragPositionRef.current ??
+      getAgentFabPinnedPosition({
+        placement,
+        bounds: session.bounds,
+        size: session.size,
+        inset: AGENT_FAB_INSET,
+      });
+    const nextPlacement = getNearestAgentFabPlacement({
+      point: droppedPosition,
+      bounds: session.bounds,
+      size: session.size,
+      inset: AGENT_FAB_INSET,
+    });
+
+    if (positionerRef.current) {
+      positionerRef.current.style.transition = SNAP_TRANSITION;
+    }
+
+    applyPosition(
+      getAgentFabPinnedPosition({
+        placement: nextPlacement,
+        bounds: session.bounds,
+        size: session.size,
+        inset: AGENT_FAB_INSET,
+      })
+    );
+
+    if (nextPlacement !== placement) {
+      onPlacementChange(nextPlacement);
+    }
+  };
+
+  const handleClickCapture = (event: ReactMouseEvent<HTMLDivElement>) => {
+    if (!suppressClickRef.current) return;
+    suppressClickRef.current = false;
+    if (suppressClickResetIdRef.current != null) {
+      window.clearTimeout(suppressClickResetIdRef.current);
+      suppressClickResetIdRef.current = null;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const handleTransitionEnd = (event: ReactTransitionEvent<HTMLDivElement>) => {
+    if (event.propertyName === "transform" && !dragSessionRef.current) {
+      event.currentTarget.style.removeProperty("transition");
+    }
+  };
+
+  useLayoutEffect(() => {
+    if (!dragSessionRef.current) {
+      applyElementPinnedPosition({
+        boundary: boundaryRef?.current,
+        element: positionerRef.current,
+        placement,
+        requiresBoundary,
+        size,
+      });
+    }
+  }, [boundaryRef, placement, requiresBoundary, size]);
+
+  useLayoutEffect(() => {
+    const syncPinnedPosition = () => {
+      if (!dragSessionRef.current) {
+        applyElementPinnedPosition({
+          boundary: boundaryRef?.current,
+          element: positionerRef.current,
+          placement,
+          requiresBoundary,
+          size,
+        });
+      }
+    };
+    const boundary = boundaryRef?.current;
+    const observer =
+      boundary && typeof ResizeObserver === "function"
+        ? new ResizeObserver(syncPinnedPosition)
+        : null;
+
+    if (boundary && observer) {
+      observer.observe(boundary);
+    }
+    const syncFrameId = requestFrame(syncPinnedPosition);
+    window.addEventListener("resize", syncPinnedPosition);
+    window.visualViewport?.addEventListener("resize", syncPinnedPosition);
+    window.visualViewport?.addEventListener("scroll", syncPinnedPosition);
+
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", syncPinnedPosition);
+      window.visualViewport?.removeEventListener("resize", syncPinnedPosition);
+      window.visualViewport?.removeEventListener("scroll", syncPinnedPosition);
+      cancelFrame(syncFrameId);
+
+      if (frameIdRef.current != null) {
+        cancelFrame(frameIdRef.current);
+        frameIdRef.current = null;
+      }
+      if (suppressClickResetIdRef.current != null) {
+        window.clearTimeout(suppressClickResetIdRef.current);
+        suppressClickResetIdRef.current = null;
+      }
+    };
+  }, [boundaryRef, placement, requiresBoundary, size]);
+
+  return (
+    <div
+      className="agent-chat-widget-positioner"
+      css={positionerCSS}
+      data-dragging={isDragging ? "true" : undefined}
+      data-placement={placement}
+      ref={positionerRef}
+      onClickCapture={handleClickCapture}
+      onPointerCancel={finishDrag}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={finishDrag}
+      onTransitionEnd={handleTransitionEnd}
+    >
+      {children}
+    </div>
+  );
+}

--- a/app/src/components/agent/AgentFabPositioner.tsx
+++ b/app/src/components/agent/AgentFabPositioner.tsx
@@ -7,28 +7,41 @@ import type {
   TransitionEvent as ReactTransitionEvent,
 } from "react";
 import { useLayoutEffect, useRef, useState } from "react";
+import invariant from "tiny-invariant";
 
 import type { AgentFabPlacement } from "@phoenix/store/agentStore";
+import type { Bounds, Point, Size } from "@phoenix/types/geometry";
 
 import {
-  AGENT_FAB_INSET,
-  AGENT_FAB_RESTING_SIZE,
-  clampAgentFabPosition,
-  getAgentFabPinnedPosition,
-  getNearestAgentFabPlacement,
-  type AgentFabBounds,
-  type AgentFabPoint,
-  type AgentFabSize,
+  clampFabPosition,
+  FAB_RESTING_SIZE,
+  getFabPinnedPosition,
+  getNearestFabPlacement,
 } from "./agentFabPositioning";
 
+// Number of pixels the pointer must travel after pointerdown before we treat
+// the gesture as a drag instead of a click. Compared as squared distance to
+// avoid the square root in the hot path.
 const DRAG_START_THRESHOLD_PX = 4;
-const SNAP_TRANSITION = "transform 180ms cubic-bezier(0.2, 0.9, 0.2, 1)";
+
+// Easing curve and duration for the snap-to-corner animation after a drop.
+const SNAP_DURATION_MS = 180;
+const SNAP_EASING = "cubic-bezier(0.2, 0.9, 0.2, 1)";
+const SNAP_TRANSITION = `transform ${SNAP_DURATION_MS}ms ${SNAP_EASING}`;
+
+// MouseEvent / PointerEvent `button` value for the primary (typically left)
+// button. The FAB only responds to primary-button gestures.
+const PRIMARY_POINTER_BUTTON = 0;
+
+// Sits above app chrome but below modal overlays. Matches the value the
+// floating button used in its previous fixed-position incarnation.
+const FAB_Z_INDEX = 1000;
 
 const positionerCSS = css`
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 1000;
+  z-index: ${FAB_Z_INDEX};
   cursor: pointer;
   touch-action: none;
   transform: translate3d(0, 0, 0);
@@ -46,23 +59,23 @@ const positionerCSS = css`
 `;
 
 type DragSession = {
-  bounds: AgentFabBounds;
+  bounds: Bounds;
   hasPointerCapture: boolean;
-  offset: AgentFabPoint;
+  offset: Point;
   pointerId: number;
-  size: AgentFabSize;
-  startPointer: AgentFabPoint;
+  size: Size;
+  startPointer: Point;
 };
 
 export type AgentFabPositionerProps = {
   boundaryRef?: RefObject<HTMLElement | null>;
   children: ReactNode;
   placement: AgentFabPlacement;
-  size?: AgentFabSize;
+  size?: Size;
   onPlacementChange: (placement: AgentFabPlacement) => void;
 };
 
-function getViewportBounds(): AgentFabBounds {
+function getViewportBounds(): Bounds {
   const visualViewport = window.visualViewport;
   if (visualViewport) {
     return {
@@ -81,38 +94,18 @@ function getViewportBounds(): AgentFabBounds {
   };
 }
 
-function getRectBounds(rect: DOMRect): AgentFabBounds {
+function getBoundaryBounds(
+  boundary: HTMLElement | null | undefined
+): Bounds | null {
+  if (!boundary) return null;
+  const rect = boundary.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) return null;
   return {
     left: rect.left,
     top: rect.top,
     width: rect.width,
     height: rect.height,
   };
-}
-
-function requestFrame(callback: FrameRequestCallback): number {
-  if (typeof window.requestAnimationFrame === "function") {
-    return window.requestAnimationFrame(callback);
-  }
-  return window.setTimeout(() => callback(performance.now()), 16);
-}
-
-function cancelFrame(frameId: number) {
-  if (typeof window.cancelAnimationFrame === "function") {
-    window.cancelAnimationFrame(frameId);
-    return;
-  }
-  window.clearTimeout(frameId);
-}
-
-function getBoundaryBounds(boundary: HTMLElement | null | undefined) {
-  if (boundary) {
-    const rect = boundary.getBoundingClientRect();
-    if (rect.width > 0 && rect.height > 0) {
-      return getRectBounds(rect);
-    }
-  }
-  return null;
 }
 
 function getPositioningBounds({
@@ -133,8 +126,8 @@ function getElementSize({
   size,
 }: {
   element: HTMLElement | null;
-  size?: AgentFabSize;
-}): AgentFabSize {
+  size?: Size;
+}): Size {
   if (size) {
     return size;
   }
@@ -147,7 +140,10 @@ function getElementSize({
     };
   }
 
-  return AGENT_FAB_RESTING_SIZE;
+  // Element hasn't been measured yet (first paint, or hidden). Fall back to
+  // the resting size so positioning math has stable inputs; the next layout
+  // effect will re-run with the real measurement.
+  return FAB_RESTING_SIZE;
 }
 
 function applyElementPosition({
@@ -155,7 +151,7 @@ function applyElementPosition({
   point,
 }: {
   element: HTMLElement | null;
-  point: AgentFabPoint;
+  point: Point;
 }) {
   if (!element) return;
   element.style.transform = `translate3d(${point.x}px, ${point.y}px, 0)`;
@@ -173,24 +169,24 @@ function applyElementPinnedPosition({
   element: HTMLElement | null;
   placement: AgentFabPlacement;
   requiresBoundary: boolean;
-  size?: AgentFabSize;
-}): boolean {
+  size?: Size;
+}) {
   const bounds = getPositioningBounds({ boundary, requiresBoundary });
   if (!bounds) {
+    // Hide the positioner until a usable boundary is available so the user
+    // never sees the FAB at a stale or default location.
     delete element?.dataset.ready;
-    return false;
+    return;
   }
 
   applyElementPosition({
     element,
-    point: getAgentFabPinnedPosition({
+    point: getFabPinnedPosition({
       placement,
       bounds,
       size: getElementSize({ element, size }),
-      inset: AGENT_FAB_INSET,
     }),
   });
-  return true;
 }
 
 export function AgentFabPositioner({
@@ -202,26 +198,30 @@ export function AgentFabPositioner({
 }: AgentFabPositionerProps) {
   const positionerRef = useRef<HTMLDivElement>(null);
   const dragSessionRef = useRef<DragSession | null>(null);
-  const frameIdRef = useRef<number | null>(null);
-  const pendingPointerRef = useRef<AgentFabPoint | null>(null);
-  const latestDragPositionRef = useRef<AgentFabPoint | null>(null);
+  const animationFrameIdRef = useRef<number | null>(null);
+  const pendingPointerRef = useRef<Point | null>(null);
+  const lastDragPositionRef = useRef<Point | null>(null);
   const hasDraggedRef = useRef(false);
-  const suppressClickRef = useRef(false);
-  const suppressClickResetIdRef = useRef<number | null>(null);
+  const suppressNextClickRef = useRef(false);
+  const suppressClickResetTimeoutIdRef = useRef<number | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const requiresBoundary = Boolean(boundaryRef);
 
+  // After a drag, an unwanted `click` event can still fire on pointerup. We
+  // swallow exactly one click immediately following a drag. A zero-delay
+  // timeout clears the flag on the next task — after the click has had a
+  // chance to fire — so a later real click is not swallowed.
   const scheduleSuppressClickReset = () => {
-    if (suppressClickResetIdRef.current != null) {
-      window.clearTimeout(suppressClickResetIdRef.current);
+    if (suppressClickResetTimeoutIdRef.current != null) {
+      window.clearTimeout(suppressClickResetTimeoutIdRef.current);
     }
-    suppressClickResetIdRef.current = window.setTimeout(() => {
-      suppressClickRef.current = false;
-      suppressClickResetIdRef.current = null;
+    suppressClickResetTimeoutIdRef.current = window.setTimeout(() => {
+      suppressNextClickRef.current = false;
+      suppressClickResetTimeoutIdRef.current = null;
     }, 0);
   };
 
-  const getBounds = (): AgentFabBounds => {
+  const getBounds = (): Bounds => {
     return (
       getPositioningBounds({
         boundary: boundaryRef?.current,
@@ -230,11 +230,11 @@ export function AgentFabPositioner({
     );
   };
 
-  const getSize = (): AgentFabSize => {
+  const getSize = (): Size => {
     return getElementSize({ element: positionerRef.current, size });
   };
 
-  const applyPosition = (point: AgentFabPoint) => {
+  const applyPosition = (point: Point) => {
     applyElementPosition({ element: positionerRef.current, point });
   };
 
@@ -242,38 +242,56 @@ export function AgentFabPositioner({
     pointer,
     session,
   }: {
-    pointer: AgentFabPoint;
+    pointer: Point;
     session: DragSession;
-  }): AgentFabPoint =>
-    clampAgentFabPosition({
+  }): Point =>
+    clampFabPosition({
       point: {
         x: pointer.x - session.offset.x,
         y: pointer.y - session.offset.y,
       },
       bounds: session.bounds,
       size: session.size,
-      inset: AGENT_FAB_INSET,
     });
 
+  const snapTo = ({
+    placement: targetPlacement,
+    session,
+  }: {
+    placement: AgentFabPlacement;
+    session: DragSession;
+  }) => {
+    if (positionerRef.current) {
+      positionerRef.current.style.transition = SNAP_TRANSITION;
+    }
+    applyPosition(
+      getFabPinnedPosition({
+        placement: targetPlacement,
+        bounds: session.bounds,
+        size: session.size,
+      })
+    );
+  };
+
   const flushPendingDragPosition = () => {
-    frameIdRef.current = null;
+    animationFrameIdRef.current = null;
     const session = dragSessionRef.current;
     const pointer = pendingPointerRef.current;
     if (!session || !pointer) return;
     pendingPointerRef.current = null;
     const nextPosition = getDragPosition({ pointer, session });
-    latestDragPositionRef.current = nextPosition;
+    lastDragPositionRef.current = nextPosition;
     applyPosition(nextPosition);
   };
 
   const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (event.button !== 0) return;
+    if (event.button !== PRIMARY_POINTER_BUTTON) return;
 
     const positioner = positionerRef.current;
     if (!positioner) return;
 
     const rect = positioner.getBoundingClientRect();
-    const nextSize =
+    const measuredSize =
       rect.width > 0 && rect.height > 0
         ? { width: rect.width, height: rect.height }
         : getSize();
@@ -287,10 +305,10 @@ export function AgentFabPositioner({
         y: pointer.y - rect.top,
       },
       pointerId: event.pointerId,
-      size: nextSize,
+      size: measuredSize,
       startPointer: pointer,
     };
-    latestDragPositionRef.current = null;
+    lastDragPositionRef.current = null;
     pendingPointerRef.current = null;
     hasDraggedRef.current = false;
   };
@@ -300,17 +318,19 @@ export function AgentFabPositioner({
     if (!session) return;
 
     const pointer = { x: event.clientX, y: event.clientY };
-    const distance =
+    const squaredDistance =
       (pointer.x - session.startPointer.x) ** 2 +
       (pointer.y - session.startPointer.y) ** 2;
 
     if (!hasDraggedRef.current) {
-      if (distance < DRAG_START_THRESHOLD_PX ** 2) {
+      if (squaredDistance < DRAG_START_THRESHOLD_PX ** 2) {
         return;
       }
       hasDraggedRef.current = true;
       session.hasPointerCapture = true;
       event.currentTarget.setPointerCapture(session.pointerId);
+      // Suppress the snap-to-corner transition while the user is dragging —
+      // the transform must follow the pointer 1:1.
       positionerRef.current?.style.setProperty("transition", "none");
       setIsDragging(true);
     }
@@ -318,8 +338,11 @@ export function AgentFabPositioner({
     event.preventDefault();
     pendingPointerRef.current = pointer;
 
-    if (frameIdRef.current == null) {
-      frameIdRef.current = requestFrame(flushPendingDragPosition);
+    // Coalesce moves into a single per-frame DOM write.
+    if (animationFrameIdRef.current == null) {
+      animationFrameIdRef.current = window.requestAnimationFrame(
+        flushPendingDragPosition
+      );
     }
   };
 
@@ -327,9 +350,9 @@ export function AgentFabPositioner({
     const session = dragSessionRef.current;
     if (!session) return;
 
-    if (frameIdRef.current != null) {
-      cancelFrame(frameIdRef.current);
-      frameIdRef.current = null;
+    if (animationFrameIdRef.current != null) {
+      window.cancelAnimationFrame(animationFrameIdRef.current);
+      animationFrameIdRef.current = null;
     }
 
     if (pendingPointerRef.current) {
@@ -338,7 +361,7 @@ export function AgentFabPositioner({
         session,
       });
       pendingPointerRef.current = null;
-      latestDragPositionRef.current = nextPosition;
+      lastDragPositionRef.current = nextPosition;
       applyPosition(nextPosition);
     }
 
@@ -353,39 +376,27 @@ export function AgentFabPositioner({
     }
 
     if (!hasDraggedRef.current) {
+      // Pure click — no transform changes, just clear any leftover transition
+      // override so the next render is in the default state.
       positionerRef.current?.style.removeProperty("transition");
       return;
     }
 
-    suppressClickRef.current = true;
+    suppressNextClickRef.current = true;
     scheduleSuppressClickReset();
-    const droppedPosition =
-      latestDragPositionRef.current ??
-      getAgentFabPinnedPosition({
-        placement,
-        bounds: session.bounds,
-        size: session.size,
-        inset: AGENT_FAB_INSET,
-      });
-    const nextPlacement = getNearestAgentFabPlacement({
-      point: droppedPosition,
+
+    // When `hasDraggedRef.current` is true, the code path above guarantees
+    // `lastDragPositionRef.current` was set — either by the rAF callback or
+    // by the pendingPointer flush at the top of this function.
+    const dropPosition = lastDragPositionRef.current;
+    invariant(dropPosition, "drag finished without a recorded position");
+    const nextPlacement = getNearestFabPlacement({
+      point: dropPosition,
       bounds: session.bounds,
       size: session.size,
-      inset: AGENT_FAB_INSET,
     });
 
-    if (positionerRef.current) {
-      positionerRef.current.style.transition = SNAP_TRANSITION;
-    }
-
-    applyPosition(
-      getAgentFabPinnedPosition({
-        placement: nextPlacement,
-        bounds: session.bounds,
-        size: session.size,
-        inset: AGENT_FAB_INSET,
-      })
-    );
+    snapTo({ placement: nextPlacement, session });
 
     if (nextPlacement !== placement) {
       onPlacementChange(nextPlacement);
@@ -393,33 +404,23 @@ export function AgentFabPositioner({
   };
 
   const handleClickCapture = (event: ReactMouseEvent<HTMLDivElement>) => {
-    if (!suppressClickRef.current) return;
-    suppressClickRef.current = false;
-    if (suppressClickResetIdRef.current != null) {
-      window.clearTimeout(suppressClickResetIdRef.current);
-      suppressClickResetIdRef.current = null;
+    if (!suppressNextClickRef.current) return;
+    suppressNextClickRef.current = false;
+    if (suppressClickResetTimeoutIdRef.current != null) {
+      window.clearTimeout(suppressClickResetTimeoutIdRef.current);
+      suppressClickResetTimeoutIdRef.current = null;
     }
     event.preventDefault();
     event.stopPropagation();
   };
 
   const handleTransitionEnd = (event: ReactTransitionEvent<HTMLDivElement>) => {
+    // Once the snap-to-corner animation finishes, clear the inline transition
+    // so the next drag starts without an animated transform.
     if (event.propertyName === "transform" && !dragSessionRef.current) {
       event.currentTarget.style.removeProperty("transition");
     }
   };
-
-  useLayoutEffect(() => {
-    if (!dragSessionRef.current) {
-      applyElementPinnedPosition({
-        boundary: boundaryRef?.current,
-        element: positionerRef.current,
-        placement,
-        requiresBoundary,
-        size,
-      });
-    }
-  }, [boundaryRef, placement, requiresBoundary, size]);
 
   useLayoutEffect(() => {
     const syncPinnedPosition = () => {
@@ -433,34 +434,37 @@ export function AgentFabPositioner({
         });
       }
     };
+
+    syncPinnedPosition();
+
     const boundary = boundaryRef?.current;
+    // ResizeObserver covers boundary-driven changes (panel resize, sidebar
+    // toggle). visualViewport.resize covers viewport-level changes that don't
+    // resize the boundary (mobile URL bar collapse, virtual keyboard).
+    // visualViewport.scroll covers pinch-zoom scrolling on mobile, which
+    // shifts where the boundary appears on screen.
     const observer =
       boundary && typeof ResizeObserver === "function"
         ? new ResizeObserver(syncPinnedPosition)
         : null;
-
     if (boundary && observer) {
       observer.observe(boundary);
     }
-    const syncFrameId = requestFrame(syncPinnedPosition);
-    window.addEventListener("resize", syncPinnedPosition);
     window.visualViewport?.addEventListener("resize", syncPinnedPosition);
     window.visualViewport?.addEventListener("scroll", syncPinnedPosition);
 
     return () => {
       observer?.disconnect();
-      window.removeEventListener("resize", syncPinnedPosition);
       window.visualViewport?.removeEventListener("resize", syncPinnedPosition);
       window.visualViewport?.removeEventListener("scroll", syncPinnedPosition);
-      cancelFrame(syncFrameId);
 
-      if (frameIdRef.current != null) {
-        cancelFrame(frameIdRef.current);
-        frameIdRef.current = null;
+      if (animationFrameIdRef.current != null) {
+        window.cancelAnimationFrame(animationFrameIdRef.current);
+        animationFrameIdRef.current = null;
       }
-      if (suppressClickResetIdRef.current != null) {
-        window.clearTimeout(suppressClickResetIdRef.current);
-        suppressClickResetIdRef.current = null;
+      if (suppressClickResetTimeoutIdRef.current != null) {
+        window.clearTimeout(suppressClickResetTimeoutIdRef.current);
+        suppressClickResetTimeoutIdRef.current = null;
       }
     };
   }, [boundaryRef, placement, requiresBoundary, size]);

--- a/app/src/components/agent/__tests__/AgentFabPositioner.test.tsx
+++ b/app/src/components/agent/__tests__/AgentFabPositioner.test.tsx
@@ -1,0 +1,246 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentFabPlacement } from "@phoenix/store/agentStore";
+
+import { AgentFabPositioner } from "../AgentFabPositioner";
+
+function dispatchPointerEvent(
+  element: Element,
+  type: string,
+  init: { clientX: number; clientY: number; pointerId?: number }
+) {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    button: 0,
+    clientX: init.clientX,
+    clientY: init.clientY,
+  });
+  Object.defineProperty(event, "pointerId", {
+    value: init.pointerId ?? 1,
+  });
+  element.dispatchEvent(event);
+}
+
+describe("AgentFabPositioner", () => {
+  let boundary: HTMLDivElement;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    boundary = document.createElement("div");
+    container = document.createElement("div");
+    document.body.appendChild(boundary);
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation(
+      (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      }
+    );
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+    vi.spyOn(boundary, "getBoundingClientRect").mockReturnValue({
+      bottom: 800,
+      height: 700,
+      left: 100,
+      right: 1000,
+      top: 100,
+      width: 900,
+      x: 100,
+      y: 100,
+      toJSON: () => ({}),
+    } as DOMRect);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    boundary.remove();
+    container.remove();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function renderPositioner({
+    onClick = vi.fn(),
+    onPlacementChange = vi.fn(),
+    placement = "bottom-end",
+  }: {
+    onClick?: () => void;
+    onPlacementChange?: (placement: AgentFabPlacement) => void;
+    placement?: AgentFabPlacement;
+  } = {}) {
+    act(() => {
+      root.render(
+        <AgentFabPositioner
+          boundaryRef={{ current: boundary }}
+          placement={placement}
+          size={{ width: 58, height: 36 }}
+          onPlacementChange={onPlacementChange}
+        >
+          <button type="button" onClick={onClick}>
+            PXI
+          </button>
+        </AgentFabPositioner>
+      );
+    });
+
+    const positioner = container.querySelector(".agent-chat-widget-positioner");
+    const button = container.querySelector("button");
+    expect(positioner).not.toBeNull();
+    expect(button).not.toBeNull();
+
+    Object.assign(positioner!, {
+      setPointerCapture: vi.fn(),
+      releasePointerCapture: vi.fn(),
+      hasPointerCapture: vi.fn(() => true),
+    });
+    vi.spyOn(positioner!, "getBoundingClientRect").mockReturnValue({
+      bottom: 800,
+      height: 36,
+      left: 906,
+      right: 964,
+      top: 740,
+      width: 58,
+      x: 906,
+      y: 740,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    return {
+      button: button!,
+      positioner: positioner!,
+    };
+  }
+
+  it("updates placement to the nearest corner after a rAF-driven drag", () => {
+    const onPlacementChange = vi.fn();
+    const { positioner } = renderPositioner({ onPlacementChange });
+
+    act(() => {
+      dispatchPointerEvent(positioner, "pointerdown", {
+        clientX: 935,
+        clientY: 758,
+      });
+      dispatchPointerEvent(positioner, "pointermove", {
+        clientX: 150,
+        clientY: 140,
+      });
+      dispatchPointerEvent(positioner, "pointerup", {
+        clientX: 150,
+        clientY: 140,
+      });
+    });
+
+    expect(window.requestAnimationFrame).toHaveBeenCalled();
+    expect(onPlacementChange).toHaveBeenCalledWith("top-start");
+  });
+
+  it("suppresses the opening click after a drag", () => {
+    const onClick = vi.fn();
+    const { button, positioner } = renderPositioner({ onClick });
+
+    act(() => {
+      dispatchPointerEvent(positioner, "pointerdown", {
+        clientX: 935,
+        clientY: 758,
+      });
+      dispatchPointerEvent(positioner, "pointermove", {
+        clientX: 150,
+        clientY: 140,
+      });
+      dispatchPointerEvent(positioner, "pointerup", {
+        clientX: 150,
+        clientY: 140,
+      });
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("keeps a normal click available when the pointer was not dragged", () => {
+    const onClick = vi.fn();
+    const { button, positioner } = renderPositioner({ onClick });
+
+    act(() => {
+      dispatchPointerEvent(positioner, "pointerdown", {
+        clientX: 935,
+        clientY: 758,
+      });
+      dispatchPointerEvent(positioner, "pointerup", {
+        clientX: 935,
+        clientY: 758,
+      });
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not capture the pointer before the user starts dragging", () => {
+    const onClick = vi.fn();
+    const { button, positioner } = renderPositioner({ onClick });
+
+    act(() => {
+      dispatchPointerEvent(button, "pointerdown", {
+        clientX: 935,
+        clientY: 758,
+      });
+      dispatchPointerEvent(button, "pointerup", {
+        clientX: 935,
+        clientY: 758,
+      });
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(positioner.setPointerCapture).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures the pointer once dragging starts", () => {
+    const { positioner } = renderPositioner();
+
+    act(() => {
+      dispatchPointerEvent(positioner, "pointerdown", {
+        clientX: 935,
+        clientY: 758,
+      });
+      dispatchPointerEvent(positioner, "pointermove", {
+        clientX: 900,
+        clientY: 730,
+      });
+    });
+
+    expect(positioner.setPointerCapture).toHaveBeenCalledWith(1);
+  });
+
+  it("does not suppress a later click when the drag release click was not emitted", () => {
+    vi.useFakeTimers();
+    const onClick = vi.fn();
+    const { button, positioner } = renderPositioner({ onClick });
+
+    act(() => {
+      dispatchPointerEvent(positioner, "pointerdown", {
+        clientX: 935,
+        clientY: 758,
+      });
+      dispatchPointerEvent(positioner, "pointermove", {
+        clientX: 150,
+        clientY: 140,
+      });
+      dispatchPointerEvent(positioner, "pointerup", {
+        clientX: 150,
+        clientY: 140,
+      });
+      vi.runOnlyPendingTimers();
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/components/agent/__tests__/agentFabPositioning.test.ts
+++ b/app/src/components/agent/__tests__/agentFabPositioning.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clampAgentFabPosition,
+  getAgentFabPinnedPosition,
+  getNearestAgentFabPlacement,
+  type AgentFabBounds,
+  type AgentFabSize,
+} from "../agentFabPositioning";
+
+const bounds: AgentFabBounds = {
+  left: 100,
+  top: 80,
+  width: 900,
+  height: 600,
+};
+
+const size: AgentFabSize = {
+  width: 58,
+  height: 36,
+};
+
+describe("agent FAB positioning", () => {
+  it("pins the FAB to the requested corner within the visible bounds", () => {
+    expect(
+      getAgentFabPinnedPosition({ placement: "top-start", bounds, size })
+    ).toEqual({
+      x: 136,
+      y: 104,
+    });
+    expect(
+      getAgentFabPinnedPosition({ placement: "top-end", bounds, size })
+    ).toEqual({
+      x: 906,
+      y: 104,
+    });
+    expect(
+      getAgentFabPinnedPosition({ placement: "bottom-start", bounds, size })
+    ).toEqual({
+      x: 136,
+      y: 620,
+    });
+    expect(
+      getAgentFabPinnedPosition({ placement: "bottom-end", bounds, size })
+    ).toEqual({
+      x: 906,
+      y: 620,
+    });
+  });
+
+  it("chooses the nearest pinned corner for dropped positions", () => {
+    expect(
+      getNearestAgentFabPlacement({
+        point: { x: 130, y: 120 },
+        bounds,
+        size,
+      })
+    ).toBe("top-start");
+    expect(
+      getNearestAgentFabPlacement({
+        point: { x: 900, y: 120 },
+        bounds,
+        size,
+      })
+    ).toBe("top-end");
+    expect(
+      getNearestAgentFabPlacement({
+        point: { x: 130, y: 610 },
+        bounds,
+        size,
+      })
+    ).toBe("bottom-start");
+    expect(
+      getNearestAgentFabPlacement({
+        point: { x: 900, y: 610 },
+        bounds,
+        size,
+      })
+    ).toBe("bottom-end");
+  });
+
+  it("clamps transient drag positions to the visible bounds", () => {
+    expect(
+      clampAgentFabPosition({
+        point: { x: -100, y: 1000 },
+        bounds,
+        size,
+      })
+    ).toEqual({
+      x: 136,
+      y: 620,
+    });
+  });
+});

--- a/app/src/components/agent/__tests__/agentFabPositioning.test.ts
+++ b/app/src/components/agent/__tests__/agentFabPositioning.test.ts
@@ -1,21 +1,21 @@
 import { describe, expect, it } from "vitest";
 
+import type { Bounds, Size } from "@phoenix/types/geometry";
+
 import {
-  clampAgentFabPosition,
-  getAgentFabPinnedPosition,
-  getNearestAgentFabPlacement,
-  type AgentFabBounds,
-  type AgentFabSize,
+  clampFabPosition,
+  getFabPinnedPosition,
+  getNearestFabPlacement,
 } from "../agentFabPositioning";
 
-const bounds: AgentFabBounds = {
+const bounds: Bounds = {
   left: 100,
   top: 80,
   width: 900,
   height: 600,
 };
 
-const size: AgentFabSize = {
+const size: Size = {
   width: 58,
   height: 36,
 };
@@ -23,25 +23,25 @@ const size: AgentFabSize = {
 describe("agent FAB positioning", () => {
   it("pins the FAB to the requested corner within the visible bounds", () => {
     expect(
-      getAgentFabPinnedPosition({ placement: "top-start", bounds, size })
+      getFabPinnedPosition({ placement: "top-start", bounds, size })
     ).toEqual({
       x: 136,
       y: 104,
     });
     expect(
-      getAgentFabPinnedPosition({ placement: "top-end", bounds, size })
+      getFabPinnedPosition({ placement: "top-end", bounds, size })
     ).toEqual({
       x: 906,
       y: 104,
     });
     expect(
-      getAgentFabPinnedPosition({ placement: "bottom-start", bounds, size })
+      getFabPinnedPosition({ placement: "bottom-start", bounds, size })
     ).toEqual({
       x: 136,
       y: 620,
     });
     expect(
-      getAgentFabPinnedPosition({ placement: "bottom-end", bounds, size })
+      getFabPinnedPosition({ placement: "bottom-end", bounds, size })
     ).toEqual({
       x: 906,
       y: 620,
@@ -50,28 +50,28 @@ describe("agent FAB positioning", () => {
 
   it("chooses the nearest pinned corner for dropped positions", () => {
     expect(
-      getNearestAgentFabPlacement({
+      getNearestFabPlacement({
         point: { x: 130, y: 120 },
         bounds,
         size,
       })
     ).toBe("top-start");
     expect(
-      getNearestAgentFabPlacement({
+      getNearestFabPlacement({
         point: { x: 900, y: 120 },
         bounds,
         size,
       })
     ).toBe("top-end");
     expect(
-      getNearestAgentFabPlacement({
+      getNearestFabPlacement({
         point: { x: 130, y: 610 },
         bounds,
         size,
       })
     ).toBe("bottom-start");
     expect(
-      getNearestAgentFabPlacement({
+      getNearestFabPlacement({
         point: { x: 900, y: 610 },
         bounds,
         size,
@@ -81,7 +81,7 @@ describe("agent FAB positioning", () => {
 
   it("clamps transient drag positions to the visible bounds", () => {
     expect(
-      clampAgentFabPosition({
+      clampFabPosition({
         point: { x: -100, y: 1000 },
         bounds,
         size,

--- a/app/src/components/agent/agentFabPositioning.ts
+++ b/app/src/components/agent/agentFabPositioning.ts
@@ -1,0 +1,149 @@
+import type { AgentFabPlacement } from "@phoenix/store/agentStore";
+
+export type AgentFabBounds = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+export type AgentFabPoint = {
+  x: number;
+  y: number;
+};
+
+export type AgentFabSize = {
+  width: number;
+  height: number;
+};
+
+export type AgentFabInset = {
+  horizontal: number;
+  vertical: number;
+};
+
+export const AGENT_FAB_RESTING_SIZE: AgentFabSize = {
+  width: 74,
+  height: 36,
+};
+
+export const AGENT_FAB_STREAMING_SIZE: AgentFabSize = {
+  width: 40,
+  height: 40,
+};
+
+export const AGENT_FAB_INSET: AgentFabInset = {
+  horizontal: 36,
+  vertical: 24,
+};
+
+const AGENT_FAB_PLACEMENTS: AgentFabPlacement[] = [
+  "top-start",
+  "top-end",
+  "bottom-start",
+  "bottom-end",
+];
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getAxisPosition({
+  min,
+  max,
+  value,
+}: {
+  min: number;
+  max: number;
+  value: number;
+}): number {
+  if (max < min) {
+    return min + (max - min) / 2;
+  }
+  return clamp(value, min, max);
+}
+
+export function clampAgentFabPosition({
+  point,
+  bounds,
+  size,
+  inset = AGENT_FAB_INSET,
+}: {
+  point: AgentFabPoint;
+  bounds: AgentFabBounds;
+  size: AgentFabSize;
+  inset?: AgentFabInset;
+}): AgentFabPoint {
+  const minX = bounds.left + inset.horizontal;
+  const maxX = bounds.left + bounds.width - size.width - inset.horizontal;
+  const minY = bounds.top + inset.vertical;
+  const maxY = bounds.top + bounds.height - size.height - inset.vertical;
+
+  return {
+    x: getAxisPosition({ min: minX, max: maxX, value: point.x }),
+    y: getAxisPosition({ min: minY, max: maxY, value: point.y }),
+  };
+}
+
+export function getAgentFabPinnedPosition({
+  placement,
+  bounds,
+  size,
+  inset = AGENT_FAB_INSET,
+}: {
+  placement: AgentFabPlacement;
+  bounds: AgentFabBounds;
+  size: AgentFabSize;
+  inset?: AgentFabInset;
+}): AgentFabPoint {
+  const x = placement.endsWith("end")
+    ? bounds.left + bounds.width - size.width - inset.horizontal
+    : bounds.left + inset.horizontal;
+  const y = placement.startsWith("bottom")
+    ? bounds.top + bounds.height - size.height - inset.vertical
+    : bounds.top + inset.vertical;
+
+  return clampAgentFabPosition({ point: { x, y }, bounds, size, inset });
+}
+
+export function getNearestAgentFabPlacement({
+  point,
+  bounds,
+  size,
+  inset = AGENT_FAB_INSET,
+}: {
+  point: AgentFabPoint;
+  bounds: AgentFabBounds;
+  size: AgentFabSize;
+  inset?: AgentFabInset;
+}): AgentFabPlacement {
+  const center = {
+    x: point.x + size.width / 2,
+    y: point.y + size.height / 2,
+  };
+
+  let nearestPlacement = AGENT_FAB_PLACEMENTS[0];
+  let nearestDistance = Number.POSITIVE_INFINITY;
+
+  for (const placement of AGENT_FAB_PLACEMENTS) {
+    const target = getAgentFabPinnedPosition({
+      placement,
+      bounds,
+      size,
+      inset,
+    });
+    const targetCenter = {
+      x: target.x + size.width / 2,
+      y: target.y + size.height / 2,
+    };
+    const distance =
+      (center.x - targetCenter.x) ** 2 + (center.y - targetCenter.y) ** 2;
+
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearestPlacement = placement;
+    }
+  }
+
+  return nearestPlacement;
+}

--- a/app/src/components/agent/agentFabPositioning.ts
+++ b/app/src/components/agent/agentFabPositioning.ts
@@ -1,43 +1,39 @@
 import type { AgentFabPlacement } from "@phoenix/store/agentStore";
+import type { Bounds, Inset, Point, Size } from "@phoenix/types/geometry";
 
-export type AgentFabBounds = {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
+// FAB dimensions derived from the animated motion.div in AgentChatWidget's
+// `AgentChatWidgetButton`. Both axes are content-box width plus horizontal
+// padding (CSS `box-sizing: content-box` is the default).
+//
+// Resting: content 58 + paddingLeft 8 + paddingRight 8 = 74 wide, 36 tall.
+// Streaming: content 40 + paddingLeft 0 + paddingRight 0 = 40 square.
+//
+// If you change those values in AgentChatWidget, update these in lockstep —
+// snap math reads from here when the live element hasn't been measured yet
+// (first paint), and AgentChatWidget passes these as the explicit size prop
+// to keep the snap math stable across the streaming-state transition.
+const FAB_CONTENT_WIDTH_RESTING = 58;
+const FAB_CONTENT_HEIGHT_RESTING = 36;
+const FAB_HORIZONTAL_PADDING_RESTING = 8;
+const FAB_CONTENT_WIDTH_STREAMING = 40;
+const FAB_CONTENT_HEIGHT_STREAMING = 40;
+
+export const FAB_RESTING_SIZE: Size = {
+  width: FAB_CONTENT_WIDTH_RESTING + 2 * FAB_HORIZONTAL_PADDING_RESTING,
+  height: FAB_CONTENT_HEIGHT_RESTING,
+};
+export const FAB_STREAMING_SIZE: Size = {
+  width: FAB_CONTENT_WIDTH_STREAMING,
+  height: FAB_CONTENT_HEIGHT_STREAMING,
 };
 
-export type AgentFabPoint = {
-  x: number;
-  y: number;
-};
+// Distance from each edge of the positioning boundary to the corresponding
+// edge of the FAB when pinned. Mirrors the original `floatingButtonCSS`
+// `bottom: 24px; right: 36px` values so the corner placement matches the
+// pre-drag location pixel-for-pixel.
+export const FAB_INSET: Inset = { horizontal: 36, vertical: 24 };
 
-export type AgentFabSize = {
-  width: number;
-  height: number;
-};
-
-export type AgentFabInset = {
-  horizontal: number;
-  vertical: number;
-};
-
-export const AGENT_FAB_RESTING_SIZE: AgentFabSize = {
-  width: 74,
-  height: 36,
-};
-
-export const AGENT_FAB_STREAMING_SIZE: AgentFabSize = {
-  width: 40,
-  height: 40,
-};
-
-export const AGENT_FAB_INSET: AgentFabInset = {
-  horizontal: 36,
-  vertical: 24,
-};
-
-const AGENT_FAB_PLACEMENTS: AgentFabPlacement[] = [
+const FAB_PLACEMENTS: AgentFabPlacement[] = [
   "top-start",
   "top-end",
   "bottom-start",
@@ -48,7 +44,7 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
-function getAxisPosition({
+function resolveAxisPosition({
   min,
   max,
   value,
@@ -57,45 +53,48 @@ function getAxisPosition({
   max: number;
   value: number;
 }): number {
+  // The boundary may be narrower/shorter than the FAB plus both insets — in
+  // that case `max < min` and `clamp` would collapse to `min`, jamming the
+  // FAB against one edge. Center it within the available space instead.
   if (max < min) {
     return min + (max - min) / 2;
   }
   return clamp(value, min, max);
 }
 
-export function clampAgentFabPosition({
+export function clampFabPosition({
   point,
   bounds,
   size,
-  inset = AGENT_FAB_INSET,
+  inset = FAB_INSET,
 }: {
-  point: AgentFabPoint;
-  bounds: AgentFabBounds;
-  size: AgentFabSize;
-  inset?: AgentFabInset;
-}): AgentFabPoint {
+  point: Point;
+  bounds: Bounds;
+  size: Size;
+  inset?: Inset;
+}): Point {
   const minX = bounds.left + inset.horizontal;
   const maxX = bounds.left + bounds.width - size.width - inset.horizontal;
   const minY = bounds.top + inset.vertical;
   const maxY = bounds.top + bounds.height - size.height - inset.vertical;
 
   return {
-    x: getAxisPosition({ min: minX, max: maxX, value: point.x }),
-    y: getAxisPosition({ min: minY, max: maxY, value: point.y }),
+    x: resolveAxisPosition({ min: minX, max: maxX, value: point.x }),
+    y: resolveAxisPosition({ min: minY, max: maxY, value: point.y }),
   };
 }
 
-export function getAgentFabPinnedPosition({
+export function getFabPinnedPosition({
   placement,
   bounds,
   size,
-  inset = AGENT_FAB_INSET,
+  inset = FAB_INSET,
 }: {
   placement: AgentFabPlacement;
-  bounds: AgentFabBounds;
-  size: AgentFabSize;
-  inset?: AgentFabInset;
-}): AgentFabPoint {
+  bounds: Bounds;
+  size: Size;
+  inset?: Inset;
+}): Point {
   const x = placement.endsWith("end")
     ? bounds.left + bounds.width - size.width - inset.horizontal
     : bounds.left + inset.horizontal;
@@ -103,44 +102,46 @@ export function getAgentFabPinnedPosition({
     ? bounds.top + bounds.height - size.height - inset.vertical
     : bounds.top + inset.vertical;
 
-  return clampAgentFabPosition({ point: { x, y }, bounds, size, inset });
+  return clampFabPosition({ point: { x, y }, bounds, size, inset });
 }
 
-export function getNearestAgentFabPlacement({
+export function getNearestFabPlacement({
   point,
   bounds,
   size,
-  inset = AGENT_FAB_INSET,
+  inset = FAB_INSET,
 }: {
-  point: AgentFabPoint;
-  bounds: AgentFabBounds;
-  size: AgentFabSize;
-  inset?: AgentFabInset;
+  point: Point;
+  bounds: Bounds;
+  size: Size;
+  inset?: Inset;
 }): AgentFabPlacement {
-  const center = {
+  const pointCenter = {
     x: point.x + size.width / 2,
     y: point.y + size.height / 2,
   };
 
-  let nearestPlacement = AGENT_FAB_PLACEMENTS[0];
-  let nearestDistance = Number.POSITIVE_INFINITY;
+  let nearestPlacement = FAB_PLACEMENTS[0];
+  let nearestSquaredDistance = Number.POSITIVE_INFINITY;
 
-  for (const placement of AGENT_FAB_PLACEMENTS) {
-    const target = getAgentFabPinnedPosition({
+  for (const placement of FAB_PLACEMENTS) {
+    const pinnedPosition = getFabPinnedPosition({
       placement,
       bounds,
       size,
       inset,
     });
-    const targetCenter = {
-      x: target.x + size.width / 2,
-      y: target.y + size.height / 2,
+    const pinnedCenter = {
+      x: pinnedPosition.x + size.width / 2,
+      y: pinnedPosition.y + size.height / 2,
     };
-    const distance =
-      (center.x - targetCenter.x) ** 2 + (center.y - targetCenter.y) ** 2;
+    // Squared distance — we only need to compare, not measure, so skip sqrt.
+    const squaredDistance =
+      (pointCenter.x - pinnedCenter.x) ** 2 +
+      (pointCenter.y - pinnedCenter.y) ** 2;
 
-    if (distance < nearestDistance) {
-      nearestDistance = distance;
+    if (squaredDistance < nearestSquaredDistance) {
+      nearestSquaredDistance = squaredDistance;
       nearestPlacement = placement;
     }
   }

--- a/app/src/pages/AuthenticatedRoot.tsx
+++ b/app/src/pages/AuthenticatedRoot.tsx
@@ -4,7 +4,6 @@ import invariant from "tiny-invariant";
 
 import { AgentContextSync } from "@phoenix/agent/context/AgentContextSync";
 import { isFullStoryEnabled, setIdentity } from "@phoenix/analytics/fullstory";
-import { AgentChatWidget } from "@phoenix/components/agent";
 import { AgentChatRuntimeProvider } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { AgentProvider } from "@phoenix/contexts/AgentContext";
 import { ViewerProvider } from "@phoenix/contexts/ViewerContext";
@@ -45,7 +44,6 @@ export function AuthenticatedRoot() {
       <AgentProvider agentsConfig={data.agentsConfig}>
         <AgentChatRuntimeProvider>
           <AgentContextSync />
-          <AgentChatWidget />
           <AppAlerts />
           <Outlet />
         </AgentChatRuntimeProvider>

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -1,10 +1,10 @@
 import { css } from "@emotion/react";
-import { Suspense, useCallback } from "react";
+import { Suspense, useCallback, useRef } from "react";
 import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 import { Outlet, useLoaderData } from "react-router";
 
 import { Counter, Flex, Icon, Icons, Loading } from "@phoenix/components";
-import { AgentChatPanel } from "@phoenix/components/agent";
+import { AgentChatPanel, AgentChatWidget } from "@phoenix/components/agent";
 import {
   Brand,
   DocsLink,
@@ -73,6 +73,7 @@ const sideLinksCSS = css`
 `;
 
 export function Layout() {
+  const contentRef = useRef<HTMLDivElement>(null);
   const isAgentsEnabled = useFeatureFlag("agents");
   const isAgentPanelOpen = useAgentContext((state) => state.isOpen);
   const activePanelLocation = useAgentContext(
@@ -107,7 +108,8 @@ export function Layout() {
             onLayoutChanged={onLayoutChanged}
           >
             <Panel id="layout-content">
-              <div data-testid="content" css={contentCSS}>
+              <div data-testid="content" css={contentCSS} ref={contentRef}>
+                <AgentChatWidget boundaryRef={contentRef} />
                 <Suspense fallback={<Loading />}>
                   <Outlet />
                 </Suspense>

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -155,6 +155,16 @@ describe("agentStore", () => {
     });
   });
 
+  describe("setFabPlacement", () => {
+    it("updates the pinned FAB corner", () => {
+      const store = createAgentStore();
+
+      store.getState().setFabPlacement("top-start");
+
+      expect(store.getState().fabPlacement).toBe("top-start");
+    });
+  });
+
   describe("observability", () => {
     it("updates observability settings without clobbering other fields", () => {
       const store = createAgentStore();
@@ -168,6 +178,7 @@ describe("agentStore", () => {
         exportRemoteTraces: false,
         hasAcknowledgedConsent: false,
       });
+      expect(store.getState().fabPlacement).toBe("bottom-end");
     });
 
     it("acknowledges consent without changing trace toggles", () => {

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -38,6 +38,13 @@ export type AgentPosition = "detached" | "pinned";
  */
 export type AgentPanelLocation = "docked" | "trace";
 
+/** Pinned corner for the global PXI floating action button. */
+export type AgentFabPlacement =
+  | "top-start"
+  | "top-end"
+  | "bottom-start"
+  | "bottom-end";
+
 /** Server-provided PXI configuration exposed to the frontend. */
 export type AgentServerConfig = {
   /** Remote collector used for optional agent trace export. */
@@ -130,6 +137,8 @@ export interface AgentProps {
   isOpen: boolean;
   /** Current layout position of the agent panel. */
   position: AgentPosition;
+  /** Pinned corner for the global PXI floating action button. */
+  fabPlacement: AgentFabPlacement;
   /**
    * Which surface currently hosts the agent chat panel.
    * Defaults to "docked". Set to "trace" when a trace slideover mounts its
@@ -161,6 +170,7 @@ export interface AgentState extends AgentProps {
   setIsOpen: (isOpen: boolean) => void;
   toggleOpen: () => void;
   setPosition: (position: AgentPosition) => void;
+  setFabPlacement: (placement: AgentFabPlacement) => void;
   setActivePanelLocation: (location: AgentPanelLocation) => void;
   createSession: () => string;
   deleteSession: (sessionId: string) => void;
@@ -333,6 +343,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
   > = (set) => ({
     isOpen: false,
     position: "detached",
+    fabPlacement: "bottom-end",
     activePanelLocation: "docked",
     sessions: [],
     activeSessionId: null,
@@ -354,6 +365,9 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
     },
     setPosition: (position) => {
       set({ position }, false, { type: "setPosition" });
+    },
+    setFabPlacement: (fabPlacement) => {
+      set({ fabPlacement }, false, { type: "setFabPlacement" });
     },
     setActivePanelLocation: (location) => {
       set({ activePanelLocation: location }, false, {
@@ -751,7 +765,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
   return create<AgentState>()(
     persist(devtools(agentStore, { name: "agentStore" }), {
       name: "arize-phoenix-agent",
-      version: 6,
+      version: 7,
       migrate: (persisted, version) => {
         const state = persisted as Partial<AgentProps> & {
           capabilities?: Partial<AgentCapabilities>;
@@ -791,6 +805,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
 
         return {
           ...state,
+          fabPlacement: state.fabPlacement ?? "bottom-end",
           sessionMap: migratedSessionMap,
           observability: {
             ...DEFAULT_AGENT_OBSERVABILITY_SETTINGS,
@@ -803,6 +818,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
       partialize: (state) => ({
         isOpen: state.isOpen,
         position: state.position,
+        fabPlacement: state.fabPlacement,
         sessions: state.sessions,
         activeSessionId: state.activeSessionId,
         sessionMap: state.sessionMap,

--- a/app/src/types/geometry.ts
+++ b/app/src/types/geometry.ts
@@ -1,0 +1,25 @@
+/** A 2D point in pixel coordinates. */
+export type Point = {
+  x: number;
+  y: number;
+};
+
+/** A 2D dimension (no origin) in pixels. */
+export type Size = {
+  width: number;
+  height: number;
+};
+
+/** An axis-aligned rectangle in pixel coordinates. */
+export type Bounds = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+/** Per-axis margin in pixels (matches CSS `inline` / `block` semantics). */
+export type Inset = {
+  horizontal: number;
+  vertical: number;
+};

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from "./geometry";
 export * from "./inferences";
 export * from "./dimension";
 export * from "./evaluators";

--- a/app/stories/AgentChatWidgetButton.stories.tsx
+++ b/app/stories/AgentChatWidgetButton.stories.tsx
@@ -108,7 +108,6 @@ const meta = {
   },
   args: {
     ariaLabel: "Open agent chat",
-    isFloating: false,
     glyphAnimation: "wave-reveal",
   },
   argTypes: {
@@ -174,7 +173,6 @@ function ClickToCycleRender(args: AgentChatWidgetButtonProps) {
               glyphAnimation={args.glyphAnimation ?? glyphAnimations[0]}
               ariaLabel={isStreaming ? "PXI is thinking" : "Open agent chat"}
               onClick={() => setIsStreaming((value) => !value)}
-              isFloating={false}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary

Makes the global PXI agent FAB movable within the main app content area and persists the selected pinned corner in the agent store.

## Why

The FAB previously rendered globally from the authenticated root with a fixed position. The movable behavior anchors the FAB to the layout content boundary, snaps to the nearest corner on release, and persists the chosen corner in the existing Zustand agent store (`fabPlacement`, persist version 6 → 7 with a defaulted migration).

## Impact

- Users can drag the PXI FAB to any corner of the content area; release snaps to the nearest corner.
- Normal clicks still open chat; drag-release clicks are suppressed.
- Stored placement survives reloads.
- The FAB is now boundary-anchored rather than viewport-anchored — overlapping in-content sticky toolbars is a known follow-up tuning concern, not a regression of the click/open path.

## Notable implementation details

- Pure positioning math lives in `agentFabPositioning.ts` (`clampFabPosition`, `getFabPinnedPosition`, `getNearestFabPlacement`) and is unit-tested separately from the React drag logic.
- The drag logic in `AgentFabPositioner.tsx` uses pointer events with rAF-coalesced moves, primary-button-only filtering, and a 4px squared-distance threshold before a click is reinterpreted as a drag.
- Magic numbers are extracted as named constants with comments tying them to their source of truth: FAB sizes are derived from the `AgentChatWidget` motion.div content + padding; the snap inset mirrors the previous `floatingButtonCSS` `bottom: 24px; right: 36px`.
- Generic geometry types (`Point`, `Size`, `Bounds`, `Inset`) lifted into `@phoenix/types/geometry` rather than scoped to the FAB.
- The dead `isFloating` prop + `floatingButtonCSS` block in `AgentChatWidgetButton` is removed now that the positioner owns fixed positioning; the Storybook story updated to match.

## Validation

- [x] `pnpm test` — 1157 passed, 12 skipped, 0 failed
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` on changed files — clean
- [x] `agentFabPositioning.test.ts` covers `clampFabPosition`, `getFabPinnedPosition`, `getNearestFabPlacement`
- [x] `AgentFabPositioner.test.tsx` covers drag-to-corner, click-suppression after drag, click-through on non-drag, pointer capture lifecycle, late-click safety after a missed synthetic click

## Test plan

- [ ] Drag the FAB to each of the four corners and reload — the chosen corner persists.
- [ ] Click the FAB without dragging — chat opens.
- [ ] Drag and release without crossing the 4px threshold — chat opens.
- [ ] Drag past 4px and release — chat does NOT open.
- [ ] Resize the layout content area while the FAB is pinned — FAB stays anchored to its corner.
- [ ] Open a modal that triggers `useHasOpenModal()` — FAB hides while the modal is open.