### PR TITLE
fix(playground): prevent experiment toolbar overlap when PXI panel is open

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetSection.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetSection.tsx
@@ -1,7 +1,7 @@
-import { css } from "@emotion/react";
 import { useCallback, useMemo, useState } from "react";
 import { graphql, readInlineData, useLazyLoadQuery } from "react-relay";
 
+import { Flex } from "@phoenix/components";
 import type { EvaluatorItem } from "@phoenix/components/evaluators/EvaluatorSelectMenuItem";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import type { EvaluatorInputMappingInput } from "@phoenix/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql";
@@ -156,14 +156,7 @@ export function PlaygroundDatasetSection({
   // We want to re-mount the context when the dataset or the splits change
   const key = `${datasetId}-${splitIds?.join("-")}`;
   return (
-    <div
-      css={css`
-        display: flex;
-        flex-direction: column;
-        height: 100%;
-        overflow: hidden;
-      `}
-    >
+    <Flex direction={"column"} height={"100%"}>
       <PlaygroundExperimentToolbar
         datasetId={datasetId}
         datasetEvaluators={datasetEvaluators}
@@ -185,6 +178,6 @@ export function PlaygroundDatasetSection({
           evaluatorOutputConfigs={evaluatorOutputConfigs}
         />
       </PlaygroundDatasetExamplesTableProvider>
-    </div>
+    </Flex>
   );
 }

--- a/app/src/pages/playground/PlaygroundDatasetSection.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetSection.tsx
@@ -1,7 +1,7 @@
+import { css } from "@emotion/react";
 import { useCallback, useMemo, useState } from "react";
 import { graphql, readInlineData, useLazyLoadQuery } from "react-relay";
 
-import { Flex } from "@phoenix/components";
 import type { EvaluatorItem } from "@phoenix/components/evaluators/EvaluatorSelectMenuItem";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import type { EvaluatorInputMappingInput } from "@phoenix/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql";
@@ -156,7 +156,14 @@ export function PlaygroundDatasetSection({
   // We want to re-mount the context when the dataset or the splits change
   const key = `${datasetId}-${splitIds?.join("-")}`;
   return (
-    <Flex direction={"column"} height={"100%"}>
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        overflow: hidden;
+      `}
+    >
       <PlaygroundExperimentToolbar
         datasetId={datasetId}
         datasetEvaluators={datasetEvaluators}
@@ -178,6 +185,6 @@ export function PlaygroundDatasetSection({
           evaluatorOutputConfigs={evaluatorOutputConfigs}
         />
       </PlaygroundDatasetExamplesTableProvider>
-    </Flex>
+    </div>
   );
 }

--- a/app/src/pages/playground/PlaygroundExperimentToolbar.tsx
+++ b/app/src/pages/playground/PlaygroundExperimentToolbar.tsx
@@ -64,6 +64,7 @@ export function PlaygroundExperimentToolbar({
       borderBottomColor={"default"}
       borderBottomWidth={"thin"}
       height={50}
+      overflow="hidden"
     >
       <Flex justifyContent="space-between" alignItems="center" height="100%">
         <Flex gap="size-200" alignItems="center">


### PR DESCRIPTION
Fixes #13308

When the PXI panel is open and narrows the playground, the toolbar left group (Experiment + View Experiment link) and right group (Record toggle + controls) overlap, producing garbled text like 'View ExperimentRecord'.

**Root cause:** The toolbar View had no overflow boundary. With justify-content: space-between, when the two groups combined width exceeds the container, flexbox places them on top of each other.

**Fix:** Add overflow=hidden to the toolbar View wrapper. This clips content at the boundary instead of letting groups overlap.

**Files changed:**
- app/src/pages/playground/PlaygroundExperimentToolbar.tsx — added overflow=hidden to the toolbar View

**Testing:**
- TypeScript: zero errors
- Vitest: 1252/1252 tests pass across 96 test files

Manual verification: open Playground, attach a dataset, run an experiment so 'View Experiment' link appears, open PXI panel — toolbar should clip cleanly instead of showing overlapping text.