### PR TITLE
fix: load evaluator subclass fields in dataloader

### DIFF
--- a/src/phoenix/server/api/dataloaders/evaluator_by_id.py
+++ b/src/phoenix/server/api/dataloaders/evaluator_by_id.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from sqlalchemy import select
+from sqlalchemy.orm import with_polymorphic
 from strawberry.dataloader import DataLoader
 from typing_extensions import TypeAlias
 
@@ -22,8 +23,12 @@ class EvaluatorByIdDataLoader(DataLoader[Key, Result]):
         evaluators_by_id: dict[Key, models.Evaluator] = {}
 
         async with self._db() as session:
+            evaluator_model = with_polymorphic(
+                models.Evaluator,
+                [models.LLMEvaluator, models.CodeEvaluator, models.BuiltinEvaluator],
+            )
             data = await session.stream_scalars(
-                select(models.Evaluator).where(models.Evaluator.id.in_(evaluator_ids))
+                select(evaluator_model).where(evaluator_model.id.in_(evaluator_ids))
             )
             async for evaluator in data:
                 evaluators_by_id[evaluator.id] = evaluator

--- a/tests/unit/server/api/dataloaders/test_evaluator_by_id.py
+++ b/tests/unit/server/api/dataloaders/test_evaluator_by_id.py
@@ -42,23 +42,3 @@ async def test_evaluator_by_id_batches_lookups(db: DbSessionFactory) -> None:
     assert [r.id if r is not None else None for r in results] == keys
     missing = await loader._load_fn([max(ids) + 1000])
     assert missing == [None]
-
-
-async def test_evaluator_by_id_loads_builtin_subclass_fields(
-    db: DbSessionFactory,
-    synced_builtin_evaluators: None,
-) -> None:
-    async with db() as session:
-        builtin_id = await session.scalar(
-            sqlalchemy.select(models.BuiltinEvaluator.id).where(
-                models.BuiltinEvaluator.key == "regex"
-            )
-        )
-    assert builtin_id is not None
-
-    loader = EvaluatorByIdDataLoader(db)
-    result = (await loader._load_fn([builtin_id]))[0]
-
-    assert isinstance(result, models.BuiltinEvaluator)
-    assert result.key == "regex"
-    assert result.output_configs

--- a/tests/unit/server/api/dataloaders/test_evaluator_by_id.py
+++ b/tests/unit/server/api/dataloaders/test_evaluator_by_id.py
@@ -42,3 +42,23 @@ async def test_evaluator_by_id_batches_lookups(db: DbSessionFactory) -> None:
     assert [r.id if r is not None else None for r in results] == keys
     missing = await loader._load_fn([max(ids) + 1000])
     assert missing == [None]
+
+
+async def test_evaluator_by_id_loads_builtin_subclass_fields(
+    db: DbSessionFactory,
+    synced_builtin_evaluators: None,
+) -> None:
+    async with db() as session:
+        builtin_id = await session.scalar(
+            sqlalchemy.select(models.BuiltinEvaluator.id).where(
+                models.BuiltinEvaluator.key == "regex"
+            )
+        )
+    assert builtin_id is not None
+
+    loader = EvaluatorByIdDataLoader(db)
+    result = (await loader._load_fn([builtin_id]))[0]
+
+    assert isinstance(result, models.BuiltinEvaluator)
+    assert result.key == "regex"
+    assert result.output_configs

--- a/tests/unit/server/api/types/test_Evaluator.py
+++ b/tests/unit/server/api/types/test_Evaluator.py
@@ -1078,6 +1078,72 @@ class TestBuiltInEvaluatorMultiOutput:
         assert isinstance(output_configs, list)
         assert len(output_configs) == 0
 
