### PR TITLE
fix: Avoid spans tab loading flicker

### DIFF
--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -3,6 +3,7 @@ import {
   startTransition,
   Suspense,
   useCallback,
+  useDeferredValue,
   useEffect,
   useMemo,
 } from "react";
@@ -64,6 +65,7 @@ const mainCSS = css`
 export function ProjectPage() {
   const { projectId } = useParams();
   const { timeRange } = useTimeRange();
+  const deferredTimeRange = useDeferredValue(timeRange);
   return (
     <>
       <TopNavActions>
@@ -71,8 +73,9 @@ export function ProjectPage() {
       </TopNavActions>
       <Suspense fallback={<Loading />}>
         <ProjectPageContent
+          key={projectId}
           projectId={projectId as string}
-          timeRange={timeRange}
+          timeRange={deferredTimeRange}
         />
       </Suspense>
     </>
@@ -148,21 +151,18 @@ function ProjectPageContentBody({
       fetchKey: `${projectId}-${timeRangeVariable.start}-${timeRangeVariable.end}`,
     }
   );
-  const [tracesQueryReference, loadTracesQuery, disposeTracesQuery] =
+  const [tracesQueryReference, loadTracesQuery] =
     useQueryLoader<ProjectPageTracesQueryType>(ProjectPageQueriesTracesQuery);
-  const [spansQueryReference, loadSpansQuery, disposeSpansQuery] =
+  const [spansQueryReference, loadSpansQuery] =
     useQueryLoader<ProjectPageSpansQueryType>(ProjectPageQueriesSpansQuery);
-  const [sessionsQueryReference, loadSessionsQuery, disposeSessionsQuery] =
+  const [sessionsQueryReference, loadSessionsQuery] =
     useQueryLoader<ProjectPageSessionsQueryType>(
       ProjectPageQueriesSessionsQuery
     );
-  const [
-    projectConfigQueryReference,
-    loadProjectConfigQuery,
-    disposeProjectConfigQuery,
-  ] = useQueryLoader<ProjectPageProjectConfigQueryType>(
-    ProjectPageQueriesProjectConfigQuery
-  );
+  const [projectConfigQueryReference, loadProjectConfigQuery] =
+    useQueryLoader<ProjectPageProjectConfigQueryType>(
+      ProjectPageQueriesProjectConfigQuery
+    );
   const tabIndex = isTab(tab) ? TAB_INDEX_MAP[tab] : 0;
   useEffect(() => {
     startTransition(() => {
@@ -188,25 +188,14 @@ function ProjectPageContentBody({
         });
       }
     });
-
-    return () => {
-      disposeSpansQuery();
-      disposeSessionsQuery();
-      disposeTracesQuery();
-      disposeProjectConfigQuery();
-    };
   }, [
     loadTracesQuery,
     projectId,
     timeRangeVariable,
     tabIndex,
-    disposeSpansQuery,
-    disposeSessionsQuery,
-    disposeTracesQuery,
     loadSpansQuery,
     loadSessionsQuery,
     loadProjectConfigQuery,
-    disposeProjectConfigQuery,
     treatOrphansAsRoots,
   ]);
 


### PR DESCRIPTION
## Summary
- Defer project time-range query inputs so brush selections can transition without forcing the project route fallback.
- Let Relay `useQueryLoader` manage tab query retention instead of manually disposing refs during reload effects.
- Key the project page content by project id so switching projects still resets the query boundary cleanly.

## Root Cause
The project page disposed active tab query references in the same effect that reloaded them for a new time range. When the sparkline brush selected a range, the spans tab lost its current query ref before the replacement query resolved, so Suspense fell back to the full loading state.

## Validation
- `./node_modules/.bin/oxlint`
- `./node_modules/.bin/oxlint src/pages/project/ProjectPage.tsx`
- `git diff --check`

## Notes
- `make lint-frontend` and `make typecheck-frontend` were blocked before running because `pnpm` attempted a non-interactive `node_modules` purge.
- Direct `./node_modules/.bin/tsc --noEmit --pretty false` still fails on existing unrelated `src/components/agent/Chat.tsx` errors around `findLast` / implicit `any`.
