### PR TITLE
feat(agent): rewind, fork, and copy controls for chat messages

### DIFF
--- a/.agents/skills/phoenix-design/rules/icons.md
+++ b/.agents/skills/phoenix-design/rules/icons.md
@@ -17,6 +17,7 @@ Phoenix has a curated icon set in `app/src/components/core/icon/Icons.tsx`. Use 
 | Video | `Icons.PlayCircleOutline` | Video-typed file attachments (no dedicated `Video*` icon). |
 | Context (generic) | `Icons.InfoOutline` | Default for an `AttachmentContextData` whose category has no canonical icon yet. |
 | Bypass / unguarded approvals | `Icons.ShieldOutline` | Warning shield for bypass/auto-approval modes where approvals are skipped. |
+| Undo / rewind | `Icons.RotateCcwOutline` | Counterclockwise arrow for reverting/undoing an action (e.g. rewinding a chat). Distinct from `HistoryOutline` (clock = history/session list). |
 
 ## When you need an icon
 

--- a/app/src/agent/chat/__tests__/rewindMessages.test.ts
+++ b/app/src/agent/chat/__tests__/rewindMessages.test.ts
@@ -1,0 +1,131 @@
+import { rewindMessages } from "@phoenix/agent/chat/rewindMessages";
+import type { AgentUIMessage } from "@phoenix/agent/chat/types";
+
+function userMessage(id: string, text: string): AgentUIMessage {
+  return {
+    id,
+    role: "user",
+    parts: [{ type: "text", text }],
+  };
+}
+
+function assistantMessage(
+  id: string,
+  parts: AgentUIMessage["parts"]
+): AgentUIMessage {
+  return { id, role: "assistant", parts };
+}
+
+const TRANSCRIPT: AgentUIMessage[] = [
+  userMessage("user-1", "first question"),
+  assistantMessage("assistant-1", [{ type: "text", text: "first answer" }]),
+  userMessage("user-2", "second question"),
+  assistantMessage("assistant-2", [{ type: "text", text: "second answer" }]),
+];
+
+describe("rewindMessages", () => {
+  it("returns null when the message id is not found", () => {
+    expect(
+      rewindMessages({ messages: TRANSCRIPT, messageId: "missing" })
+    ).toBeNull();
+  });
+
+  it("keeps everything up to and including an assistant target", () => {
+    const result = rewindMessages({
+      messages: TRANSCRIPT,
+      messageId: "assistant-1",
+    });
+
+    expect(result?.restoredInput).toBeNull();
+    expect(result?.messages.map((message) => message.id)).toEqual([
+      "user-1",
+      "assistant-1",
+    ]);
+  });
+
+  it("removes a user target and everything after, restoring its text", () => {
+    const result = rewindMessages({
+      messages: TRANSCRIPT,
+      messageId: "user-2",
+    });
+
+    expect(result?.restoredInput).toBe("second question");
+    expect(result?.messages.map((message) => message.id)).toEqual([
+      "user-1",
+      "assistant-1",
+    ]);
+  });
+
+  it("restores the full text of a multi-part user message", () => {
+    const messages: AgentUIMessage[] = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [
+          { type: "text", text: "hello " },
+          { type: "text", text: "world" },
+        ],
+      },
+    ];
+
+    const result = rewindMessages({ messages, messageId: "user-1" });
+
+    expect(result?.restoredInput).toBe("hello world");
+    expect(result?.messages).toEqual([]);
+  });
+
+  it("strips pending tool calls on the chosen assistant turn", () => {
+    const messages: AgentUIMessage[] = [
+      userMessage("user-1", "do a thing"),
+      assistantMessage("assistant-1", [
+        { type: "text", text: "on it" },
+        {
+          type: "tool-do_thing",
+          toolCallId: "call-resolved",
+          state: "output-available",
+          input: {},
+          output: "ok",
+        },
+        {
+          type: "tool-do_thing",
+          toolCallId: "call-pending",
+          state: "input-available",
+          input: {},
+        },
+      ]),
+    ];
+
+    const result = rewindMessages({ messages, messageId: "assistant-1" });
+
+    const toolParts =
+      result?.messages[1]?.parts.filter((part) =>
+        part.type.startsWith("tool-")
+      ) ?? [];
+    expect(toolParts).toHaveLength(1);
+    expect(
+      toolParts.map((part) =>
+        "toolCallId" in part ? part.toolCallId : undefined
+      )
+    ).toEqual(["call-resolved"]);
+  });
+
+  it("preserves earlier turns' tool calls untouched", () => {
+    const messages: AgentUIMessage[] = [
+      userMessage("user-1", "do a thing"),
+      assistantMessage("assistant-1", [
+        {
+          type: "tool-do_thing",
+          toolCallId: "call-1",
+          state: "input-available",
+          input: {},
+        },
+      ]),
+      assistantMessage("assistant-2", [{ type: "text", text: "later" }]),
+    ];
+
+    const result = rewindMessages({ messages, messageId: "assistant-2" });
+
+    // assistant-1 is earlier than the target and must keep its pending call.
+    expect(result?.messages[1]?.parts).toHaveLength(1);
+  });
+});

--- a/app/src/agent/chat/rewindMessages.ts
+++ b/app/src/agent/chat/rewindMessages.ts
@@ -1,0 +1,99 @@
+import { isTextUIPart, isToolUIPart } from "ai";
+
+import type { AgentUIMessage } from "./types";
+
+/**
+ * The outcome of truncating a transcript at a chosen message. Used by both the
+ * in-place rewind and the fork-into-new-session flows so the two paths share a
+ * single, well-tested truncation contract.
+ */
+export type RewindResult = {
+  /**
+   * The transcript that should replace the current one. For an assistant
+   * target this still contains the chosen assistant turn; for a user target
+   * the chosen user turn (and everything after it) is removed.
+   */
+  messages: AgentUIMessage[];
+  /**
+   * Text that should be placed back into the prompt input. Populated only when
+   * rewinding/forking from a user message so the user can edit and re-send it.
+   * `null` for assistant targets, where no input is restored.
+   */
+  restoredInput: string | null;
+};
+
+/**
+ * Concatenates the text parts of a message into the string a human typed/read.
+ * Non-text parts (tool calls, generative UI) are ignored.
+ */
+function getMessageText(message: AgentUIMessage): string {
+  return message.parts
+    .filter(isTextUIPart)
+    .map((part) => part.text)
+    .join("");
+}
+
+/**
+ * Strips tool-call parts that never reached a terminal output state. Rewinding
+ * to an assistant turn must not leave dangling/pending tool calls behind, both
+ * because the UI would show stale approval affordances and because Anthropic
+ * rejects requests that contain unresolved tool calls.
+ */
+function removePendingToolParts(message: AgentUIMessage): AgentUIMessage {
+  return {
+    ...message,
+    parts: message.parts.filter((part) => {
+      if (!isToolUIPart(part)) {
+        return true;
+      }
+      return (
+        part.state === "output-available" ||
+        part.state === "output-error" ||
+        part.state === "output-denied"
+      );
+    }),
+  };
+}
+
+/**
+ * Computes the transcript that results from rewinding (or forking) at the
+ * message with the given id.
+ *
+ * - **Assistant target**: keep everything up to and including the chosen
+ *   assistant message, clearing any pending tool calls on that turn. The chat
+ *   is reverted to the state it was in when that response completed.
+ * - **User target**: remove the chosen user message and everything after it,
+ *   and return its text as `restoredInput` so the caller can repopulate the
+ *   prompt input for editing/re-sending.
+ *
+ * Returns `null` when the id is not found, so callers can no-op safely.
+ */
+export function rewindMessages({
+  messages,
+  messageId,
+}: {
+  messages: AgentUIMessage[];
+  messageId: string;
+}): RewindResult | null {
+  const targetIndex = messages.findIndex((message) => message.id === messageId);
+  if (targetIndex === -1) {
+    return null;
+  }
+
+  const target = messages[targetIndex]!;
+
+  if (target.role === "user") {
+    return {
+      messages: messages.slice(0, targetIndex),
+      restoredInput: getMessageText(target),
+    };
+  }
+
+  const retained = messages.slice(0, targetIndex + 1);
+  return {
+    messages: retained.map((message, index) =>
+      index === targetIndex ? removePendingToolParts(message) : message
+    ),
+    restoredInput: null,
+  };
+}

