### PR TITLE
feat: Use drawer for example details

### DIFF
--- a/app/src/pages/example/ExampleDetailsDialog.tsx
+++ b/app/src/pages/example/ExampleDetailsDialog.tsx
@@ -244,10 +244,13 @@ function ExampleDetailsDialogContent({
   return (
     <>
       <DialogHeader>
-        <TitleWithID
-          title="Example"
-          id={data.example.externalId ?? exampleId}
-        />
+        <Flex direction="row" gap="size-200" alignItems="center">
+          <DialogCloseButton />
+          <TitleWithID
+            title="Example"
+            id={data.example.externalId ?? exampleId}
+          />
+        </Flex>
         <DialogTitleExtra>
           <DatasetSplits labels={datasetSplits} />
           {sourceSpanInfo ? (
@@ -274,7 +277,6 @@ function ExampleDetailsDialogContent({
               setFetchKey((key) => key + 1);
             }}
           />
-          <DialogCloseButton />
         </DialogTitleExtra>
       </DialogHeader>
       <Group orientation="vertical">
@@ -375,10 +377,12 @@ function ExampleDetailsHeaderSkeleton({ exampleId }: { exampleId: string }) {
   return (
     <>
       <DialogHeader>
-        <TitleWithID title="Example" id={exampleId} />
+        <Flex direction="row" gap="size-200" alignItems="center">
+          <DialogCloseButton />
+          <TitleWithID title="Example" id={exampleId} />
+        </Flex>
         <DialogTitleExtra>
           <Skeleton width={60} height={24} animation="wave" />
-          <DialogCloseButton />
         </DialogTitleExtra>
       </DialogHeader>
       <ExampleDetailsDialogSkeleton />

--- a/app/src/pages/example/ExamplePage.tsx
+++ b/app/src/pages/example/ExamplePage.tsx
@@ -1,8 +1,8 @@
-import { Suspense } from "react";
-import { DialogTrigger } from "react-aria-components";
 import { useNavigate, useParams } from "react-router";
 
-import { Loading, Modal, ModalOverlay } from "@phoenix/components";
+import { Drawer } from "@phoenix/components";
+import { DRAWER_DEFAULT_MIN_SIZE } from "@phoenix/components/core/overlay/constants";
+import { useDefaultDrawerSize } from "@phoenix/components/core/overlay/useDefaultDrawerSize";
 
 import { ExampleDetailsDialog } from "./ExampleDetailsDialog";
 
@@ -12,22 +12,19 @@ import { ExampleDetailsDialog } from "./ExampleDetailsDialog";
 export function ExamplePage() {
   const { exampleId, datasetId } = useParams();
   const navigate = useNavigate();
+  const { defaultSize, onSizeChange } = useDefaultDrawerSize({
+    id: "example-details",
+  });
+
   return (
-    <DialogTrigger
+    <Drawer
       isOpen
-      onOpenChange={(isOpen) => {
-        if (!isOpen) {
-          navigate(`/datasets/${datasetId}/examples`);
-        }
-      }}
+      onClose={() => navigate(`/datasets/${datasetId}/examples`)}
+      defaultSize={defaultSize}
+      minSize={DRAWER_DEFAULT_MIN_SIZE}
+      onResize={onSizeChange}
     >
-      <ModalOverlay>
-        <Modal variant="slideover" size="L">
-          <Suspense fallback={<Loading />}>
-            <ExampleDetailsDialog exampleId={exampleId as string} />
-          </Suspense>
-        </Modal>
-      </ModalOverlay>
-    </DialogTrigger>
+      <ExampleDetailsDialog exampleId={exampleId as string} />
+    </Drawer>
   );
 }

--- a/app/src/pages/examples/ExamplesTable.tsx
+++ b/app/src/pages/examples/ExamplesTable.tsx
@@ -15,7 +15,7 @@ import {
   useState,
 } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
-import { useNavigate } from "react-router";
+import { useNavigate, useParams } from "react-router";
 
 import { CopyToClipboardButton, Truncate } from "@phoenix/components";
 import { Link } from "@phoenix/components/core/Link";
@@ -63,6 +63,7 @@ export function ExamplesTable({
     setExamplesCache,
   } = useExamplesFilterContext();
   const navigate = useNavigate();
+  const { exampleId: selectedExampleId } = useParams();
   const latestVersion = useDatasetContext((state) => state.latestVersion);
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const lastSelectedRowIndexRef = useRef<number | null>(null);
@@ -437,41 +438,52 @@ export function ExamplesTable({
           <TableEmpty />
         ) : (
           <tbody>
-            {rows.map((row) => (
-              <tr key={row.id} onClick={() => navigate(`${row.original.id}`)}>
-                {row.getVisibleCells().map((cell) => {
-                  const colSizeVar = `--col-${makeSafeColumnId(cell.column.id)}-size`;
-                  return (
-                    <td
-                      key={cell.id}
-                      onClick={(e) => {
-                        // prevent the row click event from firing on the select cell
-                        if (cell.column.columnDef.id === "select") {
-                          e.stopPropagation();
-                          handleRowSelection(e, row.index, row.toggleSelected);
-                        }
-                      }}
-                      style={{
-                        ...getCommonPinningStyles(cell.column),
-                        width: `calc(var(${colSizeVar}) * 1px)`,
-                        maxWidth: `calc(var(${colSizeVar}) * 1px)`,
-                        overflowWrap: "anywhere",
-                        // prevent text selection on the select cell
-                        userSelect:
-                          cell.column.columnDef.id === "select"
-                            ? "none"
-                            : undefined,
-                      }}
-                    >
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
+            {rows.map((row) => {
+              const isSelected = row.original.id === selectedExampleId;
+              return (
+                <tr
+                  key={row.id}
+                  data-selected={isSelected}
+                  onClick={() => navigate(`${row.original.id}`)}
+                >
+                  {row.getVisibleCells().map((cell) => {
+                    const colSizeVar = `--col-${makeSafeColumnId(cell.column.id)}-size`;
+                    return (
+                      <td
+                        key={cell.id}
+                        onClick={(e) => {
+                          // prevent the row click event from firing on the select cell
+                          if (cell.column.columnDef.id === "select") {
+                            e.stopPropagation();
+                            handleRowSelection(
+                              e,
+                              row.index,
+                              row.toggleSelected
+                            );
+                          }
+                        }}
+                        style={{
+                          ...getCommonPinningStyles(cell.column),
+                          width: `calc(var(${colSizeVar}) * 1px)`,
+                          maxWidth: `calc(var(${colSizeVar}) * 1px)`,
+                          overflowWrap: "anywhere",
+                          // prevent text selection on the select cell
+                          userSelect:
+                            cell.column.columnDef.id === "select"
+                              ? "none"
+                              : undefined,
+                        }}
+                      >
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
           </tbody>
         )}
       </table>

--- a/app/src/pages/playground/PlaygroundDatasetSelect.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetSelect.tsx
@@ -69,21 +69,26 @@ export function PlaygroundDatasetSelect({
         onSelectionChange={({ datasetId, splitIds }) => {
           setDatasetId(datasetId);
           setSearchParams((prev) => {
+            const next = new URLSearchParams(prev);
+            const hasDatasetChanged = datasetId !== next.get("datasetId");
             if (datasetId) {
-              prev.set("datasetId", datasetId);
+              next.set("datasetId", datasetId);
               // Remove all existing splitId params
-              prev.delete("splitId");
+              next.delete("splitId");
               // Add each split ID as a separate param
               if (splitIds.length > 0) {
                 splitIds.forEach((splitId) => {
-                  prev.append("splitId", splitId);
+                  next.append("splitId", splitId);
                 });
               }
             } else {
-              prev.delete("datasetId");
-              prev.delete("splitId");
+              next.delete("datasetId");
+              next.delete("splitId");
             }
-            return prev;
+            if (hasDatasetChanged) {
+              next.delete("exampleId");
+            }
+            return next;
           });
         }}
       />
@@ -96,9 +101,11 @@ export function PlaygroundDatasetSelect({
           onPress={() => {
             setDatasetId(null);
             setSearchParams((prev) => {
-              prev.delete("datasetId");
-              prev.delete("splitId");
-              return prev;
+              const next = new URLSearchParams(prev);
+              next.delete("datasetId");
+              next.delete("splitId");
+              next.delete("exampleId");
+              return next;
             });
           }}
         />

--- a/app/src/pages/playground/PlaygroundExamplePage.tsx
+++ b/app/src/pages/playground/PlaygroundExamplePage.tsx
@@ -1,8 +1,8 @@
-import { Suspense } from "react";
-import { DialogTrigger } from "react-aria-components";
 import { useSearchParams } from "react-router";
 
-import { Loading, Modal, ModalOverlay } from "@phoenix/components";
+import { Drawer } from "@phoenix/components";
+import { DRAWER_DEFAULT_MIN_SIZE } from "@phoenix/components/core/overlay/constants";
+import { useDefaultDrawerSize } from "@phoenix/components/core/overlay/useDefaultDrawerSize";
 
 import { ExampleDetailsDialog } from "../example/ExampleDetailsDialog";
 
@@ -13,28 +13,45 @@ export function PlaygroundExamplePage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const exampleId = searchParams.get("exampleId");
   const datasetId = searchParams.get("datasetId");
+
   if (!exampleId || !datasetId) {
     return null;
   }
+
   return (
-    <DialogTrigger
-      isOpen
-      onOpenChange={(isOpen) => {
-        if (!isOpen) {
-          setSearchParams((prev) => {
-            prev.delete("exampleId");
-            return prev;
-          });
-        }
+    <PlaygroundExampleDrawer
+      exampleId={exampleId}
+      onClose={() => {
+        setSearchParams((prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete("exampleId");
+          return next;
+        });
       }}
+    />
+  );
+}
+
+function PlaygroundExampleDrawer({
+  exampleId,
+  onClose,
+}: {
+  exampleId: string;
+  onClose: () => void;
+}) {
+  const { defaultSize, onSizeChange } = useDefaultDrawerSize({
+    id: "playground-example-details",
+  });
+
+  return (
+    <Drawer
+      isOpen
+      onClose={onClose}
+      defaultSize={defaultSize}
+      minSize={DRAWER_DEFAULT_MIN_SIZE}
+      onResize={onSizeChange}
     >
-      <ModalOverlay>
-        <Modal variant="slideover" size="L">
-          <Suspense fallback={<Loading />}>
-            <ExampleDetailsDialog exampleId={exampleId as string} />
-          </Suspense>
-        </Modal>
-      </ModalOverlay>
-    </DialogTrigger>
+      <ExampleDetailsDialog exampleId={exampleId} />
+    </Drawer>
   );
 }


### PR DESCRIPTION
## Summary
- Replace the dataset example details modal slideover with the non-modal Drawer used for list/detail flows.
- Keep the selected example row highlighted while the drawer is open.
- Move the example drawer close button to the top-left of the header.
- Clear stale playground example selection when the playground dataset changes or is cleared.

## Why
The modal slideover blocked interaction with the examples list, so users could not click examples behind the details panel. The Drawer keeps the list interactive while details are visible. The playground dataset cleanup prevents a stale example drawer from showing an example from a previous dataset.

## Validation
- make typecheck-frontend
- make lint-frontend
- git diff --check
- Browser sanity check on the local Phoenix app for drawer rendering, row selection, switching examples, and close button placement.