### PR TITLE
feat(agent): make PXI quick actions dynamic per page context

### DIFF
--- a/.agents/skills/phoenix-pxi/SKILL.md
+++ b/.agents/skills/phoenix-pxi/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 Phoenix has a built-in AI assistant named **PXI** (pronounced "pixie"). PXI is the user-facing name for the assistant feature — backend configuration (env vars, project names) uses generic `agents`/`assistant` naming, not "PXI".
 
+**Naming in code: don't write "PXI" in code comments, docstrings, or symbol/variable names.** "PXI" is only the product/brand name for the assistant; in code prose refer to it as "the assistant". Reserve "PXI" for user-facing UI copy and docs. Keep identifiers on the generic `agent`/`assistant` vocabulary already used throughout the codebase (`AgentContext`, `useAgentChat`, etc.).
+
 The model-facing surface (tool definitions, system-prompt assembly, capability guidance) is **server-owned**. The browser is responsible for execution and dispatch only. Adding or editing a PXI tool almost always touches both the server and the frontend; this index spans both layers.
 
 ## Architecture At A Glance

--- a/app/src/agent/quickActions/__tests__/quickActions.test.tsx
+++ b/app/src/agent/quickActions/__tests__/quickActions.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_QUICK_ACTIONS } from "@phoenix/components/agent/ChatEmptyState";
+
+import { buildAgentQuickActions } from "../quickActions";
+
+const labels = (actions: ReturnType<typeof buildAgentQuickActions>) =>
+  actions.map((action) => action.label);
+
+describe("buildAgentQuickActions", () => {
+  it("falls back to the generic defaults when no actionable context is active", () => {
+    expect(buildAgentQuickActions([])).toBe(DEFAULT_QUICK_ACTIONS);
+    // app/graphql/web_access are request-only metadata and contribute nothing.
+    expect(buildAgentQuickActions(["app", "graphql", "web_access"])).toBe(
+      DEFAULT_QUICK_ACTIONS
+    );
+  });
+
+  it("surfaces playground-specific actions on the playground", () => {
+    expect(labels(buildAgentQuickActions(["playground", "app"]))).toEqual([
+      "Enhance the prompt",
+      "Run the playground",
+      "Fill in variables",
+    ]);
+  });
+
+  it("orders the most specific context's actions first", () => {
+    const actions = labels(
+      buildAgentQuickActions(["project", "trace", "span"])
+    );
+    // span (most specific) leads, then trace, then project.
+    expect(actions[0]).toBe("Explain this span");
+    expect(actions).toContain("Explain this trace");
+  });
+
+  it("caps the number of actions and dedupes shared labels", () => {
+    const actions = buildAgentQuickActions(["project", "trace", "span"]);
+    expect(actions.length).toBeLessThanOrEqual(3);
+    expect(new Set(labels(actions)).size).toBe(actions.length);
+  });
+});

--- a/app/src/agent/quickActions/quickActions.tsx
+++ b/app/src/agent/quickActions/quickActions.tsx
@@ -20,7 +20,7 @@ type AgentContextType = AgentContext["type"];
 const MAX_QUICK_ACTIONS = 3;
 
 /**
- * Specificity ranking for the page-level contexts PXI advertises. When several
+ * Specificity ranking for the page-level contexts the assistant advertises. When several
  * contexts are active at once (e.g. a span is selected inside a project), the
  * more specific context's suggestions are surfaced first because they map to
  * the narrowest, most actionable set of tools. Contexts absent from this list
@@ -36,7 +36,7 @@ const CONTEXT_SPECIFICITY: AgentContextType[] = [
 
 /**
  * Quick actions contributed by each page-level agent context. The active set is
- * derived from whatever contexts PXI is currently advertising, so the
+ * derived from whatever contexts the assistant is currently advertising, so the
  * suggestions track the tools available where the user actually is in the UI:
  * the playground exposes prompt/run actions, a project exposes trace triage and
  * filtering, and so on. The tool that backs each prompt is gated server-side by
@@ -155,7 +155,7 @@ function selectActiveContextKey(state: AgentState): string {
 }
 
 /**
- * Quick actions tailored to the agent contexts PXI is currently advertising for
+ * Quick actions tailored to the agent contexts the assistant is currently advertising for
  * the active route/page. Returns the generic defaults when the page advertises
  * no actionable context.
  */

