### PR TITLE
fix: clarify empty span annotation tool input

### DIFF
--- a/app/src/agent/extensions/__tests__/toolRegistry.test.ts
+++ b/app/src/agent/extensions/__tests__/toolRegistry.test.ts
@@ -1,5 +1,6 @@
 import { installTestStorage } from "@phoenix/__tests__/installTestStorage";
 import { handleRegisteredAgentToolCall } from "@phoenix/agent/extensions/toolRegistry";
+import { BATCH_SPAN_ANNOTATE_TOOL_NAME } from "@phoenix/agent/tools/batchSpanAnnotate";
 import { SET_PLAYGROUND_EXPERIMENT_RECORDING_TOOL_NAME } from "@phoenix/agent/tools/playgroundExperimentRecording";
 import { SET_PLAYGROUND_REPETITIONS_TOOL_NAME } from "@phoenix/agent/tools/playgroundRepetitions";
 import {
@@ -83,6 +84,31 @@ describe("toolRegistry", () => {
         tool: "ask_user",
         toolCallId: "tool-call-2",
         errorText: expect.any(String),
+      })
+    );
+  });
+
+  it("tells the agent how to recover from an empty batch span annotation call", async () => {
+    const store = createAgentStore();
+    const addToolOutput = vi.fn().mockResolvedValue(undefined);
+
+    await handleRegisteredAgentToolCall({
+      toolCall: {
+        toolCallId: "tool-call-empty-batch-annotation",
+        toolName: BATCH_SPAN_ANNOTATE_TOOL_NAME,
+        input: {},
+      },
+      sessionId: "session-1",
+      addToolOutput,
+      agentStore: store,
+    });
+
+    expect(addToolOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: "output-error",
+        tool: BATCH_SPAN_ANNOTATE_TOOL_NAME,
+        toolCallId: "tool-call-empty-batch-annotation",
+        errorText: expect.stringContaining("needs an annotations array"),
       })
     );
   });

--- a/app/src/agent/extensions/__tests__/toolRegistry.test.ts
+++ b/app/src/agent/extensions/__tests__/toolRegistry.test.ts
@@ -88,15 +88,50 @@ describe("toolRegistry", () => {
     );
   });
 
