### PR TITLE
feat: Add no-data chart overlays

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1389,9 +1389,15 @@ const chartCSS = css`
     --chart-axis-label-color: var(--global-text-color-700);
     --chart-legend-text-color: var(--global-text-color-900);
     --chart-time-range-brush-fill-color: var(--global-color-primary-100);
+    --chart-empty-state-overlay-background-color: rgba(
+      var(--global-color-gray-75-rgb),
+      0.84
+    );
+    --chart-empty-state-text-color: var(--global-text-color-500);
   }
   .theme--dark {
     --chart-tooltip-cursor-fill-color: rgba(255, 255, 255, 0.05);
+    --chart-empty-state-text-color: var(--global-text-color-700);
   }
   .theme--light {
     --chart-tooltip-cursor-fill-color: rgba(0, 0, 0, 0.02);

--- a/app/src/components/agent/generativeUI/LineChart.tsx
+++ b/app/src/components/agent/generativeUI/LineChart.tsx
@@ -10,6 +10,7 @@ import {
 } from "recharts";
 
 import {
+  ChartEmptyStateOverlay,
   GRAYSCALE_CATEGORICAL_COLORS,
   useGrayscaleCategoricalColors,
 } from "@phoenix/components/chart";
@@ -107,66 +108,61 @@ export function LineChart({
 
   const hasLegend = lines.some((line) => line.label);
   const hasXAxis = xLabels != null && xLabels.length > 0;
-
-  if (data.length === 0) {
-    return (
-      <ChartFrame title={title}>
-        <NoData />
-      </ChartFrame>
-    );
-  }
+  const hasData = data.length > 0;
 
   return (
     <ChartFrame title={title}>
-      <ResponsiveContainer
-        width="100%"
-        height={hasXAxis ? CHART_HEIGHT_WITH_XAXIS : CHART_HEIGHT}
-      >
-        <RechartsLineChart
-          data={data}
-          margin={hasXAxis ? CHART_MARGINS_WITH_XAXIS : CHART_MARGINS}
+      <ChartEmptyStateOverlay isEmpty={!hasData}>
+        <ResponsiveContainer
+          width="100%"
+          height={hasXAxis ? CHART_HEIGHT_WITH_XAXIS : CHART_HEIGHT}
         >
-          <CartesianGrid
-            horizontal
-            vertical={false}
-            stroke="var(--global-color-gray-200)"
-          />
-          <YAxis
-            width={24}
-            axisLine={false}
-            tickLine={false}
-            tick={{ fontSize: 9, fill: "var(--global-text-color-700)" }}
-            tickCount={3}
-          />
-          {hasXAxis && (
-            <XAxis
-              dataKey="x"
+          <RechartsLineChart
+            data={data}
+            margin={hasXAxis ? CHART_MARGINS_WITH_XAXIS : CHART_MARGINS}
+          >
+            <CartesianGrid
+              horizontal
+              vertical={false}
+              stroke="var(--global-color-gray-200)"
+            />
+            <YAxis
+              width={24}
               axisLine={false}
               tickLine={false}
-              tick={<CustomXAxisTick />}
-              interval="preserveStartEnd"
-              minTickGap={20}
+              tick={{ fontSize: 9, fill: "var(--global-text-color-700)" }}
+              tickCount={3}
             />
-          )}
-          {seriesKeys.map((key, index) => {
-            const colorKey =
-              GRAYSCALE_CATEGORICAL_COLORS[
-                index % GRAYSCALE_CATEGORICAL_COLORS.length
-              ];
-            return (
-              <Line
-                key={key}
-                type="monotone"
-                dataKey={key}
-                stroke={colors[colorKey]}
-                strokeWidth={2}
-                dot={false}
-                activeDot={false}
+            {hasXAxis && (
+              <XAxis
+                dataKey="x"
+                axisLine={false}
+                tickLine={false}
+                tick={<CustomXAxisTick />}
+                interval="preserveStartEnd"
+                minTickGap={20}
               />
-            );
-          })}
-        </RechartsLineChart>
-      </ResponsiveContainer>
+            )}
+            {seriesKeys.map((key, index) => {
+              const colorKey =
+                GRAYSCALE_CATEGORICAL_COLORS[
+                  index % GRAYSCALE_CATEGORICAL_COLORS.length
+                ];
+              return (
+                <Line
+                  key={key}
+                  type="monotone"
+                  dataKey={key}
+                  stroke={colors[colorKey]}
+                  strokeWidth={2}
+                  dot={false}
+                  activeDot={false}
+                />
+              );
+            })}
+          </RechartsLineChart>
+        </ResponsiveContainer>
+      </ChartEmptyStateOverlay>
       {hasLegend && (
         <div css={legendCSS}>
           {lines
@@ -191,8 +187,4 @@ export function LineChart({
       )}
     </ChartFrame>
   );
-}
-
-function NoData() {
-  return <span style={{ color: "var(--global-text-color-500)" }}>No data</span>;
 }

--- a/app/src/components/agent/generativeUI/VerticalBarChart.tsx
+++ b/app/src/components/agent/generativeUI/VerticalBarChart.tsx
@@ -9,7 +9,10 @@ import {
   YAxis,
 } from "recharts";
 
-import { useGrayscaleCategoricalColors } from "@phoenix/components/chart";
+import {
+  ChartEmptyStateOverlay,
+  useGrayscaleCategoricalColors,
+} from "@phoenix/components/chart";
 
 import { ChartFrame } from "./ChartFrame";
 import type { VerticalBarDatum } from "./types";
@@ -111,67 +114,62 @@ export function VerticalBarChart({
     ),
     20
   );
-
-  if (data.length === 0) {
-    return (
-      <ChartFrame title={title}>
-        <NoData />
-      </ChartFrame>
-    );
-  }
+  const hasData = data.length > 0;
 
   return (
     <ChartFrame title={title}>
-      <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
-        <RechartsBarChart data={chartData} margin={CHART_MARGINS}>
-          <CartesianGrid
-            horizontal
-            vertical={false}
-            stroke="var(--global-color-gray-200)"
-          />
-          <YAxis
-            width={yAxisWidth}
-            axisLine={false}
-            tickLine={false}
-            tick={{ fontSize: 9, fill: "var(--global-text-color-700)" }}
-            tickCount={3}
-            domain={[0, "dataMax"]}
-          />
-          <XAxis
-            dataKey="label"
-            axisLine={false}
-            tickLine={false}
-            tick={<CustomXAxisTick />}
-            interval="preserveStartEnd"
-            minTickGap={20}
-          />
-          {hasHighlight ? (
-            <>
+      <ChartEmptyStateOverlay isEmpty={!hasData}>
+        <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+          <RechartsBarChart data={chartData} margin={CHART_MARGINS}>
+            <CartesianGrid
+              horizontal
+              vertical={false}
+              stroke="var(--global-color-gray-200)"
+            />
+            <YAxis
+              width={yAxisWidth}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 9, fill: "var(--global-text-color-700)" }}
+              tickCount={3}
+              domain={[0, "dataMax"]}
+            />
+            <XAxis
+              dataKey="label"
+              axisLine={false}
+              tickLine={false}
+              tick={<CustomXAxisTick />}
+              interval="preserveStartEnd"
+              minTickGap={20}
+            />
+            {hasHighlight ? (
+              <>
+                <Bar
+                  dataKey="baseValue"
+                  stackId="verticalBarChart"
+                  fill={baseColor}
+                  maxBarSize={MAX_BAR_SIZE}
+                  radius={[2, 2, 0, 0]}
+                />
+                <Bar
+                  dataKey="highlightValue"
+                  stackId="verticalBarChart"
+                  fill={highlightColor}
+                  maxBarSize={MAX_BAR_SIZE}
+                  radius={[2, 2, 0, 0]}
+                />
+              </>
+            ) : (
               <Bar
                 dataKey="baseValue"
-                stackId="verticalBarChart"
                 fill={baseColor}
                 maxBarSize={MAX_BAR_SIZE}
                 radius={[2, 2, 0, 0]}
               />
-              <Bar
-                dataKey="highlightValue"
-                stackId="verticalBarChart"
-                fill={highlightColor}
-                maxBarSize={MAX_BAR_SIZE}
-                radius={[2, 2, 0, 0]}
-              />
-            </>
-          ) : (
-            <Bar
-              dataKey="baseValue"
-              fill={baseColor}
-              maxBarSize={MAX_BAR_SIZE}
-              radius={[2, 2, 0, 0]}
-            />
-          )}
-        </RechartsBarChart>
-      </ResponsiveContainer>
+            )}
+          </RechartsBarChart>
+        </ResponsiveContainer>
+      </ChartEmptyStateOverlay>
       {hasHighlight && baseLabel && highlightLabel && (
         <div css={legendRowCSS}>
           <div css={legendCSS}>
@@ -191,8 +189,4 @@ export function VerticalBarChart({
       )}
     </ChartFrame>
   );
-}
-
-function NoData() {
-  return <span style={{ color: "var(--global-text-color-500)" }}>No data</span>;
 }

--- a/app/src/components/chart/ChartEmptyStateOverlay.tsx
+++ b/app/src/components/chart/ChartEmptyStateOverlay.tsx
@@ -1,0 +1,103 @@
+import { css } from "@emotion/react";
+import type { ReactNode } from "react";
+
+import { Text } from "@phoenix/components";
+
+const DEFAULT_EMPTY_CHART_MESSAGE = "No data available";
+
+const chartEmptyStateOverlayCSS = css`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+
+  .chart-empty-state-overlay__chart {
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .chart-empty-state-overlay__mask {
+    position: absolute;
+    inset: 0;
+    background: var(--chart-empty-state-overlay-background-color);
+    pointer-events: none;
+    z-index: 2;
+  }
+
+  .chart-empty-state-overlay__message {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--global-dimension-static-size-200);
+    pointer-events: none;
+    text-align: center;
+    z-index: 3;
+  }
+
+  .chart-empty-state-overlay__message-content {
+    max-width: min(100%, 320px);
+    color: var(--chart-empty-state-text-color);
+  }
+`;
+
+type ChartEmptyStateOverlayProps = {
+  /**
+   * The chart to render underneath the empty-state overlay.
+   */
+  children: ReactNode;
+  /**
+   * Whether to show the empty-state overlay.
+   */
+  isEmpty: boolean;
+  /**
+   * Short empty-state copy shown in the center of the chart.
+   * @default "No data available"
+   */
+  message?: ReactNode;
+};
+
+/**
+ * Keeps chart axes, gridlines, and layout rendered while placing a lightweight
+ * empty-state overlay on top when the chart has no data to draw.
+ */
+export function ChartEmptyStateOverlay({
+  children,
+  isEmpty,
+  message = DEFAULT_EMPTY_CHART_MESSAGE,
+}: ChartEmptyStateOverlayProps) {
+  return (
+    <div
+      className="chart-empty-state-overlay"
+      css={chartEmptyStateOverlayCSS}
+      data-empty={isEmpty ? "true" : undefined}
+    >
+      <div
+        aria-hidden={isEmpty ? true : undefined}
+        className="chart-empty-state-overlay__chart"
+      >
+        {children}
+      </div>
+      {isEmpty ? (
+        <>
+          <div aria-hidden="true" className="chart-empty-state-overlay__mask" />
+          <div className="chart-empty-state-overlay__message" role="status">
+            <div className="chart-empty-state-overlay__message-content">
+              {typeof message === "string" ? (
+                <Text color="inherit" size="M" weight="heavy">
+                  {message}
+                </Text>
+              ) : (
+                message
+              )}
+            </div>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/app/src/components/chart/index.tsx
+++ b/app/src/components/chart/index.tsx
@@ -1,3 +1,4 @@
+export * from "./ChartEmptyStateOverlay";
 export * from "./ChartTooltip";
 export * from "./InteractiveLegend";
 export * from "./SparklineSkeleton";

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -67,7 +67,12 @@ const sideNavCSS = css`
 `;
 
 const navLinkCSS = css`
