### PR TITLE
ci: harden workflows against zizmor findings

### DIFF
--- a/.github/workflows/auto-label-external-issues.yaml
+++ b/.github/workflows/auto-label-external-issues.yaml
@@ -7,6 +7,7 @@ on:
   # default token has write permissions even for fork PRs. We only react
   # to the `opened` event and do not check out the PR head, so the
   # elevated token is not exposed to untrusted code.
+  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened]
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,6 +2,9 @@ name: "CLA Assistant"
 on:
   issue_comment:
     types: [created]
+  # zizmor: ignore[dangerous-triggers] CLA Assistant requires pull_request_target
+  # so it can update statuses/comments for external contributors without checking
+  # out or executing pull request code.
   pull_request_target:
     types: [opened, synchronize, reopened]
 
@@ -17,9 +20,10 @@ jobs:
       pull-requests: write # comment on the PR
       statuses: write # set the CLA commit status
     steps:
+      # Existing CLA integration; replacing the service requires a separate CLA migration.
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # zizmor: ignore[archived-uses] v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/collect-customer-issues.yaml
+++ b/.github/workflows/collect-customer-issues.yaml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: |
             .github/
       - name: Retrieve and format issues

--- a/.github/workflows/cost-sync.yml
+++ b/.github/workflows/cost-sync.yml
@@ -1,8 +1,7 @@
 name: Sync Model Pricing Data
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 env:
   ACTIONS_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -18,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       

--- a/.github/workflows/docker-build-experimental.yml
+++ b/.github/workflows/docker-build-experimental.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set BASE_IMAGE environment variable
         id: set-base-image

--- a/.github/workflows/docker-build-nightly.yml
+++ b/.github/workflows/docker-build-nightly.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set BASE_IMAGE environment variable
         id: set-base-image

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: extract_version
@@ -102,14 +104,20 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
       - name: Update Kustomize image version
-        run: python scripts/update_kustomize.py "${{ needs.push_to_registry.outputs.version }}"
+        env:
+          PHOENIX_VERSION: ${{ needs.push_to_registry.outputs.version }}
+        run: python scripts/update_kustomize.py "$PHOENIX_VERSION"
       - name: Update Helm chart version
-        run: python scripts/update_helm.py "${{ needs.push_to_registry.outputs.version }}"
+        env:
+          PHOENIX_VERSION: ${{ needs.push_to_registry.outputs.version }}
+        run: python scripts/update_helm.py "$PHOENIX_VERSION"
       - name: Setup helm-docs
         uses: gabe565/setup-helm-docs-action@d5c35bdc9133cfbea3b671acadf50a29029e87c2 # v1.0.4
       - name: Run helm-docs

--- a/.github/workflows/generate-sitemap.yml
+++ b/.github/workflows/generate-sitemap.yml
@@ -10,8 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   generate-sitemap:
@@ -21,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
-          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: setup node.js

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
     - name: Check out the repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Log in to Docker Hub
       uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0

--- a/.github/workflows/openapi-schema.yaml
+++ b/.github/workflows/openapi-schema.yaml
@@ -17,13 +17,20 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
           sparse-checkout: schemas/openapi.json
           sparse-checkout-cone-mode: false
       - name: Snapshot head schema
+        env:
+          BASE_REF: ${{ github.base_ref || github.event.before }}
         run: |
           jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \
             schemas/openapi.json > head.json
-          git checkout ${{ github.base_ref }}
+          if [ -z "$BASE_REF" ]; then
+            echo "::error::Could not determine base ref for OpenAPI schema comparison"
+            exit 1
+          fi
+          git checkout "$BASE_REF"
       - name: Snapshot base schema
         run: |
           jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \

--- a/.github/workflows/package-version-check.yml
+++ b/.github/workflows/package-version-check.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check pnpm version consistency
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -157,11 +157,14 @@ jobs:
     steps:
       - name: Check if package needs building
         id: check
+        env:
+          PACKAGE_PATHS: ${{ needs.list-python-packages.outputs.package_paths }}
+          MATRIX_PATH: ${{ matrix.path }}
         run: |
-          if echo '${{ needs.list-python-packages.outputs.package_paths }}' | jq -e --arg p "${{ matrix.path }}" 'index($p)' > /dev/null 2>&1; then
+          if echo "$PACKAGE_PATHS" | jq -e --arg p "$MATRIX_PATH" 'index($p)' > /dev/null 2>&1; then
             echo "needed=true" >> $GITHUB_OUTPUT
           else
-            echo "Skipping ${{ matrix.path }} — already on PyPI"
+            echo "Skipping $MATRIX_PATH — already on PyPI"
             echo "needed=false" >> $GITHUB_OUTPUT
           fi
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -228,8 +231,11 @@ jobs:
     steps:
       - name: Check if package needs publishing
         id: check
