### PR TITLE
refactor: centralize PHOENIX_WASM_BINARY_PATH in config.py

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -786,6 +786,13 @@ Accepted values: WASM, E2B, DAYTONA, VERCEL, DENO, MODAL. Case-insensitive.
 When not set, all providers are allowed. To disable all sandbox providers, set to NONE.
 Example: PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO
 """
+ENV_PHOENIX_WASM_BINARY_PATH = "PHOENIX_WASM_BINARY_PATH"
+"""
+Override path to a pre-downloaded CPython WASM binary used by the WASM sandbox
+provider. When set, the binary at this path is used as-is (no SHA verification,
+no download). When unset, the binary is downloaded on first use under
+PHOENIX_WORKING_DIR/wasm. Primarily used in CI to point at a cached binary.
+"""
 
 
 @dataclass(frozen=True)
@@ -1235,6 +1242,27 @@ def validate_env_allowed_sandbox_providers() -> None:
             f"{', '.join(sorted(names))}. "
             f"Valid names are: {', '.join(sorted(SANDBOX_BACKEND_TYPES))}"
         )
+
+
+def get_env_wasm_binary_path() -> Optional[Path]:
+    """Operator-supplied path to a pre-downloaded CPython WASM binary, if set."""
+    value = getenv(ENV_PHOENIX_WASM_BINARY_PATH)
+    return Path(value) if value else None
+
+
+def validate_env_wasm_binary_path() -> None:
+    """Raise ValueError if PHOENIX_WASM_BINARY_PATH is set but is not a readable, non-empty file."""
+    path = get_env_wasm_binary_path()
+    if path is None:
+        return
+    try:
+        _validate_file_exists_and_is_readable(path, description="WASM binary")
+    except ValueError as exc:
+        raise ValueError(
+            f"{ENV_PHOENIX_WASM_BINARY_PATH}={path} is invalid: {exc}. "
+            f"Either pre-download the CPython WASM binary to that path or unset the env "
+            f"var to fall back to the default download location under PHOENIX_WORKING_DIR."
+        ) from exc
 
 
 def get_env_disable_brute_force_login_protection() -> bool:
@@ -3390,6 +3418,7 @@ def verify_server_environment_variables() -> None:
     validate_env_support_email()
     validate_env_allowed_providers()
     validate_env_allowed_sandbox_providers()
+    validate_env_wasm_binary_path()
 
     # Notify users about deprecated environment variables if they are being used.
     if os.getenv("PHOENIX_ENABLE_WEBSOCKETS") is not None:

--- a/src/phoenix/server/sandbox/_download.py
+++ b/src/phoenix/server/sandbox/_download.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
-import os
 import urllib.request
 from pathlib import Path
 from typing import Optional
 
-from phoenix.config import _no_local_storage, get_working_dir
+from phoenix.config import (
+    ENV_PHOENIX_WASM_BINARY_PATH,
+    _no_local_storage,
+    get_env_wasm_binary_path,
+    get_working_dir,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +27,6 @@ _WASM_URL = f"{_WASM_RELEASE_BASE}/{_WASM_FILENAME}"
 
 # Operator-supplied paths are trusted as-is and NOT hash-checked.
 _WASM_SHA256 = "e5dc5a398b07b54ea8fdb503bf68fb583d533f10ec3f930963e02b9505f7a763"
-
-PHOENIX_WASM_BINARY_PATH_ENV = "PHOENIX_WASM_BINARY_PATH"
 
 
 _NO_LOCAL_STORAGE_LONG_FORM = (
@@ -55,12 +57,9 @@ def resolve_wasm_binary_if_present(
     filename: str = _WASM_FILENAME,
 ) -> Optional[Path]:
     """Return the resolved WASM binary path WITHOUT any downloads or writes."""
-    override = os.environ.get(PHOENIX_WASM_BINARY_PATH_ENV)
-    if override:
-        candidate = Path(override)
-        if candidate.is_file():
-            return candidate
-        return None
+    override = get_env_wasm_binary_path()
+    if override is not None:
+        return override if override.is_file() else None
 
     if _no_local_storage():
         return None
@@ -80,13 +79,12 @@ def ensure_wasm_binary(
     expected_sha256: Optional[str] = None,
 ) -> Path:
     """Return the path to the CPython WASM binary, downloading it if absent."""
-    override = os.environ.get(PHOENIX_WASM_BINARY_PATH_ENV)
-    if override:
-        candidate = Path(override)
-        if candidate.is_file():
-            return candidate
+    override = get_env_wasm_binary_path()
+    if override is not None:
+        if override.is_file():
+            return override
         raise WASMBinaryUnavailable(
-            f"{PHOENIX_WASM_BINARY_PATH_ENV}={override} is set but the file "
+            f"{ENV_PHOENIX_WASM_BINARY_PATH}={override} is set but the file "
             f"does not exist. Either pre-download the CPython WASM binary to "
             f"that path or unset the env var to fall back to the default "
             f"download location under PHOENIX_WORKING_DIR."

--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -36,6 +36,8 @@ from typing import TYPE_CHECKING, Iterator, Mapping, Optional
 if TYPE_CHECKING:
     import wasmtime
 
+from phoenix.config import ENV_PHOENIX_WASM_BINARY_PATH, get_env_wasm_binary_path
+
 from .types import (
     BaseNoSessionBackend,
     ExecutionResult,
@@ -47,8 +49,6 @@ from .types import (
 )
 
 logger = logging.getLogger(__name__)
-
-_WASM_BINARY_PATH_ENV = "PHOENIX_WASM_BINARY_PATH"
 
 _DEFAULT_TIMEOUT_SECONDS = 30
 _EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="wasm-sandbox")
@@ -336,11 +336,13 @@ class WASMAdapter(SandboxAdapter[WASMConfig, NoCredentials, WASMDeployment]):
         if resolved is not None:
             return WASMBinaryProbe(available=True, detail=None, path=resolved)
 
-        env_path = os.environ.get(_WASM_BINARY_PATH_ENV)
-        if env_path:
+        env_path = get_env_wasm_binary_path()
+        if env_path is not None:
             return WASMBinaryProbe(
                 available=False,
-                detail=(f"{_WASM_BINARY_PATH_ENV}={env_path} is set but the file does not exist."),
+                detail=(
+                    f"{ENV_PHOENIX_WASM_BINARY_PATH}={env_path} is set but the file does not exist."
+                ),
                 path=None,
             )
         if _no_local_storage():

--- a/tests/unit/db/test_facilitator.py
+++ b/tests/unit/db/test_facilitator.py
@@ -8,17 +8,6 @@ from _pytest.monkeypatch import MonkeyPatch
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
-from phoenix.config import (
-    ENV_PHOENIX_ADMINS,
-    ENV_PHOENIX_DISABLE_BASIC_AUTH,
-    ENV_PHOENIX_LDAP_BIND_DN,
-    ENV_PHOENIX_LDAP_BIND_PASSWORD,
-    ENV_PHOENIX_LDAP_GROUP_ROLE_MAPPINGS,
-    ENV_PHOENIX_LDAP_HOST,
-    ENV_PHOENIX_LDAP_PORT,
-    ENV_PHOENIX_LDAP_USER_SEARCH_BASE_DNS,
-    ENV_PHOENIX_LDAP_USER_SEARCH_FILTER,
-)
 from phoenix.db import models
 from phoenix.db.enums import ENUM_COLUMNS
 from phoenix.db.facilitator import (
@@ -72,7 +61,7 @@ class TestEnsureStartupAdmins:
         email_sending_fails: bool,
     ) -> None:
         monkeypatch.setenv(
-            ENV_PHOENIX_ADMINS,
+            "PHOENIX_ADMINS",
             (
                 "Washington, George, Jr.=george@example.com;"
                 "Franklin, Benjamin=benjamin@example.com;"
@@ -148,18 +137,18 @@ class TestEnsureStartupAdmins:
         """When PHOENIX_DISABLE_BASIC_AUTH=true and LDAP is configured (no OAuth2),
         startup admins should be created as LDAP users."""
         # Configure admins and disable basic auth
-        monkeypatch.setenv(ENV_PHOENIX_ADMINS, "LDAP Admin=ldap_admin@example.com")
-        monkeypatch.setenv(ENV_PHOENIX_DISABLE_BASIC_AUTH, "true")
+        monkeypatch.setenv("PHOENIX_ADMINS", "LDAP Admin=ldap_admin@example.com")
+        monkeypatch.setenv("PHOENIX_DISABLE_BASIC_AUTH", "true")
 
         # Configure minimal LDAP settings (required for LDAPConfig.from_env() to return non-None)
-        monkeypatch.setenv(ENV_PHOENIX_LDAP_HOST, "ldap.example.com")
-        monkeypatch.setenv(ENV_PHOENIX_LDAP_PORT, "389")
-        monkeypatch.setenv(ENV_PHOENIX_LDAP_BIND_DN, "cn=admin,dc=example,dc=com")
-        monkeypatch.setenv(ENV_PHOENIX_LDAP_BIND_PASSWORD, "secret")
-        monkeypatch.setenv(ENV_PHOENIX_LDAP_USER_SEARCH_BASE_DNS, '["ou=users,dc=example,dc=com"]')
-        monkeypatch.setenv(ENV_PHOENIX_LDAP_USER_SEARCH_FILTER, "(uid=%s)")
+        monkeypatch.setenv("PHOENIX_LDAP_HOST", "ldap.example.com")
+        monkeypatch.setenv("PHOENIX_LDAP_PORT", "389")
+        monkeypatch.setenv("PHOENIX_LDAP_BIND_DN", "cn=admin,dc=example,dc=com")
+        monkeypatch.setenv("PHOENIX_LDAP_BIND_PASSWORD", "secret")
+        monkeypatch.setenv("PHOENIX_LDAP_USER_SEARCH_BASE_DNS", '["ou=users,dc=example,dc=com"]')
+        monkeypatch.setenv("PHOENIX_LDAP_USER_SEARCH_FILTER", "(uid=%s)")
         monkeypatch.setenv(
-            ENV_PHOENIX_LDAP_GROUP_ROLE_MAPPINGS, '[{"group_dn": "*", "role": "MEMBER"}]'
+            "PHOENIX_LDAP_GROUP_ROLE_MAPPINGS", '[{"group_dn": "*", "role": "MEMBER"}]'
         )
 
         # Initialize enums and create admin
@@ -188,8 +177,8 @@ class TestEnsureStartupAdmins:
         """When PHOENIX_DISABLE_BASIC_AUTH=true and OAuth2 is configured,
         startup admins should be created as OAuth2 users (not LDAP)."""
         # Configure admins and disable basic auth
-        monkeypatch.setenv(ENV_PHOENIX_ADMINS, "OAuth2 Admin=oauth_admin@example.com")
-        monkeypatch.setenv(ENV_PHOENIX_DISABLE_BASIC_AUTH, "true")
+        monkeypatch.setenv("PHOENIX_ADMINS", "OAuth2 Admin=oauth_admin@example.com")
+        monkeypatch.setenv("PHOENIX_DISABLE_BASIC_AUTH", "true")
 
         # Configure OAuth2 (this takes priority over LDAP)
         monkeypatch.setenv("PHOENIX_OAUTH2_IDP1_CLIENT_ID", "test-client-id")
@@ -197,14 +186,14 @@ class TestEnsureStartupAdmins:
         monkeypatch.setenv("PHOENIX_OAUTH2_IDP1_OIDC_CONFIG_URL", "https://example.com/.well-known")
 
         # Also configure LDAP to verify OAuth2 takes priority
-        monkeypatch.setenv(ENV_PHOENIX_LDAP_HOST, "ldap.example.com")
-        monkeypatch.setenv(ENV_PHOENIX_LDAP_PORT, "389")
-        monkeypatch.setenv(ENV_PHOENIX_LDAP_BIND_DN, "cn=admin,dc=example,dc=com")
-        monkeypatch.setenv(ENV_PHOENIX_LDAP_BIND_PASSWORD, "secret")
-        monkeypatch.setenv(ENV_PHOENIX_LDAP_USER_SEARCH_BASE_DNS, '["ou=users,dc=example,dc=com"]')
-        monkeypatch.setenv(ENV_PHOENIX_LDAP_USER_SEARCH_FILTER, "(uid=%s)")
+        monkeypatch.setenv("PHOENIX_LDAP_HOST", "ldap.example.com")
+        monkeypatch.setenv("PHOENIX_LDAP_PORT", "389")
+        monkeypatch.setenv("PHOENIX_LDAP_BIND_DN", "cn=admin,dc=example,dc=com")
+        monkeypatch.setenv("PHOENIX_LDAP_BIND_PASSWORD", "secret")
+        monkeypatch.setenv("PHOENIX_LDAP_USER_SEARCH_BASE_DNS", '["ou=users,dc=example,dc=com"]')
+        monkeypatch.setenv("PHOENIX_LDAP_USER_SEARCH_FILTER", "(uid=%s)")
         monkeypatch.setenv(
-            ENV_PHOENIX_LDAP_GROUP_ROLE_MAPPINGS, '[{"group_dn": "*", "role": "MEMBER"}]'
+            "PHOENIX_LDAP_GROUP_ROLE_MAPPINGS", '[{"group_dn": "*", "role": "MEMBER"}]'
         )
 
         # Initialize enums and create admin

--- a/tests/unit/server/sandbox/test_wasm_download.py
+++ b/tests/unit/server/sandbox/test_wasm_download.py
@@ -13,7 +13,6 @@ from unittest.mock import patch
 import pytest
 
 from phoenix.server.sandbox._download import (
-    PHOENIX_WASM_BINARY_PATH_ENV,
     WASMBinaryUnavailable,
     ensure_wasm_binary,
     no_local_storage_message,
@@ -30,7 +29,7 @@ class TestResolveWasmBinaryIfPresent:
     ) -> None:
         binary = tmp_path / "operator-binary.wasm"
         binary.write_bytes(b"fake wasm")
-        monkeypatch.setenv(PHOENIX_WASM_BINARY_PATH_ENV, str(binary))
+        monkeypatch.setenv("PHOENIX_WASM_BINARY_PATH", str(binary))
 
         # cache_dir intentionally points at an empty dir to prove the
         # env-var path takes precedence and no cache lookup happened.
@@ -44,7 +43,7 @@ class TestResolveWasmBinaryIfPresent:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         missing = tmp_path / "does-not-exist.wasm"
-        monkeypatch.setenv(PHOENIX_WASM_BINARY_PATH_ENV, str(missing))
+        monkeypatch.setenv("PHOENIX_WASM_BINARY_PATH", str(missing))
 
         # Even if a cache entry exists, the env-var-set-but-missing case
         # must NOT silently fall back to the cache; the operator path is
@@ -58,7 +57,7 @@ class TestResolveWasmBinaryIfPresent:
     def test_env_var_unset_and_cache_present_returns_cache_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.delenv(PHOENIX_WASM_BINARY_PATH_ENV, raising=False)
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
         cached = cache_dir / _FILENAME
@@ -71,7 +70,7 @@ class TestResolveWasmBinaryIfPresent:
     def test_env_var_unset_and_cache_absent_returns_none(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.delenv(PHOENIX_WASM_BINARY_PATH_ENV, raising=False)
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
         cache_dir = tmp_path / "cache"
         # Note: cache_dir intentionally not created.
 
@@ -84,7 +83,7 @@ class TestResolveWasmBinaryIfPresent:
         """probe_binary() runs on every render of the sandbox-config UI; a
         network round-trip there would regress the resolver.
         """
-        monkeypatch.delenv(PHOENIX_WASM_BINARY_PATH_ENV, raising=False)
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
         cache_dir = tmp_path / "cache"
 
         with patch("phoenix.server.sandbox._download.urllib.request.urlretrieve") as mock_retrieve:
@@ -101,7 +100,7 @@ class TestEnsureWasmBinaryEnvVarOverride:
     ) -> None:
         binary = tmp_path / "operator-binary.wasm"
         binary.write_bytes(b"fake wasm")
-        monkeypatch.setenv(PHOENIX_WASM_BINARY_PATH_ENV, str(binary))
+        monkeypatch.setenv("PHOENIX_WASM_BINARY_PATH", str(binary))
 
         with patch("phoenix.server.sandbox._download.urllib.request.urlretrieve") as mock_retrieve:
             result = ensure_wasm_binary(
@@ -116,7 +115,7 @@ class TestEnsureWasmBinaryEnvVarOverride:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         missing = tmp_path / "missing.wasm"
-        monkeypatch.setenv(PHOENIX_WASM_BINARY_PATH_ENV, str(missing))
+        monkeypatch.setenv("PHOENIX_WASM_BINARY_PATH", str(missing))
 
         with patch("phoenix.server.sandbox._download.urllib.request.urlretrieve") as mock_retrieve:
             with pytest.raises(WASMBinaryUnavailable, match=re.escape(str(missing))):
@@ -134,7 +133,7 @@ class TestEnsureWasmBinaryEnvVarUnset:
     def test_env_var_unset_and_cache_present_returns_cache_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.delenv(PHOENIX_WASM_BINARY_PATH_ENV, raising=False)
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
         cached = cache_dir / _FILENAME
@@ -153,7 +152,7 @@ class TestEnsureWasmBinaryEnvVarUnset:
     def test_env_var_unset_and_cache_absent_triggers_lazy_download(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.delenv(PHOENIX_WASM_BINARY_PATH_ENV, raising=False)
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
         cache_dir = tmp_path / "cache"
 
         def _fake_retrieve(_url: str, dest: str) -> None:
@@ -180,7 +179,7 @@ class TestEnsureWasmBinaryEnvVarUnset:
         treating it as authoritative would surface a confusing
         WASMBinaryUnavailable on every probe.
         """
