### PR TITLE
ci(weekly-deps): use OIDC-minted token for post-Claude push

### DIFF
--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -191,10 +191,16 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Intentionally NO github_token: Claude only fixes files in the
-          # working tree. A separate shell step (gated on Claude's success)
-          # holds the PAT and does the commit/push/PR. Prompt injection from a
-          # malicious dep cannot reach the token from here.
+          # additional_permissions triggers an OIDC exchange that mints a
+          # short-lived app token with contents:write, exposed to subsequent
+          # steps as steps.claude_fix.outputs.github_token. Claude itself
+          # never sees the token — outputs are written after the step exits,
+          # and Claude's Bash allowlist excludes git remote/config, so prompt
+          # injection from a malicious dep cannot reach it from inside this
+          # step. The post-step commit/push uses the minted token instead of
+          # a long-lived PAT.
+          additional_permissions: |
+            contents: write
           prompt: |
             You're on branch `${{ steps.branch.outputs.branch }}`. The weekly dependency upgrade
             already ran (`uv lock --upgrade` for Python, `pnpm update -r --latest`
@@ -280,7 +286,12 @@ jobs:
       - name: Commit & open PR (after Claude fix)
         if: steps.changes.outputs.changed == 'true' && steps.verify.outcome == 'failure' && steps.claude_fix.outcome == 'success'
         env:
-          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          # OIDC-minted app token from the claude-code-action step above.
+          # Short-lived, auto-revoked at job end, and triggers downstream CI
+          # (unlike GITHUB_TOKEN). The claude-code-action step embedded this
+          # same token into the origin remote URL, so the git push below
+          # picks it up.
+          GH_TOKEN: ${{ steps.claude_fix.outputs.github_token }}
         run: |
           gh auth setup-git
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

Fixes the auth failure in the first scheduled run of the weekly dependency upgrade workflow added in #13477. Run: https://github.com/Arize-ai/phoenix/actions/runs/26601582746/job/78386310631

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/Arize-ai/phoenix.git/'
```

### Root cause

1. `actions/checkout` ran with `persist-credentials: false` — origin URL has no embedded auth.
2. `anthropics/claude-code-action` then quietly re-embedded auth into the origin URL using the workflow `GITHUB_TOKEN` (log: `Updating remote URL with authentication...`).
3. Workflow `permissions` only grants `contents: read`, so the embedded token is read-only.
4. The follow-up step's `gh auth setup-git` installed a credential helper backed by `MY_RELEASE_PLEASE_TOKEN`, but git uses URL-embedded credentials in preference to a credential helper — the PAT was ignored.
5. `git push` tried the read-only embedded token → auth failure.

Other workflows that use the same `gh auth setup-git` + PAT pattern haven't hit this because their Claude step requests `additional_permissions: contents: write`, which causes the URL to be embedded with a write-capable OIDC-minted app token. The two mechanisms then agree.

### Fix

- Add `additional_permissions: contents: write` to the Claude step. This mints a short-lived app token via OIDC and embeds it into the origin URL with write access.
- Use `steps.claude_fix.outputs.github_token` for the post-Claude commit/push instead of `secrets.MY_RELEASE_PLEASE_TOKEN`. Matches the pattern in `claude-llms-txt.yml` and `claude-skills-audit.yml`.
- The clean-upgrade path (no Claude) is unchanged — it still uses `MY_RELEASE_PLEASE_TOKEN` because there is no minted token to use.

### Security note

The "Claude itself never holds the token" property is preserved:
- `steps.claude_fix.outputs.github_token` is written **after** the action step exits, so Claude doesn't see it during its run.
- Claude's `claude_args` allowlist excludes `git remote` and `git config`, so it can't read the URL-embedded credential either.
- The minted token is short-lived (revoked at job end) and triggers downstream CI (unlike `GITHUB_TOKEN`), which is a net improvement over the long-lived PAT it replaces in this step.

## Test plan

- [ ] Manually dispatch the workflow with a tweak that forces a verify failure (e.g., bump a package that breaks lint) and confirm the after-Claude commit & push succeeds.
- [ ] Confirm the clean-upgrade path still works on a no-regression run (auth path for that branch is unchanged).