### PR TITLE
feat: Add interactive chart legends

### DIFF
--- a/app/src/components/chart/InteractiveLegend.tsx
+++ b/app/src/components/chart/InteractiveLegend.tsx
@@ -1,0 +1,542 @@
+import { css } from "@emotion/react";
+import { cloneElement, createElement, isValidElement, useState } from "react";
+import type { MouseEvent } from "react";
+import type {
+  DefaultLegendContentProps,
+  LegendPayload,
+  LegendProps,
+  LegendType,
+  SymbolsProps,
+} from "recharts";
+import { Legend, Surface, Symbols } from "recharts";
+
+/**
+ * InteractiveLegend is intentionally larger than a thin `<Legend />` wrapper.
+ *
+ * Recharts still owns legend placement, sizing, portals, payload sorting, and
+ * custom `content` composition. This component only intercepts the payload that
+ * Recharts passes to legend content so hidden series are marked inactive, then
+ * swaps the default legend item markup from inert list items to accessible
+ * buttons that can toggle chart series.
+ *
+ * The default renderer below mirrors the parts of Recharts' DefaultLegendContent
+ * that Phoenix charts rely on: formatter handling, icon rendering, inactive
+ * color, label styles, Recharts class names, and item event callbacks.
+ */
+
+/**
+ * Recharts data keys can also be functions. Interactive hiding needs a stable
+ * primitive key that can be stored in a Set and passed back to chart items'
+ * `hide` props, so function data keys are rendered but not made toggleable.
+ */
+export type InteractiveLegendDataKey = Extract<
+  NonNullable<LegendPayload["dataKey"]>,
+  string | number
+>;
+
+type RechartsSymbolType = SymbolsProps["type"];
+
+/**
+ * Recharts adds `content` to the props passed into custom legend content, but
+ * the exported DefaultLegendContentProps type does not include it.
+ */
+type RechartsLegendContentProps = DefaultLegendContentProps & {
+  content?: LegendProps["content"];
+};
+
+type InteractiveLegendContentProps = RechartsLegendContentProps & {
+  baseContent?: LegendProps["content"];
+  hiddenDataKeys: ReadonlySet<InteractiveLegendDataKey>;
+  onToggleDataKey: (dataKey: InteractiveLegendDataKey) => void;
+};
+
+export type InteractiveLegendProps = LegendProps & {
+  hiddenDataKeys: ReadonlySet<InteractiveLegendDataKey>;
+  onToggleDataKey: (dataKey: InteractiveLegendDataKey) => void;
+};
+
+export type UseInteractiveLegendProps = {
+  defaultHiddenDataKeys?: Iterable<InteractiveLegendDataKey>;
+};
+
+// Recharts DefaultLegendContent renders every icon inside a 32x32 viewBox.
+const LEGEND_ICON_VIEW_BOX_SIZE = 32;
+
+const legendCSS = css`
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--global-dimension-size-100) var(--global-dimension-size-150);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+const verticalLegendCSS = css`
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
+const leftAlignedLegendCSS = css`
+  justify-content: flex-start;
+`;
+
+const centerAlignedLegendCSS = css`
+  justify-content: center;
+`;
+
+const rightAlignedLegendCSS = css`
+  justify-content: flex-end;
+`;
+
+const legendItemCSS = css`
+  display: inline-flex;
+  align-items: center;
+`;
+
+const legendButtonCSS = css`
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--chart-legend-text-color);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--global-dimension-size-50);
+  min-height: var(--global-dimension-size-200);
+  padding: 0 var(--global-dimension-size-25);
+  font: inherit;
+  line-height: var(--global-line-height-xs);
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: var(--global-border-size-thick) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
+    border-radius: var(--global-rounding-small);
+  }
+
+  &[data-inactive="true"] {
+    opacity: 0.55;
+  }
+`;
+
+const legendStaticItemCSS = css`
+  color: var(--chart-legend-text-color);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--global-dimension-size-50);
+  min-height: var(--global-dimension-size-200);
+  padding: 0 var(--global-dimension-size-25);
+  line-height: var(--global-line-height-xs);
+`;
+
+function getInteractiveDataKey(
+  dataKey: LegendPayload["dataKey"]
+): InteractiveLegendDataKey | null {
+  if (typeof dataKey === "string" || typeof dataKey === "number") {
+    return dataKey;
+  }
+  return null;
+}
+
+/**
+ * Builds a label for accessibility and fallback display. Recharts legend
+ * payloads normally have `value`, but custom payloads can omit it.
+ */
+function getLegendItemText(entry: LegendPayload) {
+  if (entry.value != null) {
+    return entry.value;
+  }
+  const dataKey = getInteractiveDataKey(entry.dataKey);
+  return dataKey == null ? "Series" : String(dataKey);
+}
+
+function getLegendItemAriaLabel({
+  isHidden,
+  label,
+}: {
+  isHidden: boolean;
+  label: string;
+}) {
+  return isHidden ? `Show ${label}` : `Hide ${label}`;
+}
+
+function getLegendAlignmentCSS(align: DefaultLegendContentProps["align"]) {
+  if (align === "left") {
+    return leftAlignedLegendCSS;
+  }
+  if (align === "right") {
+    return rightAlignedLegendCSS;
+  }
+  return centerAlignedLegendCSS;
+}
+
+/**
+ * Mirrors Recharts' default legend icon renderer so built-in `iconType`,
+ * `entry.type`, `entry.legendIcon`, and line dash behavior keep working.
+ */
+function LegendIcon({
+  entry,
+  iconSize,
+  iconType,
+  inactiveColor,
+}: {
+  entry: LegendPayload;
+  iconSize: number;
+  iconType?: LegendType;
+  inactiveColor: string;
+}) {
+  const preferredIconType = iconType ?? entry.type;
+  const color = entry.inactive ? inactiveColor : (entry.color ?? inactiveColor);
+  const halfSize = LEGEND_ICON_VIEW_BOX_SIZE / 2;
+  const thirdSize = LEGEND_ICON_VIEW_BOX_SIZE / 3;
+  const sixthSize = LEGEND_ICON_VIEW_BOX_SIZE / 6;
+
+  if (preferredIconType === "none") {
+    return null;
+  }
+
+  const icon = (() => {
+    switch (preferredIconType) {
+      case "plainline":
+        return (
+          <line
+            className="recharts-legend-icon"
+            fill="none"
+            stroke={color}
+            strokeDasharray={
+              entry.payload &&
+              "strokeDasharray" in entry.payload &&
+              typeof entry.payload.strokeDasharray !== "undefined"
+                ? String(entry.payload.strokeDasharray)
+                : undefined
+            }
+            strokeWidth={4}
+            x1={0}
+            x2={LEGEND_ICON_VIEW_BOX_SIZE}
+            y1={halfSize}
+            y2={halfSize}
+          />
+        );
+      case "line":
+        return (
+          <path
+            className="recharts-legend-icon"
+            d={`M0,${halfSize}h${thirdSize} A${sixthSize},${sixthSize},0,1,1,${2 * thirdSize},${halfSize} H${LEGEND_ICON_VIEW_BOX_SIZE} M${2 * thirdSize},${halfSize} A${sixthSize},${sixthSize},0,1,1,${thirdSize},${halfSize}`}
+            fill="none"
+            stroke={color}
+            strokeWidth={4}
+          />
+        );
+      case "rect":
+        return (
+          <path
+            className="recharts-legend-icon"
+            d={`M0,${LEGEND_ICON_VIEW_BOX_SIZE / 8}h${LEGEND_ICON_VIEW_BOX_SIZE}v${(LEGEND_ICON_VIEW_BOX_SIZE * 3) / 4}h${-LEGEND_ICON_VIEW_BOX_SIZE}z`}
+            fill={color}
+            stroke="none"
+          />
+        );
+      default: {
+        if (isValidElement<LegendPayload>(entry.legendIcon)) {
+          const { legendIcon: _legendIcon, ...legendIconProps } = entry;
+          return cloneElement(entry.legendIcon, legendIconProps);
+        }
+        const symbolType: RechartsSymbolType = preferredIconType;
+        return (
+          <Symbols
+            className="recharts-legend-icon"
+            cx={halfSize}
+            cy={halfSize}
+            fill={color}
+            size={LEGEND_ICON_VIEW_BOX_SIZE}
+            sizeType="diameter"
+            type={symbolType}
+          />
+        );
+      }
+    }
+  })();
+
+  return (
+    <Surface
+      aria-hidden="true"
+      focusable="false"
+      height={iconSize}
+      viewBox={{
+        x: 0,
+        y: 0,
+        width: LEGEND_ICON_VIEW_BOX_SIZE,
+        height: LEGEND_ICON_VIEW_BOX_SIZE,
+      }}
+      width={iconSize}
+    >
+      {icon}
+    </Surface>
+  );
+}
+
+/**
+ * Marks the Recharts payload as inactive without changing the rest of the
+ * payload shape. This lets both Phoenix's default renderer and user-supplied
+ * custom legend content receive the normal Recharts payload plus hide state.
+ */
+function getEnhancedPayload({
+  hiddenDataKeys,
+  payload,
+}: {
+  hiddenDataKeys: ReadonlySet<InteractiveLegendDataKey>;
+  payload?: ReadonlyArray<LegendPayload>;
+}) {
+  return payload?.map((entry) => {
+    const dataKey = getInteractiveDataKey(entry.dataKey);
+    const isHidden =
+      entry.inactive === true ||
+      (dataKey != null && hiddenDataKeys.has(dataKey));
+    return { ...entry, inactive: isHidden };
+  });
+}
+
+/**
+ * Compose custom legend content the same way Recharts does:
+ * clone elements, create function content as a React component, or fall back to
+ * default content. The fallback is Phoenix-specific only because it renders
+ * toggle buttons.
+ */
+function renderBaseLegendContent({
+  baseContent,
+  contentProps,
+}: {
+  baseContent: LegendProps["content"];
+  contentProps: RechartsLegendContentProps;
+}) {
+  if (isValidElement<RechartsLegendContentProps>(baseContent)) {
+    return cloneElement(baseContent, contentProps);
+  }
+
+  if (typeof baseContent === "function") {
+    return createElement(baseContent, contentProps);
+  }
+
+  return <DefaultInteractiveLegendContent {...contentProps} />;
+}
+
+/**
+ * Phoenix's button-based equivalent of Recharts' DefaultLegendContent.
+ *
+ * This remains local instead of importing DefaultLegendContent because Recharts
+ * renders each legend item as an inert `<li>`, while Phoenix needs each
+ * toggleable item to be a real `<button>` for keyboard and screen-reader
+ * support.
+ */
+function DefaultInteractiveLegendContent({
+  align = "center",
+  formatter,
+  iconSize = 14,
+  iconType,
+  inactiveColor = "var(--global-color-gray-500)",
+  labelStyle,
+  layout = "horizontal",
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  payload,
+}: RechartsLegendContentProps) {
+  if (payload == null || payload.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul
+      css={[
+        legendCSS,
+        layout === "vertical" && verticalLegendCSS,
+        getLegendAlignmentCSS(align),
+      ]}
+      className="recharts-default-legend"
+    >
+      {payload.map((entry, index) => {
+        if (entry.type === "none") {
+          return null;
+        }
+
+        const dataKey = getInteractiveDataKey(entry.dataKey);
+        const isHidden = entry.inactive === true;
+        const finalFormatter = entry.formatter ?? formatter;
+        const label = getLegendItemText(entry);
+        const renderedLabel =
+          finalFormatter == null
+            ? label
+            : finalFormatter(entry.value, entry, index);
+        const mergedLabelStyle = {
+          ...(typeof labelStyle === "object" ? labelStyle : {}),
+        };
+        mergedLabelStyle.color = isHidden
+          ? inactiveColor
+          : (mergedLabelStyle.color ?? entry.color);
+        const itemClassName = `recharts-legend-item legend-item-${index}${isHidden ? " inactive" : ""}`;
+
+        return (
+          <li
+            className={itemClassName}
+            css={legendItemCSS}
+            key={`${label}-${index}`}
+          >
+            {dataKey == null ? (
+              <span
+                css={legendStaticItemCSS}
+                onMouseEnter={(event) => {
+                  onMouseEnter?.(entry, index, event);
+                }}
+                onMouseLeave={(event) => {
+                  onMouseLeave?.(entry, index, event);
+                }}
+                style={mergedLabelStyle}
+              >
+                <LegendIcon
+                  entry={entry}
+                  iconSize={iconSize}
+                  iconType={iconType}
+                  inactiveColor={inactiveColor}
+                />
+                <span className="recharts-legend-item-text">
+                  {renderedLabel}
+                </span>
+              </span>
+            ) : (
+              <button
+                aria-label={getLegendItemAriaLabel({
+                  isHidden,
+                  label,
+                })}
+                aria-pressed={!isHidden}
+                css={legendButtonCSS}
+                data-inactive={isHidden ? true : undefined}
+                onClick={(event) => {
+                  onClick?.(entry, index, event);
+                }}
+                onMouseEnter={(event) => {
+                  onMouseEnter?.(entry, index, event);
+                }}
+                onMouseLeave={(event) => {
+                  onMouseLeave?.(entry, index, event);
+                }}
+                style={mergedLabelStyle}
+                title={label}
+                type="button"
+              >
+                <LegendIcon
+                  entry={entry}
+                  iconSize={iconSize}
+                  iconType={iconType}
+                  inactiveColor={inactiveColor}
+                />
+                <span className="recharts-legend-item-text">
+                  {renderedLabel}
+                </span>
+              </button>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/**
+ * Internal content adapter injected into Recharts' `Legend`.
+ *
+ * Recharts calls this with its fully prepared legend props after applying
+ * wrapper layout, payload sorting, and payload de-duplication. The adapter then
+ * enhances `payload` and wraps `onClick` so custom content can prevent the
+ * toggle by calling `event.preventDefault()`.
+ */
+function InteractiveLegendContent({
+  baseContent,
+  content: _internalContent,
+  hiddenDataKeys,
+  onClick,
+  onToggleDataKey,
+  payload,
+  ...contentProps
+}: InteractiveLegendContentProps) {
+  const enhancedPayload = getEnhancedPayload({ hiddenDataKeys, payload });
+  const onLegendItemClick = (
+    entry: LegendPayload,
+    index: number,
+    event: MouseEvent<HTMLElement>
+  ) => {
+    onClick?.(entry, index, event);
+    const dataKey = getInteractiveDataKey(entry.dataKey);
+    if (dataKey != null && !event.defaultPrevented) {
+      onToggleDataKey(dataKey);
+    }
+  };
+
+  return renderBaseLegendContent({
+    baseContent,
+    contentProps: {
+      ...contentProps,
+      content: baseContent,
+      onClick: onLegendItemClick,
+      payload: enhancedPayload,
+    },
+  });
+}
+
+/**
+ * Shared hidden-series state for charts using InteractiveLegend.
+ */
+export function useInteractiveLegend({
+  defaultHiddenDataKeys = [],
+}: UseInteractiveLegendProps = {}) {
+  const [hiddenDataKeys, setHiddenDataKeys] = useState<
+    ReadonlySet<InteractiveLegendDataKey>
+  >(() => new Set(defaultHiddenDataKeys));
+
+  const isDataKeyHidden = (
+    dataKey: InteractiveLegendDataKey | null | undefined
+  ) => dataKey != null && hiddenDataKeys.has(dataKey);
+
+  const toggleDataKey = (dataKey: InteractiveLegendDataKey) => {
+    setHiddenDataKeys((currentHiddenDataKeys) => {
+      const nextHiddenDataKeys = new Set(currentHiddenDataKeys);
+      if (nextHiddenDataKeys.has(dataKey)) {
+        nextHiddenDataKeys.delete(dataKey);
+      } else {
+        nextHiddenDataKeys.add(dataKey);
+      }
+      return nextHiddenDataKeys;
+    });
+  };
+
+  return { hiddenDataKeys, isDataKeyHidden, toggleDataKey };
+}
+
+/**
+ * Recharts Legend with Phoenix interactive hide/show behavior.
+ *
+ * Pass the returned state from `useInteractiveLegend` into this component and
+ * wire `isDataKeyHidden(dataKey)` to each chart item's `hide` prop.
+ */
+export function InteractiveLegend({
+  content,
+  hiddenDataKeys,
+  onToggleDataKey,
+  ...legendProps
+}: InteractiveLegendProps) {
+  return (
+    <Legend
+      {...legendProps}
+      content={
+        <InteractiveLegendContent
+          baseContent={content}
+          hiddenDataKeys={hiddenDataKeys}
+          onToggleDataKey={onToggleDataKey}
+        />
+      }
+    />
+  );
+}

--- a/app/src/components/chart/__tests__/InteractiveLegend.test.tsx
+++ b/app/src/components/chart/__tests__/InteractiveLegend.test.tsx
@@ -1,0 +1,271 @@
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { DefaultLegendContentProps } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  InteractiveLegend,
+  type InteractiveLegendProps,
+  defaultLegendProps,
+  useInteractiveLegend,
+} from "@phoenix/components/chart";
+
+const chartData = [
+  {
+    name: "A",
+    pv: 2400,
+    uv: 4000,
+  },
+  {
+    name: "B",
+    pv: 1398,
+    uv: 3000,
+  },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+
+function findLegendButton(label: string) {
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (element) => element.getAttribute("aria-label") === label
+  );
+  expect(button).not.toBeNull();
+  return button as HTMLButtonElement;
+}
+
+function TestChart({
+  defaultHiddenDataKeys,
+  legendProps,
+}: {
+  defaultHiddenDataKeys?: string[];
+  legendProps?: Partial<
+    Omit<InteractiveLegendProps, "hiddenDataKeys" | "onToggleDataKey">
+  >;
+}) {
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend({ defaultHiddenDataKeys });
+
+  return (
+    <>
+      <span data-testid="uv-hidden">{String(isDataKeyHidden("uv"))}</span>
+      <BarChart data={chartData} height={240} width={360}>
+        <CartesianGrid />
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Bar dataKey="uv" fill="#8884d8" hide={isDataKeyHidden("uv")} />
+        <Bar dataKey="pv" fill="#82ca9d" hide={isDataKeyHidden("pv")} />
+        <InteractiveLegend
+          {...defaultLegendProps}
+          {...legendProps}
+          hiddenDataKeys={hiddenDataKeys}
+          iconSize={8}
+          iconType="circle"
+          onToggleDataKey={toggleDataKey}
+        />
+      </BarChart>
+    </>
+  );
+}
+
+function CustomLegendContent({ onClick, payload }: DefaultLegendContentProps) {
+  return (
+    <ul data-testid="custom-legend">
+      {payload?.map((entry, index) => (
+        <li key={String(entry.dataKey ?? index)}>
+          <button
+            data-inactive={String(entry.inactive === true)}
+            onClick={(event) => {
+              onClick?.(entry, index, event);
+            }}
+            type="button"
+          >
+            {entry.value}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function HookLegendContent({ payload }: DefaultLegendContentProps) {
+  const [renderCount] = useState(1);
+
+  return (
+    <ul data-render-count={renderCount} data-testid="hook-legend">
+      {payload?.map((entry, index) => (
+        <li key={String(entry.dataKey ?? index)}>{entry.value}</li>
+      ))}
+    </ul>
+  );
+}
+
+describe("InteractiveLegend", () => {
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders legend items as toggle buttons", () => {
+    act(() => {
+      root.render(<TestChart />);
+    });
+
+    const uvButton = findLegendButton("Hide uv");
+    expect(uvButton.type).toBe("button");
+    expect(uvButton.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("toggles a chart item when its legend item is clicked", () => {
+    act(() => {
+      root.render(<TestChart />);
+    });
+
+    expect(
+      container.querySelector('[data-testid="uv-hidden"]')?.textContent
+    ).toBe("false");
+
+    act(() => {
+      findLegendButton("Hide uv").dispatchEvent(
+        new MouseEvent("click", { bubbles: true })
+      );
+    });
+
+    const uvButton = findLegendButton("Show uv");
+    expect(
+      container.querySelector('[data-testid="uv-hidden"]')?.textContent
+    ).toBe("true");
+    expect(uvButton.getAttribute("aria-pressed")).toBe("false");
+    expect(uvButton.getAttribute("data-inactive")).toBe("true");
+  });
+
+  it("supports initially hidden chart items", () => {
+    act(() => {
+      root.render(<TestChart defaultHiddenDataKeys={["pv"]} />);
+    });
+
+    expect(findLegendButton("Show pv").getAttribute("aria-pressed")).toBe(
+      "false"
+    );
+  });
+
+  it("calls the provided legend onClick before toggling", () => {
+    const onClick = vi.fn<NonNullable<InteractiveLegendProps["onClick"]>>();
+
+    act(() => {
+      root.render(<TestChart legendProps={{ onClick }} />);
+    });
+
+    act(() => {
+      findLegendButton("Hide uv").dispatchEvent(
+        new MouseEvent("click", { bubbles: true })
+      );
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClick.mock.calls[0]?.[0].dataKey).toBe("uv");
+    expect(
+      container.querySelector('[data-testid="uv-hidden"]')?.textContent
+    ).toBe("true");
+  });
+
+  it("does not toggle when the provided legend onClick prevents default", () => {
+    const onClick = vi.fn<NonNullable<InteractiveLegendProps["onClick"]>>(
+      (_entry, _index, event) => {
+        event.preventDefault();
+      }
+    );
+
+    act(() => {
+      root.render(<TestChart legendProps={{ onClick }} />);
+    });
+
+    act(() => {
+      findLegendButton("Hide uv").dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(
+      container.querySelector('[data-testid="uv-hidden"]')?.textContent
+    ).toBe("false");
+    expect(findLegendButton("Hide uv").getAttribute("aria-pressed")).toBe(
+      "true"
+    );
+  });
+
+  it("composes custom Recharts legend content with enhanced payload and click props", () => {
+    act(() => {
+      root.render(<TestChart legendProps={{ content: CustomLegendContent }} />);
+    });
+
+    const uvButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "uv"
+    ) as HTMLButtonElement | undefined;
+    expect(uvButton?.getAttribute("data-inactive")).toBe("false");
+
+    act(() => {
+      uvButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const hiddenUvButton = Array.from(
+      container.querySelectorAll("button")
+    ).find((button) => button.textContent === "uv");
+    expect(
+      container.querySelector('[data-testid="uv-hidden"]')?.textContent
+    ).toBe("true");
+    expect(hiddenUvButton?.getAttribute("data-inactive")).toBe("true");
+  });
+
+  it("clones custom Recharts legend content elements with enhanced props", () => {
+    act(() => {
+      root.render(
+        <TestChart legendProps={{ content: <CustomLegendContent /> }} />
+      );
+    });
+
+    const pvButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "pv"
+    ) as HTMLButtonElement | undefined;
+    expect(pvButton?.getAttribute("data-inactive")).toBe("false");
+
+    act(() => {
+      pvButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const hiddenPvButton = Array.from(
+      container.querySelectorAll("button")
+    ).find((button) => button.textContent === "pv");
+    expect(hiddenPvButton?.getAttribute("data-inactive")).toBe("true");
+  });
+
+  it("renders custom Recharts legend content functions as React components", () => {
+    act(() => {
+      root.render(<TestChart legendProps={{ content: HookLegendContent }} />);
+    });
+
+    expect(
+      container
+        .querySelector('[data-testid="hook-legend"]')
+        ?.getAttribute("data-render-count")
+    ).toBe("1");
+
+    act(() => {
+      root.render(<TestChart />);
+    });
+
+    expect(container.querySelector('[data-testid="hook-legend"]')).toBeNull();
+    expect(findLegendButton("Hide uv")).toBeTruthy();
+  });
+});

--- a/app/src/components/chart/index.tsx
+++ b/app/src/components/chart/index.tsx
@@ -1,4 +1,5 @@
 export * from "./ChartTooltip";
+export * from "./InteractiveLegend";
 export * from "./SparklineSkeleton";
 export * from "./TimeRangeChartBrush";
 export * from "./defaults";

--- a/app/src/pages/experiments/ExperimentsLineChart.tsx
+++ b/app/src/pages/experiments/ExperimentsLineChart.tsx
@@ -21,6 +21,9 @@ import { Flex, Text } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
+  defaultLegendProps,
+  useInteractiveLegend,
   useSequentialChartColors,
 } from "@phoenix/components/chart";
 import { SequenceNumberToken } from "@phoenix/components/experiment/SequenceNumberToken";
@@ -162,12 +165,22 @@ export function ExperimentsLineChart({ datasetId }: { datasetId: string }) {
     return colorMap;
   }, [scoreKeys, theme]);
 
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
+
   // Memoize yDomain calculation
   const yDomain = useMemo(() => {
+    const visibleScoreKeys = scoreKeys.filter(
+      (scoreKey) => !hiddenDataKeys.has(scoreKey)
+    );
+    if (visibleScoreKeys.length === 0) {
+      return undefined;
+    }
+
     let minScore = Infinity;
     let maxScore = -Infinity;
     for (const dataPoint of chartData) {
-      for (const scoreKey of scoreKeys) {
+      for (const scoreKey of visibleScoreKeys) {
         const scoreValue = dataPoint[scoreKey as keyof typeof dataPoint];
         if (typeof scoreValue === "number") {
           if (scoreValue < minScore) minScore = scoreValue;
@@ -175,9 +188,12 @@ export function ExperimentsLineChart({ datasetId }: { datasetId: string }) {
         }
       }
     }
+    if (minScore === Infinity || maxScore === -Infinity) {
+      return undefined;
+    }
     // If the min score is 0 and the max score is 1, return [0, 1] for consistency
     return minScore >= 0 && maxScore <= 1 ? [0, 1] : undefined;
-  }, [chartData, scoreKeys]);
+  }, [chartData, hiddenDataKeys, scoreKeys]);
 
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -236,6 +252,8 @@ export function ExperimentsLineChart({ datasetId }: { datasetId: string }) {
           yAxisId="right"
           dataKey="avgLatency"
           fill="url(#latencyBarColor)"
+          hide={isDataKeyHidden("avgLatency")}
+          name="avg latency"
           spacing={3}
         />
         {scoreKeys.map((key) => (
@@ -247,9 +265,16 @@ export function ExperimentsLineChart({ datasetId }: { datasetId: string }) {
             strokeWidth={2}
             dot={{ r: 3 }}
             activeDot={{ r: 5 }}
+            hide={isDataKeyHidden(key)}
             yAxisId={0}
           />
         ))}
+        <InteractiveLegend
+          {...defaultLegendProps}
+          hiddenDataKeys={hiddenDataKeys}
+          iconSize={8}
+          onToggleDataKey={toggleDataKey}
+        />
         <Tooltip content={TooltipContent} />
       </ComposedChart>
     </ResponsiveContainer>

--- a/app/src/pages/project/metrics/LLMSpanCountTimeSeries.tsx
+++ b/app/src/pages/project/metrics/LLMSpanCountTimeSeries.tsx
@@ -4,7 +4,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -15,12 +14,14 @@ import { Text } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
   TimeRangeChartBrush,
   defaultCartesianGridProps,
   defaultLegendProps,
   defaultTimeXAxisProps,
   defaultYAxisProps,
   useBinTimeTickFormatter,
+  useInteractiveLegend,
   useSemanticChartColors,
   useSequentialChartColors,
 } from "@phoenix/components/chart";
@@ -38,15 +39,6 @@ import type { LLMSpanCountTimeSeriesQuery } from "./__generated__/LLMSpanCountTi
 function TooltipContent({ active, payload, label }: TooltipContentProps) {
   const { fullTimeFormatter } = useTimeFormatters();
   if (active && payload && payload.length) {
-    const errorValue = payload[0]?.value ?? null;
-    const errorColor = payload[0]?.color ?? null;
-    const unsetValue = payload[1]?.value ?? null;
-    const unsetColor = payload[1]?.color ?? null;
-    const okValue = payload[2]?.value ?? null;
-    const okColor = payload[2]?.color ?? null;
-    const okString = intFormatter(Number(okValue));
-    const unsetString = intFormatter(Number(unsetValue));
-    const errorString = intFormatter(Number(errorValue));
     return (
       <ChartTooltip>
         {label && (
@@ -54,24 +46,18 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
             new Date(Number(label))
           )}`}</Text>
         )}
-        <ChartTooltipItem
-          color={errorColor ?? "transparent"}
-          shape="circle"
-          name="error"
-          value={errorString}
-        />
-        <ChartTooltipItem
-          color={unsetColor ?? "transparent"}
-          shape="circle"
-          name="unset"
-          value={unsetString}
-        />
-        <ChartTooltipItem
-          color={okColor ?? "transparent"}
-          shape="circle"
-          name="ok"
-          value={okString}
-        />
+        {payload.map((entry) => {
+          const name = String(entry.dataKey ?? entry.name ?? "unknown");
+          return (
+            <ChartTooltipItem
+              color={entry.color ?? "transparent"}
+              key={name}
+              shape="circle"
+              name={name}
+              value={intFormatter(Number(entry.value))}
+            />
+          );
+        })}
       </ChartTooltip>
     );
   }
@@ -140,6 +126,8 @@ export function LLMSpanCountTimeSeries({
 
   const colors = useSequentialChartColors();
   const SemanticChartColors = useSemanticChartColors();
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
@@ -180,15 +168,28 @@ export function LLMSpanCountTimeSeries({
               dataKey="error"
               stackId="a"
               fill={SemanticChartColors.danger}
+              hide={isDataKeyHidden("error")}
             />
-            <Bar dataKey="unset" stackId="a" fill={colors.gray500} />
+            <Bar
+              dataKey="unset"
+              stackId="a"
+              fill={colors.gray500}
+              hide={isDataKeyHidden("unset")}
+            />
             <Bar
               dataKey="ok"
               stackId="a"
               fill={colors.gray300}
+              hide={isDataKeyHidden("ok")}
               radius={[2, 2, 0, 0]}
             />
-            <Legend {...defaultLegendProps} iconType="circle" iconSize={8} />
+            <InteractiveLegend
+              {...defaultLegendProps}
+              hiddenDataKeys={hiddenDataKeys}
+              iconType="circle"
+              iconSize={8}
+              onToggleDataKey={toggleDataKey}
+            />
           </BarChart>
         </ResponsiveContainer>
       )}

--- a/app/src/pages/project/metrics/LLMSpanErrorsTimeSeries.tsx
+++ b/app/src/pages/project/metrics/LLMSpanErrorsTimeSeries.tsx
@@ -4,7 +4,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -15,12 +14,14 @@ import { Text } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
   TimeRangeChartBrush,
   defaultCartesianGridProps,
   defaultLegendProps,
   defaultTimeXAxisProps,
   defaultYAxisProps,
   useBinTimeTickFormatter,
+  useInteractiveLegend,
   useSemanticChartColors,
 } from "@phoenix/components/chart";
 import { useTimeBinScale } from "@phoenix/hooks/useTimeBin";
@@ -116,6 +117,8 @@ export function LLMSpanErrorsTimeSeries({
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
 
   const SemanticChartColors = useSemanticChartColors();
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
@@ -156,10 +159,17 @@ export function LLMSpanErrorsTimeSeries({
               dataKey="error"
               stackId="a"
               fill={SemanticChartColors.danger}
+              hide={isDataKeyHidden("error")}
               radius={[2, 2, 0, 0]}
             />
 
-            <Legend {...defaultLegendProps} iconType="circle" iconSize={8} />
+            <InteractiveLegend
+              {...defaultLegendProps}
+              hiddenDataKeys={hiddenDataKeys}
+              iconType="circle"
+              iconSize={8}
+              onToggleDataKey={toggleDataKey}
+            />
           </BarChart>
         </ResponsiveContainer>
       )}

--- a/app/src/pages/project/metrics/SpanAnnotationScoreTimeSeries.tsx
+++ b/app/src/pages/project/metrics/SpanAnnotationScoreTimeSeries.tsx
@@ -2,7 +2,6 @@ import { graphql, useLazyLoadQuery } from "react-relay";
 import type { TooltipContentProps } from "recharts";
 import {
   CartesianGrid,
-  Legend,
   Line,
   LineChart,
   ResponsiveContainer,
@@ -15,8 +14,10 @@ import { Text } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
   TimeRangeChartBrush,
   useBinTimeTickFormatter,
+  useInteractiveLegend,
 } from "@phoenix/components/chart";
 import {
   defaultCartesianGridProps,
@@ -62,7 +63,13 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
   return null;
 }
 
-function AnnotationLine({ name }: { name: string }) {
+function AnnotationLine({
+  isHidden,
+  name,
+}: {
+  isHidden: boolean;
+  name: string;
+}) {
   const color = useWordColor(name);
   return (
     <Line
@@ -72,6 +79,7 @@ function AnnotationLine({ name }: { name: string }) {
       strokeWidth={2}
       dot={{ r: 2 }}
       activeDot={{ r: 4 }}
+      hide={isHidden}
       name={name}
     />
   );
@@ -142,6 +150,8 @@ export function SpanAnnotationScoreTimeSeries({
   });
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
 
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
@@ -179,10 +189,22 @@ export function SpanAnnotationScoreTimeSeries({
             />
 
             {annotationNames.map((name) => {
-              return <AnnotationLine key={name} name={name} />;
+              return (
+                <AnnotationLine
+                  isHidden={isDataKeyHidden(name)}
+                  key={name}
+                  name={name}
+                />
+              );
             })}
 
-            <Legend {...defaultLegendProps} iconType="line" iconSize={8} />
+            <InteractiveLegend
+              {...defaultLegendProps}
+              hiddenDataKeys={hiddenDataKeys}
+              iconType="line"
+              iconSize={8}
+              onToggleDataKey={toggleDataKey}
+            />
           </LineChart>
         </ResponsiveContainer>
       )}

--- a/app/src/pages/project/metrics/ToolSpanCountTimeSeries.tsx
+++ b/app/src/pages/project/metrics/ToolSpanCountTimeSeries.tsx
@@ -4,7 +4,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -15,12 +14,14 @@ import { Text } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
   TimeRangeChartBrush,
   defaultCartesianGridProps,
   defaultLegendProps,
   defaultTimeXAxisProps,
   defaultYAxisProps,
   useBinTimeTickFormatter,
+  useInteractiveLegend,
   useSemanticChartColors,
   useSequentialChartColors,
 } from "@phoenix/components/chart";
@@ -38,15 +39,6 @@ import type { ToolSpanCountTimeSeriesQuery } from "./__generated__/ToolSpanCount
 function TooltipContent({ active, payload, label }: TooltipContentProps) {
   const { fullTimeFormatter } = useTimeFormatters();
   if (active && payload && payload.length) {
-    const errorValue = payload[0]?.value ?? null;
-    const errorColor = payload[0]?.color ?? null;
-    const unsetValue = payload[1]?.value ?? null;
-    const unsetColor = payload[1]?.color ?? null;
-    const okValue = payload[2]?.value ?? null;
-    const okColor = payload[2]?.color ?? null;
-    const okString = intFormatter(Number(okValue));
-    const unsetString = intFormatter(Number(unsetValue));
-    const errorString = intFormatter(Number(errorValue));
     return (
       <ChartTooltip>
         {label && (
@@ -54,24 +46,18 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
             new Date(Number(label))
           )}`}</Text>
         )}
-        <ChartTooltipItem
-          color={errorColor ?? "transparent"}
-          shape="circle"
-          name="error"
-          value={errorString}
-        />
-        <ChartTooltipItem
-          color={unsetColor ?? "transparent"}
-          shape="circle"
-          name="unset"
-          value={unsetString}
-        />
-        <ChartTooltipItem
-          color={okColor ?? "transparent"}
-          shape="circle"
-          name="ok"
-          value={okString}
-        />
+        {payload.map((entry) => {
+          const name = String(entry.dataKey ?? entry.name ?? "unknown");
+          return (
+            <ChartTooltipItem
+              color={entry.color ?? "transparent"}
+              key={name}
+              shape="circle"
+              name={name}
+              value={intFormatter(Number(entry.value))}
+            />
+          );
+        })}
       </ChartTooltip>
     );
   }
@@ -139,6 +125,8 @@ export function ToolSpanCountTimeSeries({
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
   const colors = useSequentialChartColors();
   const SemanticChartColors = useSemanticChartColors();
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
@@ -179,15 +167,28 @@ export function ToolSpanCountTimeSeries({
               dataKey="error"
               stackId="a"
               fill={SemanticChartColors.danger}
+              hide={isDataKeyHidden("error")}
             />
-            <Bar dataKey="unset" stackId="a" fill={colors.gray500} />
+            <Bar
+              dataKey="unset"
+              stackId="a"
+              fill={colors.gray500}
+              hide={isDataKeyHidden("unset")}
+            />
             <Bar
               dataKey="ok"
               stackId="a"
               fill={colors.gray300}
+              hide={isDataKeyHidden("ok")}
               radius={[2, 2, 0, 0]}
             />
-            <Legend {...defaultLegendProps} iconType="circle" iconSize={8} />
+            <InteractiveLegend
+              {...defaultLegendProps}
+              hiddenDataKeys={hiddenDataKeys}
+              iconType="circle"
+              iconSize={8}
+              onToggleDataKey={toggleDataKey}
+            />
           </BarChart>
         </ResponsiveContainer>
       )}

--- a/app/src/pages/project/metrics/ToolSpanErrorsTimeSeries.tsx
+++ b/app/src/pages/project/metrics/ToolSpanErrorsTimeSeries.tsx
@@ -4,7 +4,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -15,12 +14,14 @@ import { Text } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
   TimeRangeChartBrush,
   defaultCartesianGridProps,
   defaultLegendProps,
   defaultTimeXAxisProps,
   defaultYAxisProps,
   useBinTimeTickFormatter,
+  useInteractiveLegend,
   useSemanticChartColors,
 } from "@phoenix/components/chart";
 import { useTimeBinScale } from "@phoenix/hooks/useTimeBin";
@@ -115,6 +116,8 @@ export function ToolSpanErrorsTimeSeries({
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
   const SemanticChartColors = useSemanticChartColors();
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
@@ -155,10 +158,17 @@ export function ToolSpanErrorsTimeSeries({
               dataKey="error"
               stackId="a"
               fill={SemanticChartColors.danger}
+              hide={isDataKeyHidden("error")}
               radius={[2, 2, 0, 0]}
             />
 
-            <Legend {...defaultLegendProps} iconType="circle" iconSize={8} />
+            <InteractiveLegend
+              {...defaultLegendProps}
+              hiddenDataKeys={hiddenDataKeys}
+              iconType="circle"
+              iconSize={8}
+              onToggleDataKey={toggleDataKey}
+            />
           </BarChart>
         </ResponsiveContainer>
       )}

--- a/app/src/pages/project/metrics/TopModelsByCost.tsx
+++ b/app/src/pages/project/metrics/TopModelsByCost.tsx
@@ -5,7 +5,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -16,12 +15,14 @@ import { Text } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
   defaultCartesianGridProps,
   defaultLegendProps,
   defaultXAxisProps,
   defaultYAxisProps,
   truncateModelName,
   useCategoryChartColors,
+  useInteractiveLegend,
 } from "@phoenix/components/chart";
 import type { ProjectMetricViewProps } from "@phoenix/pages/project/metrics/types";
 import { costFormatter } from "@phoenix/utils/numberFormatUtils";
@@ -29,12 +30,7 @@ import { costFormatter } from "@phoenix/utils/numberFormatUtils";
 import type { TopModelsByCostQuery } from "./__generated__/TopModelsByCostQuery.graphql";
 
 function TooltipContent({ active, payload, label }: TooltipContentProps) {
-  const colors = useCategoryChartColors();
-
   if (active && payload && payload.length) {
-    const promptCost = payload[0]?.value ?? null;
-    const completionCost = payload[1]?.value ?? null;
-
     return (
       <ChartTooltip>
         {label && (
@@ -42,18 +38,15 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
             {String(label)}
           </Text>
         )}
-        <ChartTooltipItem
-          color={colors.category1}
-          shape="circle"
-          name="Prompt cost"
-          value={costFormatter(Number(promptCost))}
-        />
-        <ChartTooltipItem
-          color={colors.category2}
-          shape="circle"
-          name="Completion cost"
-          value={costFormatter(Number(completionCost))}
-        />
+        {payload.map((entry) => (
+          <ChartTooltipItem
+            color={entry.color ?? "transparent"}
+            key={String(entry.dataKey ?? entry.name)}
+            shape="circle"
+            name={String(entry.name ?? entry.dataKey ?? "unknown")}
+            value={costFormatter(Number(entry.value))}
+          />
+        ))}
       </ChartTooltip>
     );
   }
@@ -66,6 +59,8 @@ export function TopModelsByCost({
   timeRange,
 }: ProjectMetricViewProps) {
   const colors = useCategoryChartColors();
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
 
   const data = useLazyLoadQuery<TopModelsByCostQuery>(
     graphql`
@@ -141,16 +136,26 @@ export function TopModelsByCost({
         <Bar
           dataKey="prompt_cost"
           fill={colors.category1}
+          hide={isDataKeyHidden("prompt_cost")}
+          name="Prompt cost"
           stackId="a"
           radius={[2, 0, 0, 2]}
         />
         <Bar
           dataKey="completion_cost"
           fill={colors.category2}
+          hide={isDataKeyHidden("completion_cost")}
+          name="Completion cost"
           stackId="a"
           radius={[0, 2, 2, 0]}
         />
-        <Legend {...defaultLegendProps} iconType="circle" iconSize={8} />
+        <InteractiveLegend
+          {...defaultLegendProps}
+          hiddenDataKeys={hiddenDataKeys}
+          iconType="circle"
+          iconSize={8}
+          onToggleDataKey={toggleDataKey}
+        />
       </BarChart>
     </ResponsiveContainer>
   );

--- a/app/src/pages/project/metrics/TopModelsByToken.tsx
+++ b/app/src/pages/project/metrics/TopModelsByToken.tsx
@@ -5,7 +5,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -16,12 +15,14 @@ import { Text } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
   defaultCartesianGridProps,
   defaultLegendProps,
   defaultXAxisProps,
   defaultYAxisProps,
   truncateModelName,
   useCategoryChartColors,
+  useInteractiveLegend,
 } from "@phoenix/components/chart";
 import type { ProjectMetricViewProps } from "@phoenix/pages/project/metrics/types";
 import { intFormatter } from "@phoenix/utils/numberFormatUtils";
@@ -29,12 +30,7 @@ import { intFormatter } from "@phoenix/utils/numberFormatUtils";
 import type { TopModelsByTokenQuery } from "./__generated__/TopModelsByTokenQuery.graphql";
 
 function TooltipContent({ active, payload, label }: TooltipContentProps) {
-  const colors = useCategoryChartColors();
-
   if (active && payload && payload.length) {
-    const promptTokens = payload[0]?.value ?? null;
-    const completionTokens = payload[1]?.value ?? null;
-
     return (
       <ChartTooltip>
         {label && (
@@ -42,18 +38,15 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
             {String(label)}
           </Text>
         )}
-        <ChartTooltipItem
-          color={colors.category1}
-          shape="circle"
-          name="Prompt tokens"
-          value={intFormatter(Number(promptTokens))}
-        />
-        <ChartTooltipItem
-          color={colors.category2}
-          shape="circle"
-          name="Completion tokens"
-          value={intFormatter(Number(completionTokens))}
-        />
+        {payload.map((entry) => (
+          <ChartTooltipItem
+            color={entry.color ?? "transparent"}
+            key={String(entry.dataKey ?? entry.name)}
+            shape="circle"
+            name={String(entry.name ?? entry.dataKey ?? "unknown")}
+            value={intFormatter(Number(entry.value))}
+          />
+        ))}
       </ChartTooltip>
     );
   }
@@ -66,6 +59,8 @@ export function TopModelsByToken({
   timeRange,
 }: ProjectMetricViewProps) {
   const colors = useCategoryChartColors();
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
   const data = useLazyLoadQuery<TopModelsByTokenQuery>(
     graphql`
       query TopModelsByTokenQuery($projectId: ID!, $timeRange: TimeRange!) {
@@ -145,15 +140,25 @@ export function TopModelsByToken({
           dataKey="prompt_tokens"
           stackId="a"
           fill={colors.category1}
+          hide={isDataKeyHidden("prompt_tokens")}
+          name="Prompt tokens"
           radius={[2, 0, 0, 2]}
         />
         <Bar
           dataKey="completion_tokens"
           stackId="a"
           fill={colors.category2}
+          hide={isDataKeyHidden("completion_tokens")}
+          name="Completion tokens"
           radius={[0, 2, 2, 0]}
         />
-        <Legend {...defaultLegendProps} iconType="circle" iconSize={8} />
+        <InteractiveLegend
+          {...defaultLegendProps}
+          hiddenDataKeys={hiddenDataKeys}
+          iconType="circle"
+          iconSize={8}
+          onToggleDataKey={toggleDataKey}
+        />
       </BarChart>
     </ResponsiveContainer>
   );

--- a/app/src/pages/project/metrics/TraceCountTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceCountTimeSeries.tsx
@@ -5,7 +5,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -16,12 +15,14 @@ import { Text } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
   TimeRangeChartBrush,
   defaultCartesianGridProps,
   defaultLegendProps,
   defaultTimeXAxisProps,
   defaultYAxisProps,
   useBinTimeTickFormatter,
+  useInteractiveLegend,
   useSemanticChartColors,
   useSequentialChartColors,
 } from "@phoenix/components/chart";
@@ -36,13 +37,6 @@ import type { TraceCountTimeSeriesQuery } from "./__generated__/TraceCountTimeSe
 function TooltipContent({ active, payload, label }: TooltipContentProps) {
   const { fullTimeFormatter } = useTimeFormatters();
   if (active && payload && payload.length) {
-    // For stacked bar charts, payload[0] is the first bar (error), payload[1] is the second bar (ok)
-    const errorValue = payload[0]?.value ?? null;
-    const errorColor = payload[0]?.color ?? null;
-    const okValue = payload[1]?.value ?? null;
-    const okColor = payload[1]?.color ?? null;
-    const okString = intFormatter(Number(okValue));
-    const errorString = intFormatter(Number(errorValue));
     return (
       <ChartTooltip>
         {label && (
@@ -50,18 +44,18 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
             new Date(Number(label))
           )}`}</Text>
         )}
-        <ChartTooltipItem
-          color={errorColor ?? "transparent"}
-          shape="circle"
-          name="error"
-          value={errorString}
-        />
-        <ChartTooltipItem
-          color={okColor ?? "transparent"}
-          shape="circle"
-          name="ok"
-          value={okString}
-        />
+        {payload.map((entry) => {
+          const name = String(entry.dataKey ?? entry.name ?? "unknown");
+          return (
+            <ChartTooltipItem
+              color={entry.color ?? "transparent"}
+              key={name}
+              shape="circle"
+              name={name}
+              value={intFormatter(Number(entry.value))}
+            />
+          );
+        })}
       </ChartTooltip>
     );
   }
@@ -127,6 +121,8 @@ export function TraceCountTimeSeries({
 
   const colors = useSequentialChartColors();
   const SemanticChartColors = useSemanticChartColors();
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
@@ -167,15 +163,23 @@ export function TraceCountTimeSeries({
               dataKey="error"
               stackId="a"
               fill={SemanticChartColors.danger}
+              hide={isDataKeyHidden("error")}
             />
             <Bar
               dataKey="ok"
               stackId="a"
               fill={colors.gray300}
+              hide={isDataKeyHidden("ok")}
               radius={[2, 2, 0, 0]}
             />
 
-            <Legend iconType="circle" iconSize={8} {...defaultLegendProps} />
+            <InteractiveLegend
+              iconType="circle"
+              iconSize={8}
+              {...defaultLegendProps}
+              hiddenDataKeys={hiddenDataKeys}
+              onToggleDataKey={toggleDataKey}
+            />
           </BarChart>
         </ResponsiveContainer>
       )}

--- a/app/src/pages/project/metrics/TraceErrorsTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceErrorsTimeSeries.tsx
@@ -4,7 +4,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -15,12 +14,14 @@ import { Text } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
   TimeRangeChartBrush,
   defaultCartesianGridProps,
   defaultLegendProps,
   defaultTimeXAxisProps,
   defaultYAxisProps,
   useBinTimeTickFormatter,
+  useInteractiveLegend,
   useSemanticChartColors,
 } from "@phoenix/components/chart";
 import { useTimeBinScale } from "@phoenix/hooks/useTimeBin";
@@ -117,6 +118,8 @@ export function TraceErrorsTimeSeries({
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
 
   const SemanticChartColors = useSemanticChartColors();
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
@@ -157,10 +160,17 @@ export function TraceErrorsTimeSeries({
               dataKey="error"
               stackId="a"
               fill={SemanticChartColors.danger}
+              hide={isDataKeyHidden("error")}
               radius={[2, 2, 0, 0]}
             />
 
-            <Legend {...defaultLegendProps} iconType="circle" iconSize={8} />
+            <InteractiveLegend
+              {...defaultLegendProps}
+              hiddenDataKeys={hiddenDataKeys}
+              iconType="circle"
+              iconSize={8}
+              onToggleDataKey={toggleDataKey}
+            />
           </BarChart>
         </ResponsiveContainer>
       )}

--- a/app/src/pages/project/metrics/TraceLatencyPercentilesTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceLatencyPercentilesTimeSeries.tsx
@@ -1,10 +1,8 @@
-import { useState } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
-import type { LegendProps, TooltipContentProps } from "recharts";
+import type { TooltipContentProps } from "recharts";
 import {
   CartesianGrid,
   ComposedChart,
-  Legend,
   Line,
   ResponsiveContainer,
   Tooltip,
@@ -16,7 +14,9 @@ import { Text } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
   TimeRangeChartBrush,
+  useInteractiveLegend,
   useBinTimeTickFormatter,
   useSequentialChartColors,
 } from "@phoenix/components/chart";
@@ -128,23 +128,8 @@ export function TraceLatencyPercentilesTimeSeries({
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
 
   const colors = useSequentialChartColors();
-
-  // Legend interactivity
-  const [chartState, setChartState] = useState<Record<string, boolean>>({
-    p50: false,
-    p75: false,
-    p90: false,
-    p95: false,
-    p99: false,
-    p999: false,
-    max: false,
-  });
-  const selectChartItem: LegendProps["onClick"] = (e) => {
-    setChartState({
-      ...chartState,
-      [String(e.dataKey)]: !chartState[e.dataKey as string],
-    });
-  };
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
 
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
@@ -183,7 +168,7 @@ export function TraceLatencyPercentilesTimeSeries({
               strokeWidth={1}
               activeDot={{ r: 4 }}
               name="P50"
-              hide={chartState["p50"]}
+              hide={isDataKeyHidden("p50")}
             />
             <Line
               type="monotone"
@@ -193,7 +178,7 @@ export function TraceLatencyPercentilesTimeSeries({
               dot={{ r: 2 }}
               activeDot={{ r: 4 }}
               name="P75"
-              hide={chartState["p75"]}
+              hide={isDataKeyHidden("p75")}
             />
             <Line
               type="monotone"
@@ -203,7 +188,7 @@ export function TraceLatencyPercentilesTimeSeries({
               dot={{ r: 2 }}
               activeDot={{ r: 4 }}
               name="P90"
-              hide={chartState["p90"]}
+              hide={isDataKeyHidden("p90")}
             />
             <Line
               type="monotone"
@@ -213,7 +198,7 @@ export function TraceLatencyPercentilesTimeSeries({
               dot={{ r: 2 }}
               activeDot={{ r: 4 }}
               name="P95"
-              hide={chartState["p95"]}
+              hide={isDataKeyHidden("p95")}
             />
             <Line
               type="monotone"
@@ -223,7 +208,7 @@ export function TraceLatencyPercentilesTimeSeries({
               dot={{ r: 2 }}
               activeDot={{ r: 4 }}
               name="P99"
-              hide={chartState["p99"]}
+              hide={isDataKeyHidden("p99")}
             />
             <Line
               type="monotone"
@@ -233,7 +218,7 @@ export function TraceLatencyPercentilesTimeSeries({
               dot={{ r: 2 }}
               activeDot={{ r: 4 }}
               name="P99.9"
-              hide={chartState["p999"]}
+              hide={isDataKeyHidden("p999")}
             />
             <Line
               type="monotone"
@@ -244,13 +229,14 @@ export function TraceLatencyPercentilesTimeSeries({
               dot={{ r: 2 }}
               activeDot={{ r: 4 }}
               name="Max"
-              hide={chartState["max"]}
+              hide={isDataKeyHidden("max")}
             />
-            <Legend
+            <InteractiveLegend
               {...defaultLegendProps}
+              hiddenDataKeys={hiddenDataKeys}
               iconType="line"
               iconSize={8}
-              onClick={selectChartItem}
+              onToggleDataKey={toggleDataKey}
             />
             <Tooltip
               content={TooltipContent}

--- a/app/src/pages/project/metrics/TraceTokenCostTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceTokenCostTimeSeries.tsx
@@ -4,7 +4,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -15,6 +14,7 @@ import { Text } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
   TimeRangeChartBrush,
   defaultCartesianGridProps,
   defaultLegendProps,
@@ -22,6 +22,7 @@ import {
   defaultYAxisProps,
   useBinTimeTickFormatter,
   useCategoryChartColors,
+  useInteractiveLegend,
 } from "@phoenix/components/chart";
 import { useTimeBinScale } from "@phoenix/hooks/useTimeBin";
 import { useTimeFormatters } from "@phoenix/hooks/useTimeFormatters";
@@ -35,13 +36,8 @@ import {
 import type { TraceTokenCostTimeSeriesQuery } from "./__generated__/TraceTokenCostTimeSeriesQuery.graphql";
 
 function TooltipContent({ active, payload, label }: TooltipContentProps) {
-  const chartColors = useCategoryChartColors();
   const { fullTimeFormatter } = useTimeFormatters();
   if (active && payload && payload.length) {
-    const promptValue = payload[0]?.value;
-    const completionValue = payload[1]?.value;
-    const promptString = costFormatter(Number(promptValue));
-    const completionString = costFormatter(Number(completionValue));
     return (
       <ChartTooltip>
         {label && (
@@ -49,18 +45,18 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
             new Date(Number(label))
           )}`}</Text>
         )}
-        <ChartTooltipItem
-          color={chartColors.category1}
-          shape="circle"
-          name="prompt"
-          value={promptString}
-        />
-        <ChartTooltipItem
-          color={chartColors.category2}
-          shape="circle"
-          name="completion"
-          value={completionString}
-        />
+        {payload.map((entry) => {
+          const name = String(entry.dataKey ?? entry.name ?? "unknown");
+          return (
+            <ChartTooltipItem
+              color={entry.color ?? "transparent"}
+              key={name}
+              shape="circle"
+              name={name}
+              value={costFormatter(Number(entry.value))}
+            />
+          );
+        })}
       </ChartTooltip>
     );
   }
@@ -128,6 +124,8 @@ export function TraceTokenCostTimeSeries({
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
 
   const colors = useCategoryChartColors();
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
@@ -164,15 +162,27 @@ export function TraceTokenCostTimeSeries({
               // TODO formalize this
               cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
             />
-            <Bar dataKey="prompt" stackId="a" fill={colors.category1} />
+            <Bar
+              dataKey="prompt"
+              stackId="a"
+              fill={colors.category1}
+              hide={isDataKeyHidden("prompt")}
+            />
             <Bar
               dataKey="completion"
               stackId="a"
               fill={colors.category2}
+              hide={isDataKeyHidden("completion")}
               radius={[2, 2, 0, 0]}
             />
 
-            <Legend {...defaultLegendProps} iconType="circle" iconSize={8} />
+            <InteractiveLegend
+              {...defaultLegendProps}
+              hiddenDataKeys={hiddenDataKeys}
+              iconType="circle"
+              iconSize={8}
+              onToggleDataKey={toggleDataKey}
+            />
           </BarChart>
         </ResponsiveContainer>
       )}

--- a/app/src/pages/project/metrics/TraceTokenCountTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceTokenCountTimeSeries.tsx
@@ -4,7 +4,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -15,6 +14,7 @@ import { Text } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
   TimeRangeChartBrush,
   defaultCartesianGridProps,
   defaultLegendProps,
@@ -22,6 +22,7 @@ import {
   defaultYAxisProps,
   useBinTimeTickFormatter,
   useCategoryChartColors,
+  useInteractiveLegend,
 } from "@phoenix/components/chart";
 import { useTimeBinScale } from "@phoenix/hooks/useTimeBin";
 import { useTimeFormatters } from "@phoenix/hooks/useTimeFormatters";
@@ -35,18 +36,8 @@ import {
 import type { TraceTokenCountTimeSeriesQuery } from "./__generated__/TraceTokenCountTimeSeriesQuery.graphql";
 
 function TooltipContent({ active, payload, label }: TooltipContentProps) {
-  const chartColors = useCategoryChartColors();
   const { fullTimeFormatter } = useTimeFormatters();
   if (active && payload && payload.length) {
-    // For stacked bar charts, payload[0] is the first bar (prompt), payload[1] is the second bar (completion)
-    const promptValue = payload[0]?.value ?? null;
-    const completionValue = payload[1]?.value ?? null;
-    const promptString =
-      typeof promptValue === "number" ? intFormatter(promptValue) : "--";
-    const completionString =
-      typeof completionValue === "number"
-        ? intFormatter(completionValue)
-        : "--";
     return (
       <ChartTooltip>
         {label && (
@@ -54,18 +45,22 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
             new Date(Number(label))
           )}`}</Text>
         )}
-        <ChartTooltipItem
-          color={chartColors.category1}
-          shape="circle"
-          name="prompt"
-          value={promptString}
-        />
-        <ChartTooltipItem
-          color={chartColors.category2}
-          shape="circle"
-          name="completion"
-          value={completionString}
-        />
+        {payload.map((entry) => {
+          const name = String(entry.dataKey ?? entry.name ?? "unknown");
+          return (
+            <ChartTooltipItem
+              color={entry.color ?? "transparent"}
+              key={name}
+              shape="circle"
+              name={name}
+              value={
+                typeof entry.value === "number"
+                  ? intFormatter(entry.value)
+                  : "--"
+              }
+            />
+          );
+        })}
       </ChartTooltip>
     );
   }
@@ -129,6 +124,8 @@ export function TraceTokenCountTimeSeries({
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
 
   const colors = useCategoryChartColors();
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
   return (
     <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
       {({ chartProps }) => (
@@ -166,15 +163,27 @@ export function TraceTokenCountTimeSeries({
               // TODO formalize this
               cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
             />
-            <Bar dataKey="prompt" stackId="a" fill={colors.category1} />
+            <Bar
+              dataKey="prompt"
+              stackId="a"
+              fill={colors.category1}
+              hide={isDataKeyHidden("prompt")}
+            />
             <Bar
               dataKey="completion"
               stackId="a"
               fill={colors.category2}
+              hide={isDataKeyHidden("completion")}
               radius={[2, 2, 0, 0]}
             />
 
-            <Legend {...defaultLegendProps} iconType="circle" iconSize={8} />
+            <InteractiveLegend
+              {...defaultLegendProps}
+              hiddenDataKeys={hiddenDataKeys}
+              iconType="circle"
+              iconSize={8}
+              onToggleDataKey={toggleDataKey}
+            />
           </BarChart>
         </ResponsiveContainer>
       )}

--- a/app/stories/StackedTimeSeriesBarChart.stories.tsx
+++ b/app/stories/StackedTimeSeriesBarChart.stories.tsx
@@ -4,7 +4,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -16,12 +15,14 @@ import type { SequentialChartColors } from "@phoenix/components/chart";
 import {
   ChartTooltip,
   ChartTooltipItem,
+  InteractiveLegend,
+  SEQUENTIAL_CHART_COLORS,
   defaultBarChartTooltipProps,
   defaultCartesianGridProps,
   defaultLegendProps,
   defaultXAxisProps,
   defaultYAxisProps,
-  SEQUENTIAL_CHART_COLORS,
+  useInteractiveLegend,
   useSequentialChartColors,
   useTimeTickFormatter,
 } from "@phoenix/components/chart";
@@ -149,18 +150,9 @@ const highVolumeData = [
 ];
 
 function TooltipContent({ active, payload, label }: TooltipContentProps) {
-  const chartColors = useSequentialChartColors();
   const { fullTimeFormatter } = useTimeFormatters();
 
   if (active && payload && payload.length) {
-    const metricValue = payload[1]?.value ?? null;
-    const count = payload[0]?.value ?? null;
-    const metricString =
-      typeof metricValue === "number"
-        ? numberFormatter.format(metricValue)
-        : "--";
-    const predictionCountString =
-      typeof count === "number" ? numberFormatter.format(count) : "--";
     return (
       <ChartTooltip>
         {label && (
@@ -168,18 +160,22 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
             new Date(label)
           )}`}</Text>
         )}
-        <ChartTooltipItem
-          color={chartColors.red300}
-          shape="circle"
-          name="error"
-          value={metricString}
-        />
-        <ChartTooltipItem
-          color={chartColors.default}
-          shape="circle"
-          name="ok"
-          value={predictionCountString}
-        />
+        {payload.map((entry) => {
+          const name = String(entry.dataKey ?? entry.name ?? "unknown");
+          return (
+            <ChartTooltipItem
+              color={entry.color ?? "transparent"}
+              key={name}
+              shape="circle"
+              name={name}
+              value={
+                typeof entry.value === "number"
+                  ? numberFormatter.format(entry.value)
+                  : "--"
+              }
+            />
+          );
+        })}
       </ChartTooltip>
     );
   }
@@ -215,6 +211,8 @@ function StackedBarChart({
   });
 
   const colors = useSequentialChartColors();
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
 
   return (
     <div style={{ width: "100%", height }}>
@@ -245,18 +243,26 @@ function StackedBarChart({
 
           <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
           <Tooltip {...defaultBarChartTooltipProps} content={TooltipContent} />
-          <Bar dataKey="error" stackId="a" fill={colors[firstColor]} />
+          <Bar
+            dataKey="error"
+            stackId="a"
+            fill={colors[firstColor]}
+            hide={isDataKeyHidden("error")}
+          />
           <Bar
             dataKey="ok"
             stackId="a"
             fill={colors[secondColor]}
+            hide={isDataKeyHidden("ok")}
             radius={[2, 2, 0, 0]}
           />
 
-          <Legend
+          <InteractiveLegend
             align="left"
+            hiddenDataKeys={hiddenDataKeys}
             iconType="circle"
             iconSize={8}
+            onToggleDataKey={toggleDataKey}
             {...defaultLegendProps}
           />
         </BarChart>


### PR DESCRIPTION
## Summary

Adds a reusable `InteractiveLegend` wrapper for Recharts charts and a `useInteractiveLegend` hook for shared hidden-series state. Migrates the project metrics charts and the experiments analysis chart to use the shared legend so clicking legend items hides or shows the corresponding series.

Tooltips now render from the visible Recharts payload so hidden series are removed from tooltip content, and score axes recalculate from visible score series where applicable.

## Validation

- `app/node_modules/.bin/tsc --noEmit -p app/tsconfig.json`
- `app/node_modules/.bin/oxlint app/src/components/chart/InteractiveLegend.tsx app/src/components/chart/__tests__/InteractiveLegend.test.tsx app/src/pages/project/metrics/TraceLatencyPercentilesTimeSeries.tsx app/src/pages/project/metrics/SpanAnnotationScoreTimeSeries.tsx app/src/pages/project/metrics/TopModelsByCost.tsx app/src/pages/project/metrics/TopModelsByToken.tsx app/src/pages/project/metrics/TraceCountTimeSeries.tsx app/src/pages/project/metrics/LLMSpanCountTimeSeries.tsx app/src/pages/project/metrics/TraceErrorsTimeSeries.tsx app/src/pages/project/metrics/LLMSpanErrorsTimeSeries.tsx app/src/pages/project/metrics/ToolSpanErrorsTimeSeries.tsx app/src/pages/project/metrics/TraceTokenCountTimeSeries.tsx app/src/pages/project/metrics/TraceTokenCostTimeSeries.tsx app/src/pages/project/metrics/ToolSpanCountTimeSeries.tsx app/stories/StackedTimeSeriesBarChart.stories.tsx`
- `node_modules/.bin/vitest run src/components/chart/__tests__/InteractiveLegend.test.tsx --config vite.config.mts`
- Storybook smoke with `agent-browser` on the stacked time-series chart: legend buttons toggle Hide/Show and hidden series are removed from chart and tooltip content.
