### PR TITLE
feat: lift trace UX feature flag

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1384,7 +1384,10 @@ const codeMirrorOverridesCSS = css`
 
 const chartCSS = css`
   .theme {
-    --chart-cartesian-grid-stroke-color: var(--global-color-gray-300);
+    --chart-cartesian-grid-stroke-color: rgba(
+      var(--global-color-gray-500-rgb),
+      0.24
+    );
     --chart-axis-stroke-color: var(--global-color-gray-300);
     --chart-axis-text-color: var(--global-text-color-700);
     --chart-axis-label-color: var(--global-text-color-700);

--- a/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
@@ -125,7 +125,7 @@ describe("AgentChatWidget", () => {
         <ThemeProvider themeMode="light" disableBodyTheme>
           <FeatureFlagsContext.Provider
             value={{
-              featureFlags: { agents: true, tracing_ux: false },
+              featureFlags: { agents: true },
               setFeatureFlags: vi.fn(),
             }}
           >
@@ -385,7 +385,7 @@ describe("AgentChatWidget", () => {
         <ThemeProvider themeMode="light" disableBodyTheme>
           <FeatureFlagsContext.Provider
             value={{
-              featureFlags: { agents: true, tracing_ux: false },
+              featureFlags: { agents: true },
               setFeatureFlags: vi.fn(),
             }}
           >

--- a/app/src/components/chart/__tests__/timeTicks.test.ts
+++ b/app/src/components/chart/__tests__/timeTicks.test.ts
@@ -1,0 +1,87 @@
+import { ONE_DAY_MS } from "@phoenix/constants/timeConstants";
+
+import {
+  getEvenlySpacedTimeTicks,
+  getMaxTimeTickCount,
+  getTimeAxisTicks,
+} from "../timeTicks";
+
+describe("getMaxTimeTickCount", () => {
+  it("uses the measured width and requested minimum spacing", () => {
+    expect(getMaxTimeTickCount({ width: 320, minSpacing: 96 })).toBe(4);
+  });
+
+  it("uses the fallback count before a chart is measured", () => {
+    expect(
+      getMaxTimeTickCount({
+        width: null,
+        minSpacing: 96,
+        fallbackCount: 8,
+      })
+    ).toBe(8);
+  });
+});
+
+describe("getTimeAxisTicks", () => {
+  it("selects evenly spaced ticks using the measured chart width", () => {
+    const startTimestamp = Date.UTC(2026, 3, 27);
+    const timestamps = Array.from({ length: 31 }, (_, index) => {
+      return startTimestamp + index * ONE_DAY_MS;
+    });
+
+    expect(
+      getTimeAxisTicks({
+        timestamps,
+        width: 320,
+        minSpacing: 96,
+      })
+    ).toEqual([timestamps[0], timestamps[8], timestamps[16], timestamps[24]]);
+  });
+});
+
+describe("getEvenlySpacedTimeTicks", () => {
+  it("sorts and deduplicates sparse timestamps", () => {
+    expect(
+      getEvenlySpacedTimeTicks({
+        timestamps: [3, 1, 2, 2, Number.NaN, Number.POSITIVE_INFINITY],
+        maxTickCount: 8,
+      })
+    ).toEqual([1, 2, 3]);
+  });
+
+  it("preserves endpoints when they fall on the uniform subset", () => {
+    const startTimestamp = Date.UTC(2026, 3, 27);
+    const timestamps = Array.from({ length: 31 }, (_, index) => {
+      return startTimestamp + index * ONE_DAY_MS;
+    });
+
+    const ticks = getEvenlySpacedTimeTicks({
+      timestamps,
+      maxTickCount: 16,
+    });
+
+    expect(ticks.at(0)).toBe(timestamps.at(0));
+    expect(ticks.at(-1)).toBe(timestamps.at(-1));
+    expect(ticks.slice(1).map((tick, index) => tick - ticks[index]!)).toEqual(
+      Array.from({ length: 15 }, () => 2 * ONE_DAY_MS)
+    );
+  });
+
+  it("does not force a short trailing interval to include the final timestamp", () => {
+    const startTimestamp = Date.UTC(2026, 3, 27);
+    const timestamps = Array.from({ length: 31 }, (_, index) => {
+      return startTimestamp + index * ONE_DAY_MS;
+    });
+
+    const ticks = getEvenlySpacedTimeTicks({
+      timestamps,
+      maxTickCount: 10,
+    });
+
+    expect(ticks.at(0)).toBe(timestamps.at(0));
+    expect(ticks.at(-1)).toBe(timestamps.at(28));
+    expect(ticks.slice(1).map((tick, index) => tick - ticks[index]!)).toEqual(
+      Array.from({ length: 7 }, () => 4 * ONE_DAY_MS)
+    );
+  });
+});

--- a/app/src/components/chart/defaults.tsx
+++ b/app/src/components/chart/defaults.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import type {
   CartesianGridProps,
   LabelProps,
@@ -6,6 +7,8 @@ import type {
   XAxisProps,
   YAxisProps,
 } from "recharts";
+
+import { NON_MODAL_FLOATING_Z_INDEX } from "@phoenix/components/core/zIndex";
 
 export const defaultCartesianGridProps: CartesianGridProps = {
   strokeDasharray: "4 4",
@@ -61,9 +64,23 @@ export const defaultBarChartTooltipProps: TooltipProps<any, any> = {
   },
 };
 
+export const defaultChartTooltipWrapperStyle: CSSProperties = {
+  zIndex: NON_MODAL_FLOATING_Z_INDEX,
+};
+
 export const defaultLegendProps: LegendProps = {
   align: "right",
+  wrapperStyle: {
+    userSelect: "none",
+  },
   formatter: (value) => (
-    <span style={{ color: "var(--chart-legend-text-color)" }}>{value}</span>
+    <span
+      style={{
+        color: "var(--chart-legend-text-color)",
+        userSelect: "none",
+      }}
+    >
+      {value}
+    </span>
   ),
 };

--- a/app/src/components/chart/index.tsx
+++ b/app/src/components/chart/index.tsx
@@ -7,3 +7,5 @@ export * from "./useTimeTickFormatter";
 export * from "./useBinTimeTickFormatter";
 export * from "./colors";
 export * from "./binning";
+export * from "./timeTicks";
+export * from "./useTimeAxisTicks";

--- a/app/src/components/chart/timeTicks.ts
+++ b/app/src/components/chart/timeTicks.ts
@@ -1,0 +1,86 @@
+const DEFAULT_TIME_TICK_COUNT = 6;
+const MIN_TIME_TICK_COUNT = 2;
+
+/**
+ * Calculates how many time-axis ticks can fit in a chart at the desired spacing.
+ * @param params - tick count parameters
+ * @param params.width - chart width in pixels
+ * @param params.minSpacing - minimum spacing between tick labels in pixels
+ * @param params.fallbackCount - tick count to use before the chart is measured
+ */
+export function getMaxTimeTickCount({
+  width,
+  minSpacing,
+  fallbackCount = DEFAULT_TIME_TICK_COUNT,
+}: {
+  width: number | null | undefined;
+  minSpacing: number;
+  fallbackCount?: number;
+}) {
+  if (width == null || !Number.isFinite(width) || width <= 0) {
+    return fallbackCount;
+  }
+  return Math.max(MIN_TIME_TICK_COUNT, Math.floor(width / minSpacing) + 1);
+}
+
+/**
+ * Selects a sorted, evenly spaced subset of timestamps.
+ * @param params - tick selection parameters
+ * @param params.timestamps - candidate timestamps in epoch milliseconds
+ * @param params.maxTickCount - maximum number of visible ticks
+ */
+export function getEvenlySpacedTimeTicks({
+  timestamps,
+  maxTickCount,
+}: {
+  timestamps: readonly number[];
+  maxTickCount: number;
+}) {
+  const sortedTimestamps = Array.from(
+    new Set(timestamps.filter((timestamp) => Number.isFinite(timestamp)))
+  ).sort((leftTimestamp, rightTimestamp) => leftTimestamp - rightTimestamp);
+  const normalizedMaxTickCount = Math.max(
+    MIN_TIME_TICK_COUNT,
+    Math.floor(maxTickCount)
+  );
+  if (sortedTimestamps.length <= normalizedMaxTickCount) {
+    return sortedTimestamps;
+  }
+
+  const tickStep = Math.ceil(sortedTimestamps.length / normalizedMaxTickCount);
+  const ticks: number[] = [];
+  for (let index = 0; index < sortedTimestamps.length; index += tickStep) {
+    ticks.push(sortedTimestamps[index]!);
+  }
+  return ticks;
+}
+
+/**
+ * Selects time-axis ticks that fit the measured chart width.
+ * @param params - tick selection parameters
+ * @param params.timestamps - candidate timestamps in epoch milliseconds
+ * @param params.width - chart width in pixels
+ * @param params.minSpacing - minimum spacing between tick labels in pixels
+ * @param params.fallbackCount - tick count to use before the chart is measured
+ */
+export function getTimeAxisTicks({
+  timestamps,
+  width,
+  minSpacing,
+  fallbackCount,
+}: {
+  timestamps: readonly number[];
+  width: number | null | undefined;
+  minSpacing: number;
+  fallbackCount?: number;
+}) {
+  const maxTickCount = getMaxTimeTickCount({
+    width,
+    minSpacing,
+    fallbackCount,
+  });
+  return getEvenlySpacedTimeTicks({
+    timestamps,
+    maxTickCount,
+  });
+}

--- a/app/src/components/chart/useTimeAxisTicks.ts
+++ b/app/src/components/chart/useTimeAxisTicks.ts
@@ -1,0 +1,37 @@
+import { useMemo } from "react";
+
+import { getTimeAxisTicks } from "./timeTicks";
+
+/**
+ * Returns responsive time-axis ticks for chart data.
+ * @param params - tick selection parameters
+ * @param params.data - chart data containing timestamp values
+ * @param params.getTimestamp - extracts an epoch millisecond timestamp from a datum
+ * @param params.width - chart width in pixels
+ * @param params.minSpacing - minimum spacing between tick labels in pixels
+ * @param params.fallbackCount - tick count to use before the chart is measured
+ */
+export function useTimeAxisTicks<TDatum>({
+  data,
+  getTimestamp,
+  width,
+  minSpacing,
+  fallbackCount,
+}: {
+  data: readonly TDatum[];
+  getTimestamp: (datum: TDatum) => number;
+  width: number | null | undefined;
+  minSpacing: number;
+  fallbackCount?: number;
+}) {
+  return useMemo(
+    () =>
+      getTimeAxisTicks({
+        timestamps: data.map(getTimestamp),
+        width,
+        minSpacing,
+        fallbackCount,
+      }),
+    [data, fallbackCount, getTimestamp, minSpacing, width]
+  );
+}

--- a/app/src/components/core/toggleButtonGroup/ToggleButtonGroup.tsx
+++ b/app/src/components/core/toggleButtonGroup/ToggleButtonGroup.tsx
@@ -19,16 +19,6 @@ const baseToggleButtonGroupCSS = css(`
   width: fit-content;
   & > button {
     border-radius: 0;
-    z-index: 1;
-
-    &[data-disabled] {
-      z-index: 0;
-    }
-
-    &[data-selected],
-    &[data-focus-visible] {
-      z-index: 2;
-    }
   }
 
   & > .toggle-button:not(:first-of-type):not([data-selected="true"]) {

--- a/app/src/contexts/FeatureFlagsContext.tsx
+++ b/app/src/contexts/FeatureFlagsContext.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
 
-type FeatureFlag = "agents" | "tracing_ux";
+type FeatureFlag = "agents";
 export type FeatureFlagsContextType = {
   featureFlags: Record<FeatureFlag, boolean>;
   setFeatureFlags: (featureFlags: Record<FeatureFlag, boolean>) => void;
@@ -22,7 +22,6 @@ export const LOCAL_STORAGE_FEATURE_FLAGS_KEY = "arize-phoenix-feature-flags";
 const DEFAULT_FEATURE_FLAGS: Record<FeatureFlag, boolean> = {
   // TODO: when this flag is removed, update agentStore.ts by resetting / removing the persistence migration
   agents: false,
-  tracing_ux: false,
 };
 
 function getFeatureFlags(): Record<FeatureFlag, boolean> {

--- a/app/src/pages/project/ProjectTraceCountSparkline.tsx
+++ b/app/src/pages/project/ProjectTraceCountSparkline.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { useParams } from "react-router";
 import type { TooltipContentProps } from "recharts";
@@ -20,14 +20,17 @@ import {
   SparklineSkeleton,
   TimeRangeChartBrush,
   defaultCartesianGridProps,
+  defaultChartTooltipWrapperStyle,
   defaultTimeXAxisProps,
-  defaultYAxisProps,
+  useTimeAxisTicks,
   useBinTimeTickFormatter,
   useSemanticChartColors,
   useSequentialChartColors,
 } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/components/datetime";
+import { ONE_MONTH_MS } from "@phoenix/constants/timeConstants";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
+import { useDimensions } from "@phoenix/hooks/useDimensions";
 import { useTimeBinScale } from "@phoenix/hooks/useTimeBin";
 import { useTimeFormatters } from "@phoenix/hooks/useTimeFormatters";
 import { useUTCOffsetMinutes } from "@phoenix/hooks/useUTCOffsetMinutes";
@@ -39,6 +42,38 @@ const SPARKLINE_AXIS_STYLE = {
   fill: "var(--chart-axis-text-color)",
   fontSize: 10,
 };
+const SPARKLINE_X_TICK_MIN_SPACING = 96;
+const SPARKLINE_DEFAULT_X_TICK_COUNT = 8;
+const SPARKLINE_X_AXIS_EDGE_PADDING = 28;
+
+type StartBoundedTimeRange = OpenTimeRange & { start: Date };
+type TraceCountSparklineDatum = {
+  timestamp: number;
+  ok: number;
+  error: number;
+};
+
+function getTraceCountSparklineDatumTimestamp({
+  timestamp,
+}: TraceCountSparklineDatum) {
+  return timestamp;
+}
+
+function getStartBoundedTimeRange(
+  timeRange: OpenTimeRange
+): StartBoundedTimeRange {
+  if (timeRange.start) {
+    return {
+      start: timeRange.start,
+      end: timeRange.end,
+    };
+  }
+  const anchorTime = timeRange.end ?? new Date();
+  return {
+    start: new Date(anchorTime.getTime() - ONE_MONTH_MS),
+    end: timeRange.end,
+  };
+}
 
 function getTooltipLabelDate(label: unknown) {
   if (label instanceof Date) {
@@ -87,9 +122,15 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
 export function ProjectTraceCountSparkline() {
   const { projectId } = useParams();
   const { timeRange, setCustomTimeRange } = useTimeRange();
+  const startBoundedTimeRange = useMemo(
+    () => getStartBoundedTimeRange(timeRange),
+    [timeRange]
+  );
   const { fetchKey } = useStreamState();
-  const scale = useTimeBinScale({ timeRange });
+  const scale = useTimeBinScale({ timeRange: startBoundedTimeRange });
   const utcOffsetMinutes = useUTCOffsetMinutes();
+  const sparklineRef = useRef<HTMLDivElement>(null);
+  const sparklineDimensions = useDimensions(sparklineRef);
 
   const data = useLazyLoadQuery<ProjectTraceCountSparklineQuery>(
     graphql`
@@ -117,8 +158,8 @@ export function ProjectTraceCountSparkline() {
     {
       projectId: projectId as string,
       timeRange: {
-        start: timeRange.start?.toISOString(),
-        end: timeRange.end?.toISOString(),
+        start: startBoundedTimeRange.start.toISOString(),
+        end: startBoundedTimeRange.end?.toISOString(),
       },
       timeBinConfig: {
         scale,
@@ -128,7 +169,7 @@ export function ProjectTraceCountSparkline() {
     { fetchKey, fetchPolicy: "store-and-network" }
   );
 
-  const chartData = useMemo(
+  const chartData = useMemo<TraceCountSparklineDatum[]>(
     () =>
       (data.project.traceCountByStatusTimeSeries?.data ?? []).map((datum) => ({
         timestamp: new Date(datum.timestamp).getTime(),
@@ -139,11 +180,18 @@ export function ProjectTraceCountSparkline() {
   );
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
+  const xAxisTicks = useTimeAxisTicks({
+    data: chartData,
+    getTimestamp: getTraceCountSparklineDatumTimestamp,
+    width: sparklineDimensions?.width,
+    minSpacing: SPARKLINE_X_TICK_MIN_SPACING,
+    fallbackCount: SPARKLINE_DEFAULT_X_TICK_COUNT,
+  });
   const colors = useSequentialChartColors();
   const semanticColors = useSemanticChartColors();
 
   return (
-    <div css={sparklineCSS}>
+    <div ref={sparklineRef} css={sparklineCSS}>
       <TimeRangeChartBrush onTimeRangeSelected={setCustomTimeRange}>
         {({ chartProps }) => (
           <ResponsiveContainer width="100%" height="100%">
@@ -157,29 +205,28 @@ export function ProjectTraceCountSparkline() {
               <XAxis
                 {...defaultTimeXAxisProps}
                 domain={[
-                  timeRange.start?.getTime() ?? "dataMin",
-                  timeRange.end?.getTime() ?? "dataMax",
+                  startBoundedTimeRange.start.getTime(),
+                  startBoundedTimeRange.end?.getTime() ?? "dataMax",
                 ]}
                 tickFormatter={(x) => timeTickFormatter(new Date(x))}
                 tickSize={3}
                 tickMargin={2}
+                ticks={xAxisTicks}
+                interval={0}
+                padding={{
+                  left: SPARKLINE_X_AXIS_EDGE_PADDING,
+                  right: SPARKLINE_X_AXIS_EDGE_PADDING,
+                }}
                 height={16}
                 style={SPARKLINE_AXIS_STYLE}
               />
-              <YAxis
-                {...defaultYAxisProps}
-                tickFormatter={(x) => intFormatter(x)}
-                axisLine={false}
-                tickSize={3}
-                width={24}
-                tickCount={3}
-                style={SPARKLINE_AXIS_STYLE}
-              />
+              <YAxis hide />
               <Tooltip
                 content={TooltipContent}
                 cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-                allowEscapeViewBox={{ x: true, y: true }}
-                wrapperStyle={{ zIndex: 100 }}
+                allowEscapeViewBox={{ x: false, y: false }}
+                reverseDirection={{ y: true }}
+                wrapperStyle={defaultChartTooltipWrapperStyle}
               />
               <Bar dataKey="error" stackId="a" fill={semanticColors.danger} />
               <Bar

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -61,7 +61,6 @@ import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon
 import { SpanTokenCosts } from "@phoenix/components/trace/SpanTokenCosts";
 import { SpanTokenCount } from "@phoenix/components/trace/SpanTokenCount";
 import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
-import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
@@ -212,7 +211,6 @@ export function SpansTable(props: SpansTableProps) {
   const [filterCondition, setFilterCondition] = useState<string>("");
   const { rootSpansOnly, setRootSpansOnly } = useSpanFilters();
   const projectId = useTracingContext((state) => state.projectId);
-  const isTracingUxEnabled = useFeatureFlag("tracing_ux");
 
   // Advertise the current rootSpansOnly state so the agent's context message
   // reflects whether the toggle is mounted on this tab.
@@ -870,20 +868,20 @@ export function SpansTable(props: SpansTableProps) {
     <Group orientation="horizontal" id="spans-table-layout">
       <Panel>
         <div css={spansTableCSS}>
-          {isTracingUxEnabled ? (
-            <View
-              paddingStart="size-200"
-              paddingEnd="size-200"
-              paddingTop="size-200"
-              paddingBottom="size-50"
-              flex="none"
-              overflow="visible"
-            >
-              <Suspense fallback={<ProjectTraceCountSparklineSkeleton />}>
-                <ProjectTraceCountSparkline />
-              </Suspense>
-            </View>
-          ) : null}
+          <View
+            paddingStart="size-200"
+            paddingEnd="size-200"
+            paddingTop="size-200"
+            paddingBottom="size-50"
+            flex="none"
+            overflow="visible"
+            position="relative"
+            zIndex={2}
+          >
+            <Suspense fallback={<ProjectTraceCountSparklineSkeleton />}>
+              <ProjectTraceCountSparkline />
+            </Suspense>
+          </View>
           <View
             paddingTop="size-100"
             paddingBottom="size-100"


### PR DESCRIPTION
## Summary

- remove the `tracing_ux` feature flag and render the trace count sparkline on the spans table by default
- tighten the sparkline presentation with responsive x-axis tick selection, hidden y-axis, tooltip layering, and chart/legend polish
- add reusable time tick utilities with frontend test coverage
- synthesize a one-month start for open-start custom time ranges before querying `traceCountByStatusTimeSeries`

## Why

The trace UX is ready to be lifted out from behind the experimental flag. Rendering the sparkline unconditionally exposed a resolver constraint: `traceCountByStatusTimeSeries` rejects time ranges without a start. The sparkline now bounds only the missing start so supported open-start custom ranges do not break the spans page, while existing open-end ranges keep their live behavior.

## Validation

- `make format-frontend`
- `make lint-frontend`
- `make typecheck-frontend`
- `make test-frontend`
