### PR TITLE
feat(agents): add read_prompt_tools and write_prompt_tools to PXI

### DIFF
--- a/app/src/agent/extensions/toolRegistry.ts
+++ b/app/src/agent/extensions/toolRegistry.ts
@@ -36,6 +36,14 @@ import {
   type ReadPromptInput,
 } from "@phoenix/agent/tools/playgroundPrompt";
 import {
+  parseReadPromptToolsInput,
+  parseWritePromptToolsInput,
+  READ_PROMPT_TOOLS_TOOL_NAME,
+  type ReadPromptToolsInput,
+  WRITE_PROMPT_TOOLS_TOOL_NAME,
+  type WritePromptToolsInput,
+} from "@phoenix/agent/tools/playgroundPromptTools";
+import {
   parseRunPlaygroundInput,
   RUN_PLAYGROUND_TOOL_NAME,
   type RunPlaygroundInput,
@@ -760,6 +768,83 @@ const batchSpanAnnotateAgentTool =
     },
   });
 
+const readPromptToolsAgentTool =
+  createRegisteredAgentTool<ReadPromptToolsInput>({
+    name: READ_PROMPT_TOOLS_TOOL_NAME,
+    parseInput: parseReadPromptToolsInput,
+    invalidInputErrorText: `Invalid ${READ_PROMPT_TOOLS_TOOL_NAME} input. Expected { instanceId?: number }.`,
+    execute: async ({ toolCall, input, addToolOutput, agentStore }) => {
+      const action =
+        agentStore.getState().registeredClientActions[
+          READ_PROMPT_TOOLS_TOOL_NAME
+        ];
+      if (!action) {
+        await addToolOutput({
+          state: "output-error",
+          tool: READ_PROMPT_TOOLS_TOOL_NAME,
+          toolCallId: toolCall.toolCallId,
+          errorText: "The playground is not mounted; cannot read prompt tools.",
+        });
+        return;
+      }
+      const result = await action(input);
+      if (result.ok) {
+        await addToolOutput({
+          state: "output-available",
+          tool: READ_PROMPT_TOOLS_TOOL_NAME,
+          toolCallId: toolCall.toolCallId,
+          output: result.output ?? "Prompt tools read.",
+        });
+      } else {
+        await addToolOutput({
+          state: "output-error",
+          tool: READ_PROMPT_TOOLS_TOOL_NAME,
+          toolCallId: toolCall.toolCallId,
+          errorText: result.error,
+        });
+      }
+    },
+  });
+
+const writePromptToolsAgentTool =
+  createRegisteredAgentTool<WritePromptToolsInput>({
+    name: WRITE_PROMPT_TOOLS_TOOL_NAME,
+    parseInput: parseWritePromptToolsInput,
+    invalidInputErrorText: `Invalid ${WRITE_PROMPT_TOOLS_TOOL_NAME} input. Expected { instanceId: number, expectedRevision: string, tools?: Array<{ id?: number | null, name: string, description?: string | null, parameters?: object | null, strict?: boolean | null }>, deleteToolIds?: number[] } with at least one tool to write or delete.`,
+    execute: async ({ toolCall, input, addToolOutput, agentStore }) => {
+      const action =
+        agentStore.getState().registeredClientActions[
+          WRITE_PROMPT_TOOLS_TOOL_NAME
+        ];
+      if (!action) {
+        await addToolOutput({
+          state: "output-error",
+          tool: WRITE_PROMPT_TOOLS_TOOL_NAME,
+          toolCallId: toolCall.toolCallId,
+          errorText:
+            "The playground is not mounted; cannot write prompt tools.",
+        });
+        return;
+      }
+      const result = await action(input);
+      if (result.ok) {
+        await addToolOutput({
+          state: "output-available",
+          tool: WRITE_PROMPT_TOOLS_TOOL_NAME,
+          toolCallId: toolCall.toolCallId,
+          output: result.output ?? "Prompt tools written.",
+        });
+      } else {
+        await addToolOutput({
+          state: "output-error",
+          tool: WRITE_PROMPT_TOOLS_TOOL_NAME,
+          toolCallId: toolCall.toolCallId,
+          errorText: result.error,
+        });
+      }
+    },
+  });
+
 /** Ordered registry of all frontend-executable tools. */
 const agentToolRegistry: RegisteredAgentTool<unknown>[] = [
   bashAgentTool as RegisteredAgentTool<unknown>,
@@ -771,6 +856,8 @@ const agentToolRegistry: RegisteredAgentTool<unknown>[] = [
   clonePromptInstanceAgentTool as RegisteredAgentTool<unknown>,
   editPromptAgentTool as RegisteredAgentTool<unknown>,
   savePromptAgentTool as RegisteredAgentTool<unknown>,
+  readPromptToolsAgentTool as RegisteredAgentTool<unknown>,
+  writePromptToolsAgentTool as RegisteredAgentTool<unknown>,
   runPlaygroundAgentTool as RegisteredAgentTool<unknown>,
   readPlaygroundOutputAgentTool as RegisteredAgentTool<unknown>,
   setVariableValuesAgentTool as RegisteredAgentTool<unknown>,

--- a/app/src/agent/tools/playgroundPromptTools/__tests__/playgroundPromptTools.test.ts
+++ b/app/src/agent/tools/playgroundPromptTools/__tests__/playgroundPromptTools.test.ts
@@ -1,0 +1,687 @@
+import {
+  applyWritePromptTools,
+  createReadPromptToolsClientAction,
+  createWritePromptToolsClientAction,
+  getPromptToolsSnapshot,
+  parseWritePromptToolsInput,
+  type PromptToolsSnapshot,
+  type WritePromptToolsResult,
+} from "@phoenix/agent/tools/playgroundPromptTools";
+import {
+  _resetInstanceId,
+  _resetToolId,
+  createPlaygroundStore,
+  type PlaygroundStore,
+  type Tool,
+} from "@phoenix/store/playground";
+
+const newStore = () =>
+  createPlaygroundStore({ datasetId: null, modelConfigByProvider: {} });
+
+/** Replace the tool list on the default instance (id 0). */
+const seedTools = (playgroundStore: PlaygroundStore, tools: Tool[]) => {
+  playgroundStore.getState().updateInstance({
+    instanceId: 0,
+    patch: { tools },
+    dirty: false,
+  });
+};
+
+const revisionOf = (playgroundStore: PlaygroundStore): string => {
+  const snapshot = getPromptToolsSnapshot({ playgroundStore });
+  if (!snapshot.ok) throw new Error(snapshot.error);
+  return snapshot.output.revision;
+};
+
+const functionTool = (id: number, name: string, extra = {}): Tool => ({
+  kind: "function",
+  id,
+  editorType: "json",
+  definition: { name, ...extra },
+});
+
+describe("playground prompt tools agent tools", () => {
+  beforeEach(() => {
+    localStorage.removeItem("arize-phoenix-agent");
+    _resetInstanceId();
+    _resetToolId();
+  });
+
+  describe("read_prompt_tools", () => {
+    it("reads an empty tool list with a revision", async () => {
+      const playgroundStore = newStore();
+      const read = createReadPromptToolsClientAction({ playgroundStore });
+
+      const result = await read({});
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const snapshot = JSON.parse(result.output ?? "") as PromptToolsSnapshot;
+      expect(snapshot.instanceId).toBe(0);
+      expect(snapshot.label).toBe("A");
+      expect(snapshot.tools).toEqual([]);
+      expect(snapshot.revision).toMatch(/^prompt-tools-/);
+    });
+
+    // Forward-compat guard: raw (vendor passthrough) tools are read-only today,
+    // but the read contract MUST keep surfacing them with a `kind` discriminator
+    // so a future raw-write feature has a stable seam to build on.
+    it("surfaces raw vendor tools alongside function tools with a kind discriminator", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [
+        functionTool(101, "get_weather", {
+          description: "Look up weather.",
+          parameters: { type: "object" },
+        }),
+        {
+          kind: "raw",
+          id: 102,
+          editorType: "json",
+          raw: { type: "web_search" },
+        },
+      ]);
+
+      const snapshot = getPromptToolsSnapshot({ playgroundStore });
+
+      expect(snapshot.ok).toBe(true);
+      if (!snapshot.ok) return;
+      expect(snapshot.output.tools).toEqual([
+        expect.objectContaining({
+          kind: "function",
+          id: 101,
+          name: "get_weather",
+          description: "Look up weather.",
+        }),
+        expect.objectContaining({
+          kind: "raw",
+          id: 102,
+          raw: { type: "web_search" },
+        }),
+      ]);
+    });
+
+    it("requires an explicit instanceId when multiple instances exist", () => {
+      const playgroundStore = newStore();
+      playgroundStore.getState().addInstance();
+
+      const snapshot = getPromptToolsSnapshot({ playgroundStore });
+
+      expect(snapshot).toEqual(
+        expect.objectContaining({
+          ok: false,
+          error: expect.stringContaining("Multiple playground instances"),
+        })
+      );
+    });
+  });
+
+  describe("write_prompt_tools — create / update", () => {
+    it("creates a single function tool", () => {
+      const playgroundStore = newStore();
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [{ name: "get_weather", parameters: { type: "object" } }],
+        },
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.output.results).toEqual([
+        { status: "created", toolId: expect.any(Number) },
+      ]);
+      const tools = playgroundStore.getState().instances[0]!.tools;
+      expect(tools).toHaveLength(1);
+      expect(tools[0]).toEqual(
+        expect.objectContaining({
+          kind: "function",
+          definition: expect.objectContaining({ name: "get_weather" }),
+        })
+      );
+    });
+
+    it("creates several tools in one batch with distinct ids", () => {
+      const playgroundStore = newStore();
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [{ name: "get_weather" }, { name: "get_forecast" }],
+        },
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.output.results).toHaveLength(2);
+      const [first, second] = result.output.results;
+      expect(first!.status).toBe("created");
+      expect(second!.status).toBe("created");
+      expect(first!.toolId).not.toBe(second!.toolId);
+      expect(
+        playgroundStore
+          .getState()
+          .instances[0]!.tools.map((tool) =>
+            tool.kind === "function" ? tool.definition.name : tool.kind
+          )
+      ).toEqual(["get_weather", "get_forecast"]);
+    });
+
+    it("patches an existing tool, changing only the fields present in the entry", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [
+        functionTool(101, "get_weather", {
+          description: "Original description.",
+          parameters: { type: "object", properties: { city: {} } },
+        }),
+      ]);
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [
+            {
+              id: 101,
+              name: "get_weather",
+              parameters: {
+                type: "object",
+                properties: { city: {}, units: {} },
+              },
+            },
+          ],
+        },
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.output.results).toEqual([
+        { status: "updated", toolId: 101 },
+      ]);
+      const tool = playgroundStore.getState().instances[0]!.tools[0]!;
+      expect(tool.kind).toBe("function");
+      if (tool.kind !== "function") return;
+      // parameters changed...
+      expect(tool.definition.parameters).toEqual({
+        type: "object",
+        properties: { city: {}, units: {} },
+      });
+      // ...but the untouched description is preserved (patch semantics).
+      expect(tool.definition.description).toBe("Original description.");
+    });
+
+    it("composes repeated patches to the same tool within one batch", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [functionTool(101, "get_weather")]);
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [
+            { id: 101, name: "get_weather", description: "Set first." },
+            { id: 101, name: "get_weather", parameters: { type: "object" } },
+          ],
+        },
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.output.results).toEqual([
+        { status: "updated", toolId: 101 },
+        { status: "updated", toolId: 101 },
+      ]);
+      const tool = playgroundStore.getState().instances[0]!.tools[0]!;
+      if (tool.kind !== "function") throw new Error("expected function tool");
+      // Both patches landed: the second did not clobber the first.
+      expect(tool.definition.description).toBe("Set first.");
+      expect(tool.definition.parameters).toEqual({ type: "object" });
+    });
+  });
+
+  describe("write_prompt_tools — all-or-nothing rejection", () => {
+    it("rejects the whole batch when an entry references a missing id, mutating nothing", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [functionTool(101, "existing")]);
+      const revision = revisionOf(playgroundStore);
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revision,
+          tools: [{ name: "would_be_created" }, { id: 9999, name: "missing" }],
+        },
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          ok: false,
+          error: expect.stringContaining("tools[1]"),
+        })
+      );
+      if (result.ok) return;
+      expect(result.error).toContain("9999");
+      // The valid create in tools[0] must NOT have been applied.
+      expect(playgroundStore.getState().instances[0]!.tools).toHaveLength(1);
+      expect(revisionOf(playgroundStore)).toBe(revision);
+    });
+
+    it("rejects editing a raw vendor tool with the offending index, mutating nothing", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [
+        {
+          kind: "raw",
+          id: 200,
+          editorType: "json",
+          raw: { type: "web_search" },
+        },
+      ]);
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [{ id: 200, name: "web_search" }],
+        },
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          ok: false,
+          error: expect.stringContaining("tools[0]"),
+        })
+      );
+      if (result.ok) return;
+      expect(result.error).toMatch(/raw|vendor passthrough/);
+      const tool = playgroundStore.getState().instances[0]!.tools[0]!;
+      expect(tool.kind).toBe("raw");
+    });
+
+    it("rejects a stale batch when the revision no longer matches", () => {
+      const playgroundStore = newStore();
+      const staleRevision = revisionOf(playgroundStore);
+      // Something changes the tool list after the read.
+      seedTools(playgroundStore, [functionTool(101, "added_later")]);
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: staleRevision,
+          tools: [{ name: "get_weather" }],
+        },
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          ok: false,
+          error: expect.stringContaining("has changed"),
+        })
+      );
+      expect(playgroundStore.getState().instances[0]!.tools).toHaveLength(1);
+    });
+  });
+
+  // The tool editors are uncontrolled (CodeMirror); an external write must bump
+  // a per-tool revision so the mounted editor remounts and drops its stale
+  // initial value. See PlaygroundTools key + markToolsExternallyUpdated.
+  describe("write_prompt_tools — external editor refresh", () => {
+    it("bumps the external-update revision for created and updated tools", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [functionTool(101, "get_weather")]);
+      expect(
+        playgroundStore.getState().externallyUpdatedToolRevisionById[101] ?? 0
+      ).toBe(0);
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [
+            { id: 101, name: "get_weather", description: "updated" },
+            { name: "get_forecast" },
+          ],
+        },
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const revById =
+        playgroundStore.getState().externallyUpdatedToolRevisionById;
+      // The updated tool's editor must be told to refresh...
+      expect(revById[101]).toBe(1);
+      // ...as well as the newly created one.
+      const createdId = result.output.results.find(
+        (r) => r.status === "created"
+      )!.toolId;
+      expect(revById[createdId]).toBe(1);
+    });
+
+    it("does not bump the revision for local edits via updateInstance", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [functionTool(101, "get_weather")]);
+
+      // Simulate the user typing in the editor (the path updateTool uses).
+      playgroundStore.getState().updateInstance({
+        instanceId: 0,
+        patch: {
+          tools: [functionTool(101, "get_weather", { description: "typed" })],
+        },
+        dirty: true,
+      });
+
+      expect(
+        playgroundStore.getState().externallyUpdatedToolRevisionById[101] ?? 0
+      ).toBe(0);
+    });
+  });
+
+  describe("write_prompt_tools — delete", () => {
+    it("deletes a function tool by id", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [
+        functionTool(101, "get_weather"),
+        functionTool(102, "get_forecast"),
+      ]);
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [],
+          deleteToolIds: [101],
+        },
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.output.deletedToolIds).toEqual([101]);
+      expect(result.output.results).toEqual([]);
+      expect(
+        playgroundStore.getState().instances[0]!.tools.map((tool) => tool.id)
+      ).toEqual([102]);
+    });
+
+    // Deletes are more permissive than writes: removing a tool needs no
+    // knowledge of its shape, so raw vendor tools can be deleted via PXI.
+    it("deletes a raw vendor tool even though it cannot be written", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [
+        {
+          kind: "raw",
+          id: 200,
+          editorType: "json",
+          raw: { type: "web_search" },
+        },
+      ]);
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [],
+          deleteToolIds: [200],
+        },
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.output.deletedToolIds).toEqual([200]);
+      expect(playgroundStore.getState().instances[0]!.tools).toHaveLength(0);
+    });
+
+    it("deletes and creates atomically in one batch", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [functionTool(101, "old_tool")]);
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [{ name: "new_tool" }],
+          deleteToolIds: [101],
+        },
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.output.deletedToolIds).toEqual([101]);
+      expect(result.output.results).toEqual([
+        { status: "created", toolId: expect.any(Number) },
+      ]);
+      expect(
+        playgroundStore
+          .getState()
+          .instances[0]!.tools.map((tool) =>
+            tool.kind === "function" ? tool.definition.name : tool.kind
+          )
+      ).toEqual(["new_tool"]);
+    });
+
+    it("rejects the whole batch when a delete id is missing, mutating nothing", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [functionTool(101, "existing")]);
+      const revision = revisionOf(playgroundStore);
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revision,
+          tools: [{ name: "would_be_created" }],
+          deleteToolIds: [9999],
+        },
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          ok: false,
+          error: expect.stringContaining("deleteToolIds"),
+        })
+      );
+      if (result.ok) return;
+      expect(result.error).toContain("9999");
+      expect(playgroundStore.getState().instances[0]!.tools).toHaveLength(1);
+      expect(revisionOf(playgroundStore)).toBe(revision);
+    });
+
+    it("rejects updating and deleting the same tool in one batch", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [functionTool(101, "get_weather")]);
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [{ id: 101, name: "get_weather", description: "patched" }],
+          deleteToolIds: [101],
+        },
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          ok: false,
+          error: expect.stringContaining("both updated and deleted"),
+        })
+      );
+      const tool = playgroundStore.getState().instances[0]!.tools[0]!;
+      expect(tool.kind === "function" && tool.definition.description).toBe(
+        undefined
+      );
+    });
+
+    it("resets the tool choice to auto when deleting the forced-choice tool", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [functionTool(101, "get_weather")]);
+      playgroundStore.getState().updateInstance({
+        instanceId: 0,
+        patch: {
+          toolChoice: {
+            type: "SPECIFIC_FUNCTION",
+            functionName: "get_weather",
+          },
+        },
+        dirty: false,
+      });
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [],
+          deleteToolIds: [101],
+        },
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.output.deletedToolIds).toEqual([101]);
+      expect(result.output.resetToolChoiceFrom).toBe("get_weather");
+      expect(playgroundStore.getState().instances[0]!.tools).toHaveLength(0);
+      expect(playgroundStore.getState().instances[0]!.toolChoice).toEqual({
+        type: "ZERO_OR_MORE",
+      });
+    });
+
+    it("leaves an unrelated forced tool choice untouched when deleting a different tool", () => {
+      const playgroundStore = newStore();
+      seedTools(playgroundStore, [
+        functionTool(101, "get_weather"),
+        functionTool(102, "get_forecast"),
+      ]);
+      playgroundStore.getState().updateInstance({
+        instanceId: 0,
+        patch: {
+          toolChoice: {
+            type: "SPECIFIC_FUNCTION",
+            functionName: "get_weather",
+          },
+        },
+        dirty: false,
+      });
+
+      const result = applyWritePromptTools({
+        playgroundStore,
+        input: {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [],
+          deleteToolIds: [102],
+        },
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.output.resetToolChoiceFrom).toBeUndefined();
+      expect(playgroundStore.getState().instances[0]!.toolChoice).toEqual({
+        type: "SPECIFIC_FUNCTION",
+        functionName: "get_weather",
+      });
+    });
+  });
+
+  describe("input parsing", () => {
+    it("normalizes snake_case and the `revision` alias", () => {
+      const parsed = parseWritePromptToolsInput({
+        instance_id: 0,
+        revision: "prompt-tools-abc",
+        tools: [{ name: "get_weather" }],
+      });
+
+      expect(parsed).toEqual({
+        instanceId: 0,
+        expectedRevision: "prompt-tools-abc",
+        tools: [{ name: "get_weather" }],
+      });
+    });
+
+    it("accepts a delete-only batch and normalizes the delete_tool_ids alias", () => {
+      const parsed = parseWritePromptToolsInput({
+        instanceId: 0,
+        expectedRevision: "prompt-tools-abc",
+        delete_tool_ids: [3, 4],
+      });
+
+      expect(parsed).toEqual({
+        instanceId: 0,
+        expectedRevision: "prompt-tools-abc",
+        deleteToolIds: [3, 4],
+      });
+    });
+
+    it("rejects a batch with neither tools nor deletes", () => {
+      expect(
+        parseWritePromptToolsInput({
+          instanceId: 0,
+          expectedRevision: "prompt-tools-abc",
+          tools: [],
+        })
+      ).toBeNull();
+    });
+
+    it("drops a null id (create) but keeps a numeric id (update)", () => {
+      const parsed = parseWritePromptToolsInput({
+        instanceId: 0,
+        expectedRevision: "prompt-tools-abc",
+        tools: [
+          { name: "to_create", id: null },
+          { name: "to_update", id: 7 },
+        ],
+      });
+
+      expect(parsed).not.toBeNull();
+      const tools = parsed!.tools ?? [];
+      expect("id" in tools[0]!).toBe(false);
+      expect(tools[1]).toEqual({ name: "to_update", id: 7 });
+    });
+  });
+
+  describe("write_prompt_tools client action", () => {
+    it("returns the batch results and a fresh revision as JSON", async () => {
+      const playgroundStore = newStore();
+      const write = createWritePromptToolsClientAction({ playgroundStore });
+
+      const result = await write({
+        instanceId: 0,
+        expectedRevision: revisionOf(playgroundStore),
+        tools: [{ name: "get_weather" }],
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const output = JSON.parse(result.output ?? "") as WritePromptToolsResult;
+      expect(output.results).toEqual([
+        { status: "created", toolId: expect.any(Number) },
+      ]);
+      expect(output.revision).toMatch(/^prompt-tools-/);
+    });
+
+    it("reports invalid input", async () => {
+      const playgroundStore = newStore();
+      const write = createWritePromptToolsClientAction({ playgroundStore });
+
+      const result = await write({ instanceId: 0, tools: [] });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          ok: false,
+          error: expect.stringContaining("Invalid write_prompt_tools input"),
+        })
+      );
+    });
+  });
+});

