### PR TITLE
docs(tracing): OpenInference best practices cookbook and concepts

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -398,6 +398,25 @@
                   "docs/phoenix/tracing/concepts-tracing/how-tracing-works",
                   "docs/phoenix/tracing/concepts-tracing/annotations-concepts",
                   "docs/phoenix/tracing/concepts-tracing/translating-conventions",
+                  {
+                    "group": "OpenTelemetry and OpenInference",
+                    "pages": [
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/overview",
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/signals",
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/resource",
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter",
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor",
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/tracer-provider",
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers",
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/semantic-conventions",
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds",
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/instrumentation-approaches",
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers",
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/context-propagation",
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/sampling",
+                      "docs/phoenix/tracing/concepts-tracing/otel-openinference/otel-collector"
+                    ]
+                  },
                   "docs/phoenix/tracing/concepts-tracing/faqs-tracing"
                 ]
               },
@@ -1157,6 +1176,7 @@
               "docs/phoenix/cookbook/tracing/generating-synthetic-datasets-for-llm-evaluators-and-agents",
               "docs/phoenix/cookbook/tracing/structured-data-extraction",
               "docs/phoenix/cookbook/tracing/product-recommendation-agent-google-agent-engine-and-langgraph",
+              "docs/phoenix/cookbook/tracing/openinference-best-practices",
               "docs/phoenix/cookbook/tracing/cookbooks"
             ]
           },

--- a/docs/phoenix/cookbook/tracing/openinference-best-practices.mdx
+++ b/docs/phoenix/cookbook/tracing/openinference-best-practices.mdx
@@ -42,7 +42,7 @@ Create a new directory for your script and a Python virtual environment inside i
 Install all the dependencies you will use across the rest of the guide:
 
 ```bash
-pip install openai openai-agents arize-otel \
+pip install openai openai-agents arize-phoenix-otel \
     openinference-instrumentation-openai \
     openinference-instrumentation-openai-agents \
     opentelemetry-sdk opentelemetry-exporter-otlp
@@ -154,7 +154,7 @@ with using_session(session_id=session_id):
     ask_llm("How does it relate to OpenTelemetry?")
 ```
 
