### PR TITLE
feat: add PXI assistant hotkey tooltip

### DIFF
--- a/app/src/components/agent/AgentChatWidget.tsx
+++ b/app/src/components/agent/AgentChatWidget.tsx
@@ -1,16 +1,30 @@
 import { css, keyframes } from "@emotion/react";
 import { AnimatePresence, motion } from "motion/react";
-import type { RefObject } from "react";
+import type { Ref, RefObject } from "react";
+import type { ButtonProps as AriaButtonProps } from "react-aria-components";
+import { Button as AriaButton } from "react-aria-components";
 import { createPortal } from "react-dom";
+import { useHotkeys } from "react-hotkeys-hook";
 
+import {
+  Flex,
+  Keyboard,
+  Tooltip,
+  TooltipArrow,
+  TooltipTrigger,
+  VisuallyHidden,
+} from "@phoenix/components";
 import { useTheme } from "@phoenix/contexts";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { useHasOpenModal } from "@phoenix/hooks/useHasOpenModal";
+import { useModifierKey } from "@phoenix/hooks/useModifierKey";
 
 import { AgentFabPositioner } from "./AgentFabPositioner";
 import { FAB_RESTING_SIZE, FAB_STREAMING_SIZE } from "./agentFabPositioning";
 import { PxiGlyph, type PxiGlyphAnimation } from "./PxiGlyph";
 import { useAssistantAgentEnabled } from "./useAssistantAgentEnabled";
+
+const OPEN_AGENT_HOTKEY = "mod+i";
 
 const thinkingBorderWipe = keyframes`
   0% {
@@ -306,31 +320,36 @@ const thinkingGlyphPulseCSS = css`
 
 export type { PxiGlyphAnimation } from "./PxiGlyph";
 
-export interface AgentChatWidgetButtonProps {
+export interface AgentChatWidgetButtonProps extends Omit<
+  AriaButtonProps,
+  "aria-label" | "children" | "type"
+> {
+  ref?: Ref<HTMLButtonElement>;
   isStreaming?: boolean;
-  onClick?: () => void;
   ariaLabel?: string;
   isDragHandle?: boolean;
   glyphAnimation?: PxiGlyphAnimation;
 }
 
 export function AgentChatWidgetButton({
+  ref,
   isStreaming = false,
-  onClick,
   ariaLabel = "Open agent chat",
   isDragHandle = false,
   glyphAnimation = "wave-reveal",
+  ...buttonProps
 }: AgentChatWidgetButtonProps) {
   const { theme } = useTheme();
   return (
-    <button
+    <AriaButton
+      ref={ref}
       type="button"
       css={[
         buttonCSS,
         inlineButtonCSS,
         isDragHandle ? draggableButtonCSS : undefined,
       ]}
-      onClick={onClick}
+      {...buttonProps}
       aria-label={ariaLabel}
     >
       <motion.div
@@ -396,7 +415,7 @@ export function AgentChatWidgetButton({
           </AnimatePresence>
         </div>
       </motion.div>
-    </button>
+    </AriaButton>
   );
 }
 
@@ -418,6 +437,20 @@ export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
       : false
   );
 
+  useHotkeys(
+    OPEN_AGENT_HOTKEY,
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      toggleOpen();
+    },
+    {
+      enabled: isAssistantAgentEnabled && !hasOpenModal,
+      preventDefault: true,
+    },
+    [isAssistantAgentEnabled, hasOpenModal, toggleOpen]
+  );
+
   // Use contextual entrypoints inside modals (e.g. trace slideover header)
   // instead of letting the global FAB compete with overlay hit-testing.
   if (!isAssistantAgentEnabled || isOpen || hasOpenModal) {
@@ -429,14 +462,46 @@ export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
       boundaryRef={boundaryRef}
       placement={fabPlacement}
       size={isStreaming ? FAB_STREAMING_SIZE : FAB_RESTING_SIZE}
+      onActivate={toggleOpen}
       onPlacementChange={setFabPlacement}
     >
-      <AgentChatWidgetButton
-        isDragHandle
-        isStreaming={isStreaming}
-        onClick={toggleOpen}
-      />
+      <TooltipTrigger delay={1000} closeDelay={0}>
+        <AgentChatWidgetButton
+          ariaLabel="Open assistant"
+          isDragHandle
+          isStreaming={isStreaming}
+          onPress={(event) => {
+            if (
+              event.pointerType === "keyboard" ||
+              event.pointerType === "virtual"
+            ) {
+              toggleOpen();
+            }
+          }}
+        />
+        <AgentChatWidgetTooltip />
+      </TooltipTrigger>
     </AgentFabPositioner>,
     document.body
+  );
+}
+
+function AgentChatWidgetTooltip() {
+  const modifierKey = useModifierKey();
+  const modifierGlyph = modifierKey === "Cmd" ? "⌘" : "Ctrl";
+
+  return (
+    <Tooltip placement="top" offset={6}>
+      <TooltipArrow />
+      <Flex direction="row" gap="size-100" alignItems="center">
+        <span>Open assistant</span>
+        <Keyboard>
+          <VisuallyHidden>{modifierKey}</VisuallyHidden>
+          <span aria-hidden="true">{modifierGlyph}</span>
+          <VisuallyHidden>i</VisuallyHidden>
+          <span aria-hidden="true">I</span>
+        </Keyboard>
+      </Flex>
+    </Tooltip>
   );
 }