+        env:
+          PACKAGE_PATHS: ${{ needs.list-python-packages.outputs.package_paths }}
+          MATRIX_PATH: ${{ matrix.path }}
         run: |
-          if echo '${{ needs.list-python-packages.outputs.package_paths }}' | jq -e --arg p "${{ matrix.path }}" 'index($p)' > /dev/null 2>&1; then
+          if echo "$PACKAGE_PATHS" | jq -e --arg p "$MATRIX_PATH" 'index($p)' > /dev/null 2>&1; then
             echo "needed=true" >> $GITHUB_OUTPUT
           else
             echo "needed=false" >> $GITHUB_OUTPUT
@@ -263,8 +269,11 @@ jobs:
     steps:
       - name: Check if package was published
         id: check
+        env:
+          PACKAGE_PATHS: ${{ needs.list-python-packages.outputs.package_paths }}
+          MATRIX_PATH: ${{ matrix.path }}
         run: |
-          if echo '${{ needs.list-python-packages.outputs.package_paths }}' | jq -e --arg p "${{ matrix.path }}" 'index($p)' > /dev/null 2>&1; then
+          if echo "$PACKAGE_PATHS" | jq -e --arg p "$MATRIX_PATH" 'index($p)' > /dev/null 2>&1; then
             echo "needed=true" >> $GITHUB_OUTPUT
           else
             echo "needed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/pypi-smoke-test.yml
+++ b/.github/workflows/pypi-smoke-test.yml
@@ -7,6 +7,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 13 * * *"
+  # zizmor: ignore[dangerous-triggers] This workflow_run path intentionally
+  # smoke-tests the package published by the trusted publish workflow. It does
+  # not checkout workflow_run artifacts or run code from the triggering commit.
   workflow_run:
     workflows:
       - Publish Python packages

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -37,6 +37,8 @@ jobs:
       json_canonicalization_schema: ${{ steps.filter.outputs.json_canonicalization_schema }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
@@ -71,17 +73,28 @@ jobs:
               - "**/pyproject.toml"
               - "uv.lock"
       - name: Print Filters
+        env:
+          IPYNB: ${{ steps.filter.outputs.ipynb }}
+          IPYNB_FILES: ${{ steps.filter.outputs.ipynb_files }}
+          PROMPTS: ${{ steps.filter.outputs.prompts }}
+          PHOENIX: ${{ steps.filter.outputs.phoenix }}
+          PHOENIX_CLIENT: ${{ steps.filter.outputs.phoenix_client }}
+          PHOENIX_EVALS: ${{ steps.filter.outputs.phoenix_evals }}
+          PHOENIX_OTEL: ${{ steps.filter.outputs.phoenix_otel }}
+          MIGRATIONS: ${{ steps.filter.outputs.migrations }}
+          UV_LOCK: ${{ steps.filter.outputs.uv_lock }}
+          JSON_CANONICALIZATION_SCHEMA: ${{ steps.filter.outputs.json_canonicalization_schema }}
         run: |
-          echo "ipynb: ${{ steps.filter.outputs.ipynb }}"
-          echo "ipynb_files: ${{ steps.filter.outputs.ipynb_files }}"
-          echo "prompts: ${{ steps.filter.outputs.prompts }}"
-          echo "phoenix: ${{ steps.filter.outputs.phoenix }}"
-          echo "phoenix_client: ${{ steps.filter.outputs.phoenix_client }}"
-          echo "phoenix_evals: ${{ steps.filter.outputs.phoenix_evals }}"
-          echo "phoenix_otel: ${{ steps.filter.outputs.phoenix_otel }}"
-          echo "migrations: ${{ steps.filter.outputs.migrations }}"
-          echo "uv_lock: ${{ steps.filter.outputs.uv_lock }}"
-          echo "json_canonicalization_schema: ${{ steps.filter.outputs.json_canonicalization_schema }}"
+          echo "ipynb: $IPYNB"
+          echo "ipynb_files: $IPYNB_FILES"
+          echo "prompts: $PROMPTS"
+          echo "phoenix: $PHOENIX"
+          echo "phoenix_client: $PHOENIX_CLIENT"
+          echo "phoenix_evals: $PHOENIX_EVALS"
+          echo "phoenix_otel: $PHOENIX_OTEL"
+          echo "migrations: $MIGRATIONS"
+          echo "uv_lock: $UV_LOCK"
+          echo "json_canonicalization_schema: $JSON_CANONICALIZATION_SCHEMA"
 
   phoenix-client:
     name: Phoenix Client
@@ -94,6 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: |
             requirements/
             packages/phoenix-client/
@@ -118,6 +132,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: |
             requirements/
             packages/phoenix-evals/
@@ -140,6 +155,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: |
             requirements/
             packages/phoenix-otel/
@@ -209,6 +225,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.py }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -233,6 +251,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.py }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -257,6 +277,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.py }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -281,6 +303,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.py }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -307,6 +331,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.py }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -329,6 +355,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.py }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -357,6 +385,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: |
             Makefile
             scripts/ci/