--- a/app/src/agent/tools/playgroundPromptTools/clientActions.ts
+++ b/app/src/agent/tools/playgroundPromptTools/clientActions.ts
@@ -1,0 +1,52 @@
+import type { AgentClientActionResult } from "@phoenix/store/agentStore";
+import type { PlaygroundStore } from "@phoenix/store/playground";
+
+import {
+  parseReadPromptToolsInput,
+  parseWritePromptToolsInput,
+} from "./parsers";
+import {
+  applyWritePromptTools,
+  getPromptToolsSnapshot,
+} from "./promptToolsStore";
+
+/** Returns the current prompt tool list snapshot as JSON. */
+export function createReadPromptToolsClientAction({
+  playgroundStore,
+}: {
+  playgroundStore: PlaygroundStore;
+}) {
+  return async (input: unknown): Promise<AgentClientActionResult> => {
+    const parsed = parseReadPromptToolsInput(input);
+    if (!parsed) {
+      return { ok: false, error: "Invalid read_prompt_tools input." };
+    }
+    const snapshot = getPromptToolsSnapshot({
+      playgroundStore,
+      instanceId: parsed.instanceId,
+    });
+    if (!snapshot.ok) return snapshot;
+    return { ok: true, output: JSON.stringify(snapshot.output, null, 2) };
+  };
+}
+
+/**
+ * Upserts a batch of function tools on a playground prompt instance. Verifies
+ * the input's `expectedRevision` against the current snapshot before mutating
+ * and applies the batch atomically (all-or-nothing).
+ */
+export function createWritePromptToolsClientAction({
+  playgroundStore,
+}: {
+  playgroundStore: PlaygroundStore;
+}) {
+  return async (input: unknown): Promise<AgentClientActionResult> => {
+    const parsed = parseWritePromptToolsInput(input);
+    if (!parsed) {
+      return { ok: false, error: "Invalid write_prompt_tools input." };
+    }
+    const result = applyWritePromptTools({ playgroundStore, input: parsed });
+    if (!result.ok) return result;
+    return { ok: true, output: JSON.stringify(result.output, null, 2) };
+  };
+}

