### PR TITLE
ci: install socat alongside bubblewrap so the Claude CLI sandbox can actually init

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,9 +33,17 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Install bubblewrap
-        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+      - name: Install subprocess isolation deps
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1. The Claude CLI sandbox
+        # needs both bubblewrap AND socat, and Ubuntu 24.04+ blocks the unprivileged
+        # user namespaces it relies on by default. Mirrors the upstream action's
+        # install step (which only runs when allowed_non_write_users is set).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bubblewrap socat
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude-docs-gap-audit.yml
+++ b/.github/workflows/claude-docs-gap-audit.yml
@@ -28,9 +28,17 @@ jobs:
       - name: Prepare scratch directory
         run: mkdir -p .scratch
 
-      - name: Install bubblewrap
-        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+      - name: Install subprocess isolation deps
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1. The Claude CLI sandbox
+        # needs both bubblewrap AND socat, and Ubuntu 24.04+ blocks the unprivileged
+        # user namespaces it relies on by default. Mirrors the upstream action's
+        # install step (which only runs when allowed_non_write_users is set).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bubblewrap socat
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -72,10 +72,18 @@ jobs:
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
           mkdir -p .scratch
 
-      - name: Install bubblewrap
+      - name: Install subprocess isolation deps
         if: steps.guard.outputs.ready == 'true'
-        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1. The Claude CLI sandbox
+        # needs both bubblewrap AND socat, and Ubuntu 24.04+ blocks the unprivileged
+        # user namespaces it relies on by default. Mirrors the upstream action's
+        # install step (which only runs when allowed_non_write_users is set).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bubblewrap socat
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Run Claude Code
         if: steps.guard.outputs.ready == 'true'

--- a/.github/workflows/claude-llms-txt.yml
+++ b/.github/workflows/claude-llms-txt.yml
@@ -33,9 +33,17 @@ jobs:
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
           mkdir -p .scratch
 
-      - name: Install bubblewrap
-        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+      - name: Install subprocess isolation deps
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1. The Claude CLI sandbox
+        # needs both bubblewrap AND socat, and Ubuntu 24.04+ blocks the unprivileged
+        # user namespaces it relies on by default. Mirrors the upstream action's
+        # install step (which only runs when allowed_non_write_users is set).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bubblewrap socat
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -33,9 +33,17 @@ jobs:
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
           mkdir -p .scratch
 
-      - name: Install bubblewrap
-        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+      - name: Install subprocess isolation deps
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1. The Claude CLI sandbox
+        # needs both bubblewrap AND socat, and Ubuntu 24.04+ blocks the unprivileged
+        # user namespaces it relies on by default. Mirrors the upstream action's
+        # install step (which only runs when allowed_non_write_users is set).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bubblewrap socat
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude-skills-audit.yml
+++ b/.github/workflows/claude-skills-audit.yml
@@ -51,9 +51,17 @@ jobs:
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "date=$DATE" >> "$GITHUB_OUTPUT"
 
-      - name: Install bubblewrap
-        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+      - name: Install subprocess isolation deps
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1. The Claude CLI sandbox
+        # needs both bubblewrap AND socat, and Ubuntu 24.04+ blocks the unprivileged
+        # user namespaces it relies on by default. Mirrors the upstream action's
+        # install step (which only runs when allowed_non_write_users is set).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bubblewrap socat
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -178,10 +178,18 @@ jobs:
           All verification checks passed (typecheck, fmt, lint, test, build). Review and merge."
           fi
 
-      - name: Install bubblewrap
-        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
+      - name: Install subprocess isolation deps
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1. The Claude CLI sandbox
+        # needs both bubblewrap AND socat, and Ubuntu 24.04+ blocks the unprivileged
+        # user namespaces it relies on by default. Mirrors the upstream action's
+        # install step (which only runs when allowed_non_write_users is set).
         if: steps.changes.outputs.changed == 'true' && steps.verify.outcome == 'failure'
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bubblewrap socat
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Hand off to Claude (fix regressions)
         id: claude_fix

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,9 +39,17 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Install bubblewrap
-        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+      - name: Install subprocess isolation deps
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1. The Claude CLI sandbox
+        # needs both bubblewrap AND socat, and Ubuntu 24.04+ blocks the unprivileged
+        # user namespaces it relies on by default. Mirrors the upstream action's
+        # install step (which only runs when allowed_non_write_users is set).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bubblewrap socat
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## TL;DR

Every Claude workflow that sets `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"` is force-enabling the Claude CLI's bubblewrap-based subprocess sandbox. The sandbox requires **both `bubblewrap` AND `socat`** on Linux, plus the AppArmor unprivileged-userns restriction must be off on Ubuntu 24.04+. Our prior install step in #13485 only added bubblewrap, so the sandbox init has been silently failing for every Bash subprocess. This PR installs both packages and disables the AppArmor restriction across all 8 Claude workflows.

## How this was discovered

After #13490 (auth) and #13503 (added `Agent` to `allowedTools`, enabled `show_full_output: 'true'`) both landed, claude[bot] was still silent on fresh PRs. The next test run produced this in the now-verbose SDK output ([run 26602825643](https://github.com/Arize-ai/phoenix/actions/runs/26602825643/job/78390528330)):

