### PR TITLE
ci: install bubblewrap for claude-code-action env scrubbing

### DIFF
--- a/.github/workflows/check-dependabot-uv-version.yml
+++ b/.github/workflows/check-dependabot-uv-version.yml
@@ -82,6 +82,11 @@ jobs:
         with:
           version: ${{ steps.dependabot.outputs.version }}
 
+      - name: Install bubblewrap
+        if: steps.dependabot.outputs.version != steps.repo.outputs.version && steps.existing_pr.outputs.count == '0'
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Run Claude Code
         if: steps.dependabot.outputs.version != steps.repo.outputs.version && steps.existing_pr.outputs.count == '0'
         id: claude

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,6 +32,10 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Install bubblewrap
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133

--- a/.github/workflows/claude-docs-gap-audit.yml
+++ b/.github/workflows/claude-docs-gap-audit.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Prepare scratch directory
         run: mkdir -p .scratch
 
+      - name: Install bubblewrap
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -72,6 +72,11 @@ jobs:
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
           mkdir -p .scratch
 
+      - name: Install bubblewrap
+        if: steps.guard.outputs.ready == 'true'
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Run Claude Code
         if: steps.guard.outputs.ready == 'true'
         id: claude

--- a/.github/workflows/claude-llms-txt.yml
+++ b/.github/workflows/claude-llms-txt.yml
@@ -33,6 +33,10 @@ jobs:
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
           mkdir -p .scratch
 
+      - name: Install bubblewrap
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -33,6 +33,10 @@ jobs:
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
           mkdir -p .scratch
 
+      - name: Install bubblewrap
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133

--- a/.github/workflows/claude-skills-audit.yml
+++ b/.github/workflows/claude-skills-audit.yml
@@ -51,6 +51,10 @@ jobs:
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "date=$DATE" >> "$GITHUB_OUTPUT"
 
+      - name: Install bubblewrap
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,6 +38,10 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Install bubblewrap
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133


### PR DESCRIPTION
## Summary

- #13479 set `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"` on every `claude-code-action` workflow, but the bundled `claude` CLI in v1.0.133 now hard-requires `bubblewrap` to be available when that flag is on and refuses to start otherwise:
  ```
  error: bubblewrap is required for subprocess env scrubbing and isolation.
  Install with: sudo apt-get install -y bubblewrap, set sandbox.bwrapPath in
  managed settings, or set CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0 to disable
  (loses subprocess isolation).
  ```
- `ubuntu-latest` doesn't ship bubblewrap, so every Claude run since #13479 has been failing at install time — e.g. [run 26559566054](https://github.com/Arize-ai/phoenix/actions/runs/26559566054/job/78239008542).
- Adds an `apt-get install -y bubblewrap` step before each `claude-code-action` invocation so the env-scrub hardening keeps working. Gated to match the existing conditional on `check-dependabot-uv-version.yml` (only runs when a uv bump is needed) and the `steps.guard.outputs.ready` guard on `claude-implement-issue.yml`.
- Companion to #13484 (which restored `id-token: write`); together these resolve the two regressions from #13479.
- `uvx zizmor` on the touched workflows is clean.

## Test plan

- [ ] Re-trigger the `Claude Code Review` workflow on a PR and confirm the `Install bubblewrap` step succeeds and the `Run Claude Code Review` step gets past install.
- [ ] Re-trigger `@claude` on a PR comment and confirm Claude can respond end-to-end.
- [ ] Verify the scheduled audit workflows (`claude-docs-gap-audit`, `claude-llms-txt`, `claude-release-notes`, `claude-skills-audit`) succeed on their next run or via `workflow_dispatch`.