### PR TITLE
feat(pxi): smoother shimmer + glyph in chat loading

### DIFF
--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -36,11 +36,11 @@ import { AgentModelMenu } from "./AgentModelMenu";
 import { ChatEmptyState, type EmptyStateQuickAction } from "./ChatEmptyState";
 import { ChatLantern } from "./ChatLantern";
 import { AssistantMessage, UserMessage } from "./ChatMessage";
-import { PxiGlyph } from "./PxiGlyph";
 import {
   ElicitationDraftProvider,
   type PendingElicitationDraft,
 } from "./ElicitationDraftContext";
+import { PxiGlyph } from "./PxiGlyph";
 import { useAgentChat } from "./useAgentChat";
 import type { AgentModelSelection } from "./useGenerateSessionSummary";
 

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -36,6 +36,7 @@ import { AgentModelMenu } from "./AgentModelMenu";
 import { ChatEmptyState, type EmptyStateQuickAction } from "./ChatEmptyState";
 import { ChatLantern } from "./ChatLantern";
 import { AssistantMessage, UserMessage } from "./ChatMessage";
+import { PxiGlyph } from "./PxiGlyph";
 import {
   ElicitationDraftProvider,
   type PendingElicitationDraft,
@@ -433,9 +434,23 @@ export function ChatView({
   );
 }
 
+const loadingCSS = css`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--global-dimension-size-100);
+  color: var(--global-text-color-700);
+`;
+
 /** Loading affordance shown while the assistant response is pending. */
 function Loading() {
-  return <Shimmer size="M">Thinking...</Shimmer>;
+  return (
+    <div css={loadingCSS}>
+      <PxiGlyph animation="wave-hold" size={12} />
+      <Shimmer size="S" weight="heavy">
+        Thinking...
+      </Shimmer>
+    </div>
+  );
 }
 
 /** Inline request error banner for the active chat turn. */

--- a/app/src/components/ai/shimmer/Shimmer.tsx
+++ b/app/src/components/ai/shimmer/Shimmer.tsx
@@ -1,14 +1,32 @@
-import React from "react";
+import React, { type JSX } from "react";
+import { motion, type MotionProps, useReducedMotion } from "motion/react";
 
 import { classNames } from "@phoenix/utils/classNames";
 
-import { getShimmerAnimationCSS, shimmerBaseCSS } from "./styles";
+import { shimmerBaseCSS } from "./styles";
 import type { ShimmerProps } from "./types";
+
+type IntrinsicTag = keyof JSX.IntrinsicElements;
+type MotionTagComponent = React.ComponentType<
+  MotionProps & Record<string, unknown>
+>;
+
+// Cache motion components at module level so we don't recreate them per render.
+const motionComponentCache = new Map<IntrinsicTag, MotionTagComponent>();
+
+const getMotionComponent = (element: IntrinsicTag): MotionTagComponent => {
+  let component = motionComponentCache.get(element);
+  if (!component) {
+    component = motion.create(element) as MotionTagComponent;
+    motionComponentCache.set(element, component);
+  }
+  return component;
+};
 
 export function Shimmer({
   ref,
   children,
-  elementType: Element = "p",
+  elementType = "p",
   size = "S",
   weight = "normal",
   duration = 2,
@@ -17,25 +35,42 @@ export function Shimmer({
   style,
   ...restProps
 }: ShimmerProps & { ref?: React.Ref<HTMLElement> }) {
+  const shouldReduceMotion = useReducedMotion();
   const dynamicSpread = (children?.length ?? 0) * spread;
+  const MotionComponent = getMotionComponent(elementType as IntrinsicTag);
 
   return (
-    <Element
+    <MotionComponent
       ref={ref as React.Ref<never>}
       className={classNames("shimmer", className)}
       data-size={size}
       data-weight={weight}
-      css={[shimmerBaseCSS, getShimmerAnimationCSS(duration)]}
+      css={shimmerBaseCSS}
       style={
         {
           "--shimmer-spread": `${dynamicSpread}px`,
           ...style,
         } as React.CSSProperties
       }
-      {...restProps}
+      initial={
+        shouldReduceMotion ? undefined : { backgroundPosition: "100% center" }
+      }
+      animate={
+        shouldReduceMotion ? undefined : { backgroundPosition: "0% center" }
+      }
+      transition={
+        shouldReduceMotion
+          ? undefined
+          : {
+              duration,
+              ease: "linear",
+              repeat: Number.POSITIVE_INFINITY,
+            }
+      }
+      {...(restProps as Record<string, unknown>)}
     >
       {children}
-    </Element>
+    </MotionComponent>
   );
 }
 

--- a/app/src/components/ai/shimmer/Shimmer.tsx
+++ b/app/src/components/ai/shimmer/Shimmer.tsx
@@ -1,5 +1,5 @@
-import React, { type JSX } from "react";
 import { motion, type MotionProps, useReducedMotion } from "motion/react";
+import React, { type JSX } from "react";
 
 import { classNames } from "@phoenix/utils/classNames";
 

--- a/app/src/components/ai/shimmer/Shimmer.tsx
+++ b/app/src/components/ai/shimmer/Shimmer.tsx
@@ -11,15 +11,15 @@ type MotionTagComponent = React.ComponentType<
   MotionProps & Record<string, unknown>
 >;
 
-// Cache motion components at module level so we don't recreate them per render.
+// motion.create(tag) is pure per tag — cache so we don't rebuild the component
+// on every render of Shimmer.
 const motionComponentCache = new Map<IntrinsicTag, MotionTagComponent>();
 
 const getMotionComponent = (element: IntrinsicTag): MotionTagComponent => {
-  let component = motionComponentCache.get(element);
-  if (!component) {
-    component = motion.create(element) as MotionTagComponent;
-    motionComponentCache.set(element, component);
-  }
+  const cached = motionComponentCache.get(element);
+  if (cached) return cached;
+  const component = motion.create(element) as MotionTagComponent;
+  motionComponentCache.set(element, component);
   return component;
 };
 
@@ -36,8 +36,22 @@ export function Shimmer({
   ...restProps
 }: ShimmerProps & { ref?: React.Ref<HTMLElement> }) {
   const shouldReduceMotion = useReducedMotion();
-  const dynamicSpread = (children?.length ?? 0) * spread;
   const MotionComponent = getMotionComponent(elementType as IntrinsicTag);
+  const dynamicSpread = (children?.length ?? 0) * spread;
+
+  // When the user prefers reduced motion, skip Motion entirely; the @media
+  // block in styles.ts then renders solid text.
+  const animationProps: MotionProps = shouldReduceMotion
+    ? {}
+    : {
+        initial: { backgroundPosition: "100% center" },
+        animate: { backgroundPosition: "0% center" },
+        transition: {
+          duration,
+          ease: "linear",
+          repeat: Number.POSITIVE_INFINITY,
+        },
+      };
 
   return (
     <MotionComponent
@@ -52,21 +66,9 @@ export function Shimmer({
           ...style,
         } as React.CSSProperties
       }
-      initial={
-        shouldReduceMotion ? undefined : { backgroundPosition: "100% center" }
-      }
-      animate={
-        shouldReduceMotion ? undefined : { backgroundPosition: "0% center" }
-      }
-      transition={
-        shouldReduceMotion
-          ? undefined
-          : {
-              duration,
-              ease: "linear",
-              repeat: Number.POSITIVE_INFINITY,
-            }
-      }
+      {...animationProps}
+      // HTMLAttributes.onAnimationStart collides with MotionProps' — cast so
+      // consumer HTML props pass through.
       {...(restProps as Record<string, unknown>)}
     >
       {children}

--- a/app/src/components/ai/shimmer/styles.ts
+++ b/app/src/components/ai/shimmer/styles.ts
@@ -1,15 +1,6 @@
-import { css, keyframes } from "@emotion/react";
+import { css } from "@emotion/react";
 
 import { textBaseCSS } from "../../core/content/styles";
-
-const shimmerKeyframes = keyframes`
-  from {
-    background-position: 100% center;
-  }
-  to {
-    background-position: 0% center;
-  }
-`;
 
 /**
  * Two-layer background-clip:text shimmer effect:
@@ -18,6 +9,9 @@ const shimmerKeyframes = keyframes`
  *
  * The spotlight uses the page background color, creating a high-contrast
  * "wipe" effect (text momentarily flashes to the background color).
+ *
+ * The sweep animation itself is driven by `motion` in `Shimmer.tsx`, which
+ * animates `background-position` on the top layer.
  */
 export const shimmerBaseCSS = css`
   ${textBaseCSS};
@@ -25,6 +19,9 @@ export const shimmerBaseCSS = css`
   -webkit-background-clip: text;
   color: transparent;
   background-repeat: no-repeat, padding-box;
+  background-size:
+    250% 100%,
+    auto;
   background-image:
     linear-gradient(
       90deg,
@@ -35,21 +32,9 @@ export const shimmerBaseCSS = css`
     linear-gradient(var(--global-text-color-700), var(--global-text-color-700));
 
   @media (prefers-reduced-motion: reduce) {
-    animation: none;
     background: none;
     -webkit-background-clip: initial;
     background-clip: initial;
     color: var(--global-text-color-900);
-  }
-`;
-
-export const getShimmerAnimationCSS = (duration: number) => css`
-  background-size:
-    250% 100%,
-    auto;
-  animation: ${shimmerKeyframes} ${duration}s linear infinite;
-
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
   }
 `;


### PR DESCRIPTION
## Summary
- **Shimmer**: replaced the CSS keyframes sweep with a `motion` animation on `background-position`. `motion.create(tag)` components are cached at module level (the `TextElementType` union is small and pure), and `useReducedMotion()` short-circuits the animation props so the existing `prefers-reduced-motion` CSS fallback renders solid text.
- **Chat Loading**: shrunk the "Thinking..." shimmer to `size="S" weight="heavy"` and prefixed it with a 12px `wave-hold` `PxiGlyph` so the brand mark pulses while the assistant response is pending.

## Test plan
- [ ] Storybook → AI/Shimmer: Default / Sizes / Weights / Speeds / LongText / AsHeading / AsSpan animate smoothly.
- [ ] Toggle OS "Reduce motion" and confirm Shimmer renders as static muted text.
- [ ] PXI agent chat: while a turn is `submitted`, the glyph pulses next to a small bold "Thinking..." shimmer.