-  it("tells the agent how to recover from an empty batch span annotation call", async () => {
+  it.each([
+    ["an empty object", {}],
+    ["an empty annotations array", { annotations: [] }],
+    ["a null annotations array", { annotations: null }],
+    ["an array of empty annotations", { annotations: [{}] }],
+    ["a bare empty array", []],
+    ["no input at all", undefined],
+  ])(
+    "tells the agent how to recover from a batch span annotation call with %s",
+    async (_description, input) => {
+      const store = createAgentStore();
+      const addToolOutput = vi.fn().mockResolvedValue(undefined);
+
+      await handleRegisteredAgentToolCall({
+        toolCall: {
+          toolCallId: "tool-call-empty-batch-annotation",
+          toolName: BATCH_SPAN_ANNOTATE_TOOL_NAME,
+          input,
+        },
+        sessionId: "session-1",
+        addToolOutput,
+        agentStore: store,
+      });
+
+      expect(addToolOutput).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: "output-error",
+          tool: BATCH_SPAN_ANNOTATE_TOOL_NAME,
+          toolCallId: "tool-call-empty-batch-annotation",
+          errorText: expect.stringContaining("needs an annotations array"),
+        })
+      );
+    }
+  );
+
+  it("restates the full schema when a batch span annotation call has real but invalid annotations", async () => {
     const store = createAgentStore();
     const addToolOutput = vi.fn().mockResolvedValue(undefined);
 
     await handleRegisteredAgentToolCall({
       toolCall: {
-        toolCallId: "tool-call-empty-batch-annotation",
+        toolCallId: "tool-call-invalid-batch-annotation",
         toolName: BATCH_SPAN_ANNOTATE_TOOL_NAME,
-        input: {},
+        input: { annotations: [{ name: "quality" }] },
       },
       sessionId: "session-1",
       addToolOutput,
@@ -107,8 +142,8 @@ describe("toolRegistry", () => {
       expect.objectContaining({
         state: "output-error",
         tool: BATCH_SPAN_ANNOTATE_TOOL_NAME,
-        toolCallId: "tool-call-empty-batch-annotation",
-        errorText: expect.stringContaining("needs an annotations array"),
+        toolCallId: "tool-call-invalid-batch-annotation",
+        errorText: expect.stringContaining("Invalid"),
       })
     );
   });

--- a/app/src/agent/tools/batchSpanAnnotate/batchSpanAnnotateAgentTool.ts
+++ b/app/src/agent/tools/batchSpanAnnotate/batchSpanAnnotateAgentTool.ts
@@ -1,5 +1,6 @@
 import { defineTool } from "@phoenix/agent/extensions/registry/defineTool";
 import { requireToolSession } from "@phoenix/agent/extensions/registry/requireToolSession";
+import { isPlainObject } from "@phoenix/utils/jsonUtils";
 
 import { applySpanAnnotations } from "./applySpanAnnotations";
 import { BATCH_SPAN_ANNOTATE_TOOL_NAME } from "./constants";
@@ -18,7 +19,10 @@ import type {
 export const batchSpanAnnotateAgentTool = defineTool<BatchSpanAnnotateInput>({
   name: BATCH_SPAN_ANNOTATE_TOOL_NAME,
   parseInput: parseBatchSpanAnnotateInput,
-  invalidInputErrorText: `Invalid ${BATCH_SPAN_ANNOTATE_TOOL_NAME} input. Expected { annotations: { spanId?: string, spanNodeId?: string, name: string, annotatorKind?: "LLM" | "HUMAN" | "CODE", label?: string | null, score?: number | null, explanation?: string | null, identifier?: string | null, metadata?: object | null }[] }. Each annotation requires exactly one of spanId or spanNodeId, a non-reserved name, and at least one of label, score, or explanation.`,
+  invalidInputErrorText: (input) =>
+    isPlainObject(input) && Object.keys(input).length === 0
+      ? `${BATCH_SPAN_ANNOTATE_TOOL_NAME} needs an annotations array. Call it with { annotations: [{ spanId or spanNodeId, name, and at least one of label, score, or explanation }] }. Do not call this tool until you have a real span id and annotation value.`
+      : `Invalid ${BATCH_SPAN_ANNOTATE_TOOL_NAME} input. Expected { annotations: { spanId?: string, spanNodeId?: string, name: string, annotatorKind?: "LLM" | "HUMAN" | "CODE", label?: string | null, score?: number | null, explanation?: string | null, identifier?: string | null, metadata?: object | null }[] }. Each annotation requires exactly one of spanId or spanNodeId, a non-reserved name, and at least one of label, score, or explanation.`,
   uiBehavior: {
     autoOpen: true,
     scrollIntoViewOnMount: true,

--- a/app/src/agent/tools/batchSpanAnnotate/batchSpanAnnotateAgentTool.ts
+++ b/app/src/agent/tools/batchSpanAnnotate/batchSpanAnnotateAgentTool.ts
@@ -12,6 +12,34 @@ import type {
 } from "./types";
 
 /**
+ * An annotation entry carries no proposal when it is absent or has no fields.
+ */
+function isEmptyAnnotationEntry(entry: unknown): boolean {
+  return (
+    entry == null || (isPlainObject(entry) && Object.keys(entry).length === 0)
+  );
+}
+
+/**
+ * Recognizes the payload shapes an agent sends when it calls the tool with
+ * nothing to annotate: a missing or empty wrapper object, a missing or empty
+ * `annotations` array, a bare array, or an array whose entries are all empty.
+ * These get the recovery instruction rather than the full schema restatement,
+ * which the model reads as a prompt to retry with an equally empty payload.
+ */
+function isEmptyBatchSpanAnnotateInput(input: unknown): boolean {
+  if (input == null) return true;
+  if (Array.isArray(input)) return input.every(isEmptyAnnotationEntry);
+  if (!isPlainObject(input)) return false;
+  if (Object.keys(input).length === 0) return true;
+  const { annotations } = input;
+  if (annotations == null) return true;
+  return (
+    Array.isArray(annotations) && annotations.every(isEmptyAnnotationEntry)
+  );
+}
+
+/**
  * Proposes a batch of span annotations as a pending change. Auto-applies when
  * edit approvals are bypassed; otherwise stores the proposal for the UI to
  * accept or reject. Requires an active session to attribute the change.
@@ -20,7 +48,7 @@ export const batchSpanAnnotateAgentTool = defineTool<BatchSpanAnnotateInput>({
   name: BATCH_SPAN_ANNOTATE_TOOL_NAME,
   parseInput: parseBatchSpanAnnotateInput,
   invalidInputErrorText: (input) =>
-    isPlainObject(input) && Object.keys(input).length === 0
+    isEmptyBatchSpanAnnotateInput(input)
       ? `${BATCH_SPAN_ANNOTATE_TOOL_NAME} needs an annotations array. Call it with { annotations: [{ spanId or spanNodeId, name, and at least one of label, score, or explanation }] }. Do not call this tool until you have a real span id and annotation value.`
       : `Invalid ${BATCH_SPAN_ANNOTATE_TOOL_NAME} input. Expected { annotations: { spanId?: string, spanNodeId?: string, name: string, annotatorKind?: "LLM" | "HUMAN" | "CODE", label?: string | null, score?: number | null, explanation?: string | null, identifier?: string | null, metadata?: object | null }[] }. Each annotation requires exactly one of spanId or spanNodeId, a non-reserved name, and at least one of label, score, or explanation.`,
   uiBehavior: {


### PR DESCRIPTION
﻿## Summary
- return a shorter recovery message when `batch_span_annotate` is called with `{}`
- keep the stricter parser behavior: empty annotation calls are still rejected
- cover the empty-input path in the frontend tool registry tests

Fixes #13514.

## To verify
- `corepack pnpm exec vitest run src/agent/extensions/__tests__/toolRegistry.test.ts src/agent/tools/batchSpanAnnotate/__tests__/batchSpanAnnotate.test.ts`
- `corepack pnpm exec oxlint src/agent/extensions/toolRegistry.ts src/agent/extensions/__tests__/toolRegistry.test.ts`
- `corepack pnpm exec oxfmt --check --config ../.oxfmtrc.jsonc src/agent/extensions/toolRegistry.ts src/agent/extensions/__tests__/toolRegistry.test.ts`
- `corepack pnpm run typecheck`
