### PR TITLE
ci: restore id-token: write for claude-code-action workflows

### DIFF
--- a/.github/workflows/check-dependabot-uv-version.yml
+++ b/.github/workflows/check-dependabot-uv-version.yml
@@ -15,6 +15,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,6 +23,7 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
+      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-docs-gap-audit.yml
+++ b/.github/workflows/claude-docs-gap-audit.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -12,6 +12,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
     env:
       GH_REPO: ${{ github.repository }}
       ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/claude-llms-txt.yml
+++ b/.github/workflows/claude-llms-txt.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-skills-audit.yml
+++ b/.github/workflows/claude-skills-audit.yml
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
     env:
       AUDIT_WINDOW: ${{ inputs.window || '7 days ago' }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- #13479 dropped `id-token: write` from every workflow that invokes `anthropics/claude-code-action`. The action requests a GitHub OIDC token at startup on the default GitHub App auth path ([docs/setup.md](https://github.com/anthropics/claude-code-action/blob/v1.0.133/docs/setup.md): _"The default GitHub App authentication path already requires this permission"_), so without it every `@claude` invocation fails with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable` before any work runs — e.g. [run 26558828841](https://github.com/Arize-ai/phoenix/actions/runs/26558828841/job/78236658110).
- Restores `id-token: write` on the eight workflows that call the action: `claude.yml`, `claude-code-review.yml`, `claude-docs-gap-audit.yml`, `claude-implement-issue.yml`, `claude-llms-txt.yml`, `claude-release-notes.yml`, `claude-skills-audit.yml`, `check-dependabot-uv-version.yml`.
- `uvx zizmor` on the touched workflows reports no findings.

## Test plan

- [ ] Re-trigger an `@claude` mention on a PR and confirm the `Claude Code` job runs past `Requesting OIDC token...` without retrying.
- [ ] Verify the scheduled audit workflows (`claude-docs-gap-audit`, `claude-llms-txt`, `claude-release-notes`, `claude-skills-audit`) succeed on their next run, or via `workflow_dispatch`.