### PR TITLE
ci: restore Claude code review comments and unify Claude workflow auth

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,9 +20,10 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
+      # PR/issue read+write goes through the Claude App token minted by the
+      # OIDC exchange below — the workflow GITHUB_TOKEN is only used for the
+      # initial checkout, so contents:read is all it needs.
       contents: read
-      pull-requests: read
-      issues: read
       id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
 
     steps:
@@ -42,7 +43,6 @@ jobs:
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
-          github_token: ${{ github.token }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: 'claude, cursor, codex, gitbook-bot, github-actions, dependabot[bot], cursoragent, mintlify[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude-docs-gap-audit.yml
+++ b/.github/workflows/claude-docs-gap-audit.yml
@@ -39,6 +39,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Setting additional_permissions triggers the action to explicitly request
+          # contents/pull_requests/issues: write on the OIDC-minted app token, which
+          # the post-action "Create docs gap issue" step uses via
+          # steps.claude.outputs.github_token.
+          additional_permissions: |
+            contents: write
           prompt: |
             /phoenix-docs-gap-audit
 
@@ -64,7 +70,9 @@ jobs:
 
       - name: Create docs gap issue
         env:
-          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          # App token minted by the claude-code-action OIDC exchange — short-lived
+          # and auto-revoked at job end.
+          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
         run: |
           if [ ! -s .scratch/docs-gap-issue.md ]; then
             echo "No docs gap issue body written — exiting cleanly."

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -85,6 +85,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Setting additional_permissions triggers the action to explicitly request
+          # contents/pull_requests/issues: write on the OIDC-minted app token, which
+          # the post-action "Commit and open PR" step uses via
+          # steps.claude.outputs.github_token.
+          additional_permissions: |
+            contents: write
           prompt: |
             Implement GitHub issue #${{ github.event.issue.number }} end-to-end in the working tree.
             A separate workflow step will commit, push, and open the PR; do NOT attempt
@@ -151,7 +157,9 @@ jobs:
       - name: Commit and open PR
         if: steps.guard.outputs.ready == 'true' && steps.claude.outcome == 'success'
         env:
-          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          # App token minted by the claude-code-action OIDC exchange — short-lived,
+          # auto-revoked at job end, and (unlike GITHUB_TOKEN) triggers downstream CI.
+          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
         run: |
           gh auth setup-git
           git config user.name "github-actions[bot]"

--- a/.github/workflows/claude-llms-txt.yml
+++ b/.github/workflows/claude-llms-txt.yml
@@ -44,6 +44,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Setting additional_permissions triggers the action to explicitly request
+          # contents/pull_requests/issues: write on the OIDC-minted app token, which
+          # the post-action "Commit and open pull request" step uses to git push and
+          # open the PR via steps.claude.outputs.github_token.
+          additional_permissions: |
+            contents: write
           prompt: |
             /phoenix-llms-txt
 
@@ -58,7 +64,9 @@ jobs:
       - name: Commit and open pull request
         if: steps.claude.outcome == 'success'
         env:
-          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          # App token minted by the claude-code-action OIDC exchange — short-lived,
+          # auto-revoked at job end, and (unlike GITHUB_TOKEN) triggers downstream CI.
+          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
         run: |
           if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
             echo "No llms.txt changes — exiting cleanly."

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -44,6 +44,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Setting additional_permissions triggers the action to explicitly request
+          # contents/pull_requests/issues: write on the OIDC-minted app token, which
+          # the post-action "Commit and open pull request" step uses to git push and
+          # open the PR via steps.claude.outputs.github_token.
+          additional_permissions: |
+            contents: write
           prompt: |
             /phoenix-release-notes
 
@@ -57,7 +63,9 @@ jobs:
       - name: Commit and open pull request
         if: steps.claude.outcome == 'success'
         env:
-          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          # App token minted by the claude-code-action OIDC exchange — short-lived,
+          # auto-revoked at job end, and (unlike GITHUB_TOKEN) triggers downstream CI.
+          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
         run: |
           if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
             echo "No release notes changes — exiting cleanly."

--- a/.github/workflows/claude-skills-audit.yml
+++ b/.github/workflows/claude-skills-audit.yml
@@ -62,6 +62,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Setting additional_permissions triggers the action to explicitly request
+          # contents/pull_requests/issues: write on the OIDC-minted app token, which
+          # the post-action "Commit and push" / "Open pull request" steps use via
+          # steps.claude.outputs.github_token.
+          additional_permissions: |
+            contents: write
           prompt: |
             /phoenix-skills-audit
 
@@ -108,7 +114,9 @@ jobs:
       - name: Commit and push
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          # App token minted by the claude-code-action OIDC exchange — short-lived,
+          # auto-revoked at job end, and (unlike GITHUB_TOKEN) triggers downstream CI.
+          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
           AUDIT_DATE: ${{ steps.branch.outputs.date }}
           AUDIT_BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
@@ -120,7 +128,7 @@ jobs:
       - name: Open pull request
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
           AUDIT_DATE: ${{ steps.branch.outputs.date }}
           AUDIT_BRANCH: ${{ steps.branch.outputs.branch }}
           SUMMARY_FILE: ${{ steps.summary.outputs.path }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,11 +26,12 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+      # Writes to PRs/issues and pushes from Claude go through the App token
+      # minted by the OIDC exchange below — the workflow GITHUB_TOKEN is only
+      # used for the initial checkout and the github_ci MCP server.
+      contents: read
       id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read # Used by the action's github_ci MCP server (workflow token, not app token) to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## TL;DR

Claude code review stopped posting PR comments after **May 19**. Root cause: PR #13015 incidentally added `github_token: ${{ github.token }}` to the workflow, which routed the action away from its OIDC-minted Claude App token (write-capable) and onto the workflow's `GITHUB_TOKEN` (read-only since #13201/#13479). All `gh pr comment` / inline-comment-MCP calls 403'd silently, the action exited 0, and no comment appeared.

This PR removes that one line, then takes the opportunity to harden and unify auth across all the Claude workflows the same way.

## Diagnosis

The smoking gun was in the debug log of the failing `claude-review` job ([run 26583778483](https://github.com/Arize-ai/phoenix/actions/runs/26583778483/job/78327219948)):

```
##[debug]Expanded: (true && ('***' == '') && (steps['run']['outputs']['github_token'] != '') && (steps['run']['outputs']['skipped_due_to_workflow_validation_mismatch'] != 'true'))
##[debug]Result: false
```

That condition gates the action's `Revoke app token` post-step:

```yaml
if: always() && inputs.github_token == '' && steps.run.outputs.github_token != '' && ...
```

`'***' == ''` evaluates to `false` because `inputs.github_token` is non-empty — i.e., the action took the *user-provided-token* path and never minted an app token via OIDC.

In [`src/github/token.ts`](https://github.com/anthropics/claude-code-action/blob/787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251/src/github/token.ts#L128-L148):

```ts
export async function setupGitHubToken(): Promise<string> {
  const providedToken = process.env.OVERRIDE_GITHUB_TOKEN;
  if (providedToken) {
    return providedToken;             // short-circuit — uses workflow GITHUB_TOKEN as-is
  }
  const oidcToken = await getOidcToken();
  const appToken  = await exchangeForAppToken(oidcToken, permissions);
  return appToken;
}
```

The returned token is then exported as `GITHUB_TOKEN` / `GH_TOKEN` in [`run.ts`](https://github.com/anthropics/claude-code-action/blob/787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251/src/entrypoints/run.ts#L181-L182), which the Claude subprocess (and every `gh` call inside it) inherits. So once `OVERRIDE_GITHUB_TOKEN` is set, the agent does all its GitHub I/O with the workflow token.

The workflow's `GITHUB_TOKEN` has only had `pull-requests: read` / `issues: read` since [d1f1887b8](https://github.com/Arize-ai/phoenix/commit/d1f1887b8) (Jan 2026). Comment-posting tool calls 403, the agent moves on, the action exits 0.

## Timeline

| Date | Event |
|---|---|
| ≤ May 15 | claude[bot] PR comments working (last on PR #13260) |
| **May 19** | **PR #13015 (Codex hooks) incidentally adds `github_token: ${{ github.token }}` to claude-code-review.yml** |
| May 19 → today | **Zero** claude[bot] review comments |
| May 27 | #13479 hardening drops `id-token: write`; #13484 restores it |

The dates line up exactly. The `github_token` line in #13015 isn't mentioned in that PR's description and is unrelated to its stated purpose (Codex hooks).

## Why removing the line works

Without `github_token` set:

1. `OVERRIDE_GITHUB_TOKEN` is empty → action calls `getOidcToken()` (works because `id-token: write` is present).
2. POSTs the OIDC token to `https://api.anthropic.com/api/github/github-app-token-exchange`. Anthropic verifies the OIDC claims and returns a GitHub App installation token for the Claude App installed on this repo.
3. That installation token carries the app's permissions (write to PRs/issues/contents), independent of the workflow `GITHUB_TOKEN` scopes.
4. All subsequent `gh pr comment`, inline-comment-MCP, git push, etc. use that write-capable token.

The workflow `GITHUB_TOKEN` only ends up being used for `actions/checkout` (needs `contents: read`) and the action's `github_ci` MCP server (uses workflow token explicitly, for `actions: read`).

## What this PR changes

### 1. Fix the bug

- `claude-code-review.yml`: drop `github_token: ${{ github.token }}`.

### 2. Tighten workflow `permissions` blocks now that everything routes through the app token

- `claude-code-review.yml`: drop `pull-requests: read` / `issues: read` (unused once the app token does all PR API calls). Keep `contents: read` + `id-token: write`.
- `claude.yml`: drop `contents/pull-requests/issues: write` — Claude's writes already go through the app token. Keep `contents: read` (checkout) + `id-token: write` (OIDC) + `actions: read` (the action's `github_ci` MCP server uses the workflow token explicitly).
- Other Claude workflows were already at `contents: read` + `id-token: write`; left alone.

### 3. Migrate post-Claude-action `GH_TOKEN` usage from a personal PAT to the OIDC app token

Where a workflow previously used `secrets.MY_RELEASE_PLEASE_TOKEN` *after* the Claude action ran, switch to `steps.claude.outputs.github_token`:

| Workflow | Step migrated |
|---|---|
| `claude-docs-gap-audit.yml` | Create docs gap issue |
| `claude-llms-txt.yml` | Commit and open pull request |
| `claude-release-notes.yml` | Commit and open pull request |
| `claude-skills-audit.yml` | Commit and push, Open pull request |
| `claude-implement-issue.yml` | Commit and open PR |

Benefits:
- Short-lived (auto-revoked at job end).
- Not tied to one person's PAT — org-continuity safe.
- App-issued tokens, unlike `GITHUB_TOKEN`, **do** trigger downstream workflows, so CI still runs on the resulting PRs.

Each of these workflows now also sets `additional_permissions: contents: write`. The action only sends an explicit permission body when `additional_permissions` is non-empty (see [`parseAdditionalPermissions`](https://github.com/anthropics/claude-code-action/blob/787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251/src/github/token.ts#L31-L57)) — adding any value triggers the client-side default-perm spread (`contents/pull_requests/issues: write`), guaranteeing the minted token has the scopes the post-action steps need rather than relying on undocumented server defaults.

### What stays on the PAT (intentionally)

`claude-implement-issue.yml` still uses `MY_RELEASE_PLEASE_TOKEN` in three steps:

- **Guard** (line 24) and **Claim issue** (line 54) — run *before* the Claude action, so the OIDC app token doesn't exist yet.
- **Cleanup** (line 225) — runs under `if: always()` and must succeed even when the Claude step failed early (to remove the in-progress label).

The `MY_RELEASE_PLEASE_TOKEN` *secret* also stays — it's still required by ~8 non-Claude workflows (release-please, dependabot helpers, sitemap, docker-build-release, etc.).

## Test plan

- [ ] After merge, watch the next PR for a posted Claude code review comment.
- [ ] Watch the next weekly cron firings:
  - `claude-llms-txt.yml` (Wed 15:00 UTC) — PR opened via app token
  - `claude-release-notes.yml` (Wed 14:00 UTC) — PR opened via app token
  - `claude-docs-gap-audit.yml` (Wed 16:00 UTC) — issue opened via app token
  - `claude-skills-audit.yml` (Wed 17:00 UTC) — PR opened via app token
- [ ] Trigger `claude-implement-issue.yml` by labeling an issue `good-agent-issue` — verify the post-action commit/PR flow works with the app token.
- [ ] If any of the above fails on a `contents: write` / `pull_requests: write` / `issues: write` 403, the App install may need scope adjustment (we believe it has all three because @claude already does writes).