### PR TITLE
feat: playground skill

### DIFF
--- a/app/src/agent/extensions/__tests__/toolRegistry.test.ts
+++ b/app/src/agent/extensions/__tests__/toolRegistry.test.ts
@@ -7,6 +7,7 @@ import {
   CLONE_PROMPT_INSTANCE_TOOL_NAME,
   EDIT_PROMPT_TOOL_NAME,
 } from "@phoenix/agent/tools/playgroundPrompt";
+import { RUN_PLAYGROUND_TOOL_NAME } from "@phoenix/agent/tools/playgroundRun";
 import { GENERATIVE_UI_TOOL_NAME } from "@phoenix/components/agent/generativeUICatalog";
 import { createAgentStore } from "@phoenix/store/agentStore";
 
@@ -223,6 +224,33 @@ describe("toolRegistry", () => {
         state: "output-available",
         tool: CLONE_PROMPT_INSTANCE_TOOL_NAME,
         output: "cloned",
+      })
+    );
+  });
+
+  it("dispatches run_playground to the registered client action", async () => {
+    const store = createAgentStore();
+    const addToolOutput = vi.fn().mockResolvedValue(undefined);
+    const action = vi.fn().mockResolvedValue({ ok: true, output: "started" });
+    store.getState().registerClientAction(RUN_PLAYGROUND_TOOL_NAME, action);
+
+    await handleRegisteredAgentToolCall({
+      toolCall: {
+        toolCallId: "tool-call-run-playground",
+        toolName: RUN_PLAYGROUND_TOOL_NAME,
+        input: {},
+      },
+      sessionId: "session-1",
+      addToolOutput,
+      agentStore: store,
+    });
+
+    expect(action).toHaveBeenCalledWith({});
+    expect(addToolOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: "output-available",
+        tool: RUN_PLAYGROUND_TOOL_NAME,
+        output: "started",
       })
     );
   });

--- a/app/src/agent/extensions/__tests__/toolRegistry.test.ts
+++ b/app/src/agent/extensions/__tests__/toolRegistry.test.ts
@@ -3,11 +3,13 @@ import {
   handleRegisteredAgentToolCall,
   SET_TIME_RANGE_TOOL_NAME,
 } from "@phoenix/agent/extensions/toolRegistry";
+import { READ_PLAYGROUND_OUTPUT_TOOL_NAME } from "@phoenix/agent/tools/playgroundOutput";
 import {
   CLONE_PROMPT_INSTANCE_TOOL_NAME,
   EDIT_PROMPT_TOOL_NAME,
 } from "@phoenix/agent/tools/playgroundPrompt";
 import { RUN_PLAYGROUND_TOOL_NAME } from "@phoenix/agent/tools/playgroundRun";
+import { SET_VARIABLE_VALUES_TOOL_NAME } from "@phoenix/agent/tools/playgroundVariableValues";
 import { GENERATIVE_UI_TOOL_NAME } from "@phoenix/components/agent/generativeUICatalog";
 import { createAgentStore } from "@phoenix/store/agentStore";
 
@@ -251,6 +253,70 @@ describe("toolRegistry", () => {
         state: "output-available",
         tool: RUN_PLAYGROUND_TOOL_NAME,
         output: "started",
+      })
+    );
+  });
+
+  it("dispatches read_playground_output to the registered client action", async () => {
+    const store = createAgentStore();
+    const addToolOutput = vi.fn().mockResolvedValue(undefined);
+    const action = vi
+      .fn()
+      .mockResolvedValue({ ok: true, output: "playground output" });
+    store
+      .getState()
+      .registerClientAction(READ_PLAYGROUND_OUTPUT_TOOL_NAME, action);
+
+    const input = { instanceId: 0, repetitionNumber: 1 };
+
+    await handleRegisteredAgentToolCall({
+      toolCall: {
+        toolCallId: "tool-call-read-playground-output",
+        toolName: READ_PLAYGROUND_OUTPUT_TOOL_NAME,
+        input,
+      },
+      sessionId: "session-1",
+      addToolOutput,
+      agentStore: store,
+    });
+
+    expect(action).toHaveBeenCalledWith(input);
+    expect(addToolOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: "output-available",
+        tool: READ_PLAYGROUND_OUTPUT_TOOL_NAME,
+        output: "playground output",
+      })
+    );
+  });
+
+  it("dispatches set_variable_values to the registered client action", async () => {
+    const store = createAgentStore();
+    const addToolOutput = vi.fn().mockResolvedValue(undefined);
+    const action = vi.fn().mockResolvedValue({ ok: true, output: "updated" });
+    store
+      .getState()
+      .registerClientAction(SET_VARIABLE_VALUES_TOOL_NAME, action);
+
+    const input = { values: [{ key: "question", value: "What is Phoenix?" }] };
+
+    await handleRegisteredAgentToolCall({
+      toolCall: {
+        toolCallId: "tool-call-set-variable-values",
+        toolName: SET_VARIABLE_VALUES_TOOL_NAME,
+        input,
+      },
+      sessionId: "session-1",
+      addToolOutput,
+      agentStore: store,
+    });
+
+    expect(action).toHaveBeenCalledWith(input);
+    expect(addToolOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: "output-available",
+        tool: SET_VARIABLE_VALUES_TOOL_NAME,
+        output: "updated",
       })
     );
   });

--- a/app/src/agent/extensions/toolRegistry.ts
+++ b/app/src/agent/extensions/toolRegistry.ts
@@ -11,10 +11,10 @@ import { handleBashToolCall } from "@phoenix/agent/tools/bash/handleBashToolCall
 import { parseElicitToolInput } from "@phoenix/agent/tools/elicit";
 import type { ElicitToolInput } from "@phoenix/agent/tools/elicit";
 import {
-  parseRunPlaygroundInput,
-  RUN_PLAYGROUND_TOOL_NAME,
-  type RunPlaygroundInput,
-} from "@phoenix/agent/tools/playgroundRun";
+  parseReadPlaygroundOutputInput,
+  READ_PLAYGROUND_OUTPUT_TOOL_NAME,
+  type ReadPlaygroundOutputInput,
+} from "@phoenix/agent/tools/playgroundOutput";
 import {
   CLONE_PROMPT_INSTANCE_TOOL_NAME,
   EDIT_PROMPT_TOOL_NAME,
@@ -27,6 +27,16 @@ import {
   type EditPromptInput,
   type ReadPromptInput,
 } from "@phoenix/agent/tools/playgroundPrompt";
+import {
+  parseRunPlaygroundInput,
+  RUN_PLAYGROUND_TOOL_NAME,
+  type RunPlaygroundInput,
+} from "@phoenix/agent/tools/playgroundRun";
+import {
+  parseSetVariableValuesInput,
+  SET_VARIABLE_VALUES_TOOL_NAME,
+  type SetVariableValuesInput,
+} from "@phoenix/agent/tools/playgroundVariableValues";
 import type { components } from "@phoenix/api/__generated__/v1";
 import {
   GENERATIVE_UI_TOOL_NAME,
@@ -553,6 +563,84 @@ const runPlaygroundAgentTool = createRegisteredAgentTool<RunPlaygroundInput>({
   },
 });
 
+const readPlaygroundOutputAgentTool =
+  createRegisteredAgentTool<ReadPlaygroundOutputInput>({
+    name: READ_PLAYGROUND_OUTPUT_TOOL_NAME,
+    parseInput: parseReadPlaygroundOutputInput,
+    invalidInputErrorText: `Invalid ${READ_PLAYGROUND_OUTPUT_TOOL_NAME} input. Expected { instanceId?: number, repetitionNumber?: number }.`,
+    execute: async ({ toolCall, input, addToolOutput, agentStore }) => {
+      const action =
+        agentStore.getState().registeredClientActions[
+          READ_PLAYGROUND_OUTPUT_TOOL_NAME
+        ];
+      if (!action) {
+        await addToolOutput({
+          state: "output-error",
+          tool: READ_PLAYGROUND_OUTPUT_TOOL_NAME,
+          toolCallId: toolCall.toolCallId,
+          errorText:
+            "The playground is not mounted; cannot read playground output.",
+        });
+        return;
+      }
+      const result = await action(input);
+      if (result.ok) {
+        await addToolOutput({
+          state: "output-available",
+          tool: READ_PLAYGROUND_OUTPUT_TOOL_NAME,
+          toolCallId: toolCall.toolCallId,
+          output: result.output ?? "Playground output read.",
+        });
+      } else {
+        await addToolOutput({
+          state: "output-error",
+          tool: READ_PLAYGROUND_OUTPUT_TOOL_NAME,
+          toolCallId: toolCall.toolCallId,
+          errorText: result.error,
+        });
+      }
+    },
+  });
+
+const setVariableValuesAgentTool =
+  createRegisteredAgentTool<SetVariableValuesInput>({
+    name: SET_VARIABLE_VALUES_TOOL_NAME,
+    parseInput: parseSetVariableValuesInput,
+    invalidInputErrorText: `Invalid ${SET_VARIABLE_VALUES_TOOL_NAME} input. Expected { values: { key: string, value: string }[] }.`,
+    execute: async ({ toolCall, input, addToolOutput, agentStore }) => {
+      const action =
+        agentStore.getState().registeredClientActions[
+          SET_VARIABLE_VALUES_TOOL_NAME
+        ];
+      if (!action) {
+        await addToolOutput({
+          state: "output-error",
+          tool: SET_VARIABLE_VALUES_TOOL_NAME,
+          toolCallId: toolCall.toolCallId,
+          errorText:
+            "The playground is not mounted; cannot set playground variable values.",
+        });
+        return;
+      }
+      const result = await action(input);
+      if (result.ok) {
+        await addToolOutput({
+          state: "output-available",
+          tool: SET_VARIABLE_VALUES_TOOL_NAME,
+          toolCallId: toolCall.toolCallId,
+          output: result.output ?? "Playground variable values updated.",
+        });
+      } else {
+        await addToolOutput({
+          state: "output-error",
+          tool: SET_VARIABLE_VALUES_TOOL_NAME,
+          toolCallId: toolCall.toolCallId,
+          errorText: result.error,
+        });
+      }
+    },
+  });
+
 /** Ordered registry of all frontend-executable tools. */
 const agentToolRegistry: RegisteredAgentTool<unknown>[] = [
   bashAgentTool as RegisteredAgentTool<unknown>,
@@ -564,6 +652,8 @@ const agentToolRegistry: RegisteredAgentTool<unknown>[] = [
   clonePromptInstanceAgentTool as RegisteredAgentTool<unknown>,
   editPromptAgentTool as RegisteredAgentTool<unknown>,
   runPlaygroundAgentTool as RegisteredAgentTool<unknown>,
+  readPlaygroundOutputAgentTool as RegisteredAgentTool<unknown>,
+  setVariableValuesAgentTool as RegisteredAgentTool<unknown>,
 ];
 
 /** Fast lookup map for runtime tool dispatch by name. */

--- a/app/src/agent/extensions/toolRegistry.ts
+++ b/app/src/agent/extensions/toolRegistry.ts
@@ -11,6 +11,11 @@ import { handleBashToolCall } from "@phoenix/agent/tools/bash/handleBashToolCall
 import { parseElicitToolInput } from "@phoenix/agent/tools/elicit";
 import type { ElicitToolInput } from "@phoenix/agent/tools/elicit";
 import {
+  parseRunPlaygroundInput,
+  RUN_PLAYGROUND_TOOL_NAME,
+  type RunPlaygroundInput,
+} from "@phoenix/agent/tools/playgroundRun";
+import {
   CLONE_PROMPT_INSTANCE_TOOL_NAME,
   EDIT_PROMPT_TOOL_NAME,
   parseClonePromptInstanceInput,
@@ -513,6 +518,41 @@ const editPromptAgentTool = createRegisteredAgentTool<EditPromptInput>({
   },
 });
 
+const runPlaygroundAgentTool = createRegisteredAgentTool<RunPlaygroundInput>({
+  name: RUN_PLAYGROUND_TOOL_NAME,
+  parseInput: parseRunPlaygroundInput,
+  invalidInputErrorText: `Invalid ${RUN_PLAYGROUND_TOOL_NAME} input. Expected {}.`,
+  execute: async ({ toolCall, input, addToolOutput, agentStore }) => {
+    const action =
+      agentStore.getState().registeredClientActions[RUN_PLAYGROUND_TOOL_NAME];
+    if (!action) {
+      await addToolOutput({
+        state: "output-error",
+        tool: RUN_PLAYGROUND_TOOL_NAME,
+        toolCallId: toolCall.toolCallId,
+        errorText: "The playground is not mounted; cannot run the playground.",
+      });
+      return;
+    }
+    const result = await action(input);
+    if (result.ok) {
+      await addToolOutput({
+        state: "output-available",
+        tool: RUN_PLAYGROUND_TOOL_NAME,
+        toolCallId: toolCall.toolCallId,
+        output: result.output ?? "Playground run started.",
+      });
+    } else {
+      await addToolOutput({
+        state: "output-error",
+        tool: RUN_PLAYGROUND_TOOL_NAME,
+        toolCallId: toolCall.toolCallId,
+        errorText: result.error,
+      });
+    }
+  },
+});
+
 /** Ordered registry of all frontend-executable tools. */
 const agentToolRegistry: RegisteredAgentTool<unknown>[] = [
   bashAgentTool as RegisteredAgentTool<unknown>,
@@ -523,6 +563,7 @@ const agentToolRegistry: RegisteredAgentTool<unknown>[] = [
   readPromptAgentTool as RegisteredAgentTool<unknown>,
   clonePromptInstanceAgentTool as RegisteredAgentTool<unknown>,
   editPromptAgentTool as RegisteredAgentTool<unknown>,
+  runPlaygroundAgentTool as RegisteredAgentTool<unknown>,
 ];
 
 /** Fast lookup map for runtime tool dispatch by name. */

--- a/app/src/agent/tools/playgroundOutput/__tests__/playgroundOutput.test.ts
+++ b/app/src/agent/tools/playgroundOutput/__tests__/playgroundOutput.test.ts
@@ -1,0 +1,103 @@
+import { createReadPlaygroundOutputClientAction } from "@phoenix/agent/tools/playgroundOutput";
+import {
+  _resetInstanceId,
+  _resetMessageId,
+  createPlaygroundStore,
+} from "@phoenix/store/playground";
+
+describe("playground output agent tool", () => {
+  beforeEach(() => {
+    _resetInstanceId();
+    _resetMessageId();
+  });
+
+  it("reads raw playground output and trace id for completed runs", async () => {
+    const playgroundStore = createPlaygroundStore({
+      datasetId: null,
+      modelConfigByProvider: {},
+    });
+    const instanceId = playgroundStore.getState().instances[0].id;
+    playgroundStore.getState().runPlaygroundInstances();
+    playgroundStore
+      .getState()
+      .appendRepetitionOutput(instanceId, 1, "Playground answer");
+    playgroundStore
+      .getState()
+      .setRepetitionSpanId(instanceId, 1, "span-node-id");
+    playgroundStore
+      .getState()
+      .setRepetitionTraceId(instanceId, 1, "trace-otel-id");
+    playgroundStore.getState().setRepetitionStatus(instanceId, 1, "finished");
+    playgroundStore.getState().markPlaygroundInstanceComplete(instanceId);
+    const action = createReadPlaygroundOutputClientAction({ playgroundStore });
+
+    const result = await action({});
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const output = JSON.parse(result.output ?? "") as {
+      status: string;
+      instances: {
+        instanceId: number;
+        label: string;
+        repetitions: {
+          rawOutput: string;
+          traceId: string;
+          spanNodeId: string;
+        }[];
+      }[];
+    };
+    expect(output).toEqual(
+      expect.objectContaining({
+        status: "finished",
+        instances: [
+          expect.objectContaining({
+            instanceId,
+            label: "A",
+            repetitions: [
+              expect.objectContaining({
+                rawOutput: "Playground answer",
+                traceId: "trace-otel-id",
+                spanNodeId: "span-node-id",
+              }),
+            ],
+          }),
+        ],
+      })
+    );
+  });
+
+  it("rejects reads before any run data is available", async () => {
+    const playgroundStore = createPlaygroundStore({
+      datasetId: null,
+      modelConfigByProvider: {},
+    });
+    const action = createReadPlaygroundOutputClientAction({ playgroundStore });
+
+    const result = await action({});
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: expect.stringContaining("No playground run output"),
+      })
+    );
+  });
+
+  it("rejects unexpected input fields", async () => {
+    const playgroundStore = createPlaygroundStore({
+      datasetId: null,
+      modelConfigByProvider: {},
+    });
+    const action = createReadPlaygroundOutputClientAction({ playgroundStore });
+
+    const result = await action({ instanceId: 0, extra: true });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: "Invalid read_playground_output input.",
+      })
+    );
+  });
+});

