### PR TITLE
feat(agent): collapse agent context pills into a deck

### DIFF
--- a/.agents/skills/phoenix-frontend/rules/components.md
+++ b/.agents/skills/phoenix-frontend/rules/components.md
@@ -25,6 +25,16 @@ Explore a few existing components to match the established file structure (compo
 
 React Compiler is enabled — do NOT use `useMemo`, `useCallback`, or `React.memo`. The compiler handles memoization automatically. This includes callback props passed to children; define them inline without wrapping in `useCallback`.
 
+## Conditional class names
+
+Build conditional `className` strings with `classNames` from `@phoenix/utils/classNames` (a re-export of `clsx`) — do NOT hand-roll ternaries or template literals that repeat the base class. Pass the base class as a string and toggles as an object:
+
+```tsx
+className={classNames("attachment-info", {
+  "attachment-info--with-detail": detail,
+})}
+```
+
 ## Refs
 
 React 19 treats `ref` as a regular prop — do NOT use `forwardRef`. Instead, accept `ref` directly in the props type and destructure it like any other prop. Add `ref?: Ref<ElementType>` to the props interface.

--- a/app/src/components/agent/AgentContextPills.tsx
+++ b/app/src/components/agent/AgentContextPills.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties } from "react";
+
 import type { AgentContext } from "@phoenix/agent/context/agentContextTypes";
 import { agentContextKey } from "@phoenix/agent/context/agentContextTypes";
 import { selectActiveContexts } from "@phoenix/agent/context/selectors";
@@ -23,6 +25,7 @@ function truncate(value: string, max: number): string {
   return value.length > max ? `${value.slice(0, max)}...` : value;
 }
 
+/** The context type, shown as the chip's always-visible label. */
 function contextLabel(context: AgentContext): string {
   switch (context.type) {
     case "app":
@@ -36,14 +39,30 @@ function contextLabel(context: AgentContext): string {
     case "project":
       return "Project";
     case "trace":
-      return `Trace: ${truncateId(context.otelTraceId)}`;
+      return "Trace";
+    case "span":
+      return "Span";
+  }
+}
+
+/**
+ * The id/identifier for a context, shown dimmed beside the label and revealed
+ * only when the stack is expanded. Returns undefined for contexts that have no
+ * meaningful identifier to show (e.g. project, playground).
+ */
+function contextDetail(context: AgentContext): string | undefined {
+  switch (context.type) {
+    case "trace":
+      return truncateId(context.otelTraceId);
     case "span": {
       const spanId = context.spanNodeId ?? context.otelSpanId;
       if (spanId == null) {
         throw new Error("span context must have spanNodeId or otelSpanId");
       }
-      return `Span: ${truncateId(spanId)}`;
+      return truncateId(spanId);
     }
+    default:
+      return undefined;
   }
 }
 
@@ -53,6 +72,7 @@ function toAttachmentData(context: AgentContext): AttachmentContextData {
     id: agentContextKey(context),
     category: context.type,
     label: contextLabel(context),
+    detail: contextDetail(context),
   };
 }
 
@@ -72,7 +92,8 @@ function spanFilterAttachmentData(
     type: "context",
     id,
     category: "span_filter",
-    label: `Filter: ${truncate(context.spanFilter, MAX_CONDITION_CHARS)}`,
+    label: "Filter",
+    detail: truncate(context.spanFilter, MAX_CONDITION_CHARS),
   };
 }
 