```
"result": "I'm unable to execute Bash commands in this environment — the
sandbox fails to initialize because `socat` is not installed, and even
`dangerouslyDisableSandbox: true` is being blocked by the same initialization
check. Without `gh` access I can't fetch PR #13506's metadata, diff, or
existing comments, which means I can't perform the review."
```

The trace showed Claude making 18 Bash attempts in a row, all failing the same way. The `permission_denials_count: 1` from prior runs was a red herring (it was a haiku subagent's exploratory `which gh && gh --version` which we don't allow — unrelated to the actual blocker).

## Verified against official docs

From [Configure the sandboxed Bash tool — Claude Code Docs](https://code.claude.com/docs/en/sandboxing):

> On Linux and WSL2, the sandbox relies on two packages:
> - **`bubblewrap`**: the unprivileged sandboxing tool that enforces filesystem isolation
> - **`socat`**: the relay used to route network traffic through the sandbox proxy
>
> `sudo apt-get install bubblewrap socat`

And on Ubuntu 24.04+:

> The default AppArmor policy prevents bubblewrap from creating the user namespaces it needs for isolation. To check whether your environment enforces this restriction, run `sysctl kernel.apparmor_restrict_unprivileged_userns`. If the key does not exist or returns `0`, skip this step. If it returns `1`, add an AppArmor profile that grants `bwrap` this capability.

The official doc recommends a per-binary AppArmor profile for `/usr/bin/bwrap`. The upstream `anthropics/claude-code-action` instead uses `sysctl -w kernel.apparmor_restrict_unprivileged_userns=0` in its own [conditional install step](https://github.com/anthropics/claude-code-action/blob/787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251/action.yml#L208-L226). We follow the action's pattern — for an ephemeral GitHub Actions runner that's torn down after the job, the security delta is nil.

And the trap behavior that made `dangerouslyDisableSandbox: true` ineffective is a known upstream issue: [anthropics/claude-code#50167 — *"CLAUDE_CODE_SUBPROCESS_ENV_SCRUB silently overrides sandbox.enabled:false with no warning"*](https://github.com/anthropics/claude-code/issues/50167). Setting the env var force-activates the sandbox before per-command overrides are checked.

## Why this only surfaced on `claude-code-review`

The other Claude workflows (`claude-llms-txt`, `claude-docs-gap-audit`, `claude-release-notes`, `claude-skills-audit`, `claude-implement-issue`, `claude.yml`, `claude-weekly-deps-upgrade`) have all had the same broken install since #13485 added the bubblewrap step. They appeared to be working because their primary tools are non-Bash (`Read`, `Write`, `Edit`, `Glob`, `Grep`, `Agent`) — Claude could complete its core work using those, even with every `Bash` call failing.

`claude-code-review` is the canary because the [code-review plugin](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md) is built around `Bash(gh pr view:*)`, `Bash(gh pr diff:*)`, `Bash(gh pr comment:*)`, etc. — every step needs the `gh` CLI. With Bash totally broken, the plugin can't fetch the PR, can't read its diff, can't post comments. Hence the silent failure on every PR since the env-scrub flag was added.

Affected workflows that this PR fixes (8 total):
- `claude-code-review.yml`
- `claude.yml`
- `claude-docs-gap-audit.yml`
- `claude-implement-issue.yml`
- `claude-llms-txt.yml`
- `claude-release-notes.yml`
- `claude-skills-audit.yml`
- `claude-weekly-deps-upgrade.yml`

## What this PR changes

Each workflow's `Install bubblewrap` step is replaced with `Install subprocess isolation deps`, matching the upstream action's full install:

```yaml
- name: Install subprocess isolation deps
  # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1. The Claude CLI sandbox
  # needs both bubblewrap AND socat, and Ubuntu 24.04+ blocks the unprivileged
  # user namespaces it relies on by default. Mirrors the upstream action's
  # install step (which only runs when allowed_non_write_users is set).
  run: |
    sudo apt-get update
    sudo apt-get install -y --no-install-recommends bubblewrap socat
    if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
      sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
    fi
```

For the two workflows that gate this step on a conditional (`claude-implement-issue`, `claude-weekly-deps-upgrade`), the existing `if:` is preserved.

## Test plan

- [ ] Push a fresh commit to any open PR after merge — verify `claude[bot]` either posts inline review comments or a "No issues found" summary (no more silent failures).
- [ ] Confirm in the step log (we left `show_full_output: 'true'` from #13503 on `claude-code-review`) that the final result message no longer contains "sandbox fails to initialize because `socat` is not installed" and that `gh` Bash calls actually execute.
- [ ] Watch the next weekly cron runs (`claude-llms-txt`, `claude-docs-gap-audit`, `claude-release-notes`, `claude-skills-audit`) for any behavioral improvements now that Bash tools actually work in those too.
- [ ] Optional follow-up: once the fix is confirmed, flip `show_full_output: 'true'` back off on `claude-code-review` in a separate PR (debug-only purpose).