### PR TITLE
ci(claude-review): cost-efficiency pass — sonnet orchestrator, smarter triggers, pre-fetch

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,27 +3,39 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/**'
+      - '**/*.lock'
+      - 'pnpm-lock.yaml'
+      - 'uv.lock'
+
+# Coalesce rapid pushes: only review the latest commit, cancel in-flight runs.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip drafts (plugin bails on them anyway, but only after paying for setup
+    # and the gate-check subagent), bot-authored PRs, and the bot-managed branch
+    # families. Marking a draft as ready fires `ready_for_review` and is not
+    # gated here because at that moment `draft` is already false.
+    if: |
+      !github.event.pull_request.draft &&
+      !contains(fromJSON('["release-please[bot]", "dependabot[bot]", "mintlify[bot]", "github-actions[bot]", "claude[bot]"]'), github.event.pull_request.user.login) &&
+      !startsWith(github.event.pull_request.head.ref, 'release-please--') &&
+      !startsWith(github.event.pull_request.head.ref, 'claude/') &&
+      !startsWith(github.event.pull_request.head.ref, 'skills-audit/')
 
     runs-on: ubuntu-latest
     permissions:
-      # PR/issue read+write goes through the Claude App token minted by the
-      # OIDC exchange below — the workflow GITHUB_TOKEN is only used for the
-      # initial checkout, so contents:read is all it needs.
+      # PR write goes through the Claude App token minted by the OIDC exchange
+      # in the action. The workflow GITHUB_TOKEN is used only for checkout and
+      # the pre-fetch step (PR data is already public on a public repo).
       contents: read
+      pull-requests: read
       id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
 
     steps:
@@ -45,6 +57,21 @@ jobs:
             sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           fi
 
+      - name: Pre-fetch PR data
+        # Pre-fetching the diff / metadata / prior comments avoids the gh CLI
+        # subprocess-sandbox roundtrips Claude would otherwise do for each
+        # subagent. The orchestrator (see prompt below) is told to read these
+        # files via the Read tool instead of running gh commands.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p .scratch
+          gh pr diff "$PR_NUM" > .scratch/pr-diff.patch
+          gh pr view "$PR_NUM" --json title,body,author,files,headRefOid,baseRefOid,baseRefName,headRefName > .scratch/pr-meta.json
+          gh pr view "$PR_NUM" --comments --json comments > .scratch/pr-comments.json
+          wc -l .scratch/pr-diff.patch
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
@@ -55,14 +82,35 @@ jobs:
           allowed_bots: 'claude, cursor, codex, gitbook-bot, github-actions, dependabot[bot], cursoragent, mintlify[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          # show_full_output exposes the full Claude SDK message stream in the step
-          # log. For this workflow the content is derived from a public PR diff and
-          # is not sensitive; turning it on lets us see denied-tool details
-          # (sanitized output otherwise collapses permission_denials to a count).
-          show_full_output: 'true'
           prompt: |
