### PR TITLE
chore(deps): bump eslint-plugin-react-hooks to ~7.1.1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -147,7 +147,7 @@
     "babel-plugin-relay": "^20.1.1",
     "chromatic": "^17.3.0",
     "cpy-cli": "^7.0.0",
-    "eslint-plugin-react-hooks": "~7.0.1",
+    "eslint-plugin-react-hooks": "~7.1.1",
     "graphql": "^16.14.1",
     "jsdom": "^29.1.1",
     "mprocs": "^0.9.6",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -236,7 +236,7 @@ importers:
         version: 5.2.1(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@2.8.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1
+        version: 10.0.1(eslint@10.4.1)
       '@figma/code-connect':
         specifier: ^1.4.8
         version: 1.4.8
@@ -319,8 +319,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       eslint-plugin-react-hooks:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~7.1.1
+        version: 7.1.1(eslint@10.4.1)
       graphql:
         specifier: ^16.14.1
         version: 16.14.1
@@ -1100,6 +1100,28 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.6.0':
+    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@eslint/js@10.0.1':
     resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -1108,6 +1130,14 @@ packages:
     peerDependenciesMeta:
       eslint:
         optional: true
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@exodus/bytes@1.15.1':
     resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
@@ -1140,6 +1170,26 @@ packages:
     resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
     peerDependencies:
       react-hook-form: ^7.55.0
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -2454,6 +2504,9 @@ packages:
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -2659,6 +2712,11 @@ packages:
     peerDependencies:
       acorn: ^8
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -2673,6 +2731,9 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -3266,6 +3327,9 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -3417,16 +3481,54 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  eslint-plugin-react-hooks@7.0.1:
-    resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
     engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.4.1:
+    resolution: {integrity: sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
 
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
@@ -3472,6 +3574,12 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
@@ -3497,6 +3605,10 @@ packages:
       picomatch:
         optional: true
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   file-type@21.3.4:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
     engines: {node: '>=20'}
@@ -3511,6 +3623,13 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -3576,6 +3695,10 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
@@ -3702,6 +3825,10 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
@@ -3725,6 +3852,10 @@ packages:
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -3900,6 +4031,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
   json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
 
@@ -3909,11 +4043,17 @@ packages:
   json-schema-library@9.3.5:
     resolution: {integrity: sha512-5eBDx7cbfs+RjylsVO+N36b0GOPtv78rfqgf2uON+uaHUIC62h63Y8pkV2ovKbaL4ZpQcHp21968x5nx/dFwqQ==}
 
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -3940,6 +4080,9 @@ packages:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
 
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
@@ -3952,6 +4095,10 @@ packages:
 
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lezer-json5@2.0.2:
     resolution: {integrity: sha512-NRmtBlKW/f8mA7xatKq8IUOq045t8GVHI4kZXrUtYYUdiVeGiO6zKGAV7/nUAnf5q+rYTY+SWX/gvQdFXMjNxQ==}
@@ -4372,6 +4519,9 @@ packages:
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   nearley@2.20.1:
     resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
     hasBin: true
@@ -4465,6 +4615,10 @@ packages:
 
   optimism@0.18.1:
     resolution: {integrity: sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
 
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
@@ -4656,6 +4810,10 @@ packages:
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -5325,6 +5483,10 @@ packages:
     resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
     engines: {node: '>=18', npm: '>=9'}
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
@@ -5401,6 +5563,9 @@ packages:
 
   uri-js-replace@1.0.1:
     resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
@@ -5620,6 +5785,10 @@ packages:
   widest-line@3.1.0:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
     engines: {node: '>=8'}
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -6440,7 +6609,39 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@eslint/js@10.0.1': {}
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1)':
+    dependencies:
+      eslint: 10.4.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3(supports-color@10.2.2)
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.6.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/js@10.0.1(eslint@10.4.1)':
+    optionalDependencies:
+      eslint: 10.4.1
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
 
   '@exodus/bytes@1.15.1': {}
 
@@ -6492,6 +6693,22 @@ snapshots:
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.78.0(react@19.2.7)
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@iconify/types@2.0.0': {}
 
@@ -7632,6 +7849,8 @@ snapshots:
 
   '@types/doctrine@0.0.9': {}
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.9
@@ -7873,6 +8092,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
@@ -7884,6 +8107,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       '@opentelemetry/api': 1.9.1
       zod: 4.4.3
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ansi-align@3.0.1:
     dependencies:
@@ -8495,6 +8725,8 @@ snapshots:
   deep-extend@0.6.0:
     optional: true
 
+  deep-is@0.1.4: {}
+
   deepmerge@4.3.1: {}
 
   default-browser-id@5.0.1: {}
@@ -8660,17 +8892,80 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-react-hooks@7.0.1:
+  eslint-plugin-react-hooks@7.1.1(eslint@10.4.1):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
+      eslint: 10.4.1
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.4.1:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@10.2.2)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
   esprima@4.0.1: {}
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
 
   estree-util-is-identifier-name@3.0.0: {}
 
@@ -8709,6 +9004,10 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
   fast-xml-builder@1.2.0:
     dependencies:
       path-expression-matcher: 1.5.0
@@ -8744,6 +9043,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
   file-type@21.3.4:
     dependencies:
       '@tokenizer/inflate': 0.4.1
@@ -8763,6 +9066,13 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -8825,6 +9135,10 @@ snapshots:
     optional: true
 
   glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
 
@@ -9023,6 +9337,8 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  ignore@5.3.2: {}
+
   ignore@7.0.5: {}
 
   immer@10.2.0: {}
@@ -9047,6 +9363,8 @@ snapshots:
       module-details-from-path: 1.0.4
 
   import-meta-resolve@4.2.0: {}
+
+  imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
 
@@ -9214,6 +9532,8 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-buffer@3.0.1: {}
+
   json-parse-better-errors@1.0.2: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -9228,9 +9548,13 @@ snapshots:
       smtp-address-parser: 1.0.10
       valid-url: 1.0.9
 
+  json-schema-traverse@0.4.1: {}
+
   json-schema-traverse@1.0.0: {}
 
   json-schema@0.4.0: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
 
@@ -9275,6 +9599,10 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
   khroma@2.1.0: {}
 
   kleur@3.0.3: {}
@@ -9282,6 +9610,11 @@ snapshots:
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lezer-json5@2.0.2:
     dependencies:
@@ -9865,6 +10198,8 @@ snapshots:
   napi-build-utils@2.0.0:
     optional: true
 
+  natural-compare@1.4.0: {}
+
   nearley@2.20.1:
     dependencies:
       commander: 2.20.3
@@ -9970,6 +10305,15 @@ snapshots:
       '@wry/context': 0.7.4
       '@wry/trie': 0.5.0
       tslib: 2.8.1
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
 
   ora@5.4.1:
     dependencies:
@@ -10221,6 +10565,8 @@ snapshots:
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
     optional: true
+
+  prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
 
@@ -10999,6 +11345,10 @@ snapshots:
     dependencies:
       '@mixmark-io/domino': 2.2.0
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   type-fest@0.20.2: {}
 
   type-fest@4.41.0: {}
@@ -11073,6 +11423,10 @@ snapshots:
       picocolors: 1.1.1
 
   uri-js-replace@1.0.1: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   url-parse@1.5.10:
     dependencies:
@@ -11266,6 +11620,8 @@ snapshots:
   widest-line@3.1.0:
     dependencies:
       string-width: 4.2.3
+
+  word-wrap@1.2.5: {}
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/app/src/components/agent/AgentFabPositioner.tsx
+++ b/app/src/components/agent/AgentFabPositioner.tsx
@@ -235,6 +235,16 @@ export function AgentFabPositioner({
   const [resolvedBoundary, setResolvedBoundary] = useState<HTMLElement | null>(
     () => boundaryRef?.current ?? null
   );
+  // When the FAB no longer requires a boundary (e.g. modal closes), reset
+  // resolvedBoundary in render rather than in an effect.
+  const [prevRequiresBoundary, setPrevRequiresBoundary] =
+    useState(requiresBoundary);
+  if (prevRequiresBoundary !== requiresBoundary) {
+    setPrevRequiresBoundary(requiresBoundary);
+    if (!requiresBoundary) {
+      setResolvedBoundary(null);
+    }
+  }
   useModalFloatingLayerInteractivity(positionerRef, layer === "modal");
 
   // After a drag, an unwanted `click` event can still fire on pointerup. We
@@ -492,7 +502,6 @@ export function AgentFabPositioner({
 
   useLayoutEffect(() => {
     if (!requiresBoundary) {
-      setResolvedBoundary(null);
       return;
     }
 

--- a/app/src/components/agent/ResizableFloatingPanel.tsx
+++ b/app/src/components/agent/ResizableFloatingPanel.tsx
@@ -695,8 +695,17 @@ export function ResizableFloatingPanel({
   const [isMoving, setIsMoving] = useState(false);
   const [isResizeHandleHovered, setIsResizeHandleHovered] = useState(false);
   const [resolvedBoundary, setResolvedBoundary] = useState<HTMLElement | null>(
-    () => boundaryRef?.current ?? null
+    () => (layer === "content" ? (boundaryRef?.current ?? null) : null)
   );
+  // Only the content layer tracks a boundary element; when the panel leaves
+  // it, reset resolvedBoundary in render rather than in an effect.
+  const [prevLayer, setPrevLayer] = useState(layer);
+  if (prevLayer !== layer) {
+    setPrevLayer(layer);
+    if (layer !== "content") {
+      setResolvedBoundary(null);
+    }
+  }
   const [currentBounds, setCurrentBounds] = useState(() =>
     getPanelBounds({
       boundary: boundaryRef?.current ?? null,
@@ -716,6 +725,31 @@ export function ResizableFloatingPanel({
       size,
     })
   );
+  // Re-apply the controlled size prop (clamped) whenever it, the bounds, or
+  // the minimum size change. Done in render rather than in an effect.
+  const [prevSizeSync, setPrevSizeSync] = useState({
+    currentBounds,
+    minSize,
+    size,
+  });
+  if (
+    prevSizeSync.currentBounds !== currentBounds ||
+    prevSizeSync.minSize !== minSize ||
+    prevSizeSync.size !== size
+  ) {
+    setPrevSizeSync({ currentBounds, minSize, size });
+    setCurrentGeometry((geometry) =>
+      clampGeometry({
+        bounds: currentBounds,
+        geometry: {
+          ...geometry,
+          height: size.height,
+          width: size.width,
+        },
+        minSize,
+      })
+    );
+  }
   useModalFloatingLayerInteractivity(panelRef, layer === "modal");
 
   const resizeLimits = getGeometryLimits({ bounds: currentBounds, minSize });
@@ -971,7 +1005,6 @@ export function ResizableFloatingPanel({
 
   useLayoutEffect(() => {
     if (layer !== "content") {
-      setResolvedBoundary(null);
       return;
     }
 
@@ -1049,20 +1082,6 @@ export function ResizableFloatingPanel({
       window.visualViewport?.removeEventListener("scroll", syncPanelBounds);
     };
   }, [anchorToViewport, layer, minSize, placement, resolvedBoundary]);
-
-  useEffect(() => {
-    setCurrentGeometry((geometry) =>
-      clampGeometry({
-        bounds: currentBounds,
-        geometry: {
-          ...geometry,
-          height: size.height,
-          width: size.width,
-        },
-        minSize,
-      })
-    );
-  }, [currentBounds, minSize, size]);
 
   useEffect(() => {
     const hasLayerChanged = previousLayerRef.current !== layer;

--- a/app/src/components/code/LazyEditorWrapper.tsx
+++ b/app/src/components/code/LazyEditorWrapper.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type LazyEditorWrapperProps = {
   /**
@@ -23,21 +23,21 @@ export function LazyEditorWrapper({
   children,
   ...rest
 }: LazyEditorWrapperProps) {
-  const [isVisible, setIsVisible] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   /**
-   * The two useEffect hooks below are used to initialize the JSON editor.
-   * This is necessary because code mirror needs to calculate its dimensions to initialize properly.
-   * When it is rendered outside of the viewport, the dimensions may not always be calculated correctly,
-   * resulting in the editor being invisible or cut off when it is scrolled into view.
-   * Below we use a combination of an intersection observer and a delay to ensure that the editor is initialized correctly.
+   * Code mirror needs to calculate its dimensions to initialize properly. When rendered
+   * outside the viewport, dimensions may not be calculated correctly, leaving the editor
+   * invisible or cut off when scrolled into view. We latch `isInitialized` to true the
+   * first time the wrapper intersects and never revert it.
    * For a related issue @see https://github.com/codemirror/dev/issues/1076
    */
   useEffect(() => {
     const observer = new IntersectionObserver(([entry]) => {
-      setIsVisible(entry.isIntersecting);
+      if (entry.isIntersecting) {
+        setIsInitialized(true);
+      }
     });
 
     if (wrapperRef.current) {
@@ -51,12 +51,6 @@ export function LazyEditorWrapper({
       }
     };
   }, []);
-
-  useLayoutEffect(() => {
-    if (isVisible && !isInitialized) {
-      setIsInitialized(true);
-    }
-  }, [isInitialized, isVisible]);
 
   return (
     <div

--- a/app/src/components/templateEditor/TemplateEditor.tsx
+++ b/app/src/components/templateEditor/TemplateEditor.tsx
@@ -5,7 +5,7 @@ import type {
   ReactCodeMirrorProps,
 } from "@uiw/react-codemirror";
 import CodeMirror, { EditorView, keymap } from "@uiw/react-codemirror";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 
 import { pierreDark, pierreLight } from "@phoenix/components/code";
 import { useTheme } from "@phoenix/contexts";
@@ -51,6 +51,11 @@ const baseExtensions = [
  * or, when the readOnly prop is true, the editor will reset on all value changes.
  * This is necessary because controlled react-codemirror editors incessantly reset
  * cursor position when value is updated.
+ *
+ * The `readOnly` prop must stay fixed for the lifetime of the component:
+ * toggling it from true to false would snap the displayed value back to the
+ * mount-time `defaultValue`, discarding any `defaultValue` updates mirrored
+ * while read-only. Re-mount (e.g. via `key`) instead of toggling.
  */
 export const TemplateEditor = ({
   templateFormat,
@@ -59,7 +64,10 @@ export const TemplateEditor = ({
   availablePaths,
   ...props
 }: TemplateEditorProps) => {
-  const [value, setValue] = useState(() => defaultValue);
+  const [value] = useState(() => defaultValue);
+  // In readOnly mode the editor mirrors defaultValue on every change; otherwise
+  // it stays at the initial value (CodeMirror itself is uncontrolled internally).
+  const displayValue = readOnly ? defaultValue : value;
   const { theme } = useTheme();
   const codeMirrorTheme = theme === "light" ? pierreLight : pierreDark;
   const extensions = useMemo(() => {
@@ -88,12 +96,6 @@ export const TemplateEditor = ({
     return ext;
   }, [templateFormat, availablePaths, readOnly]);
 
-  useEffect(() => {
-    if (readOnly) {
-      setValue(defaultValue);
-    }
-  }, [readOnly, defaultValue]);
-
   return (
     <CodeMirror
       theme={codeMirrorTheme}
@@ -101,7 +103,7 @@ export const TemplateEditor = ({
       basicSetup={basicSetupOptions}
       readOnly={readOnly}
       {...props}
-      value={value}
+      value={displayValue}
     />
   );
 };

--- a/app/src/components/trace/TraceTree.tsx
+++ b/app/src/components/trace/TraceTree.tsx
@@ -110,8 +110,14 @@ function SpanTreeItem<TSpan extends ISpanItem>(
     overallTimeRange,
   } = props;
   const childNodes = node.children;
-  const [isCollapsed, setIsCollapsed] = useState(false);
   const { isCollapsed: treeIsCollapsed } = useTraceTree();
+  const [isCollapsed, setIsCollapsed] = useState(treeIsCollapsed);
+  const [prevTreeIsCollapsed, setPrevTreeIsCollapsed] =
+    useState(treeIsCollapsed);
+  if (prevTreeIsCollapsed !== treeIsCollapsed) {
+    setPrevTreeIsCollapsed(treeIsCollapsed);
+    setIsCollapsed(treeIsCollapsed);
+  }
   const hasChildren = childNodes.length > 0;
   const showMetricsInTraceTree = usePreferencesContext(
     (state) => state.showMetricsInTraceTree
@@ -128,11 +134,6 @@ function SpanTreeItem<TSpan extends ISpanItem>(
       });
     }
   }, [isSelected, scrollSelectedSpanIntoView]);
-
-  // React to global changes to the trace tree state and change local state
-  useEffect(() => {
-    setIsCollapsed(treeIsCollapsed);
-  }, [treeIsCollapsed]);
 
   const { name, latencyMs, statusCode, tokenCountTotal } = node.span;
   return (

--- a/app/src/pages/datasets/DatasetFromFileForm.tsx
+++ b/app/src/pages/datasets/DatasetFromFileForm.tsx
@@ -278,6 +278,7 @@ export function DatasetFromFileForm(props: DatasetFromFileFormProps) {
     },
   });
 
+  // eslint-disable-next-line react-hooks-js/incompatible-library
   const selectedFile = watch("file");
   const inputKeys = watch("input_keys");
   const outputKeys = watch("output_keys");

--- a/app/src/pages/datasets/DatasetsTable.tsx
+++ b/app/src/pages/datasets/DatasetsTable.tsx
@@ -358,6 +358,7 @@ export function DatasetsTable(props: DatasetsTableProps) {
     return cols;
   }, [filter, labelFilter, notifySuccess, refetch, canModify]);
 
+  // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable({
     columns,
     data: tableData,

--- a/app/src/pages/evaluators/DatasetEvaluatorsTable.tsx
+++ b/app/src/pages/evaluators/DatasetEvaluatorsTable.tsx
@@ -481,6 +481,7 @@ export const DatasetEvaluatorsTable = ({
     return cols;
   }, [datasetId, updateConnectionIds]);
 
+  // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable({
     columns,
     data: tableData,

--- a/app/src/pages/evaluators/EvaluatorsTable.tsx
+++ b/app/src/pages/evaluators/EvaluatorsTable.tsx
@@ -428,6 +428,7 @@ export const EvaluatorsTable = ({
     return cols;
   }, []);
 
+  // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable({
     columns,
     data: tableData,

--- a/app/src/pages/examples/ExamplesTable.tsx
+++ b/app/src/pages/examples/ExamplesTable.tsx
@@ -317,6 +317,7 @@ export function ExamplesTable({
     return cols;
   }, [handleRowSelection]);
 
+  // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable<TableRow>({
     columns,
     data: tableData,

--- a/app/src/pages/experiment/ExperimentCompareListPage.tsx
+++ b/app/src/pages/experiment/ExperimentCompareListPage.tsx
@@ -1127,6 +1127,7 @@ export function ExperimentCompareListPage({
     getExperimentColor,
   ]);
 
+  // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable({
     data: tableData,
     columns,

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -493,6 +493,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
     return [...baseColumns, ...experimentColumns];
   }, [baseColumns, experimentColumns]);
 
+  // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable<TableRow>({
     columns: columns,
     data: tableData,

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -628,6 +628,7 @@ export function ExperimentsTable({
     },
   ];
 
+  // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable<TableRow>({
     columns: [...baseColumns, ...annotationColumns, ...tailColumns],
     data: tableData,

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -1380,6 +1380,7 @@ export function PlaygroundDatasetExamplesTable({
       setSearchParams,
     ]
   );
+  // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable<TableRow>({
     columns,
     data: tableData,

--- a/app/src/pages/playground/PlaygroundOutput.tsx
+++ b/app/src/pages/playground/PlaygroundOutput.tsx
@@ -204,6 +204,14 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
     (instance) => instance.activeRunId != null
   );
   const [apiError, setApiError] = useState<string | null>(null);
+  // Clear apiError when a new run starts (runInProgress false → true).
+  const [prevRunInProgress, setPrevRunInProgress] = useState(runInProgress);
+  if (prevRunInProgress !== runInProgress) {
+    setPrevRunInProgress(runInProgress);
+    if (runInProgress) {
+      setApiError(null);
+    }
+  }
 
   const handleChatCompletionSubscriptionPayload = useCallback(
     ({ chatCompletion }: PlaygroundOutputSubscription$data) => {
@@ -305,7 +313,6 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
     if (!runInProgress) {
       return;
     }
-    setApiError(null);
     const input = getChatCompletionInput({
       playgroundStore,
       instanceId,

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -468,6 +468,7 @@ export function SessionsTable(props: SessionsTableProps) {
   const columnVisibility = useTracingContext((state) => state.columnVisibility);
   const columnSizing = useTracingContext((state) => state.columnSizing);
   const setColumnSizing = useTracingContext((state) => state.setColumnSizing);
+  // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable<TableRow>({
     columns,
     data: tableData,

--- a/app/src/pages/project/SpanFilterConditionField.tsx
+++ b/app/src/pages/project/SpanFilterConditionField.tsx
@@ -245,16 +245,33 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
     placeholder = "filter condition (e.x. span_kind == 'LLM')",
   } = props;
   const [isFocused, setIsFocused] = useState<boolean>(false);
-  const [isConditionValidState, setIsConditionValidState] =
-    useState<boolean>(true);
-  const [errorMessage, setErrorMessage] = useState<string>("");
   const { filterCondition, setFilterCondition, appendFilterCondition } =
     useSpanFilters();
+  // A filter restored on mount starts as "not yet validated" so it isn't
+  // advertised as valid before the async validator resolves.
+  const [isConditionValidState, setIsConditionValidState] = useState<boolean>(
+    () => filterCondition.trim() === ""
+  );
+  const [errorMessage, setErrorMessage] = useState<string>("");
   const deferredFilterCondition = useDeferredValue(filterCondition);
+  const projectId = useTracingContext((state) => state.projectId);
+  // Mark "not yet validated" as soon as a new non-empty filter or project
+  // arrives, before the project-scoped async validator returns.
+  const [prevValidationInput, setPrevValidationInput] = useState(() => ({
+    deferredFilterCondition,
+    projectId,
+  }));
+  const hasValidationInputChanged =
+    prevValidationInput.deferredFilterCondition !== deferredFilterCondition ||
+    prevValidationInput.projectId !== projectId;
+  if (hasValidationInputChanged) {
+    setPrevValidationInput({ deferredFilterCondition, projectId });
+    if (deferredFilterCondition.trim() !== "") {
+      setIsConditionValidState(false);
+    }
+  }
   const { theme } = useTheme();
   const codeMirrorTheme = theme === "light" ? pierreLight : pierreDark;
-
-  const projectId = useTracingContext((state) => state.projectId);
 
   const filterConditionFieldRef = useRef<HTMLDivElement>(null);
 
@@ -285,10 +302,6 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
 
   useEffect(() => {
     let isCancelled = false;
-
-    if (deferredFilterCondition.trim() !== "") {
-      setIsConditionValidState(false);
-    }
 
     void validateSpanFilterCondition(deferredFilterCondition, projectId).then(
       (result) => {

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -808,6 +808,7 @@ export function SpansTable(props: SpansTableProps) {
   );
   const setColumnSizing = useTracingContext((state) => state.setColumnSizing);
   const columnSizing = useTracingContext((state) => state.columnSizing);
+  // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable<TableRow>({
     columns,
     data: tableData,

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -912,6 +912,7 @@ export function TracesTable(props: TracesTableProps) {
   const columnVisibility = useTracingContext((state) => state.columnVisibility);
   const setColumnSizing = useTracingContext((state) => state.setColumnSizing);
   const columnSizing = useTracingContext((state) => state.columnSizing);
+  // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable<TableRow>({
     columns,
     data: tableData,

--- a/app/stories/PromptMenu.stories.tsx
+++ b/app/stories/PromptMenu.stories.tsx
@@ -314,14 +314,18 @@ function PlaygroundRender(args: StoryArgs) {
   }, [args.promptCount, args.versionCount, args.tagCount]);
 
   // Reset selection if prompt count changes and current selection is out of range
-  React.useEffect(() => {
+  const [prevPromptsLength, setPrevPromptsLength] = React.useState(
+    prompts.length
+  );
+  if (prevPromptsLength !== prompts.length) {
+    setPrevPromptsLength(prompts.length);
     if (
       selection.selectedPromptIndex !== null &&
       selection.selectedPromptIndex >= prompts.length
     ) {
       setSelection((s) => ({ ...s, selectedPromptIndex: null }));
     }
-  }, [prompts.length, selection.selectedPromptIndex]);
+  }
 
   const selectedPrompt =
     selection.selectedPromptIndex !== null && selection.selectedPromptIndex >= 0

--- a/app/stories/Table.stories.tsx
+++ b/app/stories/Table.stories.tsx
@@ -239,6 +239,7 @@ function BaseTable<T>({
   const [sorting, setSorting] = useState<SortingState>([]);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
+  // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable<T>({
     columns,
     data,


### PR DESCRIPTION
## Summary
Bumps `eslint-plugin-react-hooks` from `~7.0.1` to `~7.1.1`. 7.1 ships two new `react-hooks-js` rules: `set-state-in-effect` and `incompatible-library`.

## Handling

**`incompatible-library`** — disabled globally. Fires 13+ times, all on TanStack Table's `useReactTable`. The rule is informational ("React Compiler skipped this component"), not actionable: TanStack Table intentionally returns non-memoizable functions, and React Compiler already skips memoization for these components transparently. See [app/.oxlintrc.json](app/.oxlintrc.json#L40-L44) for the disable + reason.

**`set-state-in-effect`** — fixed 7 violations using the canonical [reset-on-prop-change pattern](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes):

| File | Pattern |
|---|---|
| `LazyEditorWrapper.tsx` | Collapsed two effects into a single IntersectionObserver that latches `isInitialized` |
| `TraceTree.tsx` | Prev-state on `treeIsCollapsed` mirrors into local `isCollapsed` |
| `TemplateEditor.tsx` | Derived `displayValue = readOnly ? defaultValue : value` inline; dropped effect entirely |
| `PlaygroundOutput.tsx` | Clear `apiError` on `runInProgress` false → true edge |
| `SpanFilterConditionField.tsx` | Mark "not yet validated" on new non-empty filter (before async validator returns) |
| `AgentFabPositioner.tsx` | Reset `resolvedBoundary` when boundary no longer required |
| `PromptMenu.stories.tsx` | Clamp `selectedPromptIndex` on `prompts.length` change |

## Test plan
- [x] `pnpm lint` 0 errors / 0 warnings
- [x] `pnpm fmt:check` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1195 passing
- [ ] CI passes