--- a/app/src/agent/tools/playgroundPromptTools/constants.ts
+++ b/app/src/agent/tools/playgroundPromptTools/constants.ts
@@ -1,0 +1,2 @@
+export const READ_PROMPT_TOOLS_TOOL_NAME = "read_prompt_tools";
+export const WRITE_PROMPT_TOOLS_TOOL_NAME = "write_prompt_tools";

--- a/app/src/agent/tools/playgroundPromptTools/index.ts
+++ b/app/src/agent/tools/playgroundPromptTools/index.ts
@@ -1,0 +1,6 @@
+export * from "./clientActions";
+export * from "./constants";
+export * from "./parsers";
+export * from "./promptToolsStore";
+export * from "./schemas";
+export * from "./types";

--- a/app/src/agent/tools/playgroundPromptTools/parsers.ts
+++ b/app/src/agent/tools/playgroundPromptTools/parsers.ts
@@ -1,0 +1,17 @@
+import {
+  readPromptToolsInputSchema,
+  writePromptToolsInputSchema,
+} from "./schemas";
+import type { ReadPromptToolsInput, WritePromptToolsInput } from "./types";
+
+export function parseReadPromptToolsInput(
+  input: unknown
+): ReadPromptToolsInput | null {
+  return readPromptToolsInputSchema.safeParse(input).data ?? null;
+}
+
+export function parseWritePromptToolsInput(
+  input: unknown
+): WritePromptToolsInput | null {
+  return writePromptToolsInputSchema.safeParse(input).data ?? null;
+}

