### PR TITLE
feat(agents): trace debugging skill

### DIFF
--- a/evals/pxi/datasets/set_spans_filter.yaml
+++ b/evals/pxi/datasets/set_spans_filter.yaml
@@ -498,8 +498,10 @@ examples:
           - set_spans_filter
       tool_call_args:
         set_spans_filter:
-          condition: span_kind == 'LLM' or span_kind == 'TOOL'
-          rootSpansOnly: false
+          - condition: span_kind == 'LLM' or span_kind == 'TOOL'
+            rootSpansOnly: false
+          - condition: "span_kind in ('LLM', 'TOOL')"
+            rootSpansOnly: false
     metadata:
       category: combination
       annotation:

--- a/src/phoenix/server/agents/prompts/skills/debug-trace/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/debug-trace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: debug-trace
 description: >
-  Use when the user wants to know what is going wrong with their LLM application or how to improve it — e.g., "what's wrong?", "were there errors?", "where is my agent struggling?", "is retrieval working?", "debug this". Do NOT trigger for general project understanding or trace filtering requests like "show me traces with errors", "describe the trace structure", or "tell me about this project" — those don't require cross-trace diagnosis. This is an expensive, multi-step operation (many GraphQL queries, trace sampling, open-coding, clustering) — only trigger it when the user is clearly asking for a diagnostic investigation, not on casual or ambiguous questions.
+  Diagnose failure modes by systematically investigating traces. Trigger when the user explicitly asks for cross-trace diagnosis: "what's going wrong?", "were there errors?", "debug this", "where is my agent struggling?". Do NOT trigger on: (1) advice questions ("what should I do?"), (2) statistical questions ("what's the average latency?"), (3) summarize requests, (4) trace filtering ("show me traces with errors"), (5) vague questions ("is there a problem?"), (6) unrelated requests.
 ---
 
 ### Orientation

--- a/src/phoenix/server/agents/prompts/skills/debug-trace/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/debug-trace/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: trace-debugging
+name: debug-trace
 description: >
   Use when the user wants to know what is going wrong with their LLM application or how to improve it — e.g., "what's wrong?", "were there errors?", "where is my agent struggling?", "is retrieval working?", "debug this". Do NOT trigger for general project understanding or trace filtering requests like "show me traces with errors", "describe the trace structure", or "tell me about this project" — those don't require cross-trace diagnosis. This is an expensive, multi-step operation (many GraphQL queries, trace sampling, open-coding, clustering) — only trigger it when the user is clearly asking for a diagnostic investigation, not on casual or ambiguous questions.
 ---
 
 ### Orientation
 
-Your goal is to identify common failure modes across multiple traces and provide prioritized, actionable recommendations. Build a representative, evidence-backed picture of what is going wrong and why. Do not exhaustively read every trace. Start broad, inspect selectively, and stop once the main issue categories are clear.
+Your goal is to identify common failure modes and provide prioritized, actionable recommendations. If you already have a specific trace in context, skip the Steps below — apply the failure mode checklist directly to that trace and report findings. Otherwise, build a representative picture across multiple traces: start broad, inspect selectively, and stop once the main issue categories are clear.
 
 ### Common Failure Modes to Watch For
 

--- a/src/phoenix/server/agents/prompts/skills/trace-debugging/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/trace-debugging/SKILL.md
@@ -1,59 +1,41 @@
 ---
 name: trace-debugging
-description: Systematically investigate failing or slow traces in a Phoenix project. Use when the user asks why a span errored, why latency is high, why a tool call produced the wrong result, or any variant of "what went wrong" / "where do I look" inside a project's traces. Walks through narrowing with set_time_range and set_spans_filter, then inspecting span attributes for the failure signature.
+description: >
+  Use when the user wants to know what is going wrong with their LLM application or how to improve it — e.g., "what's wrong?", "were there errors?", "where is my agent struggling?", "is retrieval working?", "debug this". Do NOT trigger for general project understanding or trace filtering requests like "show me traces with errors", "describe the trace structure", or "tell me about this project" — those don't require cross-trace diagnosis. This skill samples traces, journals observations (open-coding), clusters them into failure categories (axial coding), and produces a findings report with recommendations.
 ---
 
