### PR TITLE
fix: Fix PXI FAB first-load visibility and entrance cue

### DIFF
--- a/app/src/components/agent/AgentChatWidget.tsx
+++ b/app/src/components/agent/AgentChatWidget.tsx
@@ -71,6 +71,18 @@ const hoverWipe = keyframes`
   }
 `;
 
+const hoverRingOpacity = keyframes`
+  0%, 100% {
+    opacity: 0;
+  }
+  8%, 40% {
+    opacity: 0.95;
+  }
+  55% {
+    opacity: 0;
+  }
+`;
+
 const glyphBreathe = keyframes`
   0%, 100% {
     color: var(--agent-chat-widget-glyph-rest-color);
@@ -312,6 +324,34 @@ const restingHoverWipeCSS = css`
   }
 `;
 
+const entranceHoverWipeCSS = css`
+  @media (prefers-reduced-motion: no-preference) {
+    &[data-entrance-animation="true"] .agent-chat-widget__hover-shimmer {
+      animation: ${hoverWipe} 2400ms linear 1;
+    }
+
+    &[data-entrance-animation="true"] .agent-chat-widget__hover-shimmer::before {
+      animation:
+        ${ringBreathe} 2400ms ease-in-out 1,
+        ${hoverRingOpacity} 2400ms linear 1;
+    }
+
+    &[data-entrance-animation="true"] .agent-chat-widget__content {
+      opacity: 1;
+    }
+
+    &[data-entrance-animation="true"]:hover .agent-chat-widget__hover-shimmer {
+      animation: ${hoverWipe} 2400ms linear infinite;
+    }
+
+    &[data-entrance-animation="true"]:hover
+      .agent-chat-widget__hover-shimmer::before {
+      opacity: 0.95;
+      animation: ${ringBreathe} 2400ms ease-in-out 1 both;
+    }
+  }
+`;
+
 const thinkingGlyphPulseCSS = css`
   .agent-chat-widget__content {
     animation: ${glyphBreathe} 2400ms ease-in-out infinite;
@@ -340,6 +380,7 @@ export function AgentChatWidgetButton({
   ...buttonProps
 }: AgentChatWidgetButtonProps) {
   const { theme } = useTheme();
+  const shouldShowEntranceAnimation = !isStreaming;
   return (
     <AriaButton
       ref={ref}
@@ -360,10 +401,14 @@ export function AgentChatWidgetButton({
           darkThemeThinkingGlowCSS,
           lightThemeThinkingGlowCSS,
           !isStreaming ? [thinkingBorderCSS, restingHoverWipeCSS] : undefined,
+          shouldShowEntranceAnimation ? entranceHoverWipeCSS : undefined,
           isStreaming ? thinkingBorderCSS : undefined,
           isStreaming ? thinkingGlyphPulseCSS : undefined,
         ]}
         data-theme={theme}
+        data-entrance-animation={
+          shouldShowEntranceAnimation ? "true" : undefined
+        }
         initial={false}
         animate={{
           width: isStreaming ? 40 : 58,
@@ -452,7 +497,7 @@ export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
     [isAssistantAgentEnabled, toggleOpen]
   );
 
-  if (!isAssistantAgentEnabled || isOpen) {
+  if (!isAssistantAgentEnabled) {
     return null;
   }
 
@@ -461,6 +506,7 @@ export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
   return createPortal(
     <AgentFabPositioner
       boundaryRef={hasOpenModal ? undefined : boundaryRef}
+      isHidden={isOpen}
       layer={hasOpenModal ? "modal" : "content"}
       placement={fabPlacement}
       size={isStreaming ? FAB_STREAMING_SIZE : FAB_RESTING_SIZE}

--- a/app/src/components/agent/AgentFabPositioner.tsx
+++ b/app/src/components/agent/AgentFabPositioner.tsx
@@ -54,6 +54,11 @@ const positionerCSS = css`
     visibility: visible;
   }
 
+  &[data-hidden="true"] {
+    pointer-events: none;
+    visibility: hidden;
+  }
+
   &[data-dragging="true"],
   &[data-dragging="true"] * {
     cursor: grabbing;
@@ -76,6 +81,7 @@ type DragSession = {
 export type AgentFabPositionerProps = {
   boundaryRef?: RefObject<HTMLElement | null>;
   children: ReactNode;
+  isHidden?: boolean;
   layer?: "content" | "modal";
   placement: AgentFabPlacement;
   size?: Size;
@@ -200,6 +206,7 @@ function applyElementPinnedPosition({
 export function AgentFabPositioner({
   boundaryRef,
   children,
+  isHidden = false,
   layer = "content",
   placement,
   size,
@@ -216,6 +223,9 @@ export function AgentFabPositioner({
   const suppressClickResetTimeoutIdRef = useRef<number | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const requiresBoundary = Boolean(boundaryRef);
+  const [resolvedBoundary, setResolvedBoundary] = useState<HTMLElement | null>(
+    () => boundaryRef?.current ?? null
+  );
   useModalFloatingLayerInteractivity(positionerRef, layer === "modal");
 
   // After a drag, an unwanted `click` event can still fire on pointerup. We
@@ -235,7 +245,7 @@ export function AgentFabPositioner({
   const getBounds = (): Bounds => {
     return (
       getPositioningBounds({
-        boundary: boundaryRef?.current,
+        boundary: resolvedBoundary,
         requiresBoundary,
       }) ?? getViewportBounds()
     );
@@ -453,10 +463,37 @@ export function AgentFabPositioner({
   };
 
   useLayoutEffect(() => {
+    if (!requiresBoundary) {
+      setResolvedBoundary(null);
+      return;
+    }
+
+    let animationFrameId: number | null = null;
+    const syncBoundaryElement = () => {
+      const nextBoundary = boundaryRef?.current ?? null;
+      setResolvedBoundary((currentBoundary) =>
+        currentBoundary === nextBoundary ? currentBoundary : nextBoundary
+      );
+
+      if (!nextBoundary) {
+        animationFrameId = window.requestAnimationFrame(syncBoundaryElement);
+      }
+    };
+
+    syncBoundaryElement();
+
+    return () => {
+      if (animationFrameId != null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+    };
+  }, [boundaryRef, requiresBoundary]);
+
+  useLayoutEffect(() => {
     const syncPinnedPosition = () => {
       if (!dragSessionRef.current) {
         applyElementPinnedPosition({
-          boundary: boundaryRef?.current,
+          boundary: resolvedBoundary,
           element: positionerRef.current,
           placement,
           requiresBoundary,
@@ -467,18 +504,17 @@ export function AgentFabPositioner({
 
     syncPinnedPosition();
 
-    const boundary = boundaryRef?.current;
     // ResizeObserver covers boundary-driven changes (panel resize, sidebar
     // toggle). visualViewport.resize covers viewport-level changes that don't
     // resize the boundary (mobile URL bar collapse, virtual keyboard).
     // visualViewport.scroll covers pinch-zoom scrolling on mobile, which
     // shifts where the boundary appears on screen.
     const observer =
-      boundary && typeof ResizeObserver === "function"
+      resolvedBoundary && typeof ResizeObserver === "function"
         ? new ResizeObserver(syncPinnedPosition)
         : null;
-    if (boundary && observer) {
-      observer.observe(boundary);
+    if (resolvedBoundary && observer) {
+      observer.observe(resolvedBoundary);
     }
     window.visualViewport?.addEventListener("resize", syncPinnedPosition);
     window.visualViewport?.addEventListener("scroll", syncPinnedPosition);
@@ -497,13 +533,15 @@ export function AgentFabPositioner({
         suppressClickResetTimeoutIdRef.current = null;
       }
     };
-  }, [boundaryRef, placement, requiresBoundary, size]);
+  }, [placement, requiresBoundary, resolvedBoundary, size]);
 
   return (
     <div
       className="agent-chat-widget-positioner"
       css={positionerCSS}
+      aria-hidden={isHidden ? true : undefined}
       data-dragging={isDragging ? "true" : undefined}
+      data-hidden={isHidden ? "true" : undefined}
       data-layer={layer}
       data-placement={placement}
       ref={positionerRef}

--- a/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
@@ -1,4 +1,4 @@
-import { act } from "react";
+import { act, useRef } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -16,6 +16,16 @@ import { AgentChatWidget } from "../AgentChatWidget";
 function AgentOpenState() {
   const isOpen = useAgentContext((state) => state.isOpen);
   return <span data-testid="agent-open">{String(isOpen)}</span>;
+}
+
+function AgentWidgetWithBoundary() {
+  const boundaryRef = useRef<HTMLDivElement>(null);
+  return (
+    <div ref={boundaryRef}>
+      <AgentChatWidget boundaryRef={boundaryRef} />
+      <AgentOpenState />
+    </div>
+  );
 }
 
 function dispatchCommandI() {
@@ -151,6 +161,36 @@ describe("AgentChatWidget", () => {
     expect(
       container.querySelector('[data-testid="agent-open"]')?.textContent
     ).toBe("false");
+  });
+
+  it("hides the mounted FAB while PXI is open", () => {
+    renderWidget();
+
+    const positioner = document.body.querySelector(
+      ".agent-chat-widget-positioner"
+    );
+    expect(positioner).not.toBeNull();
+    expect(positioner?.getAttribute("data-hidden")).toBeNull();
+
+    dispatchCommandI();
+
+    expect(
+      container.querySelector('[data-testid="agent-open"]')?.textContent
+    ).toBe("true");
+    expect(document.body.querySelector(".agent-chat-widget-positioner")).toBe(
+      positioner
+    );
+    expect(positioner?.getAttribute("data-hidden")).toBe("true");
+
+    dispatchCommandI();
+
+    expect(
+      container.querySelector('[data-testid="agent-open"]')?.textContent
+    ).toBe("false");
+    expect(document.body.querySelector(".agent-chat-widget-positioner")).toBe(
+      positioner
+    );
+    expect(positioner?.getAttribute("data-hidden")).toBeNull();
   });
 
   it("toggles PXI with Command+I while a modal overlay is open", () => {
@@ -315,5 +355,59 @@ describe("AgentChatWidget", () => {
     });
 
     expect(document.body.textContent).toContain("Open assistant");
+  });
+
+  it("enables the one-shot hover wipe when the FAB appears", () => {
+    renderWidget();
+
+    expect(
+      document.body.querySelector('[data-entrance-animation="true"]')
+    ).not.toBeNull();
+  });
+
+  it("marks the FAB ready on first render when constrained to a boundary", async () => {
+    const getBoundingClientRect = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue({
+        bottom: 800,
+        height: 700,
+        left: 100,
+        right: 1000,
+        top: 100,
+        width: 900,
+        x: 100,
+        y: 100,
+        toJSON: () => ({}),
+      } as DOMRect);
+
+    act(() => {
+      root.render(
+        <ThemeProvider themeMode="light" disableBodyTheme>
+          <FeatureFlagsContext.Provider
+            value={{
+              featureFlags: { agents: true, tracing_ux: false },
+              setFeatureFlags: vi.fn(),
+            }}
+          >
+            <PreferencesProvider isAssistantAgentEnabled>
+              <AgentProvider>
+                <AgentWidgetWithBoundary />
+              </AgentProvider>
+            </PreferencesProvider>
+          </FeatureFlagsContext.Provider>
+        </ThemeProvider>
+      );
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => window.requestAnimationFrame(resolve));
+    });
+
+    expect(getBoundingClientRect).toHaveBeenCalled();
+    expect(
+      document.body
+        .querySelector(".agent-chat-widget-positioner")
+        ?.getAttribute("data-ready")
+    ).toBe("true");
   });
 });


### PR DESCRIPTION
## Summary

- Fix the PXI FAB positioner so it retries resolving its content boundary when the ref is not available on the first layout pass.
- Make the FAB play its existing hover shimmer/ring as a one-shot entrance cue by default.
- Keep the FAB mounted while PXI is open and hide the positioner instead of unmounting it, so the entrance cue does not replay on every open/close cycle.
- Add regression coverage for the boundary-ref first-load path, the entrance animation state, and the mounted-hidden behavior.

## Root Cause

The FAB is portaled outside the content tree, but its positioner depends on the content boundary ref. On first load, the positioner could run before `boundaryRef.current` was set, clear `data-ready`, and never retry positioning.

## Validation

- `pnpm vitest run src/components/agent/__tests__/AgentChatWidget.test.tsx src/components/agent/__tests__/AgentFabPositioner.test.tsx`
- `pnpm lint -- src/components/agent/AgentChatWidget.tsx src/components/agent/AgentFabPositioner.tsx src/components/agent/__tests__/AgentChatWidget.test.tsx`
- `pnpm fmt:check src/components/agent/AgentChatWidget.tsx src/components/agent/AgentFabPositioner.tsx src/components/agent/__tests__/AgentChatWidget.test.tsx`
- `pnpm typecheck`
- Browser sanity check against local Phoenix at `http://localhost:6006/projects`