@@ -107,7 +128,17 @@ export function AgentContextPills() {
   });
 
   return (
-    <Attachments variant="inline">
+    <Attachments
+      variant="inline"
+      collapsible
+      // The pills sit on the prompt input surface; match the stack seam to it.
+      style={
+        {
+          "--attachment-stack-separator-color":
+            "var(--prompt-input-background-color)",
+        } as CSSProperties
+      }
+    >
       {items.map((data) => (
         <Attachment key={data.id} data={data}>
           <AttachmentPreview />

--- a/app/src/components/agent/AgentContextPills.tsx
+++ b/app/src/components/agent/AgentContextPills.tsx
@@ -45,11 +45,7 @@ function contextLabel(context: AgentContext): string {
   }
 }
 
-/**
- * The id/identifier for a context, shown dimmed beside the label and revealed
- * only when the stack is expanded. Returns undefined for contexts that have no
- * meaningful identifier to show (e.g. project, playground).
- */
+/** The id shown dimmed beside the label, or undefined when there is none. */
 function contextDetail(context: AgentContext): string | undefined {
   switch (context.type) {
     case "trace":

--- a/app/src/components/ai/attachment/AttachmentInfo.tsx
+++ b/app/src/components/ai/attachment/AttachmentInfo.tsx
@@ -1,3 +1,5 @@
+import { classNames } from "@phoenix/utils/classNames";
+
 import { useAttachmentContext } from "./AttachmentContext";
 import { attachmentInfoCSS } from "./styles";
 import type { AttachmentInfoProps } from "./types";
@@ -32,11 +34,9 @@ export function AttachmentInfo({
     <div
       ref={ref}
       css={attachmentInfoCSS}
-      className={
-        detail
-          ? "attachment-info attachment-info--with-detail"
-          : "attachment-info"
-      }
+      className={classNames("attachment-info", {
+        "attachment-info--with-detail": detail,
+      })}
       {...restProps}
     >
       <span className="attachment-info__label">{label}</span>

--- a/app/src/components/ai/attachment/AttachmentInfo.tsx
+++ b/app/src/components/ai/attachment/AttachmentInfo.tsx
@@ -1,11 +1,12 @@
 import { useAttachmentContext } from "./AttachmentContext";
 import { attachmentInfoCSS } from "./styles";
 import type { AttachmentInfoProps } from "./types";
-import { getAttachmentLabel } from "./utils";
+import { getAttachmentDetail, getAttachmentLabel } from "./utils";
 
 /**
- * Text info slot for an `<Attachment>`. Renders the attachment label and,
- * when `showMediaType` is set, the media type beneath it.
+ * Text info slot for an `<Attachment>`. Renders the attachment label, an
+ * optional dimmed detail beside it (e.g. a context's trace id), and — when
+ * `showMediaType` is set — the media type beneath it.
  *
  * Renders nothing in the `"grid"` variant — grid tiles are image-only.
  */
@@ -21,14 +22,27 @@ export function AttachmentInfo({
   }
 
   const label = getAttachmentLabel(data);
+  const detail = getAttachmentDetail(data);
   const mediaType =
     data.type === "file" || data.type === "source-document"
       ? data.mediaType
       : undefined;
 
   return (
-    <div ref={ref} css={attachmentInfoCSS} {...restProps}>
+    <div
+      ref={ref}
+      css={attachmentInfoCSS}
+      className={
+        detail
+          ? "attachment-info attachment-info--with-detail"
+          : "attachment-info"
+      }
+      {...restProps}
+    >
       <span className="attachment-info__label">{label}</span>
+      {detail ? (
+        <span className="attachment-info__detail">{detail}</span>
+      ) : null}
       {showMediaType && mediaType ? (
         <span className="attachment-info__media-type">{mediaType}</span>
       ) : null}

--- a/app/src/components/ai/attachment/Attachments.tsx
+++ b/app/src/components/ai/attachment/Attachments.tsx
@@ -14,9 +14,12 @@ import type { AttachmentsProps } from "./types";
  * - `"inline"` — compact bordered chips, ideal for context pills.
  * - `"list"` — full-width rows, ideal for file lists.
  *
+ * Pass `collapsible` (inline only) to render the items as an overlapping stack
+ * that fans out on hover/focus — see {@link AttachmentsProps.collapsible}.
+ *
  * @example
  * ```tsx
- * <Attachments variant="inline">
+ * <Attachments variant="inline" collapsible>
  *   <Attachment data={contextData}>
  *     <AttachmentPreview />
  *     <AttachmentInfo />
@@ -28,12 +31,19 @@ export function Attachments({
   children,
   ref,
   variant = "grid",
+  collapsible = false,
   ...restProps
 }: AttachmentsProps) {
   const value = useMemo(() => ({ variant }), [variant]);
   return (
     <AttachmentsContext.Provider value={value}>
-      <div ref={ref} css={attachmentsCSS} data-variant={variant} {...restProps}>
+      <div
+        ref={ref}
+        css={attachmentsCSS}
+        data-variant={variant}
+        data-collapsible={collapsible || undefined}
+        {...restProps}
+      >
         {children}
       </div>
     </AttachmentsContext.Provider>

--- a/app/src/components/ai/attachment/index.ts
+++ b/app/src/components/ai/attachment/index.ts
@@ -8,6 +8,7 @@ export { useAttachmentContext } from "./AttachmentContext";
 export {
   getMediaCategory,
   getAttachmentLabel,
+  getAttachmentDetail,
   getDefaultAttachmentIcon,
 } from "./utils";
 export type {

--- a/app/src/components/ai/attachment/styles.ts
+++ b/app/src/components/ai/attachment/styles.ts
@@ -25,6 +25,113 @@ export const attachmentsCSS = css`
     flex-direction: column;
     width: 100%;
   }
+
+  /* -------------------------------------------------------------------------
+   * Collapsible inline stack — "deck of cards"
+   *
+   * At rest only the front (last) chip is fully visible, showing its icon and
+   * label. The chips behind it stack like a deck of cards: each is pulled
+   * almost entirely under the chip in front of it, peeking out by just a thin
+   * rounded sliver on the left. Hovering or focusing the group fans the deck
+   * out into a wrapping row, restoring each chip to full size and revealing its
+   * detail (id / condition). Driven entirely by CSS state, so the full labels
+   * stay in the accessibility tree even while visually clipped.
+   * ---------------------------------------------------------------------- */
+  &[data-variant="inline"][data-collapsible] {
+    /* Surface color the chips sit on, used to draw a seam between cards. */
+    --attachment-stack-separator-color: var(--global-background-color-default);
+    /* Width of the rounded sliver each card behind the front peeks out by. */
+    --attachment-stack-peek: var(--global-dimension-size-50);
+    /* Width a collapsed card occupies before it is overlapped — wide enough
+       to show its rounded corner in the peeking sliver. */
+    --attachment-stack-card: var(--global-dimension-size-200);
+
+    flex-wrap: nowrap;
+    gap: 0;
+    transition: gap 0.2s ease;
+
+    > [data-attachment] {
+      position: relative;
+      box-shadow: 0 0 0 var(--global-border-size-thin)
+        var(--attachment-stack-separator-color);
+      transition:
+        width 0.2s ease,
+        min-width 0.2s ease,
+        padding 0.2s ease,
+        margin-left 0.2s ease;
+    }
+
+    /*
+     * Collapse every chip but the front one to a narrow, full-height card:
+     * fixed width with its contents clipped + faded so only the card's surface
+     * and rounded corner show in the peeking sliver.
+     */
+    > [data-attachment]:not(:last-child) {
+      width: var(--attachment-stack-card);
+      min-width: var(--attachment-stack-card);
+      padding: 0;
+      overflow: hidden;
+    }
+
+    > [data-attachment]:not(:last-child) > * {
+      opacity: 0;
+      transition: opacity 0.2s ease;
+    }
+
+    /*
+     * Slide every card after the first back under its predecessor, leaving only
+     * the peek sliver showing. Later cards paint on top, so the front chip ends
+     * up fully covering the deck with each card behind peeking on its left.
+     */
+    > [data-attachment] + [data-attachment] {
+      margin-left: calc(
+        var(--attachment-stack-peek) - var(--attachment-stack-card)
+      );
+    }
+
+    /* At rest no chip shows its detail. */
+    .attachment-info__detail {
+      max-width: 0;
+      opacity: 0;
+      margin-left: 0;
+    }
+
+    .attachment-info,
+    .attachment-info__detail {
+      transition:
+        max-width 0.2s ease,
+        opacity 0.2s ease,
+        margin 0.2s ease;
+    }
+  }
+
+  &[data-variant="inline"][data-collapsible]:hover,
+  &[data-variant="inline"][data-collapsible]:focus-within {
+    flex-wrap: wrap;
+    gap: var(--global-dimension-size-75);
+
+    /* Restore every collapsed card to its natural size and fan the deck out. */
+    > [data-attachment]:not(:last-child) {
+      width: auto;
+      min-width: 0;
+      padding: 0 var(--global-dimension-size-100);
+      overflow: visible;
+    }
+
+    > [data-attachment]:not(:last-child) > * {
+      opacity: 1;
+    }
+
+    > [data-attachment] + [data-attachment] {
+      margin-left: 0;
+    }
+
+    .attachment-info__detail {
+      max-width: var(--global-dimension-size-3000);
+      opacity: 1;
+      margin-left: var(--global-dimension-size-50);
+    }
+  }
 `;
 
 // ---------------------------------------------------------------------------
@@ -52,6 +159,9 @@ export const attachmentCSS = css`
       from var(--attachment-base-color) 88 calc(c * 0.4) h
     );
     --attachment-text-color: lch(from var(--attachment-base-color) 45 c h);
+    --attachment-detail-color: lch(
+      from var(--attachment-base-color) 55 c h / 0.75
+    );
 
     display: inline-flex;
     align-items: center;
@@ -76,6 +186,9 @@ export const attachmentCSS = css`
     );
     --attachment-text-color: lch(
       from var(--attachment-base-color) 90 calc(c * 0.8) h
+    );
+    --attachment-detail-color: lch(
+      from var(--attachment-base-color) 78 calc(c * 0.6) h / 0.8
     );
   }
 
@@ -154,6 +267,31 @@ export const attachmentInfoCSS = css`
     text-overflow: ellipsis;
     color: var(--global-text-color-500);
     font-size: var(--global-font-size-xs);
+  }
+
+  /*
+   * Context chips that carry a secondary detail (e.g. a trace id) lay the type
+   * label and the dimmed detail out on a single baseline-aligned row. Files use
+   * the default stacked label + media-type layout above.
+   */
+  &.attachment-info--with-detail {
+    display: inline-flex;
+    align-items: baseline;
+    overflow: hidden;
+
+    .attachment-info__label {
+      flex: 0 0 auto;
+    }
+
+    .attachment-info__detail {
+      flex: 0 1 auto;
+      min-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      color: var(--attachment-detail-color);
+      font-variant-numeric: tabular-nums;
+    }
   }
 `;
 

--- a/app/src/components/ai/attachment/styles.ts
+++ b/app/src/components/ai/attachment/styles.ts
@@ -26,24 +26,13 @@ export const attachmentsCSS = css`
     width: 100%;
   }
 
-  /* -------------------------------------------------------------------------
-   * Collapsible inline stack — "deck of cards"
-   *
-   * At rest only the front (last) chip is fully visible, showing its icon and
-   * label. The chips behind it stack like a deck of cards: each is pulled
-   * almost entirely under the chip in front of it, peeking out by just a thin
-   * rounded sliver on the left. Hovering or focusing the group fans the deck
-   * out into a wrapping row, restoring each chip to full size and revealing its
-   * detail (id / condition). Driven entirely by CSS state, so the full labels
-   * stay in the accessibility tree even while visually clipped.
-   * ---------------------------------------------------------------------- */
+  /* Collapsible inline stack: at rest only the front chip shows, the rest tuck
+     behind it as a deck peeking out by a sliver; hover/focus fans it out. */
   &[data-variant="inline"][data-collapsible] {
-    /* Surface color the chips sit on, used to draw a seam between cards. */
     --attachment-stack-separator-color: var(--global-background-color-default);
-    /* Width of the rounded sliver each card behind the front peeks out by. */
+    /* Sliver each card behind the front peeks out by, and the width of a
+       collapsed card before it is overlapped. */
     --attachment-stack-peek: var(--global-dimension-size-50);
-    /* Width a collapsed card occupies before it is overlapped — wide enough
-       to show its rounded corner in the peeking sliver. */
     --attachment-stack-card: var(--global-dimension-size-200);
 
     flex-wrap: nowrap;
@@ -61,11 +50,7 @@ export const attachmentsCSS = css`
         margin-left 0.2s ease;
     }
 
-    /*
-     * Collapse every chip but the front one to a narrow, full-height card:
-     * fixed width with its contents clipped + faded so only the card's surface
-     * and rounded corner show in the peeking sliver.
-     */
+    /* Collapse every chip but the front to a narrow card with clipped contents. */
     > [data-attachment]:not(:last-child) {
       width: var(--attachment-stack-card);
       min-width: var(--attachment-stack-card);
@@ -78,26 +63,17 @@ export const attachmentsCSS = css`
       transition: opacity 0.2s ease;
     }
 
-    /*
-     * Slide every card after the first back under its predecessor, leaving only
-     * the peek sliver showing. Later cards paint on top, so the front chip ends
-     * up fully covering the deck with each card behind peeking on its left.
-     */
+    /* Slide each card under its predecessor; later cards paint on top. */
     > [data-attachment] + [data-attachment] {
       margin-left: calc(
         var(--attachment-stack-peek) - var(--attachment-stack-card)
       );
     }
 
-    /* At rest no chip shows its detail. */
     .attachment-info__detail {
       max-width: 0;
       opacity: 0;
       margin-left: 0;
-    }
-
-    .attachment-info,
-    .attachment-info__detail {
       transition:
         max-width 0.2s ease,
         opacity 0.2s ease,
@@ -110,7 +86,6 @@ export const attachmentsCSS = css`
     flex-wrap: wrap;
     gap: var(--global-dimension-size-75);
 
-    /* Restore every collapsed card to its natural size and fan the deck out. */
     > [data-attachment]:not(:last-child) {
       width: auto;
       min-width: 0;
@@ -269,11 +244,7 @@ export const attachmentInfoCSS = css`
     font-size: var(--global-font-size-xs);
   }
 
-  /*
-   * Context chips that carry a secondary detail (e.g. a trace id) lay the type
-   * label and the dimmed detail out on a single baseline-aligned row. Files use
-   * the default stacked label + media-type layout above.
-   */
+  /* Chips with a secondary detail lay label + dimmed detail on one row. */
   &.attachment-info--with-detail {
     display: inline-flex;
     align-items: baseline;

--- a/app/src/components/ai/attachment/types.ts
+++ b/app/src/components/ai/attachment/types.ts
@@ -45,8 +45,15 @@ export type AttachmentSourceData = SourceDocumentUIPart & { id: string };
 export type AttachmentContextData = {
   type: "context";
   id: string;
-  /** Visible label, e.g. `"Project"` or `"Trace: 1a2b3c4d…"`. */
+  /** Visible label, typically the context type, e.g. `"Project"` or `"Trace"`. */
   label: string;
+  /**
+   * Optional secondary detail (e.g. a trace id or filter condition). Rendered
+   * beside the label, dimmed, and — in a collapsible group — revealed only when
+   * the stack is expanded (hovered / focused) so the chip reads as just its
+   * type + icon at rest.
+   */
+  detail?: string;
   /**
    * Optional category — drives the default icon. Free string so callers can
    * extend with their own categories without changing this union.
@@ -89,6 +96,15 @@ export interface AttachmentsProps
    * @default "grid"
    */
   variant?: AttachmentVariant;
+  /**
+   * When true (and `variant="inline"`), collapse the items into an overlapping
+   * stack — the last item stays fully visible on top, earlier items tuck behind
+   * it as icon-only chips, and every item's `detail` is hidden. Hovering or
+   * focusing the group fans the stack out into a wrapping row and reveals each
+   * detail. Ignored for non-inline variants.
+   * @default false
+   */
+  collapsible?: boolean;
   children: ReactNode;
 }
 

--- a/app/src/components/ai/attachment/utils.tsx
+++ b/app/src/components/ai/attachment/utils.tsx
@@ -40,6 +40,15 @@ export function getAttachmentLabel(data: AttachmentData): string {
   );
 }
 
+/**
+ * Optional secondary detail for an attachment (e.g. a context's trace id or
+ * filter condition), used by `<AttachmentInfo>`. Only context attachments
+ * carry a detail today.
+ */
+export function getAttachmentDetail(data: AttachmentData): string | undefined {
+  return data.type === "context" ? data.detail : undefined;
+}
+
 /** Default icon for a context category, used when no `data.icon` is set. */
 function getContextCategoryIcon(category: string | undefined): ReactNode {
   switch (category) {

--- a/app/stories/Attachments.stories.tsx
+++ b/app/stories/Attachments.stories.tsx
@@ -44,19 +44,22 @@ const CONTEXT_DATA: AttachmentContextData[] = [
     type: "context",
     id: "trace:1",
     category: "trace",
-    label: "Trace: ee6a3a45...",
+    label: "Trace",
+    detail: "ee6a3a45...",
   },
   {
     type: "context",
     id: "span:2",
     category: "span",
-    label: "Span: U3BhbjoxMTIz",
+    label: "Span",
+    detail: "U3BhbjoxMTIz",
   },
   {
     type: "context",
     id: "filter:1",
     category: "span_filter",
-    label: 'Filter: status_code = "ERROR"',
+    label: "Filter",
+    detail: 'status_code = "ERROR"',
   },
 ];
 
@@ -106,6 +109,30 @@ export const ContextPills: Story = {
   render: () => (
     <div css={containerCSS}>
       <Attachments variant="inline">
+        {CONTEXT_DATA.map((data) => (
+          <Attachment key={data.id} data={data}>
+            <AttachmentPreview />
+            <AttachmentInfo />
+          </Attachment>
+        ))}
+      </Attachments>
+    </div>
+  ),
+};
+
+/**
+ * Collapsible context stack. At rest the chips overlap into a single-line
+ * stack — the last chip stays fully visible, the rest tuck behind it as
+ * icon-only badges, and every id/detail is hidden. Hover (or focus) the group
+ * to fan the stack out and reveal each detail.
+ *
+ * This is the shape `AgentContextPills` uses above the chat input so a long
+ * list of contexts stays compact until the user wants to inspect it.
+ */
+export const CollapsibleStack: Story = {
+  render: () => (
+    <div css={containerCSS}>
+      <Attachments variant="inline" collapsible>
         {CONTEXT_DATA.map((data) => (
           <Attachment key={data.id} data={data}>
             <AttachmentPreview />


### PR DESCRIPTION
## Summary

Renders the active agent context pills above the chat input as a collapsible **deck of cards** so a long list of contexts stays compact until the user wants to inspect it.

- At rest only the front (last) chip is fully visible (icon + label). The chips behind it are pulled almost entirely under it and peek out as thin rounded slivers on the left.
- Hovering or focusing the group fans the deck out into a wrapping row, restoring each chip to full size and revealing its detail.
- Driven entirely by CSS state, so full labels stay in the accessibility tree even while visually clipped.

## Changes

- **`<Attachments>`**: new `collapsible` prop (inline variant only) that drives the deck/stack layout via `data-collapsible`. Two CSS tuning knobs: `--attachment-stack-peek` (sliver width) and `--attachment-stack-card` (collapsed card width).
- **Context chips**: split the chip's type label from its identifier — `AttachmentContextData` gains a `detail` field, with a `getAttachmentDetail` helper and an `attachment-info--with-detail` layout that renders the id/filter dimmed beside the label and hides it until expanded.
- **`AgentContextPills`**: opts into `collapsible` and matches the stack seam color to the prompt input surface; `Trace`/`Span`/`Filter` now use label + detail instead of `"Trace: …"` strings.
- **Storybook**: adds a `CollapsibleStack` story.

## Test plan

- [ ] Storybook → `Attachments / CollapsibleStack`: chips collapse into a deck at rest; hover/focus fans them out and reveals details.
- [ ] Agent chat input: context pills collapse and expand as expected in light and dark themes.