--- a/app/src/agent/tools/playgroundOutput/clientActions.ts
+++ b/app/src/agent/tools/playgroundOutput/clientActions.ts
@@ -1,0 +1,168 @@
+import type { AgentClientActionResult } from "@phoenix/store/agentStore";
+import type {
+  PlaygroundNormalizedInstance,
+  PlaygroundStore,
+} from "@phoenix/store/playground";
+
+import { getInstanceLabel } from "../playgroundPrompt";
+import { parseReadPlaygroundOutputInput } from "./parsers";
+import type {
+  PlaygroundOutputInstanceSnapshot,
+  PlaygroundOutputRepetitionSnapshot,
+  PlaygroundOutputRunStatus,
+} from "./types";
+
+function getRunStatus(
+  instances: PlaygroundOutputInstanceSnapshot[]
+): PlaygroundOutputRunStatus {
+  const repetitions = instances.flatMap((instance) => instance.repetitions);
+  if (repetitions.length === 0) {
+    return "not_started";
+  }
+
+  const hasRunningRepetition = repetitions.some(
+    (repetition) =>
+      repetition.status === "pending" ||
+      repetition.status === "streamInProgress"
+  );
+  const hasFinishedRepetition = repetitions.some(
+    (repetition) => repetition.status === "finished"
+  );
+
+  if (hasRunningRepetition && hasFinishedRepetition) {
+    return "partial";
+  }
+  if (hasRunningRepetition) {
+    return "running";
+  }
+  if (hasFinishedRepetition) {
+    return "finished";
+  }
+  return "not_started";
+}
+
+function hasRunData(repetition: PlaygroundOutputRepetitionSnapshot): boolean {
+  return (
+    repetition.status !== "notStarted" ||
+    repetition.rawOutput != null ||
+    repetition.traceId != null ||
+    repetition.spanNodeId != null ||
+    repetition.error != null ||
+    repetition.toolCalls.length > 0
+  );
+}
+
+function buildInstanceSnapshot({
+  instance,
+  instanceIndex,
+  repetitionNumber,
+}: {
+  instance: PlaygroundNormalizedInstance;
+  instanceIndex: number;
+  repetitionNumber?: number;
+}): PlaygroundOutputInstanceSnapshot {
+  const repetitions = Object.entries(instance.repetitions)
+    .map(([key, repetition]) => ({
+      repetitionNumber: Number(key),
+      repetition,
+    }))
+    .filter(
+      (
+        entry
+      ): entry is {
+        repetitionNumber: number;
+        repetition: NonNullable<
+          PlaygroundNormalizedInstance["repetitions"][number]
+        >;
+      } =>
+        entry.repetition != null &&
+        Number.isInteger(entry.repetitionNumber) &&
+        (repetitionNumber == null ||
+          entry.repetitionNumber === repetitionNumber)
+    )
+    .sort((left, right) => left.repetitionNumber - right.repetitionNumber)
+    .map(({ repetitionNumber, repetition }) => ({
+      repetitionNumber,
+      status: repetition.status,
+      rawOutput: repetition.output,
+      traceId: repetition.traceId ?? null,
+      spanNodeId: repetition.spanId,
+      error: repetition.error,
+      toolCalls: Object.values(repetition.toolCalls),
+    }));
+
+  return {
+    instanceId: instance.id,
+    index: instanceIndex,
+    label: getInstanceLabel(instanceIndex),
+    activeRunId: instance.activeRunId,
+    repetitions,
+  };
+}
+
+/**
+ * Creates the client action handler for read_playground_output.
+ * Returns raw playground run output and trace IDs from mounted browser state.
+ */
+export function createReadPlaygroundOutputClientAction({
+  playgroundStore,
+}: {
+  playgroundStore: PlaygroundStore;
+}) {
+  return async (input: unknown): Promise<AgentClientActionResult> => {
+    const parsed = parseReadPlaygroundOutputInput(input);
+    if (!parsed) {
+      return { ok: false, error: "Invalid read_playground_output input." };
+    }
+
+    const state = playgroundStore.getState();
+    const selectedInstances =
+      parsed.instanceId == null
+        ? state.instances
+        : state.instances.filter(
+            (instance) => instance.id === parsed.instanceId
+          );
+
+    if (parsed.instanceId != null && selectedInstances.length === 0) {
+      return {
+        ok: false,
+        error: `Playground instance ${parsed.instanceId} was not found.`,
+      };
+    }
+
+    const instances = selectedInstances.map((instance) =>
+      buildInstanceSnapshot({
+        instance,
+        instanceIndex: state.instances.findIndex(
+          (candidate) => candidate.id === instance.id
+        ),
+        repetitionNumber: parsed.repetitionNumber,
+      })
+    );
+
+    const repetitions = instances.flatMap((instance) => instance.repetitions);
+    const hasAnyRunData = repetitions.some(hasRunData);
+    if (!hasAnyRunData) {
+      return {
+        ok: false,
+        error:
+          "No playground run output is available. Call run_playground first, then read the output after the run starts or finishes.",
+      };
+    }
+
+    const status = getRunStatus(instances);
+    const output = {
+      status,
+      instances,
+      message:
+        status === "running" || status === "partial"
+          ? "The playground run is still in progress. Read again after it finishes for final output and traceId values."
+          : "Playground output read.",
+    };
+
+    return {
+      ok: true,
+      output: JSON.stringify(output, null, 2),
+    };
+  };
+}

--- a/app/src/agent/tools/playgroundOutput/constants.ts
+++ b/app/src/agent/tools/playgroundOutput/constants.ts
@@ -1,0 +1,1 @@
+export const READ_PLAYGROUND_OUTPUT_TOOL_NAME = "read_playground_output";

--- a/app/src/agent/tools/playgroundOutput/index.ts
+++ b/app/src/agent/tools/playgroundOutput/index.ts
@@ -1,0 +1,5 @@
+export * from "./clientActions";
+export * from "./constants";
+export * from "./parsers";
+export * from "./schemas";
+export * from "./types";