--- a/app/src/agent/tools/playgroundPromptTools/promptToolsStore.ts
+++ b/app/src/agent/tools/playgroundPromptTools/promptToolsStore.ts
@@ -1,0 +1,311 @@
+import { getInstanceLabel } from "@phoenix/agent/tools/playgroundPrompt";
+import {
+  type CanonicalToolDefinition,
+  generateToolId,
+  type PlaygroundStore,
+  type Tool,
+} from "@phoenix/store/playground";
+
+import type {
+  PromptToolsActionResult,
+  PromptToolSnapshot,
+  PromptToolsSnapshot,
+  WritePromptToolEntry,
+  WritePromptToolResult,
+  WritePromptToolsInput,
+  WritePromptToolsResult,
+} from "./types";
+
+/**
+ * Returns a snapshot of one playground prompt instance's tool list plus a
+ * content-hash revision token. If only one instance exists, it is selected
+ * automatically; otherwise `instanceId` is required.
+ */
+export function getPromptToolsSnapshot({
+  playgroundStore,
+  instanceId,
+}: {
+  playgroundStore: PlaygroundStore;
+  instanceId?: number;
+}): PromptToolsActionResult<PromptToolsSnapshot> {
+  const instance = resolveInstance({ playgroundStore, instanceId });
+  if (!instance.ok) return instance;
+  const { playgroundInstance, index } = instance.output;
+  const tools = playgroundInstance.tools.map(toPromptToolSnapshot);
+  const snapshotWithoutRevision = {
+    instanceId: playgroundInstance.id,
+    index,
+    label: getInstanceLabel(index),
+    tools,
+  };
+  return {
+    ok: true,
+    output: {
+      ...snapshotWithoutRevision,
+      revision: buildPromptToolsRevision(snapshotWithoutRevision),
+    },
+  };
+}
+
+/**
+ * Applies a `write_prompt_tools` batch to the playground store: each `tools`
+ * entry patches an existing function tool when its `id` is provided, or creates
+ * a new one otherwise, and every id in `deleteToolIds` is removed. Verifies the
+ * input's `expectedRevision` against the current snapshot before mutating;
+ * rejects on mismatch.
+ *
+ * The batch is all-or-nothing: every entry and delete id is validated against
+ * the snapshot read before anything is mutated, so a single bad entry (missing
+ * id, a raw passthrough tool on the write path, an update/delete conflict, or a
+ * delete that would orphan the forced tool choice) rejects the whole batch and
+ * leaves the playground untouched. Unlike writes, deletes may target raw vendor
+ * tools — removing a tool needs no knowledge of its shape.
+ */
+export function applyWritePromptTools({
+  playgroundStore,
+  input,
+}: {
+  playgroundStore: PlaygroundStore;
+  input: WritePromptToolsInput;
+}): PromptToolsActionResult<WritePromptToolsResult> {
+  const instance = resolveInstance({
+    playgroundStore,
+    instanceId: input.instanceId,
+  });
+  if (!instance.ok) return instance;
+  const { playgroundInstance } = instance.output;
+
+  const beforeSnapshot = getPromptToolsSnapshot({
+    playgroundStore,
+    instanceId: playgroundInstance.id,
+  });
+  if (!beforeSnapshot.ok) return beforeSnapshot;
+  if (beforeSnapshot.output.revision !== input.expectedRevision) {
+    return {
+      ok: false,
+      error:
+        "The prompt tool list has changed since it was last viewed by PXI.",
+    };
+  }
+
+  const writeEntries = input.tools ?? [];
+  const deleteIds = new Set(input.deleteToolIds ?? []);
+
+  // Validation pass — all-or-nothing. Update entries must reference an existing
+  // function tool from the snapshot we just read; ids assigned to tools created
+  // earlier in the same batch are not addressable here. Nothing is mutated
+  // until every entry and delete id is known to be applicable.
+  for (let index = 0; index < writeEntries.length; index++) {
+    const entry = writeEntries[index]!;
+    const requestedId = "id" in entry ? entry.id : undefined;
+    if (requestedId == null) continue;
+    const existing = playgroundInstance.tools.find(
+      (candidate) => candidate.id === requestedId
+    );
+    if (!existing) {
+      return {
+        ok: false,
+        error: `tools[${index}]: prompt tool ${requestedId} was not found on instance ${playgroundInstance.id}.`,
+      };
+    }
+    if (existing.kind !== "function") {
+      return {
+        ok: false,
+        error: `tools[${index}]: prompt tool ${requestedId} is a vendor passthrough (raw) tool and cannot be edited via PXI. Edit it in the playground tool editor.`,
+      };
+    }
+    if (deleteIds.has(requestedId)) {
+      return {
+        ok: false,
+        error: `tools[${index}]: prompt tool ${requestedId} cannot be both updated and deleted in the same batch.`,
+      };
+    }
+  }
+
+  const forcedChoice = playgroundInstance.toolChoice;
+  const forcedFunctionName =
+    forcedChoice?.type === "SPECIFIC_FUNCTION"
+      ? forcedChoice.functionName
+      : undefined;
+  // If a deleted tool is the prompt's forced tool choice, deleting it would
+  // orphan that choice. Rather than reject (the user would just clear the
+  // choice and retry, ending here anyway), reset the choice to auto
+  // (ZERO_OR_MORE — the instance default) and disclose it in the result.
+  let resetToolChoiceFrom: string | undefined;
+  for (const deleteId of deleteIds) {
+    const existing = playgroundInstance.tools.find(
+      (candidate) => candidate.id === deleteId
+    );
+    if (!existing) {
+      return {
+        ok: false,
+        error: `deleteToolIds: prompt tool ${deleteId} was not found on instance ${playgroundInstance.id}.`,
+      };
+    }
+    if (
+      forcedFunctionName != null &&
+      existing.kind === "function" &&
+      existing.definition.name === forcedFunctionName
+    ) {
+      resetToolChoiceFrom = forcedFunctionName;
+    }
+  }
+
+  // Apply pass — drop deleted tools first, then fold each write entry over the
+  // working copy so multiple entries (including repeated patches to the same
+  // id) compose in order.
+  let workingTools: Tool[] = playgroundInstance.tools.filter(
+    (candidate) => !deleteIds.has(candidate.id)
+  );
+  const results: WritePromptToolResult[] = [];
+  for (const entry of writeEntries) {
+    const requestedId = "id" in entry ? entry.id : undefined;
+    if (requestedId != null) {
+      workingTools = workingTools.map((candidate) =>
+        candidate.id === requestedId && candidate.kind === "function"
+          ? { ...candidate, definition: patchDefinition(candidate, entry) }
+          : candidate
+      );
+      results.push({ status: "updated", toolId: requestedId });
+    } else {
+      const newId = generateToolId();
+      workingTools = [
+        ...workingTools,
+        {
+          kind: "function",
+          id: newId,
+          editorType: "json",
+          definition: patchDefinition(null, entry),
+        },
+      ];
+      results.push({ status: "created", toolId: newId });
+    }
+  }
+
+  playgroundStore.getState().updateInstance({
+    instanceId: playgroundInstance.id,
+    patch: {
+      tools: workingTools,
+      ...(resetToolChoiceFrom != null
+        ? { toolChoice: { type: "ZERO_OR_MORE" } }
+        : {}),
+    },
+    dirty: true,
+  });
+  // The tool editors are uncontrolled (CodeMirror). Bump the external-update
+  // revision for the tools we created/updated so any mounted editor remounts
+  // and shows the new definition instead of its stale initial value.
+  playgroundStore
+    .getState()
+    .markToolsExternallyUpdated(results.map((result) => result.toolId));
+
+  const afterSnapshot = getPromptToolsSnapshot({
+    playgroundStore,
+    instanceId: playgroundInstance.id,
+  });
+  if (!afterSnapshot.ok) return afterSnapshot;
+
+  return {
+    ok: true,
+    output: {
+      results,
+      deletedToolIds: [...deleteIds],
+      ...(resetToolChoiceFrom != null ? { resetToolChoiceFrom } : {}),
+      revision: afterSnapshot.output.revision,
+    },
+  };
+}
+
+/**
+ * Builds the canonical definition for one batch entry. Pass the existing
+ * function tool to patch (only fields present in `entry` change), or `null`
+ * to create a fresh definition. `name` is always taken from the entry.
+ */
+function patchDefinition(
+  existing: Extract<Tool, { kind: "function" }> | null,
+  entry: WritePromptToolEntry
+): CanonicalToolDefinition {
+  return {
+    ...(existing ? existing.definition : {}),
+    name: entry.name,
+    ...("description" in entry
+      ? { description: entry.description ?? null }
+      : {}),
+    ...("parameters" in entry
+      ? { parameters: entry.parameters ?? undefined }
+      : {}),
+    ...("strict" in entry ? { strict: entry.strict ?? null } : {}),
+  };
+}
+
+function resolveInstance({
+  playgroundStore,
+  instanceId,
+}: {
+  playgroundStore: PlaygroundStore;
+  instanceId?: number;
+}): PromptToolsActionResult<{
+  playgroundInstance: ReturnType<
+    PlaygroundStore["getState"]
+  >["instances"][number];
+  index: number;
+}> {
+  const state = playgroundStore.getState();
+  const instances = state.instances;
+  const resolvedInstanceId =
+    instanceId ?? (instances.length === 1 ? instances[0]?.id : undefined);
+  if (resolvedInstanceId == null) {
+    return {
+      ok: false,
+      error: `Multiple playground instances are available. Pass one of these instance IDs: ${instances
+        .map((instance) => instance.id)
+        .join(", ")}.`,
+    };
+  }
+  const index = instances.findIndex(
+    (candidate) => candidate.id === resolvedInstanceId
+  );
+  if (index < 0) {
+    return {
+      ok: false,
+      error: `Playground instance ${resolvedInstanceId} was not found.`,
+    };
+  }
+  return {
+    ok: true,
+    output: { playgroundInstance: instances[index]!, index },
+  };
+}
+
+function toPromptToolSnapshot(tool: Tool): PromptToolSnapshot {
+  if (tool.kind === "function") {
+    return {
+      kind: "function",
+      id: tool.id,
+      name: tool.definition.name,
+      ...(tool.definition.description !== undefined
+        ? { description: tool.definition.description ?? null }
+        : {}),
+      ...(tool.definition.parameters !== undefined
+        ? { parameters: tool.definition.parameters }
+        : {}),
+      ...(tool.definition.strict !== undefined
+        ? { strict: tool.definition.strict ?? null }
+        : {}),
+    };
+  }
+  return {
+    kind: "raw",
+    id: tool.id,
+    raw: tool.raw,
+  };
+}
+
+function buildPromptToolsRevision(value: unknown): string {
+  const serialized = JSON.stringify(value);
+  let hash = 5381;
+  for (let index = 0; index < serialized.length; index++) {
+    hash = (hash * 33) ^ serialized.charCodeAt(index);
+  }
+  return `prompt-tools-${(hash >>> 0).toString(16)}`;
+}

--- a/app/src/agent/tools/playgroundPromptTools/schemas.ts
+++ b/app/src/agent/tools/playgroundPromptTools/schemas.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+
+import { normalizeAliases } from "@phoenix/agent/tools/playgroundPrompt";
+
+export const readPromptToolsInputSchema = z
+  .preprocess(
+    (input) => normalizeAliases(input, { instanceId: ["instance_id"] }),
+    z.object({
+      instanceId: z.number().int().optional(),
+    })
+  )
+  .transform(({ instanceId }) => {
+    return typeof instanceId === "number" ? { instanceId } : {};
+  });
+
+const writePromptToolFunctionToolSchema = z
+  .preprocess(
+    (input) =>
+      normalizeAliases(input, {
+        // Lenient on snake_case the model may emit.
+      }),
+    z.object({
+      id: z.number().int().nullable().optional(),
+      name: z.string().trim().min(1),
+      description: z.string().nullable().optional(),
+      parameters: z.record(z.string(), z.unknown()).nullable().optional(),
+      strict: z.boolean().nullable().optional(),
+    })
+  )
+  .transform((value) => ({
+    ...(value.id != null ? { id: value.id } : {}),
+    name: value.name,
+    ...(value.description !== undefined
+      ? { description: value.description }
+      : {}),
+    ...(value.parameters !== undefined ? { parameters: value.parameters } : {}),
+    ...(value.strict !== undefined ? { strict: value.strict } : {}),
+  }));
+
+export const writePromptToolsInputSchema = z
+  .preprocess(
+    (input) =>
+      normalizeAliases(input, {
+        expectedRevision: ["expected_revision", "revision"],
+        instanceId: ["instance_id"],
+        deleteToolIds: ["delete_tool_ids", "deleteIds", "delete_ids"],
+      }),
+    z.object({
+      instanceId: z.number().int(),
+      expectedRevision: z.string(),
+      tools: z.array(writePromptToolFunctionToolSchema).optional(),
+      deleteToolIds: z.array(z.number().int()).optional(),
+    })
+  )
+  .refine(
+    (value) =>
+      (value.tools?.length ?? 0) > 0 || (value.deleteToolIds?.length ?? 0) > 0,
+    { message: "Provide at least one tool to create/update or delete." }
+  );

