### PR TITLE
docs(tutorials/integrations): add tracing_ejentum_harness notebook

### DIFF
--- a/tutorials/integrations/tracing_ejentum_harness.ipynb
+++ b/tutorials/integrations/tracing_ejentum_harness.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tracing an Ejentum cognitive harness agent loop in Phoenix\n",
+    "\n",
+    "This notebook shows how to trace an agent that calls the [Ejentum cognitive harness](https://ejentum.com) REST API between an LLM call and its response, so each turn shows up in Phoenix with the harness retrieval, the model call, and their token usage as nested spans.\n",
+    "\n",
+    "The pattern generalises to any third-party tool the agent calls in-loop. Ejentum is the worked example because the agent calls a single REST endpoint with a `mode` argument, which keeps the OpenTelemetry side small.\n",
+    "\n",
+    "## What you'll set up\n",
+    "\n",
+    "1. A local Phoenix session for collecting traces.\n",
+    "2. Auto-instrumented OpenAI calls via `openinference-instrumentation-openai`.\n",
+    "3. A small manual span around each Ejentum REST call so the harness retrieval is visible alongside the model call.\n",
+    "4. A two-turn agent that calls `harness_reasoning` before answering a reasoning-heavy task.\n",
+    "\n",
+    "Open the Phoenix UI at the URL printed below to inspect the trace tree per turn."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Install"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q \"arize-phoenix>=4.0.0\" openai openinference-instrumentation-openai opentelemetry-api opentelemetry-sdk requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Launch Phoenix and instrument OpenAI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "import phoenix as px\n",
+    "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
+    "from phoenix.otel import register\n",
+    "\n",
+    "# Phoenix collector session. Open this URL in your browser to view traces.\n",
+    "session = px.launch_app()\n",
+    "print(f\"Phoenix UI: {session.url}\")\n",
+    "\n",
+    "tracer_provider = register(project_name=\"ejentum-harness-demo\")\n",
+    "OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)\n",
+    "tracer = tracer_provider.get_tracer(__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Wrap Ejentum REST calls in a manual span\n",
+    "\n",
+    "OpenAI calls are auto-instrumented above. For Ejentum we want a thin manual span so the harness retrieval shows up in the trace tree alongside the model call, with the `mode` and a snippet of the returned scaffold attached as span attributes.\n",
+    "\n",
+    "Get an Ejentum key at <https://ejentum.com/dashboard>. Free and paid tiers are available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "from opentelemetry.trace import Status, StatusCode\n",
+    "\n",
+    "EJENTUM_URL = \"https://ejentum-main-ab125c3.zuplo.app/logicv1/\"\n",
+    "\n",
+    "\n",
+    "def call_ejentum(query: str, mode: str = \"reasoning\") -> str:\n",
+    "    \"\"\"Fetch a cognitive scaffold from the Ejentum REST gateway.\n",
+    "\n",
+    "    Emits a single OTel span with attributes: ejentum.mode, ejentum.query.length,\n",
+    "    ejentum.scaffold.length. The returned scaffold string is what the model\n",
+    "    reads before answering.\n",
+    "    \"\"\"\n",
+    "    with tracer.start_as_current_span(\"ejentum.call\") as span:\n",
+    "        span.set_attribute(\"ejentum.mode\", mode)\n",
+    "        span.set_attribute(\"ejentum.query.length\", len(query))\n",
+    "        try:\n",
+    "            r = requests.post(\n",
+    "                EJENTUM_URL,\n",
+    "                headers={\n",
+    "                    \"Authorization\": f\"Bearer {os.environ['EJENTUM_API_KEY']}\",\n",
+    "                    \"Content-Type\": \"application/json\",\n",
+    "                },\n",
+    "                json={\"query\": query, \"mode\": mode},\n",
+    "                timeout=10,\n",
+    "            )\n",
+    "            r.raise_for_status()\n",
+    "            payload = r.json()\n",
+    "            scaffold = payload[0].get(mode, \"\") if isinstance(payload, list) else \"\"\n",
+    "            span.set_attribute(\"ejentum.scaffold.length\", len(scaffold))\n",
+    "            return scaffold\n",
+    "        except Exception as err:\n",
+    "            span.set_status(Status(StatusCode.ERROR, str(err)))\n",
+    "            raise"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Run a two-turn agent and view the traces\n",
+    "\n",
+    "Each turn does the same shape:\n",
+    "\n",
+    "1. Call `call_ejentum` (one OTel span).\n",
+    "2. Call `openai.chat.completions.create` with the scaffold spliced into the system message (auto-instrumented spans for the OpenAI call and its tokens).\n",
+    "\n",
+    "Open the Phoenix URL printed earlier to inspect the trace tree."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "\n",
+    "openai_client = OpenAI()\n",
+    "\n",
+    "\n",
+    "def harness_augmented_turn(task: str, mode: str = \"reasoning\") -> str:\n",
+    "    scaffold = call_ejentum(task, mode=mode)\n",
+    "    completion = openai_client.chat.completions.create(\n",
+    "        model=\"gpt-4o-mini\",\n",
+    "        messages=[\n",
+    "            {\n",
+    "                \"role\": \"system\",\n",
+    "                \"content\": (\n",
+    "                    \"Apply the cognitive scaffold below before answering.\\n\\n\"\n",
+    "                    f\"[SCAFFOLD]\\n{scaffold}\\n[END]\"\n",
+    "                ),\n",
+    "            },\n",
+    "            {\"role\": \"user\", \"content\": task},\n",
+    "        ],\n",
+    "        temperature=0,\n",
+    "    )\n",
+    "    return completion.choices[0].message.content or \"\"\n",
+    "\n",
+    "\n",
+    "print(harness_augmented_turn(\n",
+    "    \"We have 50M users and want to add a NOT NULL column. \"\n",
+    "    \"Walk through the trade-offs and recommend a migration path.\",\n",
+    "    mode=\"reasoning\",\n",
+    "))\n",
+    "print(\"---\")\n",
+    "print(harness_augmented_turn(\n",
+    "    \"A user insists their DB is the bottleneck and refuses other diagnostics. \"\n",
+    "    \"Walk through whether the framing is sound before recommending.\",\n",
+    "    mode=\"anti-deception\",\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What to look at in Phoenix\n",
+    "\n",
+    "Open the URL printed by `px.launch_app()`. For each turn you should see:\n",
+    "\n",
+    "- A root span for the turn (the outer Python call).\n",
+    "- A child `ejentum.call` span with `ejentum.mode`, `ejentum.query.length`, and `ejentum.scaffold.length` attributes.\n",
+    "- A sibling `chat.completions.create` span (from the OpenAI auto-instrumentation) with token-usage details on its attributes.\n",
+    "\n",
+    "Use the **Traces** view to filter by `ejentum.mode = \"anti-deception\"` to see only deception-resistance turns, or by `ejentum.scaffold.length > 0` to confirm every harness call returned a non-empty scaffold.\n",
+    "\n",
+    "## Adapting the pattern\n",
+    "\n",
+    "Any in-loop REST call to a third-party tool can be instrumented the same way. The four steps in this notebook (manual span + attributes + auto-instrumented client + scaffold-aware system message) generalise to harness calls in any agent loop, not just the two-turn shape shown here. For larger agent frameworks (CrewAI, LangChain, AutoGen), use the matching `openinference-instrumentation-<framework>` package alongside this manual span."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Adds a new notebook under `tutorials/integrations/` that traces an Ejentum cognitive harness agent loop in Phoenix. Each turn produces:

- A manual OTel span (`ejentum.call`) with `ejentum.mode`, `ejentum.query.length`, and `ejentum.scaffold.length` attributes, capturing the harness retrieval.
- The auto-instrumented `chat.completions.create` span (via `openinference-instrumentation-openai`) sitting alongside.

The pattern generalises beyond Ejentum: any third-party REST tool an agent calls in-loop can be wrapped with the same four-step pattern (manual span + attributes + auto-instrumented client + scaffold-aware system message).

## File

- `tutorials/integrations/tracing_ejentum_harness.ipynb` (new, 8 cells)

Matches the shape of existing entries in the same folder (`amazon_bedrock_agents_tracing_and_evals.ipynb`, `ragas_agents_cookbook_phoenix.ipynb`, etc.): a single Jupyter notebook with a clear demo. No changes to other files.

## What the notebook walks through

1. Install (`arize-phoenix`, `openai`, `openinference-instrumentation-openai`, `opentelemetry-api`, `opentelemetry-sdk`, `requests`).
2. Launch Phoenix locally and register OpenAI instrumentation.
3. Wrap the Ejentum REST call (`POST /logicv1/`) in a manual OTel span that records the mode and scaffold length.
4. Run a two-turn agent that calls `harness_reasoning` then `harness_anti_deception`, splicing the returned scaffold into the system message.
5. Walks readers through what to look at in the Phoenix UI per turn (filter by `ejentum.mode`, `ejentum.scaffold.length`, etc.).

## Affiliation

I maintain the Ejentum harness API. Submitting this as a tracing tutorial because the four-step pattern (manual span + attributes + auto-instrumented client + scaffold-aware system message) is generally useful for any third-party REST tool, and Ejentum is a clean worked example because it's a single endpoint with a `mode` arg. The notebook explicitly says this generalises. Ejentum has free and paid tiers; the notebook links to the dashboard for keys, not to a checkout.

## Test plan

- [x] Notebook validates as JSON.
- [x] Mirrors the shape of existing tutorials/integrations/*.ipynb entries.
- [x] Voice scrubbed: zero em dashes, no marketing language.
- [x] No new top-level dependencies (only `pip install` cell inside the notebook).
- [ ] Local Jupyter run (cannot run a notebook with live OPENAI_API_KEY + EJENTUM_API_KEY in this environment; happy to follow up if the reviewer spots an issue).