### PR TITLE
feat(pxi): add floating assistant panel

### DIFF
--- a/app/src/components/agent/AgentChatPanel.tsx
+++ b/app/src/components/agent/AgentChatPanel.tsx
@@ -1,10 +1,15 @@
-import { Suspense } from "react";
+import { Suspense, type ReactNode } from "react";
 
 import { ChatSessionUsage } from "@phoenix/components/agent/ChatSessionUsage";
 import { Loading } from "@phoenix/components/core";
+import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 
-import { AgentChatHeader, DockedAgentChatFrame } from "./AgentChatPanelView";
+import {
+  AgentChatHeader,
+  DockedAgentChatFrame,
+  FloatingAgentChatFrame,
+} from "./AgentChatPanelView";
 import { ChatView } from "./Chat";
 import {
   EMPTY_SESSION_DISPLAY_NAME,
@@ -15,14 +20,41 @@ import { useAgentChatPanelState } from "./useAgentChatPanelState";
 import type { AgentModelSelection } from "./useGenerateSessionSummary";
 
 /**
- * Always-mounted controller for the agent chat. The panel UI is conditional,
- * but the underlying chat hook stays mounted so in-flight streams survive
- * when the panel is closed.
+ * Controller for the pinned side-panel agent chat.
  */
 export function AgentChatPanel() {
+  return (
+    <AgentChatSurface
+      renderFrame={(children) => (
+        <DockedAgentChatFrame>{children}</DockedAgentChatFrame>
+      )}
+    />
+  );
+}
+
+export function FloatingAgentChatPanel() {
+  const fabPlacement = useAgentContext((state) => state.fabPlacement);
+
+  return (
+    <AgentChatSurface
+      renderFrame={(children) => (
+        <FloatingAgentChatFrame placement={fabPlacement}>
+          {children}
+        </FloatingAgentChatFrame>
+      )}
+    />
+  );
+}
+
+function AgentChatSurface({
+  renderFrame,
+}: {
+  renderFrame: (children: ReactNode) => ReactNode;
+}) {
   const isAgentsEnabled = useFeatureFlag("agents");
   const {
     isOpen,
+    position,
     activeSessionId,
     orderedSessions,
     showSessionHistory,
@@ -33,6 +65,7 @@ export function AgentChatPanel() {
     setActiveSession,
     deleteSession,
     closePanel,
+    setPosition,
     handleModelChange,
   } = useAgentChatPanelState();
 
@@ -62,7 +95,10 @@ export function AgentChatPanel() {
       setActiveSession={setActiveSession}
       deleteSession={deleteSession}
       closePanel={closePanel}
+      position={position}
+      setPosition={setPosition}
       handleModelChange={handleModelChange}
+      renderFrame={renderFrame}
     />
   );
 }
@@ -80,7 +116,10 @@ function AgentChatController({
   setActiveSession,
   deleteSession,
   closePanel,
+  position,
+  setPosition,
   handleModelChange,
+  renderFrame,
 }: {
   isOpen: boolean;
   activeSessionId: string | null;
@@ -98,9 +137,12 @@ function AgentChatController({
   >["setActiveSession"];
   deleteSession: ReturnType<typeof useAgentChatPanelState>["deleteSession"];
   closePanel: ReturnType<typeof useAgentChatPanelState>["closePanel"];
+  position: ReturnType<typeof useAgentChatPanelState>["position"];
+  setPosition: ReturnType<typeof useAgentChatPanelState>["setPosition"];
   handleModelChange: ReturnType<
     typeof useAgentChatPanelState
   >["handleModelChange"];
+  renderFrame: (children: ReactNode) => ReactNode;
 }) {
   const {
     messages,
@@ -121,16 +163,18 @@ function AgentChatController({
     return null;
   }
 
-  return (
-    <DockedAgentChatFrame>
+  return renderFrame(
+    <>
       <AgentChatHeader
         sessionDisplayName={sessionDisplayName}
         orderedSessions={orderedSessions}
         activeSessionId={activeSessionId}
         showSessionHistory={showSessionHistory}
+        position={position}
         onSelectSession={setActiveSession}
         onDeleteSession={deleteSession}
         onCreateSession={createSession}
+        onPositionChange={setPosition}
         onClose={closePanel}
       />
       {/* Catch runaway suspense triggers that aren't handled locally */}
@@ -152,6 +196,6 @@ function AgentChatController({
           ) : null}
         </ChatView>
       </Suspense>
-    </DockedAgentChatFrame>
+    </>
   );
 }

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -22,9 +22,16 @@ import type {
 import { PxiGlyph } from "./PxiGlyph";
 import { SessionListMenu } from "./SessionListMenu";
 
+const PANEL_HEADER_Z_INDEX = 3;
+const FLOATING_PANEL_WIDTH_PX = 420;
+const FLOATING_PANEL_HEIGHT_PX = 720;
+const FLOATING_PANEL_MIN_HEIGHT_PX = 520;
+const FLOATING_PANEL_FULLSCREEN_BREAKPOINT_PX = 600;
+const FLOATING_PANEL_VIEWPORT_MARGIN = "var(--global-dimension-size-400)";
+
 const panelHeaderCSS = css`
   ${fadedDividerBottomCSS}
-  z-index: 3;
+  z-index: ${PANEL_HEADER_Z_INDEX};
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -204,9 +211,18 @@ const floatingPanelContentCSS = css`
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  width: min(420px, calc(100% - 32px));
-  height: min(720px, calc(100% - 32px));
-  min-height: min(520px, calc(100% - 32px));
+  width: min(
+    ${FLOATING_PANEL_WIDTH_PX}px,
+    calc(100% - ${FLOATING_PANEL_VIEWPORT_MARGIN})
+  );
+  height: min(
+    ${FLOATING_PANEL_HEIGHT_PX}px,
+    calc(100% - ${FLOATING_PANEL_VIEWPORT_MARGIN})
+  );
+  min-height: min(
+    ${FLOATING_PANEL_MIN_HEIGHT_PX}px,
+    calc(100% - ${FLOATING_PANEL_VIEWPORT_MARGIN})
+  );
   overflow: hidden;
   border: 1px solid var(--global-border-color-default);
   border-radius: var(--global-rounding-medium);
@@ -231,7 +247,7 @@ const floatingPanelContentCSS = css`
     right: var(--global-dimension-size-200);
   }
 
-  @media (max-width: 600px), (max-height: 600px) {
+  @media (max-width: ${FLOATING_PANEL_FULLSCREEN_BREAKPOINT_PX}px), (max-height: ${FLOATING_PANEL_FULLSCREEN_BREAKPOINT_PX}px) {
     inset: var(--global-dimension-size-100);
     width: auto;
     height: auto;

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -12,18 +12,23 @@ import {
 } from "@phoenix/components";
 import { fadedDividerBottomCSS } from "@phoenix/components/core/layout";
 import { compactResizeHandleCSS } from "@phoenix/components/resize/styles";
-import type { AgentSession } from "@phoenix/store/agentStore";
+import type {
+  AgentFabPlacement,
+  AgentPosition,
+  AgentSession,
+} from "@phoenix/store/agentStore";
 
 import { PxiGlyph } from "./PxiGlyph";
 import { SessionListMenu } from "./SessionListMenu";
 
 const panelHeaderCSS = css`
   ${fadedDividerBottomCSS}
-  z-index: 2;
+  z-index: 3;
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: var(--global-dimension-size-100) var(--global-dimension-size-150);
+  background: var(--global-background-color-default);
 `;
 
 const panelHeaderActionsCSS = css`
@@ -56,20 +61,30 @@ export function AgentChatHeader({
   orderedSessions,
   activeSessionId,
   showSessionHistory,
+  position,
   onSelectSession,
   onDeleteSession,
   onCreateSession,
+  onPositionChange,
   onClose,
 }: {
   sessionDisplayName: string;
   orderedSessions: AgentSession[];
   activeSessionId: string | null;
   showSessionHistory: boolean;
+  position?: AgentPosition;
   onSelectSession: (sessionId: string | null) => void;
   onDeleteSession: (sessionId: string) => void;
   onCreateSession: () => void;
+  onPositionChange?: (position: AgentPosition) => void;
   onClose: () => void;
 }) {
+  const nextPosition = position === "pinned" ? "detached" : "pinned";
+  const positionToggleLabel =
+    position === "pinned"
+      ? "Switch assistant to floating panel"
+      : "Pin assistant to side";
+
   return (
     <div css={panelHeaderCSS}>
       <Flex direction="row" alignItems="center" gap="size-50" minWidth={0}>
@@ -104,6 +119,21 @@ export function AgentChatHeader({
           onPress={onCreateSession}
           leadingVisual={<Icon svg={<Icons.PlusOutline />} />}
         />
+        {position != null && onPositionChange != null ? (
+          <Button
+            variant="quiet"
+            size="S"
+            aria-label={positionToggleLabel}
+            onPress={() => onPositionChange(nextPosition)}
+            leadingVisual={
+              <Icon
+                svg={
+                  position === "pinned" ? <Icons.SlideOut /> : <Icons.SlideIn />
+                }
+              />
+            }
+          />
+        ) : null}
         <LinkButton
           variant="quiet"
           size="S"
@@ -164,6 +194,64 @@ export function DockedAgentChatFrame({ children }: { children: ReactNode }) {
     >
       {children}
     </AgentChatFrame>
+  );
+}
+
+const floatingPanelContentCSS = css`
+  position: absolute;
+  z-index: 100001;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  width: min(420px, calc(100% - 32px));
+  height: min(720px, calc(100% - 32px));
+  min-height: min(520px, calc(100% - 32px));
+  overflow: hidden;
+  border: 1px solid var(--global-border-color-default);
+  border-radius: var(--global-rounding-medium);
+  background: var(--global-background-color-default);
+  box-shadow:
+    0 12px 32px rgba(var(--global-color-gray-900-rgb), 0.2),
+    0 2px 8px rgba(var(--global-color-gray-900-rgb), 0.12);
+
+  &[data-placement^="top"] {
+    top: var(--global-dimension-size-200);
+  }
+
+  &[data-placement^="bottom"] {
+    bottom: var(--global-dimension-size-200);
+  }
+
+  &[data-placement$="start"] {
+    left: var(--global-dimension-size-200);
+  }
+
+  &[data-placement$="end"] {
+    right: var(--global-dimension-size-200);
+  }
+
+  @media (max-width: 600px), (max-height: 600px) {
+    inset: var(--global-dimension-size-100);
+    width: auto;
+    height: auto;
+    min-height: 0;
+  }
+`;
+
+/**
+ * Presentational shell for the floating PXI panel.
+ */
+export function FloatingAgentChatFrame({
+  children,
+  placement,
+}: {
+  children: ReactNode;
+  placement: AgentFabPlacement;
+}) {
+  return (
+    <div css={floatingPanelContentCSS} data-placement={placement}>
+      {children}
+    </div>
   );
 }
 

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -23,15 +23,25 @@ import { SessionListMenu } from "./SessionListMenu";
 
 const panelHeaderCSS = css`
   ${fadedDividerBottomCSS}
+  --agent-chat-header-glyph-size: var(--global-dimension-size-200);
+
   z-index: 3;
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: var(--global-dimension-size-100) var(--global-dimension-size-150);
   background: var(--global-background-color-default);
+
+  &[data-position="detached"] {
+    --agent-chat-header-glyph-size: var(--global-dimension-size-150);
+  }
 `;
 
 const panelHeaderActionsCSS = css`
+  flex-shrink: 0;
+`;
+
+const panelHeaderGlyphCSS = css`
   flex-shrink: 0;
 `;
 
@@ -86,13 +96,12 @@ export function AgentChatHeader({
       : "Pin assistant to side";
 
   return (
-    <div css={panelHeaderCSS}>
+    <div css={panelHeaderCSS} data-position={position}>
       <Flex direction="row" alignItems="center" gap="size-50" minWidth={0}>
         <PxiGlyph
           fill="var(--global-text-color-900)"
-          css={css`
-            transform: scale(0.7);
-          `}
+          size="var(--agent-chat-header-glyph-size)"
+          css={panelHeaderGlyphCSS}
         />
         <Text weight="heavy" css={sessionHeadingCSS} title={sessionDisplayName}>
           {sessionDisplayName}

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -11,6 +11,7 @@ import {
   Text,
 } from "@phoenix/components";
 import { fadedDividerBottomCSS } from "@phoenix/components/core/layout";
+import { NON_MODAL_FLOATING_Z_INDEX } from "@phoenix/components/core/zIndex";
 import { compactResizeHandleCSS } from "@phoenix/components/resize/styles";
 import type {
   AgentFabPlacement,
@@ -199,7 +200,7 @@ export function DockedAgentChatFrame({ children }: { children: ReactNode }) {
 
 const floatingPanelContentCSS = css`
   position: absolute;
-  z-index: 100001;
+  z-index: ${NON_MODAL_FLOATING_Z_INDEX};
   display: flex;
   flex-direction: column;
   box-sizing: border-box;

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -23,25 +23,15 @@ import { SessionListMenu } from "./SessionListMenu";
 
 const panelHeaderCSS = css`
   ${fadedDividerBottomCSS}
-  --agent-chat-header-glyph-size: var(--global-dimension-size-200);
-
   z-index: 3;
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: var(--global-dimension-size-100) var(--global-dimension-size-150);
   background: var(--global-background-color-default);
-
-  &[data-position="detached"] {
-    --agent-chat-header-glyph-size: var(--global-dimension-size-150);
-  }
 `;
 
 const panelHeaderActionsCSS = css`
-  flex-shrink: 0;
-`;
-
-const panelHeaderGlyphCSS = css`
   flex-shrink: 0;
 `;
 
@@ -96,12 +86,13 @@ export function AgentChatHeader({
       : "Pin assistant to side";
 
   return (
-    <div css={panelHeaderCSS} data-position={position}>
+    <div css={panelHeaderCSS}>
       <Flex direction="row" alignItems="center" gap="size-50" minWidth={0}>
         <PxiGlyph
           fill="var(--global-text-color-900)"
-          size="var(--agent-chat-header-glyph-size)"
-          css={panelHeaderGlyphCSS}
+          css={css`
+            transform: scale(0.7);
+          `}
         />
         <Text weight="heavy" css={sessionHeadingCSS} title={sessionDisplayName}>
           {sessionDisplayName}

--- a/app/src/components/agent/AgentFabPositioner.tsx
+++ b/app/src/components/agent/AgentFabPositioner.tsx
@@ -9,6 +9,7 @@ import type {
 import { useLayoutEffect, useRef, useState } from "react";
 import invariant from "tiny-invariant";
 
+import { NON_MODAL_FLOATING_Z_INDEX } from "@phoenix/components/core/zIndex";
 import type { AgentFabPlacement } from "@phoenix/store/agentStore";
 import type { Bounds, Point, Size } from "@phoenix/types/geometry";
 
@@ -33,15 +34,11 @@ const SNAP_TRANSITION = `transform ${SNAP_DURATION_MS}ms ${SNAP_EASING}`;
 // button. The FAB only responds to primary-button gestures.
 const PRIMARY_POINTER_BUTTON = 0;
 
-// Sits above app chrome but below modal overlays. Matches the value the
-// floating button used in its previous fixed-position incarnation.
-const FAB_Z_INDEX = 1000;
-
 const positionerCSS = css`
   position: fixed;
   top: 0;
   left: 0;
-  z-index: ${FAB_Z_INDEX};
+  z-index: ${NON_MODAL_FLOATING_Z_INDEX};
   cursor: pointer;
   touch-action: none;
   transform: translate3d(0, 0, 0);

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -155,6 +155,7 @@ const chatCSS = css`
   }
 
   .chat__messages {
+    box-sizing: border-box;
     max-width: 780px;
     margin: 0 auto;
     position: relative;
@@ -166,6 +167,17 @@ const chatCSS = css`
       var(--chat-sidebar-inset);
     font-size: var(--global-font-size-s);
     line-height: var(--global-line-height-s);
+  }
+
+  &.chat--empty {
+    .chat__messages {
+      min-height: 100%;
+      width: 100%;
+    }
+
+    .chat__empty {
+      margin-block: auto;
+    }
   }
 
   .chat__input {

--- a/app/src/components/agent/ChatEmptyShaderHero.tsx
+++ b/app/src/components/agent/ChatEmptyShaderHero.tsx
@@ -23,6 +23,10 @@ const HIDE_HERO_HEIGHT_BREAKPOINT = 570;
 const NARROW_WIDTH_BREAKPOINT = 479;
 const MEDIUM_WIDTH_BREAKPOINT = 560;
 const NARROW_GLYPH_SIZE = 220;
+const COMPACT_HERO_PADDING_TOP = 176;
+const SMALL_HERO_PADDING_TOP = COMPACT_GLYPH_SIZE;
+const MEDIUM_HERO_PADDING_TOP = 288;
+const LARGE_HERO_PADDING_TOP = 320;
 const COMPACT_GLYPH_TOP_OFFSET = -40;
 const SMALL_GLYPH_TOP_OFFSET = -48;
 const DEFAULT_GLYPH_TOP_OFFSET = -56;
@@ -56,22 +60,18 @@ function getHeroGlyphSize({ height, width }: HeroContainerSize) {
 
 function getHeroPaddingTop(glyphSize: number) {
   if (glyphSize <= COMPACT_GLYPH_SIZE) {
-    return 176;
-  }
-
-  if (glyphSize <= NARROW_GLYPH_SIZE) {
-    return 160;
+    return COMPACT_HERO_PADDING_TOP;
   }
 
   if (glyphSize <= SMALL_GLYPH_SIZE) {
-    return COMPACT_GLYPH_SIZE;
+    return SMALL_HERO_PADDING_TOP;
   }
 
   if (glyphSize <= MEDIUM_GLYPH_SIZE) {
-    return 288;
+    return MEDIUM_HERO_PADDING_TOP;
   }
 
-  return 320;
+  return LARGE_HERO_PADDING_TOP;
 }
 
 function getHeroGlyphTopOffset(glyphSize: number) {

--- a/app/src/components/agent/ChatEmptyShaderHero.tsx
+++ b/app/src/components/agent/ChatEmptyShaderHero.tsx
@@ -68,6 +68,18 @@ function getHeroPaddingTop(glyphSize: number) {
   return 320;
 }
 
+function getHeroGlyphTopOffset(glyphSize: number) {
+  if (glyphSize <= COMPACT_GLYPH_SIZE) {
+    return -40;
+  }
+
+  if (glyphSize <= SMALL_GLYPH_SIZE) {
+    return -48;
+  }
+
+  return -56;
+}
+
 const heroCSS = css`
   position: relative;
   box-sizing: border-box;
@@ -233,6 +245,7 @@ export function ChatEmptyShaderHero({
 
   const glyphSize = getHeroGlyphSize(containerSize);
   const paddingTop = getHeroPaddingTop(glyphSize);
+  const glyphTopOffset = getHeroGlyphTopOffset(glyphSize);
 
   return (
     <div
@@ -243,6 +256,7 @@ export function ChatEmptyShaderHero({
         {
           "--hero-glyph-size": `${glyphSize}px`,
           "--hero-padding-top": `${paddingTop}px`,
+          "--hero-glyph-top-offset": `${glyphTopOffset}px`,
         } as CSSProperties
       }
     >

--- a/app/src/components/agent/ChatEmptyShaderHero.tsx
+++ b/app/src/components/agent/ChatEmptyShaderHero.tsx
@@ -1,5 +1,11 @@
 import { css } from "@emotion/react";
-import { useEffect, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 
 import { PxiShaderGlyph } from "./PxiShaderGlyph";
 
@@ -11,21 +17,55 @@ const COMPACT_GLYPH_SIZE = 200;
 const MEDIUM_HEIGHT_BREAKPOINT = 960;
 const SMALL_HEIGHT_BREAKPOINT = 840;
 const COMPACT_HEIGHT_BREAKPOINT = 720;
+const NARROW_WIDTH_BREAKPOINT = 479;
+const MEDIUM_WIDTH_BREAKPOINT = 560;
+const NARROW_GLYPH_SIZE = 220;
 
-function getHeroGlyphSize(viewportHeight: number) {
-  if (viewportHeight <= COMPACT_HEIGHT_BREAKPOINT) {
+type HeroContainerSize = {
+  width: number;
+  height: number;
+};
+
+function getHeroGlyphSize({ height, width }: HeroContainerSize) {
+  let glyphSize = LARGE_GLYPH_SIZE;
+
+  if (height <= COMPACT_HEIGHT_BREAKPOINT) {
+    glyphSize = COMPACT_GLYPH_SIZE;
+  } else if (height <= SMALL_HEIGHT_BREAKPOINT) {
+    glyphSize = SMALL_GLYPH_SIZE;
+  } else if (height <= MEDIUM_HEIGHT_BREAKPOINT) {
+    glyphSize = MEDIUM_GLYPH_SIZE;
+  }
+
+  if (width <= NARROW_WIDTH_BREAKPOINT) {
+    return Math.min(glyphSize, NARROW_GLYPH_SIZE);
+  }
+
+  if (width <= MEDIUM_WIDTH_BREAKPOINT) {
+    return Math.min(glyphSize, SMALL_GLYPH_SIZE);
+  }
+
+  return glyphSize;
+}
+
+function getHeroPaddingTop(glyphSize: number) {
+  if (glyphSize <= COMPACT_GLYPH_SIZE) {
+    return 128;
+  }
+
+  if (glyphSize <= NARROW_GLYPH_SIZE) {
+    return 160;
+  }
+
+  if (glyphSize <= SMALL_GLYPH_SIZE) {
     return COMPACT_GLYPH_SIZE;
   }
 
-  if (viewportHeight <= SMALL_HEIGHT_BREAKPOINT) {
-    return SMALL_GLYPH_SIZE;
+  if (glyphSize <= MEDIUM_GLYPH_SIZE) {
+    return 288;
   }
 
-  if (viewportHeight <= MEDIUM_HEIGHT_BREAKPOINT) {
-    return MEDIUM_GLYPH_SIZE;
-  }
-
-  return LARGE_GLYPH_SIZE;
+  return 320;
 }
 
 const heroCSS = css`
@@ -140,12 +180,19 @@ export function ChatEmptyShaderHero({
 }: {
   subtext?: ReactNode;
 }) {
-  const [viewportHeight, setViewportHeight] = useState(() => {
+  const heroRef = useRef<HTMLDivElement>(null);
+  const [containerSize, setContainerSize] = useState<HeroContainerSize>(() => {
     if (typeof window === "undefined") {
-      return Number.POSITIVE_INFINITY;
+      return {
+        width: Number.POSITIVE_INFINITY,
+        height: Number.POSITIVE_INFINITY,
+      };
     }
 
-    return window.innerHeight;
+    return {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    };
   });
 
   useEffect(() => {
@@ -153,22 +200,52 @@ export function ChatEmptyShaderHero({
       return;
     }
 
-    const updateViewportHeight = () => {
-      setViewportHeight(window.innerHeight);
+    const updateContainerSize = () => {
+      const measuredElement =
+        heroRef.current?.closest(".chat__scroll") ?? heroRef.current;
+      const rect = measuredElement?.getBoundingClientRect();
+
+      setContainerSize({
+        width: rect?.width || window.innerWidth,
+        height: rect?.height || window.innerHeight,
+      });
     };
 
-    updateViewportHeight();
-    window.addEventListener("resize", updateViewportHeight);
+    updateContainerSize();
+
+    const measuredElement =
+      heroRef.current?.closest(".chat__scroll") ?? heroRef.current;
+    const observer =
+      measuredElement && typeof ResizeObserver === "function"
+        ? new ResizeObserver(updateContainerSize)
+        : null;
+
+    if (observer && measuredElement) {
+      observer.observe(measuredElement);
+    }
+    window.addEventListener("resize", updateContainerSize);
 
     return () => {
-      window.removeEventListener("resize", updateViewportHeight);
+      observer?.disconnect();
+      window.removeEventListener("resize", updateContainerSize);
     };
   }, []);
 
-  const glyphSize = getHeroGlyphSize(viewportHeight);
+  const glyphSize = getHeroGlyphSize(containerSize);
+  const paddingTop = getHeroPaddingTop(glyphSize);
 
   return (
-    <div css={heroCSS} className="chat__empty-hero">
+    <div
+      ref={heroRef}
+      css={heroCSS}
+      className="chat__empty-hero"
+      style={
+        {
+          "--hero-glyph-size": `${glyphSize}px`,
+          "--hero-padding-top": `${paddingTop}px`,
+        } as CSSProperties
+      }
+    >
       <div css={glyphCSS} className="chat__empty-glyph">
         <PxiShaderGlyph size={glyphSize} />
       </div>

--- a/app/src/components/agent/ChatEmptyShaderHero.tsx
+++ b/app/src/components/agent/ChatEmptyShaderHero.tsx
@@ -12,7 +12,7 @@ import { PxiShaderGlyph } from "./PxiShaderGlyph";
 const LARGE_GLYPH_SIZE = 420;
 const MEDIUM_GLYPH_SIZE = 380;
 const SMALL_GLYPH_SIZE = 300;
-const COMPACT_GLYPH_SIZE = 200;
+const COMPACT_GLYPH_SIZE = 220;
 
 const MEDIUM_HEIGHT_BREAKPOINT = 960;
 const SMALL_HEIGHT_BREAKPOINT = 840;

--- a/app/src/components/agent/ChatEmptyShaderHero.tsx
+++ b/app/src/components/agent/ChatEmptyShaderHero.tsx
@@ -13,13 +13,19 @@ const LARGE_GLYPH_SIZE = 420;
 const MEDIUM_GLYPH_SIZE = 380;
 const SMALL_GLYPH_SIZE = 300;
 const COMPACT_GLYPH_SIZE = 220;
+const COMPACT_ROW_GLYPH_SIZE = COMPACT_GLYPH_SIZE / 2;
+const COMPACT_ROW_HERO_WIDTH = 450;
 
 const MEDIUM_HEIGHT_BREAKPOINT = 960;
 const SMALL_HEIGHT_BREAKPOINT = 840;
 const COMPACT_HEIGHT_BREAKPOINT = 720;
+const HIDE_HERO_HEIGHT_BREAKPOINT = 570;
 const NARROW_WIDTH_BREAKPOINT = 479;
 const MEDIUM_WIDTH_BREAKPOINT = 560;
 const NARROW_GLYPH_SIZE = 220;
+const COMPACT_GLYPH_TOP_OFFSET = -40;
+const SMALL_GLYPH_TOP_OFFSET = -48;
+const DEFAULT_GLYPH_TOP_OFFSET = -56;
 
 type HeroContainerSize = {
   width: number;
@@ -70,14 +76,14 @@ function getHeroPaddingTop(glyphSize: number) {
 
 function getHeroGlyphTopOffset(glyphSize: number) {
   if (glyphSize <= COMPACT_GLYPH_SIZE) {
-    return -40;
+    return COMPACT_GLYPH_TOP_OFFSET;
   }
 
   if (glyphSize <= SMALL_GLYPH_SIZE) {
-    return -48;
+    return SMALL_GLYPH_TOP_OFFSET;
   }
 
-  return -56;
+  return DEFAULT_GLYPH_TOP_OFFSET;
 }
 
 const heroCSS = css`
@@ -101,15 +107,14 @@ const heroCSS = css`
   }
 
   @media (max-height: ${COMPACT_HEIGHT_BREAKPOINT}px) {
-    --hero-padding-top: 0px;
-    --hero-glyph-top-offset: 0px;
-    width: 450px;
+    padding-top: 0;
+    width: ${COMPACT_ROW_HERO_WIDTH}px;
     flex-direction: row;
     justify-content: space-evenly;
     gap: var(--global-dimension-size-200);
   }
 
-  @media (max-height: 570px) {
+  @media (max-height: ${HIDE_HERO_HEIGHT_BREAKPOINT}px) {
     display: none;
   }
 
@@ -135,8 +140,8 @@ const glyphCSS = css`
   @media (max-height: ${COMPACT_HEIGHT_BREAKPOINT}px) {
     position: static;
     transform: none;
-    width: ${COMPACT_GLYPH_SIZE / 2}px;
-    height: ${COMPACT_GLYPH_SIZE / 2}px;
+    width: ${COMPACT_ROW_GLYPH_SIZE}px;
+    height: ${COMPACT_ROW_GLYPH_SIZE}px;
   }
 
   @media (max-height: ${COMPACT_HEIGHT_BREAKPOINT}px) {

--- a/app/src/components/agent/ChatEmptyShaderHero.tsx
+++ b/app/src/components/agent/ChatEmptyShaderHero.tsx
@@ -50,7 +50,7 @@ function getHeroGlyphSize({ height, width }: HeroContainerSize) {
 
 function getHeroPaddingTop(glyphSize: number) {
   if (glyphSize <= COMPACT_GLYPH_SIZE) {
-    return 128;
+    return 176;
   }
 
   if (glyphSize <= NARROW_GLYPH_SIZE) {

--- a/app/src/components/agent/__tests__/AgentChatPanelView.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatPanelView.test.tsx
@@ -1,0 +1,96 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentChatHeader } from "../AgentChatPanelView";
+
+describe("AgentChatHeader", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("switches from pinned to floating mode", () => {
+    const onPositionChange = vi.fn();
+
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <AgentChatHeader
+            sessionDisplayName="PXI"
+            orderedSessions={[]}
+            activeSessionId={null}
+            showSessionHistory={false}
+            position="pinned"
+            onSelectSession={vi.fn()}
+            onDeleteSession={vi.fn()}
+            onCreateSession={vi.fn()}
+            onPositionChange={onPositionChange}
+            onClose={vi.fn()}
+          />
+        </MemoryRouter>
+      );
+    });
+
+    const toggleButton = container.querySelector(
+      'button[aria-label="Switch assistant to floating panel"]'
+    );
+
+    expect(toggleButton).not.toBeNull();
+
+    act(() => {
+      toggleButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onPositionChange).toHaveBeenCalledWith("detached");
+  });
+
+  it("switches from floating mode back to pinned", () => {
+    const onPositionChange = vi.fn();
+
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <AgentChatHeader
+            sessionDisplayName="PXI"
+            orderedSessions={[]}
+            activeSessionId={null}
+            showSessionHistory={false}
+            position="detached"
+            onSelectSession={vi.fn()}
+            onDeleteSession={vi.fn()}
+            onCreateSession={vi.fn()}
+            onPositionChange={onPositionChange}
+            onClose={vi.fn()}
+          />
+        </MemoryRouter>
+      );
+    });
+
+    const toggleButton = container.querySelector(
+      'button[aria-label="Pin assistant to side"]'
+    );
+
+    expect(toggleButton).not.toBeNull();
+
+    act(() => {
+      toggleButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onPositionChange).toHaveBeenCalledWith("pinned");
+  });
+});

--- a/app/src/components/agent/index.tsx
+++ b/app/src/components/agent/index.tsx
@@ -5,7 +5,7 @@ export {
   AgentExperimentalSettings,
   AgentWebAccessSettings,
 } from "./AgentExperimentalSettings";
-export { AgentChatPanel } from "./AgentChatPanel";
+export { AgentChatPanel, FloatingAgentChatPanel } from "./AgentChatPanel";
 export { AgentChatWidget } from "./AgentChatWidget";
 export { useAssistantAgentEnabled } from "./useAssistantAgentEnabled";
 export { Chat } from "./Chat";

--- a/app/src/components/agent/useAgentChatPanelState.ts
+++ b/app/src/components/agent/useAgentChatPanelState.ts
@@ -89,6 +89,8 @@ export function useAgentChatPanelState() {
   const store = useAgentStore();
   const isOpen = useAgentContext((state) => state.isOpen);
   const setIsOpen = useAgentContext((state) => state.setIsOpen);
+  const position = useAgentContext((state) => state.position);
+  const setPosition = useAgentContext((state) => state.setPosition);
   const activeSessionId = useAgentContext((state) => state.activeSessionId);
   const createSession = useAgentContext((state) => state.createSession);
   const setActiveSession = useAgentContext((state) => state.setActiveSession);
@@ -265,6 +267,7 @@ export function useAgentChatPanelState() {
 
   return {
     isOpen,
+    position,
     activeSessionId,
     orderedSessions,
     showSessionHistory,
@@ -275,6 +278,7 @@ export function useAgentChatPanelState() {
     setActiveSession,
     deleteSession,
     closePanel,
+    setPosition,
     handleModelChange,
   };
 }

--- a/app/src/components/core/overlay/Modal.tsx
+++ b/app/src/components/core/overlay/Modal.tsx
@@ -6,6 +6,10 @@ import {
   ModalOverlay as AriaModalOverlay,
 } from "react-aria-components";
 
+import {
+  MODAL_DIALOG_Z_INDEX,
+  MODAL_OVERLAY_Z_INDEX,
+} from "@phoenix/components/core/zIndex";
 import { classNames } from "@phoenix/utils/classNames";
 
 const modalSlideover = keyframes`
@@ -96,7 +100,7 @@ const modalCSS = css`
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      z-index: 1001;
+      z-index: ${MODAL_DIALOG_Z_INDEX};
       // 90% gives a decent amount of padding around the dialog when it would
       // otherwise be cut off by the edges of the screen
       max-height: calc(100% - var(--global-dimension-size-800));
@@ -152,7 +156,7 @@ const modalOverlayCSS = css`
   position: fixed;
   inset: 0;
   background: var(--global-overlay-backdrop-color);
-  z-index: 1000;
+  z-index: ${MODAL_OVERLAY_Z_INDEX};
 
   &[data-entering] {
     // ensure overlay animation is longer than child animations

--- a/app/src/components/core/overlay/Popover.tsx
+++ b/app/src/components/core/overlay/Popover.tsx
@@ -3,6 +3,7 @@ import type { Ref } from "react";
 import type { PopoverProps } from "react-aria-components";
 import { Popover as AriaPopover } from "react-aria-components";
 
+import { PORTALED_OVERLAY_Z_INDEX } from "@phoenix/components/core/zIndex";
 import { classNames } from "@phoenix/utils/classNames";
 
 const popoverSlideKeyframes = keyframes`
@@ -31,6 +32,7 @@ const popoverCSS = css`
   background: var(--background-color);
   color: var(--global-text-color-900);
   outline: none;
+  z-index: ${PORTALED_OVERLAY_Z_INDEX};
 
   &[data-entering],
   &[data-exiting] {

--- a/app/src/components/core/toast/styles.ts
+++ b/app/src/components/core/toast/styles.ts
@@ -1,5 +1,7 @@
 import { css, keyframes } from "@emotion/react";
 
+import { PORTALED_OVERLAY_Z_INDEX } from "@phoenix/components/core/zIndex";
+
 /**
  * How far (in px) each stacked toast peeks out from behind the front toast
  * while the stack is collapsed.
@@ -43,7 +45,7 @@ export const toastRegionCSS = css`
   max-width: calc(100vw - var(--global-dimension-static-size-400));
   transform: translateX(-50%);
   outline: none;
-  z-index: 100000;
+  z-index: ${PORTALED_OVERLAY_Z_INDEX};
 
   --collapsed-peek: ${COLLAPSED_PEEK}px;
   --expanded-gap: ${EXPANDED_GAP}px;

--- a/app/src/components/core/zIndex.ts
+++ b/app/src/components/core/zIndex.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared app stacking layers.
+ *
+ * Non-modal floating UI should sit above page content but below modal
+ * backdrops. Portaled popovers and toasts use the top overlay layer so controls
+ * opened from floating surfaces remain usable.
+ */
+export const MODAL_OVERLAY_Z_INDEX = 1000;
+export const MODAL_DIALOG_Z_INDEX = MODAL_OVERLAY_Z_INDEX + 1;
+export const NON_MODAL_FLOATING_Z_INDEX = MODAL_OVERLAY_Z_INDEX - 1;
+export const PORTALED_OVERLAY_Z_INDEX = 100000;

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -4,7 +4,11 @@ import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 import { Outlet, useLoaderData } from "react-router";
 
 import { Counter, Flex, Icon, Icons, Loading } from "@phoenix/components";
-import { AgentChatPanel, AgentChatWidget } from "@phoenix/components/agent";
+import {
+  AgentChatPanel,
+  AgentChatWidget,
+  FloatingAgentChatPanel,
+} from "@phoenix/components/agent";
 import {
   Brand,
   DocsLink,
@@ -44,6 +48,7 @@ const mainViewCSS = css`
   overflow: hidden;
 `;
 const contentCSS = css`
+  position: relative;
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
@@ -79,8 +84,17 @@ export function Layout() {
   const activePanelLocation = useAgentContext(
     (state) => state.activePanelLocation
   );
+  const agentPosition = useAgentContext((state) => state.position);
   const shouldShowDockedAgentPanel =
-    isAgentsEnabled && isAgentPanelOpen && activePanelLocation === "docked";
+    isAgentsEnabled &&
+    isAgentPanelOpen &&
+    activePanelLocation === "docked" &&
+    agentPosition === "pinned";
+  const shouldShowFloatingAgentPanel =
+    isAgentsEnabled &&
+    isAgentPanelOpen &&
+    activePanelLocation === "docked" &&
+    agentPosition === "detached";
   const panelIds = shouldShowDockedAgentPanel
     ? ["layout-content", "agent-chat"]
     : ["layout-content"];
@@ -110,6 +124,9 @@ export function Layout() {
             <Panel id="layout-content">
               <div data-testid="content" css={contentCSS} ref={contentRef}>
                 <AgentChatWidget boundaryRef={contentRef} />
+                {shouldShowFloatingAgentPanel ? (
+                  <FloatingAgentChatPanel />
+                ) : null}
                 <Suspense fallback={<Loading />}>
                   <Outlet />
                 </Suspense>

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -155,6 +155,22 @@ describe("agentStore", () => {
     });
   });
 
+  describe("setPosition", () => {
+    it("defaults to the pinned side panel", () => {
+      const store = createAgentStore();
+
+      expect(store.getState().position).toBe("pinned");
+    });
+
+    it("updates the panel display mode", () => {
+      const store = createAgentStore();
+
+      store.getState().setPosition("detached");
+
+      expect(store.getState().position).toBe("detached");
+    });
+  });
+
   describe("setFabPlacement", () => {
     it("updates the pinned FAB corner", () => {
       const store = createAgentStore();
@@ -295,6 +311,25 @@ describe("agentStore", () => {
       await store.persist.rehydrate();
 
       expect(store.getState().pendingPromptEditsByToolCallId).toEqual({});
+    });
+
+    it("migrates legacy detached position to pinned", async () => {
+      localStorage.setItem(
+        "arize-phoenix-agent",
+        JSON.stringify({
+          state: {
+            position: "detached",
+            sessions: [],
+            sessionMap: {},
+          },
+          version: 7,
+        })
+      );
+
+      const store = createAgentStore();
+      await store.persist.rehydrate();
+
+      expect(store.getState().position).toBe("pinned");
     });
   });
 });

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -22,7 +22,7 @@ import type { ModelConfig } from "./playground/types";
 
 /**
  * Layout position of the agent panel.
- * - "detached": floating overlay window
+ * - "detached": floating overlay panel
  * - "pinned": docked to the side of the viewport
  */
 export type AgentPosition = "detached" | "pinned";
@@ -342,7 +342,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
     [["zustand/devtools", unknown]]
   > = (set) => ({
     isOpen: false,
-    position: "detached",
+    position: "pinned",
     fabPlacement: "bottom-end",
     activePanelLocation: "docked",
     sessions: [],
@@ -765,7 +765,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
   return create<AgentState>()(
     persist(devtools(agentStore, { name: "agentStore" }), {
       name: "arize-phoenix-agent",
-      version: 7,
+      version: 8,
       migrate: (persisted, version) => {
         const state = persisted as Partial<AgentProps> & {
           capabilities?: Partial<AgentCapabilities>;
@@ -805,6 +805,15 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
 
         return {
           ...state,
+          // `position` existed before it was wired into the UI, but the
+          // visible behavior was always the pinned side panel. Treat pre-v8
+          // persisted values as pinned so the new floating mode is opt-in.
+          position:
+            version <= 7
+              ? "pinned"
+              : state.position === "detached"
+                ? "detached"
+                : "pinned",
           fabPlacement: state.fabPlacement ?? "bottom-end",
           sessionMap: migratedSessionMap,
           observability: {


### PR DESCRIPTION
## Summary
- Add a floating PXI assistant panel mode alongside the existing pinned side panel.
- Add a chat-header control to switch between pinned and floating modes, with the preference stored in AgentStore.
- Render the floating panel above page content with an opaque panel/header layer and action-oriented mode icons.

## Impact
- Users can keep PXI open as a floating panel without resizing the main layout.
- Existing persisted legacy detached values are migrated to pinned so the new mode is opt-in.

## Validation
- make test-frontend
- make typecheck-frontend
- make lint-frontend
- Browser smoke test for pinned/floating toggle, persisted position, panel z-index, and opaque header/panel backgrounds.
