### PR TITLE
fix(otel): remove dead importlib_metadata fallback

### DIFF
--- a/packages/phoenix-otel/src/phoenix/otel/__init__.py
+++ b/packages/phoenix-otel/src/phoenix/otel/__init__.py
@@ -24,14 +24,8 @@ from .otel import (
     register,
 )
 
-# Import version from package metadata
 try:
     from importlib.metadata import version
-
-    __version__ = version("arize-phoenix-otel")
-except ImportError:
-    # Fallback for Python < 3.8
-    from importlib_metadata import version
 
     __version__ = version("arize-phoenix-otel")
 except Exception:


### PR DESCRIPTION
## Summary
- Drops the `except ImportError: from importlib_metadata import version` branch in `packages/phoenix-otel/src/phoenix/otel/__init__.py`. The branch was labeled "Fallback for Python < 3.8" but `arize-phoenix-otel` already requires Python >=3.10, so it could never fire.
- Unblocks `tox -e phoenix_otel`'s `mypy` step, which was failing with:
  - `Cannot find implementation or library stub for module named "importlib_metadata"` (the third-party backport is not a declared dependency)
  - `Name "version" already defined (possibly by an import)` (both branches bound `version` in module scope)

## Test plan
- [x] `UV_PYTHON=3.10 uvx tox r -e phoenix_otel` — mypy clean, 75 pytest tests pass.