### PR TITLE
fix(agents): note python and node are unavailable in PXI bash tool

### DIFF
--- a/src/phoenix/server/agents/capabilities/tools/external/bash.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/bash.py
@@ -22,6 +22,7 @@ General purpose network access is disabled, so curl/wget and remote package inst
 should not be assumed to work.
 Built-in just-bash commands are available; do not assume apt, brew, pnpm, uv, git, \
 or other host binaries exist unless the sandbox reports them.
+Language runtimes such as python, python3, and node are not available.
 The user has no access to the filesystem. You can use the filesystem for your own \
 purposes, but if you want to share something with the user, you must display the \
 content in the rich markdown rendered chat.

--- a/src/phoenix/server/agents/prompts/tools/BASH_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/BASH_TOOL_INSTRUCTIONS.xml.j2
@@ -6,6 +6,7 @@
     - Write scratch files only under /home/user/workspace; mutations elsewhere are blocked.
     - General purpose network access is disabled, so curl/wget and remote package installs should not be assumed to work.
     - Built-in just-bash commands are available; do not assume apt, brew, pnpm, uv, git, or other host binaries exist unless the sandbox reports them.
+    - Language runtimes such as python, python3, and node are not available.
     - The user has no access to the filesystem. You can use the filesystem for your own purposes, but if you want to share something with the user, you must display the content in the rich markdown rendered chat.
     - phoenix-gql is available for GraphQL operations against the Phoenix GraphQL API. Run phoenix-gql --help for usage and current permissions.
   </constraints>


### PR DESCRIPTION
## Summary
- Adds an explicit line to the PXI agent's `bash` tool description and constraints stating that `python`, `python3`, and `node` runtimes are not available in the browser-only just-bash sandbox.
- Updates both the tool `DESCRIPTION` constant ([bash.py](src/phoenix/server/agents/capabilities/tools/external/bash.py)) and the system-prompt constraints block ([BASH_TOOL_INSTRUCTIONS.xml.j2](src/phoenix/server/agents/prompts/tools/BASH_TOOL_INSTRUCTIONS.xml.j2)) so the guidance reaches the model from both surfaces.

The existing "do not assume apt, brew, pnpm, uv, git, or other host binaries exist" line covered package managers and git, but agents tend to treat language runtimes as universally present — making the absence explicit should cut down on wasted `python`/`node` invocations.

## Test plan
- [ ] Run a PXI session and confirm the updated constraints surface in the system prompt
- [ ] Sanity-check that the agent no longer attempts `python`/`node` invocations on tasks where it previously did

🤖 Generated with [Claude Code](https://claude.com/claude-code)