-Open [Phoenix](https://localhost:6006) and navigate to the `otel-best-practices` project to view your traces.
+Open [Phoenix](http://localhost:6006) and navigate to the `otel-best-practices` project to view your traces.
 
 ### Sessions, traces, and spans
 

--- a/docs/phoenix/cookbook/tracing/openinference-best-practices.mdx
+++ b/docs/phoenix/cookbook/tracing/openinference-best-practices.mdx
@@ -1,0 +1,979 @@
+---
+title: "OpenInference Best Practices"
+description: "Learn OpenInference best practices for Phoenix and how to enrich auto-instrumented traces with LLM, tool, agent, chain, and session attributes."
+keywords: ['openinference', 'span kinds', 'tracing', 'opentelemetry', 'llm', 'tool', 'agent', 'chain', 'sessions']
+---
+
+<Frame caption="Work through this cookbook in an interactive notebook">
+<Card title="Google Colab" href="https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/tracing/openinference_best_practices_tutorial.ipynb" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/gc.ico" horizontal/>
+</Frame>
+
+This guide is a hands-on tour of OpenInference best practices for tracing AI applications with Phoenix. You will learn:
+
+- How OpenInference layers on top of OpenTelemetry to add AI-aware semantics
+- The hierarchy of sessions, traces, and spans that organizes your telemetry
+- Three ways to capture spans — auto-instrumentation, manual instrumentation, and the hybrid approach that combines them
+- The common attributes every span carries, and the kind-specific attributes for the four core span kinds (LLM, chain, agent, and tool)
+- How to add or override attributes on spans, including auto-instrumented spans you cannot access directly
+
+Each section walks through a small piece of code and what to look for in the Phoenix trace view. You can [run the companion notebook in Colab](https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/tracing/openinference_best_practices_tutorial.ipynb), or follow along locally by running each code block independently in your venv.
+
+<Info>
+Every runnable code block below is a complete, self-contained Python script. Save each to a `.py` file and run it in your venv. The same setup code (`register(...)` and `OpenAIInstrumentor().instrument(...)`) appears at the top of every block — that's intentional, so you can run any block in isolation without having to assemble pieces from earlier sections.
+</Info>
+
+## Initial setup
+
+This guide talks to a locally-running Phoenix instance. Start Phoenix in a separate terminal:
+
+```bash
+pip install arize-phoenix
+phoenix serve
+```
+
+This starts the Phoenix UI at [http://localhost:6006](http://localhost:6006). Leave it running — every code block in this guide sends traces to that endpoint.
+
+### Create a project directory and virtual environment
+
+Create a new directory for your script and a Python virtual environment inside it.
+
+### Install libraries
+
+Install all the dependencies you will use across the rest of the guide:
+
+```bash
+pip install openai openai-agents arize-otel \
+    openinference-instrumentation-openai \
+    openinference-instrumentation-openai-agents \
+    opentelemetry-sdk opentelemetry-exporter-otlp
+```
+
+### Set environment variables
+
+You need one secret: your OpenAI API key. Export it in the same shell session you will run the code from:
+
+```bash
+export OPENAI_API_KEY="your-openai-api-key"
+```
+
+The OpenAI SDK reads `OPENAI_API_KEY` automatically. Phoenix is running locally, so no Phoenix API key is needed (the `register()` call below uses the default `http://localhost:6006` endpoint).
+
+### Setup tracing
+
+Every runnable code block in this guide includes the same tracing setup at the top. It uses the `phoenix.otel.register()` convenience function to register a tracer provider that sends spans to your local Phoenix instance at `http://localhost:6006`, then enables the OpenAI auto-instrumentor so calls to the OpenAI SDK are traced automatically.
+
+See [The phoenix.otel helpers](/docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers) for the full set of `phoenix.otel` functions, including routing traces to multiple projects from a single app.
+
+Save this code as a `.py` file and run it to verify your setup before proceeding — you should see the OpenTelemetry tracing details printed to your terminal:
+
+```python
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from phoenix.otel import register
+
+tracer_provider = register(
+    project_name="otel-best-practices",
+    batch=False,
+)
+
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+```
+
+## Introduction to OpenInference
+
+[OpenInference](https://github.com/Arize-ai/openinference) is an open-source set of conventions and instrumentation libraries for tracing AI applications. It is maintained by Arize and is the standard that Phoenix uses to render LLM, tool, agent, chain, retriever, and other AI-specific spans in the trace view.
+
+OpenInference is an **extension to [OpenTelemetry](https://opentelemetry.io/docs/)**, not a replacement for it. It uses the standard OpenTelemetry SDK and libraries under the hood — the same `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` you would use for any OTel-instrumented service. What OpenInference adds is:
+
+- A set of **semantic conventions** that describe how to represent AI concepts (LLM calls, prompts, messages, tool invocations, retrieval, agent steps, sessions) as span attributes
+- A library of **auto-instrumentors** for popular LLM SDKs and orchestration frameworks (OpenAI, Anthropic, Bedrock, LangChain, LlamaIndex, CrewAI, AutoGen, and many more)
+
+Because OpenInference is built on OpenTelemetry, any tool that speaks OTel can consume the spans — but a backend that understands the OpenInference conventions (like Phoenix) can render them as a rich, AI-aware trace view rather than a generic span list.
+
+**Read more:**
+
+- [OpenTelemetry and OpenInference concepts](/docs/phoenix/tracing/concepts-tracing/otel-openinference/overview) — the full reference companion to this guide.
+- [OpenInference semantic conventions spec](https://github.com/Arize-ai/openinference/tree/main/spec) — the formal definitions for span kinds, attributes, and message structure.
+- [OpenInference repository](https://github.com/Arize-ai/openinference) — auto-instrumentors, examples, and source for every supported language and framework.
+- [OpenTelemetry documentation](https://opentelemetry.io/docs/) — the underlying observability framework that OpenInference builds on.
+
+The code below simulates having a conversation with a chatbot and asking it two related questions. It will create traces in Phoenix for a simple set of OpenAI calls. Don't worry for now about what the code is doing, we will dive into the details later.
+
+Save this code as a `.py` file and run it:
+
+```python
+import uuid
+
+from openai import OpenAI
+from openinference.instrumentation import using_session
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from openinference.semconv.trace import (
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
+from opentelemetry import trace
+from phoenix.otel import register
+
+tracer_provider = register(
+    project_name="otel-best-practices",
+    batch=False,
+)
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+
+client = OpenAI()
+session_id = str(uuid.uuid4())
+tracer = trace.get_tracer(__name__)
+system_prompt = "You are a helpful assistant. Answer in a concise manner."
+messages = [{"role": "system", "content": system_prompt}]
+
+
+def ask_llm(question: str) -> None:
+    messages.append({"role": "user", "content": question})
+
+    with tracer.start_as_current_span(
+        "openinference-intro-chain"
+    ) as chain_span:
+        chain_span.set_attribute(
+            SpanAttributes.OPENINFERENCE_SPAN_KIND,
+            OpenInferenceSpanKindValues.CHAIN.value,
+        )
+        chain_span.set_attribute(SpanAttributes.INPUT_VALUE, question)
+
+        response = client.responses.create(
+            model="gpt-5.4-mini",
+            input=messages,
+        )
+        answer = response.output_text
+
+        messages.append({"role": "assistant", "content": answer})
+        chain_span.set_attribute(SpanAttributes.OUTPUT_VALUE, answer)
+        print(answer)
+
+
+with using_session(session_id=session_id):
+    ask_llm("What is OpenInference?")
+    ask_llm("How does it relate to OpenTelemetry?")
+```
+
+Open [Phoenix](https://localhost:6006) and navigate to the `otel-best-practices` project to view your traces.
+
+### Sessions, traces, and spans
+
+Three concepts shape how OpenInference (and OpenTelemetry) organize tracing data, and they nest inside each other:
+
+- **Span** — a single step in your application, such as an LLM call, a tool invocation, or a chain stage. Each span has a name, start and end timestamps, attributes, and a potentially a parent — spans nest to form a tree. The root of the tree is known as the root span, and has no parent.
+- **Trace** — a collection of spans tied together by a shared `trace_id`. A trace represents one end-to-end request through your agent.
+- **Session** — a collection of traces tied together by a shared `session.id`. A session is a logical grouping of traces based on a shared concept, such as multiple agent interactions to solve the same task, or to help with a continuous conversation.
+
+Picture a customer-support chatbot. The user has a multi-turn conversation, and that whole conversation is one **session**. Each turn — one user message and the app's response — is one **trace**. Inside each trace, the app does several things to produce the response (classify intent, call a tool, format a reply), and each of those steps is a **span**.
+
+```
+Session: support-chat-7a3f
+│
+├── Trace 1: "Where is my order?"
+│   └── Chain span: handle_message
+│       ├── LLM span:  classify_intent
+│       ├── Tool span: lookup_order(order_id="A123")
+│       └── LLM span:  format_response
+│
+├── Trace 2: "When will it arrive?"
+│   └── Chain span: handle_message
+│       ├── LLM span:  classify_intent
+│       ├── Tool span: get_shipping_status(order_id="A123")
+│       └── LLM span:  format_response
+│
+└── Trace 3: "Thanks!"
+    └── Chain span: handle_message
+        └── LLM span: generate_acknowledgement
+```
+
+Three traces, one session. In Phoenix you can open a single trace to debug what happened in one turn, or use the session view to see all the turns together.
+
+For the full breakdown of how signals, spans, traces, and sessions fit together, see [Signals, spans, traces, and sessions](/docs/phoenix/tracing/concepts-tracing/otel-openinference/signals).
+
+#### Sessions
+
+In Phoenix, start with the **Sessions** tab. You should see a single session that represents the entire two step conversation.
+
+![The Sessions tab in Phoenix showing one session for the chatbot conversation](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/sessions.png)
+
+If you select the session, a pane will appear with details of the session, including both steps in the conversation, showing the input to and the output from the agent. It will also show the latency, so the time the agent took to run, as well as the total number of tokens used and the estimated cost based off published token pricing from the LLM provider if available.
+
+![Details pane in Phoenix for the chatbot session, showing both conversation turns with input, output, latency, tokens, and cost](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/session.png)
+
+#### Traces
+
+Select the **Traces** tab. You should see both of the steps in the conversation as distinct traces, showing the input and output to the agent.
+
+The code you ran just makes a single LLM call, so the trace has the input set to what was sent to the LLM, and the output set to the response from the LLM. In a more complicated trace, the input is what was sent to the agent, and the output is the final response sent by the agent after it has completed its entire processing, including calling LLMs or tools.
+
+![The Traces tab in Phoenix showing two traces from the chatbot conversation](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/traces.png)
+
+If you select a trace, a pane will appear with details of the trace. It will show a tree of spans, along with latency, token counts, and estimated cost.
+
+![Details pane in Phoenix for a single trace, showing the span tree with latency, token counts, and cost](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/trace.png)
+
+<Info>
+You can also navigate to the individual traces directly from the session view.
+</Info>
+
+#### Spans
+
+In the trace view you will see a tree of the spans that make up the trace. Spans are grouped into traces by having the same `trace_id` set on them. A trace is a tree of spans, so one span will be the root span at the top of the tree, and the rest of the spans will be under that tree. The hierarchy is defined using the `parent_id` on the span — each child span has its `parent_id` set to the id of the parent span.
+
+In the trace we have 2 spans:
+
+![Details pane in Phoenix for a single trace, showing the span tree with latency, token counts, and cost](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/trace.png)
+
+The root span is a **Chain** span. Chain spans are starting points for a set of related spans, you can think of them as a folder that groups spans together. In this example, the chain span isn't really necessary, it's just here to help show a tree.
+
+Under the root span is an **LLM** span called `ChatCompletion`. This span represents a call to an LLM, in our case OpenAI.
+
+![An LLM span named ChatCompletion selected in Phoenix trace tree](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/llm-span.png)
+
+Against each span is an **Attributes** tab that has JSON containing all the attributes associated with the span, such as the input and output, number of tokens used for an LLM span, and so on. We will cover these attributes in the rest of this guide.
+
+![The Attributes tab in Phoenix showing the JSON attributes for a selected span](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/span-attributes.png)
+
+OpenInference defines a fixed set of span kinds:
+
+| Span kind | Description |
+| --- | --- |
+| `LLM` | A call to a large language model. Captures the model, input messages, output messages, token counts, and cost. |
+| `CHAIN` | A starting point or link between application steps. Commonly used as a parent span to group related work into a logical block. |
+| `AGENT` | A span representing an agent's work — typically wraps LLM and tool spans together |
+| `TOOL` | A call to an external tool or function, often invoked in response to a tool-use request from an LLM |
+| `RETRIEVER` | A retrieval operation, such as fetching documents from a vector store or search index |
+| `EMBEDDING` | A call to an embedding model |
+| `RERANKER` | A reranking step that reorders a set of retrieved documents |
+| `GUARDRAIL` | A safety or policy check, such as content moderation, PII detection, or input validation |
+| `EVALUATOR` | An evaluation step that scores or judges an LLM output |
+| `PROMPT` | A prompt definition or templating step |
+| `UNKNOWN` | Used when no other kind applies |
+
+In this guide, we will be looking at LLM, chain, agent, and tool spans. For the complete reference covering every kind and the attributes each is expected to carry, see [OpenInference span kinds](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds).
+
+## Configuring sessions
+
+**Sessions** are a logical grouping of traces based on a continuous set of interactions with an agent. For example, in a chatbot, the entire multi-turn conversation that a single user has with the agent would be a session. When the same user starts a brand new conversation with no previous context, or a new user starts a conversation, this would be a new session.
+
+Sessions are explicitly managed by the engineer building the agent; they are not created automatically when sending traces.
+
+Sessions are set with the `using_session` function. This sets the session id for any spans created in any code run in this block. `using_session` is one of a small family of OpenInference context managers — see [OpenInference context managers](/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers) for the full list (`using_user`, `using_metadata`, `using_tags`, `using_prompt_template`, `using_attributes`).
+
+The following code contains a call to OpenAI inside a session. The session id is hardcoded here, so if you run this code multiple times, each run will be a new trace inside the same session.
+
+Save and run this code:
+
+```python
+from openai import OpenAI
+from openinference.instrumentation import using_session
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from phoenix.otel import register
+
+tracer_provider = register(
+    project_name="otel-best-practices",
+    batch=False,
+)
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+
+client = OpenAI()
+
+with using_session(session_id="My Session"):
+    response = client.responses.create(
+        model="gpt-5.4-mini",
+        input="What are sessions in OpenInference? Be concise.",
+    )
+    print(response.output_text)
+```
+
+Look up this session in Phoenix. You will see a single session with multiple traces depending on how many times you ran the code.
+
+![The Sessions tab in Phoenix showing a single session with multiple traces](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/sessions-1-session.png)
+
+Now run this code, which uses a different session id and so will create a new session:
+
+```python
+from openai import OpenAI
+from openinference.instrumentation import using_session
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from phoenix.otel import register
+
+tracer_provider = register(
+    project_name="otel-best-practices",
+    batch=False,
+)
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+
+client = OpenAI()
+
+with using_session(session_id="My Session 2"):
+    response = client.responses.create(
+        model="gpt-5.4-mini",
+        input="What are sessions in OpenInference? Be concise.",
+    )
+    print(response.output_text)
+```
+
+You will now see a new session in the sessions list.
+
+![The Sessions tab in Phoenix showing two distinct sessions in the list](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/sessions-2-sessions.png)
+
+## Capturing spans and traces
+
+In the examples so far you have already seen both ways that OpenInference creates spans:
+
+- **Auto-instrumentors** wrap a specific library or framework (such as the OpenAI SDK, or LangChain) and emit a span for every call to that library automatically, along with spans for the different actions that the framework performs, such as tool calling. Each call to the library or framework is a separate trace.
+- **Manual instrumentation** lets you create your own traces and spans by calling the tracer directly in your application code
+
+Most real-world applications use both. The auto-instrumentor handles the standard SDK calls; manual instrumentation captures your application's own logic that wraps around those calls.
+
+See [Instrumentation approaches](/docs/phoenix/tracing/concepts-tracing/otel-openinference/instrumentation-approaches) for a deeper comparison of auto-instrumentation, manual instrumentation, and the hybrid pattern.
+
+### Auto-instrumentors
+
+Auto-instrumentors are libraries that instrument an SDK or framework, and automatically emit spans for every call, and every action taken by the SDK or framework.
+
+You already set up an auto-instrumentor in the Initial setup section:
+
+```python
+from openinference.instrumentation.openai import OpenAIInstrumentor
+
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+```
+
+After that single call, every `client.responses.create()` and `client.chat.completions.create()` in your code creates an LLM span automatically in a new trace. If you are using a more advanced framework that handles tool calling for example, then each call to the framework would be a new trace, with spans for the LLM and tool calls, grouped under a chain span.
+
+OpenInference provides auto-instrumentors for most popular AI SDKs and orchestration frameworks: OpenAI, Anthropic, Bedrock, LangChain, LlamaIndex, CrewAI, AutoGen, and many more. See the [OpenInference repository](https://github.com/Arize-ai/openinference) for the full list.
+
+If you run the code below, the auto-instrumentor will create a trace with a single LLM span. Save it as a `.py` file and run it:
+
+```python
+from openai import OpenAI
+from openinference.instrumentation import using_session
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from phoenix.otel import register
+
+tracer_provider = register(
+    project_name="otel-best-practices",
+    batch=False,
+)
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+
+client = OpenAI()
+
+with using_session(session_id="Capturing Spans Example"):
+    response = client.responses.create(
+        model="gpt-5.4-mini",
+        input="What are sessions in OpenInference? Be concise.",
+    )
+    print(response.output_text)
+```
+
+Open the new trace in Phoenix under the `Capturing Spans Example` session. You will see a single LLM span — the auto-instrumentor created it automatically for the `client.responses.create()` call, without you writing any tracing code.
+
+### Manual instrumentation
+
+Manual instrumentation gives you full control. You call the OpenTelemetry tracer directly to start a span, set its attributes (including its OpenInference span kind), and end it when the work is done. The recommended pattern is the context-manager form, which sets the span as the active span on the OpenTelemetry context (so any spans created inside the block automatically become its children) and ends the span when the block exits:
+
+```python
+with tracer.start_as_current_span("my-span") as span:
+    span.set_attribute(
+        SpanAttributes.OPENINFERENCE_SPAN_KIND,
+        OpenInferenceSpanKindValues.CHAIN.value,
+    )
+    span.set_attribute(SpanAttributes.INPUT_VALUE, "input data")
+    # do work here
+    span.set_attribute(SpanAttributes.OUTPUT_VALUE, "result")
+```
+
+You can manually create spans of any OpenInference kind, such as chain, LLM, or tool — by setting the `openinference.span.kind` attribute on the span. The kind controls how Phoenix renders the span (the icon and the detail view) and which set of OpenInference attributes the span is expected to carry.
+
+The following code creates a trace with three manually-created spans: a parent `data-pipeline` chain span with two child spans (`step-1-validate` and `step-2-format`) nested inside. There are no LLM or tool calls — every span is created by your code. Save it as a `.py` file and run it:
+
+```python
+from openinference.instrumentation import using_session
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from openinference.semconv.trace import (
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
+from opentelemetry import trace
+from phoenix.otel import register
+
+tracer_provider = register(
+    project_name="otel-best-practices",
+    batch=False,
+)
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+
+tracer = trace.get_tracer(__name__)
+
+with using_session(session_id="Capturing Spans Example"):
+    with tracer.start_as_current_span("data-pipeline") as pipeline:
+        pipeline.set_attribute(
+            SpanAttributes.OPENINFERENCE_SPAN_KIND,
+            OpenInferenceSpanKindValues.CHAIN.value,
+        )
+        pipeline.set_attribute(SpanAttributes.INPUT_VALUE, "raw request")
+
+        with tracer.start_as_current_span("step-1-validate") as step:
+            step.set_attribute(
+                SpanAttributes.OPENINFERENCE_SPAN_KIND,
+                OpenInferenceSpanKindValues.CHAIN.value,
+            )
+            step.set_attribute(SpanAttributes.INPUT_VALUE, "raw request")
+            step.set_attribute(SpanAttributes.OUTPUT_VALUE, "validated request")
+
+        with tracer.start_as_current_span("step-2-format") as step:
+            step.set_attribute(
+                SpanAttributes.OPENINFERENCE_SPAN_KIND,
+                OpenInferenceSpanKindValues.CHAIN.value,
+            )
+            step.set_attribute(SpanAttributes.INPUT_VALUE, "validated request")
+            step.set_attribute(SpanAttributes.OUTPUT_VALUE, "formatted output")
+
+        pipeline.set_attribute(SpanAttributes.OUTPUT_VALUE, "formatted output")
+```
+
+Open the new trace in Phoenix under the `Capturing Spans Example` session. You will see a single chain span called `data-pipeline` with two child chain spans (`step-1-validate` and `step-2-format`) nested underneath.
+
+![Trace tree in Phoenix showing the data-pipeline chain span with step-1-validate and step-2-format child chain spans nested inside](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/data-pipeline.png)
+
+### Hybrid instrumentation
+
+The most powerful pattern is to use both approaches together. **Hybrid instrumentation** lets you wrap auto-instrumented calls in your own manually-created spans, so you can group SDK calls into logical units, add custom attributes, and build the trace tree that best represents your application — without losing any of the rich attributes that the auto-instrumentor captures.
+
+Auto-instrumented spans and manually-created spans nest together naturally because they share the same OpenTelemetry context. When you open a manual span with `tracer.start_as_current_span(...)`, it becomes the active span on the context. Any call to an auto-instrumented SDK inside that block will create its span as a child of your manual span.
+
+You have already seen hybrid instrumentation in the Introduction to OpenInference section. The `ask_llm` function wraps each OpenAI call in a manually-created chain span.
+
+The manually-created chain span is the parent; the LLM span that the OpenAI auto-instrumentor produces around `client.responses.create()` automatically becomes its child. That is what gives you the tree structure you saw in Phoenix when you ran the introduction example — a chain span at the top, with an LLM span nested inside.
+
+This pattern is the typical shape of a real-world traced application: manual chain or agent spans give you the high-level structure of your business logic; auto-instrumented spans fill in the low-level detail of every SDK call you make inside them.
+
+Save and run this hybrid instrumentation example:
+
+```python
+from openai import OpenAI
+from openinference.instrumentation import using_session
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from openinference.semconv.trace import (
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
+from opentelemetry import trace
+from phoenix.otel import register
+
+tracer_provider = register(
+    project_name="otel-best-practices",
+    batch=False,
+)
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+
+client = OpenAI()
+tracer = trace.get_tracer(__name__)
+
+with using_session(session_id="Capturing Spans Example"):
+    with tracer.start_as_current_span("manual-chain") as chain_span:
+        chain_span.set_attribute(
+            SpanAttributes.OPENINFERENCE_SPAN_KIND,
+            OpenInferenceSpanKindValues.CHAIN.value,
+        )
+        question = "What are sessions in OpenInference? Be concise."
+        chain_span.set_attribute(SpanAttributes.INPUT_VALUE, question)
+
+        response = client.responses.create(
+            model="gpt-5.4-mini",
+            input=question,
+        )
+
+        chain_span.set_attribute(
+            SpanAttributes.OUTPUT_VALUE, response.output_text
+        )
+        print(response.output_text)
+```
+
+Open the new trace in Phoenix under the `Capturing Spans Example` session. You will see a chain span called `manual-chain` with an LLM span nested inside it — the manual span is the parent, and the auto-instrumented LLM span automatically became its child because they share the same OpenTelemetry context.
+
+## Span attributes
+
+Every OpenInference span carries a small set of **common attributes** that apply regardless of the span kind, plus a **kind-specific set** added on top.
+
+The common attributes available on any span kind are:
+
+| Attribute | Description |
+| --- | --- |
+| `openinference.span.kind` | The span kind: `LLM`, `CHAIN`, `AGENT`, `TOOL`, `RETRIEVER`, `EMBEDDING`, `RERANKER`, `GUARDRAIL`, `EVALUATOR`, `PROMPT`, or `UNKNOWN`. Controls how Phoenix renders the span. |
+| `input.value` | The input to the span as a string. If the value is structured, serialize it to JSON and set `input.mime_type` accordingly. |
+| `input.mime_type` | The mime type of `input.value`. Defaults to `text/plain`; set to `application/json` if the value is a JSON string. |
+| `output.value` | The output from the span as a string |
+| `output.mime_type` | The mime type of `output.value`. Same convention as `input.mime_type`. |
+| `metadata` | A JSON dictionary of your own fields. Use it to attach domain-specific context such as user tier, feature flag, or request id. |
+| `session.id` | Groups multiple traces into a session. Set with `using_session(...)` or directly via `span.set_attribute(SpanAttributes.SESSION_ID, ...)`. |
+| `user.id` | Identifies the user the trace belongs to. Set with `using_user(...)` or directly. |
+| `tag.tags` | A list of string tags for filtering. Set with `using_tags(...)`. |
+
+Phoenix uses several of these directly in the UI: `openinference.span.kind` drives the span icon and the kind-specific detail view; `input.value` and `output.value` on the root span feed the trace-level input and output preview in the Traces and Sessions tabs; `session.id` groups traces into sessions; `metadata` and `tag.tags` are filterable across spans.
+
+The full attribute catalogue is described in [OpenInference semantic conventions](/docs/phoenix/tracing/concepts-tracing/otel-openinference/semantic-conventions) (the overall standard) and [OpenInference span kinds](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds) (per-kind reference).
+
+## The core span types
+
+OpenInference defines 11 span kinds, but most AI applications use just four: **LLM**, **chain**, **agent**, and **tool**. These show up in almost every real-world trace — an agent makes LLM calls, LLM calls trigger tool calls, and chain spans group the related work together. For the canonical reference of every span kind and the attributes each carries, see [OpenInference span kinds](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds).
+
+The following example uses the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) to produce a single trace containing all four kinds. The SDK has its own auto-instrumentor — `openinference-instrumentation-openai-agents` — which emits the full set of span kinds for every agent run.
+
+The Agents SDK has its own instrumentor, `OpenAIAgentsInstrumentor`. Attach it to the existing tracer provider alongside the OpenAI auto-instrumentor — the Agents SDK creates its own LLM spans, so the two cooperate without duplicating work.
+
+The code below sets up both instrumentors, defines a simple travel assistant with two tools, then asks it a question that requires both tools to be called. The run is wrapped in a session so the trace is easy to find in Phoenix. Save and run it:
+
+```python
+from agents import Agent, Runner, function_tool
+from openinference.instrumentation import using_session
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+from phoenix.otel import register
+
+tracer_provider = register(
+    project_name="otel-best-practices",
+    batch=False,
+)
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+OpenAIAgentsInstrumentor().instrument(tracer_provider=tracer_provider)
+
+
+@function_tool
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    return f"The weather in {city} is sunny and 22°C."
+
+
+@function_tool
+def get_time_zone(city: str) -> str:
+    """Get the time zone for a city."""
+    zones = {
+        "Tokyo": "JST (UTC+9)",
+        "London": "GMT (UTC+0)",
+        "New York": "EST (UTC-5)",
+    }
+    return zones.get(city, "unknown")
+
+
+travel_agent = Agent(
+    name="TravelAssistant",
+    instructions=(
+        "You are a helpful travel assistant. "
+        "Use get_weather to look up the weather for a city, "
+        "and get_time_zone to look up its time zone. "
+        "Give a concise final answer."
+    ),
+    tools=[get_weather, get_time_zone],
+)
+
+with using_session(session_id="Travel Agent Example"):
+    result = Runner.run_sync(
+        travel_agent,
+        "What's the weather and time zone in Tokyo?",
+    )
+
+print(result.final_output)
+```
+
+<Info>
+In the companion notebook, `await Runner.run(...)` is used because Jupyter supports top-level `await`. In a regular Python script, use the synchronous `Runner.run_sync(...)` instead, as shown above.
+</Info>
+
+Open the trace in Phoenix under the `otel-best-practices` project. A single agent run produces a trace containing all four core span kinds:
+
+- Two **agent** spans — an outer `Agent workflow` wrapper and an inner `TravelAssistant`
+- Three **chain** spans — one wrapping the whole workflow plus one per agent turn
+- Two **tool** spans, one for each call to `get_weather` and `get_time_zone`
+- Four **LLM** spans — each agent turn produces a Responses API call from the SDK with the underlying OpenAI client call nested inside it
+
+![Trace in Phoenix from the OpenAI Agents SDK example, showing agent, chain, tool, and LLM spans nested together](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/agent-trace.png)
+
+This is the trace shape you will see from most non-trivial agents: an outer agent/chain workflow, tool spans for each external call, and LLM spans for every model call inside.
+
+### LLM spans
+
+**LLM spans** represent a call to a large language model. They capture everything you need to debug or analyze the call: the model that was used, the input messages, the output, tools, token counts, costs, and more.
+
+In the agent trace are several LLM spans. Select one of these, and you will see the input and output from that LLM call. Against the span in the tree you will also see the number of tokens used, the latency, and the cost. In the **Attributes** tab, you can see the full attributes for the span.
+
+![The Attributes tab in Phoenix showing the full attribute set for an LLM span](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/llm-span-attributes.png)
+
+The relevant attributes for this example are:
+
+```json
+{
+    "openinference": {
+        "span": {
+            "kind": "LLM"
+        }
+    },
+    "llm": {
+        "cost": {
+            "completion": 0.0002205,
+            "completion_details": {
+                "output": 0.0002205,
+                "reasoning": 0
+            },
+            "prompt": 0.00009975,
+            "prompt_details": {
+                "cache_read": 0,
+                "input": 0.00009975
+            },
+            "total": 0.00032025
+        },
+        "input_messages": [
+            {
+                "message.content": "You are a helpful travel assistant. Use get_weather to look up the weather for a city, and get_time_zone to look up its time zone. Give a concise final answer.",
+                "message.role": "system"
+            },
+            {
+                "message.content": "What's the weather and time zone in Tokyo?",
+                "message.role": "user"
+            }
+        ],
+        "invocation_parameters": "{\"include\": [], \"model\": \"gpt-5.4-mini\", \"prompt_cache_key\": \"agents-sdk:run:1fc4521fe6f248beafa82586c8b0fa3e\", \"reasoning\": {\"effort\": \"none\"}, \"text\": {\"verbosity\": \"low\"}}",
+        "model_name": "gpt-5.4-mini-2026-03-17",
+        "output_messages": [
+            {
+                "message.role": "assistant",
+                "message.tool_calls": [
+                    {
+                        "tool_call.function.arguments": "{\"city\":\"Tokyo\"}",
+                        "tool_call.function.name": "get_weather",
+                        "tool_call.id": "call_OdvgB0fVwTcdKy6mqxV3cmuB"
+                    }
+                ]
+            },
+            {
+                "message.role": "assistant",
+                "message.tool_calls": [
+                    {
+                        "tool_call.function.arguments": "{\"city\":\"Tokyo\"}",
+                        "tool_call.function.name": "get_time_zone",
+                        "tool_call.id": "call_cnCgrd4Js5bErfROFdIoc68j"
+                    }
+                ]
+            }
+        ],
+        "provider": "openai",
+        "system": "openai",
+        "token_count": {
+            "completion": "49",
+            "completion_details": {
+                "output": "49",
+                "reasoning": "0"
+            },
+            "prompt": "133",
+            "prompt_details": {
+                "cache_read": "0",
+                "input": "133"
+            },
+            "total": "182"
+        },
+        "tools": [
+            {
+                "tool.json_schema": "{\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"city\":{\"title\":\"City\",\"type\":\"string\"}},\"required\":[\"city\"],\"title\":\"get_weather_args\",\"type\":\"object\",\"additionalProperties\":false},\"strict\":true,\"type\":\"function\",\"defer_loading\":null,\"description\":\"Get the current weather for a city.\"}"
+            },
+            {
+                "tool.json_schema": "{\"name\":\"get_time_zone\",\"parameters\":{\"properties\":{\"city\":{\"title\":\"City\",\"type\":\"string\"}},\"required\":[\"city\"],\"title\":\"get_time_zone_args\",\"type\":\"object\",\"additionalProperties\":false},\"strict\":true,\"type\":\"function\",\"defer_loading\":null,\"description\":\"Get the time zone for a city.\"}"
+            }
+        ]
+    }
+}
+```
+
+#### LLM-specific attributes
+
+Beyond the common attributes that any span carries (covered in the Span attributes section above), the OpenAI auto-instrumentor adds an LLM-specific set on every LLM span — all under the `llm.*` namespace and following the OpenInference semantic conventions:
+
+| Attribute | Description |
+| --- | --- |
+| `llm.model_name` | The exact model identifier returned by OpenAI, for example `gpt-5.4-mini-2026-03-17`. This is the resolved snapshot version, not the alias you passed in. |
+| `llm.provider` | The LLM provider, here `openai` |
+| `llm.system` | The AI system identifier, also `openai` |
+| `llm.invocation_parameters` | A JSON string of the parameters passed to the API: `{"model": "gpt-5.4-mini"}` |
+| `llm.input_messages` | The messages sent to the API as a structured array. Each entry has `message.role` and `message.content`. |
+| `llm.output_messages` | The messages returned by the API as a structured array. Each entry has `message.role` and a `message.contents` list of structured content items (with `message_content.text` and `message_content.type`). This shape is multimodal-aware — text, image, audio, and reasoning content all fit the same structure. |
+| `llm.token_count.prompt` / `.completion` / `.total` | Token counts for the call, with detail breakdowns under `llm.token_count.prompt_details.*` (`cache_read`, `input`) and `llm.token_count.completion_details.*` (`output`, `reasoning`) |
+| `llm.cost.prompt` / `.completion` / `.total` | Estimated cost in USD with the same `_details` breakdowns. Phoenix computes these from the token counts and the published pricing for the model. |
+
+Phoenix uses the LLM-specific attributes to drive the token-count and cost columns in the trace and session views, and to populate the LLM detail view (input messages, output messages, model name).
+
+### Tool spans
+
+**Tool spans** represent a call to an external tool or function — typically a function the LLM has decided to call. They capture the tool's name, the arguments the LLM passed in, and the value the tool returned.
+
+In the agent trace above you have two tool spans: `get_weather` and `get_time_zone`, one for each tool the agent invoked. Select one of them in the trace tree to see the tool-specific attributes — the tool name, the arguments the LLM passed in (`{"city": "Tokyo"}`), and the value the tool returned.
+
+![The Attributes tab in Phoenix showing the get_weather tool span attributes, including the input city and the returned weather text](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/tool-span-attributes.png)
+
+The relevant attributes for this example are:
+
+```json
+{
+    "openinference": {
+        "span": {
+            "kind": "TOOL"
+        }
+    },
+    "tool": {
+        "name": "get_weather"
+    }
+}
+```
+
+#### Tool-specific attributes
+
+Beyond the common attributes that any span carries, tool spans carry a small set of tool-specific attributes under the `tool.*` namespace:
+
+| Attribute | Description |
+| --- | --- |
+| `tool.id` | The identifier for the result of the tool call. Corresponds to the `tool_call.id` emitted by the LLM, which lets Phoenix link the tool span back to the LLM call that requested it. |
+| `tool.name` | The name of the tool |
+| `tool.description` | The tool's description. The LLM uses this when deciding which tool to call. |
+| `tool.parameters` | A JSON string of the parameter values the LLM passed to the tool |
+| `tool.json_schema` | The full JSON schema of the tool's input, typically in OpenAI tool-calling format. Tells the LLM what shape of arguments the tool expects. |
+
+Phoenix uses these to populate the tool detail view: the tool name and description appear at the top, the arguments and return value are surfaced from `input.value` and `output.value`, and the tool span links back to the parent LLM span via `tool.id`.
+
+### Agent spans
+
+**Agent spans** represent the work of an autonomous agent — the orchestration that decides when to call the LLM, when to call tools, when to call the LLM again, and when to stop. An agent span is typically the parent of the LLM, tool, and chain spans that make up the agent's loop.
+
+In the agent trace above, the `TravelAssistant` span is an agent span. Select it to see how it wraps both of the agent's turns, with all of the LLM and tool calls nested inside it.
+
+![The Attributes tab in Phoenix showing the TravelAssistant agent span attributes](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/agent-span-attributes.png)
+
+The relevant attributes for this example are:
+
+```json
+{
+    "openinference": {
+        "span": {
+            "kind": "AGENT"
+        }
+    },
+    "graph": {
+        "node": {
+            "id": "TravelAssistant"
+        }
+    }
+}
+```
+
+Note that the OpenAI Agents SDK auto-instrumentor uses `graph.node.id` to carry the agent's name (`TravelAssistant`) rather than the convention's `agent.name`. This is so Phoenix can render multi-agent systems with handoffs as a graph view. When you create agent spans manually, set `agent.name` (and optionally the `graph.node.*` attributes if you want the graph view).
+
+#### Agent-specific attributes
+
+Agent spans carry a small set of agent-specific attributes:
+
+| Attribute | Description |
+| --- | --- |
+| `agent.name` | The name of the agent. Agents that perform the same logical role should share a name so you can group their traces together. |
+| `graph.node.id` | The id of this agent's node in an execution graph. Optional — set when you want to visualize a multi-agent system as a graph in Phoenix. |
+| `graph.node.name` | A human-readable name for the graph node |
+| `graph.node.parent_id` | The id of the parent node. Leave unset for a root agent. |
+
+The `graph.node.*` attributes are how Phoenix renders multi-agent systems (LangGraph, AutoGen, CrewAI, etc.) as a graph view alongside the trace tree.
+
+### Chain spans
+
+**Chain spans** are general-purpose grouping spans. Use a chain span when you want to group a set of related work under a single parent in the trace tree — a multi-step pipeline, one agent turn, an LLM call with pre- and post-processing, or just a logical block in your application code.
+
+In the agent trace above the outer `Agent workflow` is a chain span, and each agent turn is also wrapped in a chain span called `turn`. Select a `turn` span to see how it groups the LLM and tool calls for that turn together.
+
+![The Attributes tab in Phoenix showing a turn chain span grouping the LLM and tool calls for one agent turn](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/chain-span-attributes.png)
+
+The relevant attributes for this example are:
+
+```json
+{
+    "openinference": {
+        "span": {
+            "kind": "CHAIN"
+        }
+    }
+}
+```
+
+The chain span carries only the kind and the common attributes — its value is purely structural, giving you a named parent in the trace tree.
+
+#### Chain-specific attributes
+
+Chain spans have no kind-specific attributes. They rely on the common attributes covered in the Span attributes section above — `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, and so on. The chain span's value is purely structural: it gives you a named parent in the trace tree, with whatever input and output you choose to attach to it.
+
+## Overriding or adding attributes
+
+Auto-instrumentors capture the standard OpenInference attributes for every span they create, but you often want to add your own. Common reasons:
+
+- **Tag the call for filtering** — for example `experiment="v2-prompt"` or `tenant="acme"`
+- **Attach domain metadata** — user tier, request id, feature flag value
+- **Record a prompt template** — the template string, version, and variables you used, separate from the final flattened prompt
+
+With manually-created spans you can call `span.set_attribute(...)` directly inside the `with` block, as you saw in the manual instrumentation example. With auto-instrumented spans you do not have direct access to the span object — but you can still enrich it by putting attributes into the OpenTelemetry context using the **OpenInference context managers**. The auto-instrumentor reads from that context when it creates the span. This means the attributes are applied to every span created inside the block, no matter who creates it.
+
+The available context managers are:
+
+| Context manager | Sets |
+| --- | --- |
+| `using_session(session_id)` | `session.id` |
+| `using_user(user_id)` | `user.id` |
+| `using_metadata(metadata)` | `metadata` (a JSON dictionary of your own fields) |
+| `using_tags(tags)` | `tag.tags` (a list of strings) |
+| `using_prompt_template(template=, variables=, version=)` | The `llm.prompt_template.*` attributes. Most useful on LLM spans. |
+| `using_attributes(...)` | A convenience wrapper that combines all of the above into a single call |
+
+See [OpenInference context managers](/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers) for the full reference, including detailed usage patterns and gotchas.
+
+The following code uses `using_metadata` to attach a domain-specific metadata dictionary. The example here wraps an OpenAI call so the metadata ends up on an LLM span, but the same pattern works for any span — auto-instrumented or manual — created inside the block. Save and run it:
+
+```python
+from openai import OpenAI
+from openinference.instrumentation import using_metadata, using_session
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from phoenix.otel import register
+
+tracer_provider = register(
+    project_name="otel-best-practices",
+    batch=False,
+)
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+
+client = OpenAI()
+
+with using_session(session_id="LLM Span Example"):
+    with using_metadata({"user_tier": "premium", "request_source": "cookbook"}):
+        response = client.responses.create(
+            model="gpt-5.4-mini",
+            input="What are LLM spans in OpenInference? Be concise.",
+        )
+        print(response.output_text)
+```
+
+Open the new trace in Phoenix. The LLM span now has an additional attribute:
+
+- `metadata` — a JSON string containing `{"user_tier": "premium", "request_source": "cookbook"}`
+
+It appears in the **Attributes** tab alongside the standard `llm.*` attributes.
+
+![The Attributes tab in Phoenix showing an LLM span with the custom metadata attribute alongside the standard llm.* attributes](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/llm-span-metadata.png)
+
+You can also filter spans by `metadata` values in the Phoenix trace view, which makes it easy to slice traces by tenant, feature flag, or any other domain dimension. In the **Spans** tab, set the filter to `attributes.metadata.request_source = "cookbook"` to only see spans created with the `request_source` metadata set to `cookbook`.
+
+![The Spans tab in Phoenix filtered by attributes.metadata.request_source equal to cookbook](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/metadata-filter.png)
+
+### Overriding a tool attribute
+
+You can also override attributes that an auto-instrumentor has set, or add attributes that it left out. The OpenAI Agents SDK auto-instrumentor only sets `tool.name` on tool spans — it does not populate `tool.description`. The following code redefines `get_weather` to set a custom `tool.description` attribute on the active tool span, then recreates the agent and re-runs it.
+
+The pattern works because the auto-instrumentor opens the tool span before calling your function, so the tool span is the active span when your function body runs. Calling `set_attribute(...)` on it inside the function body either overrides the attribute (if the instrumentor set it) or adds it (if the instrumentor did not).
+
+Save and run this code:
+
+```python
+from agents import Agent, Runner, function_tool
+from openinference.instrumentation import using_session
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+from openinference.semconv.trace import SpanAttributes
+from opentelemetry import trace
+from phoenix.otel import register
+
+tracer_provider = register(
+    project_name="otel-best-practices",
+    batch=False,
+)
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+OpenAIAgentsInstrumentor().instrument(tracer_provider=tracer_provider)
+
+
+@function_tool
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+
+    # Set a custom tool.description on the active tool span.
+    trace.get_current_span().set_attribute(
+        SpanAttributes.TOOL_DESCRIPTION,
+        "Looks up the current weather conditions for a given city.",
+    )
+
+    return f"The weather in {city} is sunny and 22°C."
+
+
+@function_tool
+def get_time_zone(city: str) -> str:
+    """Get the time zone for a city."""
+    zones = {
+        "Tokyo": "JST (UTC+9)",
+        "London": "GMT (UTC+0)",
+        "New York": "EST (UTC-5)",
+    }
+    return zones.get(city, "unknown")
+
+
+travel_agent = Agent(
+    name="TravelAssistant",
+    instructions=(
+        "You are a helpful travel assistant. "
+        "Use get_weather to look up the weather for a city, "
+        "and get_time_zone to look up its time zone. "
+        "Give a concise final answer."
+    ),
+    tools=[get_weather, get_time_zone],
+)
+
+with using_session(session_id="Tool Override Example"):
+    result = Runner.run_sync(
+        travel_agent,
+        "What's the weather and time zone in Tokyo?",
+    )
+
+print(result.final_output)
+```
+
+Open the new trace in Phoenix under the `otel-best-practices` project (find it via the `Tool Override Example` session). Select the `get_weather` tool span and open its **Attributes** tab. You will now see `tool.description` populated with the string you set inside the function body, alongside the standard `tool.name` the auto-instrumentor produced.
+
+![The Attributes tab in Phoenix showing the get_weather tool span with the manually-set tool.description alongside tool.name](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/tool-span-attributes-override.png)
+
+The relevant attributes for this example are:
+
+```json
+{
+    "openinference": {
+        "span": {
+            "kind": "TOOL"
+        }
+    },
+    "tool": {
+        "description": "Looks up the current weather conditions for a given city.",
+        "name": "get_weather"
+    }
+}
+```
+
+The `get_time_zone` tool span in the same trace still has only `tool.name`, which is a good visual confirmation that the override applies only to the span you set attributes on.
+
+## Summary
+
+You have now seen the building blocks for tracing AI applications with OpenInference and Phoenix:
+
+- **OpenInference layers on top of OpenTelemetry** to add semantic conventions and auto-instrumentors for AI-specific concepts. The standard OpenTelemetry SDK still drives everything underneath — `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` are all unchanged.
+- **Spans, traces, and sessions form a hierarchy.** A span is one step. A trace is a tree of spans tied together by `trace_id`. A session is a group of traces tied together by `session.id`. Sessions are how you stitch a multi-turn conversation together in Phoenix.
+- **There are three ways to capture spans.** Auto-instrumentors wrap SDKs and emit spans for every call automatically. Manual instrumentation lets you create spans yourself with `tracer.start_as_current_span(...)`. Hybrid instrumentation combines the two — your manual spans wrap auto-instrumented calls and become their parents in the trace tree.
+- **Every span carries a small set of common attributes** — `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, `user.id`, and `tag.tags` — regardless of the kind. The `openinference.span.kind` attribute drives how Phoenix renders the span.
+- **Four span kinds cover most AI applications:** LLM, chain, agent, and tool. Each adds a kind-specific set of attributes — `llm.*` for model name, token counts, and costs; `tool.*` for tool name and description; `agent.name` (or `graph.node.id` for multi-agent graphs); chain spans rely on the common attributes alone.
+- **You can enrich auto-instrumented spans.** Use OpenInference context managers like `using_session`, `using_metadata`, `using_tags`, and `using_prompt_template` to attach attributes that the auto-instrumentor picks up via the OpenTelemetry context. You can also override or add specific attributes by grabbing the active span inside a tool function and calling `set_attribute(...)` directly.
+
+### Where to go next
+
+- Read the [OpenTelemetry and OpenInference concepts](/docs/phoenix/tracing/concepts-tracing/otel-openinference/overview) section of the Arize docs for the full reference companion to this guide
+- Dive into the [OpenInference span kinds](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds) reference for every span kind and the attributes each carries
+- Read [Instrumentation approaches](/docs/phoenix/tracing/concepts-tracing/otel-openinference/instrumentation-approaches) for a deeper comparison of auto, manual, and hybrid instrumentation
+- Learn how to [propagate context across services or async boundaries](/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-propagation) when your app spans multiple processes
+- Reduce trace volume in production with [sampling](/docs/phoenix/tracing/concepts-tracing/otel-openinference/sampling)
+- Browse the [OpenInference repository](https://github.com/Arize-ai/openinference) for auto-instrumentors covering Anthropic, Bedrock, LangChain, LlamaIndex, CrewAI, AutoGen, and many others
+- Read the [OpenInference semantic conventions spec](https://github.com/Arize-ai/openinference/tree/main/spec) for the source-of-truth attribute definitions

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers.mdx
@@ -1,0 +1,156 @@
+---
+title: "OpenInference Context Managers"
+sidebarTitle: "Context managers"
+description: "Six context managers from openinference.instrumentation that attach session IDs, user IDs, metadata, tags, and prompt templates to every span in scope."
+keywords: ['using_session', 'using_user', 'using_metadata', 'using_tags', 'using_prompt_template', 'using_attributes', 'OpenInference', 'OITracer']
+---
+
+OpenInference provides a set of **context managers** that attach attributes to every span created while they're in scope. They are the easiest way to add cross-cutting context — session ID, user ID, metadata, tags, prompt templates — without modifying every span by hand.
+
+Context managers are the recommended way to handle attributes that apply to a *group* of spans. For attributes that only apply to one span, set them directly on that span instead.
+
+# How They Work
+
+Each context manager attaches a value to the OpenTelemetry context. When a span is created while the manager is in scope, the OpenInference-aware tracer returned by [`register()`](/docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers#what-register-does-under-the-hood) reads those context attributes and stamps them onto the span as it's created.
+
+This is why `register()` matters: it returns an `OITracer` instead of a vanilla OTel tracer. If you bypass `register()` and use the raw OTel tracer, these context managers still set context values, but the tracer won't pick them up automatically.
+
+# The Six Helpers
+
+All six live in `openinference.instrumentation`:
+
+| Helper | Sets | Use case |
+| :--- | :--- | :--- |
+| `using_session` | `session.id` | Group traces into a multi-turn conversation. |
+| `using_user` | `user.id` | Tag spans with the user the request belongs to. |
+| `using_metadata` | `metadata` | Arbitrary JSON-stringified data. |
+| `using_tags` | `tag.tags` | A list of tags for filtering and search. |
+| `using_prompt_template` | `llm.prompt_template.{template,version,variables}` | Attach the prompt template, its version, and the variables used. |
+| `using_attributes` | Any combination of the above | Set multiple in one block to avoid nesting. |
+
+# `using_session`
+
+Sets the `session.id` attribute on every span in scope. This is how Phoenix groups traces into a session.
+
+```python
+from openinference.instrumentation import using_session
+
+with using_session(session_id="user-42-conv-7"):
+    response = client.chat.completions.create(...)
+    # every span created in this block gets session.id = "user-42-conv-7"
+```
+
+For practical session setup, see [Set up sessions](/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-sessions).
+
+# `using_user`
+
+Sets the `user.id` attribute.
+
+```python
+from openinference.instrumentation import using_user
+
+with using_user(user_id="user-42"):
+    response = client.chat.completions.create(...)
+```
+
+# `using_metadata`
+
+Sets arbitrary JSON-stringified metadata. Useful for application-specific context (tenant, environment, request source) that doesn't fit the other helpers.
+
+```python
+from openinference.instrumentation import using_metadata
+
+with using_metadata({"tenant": "acme", "feature_flag": "v2"}):
+    response = client.chat.completions.create(...)
+```
+
+# `using_tags`
+
+Sets the `tag.tags` attribute — a list of strings used for filtering and search in the Phoenix UI.
+
+```python
+from openinference.instrumentation import using_tags
+
+with using_tags(["experiment-7", "high-priority"]):
+    response = client.chat.completions.create(...)
+```
+
+# `using_prompt_template`
+
+Sets the three prompt-template attributes — `llm.prompt_template.template`, `llm.prompt_template.version`, `llm.prompt_template.variables` — at once.
+
+```python
+from openinference.instrumentation import using_prompt_template
+
+template = "You are a helpful assistant. The user's name is {{name}}."
+
+with using_prompt_template(
+    template=template,
+    version="v3",
+    variables={"name": "Alice"},
+):
+    response = client.chat.completions.create(...)
+```
+
+Attaching the template (rather than only the final prompt) makes it possible to evaluate, compare, and re-run prompts directly from the Phoenix UI.
+
+# `using_attributes`
+
+Sets several of the above in one block — useful when you'd otherwise nest three or four context managers.
+
+```python
+from openinference.instrumentation import using_attributes
+
+with using_attributes(
+    session_id="user-42-conv-7",
+    user_id="user-42",
+    metadata={"tenant": "acme"},
+    tags=["experiment-7"],
+    prompt_template=template,
+    prompt_template_version="v3",
+    prompt_template_variables={"name": "Alice"},
+):
+    response = client.chat.completions.create(...)
+```
+
+For the canonical reference, see [Customize your traces](/docs/phoenix/tracing/how-to-tracing/add-metadata/customize-spans).
+
+# Manual Spans and Context Inheritance
+
+Context managers attach attributes to the OTel context. The `OITracer` reads those attributes when it creates a span — that's how auto-instrumented spans (and spans created with the `OITracer`) automatically inherit them.
+
+Manual spans created with a raw OTel tracer do **not** automatically pick up these context attributes. If you mix manual spans with context managers, use the helper from `openinference.instrumentation`:
+
+```python
+from openinference.instrumentation import get_attributes_from_context
+
+def create_span_with_context(tracer, name, **kwargs):
+    with tracer.start_as_current_span(name, **kwargs) as span:
+        context_attributes = dict(get_attributes_from_context())
+        span.set_attributes(context_attributes)
+        return span
+
+# Usage
+with using_session(session_id="my-session-id"):
+    with create_span_with_context(tracer, "my-manual-span") as span:
+        # span now has session.id attached
+        ...
+```
+
+This pulls the current context attributes and applies them to the new span. For more on this pattern, see [Advanced Patterns: Inheriting Context Attributes in Manual Spans](/docs/phoenix/tracing/how-to-tracing/setup-tracing#inheriting-context-attributes-in-manual-spans).
+
+# When Context Managers Help (and When They Don't)
+
+| Use a context manager when... | Set the attribute on the span directly when... |
+| :--- | :--- |
+| The value applies to many spans (whole conversation, whole request). | The value applies to just this one span. |
+| You're using auto-instrumentation and can't reach inside library code. | You're creating the span by hand anyway. |
+| You want to scope cross-cutting context cleanly with a `with` block. | The value is computed from per-span data. |
+
+---
+
+## Next step
+
+You've covered every approach to setting attributes. Next, the mechanics that keep traces intact across process, thread, and service boundaries — context propagation:
+
+<Card title="Next: Context Propagation" icon="arrow-right" href="/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-propagation" />

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers.mdx
@@ -122,13 +122,15 @@ Context managers attach attributes to the OTel context. The `OITracer` reads tho
 Manual spans created with a raw OTel tracer do **not** automatically pick up these context attributes. If you mix manual spans with context managers, use the helper from `openinference.instrumentation`:
 
 ```python
+from contextlib import contextmanager
+
 from openinference.instrumentation import get_attributes_from_context
 
+@contextmanager
 def create_span_with_context(tracer, name, **kwargs):
     with tracer.start_as_current_span(name, **kwargs) as span:
-        context_attributes = dict(get_attributes_from_context())
-        span.set_attributes(context_attributes)
-        return span
+        span.set_attributes(dict(get_attributes_from_context()))
+        yield span
 
 # Usage
 with using_session(session_id="my-session-id"):
@@ -137,7 +139,7 @@ with using_session(session_id="my-session-id"):
         ...
 ```
 
-This pulls the current context attributes and applies them to the new span. For more on this pattern, see [Advanced Patterns: Inheriting Context Attributes in Manual Spans](/docs/phoenix/tracing/how-to-tracing/setup-tracing#inheriting-context-attributes-in-manual-spans).
+This pulls the current context attributes and applies them to the new span. The `@contextmanager` decorator (with `yield span` instead of `return span`) keeps the span open for the duration of the `with` block — returning the span directly would end it before the block runs.
 
 # When Context Managers Help (and When They Don't)
 

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-propagation.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-propagation.mdx
@@ -1,0 +1,169 @@
+---
+title: "Context Propagation"
+sidebarTitle: "Context propagation"
+description: "How OpenTelemetry carries trace context across async boundaries, threads, and microservices — when propagation is automatic, when it's manual, and which propagators to use."
+keywords: ['context propagation', 'OpenTelemetry', 'baggage', 'TraceContextTextMapPropagator', 'asyncio', 'ThreadPoolExecutor', 'microservices']
+---
+
+OpenTelemetry tracks the current span via a **context** — an immutable object that holds the active span's ID, trace ID, and a few other pieces of metadata. When you call `tracer.start_as_current_span(...)`, OTel reads the current context, sets the new span as a child, and updates the context.
+
+Within a single thread of execution, this is automatic. Across threads, async boundaries, or service boundaries, the context doesn't follow on its own — you have to propagate it.
+
+# The Context Object
+
+Every span carries an immutable Context object containing:
+
+| Field | Description |
+| :--- | :--- |
+| **Span ID** | The current span's ID. |
+| **Trace ID** | The trace this span belongs to. |
+| **Trace flags** | Binary encoding of trace-level info (e.g., the sampled flag). |
+| **Trace state** | A list of key-value pairs with vendor-specific trace info. |
+| **Baggage** | Arbitrary contextual key-value data that travels alongside the trace. |
+
+**Baggage** is the channel for non-tracing data that should follow the request — feature flags, tenant IDs, request type. Baggage doesn't become span attributes automatically; if you want it on spans, you have to read it and set it explicitly.
+
+# When Propagation Is Needed (and When It Isn't)
+
+| Propagation is **NOT** needed | Propagation **IS** needed |
+| :--- | :--- |
+| Between function calls in the same module | Crossing process or service boundaries |
+| Between modules in the same process | HTTP requests |
+| Inside the same request lifecycle | gRPC calls |
+| Async code in the same process | Async jobs / background workers (separate process) |
+| | Any network boundary |
+
+Most application code falls into the left column — context propagation just works. The right column is where you need the propagators below.
+
+# Automatic Propagation
+
+In Python, OTel uses [`contextvars`](https://docs.python.org/3/library/contextvars.html) under the hood, which propagates context cleanly across:
+
+- Synchronous function calls.
+- `asyncio` tasks within the same event loop.
+- `await` boundaries.
+
+You don't have to do anything special — `tracer.start_as_current_span(...)` works as you'd expect.
+
+# Manual Context Propagation
+
+When automatic propagation breaks down — across threads, across services, into background workers — these are the tools OTel gives you:
+
+| Tool | Use |
+| :--- | :--- |
+| `context.get_current()` | Read the current context from outside the current execution path (custom threads, tasks, callbacks). |
+| `context.attach(ctx)` / `context.detach(token)` | Activate a previously captured context in a different thread or task. |
+| `set_baggage(key, value)` | Set a baggage value in the current context, to read later in the same execution path. |
+| `propagate.inject(carrier)` / `propagate.extract(carrier)` | Inject/extract context across service boundaries (HTTP/gRPC) using the globally-installed propagator. |
+
+The OTel Python API exposes `opentelemetry.propagate.inject` and `opentelemetry.propagate.extract`, which delegate to the global text-map propagator. By default that propagator is a `CompositePropagator` combining:
+
+| Propagator | Carries |
+| :--- | :--- |
+| `TraceContextTextMapPropagator` | Trace context (W3C `traceparent` and `tracestate` headers). |
+| `W3CBaggagePropagator` | Baggage. |
+
+You can swap the global propagator with `propagate.set_global_textmap(...)` if you need a different combination — for example, adding B3 for legacy systems. The OTel specification just requires SDKs to default to a composite of the W3C Trace Context and Baggage propagators; JS/Go/Java equivalents construct the same composite under slightly different names. Check the [Propagators spec](https://opentelemetry.io/docs/specs/otel/context/api-propagators/) for your language.
+
+For the Python API reference, see [OpenTelemetry Context API](https://opentelemetry-python.readthedocs.io/en/latest/api/context.html) and [Propagators API](https://opentelemetry-python.readthedocs.io/en/latest/api/propagators.html).
+
+# Async Functions (Same Service)
+
+When you launch async work from sync code, the context doesn't always follow. Capture it explicitly:
+
+```python
+import asyncio
+from opentelemetry import trace
+from opentelemetry.context import attach, detach, get_current
+
+tracer = trace.get_tracer(__name__)
+
+async def async_func(ctx):
+    token = attach(ctx)
+    try:
+        current_span = trace.get_current_span()
+        current_span.set_attribute("input.value", "User Input")
+        await asyncio.sleep(1)  # Simulate async work
+    finally:
+        detach(token)
+
+def sync_func():
+    with tracer.start_as_current_span("sync_span") as span:
+        context = get_current()
+        asyncio.run(async_func(context))
+```
+
+The pattern:
+
+1. Capture the current context **before** launching async work: `context = get_current()`.
+1. Pass the context into the async function.
+1. Inside the async function, `attach(ctx)` and store the returned token.
+1. In a `finally`, `detach(token)` to restore the previous context.
+
+For more patterns including `ThreadPoolExecutor`, see [Advanced Patterns: Manual Context Propagation](/docs/phoenix/tracing/how-to-tracing/setup-tracing#manual-context-propagation).
+
+# Across Microservices
+
+Crossing a service boundary is where propagators earn their keep. Service A injects the current context into outbound request headers; Service B extracts it on the inbound side and uses it as the parent for its own spans.
+
+**Service A** (caller):
+
+```python
+import requests
+from opentelemetry import propagate, trace
+
+tracer = trace.get_tracer(__name__)
+
+def service_a():
+    with tracer.start_as_current_span("llm_service_a") as span:
+        headers = {}                       # Prepare carrier for injected context
+        propagate.inject(carrier=headers)  # Inject current context into headers
+        response = requests.get("http://service-b:5000/endpoint", headers=headers)
+        return response
+```
+
+**Service B** (callee):
+
+```python
+from opentelemetry import propagate, trace
+
+tracer = trace.get_tracer(__name__)
+
+def service_b(request):
+    context = propagate.extract(carrier=dict(request.headers))
+    # Create a new span as child of the extracted context
+    with tracer.start_as_current_span("llm_service_b", context=context) as span:
+        ...
+```
+
+After this, Service B's span appears as a child of Service A's span — even though they ran in different processes — and both appear under the same trace ID in the Phoenix UI.
+
+```mermaid
+sequenceDiagram
+    participant A as Service A
+    participant B as Service B
+    Note over A: start_as_current_span("llm_service_a")<br/>trace_id: T1, span_id: S1
+    Note over A: propagate.inject(carrier=headers)
+    A->>+B: HTTP GET /endpoint<br/>traceparent: 00-T1-S1-01
+    Note over B: propagate.extract(carrier=request.headers)
+    Note over B: start_as_current_span("llm_service_b", context=ctx)<br/>trace_id: T1, span_id: S2, parent_id: S1
+    B-->>-A: response
+    Note over A,B: Both spans share trace_id T1.
+```
+
+# Common Propagation Failure Modes
+
+A few patterns that produce orphaned or broken traces:
+
+- **Forgetting to inject context on the caller side** — the callee starts a new trace instead of joining the existing one. Symptom: caller and callee appear as separate traces in the Phoenix UI.
+- **Using different propagators on each side** — if Service A injects W3C headers and Service B only extracts a different format, the context is silently lost. Stick with the default global propagator on both sides unless you have a specific reason not to.
+- **Stripping headers in the network layer** — proxies, API gateways, and service meshes sometimes strip headers they don't recognize. The W3C `traceparent` header is usually safe but verify with your infrastructure team.
+- **Async work that escapes the request lifecycle** — fire-and-forget tasks (background workers, queues) need explicit context capture before submission.
+
+---
+
+## Next step
+
+Context propagation is about making sure spans are connected. Sampling is about which spans get recorded at all:
+
+<Card title="Next: Sampling" icon="arrow-right" href="/docs/phoenix/tracing/concepts-tracing/otel-openinference/sampling" />

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-propagation.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-propagation.mdx
@@ -100,8 +100,6 @@ The pattern:
 1. Inside the async function, `attach(ctx)` and store the returned token.
 1. In a `finally`, `detach(token)` to restore the previous context.
 
-For more patterns including `ThreadPoolExecutor`, see [Advanced Patterns: Manual Context Propagation](/docs/phoenix/tracing/how-to-tracing/setup-tracing#manual-context-propagation).
-
 # Across Microservices
 
 Crossing a service boundary is where propagators earn their keep. Service A injects the current context into outbound request headers; Service B extracts it on the inbound side and uses it as the parent for its own spans.

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter.mdx
@@ -1,0 +1,154 @@
+---
+title: "Exporter and OTLP"
+sidebarTitle: "Exporter and OTLP"
+description: "How OpenTelemetry ships spans out of your application — exporters, the OTLP protocol, and the choice between gRPC and HTTP transport."
+keywords: ['exporter', 'OTLP', 'gRPC', 'HTTP', 'OpenTelemetry', 'OTLPSpanExporter', 'protobuf']
+---
+
+An **exporter** sends telemetry data out of your application to a backend system. It's the component that does the actual network call to Phoenix (or any other OTel-compatible backend).
+
+The exporter handles a handful of distinct concerns:
+
+| Concern | What the exporter does |
+| :--- | :--- |
+| **Serialization** | Converts spans into Protobuf, JSON, or another wire format. |
+| **Transport** | Sends the bytes over HTTP, gRPC, or another protocol. |
+| **Authentication** | Attaches API keys, tokens, or TLS credentials. |
+| **Compression** | Reduces payload size (typically gzip). |
+| **Timeouts** | Protects you from slow or broken networks. |
+
+<Info>
+Exporter timeouts are different from [Span Processor](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor) timeouts. The exporter timeout protects you from slow networks; the processor timeout protects you from slow or overloaded export pipelines. Set the processor timeout higher than the exporter timeout — see the pitfalls section below.
+</Info>
+
+For the full specification, see [Exporter documentation](https://opentelemetry.io/docs/specs/otel/protocol/exporter/).
+
+# OTLP (OpenTelemetry Protocol)
+
+OTLP is the standardized wire format and transport for OpenTelemetry data. Phoenix accepts spans over OTLP, and most OTel-compatible backends do too.
+
+OTLP defines three things:
+
+| Layer | Options |
+| :--- | :--- |
+| **Data model** | The structure of spans, metrics, and logs on the wire. |
+| **Serialization** | Protocol Buffers (compact binary format) or JSON. |
+| **Transport** | gRPC or HTTP. |
+
+For the full specification, see [OTLP Specification](https://opentelemetry.io/docs/specs/otlp/).
+
+# Transport: gRPC vs HTTP
+
+OTLP supports two transports. They're not identical — pick based on your environment.
+
+| | OTLP/gRPC | OTLP/HTTP |
+| :--- | :--- | :--- |
+| **Serialization** | Protobuf only | Protobuf or JSON |
+| **Underlying protocol** | HTTP/2 (via gRPC) | Standard HTTP POST |
+| **Default port** | 4317 | 4318 |
+| **Strengths** | Best for production, high-throughput workloads | Easier through proxies, meshes, and corporate firewalls; JSON is easier to debug |
+| **Trade-offs** | Some proxies and load balancers don't handle gRPC well | Slightly higher overhead than gRPC |
+
+## OTLP/gRPC Configuration
+
+Phoenix serves OTLP/gRPC on port `4317` by default. The gRPC endpoint is `host:port` (no URL path):
+
+```python
+import grpc
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+otlp_exporter = OTLPSpanExporter(
+    endpoint="localhost:4317",                 # host:port — no path, no scheme
+    insecure=True,                             # Local Phoenix has no TLS
+    headers={                                  # Auth header (optional for local Phoenix)
+        "Authorization": "Bearer PHOENIX_API_KEY",
+    },
+    timeout=10,                                # Network timeout (seconds)
+    compression=grpc.Compression.Gzip,         # grpc.Compression enum
+)
+```
+
+For a Phoenix Cloud or TLS-fronted Phoenix deployment, drop `insecure=True` and pass `credentials=grpc.ssl_channel_credentials()`.
+
+## OTLP/HTTP Configuration
+
+```python
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+otlp_exporter = OTLPSpanExporter(
+    endpoint="http://localhost:6006/v1/traces",
+    headers={                                  # Auth header (optional for local Phoenix)
+        "Authorization": "Bearer PHOENIX_API_KEY",
+    },
+    timeout=10,
+    compression=Compression.Gzip,              # http Compression enum
+)
+```
+
+Three differences worth knowing about the HTTP exporter:
+
+- No `credentials` constructor argument — TLS is automatic when the endpoint starts with `https://`. For client certificates, pass `certificate_file`, `client_key_file`, or `client_certificate_file`.
+- No `insecure=True` option — controlled entirely by the `http://` vs `https://` scheme on the endpoint.
+- No `protocol` constructor argument. To switch the body format between `http/protobuf` (default) and `http/json`, set `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` in the environment.
+
+For the full set of constructor parameters, see the [OTLP Exporter API reference](https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html).
+
+# Multiple Exporters
+
+You can attach multiple exporters to the same Tracer Provider — useful for development (export to Phoenix *and* to the console) or for fan-out to multiple backends.
+
+```python
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+phoenix_exporter = OTLPSpanExporter(
+    endpoint="localhost:4317",                 # host:port for gRPC
+    insecure=True,                             # Local Phoenix has no TLS
+    headers={                                  # Auth header (optional for local Phoenix)
+        "Authorization": "Bearer PHOENIX_API_KEY",
+    },
+)
+
+console_exporter = ConsoleSpanExporter()
+
+tracer_provider.add_span_processor(BatchSpanProcessor(phoenix_exporter))
+tracer_provider.add_span_processor(BatchSpanProcessor(console_exporter))
+```
+
+Each exporter gets its own span processor. They run independently — a failure in one doesn't affect the other.
+
+# Environment Variables
+
+You can configure the exporter entirely from the environment, which is the recommended pattern for production:
+
+| Generic | Traces-only override |
+| :--- | :--- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | `OTEL_EXPORTER_OTLP_TRACES_HEADERS` |
+| `OTEL_EXPORTER_OTLP_CERTIFICATE` | `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE` |
+| `OTEL_EXPORTER_OTLP_INSECURE` | `OTEL_EXPORTER_OTLP_TRACES_INSECURE` |
+| `OTEL_EXPORTER_OTLP_COMPRESSION` | `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION` |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` |
+
+The traces-only variant takes priority over the generic one when both are set. For the full reference, see [OpenTelemetry environment variables](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options).
+
+# Common Pitfalls
+
+A few exporter failure modes worth knowing about up front:
+
+- **Wrong OTLP port or endpoint** — gRPC defaults to 4317, HTTP to 4318. Mixing them up surfaces as connection refused or 404s.
+- **Wrong encoding for the transport** — gRPC requires Protobuf. Trying to send JSON over gRPC will silently fail.
+- **Proxies breaking gRPC** — corporate proxies, service meshes, and some load balancers don't handle HTTP/2 well. If you see flaky gRPC errors, switch to HTTP.
+- **TLS mismatches** — forgetting `insecure=True` when running against a local collector over `http://` fails. So does setting `insecure=False` against an `http://` endpoint. Match `insecure` to the scheme: `True` for `http://`, `False` (default) for `https://`.
+- **Exporter timeout too high** — if the exporter timeout exceeds the [Span Processor](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor) timeout, the processor can fire a retry while the original export is still in flight, leading to queue buildup and dropped spans.
+- **Spans over 4 MB hit gRPC message-size limits** — very large attributes (full document text, base64 images) can blow past the gRPC default. Truncate large attributes with [`TraceConfig`](/docs/phoenix/tracing/how-to-tracing/advanced/masking-span-attributes) or chunk them.
+
+---
+
+## Next step
+
+The exporter sends spans. The span processor decides *when* and *how often*:
+
+<Card title="Next: Span Processor" icon="arrow-right" href="/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor" />

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/instrumentation-approaches.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/instrumentation-approaches.mdx
@@ -1,0 +1,148 @@
+---
+title: "Instrumentation Approaches"
+sidebarTitle: "Instrumentation approaches"
+description: "Three ways to emit spans — auto-instrumentation, manual instrumentation, and hybrid — with trade-offs, mechanics, and the custom span processor pattern."
+keywords: ['auto-instrumentation', 'manual instrumentation', 'hybrid instrumentation', 'monkey patching', 'custom span processor', 'OpenInference', 'tracer']
+---
+
+There are three ways to emit spans from your application:
+
+| Approach | Effort | Coverage |
+| :--- | :--- | :--- |
+| **Auto-instrumentation** | Few lines of setup code | Whatever the instrumentor library supports |
+| **Manual instrumentation** | Per-span code | Anything you want to trace |
+| **Hybrid** | Auto + targeted manual work | Best of both — start broad, fill gaps |
+
+For practical setup, see [Auto-instrumentation](/docs/phoenix/tracing/how-to-tracing/setup-tracing), [Manual instrumentation](/docs/phoenix/tracing/how-to-tracing/add-metadata/customize-spans), and [Combining auto and manual](/docs/phoenix/tracing/how-to-tracing/setup-tracing). This page covers what each approach is doing under the hood.
+
+# Auto-instrumentation
+
+Auto-instrumentation automatically collects telemetry from supported libraries — no per-call code changes needed. Recommended whenever an OpenInference auto-instrumentor exists for your stack.
+
+## Initializing an Auto-instrumentor
+
+```python
+from phoenix.otel import register
+from openinference.instrumentation.openai import OpenAIInstrumentor
+
+tracer_provider = register(
+    project_name="my-project",
+    # api_key="..."  # Optional — only needed for Phoenix Cloud or authenticated instances
+)
+
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+```
+
+After this runs, every OpenAI call your application makes is traced — model name, input messages, output messages, token counts, finish reason, all set as attributes on an LLM span.
+
+For the full list of supported frameworks and providers, see [Integrations](/docs/phoenix/integrations).
+
+## How Auto-instrumentors Work
+
+Auto-instrumentors use a technique called **monkey patching** to wrap library functions with tracing logic. The mechanics:
+
+When you call `OpenAIInstrumentor().instrument()`:
+
+1. **Identify** — the instrumentor targets specific functions in the library (e.g., `openai.chat.completions.create`).
+1. **Wrap** — the original function is replaced with a wrapper that:
+   1. Creates a span before the original function runs.
+   1. Calls the original function.
+   1. Sets span attributes from the function's arguments and response (e.g., `llm.input_messages`, `llm.output_messages`, `llm.token_count.*`).
+   1. Ends the span.
+
+The wrapping happens at import time (or at `instrument()` call time, depending on the library). After that, every call to the wrapped function flows through the tracing logic transparently.
+
+For the source of every OpenInference instrumentor, see the [OpenInference repository](https://github.com/Arize-ai/openinference).
+
+# Manual Instrumentation
+
+Manual instrumentation means creating each span explicitly using the OTel `tracer` and setting attributes following the [OpenInference semantic conventions](/docs/phoenix/tracing/concepts-tracing/otel-openinference/semantic-conventions).
+
+The most common pattern uses `start_as_current_span` so the new span automatically becomes a child of the most recent active span in the OTel context:
+
+```python
+with tracer.start_as_current_span("span-name") as span:
+    span.set_attributes({
+        "openinference.span.kind": "TOOL",
+        "tool.name": "search",
+        "input.value": query,
+        "output.value": result,
+    })
+```
+
+`start_as_current_span` does two important things:
+
+1. It automatically sets the span as the active span in the OTel context, so any spans created inside the block become children.
+1. It automatically calls `span.end()` when the context-manager block exits, so you don't have to manage span lifetime by hand.
+
+When spans are created without explicitly setting their context, they inherit the most recent active span as their `parent_id` — which is exactly what you want for nested operations.
+
+## Pros and Cons
+
+| | |
+| :--- | :--- |
+| **Pros** | Full control. You decide what spans to create, what attributes to set, and how the tree is shaped. Works for any code, not just libraries the instrumentor supports. |
+| **Cons** | Tracing an entire application by hand is tedious. Custom decorators help. Instrumentation code lives alongside your application code, which adds maintenance burden and can distract from the core logic when reading the file. |
+
+## Common Pitfalls
+
+A few failure modes worth knowing about:
+
+- **Forgetting to end a span** — spans are only handed off to the [span processor](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor) when `end()` is called. A never-ended span never exports. Use `start_as_current_span` (which auto-ends) to avoid this entirely.
+- **Not setting span status** — set `Ok` or `Error` explicitly so the Phoenix UI can flag failures.
+- **Missing important semantic conventions**:
+  - `openinference.span.kind` — without this, the Phoenix UI can't pick the right icon.
+  - `input.value` and `output.value` — without these, the trace list view shows blanks.
+  - `llm.input_messages` and `llm.output_messages` on LLM spans — the chat history doesn't render in the Phoenix UI without them.
+  - `tool.name` and `tool.parameters` on tool spans — tool detail panels stay empty.
+
+For the practical how-to, see [Manual Instrumentation](/docs/phoenix/tracing/how-to-tracing/add-metadata/customize-spans).
+
+# Hybrid Instrumentation
+
+Auto-instrumentors are an easy way to *begin* tracing, but they only know about what the underlying library exposes. The most interesting parts of an AI application — tool execution in user code, custom business logic, agent loops, evaluation steps — often need extra spans or extra attributes the instrumentor can't see.
+
+Hybrid instrumentation combines auto-instrumentation with targeted manual work. Three primary ways to extend an auto-instrumented trace:
+
+| Method | Pros | Cons |
+| :--- | :--- | :--- |
+| **Manually add additional spans** with `tracer.start_as_current_span()` while the traced application is running, setting attributes on the newly created span. | Full control over what's added. Fairly easy to implement. | Depending on the instrumented library, it can be hard to insert a custom span at the right place in the trace tree. |
+| **[OpenInference Context Managers](/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers)** like `using_session`, `using_user`, `using_metadata` — apply attributes to every span created inside their scope. | Very easy to implement. No per-span code. | Adds attributes to *all* spans in scope. Useful for cross-cutting context like session ID; less useful for per-span data. |
+| **[Custom span processor](#custom-span-processor)** — a class that mutates spans as they pass through the pipeline. | Centralized — one place to enrich or filter every span. | More complex to author and reason about. |
+
+## Custom Span Processor
+
+Custom span processors are the most powerful hybrid pattern. You write a class that implements `on_start` and `on_end` (and optionally the upcoming `on_ending`) and attach it to the Tracer Provider.
+
+What you can do at each hook:
+
+| Hook | Span state | What it's good for |
+| :--- | :--- | :--- |
+| `on_start(span, parent_context)` | Mutable. Attributes may not be set yet, but name and span context can be edited. | Adding context-scoped attributes (request ID, tenant ID). |
+| `on_end(span)` | Passed in as a `ReadableSpan` — intended to be immutable. | Filtering, enriching, or modifying attributes before export. |
+| `on_ending(span)` | Mutable (still in development). | Last-moment attribute changes without the immutability workarounds. |
+
+The classic use case is **PII redaction**: walk every outgoing span and scrub sensitive values from the attributes. For practical examples, see [Mask and redact data](/docs/phoenix/tracing/how-to-tracing/advanced/masking-span-attributes).
+
+<Warning>
+The `ReadableSpan` passed to `on_end` is *intended* to be immutable. In Python you can edit it anyway, but doing so affects every downstream processor and exporter attached to the same Tracer Provider. If you need to modify a span, prefer copying the `ReadableSpan` with edited attributes rather than mutating it in place.
+</Warning>
+
+For the full lifecycle details and how `on_end` immutability varies between Python and TypeScript, see the [Span Processor](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor) page.
+
+# Choosing an Approach
+
+A practical decision tree:
+
+1. **Is there an OpenInference auto-instrumentor for your stack?** Use it. Start there.
+1. **Are there gaps it doesn't cover** (tool execution, business logic, custom retrieval)? Add manual spans for those operations.
+1. **Do you need to attach the same context to many spans** (session ID, user ID)? Use the [context managers](/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers).
+1. **Do you need centralized policy across every span** (PII redaction, attribute enrichment, conditional filtering)? Write a custom span processor.
+
+---
+
+## Next step
+
+The easiest way to add context to a whole block of spans is with the OpenInference context managers:
+
+<Card title="Next: OpenInference Context Managers" icon="arrow-right" href="/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers" />

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/otel-collector.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/otel-collector.mdx
@@ -1,0 +1,114 @@
+---
+title: "OpenTelemetry Collector"
+sidebarTitle: "OpenTelemetry Collector"
+description: "An optional intermediate service that receives spans, processes them, and exports them to a backend — with deployment models, use cases, and the most common configuration pitfalls."
+keywords: ['OpenTelemetry Collector', 'receiver', 'processor', 'exporter', 'sidecar', 'gateway', 'batch processor', 'PII redaction']
+---
+
+The **[OpenTelemetry Collector](https://opentelemetry.io/docs/collector/)** is a service that receives telemetry, processes it, and exports it to one or more backends. It's optional — most applications send spans directly from the SDK to Phoenix — but it unlocks centralized policy, multi-backend fan-out, dynamic routing, and tail sampling that the SDK can't express.
+
+# Anatomy of a Collector
+
+Collectors are composed of **pipelines**. Each pipeline chains three component types:
+
+| Component | Role |
+| :--- | :--- |
+| **Receiver** | Listens for incoming telemetry (OTLP over gRPC, OTLP over HTTP, Jaeger, Zipkin, ...). |
+| **Processor** | Transforms, filters, enriches, batches, or samples spans as they flow through. |
+| **Exporter** | Sends the processed telemetry out — to Phoenix, to another backend, to multiple backends, to disk. |
+
+All components and pipelines are defined in a single `config.yaml`. The Collector's flexibility comes from how those components are composed.
+
+<Frame>
+  <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/otel-collector-1.png" alt="OpenTelemetry Collector architecture: receivers → processors → exporters in a pipeline" />
+</Frame>
+
+For the canonical specification, see [OpenTelemetry Collector documentation](https://opentelemetry.io/docs/collector/).
+
+# Deployment Models
+
+Three common ways to deploy a Collector:
+
+| Model | How it works | Best for |
+| :--- | :--- | :--- |
+| **Agent** | Collector runs alongside the application — as a sidecar container, a daemonset, or a local process. | Simple setups, clear 1:1 mapping between app and collector. |
+| **Gateway** | A central collector receives from many applications. | Centralized policy, credential management, single point of egress. |
+| **Hybrid** | Agent collectors forward to a centralized gateway. | Large environments — distributed collection plus centralized processing. |
+
+```mermaid
+flowchart LR
+    subgraph Agent["Agent — one collector per app"]
+        direction LR
+        A1[App] --> AC[Collector] --> PHX[Phoenix]
+    end
+```
+
+```mermaid
+flowchart LR
+    subgraph Gateway["Gateway — one collector, many apps"]
+        direction LR
+        G1[App 1] --> GC[Collector]
+        G2[App 2] --> GC
+        G3[App 3] --> GC
+        GC --> PHX[Phoenix]
+    end
+```
+
+```mermaid
+flowchart LR
+    subgraph Hybrid["Hybrid — agents feeding a gateway"]
+        direction LR
+        H1[App 1] --> HA1[Agent<br/>collector] --> HG[Gateway<br/>collector]
+        H2[App 2] --> HA2[Agent<br/>collector] --> HG
+        H3[App 3] --> HA3[Agent<br/>collector] --> HG
+        HG --> PHX[Phoenix]
+    end
+```
+
+# Common Use Cases
+
+Reasons to put a Collector between your applications and Phoenix:
+
+| Use case | What the Collector does |
+| :--- | :--- |
+| **Filtering** | Drop spans by name, attribute, or pattern using a `filter` processor — useful for cutting noise from health checks or known-uninteresting paths. |
+| **PII redaction or attribute modification** | Use a `transform` processor to scrub sensitive fields, hash user IDs, or replace values before export. |
+| **Fan-out to multiple backends** | Send the same spans to Phoenix and a long-term storage system, or to Phoenix and a metrics backend, without duplicating instrumentation in the app. |
+| **Project routing** | Use a `routing` connector to send spans to different Phoenix projects (or different Phoenix instances) based on span attributes — for example, splitting tenant traffic. Phoenix itself doesn't expose multi-project routing in the SDK; the Collector is where that logic belongs. |
+| **Tail sampling** | Buffer complete traces and decide which to keep based on outcome (error spans, slow requests, specific attributes). |
+| **Credential centralization** | Application code stays free of Phoenix Cloud API keys; the Collector handles authentication at a single chokepoint. |
+| **Tail-end batching** | Reduce the number of network round-trips from your fleet to Phoenix by batching across applications at the Collector. |
+
+# Common Pitfalls
+
+A few Collector failure modes to know about:
+
+- **Forgetting Phoenix Cloud authentication** — when exporting to Phoenix Cloud or any authenticated Phoenix instance, the Collector needs to add `Authorization: Bearer <api-key>` to outbound requests. Use the `headers_setter` extension or set them in the exporter configuration. Local Phoenix doesn't require auth.
+- **Modifying shared span objects across pipelines** — when one pipeline mutates a span, every other pipeline that processes the same span sees the modification. Use a `routing` connector to duplicate spans cleanly before fan-out.
+- **No batch processor at the end of the pipeline** — for production volumes, the last processor in a pipeline should be a `batch` processor. Without it, the Collector exports one span at a time, which is inefficient.
+- **Wrong Collector endpoint** — applications need to point at the Collector's OTLP endpoint (gRPC: `:4317`, HTTP: `:4318`), not at Phoenix directly. Mixing the two is a common source of "why are some spans missing?" debugging.
+- **Receiver missing `include_metadata: true`** — when a centralized gateway uses inbound request metadata for routing (e.g., reading the target Phoenix project from a header), the receiver has to be told to make that metadata available. Without it, the routing extension has nothing to read.
+
+# Where the Collector Fits
+
+Both with and without a Collector, your application code looks the same — the [Exporter](/docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter) points at an OTLP endpoint. The difference is just which OTLP endpoint:
+
+```
+Without Collector:
+  App → Exporter → http://localhost:6006 (or Phoenix Cloud)
+
+With Collector:
+  App → Exporter → Collector → (processors) → Phoenix (and/or other backends)
+```
+
+Start without a Collector. Add one when you need centralized policy, multi-backend fan-out, tail sampling, or routing logic the SDK can't express.
+
+---
+
+## You've completed the OpenTelemetry and OpenInference reference
+
+Every concept in this section — signals, the four OTel components, the Phoenix helpers, OpenInference conventions, span kinds, instrumentation approaches, context, sampling, and the Collector — is now in your toolbox.
+
+Time to instrument:
+
+<Card title="Set up tracing" icon="arrow-right" href="/docs/phoenix/tracing/how-to-tracing" />

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/overview.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/overview.mdx
@@ -1,0 +1,96 @@
+---
+title: "OpenTelemetry and OpenInference"
+sidebarTitle: "Overview"
+description: "How Phoenix tracing is built on OpenTelemetry and OpenInference — the two open standards that make AI observability vendor-agnostic and portable."
+keywords: ['OpenTelemetry', 'OpenInference', 'observability', 'AI tracing', 'concepts', 'reference']
+---
+
+Reliability is trust at scale. Users expect AI systems to work — every time. Downtime, latency, and quietly degraded behavior erode trust faster than any single outage. Modern AI applications are some of the hardest systems to keep reliable: a single request can call a model, hit a vector store, invoke a tool, and chain back through more LLM calls before producing an answer. When something goes wrong, the failure is distributed and often silent.
+
+The goal isn't zero failures. It's **fast detection, clear visibility, and quick recovery** — and that requires observability.
+
+This video contains a walkthrough of every topic in this section:
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/fHGSxOhWO-g"
+  title="OpenTelemetry 101 for AI Tracing"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
+# The Silent Failures Problem
+
+AI systems are inherently black boxes. When an answer is wrong, the cause is rarely obvious:
+
+- Was it a bad retrieval?
+- The wrong tool call?
+- A model that picked the wrong path through an agent loop?
+- A subtle regression after a prompt change?
+
+You can't fix what you can't see. Observability turns those black boxes into something you can read — every LLM call, every tool invocation, every retrieval, captured as structured data you can query, evaluate, and debug.
+
+Phoenix is built on two open standards that make AI observability work: **OpenTelemetry** and **OpenInference**.
+
+# What is OpenTelemetry?
+
+> *"OpenTelemetry is an observability framework and toolkit designed to facilitate the generation, export, and collection of telemetry data."*
+
+[OpenTelemetry](https://opentelemetry.io) (OTel) is the industry-standard, vendor-neutral framework for collecting telemetry from any kind of software system. A few terms it's worth pinning down:
+
+- **Observability** — the ability to understand the internal state of a system by examining its outputs.
+- **Telemetry** — the data emitted by a system. The main signals are traces, metrics, and logs; the OTel spec also covers baggage and is adding events and profiles.
+- **Instrumentation** — the code that generates and exports telemetry.
+- **Auto-instrumentation** — libraries that emit telemetry without any code changes from you.
+
+## What OpenTelemetry Is and Isn't
+
+| OpenTelemetry **is** | OpenTelemetry **is not** |
+| :--- | :--- |
+| A framework | A backend |
+| Open source | A storage layer |
+| Vendor-agnostic | A frontend or UI |
+| Tool-agnostic | A visualization tool |
+| Language-agnostic | |
+| Infrastructure-agnostic | |
+| An industry standard | |
+
+That last column is why OTel pairs with a backend like Phoenix — OTel handles the collection, Phoenix handles the storage, visualization, evaluation, and the rest of the AI engineering loop.
+
+# What is OpenInference?
+
+> *"OpenInference is a set of conventions and plugins that is complementary to OpenTelemetry to enable tracing of AI applications."*
+
+[OpenInference](https://github.com/Arize-ai/openinference) is an open standard for AI/LLM observability, built on top of OpenTelemetry and maintained by Arize. Where OTel gives you the generic span and trace primitives, OpenInference adds the **AI-specific semantic conventions** — span kinds (LLM, Tool, Agent, Retriever, etc.), attribute names (`llm.input_messages`, `llm.token_count.total`), and the auto-instrumentor libraries that wrap popular AI frameworks.
+
+OpenInference has the most extensive collection of auto-instrumentors for AI/LLM applications. Supported languages include **Python, JavaScript, and Java**, with auto-instrumentors covering:
+
+LangChain, LangGraph, LlamaIndex, AutoGen, CrewAI, BeeAI, Vercel AI SDK, OpenAI, AWS Bedrock, Anthropic, Groq, LiteLLM, Portkey, Google ADK, Pydantic AI, Mistral, VertexAI, DSPy, Instructor, Haystack, Guardrails AI, Semantic Kernel, Microsoft Agent Framework, Smolagents, AWS Strands, Together AI, Pipecat, MCP — and more.
+
+For the full list, see [Integrations](/docs/phoenix/integrations).
+
+# How OpenTelemetry and OpenInference Fit Together
+
+OTel defines *how* telemetry is shaped, transported, and exported. OpenInference defines *what* AI-specific data to put inside it. Together they give you:
+
+1. **30+ native integrations** across LLM providers and agent frameworks.
+1. **Portability** — your instrumentation isn't locked to Phoenix. It works with any OTel-compatible backend.
+1. **A standardized format** for AI trace data, so tools and backends understand it without custom mapping.
+
+<Frame>
+  <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/concepts-how-to-tracing.avif" alt="How tracing works: instrumentation produces spans following OpenInference conventions, exports them over OTLP, and Phoenix ingests and visualizes them" />
+</Frame>
+
+# What's in This Section
+
+The rest of the pages in this section are a conceptual reference. They explain the **what** and **why** of each piece of the OTel + OpenInference stack. For step-by-step setup, see [Set up tracing](/docs/phoenix/tracing/how-to-tracing).
+
+All code examples are in Python. The same concepts apply in any OpenTelemetry-supported language — see the [OpenTelemetry documentation](https://opentelemetry.io/docs/languages/) for examples in JavaScript, Go, Java, and others.
+
+---
+
+## Next step
+
+Start with the fundamental data shapes — signals, spans, traces, and sessions:
+
+<Card title="Next: Signals, Spans, Traces, and Sessions" icon="arrow-right" href="/docs/phoenix/tracing/concepts-tracing/otel-openinference/signals" />

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers.mdx
@@ -1,0 +1,131 @@
+---
+title: "The phoenix.otel Helpers"
+sidebarTitle: "phoenix.otel helpers"
+description: "The arize-phoenix-otel SDK collapses raw OpenTelemetry setup into a single register() call, with auto-instrumentation discovery and Phoenix-aware defaults."
+keywords: ['phoenix.otel', 'register', 'auto_instrument', 'PHOENIX_API_KEY', 'PHOENIX_COLLECTOR_ENDPOINT', 'PHOENIX_PROJECT_NAME']
+---
+
+The previous four pages — [Resource](/docs/phoenix/tracing/concepts-tracing/otel-openinference/resource), [Exporter](/docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter), [Span Processor](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor), and [Tracer Provider](/docs/phoenix/tracing/concepts-tracing/otel-openinference/tracer-provider) — walked through the OpenTelemetry tracing components one by one. Wiring them up by hand in every application is verbose. The `phoenix.otel` SDK collapses all of it into a single function call — and adds a few Phoenix-specific capabilities on top.
+
+For the practical how-to of installing and using these helpers, see [Set up tracing](/docs/phoenix/tracing/how-to-tracing). This page covers what they do under the hood.
+
+# Appreciate the Simplicity
+
+Configuring tracing with raw OpenTelemetry — Resource, Exporter, Span Processor, Tracer Provider — looks like this:
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+def init_phoenix_tracing():
+    resource = Resource.create({
+        "openinference.project.name": "my-project",
+    })
+    otlp_exporter = OTLPSpanExporter(
+        endpoint="http://localhost:6006/v1/traces",
+    )
+    span_processor = BatchSpanProcessor(otlp_exporter)
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(span_processor)
+    trace.set_tracer_provider(tracer_provider)
+
+    return tracer_provider.get_tracer("my-project")
+```
+
+The Phoenix `register()` helper replaces all of that:
+
+```python
+from phoenix.otel import register
+
+tracer_provider = register(project_name="my-project")
+```
+
+Same outcome — Resource, Exporter, Span Processor, Tracer Provider all wired up — in much less code.
+
+# What `register()` Does Under the Hood
+
+The convenience function handles four things for you. Each one has additional capabilities specific to OpenInference and Phoenix compared to the standard OTel SDK:
+
+| Component returned by `register()` | What it adds beyond standard OTel |
+| :--- | :--- |
+| **Tracer Provider** | A Phoenix-aware provider with sensible defaults. Combined with the OpenInference instrumentation libraries, it makes the [OpenInference context managers](/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers) (`using_session`, `using_user`, `using_metadata`, etc.) attach attributes to spans automatically. |
+| **Span Processor** | Configured and pre-attached. `SimpleSpanProcessor` by default, `BatchSpanProcessor` when you pass `batch=True`. |
+| **Span Exporter** | Auto-detects gRPC or HTTP from the endpoint URL and configures the matching OTLP exporter. If `api_key` is set, it adds the `Authorization: Bearer <key>` header for you. |
+| **Resource** | Sets the project name automatically from your `project_name` argument (or the `PHOENIX_PROJECT_NAME` environment variable). |
+
+# Auto-instrumentation
+
+`register()` has an `auto_instrument=True` option that automatically calls `.instrument()` on every OpenInference auto-instrumentor installed in your environment.
+
+```python
+from phoenix.otel import register
+
+tracer_provider = register(
+    project_name="my-project",
+    auto_instrument=True,
+)
+```
+
+That single call replaces manually doing `OpenAIInstrumentor().instrument(...)`, `LangChainInstrumentor().instrument(...)`, and so on for every installed instrumentor. Just `pip install` the instrumentors you want active, and `auto_instrument=True` finds them at runtime.
+
+For the full set of installable instrumentors, see the [OpenInference repository](https://github.com/Arize-ai/openinference).
+
+# Configuration
+
+`register()` reads from environment variables when arguments aren't passed:
+
+| Argument | Environment variable | Notes |
+| :--- | :--- | :--- |
+| `project_name` | `PHOENIX_PROJECT_NAME` | Name of the project in Phoenix. Defaults to `"default"`. |
+| `endpoint` | `PHOENIX_COLLECTOR_ENDPOINT` | The collector endpoint. Defaults to `http://localhost:6006`. |
+| `api_key` | `PHOENIX_API_KEY` | Optional for local Phoenix. Required for Phoenix Cloud or any authenticated instance — added as a Bearer token header. |
+| `headers` | `PHOENIX_CLIENT_HEADERS` | Additional headers for the OTLP request (e.g. tenant identifiers). |
+
+The full signature:
+
+```python
+register(
+    *,
+    endpoint: Optional[str] = None,
+    project_name: Optional[str] = None,
+    batch: bool = False,
+    set_global_tracer_provider: bool = True,
+    headers: Optional[Dict[str, str]] = None,
+    protocol: Optional[Literal["http/protobuf", "grpc"]] = None,
+    verbose: bool = True,
+    auto_instrument: bool = False,
+    api_key: Optional[str] = None,
+)
+```
+
+All arguments are keyword-only.
+
+# Multi-project routing
+
+Phoenix is typically deployed as one instance per environment, and each application sends all of its traces to a single project. If you need to route traces from one application to multiple projects, the options are:
+
+1. **Multiple `register()` calls** with different `project_name` values and `set_global_tracer_provider=False` on all but one. You then have to track which tracer provider to use where in your code.
+1. **OpenTelemetry Collector with a routing connector** — let the application send all spans to the Collector, then route to different Phoenix projects (or different backends entirely) based on span attributes. See [OpenTelemetry Collector](/docs/phoenix/tracing/concepts-tracing/otel-openinference/otel-collector).
+
+For the common case — single app, single project — one `register()` call is everything you need.
+
+# When to Use Which
+
+| Use case | Recommended approach |
+| :--- | :--- |
+| Single project, simple app | `register(...)` |
+| Single project + auto-instrument every installed library | `register(project_name=..., auto_instrument=True)` |
+| Multiple projects from one app | Multiple `register()` calls, or an OTel Collector routing connector |
+| Maximum control, custom processor pipeline | Raw OTel — see [Tracer Provider](/docs/phoenix/tracing/concepts-tracing/otel-openinference/tracer-provider) |
+
+---
+
+## Next step
+
+You've covered every component on the OTel side. Time to learn what OpenInference adds on top — starting with the semantic conventions that make AI traces meaningful:
+
+<Card title="Next: OpenInference Semantic Conventions" icon="arrow-right" href="/docs/phoenix/tracing/concepts-tracing/otel-openinference/semantic-conventions" />

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/resource.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/resource.mdx
@@ -1,0 +1,102 @@
+---
+title: "Resource"
+sidebarTitle: "Resource"
+description: "The immutable metadata that describes who is producing telemetry — service name, environment, host, and Phoenix attributes that route spans to your project."
+keywords: ['resource', 'OpenTelemetry', 'service.name', 'openinference.project.name', 'x-project-name', 'resource attributes']
+---
+
+A **Resource** is immutable metadata that describes the entity producing telemetry. It's the answer to one question: *who is sending this data?*
+
+Every span, metric, and log your application emits carries the same Resource. It's set once, when the [Tracer Provider](/docs/phoenix/tracing/concepts-tracing/otel-openinference/tracer-provider) is created, and it never changes for the lifetime of the process.
+
+Picking the right Resource attributes is what makes your traces routable and queryable downstream.
+
+# Anatomy of a Resource
+
+| Term | What it means |
+| :--- | :--- |
+| **Describes** | Answers the question "who is sending this telemetry?" |
+| **Entity** | Service name, environment, host, pod, container — anything that identifies the producer. |
+| **Immutable** | Does not change during the process lifetime. The same Resource is attached to every span, metric, and log. |
+| **Metadata** | Key-value pairs. |
+
+Resource attributes should generally follow [OpenTelemetry resource semantic conventions](https://opentelemetry.io/docs/specs/semconv/resource/) so any OTel-compatible backend can interpret them.
+
+# Configuring a Resource
+
+```python
+from opentelemetry.sdk.resources import Resource
+
+resource = Resource.create(
+    {
+        # Service attributes
+        "service.name": "checkout",
+        "service.namespace": "acme-webstore",
+        "service.version": "v1.2.3",
+        "service.instance.id": "instance-12345",
+
+        # Environment / infrastructure attributes
+        "deployment.environment.name": "production",
+        "cloud.region": "us-east-1",
+
+        # Phoenix project routing
+        "openinference.project.name": "webstore-prod",
+    }
+)
+```
+
+For the full set of supported parameters, see the [Resource API reference](https://opentelemetry-python.readthedocs.io/en/latest/sdk/resources.html).
+
+Always use `Resource.create(...)` rather than the class constructor `Resource(attributes=...)`. `create()` merges your attributes with the defaults from the built-in resource detectors.
+
+# Phoenix–Specific Project Routing
+
+Phoenix resolves the project for an incoming OTLP request in this order of precedence:
+
+| Source | Status | Notes |
+| :--- | :--- | :--- |
+| `x-project-name` HTTP header | Highest precedence | Set per request to override the resource attribute. Useful when one application sends to multiple projects without re-creating a Tracer Provider. Pass via `register(headers={"x-project-name": "..."})` or set on the OTLP exporter directly. |
+| `openinference.project.name` resource attribute | Canonical | The name of the project in Phoenix. Defined by the OpenInference resource semconv — exposed as `ResourceAttributes.PROJECT_NAME` in the `openinference.semconv.resource` Python package, and as `SEMRESATTRS_PROJECT_NAME` in `@arizeai/openinference-semantic-conventions` for JS/TS. |
+| Server default project | Fallback | If neither of the above is set, spans land in the default project. |
+
+For the common case, set `openinference.project.name` on the Resource and forget about it.
+
+# Environment Variables
+
+The OpenTelemetry SDK can auto-detect Resource attributes from the environment, so you can avoid hardcoding them:
+
+| Environment variable | Purpose |
+| :--- | :--- |
+| `OTEL_SERVICE_NAME` | Sets `service.name`. |
+| `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated `key=value` pairs. Sets arbitrary resource attributes. |
+| `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` | Comma-separated list of built-in detectors to enable or disable. |
+
+**Code wins over environment variables.** If you set the same key in both, the value passed to `Resource.create(...)` takes precedence.
+
+The SDK also runs **built-in resource detectors** by default — they automatically fill in host, OS, process, and other infrastructure attributes. Disable them with `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS=""` if you don't want them.
+
+For the full list, see the [OpenTelemetry SDK environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/) reference.
+
+# Common Pitfalls
+
+<Warning>
+**Don't try to change the Resource per request or per span.** Only one Resource is allowed per Tracer Provider, and it's intentionally immutable. If you need per-request context (a user ID, a session ID, a customer tier), set it as a **span attribute** instead — see [Customize your traces](/docs/phoenix/tracing/how-to-tracing/add-metadata/customize-spans) and the [OpenInference context managers](/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers).
+</Warning>
+
+A few more things that trip people up:
+
+- **Not following semantic conventions** — using your own attribute names instead of `service.name`, `deployment.environment.name`, etc. means other tools (and Phoenix) can't interpret them. Stick with the [resource semconv](https://opentelemetry.io/docs/specs/semconv/resource/) whenever there's a standard key.
+- **Using the class constructor `Resource(attributes=...)` instead of `Resource.create(...)`** — bypasses built-in detectors, so you lose the auto-populated host/process attributes.
+- **Forgetting to set a project name** — without `openinference.project.name` on the Resource or an `x-project-name` request header, spans land in the default project and are hard to organize.
+
+# Where Resource Fits in the Pipeline
+
+The Resource is held by the [Tracer Provider](/docs/phoenix/tracing/concepts-tracing/otel-openinference/tracer-provider) alongside the [Span Processor](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor) pipeline (which in turn owns the [Exporter](/docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter)). Every span the provider hands out gets the same Resource stamped on it before export.
+
+---
+
+## Next step
+
+The Resource describes who is sending data. The Exporter sends it:
+
+<Card title="Next: Exporter and OTLP" icon="arrow-right" href="/docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter" />

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/sampling.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/sampling.mdx
@@ -1,0 +1,139 @@
+---
+title: "Sampling"
+sidebarTitle: "Sampling"
+description: "Head and tail sampling — how to reduce telemetry volume without losing visibility, configure samplers via SDK or environment variables, and avoid the silent always_off gotcha."
+keywords: ['sampling', 'head sampling', 'tail sampling', 'TraceIdRatioBased', 'ParentBased', 'OTEL_TRACES_SAMPLER', 'OpenTelemetry']
+---
+
+A span is **sampled** when it's processed and exported. Sampling is how you reduce telemetry volume — and the cost that goes with it — without losing the visibility you need to debug production issues.
+
+![overview of sampling suggesting you don't need all the data, just traces with errors, specific attributes, or high latency, and a sample set from the rest](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/sampling.png)
+
+The principle is **representativeness**: a smaller, well-chosen group can accurately represent a larger one. Sampling 20% of traces doesn't mean you only see 20% of failures — it means you see a statistically representative sample of your application's behavior.
+
+There are two approaches: **head sampling** and **tail sampling**. They differ in *when* the sampling decision is made.
+
+# Head Sampling
+
+The decision to sample is made **at the start of the trace**, before any spans complete.
+
+```mermaid
+flowchart LR
+    subgraph Head["Head sampling — decision at trace start"]
+        direction LR
+        H1((Trace<br/>starts)) --> H2{Keep<br/>or<br/>drop?}
+        H2 -->|keep| H3[Spans<br/>recorded] --> H4[Trace<br/>completes] --> H5[Export]
+        H2 -->|drop| HX[Spans<br/>dropped<br/>immediately]
+    end
+```
+
+| Pros | Cons |
+| :--- | :--- |
+| Efficient — no buffering required. | Can't filter by latency, error status, or any post-hoc attribute. |
+| Scales easily across distributed systems. | May drop important traces (the slow ones, the failing ones). |
+| Reduces traffic early in the pipeline. | Less precise control. |
+| Easy to configure — built into the OTel SDK. | |
+
+Head sampling is the default in the OTel SDK. The most common samplers:
+
+- `ALWAYS_ON` — sample every trace.
+- `ALWAYS_OFF` — sample nothing.
+- `TraceIdRatioBased(p)` — sample `p` fraction of traces, deterministically based on trace ID.
+- `ParentBased(...)` — defer to the parent's sampling decision when there is one; otherwise fall through to the wrapped sampler.
+
+`ParentBased` is what keeps distributed traces consistent — if the root service decides to sample a trace, downstream services see that decision in the trace context and respect it, so the whole trace lives or dies together.
+
+# Tail Sampling
+
+The decision to sample is made **after the trace has completed**, when all spans are available.
+
+```mermaid
+flowchart LR
+    subgraph Tail["Tail sampling — decision after trace completes"]
+        direction LR
+        T1((Trace<br/>starts)) --> T2[All spans<br/>buffer at<br/>Collector] --> T3[Trace<br/>completes] --> T4{Keep<br/>based on<br/>attributes,<br/>latency,<br/>errors?}
+        T4 -->|keep| T5[Export]
+        T4 -->|drop| TX[Discard]
+    end
+```
+
+| Pros | Cons |
+| :--- | :--- |
+| Can keep only error traces. | Higher resource usage — every trace must be buffered. |
+| Can keep slow traces. | More complex setup — requires the [OTel Collector](/docs/phoenix/tracing/concepts-tracing/otel-openinference/otel-collector). |
+| Can filter by any attribute. | Adds latency. |
+| Important traces are preserved. | Scalability challenges at very high volumes. |
+| Better signal-to-noise ratio. | Increased infrastructure cost. |
+| Policy-based control. | |
+
+Tail sampling lives at the Collector layer, not in the SDK — see [OTel Collector](/docs/phoenix/tracing/concepts-tracing/otel-openinference/otel-collector) for the deployment pattern.
+
+# Configuring Sampling via Environment Variables
+
+The OTel SDK reads sampler configuration from environment variables — useful for tuning sampling at deploy time without changing code.
+
+| Variable | Values |
+| :--- | :--- |
+| `OTEL_TRACES_SAMPLER` | `always_on`, `always_off`, `traceidratio`, `parentbased_traceidratio`, `parentbased_always_on`, `parentbased_always_off` |
+| `OTEL_TRACES_SAMPLER_ARG` | A float in `[0.0, 1.0]` — required by ratio-based samplers. |
+
+The static samplers:
+
+- `always_on` — sample every trace.
+- `always_off` — sample no traces.
+
+The ratio-based samplers:
+
+- `traceidratio` — sample a fraction of traces. **Each span is sampled independently**, which can break distributed traces (downstream services may drop spans the root service kept).
+- `parentbased_traceidratio` — sample a fraction at the root, then respect the parent's decision everywhere else. Keeps or drops the entire trace consistently. **Use this for distributed systems.**
+
+For the API surface, see [OpenTelemetry sampling environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration).
+
+# Configuring Sampling in the SDK
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased, ALWAYS_ON, ALWAYS_OFF
+
+# Sample 20% of new root traces; respect parent decision for child spans
+tracer_provider = TracerProvider(
+    sampler=ParentBased(TraceIdRatioBased(0.20))
+)
+
+# Or sample everything
+tracer_provider = TracerProvider(sampler=ALWAYS_ON)
+```
+
+For the API reference, see the [OpenTelemetry sampling reference](https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.sampling.html).
+
+For custom sampling logic (drop spans for specific users, sample by attribute), see [Custom Sampling](/docs/phoenix/tracing/how-to-tracing/setup-tracing#custom-sampling).
+
+# The Silent `always_off` Gotcha
+
+<Warning>
+**If your traces aren't showing up, check `OTEL_TRACES_SAMPLER` first.**
+
+A real-world failure mode: pre-set environment variables in shared environments (Kubernetes pods, base Docker images, CI runners) sometimes contain `OTEL_TRACES_SAMPLER=always_off`. This silently disables tracing — no error, no warning, no spans exported. Application code looks correct. Logs look fine. Nothing reaches Phoenix.
+
+When "no traces are showing up," check the environment variables before anything else.
+</Warning>
+
+# Practical Recommendations
+
+Most teams should start with one of these configurations:
+
+| Environment | Recommended setting |
+| :--- | :--- |
+| Development | `ALWAYS_ON` — see every trace while you're building. |
+| Staging | `ALWAYS_ON` — full visibility for validation. |
+| Production, low/medium traffic | `ALWAYS_ON` — Phoenix handles the volume; you keep full fidelity. |
+| Production, high traffic | `ParentBased(TraceIdRatioBased(0.1))` — head sample 10%, keep distributed traces consistent. Combine with tail sampling at the [Collector](/docs/phoenix/tracing/concepts-tracing/otel-openinference/otel-collector) for must-keep traces (errors, slow requests). |
+
+---
+
+## Next step
+
+The last topic in this section — the OpenTelemetry Collector. Useful for tail sampling, centralized policy, multi-backend routing, and a few other production patterns:
+
+<Card title="Next: OpenTelemetry Collector" icon="arrow-right" href="/docs/phoenix/tracing/concepts-tracing/otel-openinference/otel-collector" />

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/sampling.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/sampling.mdx
@@ -107,8 +107,6 @@ tracer_provider = TracerProvider(sampler=ALWAYS_ON)
 
 For the API reference, see the [OpenTelemetry sampling reference](https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.sampling.html).
 
-For custom sampling logic (drop spans for specific users, sample by attribute), see [Custom Sampling](/docs/phoenix/tracing/how-to-tracing/setup-tracing#custom-sampling).
-
 # The Silent `always_off` Gotcha
 
 <Warning>

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/semantic-conventions.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/semantic-conventions.mdx
@@ -1,0 +1,78 @@
+---
+title: "OpenInference Semantic Conventions"
+sidebarTitle: "Semantic conventions"
+description: "Standardized attribute names that make AI trace data portable across tools, languages, and platforms — and how OpenInference compares to the still-evolving GenAI conventions."
+keywords: ['semantic conventions', 'OpenInference', 'GenAI', 'attribute names', 'standardization', 'interoperability']
+---
+
+> *"Standardized naming schemes and attribute definitions for telemetry data across services, languages, and platforms."*
+
+A **semantic convention** is an agreement about what to call things. Without conventions, every team invents their own attribute names — one calls it `prompt`, another `input.text`, another `messages[0].content` — and tools that try to read all of those have to maintain mappings for every variant.
+
+OpenInference defines the canonical attribute names for AI/LLM telemetry. Phoenix uses these conventions to render spans in the UI, and any OTel-compatible backend that understands OpenInference can do the same.
+
+# Why Semantic Conventions Matter
+
+Three concrete benefits, all of which compound as your stack grows:
+
+| | What it gives you |
+| :--- | :--- |
+| **Consistency** | One name for each concept across services, languages, and platforms. Same key in Python, JS, and Go. |
+| **Interoperability** | Tools and backends understand your data without custom mapping. Switching backends or layering on new tools doesn't require re-instrumenting. |
+| **Best practices** | The conventions encode *what* to trace, not just *how*. They are an opinionated answer to "which attributes should I set on an LLM span?" |
+
+Two examples of OpenInference attribute names:
+
+```
+llm.token_count.total
+llm.input_messages
+```
+
+If you set `llm.input_messages` on a span, Phoenix knows it's the chat history. So does any other OpenInference-aware backend. So does anyone reading your trace export six months from now.
+
+# OpenInference vs GenAI
+
+The GenAI observability space currently has two semantic convention standards. They overlap in what they describe but differ in maturity and governance.
+
+| | OpenInference | GenAI |
+| :--- | :--- | :--- |
+| **Maintained by** | Arize | OpenTelemetry community |
+| **Status** | Stable | Still in development; not on a stable release |
+| **Stability guarantees** | Conventions are stable across releases. Breaking changes are versioned. | Conventions are subject to change at any time, with explicit guidance about version transitions and opt-in for newer experimental revisions. |
+| **Attribute prefix** | Domain-specific prefixes: `llm.*`, `tool.*`, `agent.*`, `retriever.*`, etc. | Generally prefixed `gen_ai.*` |
+| **Instrumentation libraries** | Extensive — auto-instrumentors for most popular AI frameworks. | Smaller surface area today; instrumentors are still landing. |
+| **Phoenix support** | First-class. Phoenix reads these directly. | Spans tagged with `gen_ai.*` attributes still arrive at Phoenix, but won't get the same UI treatment as OpenInference-tagged spans. |
+
+For new instrumentation today, use OpenInference. Over time the two conventions are expected to converge as the GenAI spec stabilizes — when that happens, the OpenInference auto-instrumentors will pick up the change so your application code doesn't have to.
+
+# The Authoritative Source
+
+OpenInference is open-source. The canonical attribute lists, span kind enums, MIME type values, and LLM provider/system enums live in the OpenInference repository — language-specific implementations track these definitions exactly.
+
+<CardGroup cols={2}>
+  <Card title="Python Semantic Conventions" href="https://github.com/Arize-ai/openinference/blob/main/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py" icon="python" />
+  <Card title="TS Semantic Conventions" href="https://github.com/Arize-ai/openinference/blob/main/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts" icon="js" />
+</CardGroup>
+
+When in doubt about an exact attribute name, those files are the source of truth.
+
+# What's Covered in OpenInference
+
+The conventions cover four broad categories:
+
+| Category | Examples | Where to read more |
+| :--- | :--- | :--- |
+| **Span kinds** | `LLM`, `TOOL`, `AGENT`, `CHAIN`, `RETRIEVER`, `EMBEDDING`, `RERANKER`, `GUARDRAIL`, `EVALUATOR`, `PROMPT`, `UNKNOWN` | [Span Kinds](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds) |
+| **Per-kind attributes** | `llm.input_messages`, `tool.parameters`, `agent.name`, `retrieval.documents` | [Span Kinds](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds) |
+| **Common attributes** | `input.value`, `output.value`, `input.mime_type`, `output.mime_type`, `metadata`, `session.id`, `user.id`, `tag.tags` | [Span Kinds](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds#common-attributes-across-all-kinds) |
+| **Enums** | LLM providers (`openai`, `anthropic`, `cohere`, ...), MIME types (`text/plain`, `application/json`), span kind values (ALL CAPS) | [Span Kinds](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds) and the [canonical source](https://github.com/Arize-ai/openinference/blob/main/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py) |
+
+The next page walks through the span-kind catalog in detail.
+
+---
+
+## Next step
+
+Span kinds are the most important convention OpenInference adds — they determine how spans render in the Phoenix UI and which attributes are expected:
+
+<Card title="Next: OpenInference Span Kinds" icon="arrow-right" href="/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds" />

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/signals.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/signals.mdx
@@ -1,0 +1,99 @@
+---
+title: "Signals, Spans, Traces, and Sessions"
+sidebarTitle: "Signals, spans, traces, and sessions"
+description: "The data shapes OpenTelemetry produces — signals, spans, traces, and sessions — and how they fit together into the trace tree Phoenix visualizes."
+keywords: ['signals', 'spans', 'traces', 'sessions', 'OpenTelemetry', 'span structure', 'parent span', 'root span', 'orphan span']
+---
+
+OpenTelemetry organizes telemetry into a handful of **signals** — the three you'll encounter most often are **traces**, **metrics**, and **logs**. Traces are the focus for AI applications: they're how you see what your app did, step by step, for a single request. Spans are the building blocks of a trace. Traces group into sessions when you're tracking multi-turn conversations.
+
+This page covers the data shapes. The rest of the pages in this section cover the OTel and OpenInference machinery that produces and ships them.
+
+# Signals
+
+A signal is a category of telemetry data. The three most-used signals in OpenTelemetry today:
+
+| Signal | What it is | Used to track |
+| :--- | :--- | :--- |
+| **Traces** | The path of a request through your application. A span is the unit of work that, with its peers, forms a tree (the trace). | LLM calls, tool invocations, retrievals, agent steps. |
+| **Metrics** | A measurement captured at runtime. | Aggregates like latency percentiles, request counts, token usage over time. |
+| **Logs** | A recording of an event. | One-off events, errors, audit entries. |
+
+Each signal has its own exporter and provider. The OpenTelemetry specification also defines **baggage** as a signal, with **events** and **profiles** in development — see the [OpenTelemetry signals documentation](https://opentelemetry.io/docs/concepts/signals/) for the current full set. Phoenix focuses on traces, since traces are what make AI application behavior legible.
+
+# Span Structure
+
+A **span** is a structured log representing a single unit of work — one LLM call, one tool invocation, one retrieval. It's the atomic unit of a trace, and it carries everything you need to understand what happened:
+
+| Field | Description |
+| :--- | :--- |
+| **Name** | A short label for the operation (e.g. `chat.completion`, `retrieve_docs`). |
+| **Start and end timestamps** | When the operation began and finished. |
+| **Span context** | An immutable object representing the span's identity. Contains the span ID, trace ID, trace flags, and trace state. |
+| **Parent span ID** | The ID of the parent span. Empty for a root span. |
+| **Attributes** | Key-value pairs describing what happened. This is where the [OpenInference semantic conventions](/docs/phoenix/tracing/concepts-tracing/otel-openinference/semantic-conventions) live (`llm.model_name`, `llm.input_messages`, `input.value`, etc.). |
+| **Span events** | Structured log messages attached to a span at a specific moment. |
+| **Span links** | Pointers to related spans in other traces. |
+| **Span status** | `Ok`, `Error`, or `Unset`. |
+| **Span kind** | The category of operation. OTel defines its own kinds for network spans; OpenInference adds AI-specific kinds — see [Span Kinds](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds). |
+
+For the canonical specification, see [Span Structure](https://opentelemetry.io/docs/concepts/signals/traces/#spans).
+
+# Spans, Traces, and Sessions
+
+Spans, traces, and sessions form a three-level hierarchy. The analogy that often helps:
+
+> A **session** is a conversation. A **trace** is one turn — one user input, one bot output. The **spans** inside the trace are the steps that produced that output.
+
+## Span
+
+The individual step the application takes. Spans can be nested via `parent_id`:
+
+- **Child span** — `parent_id` equals the span ID of another span in the same trace.
+- **Root span** — `parent_id` is `null`. The top of the tree.
+- **Orphan span** — `parent_id` references a span that doesn't exist in the project. Usually a sign of incomplete instrumentation or context propagation gone wrong.
+
+<Info>
+**Phoenix UI behavior**: Phoenix reads the trace-level **input** and **output** from the root span. If your root span doesn't have `input.value` and `output.value` set, the trace list view will show those columns as blank — even if child spans have rich data. This matters most for manually built traces; auto-instrumentors usually set them correctly.
+</Info>
+
+## Trace
+
+A collection of spans sharing the same `trace_id`. One trace represents the end-to-end work for a single request — a single user turn in a chat, a single API call, a single agent run.
+
+![Trace in Phoenix from the OpenAI Agents SDK example, showing agent, chain, tool, and LLM spans nested together](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/agent-trace.png)
+
+## Session
+
+A collection of traces sharing the same `session.id`. A session typically represents a multi-turn conversation — every user message and every bot response across that conversation is its own trace, all linked together by a shared session ID.
+
+You set `session.id` on your spans either:
+
+- via the [`using_session` context manager](/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers), or
+- by setting the `session.id` attribute directly on each span.
+
+For practical setup, see [Set up sessions](/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-sessions).
+
+# How They Fit Together in a Trace
+
+In a typical AI application, a single user turn might produce a trace that looks like this:
+
+```
+Session (session.id = "user-42-conv-7")
+└── Trace (one user turn)
+    └── Agent span                                         [root]
+        ├── LLM span        "decide which tool to call"
+        ├── Tool span       "search the knowledge base"
+        │   └── Retriever span
+        └── LLM span        "answer using retrieved docs"
+```
+
+Each span has its own attributes (model name, input/output, token counts), its own status, and its own start/end time. The tree structure comes entirely from `parent_id` references, and the Phoenix UI renders it visually so you can drill into any span to see exactly what happened.
+
+---
+
+## Next step
+
+You know what spans, traces, and sessions are. Next, the first of the four OTel tracing components — the Resource, which describes who is producing the telemetry:
+
+<Card title="Next: Resource" icon="arrow-right" href="/docs/phoenix/tracing/concepts-tracing/otel-openinference/resource" />

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds.mdx
@@ -1,0 +1,179 @@
+---
+title: "OpenInference Span Kinds"
+sidebarTitle: "Span kinds"
+description: "The eleven OpenInference span kinds — LLM, Tool, Agent, Chain, Retriever, and the rest — with the canonical attributes Phoenix expects on each."
+keywords: ['span kinds', 'OpenInference', 'LLM', 'TOOL', 'AGENT', 'CHAIN', 'RETRIEVER', 'EMBEDDING', 'openinference.span.kind']
+---
+
+A **span kind** is the category of operation a span represents. OpenTelemetry has its own span kinds for network calls (`SERVER`, `CLIENT`, `PRODUCER`, ...). OpenInference adds an AI-specific set: LLM, Tool, Agent, Chain, Retriever, and more.
+
+Span kind is what drives the span-kind icons in the Phoenix UI. It's also how Phoenix knows which attributes to expect — an LLM span gets a different visual treatment from a tool span.
+
+# Setting the Span Kind
+
+Span kind is set via the `openinference.span.kind` attribute. **The value is ALL CAPS** — `"TOOL"`, not `"Tool"`. Casing matters: the canonical OpenInference Python enum is `OpenInferenceSpanKindValues.TOOL = "TOOL"`.
+
+```python
+from openinference.semconv.trace import (
+    SpanAttributes,
+    OpenInferenceSpanKindValues,
+)
+
+span.set_attribute(
+    SpanAttributes.OPENINFERENCE_SPAN_KIND,
+    OpenInferenceSpanKindValues.TOOL.value,
+)
+```
+
+<Info>
+**Phoenix UI behavior**: span-kind icons in Phoenix trace tree come directly from the `openinference.span.kind` attribute. A span without that attribute renders with a blank icon. Auto-instrumentors set this for you — set it explicitly on every manual span.
+</Info>
+
+# The Eleven Span Kinds
+
+OpenInference defines eleven span-kind values. The first four (LLM, Chain, Agent, Tool) are the ones you'll encounter most often:
+
+| Icon | Span kind | Description |
+| :---: | :--- | :--- |
+| <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/llm.png" width="32" alt="LLM span-kind icon" style={{ display: "inline-block", margin: 0, verticalAlign: "middle" }} /> | **`LLM`** | A call to a large language model. |
+| <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/chain.png" width="32" alt="Chain span-kind icon" style={{ display: "inline-block", margin: 0, verticalAlign: "middle" }} /> | **`CHAIN`** | A starting point or a link between different LLM application steps. |
+| <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/agent.png" width="32" alt="Agent span-kind icon" style={{ display: "inline-block", margin: 0, verticalAlign: "middle" }} /> | **`AGENT`** | A span that encompasses calls to LLMs and tools — typically the top-level wrapper for an agent loop. |
+| <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/tool.png" width="32" alt="Tool span-kind icon" style={{ display: "inline-block", margin: 0, verticalAlign: "middle" }} /> | **`TOOL`** | A span that represents a call to an external tool, API, or function on behalf of an LLM. |
+| <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/retriever.png" width="32" alt="Retriever span-kind icon" style={{ display: "inline-block", margin: 0, verticalAlign: "middle" }} /> | **`RETRIEVER`** | A data retrieval query for context from a datastore (e.g., a vector DB query). |
+| <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/embedding.png" width="32" alt="Embedding span-kind icon" style={{ display: "inline-block", margin: 0, verticalAlign: "middle" }} /> | **`EMBEDDING`** | An encoding of unstructured data into a vector. |
+| <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/reranker.png" width="32" alt="Reranker span-kind icon" style={{ display: "inline-block", margin: 0, verticalAlign: "middle" }} /> | **`RERANKER`** | A relevance-based re-ordering of documents. |
+| <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/guardrail.png" width="32" alt="Guardrail span-kind icon" style={{ display: "inline-block", margin: 0, verticalAlign: "middle" }} /> | **`GUARDRAIL`** | A validation of LLM input or output for safety, policy, or compliance. |
+| <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/unknown.png" width="32" alt="Evaluator span-kind icon (falls back to Unknown)" style={{ display: "inline-block", margin: 0, verticalAlign: "middle" }} /> | **`EVALUATOR`** | An evaluation process — the type, configuration, and results. |
+| <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/unknown.png" width="32" alt="Prompt span-kind icon (falls back to Unknown)" style={{ display: "inline-block", margin: 0, verticalAlign: "middle" }} /> | **`PROMPT`** | A span representing prompt construction or templating. |
+| <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/unknown.png" width="32" alt="Unknown span-kind icon" style={{ display: "inline-block", margin: 0, verticalAlign: "middle" }} /> | **`UNKNOWN`** | Default when no kind is set explicitly. |
+
+# Common Attributes Across All Kinds
+
+These attributes apply to every span kind. Auto-instrumentors set them automatically; set them yourself on every manual span:
+
+| Attribute | Purpose |
+| :--- | :--- |
+| `openinference.span.kind` | The span kind (ALL CAPS — e.g., `"LLM"`). |
+| `input.value` | The span's input. Free-form string or serialized JSON. |
+| `input.mime_type` | `"text/plain"` (default) or `"application/json"`. The TS semconv also defines `"audio/wav"`. |
+| `output.value` | The span's output. |
+| `output.mime_type` | `"text/plain"` (default) or `"application/json"`. The TS semconv also defines `"audio/wav"`. |
+| `metadata` | Arbitrary JSON-stringified metadata. |
+| `session.id` | Groups traces into a session. See [Sessions](/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-sessions). |
+| `user.id` | The user the request belongs to. |
+| `tag.tags` | A list of tags for filtering and search. |
+
+<Info>
+**Phoenix UI behavior**: Phoenix reads the trace-level input and output from the **root span's** `input.value` and `output.value`. If your root span doesn't set them, the trace list view shows those columns as blank even if child spans have data.
+</Info>
+
+# Per-Kind Attributes
+
+The four most-used kinds have a richer attribute set. The full list lives in the [OpenInference semantic conventions](https://github.com/Arize-ai/openinference/blob/main/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py) — the tables below are a summary.
+
+## LLM
+
+A call to a large language model.
+
+| Attribute | Description |
+| :--- | :--- |
+| `llm.model_name` | The model identifier (e.g., `gpt-4o`, `claude-3-5-sonnet-20241022`). |
+| `llm.provider` | The provider (e.g. `openai`, `anthropic`, `mistralai`). |
+| `llm.system` | The underlying LLM system, when distinct from `provider`. |
+| `llm.input_messages` | The chat history sent to the model. |
+| `llm.output_messages` | The model's response messages. |
+| `llm.invocation_parameters` | Temperature, top-p, max tokens, etc. (JSON-stringified). |
+| `llm.tools` | Tool definitions exposed to the model. |
+| `llm.function_call` | Function call returned by the model (legacy). |
+| `llm.prompts` | The raw prompts sent (for completion-style APIs). |
+| `llm.choices` | The choices returned by the model. |
+| `llm.prompt_template.template` | The prompt template before variable substitution. |
+| `llm.prompt_template.variables` | The variables substituted into the template. |
+| `llm.prompt_template.version` | A version identifier for the template. |
+| `llm.token_count.total` | Total tokens. |
+| `llm.token_count.prompt` | Prompt tokens. |
+| `llm.token_count.completion` | Completion tokens. |
+| `llm.token_count.prompt_details.*` | Breakdown of prompt tokens (cached, audio, etc.). |
+| `llm.token_count.completion_details.*` | Breakdown of completion tokens. |
+| `llm.cost.total` | Total cost. |
+| `llm.cost.prompt`, `llm.cost.completion` | Per-direction cost. |
+| `llm.cost.*_details.*` | Breakdown of cost by token type. |
+| `llm.finish_reason` | Why the model stopped generating (`stop`, `length`, `tool_calls`, ...). |
+
+## TOOL
+
+A call to an external tool, API, or function on behalf of an LLM.
+
+| Attribute | Description |
+| :--- | :--- |
+| `tool.id` | A unique identifier for the tool invocation (often correlated with the LLM's tool-call ID). |
+| `tool.name` | The tool's name. |
+| `tool.description` | The tool's description (often matches what was shown to the model). |
+| `tool.parameters` | The JSON-serialized parameters passed to the tool. |
+| `tool.json_schema` | The tool's full JSON schema as exposed to the model. |
+
+<Info>
+Tool calls are one of the clearest cases where you must instrument manually when making an LLM calls directly, instead of via a framework. When you call OpenAI directly, the auto-instrumentor traces the model's *request* for a tool call — but the actual execution of the tool function happens in your Python code, where the instrumentor can't see it. Wrap the function in a tool span yourself.
+</Info>
+
+## AGENT
+
+A span that encompasses calls to LLMs and tools — typically the top-level wrapper for an agent loop.
+
+| Attribute | Description |
+| :--- | :--- |
+| `agent.name` | The agent's name. |
+| `graph.node.id` | Node ID for graph-based agent frameworks (e.g., LangGraph). |
+| `graph.node.name` | Node display name. |
+| `graph.node.parent_id` | Parent node ID, for graph traversal visualization. |
+
+## CHAIN
+
+A starting point or a link between different application steps. Use a chain span to group pre/post-processing logic that doesn't fit any of the more specific kinds.
+
+Chain spans use only the common attributes — `input.value`, `output.value`, `metadata`, `session.id`, etc.
+
+## Other Kinds
+
+The remaining seven span kinds — RETRIEVER, EMBEDDING, RERANKER, GUARDRAIL, EVALUATOR, PROMPT, UNKNOWN — each have their own attribute schemas. Consult the [canonical source](https://github.com/Arize-ai/openinference/blob/main/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py) for the full per-kind attribute list.
+
+# Multimodal Message Content
+
+Inputs and outputs in modern AI applications aren't always plain text. OpenInference defines a `message_content` attribute family for multimodal content:
+
+| Attribute | Description |
+| :--- | :--- |
+| `message_content.type` | One of `text`, `image`, `audio`, `reasoning`, `tool_use`. |
+| `message_content.text` | The text payload (when `type` is `text` or `reasoning`). |
+| `message_content.image` | The image payload — URL or inline base64 (when `type=image`). |
+| `message_content.id` | Provider-assigned identifier for the message content item (e.g., OpenAI Responses reasoning IDs). |
+| `message_content.signature` | Opaque vendor-issued signature (e.g., Gemini `thoughtSignature`). |
+| `message_content.data` | Opaque vendor-issued data (e.g., Anthropic `redacted_thinking.data`). |
+| `message_content.encrypted_content` | Encrypted payload for sensitive content (e.g., OpenAI `encrypted_content`). |
+
+For audio specifically, OpenInference exposes a separate set of attributes — `audio.url`, `audio.mime_type`, `audio.transcript` — see the [canonical source](https://github.com/Arize-ai/openinference/blob/main/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py).
+
+# How a Trace Tree Uses Span Kinds
+
+A typical agent trace nests span kinds inside each other:
+
+```
+AGENT span                         (agent.name = "research-assistant")
+├── LLM span                       "decide next step"
+├── TOOL span                      "search knowledge base"
+│   └── RETRIEVER span             "vector search"
+│       └── EMBEDDING span         "embed query"
+└── LLM span                       "answer with retrieved docs"
+```
+
+Each level has its own kind, its own attributes, and its own rendering in the Phoenix UI. The combination is what makes agent behavior legible.
+
+![Trace in Phoenix from the OpenAI Agents SDK example, showing agent, chain, tool, and LLM spans nested together](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/agent-trace.png)
+
+---
+
+## Next step
+
+You know what attributes go on a span. Next, the three ways to actually emit spans — auto, manual, and hybrid:
+
+<Card title="Next: Instrumentation Approaches" icon="arrow-right" href="/docs/phoenix/tracing/concepts-tracing/otel-openinference/instrumentation-approaches" />

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor.mdx
@@ -1,0 +1,99 @@
+---
+title: "Span Processor"
+sidebarTitle: "Span processor"
+description: "The OpenTelemetry component that intercepts spans at the start and end of their lifecycle — how BatchSpanProcessor and SimpleSpanProcessor differ, and how to tune them."
+keywords: ['span processor', 'BatchSpanProcessor', 'SimpleSpanProcessor', 'on_start', 'on_end', 'OpenTelemetry']
+---
+
+A **span processor** sits between your code and the [Exporter](/docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter). It intercepts spans at two key lifecycle points and decides what to do with them before they leave the process — filter, enrich, batch, or export immediately.
+
+# The Two Lifecycle Hooks
+
+Every span processor implements two methods:
+
+| Hook | When it fires | Span state | Common uses |
+| :--- | :--- | :--- | :--- |
+| `on_start(span, parent_context)` | Right after the span is created. | Mutable. Attributes may not be set yet. | Add context-scoped attributes (session ID, user ID, request ID). |
+| `on_end(span)` | After `span.end()` is called. | Passed in as a `ReadableSpan` — intended to be immutable. | Filter, enrich, or modify attributes; forward to the exporter. |
+
+![Span processor flow](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/span-processor-flow.png)
+
+> A new processor method, `on_ending`, is in development. It fires before `on_end` and gives you a mutable span — useful for modifying attributes at the last moment without the workarounds described below.
+
+## Modifying Attributes in `on_end`
+
+The `ReadableSpan` passed to `on_end` is *intended* to be immutable, but language implementations vary:
+
+- **Python** — nothing is truly immutable. Attributes and context can be edited directly.
+- **TypeScript** — `ReadableSpan` properties are `readonly`, so the object can't be reassigned, but properties can be mutated in place.
+
+<Warning>
+Editing a `ReadableSpan` in place can have unintended side effects. If multiple span processors are attached to the Tracer Provider, every downstream processor sees the modification. If you need to modify a span, prefer copying it with the edited attributes rather than mutating the original.
+</Warning>
+
+# Configuring a Span Processor
+
+The most common processor for production is `BatchSpanProcessor`, which queues spans and exports them in batches:
+
+```python
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+otlp_exporter = OTLPSpanExporter(...)
+
+span_processor = BatchSpanProcessor(
+    span_exporter=otlp_exporter,
+    max_queue_size=2048,            # env: OTEL_BSP_MAX_QUEUE_SIZE
+    schedule_delay_millis=5000,     # env: OTEL_BSP_SCHEDULE_DELAY
+    max_export_batch_size=512,      # env: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+    export_timeout_millis=30000,    # env: OTEL_BSP_EXPORT_TIMEOUT
+)
+```
+
+Each parameter has a matching environment variable, so you can leave the code unchanged and tune at deploy time. See the [BatchSpanProcessor API reference](https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.export.html#opentelemetry.sdk.trace.export.BatchSpanProcessor) for current defaults.
+
+# BatchSpanProcessor vs SimpleSpanProcessor
+
+OpenTelemetry ships two built-in processors. The difference is fundamental — when each span leaves your process.
+
+| Property | BatchSpanProcessor | SimpleSpanProcessor |
+| :--- | :--- | :--- |
+| **Best for** | Production and staging | Local debugging, demos, CI |
+| **Export behavior** | Async, in batches | Each span immediately (sync) |
+| **Impact on latency** | Low — work done off the request path | Higher — export blocks the request |
+| **Throughput** | High, optimized for volume | Low, can bottleneck under load |
+| **Reliability on exit** | Requires `force_flush()` / `shutdown()` | Spans exported immediately |
+| **Visibility speed** | Slight delay (buffering) | Immediate |
+| **Failure surfacing** | Export failures logged in background | Failures raised inline |
+| **Tuning** | Configurable (batch size, delay, timeouts) | Minimal |
+
+<Warning>
+`SimpleSpanProcessor` is synchronous and blocking. It exports each span before your code continues, which adds latency to every traced operation. Use `BatchSpanProcessor` for production.
+</Warning>
+
+# Common Pitfalls
+
+A few span-processor failure modes worth knowing about:
+
+- **Using `SimpleSpanProcessor` in production** — exports every span synchronously. Under load, this adds latency to every traced operation.
+- **`export_timeout_millis` too short** — in Python, export failures trigger exponential backoff up to 32 seconds. During that backoff, no other batches can export, the queue fills up, and spans get dropped. Set the timeout high enough that transient slowdowns don't trigger retries.
+- **`max_queue_size`, `max_export_batch_size`, or `schedule_delay_millis` too high** — spans accumulate in memory, creating memory pressure. Big batches may also exceed the backend's per-request size limit (see the >4 MB gRPC pitfall on the [Exporter page](/docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter#common-pitfalls)).
+- **Forgetting that processors run in order** — multiple processors execute in the order they were added. If one mutates a `ReadableSpan` in `on_end`, every later processor sees the mutation.
+
+# Where Span Processor Fits in the Pipeline
+
+The processor is the middle stage of the export pipeline. Spans flow:
+
+```
+Your code → Tracer → Span Processor → Exporter → Phoenix
+```
+
+The processor is owned by the [Tracer Provider](/docs/phoenix/tracing/concepts-tracing/otel-openinference/tracer-provider). You can attach multiple processors — each one independently decides whether and when to forward spans to its exporter.
+
+---
+
+## Next step
+
+The span processor decides when spans leave. The Tracer Provider holds it all together:
+
+<Card title="Next: Tracer Provider and Tracer" icon="arrow-right" href="/docs/phoenix/tracing/concepts-tracing/otel-openinference/tracer-provider" />

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/tracer-provider.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/tracer-provider.mdx
@@ -1,0 +1,120 @@
+---
+title: "Tracer Provider and Tracer"
+sidebarTitle: "Tracer provider and tracer"
+description: "The central configuration object for OpenTelemetry tracing — what the Tracer Provider owns, how to configure it, and the Lambda and Node.js shutdown gotchas to know about."
+keywords: ['tracer provider', 'tracer', 'OpenTelemetry', 'TracerProvider', 'force_flush', 'shutdown', 'AWS Lambda', 'Node.js']
+---
+
+The **Tracer Provider** is the central configuration point for tracing in your application. It owns the [Resource](/docs/phoenix/tracing/concepts-tracing/otel-openinference/resource), holds the [Span Processor](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor) pipeline, and hands out **Tracer** instances on request.
+
+It's a singleton. Set up once during application initialization, then ask it for tracers wherever you need to create spans.
+
+# Tracer vs Tracer Provider
+
+| | Tracer Provider | Tracer |
+| :--- | :--- | :--- |
+| **What it is** | The stateful runtime component that holds references to span processors, exporters, and the resource. | The object used to create spans. |
+| **How many** | Usually one per application (global singleton). | One per library, module, or component — name it after the thing it traces. |
+| **How you get it** | Constructed during app init: `TracerProvider(...)`. | Asked from the provider: `trace.get_tracer(__name__)`. |
+| **Lifetime** | The full process. | Whatever scope you keep the reference. |
+
+Trace hierarchy — parent/child relationships between spans — is usually managed automatically by creating *active* spans with `tracer.start_as_current_span(...)`. You can also manage hierarchy manually by explicitly setting the context for spans, but that's rare. See [Context Propagation](/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-propagation) for the manual path.
+
+# Configuring the Tracer Provider
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider, SpanLimits
+from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
+from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
+
+tracer_provider = TracerProvider(
+    resource=resource,                              # Resource reference
+    active_span_processor=span_processor,           # Span processor reference
+    sampler=ParentBased(TraceIdRatioBased(0.2)),    # Sampling 20%
+    shutdown_on_exit=True,                          # Default
+    id_generator=RandomIdGenerator(),               # Default
+    span_limits=SpanLimits(
+        max_attributes=64,
+        max_events=128,
+        max_links=32,
+        max_attribute_length=256,
+    ),
+)
+
+trace.set_tracer_provider(tracer_provider)
+tracer = trace.get_tracer(__name__)
+```
+
+Each option:
+
+| Parameter | What it controls |
+| :--- | :--- |
+| `resource` | The [Resource](/docs/phoenix/tracing/concepts-tracing/otel-openinference/resource) describing the producer of telemetry. |
+| `active_span_processor` | The [Span Processor](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor) pipeline that handles spans. |
+| `sampler` | Which spans get recorded. See [Sampling](/docs/phoenix/tracing/concepts-tracing/otel-openinference/sampling). |
+| `shutdown_on_exit` | Whether to automatically flush spans on process exit. |
+| `id_generator` | How span IDs and trace IDs are generated. |
+| `span_limits` | Caps on attributes, events, links, and attribute length per span. |
+
+For the full API surface, see the [TracerProvider API reference](https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.html#opentelemetry.sdk.trace.TracerProvider).
+
+# Getting a Tracer
+
+Once the provider is registered as the global, ask it for a tracer wherever you need to create spans:
+
+```python
+from opentelemetry import trace
+
+tracer = trace.get_tracer(__name__)
+
+with tracer.start_as_current_span("my-operation") as span:
+    span.set_attribute("input.value", "User input")
+    # ... do work ...
+```
+
+The convention is to pass `__name__` (the Python module name) so spans are tagged with where they came from.
+
+# Lambda and Node.js: The Two Critical Gotchas
+
+The Tracer Provider is where two of the most common "no traces" failures live, both rooted in process lifecycle:
+
+<Warning>
+**AWS Lambda — you must call `force_flush()`.**
+
+When a Lambda handler returns, the OS freezes the process. The background export thread of a `BatchSpanProcessor` doesn't get a chance to export any queued spans. They sit in memory until the next invocation, and on cold starts they're lost entirely. Always call `tracer_provider.force_flush()` before returning from the handler.
+
+Do **not** call `shutdown()` in Lambda. Warm starts reuse the process, and a shut-down Tracer Provider can't be reused.
+</Warning>
+
+<Warning>
+**Node.js — you must call `shutdown()`.**
+
+A Node.js process can exit on normal completion *before* the BatchSpanProcessor's schedule-delay timer fires. The queued spans are dropped. Call `tracerProvider.shutdown()` on process exit (typically in a `SIGTERM` or `beforeExit` handler) to force a final flush.
+</Warning>
+
+These same patterns apply to any short-lived execution environment — CI jobs, one-off scripts, serverless functions. If your process doesn't run long enough for the next batch interval to elapse, you need to flush manually.
+
+For the API surface on both methods, see the [TracerProvider API reference](https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.html#opentelemetry.sdk.trace.TracerProvider).
+
+# How They Compose
+
+The Tracer Provider is what brings the previous components together:
+
+```
+TracerProvider
+├── Resource              (who is sending — see /concepts/.../resource)
+├── Span Processor(s)     (when to export — see /concepts/.../span-processor)
+│   └── Exporter          (where to send — see /concepts/.../exporter)
+└── Tracer instances      (used in your code to create spans)
+```
+
+Configuring all of this by hand is verbose. The next page covers Phoenix `register()` helper, which handles the wiring for you.
+
+---
+
+## Next step
+
+You've seen the four OTel tracing components separately. Now see them collapsed into a single function call:
+
+<Card title="Next: The phoenix.otel Helpers" icon="arrow-right" href="/docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers" />

--- a/tutorials/tracing/openinference_best_practices_tutorial.ipynb
+++ b/tutorials/tracing/openinference_best_practices_tutorial.ipynb
@@ -96,13 +96,13 @@
   {
    "cell_type": "markdown",
    "id": "91b8854c",
-   "source": "### Launch Phoenix\n\nLaunch a Phoenix app right here in the notebook session. This runs the Phoenix server in a background thread, so everything works the same whether you are running locally or in Google Colab — there is no separate terminal or server to start.\n\nRun the cell below, then open the printed URL to view your traces.",
+   "source": "### Launch Phoenix\n\nLaunch a Phoenix app right here in the notebook session. This runs the Phoenix server in a background thread, so everything works the same whether you are running locally or in Google Colab — there is no separate terminal or server to start.\n\nRun the cell below. The Phoenix UI appears **inline** beneath it (handiest in Colab). When running locally you can instead open the printed `http://localhost:6006` URL in a separate browser tab. You can call `session.view()` again in any later cell to pull the live view back to where you are.",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "id": "fb1ef03b",
-   "source": "import phoenix as px\n\nsession = px.launch_app()\nprint(f\"🔭 Phoenix is running. Open the UI at: {session.url}\")\n\n# Enable nested event loops so the async Agents SDK example can run in the notebook.\n# Apply this AFTER launching Phoenix — applying it beforehand stops Phoenix's server\n# from starting on Python 3.12 (which is what Google Colab runs).\nimport nest_asyncio\n\nnest_asyncio.apply()",
+   "source": "import phoenix as px\n\nsession = px.launch_app()\nprint(f\"🔭 Phoenix is running. Open the UI at: {session.url}\")\n\n# Enable nested event loops so the async Agents SDK example can run in the notebook.\n# Apply this AFTER launching Phoenix — applying it beforehand stops Phoenix's server\n# from starting on Python 3.12 (which is what Google Colab runs).\nimport nest_asyncio\n\nnest_asyncio.apply()\n\n# Show the Phoenix UI inline. This is the reliable way to view it in Colab, where the\n# URL above often will not open in a separate tab. Re-run `session.view()` in any cell\n# to bring the live view to wherever you are working.\nsession.view()",
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/tutorials/tracing/openinference_best_practices_tutorial.ipynb
+++ b/tutorials/tracing/openinference_best_practices_tutorial.ipynb
@@ -55,7 +55,11 @@
    "cell_type": "markdown",
    "id": "ba2bec83",
    "metadata": {},
-   "source": "This notebook is fully self-contained: it installs Phoenix, launches it inside the notebook session, and sends traces to it. Because Phoenix runs in the session itself, the notebook works the same way whether you run it locally or in Google Colab — there is no separate terminal or server to start.\n\nThe setup steps below install the libraries, set your OpenAI API key, launch Phoenix, and configure tracing."
+   "source": [
+    "This notebook is fully self-contained: it installs Phoenix, launches it inside the notebook session, and sends traces to it. Because Phoenix runs in the session itself, the notebook works the same way whether you run it locally or in Google Colab — there is no separate terminal or server to start.\n",
+    "\n",
+    "The setup steps below install the libraries, set your OpenAI API key, launch Phoenix, and configure tracing."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -91,21 +95,50 @@
    "id": "94a0ad81",
    "metadata": {},
    "outputs": [],
-   "source": "import os\nfrom getpass import getpass\n\nOPENAI_API_KEY = globals().get(\"OPENAI_API_KEY\") or getpass(\"🔑 Enter your OpenAI API key: \")\nos.environ[\"OPENAI_API_KEY\"] = OPENAI_API_KEY"
+   "source": [
+    "import os\n",
+    "from getpass import getpass\n",
+    "\n",
+    "OPENAI_API_KEY = globals().get(\"OPENAI_API_KEY\") or getpass(\"🔑 Enter your OpenAI API key: \")\n",
+    "os.environ[\"OPENAI_API_KEY\"] = OPENAI_API_KEY"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "91b8854c",
-   "source": "### Launch Phoenix\n\nLaunch a Phoenix app right here in the notebook session. This runs the Phoenix server in a background thread, so everything works the same whether you are running locally or in Google Colab — there is no separate terminal or server to start.\n\nRun the cell below. The Phoenix UI appears **inline** beneath it (handiest in Colab). When running locally you can instead open the printed `http://localhost:6006` URL in a separate browser tab. You can call `session.view()` again in any later cell to pull the live view back to where you are.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Launch Phoenix\n",
+    "\n",
+    "Launch a Phoenix app right here in the notebook session. This runs the Phoenix server in a background thread, so everything works the same whether you are running locally or in Google Colab — there is no separate terminal or server to start.\n",
+    "\n",
+    "Run the cell below. The Phoenix UI appears **inline** beneath it (handiest in Colab). When running locally you can instead open the printed `http://localhost:6006` URL in a separate browser tab. You can call `session.view()` again in any later cell to pull the live view back to where you are."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "fb1ef03b",
-   "source": "import phoenix as px\n\nsession = px.launch_app()\nprint(f\"🔭 Phoenix is running. Open the UI at: {session.url}\")\n\n# Enable nested event loops so the async Agents SDK example can run in the notebook.\n# Apply this AFTER launching Phoenix — applying it beforehand stops Phoenix's server\n# from starting on Python 3.12 (which is what Google Colab runs).\nimport nest_asyncio\n\nnest_asyncio.apply()\n\n# Show the Phoenix UI inline. This is the reliable way to view it in Colab, where the\n# URL above often will not open in a separate tab. Re-run `session.view()` in any cell\n# to bring the live view to wherever you are working.\nsession.view()",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "fb1ef03b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import phoenix as px\n",
+    "\n",
+    "session = px.launch_app()\n",
+    "print(f\"🔭 Phoenix is running. Open the UI at: {session.url}\")\n",
+    "\n",
+    "# Enable nested event loops so the async Agents SDK example can run in the notebook.\n",
+    "# Apply this AFTER launching Phoenix — applying it beforehand stops Phoenix's server\n",
+    "# from starting on Python 3.12 (which is what Google Colab runs).\n",
+    "import nest_asyncio\n",
+    "\n",
+    "nest_asyncio.apply()\n",
+    "\n",
+    "# Show the Phoenix UI inline. This is the reliable way to view it in Colab, where the\n",
+    "# URL above often will not open in a separate tab. Re-run `session.view()` in any cell\n",
+    "# to bring the live view to wherever you are working.\n",
+    "session.view()"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -230,7 +263,9 @@
    "cell_type": "markdown",
    "id": "6dbcbc81",
    "metadata": {},
-   "source": "Open the Phoenix UI (use the URL printed when you launched Phoenix above) and navigate to the `otel-best-practices` project to view your traces."
+   "source": [
+    "Open the Phoenix UI (use the URL printed when you launched Phoenix above) and navigate to the `otel-best-practices` project to view your traces."
+   ]
   },
   {
    "cell_type": "markdown",

--- a/tutorials/tracing/openinference_best_practices_tutorial.ipynb
+++ b/tutorials/tracing/openinference_best_practices_tutorial.ipynb
@@ -1,0 +1,1319 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4bd8edfc",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/tracing/openinference_best_practices_tutorial.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d83404f",
+   "metadata": {},
+   "source": [
+    "<center>\n",
+    "    <p style=\"text-align:center\">\n",
+    "        <img alt=\"phoenix logo\" src=\"https://storage.googleapis.com/arize-phoenix-assets/assets/phoenix-logo-light.svg\" width=\"200\"/>\n",
+    "        <br>\n",
+    "        <a href=\"https://arize.com/docs/phoenix/\">Docs</a>\n",
+    "        |\n",
+    "        <a href=\"https://github.com/Arize-ai/phoenix\">GitHub</a>\n",
+    "        |\n",
+    "        <a href=\"https://join.slack.com/t/arize-ai/shared_invite/zt-3r07iavnk-ammtATWSlF0pSrd1DsMW7g\">Community</a>\n",
+    "    </p>\n",
+    "</center>\n",
+    "<h1 align=\"center\">OpenInference Best Practices</h1>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09a56820",
+   "metadata": {},
+   "source": [
+    "This notebook is a hands-on tour of OpenInference best practices for tracing AI applications with [Phoenix](https://phoenix.arize.com). You will learn:\n",
+    "\n",
+    "- How OpenInference layers on top of OpenTelemetry to add AI-aware semantics\n",
+    "- The hierarchy of sessions, traces, and spans that organizes your telemetry\n",
+    "- Three ways to capture spans — auto-instrumentation, manual instrumentation, and the hybrid approach that combines them\n",
+    "- The common attributes every span carries, and the kind-specific attributes for the four core span kinds (LLM, chain, agent, and tool)\n",
+    "- How to add or override attributes on spans, including auto-instrumented spans you cannot access directly\n",
+    "\n",
+    "Each section runs a small piece of code, then guides you through what to look for in the Phoenix trace view."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cc4be9e",
+   "metadata": {},
+   "source": [
+    "## Initial setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba2bec83",
+   "metadata": {},
+   "source": [
+    "This notebook talks to a locally-running Phoenix instance. Before running any code, start Phoenix in a separate terminal:\n",
+    "\n",
+    "```bash\n",
+    "pip install arize-phoenix\n",
+    "phoenix serve\n",
+    "```\n",
+    "\n",
+    "This starts the Phoenix UI at [http://localhost:6006](http://localhost:6006). Leave it running — the rest of this notebook will send traces to it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "808e5fea",
+   "metadata": {},
+   "source": [
+    "### Install libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "212beb4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -qq arize-phoenix arize-phoenix-otel openai openai-agents openinference-instrumentation-openai openinference-instrumentation-openai-agents"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f193e3c7",
+   "metadata": {},
+   "source": [
+    "### Setup keys\n",
+    "\n",
+    "You need an OpenAI API key for the LLM calls. Get one from your OpenAI account, then enter it when prompted below. Phoenix is running locally so no Phoenix API key is needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94a0ad81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import nest_asyncio\n",
+    "from getpass import getpass\n",
+    "\n",
+    "nest_asyncio.apply()\n",
+    "\n",
+    "OPENAI_API_KEY = globals().get(\"OPENAI_API_KEY\") or getpass(\n",
+    "    \"🔑 Enter your OpenAI API key: \"\n",
+    ")\n",
+    "os.environ[\"OPENAI_API_KEY\"] = OPENAI_API_KEY"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35091b8c",
+   "metadata": {},
+   "source": [
+    "### Setup tracing\n",
+    "\n",
+    "Use the `arize-phoenix-otel` convenience function to register a tracer provider that sends spans to Phoenix, then enable the OpenAI auto-instrumentor so calls to the OpenAI SDK are traced automatically.\n",
+    "\n",
+    "See [The phoenix.otel helpers](/docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers) for the full set of `phoenix.otel` functions, including routing traces to multiple projects from a single app."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cba74baa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from phoenix.otel import register\n",
+    "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
+    "\n",
+    "tracer_provider = register(\n",
+    "    project_name=\"otel-best-practices\",\n",
+    "    batch=False,\n",
+    ")\n",
+    "\n",
+    "OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9dda9a8",
+   "metadata": {},
+   "source": [
+    "## Introduction to OpenInference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa9ac7f7",
+   "metadata": {},
+   "source": [
+    "[OpenInference](https://github.com/Arize-ai/openinference) is an open-source set of conventions and instrumentation libraries for tracing AI applications. It is maintained by Arize and is the standard that Phoenix uses to render LLM, tool, agent, chain, retriever, and other AI-specific spans in the trace view.\n",
+    "\n",
+    "OpenInference is an **extension to [OpenTelemetry](https://opentelemetry.io/docs/)**, not a replacement for it. It uses the standard OpenTelemetry SDK and libraries under the hood — the same `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` you would use for any OTel-instrumented service. What OpenInference adds is:\n",
+    "\n",
+    "- A set of **semantic conventions** that describe how to represent AI concepts (LLM calls, prompts, messages, tool invocations, retrieval, agent steps, sessions) as span attributes\n",
+    "- A library of **auto-instrumentors** for popular LLM SDKs and orchestration frameworks (OpenAI, Anthropic, Bedrock, LangChain, LlamaIndex, CrewAI, AutoGen, and many more)\n",
+    "\n",
+    "Because OpenInference is built on OpenTelemetry, any tool that speaks OTel can consume the spans — but a backend that understands the OpenInference conventions (like Phoenix) can render them as a rich, AI-aware trace view rather than a generic span list.\n",
+    "\n",
+    "**Read more:**\n",
+    "\n",
+    "- [OpenTelemetry and OpenInference concepts](/docs/phoenix/tracing/concepts-tracing/otel-openinference/overview) — the full reference companion to this cookbook.\n",
+    "- [OpenInference semantic conventions spec](https://github.com/Arize-ai/openinference/tree/main/spec) — the formal definitions for span kinds, attributes, and message structure.\n",
+    "- [OpenInference repository](https://github.com/Arize-ai/openinference) — auto-instrumentors, examples, and source for every supported language and framework.\n",
+    "- [OpenTelemetry documentation](https://opentelemetry.io/docs/) — the underlying observability framework that OpenInference builds on."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c4ff5f2",
+   "metadata": {},
+   "source": [
+    "The code below simulates having a conversation with a chatbot and asking it two related questions. It will create traces in Phoenix for a simple set of OpenAI calls.\n",
+    "\n",
+    "Run this code. Don't worry for now about what the code is doing, we will dive into the details later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2952ced",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import uuid\n",
+    "from IPython.display import Markdown, display\n",
+    "from openai import OpenAI\n",
+    "from opentelemetry import trace\n",
+    "from openinference.instrumentation import using_session\n",
+    "from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes\n",
+    "\n",
+    "client = OpenAI()\n",
+    "session_id = str(uuid.uuid4())\n",
+    "tracer = trace.get_tracer(__name__)\n",
+    "messages = [{\"role\": \"system\", \"content\": \"You are a helpful assistant. Answer in a concise manner.\"}]\n",
+    "\n",
+    "\n",
+    "def ask_llm(question: str) -> None:\n",
+    "    messages.append({\"role\": \"user\", \"content\": question})\n",
+    "\n",
+    "    with tracer.start_as_current_span(\"openinference-intro-chain\") as chain_span:\n",
+    "        chain_span.set_attribute(\n",
+    "            SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "            OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "        )\n",
+    "        chain_span.set_attribute(SpanAttributes.INPUT_VALUE, question)\n",
+    "\n",
+    "        response = client.responses.create(\n",
+    "            model=\"gpt-5.4-mini\",\n",
+    "            input=messages,\n",
+    "        )\n",
+    "        answer = response.output_text\n",
+    "\n",
+    "        messages.append({\"role\": \"assistant\", \"content\": answer})\n",
+    "        chain_span.set_attribute(SpanAttributes.OUTPUT_VALUE, answer)\n",
+    "        display(Markdown(answer))\n",
+    "\n",
+    "\n",
+    "with using_session(session_id=session_id):\n",
+    "    ask_llm(\"What is OpenInference?\")\n",
+    "    ask_llm(\"How does it relate to OpenTelemetry?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6dbcbc81",
+   "metadata": {},
+   "source": [
+    "Open Phoenix at [http://localhost:6006](http://localhost:6006) and navigate to the `otel-best-practices` project to view your traces."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96fcd2ea",
+   "metadata": {},
+   "source": [
+    "### Sessions, traces, and spans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b440652",
+   "metadata": {},
+   "source": [
+    "Three concepts shape how OpenInference (and OpenTelemetry) organize tracing data, and they nest inside each other:\n",
+    "\n",
+    "- **Span** — a single step in your application, such as an LLM call, a tool invocation, or a chain stage. Each span has a name, start and end timestamps, attributes, and a potentially a parent — spans nest to form a tree. The root of the tree is known as the root span, and has no parent.\n",
+    "- **Trace** — a collection of spans tied together by a shared `trace_id`. A trace represents one end-to-end request through your agent.\n",
+    "- **Session** — a collection of traces tied together by a shared `session.id`. A session is a logical grouping of traces based on a shared concept, such as multiple agent interactions to solve the same task, or to help with a continuous conversation.\n",
+    "\n",
+    "Picture a customer-support chatbot. The user has a multi-turn conversation, and that whole conversation is one **session**. Each turn — one user message and the app's response — is one **trace**. Inside each trace, the app does several things to produce the response (classify intent, call a tool, format a reply), and each of those steps is a **span**.\n",
+    "\n",
+    "```\n",
+    "Session: support-chat-7a3f\n",
+    "│\n",
+    "├── Trace 1: \"Where is my order?\"\n",
+    "│   └── Chain span: handle_message\n",
+    "│       ├── LLM span:  classify_intent\n",
+    "│       ├── Tool span: lookup_order(order_id=\"A123\")\n",
+    "│       └── LLM span:  format_response\n",
+    "│\n",
+    "├── Trace 2: \"When will it arrive?\"\n",
+    "│   └── Chain span: handle_message\n",
+    "│       ├── LLM span:  classify_intent\n",
+    "│       ├── Tool span: get_shipping_status(order_id=\"A123\")\n",
+    "│       └── LLM span:  format_response\n",
+    "│\n",
+    "└── Trace 3: \"Thanks!\"\n",
+    "    └── Chain span: handle_message\n",
+    "        └── LLM span: generate_acknowledgement\n",
+    "```\n",
+    "\n",
+    "Three traces, one session. In Phoenix you can open a single trace to debug what happened in one turn, or use the session view to see all the turns together.\n",
+    "\n",
+    "For the full breakdown of how signals, spans, traces, and sessions fit together, see [Signals, spans, traces, and sessions](/docs/phoenix/tracing/concepts-tracing/otel-openinference/signals)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "376a7a01",
+   "metadata": {},
+   "source": [
+    "#### Sessions\n",
+    "\n",
+    "In Phoenix, start with the **Sessions** tab. You should see a single session that represents the entire two step conversation.\n",
+    "\n",
+    "![The Sessions tab in Phoenix showing one session for the chatbot conversation](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/sessions.png)\n",
+    "\n",
+    "If you select the session, a pane will appear with details of the session, including both steps in the conversation, showing the input to and the output from the agent. It will also show the latency, so the time the agent took to run, as well as the total number of tokens used and the estimated cost based off published token pricing from the LLM provider if available.\n",
+    "\n",
+    "![Details pane in Phoenix for the chatbot session, showing both conversation turns with input, output, latency, tokens, and cost](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/session.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b56747fc",
+   "metadata": {},
+   "source": [
+    "#### Traces\n",
+    "\n",
+    "Select the **Traces** tab. You should see both of the steps in the conversation as distinct traces, showing the input and output to the agent.\n",
+    "\n",
+    "The code you ran just makes a single LLM call, so the trace has the input set to what was sent to the LLM, and the output set to the response from the LLM. In a more complicated trace, the input is what was sent to the agent, and the output is the final response sent by the agent after it has completed its entire processing, including calling LLMs or tools.\n",
+    "\n",
+    "![The Traces tab in Phoenix showing two traces from the chatbot conversation](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/traces.png)\n",
+    "\n",
+    "If you select a trace, a pane will appear with details of the trace. It will show a tree of spans, along with latency, token counts, and estimated cost.\n",
+    "\n",
+    "![Details pane in Phoenix for a single trace, showing the span tree with latency, token counts, and cost](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/trace.png)\n",
+    "\n",
+    "> You can also navigate to the individual traces directly from the session view."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "458070aa",
+   "metadata": {},
+   "source": [
+    "#### Spans\n",
+    "\n",
+    "In the trace view you will see a tree of the spans that make up the trace. Spans are grouped into traces by having the same `trace_id` set on them. A trace is a tree of spans, so one span will be the root span at the top of the tree, and the rest of the spans will be under that tree. The hierarchy is defined using the `parent_id` on the span — each child span has its `parent_id` set to the id of the parent span.\n",
+    "\n",
+    "In the trace we have 2 spans:\n",
+    "\n",
+    "![Details pane in Phoenix for a single trace, showing the span tree with latency, token counts, and cost](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/trace.png)\n",
+    "\n",
+    "The root span is a **Chain** span. Chain spans are starting points for a set of related spans, you can think of them as a folder that groups spans together. In this example, the chain span isn't really necessary, it's just here to help show a tree.\n",
+    "\n",
+    "Under the root span is an **LLM** span called `ChatCompletion`. This span represents a call to an LLM, in our case OpenAI.\n",
+    "\n",
+    "![An LLM span named ChatCompletion selected in Phoenix trace tree](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/llm-span.png)\n",
+    "\n",
+    "Against each span is an **Attributes** tab that has JSON containing all the attributes associated with the span, such as the input and output, number of tokens used for an LLM span, and so on. We will cover these attributes in the rest of this tutorial.\n",
+    "\n",
+    "![The Attributes tab in Phoenix showing the JSON attributes for a selected span](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/span-attributes.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67de03ca",
+   "metadata": {},
+   "source": [
+    "OpenInference defines a fixed set of span kinds:\n",
+    "\n",
+    "| Span kind | Description |\n",
+    "| --- | --- |\n",
+    "| `LLM` | A call to a large language model. Captures the model, input messages, output messages, token counts, and cost. |\n",
+    "| `CHAIN` | A starting point or link between application steps. Commonly used as a parent span to group related work into a logical block. |\n",
+    "| `AGENT` | A span representing an agent's work — typically wraps LLM and tool spans together |\n",
+    "| `TOOL` | A call to an external tool or function, often invoked in response to a tool-use request from an LLM |\n",
+    "| `RETRIEVER` | A retrieval operation, such as fetching documents from a vector store or search index |\n",
+    "| `EMBEDDING` | A call to an embedding model |\n",
+    "| `RERANKER` | A reranking step that reorders a set of retrieved documents |\n",
+    "| `GUARDRAIL` | A safety or policy check, such as content moderation, PII detection, or input validation |\n",
+    "| `EVALUATOR` | An evaluation step that scores or judges an LLM output |\n",
+    "| `PROMPT` | A prompt definition or templating step |\n",
+    "| `UNKNOWN` | Used when no other kind applies |\n",
+    "\n",
+    "In this tutorial, we will be looking at LLM, chain, agent, and tool spans. For the complete reference covering every kind and the attributes each is expected to carry, see [OpenInference span kinds](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6499ee46",
+   "metadata": {},
+   "source": [
+    "## Configuring sessions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fecc96b9",
+   "metadata": {},
+   "source": [
+    "**Sessions** are a logical grouping of traces based on a continuous set of interactions with an agent. For example, in a chatbot, the entire multi-turn conversation that a single user has with the agent would be a session. When the same user starts a brand new conversation with no previous context, or a new user starts a conversation, this would be a new session.\n",
+    "\n",
+    "Sessions are explicitly managed by the engineer building the agent; they are not created automatically when sending traces.\n",
+    "\n",
+    "Sessions are set with the `using_session` function. This sets the session id for any spans created in any code run in this block. `using_session` is one of a small family of OpenInference context managers — see [OpenInference context managers](/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers) for the full list (`using_user`, `using_metadata`, `using_tags`, `using_prompt_template`, `using_attributes`).\n",
+    "\n",
+    "The following code contains a call to OpenAI inside a session. The session id is hardcoded here, so if you run this code multiple times, each run will be a new trace inside the same session."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7801593f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with using_session(session_id=\"My Session\"):\n",
+    "    response = client.responses.create(\n",
+    "        model=\"gpt-5.4-mini\",\n",
+    "        input=\"What are sessions in OpenInference? Be concise.\",\n",
+    "    )\n",
+    "    display(Markdown(response.output_text))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69000de7",
+   "metadata": {},
+   "source": [
+    "Look up this session in Phoenix. You will see a single session with multiple traces depending on how many times you ran the code.\n",
+    "\n",
+    "![The Sessions tab in Phoenix showing a single session with multiple traces](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/sessions-1-session.png)\n",
+    "\n",
+    "Now run the following code. This has a different session Id, so will create a new session."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27614472",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with using_session(session_id=\"My Session 2\"):\n",
+    "    response = client.responses.create(\n",
+    "        model=\"gpt-5.4-mini\",\n",
+    "        input=\"What are sessions in OpenInference? Be concise.\",\n",
+    "    )\n",
+    "    display(Markdown(response.output_text))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d38f8db",
+   "metadata": {},
+   "source": [
+    "You will now see a new session in the sessions list.\n",
+    "\n",
+    "![The Sessions tab in Phoenix showing two distinct sessions in the list](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/sessions-2-sessions.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a27ae35",
+   "metadata": {},
+   "source": [
+    "## Capturing spans and traces"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ed92cc0",
+   "metadata": {},
+   "source": [
+    "In the examples so far you have already seen both ways that OpenInference creates spans:\n",
+    "\n",
+    "- **Auto-instrumentors** wrap a specific library or framework (such as the OpenAI SDK, or LangChain) and emit a span for every call to that library automatically, along with spans for the different actions that the framework performs, such as tool calling. Each call to the library or framework is a separate trace.\n",
+    "- **Manual instrumentation** lets you create your own traces and spans by calling the tracer directly in your application code\n",
+    "\n",
+    "Most real-world applications use both. The auto-instrumentor handles the standard SDK calls; manual instrumentation captures your application's own logic that wraps around those calls.\n",
+    "\n",
+    "See [Instrumentation approaches](/docs/phoenix/tracing/concepts-tracing/otel-openinference/instrumentation-approaches) for a deeper comparison of auto-instrumentation, manual instrumentation, and the hybrid pattern."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98808595",
+   "metadata": {},
+   "source": [
+    "### Auto-instrumentors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd1cb351",
+   "metadata": {},
+   "source": [
+    "Auto-instrumentors are libraries that instrument an SDK or framework, and automatically emit spans for every call, and every action taken by the SDK or framework.\n",
+    "\n",
+    "You already set up an auto-instrumentor in the Initial setup section:\n",
+    "\n",
+    "```python\n",
+    "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
+    "\n",
+    "OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)\n",
+    "```\n",
+    "\n",
+    "After that single call, every `client.responses.create()` and `client.chat.completions.create()` in your code creates an LLM span automatically in a new trace. If you are using a more advanced framework that handles tool calling for example, then each call to the framework would be a new trace, with spans for the LLM and tool calls, grouped under a chain span.\n",
+    "\n",
+    "OpenInference provides auto-instrumentors for most popular AI SDKs and orchestration frameworks: OpenAI, Anthropic, Bedrock, LangChain, LlamaIndex, CrewAI, AutoGen, and many more. See the [OpenInference repository](https://github.com/Arize-ai/openinference) for the full list.\n",
+    "\n",
+    "If you run the code below, the auto-instrumentor will create a trace with a single span. You can see this in Phoenix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4707bbda",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with using_session(session_id=\"Capturing Spans Example\"):\n",
+    "    response = client.responses.create(\n",
+    "        model=\"gpt-5.4-mini\",\n",
+    "        input=\"What are sessions in OpenInference? Be concise.\",\n",
+    "    )\n",
+    "    display(Markdown(response.output_text))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b920c16",
+   "metadata": {},
+   "source": [
+    "Open the new trace in Phoenix under the `Capturing Spans Example` session. You will see a single LLM span — the auto-instrumentor created it automatically for the `client.responses.create()` call, without you writing any tracing code."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22c017fd",
+   "metadata": {},
+   "source": [
+    "### Manual instrumentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc732984",
+   "metadata": {},
+   "source": [
+    "Manual instrumentation gives you full control. You call the OpenTelemetry tracer directly to start a span, set its attributes (including its OpenInference span kind), and end it when the work is done. The recommended pattern is the context-manager form, which sets the span as the active span on the OpenTelemetry context (so any spans created inside the block automatically become its children) and ends the span when the block exits:\n",
+    "\n",
+    "```python\n",
+    "with tracer.start_as_current_span(\"my-span\") as span:\n",
+    "    span.set_attribute(\n",
+    "        SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "        OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "    )\n",
+    "    span.set_attribute(SpanAttributes.INPUT_VALUE, \"input data\")\n",
+    "    # do work here\n",
+    "    span.set_attribute(SpanAttributes.OUTPUT_VALUE, \"result\")\n",
+    "```\n",
+    "\n",
+    "You can manually create spans of any OpenInference kind, such as chain, LLM, or tool — by setting the `openinference.span.kind` attribute on the span. The kind controls how Phoenix renders the span (the icon and the detail view) and which set of OpenInference attributes the span is expected to carry.\n",
+    "\n",
+    "The following code creates a trace with three manually-created spans: a parent `data-pipeline` chain span with two child spans (`step-1-validate` and `step-2-format`) nested inside. There are no LLM or tool calls — every span is created by your code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "397c1102",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with using_session(session_id=\"Capturing Spans Example\"):\n",
+    "    with tracer.start_as_current_span(\"data-pipeline\") as pipeline:\n",
+    "        pipeline.set_attribute(\n",
+    "            SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "            OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "        )\n",
+    "        pipeline.set_attribute(SpanAttributes.INPUT_VALUE, \"raw request\")\n",
+    "\n",
+    "        with tracer.start_as_current_span(\"step-1-validate\") as step:\n",
+    "            step.set_attribute(\n",
+    "                SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "                OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "            )\n",
+    "            step.set_attribute(SpanAttributes.INPUT_VALUE, \"raw request\")\n",
+    "            step.set_attribute(SpanAttributes.OUTPUT_VALUE, \"validated request\")\n",
+    "\n",
+    "        with tracer.start_as_current_span(\"step-2-format\") as step:\n",
+    "            step.set_attribute(\n",
+    "                SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "                OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "            )\n",
+    "            step.set_attribute(SpanAttributes.INPUT_VALUE, \"validated request\")\n",
+    "            step.set_attribute(SpanAttributes.OUTPUT_VALUE, \"formatted output\")\n",
+    "\n",
+    "        pipeline.set_attribute(SpanAttributes.OUTPUT_VALUE, \"formatted output\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3c876d2",
+   "metadata": {},
+   "source": [
+    "Open the new trace in Phoenix under the `Capturing Spans Example` session. You will see a single chain span called `data-pipeline` with two child chain spans (`step-1-validate` and `step-2-format`) nested underneath.\n",
+    "\n",
+    "![Trace tree in Phoenix showing the data-pipeline chain span with step-1-validate and step-2-format child chain spans nested inside](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/data-pipeline.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad48a62a",
+   "metadata": {},
+   "source": [
+    "### Hybrid instrumentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "519f8c10",
+   "metadata": {},
+   "source": [
+    "The most powerful pattern is to use both approaches together. **Hybrid instrumentation** lets you wrap auto-instrumented calls in your own manually-created spans, so you can group SDK calls into logical units, add custom attributes, and build the trace tree that best represents your application — without losing any of the rich attributes that the auto-instrumentor captures.\n",
+    "\n",
+    "Auto-instrumented spans and manually-created spans nest together naturally because they share the same OpenTelemetry context. When you open a manual span with `tracer.start_as_current_span(...)`, it becomes the active span on the context. Any call to an auto-instrumented SDK inside that block will create its span as a child of your manual span.\n",
+    "\n",
+    "You have already seen hybrid instrumentation in the Introduction to OpenInference section. The `ask_llm` function wraps each OpenAI call in a manually-created chain span.\n",
+    "\n",
+    "The manually-created chain span is the parent; the LLM span that the OpenAI auto-instrumentor produces around `client.responses.create()` automatically becomes its child. That is what gives you the tree structure you saw in Phoenix when you ran the introduction example — a chain span at the top, with an LLM span nested inside.\n",
+    "\n",
+    "This pattern is the typical shape of a real-world traced application: manual chain or agent spans give you the high-level structure of your business logic; auto-instrumented spans fill in the low-level detail of every SDK call you make inside them.\n",
+    "\n",
+    "Run this code to see an example of hybrid instrumentation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2da697be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with using_session(session_id=\"Capturing Spans Example\"):\n",
+    "    with tracer.start_as_current_span(\"manual-chain\") as chain_span:\n",
+    "        chain_span.set_attribute(\n",
+    "            SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "            OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "        )\n",
+    "        chain_span.set_attribute(SpanAttributes.INPUT_VALUE, \"What are sessions in OpenInference? Be concise.\")\n",
+    "\n",
+    "        response = client.responses.create(\n",
+    "            model=\"gpt-5.4-mini\",\n",
+    "            input=\"What are sessions in OpenInference? Be concise.\",\n",
+    "        )\n",
+    "\n",
+    "        chain_span.set_attribute(SpanAttributes.OUTPUT_VALUE, response.output_text)\n",
+    "        display(Markdown(response.output_text))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "026931b8",
+   "metadata": {},
+   "source": [
+    "Open the new trace in Phoenix under the `Capturing Spans Example` session. You will see a chain span called `manual-chain` with an LLM span nested inside it — the manual span is the parent, and the auto-instrumented LLM span automatically became its child because they share the same OpenTelemetry context."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aee9f027",
+   "metadata": {},
+   "source": [
+    "## Span attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c34337b",
+   "metadata": {},
+   "source": [
+    "Every OpenInference span carries a small set of **common attributes** that apply regardless of the span kind, plus a **kind-specific set** added on top.\n",
+    "\n",
+    "The common attributes available on any span kind are:\n",
+    "\n",
+    "| Attribute | Description |\n",
+    "| --- | --- |\n",
+    "| `openinference.span.kind` | The span kind: `LLM`, `CHAIN`, `AGENT`, `TOOL`, `RETRIEVER`, `EMBEDDING`, `RERANKER`, `GUARDRAIL`, `EVALUATOR`, `PROMPT`, or `UNKNOWN`. Controls how Phoenix renders the span. |\n",
+    "| `input.value` | The input to the span as a string. If the value is structured, serialize it to JSON and set `input.mime_type` accordingly. |\n",
+    "| `input.mime_type` | The mime type of `input.value`. Defaults to `text/plain`; set to `application/json` if the value is a JSON string. |\n",
+    "| `output.value` | The output from the span as a string |\n",
+    "| `output.mime_type` | The mime type of `output.value`. Same convention as `input.mime_type`. |\n",
+    "| `metadata` | A JSON dictionary of your own fields. Use it to attach domain-specific context such as user tier, feature flag, or request id. |\n",
+    "| `session.id` | Groups multiple traces into a session. Set with `using_session(...)` or directly via `span.set_attribute(SpanAttributes.SESSION_ID, ...)`. |\n",
+    "| `user.id` | Identifies the user the trace belongs to. Set with `using_user(...)` or directly. |\n",
+    "| `tag.tags` | A list of string tags for filtering. Set with `using_tags(...)`. |\n",
+    "\n",
+    "Phoenix uses several of these directly in the UI: `openinference.span.kind` drives the span icon and the kind-specific detail view; `input.value` and `output.value` on the root span feed the trace-level input and output preview in the Traces and Sessions tabs; `session.id` groups traces into sessions; `metadata` and `tag.tags` are filterable across spans.\n",
+    "\n",
+    "The full attribute catalogue is described in [OpenInference semantic conventions](/docs/phoenix/tracing/concepts-tracing/otel-openinference/semantic-conventions) (the overall standard) and [OpenInference span kinds](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds) (per-kind reference)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1196cb90",
+   "metadata": {},
+   "source": [
+    "## The core span types"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36369ffb",
+   "metadata": {},
+   "source": [
+    "OpenInference defines 11 span kinds, but most AI applications use just four: **LLM**, **chain**, **agent**, and **tool**. These show up in almost every real-world trace — an agent makes LLM calls, LLM calls trigger tool calls, and chain spans group the related work together. For the canonical reference of every span kind and the attributes each carries, see [OpenInference span kinds](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds).\n",
+    "\n",
+    "The following example uses the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) to produce a single trace containing all four kinds. The SDK has its own auto-instrumentor — `openinference-instrumentation-openai-agents` — which emits the full set of span kinds for every agent run.\n",
+    "\n",
+    "Attach the Agents SDK instrumentor to the existing tracer provider. You can leave the OpenAI auto-instrumentor active alongside it — the Agents SDK creates its own LLM spans, so the two cooperate without duplicating work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e92eae93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor\n",
+    "\n",
+    "OpenAIAgentsInstrumentor().instrument(tracer_provider=tracer_provider)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c078bd26",
+   "metadata": {},
+   "source": [
+    "Define a simple travel assistant with two tools, then ask it a question that requires both tools to be called. Wrap the run in a session so the trace is easy to find in Phoenix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de04adec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from agents import Agent, Runner, function_tool\n",
+    "\n",
+    "\n",
+    "@function_tool\n",
+    "def get_weather(city: str) -> str:\n",
+    "    \"\"\"Get the current weather for a city.\"\"\"\n",
+    "    return f\"The weather in {city} is sunny and 22°C.\"\n",
+    "\n",
+    "\n",
+    "@function_tool\n",
+    "def get_time_zone(city: str) -> str:\n",
+    "    \"\"\"Get the time zone for a city.\"\"\"\n",
+    "    zones = {\n",
+    "        \"Tokyo\": \"JST (UTC+9)\",\n",
+    "        \"London\": \"GMT (UTC+0)\",\n",
+    "        \"New York\": \"EST (UTC-5)\",\n",
+    "    }\n",
+    "    return zones.get(city, \"unknown\")\n",
+    "\n",
+    "\n",
+    "travel_agent = Agent(\n",
+    "    name=\"TravelAssistant\",\n",
+    "    instructions=(\n",
+    "        \"You are a helpful travel assistant. \"\n",
+    "        \"Use get_weather to look up the weather for a city, \"\n",
+    "        \"and get_time_zone to look up its time zone. \"\n",
+    "        \"Give a concise final answer.\"\n",
+    "    ),\n",
+    "    tools=[get_weather, get_time_zone],\n",
+    ")\n",
+    "\n",
+    "with using_session(session_id=\"Travel Agent Example\"):\n",
+    "    result = await Runner.run(\n",
+    "        travel_agent,\n",
+    "        \"What's the weather and time zone in Tokyo?\",\n",
+    "    )\n",
+    "\n",
+    "display(Markdown(result.final_output))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "629abd18",
+   "metadata": {},
+   "source": [
+    "Open the trace in Phoenix under the `otel-best-practices` project. A single agent run produces a trace containing all four core span kinds:\n",
+    "\n",
+    "- Two **agent** spans — an outer `Agent workflow` wrapper and an inner `TravelAssistant`\n",
+    "- Three **chain** spans — one wrapping the whole workflow plus one per agent turn\n",
+    "- Two **tool** spans, one for each call to `get_weather` and `get_time_zone`\n",
+    "- Four **LLM** spans — each agent turn produces a Responses API call from the SDK with the underlying OpenAI client call nested inside it\n",
+    "\n",
+    "![Trace in Phoenix from the OpenAI Agents SDK example, showing agent, chain, tool, and LLM spans nested together](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/agent-trace.png)\n",
+    "\n",
+    "This is the trace shape you will see from most non-trivial agents: an outer agent/chain workflow, tool spans for each external call, and LLM spans for every model call inside."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5db075b5",
+   "metadata": {},
+   "source": [
+    "### LLM spans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "876a3cdf",
+   "metadata": {},
+   "source": [
+    "**LLM spans** represent a call to a large language model. They capture everything you need to debug or analyze the call: the model that was used, the input messages, the output, tools, token counts, costs, and more.\n",
+    "\n",
+    "In the agent trace are several LLM spans. Select one of these, and you will see the input and output from that LLM call. Against the span in the tree you will also see the number of tokens used, the latency, and the cost. In the **Attributes** tab, you can see the full attributes for the span.\n",
+    "\n",
+    "![The Attributes tab in Phoenix showing the full attribute set for an LLM span](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/llm-span-attributes.png)\n",
+    "\n",
+    "The relevant attributes for this example are:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"openinference\": {\n",
+    "        \"span\": {\n",
+    "            \"kind\": \"LLM\"\n",
+    "        }\n",
+    "    },\n",
+    "    \"llm\": {\n",
+    "        \"cost\": {\n",
+    "            \"completion\": 0.0002205,\n",
+    "            \"completion_details\": {\n",
+    "                \"output\": 0.0002205,\n",
+    "                \"reasoning\": 0\n",
+    "            },\n",
+    "            \"prompt\": 0.00009975,\n",
+    "            \"prompt_details\": {\n",
+    "                \"cache_read\": 0,\n",
+    "                \"input\": 0.00009975\n",
+    "            },\n",
+    "            \"total\": 0.00032025\n",
+    "        },\n",
+    "        \"input_messages\": [\n",
+    "            {\n",
+    "                \"message.content\": \"You are a helpful travel assistant. Use get_weather to look up the weather for a city, and get_time_zone to look up its time zone. Give a concise final answer.\",\n",
+    "                \"message.role\": \"system\"\n",
+    "            },\n",
+    "            {\n",
+    "                \"message.content\": \"What's the weather and time zone in Tokyo?\",\n",
+    "                \"message.role\": \"user\"\n",
+    "            }\n",
+    "        ],\n",
+    "        \"invocation_parameters\": \"{\\\"include\\\": [], \\\"model\\\": \\\"gpt-5.4-mini\\\", \\\"prompt_cache_key\\\": \\\"agents-sdk:run:1fc4521fe6f248beafa82586c8b0fa3e\\\", \\\"reasoning\\\": {\\\"effort\\\": \\\"none\\\"}, \\\"text\\\": {\\\"verbosity\\\": \\\"low\\\"}}\",\n",
+    "        \"model_name\": \"gpt-5.4-mini-2026-03-17\",\n",
+    "        \"output_messages\": [\n",
+    "            {\n",
+    "                \"message.role\": \"assistant\",\n",
+    "                \"message.tool_calls\": [\n",
+    "                    {\n",
+    "                        \"tool_call.function.arguments\": \"{\\\"city\\\":\\\"Tokyo\\\"}\",\n",
+    "                        \"tool_call.function.name\": \"get_weather\",\n",
+    "                        \"tool_call.id\": \"call_OdvgB0fVwTcdKy6mqxV3cmuB\"\n",
+    "                    }\n",
+    "                ]\n",
+    "            },\n",
+    "            {\n",
+    "                \"message.role\": \"assistant\",\n",
+    "                \"message.tool_calls\": [\n",
+    "                    {\n",
+    "                        \"tool_call.function.arguments\": \"{\\\"city\\\":\\\"Tokyo\\\"}\",\n",
+    "                        \"tool_call.function.name\": \"get_time_zone\",\n",
+    "                        \"tool_call.id\": \"call_cnCgrd4Js5bErfROFdIoc68j\"\n",
+    "                    }\n",
+    "                ]\n",
+    "            }\n",
+    "        ],\n",
+    "        \"provider\": \"openai\",\n",
+    "        \"system\": \"openai\",\n",
+    "        \"token_count\": {\n",
+    "            \"completion\": \"49\",\n",
+    "            \"completion_details\": {\n",
+    "                \"output\": \"49\",\n",
+    "                \"reasoning\": \"0\"\n",
+    "            },\n",
+    "            \"prompt\": \"133\",\n",
+    "            \"prompt_details\": {\n",
+    "                \"cache_read\": \"0\",\n",
+    "                \"input\": \"133\"\n",
+    "            },\n",
+    "            \"total\": \"182\"\n",
+    "        },\n",
+    "        \"tools\": [\n",
+    "            {\n",
+    "                \"tool.json_schema\": \"{\\\"name\\\":\\\"get_weather\\\",\\\"parameters\\\":{\\\"properties\\\":{\\\"city\\\":{\\\"title\\\":\\\"City\\\",\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"city\\\"],\\\"title\\\":\\\"get_weather_args\\\",\\\"type\\\":\\\"object\\\",\\\"additionalProperties\\\":false},\\\"strict\\\":true,\\\"type\\\":\\\"function\\\",\\\"defer_loading\\\":null,\\\"description\\\":\\\"Get the current weather for a city.\\\"}\"\n",
+    "            },\n",
+    "            {\n",
+    "                \"tool.json_schema\": \"{\\\"name\\\":\\\"get_time_zone\\\",\\\"parameters\\\":{\\\"properties\\\":{\\\"city\\\":{\\\"title\\\":\\\"City\\\",\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"city\\\"],\\\"title\\\":\\\"get_time_zone_args\\\",\\\"type\\\":\\\"object\\\",\\\"additionalProperties\\\":false},\\\"strict\\\":true,\\\"type\\\":\\\"function\\\",\\\"defer_loading\\\":null,\\\"description\\\":\\\"Get the time zone for a city.\\\"}\"\n",
+    "            }\n",
+    "        ]\n",
+    "    }\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "578de536",
+   "metadata": {},
+   "source": [
+    "#### LLM-specific attributes\n",
+    "\n",
+    "Beyond the common attributes that any span carries (covered in the Span attributes section above), the OpenAI auto-instrumentor adds an LLM-specific set on every LLM span — all under the `llm.*` namespace and following the OpenInference semantic conventions:\n",
+    "\n",
+    "| Attribute | Description |\n",
+    "| --- | --- |\n",
+    "| `llm.model_name` | The exact model identifier returned by OpenAI, for example `gpt-5.4-mini-2026-03-17`. This is the resolved snapshot version, not the alias you passed in. |\n",
+    "| `llm.provider` | The LLM provider, here `openai` |\n",
+    "| `llm.system` | The AI system identifier, also `openai` |\n",
+    "| `llm.invocation_parameters` | A JSON string of the parameters passed to the API: `{\"model\": \"gpt-5.4-mini\"}` |\n",
+    "| `llm.input_messages` | The messages sent to the API as a structured array. Each entry has `message.role` and `message.content`. |\n",
+    "| `llm.output_messages` | The messages returned by the API as a structured array. Each entry has `message.role` and a `message.contents` list of structured content items (with `message_content.text` and `message_content.type`). This shape is multimodal-aware — text, image, audio, and reasoning content all fit the same structure. |\n",
+    "| `llm.token_count.prompt` / `.completion` / `.total` | Token counts for the call, with detail breakdowns under `llm.token_count.prompt_details.*` (`cache_read`, `input`) and `llm.token_count.completion_details.*` (`output`, `reasoning`) |\n",
+    "| `llm.cost.prompt` / `.completion` / `.total` | Estimated cost in USD with the same `_details` breakdowns. Phoenix computes these from the token counts and the published pricing for the model. |\n",
+    "\n",
+    "Phoenix uses the LLM-specific attributes to drive the token-count and cost columns in the trace and session views, and to populate the LLM detail view (input messages, output messages, model name)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14f52e71",
+   "metadata": {},
+   "source": [
+    "### Tool spans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc996b12",
+   "metadata": {},
+   "source": [
+    "**Tool spans** represent a call to an external tool or function — typically a function the LLM has decided to call. They capture the tool's name, the arguments the LLM passed in, and the value the tool returned.\n",
+    "\n",
+    "In the agent trace above you have two tool spans: `get_weather` and `get_time_zone`, one for each tool the agent invoked. Select one of them in the trace tree to see the tool-specific attributes — the tool name, the arguments the LLM passed in (`{\"city\": \"Tokyo\"}`), and the value the tool returned.\n",
+    "\n",
+    "![The Attributes tab in Phoenix showing the get_weather tool span attributes, including the input city and the returned weather text](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/tool-span-attributes.png)\n",
+    "\n",
+    "The relevant attributes for this example are:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"openinference\": {\n",
+    "        \"span\": {\n",
+    "            \"kind\": \"TOOL\"\n",
+    "        }\n",
+    "    },\n",
+    "    \"tool\": {\n",
+    "        \"name\": \"get_weather\"\n",
+    "    }\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49782a71",
+   "metadata": {},
+   "source": [
+    "#### Tool-specific attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0e94ab2",
+   "metadata": {},
+   "source": [
+    "Beyond the common attributes that any span carries, tool spans carry a small set of tool-specific attributes under the `tool.*` namespace:\n",
+    "\n",
+    "| Attribute | Description |\n",
+    "| --- | --- |\n",
+    "| `tool.id` | The identifier for the result of the tool call. Corresponds to the `tool_call.id` emitted by the LLM, which lets Phoenix link the tool span back to the LLM call that requested it. |\n",
+    "| `tool.name` | The name of the tool |\n",
+    "| `tool.description` | The tool's description. The LLM uses this when deciding which tool to call. |\n",
+    "| `tool.parameters` | A JSON string of the parameter values the LLM passed to the tool |\n",
+    "| `tool.json_schema` | The full JSON schema of the tool's input, typically in OpenAI tool-calling format. Tells the LLM what shape of arguments the tool expects. |\n",
+    "\n",
+    "Phoenix uses these to populate the tool detail view: the tool name and description appear at the top, the arguments and return value are surfaced from `input.value` and `output.value`, and the tool span links back to the parent LLM span via `tool.id`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9cd747b9",
+   "metadata": {},
+   "source": [
+    "### Agent spans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2e53c6e",
+   "metadata": {},
+   "source": [
+    "**Agent spans** represent the work of an autonomous agent — the orchestration that decides when to call the LLM, when to call tools, when to call the LLM again, and when to stop. An agent span is typically the parent of the LLM, tool, and chain spans that make up the agent's loop.\n",
+    "\n",
+    "In the agent trace above, the `TravelAssistant` span is an agent span. Select it to see how it wraps both of the agent's turns, with all of the LLM and tool calls nested inside it.\n",
+    "\n",
+    "![The Attributes tab in Phoenix showing the TravelAssistant agent span attributes](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/agent-span-attributes.png)\n",
+    "\n",
+    "The relevant attributes for this example are:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"openinference\": {\n",
+    "        \"span\": {\n",
+    "            \"kind\": \"AGENT\"\n",
+    "        }\n",
+    "    },\n",
+    "    \"graph\": {\n",
+    "        \"node\": {\n",
+    "            \"id\": \"TravelAssistant\"\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "Note that the OpenAI Agents SDK auto-instrumentor uses `graph.node.id` to carry the agent's name (`TravelAssistant`) rather than the convention's `agent.name`. This is so Phoenix can render multi-agent systems with handoffs as a graph view. When you create agent spans manually, set `agent.name` (and optionally the `graph.node.*` attributes if you want the graph view)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a80d7aae",
+   "metadata": {},
+   "source": [
+    "#### Agent-specific attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "266e51af",
+   "metadata": {},
+   "source": [
+    "Agent spans carry a small set of agent-specific attributes:\n",
+    "\n",
+    "| Attribute | Description |\n",
+    "| --- | --- |\n",
+    "| `agent.name` | The name of the agent. Agents that perform the same logical role should share a name so you can group their traces together. |\n",
+    "| `graph.node.id` | The id of this agent's node in an execution graph. Optional — set when you want to visualize a multi-agent system as a graph in Phoenix. |\n",
+    "| `graph.node.name` | A human-readable name for the graph node |\n",
+    "| `graph.node.parent_id` | The id of the parent node. Leave unset for a root agent. |\n",
+    "\n",
+    "The `graph.node.*` attributes are how Phoenix renders multi-agent systems (LangGraph, AutoGen, CrewAI, etc.) as a graph view alongside the trace tree."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b8eb38f",
+   "metadata": {},
+   "source": [
+    "### Chain spans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a5e91b5",
+   "metadata": {},
+   "source": [
+    "**Chain spans** are general-purpose grouping spans. Use a chain span when you want to group a set of related work under a single parent in the trace tree — a multi-step pipeline, one agent turn, an LLM call with pre- and post-processing, or just a logical block in your application code.\n",
+    "\n",
+    "In the agent trace above the outer `Agent workflow` is a chain span, and each agent turn is also wrapped in a chain span called `turn`. Select a `turn` span to see how it groups the LLM and tool calls for that turn together.\n",
+    "\n",
+    "![The Attributes tab in Phoenix showing a turn chain span grouping the LLM and tool calls for one agent turn](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/chain-span-attributes.png)\n",
+    "\n",
+    "The relevant attributes for this example are:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"openinference\": {\n",
+    "        \"span\": {\n",
+    "            \"kind\": \"CHAIN\"\n",
+    "        }\n",
+    "    },\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "The chain span carries only the kind and the common attributes — its value is purely structural, giving you a named parent in the trace tree."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "896e9f95",
+   "metadata": {},
+   "source": [
+    "#### Chain-specific attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea30b7b2",
+   "metadata": {},
+   "source": [
+    "Chain spans have no kind-specific attributes. They rely on the common attributes covered in the Span attributes section above — `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, and so on. The chain span's value is purely structural: it gives you a named parent in the trace tree, with whatever input and output you choose to attach to it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "758f099b",
+   "metadata": {},
+   "source": [
+    "## Overriding or adding attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "efa8149c",
+   "metadata": {},
+   "source": [
+    "Auto-instrumentors capture the standard OpenInference attributes for every span they create, but you often want to add your own. Common reasons:\n",
+    "\n",
+    "- **Tag the call for filtering** — for example `experiment=\"v2-prompt\"` or `tenant=\"acme\"`\n",
+    "- **Attach domain metadata** — user tier, request id, feature flag value\n",
+    "- **Record a prompt template** — the template string, version, and variables you used, separate from the final flattened prompt\n",
+    "\n",
+    "With manually-created spans you can call `span.set_attribute(...)` directly inside the `with` block, as you saw in the manual instrumentation example. With auto-instrumented spans you do not have direct access to the span object — but you can still enrich it by putting attributes into the OpenTelemetry context using the **OpenInference context managers**. The auto-instrumentor reads from that context when it creates the span. This means the attributes are applied to every span created inside the block, no matter who creates it.\n",
+    "\n",
+    "The available context managers are:\n",
+    "\n",
+    "| Context manager | Sets |\n",
+    "| --- | --- |\n",
+    "| `using_session(session_id)` | `session.id` |\n",
+    "| `using_user(user_id)` | `user.id` |\n",
+    "| `using_metadata(metadata)` | `metadata` (a JSON dictionary of your own fields) |\n",
+    "| `using_tags(tags)` | `tag.tags` (a list of strings) |\n",
+    "| `using_prompt_template(template=, variables=, version=)` | The `llm.prompt_template.*` attributes. Most useful on LLM spans. |\n",
+    "| `using_attributes(...)` | A convenience wrapper that combines all of the above into a single call |\n",
+    "\n",
+    "See [OpenInference context managers](/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers) for the full reference, including detailed usage patterns and gotchas.\n",
+    "\n",
+    "The following code uses `using_metadata` to attach a domain-specific metadata dictionary. The example here wraps an OpenAI call so the metadata ends up on an LLM span, but the same pattern works for any span — auto-instrumented or manual — created inside the block."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6bd68c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openinference.instrumentation import using_metadata\n",
+    "\n",
+    "with using_session(session_id=\"LLM Span Example\"):\n",
+    "    with using_metadata({\"user_tier\": \"premium\", \"request_source\": \"cookbook\"}):\n",
+    "        response = client.responses.create(\n",
+    "            model=\"gpt-5.4-mini\",\n",
+    "            input=\"What are LLM spans in OpenInference? Be concise.\",\n",
+    "        )\n",
+    "        display(Markdown(response.output_text))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d0f10a4",
+   "metadata": {},
+   "source": [
+    "Open the new trace in Phoenix. The LLM span now has an additional attribute:\n",
+    "\n",
+    "- `metadata` — a JSON string containing `{\"user_tier\": \"premium\", \"request_source\": \"cookbook\"}`\n",
+    "\n",
+    "It appears in the **Attributes** tab alongside the standard `llm.*` attributes.\n",
+    "\n",
+    "![The Attributes tab in Phoenix showing an LLM span with the custom metadata attribute alongside the standard llm.* attributes](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/llm-span-metadata.png)\n",
+    "\n",
+    "You can also filter spans by `metadata` values in Phoenix trace view, which makes it easy to slice traces by tenant, feature flag, or any other domain dimension. In the **Spans** tab, set the filter to `attributes.metadata.request_source = \"cookbook\"` to only see spans created with the `request_source` metadata set to `cookbook`.\n",
+    "\n",
+    "![The Spans tab in Phoenix filtered by attributes.metadata.request_source equal to cookbook](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/metadata-filter.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "371062a8",
+   "metadata": {},
+   "source": [
+    "### Overriding a tool attribute"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5991f49",
+   "metadata": {},
+   "source": [
+    "You can also override attributes that an auto-instrumentor has set, or add attributes that it left out. The OpenAI Agents SDK auto-instrumentor only sets `tool.name` on tool spans — it does not populate `tool.description`. The following code redefines `get_weather` to set a custom `tool.description` attribute on the active tool span, then recreates the agent and re-runs it.\n",
+    "\n",
+    "The pattern works because the auto-instrumentor opens the tool span before calling your function, so the tool span is the active span when your function body runs. Calling `set_attribute(...)` on it inside the function body either overrides the attribute (if the instrumentor set it) or adds it (if the instrumentor did not)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48396d17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@function_tool\n",
+    "def get_weather(city: str) -> str:\n",
+    "    \"\"\"Get the current weather for a city.\"\"\"\n",
+    "\n",
+    "    # Set a custom tool.description on the active tool span.\n",
+    "    trace.get_current_span().set_attribute(\n",
+    "        SpanAttributes.TOOL_DESCRIPTION,\n",
+    "        \"Looks up the current weather conditions for a given city.\",\n",
+    "    )\n",
+    "\n",
+    "    return f\"The weather in {city} is sunny and 22°C.\"\n",
+    "\n",
+    "\n",
+    "travel_agent = Agent(\n",
+    "    name=\"TravelAssistant\",\n",
+    "    instructions=(\n",
+    "        \"You are a helpful travel assistant. \"\n",
+    "        \"Use get_weather to look up the weather for a city, \"\n",
+    "        \"and get_time_zone to look up its time zone. \"\n",
+    "        \"Give a concise final answer.\"\n",
+    "    ),\n",
+    "    tools=[get_weather, get_time_zone],\n",
+    ")\n",
+    "\n",
+    "with using_session(session_id=\"Tool Override Example\"):\n",
+    "    result = await Runner.run(\n",
+    "        travel_agent,\n",
+    "        \"What's the weather and time zone in Tokyo?\",\n",
+    "    )\n",
+    "\n",
+    "display(Markdown(result.final_output))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16fe069b",
+   "metadata": {},
+   "source": [
+    "Open the new trace in Phoenix under the `otel-best-practices` project (find it via the `Tool Override Example` session). Select the `get_weather` tool span and open its **Attributes** tab. You will now see `tool.description` populated with the string you set inside the function body, alongside the standard `tool.name` the auto-instrumentor produced.\n",
+    "\n",
+    "![The Attributes tab in Phoenix showing the get_weather tool span with the manually-set tool.description alongside tool.name](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/tool-span-attributes-override.png)\n",
+    "\n",
+    "The relevant attributes for this example are:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"openinference\": {\n",
+    "        \"span\": {\n",
+    "            \"kind\": \"TOOL\"\n",
+    "        }\n",
+    "    },\n",
+    "    \"tool\": {\n",
+    "        \"description\": \"Looks up the current weather conditions for a given city.\",\n",
+    "        \"name\": \"get_weather\"\n",
+    "    }\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "The `get_time_zone` tool span in the same trace still has only `tool.name`, which is a good visual confirmation that the override applies only to the span you set attributes on."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42656493",
+   "metadata": {},
+   "source": [
+    "## Summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe1e0e14",
+   "metadata": {},
+   "source": [
+    "You have now seen the building blocks for tracing AI applications with OpenInference and Phoenix:\n",
+    "\n",
+    "- **OpenInference layers on top of OpenTelemetry** to add semantic conventions and auto-instrumentors for AI-specific concepts. The standard OpenTelemetry SDK still drives everything underneath — `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` are all unchanged.\n",
+    "- **Spans, traces, and sessions form a hierarchy.** A span is one step. A trace is a tree of spans tied together by `trace_id`. A session is a group of traces tied together by `session.id`. Sessions are how you stitch a multi-turn conversation together in Phoenix.\n",
+    "- **There are three ways to capture spans.** Auto-instrumentors wrap SDKs and emit spans for every call automatically. Manual instrumentation lets you create spans yourself with `tracer.start_as_current_span(...)`. Hybrid instrumentation combines the two — your manual spans wrap auto-instrumented calls and become their parents in the trace tree.\n",
+    "- **Every span carries a small set of common attributes** — `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, `user.id`, and `tag.tags` — regardless of the kind. The `openinference.span.kind` attribute drives how Phoenix renders the span.\n",
+    "- **Four span kinds cover most AI applications:** LLM, chain, agent, and tool. Each adds a kind-specific set of attributes — `llm.*` for model name, token counts, and costs; `tool.*` for tool name and description; `agent.name` (or `graph.node.id` for multi-agent graphs); chain spans rely on the common attributes alone.\n",
+    "- **You can enrich auto-instrumented spans.** Use OpenInference context managers like `using_session`, `using_metadata`, `using_tags`, and `using_prompt_template` to attach attributes that the auto-instrumentor picks up via the OpenTelemetry context. You can also override or add specific attributes by grabbing the active span inside a tool function and calling `set_attribute(...)` directly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "daf3acfb",
+   "metadata": {},
+   "source": [
+    "### Where to go next"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f39bd16",
+   "metadata": {},
+   "source": [
+    "- Read the [OpenTelemetry and OpenInference concepts](/docs/phoenix/tracing/concepts-tracing/otel-openinference/overview) section of the Arize docs for the full reference companion to this cookbook\n",
+    "- Dive into the [OpenInference span kinds](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds) reference for every span kind and the attributes each carries\n",
+    "- Read [Instrumentation approaches](/docs/phoenix/tracing/concepts-tracing/otel-openinference/instrumentation-approaches) for a deeper comparison of auto, manual, and hybrid instrumentation\n",
+    "- Learn how to [propagate context across services or async boundaries](/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-propagation) when your app spans multiple processes\n",
+    "- Reduce trace volume in production with [sampling](/docs/phoenix/tracing/concepts-tracing/otel-openinference/sampling)\n",
+    "- Browse the [OpenInference repository](https://github.com/Arize-ai/openinference) for auto-instrumentors covering Anthropic, Bedrock, LangChain, LlamaIndex, CrewAI, AutoGen, and many others\n",
+    "- Read the [OpenInference semantic conventions spec](https://github.com/Arize-ai/openinference/tree/main/spec) for the source-of-truth attribute definitions"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.14.4)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/tracing/openinference_best_practices_tutorial.ipynb
+++ b/tutorials/tracing/openinference_best_practices_tutorial.ipynb
@@ -55,16 +55,7 @@
    "cell_type": "markdown",
    "id": "ba2bec83",
    "metadata": {},
-   "source": [
-    "This notebook talks to a locally-running Phoenix instance. Before running any code, start Phoenix in a separate terminal:\n",
-    "\n",
-    "```bash\n",
-    "pip install arize-phoenix\n",
-    "phoenix serve\n",
-    "```\n",
-    "\n",
-    "This starts the Phoenix UI at [http://localhost:6006](http://localhost:6006). Leave it running — the rest of this notebook will send traces to it."
-   ]
+   "source": "This notebook is fully self-contained: it installs Phoenix, launches it inside the notebook session, and sends traces to it. Because Phoenix runs in the session itself, the notebook works the same way whether you run it locally or in Google Colab — there is no separate terminal or server to start.\n\nThe setup steps below install the libraries, set your OpenAI API key, launch Phoenix, and configure tracing."
   },
   {
    "cell_type": "markdown",
@@ -111,6 +102,20 @@
     "OPENAI_API_KEY = globals().get(\"OPENAI_API_KEY\") or getpass(\"🔑 Enter your OpenAI API key: \")\n",
     "os.environ[\"OPENAI_API_KEY\"] = OPENAI_API_KEY"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91b8854c",
+   "source": "### Launch Phoenix\n\nLaunch a Phoenix app right here in the notebook session. This runs the Phoenix server in a background thread, so everything works the same whether you are running locally or in Google Colab — there is no separate terminal or server to start.\n\nRun the cell below, then open the printed URL to view your traces.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "fb1ef03b",
+   "source": "import phoenix as px\n\nsession = px.launch_app()\nprint(f\"🔭 Phoenix is running. Open the UI at: {session.url}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -235,9 +240,7 @@
    "cell_type": "markdown",
    "id": "6dbcbc81",
    "metadata": {},
-   "source": [
-    "Open Phoenix at [http://localhost:6006](http://localhost:6006) and navigate to the `otel-best-practices` project to view your traces."
-   ]
+   "source": "Open the Phoenix UI (use the URL printed when you launched Phoenix above) and navigate to the `otel-best-practices` project to view your traces."
   },
   {
    "cell_type": "markdown",

--- a/tutorials/tracing/openinference_best_practices_tutorial.ipynb
+++ b/tutorials/tracing/openinference_best_practices_tutorial.ipynb
@@ -91,17 +91,7 @@
    "id": "94a0ad81",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import os\n",
-    "from getpass import getpass\n",
-    "\n",
-    "import nest_asyncio\n",
-    "\n",
-    "nest_asyncio.apply()\n",
-    "\n",
-    "OPENAI_API_KEY = globals().get(\"OPENAI_API_KEY\") or getpass(\"🔑 Enter your OpenAI API key: \")\n",
-    "os.environ[\"OPENAI_API_KEY\"] = OPENAI_API_KEY"
-   ]
+   "source": "import os\nfrom getpass import getpass\n\nOPENAI_API_KEY = globals().get(\"OPENAI_API_KEY\") or getpass(\"🔑 Enter your OpenAI API key: \")\nos.environ[\"OPENAI_API_KEY\"] = OPENAI_API_KEY"
   },
   {
    "cell_type": "markdown",
@@ -112,7 +102,7 @@
   {
    "cell_type": "code",
    "id": "fb1ef03b",
-   "source": "import phoenix as px\n\nsession = px.launch_app()\nprint(f\"🔭 Phoenix is running. Open the UI at: {session.url}\")",
+   "source": "import phoenix as px\n\nsession = px.launch_app()\nprint(f\"🔭 Phoenix is running. Open the UI at: {session.url}\")\n\n# Enable nested event loops so the async Agents SDK example can run in the notebook.\n# Apply this AFTER launching Phoenix — applying it beforehand stops Phoenix's server\n# from starting on Python 3.12 (which is what Google Colab runs).\nimport nest_asyncio\n\nnest_asyncio.apply()",
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/tutorials/tracing/openinference_best_practices_tutorial.ipynb
+++ b/tutorials/tracing/openinference_best_practices_tutorial.ipynb
@@ -102,14 +102,13 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import nest_asyncio\n",
     "from getpass import getpass\n",
+    "\n",
+    "import nest_asyncio\n",
     "\n",
     "nest_asyncio.apply()\n",
     "\n",
-    "OPENAI_API_KEY = globals().get(\"OPENAI_API_KEY\") or getpass(\n",
-    "    \"🔑 Enter your OpenAI API key: \"\n",
-    ")\n",
+    "OPENAI_API_KEY = globals().get(\"OPENAI_API_KEY\") or getpass(\"🔑 Enter your OpenAI API key: \")\n",
     "os.environ[\"OPENAI_API_KEY\"] = OPENAI_API_KEY"
    ]
   },
@@ -132,8 +131,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from phoenix.otel import register\n",
     "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
+    "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(\n",
     "    project_name=\"otel-best-practices\",\n",
@@ -191,16 +190,19 @@
    "outputs": [],
    "source": [
     "import uuid\n",
+    "\n",
     "from IPython.display import Markdown, display\n",
     "from openai import OpenAI\n",
-    "from opentelemetry import trace\n",
     "from openinference.instrumentation import using_session\n",
     "from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes\n",
+    "from opentelemetry import trace\n",
     "\n",
     "client = OpenAI()\n",
     "session_id = str(uuid.uuid4())\n",
     "tracer = trace.get_tracer(__name__)\n",
-    "messages = [{\"role\": \"system\", \"content\": \"You are a helpful assistant. Answer in a concise manner.\"}]\n",
+    "messages = [\n",
+    "    {\"role\": \"system\", \"content\": \"You are a helpful assistant. Answer in a concise manner.\"}\n",
+    "]\n",
     "\n",
     "\n",
     "def ask_llm(question: str) -> None:\n",
@@ -631,7 +633,9 @@
     "            SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
     "            OpenInferenceSpanKindValues.CHAIN.value,\n",
     "        )\n",
-    "        chain_span.set_attribute(SpanAttributes.INPUT_VALUE, \"What are sessions in OpenInference? Be concise.\")\n",
+    "        chain_span.set_attribute(\n",
+    "            SpanAttributes.INPUT_VALUE, \"What are sessions in OpenInference? Be concise.\"\n",
+    "        )\n",
     "\n",
     "        response = client.responses.create(\n",
     "            model=\"gpt-5.4-mini\",\n",
@@ -1296,22 +1300,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": ".venv (3.14.4)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.4"
+   "name": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Ports the OpenInference best-practices content from Arize AX into Phoenix:

- A new **OpenTelemetry and OpenInference** concepts section (14 pages) under `Concepts > Tracing`, walking through signals, the four OTel components, the `phoenix.otel` helpers, OpenInference semconv and span kinds, instrumentation approaches, context managers, context propagation, sampling, and the OpenTelemetry Collector.
- A new runnable **OpenInference Best Practices** cookbook (MDX + companion Jupyter notebook in `tutorials/tracing/`) that walks through `register()`, auto- and manual instrumentation, the six OI context managers, conversational sessions, and an OpenAI Agents SDK travel agent. Every code block was verified end-to-end against a live `phoenix serve` instance during migration.
- `docs.json` updated to expose both surfaces in the nav.

Originally written for Arize AX in:
- [Arize-ai/docs#557](https://github.com/Arize-ai/docs/pull/557) — concept pages
- [Arize-ai/docs#563](https://github.com/Arize-ai/docs/pull/563) — cookbook
- [Arize-ai/tutorials#55](https://github.com/Arize-ai/tutorials/pull/55) — notebook

## What changed during the Phoenix migration

The migration is more than a find-and-replace. Notable Phoenix-specific changes vs. the AX originals:

| Area | Change |
| :--- | :--- |
| SDK | `arize.otel.register(space_id=..., api_key=...)` → `phoenix.otel.register(project_name=..., batch=False)` |
| Auth | Bearer-token / Space ID flow replaced with optional `PHOENIX_API_KEY` (omitted for local) |
| Helpers page | `arize-otel-helpers.mdx` → rewritten as `phoenix-otel-helpers.mdx` with the actual `phoenix.otel.register()` signature documented |
| Overview & Collector pages | Manually rewritten for Phoenix's local-first deployment model; removed multi-tenant routing-connector framing that doesn't apply to Phoenix |
| Resource page | Removed the `model_id` "legacy alias" claim — that's an AX ingest-side shim, Phoenix doesn't honor it. Replaced with Phoenix's real project routing order: `x-project-name` HTTP header > `openinference.project.name` resource attribute > server default |
| Exporter page | gRPC sample fixed: `endpoint="localhost:4317"` (Phoenix's actual gRPC port) + `insecure=True` for local + `compression=grpc.Compression.Gzip` (the gRPC exporter only accepts the enum, not a string). HTTP sample fixed: `compression=Compression.Gzip` (HTTP exporter also requires the enum) |
| Context propagation page | `DefaultTextMapPropagator` does not exist anywhere in `opentelemetry-python`. Rewrote all references (7 places) to use the canonical `opentelemetry.propagate.inject(carrier=...)` / `extract(carrier=...)` API. Verified end-to-end with a two-process test that produced a single linked trace in Phoenix |
| Internal doc links | 11 AX-style `how-to-tracing/*` paths rewritten to their Phoenix equivalents (e.g., `set-up-sessions` → `setup-tracing/setup-sessions`, `customize-your-traces` → `add-metadata/customize-spans`, `mask-and-redact-data` → `advanced/masking-span-attributes`) |
| Notebook branding | Open-In-Colab badge as cell 0 + Phoenix logo header as cell 1, matching other Phoenix tutorials. All `%pip install` switched to `!pip install`. |

## Verification done

Run against a freshly reinstalled `arize-phoenix 16.3.0` + `arize-phoenix-otel 0.16.1` with `phoenix serve` on `localhost:6006`:

- ✅ All 25 Python snippets across the 14 concept pages resolve symbols and import cleanly
- ✅ All 10 runnable Python blocks in the cookbook MDX execute against live Phoenix; the `otel-best-practices` project is auto-created and traces ingest
- ✅ Two-process cross-process propagation test: A (caller) and B (HTTP server) share `trace_id`, B's `parent_id` equals A's `span_id` — verified via the Phoenix API
- ✅ All 41 internal `/docs/phoenix/*` links in the migrated content resolve to existing files
- ✅ `docs.json` parses; the `check-card-links.js` workflow passes locally
- ✅ Final AX/Arize-AX residue sweep — clean

## ⚠️ Handoff: images still required

The migrated MDX and notebook reference **34 images** under two GCS paths:

```
arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/
arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/
```

These do **not exist yet**. Until they're uploaded, the docs will render with broken image links. The AX equivalents at `…/arize-docs-images/…` can be used as reference (and in some cases copied verbatim).

### Category A — Reusable as-is (12 images)

These are diagrams or generic span-kind icons that are not UI-specific to AX. **Easiest path: `gsutil cp` from the AX bucket path to the Phoenix bucket path** — no re-rendering needed.

| Filename | AX source (reference) | Phoenix target | Used in |
| :--- | :--- | :--- | :--- |
| `llm.png` | [arize-docs-images/concepts/otel/llm.png](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/concepts/otel/llm.png) | phoenix-docs-images/concepts/otel/llm.png | `span-kinds.mdx:38` |
| `chain.png` | [arize-docs-images/concepts/otel/chain.png](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/concepts/otel/chain.png) | phoenix-docs-images/concepts/otel/chain.png | `span-kinds.mdx:39` |
| `agent.png` | [arize-docs-images/concepts/otel/agent.png](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/concepts/otel/agent.png) | phoenix-docs-images/concepts/otel/agent.png | `span-kinds.mdx:40` |
| `tool.png` | [arize-docs-images/concepts/otel/tool.png](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/concepts/otel/tool.png) | phoenix-docs-images/concepts/otel/tool.png | `span-kinds.mdx:41` |
| `retriever.png` | [arize-docs-images/concepts/otel/retriever.png](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/concepts/otel/retriever.png) | phoenix-docs-images/concepts/otel/retriever.png | `span-kinds.mdx:42` |
| `embedding.png` | [arize-docs-images/concepts/otel/embedding.png](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/concepts/otel/embedding.png) | phoenix-docs-images/concepts/otel/embedding.png | `span-kinds.mdx:43` |
| `reranker.png` | [arize-docs-images/concepts/otel/reranker.png](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/concepts/otel/reranker.png) | phoenix-docs-images/concepts/otel/reranker.png | `span-kinds.mdx:44` |
| `guardrail.png` | [arize-docs-images/concepts/otel/guardrail.png](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/concepts/otel/guardrail.png) | phoenix-docs-images/concepts/otel/guardrail.png | `span-kinds.mdx:45` |
| `unknown.png` | [arize-docs-images/concepts/otel/unknown.png](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/concepts/otel/unknown.png) | phoenix-docs-images/concepts/otel/unknown.png | `span-kinds.mdx:46,47,48` (Evaluator / Prompt / Unknown — all fall back to this icon) |
| `sampling.png` | [arize-docs-images/concepts/otel/sampling.png](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/concepts/otel/sampling.png) | phoenix-docs-images/concepts/otel/sampling.png | `sampling.mdx:10` — diagram of sampling strategies (errors / attributes / latency / random sample); UI-agnostic |
| `span-processor-flow.png` | [arize-docs-images/concepts/otel/span-processor-flow.png](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/concepts/otel/span-processor-flow.png) | phoenix-docs-images/concepts/otel/span-processor-flow.png | `span-processor.mdx:19` — OTel pipeline diagram; UI-agnostic |
| `otel-collector-1.png` | [arize-docs-images/otel-collector-1.png](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/otel-collector-1.png) | phoenix-docs-images/concepts/otel/otel-collector-1.png | `otel-collector.mdx:23` — OTel Collector receivers→processors→exporters diagram; UI-agnostic *(note: AX kept this in the bucket root; Phoenix nests it under `concepts/otel/`)* |

> Suggested one-liner (you'll need GCS write access to `arize-phoenix-assets`):
> ```bash
> # Copy span-kind icons + diagrams
> for f in llm chain agent tool retriever embedding reranker guardrail unknown sampling span-processor-flow; do
>   gsutil cp gs://arize-phoenix-assets/assets/images/arize-docs-images/concepts/otel/$f.png \
>     gs://arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/$f.png
> done
> # Collector diagram lives at a different AX path
> gsutil cp gs://arize-phoenix-assets/assets/images/arize-docs-images/otel-collector-1.png \
>   gs://arize-phoenix-assets/assets/images/phoenix-docs-images/concepts/otel/otel-collector-1.png
> ```

### Category B — Phoenix UI screenshots required (18 unique images)

These show the Phoenix UI rendering traces from the cookbook notebook. They **must** be re-captured in Phoenix — the AX screenshots have AX chrome, navigation, and Space picker that don't exist in Phoenix.

**Capture workflow (one-time setup, then walk the notebook):**

1. Start Phoenix locally: `pip install arize-phoenix && phoenix serve` (UI at http://localhost:6006).
1. Open `tutorials/tracing/openinference_best_practices_tutorial.ipynb` in Jupyter against an environment with `arize-phoenix-otel`, `openinference-instrumentation-openai`, `openinference-instrumentation-openai-agents`, and `openai-agents` installed plus an `OPENAI_API_KEY`.
1. Run the notebook top-to-bottom; pause at the cells listed below to capture each screenshot in the Phoenix UI under the `otel-best-practices` project.
1. Upload each PNG to `gs://arize-phoenix-assets/assets/images/phoenix-docs-images/cookbooks/otel-cookbook/<filename>.png` (and `…/concepts/otel/agent-trace.png` for the one concept-section screenshot).
1. Use **light theme**, default zoom, and crop to remove the browser chrome. Match the AX screenshot aspect ratio where possible.

#### Phoenix UI screenshots — full list

| # | Filename | Phoenix target path | What it should show | AX reference | Referenced in |
| :--- | :--- | :--- | :--- | :--- | :--- |
| 1 | `sessions.png` | `phoenix-docs-images/cookbooks/otel-cookbook/sessions.png` | The **Sessions** tab in Phoenix showing a **single** session for the two-step chatbot conversation. Capture after running the cookbook's "Conversational sessions" block (notebook cell ~13-17). | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/sessions.png) | `openinference-best-practices.mdx:197`, notebook cell 18 |
| 2 | `session.png` | `phoenix-docs-images/cookbooks/otel-cookbook/session.png` | The session **detail pane** for the chatbot session, expanded to show both conversation turns with input, output, latency, tokens, and cost. Same data as #1 — click into the session. | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/session.png) | `openinference-best-practices.mdx:201` |
| 3 | `traces.png` | `phoenix-docs-images/cookbooks/otel-cookbook/traces.png` | The **Traces** tab showing the **two** traces from the chatbot conversation (one per turn), each with their root input/output visible. | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/traces.png) | `openinference-best-practices.mdx:209`, notebook cell 19 |
| 4 | `trace.png` | `phoenix-docs-images/cookbooks/otel-cookbook/trace.png` | Detail pane for a **single trace** showing the span tree with latency, token counts, and cost. Used twice in the doc (chatbot context and a later reference). | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/trace.png) | `openinference-best-practices.mdx:213,225`, notebook cell 20 |
| 5 | `llm-span.png` | `phoenix-docs-images/cookbooks/otel-cookbook/llm-span.png` | An **LLM span** named `ChatCompletion` selected in the trace tree, with the LLM detail visible on the right. Captured from the same chatbot trace. | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/llm-span.png) | `openinference-best-practices.mdx:231`, notebook cell 20 |
| 6 | `span-attributes.png` | `phoenix-docs-images/cookbooks/otel-cookbook/span-attributes.png` | The **Attributes** tab for a selected span, showing the raw JSON attribute set. Any span from the chatbot trace works — the AX version uses an LLM span. | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/span-attributes.png) | `openinference-best-practices.mdx:235`, notebook cell 20 |
| 7 | `sessions-1-session.png` | `phoenix-docs-images/cookbooks/otel-cookbook/sessions-1-session.png` | The **Sessions** tab showing a **single session containing multiple traces** (after re-running the same `using_session(session_id="my-session-id")` block several times). | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/sessions-1-session.png) | `openinference-best-practices.mdx:291`, notebook cell 25 |
| 8 | `sessions-2-sessions.png` | `phoenix-docs-images/cookbooks/otel-cookbook/sessions-2-sessions.png` | The **Sessions** tab showing **two distinct sessions** (after running the second `using_session(session_id="my-second-session-id")` block). | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/sessions-2-sessions.png) | `openinference-best-practices.mdx:319`, notebook cell 27 |
| 9 | `data-pipeline.png` | `phoenix-docs-images/cookbooks/otel-cookbook/data-pipeline.png` | Trace tree showing the **`data-pipeline`** chain span with **`step-1-validate`** and **`step-2-format`** child chain spans nested inside. From the "Capturing spans manually" block (notebook cell ~36, under the `Capturing Spans Example` session). | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/data-pipeline.png) | `openinference-best-practices.mdx:440`, notebook cell 37 |
| 10 | `agent-trace.png` (cookbook copy) | `phoenix-docs-images/cookbooks/otel-cookbook/agent-trace.png` | Trace from the **OpenAI Agents SDK travel agent**, showing the full span tree: outer `Agent workflow` chain → `TravelAssistant` agent → per-turn chain spans → LLM and tool spans (`get_weather`, `get_time_zone`) nested underneath. Captured under the `otel-best-practices` project after running the travel-agent block (notebook cell ~48). | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/agent-trace.png) | `openinference-best-practices.mdx:593`, notebook cell 49 |
| 11 | `llm-span-attributes.png` | `phoenix-docs-images/cookbooks/otel-cookbook/llm-span-attributes.png` | The Attributes tab for one of the **LLM spans inside the travel-agent trace**, showing the full attribute set (`llm.model_name`, `llm.input_messages.*`, `llm.output_messages.*`, `llm.token_count.*`, cost, etc.). | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/llm-span-attributes.png) | `openinference-best-practices.mdx:603`, notebook cell 51 |
| 12 | `tool-span-attributes.png` | `phoenix-docs-images/cookbooks/otel-cookbook/tool-span-attributes.png` | The Attributes tab for the **`get_weather` tool span** in the travel-agent trace, showing the input city and the returned weather text. | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/tool-span-attributes.png) | `openinference-best-practices.mdx:712`, notebook cell 54 |
| 13 | `agent-span-attributes.png` | `phoenix-docs-images/cookbooks/otel-cookbook/agent-span-attributes.png` | The Attributes tab for the **`TravelAssistant` agent span** in the travel-agent trace. | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/agent-span-attributes.png) | `openinference-best-practices.mdx:749`, notebook cell 58 |
| 14 | `chain-span-attributes.png` | `phoenix-docs-images/cookbooks/otel-cookbook/chain-span-attributes.png` | The Attributes tab for **one of the per-turn chain spans** in the travel-agent trace (grouping a single LLM + tool call pair). | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/chain-span-attributes.png) | `openinference-best-practices.mdx:789`, notebook cell 62 |
| 15 | `llm-span-metadata.png` | `phoenix-docs-images/cookbooks/otel-cookbook/llm-span-metadata.png` | An **LLM span Attributes tab** showing a **custom `metadata.request_source` attribute** alongside the standard `llm.*` attributes. From the "Adding metadata" block toward the end of the notebook. | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/llm-span-metadata.png) | `openinference-best-practices.mdx:863` |
| 16 | `metadata-filter.png` | `phoenix-docs-images/cookbooks/otel-cookbook/metadata-filter.png` | The **Spans tab** filtered by **`attributes.metadata.request_source = 'cookbook'`**, showing the filter applied and matching spans listed. | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/metadata-filter.png) | `openinference-best-practices.mdx:867` |
| 17 | `tool-span-attributes-override.png` | `phoenix-docs-images/cookbooks/otel-cookbook/tool-span-attributes-override.png` | The Attributes tab for the **`get_weather` tool span** after a manual override that sets **`tool.description`** alongside the auto-instrumented `tool.name`. From the "Tweaking spans" block near the end of the notebook. | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/tool-span-attributes-override.png) | `openinference-best-practices.mdx:940` |
| 18 | `agent-trace.png` (concepts copy) | `phoenix-docs-images/concepts/otel/agent-trace.png` | **Same screenshot content as #10** but lives under the concepts path because it's referenced from two concept pages. Easiest: capture once, upload to both `cookbooks/otel-cookbook/agent-trace.png` and `concepts/otel/agent-trace.png`. | [AX](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/concepts/otel/agent-trace.png) | `span-kinds.mdx:171`, `signals.mdx:64` |

### Category C — AX-only screenshots intentionally removed

The AX cookbook starts with `apikey.png` (Space Settings page showing Space ID + API Key). Phoenix doesn't need this — local Phoenix has no auth, so the migrated cookbook tells users to run `phoenix serve` instead. **No Phoenix replacement needed.**

### Already-shared assets (no work)

- The Phoenix logo SVG used in the notebook header (`assets/phoenix-logo-light.svg`) already exists in the bucket.
- The `concepts-how-to-tracing.avif` used at the bottom of `overview.mdx` already exists at the same path as AX uses — re-used as-is.
- The Colab badge SVG is hosted by Google, no upload needed.
- The intro YouTube embed in `overview.mdx` is the same video as the AX page (`fHGSxOhWO-g`).

## Test plan

- [x] Diagrams / icons (Category A) copied via `gsutil` from the AX bucket path to the Phoenix bucket path
- [x] Phoenix UI screenshots (Category B, 18 images) captured by walking the notebook against a local `phoenix serve` and uploaded
- [x] `mintlify dev` preview: every page in the new concepts section renders with images and no broken internal links
- [x] `mintlify dev` preview: every screenshot in the cookbook renders
- [x] Open the notebook in Colab via the badge in cell 0 — it should clone the repo and run end-to-end
- [x] Run the two-process propagation example (`tutorials/...` not part of this PR, but `context-propagation.mdx` pattern) end-to-end against a Phoenix instance to verify both spans land under one trace
- [x] Sanity-check on a phoenix.arize.com staging deploy that nav order matches `docs.json` and that the new sub-group appears under `Concepts > Tracing > OpenTelemetry and OpenInference`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