-# Trace Debugging
+### Orientation
 
-A repeatable loop for investigating failures inside a Phoenix project. The
-goal is to converge on a concrete failure signature — not just "it's slow" or
-"the LLM hallucinated" — so the user can decide what to fix or evaluate next.
+Your goal is to identify common failure modes across multiple traces and provide prioritized, actionable recommendations. You are not trying to exhaustively read every trace — you are trying to build a representative picture of what is going wrong and why.
 
-## When to Apply
+### Common Failure Modes to Watch For
 
-Trigger this workflow when the user is looking at a Phoenix project and asks
-any variant of:
+This list is non-exhaustive. Use it as a starting checklist, not a complete taxonomy.
 
-- "Why did this trace fail?"
-- "What's making latency high?"
-- "Which spans are erroring?"
-- "Where do I focus?"
+- **Explicit errors** — exceptions, error status codes, or error messages in tool call spans, LLM spans, or retriever spans
+- **Cost and latency** — unusually high token counts or slow spans that suggest room for efficiency improvements
+- **Retrieval quality** — irrelevant, missing, or low-scoring chunks in RAG applications
+- **LLM response quality** — hallucination, factual incorrectness, wrong tone, inappropriate refusals
+- **Tool use problems** — wrong tool selected, malformed invocation, or poor handling of the tool response
+- **Trajectory problems** — the agent took an inefficient path, got stuck in a loop, or failed to complete its task
+- **Instrumentation gaps** — the application is poorly traced, leaving visibility gaps that make it difficult to understand behavior
 
-## Loop
+### Steps
 
-1. **Frame the question.** Get one concrete thing to look for: an error
-   substring, a latency threshold, a tool name, a model name, an output shape.
-   Vague intent ("look at failures") becomes a vague filter and a vague answer.
+1. **Orient** — Use the `phoenix-gql` CLI to pull a sample of traces and understand the project structure (span types present, typical trace shapes, time range).
+2. **Select** — Determine which traces and spans to examine. Aim for a representative sample rather than exhaustive coverage. Be mindful of your context window.
+3. **Open-code** — Write open-ended notes about individual traces, flagging problems, surprises, and incorrect behaviors. Focus on the first failure in each trace, since upstream errors often cause downstream issues. Tag independent downstream failures if feasible.
+4. **Axial-code** — Cluster your notes. Let failure categories emerge naturally. Count occurrences per category.
+5. **Summarize** — Report findings to the user using the output format below.
 
-2. **Narrow the window.** Use `set_time_range` to clamp to the smallest window
-   that still contains the behavior. A 24-hour view hides patterns that a
-   1-hour view exposes.
+### Output Format
 
-3. **Narrow the spans.** Use `set_spans_filter` to keep only spans that match
-   the frame. Start broad (`status_code == 'ERROR'`), then layer constraints
-   (`span_kind == 'LLM'`, attribute predicates) as you learn what the failure
-   class actually is.
+- **Analysis scope** — brief summary of what was analyzed: number of traces examined, time range if relevant, any filters applied
+- **Findings table** — one row per issue category with: label, short description, occurrence count, one or two representative trace links
+- **Recommendations** — for each issue, a concrete suggested fix (prompt change, parameter adjustment, tool fix, instrumentation improvement, etc.), if one can be identified
 
-4. **Read a few end-to-end.** Pick 3–5 surviving traces and read them top to
-   bottom. Patterns at the trace level (e.g. retriever returned empty, tool
-   args malformed, model retried 4×) only show up when you see the sequence.
+### Caveats and Pitfalls
 