@@ -394,6 +423,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: |
             requirements/
             src/phoenix/
@@ -454,6 +484,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: |
             requirements/
             src/phoenix/
@@ -539,6 +570,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: src/phoenix/
       - name: Install Phoenix from current branch
         run: |
@@ -574,6 +606,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: |
             requirements/
             packages/phoenix-client/

--- a/.github/workflows/sync-lockfile-release-pr.yml
+++ b/.github/workflows/sync-lockfile-release-pr.yml
@@ -18,17 +18,20 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref_name }}
-          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.11.8"
+          enable-cache: false
 
       - name: Update lockfile
         run: uv lock
 
       - name: Commit and push if changed
+        env:
+          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
         run: |
           if git diff --quiet uv.lock; then
             echo "uv.lock is already up to date"
@@ -38,4 +41,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add uv.lock
           git commit -m "chore: sync uv.lock"
+          gh auth setup-git
           git push

--- a/.github/workflows/typescript-packages-publish-experimental.yml
+++ b/.github/workflows/typescript-packages-publish-experimental.yml
@@ -1,7 +1,7 @@
 name: Publish Any Pull Request
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 # TODO: Only publish on pull requests by arize team members
 on:
   pull_request:
@@ -46,6 +46,9 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.phoenix-client == 'true' || needs.changes.outputs.phoenix-mcp == 'true' || needs.changes.outputs.phoenix-evals == 'true' || needs.changes.outputs.phoenix-otel == 'true' || needs.changes.outputs.phoenix-cli == 'true' || needs.changes.outputs.workflow_file == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # pkg-pr-new comments preview install URLs on the PR
 
     steps:
       - name: Checkout code

--- a/.github/workflows/typescript-packages-publish.yml
+++ b/.github/workflows/typescript-packages-publish.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.MY_CHANGESET_TOKEN }}
+          persist-credentials: false
       - name: setup node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/update-phoenix-package-versions.yml
+++ b/.github/workflows/update-phoenix-package-versions.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           ref: main
+          persist-credentials: false
 
       - name: Validate version input
         run: |


### PR DESCRIPTION
## Summary

Workflow hardening pass driven by `uvx zizmor`. All 21 modified workflows pass zizmor with no findings.

- **`persist-credentials: false`** on every `actions/checkout` step. Without this the workflow's `GITHUB_TOKEN` (and any custom PAT passed via `token:`) is left in `.git/config` and is reachable from any subsequent step or composite action — the `artipacked` finding. Drops the now-dead `token:` inputs in workflows where the helper credentials are no longer used.
- **Template-injection hardening** for `${{ ... }}` interpolations that flow into shell strings: cross-job outputs (`needs.*.outputs.*`), matrix values, and `dorny/paths-filter` outputs now route through `env:` blocks so they're shell-quoted as `$VAR` rather than spliced into the script verbatim. Affects `docker-build-release.yml`, `publish.yaml`, `python-CI.yml`, `openapi-schema.yaml`.
- **Scoped least-privilege**: `cost-sync.yml`, `generate-sitemap.yml`, `typescript-packages-publish-experimental.yml` drop workflow-level write scopes; jobs that genuinely need write (`pkg-pr-new` commenting, `peter-evans/create-pull-request`) get it via the action's own token or per-job `permissions:`.
- **Documented suppressions** for findings that are intentional: `dangerous-triggers` on `auto-label-external-issues.yaml`, `cla.yml`, `pypi-smoke-test.yml`'s `workflow_run` block; `archived-uses` on the `contributor-assistant/github-action` step in `cla.yml`.
- **`sync-lockfile-release-pr.yml`** swaps persisted-credential `git push` for `gh auth setup-git` keyed off `GH_TOKEN`, the canonical pattern for "push back from a workflow without `persist-credentials: true`".

The `claude-*.yaml` workflows have the same `artipacked` pattern but are being addressed in a separate PR.

## Test plan

- [x] `uvx zizmor` on all 21 modified workflows — clean (0 findings, suppressions accounted for)
- [ ] CI passes on this branch (python-CI, helm-ci, package-version-check, openapi-schema, typescript-CI, etc. all run on PR)
- [ ] Sanity-check workflow runs that exercise PR-creation paths (`typescript-packages-publish-experimental` should still post the `pkg-pr-new` preview comment on this PR if the changed files match)