--- a/app/src/components/agent/AgentFabPositioner.tsx
+++ b/app/src/components/agent/AgentFabPositioner.tsx
@@ -72,6 +72,7 @@ export type AgentFabPositionerProps = {
   children: ReactNode;
   placement: AgentFabPlacement;
   size?: Size;
+  onActivate?: () => void;
   onPlacementChange: (placement: AgentFabPlacement) => void;
 };
 
@@ -194,6 +195,7 @@ export function AgentFabPositioner({
   children,
   placement,
   size,
+  onActivate,
   onPlacementChange,
 }: AgentFabPositionerProps) {
   const positionerRef = useRef<HTMLDivElement>(null);
@@ -297,7 +299,7 @@ export function AgentFabPositioner({
         : getSize();
     const pointer = { x: event.clientX, y: event.clientY };
 
-    dragSessionRef.current = {
+    const session: DragSession = {
       bounds: getBounds(),
       hasPointerCapture: false,
       offset: {
@@ -308,6 +310,12 @@ export function AgentFabPositioner({
       size: measuredSize,
       startPointer: pointer,
     };
+    // Capture immediately so touch drags stay connected before the movement
+    // threshold is crossed, even when the trigger child releases implicit
+    // pointer capture.
+    event.currentTarget.setPointerCapture(session.pointerId);
+    session.hasPointerCapture = true;
+    dragSessionRef.current = session;
     lastDragPositionRef.current = null;
     pendingPointerRef.current = null;
     hasDraggedRef.current = false;
@@ -327,8 +335,10 @@ export function AgentFabPositioner({
         return;
       }
       hasDraggedRef.current = true;
-      session.hasPointerCapture = true;
-      event.currentTarget.setPointerCapture(session.pointerId);
+      if (!session.hasPointerCapture) {
+        event.currentTarget.setPointerCapture(session.pointerId);
+        session.hasPointerCapture = true;
+      }
       // Suppress the snap-to-corner transition while the user is dragging —
       // the transform must follow the pointer 1:1.
       positionerRef.current?.style.setProperty("transition", "none");
@@ -379,6 +389,9 @@ export function AgentFabPositioner({
       // Pure click — no transform changes, just clear any leftover transition
       // override so the next render is in the default state.
       positionerRef.current?.style.removeProperty("transition");
+      if (event.type === "pointerup") {
+        onActivate?.();
+      }
       return;
     }
 
@@ -477,10 +490,10 @@ export function AgentFabPositioner({
       data-placement={placement}
       ref={positionerRef}
       onClickCapture={handleClickCapture}
-      onPointerCancel={finishDrag}
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={finishDrag}
+      onPointerCancelCapture={finishDrag}
+      onPointerDownCapture={handlePointerDown}
+      onPointerMoveCapture={handlePointerMove}
+      onPointerUpCapture={finishDrag}
       onTransitionEnd={handleTransitionEnd}
     >
       {children}

--- a/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
@@ -1,0 +1,216 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentProvider, useAgentContext } from "@phoenix/contexts/AgentContext";
+import { FeatureFlagsContext } from "@phoenix/contexts/FeatureFlagsContext";
+import { PreferencesProvider } from "@phoenix/contexts/PreferencesContext";
+import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
+
+import { AgentChatWidget } from "../AgentChatWidget";
+
+function AgentOpenState() {
+  const isOpen = useAgentContext((state) => state.isOpen);
+  return <span data-testid="agent-open">{String(isOpen)}</span>;
+}
+
+function dispatchCommandI() {
+  act(() => {
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        code: "KeyI",
+        key: "i",
+        metaKey: true,
+      })
+    );
+  });
+}
+
+function dispatchPointerEvent(
+  element: Element,
+  type: string,
+  init: {
+    clientX: number;
+    clientY: number;
+    pointerId?: number;
+    pointerType?: string;
+  }
+) {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    button: 0,
+    clientX: init.clientX,
+    clientY: init.clientY,
+  });
+  Object.defineProperty(event, "pointerId", {
+    value: init.pointerId ?? 1,
+  });
+  Object.defineProperty(event, "pointerType", {
+    value: init.pointerType ?? "mouse",
+  });
+  element.dispatchEvent(event);
+}
+
+describe("AgentChatWidget", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    localStorage.clear();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        media: "",
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    localStorage.clear();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function renderWidget({
+    isAssistantAgentEnabled = true,
+  }: {
+    isAssistantAgentEnabled?: boolean;
+  } = {}) {
+    act(() => {
+      root.render(
+        <ThemeProvider themeMode="light" disableBodyTheme>
+          <FeatureFlagsContext.Provider
+            value={{
+              featureFlags: { agents: true, tracing_ux: false },
+              setFeatureFlags: vi.fn(),
+            }}
+          >
+            <PreferencesProvider
+              isAssistantAgentEnabled={isAssistantAgentEnabled}
+            >
+              <AgentProvider>
+                <AgentChatWidget />
+                <AgentOpenState />
+              </AgentProvider>
+            </PreferencesProvider>
+          </FeatureFlagsContext.Provider>
+        </ThemeProvider>
+      );
+    });
+  }
+
+  it("toggles PXI with Command+I", () => {
+    renderWidget();
+
+    expect(
+      container.querySelector('[data-testid="agent-open"]')?.textContent
+    ).toBe("false");
+
+    dispatchCommandI();
+
+    expect(
+      container.querySelector('[data-testid="agent-open"]')?.textContent
+    ).toBe("true");
+
+    dispatchCommandI();
+
+    expect(
+      container.querySelector('[data-testid="agent-open"]')?.textContent
+    ).toBe("false");
+  });
+
+  it("ignores Command+I when PXI is disabled", () => {
+    renderWidget({ isAssistantAgentEnabled: false });
+
+    dispatchCommandI();
+
+    expect(
+      container.querySelector('[data-testid="agent-open"]')?.textContent
+    ).toBe("false");
+  });
+
+  it("toggles PXI when the FAB is clicked", () => {
+    renderWidget();
+
+    const fabButton = document.body.querySelector(
+      'button[aria-label="Open assistant"]'
+    );
+    const positioner = document.body.querySelector(
+      ".agent-chat-widget-positioner"
+    );
+    expect(fabButton).not.toBeNull();
+    expect(positioner).not.toBeNull();
+    Object.assign(positioner!, {
+      setPointerCapture: vi.fn(),
+      releasePointerCapture: vi.fn(),
+      hasPointerCapture: vi.fn(() => true),
+    });
+
+    act(() => {
+      dispatchPointerEvent(fabButton!, "pointerdown", {
+        clientX: 935,
+        clientY: 758,
+      });
+      dispatchPointerEvent(fabButton!, "pointerup", {
+        clientX: 935,
+        clientY: 758,
+      });
+    });
+
+    expect(
+      container.querySelector('[data-testid="agent-open"]')?.textContent
+    ).toBe("true");
+  });
+
+  it("shows the shortcut tooltip when the FAB is hovered", () => {
+    vi.useFakeTimers();
+    renderWidget();
+
+    const fabButton = document.body.querySelector(
+      'button[aria-label="Open assistant"]'
+    ) as HTMLButtonElement | null;
+    expect(fabButton).not.toBeNull();
+
+    act(() => {
+      document.dispatchEvent(
+        new MouseEvent("mousemove", {
+          bubbles: true,
+          clientX: 935,
+          clientY: 758,
+        })
+      );
+      dispatchPointerEvent(fabButton!, "pointerover", {
+        clientX: 935,
+        clientY: 758,
+        pointerType: "mouse",
+      });
+      fabButton?.dispatchEvent(
+        new MouseEvent("mouseover", {
+          bubbles: true,
+          clientX: 935,
+          clientY: 758,
+        })
+      );
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(document.body.textContent).toContain("Open assistant");
+  });
+});

--- a/app/src/components/agent/__tests__/AgentFabPositioner.test.tsx
+++ b/app/src/components/agent/__tests__/AgentFabPositioner.test.tsx
@@ -1,4 +1,4 @@
-import { act } from "react";
+import { act, type PointerEvent as ReactPointerEvent } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -67,22 +67,40 @@ describe("AgentFabPositioner", () => {
 
   function renderPositioner({
     onClick = vi.fn(),
+    onActivate = vi.fn(),
     onPlacementChange = vi.fn(),
     placement = "bottom-end",
+    stopPointerPropagation = false,
   }: {
     onClick?: () => void;
+    onActivate?: () => void;
     onPlacementChange?: (placement: AgentFabPlacement) => void;
     placement?: AgentFabPlacement;
+    stopPointerPropagation?: boolean;
   } = {}) {
+    const stopPropagation = (event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (stopPointerPropagation) {
+        event.stopPropagation();
+      }
+    };
+
     act(() => {
       root.render(
         <AgentFabPositioner
           boundaryRef={{ current: boundary }}
           placement={placement}
           size={{ width: 58, height: 36 }}
+          onActivate={onActivate}
           onPlacementChange={onPlacementChange}
         >
-          <button type="button" onClick={onClick}>
+          <button
+            type="button"
+            onClick={onClick}
+            onPointerCancel={stopPropagation}
+            onPointerDown={stopPropagation}
+            onPointerMove={stopPropagation}
+            onPointerUp={stopPropagation}
+          >
             PXI
           </button>
         </AgentFabPositioner>
@@ -140,6 +158,71 @@ describe("AgentFabPositioner", () => {
     expect(onPlacementChange).toHaveBeenCalledWith("top-start");
   });
 
+  it("supports dragging when trigger children consume pointer events", () => {
+    const onPlacementChange = vi.fn();
+    const { button } = renderPositioner({
+      onPlacementChange,
+      stopPointerPropagation: true,
+    });
+
+    act(() => {
+      dispatchPointerEvent(button, "pointerdown", {
+        clientX: 935,
+        clientY: 758,
+      });
+      dispatchPointerEvent(button, "pointermove", {
+        clientX: 150,
+        clientY: 140,
+      });
+      dispatchPointerEvent(button, "pointerup", {
+        clientX: 150,
+        clientY: 140,
+      });
+    });
+
+    expect(onPlacementChange).toHaveBeenCalledWith("top-start");
+  });
+
+  it("activates on a pure pointer release", () => {
+    const onActivate = vi.fn();
+    const { button } = renderPositioner({ onActivate });
+
+    act(() => {
+      dispatchPointerEvent(button, "pointerdown", {
+        clientX: 935,
+        clientY: 758,
+      });
+      dispatchPointerEvent(button, "pointerup", {
+        clientX: 935,
+        clientY: 758,
+      });
+    });
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not activate after a drag", () => {
+    const onActivate = vi.fn();
+    const { button } = renderPositioner({ onActivate });
+
+    act(() => {
+      dispatchPointerEvent(button, "pointerdown", {
+        clientX: 935,
+        clientY: 758,
+      });
+      dispatchPointerEvent(button, "pointermove", {
+        clientX: 150,
+        clientY: 140,
+      });
+      dispatchPointerEvent(button, "pointerup", {
+        clientX: 150,
+        clientY: 140,
+      });
+    });
+
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+
   it("suppresses the opening click after a drag", () => {
     const onClick = vi.fn();
     const { button, positioner } = renderPositioner({ onClick });
@@ -182,7 +265,7 @@ describe("AgentFabPositioner", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it("does not capture the pointer before the user starts dragging", () => {
+  it("captures the pointer while a drag is pending without blocking normal click", () => {
     const onClick = vi.fn();
     const { button, positioner } = renderPositioner({ onClick });
 
@@ -198,11 +281,12 @@ describe("AgentFabPositioner", () => {
       button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    expect(positioner.setPointerCapture).not.toHaveBeenCalled();
+    expect(positioner.setPointerCapture).toHaveBeenCalledWith(1);
+    expect(positioner.releasePointerCapture).toHaveBeenCalledWith(1);
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it("captures the pointer once dragging starts", () => {
+  it("keeps pointer capture while dragging", () => {
     const { positioner } = renderPositioner();
 
     act(() => {
@@ -217,6 +301,7 @@ describe("AgentFabPositioner", () => {
     });
 
     expect(positioner.setPointerCapture).toHaveBeenCalledWith(1);
+    expect(positioner.setPointerCapture).toHaveBeenCalledTimes(1);
   });
 
   it("does not suppress a later click when the drag release click was not emitted", () => {


### PR DESCRIPTION
## Summary
- add a global Cmd/Ctrl+I shortcut to toggle the PXI assistant
- add a 1 second delayed FAB tooltip that says "Open assistant" and shows the shortcut
- keep FAB dragging reliable with tooltip/react-aria trigger children by capturing pointer events immediately
- add regression coverage for shortcut, tooltip, and drag behavior

## Validation
- make test-frontend
- make typecheck-frontend
- make lint-frontend