### PR TITLE
feat(agent): show a Beta badge in the PXI header on new chats

### DIFF
--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -28,8 +28,8 @@ import type { Size } from "@phoenix/types/geometry";
 
 import { PxiGlyph } from "./PxiGlyph";
 import { ResizableFloatingPanel } from "./ResizableFloatingPanel";
-import { EMPTY_SESSION_DISPLAY_NAME } from "./sessionSummaryUtils";
 import { SessionListMenu } from "./SessionListMenu";
+import { EMPTY_SESSION_DISPLAY_NAME } from "./sessionSummaryUtils";
 
 const PANEL_HEADER_Z_INDEX = 3;
 const FLOATING_PANEL_WIDTH_PX = 520;

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -1,15 +1,20 @@
 import { css } from "@emotion/react";
 import type { ReactNode, RefObject } from "react";
+import { Pressable } from "react-aria";
 import { createPortal } from "react-dom";
 import { Panel, Separator } from "react-resizable-panels";
 
 import {
+  Badge,
   Button,
   Flex,
   Icon,
   Icons,
   LinkButton,
+  RichTooltip,
   Text,
+  TooltipArrow,
+  TooltipTrigger,
 } from "@phoenix/components";
 import { fadedDividerBottomCSS } from "@phoenix/components/core/layout";
 import { compactResizeHandleCSS } from "@phoenix/components/resize/styles";
@@ -23,6 +28,7 @@ import type { Size } from "@phoenix/types/geometry";
 
 import { PxiGlyph } from "./PxiGlyph";
 import { ResizableFloatingPanel } from "./ResizableFloatingPanel";
+import { EMPTY_SESSION_DISPLAY_NAME } from "./sessionSummaryUtils";
 import { SessionListMenu } from "./SessionListMenu";
 
 const PANEL_HEADER_Z_INDEX = 3;
@@ -111,6 +117,9 @@ export function AgentChatHeader({
     position === "pinned"
       ? "Switch assistant to floating panel"
       : "Pin assistant to side";
+  // Only surface the beta badge on the empty/new session, where there is no
+  // summary yet competing for space in the header.
+  const showBetaBadge = sessionDisplayName === EMPTY_SESSION_DISPLAY_NAME;
 
   return (
     <div className="agent-chat-panel__header" css={panelHeaderCSS}>
@@ -124,6 +133,29 @@ export function AgentChatHeader({
         <Text weight="heavy" css={sessionHeadingCSS} title={sessionDisplayName}>
           {sessionDisplayName}
         </Text>
+        {showBetaBadge ? (
+          <TooltipTrigger delay={0}>
+            <Pressable>
+              <span
+                role="button"
+                tabIndex={0}
+                css={css`
+                  display: inline-flex;
+                  flex: none;
+                  cursor: default;
+                `}
+              >
+                <Badge variant="info">Beta</Badge>
+              </span>
+            </Pressable>
+            <RichTooltip>
+              <TooltipArrow />
+              <Text size="XS">
+                The assistant is in beta — expect changes as it evolves.
+              </Text>
+            </RichTooltip>
+          </TooltipTrigger>
+        ) : null}
       </Flex>
       <Flex
         direction="row"


### PR DESCRIPTION
## Summary

Adds a small **Beta** badge to the PXI assistant chat panel header to set expectations that the assistant is still evolving.

- New `info`-variant `Badge` reading **"Beta"**, placed next to the assistant title in the shared `AgentChatHeader`.
- Wrapped in a `RichTooltip` (keyboard-focusable) that reads: *"The assistant is in beta — expect changes as it evolves."*
- The badge only renders on the empty/new session state — when `sessionDisplayName` is still the `"New chat"` fallback (no LLM `shortSummary` and no first-message title). Once a session summary exists, the badge hides so it doesn't compete with the title for header space.

Because the header is shared across the docked, floating, and trace-slideover surfaces, the badge appears consistently everywhere PXI is shown.

## Verification

- `tsc --noEmit` passes
- `oxlint` passes
- `prettier` formatted