--- a/app/src/agent/quickActions/quickActions.tsx
+++ b/app/src/agent/quickActions/quickActions.tsx
@@ -1,0 +1,167 @@
+import { Icons } from "@phoenix/components";
+import {
+  DEFAULT_QUICK_ACTIONS,
+  type EmptyStateQuickAction,
+} from "@phoenix/components/agent/ChatEmptyState";
+import { useAgentContext } from "@phoenix/contexts/AgentContext";
+import type { AgentState } from "@phoenix/store/agentStore";
+
+import type { AgentContext } from "../context/agentContextTypes";
+import { selectActiveContexts } from "../context/selectors";
+
+type AgentContextType = AgentContext["type"];
+
+/**
+ * Maximum number of quick actions surfaced in the empty state. Page contexts
+ * can contribute more than this between them; we cap so the empty state stays
+ * scannable and keep only the most useful suggestions, drawn from the most
+ * specific context first.
+ */
+const MAX_QUICK_ACTIONS = 3;
+
+/**
+ * Specificity ranking for the page-level contexts PXI advertises. When several
+ * contexts are active at once (e.g. a span is selected inside a project), the
+ * more specific context's suggestions are surfaced first because they map to
+ * the narrowest, most actionable set of tools. Contexts absent from this list
+ * (`app`, `graphql`, `web_access`) are request-only runtime metadata and
+ * contribute no page-level suggestions.
+ */
+const CONTEXT_SPECIFICITY: AgentContextType[] = [
+  "span",
+  "trace",
+  "project",
+  "playground",
+];
+
+/**
+ * Quick actions contributed by each page-level agent context. The active set is
+ * derived from whatever contexts PXI is currently advertising, so the
+ * suggestions track the tools available where the user actually is in the UI:
+ * the playground exposes prompt/run actions, a project exposes trace triage and
+ * filtering, and so on. The tool that backs each prompt is gated server-side by
+ * the same context, so a suggestion only appears when its tools are available.
+ */
+const QUICK_ACTIONS_BY_CONTEXT: Partial<
+  Record<AgentContextType, EmptyStateQuickAction[]>
+> = {
+  playground: [
+    {
+      icon: <Icons.EditOutline />,
+      label: "Enhance the prompt",
+      prompt:
+        "Improve the prompt in the playground to be clearer and more effective.",
+    },
+    {
+      icon: <Icons.PlayCircleOutline />,
+      label: "Run the playground",
+      prompt: "Run the playground and summarize the results.",
+    },
+    {
+      icon: <Icons.Code />,
+      label: "Fill in variables",
+      prompt: "Fill in the playground variables with realistic test values.",
+    },
+  ],
+  project: [
+    {
+      icon: <Icons.Trace />,
+      label: "Find critical issues",
+      prompt: "Find critical issues in my traces.",
+    },
+    {
+      icon: <Icons.FunnelOutline />,
+      label: "Filter to errors",
+      prompt: "Filter the spans to show only the ones with errors.",
+    },
+    {
+      icon: <Icons.SearchOutline />,
+      label: "Search this project",
+      prompt: "Search this project for spans related to a topic I describe.",
+    },
+  ],
+  trace: [
+    {
+      icon: <Icons.BookOutline />,
+      label: "Explain this trace",
+      prompt: "Explain what happened in this trace.",
+    },
+    {
+      icon: <Icons.Trace />,
+      label: "Find what went wrong",
+      prompt: "Find what went wrong in this trace.",
+    },
+  ],
+  span: [
+    {
+      icon: <Icons.BulbOutline />,
+      label: "Explain this span",
+      prompt: "Explain what this span is doing.",
+    },
+    {
+      icon: <Icons.SearchOutline />,
+      label: "Debug this span",
+      prompt: "Help me debug this span.",
+    },
+  ],
+};
+
+/**
+ * Build the quick actions for a set of active page-context types.
+ *
+ * Contexts are visited most-specific first so the narrowest suggestions lead;
+ * actions are deduped by label and capped at {@link MAX_QUICK_ACTIONS}. When no
+ * active context contributes anything, the generic {@link DEFAULT_QUICK_ACTIONS}
+ * are returned so the empty state is never blank.
+ */
+export function buildAgentQuickActions(
+  contextTypes: readonly AgentContextType[]
+): EmptyStateQuickAction[] {
+  const present = new Set(contextTypes);
+  const actions: EmptyStateQuickAction[] = [];
+  const seenLabels = new Set<string>();
+
+  for (const contextType of CONTEXT_SPECIFICITY) {
+    if (!present.has(contextType)) {
+      continue;
+    }
+    for (const action of QUICK_ACTIONS_BY_CONTEXT[contextType] ?? []) {
+      if (seenLabels.has(action.label)) {
+        continue;
+      }
+      seenLabels.add(action.label);
+      actions.push(action);
+      if (actions.length >= MAX_QUICK_ACTIONS) {
+        return actions;
+      }
+    }
+  }
+
+  return actions.length > 0 ? actions : DEFAULT_QUICK_ACTIONS;
+}
+
+/**
+ * Stable, comma-joined key of the distinct active context types. Subscribing to
+ * this string (rather than the context array, which is a fresh reference on
+ * every store update) keeps the chat view from re-rendering on unrelated agent
+ * state changes such as streaming tokens.
+ */
+function selectActiveContextKey(state: AgentState): string {
+  const seen = new Set<AgentContextType>();
+  for (const context of selectActiveContexts(state)) {
+    seen.add(context.type);
+  }
+  return Array.from(seen).sort().join(",");
+}
+
+/**
+ * Quick actions tailored to the agent contexts PXI is currently advertising for
+ * the active route/page. Returns the generic defaults when the page advertises
+ * no actionable context.
+ */
+export function useAgentQuickActions(): EmptyStateQuickAction[] {
+  const contextKey = useAgentContext(selectActiveContextKey);
+  return buildAgentQuickActions(
+    contextKey ? (contextKey.split(",") as AgentContextType[]) : []
+  );
+}

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -386,7 +386,7 @@ export function ChatView({
     [canToggleEditPermission, editPermissionMode, setPermissions]
   );
 
-  // Quick actions track the agent contexts PXI is advertising for the current
+  // Quick actions track the agent contexts the assistant is advertising for the current
   // route, so the empty state suggests what the assistant can actually do here
   // (e.g. run/enhance prompts on the playground). An explicit prop still wins
   // for callers that want a fixed set.

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -11,6 +11,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { useStickToBottom } from "use-stick-to-bottom";
 
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
+import { useAgentQuickActions } from "@phoenix/agent/quickActions/quickActions";
 import type {
   ElicitToolOutput,
   PendingElicitation,
@@ -385,6 +386,13 @@ export function ChatView({
     [canToggleEditPermission, editPermissionMode, setPermissions]
   );
 
+  // Quick actions track the agent contexts PXI is advertising for the current
+  // route, so the empty state suggests what the assistant can actually do here
+  // (e.g. run/enhance prompts on the playground). An explicit prop still wins
+  // for callers that want a fixed set.
+  const contextualQuickActions = useAgentQuickActions();
+  const quickActions = emptyStateQuickActions ?? contextualQuickActions;
+
   const handleQuickAction = (prompt: string) => {
     setInputValue(prompt);
     textareaRef.current?.focus();
@@ -409,7 +417,7 @@ export function ChatView({
                 <ChatEmptyState
                   key={theme}
                   subtext={emptyStateSubtext}
-                  quickActions={emptyStateQuickActions}
+                  quickActions={quickActions}
                   onQuickAction={handleQuickAction}
                 >
                   {missingCredentialsProvider ? (

--- a/app/src/components/agent/ChatEmptyState.tsx
+++ b/app/src/components/agent/ChatEmptyState.tsx
@@ -11,7 +11,13 @@ export type EmptyStateQuickAction = {
   prompt: string;
 };
 
-const DEFAULT_QUICK_ACTIONS: EmptyStateQuickAction[] = [
+/**
+ * Fallback quick actions shown when PXI has no page-specific context to draw
+ * suggestions from (e.g. on a route that advertises no agent context). When a
+ * page does advertise context, {@link useAgentQuickActions} supplies a tailored
+ * set instead.
+ */
+export const DEFAULT_QUICK_ACTIONS: EmptyStateQuickAction[] = [
   {
     icon: <Icons.BulbOutline />,
     label: "How do I use Phoenix?",

--- a/app/src/components/agent/ChatEmptyState.tsx
+++ b/app/src/components/agent/ChatEmptyState.tsx
@@ -12,7 +12,7 @@ export type EmptyStateQuickAction = {
 };
 
 /**
- * Fallback quick actions shown when PXI has no page-specific context to draw
+ * Fallback quick actions shown when the assistant has no page-specific context to draw
  * suggestions from (e.g. on a route that advertises no agent context). When a
  * page does advertise context, {@link useAgentQuickActions} supplies a tailored
  * set instead.


### PR DESCRIPTION
## Summary

PXI's empty-state quick actions were hardcoded and identical on every page. This makes them **dynamic based on where the user is in the UI**, derived from the agent contexts PXI already advertises for the active route — the same signal that gates server-side contextual tools, so suggestions can't drift from what the assistant can actually do.

Examples:
- **Playground** → Enhance the prompt · Run the playground · Fill in variables
- **Project** → Find critical issues · Filter to errors · Search this project
- **Trace / Span** → explain / debug / find-what-went-wrong
- **No actionable context** → falls back to the generic defaults (never blank)

When multiple contexts stack (e.g. a span selected inside a project), the most specific context's suggestions lead. The set is capped at **3** to keep the empty state scannable.

## Implementation

- New `app/src/agent/quickActions/quickActions.tsx`:
  - `QUICK_ACTIONS_BY_CONTEXT` — page-context-keyed suggestion registry.
  - `buildAgentQuickActions(types)` — pure: most-specific-first ordering, dedupe by label, cap at 3, default fallback.
  - `useAgentQuickActions()` — subscribes to a **stable comma-joined key** of active context types (not the fresh-every-update context array) so `ChatView` doesn't re-render on every streaming token.
- `ChatView` now uses `emptyStateQuickActions ?? useAgentQuickActions()` — the explicit prop still wins for callers that want a fixed set.
- `DEFAULT_QUICK_ACTIONS` exported from `ChatEmptyState` as the shared fallback (single source of truth).

## Testing

- Unit tests for `buildAgentQuickActions` (fallback, playground set, specificity ordering, cap/dedupe).
- `tsc --noEmit`, `oxlint`, `oxfmt --check`, `vitest` all pass.

Closes #13153