### PR TITLE
feat(agents): add Claude Opus 4.8 support to PXI

### DIFF
--- a/app/src/components/agent/agentCuratedModels.ts
+++ b/app/src/components/agent/agentCuratedModels.ts
@@ -13,6 +13,7 @@ export type AgentPlaygroundModel = {
 
 export const AGENT_CURATED_BUILT_IN_MODELS: readonly AgentBuiltInModelSelection[] =
   [
+    { provider: "ANTHROPIC", modelName: "claude-opus-4-8" },
     { provider: "ANTHROPIC", modelName: "claude-opus-4-6" },
     { provider: "ANTHROPIC", modelName: "claude-sonnet-4-6" },
     { provider: "OPENAI", modelName: "gpt-5.4" },

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1383,6 +1383,7 @@ class TogetherStreamingClient(OpenAIBaseStreamingClient):
     provider_key=GenerativeProviderKey.AWS,
     model_names=[
         PROVIDER_DEFAULT,
+        "anthropic.claude-opus-4-8",
         "anthropic.claude-opus-4-7",
         "anthropic.claude-opus-4-6-v1",
         "anthropic.claude-sonnet-4-6",
@@ -2167,6 +2168,7 @@ class AzureOpenAIReasoningNonStreamingClient(
     provider_key=GenerativeProviderKey.ANTHROPIC,
     model_names=[
         PROVIDER_DEFAULT,
+        "claude-opus-4-8",
         "claude-opus-4-7",
     ],
 )


### PR DESCRIPTION
## Summary
- Registers `claude-opus-4-8` on `AnthropicStreamingClient` (adaptive-thinking only, mirroring how 4.7 was added in #12738) and `anthropic.claude-opus-4-8` on the AWS Bedrock client so the model surfaces in the `playgroundModels` GraphQL field.
- Adds `claude-opus-4-8` to the PXI agent curated list so it appears as a featured pick in the agent model menu (placed first in the row).

Default model in `agentModelConfig.ts` / `agentStore.ts` stays on `claude-opus-4-6`. Cost manifest entry not added — needs real prices.

## Test plan
- [ ] PXI model menu shows "claude-opus-4-8" in the curated/featured row
- [ ] Selecting it and sending a message returns a successful response (requires `ANTHROPIC_API_KEY`)
- [ ] Playground page lists the model under Anthropic and AWS Bedrock provider sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)