### PR TITLE
ci: include evals/ in all-platforms unit tests sparse-checkout

### DIFF
--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -72,6 +72,7 @@ jobs:
             requirements/
             src/phoenix/
             packages/phoenix-evals/
+            evals/
             tests/unit/
             tests/conftest.py
             tests/__generated__/


### PR DESCRIPTION
## Summary
- The scheduled `Python All Platforms` workflow has been failing nightly since #13273 — its Unit Tests job's sparse-checkout omits `evals/`, but the new `tests/unit/pxi/evals/` modules import from `evals.pxi.harness` and `evals.pxi.evaluators`, producing `ModuleNotFoundError: No module named 'evals'` at collection time.
- The PR-triggered `python-CI.yml` Unit Tests job already lists `evals/`, which is why this slipped past PR checks and only surfaces on the nightly all-platforms run.
- Adds `evals/` to the all-platforms Unit Tests sparse-checkout. No other job in this workflow references `evals/`.

Example failing job: https://github.com/Arize-ai/phoenix/actions/runs/26470920876/job/77943868636

## Test plan
- [ ] Next scheduled `Python All Platforms` run passes the Unit Tests matrix.
- [ ] Manual trigger of the workflow on this branch collects `tests/unit/pxi/evals/test_datasets.py` etc. without `ModuleNotFoundError`.