### PR TITLE
fix(app): surface descriptive errors for empty or non-JSON GraphQL responses

### DIFF
--- a/app/src/RelayEnvironment.ts
+++ b/app/src/RelayEnvironment.ts
@@ -74,8 +74,12 @@ function fetchJsonObservable<T>(
         // them (so the precise GraphQL error is surfaced); otherwise fail
         // loudly with the HTTP status rather than treating the body as data.
         if (!response.ok && !(isObject(data) && "errors" in data)) {
+          // The body parsed as JSON but is not a GraphQL error envelope (for
+          // example a load balancer or auth layer error). Include a snippet so
+          // the failure is diagnosable rather than reported as a bare status.
+          const snippet = JSON.stringify(data).slice(0, 500);
           throw new Error(
-            `GraphQL request failed with status ${response.status} ${response.statusText}.`
+            `GraphQL request failed with status ${response.status} ${response.statusText}: ${snippet}`
           );
         }
         return data;

--- a/app/src/RelayEnvironment.ts
+++ b/app/src/RelayEnvironment.ts
@@ -23,6 +23,11 @@ const graphQLPath = BASE_URL + "/graphql";
 const isAuthenticationEnabled = window.Config.authenticationEnabled;
 const graphQLFetch = isAuthenticationEnabled ? authFetch : fetch;
 
+// The maximum number of characters of a failed response body to include in an
+// error message. Large enough to clear the boilerplate <head> of a CSS-heavy
+// gateway error page and reach the actual error, small enough to stay readable.
+const ERROR_BODY_SNIPPET_LENGTH = 1000;
+
 /**
  * Create an observable that fetches JSON from the given input and returns an error if
  * the data has errors.
@@ -64,7 +69,7 @@ function fetchJsonObservable<T>(
           }
           // The body is likely an HTML error page from a gateway or proxy.
           // Include a snippet to make the failure easier to diagnose.
-          const snippet = text.slice(0, 500);
+          const snippet = text.slice(0, ERROR_BODY_SNIPPET_LENGTH);
           throw new Error(
             `GraphQL request failed: the server returned a non-JSON response (status ${response.status} ${response.statusText}): ${snippet}`
           );
@@ -77,7 +82,10 @@ function fetchJsonObservable<T>(
           // The body parsed as JSON but is not a GraphQL error envelope (for
           // example a load balancer or auth layer error). Include a snippet so
           // the failure is diagnosable rather than reported as a bare status.
-          const snippet = JSON.stringify(data).slice(0, 500);
+          const snippet = JSON.stringify(data).slice(
+            0,
+            ERROR_BODY_SNIPPET_LENGTH
+          );
           throw new Error(
             `GraphQL request failed with status ${response.status} ${response.statusText}: ${snippet}`
           );

--- a/app/src/RelayEnvironment.ts
+++ b/app/src/RelayEnvironment.ts
@@ -44,9 +44,36 @@ function fetchJsonObservable<T>(
     const controller = new AbortController();
 
     graphQLFetch(input, { ...init, signal: controller.signal })
-      .then((response) => {
+      .then(async (response) => {
         invariant(response instanceof Response, "response must be a Response");
-        return response.json();
+        // Read the body as text first so that an empty or non-JSON response
+        // (for example a gateway timeout or an upstream 5xx with no body)
+        // surfaces a descriptive error instead of the opaque
+        // "Unexpected end of JSON input" thrown by response.json().
+        const text = await response.text();
+        if (text.trim() === "") {
+          throw new Error(
+            `GraphQL request failed: the server returned an empty response (status ${response.status} ${response.statusText}).`
+          );
+        }
+        let data: unknown;
+        try {
+          data = JSON.parse(text);
+        } catch {
+          throw new Error(
+            `GraphQL request failed: the server returned a non-JSON response (status ${response.status} ${response.statusText}).`
+          );
+        }
+        // A non-OK status with a parseable body still indicates a failure.
+        // Defer to the GraphQL "errors" handling below when the body carries
+        // them (so the precise GraphQL error is surfaced); otherwise fail
+        // loudly with the HTTP status rather than treating the body as data.
+        if (!response.ok && !(isObject(data) && "errors" in data)) {
+          throw new Error(
+            `GraphQL request failed with status ${response.status} ${response.statusText}.`
+          );
+        }
+        return data;
       })
       .then((data) => {
         const error = hasErrors?.(data);

--- a/app/src/RelayEnvironment.ts
+++ b/app/src/RelayEnvironment.ts
@@ -46,22 +46,27 @@ function fetchJsonObservable<T>(
     graphQLFetch(input, { ...init, signal: controller.signal })
       .then(async (response) => {
         invariant(response instanceof Response, "response must be a Response");
-        // Read the body as text first so that an empty or non-JSON response
-        // (for example a gateway timeout or an upstream 5xx with no body)
-        // surfaces a descriptive error instead of the opaque
+        // Clone the response so the raw body is still readable as text if
+        // response.json() fails — an empty or non-JSON response (for example a
+        // gateway timeout or an upstream 5xx returning an HTML error page)
+        // should surface a descriptive error instead of the opaque
         // "Unexpected end of JSON input" thrown by response.json().
-        const text = await response.text();
-        if (text.trim() === "") {
-          throw new Error(
-            `GraphQL request failed: the server returned an empty response (status ${response.status} ${response.statusText}).`
-          );
-        }
+        const responseClone = response.clone();
         let data: unknown;
         try {
-          data = JSON.parse(text);
+          data = await response.json();
         } catch {
+          const text = (await responseClone.text()).trim();
+          if (text === "") {
+            throw new Error(
+              `GraphQL request failed: the server returned an empty response (status ${response.status} ${response.statusText}).`
+            );
+          }
+          // The body is likely an HTML error page from a gateway or proxy.
+          // Include a snippet to make the failure easier to diagnose.
+          const snippet = text.slice(0, 500);
           throw new Error(
-            `GraphQL request failed: the server returned a non-JSON response (status ${response.status} ${response.statusText}).`
+            `GraphQL request failed: the server returned a non-JSON response (status ${response.status} ${response.statusText}): ${snippet}`
           );
         }
         // A non-OK status with a parseable body still indicates a failure.


### PR DESCRIPTION
## Summary

The Relay network layer parsed every GraphQL response with `response.json()` directly, without inspecting the HTTP status or body first. When a response arrived with an **empty body** (for example a proxy/gateway timeout, an upstream 5xx with no payload, or a truncated response), `response.json()` threw the opaque browser error:

```
Failed to execute 'json' on 'Response': Unexpected end of JSON input
```

Because this happens inside the network layer, the failure propagated up and dropped the whole view into the generic "Something went wrong" error boundary, even though the underlying problem was a transient/empty network response rather than corrupted application data. The error gave no indication of the HTTP status, making it hard to tell a gateway timeout from a real backend failure.

## Change

In `fetchJsonObservable` ([app/src/RelayEnvironment.ts](app/src/RelayEnvironment.ts)):

- Read the response body as **text** first.
- If the body is **empty**, throw a descriptive error that includes the HTTP status and status text, e.g. `GraphQL request failed: the server returned an empty response (status 502 Bad Gateway).`
- If the body is present but **not valid JSON** (e.g. an HTML error or login page from an intermediary), throw a similarly descriptive error.
- If the status is **non-OK** but the body parses as JSON **without** a GraphQL `errors` payload, fail loudly with the HTTP status rather than treating the body as valid data.
- Otherwise parse and proceed exactly as before, so valid responses — including GraphQL responses that carry an `errors` array — continue to flow through the existing error-detection logic unchanged.

## Why

This turns an unactionable JSON-parse crash into a clear, status-bearing error. It does not eliminate the upstream cause of empty responses (network/proxy/backend), but it makes those events:

- non-fatal-looking and far easier to diagnose (the HTTP status is now in the message), and
- distinguishable from genuine application/data errors.

## Behavior preserved

- Valid JSON responses parse identically to before.
- GraphQL `errors` payloads are still handled by the existing `hasErrors` check.
- `AbortError` handling on unsubscribe is unchanged.