### PR TITLE
refactor: drop unused ALLOWLIST sandbox internet-access mode

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2174,7 +2174,6 @@ input InternetAccessInput {
 enum InternetAccessMode {
   NONE
   BOOLEAN
-  ALLOWLIST
 }
 
 """

--- a/app/src/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideoverQuery.graphql.ts
+++ b/app/src/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideoverQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<18f468bcb4196b93256217886590e55b>>
+ * @generated SignedSource<<7204aa058652346c35570d70df076ab9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 export type InternetAccessChoice = "ALLOW" | "DENY";
-export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
+export type InternetAccessMode = "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type SandboxBackendStatus = "AVAILABLE" | "DISABLED" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
 export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";

--- a/app/src/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery.graphql.ts
+++ b/app/src/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<17ff36e3b325f879d3cec9dd4b928d5a>>
+ * @generated SignedSource<<c3cf27951b6e6d3790f88b11dc30ce56>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
 export type InternetAccessChoice = "ALLOW" | "DENY";
-export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
+export type InternetAccessMode = "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
 export type SandboxBackendStatus = "AVAILABLE" | "DISABLED" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";

--- a/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorDetails.tsx
+++ b/app/src/pages/dataset/evaluators/CodeDatasetEvaluatorDetails.tsx
@@ -344,8 +344,6 @@ function getInternetAccessLabel(
   switch (internetAccess) {
     case "BOOLEAN":
       return "Configurable";
-    case "ALLOWLIST":
-      return "Allowlist";
     case "NONE":
       return "Not supported";
     default:

--- a/app/src/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql.ts
+++ b/app/src/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ca3b6a617e87739e4d3dccda7b2e0c73>>
+ * @generated SignedSource<<e487a5627240430c032fd01fcc4c11ea>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
-export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
+export type InternetAccessMode = "BOOLEAN" | "NONE";
 export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";
 export type datasetEvaluatorDetailsLoaderQuery$variables = {
   datasetEvaluatorId: string;

--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -644,7 +644,6 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
                 </Text>
               </Flex>
             ) : null}
-            {/* "ALLOWLIST" mode is reserved for future use — not user-selectable here. */}
             {activeBackend?.internetAccess === "BOOLEAN" ? (
               <Controller
                 name="internetAccessEnabled"

--- a/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<09387a4534ce7e7309c5f4cc9ee2fdb1>>
+ * @generated SignedSource<<8117136b5c124d3dcda758affc7302ec>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ReaderFragment } from 'relay-runtime';
 export type InternetAccessChoice = "ALLOW" | "DENY";
-export type InternetAccessMode = "ALLOWLIST" | "BOOLEAN" | "NONE";
+export type InternetAccessMode = "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type SandboxBackendStatus = "AVAILABLE" | "DISABLED" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
 export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";

--- a/src/phoenix/server/api/types/SandboxConfig.py
+++ b/src/phoenix/server/api/types/SandboxConfig.py
@@ -86,7 +86,6 @@ class InternetAccessMode(Enum):
 
     NONE = "none"
     BOOLEAN = "boolean"
-    ALLOWLIST = "allowlist"
 
 
 @strawberry.enum

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -61,7 +61,7 @@ class AdapterMetadata:
     supports_dependencies: bool = False
     hosting_type: Literal["local", "hosted"] = "hosted"
     supports_env_vars: bool = False
-    internet_access_capability: Literal["none", "boolean", "allowlist"] = "none"
+    internet_access_capability: Literal["none", "boolean"] = "none"
 
     @classmethod
     def from_cls(cls, adapter_cls: type[SandboxAdapter[Any, Any, Any]]) -> "AdapterMetadata":


### PR DESCRIPTION
## Summary
- `InternetAccessMode.ALLOWLIST` on the GraphQL `SandboxBackendInfo.internetAccess` field was never produced by any adapter — `AdapterMetadata.from_cls` only ever assigns `"boolean"` or `"none"`.
- Frontend handling for it (a switch case in `CodeDatasetEvaluatorDetails` and a `"reserved for future use"` comment in `SandboxConfigDialog`) was scaffolding only.
- This PR removes the enum value, narrows the `internet_access_capability` `Literal[...]`, drops the unreachable frontend branches, and regenerates the schema + Relay artifacts. When/if per-domain allowlisting actually lands, the value can be reintroduced alongside a real implementation.

## Test plan
- [x] `make typecheck-python` passes
- [x] `make typecheck-frontend` passes
- [x] `tests/unit/server/sandbox/test_unified_config_contract.py` + `tests/unit/server/api/test_capability_advertisement.py` pass