### PR TITLE
ci: enable Agent tool and debug output for Claude code review; bump to opus-4-8

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,9 +47,14 @@ jobs:
           allowed_bots: 'claude, cursor, codex, gitbook-bot, github-actions, dependabot[bot], cursoragent, mintlify[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          # show_full_output exposes the full Claude SDK message stream in the step
+          # log. For this workflow the content is derived from a public PR diff and
+          # is not sensitive; turning it on lets us see denied-tool details
+          # (sanitized output otherwise collapses permission_denials to a count).
+          show_full_output: 'true'
           prompt: |
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(git fetch *),Bash(git diff *),Bash(git log *),Bash(git show *)"
+            --allowedTools "Agent,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(git fetch *),Bash(git diff *),Bash(git log *),Bash(git show *)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-docs-gap-audit.yml
+++ b/.github/workflows/claude-docs-gap-audit.yml
@@ -66,7 +66,7 @@ jobs:
 
             Do not commit, push, open a PR, or create the issue yourself. The workflow
             handles publishing after you write the issue body file.
-          claude_args: '--model claude-opus-4-7 --allowedTools Skill,Read,Glob,Grep,Agent,Write,"Bash(git fetch:*)","Bash(git log:*)","Bash(git diff:*)","Bash(git show:*)","Bash(date:*)","Bash(ls:*)","Bash(mkdir:*)"'
+          claude_args: '--model claude-opus-4-8 --allowedTools Skill,Read,Glob,Grep,Agent,Write,"Bash(git fetch:*)","Bash(git log:*)","Bash(git diff:*)","Bash(git show:*)","Bash(date:*)","Bash(ls:*)","Bash(mkdir:*)"'
 
       - name: Create docs gap issue
         env:

--- a/.github/workflows/claude-llms-txt.yml
+++ b/.github/workflows/claude-llms-txt.yml
@@ -59,7 +59,7 @@ jobs:
 
             When done, write a PR body to `.scratch/pr-body.md`. Do not commit,
             push, or open a PR; the workflow handles publishing.
-          claude_args: '--model claude-opus-4-7 --allowedTools Skill,Read,Write,Edit,Glob,Grep,Agent,"Bash(git status:*)","Bash(git diff:*)","Bash(find:*)","Bash(comm:*)","Bash(sort:*)","Bash(wc:*)","Bash(mkdir:*)","Bash(ls:*)","Bash(date:*)"'
+          claude_args: '--model claude-opus-4-8 --allowedTools Skill,Read,Write,Edit,Glob,Grep,Agent,"Bash(git status:*)","Bash(git diff:*)","Bash(find:*)","Bash(comm:*)","Bash(sort:*)","Bash(wc:*)","Bash(mkdir:*)","Bash(ls:*)","Bash(date:*)"'
 
       - name: Commit and open pull request
         if: steps.claude.outcome == 'success'

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -58,7 +58,7 @@ jobs:
             When done, write a PR body to `.scratch/pr-body.md`. Do not commit,
             push, or open a PR; the workflow handles publishing.
             The workflow will open a PR titled "docs: Add Phoenix release notes".
-          claude_args: '--model claude-opus-4-7 --allowedTools Skill,Read,Write,Edit,Glob,Grep,Agent,"Bash(git fetch:*)","Bash(git log:*)","Bash(git diff:*)","Bash(git show:*)","Bash(mkdir:*)","Bash(ls:*)","Bash(date:*)"'
+          claude_args: '--model claude-opus-4-8 --allowedTools Skill,Read,Write,Edit,Glob,Grep,Agent,"Bash(git fetch:*)","Bash(git log:*)","Bash(git diff:*)","Bash(git show:*)","Bash(mkdir:*)","Bash(ls:*)","Bash(date:*)"'
 
       - name: Commit and open pull request
         if: steps.claude.outcome == 'success'

--- a/.github/workflows/claude-skills-audit.yml
+++ b/.github/workflows/claude-skills-audit.yml
@@ -95,7 +95,7 @@ jobs:
             even if there are no changes to apply. If there are no user-facing changes
             (only deps, refactors, frontend, feature flags), still write the summary file
             and have its first line be exactly: NO_CHANGES
