### PR TITLE
feat(agents): Make assistant accessible over modal overlays

### DIFF
--- a/app/src/components/agent/AgentChatPanel.tsx
+++ b/app/src/components/agent/AgentChatPanel.tsx
@@ -45,8 +45,8 @@ type AgentChatSurfaceProps = {
    * Modal-layer panels intentionally hide these controls because that layer is
    * forced by the currently active modal, not by the user's saved layout
    * preference. Showing the pin/detach toggle there would imply the user can
-   * dock PXI behind the modal, which would move it out of the active modal
-   * scope and make it unavailable again.
+   * dock the assistant behind the modal, which would move it out of the active
+   * modal scope and make it unavailable again.
    */
   showPositionControls?: boolean;
 };
@@ -65,11 +65,12 @@ export function AgentChatPanel() {
 }
 
 /**
- * Controller for PXI's floating chat surface.
+ * Controller for the assistant's floating chat surface.
  *
  * The `modal` layer is used only as an accessibility escape hatch while an
- * overlay is active. It keeps PXI above the modal mask and inside the modal's
- * interaction scope without mutating the user's normal pinned/detached setting.
+ * overlay is active. It keeps the assistant above the modal mask and inside the
+ * modal's interaction scope without mutating the user's normal pinned/detached
+ * setting.
  */
 export function FloatingAgentChatPanel({
   layer = "content",

--- a/app/src/components/agent/AgentChatPanel.tsx
+++ b/app/src/components/agent/AgentChatPanel.tsx
@@ -20,6 +20,37 @@ import { useAgentChat } from "./useAgentChat";
 import { useAgentChatPanelState } from "./useAgentChatPanelState";
 import type { AgentModelSelection } from "./useGenerateSessionSummary";
 
+type AgentChatPanelLayer = "content" | "modal";
+
+type FloatingAgentChatPanelProps = {
+  /**
+   * Controls which stacking and interaction layer owns the floating panel.
+   *
+   * - `content` is the normal floating assistant surface rendered over page
+   *   content. It reflects the user's persisted pinned/detached preference and
+   *   may expose controls that change that preference.
+   * - `modal` is a temporary modal-scoped surface used while a modal or
+   *   slideover is active. It portals into the active modal's portal container
+   *   so React Aria keeps the assistant interactive instead of marking it inert.
+   */
+  layer?: AgentChatPanelLayer;
+};
+
+type AgentChatSurfaceProps = {
+  renderFrame: (children: ReactNode) => ReactNode;
+  /**
+   * Whether the header should expose controls for switching between pinned and
+   * detached assistant layouts.
+   *
+   * Modal-layer panels intentionally hide these controls because that layer is
+   * forced by the currently active modal, not by the user's saved layout
+   * preference. Showing the pin/detach toggle there would imply the user can
+   * dock PXI behind the modal, which would move it out of the active modal
+   * scope and make it unavailable again.
+   */
+  showPositionControls?: boolean;
+};
+
 /**
  * Controller for the pinned side-panel agent chat.
  */
@@ -33,11 +64,16 @@ export function AgentChatPanel() {
   );
 }
 
+/**
+ * Controller for PXI's floating chat surface.
+ *
+ * The `modal` layer is used only as an accessibility escape hatch while an
+ * overlay is active. It keeps PXI above the modal mask and inside the modal's
+ * interaction scope without mutating the user's normal pinned/detached setting.
+ */
 export function FloatingAgentChatPanel({
   layer = "content",
-}: {
-  layer?: "content" | "modal";
-}) {
+}: FloatingAgentChatPanelProps) {
   const fabPlacement = useAgentContext((state) => state.fabPlacement);
   const [panelSize, setPanelSize] = useState(DEFAULT_FLOATING_AGENT_CHAT_SIZE);
 
@@ -61,10 +97,7 @@ export function FloatingAgentChatPanel({
 function AgentChatSurface({
   renderFrame,
   showPositionControls = true,
-}: {
-  renderFrame: (children: ReactNode) => ReactNode;
-  showPositionControls?: boolean;
-}) {
+}: AgentChatSurfaceProps) {
   const isAgentsEnabled = useFeatureFlag("agents");
   const {
     isOpen,

--- a/app/src/components/agent/AgentChatPanel.tsx
+++ b/app/src/components/agent/AgentChatPanel.tsx
@@ -33,14 +33,20 @@ export function AgentChatPanel() {
   );
 }
 
-export function FloatingAgentChatPanel() {
+export function FloatingAgentChatPanel({
+  layer = "content",
+}: {
+  layer?: "content" | "modal";
+}) {
   const fabPlacement = useAgentContext((state) => state.fabPlacement);
   const [panelSize, setPanelSize] = useState(DEFAULT_FLOATING_AGENT_CHAT_SIZE);
 
   return (
     <AgentChatSurface
+      showPositionControls={layer !== "modal"}
       renderFrame={(children) => (
         <FloatingAgentChatFrame
+          layer={layer}
           placement={fabPlacement}
           size={panelSize}
           onSizeChange={setPanelSize}
@@ -54,8 +60,10 @@ export function FloatingAgentChatPanel() {
 
 function AgentChatSurface({
   renderFrame,
+  showPositionControls = true,
 }: {
   renderFrame: (children: ReactNode) => ReactNode;
+  showPositionControls?: boolean;
 }) {
   const isAgentsEnabled = useFeatureFlag("agents");
   const {
@@ -101,8 +109,8 @@ function AgentChatSurface({
       setActiveSession={setActiveSession}
       deleteSession={deleteSession}
       closePanel={closePanel}
-      position={position}
-      setPosition={setPosition}
+      position={showPositionControls ? position : undefined}
+      setPosition={showPositionControls ? setPosition : undefined}
       handleModelChange={handleModelChange}
       renderFrame={renderFrame}
     />
@@ -143,8 +151,8 @@ function AgentChatController({
   >["setActiveSession"];
   deleteSession: ReturnType<typeof useAgentChatPanelState>["deleteSession"];
   closePanel: ReturnType<typeof useAgentChatPanelState>["closePanel"];
-  position: ReturnType<typeof useAgentChatPanelState>["position"];
-  setPosition: ReturnType<typeof useAgentChatPanelState>["setPosition"];
+  position?: ReturnType<typeof useAgentChatPanelState>["position"];
+  setPosition?: ReturnType<typeof useAgentChatPanelState>["setPosition"];
   handleModelChange: ReturnType<
     typeof useAgentChatPanelState
   >["handleModelChange"];

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -13,7 +13,7 @@ import {
 } from "@phoenix/components";
 import { fadedDividerBottomCSS } from "@phoenix/components/core/layout";
 import { compactResizeHandleCSS } from "@phoenix/components/resize/styles";
-import { useOpenModalFloatingLayerElement } from "@phoenix/hooks/useHasOpenModal";
+import { useActiveModalPortalContainerElement } from "@phoenix/hooks/useHasOpenModal";
 import type {
   AgentFabPlacement,
   AgentPosition,
@@ -233,7 +233,7 @@ export function FloatingAgentChatFrame({
   size?: Size;
   onSizeChange?: (size: Size) => void;
 }) {
-  const modalFloatingLayerElement = useOpenModalFloatingLayerElement();
+  const activeModalPortalContainer = useActiveModalPortalContainerElement();
   const panel = (
     <ResizableFloatingPanel
       layer={layer}
@@ -250,7 +250,7 @@ export function FloatingAgentChatFrame({
     return panel;
   }
 
-  return createPortal(panel, modalFloatingLayerElement ?? document.body);
+  return createPortal(panel, activeModalPortalContainer ?? document.body);
 }
 
 const tracePanelContentCSS = css`

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -45,15 +45,17 @@ const panelHeaderCSS = css`
   ${fadedDividerBottomCSS}
   flex: none;
   z-index: ${PANEL_HEADER_Z_INDEX};
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
+  column-gap: var(--global-dimension-size-100);
   padding: var(--global-dimension-size-100) var(--global-dimension-size-150);
   background: var(--global-background-color-default);
 `;
 
 const panelHeaderActionsCSS = css`
-  flex-shrink: 0;
+  justify-self: end;
+  min-width: max-content;
 `;
 
 const sessionHeadingCSS = css`

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -43,6 +43,7 @@ const MIN_FLOATING_AGENT_CHAT_SIZE: Size = {
 
 const panelHeaderCSS = css`
   ${fadedDividerBottomCSS}
+  flex: none;
   z-index: ${PANEL_HEADER_Z_INDEX};
   display: flex;
   align-items: center;

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -43,12 +43,14 @@ const MIN_FLOATING_AGENT_CHAT_SIZE: Size = {
 
 const panelHeaderCSS = css`
   ${fadedDividerBottomCSS}
+  box-sizing: border-box;
   flex: none;
   z-index: ${PANEL_HEADER_Z_INDEX};
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   column-gap: var(--global-dimension-size-100);
+  min-height: var(--global-dimension-size-600);
   padding: var(--global-dimension-size-100) var(--global-dimension-size-150);
   background: var(--global-background-color-default);
 `;

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -74,7 +74,7 @@ const panelContentCSS = css`
 `;
 
 /**
- * Shared header for PXI chat surfaces.
+ * Shared header for assistant chat surfaces.
  */
 export function AgentChatHeader({
   sessionDisplayName,
@@ -174,7 +174,7 @@ export function AgentChatHeader({
 }
 
 /**
- * Shared content frame for the docked and embedded PXI surfaces.
+ * Shared content frame for the docked and embedded assistant surfaces.
  */
 function AgentChatFrame({
   panelId,
@@ -218,7 +218,7 @@ export function DockedAgentChatFrame({ children }: { children: ReactNode }) {
 }
 
 /**
- * Presentational shell for the floating PXI panel.
+ * Presentational shell for the floating assistant panel.
  */
 export function FloatingAgentChatFrame({
   children,
@@ -265,7 +265,7 @@ const tracePanelContentCSS = css`
 `;
 
 /**
- * Presentational shell for the trace slideover's embedded PXI panel.
+ * Presentational shell for the trace slideover's embedded assistant panel.
  */
 export function TraceAgentChatFrame({ children }: { children: ReactNode }) {
   return (

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/react";
 import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { Panel, Separator } from "react-resizable-panels";
 
 import {
@@ -12,6 +13,7 @@ import {
 } from "@phoenix/components";
 import { fadedDividerBottomCSS } from "@phoenix/components/core/layout";
 import { compactResizeHandleCSS } from "@phoenix/components/resize/styles";
+import { useOpenModalFloatingLayerElement } from "@phoenix/hooks/useHasOpenModal";
 import type {
   AgentFabPlacement,
   AgentPosition,
@@ -220,17 +222,21 @@ export function DockedAgentChatFrame({ children }: { children: ReactNode }) {
  */
 export function FloatingAgentChatFrame({
   children,
+  layer = "content",
   placement,
   size = DEFAULT_FLOATING_AGENT_CHAT_SIZE,
   onSizeChange,
 }: {
   children: ReactNode;
+  layer?: "content" | "modal";
   placement: AgentFabPlacement;
   size?: Size;
   onSizeChange?: (size: Size) => void;
 }) {
-  return (
+  const modalFloatingLayerElement = useOpenModalFloatingLayerElement();
+  const panel = (
     <ResizableFloatingPanel
+      layer={layer}
       minSize={MIN_FLOATING_AGENT_CHAT_SIZE}
       placement={placement}
       size={size}
@@ -239,6 +245,12 @@ export function FloatingAgentChatFrame({
       {children}
     </ResizableFloatingPanel>
   );
+
+  if (layer !== "modal") {
+    return panel;
+  }
+
+  return createPortal(panel, modalFloatingLayerElement ?? document.body);
 }
 
 const tracePanelContentCSS = css`

--- a/app/src/components/agent/AgentChatWidget.tsx
+++ b/app/src/components/agent/AgentChatWidget.tsx
@@ -16,7 +16,7 @@ import {
 } from "@phoenix/components";
 import { useTheme } from "@phoenix/contexts";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
-import { useHasOpenModal } from "@phoenix/hooks/useHasOpenModal";
+import { useOpenModalFloatingLayerElement } from "@phoenix/hooks/useHasOpenModal";
 import { useModifierKey } from "@phoenix/hooks/useModifierKey";
 
 import { AgentFabPositioner } from "./AgentFabPositioner";
@@ -430,7 +430,8 @@ export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
   const fabPlacement = useAgentContext((state) => state.fabPlacement);
   const setFabPlacement = useAgentContext((state) => state.setFabPlacement);
   const activeSessionId = useAgentContext((state) => state.activeSessionId);
-  const hasOpenModal = useHasOpenModal();
+  const modalFloatingLayerElement = useOpenModalFloatingLayerElement();
+  const hasOpenModal = modalFloatingLayerElement !== null;
   const isStreaming = useAgentContext((state) =>
     activeSessionId
       ? state.chatStatusBySessionId[activeSessionId] === "streaming"
@@ -445,21 +446,22 @@ export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
       toggleOpen();
     },
     {
-      enabled: isAssistantAgentEnabled && !hasOpenModal,
+      enabled: isAssistantAgentEnabled,
       preventDefault: true,
     },
-    [isAssistantAgentEnabled, hasOpenModal, toggleOpen]
+    [isAssistantAgentEnabled, toggleOpen]
   );
 
-  // Use contextual entrypoints inside modals (e.g. trace slideover header)
-  // instead of letting the global FAB compete with overlay hit-testing.
-  if (!isAssistantAgentEnabled || isOpen || hasOpenModal) {
+  if (!isAssistantAgentEnabled || isOpen) {
     return null;
   }
 
+  const portalContainer = modalFloatingLayerElement ?? document.body;
+
   return createPortal(
     <AgentFabPositioner
-      boundaryRef={boundaryRef}
+      boundaryRef={hasOpenModal ? undefined : boundaryRef}
+      layer={hasOpenModal ? "modal" : "content"}
       placement={fabPlacement}
       size={isStreaming ? FAB_STREAMING_SIZE : FAB_RESTING_SIZE}
       onActivate={toggleOpen}
@@ -482,7 +484,7 @@ export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
         <AgentChatWidgetTooltip />
       </TooltipTrigger>
     </AgentFabPositioner>,
-    document.body
+    portalContainer ?? document.body
   );
 }
 

--- a/app/src/components/agent/AgentChatWidget.tsx
+++ b/app/src/components/agent/AgentChatWidget.tsx
@@ -16,7 +16,7 @@ import {
 } from "@phoenix/components";
 import { useTheme } from "@phoenix/contexts";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
-import { useOpenModalFloatingLayerElement } from "@phoenix/hooks/useHasOpenModal";
+import { useActiveModalPortalContainerElement } from "@phoenix/hooks/useHasOpenModal";
 import { useModifierKey } from "@phoenix/hooks/useModifierKey";
 
 import { AgentFabPositioner } from "./AgentFabPositioner";
@@ -430,8 +430,8 @@ export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
   const fabPlacement = useAgentContext((state) => state.fabPlacement);
   const setFabPlacement = useAgentContext((state) => state.setFabPlacement);
   const activeSessionId = useAgentContext((state) => state.activeSessionId);
-  const modalFloatingLayerElement = useOpenModalFloatingLayerElement();
-  const hasOpenModal = modalFloatingLayerElement !== null;
+  const activeModalPortalContainer = useActiveModalPortalContainerElement();
+  const hasOpenModal = activeModalPortalContainer !== null;
   const isStreaming = useAgentContext((state) =>
     activeSessionId
       ? state.chatStatusBySessionId[activeSessionId] === "streaming"
@@ -456,7 +456,7 @@ export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
     return null;
   }
 
-  const portalContainer = modalFloatingLayerElement ?? document.body;
+  const portalContainer = activeModalPortalContainer ?? document.body;
 
   return createPortal(
     <AgentFabPositioner

--- a/app/src/components/agent/AgentFabPositioner.tsx
+++ b/app/src/components/agent/AgentFabPositioner.tsx
@@ -4,12 +4,16 @@ import type {
   PointerEvent as ReactPointerEvent,
   ReactNode,
   RefObject,
+  SyntheticEvent as ReactSyntheticEvent,
   TransitionEvent as ReactTransitionEvent,
 } from "react";
 import { useLayoutEffect, useRef, useState } from "react";
 import invariant from "tiny-invariant";
 
-import { NON_MODAL_FLOATING_Z_INDEX } from "@phoenix/components/core/zIndex";
+import {
+  MODAL_FLOATING_UI_Z_INDEX,
+  NON_MODAL_FLOATING_Z_INDEX,
+} from "@phoenix/components/core/zIndex";
 import type { AgentFabPlacement } from "@phoenix/store/agentStore";
 import type { Bounds, Point, Size } from "@phoenix/types/geometry";
 
@@ -19,6 +23,7 @@ import {
   getFabPinnedPosition,
   getNearestFabPlacement,
 } from "./agentFabPositioning";
+import { useModalFloatingLayerInteractivity } from "./useModalFloatingLayerInteractivity";
 
 // Number of pixels the pointer must travel after pointerdown before we treat
 // the gesture as a drag instead of a click. Compared as squared distance to
@@ -53,6 +58,10 @@ const positionerCSS = css`
   &[data-dragging="true"] * {
     cursor: grabbing;
   }
+
+  &[data-layer="modal"] {
+    z-index: ${MODAL_FLOATING_UI_Z_INDEX};
+  }
 `;
 
 type DragSession = {
@@ -67,6 +76,7 @@ type DragSession = {
 export type AgentFabPositionerProps = {
   boundaryRef?: RefObject<HTMLElement | null>;
   children: ReactNode;
+  layer?: "content" | "modal";
   placement: AgentFabPlacement;
   size?: Size;
   onActivate?: () => void;
@@ -190,6 +200,7 @@ function applyElementPinnedPosition({
 export function AgentFabPositioner({
   boundaryRef,
   children,
+  layer = "content",
   placement,
   size,
   onActivate,
@@ -205,6 +216,7 @@ export function AgentFabPositioner({
   const suppressClickResetTimeoutIdRef = useRef<number | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const requiresBoundary = Boolean(boundaryRef);
+  useModalFloatingLayerInteractivity(positionerRef, layer === "modal");
 
   // After a drag, an unwanted `click` event can still fire on pointerup. We
   // swallow exactly one click immediately following a drag. A zero-delay
@@ -424,6 +436,14 @@ export function AgentFabPositioner({
     event.stopPropagation();
   };
 
+  const stopModalLayerPropagation = (
+    event: ReactSyntheticEvent<HTMLDivElement>
+  ) => {
+    if (layer === "modal") {
+      event.stopPropagation();
+    }
+  };
+
   const handleTransitionEnd = (event: ReactTransitionEvent<HTMLDivElement>) => {
     // Once the snap-to-corner animation finishes, clear the inline transition
     // so the next drag starts without an animated transform.
@@ -484,12 +504,18 @@ export function AgentFabPositioner({
       className="agent-chat-widget-positioner"
       css={positionerCSS}
       data-dragging={isDragging ? "true" : undefined}
+      data-layer={layer}
       data-placement={placement}
       ref={positionerRef}
+      onClick={stopModalLayerPropagation}
       onClickCapture={handleClickCapture}
+      onPointerCancel={stopModalLayerPropagation}
       onPointerCancelCapture={finishDrag}
+      onPointerDown={stopModalLayerPropagation}
       onPointerDownCapture={handlePointerDown}
+      onPointerMove={stopModalLayerPropagation}
       onPointerMoveCapture={handlePointerMove}
+      onPointerUp={stopModalLayerPropagation}
       onPointerUpCapture={finishDrag}
       onTransitionEnd={handleTransitionEnd}
     >

--- a/app/src/components/agent/PxiGlyph.tsx
+++ b/app/src/components/agent/PxiGlyph.tsx
@@ -179,7 +179,7 @@ const thinkingGlyphAnimationCSS: Record<
 };
 
 /**
- * PXI brand glyph. When `animation` is set, renders an animated 3x3 grid;
+ * Assistant brand glyph. When `animation` is set, renders an animated 3x3 grid;
  * otherwise renders the static rounded-square 5-cell brand mark.
  */
 export function PxiGlyph({

--- a/app/src/components/agent/ResizableFloatingPanel.tsx
+++ b/app/src/components/agent/ResizableFloatingPanel.tsx
@@ -4,18 +4,26 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   PointerEvent as ReactPointerEvent,
   ReactNode,
+  SyntheticEvent as ReactSyntheticEvent,
 } from "react";
 import { useEffect, useId, useRef, useState } from "react";
 
-import { NON_MODAL_FLOATING_Z_INDEX } from "@phoenix/components/core/zIndex";
+import {
+  MODAL_FLOATING_UI_Z_INDEX,
+  NON_MODAL_FLOATING_Z_INDEX,
+} from "@phoenix/components/core/zIndex";
 import type { AgentFabPlacement } from "@phoenix/store/agentStore";
 import type { Point, Size } from "@phoenix/types/geometry";
+
+import { useModalFloatingLayerInteractivity } from "./useModalFloatingLayerInteractivity";
 
 const FULLSCREEN_BREAKPOINT_PX = 600;
 const KEYBOARD_RESIZE_STEP_PX = 24;
 const PRIMARY_POINTER_BUTTON = 0;
 const RESIZE_HANDLE_SIZE_PX = 6;
 const RESIZE_HANDLE_Z_INDEX = 4;
+
+type FloatingPanelLayer = "content" | "modal";
 
 type ResizeAxis = "horizontal" | "vertical";
 
@@ -44,6 +52,7 @@ type ResizeSession = {
 
 export type ResizableFloatingPanelProps = {
   children: ReactNode;
+  layer?: FloatingPanelLayer;
   minSize: Size;
   placement: AgentFabPlacement;
   size: Size;
@@ -81,20 +90,33 @@ function getFallbackResizeLimits(minSize: Size): ResizeLimits {
   };
 }
 
-function getPanelBoundaryRect(panel: HTMLElement): DOMRect {
+function getViewportRect(): DOMRect {
+  return new DOMRect(0, 0, window.innerWidth, window.innerHeight);
+}
+
+function getPanelBoundaryRect(
+  panel: HTMLElement,
+  layer: FloatingPanelLayer
+): DOMRect {
+  if (layer === "modal") {
+    return getViewportRect();
+  }
+
   const boundary = panel.offsetParent ?? panel.parentElement;
   return boundary instanceof HTMLElement
     ? boundary.getBoundingClientRect()
-    : new DOMRect(0, 0, window.innerWidth, window.innerHeight);
+    : getViewportRect();
 }
 
 function getResizeLimits({
   minSize,
   panel,
+  layer,
   placement,
 }: {
   minSize: Size;
   panel: HTMLElement | null;
+  layer: FloatingPanelLayer;
   placement: AgentFabPlacement;
 }): ResizeLimits {
   if (!panel) {
@@ -102,7 +124,7 @@ function getResizeLimits({
   }
 
   const panelRect = panel.getBoundingClientRect();
-  const boundaryRect = getPanelBoundaryRect(panel);
+  const boundaryRect = getPanelBoundaryRect(panel, layer);
   const horizontalInset = placement.endsWith("end")
     ? Math.max(boundaryRect.right - panelRect.right, 0)
     : Math.max(panelRect.left - boundaryRect.left, 0);
@@ -253,6 +275,11 @@ const resizableFloatingPanelCSS = css`
     user-select: none;
   }
 
+  &[data-layer="modal"] {
+    position: fixed;
+    z-index: ${MODAL_FLOATING_UI_Z_INDEX};
+  }
+
   &[data-placement^="top"] {
     top: var(--global-dimension-size-200);
   }
@@ -376,6 +403,7 @@ const resizableFloatingPanelCSS = css`
 
 export function ResizableFloatingPanel({
   children,
+  layer = "content",
   minSize,
   placement,
   size,
@@ -387,8 +415,10 @@ export function ResizableFloatingPanel({
   const pendingSizeRef = useRef<Size | null>(null);
   const animationFrameIdRef = useRef<number | null>(null);
   const [resizingEdge, setResizingEdge] = useState<ResizeEdge | null>(null);
+  useModalFloatingLayerInteractivity(panelRef, layer === "modal");
 
   const resizeLimits = getResizeLimits({
+    layer,
     minSize,
     panel: panelRef.current,
     placement,
@@ -397,6 +427,7 @@ export function ResizableFloatingPanel({
   const commitSize = (
     nextSize: Size,
     limits = getResizeLimits({
+      layer,
       minSize,
       panel: panelRef.current,
       placement,
@@ -427,7 +458,7 @@ export function ResizableFloatingPanel({
     resizeSessionRef.current = {
       axis,
       edge,
-      limits: getResizeLimits({ minSize, panel, placement }),
+      limits: getResizeLimits({ layer, minSize, panel, placement }),
       pointerId: event.pointerId,
       startPointer: { x: event.clientX, y: event.clientY },
       startSize: getPanelSizeFromElement({
@@ -482,6 +513,7 @@ export function ResizableFloatingPanel({
     { axis, edge }: ResizeHandleConfig
   ) => {
     const limits = getResizeLimits({
+      layer,
       minSize,
       panel: panelRef.current,
       placement,
@@ -533,14 +565,28 @@ export function ResizableFloatingPanel({
     };
   }, []);
 
+  const stopModalLayerPropagation = (
+    event: ReactSyntheticEvent<HTMLDivElement>
+  ) => {
+    if (layer === "modal") {
+      event.stopPropagation();
+    }
+  };
+
   return (
     <div
       id={panelId}
       className="resizable-floating-panel"
       css={resizableFloatingPanelCSS}
+      data-layer={layer}
       data-placement={placement}
       data-resizing={resizingEdge == null ? undefined : "true"}
       ref={panelRef}
+      onClick={stopModalLayerPropagation}
+      onPointerCancel={stopModalLayerPropagation}
+      onPointerDown={stopModalLayerPropagation}
+      onPointerMove={stopModalLayerPropagation}
+      onPointerUp={stopModalLayerPropagation}
       style={
         {
           "--resizable-floating-panel-height": `${size.height}px`,

--- a/app/src/components/agent/__tests__/AgentChatPanelView.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatPanelView.test.tsx
@@ -3,6 +3,11 @@ import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  MODAL_OVERLAY_CLASS_NAME,
+  MODAL_PORTAL_CONTAINER_ATTR,
+} from "@phoenix/components/core/overlay/constants";
+
 import { AgentChatHeader, FloatingAgentChatFrame } from "../AgentChatPanelView";
 
 describe("AgentChatHeader", () => {
@@ -22,7 +27,7 @@ describe("AgentChatHeader", () => {
     });
     container.remove();
     document
-      .querySelectorAll(".react-aria-ModalOverlay")
+      .querySelectorAll(`.${MODAL_OVERLAY_CLASS_NAME}`)
       .forEach((element) => element.remove());
     vi.restoreAllMocks();
   });
@@ -97,13 +102,11 @@ describe("AgentChatHeader", () => {
     expect(onPositionChange).toHaveBeenCalledWith("pinned");
   });
 
-  it("portals the floating panel into the modal overlay layer", () => {
+  it("portals the floating panel into the modal portal container", () => {
     const overlay = document.createElement("div");
     const modalRoot = document.createElement("div");
-    overlay.className = "react-aria-ModalOverlay";
-    modalRoot.dataset.rac = "";
-    modalRoot.dataset.size = "S";
-    modalRoot.dataset.variant = "default";
+    overlay.className = MODAL_OVERLAY_CLASS_NAME;
+    modalRoot.setAttribute(MODAL_PORTAL_CONTAINER_ATTR, "");
     overlay.appendChild(modalRoot);
     document.body.appendChild(overlay);
 

--- a/app/src/components/agent/__tests__/AgentChatPanelView.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatPanelView.test.tsx
@@ -3,7 +3,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { AgentChatHeader } from "../AgentChatPanelView";
+import { AgentChatHeader, FloatingAgentChatFrame } from "../AgentChatPanelView";
 
 describe("AgentChatHeader", () => {
   let container: HTMLDivElement;
@@ -21,6 +21,9 @@ describe("AgentChatHeader", () => {
       root.unmount();
     });
     container.remove();
+    document
+      .querySelectorAll(".react-aria-ModalOverlay")
+      .forEach((element) => element.remove());
     vi.restoreAllMocks();
   });
 
@@ -92,5 +95,28 @@ describe("AgentChatHeader", () => {
     });
 
     expect(onPositionChange).toHaveBeenCalledWith("pinned");
+  });
+
+  it("portals the floating panel into the modal overlay layer", () => {
+    const overlay = document.createElement("div");
+    const modalRoot = document.createElement("div");
+    overlay.className = "react-aria-ModalOverlay";
+    modalRoot.dataset.rac = "";
+    modalRoot.dataset.size = "S";
+    modalRoot.dataset.variant = "default";
+    overlay.appendChild(modalRoot);
+    document.body.appendChild(overlay);
+
+    act(() => {
+      root.render(
+        <FloatingAgentChatFrame layer="modal" placement="bottom-end">
+          <span>PXI content</span>
+        </FloatingAgentChatFrame>
+      );
+    });
+
+    const panel = modalRoot.querySelector(".resizable-floating-panel");
+    expect(panel).not.toBeNull();
+    expect(panel?.getAttribute("data-layer")).toBe("modal");
   });
 });

--- a/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
@@ -2,6 +2,10 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  MODAL_OVERLAY_CLASS_NAME,
+  MODAL_PORTAL_CONTAINER_ATTR,
+} from "@phoenix/components/core/overlay/constants";
 import { AgentProvider, useAgentContext } from "@phoenix/contexts/AgentContext";
 import { FeatureFlagsContext } from "@phoenix/contexts/FeatureFlagsContext";
 import { PreferencesProvider } from "@phoenix/contexts/PreferencesContext";
@@ -31,10 +35,8 @@ function dispatchCommandI() {
 function appendModalOverlay() {
   const overlay = document.createElement("div");
   const modalRoot = document.createElement("div");
-  overlay.className = "react-aria-ModalOverlay";
-  modalRoot.dataset.rac = "";
-  modalRoot.dataset.size = "S";
-  modalRoot.dataset.variant = "default";
+  overlay.className = MODAL_OVERLAY_CLASS_NAME;
+  modalRoot.setAttribute(MODAL_PORTAL_CONTAINER_ATTR, "");
   overlay.appendChild(modalRoot);
   document.body.appendChild(overlay);
   return overlay;
@@ -96,7 +98,7 @@ describe("AgentChatWidget", () => {
     });
     container.remove();
     document
-      .querySelectorAll(".react-aria-ModalOverlay")
+      .querySelectorAll(`.${MODAL_OVERLAY_CLASS_NAME}`)
       .forEach((element) => element.remove());
     localStorage.clear();
     vi.useRealTimers();
@@ -205,7 +207,7 @@ describe("AgentChatWidget", () => {
     ).toBe("true");
   });
 
-  it("keeps the FAB available in the modal floating layer", () => {
+  it("keeps the FAB available in the modal portal container", () => {
     const overlay = appendModalOverlay();
     const modalRoot = overlay.firstElementChild;
     renderWidget();
@@ -232,10 +234,8 @@ describe("AgentChatWidget", () => {
 
     const secondOverlay = document.createElement("div");
     const secondModalRoot = document.createElement("div");
-    secondOverlay.className = "react-aria-ModalOverlay";
-    secondModalRoot.dataset.rac = "";
-    secondModalRoot.dataset.size = "S";
-    secondModalRoot.dataset.variant = "default";
+    secondOverlay.className = MODAL_OVERLAY_CLASS_NAME;
+    secondModalRoot.setAttribute(MODAL_PORTAL_CONTAINER_ATTR, "");
     secondOverlay.appendChild(secondModalRoot);
     await act(async () => {
       document.body.appendChild(secondOverlay);

--- a/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
@@ -28,6 +28,18 @@ function dispatchCommandI() {
   });
 }
 
+function appendModalOverlay() {
+  const overlay = document.createElement("div");
+  const modalRoot = document.createElement("div");
+  overlay.className = "react-aria-ModalOverlay";
+  modalRoot.dataset.rac = "";
+  modalRoot.dataset.size = "S";
+  modalRoot.dataset.variant = "default";
+  overlay.appendChild(modalRoot);
+  document.body.appendChild(overlay);
+  return overlay;
+}
+
 function dispatchPointerEvent(
   element: Element,
   type: string,
@@ -83,6 +95,9 @@ describe("AgentChatWidget", () => {
       root.unmount();
     });
     container.remove();
+    document
+      .querySelectorAll(".react-aria-ModalOverlay")
+      .forEach((element) => element.remove());
     localStorage.clear();
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -136,6 +151,17 @@ describe("AgentChatWidget", () => {
     ).toBe("false");
   });
 
+  it("toggles PXI with Command+I while a modal overlay is open", () => {
+    appendModalOverlay();
+    renderWidget();
+
+    dispatchCommandI();
+
+    expect(
+      container.querySelector('[data-testid="agent-open"]')?.textContent
+    ).toBe("true");
+  });
+
   it("ignores Command+I when PXI is disabled", () => {
     renderWidget({ isAssistantAgentEnabled: false });
 
@@ -147,6 +173,83 @@ describe("AgentChatWidget", () => {
   });
 
   it("toggles PXI when the FAB is clicked", () => {
+    renderWidget();
+
+    const fabButton = document.body.querySelector(
+      'button[aria-label="Open assistant"]'
+    );
+    const positioner = document.body.querySelector(
+      ".agent-chat-widget-positioner"
+    );
+    expect(fabButton).not.toBeNull();
+    expect(positioner).not.toBeNull();
+    Object.assign(positioner!, {
+      setPointerCapture: vi.fn(),
+      releasePointerCapture: vi.fn(),
+      hasPointerCapture: vi.fn(() => true),
+    });
+
+    act(() => {
+      dispatchPointerEvent(fabButton!, "pointerdown", {
+        clientX: 935,
+        clientY: 758,
+      });
+      dispatchPointerEvent(fabButton!, "pointerup", {
+        clientX: 935,
+        clientY: 758,
+      });
+    });
+
+    expect(
+      container.querySelector('[data-testid="agent-open"]')?.textContent
+    ).toBe("true");
+  });
+
+  it("keeps the FAB available in the modal floating layer", () => {
+    const overlay = appendModalOverlay();
+    const modalRoot = overlay.firstElementChild;
+    renderWidget();
+
+    const positioner = document.body.querySelector(
+      ".agent-chat-widget-positioner"
+    );
+
+    expect(positioner).not.toBeNull();
+    expect(positioner?.getAttribute("data-layer")).toBe("modal");
+    expect(modalRoot?.contains(positioner)).toBe(true);
+  });
+
+  it("moves the modal-layer FAB when a newer modal becomes active", async () => {
+    const firstOverlay = appendModalOverlay();
+    const firstModalRoot = firstOverlay.firstElementChild;
+    renderWidget();
+
+    const positioner = document.body.querySelector(
+      ".agent-chat-widget-positioner"
+    );
+    expect(positioner).not.toBeNull();
+    expect(firstModalRoot?.contains(positioner)).toBe(true);
+
+    const secondOverlay = document.createElement("div");
+    const secondModalRoot = document.createElement("div");
+    secondOverlay.className = "react-aria-ModalOverlay";
+    secondModalRoot.dataset.rac = "";
+    secondModalRoot.dataset.size = "S";
+    secondModalRoot.dataset.variant = "default";
+    secondOverlay.appendChild(secondModalRoot);
+    await act(async () => {
+      document.body.appendChild(secondOverlay);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const movedPositioner = document.body.querySelector(
+      ".agent-chat-widget-positioner"
+    );
+    expect(secondModalRoot.contains(movedPositioner)).toBe(true);
+  });
+
+  it("toggles PXI when the modal-layer FAB is clicked", () => {
+    appendModalOverlay();
     renderWidget();
 
     const fabButton = document.body.querySelector(

--- a/app/src/components/agent/__tests__/ResizableFloatingPanel.test.tsx
+++ b/app/src/components/agent/__tests__/ResizableFloatingPanel.test.tsx
@@ -76,8 +76,10 @@ describe("ResizableFloatingPanel", () => {
 
   function renderResizablePanel({
     onSizeChange = vi.fn(),
+    layer = "content",
     placement = "bottom-end",
   }: {
+    layer?: "content" | "modal";
     onSizeChange?: (size: Size) => void;
     placement?: AgentFabPlacement;
   } = {}) {
@@ -85,6 +87,7 @@ describe("ResizableFloatingPanel", () => {
       const [size, setSize] = useState(() => ({ ...DEFAULT_SIZE }));
       return (
         <ResizableFloatingPanel
+          layer={layer}
           minSize={MIN_SIZE}
           placement={placement}
           size={size}
@@ -137,6 +140,13 @@ describe("ResizableFloatingPanel", () => {
 
     expect(widthHandle.getAttribute("data-edge")).toBe("right");
     expect(heightHandle.getAttribute("data-edge")).toBe("bottom");
+  });
+
+  it("uses fixed positioning in the modal layer", () => {
+    const { panel } = renderResizablePanel({ layer: "modal" });
+
+    expect(panel.getAttribute("data-layer")).toBe("modal");
+    expect(getComputedStyle(panel).position).toBe("fixed");
   });
 
   it("resizes horizontally from the bottom-end panel's left edge", () => {

--- a/app/src/components/agent/useModalFloatingLayerInteractivity.ts
+++ b/app/src/components/agent/useModalFloatingLayerInteractivity.ts
@@ -1,0 +1,36 @@
+import { useLayoutEffect, type RefObject } from "react";
+
+export function useModalFloatingLayerInteractivity(
+  ref: RefObject<HTMLElement | null>,
+  isModalLayer: boolean
+) {
+  useLayoutEffect(() => {
+    if (!isModalLayer) {
+      return;
+    }
+
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+
+    const enableInteractivity = () => {
+      element.inert = false;
+      element.removeAttribute("inert");
+      element.removeAttribute("aria-hidden");
+    };
+
+    enableInteractivity();
+    const animationFrameId = window.requestAnimationFrame(enableInteractivity);
+    const observer = new MutationObserver(enableInteractivity);
+    observer.observe(element, {
+      attributeFilter: ["aria-hidden", "inert"],
+      attributes: true,
+    });
+
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+      observer.disconnect();
+    };
+  }, [isModalLayer, ref]);
+}

--- a/app/src/components/agent/useModalFloatingLayerInteractivity.ts
+++ b/app/src/components/agent/useModalFloatingLayerInteractivity.ts
@@ -1,5 +1,20 @@
 import { useLayoutEffect, type RefObject } from "react";
 
+/**
+ * Keeps an assistant-owned floating surface interactive while it is rendered in
+ * the active modal layer.
+ *
+ * React Aria protects modal focus by marking content outside the active modal
+ * scope as `inert` and/or `aria-hidden`. The assistant FAB and floating panel
+ * are portaled into the modal portal container, but React Aria may still apply
+ * those attributes during the same commit as the portal move. This hook
+ * removes the attributes from the assistant surface itself so pointer, keyboard,
+ * and assistive-technology access continue to work above the modal mask.
+ *
+ * Only use this for surfaces that are intentionally part of the active modal
+ * interaction layer. Normal page-level floating UI should remain inert while a
+ * modal is open.
+ */
 export function useModalFloatingLayerInteractivity(
   ref: RefObject<HTMLElement | null>,
   isModalLayer: boolean
@@ -21,7 +36,11 @@ export function useModalFloatingLayerInteractivity(
     };
 
     enableInteractivity();
+    // React Aria can apply modal isolation attributes after our layout effect
+    // runs, so retry once on the next frame after the overlay settles.
     const animationFrameId = window.requestAnimationFrame(enableInteractivity);
+    // Keep the surface interactive if React Aria re-applies isolation
+    // attributes while stacked modals mount, unmount, or change active scope.
     const observer = new MutationObserver(enableInteractivity);
     observer.observe(element, {
       attributeFilter: ["aria-hidden", "inert"],

--- a/app/src/components/core/overlay/Modal.tsx
+++ b/app/src/components/core/overlay/Modal.tsx
@@ -12,6 +12,11 @@ import {
 } from "@phoenix/components/core/zIndex";
 import { classNames } from "@phoenix/utils/classNames";
 
+import {
+  MODAL_OVERLAY_CLASS_NAME,
+  MODAL_PORTAL_CONTAINER_ATTR,
+} from "./constants";
+
 const modalSlideover = keyframes`
   from {
     transform: translateX(100%);
@@ -144,6 +149,7 @@ function Modal({ ref, ...props }: ModalProps & { ref?: Ref<HTMLDivElement> }) {
   return (
     <AriaModal
       {...rest}
+      {...{ [MODAL_PORTAL_CONTAINER_ATTR]: "" }}
       data-size={size}
       data-variant={variant}
       ref={ref}
@@ -178,7 +184,7 @@ function ModalOverlay({
       {...props}
       data-testid="modal-overlay"
       css={modalOverlayCSS}
-      className={classNames(props.className, "react-aria-ModalOverlay")}
+      className={classNames(props.className, MODAL_OVERLAY_CLASS_NAME)}
       // default to true, but allow for override
       isDismissable={props.isDismissable ?? true}
       ref={ref}

--- a/app/src/components/core/overlay/constants.ts
+++ b/app/src/components/core/overlay/constants.ts
@@ -29,3 +29,17 @@ export const DRAWER_DEFAULT_MAX_SIZE: SizeValue = "95%";
  * of `minSize`.
  */
 export const DRAWER_HARD_MIN_SIZE_PX = 320;
+
+/**
+ * Stable class added to every Phoenix modal overlay so app-level code can
+ * observe the topmost modal without depending on React Aria internals.
+ */
+export const MODAL_OVERLAY_CLASS_NAME = "react-aria-ModalOverlay";
+
+/**
+ * Marks the element inside a modal overlay that same-modal portals should use
+ * as their container. Portaling into this element keeps those portals inside
+ * React Aria's modal scope instead of making them overlay-dismiss targets.
+ */
+export const MODAL_PORTAL_CONTAINER_ATTR = "data-modal-portal-container";
+export const MODAL_PORTAL_CONTAINER_SELECTOR = `[${MODAL_PORTAL_CONTAINER_ATTR}]`;

--- a/app/src/components/core/zIndex.ts
+++ b/app/src/components/core/zIndex.ts
@@ -2,10 +2,13 @@
  * Shared app stacking layers.
  *
  * Non-modal floating UI should sit above page content but below modal
- * backdrops. Portaled popovers and toasts use the top overlay layer so controls
- * opened from floating surfaces remain usable.
+ * backdrops. Modal floating UI is reserved for controls that intentionally
+ * remain available while a modal backdrop is mounted. Portaled popovers and
+ * toasts use the top overlay layer so controls opened from floating surfaces
+ * remain usable.
  */
 export const MODAL_OVERLAY_Z_INDEX = 1000;
 export const MODAL_DIALOG_Z_INDEX = MODAL_OVERLAY_Z_INDEX + 1;
 export const NON_MODAL_FLOATING_Z_INDEX = MODAL_OVERLAY_Z_INDEX - 1;
+export const MODAL_FLOATING_UI_Z_INDEX = MODAL_DIALOG_Z_INDEX + 1;
 export const PORTALED_OVERLAY_Z_INDEX = 100000;

--- a/app/src/hooks/useHasOpenModal.ts
+++ b/app/src/hooks/useHasOpenModal.ts
@@ -2,33 +2,61 @@ import { useSyncExternalStore } from "react";
 
 const MODAL_SELECTOR = ".react-aria-ModalOverlay";
 
-let hasOpenModalSnapshot = false;
+let openModalFloatingLayerSnapshot: HTMLElement | null = null;
 let observer: MutationObserver | null = null;
 const listeners = new Set<() => void>();
 
 /**
- * Reads the current modal-open state directly from the DOM.
+ * Reads the current active modal floating layer directly from the DOM.
  *
  * This stays outside React state so multiple hook consumers can share the same
  * source of truth through `useSyncExternalStore`.
  */
-function getHasOpenModalSnapshot() {
+function getOpenModalFloatingLayerSnapshot() {
+  return getOpenModalFloatingLayerElement();
+}
+
+export function getOpenModalOverlayElement() {
   if (typeof document === "undefined") {
-    return false;
+    return null;
   }
-  return document.querySelector(MODAL_SELECTOR) !== null;
+
+  const overlays = document.querySelectorAll<HTMLElement>(MODAL_SELECTOR);
+  return overlays.item(overlays.length - 1) ?? null;
+}
+
+export function getOpenModalFloatingLayerElement() {
+  const overlay = getOpenModalOverlayElement();
+  if (!overlay) {
+    return null;
+  }
+
+  for (const child of overlay.children) {
+    if (!(child instanceof HTMLElement)) {
+      continue;
+    }
+    if (
+      child.classList.contains("agent-chat-widget-positioner") ||
+      child.classList.contains("resizable-floating-panel")
+    ) {
+      continue;
+    }
+    return child;
+  }
+
+  return overlay;
 }
 
 /**
- * Recomputes the modal-open snapshot and notifies subscribers only when the
- * boolean value actually changes.
+ * Recomputes the active modal floating layer snapshot and notifies subscribers
+ * only when the layer identity changes.
  */
 function emitIfChanged() {
-  const nextSnapshot = getHasOpenModalSnapshot();
-  if (nextSnapshot === hasOpenModalSnapshot) {
+  const nextSnapshot = getOpenModalFloatingLayerSnapshot();
+  if (nextSnapshot === openModalFloatingLayerSnapshot) {
     return;
   }
-  hasOpenModalSnapshot = nextSnapshot;
+  openModalFloatingLayerSnapshot = nextSnapshot;
   listeners.forEach((listener) => listener());
 }
 
@@ -43,7 +71,7 @@ function ensureObserver() {
     return;
   }
 
-  hasOpenModalSnapshot = getHasOpenModalSnapshot();
+  openModalFloatingLayerSnapshot = getOpenModalFloatingLayerSnapshot();
   observer = new MutationObserver(emitIfChanged);
   observer.observe(document.body, {
     childList: true,
@@ -66,8 +94,8 @@ function cleanupObserver() {
 }
 
 /**
- * Registers a `useSyncExternalStore` subscriber against the shared modal-open
- * snapshot and ensures the DOM observer is active while needed.
+ * Registers a `useSyncExternalStore` subscriber against the shared active modal
+ * floating layer snapshot and ensures the DOM observer is active while needed.
  */
 function subscribe(listener: () => void) {
   ensureObserver();
@@ -85,8 +113,18 @@ function subscribe(listener: () => void) {
  *
  * The implementation uses a single shared `MutationObserver` at module scope so
  * multiple consumers reuse the same DOM subscription instead of each attaching
- * their own observer. During SSR, the hook always reports `false`.
+ * their own observer. The snapshot tracks the active floating layer element,
+ * not just the boolean open state, so consumers re-render when stacked modals
+ * change the top layer. During SSR, the hook always reports `false`.
  */
 export function useHasOpenModal() {
-  return useSyncExternalStore(subscribe, getHasOpenModalSnapshot, () => false);
+  return useOpenModalFloatingLayerElement() !== null;
+}
+
+export function useOpenModalFloatingLayerElement() {
+  return useSyncExternalStore(
+    subscribe,
+    getOpenModalFloatingLayerSnapshot,
+    () => null
+  );
 }

--- a/app/src/hooks/useHasOpenModal.ts
+++ b/app/src/hooks/useHasOpenModal.ts
@@ -1,62 +1,62 @@
 import { useSyncExternalStore } from "react";
 
-const MODAL_SELECTOR = ".react-aria-ModalOverlay";
+import {
+  MODAL_OVERLAY_CLASS_NAME,
+  MODAL_PORTAL_CONTAINER_ATTR,
+  MODAL_PORTAL_CONTAINER_SELECTOR,
+} from "@phoenix/components/core/overlay/constants";
 
-let openModalFloatingLayerSnapshot: HTMLElement | null = null;
+const MODAL_OVERLAY_SELECTOR = `.${MODAL_OVERLAY_CLASS_NAME}`;
+
+let activeModalPortalContainerSnapshot: HTMLElement | null = null;
 let observer: MutationObserver | null = null;
 const listeners = new Set<() => void>();
 
 /**
- * Reads the current active modal floating layer directly from the DOM.
+ * Reads the current active modal portal container directly from the DOM.
  *
  * This stays outside React state so multiple hook consumers can share the same
  * source of truth through `useSyncExternalStore`.
  */
-function getOpenModalFloatingLayerSnapshot() {
-  return getOpenModalFloatingLayerElement();
+function getActiveModalPortalContainerSnapshot() {
+  return getActiveModalPortalContainerElement();
 }
 
-export function getOpenModalOverlayElement() {
+export function getActiveModalOverlayElement() {
   if (typeof document === "undefined") {
     return null;
   }
 
-  const overlays = document.querySelectorAll<HTMLElement>(MODAL_SELECTOR);
+  const overlays = document.querySelectorAll<HTMLElement>(
+    MODAL_OVERLAY_SELECTOR
+  );
   return overlays.item(overlays.length - 1) ?? null;
 }
 
-export function getOpenModalFloatingLayerElement() {
-  const overlay = getOpenModalOverlayElement();
+export function getActiveModalPortalContainerElement() {
+  const overlay = getActiveModalOverlayElement();
   if (!overlay) {
     return null;
   }
 
-  for (const child of overlay.children) {
-    if (!(child instanceof HTMLElement)) {
-      continue;
-    }
-    if (
-      child.classList.contains("agent-chat-widget-positioner") ||
-      child.classList.contains("resizable-floating-panel")
-    ) {
-      continue;
-    }
-    return child;
-  }
-
-  return overlay;
+  // Phoenix modals declare a portal container. Fall back to the overlay for
+  // raw React Aria overlays that do not use the Phoenix Modal wrapper.
+  return (
+    overlay.querySelector<HTMLElement>(MODAL_PORTAL_CONTAINER_SELECTOR) ??
+    overlay
+  );
 }
 
 /**
- * Recomputes the active modal floating layer snapshot and notifies subscribers
- * only when the layer identity changes.
+ * Recomputes the active modal portal container snapshot and notifies
+ * subscribers only when the container identity changes.
  */
 function emitIfChanged() {
-  const nextSnapshot = getOpenModalFloatingLayerSnapshot();
-  if (nextSnapshot === openModalFloatingLayerSnapshot) {
+  const nextSnapshot = getActiveModalPortalContainerSnapshot();
+  if (nextSnapshot === activeModalPortalContainerSnapshot) {
     return;
   }
-  openModalFloatingLayerSnapshot = nextSnapshot;
+  activeModalPortalContainerSnapshot = nextSnapshot;
   listeners.forEach((listener) => listener());
 }
 
@@ -71,13 +71,13 @@ function ensureObserver() {
     return;
   }
 
-  openModalFloatingLayerSnapshot = getOpenModalFloatingLayerSnapshot();
+  activeModalPortalContainerSnapshot = getActiveModalPortalContainerSnapshot();
   observer = new MutationObserver(emitIfChanged);
   observer.observe(document.body, {
     childList: true,
     subtree: true,
     attributes: true,
-    attributeFilter: ["class"],
+    attributeFilter: ["class", MODAL_PORTAL_CONTAINER_ATTR],
   });
 }
 
@@ -94,8 +94,8 @@ function cleanupObserver() {
 }
 
 /**
- * Registers a `useSyncExternalStore` subscriber against the shared active modal
- * floating layer snapshot and ensures the DOM observer is active while needed.
+ * Registers a `useSyncExternalStore` subscriber against the active modal portal
+ * container and ensures the DOM observer is active while needed.
  */
 function subscribe(listener: () => void) {
   ensureObserver();
@@ -113,18 +113,24 @@ function subscribe(listener: () => void) {
  *
  * The implementation uses a single shared `MutationObserver` at module scope so
  * multiple consumers reuse the same DOM subscription instead of each attaching
- * their own observer. The snapshot tracks the active floating layer element,
+ * their own observer. The snapshot tracks the active portal container element,
  * not just the boolean open state, so consumers re-render when stacked modals
- * change the top layer. During SSR, the hook always reports `false`.
+ * change the active modal. During SSR, the hook always reports `false`.
  */
 export function useHasOpenModal() {
-  return useOpenModalFloatingLayerElement() !== null;
+  return useActiveModalPortalContainerElement() !== null;
 }
 
-export function useOpenModalFloatingLayerElement() {
+/**
+ * Returns the portal container for the topmost open modal.
+ *
+ * Consumers that need to remain interactive while a modal is open should portal
+ * into this element so they stay within React Aria's active modal scope.
+ */
+export function useActiveModalPortalContainerElement() {
   return useSyncExternalStore(
     subscribe,
-    getOpenModalFloatingLayerSnapshot,
+    getActiveModalPortalContainerSnapshot,
     () => null
   );
 }

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -29,6 +29,7 @@ import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
+import { useHasOpenModal } from "@phoenix/hooks/useHasOpenModal";
 import { prependBasename } from "@phoenix/utils/routingUtils";
 
 import type { LayoutLoaderData } from "./layoutLoader";
@@ -94,16 +95,18 @@ export function Layout() {
     (state) => state.activePanelLocation
   );
   const agentPosition = useAgentContext((state) => state.position);
+  const hasOpenModal = useHasOpenModal();
   const shouldShowDockedAgentPanel =
     isAgentsEnabled &&
     isAgentPanelOpen &&
     activePanelLocation === "docked" &&
-    agentPosition === "pinned";
+    agentPosition === "pinned" &&
+    !hasOpenModal;
   const shouldShowFloatingAgentPanel =
     isAgentsEnabled &&
     isAgentPanelOpen &&
     activePanelLocation === "docked" &&
-    agentPosition === "detached";
+    (agentPosition === "detached" || hasOpenModal);
   const panelIds = shouldShowDockedAgentPanel
     ? ["layout-content", "agent-chat"]
     : ["layout-content"];
@@ -134,7 +137,9 @@ export function Layout() {
               <div data-testid="content" css={contentCSS} ref={contentRef}>
                 <AgentChatWidget boundaryRef={contentRef} />
                 {shouldShowFloatingAgentPanel ? (
-                  <FloatingAgentChatPanel />
+                  <FloatingAgentChatPanel
+                    layer={hasOpenModal ? "modal" : "content"}
+                  />
                 ) : null}
                 <Suspense fallback={<Loading />}>
                   <Outlet />


### PR DESCRIPTION
## Summary

- keeps the global PXI FAB available while React Aria modals or slideovers are open
- forces PXI into an unpinned modal-layer floating panel above the mask while preserving the stored pinned/detached preference
- tracks the active modal floating layer by element identity so stacked modals move PXI to the top modal
- includes modal-layer interactivity handling and regression coverage for modal clicks and stacked overlays

## Why

React Aria marks content outside the active modal as inert and dismisses on outside interactions. PXI previously disappeared or became unreachable when a modal/slideover was mounted. The fix portals PXI into the active modal layer, gives it a modal floating z-index, and suppresses overlay-dismiss propagation for PXI interactions.
<img width="2560" height="1322" alt="Screenshot 2026-05-26 at 12 56 20 PM" src="https://github.com/user-attachments/assets/918b5cf6-e068-414a-9a01-f0adaf7f43cc" />