-        monkeypatch.setenv(PHOENIX_WASM_BINARY_PATH_ENV, "")
+        monkeypatch.setenv("PHOENIX_WASM_BINARY_PATH", "")
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
         cached = cache_dir / _FILENAME
@@ -194,7 +193,7 @@ class TestEnsureWasmBinaryEnvVarUnset:
     ) -> None:
         import hashlib
 
-        monkeypatch.delenv(PHOENIX_WASM_BINARY_PATH_ENV, raising=False)
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
         wasm_dir = tmp_path / "wasm"
         wasm_dir.mkdir()
         cached = wasm_dir / _FILENAME
@@ -214,7 +213,7 @@ class TestEnsureWasmBinaryEnvVarUnset:
     def test_no_local_storage_raises_unavailable(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.delenv(PHOENIX_WASM_BINARY_PATH_ENV, raising=False)
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
         monkeypatch.setattr("phoenix.server.sandbox._download._no_local_storage", lambda: True)
         wasm_dir = tmp_path / "wasm"
 
@@ -240,7 +239,7 @@ class TestPrefetchWasmBinaryIfNeeded:
         # integrity check passes without the real 26MB upstream binary.
         import hashlib
 
-        monkeypatch.delenv(PHOENIX_WASM_BINARY_PATH_ENV, raising=False)
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
         wasm_dir = tmp_path / "wasm"
         monkeypatch.setattr("phoenix.server.sandbox._download._default_wasm_dir", lambda: wasm_dir)
 
@@ -265,7 +264,7 @@ class TestPrefetchWasmBinaryIfNeeded:
     ) -> None:
         import hashlib
 