--- a/app/src/agent/tools/playgroundOutput/parsers.ts
+++ b/app/src/agent/tools/playgroundOutput/parsers.ts
@@ -1,0 +1,8 @@
+import { readPlaygroundOutputInputSchema } from "./schemas";
+import type { ReadPlaygroundOutputInput } from "./types";
+
+export function parseReadPlaygroundOutputInput(
+  input: unknown
+): ReadPlaygroundOutputInput | null {
+  return readPlaygroundOutputInputSchema.safeParse(input).data ?? null;
+}

--- a/app/src/agent/tools/playgroundOutput/schemas.ts
+++ b/app/src/agent/tools/playgroundOutput/schemas.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const readPlaygroundOutputInputSchema = z
+  .preprocess(
+    (input) => (input == null ? {} : input),
+    z
+      .object({
+        instanceId: z.number().int().optional(),
+        repetitionNumber: z.number().int().min(1).optional(),
+      })
+      .strict()
+  )
+  .transform(({ instanceId, repetitionNumber }) => ({
+    ...(typeof instanceId === "number" ? { instanceId } : {}),
+    ...(typeof repetitionNumber === "number" ? { repetitionNumber } : {}),
+  }));

--- a/app/src/agent/tools/playgroundOutput/types.ts
+++ b/app/src/agent/tools/playgroundOutput/types.ts
@@ -1,0 +1,43 @@
+import type { z } from "zod";
+
+import type {
+  PlaygroundError,
+  PlaygroundRepetition,
+  PlaygroundRepetitionStatus,
+} from "@phoenix/store/playground";
+
+import type { readPlaygroundOutputInputSchema } from "./schemas";
+
+export type ReadPlaygroundOutputInput = z.output<
+  typeof readPlaygroundOutputInputSchema
+>;
+
+export type PlaygroundOutputRunStatus =
+  | "not_started"
+  | "running"
+  | "partial"
+  | "finished";
+
+export type PlaygroundOutputRepetitionSnapshot = {
+  repetitionNumber: number;
+  status: PlaygroundRepetitionStatus;
+  rawOutput: PlaygroundRepetition["output"];
+  traceId: string | null;
+  spanNodeId: string | null;
+  error: PlaygroundError | null;
+  toolCalls: PlaygroundRepetition["toolCalls"][string][];
+};
+
+export type PlaygroundOutputInstanceSnapshot = {
+  instanceId: number;
+  index: number;
+  label: string;
+  activeRunId: number | null;
+  repetitions: PlaygroundOutputRepetitionSnapshot[];
+};
+
+export type PlaygroundOutputSnapshot = {
+  status: PlaygroundOutputRunStatus;
+  instances: PlaygroundOutputInstanceSnapshot[];
+  message: string;
+};

--- a/app/src/agent/tools/playgroundRun/__tests__/playgroundRun.test.ts
+++ b/app/src/agent/tools/playgroundRun/__tests__/playgroundRun.test.ts
@@ -1,0 +1,80 @@
+import { createRunPlaygroundClientAction } from "@phoenix/agent/tools/playgroundRun";
+import {
+  _resetInstanceId,
+  _resetMessageId,
+  createPlaygroundStore,
+} from "@phoenix/store/playground";
+
+describe("playground run agent tool", () => {
+  beforeEach(() => {
+    _resetInstanceId();
+    _resetMessageId();
+  });
+
+  it("starts a playground run for all current instances", async () => {
+    const playgroundStore = createPlaygroundStore({
+      datasetId: null,
+      modelConfigByProvider: {},
+    });
+    playgroundStore.getState().addInstance();
+    const action = createRunPlaygroundClientAction({ playgroundStore });
+
+    const result = await action({});
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const output = JSON.parse(result.output ?? "") as {
+      status: string;
+      instances: { instanceId: number; label: string }[];
+    };
+    expect(output).toEqual(
+      expect.objectContaining({
+        status: "started",
+        instances: [
+          { instanceId: 0, label: "A" },
+          { instanceId: 1, label: "B" },
+        ],
+      })
+    );
+    expect(
+      playgroundStore
+        .getState()
+        .instances.every((instance) => instance.activeRunId != null)
+    ).toBe(true);
+  });
+
+  it("rejects run requests while the playground is already running", async () => {
+    const playgroundStore = createPlaygroundStore({
+      datasetId: null,
+      modelConfigByProvider: {},
+    });
+    playgroundStore.getState().runPlaygroundInstances();
+    const action = createRunPlaygroundClientAction({ playgroundStore });
+
+    const result = await action({});
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: expect.stringContaining("already running"),
+      })
+    );
+  });
+
+  it("rejects unexpected input fields", async () => {
+    const playgroundStore = createPlaygroundStore({
+      datasetId: null,
+      modelConfigByProvider: {},
+    });
+    const action = createRunPlaygroundClientAction({ playgroundStore });
+
+    const result = await action({ instanceId: 0 });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: "Invalid run_playground input.",
+      })
+    );
+  });
+});

--- a/app/src/agent/tools/playgroundRun/clientActions.ts
+++ b/app/src/agent/tools/playgroundRun/clientActions.ts
@@ -1,0 +1,61 @@
+import type { AgentClientActionResult } from "@phoenix/store/agentStore";
+import type { PlaygroundStore } from "@phoenix/store/playground";
+
+import { getInstanceLabel } from "../playgroundPrompt";
+import { parseRunPlaygroundInput } from "./parsers";
+
+/**
+ * Creates the client action handler for run_playground.
+ * Starts the same run the playground Run button would start.
+ */
+export function createRunPlaygroundClientAction({
+  playgroundStore,
+}: {
+  playgroundStore: PlaygroundStore;
+}) {
+  return async (input: unknown): Promise<AgentClientActionResult> => {
+    const parsed = parseRunPlaygroundInput(input);
+    if (!parsed) {
+      return { ok: false, error: "Invalid run_playground input." };
+    }
+
+    const state = playgroundStore.getState();
+    const hasInstances = state.instances.length > 0;
+    if (!hasInstances) {
+      return {
+        ok: false,
+        error: "The playground has no prompt instances to run.",
+      };
+    }
+
+    const isRunning = state.instances.some(
+      (instance) => instance.activeRunId != null
+    );
+    if (isRunning) {
+      return {
+        ok: false,
+        error:
+          "The playground is already running. Wait for the current run to finish or stop it before starting another run.",
+      };
+    }
+
+    const instances = state.instances.map((instance, index) => ({
+      instanceId: instance.id,
+      label: getInstanceLabel(index),
+    }));
+    state.runPlaygroundInstances();
+
+    return {
+      ok: true,
+      output: JSON.stringify(
+        {
+          status: "started",
+          instances,
+          message: "Playground run started.",
+        },
+        null,
+        2
+      ),
+    };
+  };
+}

--- a/app/src/agent/tools/playgroundRun/constants.ts
+++ b/app/src/agent/tools/playgroundRun/constants.ts
@@ -1,0 +1,1 @@
+export const RUN_PLAYGROUND_TOOL_NAME = "run_playground";

--- a/app/src/agent/tools/playgroundRun/index.ts
+++ b/app/src/agent/tools/playgroundRun/index.ts
@@ -1,0 +1,5 @@
+export * from "./clientActions";
+export * from "./constants";
+export * from "./parsers";
+export * from "./schemas";
+export * from "./types";

--- a/app/src/agent/tools/playgroundRun/parsers.ts
+++ b/app/src/agent/tools/playgroundRun/parsers.ts
@@ -1,0 +1,8 @@
+import { runPlaygroundInputSchema } from "./schemas";
+import type { RunPlaygroundInput } from "./types";
+
+export function parseRunPlaygroundInput(
+  input: unknown
+): RunPlaygroundInput | null {
+  return runPlaygroundInputSchema.safeParse(input).data ?? null;
+}

--- a/app/src/agent/tools/playgroundRun/schemas.ts
+++ b/app/src/agent/tools/playgroundRun/schemas.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
 
 export const runPlaygroundInputSchema = z
-  .preprocess(
-    (input) => (input == null ? {} : input),
-    z.object({}).strict()
-  )
+  .preprocess((input) => (input == null ? {} : input), z.object({}).strict())
   .transform(() => ({}));

--- a/app/src/agent/tools/playgroundRun/schemas.ts
+++ b/app/src/agent/tools/playgroundRun/schemas.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const runPlaygroundInputSchema = z
+  .preprocess(
+    (input) => (input == null ? {} : input),
+    z.object({}).strict()
+  )
+  .transform(() => ({}));

--- a/app/src/agent/tools/playgroundRun/types.ts
+++ b/app/src/agent/tools/playgroundRun/types.ts
@@ -1,0 +1,5 @@
+import type { z } from "zod";
+
+import type { runPlaygroundInputSchema } from "./schemas";
+
+export type RunPlaygroundInput = z.output<typeof runPlaygroundInputSchema>;

--- a/app/src/agent/tools/playgroundVariableValues/__tests__/playgroundVariableValues.test.ts
+++ b/app/src/agent/tools/playgroundVariableValues/__tests__/playgroundVariableValues.test.ts
@@ -1,0 +1,44 @@
+import { createSetVariableValuesClientAction } from "@phoenix/agent/tools/playgroundVariableValues";
+import { createPlaygroundStore } from "@phoenix/store/playground";
+
+describe("playground variable values agent tool", () => {
+  it("sets playground variable values", async () => {
+    const playgroundStore = createPlaygroundStore({
+      datasetId: null,
+      modelConfigByProvider: {},
+    });
+    playgroundStore.getState().setVariableValue("question", "old question");
+    const action = createSetVariableValuesClientAction({ playgroundStore });
+
+    const result = await action({
+      values: [
+        { key: "question", value: "new question" },
+        { key: "answer", value: "" },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(playgroundStore.getState().input.variablesValueCache).toEqual({
+      question: "new question",
+      answer: "",
+    });
+  });
+
+  it("rejects invalid input", async () => {
+    const playgroundStore = createPlaygroundStore({
+      datasetId: null,
+      modelConfigByProvider: {},
+    });
+    const action = createSetVariableValuesClientAction({ playgroundStore });
+
+    const result = await action({ values: [{ key: "", value: "ignored" }] });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: "Invalid set_variable_values input.",
+      })
+    );
+    expect(playgroundStore.getState().input.variablesValueCache).toEqual({});
+  });
+});

--- a/app/src/agent/tools/playgroundVariableValues/clientActions.ts
+++ b/app/src/agent/tools/playgroundVariableValues/clientActions.ts
@@ -1,0 +1,38 @@
+import type { AgentClientActionResult } from "@phoenix/store/agentStore";
+import type { PlaygroundStore } from "@phoenix/store/playground";
+
+import { parseSetVariableValuesInput } from "./parsers";
+
+/**
+ * Creates the client action handler for set_variable_values.
+ * Stores manual playground variable values in the mounted playground store.
+ */
+export function createSetVariableValuesClientAction({
+  playgroundStore,
+}: {
+  playgroundStore: PlaygroundStore;
+}) {
+  return async (input: unknown): Promise<AgentClientActionResult> => {
+    const parsed = parseSetVariableValuesInput(input);
+    if (!parsed) {
+      return { ok: false, error: "Invalid set_variable_values input." };
+    }
+
+    playgroundStore.getState().setVariableValues(parsed.values);
+
+    const variableKeys = parsed.values.map(({ key }) => key);
+
+    return {
+      ok: true,
+      output: JSON.stringify(
+        {
+          status: "updated",
+          variables: variableKeys,
+          message: `Set ${variableKeys.length} playground variable value${variableKeys.length === 1 ? "" : "s"}.`,
+        },
+        null,
+        2
+      ),
+    };
+  };
+}

