### PR TITLE
docs(graphql): describe Span token count fields and TokenCountPromptDetails

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3588,22 +3588,22 @@ type Span implements Node {
   numDocuments: Int
 
   """
-  Total LLM token count for this span only (prompt plus completion). Typically populated on LLM spans. For a subtree rollup, use `cumulativeTokenCountTotal`.
+  Total LLM token count for this span only (prompt plus completion). Typically populated on LLM spans.
   """
   tokenCountTotal: Int
 
   """
-  Prompt (input) token count for this span only. For a subtree rollup, use `cumulativeTokenCountPrompt`. For a breakdown by prompt token kind (cache reads/writes, audio), see `tokenPromptDetails`.
+  Prompt token count for this span only. Typically populated on LLM spans.
   """
   tokenCountPrompt: Int
 
   """
-  Completion (output) token count for this span only. For a subtree rollup, use `cumulativeTokenCountCompletion`.
+  Completion token count for this span only. Typically populated on LLM spans.
   """
   tokenCountCompletion: Int
 
   """
-  Breakdown of this span's prompt tokens by kind (e.g. cache reads, cache writes, audio). These counts are a decomposition of `tokenCountPrompt`, not additive on top of it, and are typically used for cost analysis.
+  Breakdown of this span's prompt tokens by kind (e.g., cache reads, cache writes, audio). These counts are a decomposition of `tokenCountPrompt`, not additive on top of it, and are typically used for cost analysis.
   """
   tokenPromptDetails: TokenCountPromptDetails!
   input: SpanIOValue
@@ -3616,12 +3616,12 @@ type Span implements Node {
   cumulativeTokenCountTotal: Float
 
   """
-  Cumulative (prompt) token count from self and all descendant spans (children, grandchildren, etc.)
+  Cumulative prompt token count from self and all descendant spans (children, grandchildren, etc.)
   """
   cumulativeTokenCountPrompt: Float
 
   """
-  Cumulative (completion) token count from self and all descendant spans (children, grandchildren, etc.)
+  Cumulative completion token count from self and all descendant spans (children, grandchildren, etc.)
   """
   cumulativeTokenCountCompletion: Float
 
@@ -3965,7 +3965,7 @@ type TimeSeriesDataPoint {
 }
 
 """
-Breakdown of an LLM span's prompt tokens by kind. These counts are a decomposition of the span's total prompt token count, not additive on top of it, and are typically used for cost analysis.
+Breakdown of an LLM span's prompt tokens by kind. These counts are a decomposition of the span's prompt token count, not additive on top of it, and are typically used for cost analysis.
 """
 type TokenCountPromptDetails {
   """Prompt tokens served from the provider's prompt cache."""
@@ -3974,7 +3974,7 @@ type TokenCountPromptDetails {
   """Prompt tokens written into the provider's prompt cache."""
   cacheWrite: Int
 
-  """Prompt tokens that were audio input."""
+  """Prompt tokens that were audio tokens."""
   audio: Int
 }
 

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3586,9 +3586,25 @@ type Span implements Node {
   """Metadata as a JSON string"""
   metadata: String
   numDocuments: Int
+
+  """
+  Total LLM token count for this span only (prompt plus completion). Typically populated on LLM spans. For a subtree rollup, use `cumulativeTokenCountTotal`.
+  """
   tokenCountTotal: Int
+
+  """
+  Prompt (input) token count for this span only. For a subtree rollup, use `cumulativeTokenCountPrompt`. For a breakdown by prompt token kind (cache reads/writes, audio), see `tokenPromptDetails`.
+  """
   tokenCountPrompt: Int
+
+  """
+  Completion (output) token count for this span only. For a subtree rollup, use `cumulativeTokenCountCompletion`.
+  """
   tokenCountCompletion: Int
+
+  """
+  Breakdown of this span's prompt tokens by kind (e.g. cache reads, cache writes, audio). These counts are a decomposition of `tokenCountPrompt`, not additive on top of it, and are typically used for cost analysis.
+  """
   tokenPromptDetails: TokenCountPromptDetails!
   input: SpanIOValue
   output: SpanIOValue
@@ -3948,9 +3964,17 @@ type TimeSeriesDataPoint {
   value: Float
 }
 
+"""
+Breakdown of an LLM span's prompt tokens by kind. These counts are a decomposition of the span's total prompt token count, not additive on top of it, and are typically used for cost analysis.
+"""
 type TokenCountPromptDetails {
+  """Prompt tokens served from the provider's prompt cache."""
   cacheRead: Int
+
+  """Prompt tokens written into the provider's prompt cache."""
   cacheWrite: Int
+
+  """Prompt tokens that were audio input."""
   audio: Int
 }
 

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -322,7 +322,11 @@ class Span(Node):
         )
         return cast(int, value)
 
-    @strawberry.field
+    @strawberry.field(
+        description="Total LLM token count for this span only (prompt plus completion). "
+        "Typically populated on LLM spans. For a subtree rollup, use "
+        "`cumulativeTokenCountTotal`.",
+    )  # type: ignore
     async def token_count_total(
         self,
         info: Info[Context, None],
@@ -334,7 +338,12 @@ class Span(Node):
         )
         return cast(Optional[int], value)
 
-    @strawberry.field
+    @strawberry.field(
+        description="Prompt (input) token count for this span only. "
+        "For a subtree rollup, use `cumulativeTokenCountPrompt`. "
+        "For a breakdown by prompt token kind (cache reads/writes, audio), "
+        "see `tokenPromptDetails`.",
+    )  # type: ignore
     async def token_count_prompt(
         self,
         info: Info[Context, None],
@@ -346,7 +355,10 @@ class Span(Node):
         )
         return cast(Optional[int], value)
 
-    @strawberry.field
+    @strawberry.field(
+        description="Completion (output) token count for this span only. "
+        "For a subtree rollup, use `cumulativeTokenCountCompletion`.",
+    )  # type: ignore
     async def token_count_completion(
         self,
         info: Info[Context, None],
@@ -358,7 +370,11 @@ class Span(Node):
         )
         return cast(Optional[int], value)
 
-    @strawberry.field
+    @strawberry.field(
+        description="Breakdown of this span's prompt tokens by kind (e.g. cache reads, "
+        "cache writes, audio). These counts are a decomposition of `tokenCountPrompt`, "
+        "not additive on top of it, and are typically used for cost analysis.",
+    )  # type: ignore
     async def token_prompt_details(
         self,
         info: Info[Context, None],

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -324,8 +324,7 @@ class Span(Node):
 
     @strawberry.field(
         description="Total LLM token count for this span only (prompt plus completion). "
-        "Typically populated on LLM spans. For a subtree rollup, use "
-        "`cumulativeTokenCountTotal`.",
+        "Typically populated on LLM spans."
     )  # type: ignore
     async def token_count_total(
         self,
@@ -339,10 +338,8 @@ class Span(Node):
         return cast(Optional[int], value)
 
     @strawberry.field(
-        description="Prompt (input) token count for this span only. "
-        "For a subtree rollup, use `cumulativeTokenCountPrompt`. "
-        "For a breakdown by prompt token kind (cache reads/writes, audio), "
-        "see `tokenPromptDetails`.",
+        description="Prompt token count for this span only. "
+        "Typically populated on LLM spans."
     )  # type: ignore
     async def token_count_prompt(
         self,
@@ -356,8 +353,8 @@ class Span(Node):
         return cast(Optional[int], value)
 
     @strawberry.field(
-        description="Completion (output) token count for this span only. "
-        "For a subtree rollup, use `cumulativeTokenCountCompletion`.",
+        description="Completion token count for this span only. "
+        "Typically populated on LLM spans."
     )  # type: ignore
     async def token_count_completion(
         self,
@@ -371,7 +368,7 @@ class Span(Node):
         return cast(Optional[int], value)
 
     @strawberry.field(
-        description="Breakdown of this span's prompt tokens by kind (e.g. cache reads, "
+        description="Breakdown of this span's prompt tokens by kind (e.g., cache reads, "
         "cache writes, audio). These counts are a decomposition of `tokenCountPrompt`, "
         "not additive on top of it, and are typically used for cost analysis.",
     )  # type: ignore
@@ -508,7 +505,7 @@ class Span(Node):
         return float(value) if value is not None else None
 
     @strawberry.field(
-        description="Cumulative (prompt) token count from self and all descendant "
+        description="Cumulative prompt token count from self and all descendant "
         "spans (children, grandchildren, etc.)",
     )  # type: ignore
     async def cumulative_token_count_prompt(
@@ -523,7 +520,7 @@ class Span(Node):
         return float(value) if value is not None else None
 
     @strawberry.field(
-        description="Cumulative (completion) token count from self and all descendant "
+        description="Cumulative completion token count from self and all descendant "
         "spans (children, grandchildren, etc.)",
     )  # type: ignore
     async def cumulative_token_count_completion(

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -338,8 +338,7 @@ class Span(Node):
         return cast(Optional[int], value)
 
     @strawberry.field(
-        description="Prompt token count for this span only. "
-        "Typically populated on LLM spans."
+        description="Prompt token count for this span only. Typically populated on LLM spans."
     )  # type: ignore
     async def token_count_prompt(
         self,
@@ -353,8 +352,7 @@ class Span(Node):
         return cast(Optional[int], value)
 
     @strawberry.field(
-        description="Completion token count for this span only. "
-        "Typically populated on LLM spans."
+        description="Completion token count for this span only. Typically populated on LLM spans."
     )  # type: ignore
     async def token_count_completion(
         self,

--- a/src/phoenix/server/api/types/TokenCountPromptDetails.py
+++ b/src/phoenix/server/api/types/TokenCountPromptDetails.py
@@ -3,8 +3,23 @@ from typing import Optional
 import strawberry
 
 
-@strawberry.type
+@strawberry.type(
+    description=(
+        "Breakdown of an LLM span's prompt tokens by kind. These counts are a "
+        "decomposition of the span's total prompt token count, not additive on top "
+        "of it, and are typically used for cost analysis."
+    ),
+)
 class TokenCountPromptDetails:
-    cache_read: Optional[int]
-    cache_write: Optional[int]
-    audio: Optional[int]
+    cache_read: Optional[int] = strawberry.field(
+        description="Prompt tokens served from the provider's prompt cache.",
+        default=None,
+    )
+    cache_write: Optional[int] = strawberry.field(
+        description="Prompt tokens written into the provider's prompt cache.",
+        default=None,
+    )
+    audio: Optional[int] = strawberry.field(
+        description="Prompt tokens that were audio input.",
+        default=None,
+    )

--- a/src/phoenix/server/api/types/TokenCountPromptDetails.py
+++ b/src/phoenix/server/api/types/TokenCountPromptDetails.py
@@ -6,7 +6,7 @@ import strawberry
 @strawberry.type(
     description=(
         "Breakdown of an LLM span's prompt tokens by kind. These counts are a "
-        "decomposition of the span's total prompt token count, not additive on top "
+        "decomposition of the span's prompt token count, not additive on top "
         "of it, and are typically used for cost analysis."
     ),
 )
@@ -20,6 +20,6 @@ class TokenCountPromptDetails:
         default=None,
     )
     audio: Optional[int] = strawberry.field(
-        description="Prompt tokens that were audio input.",
+        description="Prompt tokens that were audio tokens.",
         default=None,
     )


### PR DESCRIPTION
GraphQL schema is consumed by agent, needs better descriptions for these fields