### PR TITLE
docs(skills): weekly audit — 2026-05-27

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -286,6 +286,8 @@ px api graphql '{ projectCount datasetCount promptCount evaluatorCount }'
 px api graphql '{ projects { edges { node { name traceCount tokenCountTotal } } } }' | jq '.data.projects.edges[].node'
 px api graphql '{ datasets { edges { node { name exampleCount experimentCount } } } }' | jq '.data.datasets.edges[].node'
 px api graphql '{ evaluators { edges { node { name kind } } } }' | jq '.data.evaluators.edges[].node'
+# evaluator kind values: "LLM" | "CODE" | "BUILTIN"
+# CODE = server-side code evaluator running in a sandbox; BUILTIN = pre-built server evaluator
 
 # Introspect any type
 px api graphql '{ __type(name: "Project") { fields { name type { name } } } }' | jq '.data.__type.fields[]'


### PR DESCRIPTION
# Phoenix Skills Audit — 2026-05-20 to 2026-05-27

**Audited against:** `origin/main` at `1a3684126dc165438aac65a5f2f81a109c7464c4`
**Commits analyzed:** 42 (1 user-facing, 41 skipped)

## Edits applied

### phoenix-cli
- `SKILL.md` — added inline comments to the GraphQL evaluators example noting that `kind` now has three valid values: `"LLM"` | `"CODE"` | `"BUILTIN"`. Grounded in `src/phoenix/db/models.py` (commit `e294d939f`): `EvaluatorKind: TypeAlias = Literal["LLM", "CODE", "BUILTIN"]`. Before this commit only `"LLM"` was a valid kind. The new `"CODE"` kind represents server-side code evaluators running in sandbox environments (Deno WASM, E2B, Modal, Daytona, Vercel); `"BUILTIN"` represents pre-built server evaluators.

### phoenix-tracing
No edits applied.

### phoenix-evals
No edits applied.

## Skipped commits

| Commit | Reason |
|--------|--------|
| `9fe3f1562` | Internal spec doc (`internal_docs/specs/`). Not user-facing. |
| `06da8eb5f` | `chore(main): release arize-phoenix 16.3.0` — release-please bookkeeping. |
| `47b82ff33` | `refactor(agents)`: PXI agent internal refactor — no public surface. |
| `5ef972923` | `feat(agents)`: PXI agent skills capability — internal server agent, not user SDK. |
| `4a6e5b3f0` | Frontend PXI fix — no skill surface. |
| `4fe68f8e0` | Frontend drag-to-zoom — no skill surface. |
| `bbe5cb9ee` | Frontend PXI model selector — no skill surface. |
| `a53c8603a` | Release bookkeeping. |
| `5d4f34f54` | `fix: confine token counts to LLM spans at ingestion` — `src/phoenix/tracers.py`. The CLI skill session JSON shape already says "cumulative across all LLM spans"; the code fix brings the behavior into line with the already-correct documentation. No update needed. |
| `a8f071782` | CI-only change (sparse checkout). |
| `008a7a1dd` | `fix(otel): remove dead importlib_metadata fallback` — dead code cleanup for Python < 3.8 compatibility shim. No user-facing change; Phoenix already requires ≥ 3.8. |
| `b2f99663e` | Feature flag update (Codex hooks). |
| `7b6af221f` | Frontend PXI modal accessibility — no skill surface. |
| `1f713c2e7` | Release bookkeeping. |
| `bfee39579` | `fix: aggregate token counts from LLM spans only` — internal refactor renames `cumulative_token_counts_by_session` → `token_counts_by_session`. No REST/GraphQL contract change. |
| `b7fa39227` | Frontend example details drawer — no skill surface. |
| `150a83d9e` | Frontend layout — no skill surface. |
| `6a9c58859` | Cost/pricing model update — no skill surface. |
| `b43ddb49a` | Dashboards route — frontend. |
| `4458cdc75` | UI icon change — frontend. |
| `6295e1876`, `1a387a3f7`, `d3a34c0a5`, `6ebb79f27` | PXI chat UI features — frontend only. |
| `1de682108` | Previous weekly skills audit. |
| `119f26bca` | `oxfmt` formatting pass — no logic change. |
| `5345014a5` | PXI FAB geometry refactor — frontend. |
| `6272f3068` | PXI FAB movable — frontend. |
| `19897909a` | Adds `pxi-eval-dataset` skill — out-of-scope (not one of the three owned skills). |
| `7250ad0a1` | CI eval harness change. |
| `aa22eda65` | PXI eval harness refactor — internal. |
| `aed6d434d` | `chore: remove unused PHOENIX_SANDBOX_PROVIDER` — removed env var never documented in any of the three skills. |
| `88314e07e`, `eaf66a71c`, `eff1c2af0`, `5420188ac` | Release/kustomize/sitemap bookkeeping. |
| `78d1e96ee` | PXI agent tool group fix — internal. |
| `41eb4fcb0` | `feat(agents): Enable provider native web search/fetch` — PXI agent capability; Python/TS client generated files changed only to reflect capability advertisement fields (internal GraphQL field), no user-callable SDK surface added. |
| `ed0cf221e`, `45e1fb9de`, `bb31a522d` | Release bookkeeping / playground fix. |
| `f6b681a2d` | Docs-only: judge prompt template guide. |
| `f5a74878e`, `64116602f`, `7907251f0`, `c0b00d873` | Deps / sitemap / release notes. |
| `743cc90e7` | Self-hosting docs — no skill surface. |
| `80ced9f4c` | Playground fix — no skill surface. |
| `c74574d39` | UI elicitation UX — frontend. |
| `006815952` | Playground model picker fix — frontend. |
| `1a3684126` | `fix: load evaluator subclass fields in dataloader` — internal SQLAlchemy polymorphic-load fix; no public API change. |

