### PR TITLE
fix: confine token counts to LLM spans at ingestion

### DIFF
--- a/src/phoenix/db/insertion/span.py
+++ b/src/phoenix/db/insertion/span.py
@@ -9,7 +9,7 @@ from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.trace.attributes import get_attribute_value
-from phoenix.trace.schemas import Span, SpanStatusCode
+from phoenix.trace.schemas import Span, SpanKind, SpanStatusCode
 
 
 class SpanInsertionEvent(NamedTuple):
@@ -104,30 +104,23 @@ async def insert_span(
     )
 
     cumulative_error_count = int(span.status_code is SpanStatusCode.ERROR)
-    try:
-        cumulative_llm_token_count_prompt = int(
-            get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_PROMPT) or 0
-        )
-    except BaseException:
-        cumulative_llm_token_count_prompt = 0
-    try:
-        cumulative_llm_token_count_completion = int(
-            get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) or 0
-        )
-    except BaseException:
-        cumulative_llm_token_count_completion = 0
-    try:
-        llm_token_count_prompt = int(
-            get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_PROMPT) or 0
-        )
-    except BaseException:
-        llm_token_count_prompt = 0
-    try:
-        llm_token_count_completion = int(
-            get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) or 0
-        )
-    except BaseException:
-        llm_token_count_completion = 0
+    llm_token_count_prompt: Optional[int] = None
+    llm_token_count_completion: Optional[int] = None
+    if span.span_kind is SpanKind.LLM:
+        try:
+            llm_token_count_prompt = int(
+                get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_PROMPT) or 0
+            )
+        except BaseException:
+            llm_token_count_prompt = 0
+        try:
+            llm_token_count_completion = int(
+                get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) or 0
+            )
+        except BaseException:
+            llm_token_count_completion = 0
+    cumulative_llm_token_count_prompt = llm_token_count_prompt or 0
+    cumulative_llm_token_count_completion = llm_token_count_completion or 0
     if accumulation := (
         await session.execute(
             select(

--- a/src/phoenix/tracers.py
+++ b/src/phoenix/tracers.py
@@ -377,10 +377,11 @@ def _get_cumulative_counts(spans: Sequence[models.Span]) -> list[CumulativeCount
             if span.parent_id not in parent_to_children_ids:
                 parent_to_children_ids[span.parent_id] = []
             parent_to_children_ids[span.parent_id].append(span.span_id)
+        is_llm_span = (span.span_kind or "").upper() == "LLM"
         counts_by_span_id[span.span_id] = CumulativeCount(
             errors=int(span.status_code == "ERROR"),
-            prompt_tokens=span.llm_token_count_prompt or 0,
-            completion_tokens=span.llm_token_count_completion or 0,
+            prompt_tokens=(span.llm_token_count_prompt or 0) if is_llm_span else 0,
+            completion_tokens=(span.llm_token_count_completion or 0) if is_llm_span else 0,
         )
 
     # iterative post-order traversal


### PR DESCRIPTION
## Summary

Restrict both `llm_token_count_*` (own) and `cumulative_llm_token_count_*` (rollup) populations to spans with `span_kind = 'LLM'` during ingestion. Some instrumentors (Strands Agents, smolagents) propagate the rolled-up token usage onto wrapping agent/tool/chain spans via OpenInference attributes; storing those values on non-LLM spans muddles both columns. After this fix, non-LLM spans store NULL for own and the cumulative rollup correctly sums only LLM-kind descendants.

Resolves https://github.com/Arize-ai/openinference/issues/3164