--- a/app/src/agent/tools/playgroundPromptTools/types.ts
+++ b/app/src/agent/tools/playgroundPromptTools/types.ts
@@ -1,0 +1,69 @@
+import type { z } from "zod";
+
+import type {
+  readPromptToolsInputSchema,
+  writePromptToolsInputSchema,
+} from "./schemas";
+
+export type ReadPromptToolsInput = z.output<typeof readPromptToolsInputSchema>;
+
+export type WritePromptToolsInput = z.output<
+  typeof writePromptToolsInputSchema
+>;
+
+/** A single tool entry within a `write_prompt_tools` batch. */
+export type WritePromptToolEntry = NonNullable<
+  WritePromptToolsInput["tools"]
+>[number];
+
+/** Function tool projection sent to PXI in `read_prompt_tools` output. */
+export type FunctionPromptToolSnapshot = {
+  kind: "function";
+  id: number;
+  name: string;
+  description?: string | null;
+  parameters?: unknown;
+  strict?: boolean | null;
+};
+
+/** Vendor passthrough tool — PXI sees the opaque blob but cannot write it. */
+export type RawPromptToolSnapshot = {
+  kind: "raw";
+  id: number;
+  raw: Record<string, unknown>;
+};
+
+export type PromptToolSnapshot =
+  | FunctionPromptToolSnapshot
+  | RawPromptToolSnapshot;
+
+/** Snapshot of one prompt instance's tool list, with a content-hash revision. */
+export type PromptToolsSnapshot = {
+  instanceId: number;
+  index: number;
+  label: string;
+  tools: PromptToolSnapshot[];
+  revision: string;
+};
+
+export type PromptToolsActionResult<TOutput> =
+  | { ok: true; output: TOutput }
+  | { ok: false; error: string };
+
+/** Per-entry outcome within a `write_prompt_tools` batch. */
+export type WritePromptToolResult = {
+  status: "created" | "updated";
+  toolId: number;
+};
+
+/** Returned to PXI from `write_prompt_tools` describing the applied batch. */
+export type WritePromptToolsResult = {
+  results: WritePromptToolResult[];
+  deletedToolIds: number[];
+  /**
+   * Set when a deleted tool was the prompt's forced tool choice: its value is
+   * that tool's name, and the tool choice was reset to auto (ZERO_OR_MORE).
+   */
+  resetToolChoiceFrom?: string;
+  revision: string;
+};

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -24,6 +24,12 @@ import {
   READ_PROMPT_TOOL_NAME,
 } from "@phoenix/agent/tools/playgroundPrompt";
 import {
+  createReadPromptToolsClientAction,
+  createWritePromptToolsClientAction,
+  READ_PROMPT_TOOLS_TOOL_NAME,
+  WRITE_PROMPT_TOOLS_TOOL_NAME,
+} from "@phoenix/agent/tools/playgroundPromptTools";
+import {
   createRunPlaygroundClientAction,
   RUN_PLAYGROUND_TOOL_NAME,
 } from "@phoenix/agent/tools/playgroundRun";
@@ -329,6 +335,14 @@ function PlaygroundContent() {
       SET_VARIABLE_VALUES_TOOL_NAME,
       createSetVariableValuesClientAction({ playgroundStore })
     );
