### PR TITLE
fix: avoid PXI initial scroll animation

### DIFF
--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -289,7 +289,9 @@ export function ChatView({
   emptyStateQuickActions?: EmptyStateQuickAction[];
 }>) {
   const { theme } = useTheme();
-  const { contentRef, scrollRef, scrollToBottom } = useStickToBottom();
+  const { contentRef, scrollRef, scrollToBottom } = useStickToBottom({
+    initial: "instant",
+  });
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [inputValue, setInputValue] = useState("");
   const [elicitationDraft, setElicitationDraft] =


### PR DESCRIPTION
## Summary
- make PXI chat use an instant initial stick-to-bottom scroll on mount
- preserve existing resize and submit scroll behavior


Partially resolves #13424