### PR TITLE
feat(ui): use trace icon for project everywhere

### DIFF
--- a/app/src/components/ai/attachment/utils.tsx
+++ b/app/src/components/ai/attachment/utils.tsx
@@ -44,7 +44,7 @@ export function getAttachmentLabel(data: AttachmentData): string {
 function getContextCategoryIcon(category: string | undefined): ReactNode {
   switch (category) {
     case "project":
-      return <Icon svg={<Icons.GridOutline />} />;
+      return <Icon svg={<Icons.Trace />} />;
     case "trace":
       return <Icon svg={<Icons.Trace />} />;
     case "span":

--- a/app/src/pages/projects/NewProjectButton.tsx
+++ b/app/src/pages/projects/NewProjectButton.tsx
@@ -57,7 +57,7 @@ export function NewProjectButton({
       <DialogTrigger>
         <Button
           data-testid="create-project-button"
-          leadingVisual={<Icon svg={<Icons.GridOutline />} />}
+          leadingVisual={<Icon svg={<Icons.Trace />} />}
           size="M"
           variant={variant}
         >


### PR DESCRIPTION
## Summary
- Swap the project-representational icon from `Icons.GridOutline` to `Icons.Trace` in the two remaining spots so all project surfaces match the sidebar Tracing nav link.
- Updates the "New Project" button (`NewProjectButton.tsx`) and the PXI attachment `project` category icon (`attachment/utils.tsx`).

## Test plan
- [ ] Open the Projects page — confirm the "New Project" button shows the trace icon.
- [ ] Attach a project context in the PXI assistant panel — confirm the attachment chip shows the trace icon.
- [ ] Verify the sidebar Tracing/Projects nav link still renders the trace icon (unchanged).