### PR TITLE
chore: simplify pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,1 @@
-## PXI evals
-
-- [ ] If this PR touches `evals/**` or `src/phoenix/server/agents/**`, I checked the **PXI Evals** workflow result, or noted why it was not needed.
-
-The PXI eval workflow is a targeted signal for PXI eval and agent changes. Reviewers may merge with judgment when a run is not relevant or a failure is understood.
+resolves #<issue-number>


### PR DESCRIPTION
resolves #<issue-number>

## What changed
- Replaced the PXI-specific pull request template with a single issue reference placeholder.

## Why
- Keeps new PR descriptions aligned with the contribution guideline that the first line references the tracked issue.

## Validation
- Not run; markdown template-only change.
