### PR TITLE
fix: report missing spans in annotation mutation

### DIFF
--- a/src/phoenix/server/api/mutations/span_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/span_annotations_mutations.py
@@ -54,6 +54,7 @@ class SpanAnnotationMutationMixin:
         processed_annotations_map: dict[int, models.SpanAnnotation] = {}
 
         span_rowids = []
+        span_ids_by_rowid: dict[int, list[str]] = {}
         for idx, annotation_input in enumerate(input):
             try:
                 span_rowid = from_global_id_with_expected_type(annotation_input.span_id, "Span")
@@ -62,8 +63,22 @@ class SpanAnnotationMutationMixin:
                     f"Invalid span ID for annotation at index {idx}: {annotation_input.span_id}"
                 )
             span_rowids.append(span_rowid)
+            span_ids_by_rowid.setdefault(span_rowid, []).append(str(annotation_input.span_id))
 
         async with info.context.db() as session:
+            span_rowid_result = await session.scalars(
+                select(models.Span.id).where(models.Span.id.in_(tuple(span_ids_by_rowid)))
+            )
+            existing_span_rowids = set(span_rowid_result.all())
+            missing_span_ids = [
+                span_id
+                for span_rowid, span_ids in span_ids_by_rowid.items()
+                if span_rowid not in existing_span_rowids
+                for span_id in span_ids
+            ]
+            if missing_span_ids:
+                raise NotFound(f"Could not find spans with IDs: {', '.join(missing_span_ids)}")
+
             for idx, (span_rowid, annotation_input) in enumerate(zip(span_rowids, input)):
                 resolved_identifier = ""
                 if isinstance(annotation_input.identifier, str):

--- a/tests/unit/server/api/mutations/test_span_annotation_mutations.py
+++ b/tests/unit/server/api/mutations/test_span_annotation_mutations.py
@@ -242,6 +242,32 @@ class TestSpanAnnotationMutations:
             "Use the createSpanNote mutation or POST /v1/span_notes instead."
         ) in response.errors[0].message
 
+    async def test_create_span_annotations_reports_missing_span(
+        self,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        missing_span_id = str(GlobalID("Span", "999"))
+        response = await gql_client.execute(
+            self.CREATE_SPAN_ANNOTATIONS_MUTATION,
+            {
+                "input": [
+                    {
+                        "spanId": missing_span_id,
+                        "name": "missing_span",
+                        "explanation": "This should fail with a clear error",
+                        "annotatorKind": AnnotatorKind.HUMAN.name,
+                        "metadata": {},
+                        "identifier": "",
+                        "source": AnnotationSource.API.name,
+                    }
+                ]
+            },
+        )
+
+        assert response.data is None
+        assert response.errors
+        assert response.errors[0].message == f"Could not find spans with IDs: {missing_span_id}"
+
     async def test_create_span_note_uses_uuidv4_identifier(
         self,
         gql_client: AsyncGraphQLClient,


### PR DESCRIPTION
﻿## Summary

Fixes the `createSpanAnnotations` half of #13513.

When a request used a valid Relay `Span` ID that did not resolve to a real span row, the mutation went straight into the insert/upsert path. SQLite/Postgres then raised a foreign-key error, and the GraphQL error masker surfaced only `an unexpected error occurred`.

This change resolves all input span IDs once, checks the referenced spans before writing annotations, and raises a normal `NotFound` error with the original GraphQL IDs. The existing invalid-ID shape is unchanged.

## To verify

uv run --group dev python -m pytest tests\unit\server\api\mutations\test_span_annotation_mutations.py -q
uv run --group dev python -m ruff check src\phoenix\server\api\mutations\span_annotations_mutations.py tests\unit\server\api\mutations\test_span_annotation_mutations.py
uv run --group dev python -m ruff format --check src\phoenix\server\api\mutations\span_annotations_mutations.py tests\unit\server\api\mutations\test_span_annotation_mutations.py
uv run --group dev python -m py_compile src\phoenix\server\api\mutations\span_annotations_mutations.py tests\unit\server\api\mutations\test_span_annotation_mutations.py
git diff --check