+    registerClientAction(
+      READ_PROMPT_TOOLS_TOOL_NAME,
+      createReadPromptToolsClientAction({ playgroundStore })
+    );
+    registerClientAction(
+      WRITE_PROMPT_TOOLS_TOOL_NAME,
+      createWritePromptToolsClientAction({ playgroundStore })
+    );
     return () => {
       unregisterClientAction(READ_PROMPT_TOOL_NAME);
       unregisterClientAction(CLONE_PROMPT_INSTANCE_TOOL_NAME);
@@ -337,6 +351,8 @@ function PlaygroundContent() {
       unregisterClientAction(RUN_PLAYGROUND_TOOL_NAME);
       unregisterClientAction(READ_PLAYGROUND_OUTPUT_TOOL_NAME);
       unregisterClientAction(SET_VARIABLE_VALUES_TOOL_NAME);
+      unregisterClientAction(READ_PROMPT_TOOLS_TOOL_NAME);
+      unregisterClientAction(WRITE_PROMPT_TOOLS_TOOL_NAME);
       for (const pendingEdit of Object.values(
         agentStore.getState().pendingPromptEditsByToolCallId
       )) {

--- a/app/src/pages/playground/PlaygroundTools.tsx
+++ b/app/src/pages/playground/PlaygroundTools.tsx
@@ -21,6 +21,9 @@ export function PlaygroundTools(props: PlaygroundToolsProps) {
     )
   );
   const updateInstance = usePlaygroundContext((state) => state.updateInstance);
+  const externallyUpdatedToolRevisionById = usePlaygroundContext(
+    (state) => state.externallyUpdatedToolRevisionById
+  );
   if (instance == null) {
     throw new Error(`Playground instance ${instanceId} not found`);
   }
@@ -74,9 +77,14 @@ export function PlaygroundTools(props: PlaygroundToolsProps) {
           />
           <Flex direction={"column"} gap="size-200">
             {tools.map((tool) => {
+              // Fold the external-update revision into the key so an external
+              // tool write (e.g. PXI) remounts the uncontrolled editor with the
+              // new definition. Local typing does not bump the revision.
+              const externalRevision =
+                externallyUpdatedToolRevisionById[tool.id] ?? 0;
               return (
                 <PlaygroundTool
-                  key={tool.id}
+                  key={`${tool.id}-${externalRevision}`}
                   playgroundInstanceId={instanceId}
                   toolId={tool.id}
                 />

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -273,6 +273,7 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
     instances,
     allInstanceMessages: instanceMessages,
     externallyUpdatedMessageRevisionById: {},
+    externallyUpdatedToolRevisionById: {},
     stateByDatasetId: props.stateByDatasetId
       ? props.stateByDatasetId
       : props.datasetId
@@ -783,6 +784,20 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
         },
         false,
         { type: "updateInstance" }
+      );
+    },
+    markToolsExternallyUpdated: (toolIds) => {
+      if (toolIds.length === 0) return;
+      set(
+        (state) => {
+          const next = { ...state.externallyUpdatedToolRevisionById };
+          for (const toolId of toolIds) {
+            next[toolId] = (next[toolId] ?? 0) + 1;
+          }
+          return { externallyUpdatedToolRevisionById: next };
+        },
+        false,
+        { type: "markToolsExternallyUpdated" }
       );
     },
     runPlaygroundInstances: () => {

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -464,6 +464,13 @@ export interface PlaygroundState extends Omit<PlaygroundProps, "instances"> {
   externallyUpdatedMessageRevisionById: Record<number, number>;
 
   /**
+   * Per-tool revision bumped only by external programmatic edits (e.g. PXI's
+   * write_prompt_tools) that need to reset the uncontrolled tool editor. Normal
+   * typing in the editor does not update it.
+   */
+  externallyUpdatedToolRevisionById: Record<number, number>;
+
+  /**
    * A map of instance id to whether the instance is dirty
    */
   dirtyInstances: Record<number, boolean>;
@@ -544,6 +551,12 @@ export interface PlaygroundState extends Omit<PlaygroundProps, "instances"> {
      */
     dirty: boolean | null;
   }) => void;
+  /**
+   * Bump the external-update revision for the given tool ids so their
+   * uncontrolled editors remount and pick up programmatic changes. Call only
+   * for external edits (e.g. PXI writes), never for local typing.
+   */
+  markToolsExternallyUpdated: (toolIds: number[]) => void;
   /**
    * Replace the canonical invocation config for a model wholesale. Used for
    * bulk hydration (saved prompt loads, span replay).

--- a/src/phoenix/server/agents/capabilities/tools/external/__init__.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/__init__.py
@@ -16,12 +16,14 @@ from phoenix.server.agents.capabilities.tools.external import (
     edit_prompt_instance,
     read_playground_output,
     read_prompt_instance,
+    read_prompt_tools,
     render_generative_ui,
     run_playground,
     save_prompt,
     set_spans_filter,
     set_time_range,
     set_variable_values,
+    write_prompt_tools,
 )
 from phoenix.server.agents.capabilities.tools.external.ask_user import AskUserCapability
 from phoenix.server.agents.capabilities.tools.external.bash import BashCapability
@@ -40,6 +42,9 @@ from phoenix.server.agents.capabilities.tools.external.read_playground_output im
 from phoenix.server.agents.capabilities.tools.external.read_prompt_instance import (
     ReadPromptInstanceCapability,
 )
+from phoenix.server.agents.capabilities.tools.external.read_prompt_tools import (
+    ReadPromptToolsCapability,
+)
 from phoenix.server.agents.capabilities.tools.external.render_generative_ui import (
     RenderGenerativeUICapability,
 )
@@ -56,6 +61,9 @@ from phoenix.server.agents.capabilities.tools.external.set_time_range import (
 from phoenix.server.agents.capabilities.tools.external.set_variable_values import (
     SetVariableValuesCapability,
 )
+from phoenix.server.agents.capabilities.tools.external.write_prompt_tools import (
+    WritePromptToolsCapability,
+)
 from phoenix.server.agents.prompts import AgentPrompts
 from phoenix.server.agents.types import AgentDependencies
 
@@ -68,6 +76,7 @@ _EXTERNAL_TOOL_DEFINITIONS_BY_NAME: dict[str, ToolDefinition] = {
         clone_prompt_instance.TOOL_DEFINITION,
         edit_prompt_instance.TOOL_DEFINITION,
         read_prompt_instance.TOOL_DEFINITION,
+        read_prompt_tools.TOOL_DEFINITION,
         read_playground_output.TOOL_DEFINITION,
         render_generative_ui.RENDER_GENERATIVE_UI_TOOL_DEFINITION,
         run_playground.TOOL_DEFINITION,
@@ -75,6 +84,7 @@ _EXTERNAL_TOOL_DEFINITIONS_BY_NAME: dict[str, ToolDefinition] = {
         set_spans_filter.TOOL_DEFINITION,
         set_time_range.TOOL_DEFINITION,
         set_variable_values.TOOL_DEFINITION,
+        write_prompt_tools.TOOL_DEFINITION,
     )
 }
 
@@ -102,10 +112,12 @@ def get_external_tool_capability_function(
     dynamic_capabilities: list[AbstractDynamicCapability[AgentDependencies]] = [
         SetSpansFilterCapability(instructions=prompts.set_spans_filter_tool),
         ReadPromptInstanceCapability(instructions=prompts.read_prompt_instance_tool),
+        ReadPromptToolsCapability(instructions=prompts.read_prompt_tools_tool),
         ReadPlaygroundOutputCapability(instructions=prompts.read_playground_output_tool),
         ClonePromptInstanceCapability(instructions=prompts.clone_prompt_instance_tool),
         EditPromptInstanceCapability(instructions=prompts.edit_prompt_instance_tool),
         SavePromptCapability(instructions=prompts.save_prompt_tool),
+        WritePromptToolsCapability(instructions=prompts.write_prompt_tools_tool),
         RunPlaygroundCapability(instructions=prompts.run_playground_tool),
         SetVariableValuesCapability(instructions=prompts.set_variable_values_tool),
     ]
@@ -124,6 +136,7 @@ __all__ = [
     "ClonePromptInstanceCapability",
     "EditPromptInstanceCapability",
     "ReadPromptInstanceCapability",
+    "ReadPromptToolsCapability",
     "ReadPlaygroundOutputCapability",
     "RenderGenerativeUICapability",
     "RunPlaygroundCapability",
@@ -131,6 +144,7 @@ __all__ = [
     "SetSpansFilterCapability",
     "SetTimeRangeCapability",
     "SetVariableValuesCapability",
+    "WritePromptToolsCapability",
     "get_external_tool_capability_function",
     "get_external_tool_definition",
 ]

--- a/src/phoenix/server/agents/capabilities/tools/external/read_prompt_tools.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/read_prompt_tools.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from jinja2 import Template
+from pydantic_ai import RunContext
+from pydantic_ai.tools import SystemPromptFunc, ToolDefinition
+from pydantic_ai.toolsets import AgentToolset
+from pydantic_ai.toolsets.external import ExternalToolset
+from typing_extensions import override
+
+from phoenix.server.agents.capabilities.base import AbstractDynamicCapability
+from phoenix.server.agents.types import AgentDependencies
+
+NAME = "read_prompt_tools"
+
+DESCRIPTION = (
+    "Read the function/tool definitions attached to one playground prompt instance. "
+    "Returns the list of tools (id, name, description, parameters JSON Schema, strict flag) "
+    "and a `revision` token. Always call this before `write_prompt_tools` and pass the "
+    "returned `revision` back as `expectedRevision`; stale writes are rejected if the "
+    "tool list changed in between. "
+    "If there is exactly one playground instance, `instanceId` may be omitted. If there "
+    "are multiple comparison instances, pass the specific `instanceId`. Vendor passthrough "
+    'tools (e.g. provider builtins like `web_search`) are surfaced with `kind: "raw"` '
+    "and an opaque `raw` blob; only function tools can be written via `write_prompt_tools`."
+)
+
+PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "instanceId": {
+            "type": "integer",
+            "description": (
+                "The playground instance ID to read. Omit only when there is exactly one "
+                "playground instance."
+            ),
+        },
+    },
+    "additionalProperties": False,
+}
+
+TOOL_DEFINITION = ToolDefinition(
+    name=NAME,
+    description=DESCRIPTION,
+    parameters_json_schema=PARAMETERS,
+    kind="external",
+)
+
+
+@dataclass
+class ReadPromptToolsCapability(AbstractDynamicCapability[AgentDependencies]):
+    instructions: Template
+
+    def get_toolset(self) -> AgentToolset[AgentDependencies] | None:
+        return ExternalToolset[AgentDependencies]([TOOL_DEFINITION])
+
+    @override
+    def get_dynamic_instructions(self) -> SystemPromptFunc[AgentDependencies]:
+        instructions = self.instructions
+
+        def _instructions(ctx: RunContext[AgentDependencies]) -> str:
+            return instructions.render()
+
+        return _instructions
+
+    @override
+    def include_for_run(self, ctx: RunContext[AgentDependencies]) -> bool:
+        return ctx.deps.contexts.playground is not None

--- a/src/phoenix/server/agents/capabilities/tools/external/write_prompt_tools.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/write_prompt_tools.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from jinja2 import Template
+from pydantic_ai import RunContext
+from pydantic_ai.tools import SystemPromptFunc, ToolDefinition
+from pydantic_ai.toolsets import AgentToolset
+from pydantic_ai.toolsets.external import ExternalToolset
+
+from phoenix.server.agents.capabilities.base import AbstractDynamicCapability
+from phoenix.server.agents.types import AgentDependencies
+
+NAME = "write_prompt_tools"
+
+DESCRIPTION = (
+    "Create, update, and/or delete function/tool definitions on a playground prompt "
+    "instance in a single atomic batch. "
+    "Always call `read_prompt_tools` first and pass its `revision` as `expectedRevision`; "
+    "the whole batch is rejected if the tool list changed since that read. "
+    "Within each entry of `tools`, pass `id` to update an existing function tool (patch — "
+    "only fields present in the entry change); omit `id` or pass null to create a new one "
+    "(the runtime assigns the id). Each entry's `name` is always required. `parameters` is "
+    "a JSON Schema object describing the function arguments. "
+    "`deleteToolIds` is a list of tool ids to remove; unlike writes, deletes may target "
+    "either function tools or vendor passthrough (raw) tools, since removing a tool needs "
+    "no knowledge of its shape. Provide at least one of `tools` or `deleteToolIds`. "
+    "The batch is all-or-nothing: if any entry references a missing id, a raw tool on the "
+    "write path, or the same id in both `tools` and `deleteToolIds`, nothing is applied and "
+    "the error explains which. Deleting the tool that is the forced tool choice succeeds: the "
+    "tool choice is reset to auto (zero-or-more) and the result reports `resetToolChoiceFrom` "
+    "with that tool's name — surface this to the user. "
+    "Common valid examples: "
+    'create two: {"instanceId":1,"expectedRevision":"prompt-tools-abc","tools":['
+    '{"name":"get_weather","description":"Look up the current weather for a city",'
+    '"parameters":{"type":"object","properties":{"city":{"type":"string"}},'
+    '"required":["city"]}},'
+    '{"name":"get_forecast","parameters":{"type":"object","properties":'
+    '{"city":{"type":"string"},"days":{"type":"integer"}},"required":["city","days"]}}]}; '
+    'create one and update another: {"instanceId":1,"expectedRevision":"prompt-tools-abc",'
+    '"tools":[{"name":"get_time","parameters":{"type":"object","properties":'
+    '{"timezone":{"type":"string"}},"required":["timezone"]}},'
+    '{"id":3,"name":"get_weather","parameters":{"type":"object","properties":'
+    '{"city":{"type":"string"},"units":{"type":"string","enum":["c","f"]}},'
+    '"required":["city"]}}]}; '
+    'delete one and add another in one batch: {"instanceId":1,'
+    '"expectedRevision":"prompt-tools-abc","deleteToolIds":[3],'
+    '"tools":[{"name":"get_forecast","parameters":{"type":"object","properties":'
+    '{"city":{"type":"string"}},"required":["city"]}}]}; '
+    'delete only: {"instanceId":1,"expectedRevision":"prompt-tools-abc","deleteToolIds":[3,4]}. '
+    "This tool only writes function tools; it does not author vendor passthrough tools "
+    '(those appear in `read_prompt_tools` with `kind: "raw"`), though it can delete them.'
+)
+
+TOOL_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "A function tool to create or update. Omit `id` (or pass null) to create a new "
+        "tool; pass an existing `id` from `read_prompt_tools` to update one."
+    ),
+    "properties": {
+        "id": {
+            "type": ["integer", "null"],
+            "description": (
+                "Existing function tool id from `read_prompt_tools`. Omit or null to create "
+                "a new tool."
+            ),
+        },
+        "name": {
+            "type": "string",
+            "description": "Function tool name. Required for both create and update.",
+        },
+        "description": {
+            "type": ["string", "null"],
+            "description": "Human-readable description of what the function does.",
+        },
+        "parameters": {
+            "type": ["object", "null"],
+            "description": (
+                "JSON Schema object describing the function arguments. Typical shape: "
+                '`{"type":"object","properties":{...},"required":[...]}`.'
+            ),
+            "additionalProperties": True,
+        },
+        "strict": {
+            "type": ["boolean", "null"],
+            "description": (
+                "Provider strict-mode flag. Leave unset unless the user asks for it; "
+                "some providers reject schemas with optional/loose fields when strict."
+            ),
+        },
+    },
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "instanceId": {
+            "type": "integer",
+            "description": "The playground instance ID whose tools list will be updated.",
+        },
+        "expectedRevision": {
+            "type": "string",
+            "description": ("The exact revision returned by the latest `read_prompt_tools` call."),
+        },
+        "tools": {
+            "type": "array",
+            "items": TOOL_SCHEMA,
+            "description": (
+                "Function tools to create or update, applied atomically in the order given. "
+                "Each entry shares the single `expectedRevision` check. Provide at least one "
+                "of `tools` or `deleteToolIds`."
+            ),
+        },
+        "deleteToolIds": {
+            "type": "array",
+            "items": {"type": "integer"},
+            "description": (
+                "Ids of tools to delete (function or raw), from the latest `read_prompt_tools` "
+                "snapshot. Applied atomically with any `tools` writes. Provide at least one of "
+                "`tools` or `deleteToolIds`."
+            ),
+        },
+    },
+    "required": ["instanceId", "expectedRevision"],
+    "additionalProperties": False,
+}
+
+TOOL_DEFINITION = ToolDefinition(
+    name=NAME,
+    description=DESCRIPTION,
+    parameters_json_schema=PARAMETERS,
+    kind="external",
+)
+
+
+@dataclass
+class WritePromptToolsCapability(AbstractDynamicCapability[AgentDependencies]):
+    instructions: Template
+
+    def get_toolset(self) -> AgentToolset[AgentDependencies] | None:
+        return ExternalToolset[AgentDependencies]([TOOL_DEFINITION])
+
+    def get_dynamic_instructions(self) -> SystemPromptFunc[AgentDependencies]:
+        instructions = self.instructions
+
+        def _instructions(ctx: RunContext[AgentDependencies]) -> str:
+            return instructions.render()
+
+        return _instructions
+
+    def include_for_run(self, ctx: RunContext[AgentDependencies]) -> bool:
+        return ctx.deps.contexts.playground is not None

--- a/src/phoenix/server/agents/prompts/__init__.py
+++ b/src/phoenix/server/agents/prompts/__init__.py
@@ -29,6 +29,12 @@ _CLONE_PROMPT_INSTANCE_TOOL_INSTRUCTIONS = get_template(
 _EDIT_PROMPT_INSTANCE_TOOL_INSTRUCTIONS = get_template(
     "tools/EDIT_PROMPT_INSTANCE_TOOL_INSTRUCTIONS.xml.j2"
 )
+_READ_PROMPT_TOOLS_TOOL_INSTRUCTIONS = get_template(
+    "tools/READ_PROMPT_TOOLS_TOOL_INSTRUCTIONS.xml.j2"
+)
+_WRITE_PROMPT_TOOLS_TOOL_INSTRUCTIONS = get_template(
+    "tools/WRITE_PROMPT_TOOLS_TOOL_INSTRUCTIONS.xml.j2"
+)
 _RUN_PLAYGROUND_TOOL_INSTRUCTIONS = get_template("tools/RUN_PLAYGROUND_TOOL_INSTRUCTIONS.xml.j2")
 _SAVE_PROMPT_TOOL_INSTRUCTIONS = get_template("tools/SAVE_PROMPT_TOOL_INSTRUCTIONS.xml.j2")
 _SET_VARIABLE_VALUES_TOOL_INSTRUCTIONS = get_template(
@@ -69,6 +75,8 @@ class AgentPrompts:
     clone_prompt_instance_tool: Template = _CLONE_PROMPT_INSTANCE_TOOL_INSTRUCTIONS
     edit_prompt_instance_tool: Template = _EDIT_PROMPT_INSTANCE_TOOL_INSTRUCTIONS
     save_prompt_tool: Template = _SAVE_PROMPT_TOOL_INSTRUCTIONS
+    read_prompt_tools_tool: Template = _READ_PROMPT_TOOLS_TOOL_INSTRUCTIONS
+    write_prompt_tools_tool: Template = _WRITE_PROMPT_TOOLS_TOOL_INSTRUCTIONS
     run_playground_tool: Template = _RUN_PLAYGROUND_TOOL_INSTRUCTIONS
     set_variable_values_tool: Template = _SET_VARIABLE_VALUES_TOOL_INSTRUCTIONS
     batch_span_annotate_tool: Template = _BATCH_SPAN_ANNOTATE_TOOL_INSTRUCTIONS

--- a/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
@@ -65,3 +65,204 @@ they are comparing prompt variants using evaluator results.
    exact name.
 9. Continue the hypothesis, edit, run, compare loop until the dataset-backed results satisfy the
    user's goal.
+
+## Workflow: Author, Refine, Or Remove A Function Tool
+
+Use this workflow when the user wants the model to be able to call a function/tool from the prompt,
+when they want to refine the signature of an existing one, or when they want to remove a tool.
+Function tools are JSON-Schema function definitions stored on the playground prompt instance
+(alongside messages and model config). They are the things the model can "call" during a run.
+
+1. Call `read_prompt_tools` before doing anything else. The result gives you the current tool list,
+   each tool's id and kind, and a `revision` token. Use the existing ids and names to decide
+   whether you should update an existing tool, create a new one, or delete one.
+2. If the user described a function in words, propose a concrete JSON Schema for it. Default to
+   lowercase snake_case parameter names and a `{"type":"object","properties":{...},"required":[...]}`
+   shape unless the user specifies otherwise.
+3. Call `write_prompt_tools` with the latest `revision`. Put every change in a single call: `tools`
+   is an array of creates/updates (omit `id` to create, pass an existing `id` to patch — only the
+   fields you include change), and `deleteToolIds` is a list of ids to remove. Deletes may target
+   `raw` vendor tools too, even though writes can't. The batch is all-or-nothing: if any change is
+   invalid (missing id, a `raw` tool on the write path, or the same id created/updated and deleted)
+   nothing is applied and the error explains which. Deleting the tool that is the forced tool choice
+   is allowed — the choice is reset to auto and reported back; mention that to the user.
+4. After the write, briefly summarize what changed in plain English (which tools were created vs
+   updated) so the user knows what to look for in the tool editor. If you created tools, tell them
+   the new ids.
+5. If the user wants the model to use the new tool in a run, call `run_playground` and then
+   `read_playground_output` to see whether the model actually invoked it.
+
+### Few-shot examples
+
+These are concrete, runnable shapes — treat them as templates, not as fixed prompts. Always pass
+the latest `revision` returned by `read_prompt_tools`.
+
+**Create a brand-new tool.** One entry with no `id`.
+
+```json
+{
+  "instanceId": 1,
+  "expectedRevision": "prompt-tools-abc",
+  "tools": [
+    {
+      "name": "get_weather",
+      "description": "Look up the current weather for a city.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "city": { "type": "string", "description": "City name, e.g. \"San Francisco\"." },
+          "units": { "type": "string", "enum": ["c", "f"], "description": "Temperature units." }
+        },
+        "required": ["city"]
+      }
+    }
+  ]
+}
+```
+
+**Create several tools at once.** Put every tool in the `tools` array — one call, one revision
+check. Prefer this over issuing one call per tool.
+
+```json
+{
+  "instanceId": 1,
+  "expectedRevision": "prompt-tools-abc",
+  "tools": [
+    {
+      "name": "get_weather",
+      "parameters": {
+        "type": "object",
+        "properties": { "city": { "type": "string" } },
+        "required": ["city"]
+      }
+    },
+    {
+      "name": "get_forecast",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "city": { "type": "string" },
+          "days": { "type": "integer" }
+        },
+        "required": ["city", "days"]
+      }
+    }
+  ]
+}
+```
+
+**Add a required parameter to an existing tool.** Pass the existing `id` and the full new
+`parameters` schema. Patch semantics — `name` is required even if unchanged.
+
+```json
+{
+  "instanceId": 1,
+  "expectedRevision": "prompt-tools-abc",
+  "tools": [
+    {
+      "id": 3,
+      "name": "get_weather",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "city": { "type": "string" },
+          "units": { "type": "string", "enum": ["c", "f"] }
+        },
+        "required": ["city", "units"]
+      }
+    }
+  ]
+}
+```
+
+**Create one tool and patch another in the same batch.** Mix entries with and without `id`.
+
+```json
+{
+  "instanceId": 1,
+  "expectedRevision": "prompt-tools-abc",
+  "tools": [
+    {
+      "name": "get_time",
+      "parameters": {
+        "type": "object",
+        "properties": { "timezone": { "type": "string" } },
+        "required": ["timezone"]
+      }
+    },
+    {
+      "id": 3,
+      "name": "get_weather",
+      "description": "Look up the current weather for a city. Returns temperature, humidity, and conditions."
+    }
+  ]
+}
+```
+
+**Define a tool that returns structured output via a categorical choice.** The model is forced to
+pick one of the enum labels and optionally explain.
+
+```json
+{
+  "instanceId": 1,
+  "expectedRevision": "prompt-tools-abc",
+  "tools": [
+    {
+      "name": "classify_sentiment",
+      "description": "Classify the sentiment of the input as positive, negative, or neutral.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "enum": ["positive", "negative", "neutral"],
+            "description": "The sentiment classification."
+          },
+          "explanation": {
+            "type": "string",
+            "description": "Short justification for the label."
+          }
+        },
+        "required": ["label"]
+      }
+    }
+  ]
+}
+```
+
+**Delete a tool — and optionally swap in a replacement in the same batch.** `deleteToolIds` removes
+by id; combine it with `tools` to delete and add atomically. Deletes may target `raw` vendor tools.
+
+```json
+{
+  "instanceId": 1,
+  "expectedRevision": "prompt-tools-abc",
+  "deleteToolIds": [3],
+  "tools": [
+    {
+      "name": "get_forecast",
+      "parameters": {
+        "type": "object",
+        "properties": { "city": { "type": "string" } },
+        "required": ["city"]
+      }
+    }
+  ]
+}
+```
+
+### Things to avoid
+
+- Don't call `write_prompt_tools` without calling `read_prompt_tools` first this turn — the
+  `expectedRevision` will be stale and the write will be rejected.
+- Don't try to *write* a tool whose `kind` was `raw` in the read snapshot. Vendor passthrough tools
+  (e.g. provider builtins like `web_search`) are not editable through PXI — tell the user to author
+  those in the playground tool editor. A `raw` entry in `tools` rejects the whole batch. (You *can*
+  delete a `raw` tool via `deleteToolIds`, though.)
+- Deleting the tool that is the prompt's forced tool choice (tool_choice = specific function) is
+  allowed — the tool choice is automatically reset to auto (zero-or-more) and the result reports
+  `resetToolChoiceFrom`. Tell the user, since it changes how the model picks tools at run time.
+- Don't invent tool `id`s. An entry's `id` (and every `deleteToolIds` id) comes from a read
+  snapshot, or is omitted for create. You cannot reference an id created earlier in the same batch.
+- Don't issue multiple `write_prompt_tools` calls in a row without re-reading the revision between
+  them. Each successful write or delete changes the revision. Batch the changes into one call.

--- a/src/phoenix/server/agents/prompts/tools/READ_PROMPT_TOOLS_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/READ_PROMPT_TOOLS_TOOL_INSTRUCTIONS.xml.j2
@@ -1,0 +1,12 @@
+<tool name="read_prompt_tools">
+  <description>Read the function/tool definitions attached to one playground prompt instance, including a `revision` token required to safely call `write_prompt_tools`.</description>
+  <when_to_use>
+    - Before calling `write_prompt_tools` — you need the latest `revision` to pass as `expectedRevision` and the existing tool `id`s to do an update.
+    - Whenever the user asks what tools the prompt currently exposes, or wants to add to / refine the existing tool list.
+  </when_to_use>
+  <guidelines>
+    - The returned `revision` is opaque. Pass it back unchanged as `expectedRevision` when calling `write_prompt_tools`. If the tool list changes between read and write, the write will be rejected; re-read and retry.
+    - Each tool entry includes a `kind`: `function` tools are editable via `write_prompt_tools`; `raw` tools are vendor passthrough blobs and cannot be edited from PXI (the user manages them directly in the playground tool editor).
+    - If there is exactly one playground instance, you may omit `instanceId`. Otherwise pass the specific numeric `instanceId` — use the alphabetic `label` from `read_prompt_instance` (A, B, C, D) only when talking to the user.
+  </guidelines>
+</tool>

--- a/src/phoenix/server/agents/prompts/tools/WRITE_PROMPT_TOOLS_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/WRITE_PROMPT_TOOLS_TOOL_INSTRUCTIONS.xml.j2
@@ -1,0 +1,31 @@
+<tool name="write_prompt_tools">
+  <description>Create, update, and/or delete function tools on a playground prompt instance in a single atomic batch. This applies the change to the playground state immediately (no accept/reject diff); the user sees the tool editor update.</description>
+  <when_to_use>
+    - The user asks to add, edit, refine, or remove one or more function/tools the model can call from a playground prompt.
+    - You've inferred from the prompt and the task that specific function tools would help and want to propose them concretely. Batch all the changes you intend to make — creates, updates, and deletes — into one call.
+  </when_to_use>
+  <preflight>
+    - Always call `read_prompt_tools` first to obtain the latest `revision` and existing tool `id`s.
+    - Pass that `revision` back as `expectedRevision`. If the tool list changed since the read, the whole batch is rejected; re-read and retry.
+  </preflight>
+  <semantics>
+    - `tools` is an array. Each entry is one function tool to create or update; they are applied atomically in the order given against the single `expectedRevision`.
+    - Omit an entry's `id` (or pass null) to create a new function tool. The runtime assigns the id.
+    - Pass an existing `id` from `read_prompt_tools` in an entry to update that tool. Only fields present in the entry are changed; absent fields are left untouched (patch semantics). `name` is always required even when patching.
+    - `deleteToolIds` is a list of tool ids to remove. Unlike writes, deletes MAY target raw vendor tools as well as function tools — removing a tool needs no knowledge of its shape, so this is the one way to drop a vendor `web_search`/`computer_use` tool via PXI. Provide at least one of `tools` or `deleteToolIds`.
+    - The batch is all-or-nothing. It is rejected (and nothing is applied) if any entry references a missing id, a `tools` entry targets a raw tool, or the same id appears in both `tools` and `deleteToolIds`. The error explains which; fix it and resend with a fresh `revision`.
+    - Deleting the tool that is the prompt's forced tool choice (tool_choice = specific function) is allowed: the tool choice is automatically reset to auto (zero-or-more) as part of the same batch, and the result reports `resetToolChoiceFrom` with that tool's name. Call this out to the user, since it changes how the model selects tools at run time.
+    - An entry's `id` and every `deleteToolIds` id must come from the most recent `read_prompt_tools` snapshot — you cannot reference an id created earlier in the same batch (ids are assigned by the runtime).
+    - `parameters` is a JSON Schema object. The typical shape is `{"type":"object","properties":{...},"required":[...]}`. Keep parameter names lowercase snake_case to match common provider conventions unless the user specifies otherwise.
+    - Only emit `strict: true` if the user asks for strict mode. Strict mode rejects schemas that are not fully constrained on some providers; the safe default is to leave it unset.
+  </semantics>
+  <invariants>
+    - This tool writes function tools only — it cannot create or edit raw vendor tools (`web_search`, `computer_use`, etc., surfaced with `kind: "raw"` by `read_prompt_tools`); point the user at the playground's tool editor to author those. It CAN delete them via `deleteToolIds`.
+    - Prefer one batch call over several sequential calls. Each successful write or delete changes the `revision`, so issuing a second call without re-reading will be rejected; batching creates, updates, and deletes together avoids that round-trip entirely.
+  </invariants>
+  <guidelines>
+    - Before adding a tool, check whether one with the same `name` already exists in the read snapshot. If yes, update it by `id` rather than creating a duplicate.
+    - After writing, briefly summarize what changed in plain English (which tools were created, updated, or deleted) so the user knows what to look for in the tool editor.
+    - If the user describes tools but the design isn't fully specified (e.g., parameter types, required fields), propose a concrete schema; do not stop to ask unless something is genuinely ambiguous.
+  </guidelines>
+</tool>


### PR DESCRIPTION
## Summary

- Adds `read_prompt_tools` and `write_prompt_tools` external tools that let PXI inspect and mutate function-tool definitions on a playground prompt instance. Read returns the tool list + a content-hash revision token; write takes that revision back as `expectedRevision`.
- `write_prompt_tools` performs a **single atomic (all-or-nothing) batch** against one `expectedRevision`. It can **create** (`tools` entry with no `id`), **update/patch** (`tools` entry with an existing `id` — only fields present in the entry change), and **delete** (`deleteToolIds: number[]`) in one call. Provide at least one of `tools` or `deleteToolIds`. Batching avoids the read→write→re-read round-trip sequential calls would force, since every successful mutation rotates the revision.
- **Validation is up front and all-or-nothing**: the batch is rejected (and nothing applied) if any entry references a missing id, a `tools` entry targets a `raw` tool, or the same id is both written and deleted. The error explains which.
- **Deleting the forced tool choice is handled gracefully, not rejected.** If a deleted tool is the prompt's forced tool choice (`tool_choice = specific function`), the choice is reset to auto (`ZERO_OR_MORE`, the instance default) as part of the same atomic batch, and the result reports `resetToolChoiceFrom` so PXI can disclose the change to the user.
- **Vendor passthrough tools** (`kind: "raw"` — e.g. provider builtins like `web_search`) are surfaced **read-only** and cannot be *created or edited* via PXI (users author those in the playground tool editor). They **can be deleted** via `deleteToolIds`, since removing a tool needs no knowledge of its shape. Authoring/editing raw tools is deliberately punted; the design is forward-compatible (generic `write_prompt_tools` name + raw-aware read contract, locked by a test).
- **Playground editor refresh fix.** The tool editor's CodeMirror is uncontrolled and seeds its value once; its reset effect didn't depend on the tool definition, so an external in-place tool update (same `tool.id`) left the mounted editor showing stale JSON. Fixed by mirroring the existing message-editor pattern: a per-tool `externallyUpdatedToolRevisionById` is bumped only by external writes (`markToolsExternallyUpdated`, called from `applyWritePromptTools`) and folded into the tool's React `key` in `PlaygroundTools`, so the editor remounts on an external write but not on local typing.
- Both tools self-gate on the playground context via `include_for_run`, matching the existing prompt-instance tool pattern.
- Appends an "Author, Refine, Or Remove A Function Tool" workflow to the playground skill with few-shot examples (create one, create several, add a required param, create-one-and-patch-another, structured-output classifier, delete-and-replace).

No accept/reject diff in v1 — direct apply with a revision guard is enough for tool definitions; easy to upgrade to a diff later if the consensus shifts.

Closes #13462.

## Follow-ups

- #13549 — show an accept/reject diff for `write_prompt_tools` (gate mutations behind approval)
- #13550 — support authoring/editing raw vendor tools (web_search, etc.)
- #13551 — let PXI set the prompt tool choice (`tool_choice`)

## Test plan

- [x] `vitest` — `playgroundPromptTools.test.ts`, 25 passing (parsing incl. delete-only + aliases, batch create/update, patch-composition, create/update/delete all-or-nothing rejection with offending index, update-and-delete conflict, raw-tool delete, forced-choice delete resets tool choice to auto, unrelated forced choice untouched, stale-revision rejection, external-editor-refresh revision bumps on write but not on local edits, and a forward-compat guard that read keeps surfacing `raw` tools with their `kind` discriminator)
- [x] `vitest` — full playground suites green (84 tests) after the shared-store change
- [x] `tsc --noEmit` clean on all touched/added files
- [x] `ruff check` clean on new Python
- [x] `pytest tests/unit/server/agents/capabilities/test_external_tools.py` passes (auto-covers the new tool's schema invariants)
- [ ] Manual: open playground, ask PXI to add a function tool, confirm it appears in the tool editor with the right id, name, and parameters
- [ ] Manual: ask PXI to add several tools at once, confirm they all appear from one batch
- [ ] Manual: ask PXI to refine the description / add a required param to an existing tool, confirm patch semantics (untouched fields preserved) **and that the open editor refreshes to the new JSON**
- [ ] Manual: ask PXI to delete a tool (and to delete-and-replace in one go); confirm the removed tool disappears and any replacement appears
- [ ] Manual: try to edit a vendor `raw` tool (e.g. an OpenAI Responses `web_search`) and confirm PXI returns the editor-pointer error and applies nothing; confirm PXI *can* delete it
- [ ] Manual: set a specific-function tool choice, then ask PXI to delete that tool — confirm the tool is deleted, the tool choice flips to auto, and PXI tells you it did so
- [ ] Manual: have PXI write a tool, then edit the tool list manually, then ask PXI to write again — confirm the stale-revision rejection fires