--- a/app/src/agent/tools/playgroundVariableValues/constants.ts
+++ b/app/src/agent/tools/playgroundVariableValues/constants.ts
@@ -1,0 +1,1 @@
+export const SET_VARIABLE_VALUES_TOOL_NAME = "set_variable_values";

--- a/app/src/agent/tools/playgroundVariableValues/index.ts
+++ b/app/src/agent/tools/playgroundVariableValues/index.ts
@@ -1,0 +1,5 @@
+export * from "./clientActions";
+export * from "./constants";
+export * from "./parsers";
+export * from "./schemas";
+export * from "./types";

--- a/app/src/agent/tools/playgroundVariableValues/parsers.ts
+++ b/app/src/agent/tools/playgroundVariableValues/parsers.ts
@@ -1,0 +1,8 @@
+import { setVariableValuesInputSchema } from "./schemas";
+import type { SetVariableValuesInput } from "./types";
+
+export function parseSetVariableValuesInput(
+  input: unknown
+): SetVariableValuesInput | null {
+  return setVariableValuesInputSchema.safeParse(input).data ?? null;
+}

--- a/app/src/agent/tools/playgroundVariableValues/schemas.ts
+++ b/app/src/agent/tools/playgroundVariableValues/schemas.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const setVariableValuesInputSchema = z
+  .object({
+    values: z
+      .array(z.object({ key: z.string().min(1), value: z.string() }).strict())
+      .min(1),
+  })
+  .strict();

