### PR TITLE
feat(filter): make span_kind comparisons case-insensitive

### DIFF
--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -305,20 +305,17 @@ def _is_span_kind(node: typing.Any) -> TypeGuard[ast.Name]:
     return isinstance(node, ast.Name) and node.id == "span_kind"
 
 
-def _upper_string_literal(node: ast.expr) -> ast.expr:
-    """
-    Uppercase a string `ast.Constant`, or each string `ast.Constant` inside an
-    `ast.List`/`ast.Tuple`. Other nodes are returned unchanged. Used to
-    normalize literals compared against `span_kind`, whose stored values are
-    canonical uppercase (see `SpanKind` in `phoenix.trace.schemas`).
-    """
+def _convert_to_uppercase(node: ast.expr) -> ast.expr:
+    """Converts constants and lists/ tuples of constants to uppercase."""
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return ast.Constant(value=node.value.upper(), kind=node.kind)
     if isinstance(node, (ast.List, ast.Tuple)):
-        new_elts = [_upper_string_literal(elt) for elt in node.elts]
+        new_elts = [_convert_to_uppercase(elt) for elt in node.elts]
         if isinstance(node, ast.List):
             return ast.List(elts=new_elts, ctx=node.ctx)
-        return ast.Tuple(elts=new_elts, ctx=node.ctx)
+        if isinstance(node, ast.Tuple):
+            return ast.Tuple(elts=new_elts, ctx=node.ctx)
+        assert_never(node)
     return node
 
 
@@ -524,13 +521,10 @@ class _FilterTranslator(_ProjectionTranslator):
                 left = comparator
             return ast.Call(func=ast.Name(id="and_", ctx=ast.Load()), args=args, keywords=[])
         left, op, right = self.visit(node.left), node.ops[0], self.visit(node.comparators[0])
-        # span_kind is stored in canonical uppercase (see `SpanKind` in
-        # phoenix.trace.schemas); uppercase string literals compared against it
-        # so the UI's lowercase display values can be used directly in filters.
         if _is_span_kind(left):
-            right = _upper_string_literal(right)
+            right = _convert_to_uppercase(right)
         elif _is_span_kind(right):
-            left = _upper_string_literal(left)
+            left = _convert_to_uppercase(left)
         if _is_subscript(left, "attributes"):
             left = (
                 _as_bool_attribute(left) if _is_bool_constant(right) else _cast_as("String", left)

--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -301,6 +301,27 @@ def _is_string_constant(node: typing.Any) -> TypeGuard[ast.Constant]:
     return isinstance(node, ast.Constant) and isinstance(node.value, str)
 
 
+def _is_span_kind(node: typing.Any) -> TypeGuard[ast.Name]:
+    return isinstance(node, ast.Name) and node.id == "span_kind"
+
+
+def _upper_string_literal(node: ast.expr) -> ast.expr:
+    """
+    Uppercase a string `ast.Constant`, or each string `ast.Constant` inside an
+    `ast.List`/`ast.Tuple`. Other nodes are returned unchanged. Used to
+    normalize literals compared against `span_kind`, whose stored values are
+    canonical uppercase (see `SpanKind` in `phoenix.trace.schemas`).
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return ast.Constant(value=node.value.upper(), kind=node.kind)
+    if isinstance(node, (ast.List, ast.Tuple)):
+        new_elts = [_upper_string_literal(elt) for elt in node.elts]
+        if isinstance(node, ast.List):
+            return ast.List(elts=new_elts, ctx=node.ctx)
+        return ast.Tuple(elts=new_elts, ctx=node.ctx)
+    return node
+
+
 def _is_float_constant(node: typing.Any) -> TypeGuard[ast.Constant]:
     return (
         isinstance(node, ast.Constant)
@@ -503,6 +524,13 @@ class _FilterTranslator(_ProjectionTranslator):
                 left = comparator
             return ast.Call(func=ast.Name(id="and_", ctx=ast.Load()), args=args, keywords=[])
         left, op, right = self.visit(node.left), node.ops[0], self.visit(node.comparators[0])
+        # span_kind is stored in canonical uppercase (see `SpanKind` in
+        # phoenix.trace.schemas); uppercase string literals compared against it
+        # so the UI's lowercase display values can be used directly in filters.
+        if _is_span_kind(left):
+            right = _upper_string_literal(right)
+        elif _is_span_kind(right):
+            left = _upper_string_literal(left)
         if _is_subscript(left, "attributes"):
             left = (
                 _as_bool_attribute(left) if _is_bool_constant(right) else _cast_as("String", left)

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -168,6 +168,36 @@ def test_get_attribute_keys_list(expression: str, expected: Optional[list[str]])
             "metadata['is_empty'] is not False",
             "attributes[['metadata', 'is_empty']].as_boolean() != False",
         ),
+        # span_kind comparisons normalize the string literal to uppercase
+        # so users can filter using the lowercase values shown in the UI.
+        (
+            "span_kind == 'chain'",
+            "span_kind == 'CHAIN'",
+        ),
+        (
+            "span_kind == 'Chain'",
+            "span_kind == 'CHAIN'",
+        ),
+        (
+            "'chain' == span_kind",
+            "'CHAIN' == span_kind",
+        ),
+        (
+            "span_kind != 'llm'",
+            "span_kind != 'LLM'",
+        ),
+        (
+            "span_kind in ('chain', 'LLM')",
+            "span_kind.in_(('CHAIN', 'LLM'))",
+        ),
+        (
+            "span_kind not in ['chain', 'tool']",
+            "span_kind.not_in(['CHAIN', 'TOOL'])",
+        ),
+        (
+            "'cha' in span_kind",
+            "TextContains(span_kind, 'CHA')",
+        ),
     ],
 )
 async def test_filter_translated(

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -168,8 +168,6 @@ def test_get_attribute_keys_list(expression: str, expected: Optional[list[str]])
             "metadata['is_empty'] is not False",
             "attributes[['metadata', 'is_empty']].as_boolean() != False",
         ),
-        # span_kind comparisons normalize the string literal to uppercase
-        # so users can filter using the lowercase values shown in the UI.
         (
             "span_kind == 'chain'",
             "span_kind == 'CHAIN'",


### PR DESCRIPTION
## Summary
- Trace filter DSL now uppercases string literals on the other side of any `span_kind` comparison so users can filter using the lowercase values shown in the Traces UI — e.g. `span_kind == 'chain'`, `span_kind in ('chain', 'llm')`, or `'cha' in span_kind` all work.
- `span_kind` values are stored canonically uppercase (`SpanKind` enum in `phoenix.trace.schemas`), so normalizing the literal keeps the SQL unchanged for users who already type uppercase and avoids defeating any future index on the column.
- Applies to `==`, `!=`, `is`/`is not`, `in`/`not in` (lists and tuples), and the `TextContains` substring form. Non-`span_kind` filters are unaffected.

## Test plan
- [x] `uv run --frozen pytest tests/unit/trace/dsl/test_filter.py` — new cases cover lowercase, mixed-case, reversed operands, `in`/`not in` lists, and substring containment.
- [x] `uv run --frozen pytest tests/unit/trace/ tests/unit/server/api/routers/v1/test_spans.py` — no regressions.
- [x] `uv run mypy src/phoenix/trace/dsl/filter.py` — clean.

Closes #11220

🤖 Generated with [Claude Code](https://claude.com/claude-code)