### PR TITLE
chore: Update Codex hooks feature flag

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,2 @@
 [features]
-codex_hooks = true
+hooks = true


### PR DESCRIPTION
## Summary

Updates the Codex feature flag for lifecycle hooks from the deprecated `[features].codex_hooks` key to `[features].hooks`.

## Why

Codex now warns that `[features].codex_hooks` is deprecated. The supported feature flag is `hooks`, while the existing `.codex/hooks.json` configuration remains unchanged.

## Validation

- `git diff --check -- .codex/config.toml`
- `rg -n "codex_hooks|features\.codex_hooks" .codex` returned no matches