-5. **Name the failure.** Write down the signature in one sentence:
-   *"Retriever returns zero docs when the query contains a date range, so the
-   LLM fabricates an answer."* If you can't write that sentence, you haven't
-   narrowed enough — return to step 3.
-
-6. **Decide the next move.** A named failure points at exactly one of:
-   instrument the gap, fix the code, write an eval that catches the class, or
-   collect a dataset. Don't skip naming — undirected fixes are how regressions
-   come back.
-
-## Anti-patterns
-
-- **Scrolling without a frame.** Looking at the trace list with no filter is
-  triage, not debugging. Always commit to one question before looking.
-- **One trace, one conclusion.** A single failing trace tells you a failure
-  exists. It does not tell you the class. Inspect a handful before naming.
-- **Filtering on output text.** Output strings are noisy and vary per call.
-  Filter on structural attributes (status, span kind, tool name, model name)
-  first; use output substrings only to confirm a hypothesis.
+- Existing evals and annotations are useful signal, but treat them as one input among many — they may be incomplete or incorrect.
+- Span status codes are not a reliable proxy for whether an error actually occurred. An exception in the output may be expected behavior; a success status code may mask an error message buried in the span attributes.
+- Do not overload your context by reading too many full spans. Read enough to support meaningful recommendations, then stop.

--- a/src/phoenix/server/agents/prompts/skills/trace-debugging/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/trace-debugging/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: trace-debugging
 description: >
-  Use when the user wants to know what is going wrong with their LLM application or how to improve it — e.g., "what's wrong?", "were there errors?", "where is my agent struggling?", "is retrieval working?", "debug this". Do NOT trigger for general project understanding or trace filtering requests like "show me traces with errors", "describe the trace structure", or "tell me about this project" — those don't require cross-trace diagnosis. This skill samples traces, journals observations (open-coding), clusters them into failure categories (axial coding), and produces a findings report with recommendations.
+  Use when the user wants to know what is going wrong with their LLM application or how to improve it — e.g., "what's wrong?", "were there errors?", "where is my agent struggling?", "is retrieval working?", "debug this". Do NOT trigger for general project understanding or trace filtering requests like "show me traces with errors", "describe the trace structure", or "tell me about this project" — those don't require cross-trace diagnosis. This is an expensive, multi-step operation (many GraphQL queries, trace sampling, open-coding, clustering) — only trigger it when the user is clearly asking for a diagnostic investigation, not on casual or ambiguous questions.
 ---
 
 ### Orientation
 
-Your goal is to identify common failure modes across multiple traces and provide prioritized, actionable recommendations. You are not trying to exhaustively read every trace — you are trying to build a representative picture of what is going wrong and why.
+Your goal is to identify common failure modes across multiple traces and provide prioritized, actionable recommendations. Build a representative, evidence-backed picture of what is going wrong and why. Do not exhaustively read every trace. Start broad, inspect selectively, and stop once the main issue categories are clear.
 
 ### Common Failure Modes to Watch For
 
@@ -22,11 +22,28 @@ This list is non-exhaustive. Use it as a starting checklist, not a complete taxo
 
 ### Steps
 
-1. **Orient** — Use the `phoenix-gql` CLI to pull a sample of traces and understand the project structure (span types present, typical trace shapes, time range).
-2. **Select** — Determine which traces and spans to examine. Aim for a representative sample rather than exhaustive coverage. Be mindful of your context window.
-3. **Open-code** — Write open-ended notes about individual traces, flagging problems, surprises, and incorrect behaviors. Focus on the first failure in each trace, since upstream errors often cause downstream issues. Tag independent downstream failures if feasible.
-4. **Axial-code** — Cluster your notes. Let failure categories emerge naturally. Count occurrences per category.
-5. **Summarize** — Report findings to the user using the output format below.
+Default query budget: 1–3 orientation queries, 3–5 aggregate or sampling queries, 3–7 targeted drilldowns. Avoid more than 20 GraphQL calls without summarizing progress. Avoid reading more than 5–10 full span inputs or outputs. Prefer fewer, richer queries — use GraphQL aliases to batch independent lookups. Use available GraphQL recipes before writing new queries.
+
+1. **Orient** — Read `/phoenix/agent-start.md`. Use the `phoenix-gql` CLI to get a compact project overview in one aliased query: trace count, span count, latency quantiles, token totals, annotation names, slow traces, high-token traces, error spans.
+
+2. **Select** — Choose a representative sample. Prioritize slow traces, high-token traces, and errored traces; include a few normal traces for comparison. Prefer diversity over volume.
+
+3. **Open-code** — For each trace, write free-form notes on problems, surprises, and incorrect behaviors. Focus on the first failure in a trace, since upstream errors often cause downstream issues. Note independent downstream failures only when they reveal a separate root cause.
+
+4. **Axial-code** — Cluster your notes into named failure categories. Let categories emerge from the data. Distinguish exact counts from sampled or estimated counts.
+
+5. **Summarize** — Report findings using the output format below.
+
+### Observation Journal
+
+Output this table inline in the conversation as you work — it stays compact by design and needs to be visible for axial-coding. Only write it to a file if the user asks for exhaustive analysis across a large number of traces.
+
+For each inspected trace, add a row. Keep `observations` free-form. Fill in `tentative_category` only when the pattern is clear — leave it blank otherwise.
+
+| trace_id | observations | tentative_category |
+| -------- | ------------ | ------------------ |
+
+Use this journal as the input to axial-coding.
 
 ### Output Format
 