+    async def test_builtin_null_output_configs_falls_back_to_base_evaluator(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        synced_builtin_evaluators: None,
+    ) -> None:
+        """Verify that null output_configs falls back to the builtin evaluator's configs."""
+        from sqlalchemy import select
+
+        async with db() as session:
+            dataset = models.Dataset(
+                name=f"test-dataset-null-output-configs-{token_hex(4)}",
+                metadata_={},
+            )
+            session.add(dataset)
+            await session.flush()
+
+            project = models.Project(name=f"test-null-output-configs-project-{token_hex(4)}")
+            session.add(project)
+            await session.flush()
+
+            contains_id = await session.scalar(
+                select(models.BuiltinEvaluator.id).where(models.BuiltinEvaluator.key == "contains")
+            )
+            assert contains_id is not None
+
+            dataset_eval = models.DatasetEvaluators(
+                dataset_id=dataset.id,
+                evaluator_id=contains_id,
+                name=Identifier("contains_null_output_configs"),
+                input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
+                output_configs=None,
+                project_id=project.id,
+            )
+            session.add(dataset_eval)
+            await session.flush()
+            dataset_eval_id = dataset_eval.id
+
+        resp = await gql_client.execute(
+            """query ($id: ID!) {
+                node(id: $id) {
+                    ... on DatasetEvaluator {
+                        name
+                        outputConfigs {
+                            __typename
+                            ... on CategoricalAnnotationConfig {
+                                name
+                                optimizationDirection
+                                values { label score }
+                            }
+                        }
+                    }
+                }
+            }""",
+            variables={"id": str(GlobalID(DatasetEvaluator.__name__, str(dataset_eval_id)))},
+        )
+        assert not resp.errors and resp.data
+        node = resp.data["node"]
+        assert node["name"] == "contains_null_output_configs"
+        output_configs = node["outputConfigs"]
+        assert isinstance(output_configs, list)
+        assert len(output_configs) >= 1
+        output_config = output_configs[0]
+        assert output_config["__typename"] == "CategoricalAnnotationConfig"
+        assert output_config["name"] == "contains"
+
 
 class TestLLMEvaluatorOutputConfigs:
     """Tests for LLMEvaluator.outputConfigs GraphQL field resolution."""

--- a/tests/unit/server/api/types/test_Evaluator.py
+++ b/tests/unit/server/api/types/test_Evaluator.py
@@ -2,6 +2,7 @@ from secrets import token_hex
 from typing import Any, AsyncIterator
 
 import pytest
+from sqlalchemy import select
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
@@ -1085,8 +1086,6 @@ class TestBuiltInEvaluatorMultiOutput:
         synced_builtin_evaluators: None,
     ) -> None:
         """Verify that null output_configs falls back to the builtin evaluator's configs."""
-        from sqlalchemy import select
-
         async with db() as session:
             dataset = models.Dataset(
                 name=f"test-dataset-null-output-configs-{token_hex(4)}",


### PR DESCRIPTION
## Problem

A built-in dataset evaluator can validly have `output_configs = null`. In that state, `DatasetEvaluator.outputConfigs` treats the missing dataset-level override as a signal to fall back to the base built-in evaluator config.

The playground crashed on that fallback path because `EvaluatorByIdDataLoader` selected only the base `evaluators` table. SQLAlchemy could return a `BuiltinEvaluator` instance, but subclass fields such as `BuiltinEvaluator.key` were still unloaded. Once the dataloader session closed, the GraphQL resolver tried to read `evaluator.key`, SQLAlchemy attempted a lazy refresh, and the detached ORM instance raised `DetachedInstanceError`.

## Solution

Update `EvaluatorByIdDataLoader` to query evaluators with `with_polymorphic(models.Evaluator, [models.LLMEvaluator, models.CodeEvaluator, models.BuiltinEvaluator])`, matching the existing evaluator query patterns used elsewhere in the API. This eagerly loads subclass-table fields while the session is open, so resolvers can safely read built-in evaluator fields after the loader returns.

This preserves the existing output-config semantics:

- `output_configs = null`: fall back to the base evaluator config
- `output_configs = []`: explicit empty override

## Testing

- `uv run pytest tests/unit/server/api/dataloaders/test_evaluator_by_id.py -n auto`
- `uv run pytest tests/unit/server/api/types/test_Evaluator.py::TestBuiltInEvaluatorMultiOutput::test_builtin_empty_output_configs_returns_empty tests/unit/server/api/types/test_Evaluator.py::TestBuiltInEvaluatorMultiOutput::test_builtin_null_output_configs_falls_back_to_base_evaluator -n auto`
- `uv run ruff check src/phoenix/server/api/dataloaders/evaluator_by_id.py tests/unit/server/api/dataloaders/test_evaluator_by_id.py tests/unit/server/api/types/test_Evaluator.py`
- `uv run ruff format --check src/phoenix/server/api/dataloaders/evaluator_by_id.py tests/unit/server/api/dataloaders/test_evaluator_by_id.py tests/unit/server/api/types/test_Evaluator.py`

Related issue: N/A