-          claude_args: '--model claude-opus-4-7 --allowedTools Skill,Read,Glob,Grep,Edit,Write,Agent,"Bash(git fetch:*)","Bash(git log:*)","Bash(git diff:*)","Bash(git show:*)","Bash(date:*)","Bash(ls:*)"'
+          claude_args: '--model claude-opus-4-8 --allowedTools Skill,Read,Glob,Grep,Edit,Write,Agent,"Bash(git fetch:*)","Bash(git log:*)","Bash(git diff:*)","Bash(git show:*)","Bash(date:*)","Bash(ls:*)"'
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
## Why

Follow-up to #13490. After that PR fixed the auth layer, claude[bot] still wasn't posting comments on fresh PRs even though jobs succeeded. The result message consistently showed `permission_denials_count: 1` — Claude was attempting one tool call that wasn't in our `allowedTools`.

Reading the [code-review plugin source](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md), every step of its review flow says:

> 1. Launch a haiku agent to check ...
> 2. Launch a haiku agent to return a list of file paths ...
> 3. Launch a sonnet agent to view the pull request ...
> 4. Launch 4 agents in parallel to independently review the changes
> 5. For each issue found ... launch parallel subagents to validate

Launching subagents is the **`Agent`** tool in Claude Code. Our `claude-code-review.yml` didn't include it. The four sibling Claude workflows in this repo (`claude-docs-gap-audit`, `claude-llms-txt`, `claude-release-notes`, `claude-skills-audit`) all do — and they work. This was an asymmetric oversight.

## What this PR changes

### 1. Add `Agent` to allowedTools in `claude-code-review.yml`

Prepended `Agent,` to the `--allowedTools` list. This unblocks the plugin's haiku/sonnet/opus subagent launches.

### 2. Set `show_full_output: 'true'` on the same workflow

So that if `Agent` alone isn't sufficient (i.e., the plugin needs another tool we haven't anticipated), we can see exactly which tool is denied in the step log rather than just a count.

Audited the action's [output sanitizer](https://github.com/anthropics/claude-code-action/blob/787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251/base-action/src/run-claude-sdk.ts#L86-L129) — with `show_full_output: false` (default) the sanitizer collapses `permission_denials` to just `permission_denials_count`. There is no middle ground in the action: either you see the system-init + result summary, or you see every SDK message. For this workflow the full content is derived from a public PR diff (no secrets in env — we already set `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"`), so the exposure is acceptable. Can be flipped back off in a follow-up once we've confirmed the fix.

### 3. Bump pinned model: `claude-opus-4-7` → `claude-opus-4-8`

Affects four workflows:
- `claude-docs-gap-audit.yml`
- `claude-llms-txt.yml`
- `claude-release-notes.yml`
- `claude-skills-audit.yml`

The code-review workflow itself doesn't pin a model — it uses the action's default.

## Test plan

- [ ] Open a fresh PR (or push to a PR that has never been reviewed by claude[bot]) and watch the workflow.
- [ ] Verify the step log now shows the full SDK message stream — including any remaining `permission_denials` content if the plugin needs more tools than `Agent`.
- [ ] Verify a `claude[bot]` comment (either inline review or "No issues found" summary) is actually posted.
- [ ] Watch the next weekly cron runs (`claude-docs-gap-audit`, `claude-llms-txt`, `claude-release-notes`, `claude-skills-audit`) to confirm `opus-4-8` is accepted by the API.

## Related: plugin idempotency footgun (not fixed here, just documented)

While investigating, we noticed the plugin's [step 1](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md) tells a haiku subagent to skip the review if "Claude has already commented on this PR (check `gh pr view <PR> --comments` for comments left by claude)."

A few things to know about this gate:

- **It's not deterministic.** The check is delegated to a haiku LLM, not hard-coded logic, so different runs on the same PR could conclude differently.
- **There's no freshness or commit-since-comment logic** in the spec. A clean-review "No issues found" summary posted weeks ago will very likely cause the plugin to bail on subsequent pushes, even when substantial new code has been added.
- **The data source (`gh pr view --comments`) only includes top-level issue comments.** So:
  - "No issues found" summary → top-level → likely gates future reviews
  - Inline review comments only (issues-found path) → not in `--comments` → does *not* gate future reviews

This means clean-review PRs are effectively reviewed once, and a force-push or rebased branch will not refresh the verdict. To force a re-review today, the workaround is to delete the prior `claude[bot]` top-level comment.

This is upstream plugin behavior — fixing it would require a PR to [`anthropics/claude-code`](https://github.com/anthropics/claude-code/tree/main/plugins/code-review), not this repo. Flagged here so future debugging doesn't get confused by it.