--- a/src/phoenix/server/agents/skills/__init__.py
+++ b/src/phoenix/server/agents/skills/__init__.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from phoenix.server.agents.capabilities.skills import Skill
-from phoenix.server.agents.skills.trace_debugging import TRACE_DEBUGGING_SKILL
+from phoenix.server.agents.skills.debug_trace import DEBUG_TRACE_SKILL
 
 
 def build_skills() -> list[Skill]:
     """Return the skills bundled with the PXI agent."""
-    return [TRACE_DEBUGGING_SKILL]
+    return [DEBUG_TRACE_SKILL]
 
 
 __all__ = ["build_skills"]

--- a/src/phoenix/server/agents/skills/debug_trace.py
+++ b/src/phoenix/server/agents/skills/debug_trace.py
@@ -8,4 +8,4 @@ _SKILL_PATH = (
     Path(__file__).resolve().parent.parent / "prompts" / "skills" / "debug-trace" / "SKILL.md"
 )
 
-TRACE_DEBUGGING_SKILL = Skill.from_file(_SKILL_PATH)
+DEBUG_TRACE_SKILL = Skill.from_file(_SKILL_PATH)

--- a/src/phoenix/server/agents/skills/trace_debugging.py
+++ b/src/phoenix/server/agents/skills/trace_debugging.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from phoenix.server.agents.capabilities.skills import Skill
 
 _SKILL_PATH = (
-    Path(__file__).resolve().parent.parent / "prompts" / "skills" / "trace-debugging" / "SKILL.md"
+    Path(__file__).resolve().parent.parent / "prompts" / "skills" / "debug-trace" / "SKILL.md"
 )
 
 TRACE_DEBUGGING_SKILL = Skill.from_file(_SKILL_PATH)

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -440,7 +440,7 @@ class TestDocsMCPToolset:
 
 
 class TestSkillsCapability:
-    async def test_bundled_trace_debugging_skill_advertised_inside_cache_boundary(
+    async def test_bundled_debug_trace_skill_advertised_inside_cache_boundary(
         self,
         anthropic_model: AnthropicModel,
         captured_request: CapturedRequest,

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -453,7 +453,7 @@ class TestSkillsCapability:
         cached_blocks, _ = _partition_system_blocks_by_cache_breakpoint(captured_request.body)
         cached_text = _get_concatenated_text(cached_blocks)
         assert "<available_skills>" in cached_text
-        assert "<name>trace-debugging</name>" in cached_text
+        assert "<name>debug-trace</name>" in cached_text
 
     async def test_skill_tools_are_advertised(
         self,


### PR DESCRIPTION
## Summary

- Renames the trace debugging agent skill from `trace-debugging` to `debug-trace` for naming consistency
- Rewrites `SKILL.md` based on dogfooding — updated trigger conditions, instructions, and skill behavior
- Updates `trace_debugging.py` and agent factory test to reference the renamed skill directory

## Test plan

- [x] Confirm `debug-trace/SKILL.md` loads correctly in the agent skill registry
- [x] Verify no references to the old `trace-debugging` path remain (`grep -r "trace-debugging" agents/`)
- [ ] Run `tests/unit/server/agents/test_agent_factory.py` and confirm it passes
- [x] Invoke the skill against a real trace and confirm triggering and output match the updated `SKILL.md` description