+            PR #${{ github.event.pull_request.number }} data is pre-fetched at:
+              - `.scratch/pr-diff.patch` — full PR diff
+              - `.scratch/pr-meta.json`  — title, body, author, files, refs
+              - `.scratch/pr-comments.json` — top-level comments (for idempotency)
+            Read these files via the Read tool instead of running `gh pr diff` / `gh pr view`.
+
+            Review guidelines for this repository:
+            - Reserve "Important" for findings that would break behavior, leak data,
+              or block a rollback: incorrect logic, unscoped DB queries, missing
+              async/await, race conditions, PII in logs, non-reversible migrations,
+              breaking API changes. Style, naming, and refactoring suggestions are
+              Nits at most.
+            - Report at most 3 Nits per review. If you found more, say
+              "plus N similar items" in the summary instead of posting them inline.
+              If everything you found is a Nit, lead the summary with
+              "No blocking issues."
+            - After the first review on this PR, post Important findings only;
+              do not re-flag prior Nits on subsequent pushes. Use the pre-fetched
+              `pr-comments.json` to see what has already been flagged.
+            - Do not report: anything CI enforces (ruff, mypy, oxlint, oxfmt),
+              generated files (**/*_pb2.py, **/generated/**), lockfiles, or
+              docs-only changes under `docs/`.
+            - Always check: migrations are reversible (or noted), new REST endpoints
+              have authentication, GraphQL resolvers handle the unauthenticated
+              case, new async functions are awaited at call sites.
+
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
           claude_args: |
-            --allowedTools "Agent,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(git fetch *),Bash(git diff *),Bash(git log *),Bash(git show *)"
+            --model claude-sonnet-4-6 --max-turns 30 --allowedTools "Agent,Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr:*),Bash(git:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,10 +3,17 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+    # `.github/workflows/**` and `.github/actions/**` are intentionally NOT
+    # ignored: that's the file class where recent auth/permission/sandbox
+    # regressions (#13484, #13485, #13490, #13503, #13506, #13508) landed,
+    # and exactly where LLM review is most useful.
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
-      - '.github/**'
+      - '.github/CODEOWNERS'
+      - '.github/dependabot.yml'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
       - '**/*.lock'
       - 'pnpm-lock.yaml'
       - 'uv.lock'
@@ -19,11 +26,16 @@ concurrency:
 jobs:
   claude-review:
     # Skip drafts (plugin bails on them anyway, but only after paying for setup
-    # and the gate-check subagent), bot-authored PRs, and the bot-managed branch
-    # families. Marking a draft as ready fires `ready_for_review` and is not
-    # gated here because at that moment `draft` is already false.
+    # and the gate-check subagent), bot-authored PRs, the bot-managed branch
+    # families, and PRs from forks. The fork gate matters because a fork PR's
+    # body / diff / commit messages are attacker-controlled and would be parsed
+    # by the orchestrator (prompt-injection surface against the App token).
+    # Same-repo PRs are restricted to authenticated contributors. Marking a
+    # draft as ready fires `ready_for_review` and is not gated here because at
+    # that moment `draft` is already false.
     if: |
       !github.event.pull_request.draft &&
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name &&
       !contains(fromJSON('["release-please[bot]", "dependabot[bot]", "mintlify[bot]", "github-actions[bot]", "claude[bot]"]'), github.event.pull_request.user.login) &&
       !startsWith(github.event.pull_request.head.ref, 'release-please--') &&
       !startsWith(github.event.pull_request.head.ref, 'claude/') &&
@@ -58,19 +70,82 @@ jobs:
           fi
 
       - name: Pre-fetch PR data
-        # Pre-fetching the diff / metadata / prior comments avoids the gh CLI
+        # Pre-fetching the diff / metadata / comments avoids the gh CLI
         # subprocess-sandbox roundtrips Claude would otherwise do for each
         # subagent. The orchestrator (see prompt below) is told to read these
         # files via the Read tool instead of running gh commands.
+        #
+        # Three comment sources, because GitHub splits them:
+        #   - pr-inline-comments.json: per-file/per-line review comments (the
+        #     real substance of code review; needed for re-review convergence)
+        #   - pr-review-threads.json:  isResolved/isOutdated state for those
+        #     inline comments (so we can skip already-resolved threads)
+        #   - pr-issue-comments.json:  top-level conversation comments (what
+        #     the plugin's step-1 "has Claude commented?" gate looks at)
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUM: ${{ github.event.pull_request.number }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
         run: |
           mkdir -p .scratch
-          gh pr diff "$PR_NUM" > .scratch/pr-diff.patch
-          gh pr view "$PR_NUM" --json title,body,author,files,headRefOid,baseRefOid,baseRefName,headRefName > .scratch/pr-meta.json
-          gh pr view "$PR_NUM" --comments --json comments > .scratch/pr-comments.json
-          wc -l .scratch/pr-diff.patch
+
+          # Full diff (kept for completeness; the filtered version below is
+          # what the orchestrator is told to read).
+          gh pr diff "$PR_NUM" > .scratch/pr-diff-full.patch
+
+          # Filtered diff: drop lockfiles and generated code so subagents
+          # don't burn tokens reasoning about content the review rules tell
+          # them to ignore anyway. Plain Python (on the runner already).
+          python3 - <<'PY' < .scratch/pr-diff-full.patch > .scratch/pr-diff.patch
+          import sys
+          EXCLUDE = (
+              'pnpm-lock.yaml', 'uv.lock', 'package-lock.json', 'yarn.lock',
+              '_pb2.py', '_pb2.pyi', '_pb2_grpc.py',
+              '/generated/', '/__generated__/',
+              '.generated.ts', '.generated.tsx', '.generated.d.ts',
+          )
+          buf, skip = [], False
+          for line in sys.stdin:
+              if line.startswith('diff --git '):
+                  if buf and not skip:
+                      sys.stdout.write(''.join(buf))
+                  buf = [line]
+                  skip = any(p in line for p in EXCLUDE)
+              else:
+                  buf.append(line)
+          if buf and not skip:
+              sys.stdout.write(''.join(buf))
+          PY
+
+          wc -l .scratch/pr-diff-full.patch .scratch/pr-diff.patch
+
+          gh pr view "$PR_NUM" --json title,body,author,files,headRefOid,baseRefOid,baseRefName,headRefName \
+            > .scratch/pr-meta.json
+
+          # Top-level issue/conversation comments (for the plugin's step-1
+          # idempotency check — "has Claude already commented on this PR?").
+          gh pr view "$PR_NUM" --comments --json comments \
+            > .scratch/pr-issue-comments.json
+
+          # Inline review comments — per-file, per-line. This is what the
+          # re-review convergence rule actually needs. `gh pr view --comments`
+          # does NOT include these; we have to hit the pulls/comments endpoint.
+          gh api --paginate "repos/${OWNER}/${REPO}/pulls/${PR_NUM}/comments" \
+            --jq '[.[] | {id, in_reply_to_id, user: .user.login, path, line, original_line, side, commit_id, created_at, updated_at, body}]' \
+            > .scratch/pr-inline-comments.json
+
+          # Thread state (isResolved / isOutdated) for the inline comments,
+          # so the convergence rule can skip already-resolved findings.
+          gh api graphql -f query='
+            query($owner:String!,$repo:String!,$num:Int!){
+              repository(owner:$owner,name:$repo){
+                pullRequest(number:$num){
+                  reviewThreads(first:100){
+                    nodes{ isResolved isOutdated path line
+                      comments(first:50){ nodes{ databaseId author{login} body createdAt } } } } } } }' \
+            -F owner="${OWNER}" -F repo="${REPO}" -F num="${PR_NUM}" \
+            > .scratch/pr-review-threads.json
 
       - name: Run Claude Code Review
         id: claude-review
@@ -90,10 +165,20 @@ jobs:
           show_full_output: 'true'
           prompt: |
             PR #${{ github.event.pull_request.number }} data is pre-fetched at:
-              - `.scratch/pr-diff.patch` — full PR diff
-              - `.scratch/pr-meta.json`  — title, body, author, files, refs
-              - `.scratch/pr-comments.json` — top-level comments (for idempotency)
-            Read these files via the Read tool instead of running `gh pr diff` / `gh pr view`.
+              - `.scratch/pr-diff.patch` — PR diff with lockfiles and generated
+                files removed; use this for the review.
+              - `.scratch/pr-diff-full.patch` — unfiltered diff; only consult
+                if you specifically need to inspect a generated file.
+              - `.scratch/pr-meta.json`  — title, body, author, files, refs.
+              - `.scratch/pr-issue-comments.json` — top-level conversation
+                comments (for the "has Claude already commented?" check).
+              - `.scratch/pr-inline-comments.json` — per-file, per-line review
+                comments from prior reviews (for re-review convergence).
+              - `.scratch/pr-review-threads.json` — thread state
+                (isResolved / isOutdated) for those inline comments.
+            Read these files via the Read tool instead of running
+            `gh pr diff` / `gh pr view` / `gh api`. Pass the relevant paths
+            into any subagent task descriptions you launch.
 
             Review guidelines for this repository:
             - Reserve "Important" for findings that would break behavior, leak data,
@@ -106,17 +191,25 @@ jobs:
               If everything you found is a Nit, lead the summary with
               "No blocking issues."
             - After the first review on this PR, post Important findings only;
-              do not re-flag prior Nits on subsequent pushes. Use the pre-fetched
-              `pr-comments.json` to see what has already been flagged.
+              do not re-flag prior Nits on subsequent pushes. Use
+              `pr-inline-comments.json` to see what has already been flagged and
+              `pr-review-threads.json` to skip threads already marked resolved.
             - Do not report: anything CI enforces (ruff, mypy, oxlint, oxfmt),
-              generated files (**/*_pb2.py, **/generated/**), lockfiles, or
-              docs-only changes under `docs/`.
+              generated files (**/*_pb2.py, **/generated/**, **/__generated__/**,
+              **/*.generated.ts), lockfiles, or docs-only changes under `docs/`.
             - Always check: migrations are reversible (or noted), new REST endpoints
               have authentication, GraphQL resolvers handle the unauthenticated
               case, new async functions are awaited at call sites.
 
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
+          # allowedTools: deliberately read-only. The Claude App token has
+          # contents/pull_requests/issues: write, so any broader Bash patterns
+          # (e.g., Bash(gh pr:*) matches `gh pr merge --admin`, `gh pr edit --base`,
+          # `gh pr review --approve`, `gh pr close`; Bash(git:*) matches `git push`,
+          # `git reset --hard`, `git -c core.sshCommand=...`) would expose
+          # destructive surface to prompt-injected input. Keep these scoped to
+          # the specific subcommands the plugin actually needs.
           claude_args: |
-            --model claude-sonnet-4-6 --max-turns 30 --allowedTools "Agent,Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr:*),Bash(git:*)"
+            --model claude-sonnet-4-6 --max-turns 30 --allowedTools "Agent,Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr status:*),Bash(gh pr comment:*),Bash(git fetch:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(git blame:*),Bash(git ls-files:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -82,6 +82,12 @@ jobs:
           allowed_bots: 'claude, cursor, codex, gitbook-bot, github-actions, dependabot[bot], cursoragent, mintlify[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          # Keep on while the workflow is still being tuned: with sanitizer-only
+          # output, permission_denials collapses to a count, which isn't enough
+          # to debug regressions. Phoenix is a public repo and the action masks
+          # secrets via core.setSecret, so nothing meaningful leaks. Revisit
+          # once the workflow has been stable and unchanged for ≥4 weeks.
+          show_full_output: 'true'
           prompt: |
             PR #${{ github.event.pull_request.number }} data is pre-fetched at:
               - `.scratch/pr-diff.patch` — full PR diff


### PR DESCRIPTION
## TL;DR

Bundles workflow-file changes into `.github/workflows/claude-code-review.yml` to cut per-run cost from **~$10** baseline toward **~$2-3** (estimated), eliminate runs that shouldn't happen at all, and harden the workflow against prompt-injection via PR content. Single-file diff. No new files. No new write permissions on the workflow token.

> **Caveat on the estimates below**: the plugin's prompt is delivered only to the top-level orchestrator. Subagents (the haiku/sonnet/opus agents the plugin launches in steps 1-5) see only what the orchestrator chooses to copy into their task descriptions — the plugin's only forwarding contract is "tell each subagent the PR title + description." So the per-run savings from pre-fetch and inline guidelines are **best-effort, not guaranteed**. The floor (orchestrator-only effects + workflow-level skips + sonnet swap) is **~40-50%**. The ceiling (all hints propagate to all subagents) is **~65-80%**. First non-bot PR after merge will show which end we land near — see the test plan for the grep check to measure.

Builds on #13490 (auth), #13503 (Agent tool + diagnosis), and #13508 (sandbox deps), all merged. Plugin path is stable end-to-end (verified on #13486). This PR is optimization + hardening.

## Changes (1-9)

### 1. Concurrency: cancel-in-progress per PR
```yaml
concurrency:
  group: claude-review-${{ github.event.pull_request.number }}
  cancel-in-progress: true
```
Rapid pushes only review the latest commit. **Confidence: high. Floor and ceiling both benefit.**

### 2. `paths-ignore` (narrowed)
```yaml
paths-ignore:
  - 'docs/**'
  - '**/*.md'
  - '.github/CODEOWNERS'
  - '.github/dependabot.yml'
  - '.github/ISSUE_TEMPLATE/**'
  - '.github/pull_request_template.md'
  - '**/*.lock'
  - 'pnpm-lock.yaml'
  - 'uv.lock'
```
**Important**: an earlier draft of this PR ignored all of `.github/**`. That hid the exact file class where recent auth/sandbox bugs land (#13484, #13485, #13490, #13503, #13506, #13508 would all have been skipped). Narrowed to truly inert paths only — `.github/workflows/**` and `.github/actions/**` now get reviewed. **Confidence: high.**

### 3. Job `if:` — skip drafts, fork PRs, bot authors, bot-branch families
```yaml
if: |
  !github.event.pull_request.draft &&
  github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name &&
  !contains(fromJSON('["release-please[bot]", "dependabot[bot]", "mintlify[bot]", "github-actions[bot]", "claude[bot]"]'), github.event.pull_request.user.login) &&
  !startsWith(github.event.pull_request.head.ref, 'release-please--') &&
  !startsWith(github.event.pull_request.head.ref, 'claude/') &&
  !startsWith(github.event.pull_request.head.ref, 'skills-audit/')
```
- **Drafts**: plugin bails internally but only after paying for setup + the gate-check subagent.
- **Fork PRs**: their body/diff/comments are attacker-controlled and the orchestrator ingests them as untrusted input. Fork PRs already can't access `ANTHROPIC_API_KEY` (GitHub blocks secrets on `pull_request` from forks), so this gate just avoids confusing failed-run noise — but it also makes the security stance explicit.
- **Bot authors / bot branches**: mechanical PRs don't need code review.

**Confidence: high.**

### 4. Orchestrator: opus → sonnet
```yaml
claude_args: --model claude-sonnet-4-6 ...
```
The plugin's command [hard-codes its own per-step models](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md) (haiku for the gate, sonnet for PR summary + CLAUDE.md, opus for bug-finding agents). The action-level model only affects the **orchestrator** that coordinates these subagents. Largest single cost lever. **Confidence: high.**

### 5. `--max-turns 30` runaway safety net
Recent $9.87 run hit 28 turns. Hard cap prevents pathological loops from billing indefinitely. **Confidence: high (safety net, not optimization).**

### 6. `allowedTools` — explicit read-only set
**Before** (broad wildcards from an earlier draft): `Bash(gh pr:*), Bash(git:*)`

**After** (explicit read-only):
```
Agent, Read, Glob, Grep, mcp__github_inline_comment__create_inline_comment,
Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr list:*), Bash(gh pr checks:*),
Bash(gh pr status:*), Bash(gh pr comment:*),
Bash(git fetch:*), Bash(git diff:*), Bash(git log:*), Bash(git show:*),
Bash(git status:*), Bash(git blame:*), Bash(git ls-files:*)
```

The wildcard form was a security regression: `Bash(gh pr:*)` matched `gh pr merge --admin`, `gh pr edit --base`, `gh pr review --approve`, `gh pr close`, `gh pr reopen`. `Bash(git:*)` matched `git push`, `git push --force`, `git reset --hard`, plus `git -c core.sshCommand=…`. With the App token's `contents/pull_requests/issues: write`, those were exploitable via prompt injection in PR bodies/comments. The wildcards were not load-bearing for the cost goal — the original "where do I write the diff?" denial spiral is already addressed by pre-fetch + `Read/Glob/Grep`.

**Why `Read,Glob,Grep` matter**: in-process file inspection, no bubblewrap sandbox, no subprocess init overhead. The recent run trace showed Claude burning ~5-6 turns trying to redirect `gh pr diff` output to a file. With `Read`, Claude reads the pre-fetched file directly.

**Confidence: high (security + cost both improved).**

### 7. Pre-fetch PR data (with three comment sources)
```yaml
- name: Pre-fetch PR data
  env:
    GH_TOKEN: ${{ github.token }}
    PR_NUM: ${{ github.event.pull_request.number }}
    OWNER: ${{ github.repository_owner }}
    REPO: ${{ github.event.repository.name }}
  run: |
    mkdir -p .scratch
    gh pr diff "$PR_NUM" > .scratch/pr-diff-full.patch
    # ... (filter step — see change #9)
    gh pr view "$PR_NUM" --json title,body,author,files,headRefOid,baseRefOid,baseRefName,headRefName \
      > .scratch/pr-meta.json
    gh pr view "$PR_NUM" --comments --json comments \
      > .scratch/pr-issue-comments.json
    gh api --paginate "repos/${OWNER}/${REPO}/pulls/${PR_NUM}/comments" \
      --jq '[.[] | {id, in_reply_to_id, user: .user.login, path, line, original_line, side, commit_id, created_at, updated_at, body}]' \
      > .scratch/pr-inline-comments.json
    gh api graphql -f query='...reviewThreads { isResolved isOutdated ... }...' \
      > .scratch/pr-review-threads.json
```

**Important fix from review**: an earlier draft used only `gh pr view --comments`, which returns only top-level conversation comments. Verified empirically on PR #13486: that endpoint returned 0 while the inline-comments endpoint returned 4 (including a `claude[bot]` bug finding). The re-review convergence rule was **silently broken** — it would re-flag prior nits on every push, exactly what the rule exists to prevent. Three comment files now:
- `pr-inline-comments.json` — per-file/per-line review comments (what convergence actually needs)
- `pr-review-threads.json` — `isResolved` / `isOutdated` state (so already-resolved threads can be skipped)
- `pr-issue-comments.json` — top-level comments (what the plugin's step-1 "has Claude commented?" gate looks at)

**Confidence: medium-high at orchestrator hop, medium at subagent hop.** The orchestrator will likely use `Read` instead of `gh pr view` (high), but the four step-4 review subagents are launched fresh by the orchestrator and the plugin's contract only guarantees "PR title + description" is forwarded. We prepend an explicit instruction to pass the paths into subagent task descriptions; whether the orchestrator follows it is best-effort.

### 8. Inline review guidelines in the prompt
Anthropic's `REVIEW.md` mechanism doesn't apply to the self-hosted plugin (verified by reading the plugin source — it doesn't reference `REVIEW.md`). So review-specific rules live in the workflow prompt:

- **Cap nits at 3** — caps inline-comment volume.
- **Re-review convergence** — post Important only on subsequent pushes; consult pre-fetched inline comments and resolved-thread state.
- **Do-not-report** — anything CI enforces (ruff/mypy/oxlint/oxfmt), generated files, lockfiles.
- **Always-check** — migrations are reversible, new REST endpoints have auth, GraphQL resolvers handle unauthenticated case, async functions are awaited at call sites.

**Confidence caveat (Finding 4)**: the plugin explicitly tells step-4 subagents to *"focus only on the diff itself without reading extra context"* and *"not flag issues that you cannot validate without looking at context outside of the git diff."* That **directly conflicts** with the "always-check" rule (which requires reading files outside the diff). The orchestrator would have to override the plugin's framing for always-check findings to surface. Worth flagging this as the most-fragile mechanism in the bundle.

**Confidence per sub-mechanism**:
- Cap nits at 3 — low-to-medium (plugin already enforces "high signal only"; this is a ceiling at the summary stage)
- Re-review convergence — low (three propagation hops: orchestrator reads comments → forwards rule → subagents respect it)
- Do-not-report — medium (largely redundant with the plugin's own false-positive list, so partial propagation still works)
- Always-check — low (net-new behavior; directly conflicts with plugin's diff-only framing)

### 9. Filter generated files out of the diff
```bash
python3 - <<'PY' < .scratch/pr-diff-full.patch > .scratch/pr-diff.patch
import sys
EXCLUDE = ('pnpm-lock.yaml', 'uv.lock', 'package-lock.json', 'yarn.lock',
           '_pb2.py', '_pb2.pyi', '_pb2_grpc.py',
           '/generated/', '/__generated__/',
           '.generated.ts', '.generated.tsx', '.generated.d.ts')
buf, skip = [], False
for line in sys.stdin:
    if line.startswith('diff --git '):
        if buf and not skip: sys.stdout.write(''.join(buf))
        buf = [line]; skip = any(p in line for p in EXCLUDE)
    else: buf.append(line)
if buf and not skip: sys.stdout.write(''.join(buf))
PY
```
Generated files in the diff are pure token noise — the review rules already tell Claude to ignore them, but only after it tokenizes them. A 2000-line lockfile is ~25K input tokens × ~6 subagents × Sonnet input pricing = ~$0.45/review wasted. `pr-diff-full.patch` is kept in case a subagent genuinely needs to inspect a generated file. **Confidence: high (deterministic filter, no propagation dependency).**

## `show_full_output: 'true'` is kept (not removed)
With sanitizer-only output, `permission_denials` collapses to a count — not enough to debug regressions in this still-evolving workflow. The diagnostic chain that found the socat sandbox failure, the Agent denial, and the gh-redirect spiral all required `show_full_output`. Costs are log volume only (3-5×); Phoenix is public and the action masks secrets via `core.setSecret`. Revisit removal once the workflow has been stable and unchanged for ≥4 weeks.

## Things considered and rejected

- **`REVIEW.md`**: plugin doesn't read it. Only Anthropic's managed Code Review service does.
- **Session resume via `--resume`**: caches conversation log, not knowledge; prompt cache TTL is 5min; plugin re-dispatches fresh subagents regardless. Wrong tool for the goal.
- **Per-PR notes-as-hidden-comment**: real pattern, ~100 lines of prompt engineering for uncertain payoff. Better as a Phase 2 if push-per-PR distribution justifies it.
- **GitHub Actions cache for plugin/Bun install**: saves ~30s wall time, $0 tokens. Trivial to add later.
- **Subdirectory `CLAUDE.md` / architecture docs**: long-term lever; benefits every Claude Code session; needs area owners.
- **Migrate to Anthropic's managed Code Review service**: would cost more ($15-25 vs ~$10), trades flexibility for ops simplicity. Self-hosted is stable; staying put.
- **Forking the plugin** to bake pre-fetched paths into step-4 subagent task templates: noted as a follow-up if telemetry (see test plan) shows weak propagation.

## Test plan

- [ ] After merge, push to a fresh non-bot non-draft PR. Verify `claude[bot]` posts (inline findings or "No blocking issues" summary).
- [ ] Confirm `Install subprocess isolation deps`, `Pre-fetch PR data`, and `Run Claude Code Review` steps all succeed.
- [ ] Open a draft PR — should be skipped entirely.
- [ ] Open a PR from a fork (if any external contributors are around) — should be skipped.
- [ ] Watch a release-please PR — should be skipped.
- [ ] Open a PR that touches only `.github/workflows/` — should NOT be skipped (this is the fix for Finding 3).
- [ ] **Propagation telemetry**: after the first run with `show_full_output: 'true'`, grep the step log for `gh pr diff` or `gh pr view` invocations originating from subagent Bash calls. **Zero invocations** = pre-fetch hints propagated successfully to subagents and items 7/8 savings are fully realized. **Non-zero** = subagents bypassed the pre-fetch; per-run savings will land closer to the floor than the ceiling.
- [ ] After 3-5 real reviews, sanity-check per-review cost in Anthropic billing — should be materially lower than the prior $9.87 baseline.
- [ ] Rollback if anything misbehaves: `git revert` of the bundle — no schema/state changes.

## Follow-ups if propagation is weak

If telemetry shows subagents bypassing the pre-fetch (i.e., subagent-originated `gh pr diff` / `gh pr view` calls), the right next step is **not** more prompt text:
1. **Fork the plugin** so the step-4 subagent task templates explicitly mention `.scratch/pr-diff.patch` and the review rules. Most reliable; medium effort.
2. **Mechanically force subagents into pre-fetched paths**: remove `Bash(gh pr diff:*)` and `Bash(gh pr view:*)` from the allowlist so subagents physically can't call them and have to use `Read(.scratch/**)`. Risk: breaks the plugin's step 1 gate-check subagent which calls `gh pr view --comments`. Mitigation: pre-fetch covers that too, but the plugin doesn't know to read the pre-fetched file.

Worth deciding empirically after the first few real runs rather than over-engineering up front.
