### PR TITLE
feat: Fix agent chat layout panels

### DIFF
--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -44,15 +44,24 @@ const mainViewCSS = css`
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
+  min-width: 0;
   height: 100%;
   overflow: hidden;
 `;
+
+const layoutContentPanelCSS = css`
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+`;
+
 const contentCSS = css`
   position: relative;
   flex: 1 1 auto;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  height: 100%;
   overflow: hidden;
   box-sizing: border-box;
   border-left: 1px solid var(--global-border-color-default);
@@ -110,18 +119,18 @@ export function Layout() {
         <NavTitle />
         <SideNav />
         <div css={mainViewCSS}>
-          <TopNavbar>
-            <SideNavToggleButton />
-            <NavBreadcrumb />
-            <TopNavActionsSlot />
-          </TopNavbar>
           <Group
             id="layout-panels"
             orientation="horizontal"
             defaultLayout={defaultLayout}
             onLayoutChanged={onLayoutChanged}
           >
-            <Panel id="layout-content">
+            <Panel id="layout-content" css={layoutContentPanelCSS}>
+              <TopNavbar>
+                <SideNavToggleButton />
+                <NavBreadcrumb />
+                <TopNavActionsSlot />
+              </TopNavbar>
               <div data-testid="content" css={contentCSS} ref={contentRef}>
                 <AgentChatWidget boundaryRef={contentRef} />
                 {shouldShowFloatingAgentPanel ? (


### PR DESCRIPTION
## Summary
- Move the top nav into the resizable content panel so the docked agent chat can sit beside the full main view.
- Make the layout content panel a column flex container and let the content pane consume remaining height below the nav.
- Add min-width constraints so the panel group can shrink without clipping the viewport.

## Why
The prior layout moved the top nav into the panel group but left the panel as a block container and kept the content at height: 100%. That made the main content size as content height plus nav height, and narrower layouts could clip the docked assistant panel.

## Impact
The main content remains below the top nav while the pinned agent chat stays full-height beside it. Detached/floating chat remains bounded by the content region.

## Validation
- make lint-frontend
- make typecheck-frontend
- git diff --check
- Browser geometry check for docked and detached agent chat layouts