-        monkeypatch.delenv(PHOENIX_WASM_BINARY_PATH_ENV, raising=False)
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
         wasm_dir = tmp_path / "wasm"
         monkeypatch.setattr("phoenix.server.sandbox._download._default_wasm_dir", lambda: wasm_dir)
 
@@ -291,7 +290,7 @@ class TestPrefetchWasmBinaryIfNeeded:
     async def test_prefetch_fails_soft_on_download_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        monkeypatch.delenv(PHOENIX_WASM_BINARY_PATH_ENV, raising=False)
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
         wasm_dir = tmp_path / "wasm"
         monkeypatch.setattr("phoenix.server.sandbox._download._default_wasm_dir", lambda: wasm_dir)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,10 +9,6 @@ from _pytest.monkeypatch import MonkeyPatch
 from starlette.datastructures import URL
 
 from phoenix.config import (
-    ENV_PHOENIX_ADMINS,
-    ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES,
-    ENV_PHOENIX_SQL_DATABASE_SCHEMA,
-    ENV_PHOENIX_SQL_DATABASE_URL,
     AssignableUserRoleName,
     OAuth2ClientConfig,
     ensure_working_dir_if_needed,
@@ -123,8 +119,8 @@ class TestGetEnvDatabaseSchema:
 
     @staticmethod
     def _clear_db_env(monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv(ENV_PHOENIX_SQL_DATABASE_URL, raising=False)
-        monkeypatch.delenv(ENV_PHOENIX_SQL_DATABASE_SCHEMA, raising=False)
+        monkeypatch.delenv("PHOENIX_SQL_DATABASE_URL", raising=False)
+        monkeypatch.delenv("PHOENIX_SQL_DATABASE_SCHEMA", raising=False)
         for key in (
             "PHOENIX_POSTGRES_USER",
             "PHOENIX_POSTGRES_PASSWORD",
@@ -138,28 +134,28 @@ class TestGetEnvDatabaseSchema:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         self._clear_db_env(monkeypatch)
-        monkeypatch.setenv(ENV_PHOENIX_SQL_DATABASE_URL, "sqlite:////tmp/phoenix.db")
-        monkeypatch.setenv(ENV_PHOENIX_SQL_DATABASE_SCHEMA, "custom")
+        monkeypatch.setenv("PHOENIX_SQL_DATABASE_URL", "sqlite:////tmp/phoenix.db")
+        monkeypatch.setenv("PHOENIX_SQL_DATABASE_SCHEMA", "custom")
         assert get_env_database_schema() is None
 
     def test_postgres_unset_schema_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._clear_db_env(monkeypatch)
-        monkeypatch.setenv(ENV_PHOENIX_SQL_DATABASE_URL, self._PG_URL)
-        monkeypatch.delenv(ENV_PHOENIX_SQL_DATABASE_SCHEMA, raising=False)
+        monkeypatch.setenv("PHOENIX_SQL_DATABASE_URL", self._PG_URL)
+        monkeypatch.delenv("PHOENIX_SQL_DATABASE_SCHEMA", raising=False)
         assert get_env_database_schema() is None
 
     def test_postgres_empty_string_schema_returns_none(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         self._clear_db_env(monkeypatch)
-        monkeypatch.setenv(ENV_PHOENIX_SQL_DATABASE_URL, self._PG_URL)
-        monkeypatch.setenv(ENV_PHOENIX_SQL_DATABASE_SCHEMA, "")
+        monkeypatch.setenv("PHOENIX_SQL_DATABASE_URL", self._PG_URL)
+        monkeypatch.setenv("PHOENIX_SQL_DATABASE_SCHEMA", "")
         assert get_env_database_schema() is None
 
     def test_postgres_non_empty_schema_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._clear_db_env(monkeypatch)
-        monkeypatch.setenv(ENV_PHOENIX_SQL_DATABASE_URL, self._PG_URL)
-        monkeypatch.setenv(ENV_PHOENIX_SQL_DATABASE_SCHEMA, "phoenix_app")
+        monkeypatch.setenv("PHOENIX_SQL_DATABASE_URL", self._PG_URL)
+        monkeypatch.setenv("PHOENIX_SQL_DATABASE_SCHEMA", "phoenix_app")
         assert get_env_database_schema() == "phoenix_app"
 
 
@@ -246,9 +242,9 @@ class TestGetEnvStartupAdmins:
         expected_result: dict[str, str],
     ) -> None:
         if env_value:
-            monkeypatch.setenv(ENV_PHOENIX_ADMINS, env_value)
+            monkeypatch.setenv("PHOENIX_ADMINS", env_value)
         else:
-            monkeypatch.delenv(ENV_PHOENIX_ADMINS, raising=False)
+            monkeypatch.delenv("PHOENIX_ADMINS", raising=False)
         result = get_env_admins()
         assert result == expected_result
 
@@ -312,7 +308,7 @@ class TestGetEnvStartupAdmins:
         env_value: str,
         expected_error_msg: str,
     ) -> None:
-        monkeypatch.setenv(ENV_PHOENIX_ADMINS, env_value)
+        monkeypatch.setenv("PHOENIX_ADMINS", env_value)
         with pytest.raises(ValueError) as e:
             get_env_admins()
         assert expected_error_msg in str(e.value)
@@ -844,38 +840,33 @@ def test_ensure_working_dir_if_needed_skips_when_no_local_storage(
     mkdir_spy.assert_not_called()
 
 
-def test_allow_external_resources_env_var_exists() -> None:
-    """Test that the ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES constant is properly defined."""
-    assert ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES == "PHOENIX_ALLOW_EXTERNAL_RESOURCES"
-
-
 def test_allow_external_resources_env_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that the environment variable parsing logic works correctly."""
     import os
 
     # Test default (env var not set) - should be True
-    monkeypatch.delenv(ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES, raising=False)
-    assert os.getenv(ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES, "True").lower() == "true"
+    monkeypatch.delenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", raising=False)
+    assert os.getenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "True").lower() == "true"
 
     # Test explicit True
-    monkeypatch.setenv(ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES, "True")
-    assert os.getenv(ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES, "True").lower() == "true"
+    monkeypatch.setenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "True")
+    assert os.getenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "True").lower() == "true"
 
     # Test explicit true (lowercase)
-    monkeypatch.setenv(ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES, "true")
-    assert os.getenv(ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES, "True").lower() == "true"
+    monkeypatch.setenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "true")
+    assert os.getenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "True").lower() == "true"
 
     # Test explicit False
-    monkeypatch.setenv(ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES, "False")
-    assert os.getenv(ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES, "True").lower() == "false"
+    monkeypatch.setenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "False")
+    assert os.getenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "True").lower() == "false"
 
     # Test explicit false (lowercase)
-    monkeypatch.setenv(ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES, "false")
-    assert os.getenv(ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES, "True").lower() == "false"
+    monkeypatch.setenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "false")
+    assert os.getenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "True").lower() == "false"
 
     # Test invalid value - should be false (not "true")
-    monkeypatch.setenv(ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES, "invalid")
-    assert os.getenv(ENV_PHOENIX_ALLOW_EXTERNAL_RESOURCES, "True").lower() != "true"
+    monkeypatch.setenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "invalid")
+    assert os.getenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "True").lower() != "true"
 
 
 class TestOAuth2ClientConfigFromEnv:
@@ -2305,6 +2296,48 @@ class TestValidateEnvAllowedSandboxProviders:
 
         with pytest.raises(ValueError, match="VERCEL_PYTHON"):
             validate_env_allowed_sandbox_providers()
+
+
+class TestValidateEnvWasmBinaryPath:
+    def test_unset_does_not_raise(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
+        from phoenix.config import validate_env_wasm_binary_path
+
+        validate_env_wasm_binary_path()
+
+    def test_set_to_existing_file_does_not_raise(
+        self, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        binary = tmp_path / "python-3.12.0.wasm"
+        binary.write_bytes(b"fake wasm")
+        monkeypatch.setenv("PHOENIX_WASM_BINARY_PATH", str(binary))
+        from phoenix.config import validate_env_wasm_binary_path
+
+        validate_env_wasm_binary_path()
+
+    def test_set_to_missing_file_raises(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+        missing = tmp_path / "does-not-exist.wasm"
+        monkeypatch.setenv("PHOENIX_WASM_BINARY_PATH", str(missing))
+        from phoenix.config import validate_env_wasm_binary_path
+
+        with pytest.raises(ValueError, match="PHOENIX_WASM_BINARY_PATH"):
+            validate_env_wasm_binary_path()
+
+    def test_set_to_directory_raises(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("PHOENIX_WASM_BINARY_PATH", str(tmp_path))
+        from phoenix.config import validate_env_wasm_binary_path
+
+        with pytest.raises(ValueError, match="PHOENIX_WASM_BINARY_PATH"):
+            validate_env_wasm_binary_path()
+
+    def test_set_to_empty_file_raises(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+        empty = tmp_path / "empty.wasm"
+        empty.touch()
+        monkeypatch.setenv("PHOENIX_WASM_BINARY_PATH", str(empty))
+        from phoenix.config import validate_env_wasm_binary_path
+
+        with pytest.raises(ValueError, match="empty"):
+            validate_env_wasm_binary_path()
 
 
 class TestPostgresConnectionStringManagedIdentity:


### PR DESCRIPTION
## Summary
- Move `PHOENIX_WASM_BINARY_PATH` into [`src/phoenix/config.py`](https://github.com/Arize-ai/phoenix/blob/main/src/phoenix/config.py) alongside other `PHOENIX_*` env vars; dedupe the two local copies in [`sandbox/_download.py`](https://github.com/Arize-ai/phoenix/blob/main/src/phoenix/server/sandbox/_download.py) and [`sandbox/wasm_backend.py`](https://github.com/Arize-ai/phoenix/blob/main/src/phoenix/server/sandbox/wasm_backend.py).
- Add `get_env_wasm_binary_path() -> Optional[Path]` that strips whitespace via `getenv()` and returns a `Path` directly, dropping the `Path(override)` boilerplate at every call site.
- Add `validate_env_wasm_binary_path()` and wire it into the existing startup `validate_*` pass. Fails launch with a `ValueError` when the operator-supplied path is missing, empty, unreadable, or a directory — uses the same `_validate_file_exists_and_is_readable()` helper as the TLS validator.
- Sweep `tests/unit/test_config.py`, `tests/unit/db/test_facilitator.py`, and `tests/unit/server/sandbox/test_wasm_download.py` to use literal env-var strings instead of importing `ENV_*` constants, keeping the wire contract explicit at the test boundary.

Behavior change: an operator who sets `PHOENIX_WASM_BINARY_PATH` to a nonexistent/empty/unreadable path will now hit a `ValueError` at server startup instead of getting a silently-degraded WASM provider at first request.

## Test plan
- [x] `pytest tests/unit/test_config.py::TestValidateEnvWasmBinaryPath` — new validator coverage (unset, present, missing, empty, directory)
- [x] `pytest tests/unit/server/sandbox/test_wasm_download.py tests/unit/server/api/test_wasm_backend.py` — existing override behavior
- [x] `pytest tests/unit/test_config.py tests/unit/db/test_facilitator.py` — string-literal sweep doesn't break anything
- [x] `ruff check` clean on all touched files