--- a/app/src/components/agent/AgentChatPanel.tsx
+++ b/app/src/components/agent/AgentChatPanel.tsx
@@ -219,6 +219,8 @@ function AgentChatController({
     pendingElicitation,
     handleElicitationSubmit,
     handleElicitationCancel,
+    rewindToMessage,
+    forkFromMessage,
   } = useAgentChat({
     sessionId: activeSessionId,
     chatApiUrl,
@@ -247,6 +249,7 @@ function AgentChatController({
       {/* Catch runaway suspense triggers that aren't handled locally */}
       <Suspense fallback={<Loading />}>
         <ChatView
+          sessionId={activeSessionId}
           messages={messages}
           sendMessage={sendMessage}
           stop={stop}
@@ -255,6 +258,8 @@ function AgentChatController({
           pendingElicitation={pendingElicitation}
           handleElicitationSubmit={handleElicitationSubmit}
           handleElicitationCancel={handleElicitationCancel}
+          rewindToMessage={rewindToMessage}
+          forkFromMessage={forkFromMessage}
           modelMenuValue={menuValue}
           onModelChange={handleModelChange}
         >

--- a/app/src/components/agent/AssistantMessageActions.tsx
+++ b/app/src/components/agent/AssistantMessageActions.tsx
@@ -1,6 +1,6 @@
 import { isTextUIPart } from "ai";
 import copy from "copy-to-clipboard";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import { authApiFetch } from "@phoenix/api/authApiFetch";
@@ -118,13 +118,19 @@ async function postAnnotation(
  * - Copy: copies the assistant's text response to the clipboard.
  * - Trace: opens the associated trace in a new tab. Requires `traceId`.
  *
- * The component silently renders nothing if the message has no text and no
- * metadata capable of supporting any action.
+ * `children` are rendered after the built-in actions in the same toolbar row
+ * (e.g. rewind/fork controls), and force the toolbar to render even when the
+ * message itself supports no built-in actions.
+ *
+ * The component silently renders nothing if the message has no text, no
+ * metadata capable of supporting any action, and no `children`.
  */
 export function AssistantMessageActions({
   message,
+  children,
 }: {
   message: AgentUIMessage;
+  children?: ReactNode;
 }) {
   const { viewer } = useViewer();
   const storeLocalTraces = useAgentContext(
@@ -140,7 +146,7 @@ export function AssistantMessageActions({
   const canAnnotate = storeLocalTraces && metadata?.trace != null;
   const canOpenTrace = storeLocalTraces && metadata?.trace != null;
 
-  if (!hasMessageText && !canAnnotate && !canOpenTrace) {
+  if (!hasMessageText && !canAnnotate && !canOpenTrace && !children) {
     return null;
   }
 
@@ -262,6 +268,7 @@ export function AssistantMessageActions({
             <Icon svg={<Icons.Trace />} />
           </MessageAction>
         ) : null}
+        {children}
       </MessageActions>
     </MessageToolbar>
   );

--- a/app/src/components/agent/AssistantMessageActions.tsx
+++ b/app/src/components/agent/AssistantMessageActions.tsx
@@ -1,5 +1,4 @@
 import { isTextUIPart } from "ai";
-import copy from "copy-to-clipboard";
 import { type ReactNode, useState } from "react";
 
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
@@ -13,6 +12,8 @@ import {
 import { useViewer } from "@phoenix/contexts";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { prependBasename } from "@phoenix/utils/routingUtils";
+
+import { MessageCopyAction } from "./MessageCopyAction";
 
 /**
  * Annotation name used for both span- and trace-level user feedback on
@@ -150,13 +151,6 @@ export function AssistantMessageActions({
     return null;
   }
 
-  const handleCopy = () => {
-    if (!hasMessageText) {
-      return;
-    }
-    copy(messageText);
-  };
-
   const handleOpenTrace = () => {
     if (!canOpenTrace || !metadata?.trace) {
       return;
@@ -250,15 +244,7 @@ export function AssistantMessageActions({
             />
           </MessageAction>
         ) : null}
-        {hasMessageText ? (
-          <MessageAction
-            label="Copy"
-            tooltip="Copy this response"
-            onPress={handleCopy}
-          >
-            <Icon svg={<Icons.DuplicateOutline />} />
-          </MessageAction>
-        ) : null}
+        {hasMessageText ? <MessageCopyAction text={messageText} /> : null}
         {canOpenTrace ? (
           <MessageAction
             label="Trace"

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -3,6 +3,7 @@ import type { ChatStatus } from "ai";
 import {
   type CSSProperties,
   type ReactNode,
+  useMemo,
   useRef,
   type PropsWithChildren,
   useState,
@@ -29,7 +30,7 @@ import {
 import { Shimmer } from "@phoenix/components/ai/shimmer";
 import type { ModelMenuValue } from "@phoenix/components/generative/ModelMenu";
 import { useTheme } from "@phoenix/contexts";
-import { useAgentContext } from "@phoenix/contexts/AgentContext";
+import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 
 import { AgentConsentGate } from "./AgentConsentGate";
 import { AgentContextPills } from "./AgentContextPills";
@@ -44,11 +45,20 @@ import {
 import { AgentModelMenu } from "./AgentModelMenu";
 import { ChatEmptyState, type EmptyStateQuickAction } from "./ChatEmptyState";
 import { ChatLantern } from "./ChatLantern";
-import { AssistantMessage, UserMessage } from "./ChatMessage";
+import {
+  AssistantMessage,
+  type MessageRewindRequest,
+  UserMessage,
+} from "./ChatMessage";
 import {
   ElicitationDraftProvider,
   type PendingElicitationDraft,
 } from "./ElicitationDraftContext";
+import {
+  MessageRewindConfirmation,
+  type MessageRewindMode,
+  type MessageRewindRole,
+} from "./MessageRewindDialog";
 import { PxiGlyph } from "./PxiGlyph";
 import { isToolUIPart } from "./toolPartTypes";
 import { useAgentChat } from "./useAgentChat";
@@ -277,10 +287,13 @@ export function Chat({
     pendingElicitation,
     handleElicitationSubmit,
     handleElicitationCancel,
+    rewindToMessage,
+    forkFromMessage,
   } = useAgentChat({ sessionId, chatApiUrl, modelSelection });
 
   return (
     <ChatView
+      sessionId={sessionId}
       messages={messages}
       sendMessage={sendMessage}
       stop={stop}
@@ -289,6 +302,8 @@ export function Chat({
       pendingElicitation={pendingElicitation}
       handleElicitationSubmit={handleElicitationSubmit}
       handleElicitationCancel={handleElicitationCancel}
+      rewindToMessage={rewindToMessage}
+      forkFromMessage={forkFromMessage}
       modelMenuValue={modelMenuValue}
       onModelChange={onModelChange}
       emptyStateSubtext={emptyStateSubtext}
@@ -304,6 +319,7 @@ export function Chat({
  * controller path that keeps streaming alive while the panel is hidden.
  */
 export function ChatView({
+  sessionId,
   messages,
   sendMessage,
   stop,
@@ -312,12 +328,15 @@ export function ChatView({
   pendingElicitation,
   handleElicitationSubmit,
   handleElicitationCancel,
+  rewindToMessage,
+  forkFromMessage,
   modelMenuValue,
   onModelChange,
   children,
   emptyStateSubtext,
   emptyStateQuickActions,
 }: PropsWithChildren<{
+  sessionId?: string | null;
   messages: AgentUIMessage[];
   sendMessage: (message: { text: string }) => void;
   stop: () => Promise<void>;
@@ -326,6 +345,13 @@ export function ChatView({
   pendingElicitation: PendingElicitation | null;
   handleElicitationSubmit: (output: ElicitToolOutput) => void;
   handleElicitationCancel: () => void;
+  /**
+   * Truncates the active session at a message; returns user text to restore.
+   * Absent on read-only surfaces, which hides the rewind/fork controls.
+   */
+  rewindToMessage?: (messageId: string) => string | null;
+  /** Branches a new session from a message; absent hides the fork control. */
+  forkFromMessage?: (messageId: string) => string | null;
   modelMenuValue: ModelMenuValue;
   onModelChange: (model: ModelMenuValue) => void;
   emptyStateSubtext?: ReactNode;
@@ -335,8 +361,17 @@ export function ChatView({
   const { contentRef, scrollRef, scrollToBottom } = useStickToBottom({
     initial: "instant",
   });
+  const store = useAgentStore();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [inputValue, setInputValue] = useState("");
+  // Seed the input from any prompt staged for this session (e.g. forked from a
+  // user message). The controller remounts this view per session, so the lazy
+  // initializer runs once per session and the store entry is consumed exactly
+  // once. Reading it here (rather than in an effect) avoids a cascading render.
+  const [inputValue, setInputValue] = useState(
+    () =>
+      (sessionId ? store.getState().consumePendingInput(sessionId) : null) ?? ""
+  );
+
   const [elicitationDraft, setElicitationDraft] =
     useState<PendingElicitationDraft | null>(null);
   const hasAcknowledgedConsent = useAgentContext(
@@ -390,6 +425,44 @@ export function ChatView({
     textareaRef.current?.focus();
   };
 
+  // Pending rewind/fork confirmation, shown inline in place of the prompt
+  // input. Panel-local because the confirmation is an inline surface, not a
+  // modal — a modal would flip the global open-modal observer and re-parent
+  // this panel between its docked/floating layouts, tearing the surface down.
+  const [rewindRequest, setRewindRequest] = useState<{
+    mode: MessageRewindMode;
+    messageId: string;
+    role: MessageRewindRole;
+  } | null>(null);
+
+  // Rewind/fork mutate or branch finalized history, so they are only offered
+  // once the chat has settled — never mid-request.
+  const onRewindRequest = useMemo<MessageRewindRequest | undefined>(() => {
+    if (status !== "ready" || !rewindToMessage) {
+      return undefined;
+    }
+    return (request) => setRewindRequest(request);
+  }, [status, rewindToMessage]);
+
+  const handleConfirmRewind = () => {
+    if (!rewindRequest) {
+      return;
+    }
+    const { mode, messageId } = rewindRequest;
+    setRewindRequest(null);
+    if (mode === "fork") {
+      // Forking switches the active session, which remounts this view; the new
+      // session restores any staged input via the lazy initializer above.
+      forkFromMessage?.(messageId);
+    } else {
+      const restoredInput = rewindToMessage?.(messageId);
+      if (restoredInput != null) {
+        setInputValue(restoredInput);
+        textareaRef.current?.focus();
+      }
+    }
+  };
+
   return (
     <ElicitationDraftProvider draft={resolvedElicitationDraft}>
       <div
@@ -423,7 +496,13 @@ export function ChatView({
               )}
               {messages.map((message, index) => {
                 if (message.role === "user") {
-                  return <UserMessage key={message.id} parts={message.parts} />;
+                  return (
+                    <UserMessage
+                      key={message.id}
+                      message={message}
+                      onRewindRequest={onRewindRequest}
+                    />
+                  );
                 }
                 // Only the last assistant message can still be streaming — hide
                 // its actions until the chat reports it is settled.
@@ -434,6 +513,7 @@ export function ChatView({
                     key={message.id}
                     message={message}
                     showActions={showActions}
+                    onRewindRequest={onRewindRequest}
                   />
                 );
               })}
@@ -446,6 +526,15 @@ export function ChatView({
           {!hasAcknowledgedConsent ? (
             <PromptInput status={status} isDisabled mode="elicitation">
               <AgentConsentGate />
+            </PromptInput>
+          ) : rewindRequest ? (
+            <PromptInput status={status} isDisabled mode="elicitation">
+              <MessageRewindConfirmation
+                mode={rewindRequest.mode}
+                role={rewindRequest.role}
+                onConfirm={handleConfirmRewind}
+                onCancel={() => setRewindRequest(null)}
+              />
             </PromptInput>
           ) : pendingElicitation ? (
             <PromptInput status={status} isDisabled mode="elicitation">

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -508,11 +508,16 @@ export function ChatView({
                 // its actions until the chat reports it is settled.
                 const isLast = index === messages.length - 1;
                 const showActions = !isLast || status === "ready";
+                // Pin the most recent assistant turn's toolbar so its actions
+                // stay visible; other turns reveal their toolbars on hover to
+                // cut down on stacked-toolbar clutter.
+                const pinToolbar = isLast && status === "ready";
                 return (
                   <AssistantMessage
                     key={message.id}
                     message={message}
                     showActions={showActions}
+                    pinToolbar={pinToolbar}
                     onRewindRequest={onRewindRequest}
                   />
                 );

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -512,6 +512,9 @@ export function ChatView({
                 // stay visible; other turns reveal their toolbars on hover to
                 // cut down on stacked-toolbar clutter.
                 const pinToolbar = isLast && status === "ready";
+                // Rewinding to the last assistant turn is a no-op: nothing
+                // follows it to truncate and, once settled, it has no pending
+                // tool calls to clear. Hide the rewind control there.
                 return (
                   <AssistantMessage
                     key={message.id}
@@ -519,6 +522,7 @@ export function ChatView({
                     showActions={showActions}
                     pinToolbar={pinToolbar}
                     onRewindRequest={onRewindRequest}
+                    allowRewind={!isLast}
                   />
                 );
               })}

--- a/app/src/components/agent/ChatMessage.tsx
+++ b/app/src/components/agent/ChatMessage.tsx
@@ -13,6 +13,7 @@ import { MarkdownBlock } from "@phoenix/components/markdown";
 import { AssistantMessageActions } from "./AssistantMessageActions";
 import { GenerativeUI } from "./generativeUI";
 import { groupMessageParts } from "./groupMessageParts";
+import { MessageCopyAction } from "./MessageCopyAction";
 import { MessageRewindActions } from "./MessageRewindActions";
 import type {
   MessageRewindMode,
@@ -43,8 +44,9 @@ const assistantMessageCSS = css`
 // ---------------------------------------------------------------------------
 
 /**
- * Renders a user message bubble (right-aligned, primary colour). When
- * `rewindHandlers` is provided a rewind/fork toolbar is shown below the bubble.
+ * Renders a user message bubble (right-aligned, primary colour) with a toolbar
+ * for copying the message and, when `onRewindRequest` is provided, rewinding or
+ * forking the conversation from it.
  */
 export function UserMessage({
   message,
@@ -57,18 +59,22 @@ export function UserMessage({
     .filter(isTextUIPart)
     .map((p) => p.text)
     .join("");
+  const hasText = text.trim().length > 0;
 
   return (
     <Message from="user">
       <MessageContent>{text}</MessageContent>
-      {onRewindRequest ? (
+      {hasText || onRewindRequest ? (
         <MessageToolbar>
           <MessageActions>
-            <MessageRewindActions
-              messageId={message.id}
-              role="user"
-              onRequest={onRewindRequest}
-            />
+            <MessageCopyAction text={text} />
+            {onRewindRequest ? (
+              <MessageRewindActions
+                messageId={message.id}
+                role="user"
+                onRequest={onRewindRequest}
+              />
+            ) : null}
           </MessageActions>
         </MessageToolbar>
       ) : null}

--- a/app/src/components/agent/ChatMessage.tsx
+++ b/app/src/components/agent/ChatMessage.tsx
@@ -85,20 +85,26 @@ export function UserMessage({
  * `showActions` gates the feedback/copy/trace toolbar — callers should set
  * it to `false` while this particular message is still streaming so users
  * don't interact with incomplete content.
+ *
+ * `pinToolbar` keeps the toolbar always visible instead of revealing it on
+ * hover/focus. Callers use it for the most recent assistant turn, whose actions
+ * (copy, feedback, trace) are the ones users reach for most often.
  */
 export function AssistantMessage({
   message,
   showActions = true,
+  pinToolbar = false,
   onRewindRequest,
 }: {
   message: AgentUIMessage;
   showActions?: boolean;
+  pinToolbar?: boolean;
   onRewindRequest?: MessageRewindRequest;
 }) {
   const grouped = groupMessageParts(message.parts);
 
   return (
-    <Message from="assistant">
+    <Message from="assistant" data-pin-toolbar={pinToolbar || undefined}>
       <MessageContent>
         <div css={assistantMessageCSS}>
           {grouped.map((group) => {

--- a/app/src/components/agent/ChatMessage.tsx
+++ b/app/src/components/agent/ChatMessage.tsx
@@ -2,14 +2,35 @@ import { css } from "@emotion/react";
 import { isTextUIPart } from "ai";
 
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
-import { Message, MessageContent } from "@phoenix/components/ai/message";
+import {
+  Message,
+  MessageActions,
+  MessageContent,
+  MessageToolbar,
+} from "@phoenix/components/ai/message";
 import { MarkdownBlock } from "@phoenix/components/markdown";
 
 import { AssistantMessageActions } from "./AssistantMessageActions";
 import { GenerativeUI } from "./generativeUI";
 import { groupMessageParts } from "./groupMessageParts";
+import { MessageRewindActions } from "./MessageRewindActions";
+import type {
+  MessageRewindMode,
+  MessageRewindRole,
+} from "./MessageRewindDialog";
 import { ToolPart } from "./ToolPart";
 import { ToolPartGroup } from "./ToolPartGroup";
+
+/**
+ * Reports a rewind/fork request from a message's controls up to the chat view,
+ * which owns the single confirmation dialog. Optional so messages can render
+ * without the controls (e.g. while streaming) by omitting the prop entirely.
+ */
+export type MessageRewindRequest = (request: {
+  mode: MessageRewindMode;
+  messageId: string;
+  role: MessageRewindRole;
+}) => void;
 
 const assistantMessageCSS = css`
   align-self: flex-start;
@@ -21,9 +42,18 @@ const assistantMessageCSS = css`
 // Components
 // ---------------------------------------------------------------------------
 
-/** Renders a user message bubble (right-aligned, primary colour). */
-export function UserMessage({ parts }: { parts: AgentUIMessage["parts"] }) {
-  const text = parts
+/**
+ * Renders a user message bubble (right-aligned, primary colour). When
+ * `rewindHandlers` is provided a rewind/fork toolbar is shown below the bubble.
+ */
+export function UserMessage({
+  message,
+  onRewindRequest,
+}: {
+  message: AgentUIMessage;
+  onRewindRequest?: MessageRewindRequest;
+}) {
+  const text = message.parts
     .filter(isTextUIPart)
     .map((p) => p.text)
     .join("");
@@ -31,6 +61,17 @@ export function UserMessage({ parts }: { parts: AgentUIMessage["parts"] }) {
   return (
     <Message from="user">
       <MessageContent>{text}</MessageContent>
+      {onRewindRequest ? (
+        <MessageToolbar>
+          <MessageActions>
+            <MessageRewindActions
+              messageId={message.id}
+              role="user"
+              onRequest={onRewindRequest}
+            />
+          </MessageActions>
+        </MessageToolbar>
+      ) : null}
     </Message>
   );
 }
@@ -48,9 +89,11 @@ export function UserMessage({ parts }: { parts: AgentUIMessage["parts"] }) {
 export function AssistantMessage({
   message,
   showActions = true,
+  onRewindRequest,
 }: {
   message: AgentUIMessage;
   showActions?: boolean;
+  onRewindRequest?: MessageRewindRequest;
 }) {
   const grouped = groupMessageParts(message.parts);
 
@@ -95,7 +138,17 @@ export function AssistantMessage({
           })}
         </div>
       </MessageContent>
-      {showActions ? <AssistantMessageActions message={message} /> : null}
+      {showActions ? (
+        <AssistantMessageActions message={message}>
+          {onRewindRequest ? (
+            <MessageRewindActions
+              messageId={message.id}
+              role="assistant"
+              onRequest={onRewindRequest}
+            />
+          ) : null}
+        </AssistantMessageActions>
+      ) : null}
     </Message>
   );
 }

--- a/app/src/components/agent/ChatMessage.tsx
+++ b/app/src/components/agent/ChatMessage.tsx
@@ -95,17 +95,23 @@ export function UserMessage({
  * `pinToolbar` keeps the toolbar always visible instead of revealing it on
  * hover/focus. Callers use it for the most recent assistant turn, whose actions
  * (copy, feedback, trace) are the ones users reach for most often.
+ *
+ * `allowRewind` gates the rewind control. Callers set it to `false` for the
+ * last assistant turn, where rewinding to that response is a no-op (see
+ * {@link MessageRewindActions}); fork stays available there.
  */
 export function AssistantMessage({
   message,
   showActions = true,
   pinToolbar = false,
   onRewindRequest,
+  allowRewind = true,
 }: {
   message: AgentUIMessage;
   showActions?: boolean;
   pinToolbar?: boolean;
   onRewindRequest?: MessageRewindRequest;
+  allowRewind?: boolean;
 }) {
   const grouped = groupMessageParts(message.parts);
 
@@ -157,6 +163,7 @@ export function AssistantMessage({
               messageId={message.id}
               role="assistant"
               onRequest={onRewindRequest}
+              showRewind={allowRewind}
             />
           ) : null}
         </AssistantMessageActions>

--- a/app/src/components/agent/MessageCopyAction.tsx
+++ b/app/src/components/agent/MessageCopyAction.tsx
@@ -1,0 +1,42 @@
+import copy from "copy-to-clipboard";
+import { useState } from "react";
+
+import { Icon, Icons } from "@phoenix/components";
+import { MessageAction } from "@phoenix/components/ai/message";
+
+const SHOW_COPIED_TIMEOUT_MS = 2000;
+
+/**
+ * Copy-to-clipboard control for a chat message, rendered as a bare
+ * {@link MessageAction} so it slots into an existing `MessageActions` row.
+ *
+ * Mirrors the app-wide copy affordance: the duplicate glyph swaps to a success
+ * checkmark briefly after copying. Renders nothing when there is no text to
+ * copy.
+ */
+export function MessageCopyAction({ text }: { text: string }) {
+  const [isCopied, setIsCopied] = useState(false);
+
+  if (text.trim().length === 0) {
+    return null;
+  }
+
+  const handleCopy = () => {
+    copy(text);
+    setIsCopied(true);
+    setTimeout(() => setIsCopied(false), SHOW_COPIED_TIMEOUT_MS);
+  };
+
+  return (
+    <MessageAction
+      label="Copy"
+      tooltip={isCopied ? "Copied" : "Copy message"}
+      onPress={handleCopy}
+    >
+      <Icon
+        svg={isCopied ? <Icons.Checkmark /> : <Icons.DuplicateOutline />}
+        color={isCopied ? "success" : "inherit"}
+      />
+    </MessageAction>
+  );
+}

--- a/app/src/components/agent/MessageRewindActions.tsx
+++ b/app/src/components/agent/MessageRewindActions.tsx
@@ -1,4 +1,13 @@
-import { Icon, Icons } from "@phoenix/components";
+import type { Key } from "react";
+
+import {
+  Icon,
+  Icons,
+  Menu,
+  MenuContainer,
+  MenuItem,
+  MenuTrigger,
+} from "@phoenix/components";
 import { MessageAction } from "@phoenix/components/ai/message";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
 
@@ -9,19 +18,29 @@ import type {
 
 /**
  * Rewind (and, when session storage is enabled, fork) controls rendered under a
- * user or assistant message. Renders bare {@link MessageAction} buttons so
- * callers can place them inside an existing `MessageActions` row.
+ * user or assistant message. These are uncommon, mostly-destructive actions, so
+ * they are tucked behind a single "more actions" overflow button rather than
+ * sitting inline next to the everyday copy/feedback controls.
  *
- * Pressing a control reports the requested action and the target message up to
- * the chat view via `onRequest`, which owns the single confirmation dialog. The
- * dialog is intentionally NOT rendered here: mounting a React Aria modal inside
- * the scroll-managed message list triggers a remount loop with the
- * stick-to-bottom observers, so the overlay must live outside the list.
+ * Selecting an item reports the requested action and the target message up to
+ * the chat view via `onRequest`, which owns the single confirmation surface. The
+ * confirmation is intentionally NOT rendered here: it is an inline panel shown
+ * in place of the prompt input, because mounting a React Aria modal would flip
+ * the global open-modal observer and re-parent the agent panel in a loop. The
+ * overflow menu itself is a popover (not a modal overlay), so it does not trip
+ * that observer.
+ *
+ * `showRewind` gates the rewind item. Callers set it to `false` for the last
+ * assistant turn, where rewinding to that response is a no-op — there is nothing
+ * after it to truncate and the chat has settled, so no pending tool calls remain
+ * to clear. Fork stays available there because it branches a separate session.
+ * When neither item would render, the whole control is omitted.
  */
 export function MessageRewindActions({
   messageId,
   role,
   onRequest,
+  showRewind = true,
 }: {
   messageId: string;
   role: MessageRewindRole;
@@ -30,33 +49,49 @@ export function MessageRewindActions({
     messageId: string;
     role: MessageRewindRole;
   }) => void;
+  showRewind?: boolean;
 }) {
   const canFork = useAgentContext(
     (state) => state.capabilities["session.storeSessions"]
   );
 
+  if (!showRewind && !canFork) {
+    return null;
+  }
+
+  const handleAction = (key: Key) => {
+    if (key === "rewind" || key === "fork") {
+      onRequest({ mode: key, messageId, role });
+    }
+  };
+
   return (
-    <>
-      <MessageAction
-        label="Rewind to this message"
-        tooltip={
-          role === "user"
-            ? "Undo the chat to this message and restore it to the input"
-            : "Undo the chat back to this response"
-        }
-        onPress={() => onRequest({ mode: "rewind", messageId, role })}
-      >
-        <Icon svg={<Icons.RotateCcwOutline />} />
+    <MenuTrigger>
+      <MessageAction label="More actions">
+        <Icon svg={<Icons.MoreHorizontalOutline />} />
       </MessageAction>
-      {canFork ? (
-        <MessageAction
-          label="Fork from this message"
-          tooltip="Start a new chat from this message"
-          onPress={() => onRequest({ mode: "fork", messageId, role })}
-        >
-          <Icon svg={<Icons.GitBranchOutline />} />
-        </MessageAction>
-      ) : null}
-    </>
+      <MenuContainer placement="bottom end" minHeight="auto">
+        <Menu onAction={handleAction}>
+          {showRewind ? (
+            <MenuItem
+              id="rewind"
+              leadingContent={<Icon svg={<Icons.RotateCcwOutline />} />}
+            >
+              {role === "user"
+                ? "Rewind to this message"
+                : "Rewind to this response"}
+            </MenuItem>
+          ) : null}
+          {canFork ? (
+            <MenuItem
+              id="fork"
+              leadingContent={<Icon svg={<Icons.GitBranchOutline />} />}
+            >
+              Fork from this message
+            </MenuItem>
+          ) : null}
+        </Menu>
+      </MenuContainer>
+    </MenuTrigger>
   );
 }

--- a/app/src/components/agent/MessageRewindActions.tsx
+++ b/app/src/components/agent/MessageRewindActions.tsx
@@ -1,0 +1,62 @@
+import { Icon, Icons } from "@phoenix/components";
+import { MessageAction } from "@phoenix/components/ai/message";
+import { useAgentContext } from "@phoenix/contexts/AgentContext";
+
+import type {
+  MessageRewindMode,
+  MessageRewindRole,
+} from "./MessageRewindDialog";
+
+/**
+ * Rewind (and, when session storage is enabled, fork) controls rendered under a
+ * user or assistant message. Renders bare {@link MessageAction} buttons so
+ * callers can place them inside an existing `MessageActions` row.
+ *
+ * Pressing a control reports the requested action and the target message up to
+ * the chat view via `onRequest`, which owns the single confirmation dialog. The
+ * dialog is intentionally NOT rendered here: mounting a React Aria modal inside
+ * the scroll-managed message list triggers a remount loop with the
+ * stick-to-bottom observers, so the overlay must live outside the list.
+ */
+export function MessageRewindActions({
+  messageId,
+  role,
+  onRequest,
+}: {
+  messageId: string;
+  role: MessageRewindRole;
+  onRequest: (request: {
+    mode: MessageRewindMode;
+    messageId: string;
+    role: MessageRewindRole;
+  }) => void;
+}) {
+  const canFork = useAgentContext(
+    (state) => state.capabilities["session.storeSessions"]
+  );
+
+  return (
+    <>
+      <MessageAction
+        label="Rewind to this message"
+        tooltip={
+          role === "user"
+            ? "Undo the chat to this message and restore it to the input"
+            : "Undo the chat back to this response"
+        }
+        onPress={() => onRequest({ mode: "rewind", messageId, role })}
+      >
+        <Icon svg={<Icons.RotateCcwOutline />} />
+      </MessageAction>
+      {canFork ? (
+        <MessageAction
+          label="Fork from this message"
+          tooltip="Start a new chat from this message"
+          onPress={() => onRequest({ mode: "fork", messageId, role })}
+        >
+          <Icon svg={<Icons.GitBranchOutline />} />
+        </MessageAction>
+      ) : null}
+    </>
+  );
+}

--- a/app/src/components/agent/MessageRewindDialog.tsx
+++ b/app/src/components/agent/MessageRewindDialog.tsx
@@ -1,0 +1,119 @@
+import { css } from "@emotion/react";
+
+import { Button, Flex, Text } from "@phoenix/components";
+
+/** Which action the confirmation is gating. */
+export type MessageRewindMode = "rewind" | "fork";
+
+/** Whose message the action targets, which changes the explanatory copy. */
+export type MessageRewindRole = "user" | "assistant";
+
+type ConfirmationCopy = {
+  title: string;
+  description: string;
+  confirmLabel: string;
+};
+
+/**
+ * Resolves the title/description/confirm-label from the action mode and the
+ * target message's role. User-targeted actions explain that the message is
+ * restored to the input for editing; assistant-targeted actions explain that
+ * the conversation reverts to that response.
+ */
+function getConfirmationCopy({
+  mode,
+  role,
+}: {
+  mode: MessageRewindMode;
+  role: MessageRewindRole;
+}): ConfirmationCopy {
+  if (mode === "fork") {
+    return {
+      title: "Fork conversation",
+      description:
+        role === "user"
+          ? "Create a new chat from this point. This message is removed from the new chat and placed back in the input so you can edit and re-send it. The current chat is left unchanged."
+          : "Create a new chat that ends at this response. The current chat is left unchanged.",
+      confirmLabel: "Fork conversation",
+    };
+  }
+  return {
+    title: "Rewind conversation",
+    description:
+      role === "user"
+        ? "Remove this message and everything after it, and place it back in the input so you can edit and re-send it. This cannot be undone."
+        : "Revert the chat to this response and discard everything after it, including any pending tool calls. This cannot be undone.",
+    confirmLabel: "Rewind conversation",
+  };
+}
+
+const confirmationCSS = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-size-200);
+  padding: var(--global-dimension-size-200);
+`;
+
+const confirmationHeaderCSS = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-size-100);
+`;
+
+const confirmationActionsCSS = css`
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--global-dimension-size-100);
+  flex-wrap: wrap;
+`;
+
+/**
+ * Inline confirmation shown in place of the prompt input before rewinding or
+ * forking a conversation at a chosen message.
+ *
+ * This is intentionally an inline panel rather than a React Aria modal. Opening
+ * a modal flips the app's global open-modal observer, which re-parents the
+ * agent chat panel between its docked and floating layouts; a modal owned by
+ * the panel would be torn down the instant it opened, looping forever. An
+ * inline confirmation keeps the interaction scoped to the panel and avoids that
+ * feedback entirely, mirroring the consent gate and elicitation surfaces.
+ */
+export function MessageRewindConfirmation({
+  mode,
+  role,
+  onConfirm,
+  onCancel,
+}: {
+  mode: MessageRewindMode;
+  role: MessageRewindRole;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const { title, description, confirmLabel } = getConfirmationCopy({
+    mode,
+    role,
+  });
+
+  return (
+    <div css={confirmationCSS} role="alertdialog" aria-label={title}>
+      <div css={confirmationHeaderCSS}>
+        <Text elementType="h3" size="L" weight="heavy">
+          {title}
+        </Text>
+        <Text color="text-700">{description}</Text>
+      </div>
+      <Flex direction="row" css={confirmationActionsCSS}>
+        <Button variant="default" size="S" onPress={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          variant={mode === "rewind" ? "danger" : "primary"}
+          size="S"
+          onPress={onConfirm}
+        >
+          {confirmLabel}
+        </Button>
+      </Flex>
+    </div>
+  );
+}

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -279,7 +279,13 @@ export function useAgentChat({
   // or fork, so stale Accept/Reject affordances don't dangle against tool calls
   // the transcript no longer contains.
   const clearDroppedToolState = useCallback(
-    ({ previous, next }: { previous: AgentUIMessage[]; next: AgentUIMessage[] }) => {
+    ({
+      previous,
+      next,
+    }: {
+      previous: AgentUIMessage[];
+      next: AgentUIMessage[];
+    }) => {
       if (!sessionId) {
         return;
       }

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -1,11 +1,12 @@
 import { Chat, useChat } from "@ai-sdk/react";
 import type { ChatStatus } from "ai";
-import { DefaultChatTransport, isToolUIPart } from "ai";
-import { useEffect, useRef } from "react";
+import { DefaultChatTransport, getToolName, isToolUIPart } from "ai";
+import { useCallback, useEffect, useRef } from "react";
 
 import { buildAgentChatRequestBody } from "@phoenix/agent/chat/buildAgentChatRequestBody";
 import { handleAgentToolCall } from "@phoenix/agent/chat/handleAgentToolCall";
 import { getUnresolvedToolCalls } from "@phoenix/agent/chat/interruptToolCalls";
+import { rewindMessages } from "@phoenix/agent/chat/rewindMessages";
 import {
   shouldSendAutomaticallyAfterToolOutput,
   SYSTEM_INTERRUPT_ERROR,
@@ -274,6 +275,88 @@ export function useAgentChat({
     store.getState().setPendingElicitation(sessionId, null);
   };
 
+  // Releases approval/elicitation state owned by tool calls dropped by a rewind
+  // or fork, so stale Accept/Reject affordances don't dangle against tool calls
+  // the transcript no longer contains.
+  const clearDroppedToolState = useCallback(
+    ({ previous, next }: { previous: AgentUIMessage[]; next: AgentUIMessage[] }) => {
+      if (!sessionId) {
+        return;
+      }
+      const retained = new Set(
+        next.flatMap((message) =>
+          message.parts.filter(isToolUIPart).map((part) => part.toolCallId)
+        )
+      );
+      const state = store.getState();
+      for (const message of previous) {
+        for (const part of message.parts) {
+          if (!isToolUIPart(part) || retained.has(part.toolCallId)) {
+            continue;
+          }
+          const toolName = getToolName(part);
+          if (toolName === EDIT_PROMPT_TOOL_NAME) {
+            state.setPendingPromptEdit(part.toolCallId, null);
+          } else if (toolName === BATCH_SPAN_ANNOTATE_TOOL_NAME) {
+            state.setPendingBatchSpanAnnotate(part.toolCallId, null);
+          } else if (pendingElicitation?.toolCallId === part.toolCallId) {
+            state.setPendingElicitation(sessionId, null);
+          }
+        }
+      }
+    },
+    [pendingElicitation, sessionId, store]
+  );
+
+  // Rewinds the active session in place to the chosen message, truncating the
+  // transcript and releasing stale tool state. Returns the user message text to
+  // restore into the input (user target) or null (assistant target / no-op).
+  const rewindToMessage = useCallback(
+    (messageId: string): string | null => {
+      if (!sessionId || !chatInstance || isRequestActive(chatInstance.status)) {
+        return null;
+      }
+      const result = rewindMessages({
+        messages: chatInstance.messages,
+        messageId,
+      });
+      if (!result) {
+        return null;
+      }
+      clearDroppedToolState({
+        previous: chatInstance.messages,
+        next: result.messages,
+      });
+      setMessages(result.messages);
+      store.getState().setSessionMessages(sessionId, result.messages);
+      return result.restoredInput;
+    },
+    [chatInstance, clearDroppedToolState, sessionId, setMessages, store]
+  );
+
+  // Forks the active session into a new session truncated to the chosen
+  // message, leaving the current session untouched. Returns the new session id.
+  const forkFromMessage = useCallback(
+    (messageId: string): string | null => {
+      if (!sessionId || !chatInstance) {
+        return null;
+      }
+      const result = rewindMessages({
+        messages: chatInstance.messages,
+        messageId,
+      });
+      if (!result) {
+        return null;
+      }
+      return store.getState().forkSession({
+        sourceSessionId: sessionId,
+        messages: result.messages,
+        restoredInput: result.restoredInput,
+      });
+    },
+    [chatInstance, sessionId, store]
+  );
+
   return {
     messages,
     sendMessage: handleSendMessage,
@@ -283,6 +366,8 @@ export function useAgentChat({
     pendingElicitation,
     handleElicitationSubmit,
     handleElicitationCancel,
+    rewindToMessage,
+    forkFromMessage,
   } as {
     messages: AgentUIMessage[];
     sendMessage: (message: { text: string }) => void;
@@ -292,6 +377,8 @@ export function useAgentChat({
     pendingElicitation: PendingElicitation | null;
     handleElicitationSubmit: (output: ElicitToolOutput) => void;
     handleElicitationCancel: () => void;
+    rewindToMessage: (messageId: string) => string | null;
+    forkFromMessage: (messageId: string) => string | null;
   };
 }
 

--- a/app/src/components/ai/message/styles.ts
+++ b/app/src/components/ai/message/styles.ts
@@ -116,6 +116,30 @@ export const messageToolbarCSS = css`
   gap: var(--global-dimension-size-100);
   padding-top: var(--global-dimension-size-50);
   width: 100%;
+
+  /* Reveal-on-interaction: keep per-message action toolbars hidden by default
+     to reduce the persistent visual noise of stacked toolbars, and reveal them
+     when the message is hovered or contains keyboard focus. A message can opt
+     out (always show) via [data-pin-toolbar="true"] on the Message root — used
+     for the most recent assistant turn. */
+  opacity: 0;
+  transition: opacity 0.12s ease;
+
+  [data-from]:hover > &,
+  [data-from]:focus-within > &,
+  [data-pin-toolbar="true"] > & {
+    opacity: 1;
+  }
+
+  @media (hover: none) {
+    /* Touch devices have no hover; keep toolbars visible so the actions remain
+       reachable. */
+    opacity: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 `;
 
 // ---------------------------------------------------------------------------

--- a/app/src/components/ai/message/styles.ts
+++ b/app/src/components/ai/message/styles.ts
@@ -131,6 +131,15 @@ export const messageToolbarCSS = css`
     opacity: 1;
   }
 
+  /* Keep the toolbar visible while one of its actions has an open menu/popover.
+     The popover is portaled out of the message and takes focus with it, so
+     :hover and :focus-within on the message both drop — but the trigger button
+     keeps aria-expanded set, so the toolbar anchoring the open menu stays put
+     instead of fading out from under it. */
+  &:has([aria-expanded="true"]) {
+    opacity: 1;
+  }
+
   @media (hover: none) {
     /* Touch devices have no hover; keep toolbars visible so the actions remain
        reachable. */

--- a/app/src/components/core/icon/Icons.tsx
+++ b/app/src/components/core/icon/Icons.tsx
@@ -1957,6 +1957,23 @@ export const QuestionOutline = () => (
   </svg>
 );
 
+export const RotateCcwOutline = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" fill="none" />
+    <path d="M3 3v5h5" fill="none" />
+  </svg>
+);
+
 export const Refresh = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g data-name="Layer 2">

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -144,6 +144,158 @@ describe("agentStore", () => {
     });
   });
 
+  describe("forkSession", () => {
+    it("creates a new active session retaining the source session", () => {
+      const store = createAgentStore();
+      store.getState().setCapability({
+        key: "session.storeSessions",
+        enabled: true,
+      });
+      const sourceId = store.getState().createSession();
+      const messages = [
+        { id: "user-1", role: "user" as const, parts: [] },
+      ];
+
+      const forkId = store.getState().forkSession({
+        sourceSessionId: sourceId,
+        messages,
+      });
+
+      expect(forkId).not.toBeNull();
+      const state = store.getState();
+      expect(state.activeSessionId).toBe(forkId);
+      // Source session is preserved alongside the fork.
+      expect(state.sessionMap[sourceId]).toBeDefined();
+      expect(state.sessionMap[forkId!].messages).toEqual(messages);
+    });
+
+    it("copies the source session's model config and context", () => {
+      const store = createAgentStore();
+      const sourceId = store.getState().createSession();
+      store
+        .getState()
+        .updateSessionModelConfig(sourceId, { modelName: "gpt-4o" });
+      store.getState().addSessionContext(sourceId, "span:123");
+
+      const forkId = store.getState().forkSession({
+        sourceSessionId: sourceId,
+        messages: [],
+      });
+
+      const forked = store.getState().sessionMap[forkId!];
+      expect(forked.modelConfig.modelName).toBe("gpt-4o");
+      expect(forked.context).toEqual(["span:123"]);
+    });
+
+    it("stages restored input for the forked session", () => {
+      const store = createAgentStore();
+      const sourceId = store.getState().createSession();
+
+      const forkId = store.getState().forkSession({
+        sourceSessionId: sourceId,
+        messages: [],
+        restoredInput: "edit me",
+      });
+
+      expect(store.getState().consumePendingInput(forkId!)).toBe("edit me");
+      // Consuming clears the staged input.
+      expect(store.getState().consumePendingInput(forkId!)).toBeNull();
+    });
+
+    it("prefixes the source summary with (fork)", () => {
+      const store = createAgentStore();
+      const sourceId = store.getState().createSession();
+      store.getState().updateSessionSummary(sourceId, "Debugging traces");
+
+      const forkId = store.getState().forkSession({
+        sourceSessionId: sourceId,
+        messages: [],
+      });
+
+      expect(store.getState().sessionMap[forkId!].shortSummary).toBe(
+        "(fork) Debugging traces"
+      );
+    });
+
+    it("derives the fork summary from the first user message when unsummarized", () => {
+      const store = createAgentStore();
+      const sourceId = store.getState().createSession();
+
+      const forkId = store.getState().forkSession({
+        sourceSessionId: sourceId,
+        messages: [
+          {
+            id: "user-1",
+            role: "user" as const,
+            parts: [{ type: "text" as const, text: "How do I trace OpenAI?" }],
+          },
+        ],
+      });
+
+      // The source session still has the messages too (fork copies them), but
+      // here we assert the fork derives its own label from its messages.
+      store.getState().setSessionMessages(sourceId, [
+        {
+          id: "user-1",
+          role: "user",
+          parts: [{ type: "text", text: "How do I trace OpenAI?" }],
+        },
+      ]);
+      const refork = store.getState().forkSession({
+        sourceSessionId: sourceId,
+        messages: [],
+      });
+      expect(store.getState().sessionMap[refork!].shortSummary).toBe(
+        "(fork) How do I trace OpenAI?"
+      );
+      expect(forkId).not.toBeNull();
+    });
+
+    it("does not stack the (fork) prefix when forking a fork", () => {
+      const store = createAgentStore();
+      const sourceId = store.getState().createSession();
+      store.getState().updateSessionSummary(sourceId, "(fork) Original");
+
+      const forkId = store.getState().forkSession({
+        sourceSessionId: sourceId,
+        messages: [],
+      });
+
+      expect(store.getState().sessionMap[forkId!].shortSummary).toBe(
+        "(fork) Original"
+      );
+    });
+
+    it("returns null and no-ops for an unknown source session", () => {
+      const store = createAgentStore();
+      const before = store.getState().sessions;
+
+      const forkId = store.getState().forkSession({
+        sourceSessionId: "missing",
+        messages: [],
+      });
+
+      expect(forkId).toBeNull();
+      expect(store.getState().sessions).toBe(before);
+    });
+  });
+
+  describe("pending input", () => {
+    it("sets and consumes pending input once", () => {
+      const store = createAgentStore();
+      store.getState().setPendingInput("session-1", "hello");
+      expect(store.getState().consumePendingInput("session-1")).toBe("hello");
+      expect(store.getState().consumePendingInput("session-1")).toBeNull();
+    });
+
+    it("clears pending input when set to null", () => {
+      const store = createAgentStore();
+      store.getState().setPendingInput("session-1", "hello");
+      store.getState().setPendingInput("session-1", null);
+      expect(store.getState().consumePendingInput("session-1")).toBeNull();
+    });
+  });
+
   describe("toggleOpen", () => {
     it("toggles isOpen", () => {
       const store = createAgentStore();

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -152,9 +152,7 @@ describe("agentStore", () => {
         enabled: true,
       });
       const sourceId = store.getState().createSession();
-      const messages = [
-        { id: "user-1", role: "user" as const, parts: [] },
-      ];
+      const messages = [{ id: "user-1", role: "user" as const, parts: [] }];
 
       const forkId = store.getState().forkSession({
         sourceSessionId: sourceId,

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -1,4 +1,4 @@
-import type { ChatStatus } from "ai";
+import { isTextUIPart, type ChatStatus } from "ai";
 import type { StateCreator } from "zustand";
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
@@ -141,6 +141,42 @@ const DEFAULT_AGENT_PERMISSIONS: AgentPermissions = {
 
 const MAX_STORED_AGENT_SESSIONS = 3;
 
+/** Prefix applied to a forked session's summary to denote its origin. */
+const FORK_SUMMARY_PREFIX = "(fork) ";
+
+/** Max length for a derived (non-LLM) fork summary before truncation. */
+const FORK_SUMMARY_MAX_LENGTH = 50;
+
+/**
+ * Builds the summary for a session forked from `source`. Reuses the source's
+ * LLM-generated summary when available, otherwise derives a short label from
+ * its first user message, then prefixes it with `(fork)`. Seeding a non-empty
+ * summary here also prevents the async summarizer from overwriting it.
+ */
+function buildForkSummary(source: AgentSession): string {
+  let base = source.shortSummary.trim();
+  if (!base) {
+    const firstUserMessage = source.messages.find(
+      (message) => message.role === "user"
+    );
+    const text = firstUserMessage?.parts
+      .filter(isTextUIPart)
+      .map((part) => part.text)
+      .join(" ")
+      .trim();
+    base = text
+      ? text.length > FORK_SUMMARY_MAX_LENGTH
+        ? `${text.slice(0, FORK_SUMMARY_MAX_LENGTH)}...`
+        : text
+      : "";
+  }
+  // Avoid stacking "(fork) (fork) ..." when forking a fork.
+  if (base.startsWith(FORK_SUMMARY_PREFIX)) {
+    return base;
+  }
+  return base ? `${FORK_SUMMARY_PREFIX}${base}` : FORK_SUMMARY_PREFIX.trim();
+}
+
 /**
  * Serializable properties that define the agent's state.
  * These are the values persisted to local storage.
@@ -181,6 +217,11 @@ export interface AgentState extends AgentProps {
   setFabPlacement: (placement: AgentFabPlacement) => void;
   createSession: () => string;
   deleteSession: (sessionId: string) => void;
+  forkSession: (params: {
+    sourceSessionId: string;
+    messages: AgentUIMessage[];
+    restoredInput?: string | null;
+  }) => string | null;
   setActiveSession: (sessionId: string | null) => void;
   updateSessionSummary: (sessionId: string, summary: string) => void;
   updateSessionModelConfig: (
@@ -214,6 +255,16 @@ export interface AgentState extends AgentProps {
   ) => void;
   chatStatusBySessionId: Record<string, ChatStatus>;
   setSessionChatStatus: (sessionId: string, status: ChatStatus) => void;
+
+  /**
+   * Prompt-input text staged for a session that has not yet (re)mounted its
+   * chat view. Used when forking from a user message: the new session opens
+   * with the rewound user message restored into the input so it can be edited
+   * and re-sent. Ephemeral and consumed once by the view on mount.
+   */
+  pendingInputBySessionId: Record<string, string>;
+  setPendingInput: (sessionId: string, input: string | null) => void;
+  consumePendingInput: (sessionId: string) => string | null;
   setSessionUsage: (
     sessionId: string,
     newUsage: {
@@ -322,6 +373,7 @@ function buildSessionRetentionPatch({
   | "sessionMap"
   | "pendingElicitationBySessionId"
   | "chatStatusBySessionId"
+  | "pendingInputBySessionId"
 > {
   const retainedSessionIdSet = new Set(retainedSessionIds);
   return {
@@ -337,6 +389,10 @@ function buildSessionRetentionPatch({
     }),
     chatStatusBySessionId: pruneSessionScopedRecord({
       record: state.chatStatusBySessionId,
+      retainedSessionIds: retainedSessionIdSet,
+    }),
+    pendingInputBySessionId: pruneSessionScopedRecord({
+      record: state.pendingInputBySessionId,
       retainedSessionIds: retainedSessionIdSet,
     }),
   };
@@ -355,7 +411,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
   const agentStore: StateCreator<
     AgentState,
     [["zustand/devtools", unknown]]
-  > = (set) => ({
+  > = (set, get) => ({
     isOpen: false,
     position: "pinned",
     fabPlacement: "bottom-end",
@@ -422,6 +478,50 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
       );
       return sessionId;
     },
+    forkSession: ({ sourceSessionId, messages, restoredInput }) => {
+      const sessionId = generateUUID();
+      let created = false;
+      set(
+        (state) => {
+          const source = state.sessionMap[sourceSessionId];
+          if (!source) return state;
+          created = true;
+          const session: AgentSession = {
+            id: sessionId,
+            shortSummary: buildForkSummary(source),
+            messages,
+            // Carry over the source session's context and model so the fork
+            // continues the same conversation under the same configuration.
+            context: [...source.context],
+            modelConfig: { ...source.modelConfig },
+            createdAt: Date.now(),
+          };
+          // Forking always retains the source session alongside the new one;
+          // the standard retention rule then trims to the most recent few.
+          const nextSessionIds = [...state.sessions, sessionId].slice(
+            -MAX_STORED_AGENT_SESSIONS
+          );
+          const pendingInputBySessionId = { ...state.pendingInputBySessionId };
+          if (restoredInput) {
+            pendingInputBySessionId[sessionId] = restoredInput;
+          }
+          return {
+            ...buildSessionRetentionPatch({
+              state: {
+                ...state,
+                sessionMap: { ...state.sessionMap, [sessionId]: session },
+              },
+              retainedSessionIds: nextSessionIds,
+              activeSessionId: sessionId,
+            }),
+            pendingInputBySessionId,
+          };
+        },
+        false,
+        { type: "forkSession" }
+      );
+      return created ? sessionId : null;
+    },
     deleteSession: (sessionId) => {
       set(
         (state) => {
@@ -435,6 +535,10 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
           delete newPendingElicitationBySessionId[sessionId];
           const newChatStatusBySessionId = { ...state.chatStatusBySessionId };
           delete newChatStatusBySessionId[sessionId];
+          const newPendingInputBySessionId = {
+            ...state.pendingInputBySessionId,
+          };
+          delete newPendingInputBySessionId[sessionId];
           const newSessions = state.sessions.filter((id) => id !== sessionId);
           const newActiveSessionId =
             state.activeSessionId === sessionId
@@ -446,6 +550,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
             activeSessionId: newActiveSessionId,
             pendingElicitationBySessionId: newPendingElicitationBySessionId,
             chatStatusBySessionId: newChatStatusBySessionId,
+            pendingInputBySessionId: newPendingInputBySessionId,
           };
         },
         false,
@@ -587,6 +692,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
           sessionMap: {},
           pendingElicitationBySessionId: {},
           chatStatusBySessionId: {},
+          pendingInputBySessionId: {},
         },
         false,
         { type: "clearAllSessions" }
@@ -631,6 +737,41 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         false,
         { type: "setPendingElicitation" }
       );
+    },
+
+    pendingInputBySessionId: {},
+    setPendingInput: (sessionId, input) => {
+      set(
+        (state) => {
+          const next = { ...state.pendingInputBySessionId };
+          if (input) {
+            next[sessionId] = input;
+          } else {
+            delete next[sessionId];
+          }
+          return { pendingInputBySessionId: next };
+        },
+        false,
+        { type: "setPendingInput" }
+      );
+    },
+    consumePendingInput: (sessionId) => {
+      const input = get().pendingInputBySessionId[sessionId] ?? null;
+      if (input != null) {
+        set(
+          (state) => {
+            if (!(sessionId in state.pendingInputBySessionId)) {
+              return state;
+            }
+            const next = { ...state.pendingInputBySessionId };
+            delete next[sessionId];
+            return { pendingInputBySessionId: next };
+          },
+          false,
+          { type: "consumePendingInput" }
+        );
+      }
+      return input;
     },
 
     chatStatusBySessionId: {},


### PR DESCRIPTION
## Summary

UX improvements to the in-app PXI chat message controls.

- **Rewind** — appears under user and assistant messages. Opens an inline confirmation before truncating the conversation. Rewinding to an assistant message reverts to that response and clears pending tool calls; rewinding to a user message removes it and everything after, restoring its text to the prompt input for editing/re-sending.
- **Fork** — appears when the "store recent sessions" capability is enabled. Branches a new session from the chosen message, leaving the current session unchanged. Forked sessions are summarized as `(fork) <source summary>`.
- **Copy** — every message (user and assistant) now has a copy button using the app-wide affordance (duplicate glyph → success checkmark).
- **Reduced clutter** — per-message toolbars are hidden by default and revealed on hover/focus; the most recent assistant turn stays pinned. Touch devices keep toolbars visible.

https://github.com/user-attachments/assets/9c4cf89c-594d-4c9b-89f9-2682b38da7d2


## Implementation notes

- The rewind/fork confirmation is rendered inline (not a React Aria modal) because opening a modal flips the global open-modal observer, which re-parents the agent panel between its docked and floating layouts and would tear the confirmation down in a loop.
- Truncation logic lives in a shared, unit-tested `rewindMessages` helper; fork retention/summary live in the agent store.
- Added a `RotateCcwOutline` undo icon (distinct from the clock-style history icon).

## Testing

- `make typecheck-frontend` / `make lint-frontend` pass.
- Added unit tests for `rewindMessages` and the store `forkSession`/fork-summary behavior.
- Verified all flows live (rewind user/assistant, fork, copy, hover-reveal) with agent-browser.