+  --nav-link-icon-size: calc(
+    var(--nav-collapsed-width) - var(--global-dimension-static-size-200)
+  );
+
   width: 100%;
+  min-height: var(--nav-link-icon-size);
   color: var(--global-color-gray-500);
   background-color: transparent;
   border-radius: var(--global-rounding-small);
@@ -90,8 +95,14 @@ const navLinkCSS = css`
     background-color: var(--global-color-gray-200);
   }
   & > .icon-wrap {
+    box-sizing: border-box;
+    width: var(--nav-link-icon-size);
+    height: var(--nav-link-icon-size);
+    flex: 0 0 var(--nav-link-icon-size);
     padding: var(--global-dimension-size-100);
-    display: inline-block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
   .text {
     padding-inline-start: var(--global-dimension-size-50);

--- a/app/src/pages/experiments/ExperimentsLineChart.tsx
+++ b/app/src/pages/experiments/ExperimentsLineChart.tsx
@@ -19,6 +19,7 @@ import {
 
 import { Flex, Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -194,89 +195,96 @@ export function ExperimentsLineChart({ datasetId }: { datasetId: string }) {
     // If the min score is 0 and the max score is 1, return [0, 1] for consistency
     return minScore >= 0 && maxScore <= 1 ? [0, 1] : undefined;
   }, [chartData, hiddenDataKeys, scoreKeys]);
+  const hasData = chartData.some((dataPoint) => {
+    return Object.entries(dataPoint).some(
+      ([key, value]) => key !== "iteration" && typeof value === "number"
+    );
+  });
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
-      <ComposedChart
-        data={chartData}
-        margin={chartMargins}
-        syncId="dimensionDetails"
-      >
-        <defs>
-          <linearGradient id="latencyBarColor" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="5%" stopColor={gray300} stopOpacity={0.3} />
-            <stop offset="95%" stopColor={gray300} stopOpacity={0} />
-          </linearGradient>
-        </defs>
-        <CartesianGrid
-          strokeDasharray="4 4"
-          stroke="var(--global-color-gray-500)"
-          strokeOpacity={0.5}
-        />
-        <XAxis
-          dataKey="iteration"
-          tick={{ fontSize: 12, fill: "var(--global-text-color-700)" }}
-        />
-        <YAxis
-          stroke="var(--global-color-gray-500)"
-          label={{
-            value: "Score",
-            angle: -90,
-            position: "insideLeft",
-            style: {
-              textAnchor: "middle",
-              fill: "var(--global-text-color-900)",
-            },
-          }}
-          style={{ fill: "var(--global-text-color-700)" }}
-          domain={yDomain}
-        />
-        <YAxis
-          yAxisId="right"
-          orientation="right"
-          stroke="var(--global-color-gray-500)"
-          label={{
-            value: "avg latency",
-            angle: 90,
-            position: "insideRight",
-            style: {
-              textAnchor: "middle",
-              fill: "var(--global-text-color-900)",
-            },
-          }}
-          style={{ fill: "var(--global-text-color-700)" }}
-          tickFormatter={latencyFormatter}
-        />
-
-        <Bar
-          yAxisId="right"
-          dataKey="avgLatency"
-          fill="url(#latencyBarColor)"
-          hide={isDataKeyHidden("avgLatency")}
-          name="avg latency"
-          spacing={3}
-        />
-        {scoreKeys.map((key) => (
-          <Line
-            key={key}
-            type="monotone"
-            dataKey={key}
-            stroke={lineColors[key]}
-            strokeWidth={2}
-            dot={{ r: 3 }}
-            activeDot={{ r: 5 }}
-            hide={isDataKeyHidden(key)}
-            yAxisId={0}
+    <ChartEmptyStateOverlay isEmpty={!hasData}>
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart
+          data={chartData}
+          margin={chartMargins}
+          syncId="dimensionDetails"
+        >
+          <defs>
+            <linearGradient id="latencyBarColor" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor={gray300} stopOpacity={0.3} />
+              <stop offset="95%" stopColor={gray300} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid
+            strokeDasharray="4 4"
+            stroke="var(--global-color-gray-500)"
+            strokeOpacity={0.5}
           />
-        ))}
-        <InteractiveLegend
-          {...defaultLegendProps}
-          hiddenDataKeys={hiddenDataKeys}
-          iconSize={8}
-          onToggleDataKey={toggleDataKey}
-        />
-        <Tooltip content={TooltipContent} />
-      </ComposedChart>
-    </ResponsiveContainer>
+          <XAxis
+            dataKey="iteration"
+            tick={{ fontSize: 12, fill: "var(--global-text-color-700)" }}
+          />
+          <YAxis
+            stroke="var(--global-color-gray-500)"
+            label={{
+              value: "Score",
+              angle: -90,
+              position: "insideLeft",
+              style: {
+                textAnchor: "middle",
+                fill: "var(--global-text-color-900)",
+              },
+            }}
+            style={{ fill: "var(--global-text-color-700)" }}
+            domain={yDomain}
+          />
+          <YAxis
+            yAxisId="right"
+            orientation="right"
+            stroke="var(--global-color-gray-500)"
+            label={{
+              value: "avg latency",
+              angle: 90,
+              position: "insideRight",
+              style: {
+                textAnchor: "middle",
+                fill: "var(--global-text-color-900)",
+              },
+            }}
+            style={{ fill: "var(--global-text-color-700)" }}
+            tickFormatter={latencyFormatter}
+          />
+
+          <Bar
+            yAxisId="right"
+            dataKey="avgLatency"
+            fill="url(#latencyBarColor)"
+            hide={isDataKeyHidden("avgLatency")}
+            name="avg latency"
+            spacing={3}
+          />
+          {scoreKeys.map((key) => (
+            <Line
+              key={key}
+              type="monotone"
+              dataKey={key}
+              stroke={lineColors[key]}
+              strokeWidth={2}
+              dot={{ r: 3 }}
+              activeDot={{ r: 5 }}
+              hide={isDataKeyHidden(key)}
+              yAxisId={0}
+            />
+          ))}
+          <InteractiveLegend
+            {...defaultLegendProps}
+            hiddenDataKeys={hiddenDataKeys}
+            iconSize={8}
+            onToggleDataKey={toggleDataKey}
+          />
+          <Tooltip content={TooltipContent} />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </ChartEmptyStateOverlay>
   );
 }

--- a/app/src/pages/project/ProjectTraceCountSparkline.tsx
+++ b/app/src/pages/project/ProjectTraceCountSparkline.tsx
@@ -15,6 +15,7 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   SparklineSkeleton,
@@ -51,6 +52,7 @@ type TraceCountSparklineDatum = {
   timestamp: number;
   ok: number;
   error: number;
+  total: number;
 };
 
 function getTraceCountSparklineDatumTimestamp({
@@ -175,9 +177,11 @@ export function ProjectTraceCountSparkline() {
         timestamp: new Date(datum.timestamp).getTime(),
         ok: datum.okCount,
         error: datum.errorCount,
+        total: datum.okCount + datum.errorCount,
       })),
     [data.project.traceCountByStatusTimeSeries?.data]
   );
+  const hasData = chartData.some((datum) => datum.total > 0);
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
   const xAxisTicks = useTimeAxisTicks({
@@ -194,49 +198,57 @@ export function ProjectTraceCountSparkline() {
     <div ref={sparklineRef} css={sparklineCSS}>
       <TimeRangeChartBrush onTimeRangeSelected={setCustomTimeRange}>
         {({ chartProps }) => (
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={chartData}
-              margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
-              barSize={10}
-              {...chartProps}
-            >
-              <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
-              <XAxis
-                {...defaultTimeXAxisProps}
-                domain={[
-                  startBoundedTimeRange.start.getTime(),
-                  startBoundedTimeRange.end?.getTime() ?? "dataMax",
-                ]}
-                tickFormatter={(x) => timeTickFormatter(new Date(x))}
-                tickSize={3}
-                tickMargin={2}
-                ticks={xAxisTicks}
-                interval={0}
-                padding={{
-                  left: SPARKLINE_X_AXIS_EDGE_PADDING,
-                  right: SPARKLINE_X_AXIS_EDGE_PADDING,
-                }}
-                height={16}
-                style={SPARKLINE_AXIS_STYLE}
-              />
-              <YAxis hide />
-              <Tooltip
-                content={TooltipContent}
-                cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-                allowEscapeViewBox={{ x: false, y: false }}
-                reverseDirection={{ y: true }}
-                wrapperStyle={defaultChartTooltipWrapperStyle}
-              />
-              <Bar dataKey="error" stackId="a" fill={semanticColors.danger} />
-              <Bar
-                dataKey="ok"
-                stackId="a"
-                fill={colors.gray300}
-                radius={[2, 2, 0, 0]}
-              />
-            </BarChart>
-          </ResponsiveContainer>
+          <ChartEmptyStateOverlay
+            isEmpty={!hasData}
+            message="No data in this time range"
+          >
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={chartData}
+                margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
+                barSize={10}
+                {...chartProps}
+              >
+                <CartesianGrid
+                  {...defaultCartesianGridProps}
+                  vertical={false}
+                />
+                <XAxis
+                  {...defaultTimeXAxisProps}
+                  domain={[
+                    startBoundedTimeRange.start.getTime(),
+                    startBoundedTimeRange.end?.getTime() ?? "dataMax",
+                  ]}
+                  tickFormatter={(x) => timeTickFormatter(new Date(x))}
+                  tickSize={3}
+                  tickMargin={2}
+                  ticks={xAxisTicks}
+                  interval={0}
+                  padding={{
+                    left: SPARKLINE_X_AXIS_EDGE_PADDING,
+                    right: SPARKLINE_X_AXIS_EDGE_PADDING,
+                  }}
+                  height={16}
+                  style={SPARKLINE_AXIS_STYLE}
+                />
+                <YAxis hide />
+                <Tooltip
+                  content={TooltipContent}
+                  cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+                  allowEscapeViewBox={{ x: false, y: false }}
+                  reverseDirection={{ y: true }}
+                  wrapperStyle={defaultChartTooltipWrapperStyle}
+                />
+                <Bar dataKey="error" stackId="a" fill={semanticColors.danger} />
+                <Bar
+                  dataKey="ok"
+                  stackId="a"
+                  fill={colors.gray300}
+                  radius={[2, 2, 0, 0]}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </ChartEmptyStateOverlay>
         )}
       </TimeRangeChartBrush>
     </div>

--- a/app/src/pages/project/metrics/LLMSpanCountTimeSeries.tsx
+++ b/app/src/pages/project/metrics/LLMSpanCountTimeSeries.tsx
@@ -12,6 +12,7 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -93,6 +94,7 @@ export function LLMSpanCountTimeSeries({
                 okCount
                 errorCount
                 unsetCount
+                totalCount
               }
             }
           }
@@ -119,8 +121,10 @@ export function LLMSpanCountTimeSeries({
       error: datum.errorCount,
       unset: datum.unsetCount,
       ok: datum.okCount,
+      total: datum.totalCount ?? 0,
     })
   );
+  const hasData = chartData.some((datum) => datum.total > 0);
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
 
@@ -131,67 +135,72 @@ export function LLMSpanCountTimeSeries({
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            data={chartData}
-            margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
-            barSize={10}
-            syncId={"projectMetrics"}
-            {...chartProps}
-          >
-            <XAxis
-              {...defaultTimeXAxisProps}
-              domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
-              tickFormatter={(x) => timeTickFormatter(new Date(x))}
-            />
-            <YAxis
-              {...defaultYAxisProps}
-              width={55}
-              tickFormatter={(x) => intShortFormatter(x)}
-              label={{
-                value: "Count",
-                angle: -90,
-                dx: -28,
-                style: {
-                  textAnchor: "middle",
-                  fill: "var(--chart-axis-label-color)",
-                },
-              }}
-            />
-            <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
-            <Tooltip
-              content={TooltipContent}
-              // TODO formalize this
-              cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-            />
-            <Bar
-              dataKey="error"
-              stackId="a"
-              fill={SemanticChartColors.danger}
-              hide={isDataKeyHidden("error")}
-            />
-            <Bar
-              dataKey="unset"
-              stackId="a"
-              fill={colors.gray500}
-              hide={isDataKeyHidden("unset")}
-            />
-            <Bar
-              dataKey="ok"
-              stackId="a"
-              fill={colors.gray300}
-              hide={isDataKeyHidden("ok")}
-              radius={[2, 2, 0, 0]}
-            />
-            <InteractiveLegend
-              {...defaultLegendProps}
-              hiddenDataKeys={hiddenDataKeys}
-              iconType="circle"
-              iconSize={8}
-              onToggleDataKey={toggleDataKey}
-            />
-          </BarChart>
-        </ResponsiveContainer>
+        <ChartEmptyStateOverlay
+          isEmpty={!hasData}
+          message="No data in this time range"
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={chartData}
+              margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
+              barSize={10}
+              syncId={"projectMetrics"}
+              {...chartProps}
+            >
+              <XAxis
+                {...defaultTimeXAxisProps}
+                domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
+                tickFormatter={(x) => timeTickFormatter(new Date(x))}
+              />
+              <YAxis
+                {...defaultYAxisProps}
+                width={55}
+                tickFormatter={(x) => intShortFormatter(x)}
+                label={{
+                  value: "Count",
+                  angle: -90,
+                  dx: -28,
+                  style: {
+                    textAnchor: "middle",
+                    fill: "var(--chart-axis-label-color)",
+                  },
+                }}
+              />
+              <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+              <Tooltip
+                content={TooltipContent}
+                // TODO formalize this
+                cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+              />
+              <Bar
+                dataKey="error"
+                stackId="a"
+                fill={SemanticChartColors.danger}
+                hide={isDataKeyHidden("error")}
+              />
+              <Bar
+                dataKey="unset"
+                stackId="a"
+                fill={colors.gray500}
+                hide={isDataKeyHidden("unset")}
+              />
+              <Bar
+                dataKey="ok"
+                stackId="a"
+                fill={colors.gray300}
+                hide={isDataKeyHidden("ok")}
+                radius={[2, 2, 0, 0]}
+              />
+              <InteractiveLegend
+                {...defaultLegendProps}
+                hiddenDataKeys={hiddenDataKeys}
+                iconType="circle"
+                iconSize={8}
+                onToggleDataKey={toggleDataKey}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>
   );

--- a/app/src/pages/project/metrics/LLMSpanErrorsTimeSeries.tsx
+++ b/app/src/pages/project/metrics/LLMSpanErrorsTimeSeries.tsx
@@ -12,6 +12,7 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -87,6 +88,7 @@ export function LLMSpanErrorsTimeSeries({
               data {
                 timestamp
                 errorCount
+                totalCount
               }
             }
           }
@@ -111,8 +113,10 @@ export function LLMSpanErrorsTimeSeries({
     (datum) => ({
       timestamp: new Date(datum.timestamp).getTime(),
       error: datum.errorCount,
+      total: datum.totalCount ?? 0,
     })
   );
+  const hasData = chartData.some((datum) => datum.total > 0);
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
 
@@ -122,56 +126,61 @@ export function LLMSpanErrorsTimeSeries({
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            data={chartData}
-            margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
-            barSize={10}
-            syncId={"projectMetrics"}
-            {...chartProps}
-          >
-            <XAxis
-              {...defaultTimeXAxisProps}
-              domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
-              tickFormatter={(x) => timeTickFormatter(new Date(x))}
-            />
-            <YAxis
-              {...defaultYAxisProps}
-              width={55}
-              tickFormatter={(x) => intShortFormatter(x)}
-              label={{
-                value: "Count",
-                angle: -90,
-                dx: -28,
-                style: {
-                  textAnchor: "middle",
-                  fill: "var(--chart-axis-label-color)",
-                },
-              }}
-            />
-            <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
-            <Tooltip
-              content={TooltipContent}
-              // TODO formalize this
-              cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-            />
-            <Bar
-              dataKey="error"
-              stackId="a"
-              fill={SemanticChartColors.danger}
-              hide={isDataKeyHidden("error")}
-              radius={[2, 2, 0, 0]}
-            />
+        <ChartEmptyStateOverlay
+          isEmpty={!hasData}
+          message="No data in this time range"
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={chartData}
+              margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
+              barSize={10}
+              syncId={"projectMetrics"}
+              {...chartProps}
+            >
+              <XAxis
+                {...defaultTimeXAxisProps}
+                domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
+                tickFormatter={(x) => timeTickFormatter(new Date(x))}
+              />
+              <YAxis
+                {...defaultYAxisProps}
+                width={55}
+                tickFormatter={(x) => intShortFormatter(x)}
+                label={{
+                  value: "Count",
+                  angle: -90,
+                  dx: -28,
+                  style: {
+                    textAnchor: "middle",
+                    fill: "var(--chart-axis-label-color)",
+                  },
+                }}
+              />
+              <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+              <Tooltip
+                content={TooltipContent}
+                // TODO formalize this
+                cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+              />
+              <Bar
+                dataKey="error"
+                stackId="a"
+                fill={SemanticChartColors.danger}
+                hide={isDataKeyHidden("error")}
+                radius={[2, 2, 0, 0]}
+              />
 
-            <InteractiveLegend
-              {...defaultLegendProps}
-              hiddenDataKeys={hiddenDataKeys}
-              iconType="circle"
-              iconSize={8}
-              onToggleDataKey={toggleDataKey}
-            />
-          </BarChart>
-        </ResponsiveContainer>
+              <InteractiveLegend
+                {...defaultLegendProps}
+                hiddenDataKeys={hiddenDataKeys}
+                iconType="circle"
+                iconSize={8}
+                onToggleDataKey={toggleDataKey}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>
   );

--- a/app/src/pages/project/metrics/SpanAnnotationScoreTimeSeries.tsx
+++ b/app/src/pages/project/metrics/SpanAnnotationScoreTimeSeries.tsx
@@ -12,6 +12,7 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -150,63 +151,69 @@ export function SpanAnnotationScoreTimeSeries({
   });
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
+  const hasData = annotationNames.length > 0;
   const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
     useInteractiveLegend();
 
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart
-            data={chartData}
-            margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
-            syncId={"projectMetrics"}
-            {...chartProps}
-          >
-            <XAxis
-              {...defaultTimeXAxisProps}
-              domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
-              tickFormatter={(x) => timeTickFormatter(new Date(x))}
-            />
-            <YAxis
-              width={55}
-              tickFormatter={(x) => formatFloat(x)}
-              label={{
-                value: "Score",
-                angle: -90,
-                dx: -28,
-                style: {
-                  textAnchor: "middle",
-                  fill: "var(--chart-axis-label-color)",
-                },
-              }}
-              {...defaultYAxisProps}
-            />
-            <CartesianGrid vertical={false} {...defaultCartesianGridProps} />
-            <Tooltip
-              content={TooltipContent}
-              cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-            />
+        <ChartEmptyStateOverlay
+          isEmpty={!hasData}
+          message="No data in this time range"
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart
+              data={chartData}
+              margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
+              syncId={"projectMetrics"}
+              {...chartProps}
+            >
+              <XAxis
+                {...defaultTimeXAxisProps}
+                domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
+                tickFormatter={(x) => timeTickFormatter(new Date(x))}
+              />
+              <YAxis
+                width={55}
+                tickFormatter={(x) => formatFloat(x)}
+                label={{
+                  value: "Score",
+                  angle: -90,
+                  dx: -28,
+                  style: {
+                    textAnchor: "middle",
+                    fill: "var(--chart-axis-label-color)",
+                  },
+                }}
+                {...defaultYAxisProps}
+              />
+              <CartesianGrid vertical={false} {...defaultCartesianGridProps} />
+              <Tooltip
+                content={TooltipContent}
+                cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+              />
 
-            {annotationNames.map((name) => {
-              return (
-                <AnnotationLine
-                  isHidden={isDataKeyHidden(name)}
-                  key={name}
-                  name={name}
-                />
-              );
-            })}
+              {annotationNames.map((name) => {
+                return (
+                  <AnnotationLine
+                    isHidden={isDataKeyHidden(name)}
+                    key={name}
+                    name={name}
+                  />
+                );
+              })}
 
-            <InteractiveLegend
-              {...defaultLegendProps}
-              hiddenDataKeys={hiddenDataKeys}
-              iconType="line"
-              iconSize={8}
-              onToggleDataKey={toggleDataKey}
-            />
-          </LineChart>
-        </ResponsiveContainer>
+              <InteractiveLegend
+                {...defaultLegendProps}
+                hiddenDataKeys={hiddenDataKeys}
+                iconType="line"
+                iconSize={8}
+                onToggleDataKey={toggleDataKey}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>
   );

--- a/app/src/pages/project/metrics/ToolSpanCountTimeSeries.tsx
+++ b/app/src/pages/project/metrics/ToolSpanCountTimeSeries.tsx
@@ -12,6 +12,7 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -93,6 +94,7 @@ export function ToolSpanCountTimeSeries({
                 okCount
                 errorCount
                 unsetCount
+                totalCount
               }
             }
           }
@@ -119,8 +121,10 @@ export function ToolSpanCountTimeSeries({
       error: datum.errorCount,
       unset: datum.unsetCount,
       ok: datum.okCount,
+      total: datum.totalCount ?? 0,
     })
   );
+  const hasData = chartData.some((datum) => datum.total > 0);
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
   const colors = useSequentialChartColors();
@@ -130,67 +134,72 @@ export function ToolSpanCountTimeSeries({
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            data={chartData}
-            margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
-            barSize={10}
-            syncId={"projectMetrics"}
-            {...chartProps}
-          >
-            <XAxis
-              {...defaultTimeXAxisProps}
-              domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
-              tickFormatter={(x) => timeTickFormatter(new Date(x))}
-            />
-            <YAxis
-              {...defaultYAxisProps}
-              width={55}
-              tickFormatter={(x) => intShortFormatter(x)}
-              label={{
-                value: "Count",
-                angle: -90,
-                dx: -28,
-                style: {
-                  textAnchor: "middle",
-                  fill: "var(--chart-axis-label-color)",
-                },
-              }}
-            />
-            <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
-            <Tooltip
-              content={TooltipContent}
-              // TODO formalize this
-              cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-            />
-            <Bar
-              dataKey="error"
-              stackId="a"
-              fill={SemanticChartColors.danger}
-              hide={isDataKeyHidden("error")}
-            />
-            <Bar
-              dataKey="unset"
-              stackId="a"
-              fill={colors.gray500}
-              hide={isDataKeyHidden("unset")}
-            />
-            <Bar
-              dataKey="ok"
-              stackId="a"
-              fill={colors.gray300}
-              hide={isDataKeyHidden("ok")}
-              radius={[2, 2, 0, 0]}
-            />
-            <InteractiveLegend
-              {...defaultLegendProps}
-              hiddenDataKeys={hiddenDataKeys}
-              iconType="circle"
-              iconSize={8}
-              onToggleDataKey={toggleDataKey}
-            />
-          </BarChart>
-        </ResponsiveContainer>
+        <ChartEmptyStateOverlay
+          isEmpty={!hasData}
+          message="No data in this time range"
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={chartData}
+              margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
+              barSize={10}
+              syncId={"projectMetrics"}
+              {...chartProps}
+            >
+              <XAxis
+                {...defaultTimeXAxisProps}
+                domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
+                tickFormatter={(x) => timeTickFormatter(new Date(x))}
+              />
+              <YAxis
+                {...defaultYAxisProps}
+                width={55}
+                tickFormatter={(x) => intShortFormatter(x)}
+                label={{
+                  value: "Count",
+                  angle: -90,
+                  dx: -28,
+                  style: {
+                    textAnchor: "middle",
+                    fill: "var(--chart-axis-label-color)",
+                  },
+                }}
+              />
+              <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+              <Tooltip
+                content={TooltipContent}
+                // TODO formalize this
+                cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+              />
+              <Bar
+                dataKey="error"
+                stackId="a"
+                fill={SemanticChartColors.danger}
+                hide={isDataKeyHidden("error")}
+              />
+              <Bar
+                dataKey="unset"
+                stackId="a"
+                fill={colors.gray500}
+                hide={isDataKeyHidden("unset")}
+              />
+              <Bar
+                dataKey="ok"
+                stackId="a"
+                fill={colors.gray300}
+                hide={isDataKeyHidden("ok")}
+                radius={[2, 2, 0, 0]}
+              />
+              <InteractiveLegend
+                {...defaultLegendProps}
+                hiddenDataKeys={hiddenDataKeys}
+                iconType="circle"
+                iconSize={8}
+                onToggleDataKey={toggleDataKey}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>
   );

--- a/app/src/pages/project/metrics/ToolSpanErrorsTimeSeries.tsx
+++ b/app/src/pages/project/metrics/ToolSpanErrorsTimeSeries.tsx
@@ -12,6 +12,7 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -87,6 +88,7 @@ export function ToolSpanErrorsTimeSeries({
               data {
                 timestamp
                 errorCount
+                totalCount
               }
             }
           }
@@ -111,8 +113,10 @@ export function ToolSpanErrorsTimeSeries({
     (datum) => ({
       timestamp: new Date(datum.timestamp).getTime(),
       error: datum.errorCount,
+      total: datum.totalCount ?? 0,
     })
   );
+  const hasData = chartData.some((datum) => datum.total > 0);
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
   const SemanticChartColors = useSemanticChartColors();
@@ -121,56 +125,61 @@ export function ToolSpanErrorsTimeSeries({
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            data={chartData}
-            margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
-            barSize={10}
-            syncId={"projectMetrics"}
-            {...chartProps}
-          >
-            <XAxis
-              {...defaultTimeXAxisProps}
-              domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
-              tickFormatter={(x) => timeTickFormatter(new Date(x))}
-            />
-            <YAxis
-              {...defaultYAxisProps}
-              width={55}
-              tickFormatter={(x) => intShortFormatter(x)}
-              label={{
-                value: "Count",
-                angle: -90,
-                dx: -28,
-                style: {
-                  textAnchor: "middle",
-                  fill: "var(--chart-axis-label-color)",
-                },
-              }}
-            />
-            <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
-            <Tooltip
-              content={TooltipContent}
-              // TODO formalize this
-              cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-            />
-            <Bar
-              dataKey="error"
-              stackId="a"
-              fill={SemanticChartColors.danger}
-              hide={isDataKeyHidden("error")}
-              radius={[2, 2, 0, 0]}
-            />
+        <ChartEmptyStateOverlay
+          isEmpty={!hasData}
+          message="No data in this time range"
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={chartData}
+              margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
+              barSize={10}
+              syncId={"projectMetrics"}
+              {...chartProps}
+            >
+              <XAxis
+                {...defaultTimeXAxisProps}
+                domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
+                tickFormatter={(x) => timeTickFormatter(new Date(x))}
+              />
+              <YAxis
+                {...defaultYAxisProps}
+                width={55}
+                tickFormatter={(x) => intShortFormatter(x)}
+                label={{
+                  value: "Count",
+                  angle: -90,
+                  dx: -28,
+                  style: {
+                    textAnchor: "middle",
+                    fill: "var(--chart-axis-label-color)",
+                  },
+                }}
+              />
+              <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+              <Tooltip
+                content={TooltipContent}
+                // TODO formalize this
+                cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+              />
+              <Bar
+                dataKey="error"
+                stackId="a"
+                fill={SemanticChartColors.danger}
+                hide={isDataKeyHidden("error")}
+                radius={[2, 2, 0, 0]}
+              />
 
-            <InteractiveLegend
-              {...defaultLegendProps}
-              hiddenDataKeys={hiddenDataKeys}
-              iconType="circle"
-              iconSize={8}
-              onToggleDataKey={toggleDataKey}
-            />
-          </BarChart>
-        </ResponsiveContainer>
+              <InteractiveLegend
+                {...defaultLegendProps}
+                hiddenDataKeys={hiddenDataKeys}
+                iconType="circle"
+                iconSize={8}
+                onToggleDataKey={toggleDataKey}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>
   );

--- a/app/src/pages/project/metrics/TopModelsByCost.tsx
+++ b/app/src/pages/project/metrics/TopModelsByCost.tsx
@@ -13,6 +13,7 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -106,57 +107,63 @@ export function TopModelsByCost({
       };
     });
   }, [data]);
+  const hasData = chartData.length > 0;
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
-      <BarChart
-        data={chartData}
-        margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
-        layout="vertical"
-        barSize={10}
-      >
-        <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
-        <Tooltip
-          content={TooltipContent}
-          cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-        />
-        <XAxis
-          {...defaultXAxisProps}
-          type="number"
-          tickLine={false}
-          tickFormatter={costFormatter}
-        />
-        <YAxis
-          {...defaultYAxisProps}
-          dataKey="model"
-          type="category"
-          width={120}
-          tickFormatter={truncateModelName}
-        />
-        <Bar
-          dataKey="prompt_cost"
-          fill={colors.category1}
-          hide={isDataKeyHidden("prompt_cost")}
-          name="Prompt cost"
-          stackId="a"
-          radius={[2, 0, 0, 2]}
-        />
-        <Bar
-          dataKey="completion_cost"
-          fill={colors.category2}
-          hide={isDataKeyHidden("completion_cost")}
-          name="Completion cost"
-          stackId="a"
-          radius={[0, 2, 2, 0]}
-        />
-        <InteractiveLegend
-          {...defaultLegendProps}
-          hiddenDataKeys={hiddenDataKeys}
-          iconType="circle"
-          iconSize={8}
-          onToggleDataKey={toggleDataKey}
-        />
-      </BarChart>
-    </ResponsiveContainer>
+    <ChartEmptyStateOverlay
+      isEmpty={!hasData}
+      message="No data in this time range"
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          data={chartData}
+          margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
+          layout="vertical"
+          barSize={10}
+        >
+          <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+          <Tooltip
+            content={TooltipContent}
+            cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+          />
+          <XAxis
+            {...defaultXAxisProps}
+            type="number"
+            tickLine={false}
+            tickFormatter={costFormatter}
+          />
+          <YAxis
+            {...defaultYAxisProps}
+            dataKey="model"
+            type="category"
+            width={120}
+            tickFormatter={truncateModelName}
+          />
+          <Bar
+            dataKey="prompt_cost"
+            fill={colors.category1}
+            hide={isDataKeyHidden("prompt_cost")}
+            name="Prompt cost"
+            stackId="a"
+            radius={[2, 0, 0, 2]}
+          />
+          <Bar
+            dataKey="completion_cost"
+            fill={colors.category2}
+            hide={isDataKeyHidden("completion_cost")}
+            name="Completion cost"
+            stackId="a"
+            radius={[0, 2, 2, 0]}
+          />
+          <InteractiveLegend
+            {...defaultLegendProps}
+            hiddenDataKeys={hiddenDataKeys}
+            iconType="circle"
+            iconSize={8}
+            onToggleDataKey={toggleDataKey}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </ChartEmptyStateOverlay>
   );
 }

--- a/app/src/pages/project/metrics/TopModelsByToken.tsx
+++ b/app/src/pages/project/metrics/TopModelsByToken.tsx
@@ -13,6 +13,7 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -108,58 +109,64 @@ export function TopModelsByToken({
       };
     });
   }, [data]);
+  const hasData = chartData.length > 0;
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
-      <BarChart
-        data={chartData}
-        margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
-        layout="vertical"
-        barSize={10}
-      >
-        <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
-        <Tooltip
-          content={TooltipContent}
-          // TODO formalize this
-          cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-        />
-        <XAxis
-          {...defaultXAxisProps}
-          type="number"
-          tickLine={false}
-          tickFormatter={intFormatter}
-        />
-        <YAxis
-          {...defaultYAxisProps}
-          dataKey="model"
-          type="category"
-          width={120}
-          tickFormatter={truncateModelName}
-        />
-        <Bar
-          dataKey="prompt_tokens"
-          stackId="a"
-          fill={colors.category1}
-          hide={isDataKeyHidden("prompt_tokens")}
-          name="Prompt tokens"
-          radius={[2, 0, 0, 2]}
-        />
-        <Bar
-          dataKey="completion_tokens"
-          stackId="a"
-          fill={colors.category2}
-          hide={isDataKeyHidden("completion_tokens")}
-          name="Completion tokens"
-          radius={[0, 2, 2, 0]}
-        />
-        <InteractiveLegend
-          {...defaultLegendProps}
-          hiddenDataKeys={hiddenDataKeys}
-          iconType="circle"
-          iconSize={8}
-          onToggleDataKey={toggleDataKey}
-        />
-      </BarChart>
-    </ResponsiveContainer>
+    <ChartEmptyStateOverlay
+      isEmpty={!hasData}
+      message="No data in this time range"
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          data={chartData}
+          margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
+          layout="vertical"
+          barSize={10}
+        >
+          <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+          <Tooltip
+            content={TooltipContent}
+            // TODO formalize this
+            cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+          />
+          <XAxis
+            {...defaultXAxisProps}
+            type="number"
+            tickLine={false}
+            tickFormatter={intFormatter}
+          />
+          <YAxis
+            {...defaultYAxisProps}
+            dataKey="model"
+            type="category"
+            width={120}
+            tickFormatter={truncateModelName}
+          />
+          <Bar
+            dataKey="prompt_tokens"
+            stackId="a"
+            fill={colors.category1}
+            hide={isDataKeyHidden("prompt_tokens")}
+            name="Prompt tokens"
+            radius={[2, 0, 0, 2]}
+          />
+          <Bar
+            dataKey="completion_tokens"
+            stackId="a"
+            fill={colors.category2}
+            hide={isDataKeyHidden("completion_tokens")}
+            name="Completion tokens"
+            radius={[0, 2, 2, 0]}
+          />
+          <InteractiveLegend
+            {...defaultLegendProps}
+            hiddenDataKeys={hiddenDataKeys}
+            iconType="circle"
+            iconSize={8}
+            onToggleDataKey={toggleDataKey}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </ChartEmptyStateOverlay>
   );
 }

--- a/app/src/pages/project/metrics/TraceCountTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceCountTimeSeries.tsx
@@ -13,6 +13,7 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -88,6 +89,7 @@ export function TraceCountTimeSeries({
                 timestamp
                 okCount
                 errorCount
+                totalCount
               }
             }
           }
@@ -113,9 +115,11 @@ export function TraceCountTimeSeries({
         timestamp: new Date(datum.timestamp).getTime(),
         ok: datum.okCount,
         error: datum.errorCount,
+        total: datum.totalCount,
       })),
     [data.project.traceCountByStatusTimeSeries?.data]
   );
+  const hasData = chartData.some((datum) => datum.total > 0);
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
 
@@ -126,62 +130,67 @@ export function TraceCountTimeSeries({
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            data={chartData}
-            margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
-            barSize={10}
-            syncId={"projectMetrics"}
-            {...chartProps}
-          >
-            <XAxis
-              {...defaultTimeXAxisProps}
-              domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
-              tickFormatter={(x) => timeTickFormatter(new Date(x))}
-            />
-            <YAxis
-              {...defaultYAxisProps}
-              width={55}
-              tickFormatter={(x) => intFormatter(x)}
-              label={{
-                value: "Count",
-                angle: -90,
-                dx: -28,
-                style: {
-                  textAnchor: "middle",
-                  fill: "var(--chart-axis-label-color)",
-                },
-              }}
-            />
-            <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
-            <Tooltip
-              content={TooltipContent}
-              // TODO formalize this
-              cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-            />
-            <Bar
-              dataKey="error"
-              stackId="a"
-              fill={SemanticChartColors.danger}
-              hide={isDataKeyHidden("error")}
-            />
-            <Bar
-              dataKey="ok"
-              stackId="a"
-              fill={colors.gray300}
-              hide={isDataKeyHidden("ok")}
-              radius={[2, 2, 0, 0]}
-            />
+        <ChartEmptyStateOverlay
+          isEmpty={!hasData}
+          message="No data in this time range"
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={chartData}
+              margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
+              barSize={10}
+              syncId={"projectMetrics"}
+              {...chartProps}
+            >
+              <XAxis
+                {...defaultTimeXAxisProps}
+                domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
+                tickFormatter={(x) => timeTickFormatter(new Date(x))}
+              />
+              <YAxis
+                {...defaultYAxisProps}
+                width={55}
+                tickFormatter={(x) => intFormatter(x)}
+                label={{
+                  value: "Count",
+                  angle: -90,
+                  dx: -28,
+                  style: {
+                    textAnchor: "middle",
+                    fill: "var(--chart-axis-label-color)",
+                  },
+                }}
+              />
+              <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+              <Tooltip
+                content={TooltipContent}
+                // TODO formalize this
+                cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+              />
+              <Bar
+                dataKey="error"
+                stackId="a"
+                fill={SemanticChartColors.danger}
+                hide={isDataKeyHidden("error")}
+              />
+              <Bar
+                dataKey="ok"
+                stackId="a"
+                fill={colors.gray300}
+                hide={isDataKeyHidden("ok")}
+                radius={[2, 2, 0, 0]}
+              />
 
-            <InteractiveLegend
-              iconType="circle"
-              iconSize={8}
-              {...defaultLegendProps}
-              hiddenDataKeys={hiddenDataKeys}
-              onToggleDataKey={toggleDataKey}
-            />
-          </BarChart>
-        </ResponsiveContainer>
+              <InteractiveLegend
+                iconType="circle"
+                iconSize={8}
+                {...defaultLegendProps}
+                hiddenDataKeys={hiddenDataKeys}
+                onToggleDataKey={toggleDataKey}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>
   );

--- a/app/src/pages/project/metrics/TraceErrorsTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceErrorsTimeSeries.tsx
@@ -12,6 +12,7 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -89,6 +90,7 @@ export function TraceErrorsTimeSeries({
               data {
                 timestamp
                 errorCount
+                totalCount
               }
             }
           }
@@ -112,8 +114,10 @@ export function TraceErrorsTimeSeries({
     (datum) => ({
       timestamp: new Date(datum.timestamp).getTime(),
       error: datum.errorCount,
+      total: datum.totalCount,
     })
   );
+  const hasData = chartData.some((datum) => datum.total > 0);
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
 
@@ -123,56 +127,61 @@ export function TraceErrorsTimeSeries({
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            data={chartData}
-            margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
-            barSize={10}
-            syncId={"projectMetrics"}
-            {...chartProps}
-          >
-            <XAxis
-              {...defaultTimeXAxisProps}
-              domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
-              tickFormatter={(x) => timeTickFormatter(new Date(x))}
-            />
-            <YAxis
-              {...defaultYAxisProps}
-              width={55}
-              tickFormatter={(x) => intFormatter(x)}
-              label={{
-                value: "Count",
-                angle: -90,
-                dx: -28,
-                style: {
-                  textAnchor: "middle",
-                  fill: "var(--chart-axis-label-color)",
-                },
-              }}
-            />
-            <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
-            <Tooltip
-              content={TooltipContent}
-              // TODO formalize this
-              cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-            />
-            <Bar
-              dataKey="error"
-              stackId="a"
-              fill={SemanticChartColors.danger}
-              hide={isDataKeyHidden("error")}
-              radius={[2, 2, 0, 0]}
-            />
+        <ChartEmptyStateOverlay
+          isEmpty={!hasData}
+          message="No data in this time range"
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={chartData}
+              margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
+              barSize={10}
+              syncId={"projectMetrics"}
+              {...chartProps}
+            >
+              <XAxis
+                {...defaultTimeXAxisProps}
+                domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
+                tickFormatter={(x) => timeTickFormatter(new Date(x))}
+              />
+              <YAxis
+                {...defaultYAxisProps}
+                width={55}
+                tickFormatter={(x) => intFormatter(x)}
+                label={{
+                  value: "Count",
+                  angle: -90,
+                  dx: -28,
+                  style: {
+                    textAnchor: "middle",
+                    fill: "var(--chart-axis-label-color)",
+                  },
+                }}
+              />
+              <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+              <Tooltip
+                content={TooltipContent}
+                // TODO formalize this
+                cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+              />
+              <Bar
+                dataKey="error"
+                stackId="a"
+                fill={SemanticChartColors.danger}
+                hide={isDataKeyHidden("error")}
+                radius={[2, 2, 0, 0]}
+              />
 
-            <InteractiveLegend
-              {...defaultLegendProps}
-              hiddenDataKeys={hiddenDataKeys}
-              iconType="circle"
-              iconSize={8}
-              onToggleDataKey={toggleDataKey}
-            />
-          </BarChart>
-        </ResponsiveContainer>
+              <InteractiveLegend
+                {...defaultLegendProps}
+                hiddenDataKeys={hiddenDataKeys}
+                iconType="circle"
+                iconSize={8}
+                onToggleDataKey={toggleDataKey}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>
   );

--- a/app/src/pages/project/metrics/TraceLatencyPercentilesTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceLatencyPercentilesTimeSeries.tsx
@@ -12,6 +12,7 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -124,6 +125,7 @@ export function TraceLatencyPercentilesTimeSeries({
     p999: typeof datum.p999 === "number" ? datum.p999 / 1000 : null,
     max: typeof datum.max === "number" ? datum.max / 1000 : null,
   }));
+  const hasData = chartData.some((datum) => datum.max != null);
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
 
@@ -134,116 +136,121 @@ export function TraceLatencyPercentilesTimeSeries({
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
-        <ResponsiveContainer width="100%" height="100%">
-          <ComposedChart
-            data={chartData}
-            margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
-            syncId={"projectMetrics"}
-            {...chartProps}
-          >
-            <CartesianGrid vertical={false} {...defaultCartesianGridProps} />
-            <XAxis
-              {...defaultTimeXAxisProps}
-              domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
-              tickFormatter={(x) => timeTickFormatter(new Date(x))}
-            />
-            <YAxis
-              width={70}
-              tickFormatter={(x) => intFormatter(x)}
-              label={{
-                value: "Latency (s)",
-                angle: -90,
-                dx: -28,
-                style: {
-                  textAnchor: "middle",
-                  fill: "var(--chart-axis-label-color)",
-                },
-              }}
-              {...defaultYAxisProps}
-            />
-            <Line
-              type="monotone"
-              dataKey="p50"
-              stroke={colors.blue400}
-              strokeWidth={1}
-              activeDot={{ r: 4 }}
-              name="P50"
-              hide={isDataKeyHidden("p50")}
-            />
-            <Line
-              type="monotone"
-              dataKey="p75"
-              stroke={colors.blue400}
-              strokeWidth={1}
-              dot={{ r: 2 }}
-              activeDot={{ r: 4 }}
-              name="P75"
-              hide={isDataKeyHidden("p75")}
-            />
-            <Line
-              type="monotone"
-              dataKey="p90"
-              stroke={colors.blue500}
-              strokeWidth={2}
-              dot={{ r: 2 }}
-              activeDot={{ r: 4 }}
-              name="P90"
-              hide={isDataKeyHidden("p90")}
-            />
-            <Line
-              type="monotone"
-              dataKey="p95"
-              stroke={colors.blue600}
-              strokeWidth={2}
-              dot={{ r: 2 }}
-              activeDot={{ r: 4 }}
-              name="P95"
-              hide={isDataKeyHidden("p95")}
-            />
-            <Line
-              type="monotone"
-              dataKey="p99"
-              stroke={colors.blue700}
-              strokeWidth={2}
-              dot={{ r: 2 }}
-              activeDot={{ r: 4 }}
-              name="P99"
-              hide={isDataKeyHidden("p99")}
-            />
-            <Line
-              type="monotone"
-              dataKey="p999"
-              stroke={colors.blue800}
-              strokeWidth={2}
-              dot={{ r: 2 }}
-              activeDot={{ r: 4 }}
-              name="P99.9"
-              hide={isDataKeyHidden("p999")}
-            />
-            <Line
-              type="monotone"
-              dataKey="max"
-              stroke={colors.blue900}
-              strokeWidth={2}
-              strokeDasharray={"5 5"}
-              dot={{ r: 2 }}
-              activeDot={{ r: 4 }}
-              name="Max"
-              hide={isDataKeyHidden("max")}
-            />
-            <InteractiveLegend
-              {...defaultLegendProps}
-              hiddenDataKeys={hiddenDataKeys}
-              iconType="line"
-              iconSize={8}
-              onToggleDataKey={toggleDataKey}
-            />
-            <Tooltip
-              content={TooltipContent}
-              cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-            />
-          </ComposedChart>
-        </ResponsiveContainer>
+        <ChartEmptyStateOverlay
+          isEmpty={!hasData}
+          message="No data in this time range"
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart
+              data={chartData}
+              margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
+              syncId={"projectMetrics"}
+              {...chartProps}
+            >
+              <CartesianGrid vertical={false} {...defaultCartesianGridProps} />
+              <XAxis
+                {...defaultTimeXAxisProps}
+                domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
+                tickFormatter={(x) => timeTickFormatter(new Date(x))}
+              />
+              <YAxis
+                width={70}
+                tickFormatter={(x) => intFormatter(x)}
+                label={{
+                  value: "Latency (s)",
+                  angle: -90,
+                  dx: -28,
+                  style: {
+                    textAnchor: "middle",
+                    fill: "var(--chart-axis-label-color)",
+                  },
+                }}
+                {...defaultYAxisProps}
+              />
+              <Line
+                type="monotone"
+                dataKey="p50"
+                stroke={colors.blue400}
+                strokeWidth={1}
+                activeDot={{ r: 4 }}
+                name="P50"
+                hide={isDataKeyHidden("p50")}
+              />
+              <Line
+                type="monotone"
+                dataKey="p75"
+                stroke={colors.blue400}
+                strokeWidth={1}
+                dot={{ r: 2 }}
+                activeDot={{ r: 4 }}
+                name="P75"
+                hide={isDataKeyHidden("p75")}
+              />
+              <Line
+                type="monotone"
+                dataKey="p90"
+                stroke={colors.blue500}
+                strokeWidth={2}
+                dot={{ r: 2 }}
+                activeDot={{ r: 4 }}
+                name="P90"
+                hide={isDataKeyHidden("p90")}
+              />
+              <Line
+                type="monotone"
+                dataKey="p95"
+                stroke={colors.blue600}
+                strokeWidth={2}
+                dot={{ r: 2 }}
+                activeDot={{ r: 4 }}
+                name="P95"
+                hide={isDataKeyHidden("p95")}
+              />
+              <Line
+                type="monotone"
+                dataKey="p99"
+                stroke={colors.blue700}
+                strokeWidth={2}
+                dot={{ r: 2 }}
+                activeDot={{ r: 4 }}
+                name="P99"
+                hide={isDataKeyHidden("p99")}
+              />
+              <Line
+                type="monotone"
+                dataKey="p999"
+                stroke={colors.blue800}
+                strokeWidth={2}
+                dot={{ r: 2 }}
+                activeDot={{ r: 4 }}
+                name="P99.9"
+                hide={isDataKeyHidden("p999")}
+              />
+              <Line
+                type="monotone"
+                dataKey="max"
+                stroke={colors.blue900}
+                strokeWidth={2}
+                strokeDasharray={"5 5"}
+                dot={{ r: 2 }}
+                activeDot={{ r: 4 }}
+                name="Max"
+                hide={isDataKeyHidden("max")}
+              />
+              <InteractiveLegend
+                {...defaultLegendProps}
+                hiddenDataKeys={hiddenDataKeys}
+                iconType="line"
+                iconSize={8}
+                onToggleDataKey={toggleDataKey}
+              />
+              <Tooltip
+                content={TooltipContent}
+                cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>
   );

--- a/app/src/pages/project/metrics/TraceTokenCostTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceTokenCostTimeSeries.tsx
@@ -12,6 +12,7 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -114,12 +115,15 @@ export function TraceTokenCostTimeSeries({
       timestamp: string;
       promptCost: number | null;
       completionCost: number | null;
+      totalCost: number | null;
     }) => ({
       timestamp: new Date(datum.timestamp).getTime(),
       prompt: datum.promptCost,
       completion: datum.completionCost,
+      total: datum.totalCost,
     })
   );
+  const hasData = chartData.some((datum) => typeof datum.total === "number");
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
 
@@ -129,62 +133,67 @@ export function TraceTokenCostTimeSeries({
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            data={chartData}
-            margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
-            barSize={10}
-            syncId={"projectMetrics"}
-            {...chartProps}
-          >
-            <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
-            <XAxis
-              {...defaultTimeXAxisProps}
-              domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
-              tickFormatter={(x) => timeTickFormatter(new Date(x))}
-            />
-            <YAxis
-              {...defaultYAxisProps}
-              width={70}
-              tickFormatter={(x) => floatShortFormatter(x)}
-              label={{
-                value: "Cost (USD)",
-                angle: -90,
-                dx: -28,
-                style: {
-                  textAnchor: "middle",
-                  fill: "var(--chart-axis-label-color)",
-                },
-              }}
-            />
-            <Tooltip
-              content={TooltipContent}
-              // TODO formalize this
-              cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-            />
-            <Bar
-              dataKey="prompt"
-              stackId="a"
-              fill={colors.category1}
-              hide={isDataKeyHidden("prompt")}
-            />
-            <Bar
-              dataKey="completion"
-              stackId="a"
-              fill={colors.category2}
-              hide={isDataKeyHidden("completion")}
-              radius={[2, 2, 0, 0]}
-            />
+        <ChartEmptyStateOverlay
+          isEmpty={!hasData}
+          message="No data in this time range"
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={chartData}
+              margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
+              barSize={10}
+              syncId={"projectMetrics"}
+              {...chartProps}
+            >
+              <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+              <XAxis
+                {...defaultTimeXAxisProps}
+                domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
+                tickFormatter={(x) => timeTickFormatter(new Date(x))}
+              />
+              <YAxis
+                {...defaultYAxisProps}
+                width={70}
+                tickFormatter={(x) => floatShortFormatter(x)}
+                label={{
+                  value: "Cost (USD)",
+                  angle: -90,
+                  dx: -28,
+                  style: {
+                    textAnchor: "middle",
+                    fill: "var(--chart-axis-label-color)",
+                  },
+                }}
+              />
+              <Tooltip
+                content={TooltipContent}
+                // TODO formalize this
+                cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+              />
+              <Bar
+                dataKey="prompt"
+                stackId="a"
+                fill={colors.category1}
+                hide={isDataKeyHidden("prompt")}
+              />
+              <Bar
+                dataKey="completion"
+                stackId="a"
+                fill={colors.category2}
+                hide={isDataKeyHidden("completion")}
+                radius={[2, 2, 0, 0]}
+              />
 
-            <InteractiveLegend
-              {...defaultLegendProps}
-              hiddenDataKeys={hiddenDataKeys}
-              iconType="circle"
-              iconSize={8}
-              onToggleDataKey={toggleDataKey}
-            />
-          </BarChart>
-        </ResponsiveContainer>
+              <InteractiveLegend
+                {...defaultLegendProps}
+                hiddenDataKeys={hiddenDataKeys}
+                iconType="circle"
+                iconSize={8}
+                onToggleDataKey={toggleDataKey}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>
   );

--- a/app/src/pages/project/metrics/TraceTokenCountTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceTokenCountTimeSeries.tsx
@@ -12,6 +12,7 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -118,8 +119,10 @@ export function TraceTokenCountTimeSeries({
       timestamp: new Date(datum.timestamp).getTime(),
       prompt: datum.promptTokenCount ?? 0,
       completion: datum.completionTokenCount ?? 0,
+      total: datum.totalTokenCount,
     })
   );
+  const hasData = chartData.some((datum) => typeof datum.total === "number");
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
 
@@ -129,63 +132,68 @@ export function TraceTokenCountTimeSeries({
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            data={chartData}
-            margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
-            barSize={10}
-            syncId={"projectMetrics"}
-            {...chartProps}
-          >
-            <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
-            <XAxis
-              {...defaultTimeXAxisProps}
-              domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
-              tickFormatter={(x) => timeTickFormatter(new Date(x))}
-            />
-            <YAxis
-              {...defaultYAxisProps}
-              width={70}
-              tickFormatter={(x) => intShortFormatter(x)}
-              label={{
-                value: "Tokens",
-                angle: -90,
-                dx: -28,
-                style: {
-                  textAnchor: "middle",
-                  fill: "var(--chart-axis-label-color)",
-                },
-              }}
-              style={{ fill: "var(--global-text-color-700)" }}
-            />
-            <Tooltip
-              content={TooltipContent}
-              // TODO formalize this
-              cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
-            />
-            <Bar
-              dataKey="prompt"
-              stackId="a"
-              fill={colors.category1}
-              hide={isDataKeyHidden("prompt")}
-            />
-            <Bar
-              dataKey="completion"
-              stackId="a"
-              fill={colors.category2}
-              hide={isDataKeyHidden("completion")}
-              radius={[2, 2, 0, 0]}
-            />
+        <ChartEmptyStateOverlay
+          isEmpty={!hasData}
+          message="No data in this time range"
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={chartData}
+              margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
+              barSize={10}
+              syncId={"projectMetrics"}
+              {...chartProps}
+            >
+              <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+              <XAxis
+                {...defaultTimeXAxisProps}
+                domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
+                tickFormatter={(x) => timeTickFormatter(new Date(x))}
+              />
+              <YAxis
+                {...defaultYAxisProps}
+                width={70}
+                tickFormatter={(x) => intShortFormatter(x)}
+                label={{
+                  value: "Tokens",
+                  angle: -90,
+                  dx: -28,
+                  style: {
+                    textAnchor: "middle",
+                    fill: "var(--chart-axis-label-color)",
+                  },
+                }}
+                style={{ fill: "var(--global-text-color-700)" }}
+              />
+              <Tooltip
+                content={TooltipContent}
+                // TODO formalize this
+                cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+              />
+              <Bar
+                dataKey="prompt"
+                stackId="a"
+                fill={colors.category1}
+                hide={isDataKeyHidden("prompt")}
+              />
+              <Bar
+                dataKey="completion"
+                stackId="a"
+                fill={colors.category2}
+                hide={isDataKeyHidden("completion")}
+                radius={[2, 2, 0, 0]}
+              />
 
-            <InteractiveLegend
-              {...defaultLegendProps}
-              hiddenDataKeys={hiddenDataKeys}
-              iconType="circle"
-              iconSize={8}
-              onToggleDataKey={toggleDataKey}
-            />
-          </BarChart>
-        </ResponsiveContainer>
+              <InteractiveLegend
+                {...defaultLegendProps}
+                hiddenDataKeys={hiddenDataKeys}
+                iconType="circle"
+                iconSize={8}
+                onToggleDataKey={toggleDataKey}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>
   );

--- a/app/src/pages/project/metrics/__generated__/LLMSpanCountTimeSeriesQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/LLMSpanCountTimeSeriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b3cecfe51b85eafa8af3b254238af2d7>>
+ * @generated SignedSource<<181ee79c92bd4c208e168c5781dc55d3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,6 +31,7 @@ export type LLMSpanCountTimeSeriesQuery$data = {
         readonly errorCount: number | null;
         readonly okCount: number | null;
         readonly timestamp: string;
+        readonly totalCount: number | null;
         readonly unsetCount: number | null;
       }>;
     };
@@ -131,6 +132,13 @@ v5 = {
               "kind": "ScalarField",
               "name": "unsetCount",
               "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totalCount",
+              "storageKey": null
             }
           ],
           "storageKey": null
@@ -210,16 +218,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d53f83979a3c6e1c08999f5b6ac8a3f7",
+    "cacheID": "6a6e7489667ea6980a05555ca5062468",
     "id": null,
     "metadata": {},
     "name": "LLMSpanCountTimeSeriesQuery",
     "operationKind": "query",
-    "text": "query LLMSpanCountTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n  $filterCondition: String!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanCountTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig, filterCondition: $filterCondition) {\n        data {\n          timestamp\n          okCount\n          errorCount\n          unsetCount\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query LLMSpanCountTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n  $filterCondition: String!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanCountTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig, filterCondition: $filterCondition) {\n        data {\n          timestamp\n          okCount\n          errorCount\n          unsetCount\n          totalCount\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "514bda0696087b04a30995ca559b80c1";
+(node as any).hash = "fc7a69871588b337becde160b829aa8e";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/LLMSpanErrorsTimeSeriesQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/LLMSpanErrorsTimeSeriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cf07b76c65dd3d29b8b588edc6e9018d>>
+ * @generated SignedSource<<b6336f61a6dce03a815948dffbe85a23>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,6 +30,7 @@ export type LLMSpanErrorsTimeSeriesQuery$data = {
       readonly data: ReadonlyArray<{
         readonly errorCount: number | null;
         readonly timestamp: string;
+        readonly totalCount: number | null;
       }>;
     };
   };
@@ -115,6 +116,13 @@ v5 = {
               "kind": "ScalarField",
               "name": "errorCount",
               "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totalCount",
+              "storageKey": null
             }
           ],
           "storageKey": null
@@ -194,16 +202,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1b8e901b031f21828f03593299119bb0",
+    "cacheID": "b2136c06843da2c50b9931973559090d",
     "id": null,
     "metadata": {},
     "name": "LLMSpanErrorsTimeSeriesQuery",
     "operationKind": "query",
-    "text": "query LLMSpanErrorsTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n  $filterCondition: String!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanCountTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig, filterCondition: $filterCondition) {\n        data {\n          timestamp\n          errorCount\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query LLMSpanErrorsTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n  $filterCondition: String!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanCountTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig, filterCondition: $filterCondition) {\n        data {\n          timestamp\n          errorCount\n          totalCount\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "b865d5f1114d973668d82efdedc53b21";
+(node as any).hash = "96279ea8d5777c899d98e30c09a87b58";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/ToolSpanCountTimeSeriesQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ToolSpanCountTimeSeriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<40a407ecc2288b28869dd5e2a96f00a0>>
+ * @generated SignedSource<<14ff25380b1ade07375796a583c4acf8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,6 +31,7 @@ export type ToolSpanCountTimeSeriesQuery$data = {
         readonly errorCount: number | null;
         readonly okCount: number | null;
         readonly timestamp: string;
+        readonly totalCount: number | null;
         readonly unsetCount: number | null;
       }>;
     };
@@ -131,6 +132,13 @@ v5 = {
               "kind": "ScalarField",
               "name": "unsetCount",
               "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totalCount",
+              "storageKey": null
             }
           ],
           "storageKey": null
@@ -210,16 +218,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0a5e4bdb5bcce53751043c0baded7246",
+    "cacheID": "ba44ceb51f7535384ba5f52ec2b75800",
     "id": null,
     "metadata": {},
     "name": "ToolSpanCountTimeSeriesQuery",
     "operationKind": "query",
-    "text": "query ToolSpanCountTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n  $filterCondition: String!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanCountTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig, filterCondition: $filterCondition) {\n        data {\n          timestamp\n          okCount\n          errorCount\n          unsetCount\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ToolSpanCountTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n  $filterCondition: String!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanCountTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig, filterCondition: $filterCondition) {\n        data {\n          timestamp\n          okCount\n          errorCount\n          unsetCount\n          totalCount\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "3eccaa798cffe752af3f941b03e3047d";
+(node as any).hash = "91c3113c1baf69f4da181dbc4892e1c3";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/ToolSpanErrorsTimeSeriesQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ToolSpanErrorsTimeSeriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<06e5adcec77318099d63126bde94593a>>
+ * @generated SignedSource<<994a8cd53024678b610b9f22efe2e29d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,6 +30,7 @@ export type ToolSpanErrorsTimeSeriesQuery$data = {
       readonly data: ReadonlyArray<{
         readonly errorCount: number | null;
         readonly timestamp: string;
+        readonly totalCount: number | null;
       }>;
     };
   };
@@ -115,6 +116,13 @@ v5 = {
               "kind": "ScalarField",
               "name": "errorCount",
               "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totalCount",
+              "storageKey": null
             }
           ],
           "storageKey": null
@@ -194,16 +202,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d07d10e3b5535a3248d2616aad003c16",
+    "cacheID": "3f63fc68107ffe5ee79812314736eab9",
     "id": null,
     "metadata": {},
     "name": "ToolSpanErrorsTimeSeriesQuery",
     "operationKind": "query",
-    "text": "query ToolSpanErrorsTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n  $filterCondition: String!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanCountTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig, filterCondition: $filterCondition) {\n        data {\n          timestamp\n          errorCount\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ToolSpanErrorsTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n  $filterCondition: String!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanCountTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig, filterCondition: $filterCondition) {\n        data {\n          timestamp\n          errorCount\n          totalCount\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d4e6aef140bdee0a0e33a519f47785d1";
+(node as any).hash = "8b5da3e61f170284b782cd8404e3386a";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/TraceCountTimeSeriesQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/TraceCountTimeSeriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a8a22d4e700bcf71d45240f63e0bb5ac>>
+ * @generated SignedSource<<355d44f49e3b75ef64d79155c6060536>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,6 +30,7 @@ export type TraceCountTimeSeriesQuery$data = {
         readonly errorCount: number;
         readonly okCount: number;
         readonly timestamp: string;
+        readonly totalCount: number;
       }>;
     };
   };
@@ -112,6 +113,13 @@ v4 = {
               "kind": "ScalarField",
               "name": "errorCount",
               "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totalCount",
+              "storageKey": null
             }
           ],
           "storageKey": null
@@ -189,16 +197,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8a15201a8fa5e84fe8ead9a696d5db46",
+    "cacheID": "eae33be75948df6608bc20d9eacf4298",
     "id": null,
     "metadata": {},
     "name": "TraceCountTimeSeriesQuery",
     "operationKind": "query",
-    "text": "query TraceCountTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      traceCountByStatusTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          okCount\n          errorCount\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query TraceCountTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      traceCountByStatusTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          okCount\n          errorCount\n          totalCount\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "eaa82065496e0128142e6922554d0ddf";
+(node as any).hash = "f793529abd50aadd85049f7ac4390424";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/TraceErrorsTimeSeriesQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/TraceErrorsTimeSeriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f80a4a2bb9a4d45bc82dc995e7c65fac>>
+ * @generated SignedSource<<09227f0f5daeccc0801e369ca7094011>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -29,6 +29,7 @@ export type TraceErrorsTimeSeriesQuery$data = {
       readonly data: ReadonlyArray<{
         readonly errorCount: number;
         readonly timestamp: string;
+        readonly totalCount: number;
       }>;
     };
   };
@@ -103,6 +104,13 @@ v4 = {
               "args": null,
               "kind": "ScalarField",
               "name": "errorCount",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totalCount",
               "storageKey": null
             }
           ],
@@ -181,16 +189,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "14406c9b74559086ef4c1a390d71c30a",
+    "cacheID": "af40f7805883aad1b7c55dd4122fbd9f",
     "id": null,
     "metadata": {},
     "name": "TraceErrorsTimeSeriesQuery",
     "operationKind": "query",
-    "text": "query TraceErrorsTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      traceCountByStatusTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          errorCount\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query TraceErrorsTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      traceCountByStatusTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          errorCount\n          totalCount\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e200b36b8a75e09ce855dc7230a68ec1";
+(node as any).hash = "654925c22f25366d4cc7c22c323d1044";
 
 export default node;

--- a/app/stories/ChartEmptyStateOverlay.stories.tsx
+++ b/app/stories/ChartEmptyStateOverlay.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import {
+  ChartEmptyStateOverlay,
+  defaultCartesianGridProps,
+  defaultXAxisProps,
+  defaultYAxisProps,
+} from "@phoenix/components/chart";
+
+const chartData = [
+  { name: "Mon", value: 24 },
+  { name: "Tue", value: 32 },
+  { name: "Wed", value: 18 },
+  { name: "Thu", value: 41 },
+  { name: "Fri", value: 29 },
+];
+
+function ExampleChart({ isEmpty }: { isEmpty: boolean }) {
+  const data = isEmpty ? [] : chartData;
+  return (
+    <div style={{ width: "100%", height: 280 }}>
+      <ChartEmptyStateOverlay
+        isEmpty={isEmpty}
+        message="No data in this time range"
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={data}
+            margin={{ top: 8, right: 18, left: 8, bottom: 8 }}
+            barSize={16}
+          >
+            <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+            <XAxis {...defaultXAxisProps} dataKey="name" />
+            <YAxis {...defaultYAxisProps} width={48} />
+            <Tooltip />
+            <Bar
+              dataKey="value"
+              fill="var(--global-color-gray-500)"
+              radius={[2, 2, 0, 0]}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </ChartEmptyStateOverlay>
+    </div>
+  );
+}
+
+const meta: Meta<typeof ExampleChart> = {
+  title: "Charting/Chart Empty State Overlay",
+  component: ExampleChart,
+  parameters: {
+    layout: "padded",
+  },
+  argTypes: {
+    isEmpty: {
+      control: "boolean",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ExampleChart>;
+
+export const Empty: Story = {
+  args: {
+    isEmpty: true,
+  },
+};
+
+export const WithData: Story = {
+  args: {
+    isEmpty: false,
+  },
+};


### PR DESCRIPTION
## Summary
- Add a reusable `ChartEmptyStateOverlay` that keeps chart axes/gridlines visible while showing no-data copy.
- Apply the overlay to generative UI charts, experiment charts, project sparklines, and project metric charts.
- Include `totalCount` in relevant time-series Relay queries so zero-valued buckets can be treated as empty data.

## Why
Existing empty chart states were inconsistent: some charts replaced the visualization entirely, while others rendered an empty chart without clear no-data feedback. The overlay provides a shared no-data treatment without disrupting chart layout.

## Impact
Users see a consistent “No data” message while retaining time ranges, axes, and chart structure for context.

## Validation
- `git diff --check`
- `make lint-frontend typecheck-frontend`