--- a/app/src/agent/tools/playgroundVariableValues/types.ts
+++ b/app/src/agent/tools/playgroundVariableValues/types.ts
@@ -1,0 +1,7 @@
+import type { z } from "zod";
+
+import type { setVariableValuesInputSchema } from "./schemas";
+
+export type SetVariableValuesInput = z.output<
+  typeof setVariableValuesInputSchema
+>;

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -12,6 +12,10 @@ import { useBlocker, useSearchParams } from "react-router";
 
 import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
 import {
+  createRunPlaygroundClientAction,
+  RUN_PLAYGROUND_TOOL_NAME,
+} from "@phoenix/agent/tools/playgroundRun";
+import {
   CLONE_PROMPT_INSTANCE_TOOL_NAME,
   createClonePromptInstanceClientAction,
   createEditPromptClientAction,
@@ -286,10 +290,15 @@ function PlaygroundContent() {
       EDIT_PROMPT_TOOL_NAME,
       createEditPromptClientAction({ playgroundStore, setPendingPromptEdit })
     );
+    registerClientAction(
+      RUN_PLAYGROUND_TOOL_NAME,
+      createRunPlaygroundClientAction({ playgroundStore })
+    );
     return () => {
       unregisterClientAction(READ_PROMPT_TOOL_NAME);
       unregisterClientAction(CLONE_PROMPT_INSTANCE_TOOL_NAME);
       unregisterClientAction(EDIT_PROMPT_TOOL_NAME);
+      unregisterClientAction(RUN_PLAYGROUND_TOOL_NAME);
       for (const pendingEdit of Object.values(
         agentStore.getState().pendingPromptEditsByToolCallId
       )) {

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -12,9 +12,9 @@ import { useBlocker, useSearchParams } from "react-router";
 
 import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
 import {
-  createRunPlaygroundClientAction,
-  RUN_PLAYGROUND_TOOL_NAME,
-} from "@phoenix/agent/tools/playgroundRun";
+  createReadPlaygroundOutputClientAction,
+  READ_PLAYGROUND_OUTPUT_TOOL_NAME,
+} from "@phoenix/agent/tools/playgroundOutput";
 import {
   CLONE_PROMPT_INSTANCE_TOOL_NAME,
   createClonePromptInstanceClientAction,
@@ -23,6 +23,14 @@ import {
   EDIT_PROMPT_TOOL_NAME,
   READ_PROMPT_TOOL_NAME,
 } from "@phoenix/agent/tools/playgroundPrompt";
+import {
+  createRunPlaygroundClientAction,
+  RUN_PLAYGROUND_TOOL_NAME,
+} from "@phoenix/agent/tools/playgroundRun";
+import {
+  createSetVariableValuesClientAction,
+  SET_VARIABLE_VALUES_TOOL_NAME,
+} from "@phoenix/agent/tools/playgroundVariableValues";
 import {
   Button,
   Disclosure,
@@ -294,11 +302,21 @@ function PlaygroundContent() {
       RUN_PLAYGROUND_TOOL_NAME,
       createRunPlaygroundClientAction({ playgroundStore })
     );
+    registerClientAction(
+      READ_PLAYGROUND_OUTPUT_TOOL_NAME,
+      createReadPlaygroundOutputClientAction({ playgroundStore })
+    );
+    registerClientAction(
+      SET_VARIABLE_VALUES_TOOL_NAME,
+      createSetVariableValuesClientAction({ playgroundStore })
+    );
     return () => {
       unregisterClientAction(READ_PROMPT_TOOL_NAME);
       unregisterClientAction(CLONE_PROMPT_INSTANCE_TOOL_NAME);
       unregisterClientAction(EDIT_PROMPT_TOOL_NAME);
       unregisterClientAction(RUN_PLAYGROUND_TOOL_NAME);
+      unregisterClientAction(READ_PLAYGROUND_OUTPUT_TOOL_NAME);
+      unregisterClientAction(SET_VARIABLE_VALUES_TOOL_NAME);
       for (const pendingEdit of Object.values(
         agentStore.getState().pendingPromptEditsByToolCallId
       )) {

--- a/app/src/pages/playground/PlaygroundOutput.tsx
+++ b/app/src/pages/playground/PlaygroundOutput.tsx
@@ -164,6 +164,7 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
     appendRepetitionOutput,
     setSelectedRepetitionNumber,
     setRepetitionSpanId,
+    setRepetitionTraceId,
     setRepetitionError,
     setRepetitionStatus,
     addRepetitionPartialToolCall,
@@ -173,6 +174,7 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
     appendRepetitionOutput: state.appendRepetitionOutput,
     setSelectedRepetitionNumber: state.setSelectedRepetitionNumber,
     setRepetitionSpanId: state.setRepetitionSpanId,
+    setRepetitionTraceId: state.setRepetitionTraceId,
     setRepetitionError: state.setRepetitionError,
     setRepetitionStatus: state.setRepetitionStatus,
     addRepetitionPartialToolCall: state.addRepetitionPartialToolCall,
@@ -263,6 +265,13 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
             chatCompletion.repetitionNumber,
             chatCompletion.span.id
           );
+          if (chatCompletion.span.trace?.traceId != null) {
+            setRepetitionTraceId(
+              instanceId,
+              chatCompletion.repetitionNumber,
+              chatCompletion.span.trace.traceId
+            );
+          }
         }
         return;
       }
@@ -286,6 +295,7 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
       instanceId,
       appendRepetitionOutput,
       setRepetitionSpanId,
+      setRepetitionTraceId,
       setRepetitionStatus,
       setRepetitionError,
     ]
@@ -472,6 +482,9 @@ graphql`
       ... on ChatCompletionSubscriptionResult {
         span {
           id
+          trace {
+            traceId
+          }
         }
       }
       ... on ChatCompletionSubscriptionError {

--- a/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2bbfd49d87d84e43495f63d590e607d6>>
+ * @generated SignedSource<<5fe6cd8522c4373f8e05b91d455d93b7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -239,6 +239,9 @@ export type PlaygroundOutputSubscription$data = {
     readonly repetitionNumber: number | null;
     readonly span?: {
       readonly id: string;
+      readonly trace: {
+        readonly traceId: string;
+      };
     } | null;
   };
 };
@@ -255,133 +258,157 @@ var v0 = [
     "name": "input"
   }
 ],
-v1 = {
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "repetitionNumber",
+  "storageKey": null
+},
+v4 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "content",
+      "storageKey": null
+    }
+  ],
+  "type": "TextChunk",
+  "abstractKey": null
+},
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v2 = [
-  {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
-    ],
-    "concreteType": null,
-    "kind": "LinkedField",
-    "name": "chatCompletion",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "__typename",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "repetitionNumber",
-        "storageKey": null
-      },
-      {
-        "kind": "InlineFragment",
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "content",
-            "storageKey": null
-          }
-        ],
-        "type": "TextChunk",
-        "abstractKey": null
-      },
-      {
-        "kind": "InlineFragment",
-        "selections": [
-          (v1/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "FunctionCallChunk",
-            "kind": "LinkedField",
-            "name": "function",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "name",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "arguments",
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          }
-        ],
-        "type": "ToolCallChunk",
-        "abstractKey": null
-      },
-      {
-        "kind": "InlineFragment",
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Span",
-            "kind": "LinkedField",
-            "name": "span",
-            "plural": false,
-            "selections": [
-              (v1/*: any*/)
-            ],
-            "storageKey": null
-          }
-        ],
-        "type": "ChatCompletionSubscriptionResult",
-        "abstractKey": null
-      },
-      {
-        "kind": "InlineFragment",
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "message",
-            "storageKey": null
-          }
-        ],
-        "type": "ChatCompletionSubscriptionError",
-        "abstractKey": null
-      }
-    ],
-    "storageKey": null
-  }
-];
+v6 = {
+  "kind": "InlineFragment",
+  "selections": [
+    (v5/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "FunctionCallChunk",
+      "kind": "LinkedField",
+      "name": "function",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "arguments",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "ToolCallChunk",
+  "abstractKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "traceId",
+  "storageKey": null
+},
+v8 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "message",
+      "storageKey": null
+    }
+  ],
+  "type": "ChatCompletionSubscriptionError",
+  "abstractKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "PlaygroundOutputSubscription",
-    "selections": (v2/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "chatCompletion",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/),
+          (v6/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Span",
+                "kind": "LinkedField",
+                "name": "span",
+                "plural": false,
+                "selections": [
+                  (v5/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Trace",
+                    "kind": "LinkedField",
+                    "name": "trace",
+                    "plural": false,
+                    "selections": [
+                      (v7/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "ChatCompletionSubscriptionResult",
+            "abstractKey": null
+          },
+          (v8/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Subscription",
     "abstractKey": null
   },
@@ -390,19 +417,68 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "PlaygroundOutputSubscription",
-    "selections": (v2/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "chatCompletion",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/),
+          (v6/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Span",
+                "kind": "LinkedField",
+                "name": "span",
+                "plural": false,
+                "selections": [
+                  (v5/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Trace",
+                    "kind": "LinkedField",
+                    "name": "trace",
+                    "plural": false,
+                    "selections": [
+                      (v7/*: any*/),
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "ChatCompletionSubscriptionResult",
+            "abstractKey": null
+          },
+          (v8/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "e74612af0887018cc61d185ed2105c5c",
+    "cacheID": "492e03d2e13daa952983f382e32009b3",
     "id": null,
     "metadata": {},
     "name": "PlaygroundOutputSubscription",
     "operationKind": "subscription",
-    "text": "subscription PlaygroundOutputSubscription(\n  $input: ChatCompletionInput!\n) {\n  chatCompletion(input: $input) {\n    __typename\n    repetitionNumber\n    ... on TextChunk {\n      content\n    }\n    ... on ToolCallChunk {\n      id\n      function {\n        name\n        arguments\n      }\n    }\n    ... on ChatCompletionSubscriptionResult {\n      span {\n        id\n      }\n    }\n    ... on ChatCompletionSubscriptionError {\n      message\n    }\n  }\n}\n"
+    "text": "subscription PlaygroundOutputSubscription(\n  $input: ChatCompletionInput!\n) {\n  chatCompletion(input: $input) {\n    __typename\n    repetitionNumber\n    ... on TextChunk {\n      content\n    }\n    ... on ToolCallChunk {\n      id\n      function {\n        name\n        arguments\n      }\n    }\n    ... on ChatCompletionSubscriptionResult {\n      span {\n        id\n        trace {\n          traceId\n          id\n        }\n      }\n    }\n    ... on ChatCompletionSubscriptionError {\n      message\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "964992cecd018dc17131050b7553a3d1";
+(node as any).hash = "44701c74231e54286f41785c4fc3a530";
 
 export default node;

--- a/app/src/store/playground/__tests__/playgroundStore.test.ts
+++ b/app/src/store/playground/__tests__/playgroundStore.test.ts
@@ -351,6 +351,27 @@ describe("setRepetitionSpanId", () => {
   });
 });
 
+describe("setRepetitionTraceId", () => {
+  it("should set repetition trace id", () => {
+    const initialProps: InitialPlaygroundState = {
+      modelConfigByProvider: {},
+      datasetId: null,
+    };
+    const store = createPlaygroundStore(initialProps);
+    store.getState().runPlaygroundInstances();
+    const instanceId = store.getState().instances[0].id;
+
+    expect(store.getState().instances[0].repetitions[1]!.traceId).toBe(
+      undefined
+    );
+
+    store.getState().setRepetitionTraceId(instanceId, 1, "trace-abc-123");
+    expect(store.getState().instances[0].repetitions[1]!.traceId).toBe(
+      "trace-abc-123"
+    );
+  });
+});
+
 describe("addRepetitionPartialToolCall", () => {
   it("should add new tool call and concatenate arguments to existing tool call", () => {
     const initialProps: InitialPlaygroundState = {
@@ -1031,6 +1052,26 @@ describe("updateModelSupportedInvocationParameters", () => {
     store.getState().deleteResponseFormat({ instanceId });
 
     expect(store.getState().instances[0].model.responseFormat).toBeUndefined();
+  });
+});
+
+describe("setVariableValues", () => {
+  it("should set multiple variable values without clearing existing values", () => {
+    const store = createPlaygroundStore({
+      modelConfigByProvider: {},
+      datasetId: null,
+    });
+
+    store.getState().setVariableValue("question", "old question");
+    store.getState().setVariableValues([
+      { key: "question", value: "new question" },
+      { key: "answer", value: "new answer" },
+    ]);
+
+    expect(store.getState().input.variablesValueCache).toEqual({
+      question: "new question",
+      answer: "new answer",
+    });
   });
 });
 

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -887,6 +887,25 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
         { type: "setVariableValue" }
       );
     },
+    setVariableValues: (values: { key: string; value: string }[]) => {
+      const input = get().input;
+      const variableValues = Object.fromEntries(
+        values.map(({ key, value }) => [key, value])
+      );
+      set(
+        {
+          input: {
+            ...input,
+            variablesValueCache: {
+              ...input.variablesValueCache,
+              ...variableValues,
+            },
+          },
+        },
+        false,
+        { type: "setVariableValues" }
+      );
+    },
     setStreaming: (streaming: boolean) => {
       set({ streaming }, false, { type: "setStreaming" });
     },
@@ -1330,6 +1349,36 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
         },
         false,
         { type: "setRepetitionSpanId" }
+      );
+    },
+    setRepetitionTraceId: (
+      instanceId: number,
+      repetitionNumber: number,
+      traceId: string
+    ) => {
+      set(
+        {
+          instances: get().instances.map((instance) => {
+            if (instance.id !== instanceId) {
+              return instance;
+            }
+            const repetition = instance.repetitions[repetitionNumber];
+            return {
+              ...instance,
+              repetitions: {
+                ...instance.repetitions,
+                [repetitionNumber]: repetition
+                  ? {
+                      ...repetition,
+                      traceId,
+                    }
+                  : undefined,
+              },
+            };
+          }),
+        },
+        false,
+        { type: "setRepetitionTraceId" }
       );
     },
     initExperimentRunProgress: (instanceId, progress) => {

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -229,6 +229,7 @@ export type PlaygroundRepetition = {
   output: ChatMessage[] | string | null;
   toolCalls: Record<ToolCallId, PartialOutputToolCall>;
   spanId: string | null;
+  traceId?: string | null;
   error: PlaygroundError | null;
   status: PlaygroundRepetitionStatus;
 };
@@ -623,6 +624,10 @@ export interface PlaygroundState extends Omit<PlaygroundProps, "instances"> {
    */
   setVariableValue: (key: string, value: string) => void;
   /**
+   * Set multiple variable values in the input
+   */
+  setVariableValues: (values: { key: string; value: string }[]) => void;
+  /**
    * set the streaming mode for the playground
    */
   setStreaming: (streaming: boolean) => void;
@@ -709,6 +714,14 @@ export interface PlaygroundState extends Omit<PlaygroundProps, "instances"> {
     instanceId: number,
     repetitionNumber: number,
     spanId: string
+  ) => void;
+  /**
+   * Set the trace id for a repetition
+   */
+  setRepetitionTraceId: (
+    instanceId: number,
+    repetitionNumber: number,
+    traceId: string
   ) => void;
   /**
    * Set the status for a repetition

--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from openinference.instrumentation import OITracer, TraceConfig
 from opentelemetry.trace import NoOpTracerProvider, Tracer, TracerProvider
-from pydantic_ai import Agent, DeferredToolRequests
+from pydantic_ai import Agent, DeferredToolRequests, RunContext
 from pydantic_ai.capabilities import (
     AbstractCapability,
+    CapabilityFunc,
     CombinedCapability,
     DynamicCapability,
 )
@@ -35,6 +36,24 @@ from phoenix.server.agents.web_access import (
 )
 
 
+def get_skills_capability_function(
+    *,
+    prompts: AgentPrompts,
+) -> CapabilityFunc[AgentDependencies]:
+    def _build(ctx: RunContext[AgentDependencies]) -> AbstractCapability[AgentDependencies]:
+        return SkillsCapability(
+            toolset=SkillsToolset(
+                skills=build_skills(include_playground=ctx.deps.contexts.playground is not None),
+                load_skill_template=prompts.load_skill,
+                load_skill_tool_template=prompts.load_skill_tool,
+                read_skill_resource_tool_template=prompts.read_skill_resource_tool,
+            ),
+            instructions=prompts.skills,
+        )
+
+    return _build
+
+
 def build_agent(
     *,
     model: Model,
@@ -58,14 +77,10 @@ def build_agent(
         DynamicCapability(
             capability_func=get_context_capability_function(prompts=resolved_prompts),
         ),
-        SkillsCapability(
-            toolset=SkillsToolset(
-                skills=build_skills(),
-                load_skill_template=resolved_prompts.load_skill,
-                load_skill_tool_template=resolved_prompts.load_skill_tool,
-                read_skill_resource_tool_template=resolved_prompts.read_skill_resource_tool,
+        DynamicCapability(
+            capability_func=get_skills_capability_function(
+                prompts=resolved_prompts,
             ),
-            instructions=resolved_prompts.skills,
         ),
     ]
     if isinstance(model, AnthropicModel):

--- a/src/phoenix/server/agents/capabilities/tools/external/__init__.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/__init__.py
@@ -15,6 +15,7 @@ from phoenix.server.agents.capabilities.tools.external import (
     edit_prompt_instance,
     read_prompt_instance,
     render_generative_ui,
+    run_playground,
     set_spans_filter,
     set_time_range,
 )
@@ -31,6 +32,9 @@ from phoenix.server.agents.capabilities.tools.external.read_prompt_instance impo
 )
 from phoenix.server.agents.capabilities.tools.external.render_generative_ui import (
     RenderGenerativeUICapability,
+)
+from phoenix.server.agents.capabilities.tools.external.run_playground import (
+    RunPlaygroundCapability,
 )
 from phoenix.server.agents.capabilities.tools.external.set_spans_filter import (
     SetSpansFilterCapability,
@@ -50,6 +54,7 @@ _EXTERNAL_TOOL_DEFINITIONS_BY_NAME: dict[str, ToolDefinition] = {
         edit_prompt_instance.TOOL_DEFINITION,
         read_prompt_instance.TOOL_DEFINITION,
         render_generative_ui.RENDER_GENERATIVE_UI_TOOL_DEFINITION,
+        run_playground.TOOL_DEFINITION,
         set_spans_filter.TOOL_DEFINITION,
         set_time_range.TOOL_DEFINITION,
     )
@@ -80,6 +85,7 @@ def get_external_tool_capability_function(
         ReadPromptInstanceCapability(instructions=prompts.read_prompt_instance_tool),
         ClonePromptInstanceCapability(instructions=prompts.clone_prompt_instance_tool),
         EditPromptInstanceCapability(instructions=prompts.edit_prompt_instance_tool),
+        RunPlaygroundCapability(instructions=prompts.run_playground_tool),
     ]
 
     def _build(ctx: RunContext[AgentDependencies]) -> AbstractCapability[AgentDependencies]:
@@ -96,6 +102,7 @@ __all__ = [
     "EditPromptInstanceCapability",
     "ReadPromptInstanceCapability",
     "RenderGenerativeUICapability",
+    "RunPlaygroundCapability",
     "SetSpansFilterCapability",
     "SetTimeRangeCapability",
     "get_external_tool_capability_function",

--- a/src/phoenix/server/agents/capabilities/tools/external/__init__.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/__init__.py
@@ -13,11 +13,13 @@ from phoenix.server.agents.capabilities.tools.external import (
     bash,
     clone_prompt_instance,
     edit_prompt_instance,
+    read_playground_output,
     read_prompt_instance,
     render_generative_ui,
     run_playground,
     set_spans_filter,
     set_time_range,
+    set_variable_values,
 )
 from phoenix.server.agents.capabilities.tools.external.ask_user import AskUserCapability
 from phoenix.server.agents.capabilities.tools.external.bash import BashCapability
@@ -26,6 +28,9 @@ from phoenix.server.agents.capabilities.tools.external.clone_prompt_instance imp
 )
 from phoenix.server.agents.capabilities.tools.external.edit_prompt_instance import (
     EditPromptInstanceCapability,
+)
+from phoenix.server.agents.capabilities.tools.external.read_playground_output import (
+    ReadPlaygroundOutputCapability,
 )
 from phoenix.server.agents.capabilities.tools.external.read_prompt_instance import (
     ReadPromptInstanceCapability,
@@ -42,6 +47,9 @@ from phoenix.server.agents.capabilities.tools.external.set_spans_filter import (
 from phoenix.server.agents.capabilities.tools.external.set_time_range import (
     SetTimeRangeCapability,
 )
+from phoenix.server.agents.capabilities.tools.external.set_variable_values import (
+    SetVariableValuesCapability,
+)
 from phoenix.server.agents.prompts import AgentPrompts
 from phoenix.server.agents.types import AgentDependencies
 
@@ -53,10 +61,12 @@ _EXTERNAL_TOOL_DEFINITIONS_BY_NAME: dict[str, ToolDefinition] = {
         clone_prompt_instance.TOOL_DEFINITION,
         edit_prompt_instance.TOOL_DEFINITION,
         read_prompt_instance.TOOL_DEFINITION,
+        read_playground_output.TOOL_DEFINITION,
         render_generative_ui.RENDER_GENERATIVE_UI_TOOL_DEFINITION,
         run_playground.TOOL_DEFINITION,
         set_spans_filter.TOOL_DEFINITION,
         set_time_range.TOOL_DEFINITION,
+        set_variable_values.TOOL_DEFINITION,
     )
 }
 
@@ -83,9 +93,11 @@ def get_external_tool_capability_function(
     dynamic_capabilities: list[AbstractDynamicCapability[AgentDependencies]] = [
         SetSpansFilterCapability(instructions=prompts.set_spans_filter_tool),
         ReadPromptInstanceCapability(instructions=prompts.read_prompt_instance_tool),
+        ReadPlaygroundOutputCapability(instructions=prompts.read_playground_output_tool),
         ClonePromptInstanceCapability(instructions=prompts.clone_prompt_instance_tool),
         EditPromptInstanceCapability(instructions=prompts.edit_prompt_instance_tool),
         RunPlaygroundCapability(instructions=prompts.run_playground_tool),
+        SetVariableValuesCapability(instructions=prompts.set_variable_values_tool),
     ]
 
     def _build(ctx: RunContext[AgentDependencies]) -> AbstractCapability[AgentDependencies]:
@@ -101,10 +113,12 @@ __all__ = [
     "ClonePromptInstanceCapability",
     "EditPromptInstanceCapability",
     "ReadPromptInstanceCapability",
+    "ReadPlaygroundOutputCapability",
     "RenderGenerativeUICapability",
     "RunPlaygroundCapability",
     "SetSpansFilterCapability",
     "SetTimeRangeCapability",
+    "SetVariableValuesCapability",
     "get_external_tool_capability_function",
     "get_external_tool_definition",
 ]

--- a/src/phoenix/server/agents/capabilities/tools/external/read_playground_output.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/read_playground_output.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from jinja2 import Template
+from pydantic_ai import RunContext
+from pydantic_ai.tools import SystemPromptFunc, ToolDefinition
+from pydantic_ai.toolsets import AgentToolset
+from pydantic_ai.toolsets.external import ExternalToolset
+
+from phoenix.server.agents.capabilities.base import AbstractDynamicCapability
+from phoenix.server.agents.types import AgentDependencies
+
+NAME = "read_playground_output"
+
+DESCRIPTION = (
+    "Read the output from the currently mounted playground's latest run. The result "
+    "includes each matching instance's raw output, run status, errors, tool calls, "
+    "and traceId when the run produced a Phoenix trace. Use this after `run_playground` "
+    "finishes so you can inspect the model response and analyze the trace."
+)
+
+PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "instanceId": {
+            "type": "integer",
+            "description": (
+                "Optional playground instance ID to read. Omit to read outputs for all "
+                "visible comparison instances."
+            ),
+        },
+        "repetitionNumber": {
+            "type": "integer",
+            "minimum": 1,
+            "description": (
+                "Optional repetition number to read for each selected instance. Omit to "
+                "read every available repetition."
+            ),
+        },
+    },
+    "additionalProperties": False,
+}
+
+TOOL_DEFINITION = ToolDefinition(
+    name=NAME,
+    description=DESCRIPTION,
+    parameters_json_schema=PARAMETERS,
+    kind="external",
+)
+
+
+@dataclass
+class ReadPlaygroundOutputCapability(AbstractDynamicCapability[AgentDependencies]):
+    instructions: Template
+
+    def get_toolset(self) -> AgentToolset[AgentDependencies] | None:
+        return ExternalToolset[AgentDependencies]([TOOL_DEFINITION])
+
+    def get_dynamic_instructions(self) -> SystemPromptFunc[AgentDependencies]:
+        instructions = self.instructions
+
+        def _instructions(ctx: RunContext[AgentDependencies]) -> str:
+            return instructions.render()
+
+        return _instructions
+
+    def include_for_run(self, ctx: RunContext[AgentDependencies]) -> bool:
+        return ctx.deps.contexts.playground is not None

--- a/src/phoenix/server/agents/capabilities/tools/external/run_playground.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/run_playground.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from jinja2 import Template
+from pydantic_ai import RunContext
+from pydantic_ai.tools import SystemPromptFunc, ToolDefinition
+from pydantic_ai.toolsets import AgentToolset
+from pydantic_ai.toolsets.external import ExternalToolset
+
+from phoenix.server.agents.capabilities.base import AbstractDynamicCapability
+from phoenix.server.agents.types import AgentDependencies
+
+NAME = "run_playground"
+
+DESCRIPTION = (
+    "Run the currently mounted playground using the browser UI state. This starts "
+    "the same run the user would start with the playground Run button, so it uses "
+    "the current prompt instances, model settings, inputs, dataset selection, tools, "
+    "and streaming preferences visible in the UI. It runs all current comparison "
+    "instances together."
+)
+
+PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+TOOL_DEFINITION = ToolDefinition(
+    name=NAME,
+    description=DESCRIPTION,
+    parameters_json_schema=PARAMETERS,
+    kind="external",
+)
+
+
+@dataclass
+class RunPlaygroundCapability(AbstractDynamicCapability[AgentDependencies]):
+    instructions: Template
+
+    def get_toolset(self) -> AgentToolset[AgentDependencies] | None:
+        return ExternalToolset[AgentDependencies]([TOOL_DEFINITION])
+
+    def get_dynamic_instructions(self) -> SystemPromptFunc[AgentDependencies]:
+        instructions = self.instructions
+
+        def _instructions(ctx: RunContext[AgentDependencies]) -> str:
+            return instructions.render()
+
+        return _instructions
+
+    def include_for_run(self, ctx: RunContext[AgentDependencies]) -> bool:
+        return ctx.deps.contexts.playground is not None

--- a/src/phoenix/server/agents/capabilities/tools/external/set_variable_values.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/set_variable_values.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from jinja2 import Template
+from pydantic_ai import RunContext
+from pydantic_ai.tools import SystemPromptFunc, ToolDefinition
+from pydantic_ai.toolsets import AgentToolset
+from pydantic_ai.toolsets.external import ExternalToolset
+
+from phoenix.server.agents.capabilities.base import AbstractDynamicCapability
+from phoenix.server.agents.types import AgentDependencies
+
+NAME = "set_variable_values"
+
+DESCRIPTION = (
+    "Set manual input values for template variables in the currently mounted "
+    "playground. Use this when the user asks to fill, provide, change, or set "
+    "playground variables before running or comparing prompts. This only updates "
+    "variable values in browser UI state; it does not edit prompt messages, change "
+    "dataset mappings, or run the playground."
+)
+
+PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "values": {
+            "type": "array",
+            "description": (
+                "Variable key/value pairs to store in the playground. Use the variable "
+                "keys exactly as they appear in the prompt template."
+            ),
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "The template variable key to set.",
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": (
+                            "The string value to store for the variable. Pass an empty "
+                            "string to clear a variable value."
+                        ),
+                    },
+                },
+                "required": ["key", "value"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["values"],
+    "additionalProperties": False,
+}
+
+TOOL_DEFINITION = ToolDefinition(
+    name=NAME,
+    description=DESCRIPTION,
+    parameters_json_schema=PARAMETERS,
+    kind="external",
+)
+
+
+@dataclass
+class SetVariableValuesCapability(AbstractDynamicCapability[AgentDependencies]):
+    instructions: Template
+
+    def get_toolset(self) -> AgentToolset[AgentDependencies] | None:
+        return ExternalToolset[AgentDependencies]([TOOL_DEFINITION])
+
+    def get_dynamic_instructions(self) -> SystemPromptFunc[AgentDependencies]:
+        instructions = self.instructions
+
+        def _instructions(ctx: RunContext[AgentDependencies]) -> str:
+            return instructions.render()
+
+        return _instructions
+
+    def include_for_run(self, ctx: RunContext[AgentDependencies]) -> bool:
+        return ctx.deps.contexts.playground is not None

--- a/src/phoenix/server/agents/prompts/__init__.py
+++ b/src/phoenix/server/agents/prompts/__init__.py
@@ -20,6 +20,9 @@ _SET_SPANS_FILTER_TOOL_INSTRUCTIONS = get_template(
 _READ_PROMPT_INSTANCE_TOOL_INSTRUCTIONS = get_template(
     "tools/READ_PROMPT_INSTANCE_TOOL_INSTRUCTIONS.xml.j2"
 )
+_READ_PLAYGROUND_OUTPUT_TOOL_INSTRUCTIONS = get_template(
+    "tools/READ_PLAYGROUND_OUTPUT_TOOL_INSTRUCTIONS.xml.j2"
+)
 _CLONE_PROMPT_INSTANCE_TOOL_INSTRUCTIONS = get_template(
     "tools/CLONE_PROMPT_INSTANCE_TOOL_INSTRUCTIONS.xml.j2"
 )
@@ -27,6 +30,9 @@ _EDIT_PROMPT_INSTANCE_TOOL_INSTRUCTIONS = get_template(
     "tools/EDIT_PROMPT_INSTANCE_TOOL_INSTRUCTIONS.xml.j2"
 )
 _RUN_PLAYGROUND_TOOL_INSTRUCTIONS = get_template("tools/RUN_PLAYGROUND_TOOL_INSTRUCTIONS.xml.j2")
+_SET_VARIABLE_VALUES_TOOL_INSTRUCTIONS = get_template(
+    "tools/SET_VARIABLE_VALUES_TOOL_INSTRUCTIONS.xml.j2"
+)
 _APP_CONTEXT_TEMPLATE = get_template("context/APP_CONTEXT_INSTRUCTIONS.xml.j2")
 _PROJECT_CONTEXT_TEMPLATE = get_template("context/PROJECT_CONTEXT_INSTRUCTIONS.xml.j2")
 _TRACE_CONTEXT_TEMPLATE = get_template("context/TRACE_CONTEXT_INSTRUCTIONS.xml.j2")
@@ -55,9 +61,11 @@ class AgentPrompts:
     render_generative_ui_tool: Template = _RENDER_GENERATIVE_UI_TOOL_INSTRUCTIONS
     set_spans_filter_tool: Template = _SET_SPANS_FILTER_TOOL_INSTRUCTIONS
     read_prompt_instance_tool: Template = _READ_PROMPT_INSTANCE_TOOL_INSTRUCTIONS
+    read_playground_output_tool: Template = _READ_PLAYGROUND_OUTPUT_TOOL_INSTRUCTIONS
     clone_prompt_instance_tool: Template = _CLONE_PROMPT_INSTANCE_TOOL_INSTRUCTIONS
     edit_prompt_instance_tool: Template = _EDIT_PROMPT_INSTANCE_TOOL_INSTRUCTIONS
     run_playground_tool: Template = _RUN_PLAYGROUND_TOOL_INSTRUCTIONS
+    set_variable_values_tool: Template = _SET_VARIABLE_VALUES_TOOL_INSTRUCTIONS
     app_context: Template = _APP_CONTEXT_TEMPLATE
     project_context: Template = _PROJECT_CONTEXT_TEMPLATE
     trace_context: Template = _TRACE_CONTEXT_TEMPLATE

--- a/src/phoenix/server/agents/prompts/__init__.py
+++ b/src/phoenix/server/agents/prompts/__init__.py
@@ -26,6 +26,7 @@ _CLONE_PROMPT_INSTANCE_TOOL_INSTRUCTIONS = get_template(
 _EDIT_PROMPT_INSTANCE_TOOL_INSTRUCTIONS = get_template(
     "tools/EDIT_PROMPT_INSTANCE_TOOL_INSTRUCTIONS.xml.j2"
 )
+_RUN_PLAYGROUND_TOOL_INSTRUCTIONS = get_template("tools/RUN_PLAYGROUND_TOOL_INSTRUCTIONS.xml.j2")
 _APP_CONTEXT_TEMPLATE = get_template("context/APP_CONTEXT_INSTRUCTIONS.xml.j2")
 _PROJECT_CONTEXT_TEMPLATE = get_template("context/PROJECT_CONTEXT_INSTRUCTIONS.xml.j2")
 _TRACE_CONTEXT_TEMPLATE = get_template("context/TRACE_CONTEXT_INSTRUCTIONS.xml.j2")
@@ -56,6 +57,7 @@ class AgentPrompts:
     read_prompt_instance_tool: Template = _READ_PROMPT_INSTANCE_TOOL_INSTRUCTIONS
     clone_prompt_instance_tool: Template = _CLONE_PROMPT_INSTANCE_TOOL_INSTRUCTIONS
     edit_prompt_instance_tool: Template = _EDIT_PROMPT_INSTANCE_TOOL_INSTRUCTIONS
+    run_playground_tool: Template = _RUN_PLAYGROUND_TOOL_INSTRUCTIONS
     app_context: Template = _APP_CONTEXT_TEMPLATE
     project_context: Template = _PROJECT_CONTEXT_TEMPLATE
     trace_context: Template = _TRACE_CONTEXT_TEMPLATE

--- a/src/phoenix/server/agents/prompts/context/PLAYGROUND_CONTEXT_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/context/PLAYGROUND_CONTEXT_INSTRUCTIONS.xml.j2
@@ -5,5 +5,5 @@
     <instance label="{{ instance_labels[loop.index0] }}" instance_id="{{ instance_id }}"/>
 {% endfor %}
   </instances>
-  <guidance>Call `read_prompt_instance` before proposing edits, `clone_prompt_instance` to create comparison variants, `edit_prompt_instance` to show the user an approval diff before changing prompt messages, and `run_playground` when the user wants to run the mounted playground.</guidance>
+  <guidance>Call `read_prompt_instance` before proposing edits, `clone_prompt_instance` to create comparison variants, `edit_prompt_instance` to show the user an approval diff before changing prompt messages, `set_variable_values` when the user wants to populate playground variable inputs, `run_playground` when the user wants to run the mounted playground, and `read_playground_output` after a run finishes when you need the raw output or traceId.</guidance>
 </phoenix_playground_context>

--- a/src/phoenix/server/agents/prompts/context/PLAYGROUND_CONTEXT_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/context/PLAYGROUND_CONTEXT_INSTRUCTIONS.xml.j2
@@ -1,9 +1,9 @@
 <phoenix_playground_context>
-  <description>The playground prompt editor is mounted. Use the alphabetic `label` (A, B, C, D) when discussing instances with the user, and pass the numeric `instance_id` when calling tools.</description>
+  <description>The playground prompt editor is mounted. Use the alphabetic `label` (A, B, C, D) when discussing instances with the user, and pass the numeric `instanceId` when calling tools.</description>
   <instances>
 {% for instance_id in playground.instance_ids %}
-    <instance label="{{ instance_labels[loop.index0] }}" instance_id="{{ instance_id }}"/>
+    <instance label="{{ instance_labels[loop.index0] }}" instanceId="{{ instance_id }}"/>
 {% endfor %}
   </instances>
-  <guidance>Call `read_prompt_instance` before proposing edits, `clone_prompt_instance` to create comparison variants, `edit_prompt_instance` to show the user an approval diff before changing prompt messages, `set_variable_values` when the user wants to populate playground variable inputs, `run_playground` when the user wants to run the mounted playground, and `read_playground_output` after a run finishes when you need the raw output or traceId.</guidance>
+  <guidance>Call `read_prompt_instance` before proposing edits, `clone_prompt_instance` to create comparison variants, `edit_prompt_instance` to show the user an approval diff before changing prompt messages, `set_variable_values` when the user wants to populate manual playground variable inputs, `run_playground` when the user wants to run the mounted playground, and `read_playground_output` after a manual run finishes when you need the raw output or traceId. For dataset-backed experiment results, use `bash` with `phoenix-gql` instead of `read_playground_output`.</guidance>
 </phoenix_playground_context>

--- a/src/phoenix/server/agents/prompts/context/PLAYGROUND_CONTEXT_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/context/PLAYGROUND_CONTEXT_INSTRUCTIONS.xml.j2
@@ -5,5 +5,5 @@
     <instance label="{{ instance_labels[loop.index0] }}" instance_id="{{ instance_id }}"/>
 {% endfor %}
   </instances>
-  <guidance>Call `read_prompt_instance` before proposing edits, `clone_prompt_instance` to create comparison variants, and `edit_prompt_instance` to show the user an approval diff before changing prompt messages.</guidance>
+  <guidance>Call `read_prompt_instance` before proposing edits, `clone_prompt_instance` to create comparison variants, `edit_prompt_instance` to show the user an approval diff before changing prompt messages, and `run_playground` when the user wants to run the mounted playground.</guidance>
 </phoenix_playground_context>

--- a/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
@@ -45,8 +45,9 @@ they are comparing prompt variants using evaluator results.
    relevant variables, output format, and any constraints needed for consistent evaluation.
 3. Run the playground over the dataset. Each prompt instance run over a dataset is captured as an
    experiment, with outputs and evaluator annotations available for review.
-4. Review the experiment outputs and annotations to find recurring failure patterns. Separate model
-   randomness from prompt issues when possible.
+4. Review the experiment outputs and annotations to find recurring failure patterns. Use `bash` with
+   `phoenix-gql` to inspect dataset-backed experiment results when needed; `read_playground_output`
+   only reads manual playground runs. Separate model randomness from prompt issues when possible.
 5. Use or add evaluators when they make issue detection more systematic, especially for failures
    that are hard to spot by manual review alone.
 6. Form a specific hypothesis for improving the prompt, then use `edit_prompt_instance` or

--- a/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
@@ -26,9 +26,12 @@ dataset-backed evaluation loop is in scope.
 5. Use `clone_prompt_instance` when comparing alternatives would help the user choose between
    prompt variants. Discuss variants by their alphabetic labels, but pass numeric instance IDs to
    tools.
-6. Call `run_playground` only when the user asks to run, try, test, or compare the current prompt.
+6. Use `set_variable_values` when the user provides manual values for prompt template variables.
+7. Call `run_playground` only when the user asks to run, try, test, or compare the current prompt.
    Treat the output as qualitative feedback rather than dataset-backed evidence.
-7. Inspect the output with the user, identify the next concrete improvement, and repeat the edit or
+8. After the run finishes, call `read_playground_output` to inspect raw output and get the traceId
+   for trace analysis when needed.
+9. Inspect the output with the user, identify the next concrete improvement, and repeat the edit or
    comparison loop until the prompt is useful for the task.
 
 ## Workflow: Iterate Over A Dataset With Evaluators And Experiments

--- a/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
@@ -5,16 +5,52 @@ description: Author, edit, or iterate on prompts in the Phoenix prompt playgroun
 
 # Prompt Playground
 
-The prompt playground is a tool for optimizing prompts. It lets you run prompts over datasets and identify issues using evaluators. The playground should be used via best practices rooted in the scientific method where the prompt and model act as un-controlled variables. Each prompt instance when run over a dataset is captured as experiment. Experiments capture the outputs, and the evaluation results in the form of annotations.
+The prompt playground is a tool for authoring and optimizing prompts. It supports two different
+ways of working: fast manual prompt iteration without a dataset, and dataset-backed prompt
+experimentation with evaluators and experiments. Choose the workflow that matches the user's
+current goal and the UI context they have mounted.
 
-## Workflow
+## Workflow: Create And Iterate Without A Dataset
 
-1. Make sure you have a well contructed prompt that clearly performs the task defined by the user
-2. Have a dataset over which you can test that prompt.
-3. Run the playground to determine what the output looks like. This will be captured as experiments, one experiment per prompt.
-4. Look at the experiment and try to identify areas that require improvement.
-5. Figure out if you can use evaluators to make it easy to identify the issues.
-6. Come up with a hypothesis for how the prompt can be improved.
-7. Make the necessary modifications to the prompt or suggest an alternative prompt as another instance. Run the playground to prove that there is an improvement.
-8. If there is an improvement, save the prompt as a snapshot. Determine if there is further refinement possible.
-9. Go back to step 6 and iterate until the prompt satisfies the goal of the task
+Use this workflow when the user wants to draft, rewrite, or manually improve a prompt and no
+dataset-backed evaluation loop is in scope.
+
+1. Clarify the task the prompt must perform: input variables, expected output shape, audience,
+   constraints, and examples of good or bad behavior when available.
+2. If a playground prompt already exists, call `read_prompt_instance` before proposing changes so
+   you have the current messages, message IDs, labels, and revision.
+3. Draft or revise the prompt so it clearly states the task, required context, output contract, and
+   success criteria. Keep the prompt directly tied to the user's stated goal.
+4. Use `edit_prompt_instance` for changes to the mounted prompt so the user can review the diff
+   before accepting it.
+5. Use `clone_prompt_instance` when comparing alternatives would help the user choose between
+   prompt variants. Discuss variants by their alphabetic labels, but pass numeric instance IDs to
+   tools.
+6. Call `run_playground` only when the user asks to run, try, test, or compare the current prompt.
+   Treat the output as qualitative feedback rather than dataset-backed evidence.
+7. Inspect the output with the user, identify the next concrete improvement, and repeat the edit or
+   comparison loop until the prompt is useful for the task.
+
+## Workflow: Iterate Over A Dataset With Evaluators And Experiments
+
+Use this workflow when the user wants evidence that a prompt is improving across a dataset, or when
+they are comparing prompt variants using evaluator results.
+
+1. Confirm the dataset represents the task the prompt is meant to solve, including the important
+   input fields, expected outputs, and failure modes.
+2. Make sure the starting prompt is well formed before running it: it should define the task,
+   relevant variables, output format, and any constraints needed for consistent evaluation.
+3. Run the playground over the dataset. Each prompt instance run over a dataset is captured as an
+   experiment, with outputs and evaluator annotations available for review.
+4. Review the experiment outputs and annotations to find recurring failure patterns. Separate model
+   randomness from prompt issues when possible.
+5. Use or add evaluators when they make issue detection more systematic, especially for failures
+   that are hard to spot by manual review alone.
+6. Form a specific hypothesis for improving the prompt, then use `edit_prompt_instance` or
+   `clone_prompt_instance` to create the next candidate.
+7. Rerun the playground and compare experiments. Look for evaluator improvements, fewer repeated
+   failure modes, and acceptable tradeoffs in output quality.
+8. Save a prompt snapshot only after the evidence shows an improvement or the user explicitly
+   accepts the tradeoff.
+9. Continue the hypothesis, edit, run, compare loop until the dataset-backed results satisfy the
+   user's goal.

--- a/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: playground
+description: Author, edit, or iterate on prompts in the Phoenix prompt playground. Load before any playground tool call, including single-shot prompt rewrites.
+---
+
+# Prompt Playground
+
+The prompt playground is a tool for optimizing prompts. It lets you run prompts over datasets and identify issues using evaluators. The playground should be used via best practices rooted in the scientific method where the prompt and model act as un-controlled variables. Each prompt instance when run over a dataset is captured as experiment. Experiments capture the outputs, and the evaluation results in the form of annotations.
+
+## Workflow
+
+1. Make sure you have a well contructed prompt that clearly performs the task defined by the user
+2. Have a dataset over which you can test that prompt.
+3. Run the playground to determine what the output looks like. This will be captured as experiments, one experiment per prompt.
+4. Look at the experiment and try to identify areas that require improvement.
+5. Figure out if you can use evaluators to make it easy to identify the issues.
+6. Come up with a hypothesis for how the prompt can be improved.
+7. Make the necessary modifications to the prompt or suggest an alternative prompt as another instance. Run the playground to prove that there is an improvement.
+8. If there is an improvement, save the prompt as a snapshot. Determine if there is further refinement possible.
+9. Go back to step 6 and iterate until the prompt satisfies the goal of the task

--- a/src/phoenix/server/agents/prompts/tools/READ_PLAYGROUND_OUTPUT_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/READ_PLAYGROUND_OUTPUT_TOOL_INSTRUCTIONS.xml.j2
@@ -1,0 +1,14 @@
+<tool name="read_playground_output">
+  <description>Read raw output and trace metadata from the mounted playground's latest run.</description>
+  <when_to_use>
+    - After `run_playground` completes and the user wants to inspect or compare the output.
+    - When you need the playground run `traceId` to analyze why a response behaved a certain way.
+  </when_to_use>
+  <guidelines>
+    - Omit arguments to read every visible comparison instance and repetition.
+    - Pass `instanceId` when the user asks about a specific comparison instance.
+    - Pass `repetitionNumber` when the playground has multiple repetitions and the user asks about one run.
+    - The returned `rawOutput` is the playground's stored model output. Use `traceId` for trace analysis when it is present.
+    - If the run is still pending or streaming, wait for it to finish before drawing conclusions from the output.
+  </guidelines>
+</tool>

--- a/src/phoenix/server/agents/prompts/tools/RUN_PLAYGROUND_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/RUN_PLAYGROUND_TOOL_INSTRUCTIONS.xml.j2
@@ -8,5 +8,6 @@
     - This tool has no arguments. The browser decides what to run from the current playground UI state.
     - It runs all currently visible comparison instances together. If the user asks for only one instance, explain that the current UI action runs all visible instances.
     - Do not call this while a playground run is already active; wait for the current run to finish or ask the user whether to stop it.
+    - After the run finishes, call `read_playground_output` to inspect the raw output and retrieve traceId values.
   </guidelines>
 </tool>

--- a/src/phoenix/server/agents/prompts/tools/RUN_PLAYGROUND_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/RUN_PLAYGROUND_TOOL_INSTRUCTIONS.xml.j2
@@ -1,0 +1,12 @@
+<tool name="run_playground">
+  <description>Start a playground run using the current browser UI state.</description>
+  <when_to_use>
+    - The user asks to run, try, execute, test, or compare the current playground prompt.
+    - After a user-approved prompt edit when the user wants to see the result.
+  </when_to_use>
+  <guidelines>
+    - This tool has no arguments. The browser decides what to run from the current playground UI state.
+    - It runs all currently visible comparison instances together. If the user asks for only one instance, explain that the current UI action runs all visible instances.
+    - Do not call this while a playground run is already active; wait for the current run to finish or ask the user whether to stop it.
+  </guidelines>
+</tool>

--- a/src/phoenix/server/agents/prompts/tools/SET_VARIABLE_VALUES_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/SET_VARIABLE_VALUES_TOOL_INSTRUCTIONS.xml.j2
@@ -1,0 +1,13 @@
+<tool name="set_variable_values">
+  <description>Set manual input values for template variables in the currently mounted playground.</description>
+  <use_when>
+    - The user asks to fill, provide, set, update, or clear playground variable inputs.
+    - The user provides concrete variable values before asking you to run, test, or compare a playground prompt.
+  </use_when>
+  <rules>
+    - Pass variable keys exactly as they appear in the prompt template, including dots or bracket notation if present.
+    - Values are strings. Convert concise scalar user input to strings; do not invent missing values.
+    - This tool only updates manual variable inputs. It does not edit prompt messages, change dataset variable mappings, or run the playground.
+    - If the user wants to run after variables are set, call `run_playground` after this tool succeeds.
+  </rules>
+</tool>

--- a/src/phoenix/server/agents/skills/__init__.py
+++ b/src/phoenix/server/agents/skills/__init__.py
@@ -5,9 +5,12 @@ from phoenix.server.agents.skills.debug_trace import DEBUG_TRACE_SKILL
 from phoenix.server.agents.skills.playground import PLAYGROUND_SKILL
 
 
-def build_skills() -> list[Skill]:
+def build_skills(*, include_playground: bool = False) -> list[Skill]:
     """Return the skills bundled with the PXI agent."""
-    return [DEBUG_TRACE_SKILL, PLAYGROUND_SKILL]
+    skills = [DEBUG_TRACE_SKILL]
+    if include_playground:
+        skills.append(PLAYGROUND_SKILL)
+    return skills
 
 
 __all__ = ["build_skills"]

--- a/src/phoenix/server/agents/skills/__init__.py
+++ b/src/phoenix/server/agents/skills/__init__.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from phoenix.server.agents.capabilities.skills import Skill
 from phoenix.server.agents.skills.debug_trace import DEBUG_TRACE_SKILL
+from phoenix.server.agents.skills.playground import PLAYGROUND_SKILL
 
 
 def build_skills() -> list[Skill]:
     """Return the skills bundled with the PXI agent."""
-    return [DEBUG_TRACE_SKILL]
+    return [DEBUG_TRACE_SKILL, PLAYGROUND_SKILL]
 
 
 __all__ = ["build_skills"]

--- a/src/phoenix/server/agents/skills/playground.py
+++ b/src/phoenix/server/agents/skills/playground.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from phoenix.server.agents.capabilities.skills import Skill
+
+_SKILL_PATH = (
+    Path(__file__).resolve().parent.parent / "prompts" / "skills" / "playground" / "SKILL.md"
+)
+
+PLAYGROUND_SKILL = Skill.from_file(_SKILL_PATH)

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -440,7 +440,7 @@ class TestDocsMCPToolset:
 
 
 class TestSkillsCapability:
-    async def test_bundled_debug_trace_skill_advertised_inside_cache_boundary(
+    async def test_bundled_skills_advertised_inside_cache_boundary(
         self,
         anthropic_model: AnthropicModel,
         captured_request: CapturedRequest,
@@ -454,6 +454,7 @@ class TestSkillsCapability:
         cached_text = _get_concatenated_text(cached_blocks)
         assert "<available_skills>" in cached_text
         assert "<name>debug-trace</name>" in cached_text
+        assert "<name>playground</name>" in cached_text
 
     async def test_skill_tools_are_advertised(
         self,

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -477,7 +477,7 @@ class TestDocsMCPToolset:
 
 
 class TestSkillsCapability:
-    async def test_bundled_skills_advertised_inside_cache_boundary(
+    async def test_global_bundled_skills_advertised_inside_cache_boundary(
         self,
         anthropic_model: AnthropicModel,
         captured_request: CapturedRequest,
@@ -491,7 +491,7 @@ class TestSkillsCapability:
         cached_text = _get_concatenated_text(cached_blocks)
         assert "<available_skills>" in cached_text
         assert "<name>debug-trace</name>" in cached_text
-        assert "<name>playground</name>" in cached_text
+        assert "<name>playground</name>" not in cached_text
 
     async def test_skill_tools_are_advertised(
         self,

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -53,6 +53,7 @@ DYNAMIC_TOOL_INSTRUCTIONS: frozenset[str] = frozenset(
         _DEFAULT_PROMPTS.read_prompt_instance_tool.render(),
         _DEFAULT_PROMPTS.clone_prompt_instance_tool.render(),
         _DEFAULT_PROMPTS.edit_prompt_instance_tool.render(),
+        _DEFAULT_PROMPTS.run_playground_tool.render(),
     }
 )
 
@@ -404,6 +405,36 @@ class TestUIContextInstructions:
         )
         assert "<phoenix_gql_mutations_policy>" in uncached_texts
         assert "<phoenix_gql_mutations_policy>" not in cached_texts
+
+
+class TestPlaygroundTools:
+    async def test_run_playground_tool_is_absent_without_playground_context(
+        self,
+        anthropic_model: AnthropicModel,
+        captured_request: CapturedRequest,
+    ) -> None:
+        agent = build_agent(model=anthropic_model)
+        deps = AgentDependencies(contexts=ResolvedContexts())
+
+        await agent.run("hello", deps=deps)
+
+        assert "run_playground" not in _get_tool_names(captured_request.body)
+
+    async def test_run_playground_tool_is_advertised_with_playground_context(
+        self,
+        anthropic_model: AnthropicModel,
+        captured_request: CapturedRequest,
+    ) -> None:
+        agent = build_agent(model=anthropic_model)
+        deps = AgentDependencies(
+            contexts=ResolvedContexts(
+                playground=PlaygroundContext(type="playground", instance_ids=[1]),
+            ),
+        )
+
+        await agent.run("hello", deps=deps)
+
+        assert "run_playground" in _get_tool_names(captured_request.body)
 
 
 class TestDocsMCPToolset:

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -51,9 +51,11 @@ DYNAMIC_TOOL_INSTRUCTIONS: frozenset[str] = frozenset(
     {
         _DEFAULT_PROMPTS.set_spans_filter_tool.render(),
         _DEFAULT_PROMPTS.read_prompt_instance_tool.render(),
+        _DEFAULT_PROMPTS.read_playground_output_tool.render(),
         _DEFAULT_PROMPTS.clone_prompt_instance_tool.render(),
         _DEFAULT_PROMPTS.edit_prompt_instance_tool.render(),
         _DEFAULT_PROMPTS.run_playground_tool.render(),
+        _DEFAULT_PROMPTS.set_variable_values_tool.render(),
     }
 )
 
@@ -419,6 +421,8 @@ class TestPlaygroundTools:
         await agent.run("hello", deps=deps)
 
         assert "run_playground" not in _get_tool_names(captured_request.body)
+        assert "read_playground_output" not in _get_tool_names(captured_request.body)
+        assert "set_variable_values" not in _get_tool_names(captured_request.body)
 
     async def test_run_playground_tool_is_advertised_with_playground_context(
         self,
@@ -435,6 +439,8 @@ class TestPlaygroundTools:
         await agent.run("hello", deps=deps)
 
         assert "run_playground" in _get_tool_names(captured_request.body)
+        assert "read_playground_output" in _get_tool_names(captured_request.body)
+        assert "set_variable_values" in _get_tool_names(captured_request.body)
 
 
 class TestDocsMCPToolset:


### PR DESCRIPTION
## Summary

Adds the PXI **playground skill** and the tool surface the agent uses to iterate on prompts inside the playground:

- **Skill**: registers the playground skill on the PXI agent, splits the skill instructions into focused workflows, and wires playground context into the agent.
- **Tools** the agent can invoke against a mounted playground:
  - `run_playground` — runs the currently mounted playground instances
  - `read_playground_output` — inspects raw output and surfaces `traceId` for downstream trace analysis
  - `set_variable_values` — populates prompt template variable inputs
- **Frontend plumbing**: surfaces `traceId` on playground repetitions via the GraphQL subscription, adds `setRepetitionTraceId` / `setVariableValues` to the playground store, and registers client actions on Playground mount.

Closes #13447
Closes #13444

## Test plan

- [x] `pnpm vitest run` for the affected frontend modules (`toolRegistry`, `playgroundStore`, new tool client actions)
- [x] `uv run pytest tests/unit/server/agents/test_agent_factory.py`
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm fmt:check`
- [ ] Manually drive the playground from the PXI agent: have it set variable values, run a playground instance, and read the output / traceId.