## Candidate `e294d939f` — detailed assessment

`feat!: Sandboxing and Code Evaluators` is the largest commit in this window, touching >200 files. After reading `src/phoenix/db/models.py`, `src/phoenix/server/api/types/Evaluator.py`, `src/phoenix/server/api/mutations/evaluator_mutations.py`, and both client generated files (`packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py`, `js/packages/phoenix-client/src/__generated__/api/v1.ts`):

- **Python client additions**: `FreeformAnnotationConfig`, `FreeformAnnotationConfigData`, `CreateAnnotationConfigResponseBody`, `DeleteAnnotationConfigResponseBody` TypedDicts — annotation config CRUD types; no evaluator or tracing surface. Not documented in any of the three skills. No update needed.
- **TypeScript client additions**: `optimization_direction`, `threshold`, `lower_bound`, `upper_bound` optional fields on freeform annotation config shape — same scope as above. Not documented in skills.
- **GraphQL mutations added**: `create_code_evaluator`, `patch_code_evaluator`, `create_code_evaluator_version`, `create_dataset_code_evaluator`, `update_dataset_code_evaluator` — all server-side, UI-driven. Not accessible via Python `arize-phoenix-evals` SDK. **Out of scope for `phoenix-evals` skill** (which documents client-side SDK evals, not server-side UI evaluators).
- **New `kind` values on `Evaluator` type**: `"CODE"` and `"BUILTIN"` added alongside existing `"LLM"`. The `phoenix-cli` GraphQL evaluators example queries `kind` without listing valid values — **update applied** (see Edits applied above).
- **Annotation config REST fields**: `FreeformAnnotationConfig` gains `optimization_direction`, `threshold`, `lower_bound`, `upper_bound`. The CLI skill does not document the annotation config JSON shape; no update needed.
- **New env var `PHOENIX_ALLOWED_SANDBOX_PROVIDERS`**: Server-side self-hosting configuration. Not in scope for any of the three client/CLI skills.
- **Removed env var `PHOENIX_SANDBOX_PROVIDER`** (commit `aed6d434d`): Was never documented in the three skills.

## Out-of-scope findings

- **`phoenix-server` skill**: The new GraphQL mutations (`create_code_evaluator`, etc.) and `SandboxConfig` types are significant additions to the backend API surface. The `phoenix-server` skill should be updated to document these mutations and types, but that skill is not owned by this audit.
- **`pxi-eval-dataset` skill**: Added in commit `19897909a`. Not one of the three owned skills.
