### PR TITLE
docs: add 'Read more' links to release notes

### DIFF
--- a/.agents/skills/phoenix-release-notes/SKILL.md
+++ b/.agents/skills/phoenix-release-notes/SKILL.md
@@ -56,10 +56,10 @@ gh release list --repo Arize-ai/phoenix --limit 30
 ls docs/phoenix/release-notes/*/
 
 # Dates already covered in the aggregate file
-grep 'Update label=' docs/phoenix/release-notes.mdx
+grep 'ReleaseUpdate label=' docs/phoenix/release-notes.mdx
 ```
 
-Each `<Update>` entry in the aggregate file covers a date. Multiple versions released on the same
+Each `<ReleaseUpdate>` entry in the aggregate file covers a date. Multiple versions released on the same
 date get combined into one entry. Identify releases that have no corresponding coverage.
 
 ## Step 2: Analyze Commits
@@ -249,12 +249,17 @@ Match the version line to which packages are involved:
 
 File: `docs/phoenix/release-notes.mdx`
 
-Insert each new `<Update>` block at the correct chronological position relative to **all**
+Insert each new `<ReleaseUpdate>` block at the correct chronological position relative to **all**
 existing blocks — not as a contiguous group at the top. Each block is a condensed summary
 linking to the individual file.
 
+The file imports the `ReleaseUpdate` component at the top (after the frontmatter):
 ```mdx
-<Update label="MM.DD.YYYY">
+import { ReleaseUpdate } from "../snippets/ReleaseUpdate.jsx";
+```
+
+```mdx
+<ReleaseUpdate label="MM.DD.YYYY" href="/docs/phoenix/release-notes/MM-YYYY/MM-DD-YYYY-slug-title">
 ## [MM.DD.YYYY: Feature Title](/docs/phoenix/release-notes/MM-YYYY/MM-DD-YYYY-slug-title)
 **Available in ...**
 
@@ -262,14 +267,15 @@ Brief 1-3 sentence summary. Action-oriented.
 
 - **Key capability** with brief description
 - **Another capability** with brief description
-</Update>
+</ReleaseUpdate>
 ```
 
 Rules:
 - `label` uses dot separators: `MM.DD.YYYY`
+- `href` must match the link in the heading
 - Link path has no `.mdx` extension
 - Keep each block to 5-10 lines
-- If one MDX file covers multiple features, create separate `<Update>` blocks per feature date
+- If one MDX file covers multiple features, create separate `<ReleaseUpdate>` blocks per feature date
 
 ### Reverse-chronological insertion (do not skip this)
 
@@ -406,7 +412,7 @@ grep -l '^title: "Release Notes"$' docs/phoenix/release-notes/**/*.mdx 2>/dev/nu
   || echo "OK: all per-date files have descriptive titles"
 
 # Confirm reverse-chronological order in the aggregate file
-grep -nP 'Update label="[\d.]+' docs/phoenix/release-notes.mdx \
+grep -nP 'ReleaseUpdate label="[\d.]+' docs/phoenix/release-notes.mdx \
   | awk -F'[:."]' '{ printf "%s %s%s%s\n", $1, $5, $3, $4 }' \
   | awk 'NR>1 && $2>prev { print "OUT OF ORDER at release-notes.mdx:" $1 " — " $2 " appears above " prev; bad=1 } { prev=$2 } END { if (!bad) print "OK: reverse-chronological order intact" }'
 ```

--- a/.agents/skills/phoenix-release-notes/SKILL.md
+++ b/.agents/skills/phoenix-release-notes/SKILL.md
@@ -259,8 +259,7 @@ import { ReleaseUpdate } from "../snippets/ReleaseUpdate.jsx";
 ```
 
 ```mdx
-<ReleaseUpdate label="MM.DD.YYYY" href="/docs/phoenix/release-notes/MM-YYYY/MM-DD-YYYY-slug-title">
-## [MM.DD.YYYY: Feature Title](/docs/phoenix/release-notes/MM-YYYY/MM-DD-YYYY-slug-title)
+<ReleaseUpdate label="MM.DD.YYYY" href="/docs/phoenix/release-notes/MM-YYYY/MM-DD-YYYY-slug-title" title="Feature Title">
 **Available in ...**
 
 Brief 1-3 sentence summary. Action-oriented.
@@ -272,7 +271,8 @@ Brief 1-3 sentence summary. Action-oriented.
 
 Rules:
 - `label` uses dot separators: `MM.DD.YYYY`
-- `href` must match the link in the heading
+- `title` is the feature title (without date prefix — the component generates `label: title` as the heading)
+- `href` is the link to the individual MDX file
 - Link path has no `.mdx` extension
 - Keep each block to 5-10 lines
 - If one MDX file covers multiple features, create separate `<ReleaseUpdate>` blocks per feature date

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -3,6 +3,8 @@ title: "Release Notes"
 description: The latest from the Phoenix team.
 ---
 
+import { ReleaseUpdate } from "../snippets/ReleaseUpdate.jsx";
+
 <Card title="Releases · Arize-ai/phoenix" href="https://github.com/Arize-ai/phoenix/releases" icon="github" horizontal>
 GitHub
 </Card>
@@ -11,7 +13,7 @@ GitHub
 **We want to hear from you!** The DevRel team wants to hear from the Phoenix community. If you're building with Phoenix and want to tell us what's working, what's painful, or what you wish existed, [grab 25 minutes with us](https://cal.com/team/arize-devrel/user-interview).
 </Info>
 
-<Update label="05.27.2026">
+<ReleaseUpdate label="05.27.2026" href="/docs/phoenix/release-notes/05-2026/05-27-2026-drag-to-zoom">
 ## [05.27.2026: Drag-to-Zoom on Project Metric Charts](/docs/phoenix/release-notes/05-2026/05-27-2026-drag-to-zoom)
 **Available in arize-phoenix 16.3.0+**
 
@@ -19,9 +21,9 @@ Click and drag across any project metric chart or the spans sparkline to zoom in
 
 - **All charts covered** — latency, error rate, token usage, and the trace-count sparkline all support brush selection
 - **Adaptive tick density** — x-axis labels scale with rendered pixel width, staying readable at any zoom level
-</Update>
+</ReleaseUpdate>
 
-<Update label="05.21.2026">
+<ReleaseUpdate label="05.21.2026" href="/docs/phoenix/release-notes/05-2026/05-21-2026-code-evaluators">
 ## [05.21.2026: Code Evaluators](/docs/phoenix/release-notes/05-2026/05-21-2026-code-evaluators)
 **Available in arize-phoenix 16.0.0+**
 
@@ -30,9 +32,9 @@ Write Python or TypeScript `evaluate()` functions directly in the Phoenix UI and
 - **Local or hosted sandboxes** — WebAssembly and Deno ship with Phoenix; E2B, Daytona, Vercel, and Modal add network and package support
 - **Versioned and traced** — every save creates a new version, and each execution appears as a span
 - **Dry-run before saving** — test the evaluator against a real dataset example from the UI
-</Update>
+</ReleaseUpdate>
 
-<Update label="05.15.2026">
+<ReleaseUpdate label="05.15.2026" href="/docs/phoenix/release-notes/05-2026/05-15-2026-otel-semconv-conversion">
 ## [05.15.2026: OTel GenAI Semantic Convention Auto-Conversion](/docs/phoenix/release-notes/05-2026/05-15-2026-otel-semconv-conversion)
 **Available in arize-phoenix 15.10.0+**
 
@@ -41,17 +43,17 @@ Phoenix now automatically converts OTel GenAI semantic convention attributes (`g
 - **Zero-config** — point any OTel-native instrumentation at Phoenix's OTLP endpoint; conversion happens server-side
 - **OpenInference wins** — spans that already carry OpenInference attributes are untouched; conversion only fills in what's missing
 - **Full coverage** — input/output messages, tool definitions and results, system instructions, retrieval documents, usage tokens, provider, and model name
-</Update>
+</ReleaseUpdate>
 
-<Update label="05.15.2026">
+<ReleaseUpdate label="05.15.2026" href="/docs/phoenix/release-notes/05-2026/05-15-2026-session-feedback-and-atif">
 ## [05.15.2026: Session Trace Feedback and ATIF v1.7](/docs/phoenix/release-notes/05-2026/05-15-2026-session-feedback-and-atif)
 **Available in arize-phoenix 15.10.0+ (server), arize-phoenix-client 2.7.0+ (Python)**
 
 - **Session feedback toolbar** — thumbs-up/down and annotate buttons appear on each turn in Session Details; clicking creates a `user_feedback` trace annotation with toggle behavior
 - **ATIF v1.7 trajectory upload** — `upload_atif_trajectories_as_spans` now supports embedded subagent trajectories via `subagent_trajectories`, `trajectory_id`-based deterministic span IDs for idempotent re-uploads, `session_id` in trajectory headers, and deterministic dispatch steps (`llm_call_count: 0`)
-</Update>
+</ReleaseUpdate>
 
-<Update label="05.13.2026">
+<ReleaseUpdate label="05.13.2026" href="/docs/phoenix/release-notes/05-2026/05-13-2026-playground-thinking-controls">
 ## [05.13.2026: Playground Thinking Controls](/docs/phoenix/release-notes/05-2026/05-13-2026-playground-thinking-controls)
 **Available in arize-phoenix 15.8.0+**
 
@@ -59,9 +61,9 @@ The Playground now exposes first-class extended thinking controls for Anthropic 
 
 - **Anthropic** — Thinking mode (adaptive/enabled/off), token budget (min 1,024), thinking display toggle, and output effort level
 - **Google** — Thinking budget and thinking level (LOW / MEDIUM / HIGH)
-</Update>
+</ReleaseUpdate>
 
-<Update label="05.13.2026">
+<ReleaseUpdate label="05.13.2026" href="/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations">
 ## [05.13.2026: Session Enhancements and Annotation Identifiers](/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations)
 **Available in arize-phoenix 15.7.0+**
 
@@ -69,17 +71,17 @@ The Playground now exposes first-class extended thinking controls for Anthropic 
 - **Note identifier field** — `POST /v1/{trace,span,session}_notes` accepts an optional `identifier` for upsert semantics; repeated calls with the same identifier overwrite the existing note
 - **New CLI annotation commands** — `px {trace,span,session}-annotations delete` for bulk-remove by identifier or time range, `px project get <name>` to fetch project metadata; `--identifier` flag on `annotate` and `add-note`
 - **Security** — f-string template formatter now blocks dunder/private attribute traversal, preventing format-string injection through user-supplied variables
-</Update>
+</ReleaseUpdate>
 
-<Update label="05.10.2026">
+<ReleaseUpdate label="05.10.2026" href="/docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences">
 ## [05.10.2026: Playground Preferences](/docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences)
 **Available in arize-phoenix 15.6.0+**
 
 - **Default provider and model** — save a personal Playground default on the AI Providers settings page; Phoenix stores it in your browser and applies it to every new session
 - **Metrics aside always on** — the latency/token/error metrics panel on the right side of the spans table is now visible by default, no longer gated behind a feature flag
-</Update>
+</ReleaseUpdate>
 
-<Update label="05.08.2026">
+<ReleaseUpdate label="05.08.2026" href="/docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header">
 ## [05.08.2026: OTLP Project Routing via HTTP Header](/docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header)
 **Available in arize-phoenix 15.5.0+**
 
@@ -87,9 +89,9 @@ Set the `x-project-name` HTTP header on OTLP exports to route all spans in the r
 
 - **Works with any OTLP sender** — SDK header option, Collector `headers` config, or `OTEL_EXPORTER_OTLP_HEADERS` env var
 - **Bug fix** — deleting a dataset evaluator link no longer removes the shared evaluator row (arize-phoenix 15.5.1+)
-</Update>
+</ReleaseUpdate>
 
-<Update label="05.05.2026">
+<ReleaseUpdate label="05.05.2026" href="/docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools">
 ## [05.05.2026: Provider Tools in Playground and Prompts](/docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools)
 **Available in arize-phoenix 15.4.0+**
 
@@ -98,9 +100,9 @@ Phoenix Playground and the Prompts library now support vendor-native tools — w
 - **Generic passthrough** — any tool the provider SDK accepts works without a library update; verified examples include Anthropic `web_search` / `code_execution` / `computer_use`, OpenAI Responses `web_search` / `file_search` / `code_interpreter` / `computer_use_preview`, and Gemini `google_search` grounding
 - **Mix with function tools** — provider tools and function tools coexist on the same prompt version
 - **SDK export** — Python and TypeScript clients preserve provider tools when formatting prompts
-</Update>
+</ReleaseUpdate>
 
-<Update label="05.05.2026">
+<ReleaseUpdate label="05.05.2026" href="/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates">
 ## [05.05.2026: REST API Updates — Annotation Delete, Token Counts, and More](/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates)
 **Available in arize-phoenix 15.3.0–15.4.0+, arize-phoenix-evals 3.1.0+**
 
@@ -108,9 +110,9 @@ Phoenix Playground and the Prompts library now support vendor-native tools — w
 - **Token counts in REST** — trace and session list endpoints now return `cumulative_token_count_prompt`, `_completion`, and `_total` fields
 - **Experiment CSV metadata** — downloading an experiment as CSV now includes per-example dataset metadata as `metadata_<key>` columns
 - **Evals runtime capability detection** — OpenAI reasoning models (`o1`, `o3`, `o3-mini`, `o4-mini`) now work with `ClassificationEvaluator` automatically
-</Update>
+</ReleaseUpdate>
 
-<Update label="05.01.2026">
+<ReleaseUpdate label="05.01.2026" href="/docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing">
 ## [05.01.2026: TanStack AI Tracing](/docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing)
 **Available in @arizeai/openinference-tanstack-ai 0.1.0+**
 
@@ -119,9 +121,9 @@ A new OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/
 - **Install** — `npm install --save @arizeai/openinference-tanstack-ai @tanstack/ai`
 - **Usage** — drop `openInferenceMiddleware()` into the `middleware` option of any `chat()` call
 - **Feedback welcome** — this integration is brand new; please reach out via the [OpenInference repo](https://github.com/Arize-ai/openinference)
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.30.2026">
+<ReleaseUpdate label="04.30.2026" href="/docs/phoenix/release-notes/04-2026/04-30-2026-cli-auth-profiles">
 ## [04.30.2026: CLI Named Auth Profiles](/docs/phoenix/release-notes/04-2026/04-30-2026-cli-auth-profiles)
 **Available in @arizeai/phoenix-cli 1.4.0+**
 
@@ -130,9 +132,9 @@ A new OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/
 - **Commands** — `px profile create`, `list`, `show`, `edit`, `use`, `delete`
 - **Profile status** — `px auth status` surfaces the active profile name
 - **Editor autocomplete** — JSON Schema published for `~/.px/profiles.json`
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.30.2026">
+<ReleaseUpdate label="04.30.2026" href="/docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements">
 ## [04.30.2026: Annotation Enhancements — Sessions, TypeScript, and Identifier Queries](/docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements)
 **Available in arize-phoenix 15.1.0+ (server), @arizeai/phoenix-cli 1.4.0+ (CLI), @arizeai/phoenix-client 6.9.0+ (TypeScript)**
 
@@ -140,23 +142,23 @@ A new OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/
 - **TypeScript trace annotations** — `addTraceAnnotation` and `logTraceAnnotations` exported from `@arizeai/phoenix-client/traces`
 - **`addSessionNote`** in `@arizeai/phoenix-client/sessions`
 - **Query by identifier** — GET annotation endpoints for spans, traces, and sessions accept `?identifier=` to retrieve all annotations sharing a tag, project-wide
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.29.2026">
+<ReleaseUpdate label="04.29.2026" href="/docs/phoenix/release-notes/04-2026/04-29-2026-dataset-upsert">
 ## [04.29.2026: Dataset Upsert](/docs/phoenix/release-notes/04-2026/04-29-2026-dataset-upsert)
 **Breaking change in arize-phoenix-client 2.6.0+ (Python) and arize-phoenix 15.0.0+ (server)**
 
 `client.datasets.create_dataset()` now defaults to upsert semantics: if a dataset with the same name exists, examples are merged into the latest version rather than returning a conflict error. Supply a stable `id` on each example for deterministic in-place updates on re-upload.
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.28.2026">
+<ReleaseUpdate label="04.28.2026" href="/docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api">
 ## [04.28.2026: Session Notes API](/docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api)
 **Available in arize-phoenix 14.16.0+**
 
 Phoenix now supports creating session notes through `POST /v1/session_notes`. The generic session annotation endpoint now reserves `name="note"` for note-specific APIs, so use `POST /v1/session_notes` for session notes and `POST /v1/session_annotations` for regular annotations.
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.24.2026">
+<ReleaseUpdate label="04.24.2026" href="/docs/phoenix/release-notes/04-2026/04-24-2026-trace-notes-api">
 ## [04.24.2026: Trace Notes API](/docs/phoenix/release-notes/04-2026/04-24-2026-trace-notes-api)
 **Available in arize-phoenix 14.13.0+ (server), @arizeai/phoenix-client 6.8.0+ (TypeScript), @arizeai/phoenix-cli 1.3.0+ (CLI)**
 
@@ -165,9 +167,9 @@ Add notes to traces via the REST endpoint, TypeScript client, or CLI. Notes are 
 - **TypeScript** — `addTraceNote({ traceNote: { traceId, note } })` from `@arizeai/phoenix-client/traces`
 - **CLI** — `px trace add-note <trace-id> --text "..."` and `--include-notes` flag on `px trace get` / `px trace list`
 - **Reserved name** — `note` is no longer accepted on the generic annotation endpoints; use `POST /v1/trace_notes`
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.24.2026">
+<ReleaseUpdate label="04.24.2026" href="/docs/phoenix/release-notes/04-2026/04-24-2026-phoenix-otel-python-0-16">
 ## [04.24.2026: arize-phoenix-otel 0.16](/docs/phoenix/release-notes/04-2026/04-24-2026-phoenix-otel-python-0-16)
 **Available in arize-phoenix-otel 0.16.0+**
 
@@ -176,9 +178,9 @@ Add notes to traces via the REST endpoint, TypeScript client, or CLI. Notes are 
 - **Context managers** — `using_session`, `using_user`, `using_metadata`, `using_tags`, `using_attributes`, `using_prompt_template`, `suppress_tracing` (usable as `with` blocks or decorators)
 - **Semantic conventions** — `SpanAttributes`, `OpenInferenceSpanKindValues`, `OpenInferenceMimeTypeValues`
 - **Single install** — `pip install "arize-phoenix-otel>=0.16.0"` is enough for `register()` + context propagation
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.22.2026">
+<ReleaseUpdate label="04.22.2026" href="/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id">
 ## [04.22.2026: Secrets Settings Page](/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id)
 **Available in arize-phoenix 14.11.0+**
 
@@ -187,9 +189,9 @@ A new **Settings → Secrets** page lets admins add, replace, and delete encrypt
 - **Add / Replace / Delete** secrets from the browser
 - **Search and filter** the secrets list by key name or owner
 - **Admin-only** — all mutations require admin access
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.22.2026">
+<ReleaseUpdate label="04.22.2026" href="/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id">
 ## [04.22.2026: `trace_id` in Experiment Evaluators](/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id)
 **Available in arize-phoenix-client 2.4.0+**
 
@@ -197,9 +199,9 @@ Evaluator functions now receive the originating trace ID for each experiment run
 
 - **Optional** — evaluators without `trace_id` are unaffected
 - **Works sync and async** — supported on both function-based and protocol-based evaluators
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.20.2026">
+<ReleaseUpdate label="04.20.2026" href="/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7">
 ## [04.20.2026: Span Attribute Filtering](/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7)
 **Available in arize-phoenix 14.9.0+ (server), arize-phoenix-client 2.4.0+ (Python), @arizeai/phoenix-client 6.7.0+ (TypeScript)**
 
@@ -209,23 +211,23 @@ Filter spans by stored attribute values using the Python client, TypeScript clie
 - **TypeScript** — `getSpans({ ..., attributes: { "llm.model_name": "gpt-4o" } })`
 - **CLI** — `px span list --attribute "llm.model_name:gpt-4o"`
 - **Type-aware** — `int`, `float`, `bool`, and `str` values each match their corresponding stored type
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.20.2026">
+<ReleaseUpdate label="04.20.2026" href="/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7">
 ## [04.20.2026: CLI Span Notes](/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7)
 **Available in @arizeai/phoenix-cli 1.1.0+**
 
 `px span add-note <span-id> --text "..."` attaches a free-text note to any span. Pass `--include-notes` to `px span list` or `px trace get` to read notes back alongside span data.
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.20.2026">
+<ReleaseUpdate label="04.20.2026" href="/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7">
 ## [04.20.2026: Claude Opus 4.7 in the Playground](/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7)
 **Available in arize-phoenix 14.9.0+**
 
 Claude Opus 4.7 is now available as a model option in the Phoenix Playground. Select it from the model picker to compare outputs against other Anthropic and cross-provider models.
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.16.2026">
+<ReleaseUpdate label="04.16.2026" href="/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres">
 ## [04.16.2026: Azure Managed Identity for PostgreSQL](/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres)
 **Available in arize-phoenix 14.8.0+**
 
@@ -234,9 +236,9 @@ Connect Phoenix to Azure Database for PostgreSQL using Microsoft Entra managed i
 - **Zero-credential setup** — tokens are fetched and refreshed automatically on each connection
 - **New `[azure]` extra** — `pip install 'arize-phoenix[azure]'` pulls in `azure-identity` and `aiohttp`
 - **`PHOENIX_POSTGRES_AWS_IAM_TOKEN_LIFETIME_SECONDS` deprecated** — silently ignored with a startup warning
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.14.2026">
+<ReleaseUpdate label="04.14.2026" href="/docs/phoenix/release-notes/04-2026/04-14-2026-cli-annotation-commands">
 ## [04.14.2026: CLI Annotation Commands](/docs/phoenix/release-notes/04-2026/04-14-2026-cli-annotation-commands)
 **Available in @arizeai/phoenix-cli 1.0.4+**
 
@@ -245,9 +247,9 @@ Connect Phoenix to Azure Database for PostgreSQL using Microsoft Entra managed i
 - **`px span annotate <span-id>`** — attach a label, score, or explanation to any span by OTel span ID
 - **`px trace annotate <trace-id>`** — annotate a full trace by OTel trace ID
 - **Annotator kinds** — `HUMAN`, `LLM`, or `CODE`; submitting again with the same name updates the existing entry
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.13.2026">
+<ReleaseUpdate label="04.13.2026" href="/docs/phoenix/release-notes/04-2026/04-13-2026-phoenix-otel-ts-1-0">
 ## [04.13.2026: @arizeai/phoenix-otel 1.0](/docs/phoenix/release-notes/04-2026/04-13-2026-phoenix-otel-ts-1-0)
 **Available in @arizeai/phoenix-otel 1.0.0+**
 
@@ -259,9 +261,9 @@ Connect Phoenix to Azure Database for PostgreSQL using Microsoft Entra managed i
 - **Attribute builders** — `getLLMAttributes`, `getRetrieverAttributes`, `getEmbeddingAttributes`, `getToolAttributes`, and more for raw OTel spans
 - **Semantic conventions** — `SemanticConventions` and `OpenInferenceSpanKind` re-exported; no second dependency needed
 - **Redaction** — `OITracer` + `traceConfig` or `OPENINFERENCE_HIDE_*` env vars strip sensitive attributes before export
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.10.2026">
+<ReleaseUpdate label="04.10.2026" href="/docs/phoenix/release-notes/04-2026/04-10-2026-shareable-url-redirects">
 ## [04.10.2026: Shareable Project URLs](/docs/phoenix/release-notes/04-2026/04-10-2026-shareable-url-redirects)
 **Available in arize-phoenix 14.2.0+**
 
@@ -269,9 +271,9 @@ Navigate to `/redirects/projects/{project_name}` and Phoenix resolves the name a
 
 - **Project by name** — `/redirects/projects/default` resolves and redirects to the project page
 - **Other patterns** — traces, spans, sessions, and prompt tags are also supported via `/redirects/...`
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.07.2026">
+<ReleaseUpdate label="04.07.2026" href="/docs/phoenix/release-notes/04-2026/04-07-2026-postgresql-read-replica">
 ## [04.07.2026: PostgreSQL Read Replica Routing](/docs/phoenix/release-notes/04-2026/04-07-2026-postgresql-read-replica)
 **Available in arize-phoenix 14.0.0+**
 
@@ -279,9 +281,9 @@ Route read-only queries (GraphQL resolvers, REST reads, dataloaders) to an optio
 
 - **Set and go** — point the env var at your replica; writes always go to the primary
 - **No config change needed** when a replica is not configured — falls back to primary
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.07.2026">
+<ReleaseUpdate label="04.07.2026" href="/docs/phoenix/release-notes/04-2026/04-07-2026-phoenix-v14-breaking-changes">
 ## [04.07.2026: Breaking Changes — Phoenix v14](/docs/phoenix/release-notes/04-2026/04-07-2026-phoenix-v14-breaking-changes)
 **Breaking changes in arize-phoenix 14.0.0, arize-phoenix-evals 3.0.0, arize-phoenix-client 2.3.1+**
 
@@ -293,9 +295,9 @@ Phoenix v14 removes several legacy APIs. See the [migration guide](https://githu
 - **Evals 1.0 removed** — `arize-phoenix-evals` 3.0.0 drops the `legacy/` subpackage; `phoenix.experiments` is replaced by `phoenix.client.experiments`
 - **GraphQL pagination requires `first`** — `Project.spans`, `Trace.spans`, and `ProjectSession.traces` now require an explicit `first` argument (max 1000)
 - **Resume interrupted SDK experiments** — continue missing or failed runs with `resume_experiment` and `async_resume_experiment`
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.03.2026">
+<ReleaseUpdate label="04.03.2026" href="/docs/phoenix/release-notes/04-2026/04-03-2026-atif-trajectory-upload">
 ## [04.03.2026: ATIF Trajectory Upload](/docs/phoenix/release-notes/04-2026/04-03-2026-atif-trajectory-upload)
 **Available in arize-phoenix-client 2.3.0+ (Python)**
 
@@ -304,16 +306,16 @@ Phoenix v14 removes several legacy APIs. See the [migration guide](https://githu
 - **Supports ATIF v1.0–v1.6** including multimodal content (images) in v1.6+
 - **Subagent linking** — upload parent and child trajectories together to link them into one trace
 - **Idempotent** — trace/span IDs are derived from `session_id` via SHA-256; re-uploading the same file is safe
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.01.2026">
+<ReleaseUpdate label="04.01.2026" href="/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314">
 ## [04.01.2026: Python 3.14 Support](/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314)
 **Available in arize-phoenix 13.21.0+, arize-phoenix-client 2.2.0+, arize-phoenix-evals 2.13.0+**
 
 Phoenix server, Python client SDK, and evals library now support Python 3.14 on Linux and macOS.
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.01.2026">
+<ReleaseUpdate label="04.01.2026" href="/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314">
 ## [04.01.2026: Secrets Management REST API](/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314)
 **Available in arize-phoenix 13.21.0+**
 
@@ -321,9 +323,9 @@ Admin users can store encrypted LLM provider API keys in Phoenix via `PUT /v1/se
 
 - **`PUT /v1/secrets`** — batch upsert/delete with `value: null` to remove a key
 - **Admin-only**, atomic, silent no-op for deleting non-existent keys
-</Update>
+</ReleaseUpdate>
 
-<Update label="04.01.2026">
+<ReleaseUpdate label="04.01.2026" href="/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314">
 ## [04.01.2026: `get_traces` — Retrieve Traces via Python SDK](/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314)
 **Available in arize-phoenix 13.15.0+ (server), arize-phoenix-client 2.2.0+ (Python)**
 
@@ -332,9 +334,9 @@ Admin users can store encrypted LLM provider API keys in Phoenix via `PUT /v1/se
 - **`include_spans=True`** to embed full span detail in each trace
 - **`session_id`** to filter to one or more sessions
 - Async variant available on `AsyncClient`
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.30.2026">
+<ReleaseUpdate label="03.30.2026" href="/docs/phoenix/release-notes/03-2026/03-30-2026-delete-prompts-api">
 ## [03.30.2026: Delete Prompts and Prompt Version Tags](/docs/phoenix/release-notes/03-2026/03-30-2026-delete-prompts-api)
 **Available in arize-phoenix 13.20.0+**
 
@@ -342,19 +344,19 @@ Two new REST endpoints let you delete prompts and remove tags from prompt versio
 
 - **`DELETE /v1/prompts/{prompt_identifier}`** — permanently deletes a prompt and all its versions, tags, and labels
 - **`DELETE /v1/prompt_versions/{id}/tags/{tag_name}`** — removes a single tag from a specific prompt version
-</Update>
+</ReleaseUpdate>
 
 
-<Update label="03.24.2026">
+<ReleaseUpdate label="03.24.2026" href="/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates">
 ## [03.24.2026: Prompt Version Diff View](/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates)
 **Available in arize-phoenix 13.18.0+**
 
 The Prompts UI now shows a line-by-line diff between any two prompt versions. See exactly what changed — message content, tool call arguments, and tool results — without leaving Phoenix.
 
 - **Side-by-side diff** across the full chat template, including all content part types
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.24.2026">
+<ReleaseUpdate label="03.24.2026" href="/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates">
 ## [03.24.2026: Evals Accept Structured Data Inputs](/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates)
 **Available in arize-phoenix-evals 2.12.0+**
 
@@ -362,16 +364,16 @@ Evaluators now accept dicts and lists as template variable values, JSON-serializ
 
 - **Structured inputs** (dicts, lists) are JSON-serialized before prompt rendering — no manual `json.dumps()` needed
 - **LLM invocation kwargs** accepted by all built-in evaluators (`FaithfulnessEvaluator`, `CorrectnessEvaluator`, etc.)
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.23.2026">
+<ReleaseUpdate label="03.23.2026" href="/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api">
 ## [03.23.2026: `px auth status` Shows Username and Role](/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api)
 **Available in arize-phoenix 13.17.0+ and @arizeai/phoenix-cli 0.12.0+**
 
 `px auth status` now verifies credentials against the server and displays the authenticated username and role alongside the endpoint and token info.
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.22.2026">
+<ReleaseUpdate label="03.22.2026" href="/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api">
 ## [03.22.2026: `px spans` — Fetch and Filter Spans from the CLI](/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api)
 **Available in arize-phoenix 13.16.0+ and @arizeai/phoenix-cli 0.12.0+**
 
@@ -380,16 +382,16 @@ Evaluators now accept dicts and lists as template variable values, JSON-serializ
 - **`--span-kind`**, **`--status-code`**, **`--name`**, **`--trace-id`** filters
 - **`--last-n-minutes`** / **`--since`** time range controls
 - **`--include-annotations`** to attach span annotations to the output
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.22.2026">
+<ReleaseUpdate label="03.22.2026" href="/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api">
 ## [03.22.2026: `px self update` and `GET /v1/user`](/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api)
 **Available in arize-phoenix 13.16.0+ and @arizeai/phoenix-cli 0.12.0+**
 
 `px self update` upgrades the installed CLI to the latest version, detecting npm, pnpm, bun, or Deno automatically. `GET /v1/user` returns the authenticated user's profile (username, email, role) or an anonymous representation when auth is disabled.
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.18.2026">
+<ReleaseUpdate label="03.18.2026" href="/docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements">
 ## [03.18.2026: Span Filters — Name, Kind, and Status Code](/docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements)
 **Available in arize-phoenix 13.15.0+ (server), arize-phoenix-client 2.1.0+ (Python), @arizeai/phoenix-client 6.5.1+ (TypeScript)**
 
@@ -400,18 +402,18 @@ Filter spans directly by name, span kind (`LLM`, `CHAIN`, `TOOL`, etc.), and sta
 - **`status_code` filter** to isolate error, success, or unset spans
 - **Available in Python via `client.spans.get_spans(name=..., span_kind=..., status_code=...)`**
 - **Available in TypeScript via `getSpans({ name, spanKind, statusCode })`**
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.13.2026">
+<ReleaseUpdate label="03.13.2026" href="/docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements">
 ## [03.13.2026: List Traces by Project](/docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements)
 **Available in arize-phoenix 13.15.0+**
 
 A new `GET /v1/projects/{project_identifier}/traces` REST endpoint lists traces with time filtering, sort order, cursor pagination, optional inline spans, and session filtering.
 
 - **`GET /v1/projects/{project}/traces`** with `sort`, `order`, `limit`, `cursor`, `include_spans`, and `session_identifier` params
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.11.2026">
+<ReleaseUpdate label="03.11.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
 ## [03.11.2026: Session Turns API](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
 **Available in arize-phoenix-client 2.0.0+ (Python) and @arizeai/phoenix-client 6.4.0+ (TypeScript)**
 
@@ -421,9 +423,9 @@ Phoenix now provides a dedicated session turns API that reconstructs the ordered
 - **`SessionTurnIO` with MIME type** — supports `text/plain`, `application/json`, and image types
 - **Batched root span fetching** with pagination to handle large sessions
 - **Async variants available** in both Python and TypeScript clients
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.10.2026">
+<ReleaseUpdate label="03.10.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
 ## [03.10.2026: Session Management REST APIs](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
 **Available in arize-phoenix 13.13.0+ (server), arize-phoenix-client 1.31.0+ (Python), @arizeai/phoenix-client 6.1.0+ (TypeScript)**
 
@@ -434,9 +436,9 @@ Phoenix now exposes comprehensive session management through REST API endpoints 
 - **Session deletion** with automatic cascade through traces and spans
 - **DataFrame export** in Python for sessions data analysis
 - **Configurable timeouts** for all session operations
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.09.2026">
+<ReleaseUpdate label="03.09.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
 ## [03.09.2026: Filter Spans by Trace ID and Parent Relationships](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
 **Available in arize-phoenix 13.12.0+ (server), arize-phoenix-client 2.0.0+ (Python), @arizeai/phoenix-client 6.3.0+ (TypeScript)**
 
@@ -446,23 +448,23 @@ Span queries now support filtering by trace ID and parent relationships, enablin
 - **Parent ID filtering** to query root spans or span children
 - **Multi-trace queries** via repeated trace ID parameters
 - **Composable with existing filters** like time ranges and limits
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.04.2026">
+<ReleaseUpdate label="03.04.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
 ## [03.04.2026: Incremental Evaluation Metrics in Playground](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
 **Available in arize-phoenix 13.8.0+**
 
 The Playground now displays evaluation metrics, cost, and latency aggregates in real-time as dataset experiments run. Metrics update incrementally every ~2 seconds, providing immediate feedback on experiment performance without waiting for completion.
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.04.2026">
+<ReleaseUpdate label="03.04.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
 ## [03.04.2026: Brute Force Login Protection](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
 **Available in arize-phoenix 13.8.0+**
 
 Phoenix now automatically protects login endpoints against brute force attacks. After 5 consecutive failed attempts, the account is temporarily locked for 5 minutes. Enabled by default with configurable thresholds via `PHOENIX_BRUTE_FORCE_LOGIN_PROTECTION_MAX_ATTEMPTS`.
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.07.2026">
+<ReleaseUpdate label="03.07.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
 ## [03.07.2026: Unified Dataset Upload with Drag-and-Drop](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
 **Available in arize-phoenix 13.9.0+**
 
@@ -473,9 +475,9 @@ Dataset creation from files is now streamlined with automatic file type detectio
 - **Streaming parser** that handles large files efficiently
 - **RFC 4180 CSV support** including quoted fields, escaped quotes, and BOM handling
 - **Detailed error messages** for parsing issues with line-by-line feedback
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.10.2026">
+<ReleaseUpdate label="03.10.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
 ## [03.10.2026: Drag-and-Drop Column Assignment for Datasets](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
 **Available in arize-phoenix 13.13.0+**
 
@@ -486,9 +488,9 @@ Dataset creation now features an intuitive drag-and-drop column assignment inter
 - **Live dataset preview** showing the final structure as you make changes
 - **Keyboard navigation support** for accessibility
 - **Raw data preview** in tabular format alongside final dataset view
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.08.2026">
+<ReleaseUpdate label="03.08.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
 ## [03.08.2026: Extended Model Provider Support](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
 **Available in arize-phoenix 13.10.0+ (Cerebras, Fireworks, Groq, Moonshot) and arize-phoenix 13.11.0+ (Perplexity, Together AI)**
 
@@ -501,9 +503,9 @@ Phoenix Playground now supports six additional OpenAI-compatible model providers
 - **Groq** for low-latency Llama and Qwen deployments
 - **Moonshot (Kimi)** with extended 128k and 32k context models
 - **Cost tracking enabled** for Cerebras, Fireworks, Groq, and Moonshot
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.10.2026">
+<ReleaseUpdate label="03.10.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
 ## [03.10.2026: Provider Visibility Controls](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
 **Available in arize-phoenix 13.13.0+**
 
@@ -512,41 +514,41 @@ Control which model providers appear in the Phoenix UI using the `PHOENIX_ALLOWE
 - **Allow-list mode** to show only specified providers
 - **Case-insensitive configuration** with typo detection warnings
 - **Set to NONE** to hide all providers from the UI
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.08.2026">
+<ReleaseUpdate label="03.08.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
 ## [03.08.2026: Latest OpenAI GPT Models](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
 **Available in arize-phoenix 13.10.0+**
 
 Phoenix Playground now includes the latest OpenAI models: GPT-5.4 family, GPT-5.3-chat-latest, GPT-5.2-pro variants, and o3-pro-2025-06-10. All models include cost tracking and are ready to use in experiments and prompt testing.
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.08.2026">
+<ReleaseUpdate label="03.08.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
 ## [03.08.2026: Project Editing from Settings](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
 **Available in arize-phoenix 13.10.0+**
 
 Edit project descriptions and customize gradient colors directly from the Project Settings page. Click the edit button to update project metadata inline, with changes persisting immediately across the Phoenix UI.
-</Update>
+</ReleaseUpdate>
 
 
-<Update label="03.11.2026">
+<ReleaseUpdate label="03.11.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
 ## [03.11.2026: Breaking Change: Removed Deprecated Annotations API](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
 **Breaking change in arize-phoenix-client 2.0.0**
 
 The deprecated `client.annotations` module has been removed. All annotation methods remain available on `client.spans`. Update your code to use `client.spans.add_span_annotation()` and `client.spans.log_span_annotations()` instead of the `client.annotations` variants.
-</Update>
+</ReleaseUpdate>
 
-<Update label="03.05.2026">
+<ReleaseUpdate label="03.05.2026" href="/docs/phoenix/release-notes/03-2026/03-05-2026-sdk-session-retrieval">
 ## [03.05.2026: SDK Session Retrieval](/docs/phoenix/release-notes/03-2026/03-05-2026-sdk-session-retrieval)
 Session retrieval is now available in the Python client (`client.sessions.get()`, `client.sessions.list()`, `get_sessions_dataframe()`) and the TypeScript client (`getSession()`, `listSessions()`). Both SDKs support automatic pagination and async usage for working with session turns data.
-</Update>
+</ReleaseUpdate>
 
-<Update label="02.27.2026">
+<ReleaseUpdate label="02.27.2026" href="/docs/phoenix/release-notes/02-2026/02-27-2026-cli-sessions-and-rest-api">
 ## [02.27.2026: Sessions API and CLI Support](/docs/phoenix/release-notes/02-2026/02-27-2026-cli-sessions-and-rest-api)
 REST API endpoints for listing and getting sessions (`GET /v1/sessions`, `GET /v1/sessions/{id}`) and CLI commands (`px sessions`, `px session <id>`) for exploring multi-turn conversations from the terminal.
-</Update>
+</ReleaseUpdate>
 
-<Update label="02.24.2026">
+<ReleaseUpdate label="02.24.2026" href="/docs/phoenix/integrations/typescript/claude-agent-sdk">
 ## 02.24.2026: Claude Agent SDK Integration
 
 Phoenix now supports tracing for [Anthropic's Claude Agent SDK](https://docs.anthropic.com/en/docs/agents/claude-agent-sdk) via a new OpenInference instrumentation package. The integration automatically captures **AGENT** and **TOOL** spans, giving you full visibility into your Claude Agent SDK applications.
@@ -554,9 +556,9 @@ Phoenix now supports tracing for [Anthropic's Claude Agent SDK](https://docs.ant
 - Install `@arizeai/openinference-instrumentation-claude-agent-sdk` alongside `@arizeai/phoenix-otel`
 - See agent execution flows and tool invocations in Phoenix's trace UI
 - [Get started →](/docs/phoenix/integrations/typescript/claude-agent-sdk)
-</Update>
+</ReleaseUpdate>
 
-<Update label="02.14.2026">
+<ReleaseUpdate label="02.14.2026" href="/docs/phoenix/release-notes/02-2026/02-14-2026-phoenix-13-0">
 ## [02.14.2026: Phoenix 13.0](/docs/phoenix/release-notes/02-2026/02-14-2026-phoenix-13-0)
 **Phoenix 13.0** is a major release centered on **Dataset Evaluators**, with support for **custom model providers**, **OpenAI Responses API type selection**, and extensive **Playground** and **dataset/experiment UX** improvements.
 
@@ -567,9 +569,9 @@ Highlights include:
 - Choose OpenAI API type per configuration (`chat.completions.create` or `responses.create`) with automatic parameter compatibility handling.
 - Use new Playground workflows such as cancellation, template variable autocomplete, appended messages, improved prompt selection, and URL state for prompt IDs/versions/tags.
 - Get expanded dataset and experiment ergonomics, model/provider updates (including Claude Opus 4.6 and Azure OpenAI v1 migration), and infrastructure improvements like a session ID index for spans.
-</Update>
+</ReleaseUpdate>
 
-<Update label="02.12.2026">
+<ReleaseUpdate label="02.12.2026" href="/docs/phoenix/release-notes/02-2026/02-12-2026-openai-responses-api-support">
 ## [02.12.2026: OpenAI Responses API Type Support](/docs/phoenix/release-notes/02-2026/02-12-2026-openai-responses-api-support)
 Phoenix now supports selecting the **OpenAI API type** for OpenAI and Azure OpenAI calls in the Playground and custom providers. Choose **Chat Completions** (`chat.completions.create`) or **Responses** (`responses.create`) depending on the model and features you want to use.
 
@@ -580,9 +582,9 @@ Phoenix now supports selecting the **OpenAI API type** for OpenAI and Azure Open
 - **Parameter compatibility:** Phoenix maps shared invocation parameters to the chosen API type and filters unsupported fields automatically.
 
 To get started, open the Playground model configuration panel and select an **OpenAI API type**, or set it in **Settings → AI Providers → Custom Providers** for server-managed routing.
-</Update>
+</ReleaseUpdate>
 
-<Update label="02.12.2026">
+<ReleaseUpdate label="02.12.2026" href="/docs/phoenix/release-notes/02-2026/02-12-2026-dataset-evaluators">
 ## [02.12.2026: Dataset Evaluators](/docs/phoenix/release-notes/02-2026/02-12-2026-dataset-evaluators)
 **Requires Phoenix 13.x.**
 **Dataset evaluators** let you attach evaluators directly to a dataset so they automatically run server-side whenever you execute experiments from the Phoenix UI (for example, from the Playground). This turns your dataset into a reusable evaluation suite and removes the need to reconfigure evaluators for every experiment.
@@ -594,9 +596,9 @@ To get started, open the Playground model configuration panel and select an **Op
 - **Built-in visibility:** Each evaluator captures traces for debugging and refinement, with details available from the evaluator view.
 
 To get started, open a dataset, navigate to the **Evaluators** tab, click **Add evaluator**, configure your input mapping, and run an experiment from the Playground to see server-side scores and traces.
-</Update>
+</ReleaseUpdate>
 
-<Update label="02.11.2026">
+<ReleaseUpdate label="02.11.2026" href="/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers">
 ## [02.11.2026: Custom Providers for Playground and Prompts](/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers)
 Phoenix now supports **custom providers** for OpenAI, Azure OpenAI, Anthropic, AWS Bedrock, and Google GenAI. Custom providers let you store provider credentials and routing configuration on the server and reuse them across the playground and saved prompt versions.
 
@@ -610,9 +612,9 @@ Phoenix now supports **custom providers** for OpenAI, Azure OpenAI, Anthropic, A
 - **Request-level overrides:** Continue to supply custom request headers per prompt while using custom provider configuration for routing and authentication.
 
 To get started, open **Settings → AI Providers → Custom Providers**, create a provider configuration, and select it from the model menu in the playground.
-</Update>
+</ReleaseUpdate>
 
-<Update label="02.09.2026">
+<ReleaseUpdate label="02.09.2026" href="/docs/phoenix/release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support">
 ## [02.09.2026: Claude Opus 4.6 Model Support](/docs/phoenix/release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support)
 Phoenix playground now supports Claude Opus 4.6, Anthropic's latest flagship model. Select `claude-opus-4-6` in the Anthropic provider or `anthropic.claude-opus-4-6-v1` in AWS Bedrock to start using the model with full extended thinking parameter support and accurate cost tracking.
 
@@ -623,9 +625,9 @@ Phoenix playground now supports Claude Opus 4.6, Anthropic's latest flagship mod
 - **Automatic cost tracking:** Token costs are calculated using the latest pricing ($5 per million input tokens, $25 per million output tokens, plus cache read/write rates)
 
 The model appears in playground dropdowns alongside other Claude models and inherits the same reasoning capabilities as other Claude 4.x models.
-</Update>
+</ReleaseUpdate>
 
-<Update label="01.31.2026">
+<ReleaseUpdate label="01.31.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
 ## [01.31.2026: Tool Selection and Tool Invocation Evaluators](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
 **Available in arize-phoenix-evals 0.16.0+ (Python) and @arizeai/phoenix-evals 1.3.0+ (TypeScript)**
 
@@ -638,9 +640,9 @@ These evaluators help developers:
 - **Validate multi-tool and multi-turn interactions** across complex agent workflows
 
 Both evaluators are available as `ToolSelectionEvaluator` and `ToolInvocationEvaluator` in Python's `phoenix.evals.metrics` module, and as `createToolSelectionEvaluator` and `createToolInvocationEvaluator` in TypeScript.
-</Update>
+</ReleaseUpdate>
 
-<Update label="01.28.2026">
+<ReleaseUpdate label="01.28.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
 ## [01.28.2026: Configurable Email Extraction for OAuth2 Providers](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
 **Available in Phoenix 12.33.1+**
 
@@ -649,22 +651,22 @@ Phoenix now supports custom email extraction from OAuth2 identity providers thro
 Configure email extraction using JMESPath expressions:
 
 ```bash
-</Update>
+</ReleaseUpdate>
 
-<Update label="02.01.2026">
+<ReleaseUpdate label="02.01.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
 ## [02.01.2026: Extract from Azure AD preferred_username claim](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
 PHOENIX_OAUTH2_AZURE_AD_EMAIL_ATTRIBUTE_PATH=preferred_username
-</Update>
+</ReleaseUpdate>
 
-<Update label="02.01.2026">
+<ReleaseUpdate label="02.01.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
 ## [02.01.2026: Extract from nested claims](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
 PHOENIX_OAUTH2_CUSTOM_IDP_EMAIL_ATTRIBUTE_PATH=user.contact.email
 ```
 
 The default behavior remains unchanged, using the standard OIDC `email` claim when no custom path is specified. JMESPath expressions are validated at startup for immediate feedback on configuration errors.
-</Update>
+</ReleaseUpdate>
 
-<Update label="01.22.2026">
+<ReleaseUpdate label="01.22.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
 ## [01.22.2026: CLI Commands for Prompts, Datasets, and Experiments](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
 **Available in @arizeai/phoenix-cli 0.4.0+**
 
@@ -686,16 +688,16 @@ The Phoenix CLI now provides comprehensive commands for managing prompts, datase
 - **Track changes** across prompt and model variations
 
 These commands integrate seamlessly with AI coding assistants and enable systematic testing of LLM applications through terminal-based workflows.
-</Update>
+</ReleaseUpdate>
 
-<Update label="01.23.2026">
+<ReleaseUpdate label="01.23.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
 ## [01.23.2026: CLI Authentication Configuration](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
 **Available in @arizeai/phoenix-cli 0.4.0+**
 
 The Phoenix CLI now includes enhanced authentication configuration commands, resolving database race conditions and improving connection reliability. Users can configure authentication settings directly through the CLI for more predictable and stable connections to Phoenix servers.
-</Update>
+</ReleaseUpdate>
 
-<Update label="01.21.2026">
+<ReleaseUpdate label="01.21.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
 ## [01.21.2026: Create Datasets from Traces with Span Associations](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
 **Available in arize-phoenix-client 1.28.0+ (Python) and @arizeai/phoenix-client 2.0.0+ (TypeScript)**
 
@@ -735,9 +737,9 @@ Key capabilities:
 - **Graceful fallback** when span IDs are missing or invalid
 - **Backwards compatible** with existing dataset creation workflows
 - **Bidirectional navigation** between evaluation results and production traces
-</Update>
+</ReleaseUpdate>
 
-<Update label="01.19.2026">
+<ReleaseUpdate label="01.19.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
 ## [01.19.2026: Export Annotations with Traces](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
 **Available in @arizeai/phoenix-cli 0.3.0+**
 
@@ -748,105 +750,105 @@ px traces export --include-annotations > traces_with_feedback.jsonl
 ```
 
 This enables teams to maintain complete evaluation history when moving data between environments or conducting retrospective analysis of model performance.
-</Update>
+</ReleaseUpdate>
 
-<Update label="01.22.2026">
+<ReleaseUpdate label="01.22.2026" href="/docs/phoenix/release-notes/01-2026/01-22-2026-cli-prompt-commands">
 ## [01.22.2026: CLI Prompt Commands: Pipe Prompts to AI Assistants](/docs/phoenix/release-notes/01-2026/01-22-2026-cli-prompt-commands) 📝
 
 **Available in @arizeai/phoenix-cli 0.4.0+**
 
 Phoenix CLI now supports prompt introspection with `px prompts` and `px prompt`. List prompts, view their content, and pipe them directly to AI assistants like Claude Code for optimization suggestions. The `--format text` option outputs prompts with XML-style role tags, ideal for analysis workflows.
-</Update>
+</ReleaseUpdate>
 
-<Update label="01.21.2026">
+<ReleaseUpdate label="01.21.2026" href="/docs/phoenix/release-notes/01-2026/01-21-2026-create-datasets-from-traces">
 ## [01.21.2026: Create Datasets from Traces with Span Associations](/docs/phoenix/release-notes/01-2026/01-21-2026-create-datasets-from-traces) 🔗
 
 **Available in arize-phoenix-client 1.28.0+ (Python) and @arizeai/phoenix-client 2.0.0+ (TypeScript)**
 
 The Phoenix client now enables converting production traces into curated datasets while preserving associations back to source spans. Query spans using client methods, then create datasets with span associations to maintain bidirectional links. Use this to build golden datasets from validated interactions, curate edge cases from failed traces, or create regression test suites from critical user flows.
-</Update>
+</ReleaseUpdate>
 
-<Update label="01.21.2026">
+<ReleaseUpdate label="01.21.2026" href="/docs/phoenix/release-notes/01-2026/01-21-2026-cli-datasets-experiments-annotations">
 ## [01.21.2026: Phoenix CLI: Datasets, Experiments & Annotations](/docs/phoenix/release-notes/01-2026/01-21-2026-cli-datasets-experiments-annotations) 🧪
 
 **Available in @arizeai/phoenix-cli 0.2.0+**
 
 The Phoenix CLI now supports datasets, experiments, and annotations. Pull evaluation data, export experiment results, and access human feedback directly from the terminal. Works well with AI coding assistants for analyzing test cases and reviewing results.
-</Update>
+</ReleaseUpdate>
 
-<Update label="01.17.2026">
+<ReleaseUpdate label="01.17.2026" href="/docs/phoenix/release-notes/01-2026/01-17-2026-phoenix-cli-ai-agent-debugging">
 ## [01.17.2026: Phoenix CLI: Terminal Access for AI Coding Assistants](/docs/phoenix/release-notes/01-2026/01-17-2026-phoenix-cli-ai-agent-debugging) 🖥️
 
 **Available in @arizeai/phoenix-cli 0.1.0+**
 
 AI coding assistants operate through terminals and files—they run shell commands, read output, and process data. The new Phoenix CLI makes trace data accessible through these interfaces, enabling tools like Claude Code, Cursor, and Windsurf to query your Phoenix instance directly. Export traces to JSON, pipe to `jq`, or save to disk for analysis.
-</Update>
+</ReleaseUpdate>
 
-<Update label="01.05.2026">
+<ReleaseUpdate label="01.05.2026" href="/docs/phoenix/release-notes/01-2026/01-05-2026-appended-messages-for-playground-experiments">
 ## [01.05.2026: Appended Messages for Playground Experiments](/docs/phoenix/release-notes/01-2026/01-05-2026-appended-messages-for-playground-experiments) 💬
 
 **Available in Phoenix 13.0+**
 
 The Prompt Playground now supports appending conversation history from dataset examples to your prompts. This enables powerful A/B testing workflows for comparing models and system prompts against the same conversation threads. Specify a dot-notation path to messages in your dataset (e.g., `messages` or `input.messages`) and run experiments across all prompt variants.
-</Update>
+</ReleaseUpdate>
 
-<Update label="12.20.2025">
+<ReleaseUpdate label="12.20.2025" href="/docs/phoenix/release-notes/12-2025/12-20-2025-improved-user-preferences">
 ## [12.20.2025: Improved User Preferences](/docs/phoenix/release-notes/12-2025/12-20-2025-improved-user-preferences) ⚙️
 
 **Available in Phoenix 12.27+**
 
 Phoenix now offers enhanced user preference settings, giving you more control over your experience. This update includes theme selection in viewer preferences and programming language preference.
-</Update>
+</ReleaseUpdate>
 
-<Update label="12.12.2025">
+<ReleaseUpdate label="12.12.2025" href="/docs/phoenix/release-notes/12-2025/12-12-2025-support-for-gemini-tool-calls">
 ## [12.12.2025: Support for Gemini Tool Calls](/docs/phoenix/release-notes/12-2025/12-12-2025-support-for-gemini-tool-calls) 🤖
 
 **Available in Phoenix 12.25+**
 
 Phoenix now supports Gemini tool calls, enabling enhanced integration capabilities with Google's Gemini models. This update allows for more robust and feature-complete interactions with Gemini, including improved request/response translation and advanced conversation handling with tool calls.
-</Update>
+</ReleaseUpdate>
 
-<Update label="12.09.2025">
+<ReleaseUpdate label="12.09.2025" href="/docs/phoenix/release-notes/12-2025/12-09-2025-span-notes-api">
 ## [12.09.2025: Span Notes API](/docs/phoenix/release-notes/12-2025/12-09-2025-span-notes-api) 📝
 
 **Available in Phoenix 12.21+**
 
 New dedicated endpoints for span notes enable open coding and seamless annotation integrations. Add notes to spans programmatically using the Phoenix client in both Python and TypeScript—perfect for debugging sessions, human feedback, and building custom annotation pipelines.
-</Update>
+</ReleaseUpdate>
 
-<Update label="12.06.2025">
+<ReleaseUpdate label="12.06.2025" href="/docs/phoenix/release-notes/12-2025/12-06-2025-ldap-authentication-support">
 ## [12.06.2025: LDAP Authentication Support](/docs/phoenix/release-notes/12-2025/12-06-2025-ldap-authentication-support) 🔐
 
 **Available in Phoenix 12.20+**
 
 Phoenix now supports authentication against LDAP directories, enabling integration with enterprise identity infrastructure including Microsoft Active Directory, OpenLDAP, and any LDAP v3 compliant directory. Key features include group-based role mapping, multi-server failover, TLS encryption, and automatic user provisioning.
-</Update>
+</ReleaseUpdate>
 
-<Update label="12.04.2025">
+<ReleaseUpdate label="12.04.2025" href="/docs/phoenix/release-notes/12-2025/12-04-2025-evaluator-message-formats">
 ## [12.04.2025: Evaluator Message Formats](/docs/phoenix/release-notes/12-2025/12-04-2025-evaluator-message-formats) 💬
 
 **Available in phoenix-evals 0.22+ (Python) and @arizeai/phoenix-evals 2.0+ (TypeScript)**
 
 Phoenix evaluators now support flexible prompt formats including simple string templates and OpenAI-style message arrays for multi-turn prompts. Python supports both f-string and mustache syntax, while TypeScript uses mustache syntax. Adapters handle provider-specific transformations automatically.
-</Update>
+</ReleaseUpdate>
 
-<Update label="12.03.2025">
+<ReleaseUpdate label="12.03.2025" href="/docs/phoenix/release-notes/12-2025/12-03-2025-typescript-create-evaluator">
 ## [12.03.2025: TypeScript createEvaluator](/docs/phoenix/release-notes/12-2025/12-03-2025-typescript-create-evaluator) 🧪
 
 **Available in @arizeai/phoenix-evals 2.0+**
 
 The `createEvaluator` utility provides a type-safe way to build custom code evaluators for experiments in TypeScript. Define evaluators with full type inference, access `input`, `output`, `expected`, and `metadata` parameters, and integrate seamlessly with `runExperiment`.
-</Update>
+</ReleaseUpdate>
 
-<Update label="12.01.2025">
+<ReleaseUpdate label="12.01.2025" href="/docs/phoenix/release-notes/12-2025/12-01-2025-splits-on-experiments-table">
 ## [12.01.2025: Splits on Experiments Table](/docs/phoenix/release-notes/12-2025/12-01-2025-splits-on-experiments-table) 📊
 
 **Available in Phoenix 12.20+**
 
 You can now view and filter experiment results by data splits directly in the experiments table. This enhancement makes it easier to analyze performance across different data subsets (such as train, validation, and test) and compare how your models perform on each split.
-</Update>
+</ReleaseUpdate>
 
-<Update label="11.29.2025">
+<ReleaseUpdate label="11.29.2025" href="/docs/phoenix/release-notes/11-2025/11-29-2025-add-support-for-claude-opus-4-5">
 ## [11.29.2025: Add support for Claude Opus 4-5](/docs/phoenix/release-notes/11-2025/11-29-2025-add-support-for-claude-opus-4-5) 🤖
 
 **Available in Phoenix 12.18+**
@@ -856,9 +858,9 @@ You can now view and filter experiment results by data splits directly in the ex
 </Frame>
 
 Phoenix now supports Claude Opus 4 and 4-5 as models you can invoke from the Playground.
-</Update>
+</ReleaseUpdate>
 
-<Update label="11.27.2025">
+<ReleaseUpdate label="11.27.2025" href="/docs/phoenix/release-notes/11-2025/11-27-2025-show-server-credential-setup-in-playground-api-keys">
 ## [11.27.2025: Show Server Credential Setup in Playground API Keys](/docs/phoenix/release-notes/11-2025/11-27-2025-show-server-credential-setup-in-playground-api-keys) 🔐
 
 **Available in Phoenix 12.18+**
@@ -868,9 +870,9 @@ Phoenix now supports Claude Opus 4 and 4-5 as models you can invoke from the Pla
 </Frame>
 
 The Playground now clearly indicates when server credentials are configured.
-</Update>
+</ReleaseUpdate>
 
-<Update label="11.25.2025">
+<ReleaseUpdate label="11.25.2025" href="/docs/phoenix/release-notes/11-2025/11-25-2025-split-assignments-when-uploading-a-dataset">
 ## [11.25.2025: Split Assignments When Uploading a Dataset](/docs/phoenix/release-notes/11-2025/11-25-2025-split-assignments-when-uploading-a-dataset) 🗂️
 
 **Available in Phoenix 12.18+**
@@ -880,9 +882,9 @@ The Playground now clearly indicates when server credentials are configured.
 </Frame>
 
 You can now assign data splits (ex: train/test/validation) directly when uploading a dataset into Arize Phoenix.
-</Update>
+</ReleaseUpdate>
 
-<Update label="11.23.2025">
+<ReleaseUpdate label="11.23.2025" href="/docs/phoenix/release-notes/11-2025/11-23-2025-repetitions-for-manual-playground-invocations">
 ## [11.23.2025: Repetitions for Manual Playground Invocations](/docs/phoenix/release-notes/11-2025/11-23-2025-repetitions-for-manual-playground-invocations) 🛝
 
 **Available in Phoenix 12.17+**
@@ -892,25 +894,25 @@ You can now assign data splits (ex: train/test/validation) directly when uploadi
 </Frame>
 
 This update adds an easy way to run several repetitions of the same prompt directly from the Playground.
-</Update>
+</ReleaseUpdate>
 
-<Update label="11.14.2025">
+<ReleaseUpdate label="11.14.2025" href="/docs/phoenix/release-notes/11-2025/11-19-2025-expanded-provider-support-with-openai-5-1-+-gemini-3">
 ## [11.14.2025: Expanded Provider Support with OpenAI 5.1 + Gemini 3](/docs/phoenix/release-notes/11-2025/11-19-2025-expanded-provider-support-with-openai-5-1-+-gemini-3) 🔧
 
 **Available in Phoenix 12.15+**
 
 This update enhances LLM provider support by adding **OpenAI v5.1** compatibility (including reasoning capabilities), expanding support for **Google DeepMind/Gemini** models, and introducing the **gemini-3** model variant.
-</Update>
+</ReleaseUpdate>
 
-<Update label="11.12.2025">
+<ReleaseUpdate label="11.12.2025" href="/docs/phoenix/release-notes/11-2025/11-12-2025-updated-anthropic-model-list">
 ## [11.12.2025: Updated Anthropic Model List](/docs/phoenix/release-notes/11-2025/11-12-2025-updated-anthropic-model-list) 🧠
 
 **Available in Phoenix 12.15+**
 
 This update enhances the Anthropic model registrations in Arize Phoenix by adding support for the **4.5 Sonnet/Haiku variants** and removing several legacy **3.x Sonnet/Opus entries.**
-</Update>
+</ReleaseUpdate>
 
-<Update label="11.09.2025">
+<ReleaseUpdate label="11.09.2025" href="/docs/phoenix/release-notes/11-2025/11-09-2025-openinference-typescript-2-0">
 ## [11.09.2025: OpenInference TypeScript 2.0](/docs/phoenix/release-notes/11-2025/11-09-2025-openinference-typescript-2-0) 💻
 
 <Frame>
@@ -922,9 +924,9 @@ This update enhances the Anthropic model registrations in Arize Phoenix by addin
 * Added **decorator-based method tracing**, enabling automatic span creation on class methods via the `@observe` decorator.
 * Expanded **attribute helper utilities** for standardized OpenTelemetry metadata creation, including helpers for **inputs/outputs**, **LLM operations**, **embeddings**, **retrievers**, and **tool definitions**.
 * Overall, tracing workflows, agent behavior, and external tool calls is now significantly simpler and more consistent across languages.
-</Update>
+</ReleaseUpdate>
 
-<Update label="11.07.2025">
+<ReleaseUpdate label="11.07.2025" href="/docs/phoenix/release-notes/11-2025/11-07-2025-timezone-preference">
 ## [11.07.2025: Timezone Preference](/docs/phoenix/release-notes/11-2025/11-07-2025-timezone-preference) 🌍
 
 **Available in Phoenix 12.11+**
@@ -934,9 +936,9 @@ This update enhances the Anthropic model registrations in Arize Phoenix by addin
 </Frame>
 
 This update adds a new **display timezone preference** feature for users: you can now specify how timestamps are shown across the UI, making time-based data more intuitive and aligned with your locale.
-</Update>
+</ReleaseUpdate>
 
-<Update label="11.05.2025">
+<ReleaseUpdate label="11.05.2025" href="/docs/phoenix/release-notes/11-2025/11-05-2025-metadata-for-prompts">
 ## [11.05.2025: Metadata for Prompts](/docs/phoenix/release-notes/11-2025/11-05-2025-metadata-for-prompts) 🗂️
 
 **Available in Phoenix 12.10+**
@@ -946,9 +948,9 @@ This update adds a new **display timezone preference** feature for users: you ca
 </Frame>
 
 Added full prompt-level metadata support across API, UI, and clients: you can now create, clone, patch, and display a JSON `metadata` field for prompts.
-</Update>
+</ReleaseUpdate>
 
-<Update label="11.03.2025">
+<ReleaseUpdate label="11.03.2025" href="/docs/phoenix/release-notes/11-2025/11-03-2025-playground-dataset-label-display">
 ## [11.03.2025: Playground Dataset Label Display](/docs/phoenix/release-notes/11-2025/11-03-2025-playground-dataset-label-display) 🏷️
 
 **Available in Phoenix 12.10+**
@@ -958,17 +960,17 @@ Added full prompt-level metadata support across API, UI, and clients: you can no
 </Frame>
 
 You can now view dataset labels as you load datasets into the Playground. This enhancement makes it easier to identify and select your desired dataset.
-</Update>
+</ReleaseUpdate>
 
-<Update label="11.01.2025">
+<ReleaseUpdate label="11.01.2025" href="/docs/phoenix/release-notes/11-2025/11-01-2025-resume-experiments-and-evaluations">
 ## [11.01.2025: Resume Experiments and Evaluations](/docs/phoenix/release-notes/11-2025/11-01-2025-resume-experiments-and-evaluations) 🔄
 
 **Available in Phoenix 12.10+**
 
 This release allows you to resume your experiments and evaluations at your convenience. If certain examples fail, there is no need to repeat an entire task you already completed. This feature provides you with new management capabilities across servers and clients. It's designed to save effort, making your experimentation workflow more flexible.
-</Update>
+</ReleaseUpdate>
 
-<Update label="10.30.2025">
+<ReleaseUpdate label="10.30.2025" href="/docs/phoenix/release-notes/10-2025/10-30-2025-metadata-support-for-experiment-run-annotations">
 ## [10.30.2025: Metadata Support for Experiment Run Annotations](/docs/phoenix/release-notes/10-2025/10-30-2025-metadata-support-for-experiment-run-annotations) 🧩
 
 **Available in Phoenix 12.9+**
@@ -978,17 +980,17 @@ This release allows you to resume your experiments and evaluations at your conve
 </Frame>
 
 Added **metadata support for experiment run annotations**, with GraphQL updates to fetch and expose this information. The annotation details view now displays formatted JSON metadata across both **compare** and **example** views for easier inspection and debugging.
-</Update>
+</ReleaseUpdate>
 
-<Update label="10.28.2025">
+<ReleaseUpdate label="10.28.2025" href="/docs/phoenix/release-notes/10-2025/10-28-2025-enable-aws-iam-auth-for-db-configuration">
 ## [10.28.2025: Enable AWS IAM Auth for DB Configuration](/docs/phoenix/release-notes/10-2025/10-28-2025-enable-aws-iam-auth-for-db-configuration) 🔐
 
 **Available in Phoenix 12.9+**
 
 Added support for **AWS IAM–based authentication** for PostgreSQL connections to **AWS Aurora and RDS**. This enhancement enables the use of **short-lived IAM tokens** instead of static passwords, improving security and compliance for database access.
-</Update>
+</ReleaseUpdate>
 
-<Update label="10.26.2025">
+<ReleaseUpdate label="10.26.2025" href="/docs/phoenix/release-notes/10-2025/10-26-2025-add-split-edit-menu-to-examples">
 ## [10.26.2025: Add Split Edit Menu to Examples](/docs/phoenix/release-notes/10-2025/10-26-2025-add-split-edit-menu-to-examples) ䷖
 
 **Available in Phoenix 12.8+**
@@ -998,9 +1000,9 @@ Added support for **AWS IAM–based authentication** for PostgreSQL connections 
 </Frame>
 
 Added a new **"Split"** dropdown to single-example view on the dataset pages, allowing users to update the data split classification (e.g., train/validation/test) directly from the example level. This improvement makes it easier to correct or adjust split assignments dynamically.
-</Update>
+</ReleaseUpdate>
 
-<Update label="10.24.2025">
+<ReleaseUpdate label="10.24.2025" href="/docs/phoenix/release-notes/10-2025/10-24-2025-filter-prompts-page-by-label">
 ## [10.24.2025: Filter Prompts Page by Label](/docs/phoenix/release-notes/10-2025/10-24-2025-filter-prompts-page-by-label) 🏷️
 
 **Available in Phoenix 12.7+**
@@ -1010,17 +1012,17 @@ Added a new **"Split"** dropdown to single-example view on the dataset pages, al
 </Frame>
 
 Added filtering by label on the Prompts page—users can now pick one or more labels to narrow the prompts list.
-</Update>
+</ReleaseUpdate>
 
-<Update label="10.20.2025">
+<ReleaseUpdate label="10.20.2025" href="/docs/phoenix/release-notes/10-2025/10-20-2025-splits">
 ## [10.20.2025: Splits](/docs/phoenix/release-notes/10-2025/10-20-2025-splits) ䷖
 
 **Available in Phoenix 12.7+**
 
 In Arize Phoenix, _splits_ let you categorize your dataset into distinct subsets—such as **train**, **validation**, or **test**—enabling structured workflows for experiments and evaluations. This capability offers more flexibility in how you organize, filter, and compare your data across different stages or experimental conditions.
-</Update>
+</ReleaseUpdate>
 
-<Update label="10.18.2025">
+<ReleaseUpdate label="10.18.2025" href="/docs/phoenix/release-notes/10-2025/10-18-2025-filter-annotations-in-compare-experiments-slideover">
 ## [10.18.2025: Filter Annotations in Compare Experiments Slideover](/docs/phoenix/release-notes/10-2025/10-18-2025-filter-annotations-in-compare-experiments-slideover) ✍️
 
 **Available in Phoenix 12.7+**
@@ -1030,9 +1032,9 @@ In Arize Phoenix, _splits_ let you categorize your dataset into distinct subsets
 </Frame>
 
 Added filtering of annotations in the experiment compare slideover so that only annotations present on the selected experiment runs are displayed. This ensures a cleaner UI and avoids filters for annotations that don't appear in the comparison set.
-</Update>
+</ReleaseUpdate>
 
-<Update label="10.15.2025">
+<ReleaseUpdate label="10.15.2025" href="/docs/phoenix/release-notes/10-2025/10-15-2025-enhanced-filtering-for-examples-table">
 ## [10.15.2025: Enhanced Filtering for Examples Table](/docs/phoenix/release-notes/10-2025/10-15-2025-enhanced-filtering-for-examples-table) 🔍
 
 **Available in Phoenix 12.5+**
@@ -1042,9 +1044,9 @@ Added filtering of annotations in the experiment compare slideover so that only 
 </Frame>
 
 Added filtering capabilities to the **Dataset Examples table**, allowing users to search examples by text or split ID. Additionally, the split-management filter menu has been reorganized to separate filtering by splits from split management actions.
-</Update>
+</ReleaseUpdate>
 
-<Update label="10.13.2025">
+<ReleaseUpdate label="10.13.2025" href="/docs/phoenix/release-notes/10-2025/10-13-2025-view-traces-in-compare-experiments">
 ## [10.13.2025: View Traces in Compare Experiments](/docs/phoenix/release-notes/10-2025/10-13-2025-view-traces-in-compare-experiments) 🧪
 
 **Available in Phoenix 12.5+**
@@ -1054,17 +1056,17 @@ Added filtering capabilities to the **Dataset Examples table**, allowing users t
 </Frame>
 
 We've added trace-links to the experiment compare slideover for runs and annotations. Clicking the new trace icons opens the Trace View.
-</Update>
+</ReleaseUpdate>
 
-<Update label="10.10.2025">
+<ReleaseUpdate label="10.10.2025" href="/docs/phoenix/release-notes/10-2025/10-10-2025-viewer-role">
 ## [10.10.2025: Viewer Role](/docs/phoenix/release-notes/10-2025/10-10-2025-viewer-role) 👀
 
 **Available in Phoenix 12.5+**
 
 Introduced a new **VIEWER role** with enforced read-only permissions across both GraphQL and REST APIs, improving access control and security.
-</Update>
+</ReleaseUpdate>
 
-<Update label="10.08.2025">
+<ReleaseUpdate label="10.08.2025" href="/docs/phoenix/release-notes/10-2025/10-08-2025-dataset-labels">
 ## [10.08.2025: Dataset Labels](/docs/phoenix/release-notes/10-2025/10-08-2025-dataset-labels) 🏷️
 
 **Available in Phoenix 12.3+**
@@ -1074,9 +1076,9 @@ Introduced a new **VIEWER role** with enforced read-only permissions across both
 </Frame>
 
 Added support for **dataset labels** — you can now label datasets and view these labels in a dedicated column on the dataset list page, making it easier to **filter and group datasets**. All dataset labels can also be managed and viewed in the **"Datasets" tab** on the Settings page.
-</Update>
+</ReleaseUpdate>
 
-<Update label="10.06.2025">
+<ReleaseUpdate label="10.06.2025" href="/docs/phoenix/release-notes/10-2025/10-06-2025-paginate-compare-experiments">
 ## [10.06.2025: Paginate Compare Experiments](/docs/phoenix/release-notes/10-2025/10-06-2025-paginate-compare-experiments) 📃
 
 **Available in Phoenix 12.3+**
@@ -1086,9 +1088,9 @@ Added support for **dataset labels** — you can now label datasets and view the
 </Frame>
 
 We added pagination to the **experiment comparison slideover** on the list page for smoother navigation through results. We also introduced a new **repetition number column**, visible only when the base experiment includes multiple repetitions.
-</Update>
+</ReleaseUpdate>
 
-<Update label="10.05.2025">
+<ReleaseUpdate label="10.05.2025" href="/docs/phoenix/release-notes/10-2025/10-05-2025-load-prompt-by-tag-into-playground">
 ## [10.05.2025: Load Prompt by Tag into Playground](/docs/phoenix/release-notes/10-2025/10-05-2025-load-prompt-by-tag-into-playground) 🛝
 
 **Available in Phoenix 12.2+**
@@ -1098,9 +1100,9 @@ We added pagination to the **experiment comparison slideover** on the list page 
 </Frame>
 
 We have added support for **selecting and loading prompts by tag** in the Playground. Users can now open specific prompts tagged for easier comparison and reproducibility.
-</Update>
+</ReleaseUpdate>
 
-<Update label="10.03.2025">
+<ReleaseUpdate label="10.03.2025" href="/docs/phoenix/release-notes/10-2025/10-03-2025-prompt-version-editing-in-playground">
 ## [10.03.2025: Prompt Version Editing in Playground](/docs/phoenix/release-notes/10-2025/10-03-2025-prompt-version-editing-in-playground) 🛝
 
 **Available in Phoenix 12.2+**
@@ -1110,9 +1112,9 @@ We have added support for **selecting and loading prompts by tag** in the Playgr
 </Frame>
 
 We added support for **prompt versioning in the Playground** — users can now select, edit, and experiment with specific prompt versions directly. This update improves traceability and reproducibility for prompt iterations, making it easier to manage and compare different versions.
-</Update>
+</ReleaseUpdate>
 
-<Update label="09.29.2025">
+<ReleaseUpdate label="09.29.2025" href="/docs/phoenix/release-notes/09-2025/09-29-2025-day-0-support-for-claude-sonnet-4.5">
 ## [09.29.2025: Day 0 support for Claude Sonnet 4.5](/docs/phoenix/release-notes/09-2025/09-29-2025-day-0-support-for-claude-sonnet-4.5) ⚡
 
 **Available in Phoenix 12.1+**
@@ -1122,18 +1124,18 @@ We added support for **prompt versioning in the Playground** — users can now s
 </Frame>
 
 Day-0 support for Claude Sonnet 4.5.
-</Update>
+</ReleaseUpdate>
 
-<Update label="09.27.2025">
+<ReleaseUpdate label="09.27.2025" href="/docs/phoenix/release-notes/09-2025/09-27-2025-dataset-splits">
 ## [09.27.2025: Dataset Splits ](/docs/phoenix/release-notes/09-2025/09-27-2025-dataset-splits)📊
 
 **Available in Phoenix 12.0+**
 
 Add support for custom dataset splits to organize examples by category.
 
-</Update>
+</ReleaseUpdate>
 
-<Update label="09.26.2025">
+<ReleaseUpdate label="09.26.2025" href="/docs/phoenix/release-notes/09-2025/09-26-2025-session-annotations">
 ## [09.26.2025: Session Annotations 🗂️](/docs/phoenix/release-notes/09-2025/09-26-2025-session-annotations)&#x20;
 
 **Available in Phoenix 12.0+**
@@ -1144,9 +1146,9 @@ Add support for custom dataset splits to organize examples by category.
 
 You can now annotate sessions with conversational evaluations like coherency and tone.&#x20;
 
-</Update>
+</ReleaseUpdate>
 
-<Update label="09.25.2025">
+<ReleaseUpdate label="09.25.2025" href="/docs/phoenix/release-notes/09-2025/09-25-2025-repetitions">
 ## [09.25.2025: Repetitions](/docs/phoenix/release-notes/09-2025/09-25-2025-repetitions) 🔁
 
 **Available in Phoenix 11.38+**
@@ -1157,9 +1159,9 @@ You can now annotate sessions with conversational evaluations like coherency and
 
 Support for repetitions is now enabled in Playground and SDK workflows.
 
-</Update>
+</ReleaseUpdate>
 
-<Update label="09.24.2025">
+<ReleaseUpdate label="09.24.2025" href="/docs/phoenix/release-notes/09-2025/09-24-2025-custom-http-headers-for-requests-in-playground">
 ## [09.24.2025: Custom HTTP headers for requests in Playground](/docs/phoenix/release-notes/09-2025/09-24-2025-custom-http-headers-for-requests-in-playground) 🛠️
 
 **Available in Phoenix 11.36+**
@@ -1170,9 +1172,9 @@ Support for repetitions is now enabled in Playground and SDK workflows.
 
 Enable configuring custom HTTP headers for playground requests.
 
-</Update>
+</ReleaseUpdate>
 
-<Update label="09.23.2025">
+<ReleaseUpdate label="09.23.2025" href="/docs/phoenix/release-notes/09-2025/09-23-2025-repetitions-in-experiment-compare-slideover">
 ## [09.23.2025: Repetitions in experiment compare slideover ](/docs/phoenix/release-notes/09-2025/09-23-2025-repetitions-in-experiment-compare-slideover)🔄
 
 **Available in Phoenix 11.36+**
@@ -1183,15 +1185,15 @@ Enable configuring custom HTTP headers for playground requests.
 
 Show experiment repetitions as separate cards in the compare slideover 🔄
 
-</Update>
+</ReleaseUpdate>
 
-<Update label="09.22.2025">
+<ReleaseUpdate label="09.22.2025" href="/docs/phoenix/release-notes/09-2025/09-22-2025-helm-configurable-image-registry-and-ipv6-support">
 ## [09.22.2025: Helm configurable image registry & IPv6 support ](/docs/phoenix/release-notes/09-2025/09-22-2025-helm-configurable-image-registry-and-ipv6-support)🌐
 
 **Available in Phoenix 11.35+**
-</Update>
+</ReleaseUpdate>
 
-<Update label="09.17.2025">
+<ReleaseUpdate label="09.17.2025" href="/docs/phoenix/release-notes/09-2025/09-17-2025-experiment-compare-details-slideover-in-list-view">
 ## [09.17.2025: Experiment compare details slideover in list view](/docs/phoenix/release-notes/09-2025/09-17-2025-experiment-compare-details-slideover-in-list-view) 🔍
 
 **Available in Phoenix 11.34+**
@@ -1203,9 +1205,9 @@ Show experiment repetitions as separate cards in the compare slideover 🔄
 
 Added a slideover in the experiments list view to show compare details inline.
 
-</Update>
+</ReleaseUpdate>
 
-<Update label="09.15.2025">
+<ReleaseUpdate label="09.15.2025" href="/docs/phoenix/release-notes/09-2025/09-15-2025-prompt-labels">
 ## [09.15.2025: Prompt Labels 🏷️](/docs/phoenix/release-notes/09-2025/09-15-2025-prompt-labels)
 
 **Available in Phoenix 11.33+**
@@ -1216,9 +1218,9 @@ Added a slideover in the experiments list view to show compare details inline.
 
 We’ve added support for labeling prompts so you can categorize them by use-case, provider, or any custom tag.
 
-</Update>
+</ReleaseUpdate>
 
-<Update label="09.12.2025">
+<ReleaseUpdate label="09.12.2025" href="/docs/phoenix/release-notes/09-2025/09-12-2025-enable-paging-in-experiment-compare-details">
 ## [09.12.2025: Enable Paging in Experiment Compare Details 📄](/docs/phoenix/release-notes/09-2025/09-12-2025-enable-paging-in-experiment-compare-details)
 
 **Available in Phoenix 11.33+**
@@ -1229,7 +1231,7 @@ We’ve added support for labeling prompts so you can categorize them by use-cas
 
 We’ve added paging functionality to the Experiment Compare details slide-over view, allowing users to navigate between individual examples using arrow buttons or keyboard shortcuts (`J` / `K`). Pagination
 
-</Update>
+</ReleaseUpdate>
 
 ## See more
 

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -13,8 +13,7 @@ GitHub
 **We want to hear from you!** The DevRel team wants to hear from the Phoenix community. If you're building with Phoenix and want to tell us what's working, what's painful, or what you wish existed, [grab 25 minutes with us](https://cal.com/team/arize-devrel/user-interview).
 </Info>
 
-<ReleaseUpdate label="05.27.2026" href="/docs/phoenix/release-notes/05-2026/05-27-2026-drag-to-zoom">
-## [05.27.2026: Drag-to-Zoom on Project Metric Charts](/docs/phoenix/release-notes/05-2026/05-27-2026-drag-to-zoom)
+<ReleaseUpdate label="05.27.2026" href="/docs/phoenix/release-notes/05-2026/05-27-2026-drag-to-zoom" title="Drag-to-Zoom on Project Metric Charts">
 **Available in arize-phoenix 16.3.0+**
 
 Click and drag across any project metric chart or the spans sparkline to zoom into a custom time window. All metric panels share the same time-range context, so one brush selection updates latency, error rate, token usage, and trace-count charts simultaneously.
@@ -23,8 +22,7 @@ Click and drag across any project metric chart or the spans sparkline to zoom in
 - **Adaptive tick density** — x-axis labels scale with rendered pixel width, staying readable at any zoom level
 </ReleaseUpdate>
 
-<ReleaseUpdate label="05.21.2026" href="/docs/phoenix/release-notes/05-2026/05-21-2026-code-evaluators">
-## [05.21.2026: Code Evaluators](/docs/phoenix/release-notes/05-2026/05-21-2026-code-evaluators)
+<ReleaseUpdate label="05.21.2026" href="/docs/phoenix/release-notes/05-2026/05-21-2026-code-evaluators" title="Code Evaluators">
 **Available in arize-phoenix 16.0.0+**
 
 Write Python or TypeScript `evaluate()` functions directly in the Phoenix UI and attach them to a dataset. Phoenix runs each function in an isolated sandbox and records the output as an annotation on every experiment run — no SDK, local runtime, or deploy step required.
@@ -34,8 +32,7 @@ Write Python or TypeScript `evaluate()` functions directly in the Phoenix UI and
 - **Dry-run before saving** — test the evaluator against a real dataset example from the UI
 </ReleaseUpdate>
 
-<ReleaseUpdate label="05.15.2026" href="/docs/phoenix/release-notes/05-2026/05-15-2026-otel-semconv-conversion">
-## [05.15.2026: OTel GenAI Semantic Convention Auto-Conversion](/docs/phoenix/release-notes/05-2026/05-15-2026-otel-semconv-conversion)
+<ReleaseUpdate label="05.15.2026" href="/docs/phoenix/release-notes/05-2026/05-15-2026-otel-semconv-conversion" title="OTel GenAI Semantic Convention Auto-Conversion">
 **Available in arize-phoenix 15.10.0+**
 
 Phoenix now automatically converts OTel GenAI semantic convention attributes (`gen_ai.*`) to OpenInference at ingest time. Traces from OpenTelemetry-native instrumentations — OpenAI, Anthropic, and Google GenAI contrib packages — now render with full message I/O, tool calls, retrieval documents, and token counts without code changes.
@@ -45,16 +42,14 @@ Phoenix now automatically converts OTel GenAI semantic convention attributes (`g
 - **Full coverage** — input/output messages, tool definitions and results, system instructions, retrieval documents, usage tokens, provider, and model name
 </ReleaseUpdate>
 
-<ReleaseUpdate label="05.15.2026" href="/docs/phoenix/release-notes/05-2026/05-15-2026-session-feedback-and-atif">
-## [05.15.2026: Session Trace Feedback and ATIF v1.7](/docs/phoenix/release-notes/05-2026/05-15-2026-session-feedback-and-atif)
+<ReleaseUpdate label="05.15.2026" href="/docs/phoenix/release-notes/05-2026/05-15-2026-session-feedback-and-atif" title="Session Trace Feedback and ATIF v1.7">
 **Available in arize-phoenix 15.10.0+ (server), arize-phoenix-client 2.7.0+ (Python)**
 
 - **Session feedback toolbar** — thumbs-up/down and annotate buttons appear on each turn in Session Details; clicking creates a `user_feedback` trace annotation with toggle behavior
 - **ATIF v1.7 trajectory upload** — `upload_atif_trajectories_as_spans` now supports embedded subagent trajectories via `subagent_trajectories`, `trajectory_id`-based deterministic span IDs for idempotent re-uploads, `session_id` in trajectory headers, and deterministic dispatch steps (`llm_call_count: 0`)
 </ReleaseUpdate>
 
-<ReleaseUpdate label="05.13.2026" href="/docs/phoenix/release-notes/05-2026/05-13-2026-playground-thinking-controls">
-## [05.13.2026: Playground Thinking Controls](/docs/phoenix/release-notes/05-2026/05-13-2026-playground-thinking-controls)
+<ReleaseUpdate label="05.13.2026" href="/docs/phoenix/release-notes/05-2026/05-13-2026-playground-thinking-controls" title="Playground Thinking Controls">
 **Available in arize-phoenix 15.8.0+**
 
 The Playground now exposes first-class extended thinking controls for Anthropic and Google models, persisted with saved prompts.
@@ -63,8 +58,7 @@ The Playground now exposes first-class extended thinking controls for Anthropic 
 - **Google** — Thinking budget and thinking level (LOW / MEDIUM / HIGH)
 </ReleaseUpdate>
 
-<ReleaseUpdate label="05.13.2026" href="/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations">
-## [05.13.2026: Session Enhancements and Annotation Identifiers](/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations)
+<ReleaseUpdate label="05.13.2026" href="/docs/phoenix/release-notes/05-2026/05-13-2026-session-and-annotations" title="Session Enhancements and Annotation Identifiers">
 **Available in arize-phoenix 15.7.0+**
 
 - **Expandable session turns** — long messages in Session Details are now collapsed by default with an expand/collapse toggle
@@ -73,16 +67,14 @@ The Playground now exposes first-class extended thinking controls for Anthropic 
 - **Security** — f-string template formatter now blocks dunder/private attribute traversal, preventing format-string injection through user-supplied variables
 </ReleaseUpdate>
 
-<ReleaseUpdate label="05.10.2026" href="/docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences">
-## [05.10.2026: Playground Preferences](/docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences)
+<ReleaseUpdate label="05.10.2026" href="/docs/phoenix/release-notes/05-2026/05-10-2026-playground-preferences" title="Playground Preferences">
 **Available in arize-phoenix 15.6.0+**
 
 - **Default provider and model** — save a personal Playground default on the AI Providers settings page; Phoenix stores it in your browser and applies it to every new session
 - **Metrics aside always on** — the latency/token/error metrics panel on the right side of the spans table is now visible by default, no longer gated behind a feature flag
 </ReleaseUpdate>
 
-<ReleaseUpdate label="05.08.2026" href="/docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header">
-## [05.08.2026: OTLP Project Routing via HTTP Header](/docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header)
+<ReleaseUpdate label="05.08.2026" href="/docs/phoenix/release-notes/05-2026/05-08-2026-otlp-project-header" title="OTLP Project Routing via HTTP Header">
 **Available in arize-phoenix 15.5.0+**
 
 Set the `x-project-name` HTTP header on OTLP exports to route all spans in the request to a named Phoenix project. The header takes precedence over the `openinference.project.name` resource attribute, so tools like the OpenTelemetry Collector can route traces without modifying the instrumented application.
@@ -91,8 +83,7 @@ Set the `x-project-name` HTTP header on OTLP exports to route all spans in the r
 - **Bug fix** — deleting a dataset evaluator link no longer removes the shared evaluator row (arize-phoenix 15.5.1+)
 </ReleaseUpdate>
 
-<ReleaseUpdate label="05.05.2026" href="/docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools">
-## [05.05.2026: Provider Tools in Playground and Prompts](/docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools)
+<ReleaseUpdate label="05.05.2026" href="/docs/phoenix/release-notes/05-2026/05-05-2026-provider-tools" title="Provider Tools in Playground and Prompts">
 **Available in arize-phoenix 15.4.0+**
 
 Phoenix Playground and the Prompts library now support vendor-native tools — web search, code execution, computer use, grounding, and more — alongside existing function tools. Paste any provider's tool JSON into the Playground and Phoenix stores and round-trips it verbatim.
@@ -102,8 +93,7 @@ Phoenix Playground and the Prompts library now support vendor-native tools — w
 - **SDK export** — Python and TypeScript clients preserve provider tools when formatting prompts
 </ReleaseUpdate>
 
-<ReleaseUpdate label="05.05.2026" href="/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates">
-## [05.05.2026: REST API Updates — Annotation Delete, Token Counts, and More](/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates)
+<ReleaseUpdate label="05.05.2026" href="/docs/phoenix/release-notes/05-2026/05-05-2026-rest-api-updates" title="REST API Updates — Annotation Delete, Token Counts, and More">
 **Available in arize-phoenix 15.3.0–15.4.0+, arize-phoenix-evals 3.1.0+**
 
 - **Filter-based annotation DELETE** — `DELETE /v1/projects/{project}/span_annotations`, `trace_annotations`, and `session_annotations` bulk-remove annotations by `identifier`, `name`, `annotator_kind`, or time range
@@ -112,8 +102,7 @@ Phoenix Playground and the Prompts library now support vendor-native tools — w
 - **Evals runtime capability detection** — OpenAI reasoning models (`o1`, `o3`, `o3-mini`, `o4-mini`) now work with `ClassificationEvaluator` automatically
 </ReleaseUpdate>
 
-<ReleaseUpdate label="05.01.2026" href="/docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing">
-## [05.01.2026: TanStack AI Tracing](/docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing)
+<ReleaseUpdate label="05.01.2026" href="/docs/phoenix/release-notes/05-2026/05-01-2026-tanstack-ai-tracing" title="TanStack AI Tracing">
 **Available in @arizeai/openinference-tanstack-ai 0.1.0+**
 
 A new OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/docs/getting-started/overview) emits `AGENT`, `LLM`, and `TOOL` spans for `chat()` calls — covering streaming, non-streaming, and tool-loop flows across any TanStack AI provider adapter.
@@ -123,8 +112,7 @@ A new OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/
 - **Feedback welcome** — this integration is brand new; please reach out via the [OpenInference repo](https://github.com/Arize-ai/openinference)
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.30.2026" href="/docs/phoenix/release-notes/04-2026/04-30-2026-cli-auth-profiles">
-## [04.30.2026: CLI Named Auth Profiles](/docs/phoenix/release-notes/04-2026/04-30-2026-cli-auth-profiles)
+<ReleaseUpdate label="04.30.2026" href="/docs/phoenix/release-notes/04-2026/04-30-2026-cli-auth-profiles" title="CLI Named Auth Profiles">
 **Available in @arizeai/phoenix-cli 1.4.0+**
 
 `px profile` commands let you store named connection profiles — endpoint, project, API key, and headers — and switch between Phoenix instances without re-exporting environment variables. The active profile slots into the existing config resolution chain below env vars, so existing scripts are unaffected.
@@ -134,8 +122,7 @@ A new OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/
 - **Editor autocomplete** — JSON Schema published for `~/.px/profiles.json`
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.30.2026" href="/docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements">
-## [04.30.2026: Annotation Enhancements — Sessions, TypeScript, and Identifier Queries](/docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements)
+<ReleaseUpdate label="04.30.2026" href="/docs/phoenix/release-notes/04-2026/04-30-2026-annotation-enhancements" title="Annotation Enhancements — Sessions, TypeScript, and Identifier Queries">
 **Available in arize-phoenix 15.1.0+ (server), @arizeai/phoenix-cli 1.4.0+ (CLI), @arizeai/phoenix-client 6.9.0+ (TypeScript)**
 
 - **CLI session annotations** — `px session annotate <id>` and `px session add-note <id>` with `--include-annotations` / `--include-notes` flags on list and get
@@ -144,22 +131,19 @@ A new OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/
 - **Query by identifier** — GET annotation endpoints for spans, traces, and sessions accept `?identifier=` to retrieve all annotations sharing a tag, project-wide
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.29.2026" href="/docs/phoenix/release-notes/04-2026/04-29-2026-dataset-upsert">
-## [04.29.2026: Dataset Upsert](/docs/phoenix/release-notes/04-2026/04-29-2026-dataset-upsert)
+<ReleaseUpdate label="04.29.2026" href="/docs/phoenix/release-notes/04-2026/04-29-2026-dataset-upsert" title="Dataset Upsert">
 **Breaking change in arize-phoenix-client 2.6.0+ (Python) and arize-phoenix 15.0.0+ (server)**
 
 `client.datasets.create_dataset()` now defaults to upsert semantics: if a dataset with the same name exists, examples are merged into the latest version rather than returning a conflict error. Supply a stable `id` on each example for deterministic in-place updates on re-upload.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.28.2026" href="/docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api">
-## [04.28.2026: Session Notes API](/docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api)
+<ReleaseUpdate label="04.28.2026" href="/docs/phoenix/release-notes/04-2026/04-28-2026-session-notes-api" title="Session Notes API">
 **Available in arize-phoenix 14.16.0+**
 
 Phoenix now supports creating session notes through `POST /v1/session_notes`. The generic session annotation endpoint now reserves `name="note"` for note-specific APIs, so use `POST /v1/session_notes` for session notes and `POST /v1/session_annotations` for regular annotations.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.24.2026" href="/docs/phoenix/release-notes/04-2026/04-24-2026-trace-notes-api">
-## [04.24.2026: Trace Notes API](/docs/phoenix/release-notes/04-2026/04-24-2026-trace-notes-api)
+<ReleaseUpdate label="04.24.2026" href="/docs/phoenix/release-notes/04-2026/04-24-2026-trace-notes-api" title="Trace Notes API">
 **Available in arize-phoenix 14.13.0+ (server), @arizeai/phoenix-client 6.8.0+ (TypeScript), @arizeai/phoenix-cli 1.3.0+ (CLI)**
 
 Add notes to traces via the REST endpoint, TypeScript client, or CLI. Notes are stored separately from annotations and support multiple entries per trace.
@@ -169,8 +153,7 @@ Add notes to traces via the REST endpoint, TypeScript client, or CLI. Notes are 
 - **Reserved name** — `note` is no longer accepted on the generic annotation endpoints; use `POST /v1/trace_notes`
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.24.2026" href="/docs/phoenix/release-notes/04-2026/04-24-2026-phoenix-otel-python-0-16">
-## [04.24.2026: arize-phoenix-otel 0.16](/docs/phoenix/release-notes/04-2026/04-24-2026-phoenix-otel-python-0-16)
+<ReleaseUpdate label="04.24.2026" href="/docs/phoenix/release-notes/04-2026/04-24-2026-phoenix-otel-python-0-16" title="arize-phoenix-otel 0.16">
 **Available in arize-phoenix-otel 0.16.0+**
 
 `arize-phoenix-otel` now re-exports the most common OpenInference context managers and semantic conventions, so manual instrumentation no longer requires installing `openinference-instrumentation` or `openinference-semantic-conventions` as separate dependencies.
@@ -180,8 +163,7 @@ Add notes to traces via the REST endpoint, TypeScript client, or CLI. Notes are 
 - **Single install** — `pip install "arize-phoenix-otel>=0.16.0"` is enough for `register()` + context propagation
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.22.2026" href="/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id">
-## [04.22.2026: Secrets Settings Page](/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id)
+<ReleaseUpdate label="04.22.2026" href="/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id" title="Secrets Settings Page">
 **Available in arize-phoenix 14.11.0+**
 
 A new **Settings → Secrets** page lets admins add, replace, and delete encrypted LLM provider credentials (e.g. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) directly in the Phoenix UI — no REST API calls required.
@@ -191,8 +173,7 @@ A new **Settings → Secrets** page lets admins add, replace, and delete encrypt
 - **Admin-only** — all mutations require admin access
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.22.2026" href="/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id">
-## [04.22.2026: `trace_id` in Experiment Evaluators](/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id)
+<ReleaseUpdate label="04.22.2026" href="/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id" title="`trace_id` in Experiment Evaluators">
 **Available in arize-phoenix-client 2.4.0+**
 
 Evaluator functions now receive the originating trace ID for each experiment run. Add a `trace_id` keyword argument to any evaluator function or `Evaluator` class method to access it.
@@ -201,8 +182,7 @@ Evaluator functions now receive the originating trace ID for each experiment run
 - **Works sync and async** — supported on both function-based and protocol-based evaluators
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.20.2026" href="/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7">
-## [04.20.2026: Span Attribute Filtering](/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7)
+<ReleaseUpdate label="04.20.2026" href="/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7" title="Span Attribute Filtering">
 **Available in arize-phoenix 14.9.0+ (server), arize-phoenix-client 2.4.0+ (Python), @arizeai/phoenix-client 6.7.0+ (TypeScript)**
 
 Filter spans by stored attribute values using the Python client, TypeScript client, REST API, or CLI. Multiple filters are AND-ed together; the value's JS/Python type selects which storage type is matched.
@@ -213,22 +193,19 @@ Filter spans by stored attribute values using the Python client, TypeScript clie
 - **Type-aware** — `int`, `float`, `bool`, and `str` values each match their corresponding stored type
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.20.2026" href="/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7">
-## [04.20.2026: CLI Span Notes](/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7)
+<ReleaseUpdate label="04.20.2026" href="/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7" title="CLI Span Notes">
 **Available in @arizeai/phoenix-cli 1.1.0+**
 
 `px span add-note <span-id> --text "..."` attaches a free-text note to any span. Pass `--include-notes` to `px span list` or `px trace get` to read notes back alongside span data.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.20.2026" href="/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7">
-## [04.20.2026: Claude Opus 4.7 in the Playground](/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7)
+<ReleaseUpdate label="04.20.2026" href="/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7" title="Claude Opus 4.7 in the Playground">
 **Available in arize-phoenix 14.9.0+**
 
 Claude Opus 4.7 is now available as a model option in the Phoenix Playground. Select it from the model picker to compare outputs against other Anthropic and cross-provider models.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.16.2026" href="/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres">
-## [04.16.2026: Azure Managed Identity for PostgreSQL](/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres)
+<ReleaseUpdate label="04.16.2026" href="/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres" title="Azure Managed Identity for PostgreSQL">
 **Available in arize-phoenix 14.8.0+**
 
 Connect Phoenix to Azure Database for PostgreSQL using Microsoft Entra managed identity — no static database password required. Install the `azure` extra and set `PHOENIX_POSTGRES_USE_AZURE_MANAGED_IDENTITY=true`.
@@ -238,8 +215,7 @@ Connect Phoenix to Azure Database for PostgreSQL using Microsoft Entra managed i
 - **`PHOENIX_POSTGRES_AWS_IAM_TOKEN_LIFETIME_SECONDS` deprecated** — silently ignored with a startup warning
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.14.2026" href="/docs/phoenix/release-notes/04-2026/04-14-2026-cli-annotation-commands">
-## [04.14.2026: CLI Annotation Commands](/docs/phoenix/release-notes/04-2026/04-14-2026-cli-annotation-commands)
+<ReleaseUpdate label="04.14.2026" href="/docs/phoenix/release-notes/04-2026/04-14-2026-cli-annotation-commands" title="CLI Annotation Commands">
 **Available in @arizeai/phoenix-cli 1.0.4+**
 
 `px span annotate` and `px trace annotate` write labels, scores, and explanations to spans and traces from the terminal. Pass `--include-annotations` to `px trace get` or `px span list` to read annotations back alongside the data.
@@ -249,8 +225,7 @@ Connect Phoenix to Azure Database for PostgreSQL using Microsoft Entra managed i
 - **Annotator kinds** — `HUMAN`, `LLM`, or `CODE`; submitting again with the same name updates the existing entry
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.13.2026" href="/docs/phoenix/release-notes/04-2026/04-13-2026-phoenix-otel-ts-1-0">
-## [04.13.2026: @arizeai/phoenix-otel 1.0](/docs/phoenix/release-notes/04-2026/04-13-2026-phoenix-otel-ts-1-0)
+<ReleaseUpdate label="04.13.2026" href="/docs/phoenix/release-notes/04-2026/04-13-2026-phoenix-otel-ts-1-0" title="@arizeai/phoenix-otel 1.0">
 **Available in @arizeai/phoenix-otel 1.0.0+**
 
 `@arizeai/phoenix-otel` now re-exports the full `@arizeai/openinference-core` and `@arizeai/openinference-semantic-conventions` surface from a single import.
@@ -263,8 +238,7 @@ Connect Phoenix to Azure Database for PostgreSQL using Microsoft Entra managed i
 - **Redaction** — `OITracer` + `traceConfig` or `OPENINFERENCE_HIDE_*` env vars strip sensitive attributes before export
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.10.2026" href="/docs/phoenix/release-notes/04-2026/04-10-2026-shareable-url-redirects">
-## [04.10.2026: Shareable Project URLs](/docs/phoenix/release-notes/04-2026/04-10-2026-shareable-url-redirects)
+<ReleaseUpdate label="04.10.2026" href="/docs/phoenix/release-notes/04-2026/04-10-2026-shareable-url-redirects" title="Shareable Project URLs">
 **Available in arize-phoenix 14.2.0+**
 
 Navigate to `/redirects/projects/{project_name}` and Phoenix resolves the name and redirects to the project page — no internal ID required. Construct stable, bookmarkable links using the project name you already set in `PHOENIX_PROJECT_NAME`.
@@ -273,8 +247,7 @@ Navigate to `/redirects/projects/{project_name}` and Phoenix resolves the name a
 - **Other patterns** — traces, spans, sessions, and prompt tags are also supported via `/redirects/...`
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.07.2026" href="/docs/phoenix/release-notes/04-2026/04-07-2026-postgresql-read-replica">
-## [04.07.2026: PostgreSQL Read Replica Routing](/docs/phoenix/release-notes/04-2026/04-07-2026-postgresql-read-replica)
+<ReleaseUpdate label="04.07.2026" href="/docs/phoenix/release-notes/04-2026/04-07-2026-postgresql-read-replica" title="PostgreSQL Read Replica Routing">
 **Available in arize-phoenix 14.0.0+**
 
 Route read-only queries (GraphQL resolvers, REST reads, dataloaders) to an optional PostgreSQL read replica via `PHOENIX_SQL_DATABASE_READ_REPLICA_URL`, reducing load on the primary under high span ingestion.
@@ -283,8 +256,7 @@ Route read-only queries (GraphQL resolvers, REST reads, dataloaders) to an optio
 - **No config change needed** when a replica is not configured — falls back to primary
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.07.2026" href="/docs/phoenix/release-notes/04-2026/04-07-2026-phoenix-v14-breaking-changes">
-## [04.07.2026: Breaking Changes — Phoenix v14](/docs/phoenix/release-notes/04-2026/04-07-2026-phoenix-v14-breaking-changes)
+<ReleaseUpdate label="04.07.2026" href="/docs/phoenix/release-notes/04-2026/04-07-2026-phoenix-v14-breaking-changes" title="Breaking Changes — Phoenix v14">
 **Breaking changes in arize-phoenix 14.0.0, arize-phoenix-evals 3.0.0, arize-phoenix-client 2.3.1+**
 
 Phoenix v14 removes several legacy APIs. See the [migration guide](https://github.com/Arize-ai/phoenix/blob/main/MIGRATION.md) for step-by-step instructions.
@@ -297,8 +269,7 @@ Phoenix v14 removes several legacy APIs. See the [migration guide](https://githu
 - **Resume interrupted SDK experiments** — continue missing or failed runs with `resume_experiment` and `async_resume_experiment`
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.03.2026" href="/docs/phoenix/release-notes/04-2026/04-03-2026-atif-trajectory-upload">
-## [04.03.2026: ATIF Trajectory Upload](/docs/phoenix/release-notes/04-2026/04-03-2026-atif-trajectory-upload)
+<ReleaseUpdate label="04.03.2026" href="/docs/phoenix/release-notes/04-2026/04-03-2026-atif-trajectory-upload" title="ATIF Trajectory Upload">
 **Available in arize-phoenix-client 2.3.0+ (Python)**
 
 `upload_atif_trajectories_as_spans` converts [ATIF](https://github.com/harbor-ai/agent-trajectory-format) (Agent Trajectory Interchange Format) trajectory JSON files into OpenTelemetry span trees and uploads them to Phoenix. Visualize offline Harbor agent runs alongside live instrumented traces.
@@ -308,15 +279,13 @@ Phoenix v14 removes several legacy APIs. See the [migration guide](https://githu
 - **Idempotent** — trace/span IDs are derived from `session_id` via SHA-256; re-uploading the same file is safe
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.01.2026" href="/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314">
-## [04.01.2026: Python 3.14 Support](/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314)
+<ReleaseUpdate label="04.01.2026" href="/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314" title="Python 3.14 Support">
 **Available in arize-phoenix 13.21.0+, arize-phoenix-client 2.2.0+, arize-phoenix-evals 2.13.0+**
 
 Phoenix server, Python client SDK, and evals library now support Python 3.14 on Linux and macOS.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.01.2026" href="/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314">
-## [04.01.2026: Secrets Management REST API](/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314)
+<ReleaseUpdate label="04.01.2026" href="/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314" title="Secrets Management REST API">
 **Available in arize-phoenix 13.21.0+**
 
 Admin users can store encrypted LLM provider API keys in Phoenix via `PUT /v1/secrets`. Atomically upsert or delete multiple secrets in one request; values are AES-encrypted at rest and never returned in responses.
@@ -325,8 +294,7 @@ Admin users can store encrypted LLM provider API keys in Phoenix via `PUT /v1/se
 - **Admin-only**, atomic, silent no-op for deleting non-existent keys
 </ReleaseUpdate>
 
-<ReleaseUpdate label="04.01.2026" href="/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314">
-## [04.01.2026: `get_traces` — Retrieve Traces via Python SDK](/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314)
+<ReleaseUpdate label="04.01.2026" href="/docs/phoenix/release-notes/04-2026/04-01-2026-get-traces-secrets-api-and-python-314" title="`get_traces` — Retrieve Traces via Python SDK">
 **Available in arize-phoenix 13.15.0+ (server), arize-phoenix-client 2.2.0+ (Python)**
 
 `client.traces.get_traces()` fetches traces for a project with time range filtering, session filtering, sort control, and automatic cursor-based pagination.
@@ -336,8 +304,7 @@ Admin users can store encrypted LLM provider API keys in Phoenix via `PUT /v1/se
 - Async variant available on `AsyncClient`
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.30.2026" href="/docs/phoenix/release-notes/03-2026/03-30-2026-delete-prompts-api">
-## [03.30.2026: Delete Prompts and Prompt Version Tags](/docs/phoenix/release-notes/03-2026/03-30-2026-delete-prompts-api)
+<ReleaseUpdate label="03.30.2026" href="/docs/phoenix/release-notes/03-2026/03-30-2026-delete-prompts-api" title="Delete Prompts and Prompt Version Tags">
 **Available in arize-phoenix 13.20.0+**
 
 Two new REST endpoints let you delete prompts and remove tags from prompt versions programmatically.
@@ -347,8 +314,7 @@ Two new REST endpoints let you delete prompts and remove tags from prompt versio
 </ReleaseUpdate>
 
 
-<ReleaseUpdate label="03.24.2026" href="/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates">
-## [03.24.2026: Prompt Version Diff View](/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates)
+<ReleaseUpdate label="03.24.2026" href="/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates" title="Prompt Version Diff View">
 **Available in arize-phoenix 13.18.0+**
 
 The Prompts UI now shows a line-by-line diff between any two prompt versions. See exactly what changed — message content, tool call arguments, and tool results — without leaving Phoenix.
@@ -356,8 +322,7 @@ The Prompts UI now shows a line-by-line diff between any two prompt versions. Se
 - **Side-by-side diff** across the full chat template, including all content part types
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.24.2026" href="/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates">
-## [03.24.2026: Evals Accept Structured Data Inputs](/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates)
+<ReleaseUpdate label="03.24.2026" href="/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates" title="Evals Accept Structured Data Inputs">
 **Available in arize-phoenix-evals 2.12.0+**
 
 Evaluators now accept dicts and lists as template variable values, JSON-serializing them automatically. Built-in evaluators also accept `**kwargs` forwarded to the LLM on every call (e.g., `temperature=0.0`).
@@ -366,15 +331,13 @@ Evaluators now accept dicts and lists as template variable values, JSON-serializ
 - **LLM invocation kwargs** accepted by all built-in evaluators (`FaithfulnessEvaluator`, `CorrectnessEvaluator`, etc.)
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.23.2026" href="/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api">
-## [03.23.2026: `px auth status` Shows Username and Role](/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api)
+<ReleaseUpdate label="03.23.2026" href="/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api" title="`px auth status` Shows Username and Role">
 **Available in arize-phoenix 13.17.0+ and @arizeai/phoenix-cli 0.12.0+**
 
 `px auth status` now verifies credentials against the server and displays the authenticated username and role alongside the endpoint and token info.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.22.2026" href="/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api">
-## [03.22.2026: `px spans` — Fetch and Filter Spans from the CLI](/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api)
+<ReleaseUpdate label="03.22.2026" href="/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api" title="`px spans` — Fetch and Filter Spans from the CLI">
 **Available in arize-phoenix 13.16.0+ and @arizeai/phoenix-cli 0.12.0+**
 
 `px spans` fetches spans for a project with filtering by kind, status code, name, trace ID, and time window. Output to the terminal or save to JSON for offline use.
@@ -384,15 +347,13 @@ Evaluators now accept dicts and lists as template variable values, JSON-serializ
 - **`--include-annotations`** to attach span annotations to the output
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.22.2026" href="/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api">
-## [03.22.2026: `px self update` and `GET /v1/user`](/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api)
+<ReleaseUpdate label="03.22.2026" href="/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api" title="`px self update` and `GET /v1/user`">
 **Available in arize-phoenix 13.16.0+ and @arizeai/phoenix-cli 0.12.0+**
 
 `px self update` upgrades the installed CLI to the latest version, detecting npm, pnpm, bun, or Deno automatically. `GET /v1/user` returns the authenticated user's profile (username, email, role) or an anonymous representation when auth is disabled.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.18.2026" href="/docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements">
-## [03.18.2026: Span Filters — Name, Kind, and Status Code](/docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements)
+<ReleaseUpdate label="03.18.2026" href="/docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements" title="Span Filters — Name, Kind, and Status Code">
 **Available in arize-phoenix 13.15.0+ (server), arize-phoenix-client 2.1.0+ (Python), @arizeai/phoenix-client 6.5.1+ (TypeScript)**
 
 Filter spans directly by name, span kind (`LLM`, `CHAIN`, `TOOL`, etc.), and status code (`OK`, `ERROR`, `UNSET`) in both the REST API and SDK clients. Filters are OR-combined within a field and AND-combined across fields.
@@ -404,8 +365,7 @@ Filter spans directly by name, span kind (`LLM`, `CHAIN`, `TOOL`, etc.), and sta
 - **Available in TypeScript via `getSpans({ name, spanKind, statusCode })`**
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.13.2026" href="/docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements">
-## [03.13.2026: List Traces by Project](/docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements)
+<ReleaseUpdate label="03.13.2026" href="/docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements" title="List Traces by Project">
 **Available in arize-phoenix 13.15.0+**
 
 A new `GET /v1/projects/{project_identifier}/traces` REST endpoint lists traces with time filtering, sort order, cursor pagination, optional inline spans, and session filtering.
@@ -413,8 +373,7 @@ A new `GET /v1/projects/{project_identifier}/traces` REST endpoint lists traces 
 - **`GET /v1/projects/{project}/traces`** with `sort`, `order`, `limit`, `cursor`, `include_spans`, and `session_identifier` params
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.11.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
-## [03.11.2026: Session Turns API](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
+<ReleaseUpdate label="03.11.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api" title="Session Turns API">
 **Available in arize-phoenix-client 2.0.0+ (Python) and @arizeai/phoenix-client 6.4.0+ (TypeScript)**
 
 Phoenix now provides a dedicated session turns API that reconstructs the ordered input/output pairs across all traces in a session. The new `get_session_turns()` method (Python) and `getSessionTurns()` function (TypeScript) extract root span `input.value` / `output.value` attributes and return chronologically ordered `SessionTurn` objects.
@@ -425,8 +384,7 @@ Phoenix now provides a dedicated session turns API that reconstructs the ordered
 - **Async variants available** in both Python and TypeScript clients
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.10.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
-## [03.10.2026: Session Management REST APIs](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
+<ReleaseUpdate label="03.10.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api" title="Session Management REST APIs">
 **Available in arize-phoenix 13.13.0+ (server), arize-phoenix-client 1.31.0+ (Python), @arizeai/phoenix-client 6.1.0+ (TypeScript)**
 
 Phoenix now exposes comprehensive session management through REST API endpoints on the server. Retrieve individual sessions, list sessions with pagination and project filtering, and delete sessions with cascading cleanup of associated traces, spans, and annotations.
@@ -438,8 +396,7 @@ Phoenix now exposes comprehensive session management through REST API endpoints 
 - **Configurable timeouts** for all session operations
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.09.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
-## [03.09.2026: Filter Spans by Trace ID and Parent Relationships](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
+<ReleaseUpdate label="03.09.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api" title="Filter Spans by Trace ID and Parent Relationships">
 **Available in arize-phoenix 13.12.0+ (server), arize-phoenix-client 2.0.0+ (Python), @arizeai/phoenix-client 6.3.0+ (TypeScript)**
 
 Span queries now support filtering by trace ID and parent relationships, enabling precise navigation of trace hierarchies. Query for root spans using `parent_id=null` or retrieve all children of a specific parent span to reconstruct execution trees programmatically.
@@ -450,22 +407,19 @@ Span queries now support filtering by trace ID and parent relationships, enablin
 - **Composable with existing filters** like time ranges and limits
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.04.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
-## [03.04.2026: Incremental Evaluation Metrics in Playground](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
+<ReleaseUpdate label="03.04.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api" title="Incremental Evaluation Metrics in Playground">
 **Available in arize-phoenix 13.8.0+**
 
 The Playground now displays evaluation metrics, cost, and latency aggregates in real-time as dataset experiments run. Metrics update incrementally every ~2 seconds, providing immediate feedback on experiment performance without waiting for completion.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.04.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
-## [03.04.2026: Brute Force Login Protection](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
+<ReleaseUpdate label="03.04.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api" title="Brute Force Login Protection">
 **Available in arize-phoenix 13.8.0+**
 
 Phoenix now automatically protects login endpoints against brute force attacks. After 5 consecutive failed attempts, the account is temporarily locked for 5 minutes. Enabled by default with configurable thresholds via `PHOENIX_BRUTE_FORCE_LOGIN_PROTECTION_MAX_ATTEMPTS`.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.07.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
-## [03.07.2026: Unified Dataset Upload with Drag-and-Drop](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
+<ReleaseUpdate label="03.07.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api" title="Unified Dataset Upload with Drag-and-Drop">
 **Available in arize-phoenix 13.9.0+**
 
 Dataset creation from files is now streamlined with automatic file type detection and a unified upload experience. Drag-and-drop CSV or JSONL files anywhere in the upload form, and Phoenix automatically parses headers and previews data without loading entire files into memory.
@@ -477,8 +431,7 @@ Dataset creation from files is now streamlined with automatic file type detectio
 - **Detailed error messages** for parsing issues with line-by-line feedback
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.10.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
-## [03.10.2026: Drag-and-Drop Column Assignment for Datasets](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
+<ReleaseUpdate label="03.10.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api" title="Drag-and-Drop Column Assignment for Datasets">
 **Available in arize-phoenix 13.13.0+**
 
 Dataset creation now features an intuitive drag-and-drop column assignment interface. Assign columns to input, output, or metadata buckets with automatic suggestions based on common naming conventions, and preview exactly how your data will appear in the final dataset.
@@ -490,8 +443,7 @@ Dataset creation now features an intuitive drag-and-drop column assignment inter
 - **Raw data preview** in tabular format alongside final dataset view
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.08.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
-## [03.08.2026: Extended Model Provider Support](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
+<ReleaseUpdate label="03.08.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api" title="Extended Model Provider Support">
 **Available in arize-phoenix 13.10.0+ (Cerebras, Fireworks, Groq, Moonshot) and arize-phoenix 13.11.0+ (Perplexity, Together AI)**
 
 Phoenix Playground now supports six additional OpenAI-compatible model providers: Perplexity AI, Together AI, Cerebras, Fireworks AI, Groq, and Moonshot (Kimi). Access hundreds of new models including specialized reasoning models and fine-tuned variants through familiar OpenAI-compatible APIs.
@@ -505,8 +457,7 @@ Phoenix Playground now supports six additional OpenAI-compatible model providers
 - **Cost tracking enabled** for Cerebras, Fireworks, Groq, and Moonshot
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.10.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
-## [03.10.2026: Provider Visibility Controls](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
+<ReleaseUpdate label="03.10.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api" title="Provider Visibility Controls">
 **Available in arize-phoenix 13.13.0+**
 
 Control which model providers appear in the Phoenix UI using the `PHOENIX_ALLOWED_PROVIDERS` environment variable. Set it to a comma-separated list of provider names to show only those providers, keeping your interface focused on the tools you actually use.
@@ -516,41 +467,34 @@ Control which model providers appear in the Phoenix UI using the `PHOENIX_ALLOWE
 - **Set to NONE** to hide all providers from the UI
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.08.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
-## [03.08.2026: Latest OpenAI GPT Models](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
+<ReleaseUpdate label="03.08.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api" title="Latest OpenAI GPT Models">
 **Available in arize-phoenix 13.10.0+**
 
 Phoenix Playground now includes the latest OpenAI models: GPT-5.4 family, GPT-5.3-chat-latest, GPT-5.2-pro variants, and o3-pro-2025-06-10. All models include cost tracking and are ready to use in experiments and prompt testing.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.08.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
-## [03.08.2026: Project Editing from Settings](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
+<ReleaseUpdate label="03.08.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api" title="Project Editing from Settings">
 **Available in arize-phoenix 13.10.0+**
 
 Edit project descriptions and customize gradient colors directly from the Project Settings page. Click the edit button to update project metadata inline, with changes persisting immediately across the Phoenix UI.
 </ReleaseUpdate>
 
 
-<ReleaseUpdate label="03.11.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api">
-## [03.11.2026: Breaking Change: Removed Deprecated Annotations API](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
+<ReleaseUpdate label="03.11.2026" href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api" title="Breaking Change: Removed Deprecated Annotations API">
 **Breaking change in arize-phoenix-client 2.0.0**
 
 The deprecated `client.annotations` module has been removed. All annotation methods remain available on `client.spans`. Update your code to use `client.spans.add_span_annotation()` and `client.spans.log_span_annotations()` instead of the `client.annotations` variants.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="03.05.2026" href="/docs/phoenix/release-notes/03-2026/03-05-2026-sdk-session-retrieval">
-## [03.05.2026: SDK Session Retrieval](/docs/phoenix/release-notes/03-2026/03-05-2026-sdk-session-retrieval)
+<ReleaseUpdate label="03.05.2026" href="/docs/phoenix/release-notes/03-2026/03-05-2026-sdk-session-retrieval" title="SDK Session Retrieval">
 Session retrieval is now available in the Python client (`client.sessions.get()`, `client.sessions.list()`, `get_sessions_dataframe()`) and the TypeScript client (`getSession()`, `listSessions()`). Both SDKs support automatic pagination and async usage for working with session turns data.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="02.27.2026" href="/docs/phoenix/release-notes/02-2026/02-27-2026-cli-sessions-and-rest-api">
-## [02.27.2026: Sessions API and CLI Support](/docs/phoenix/release-notes/02-2026/02-27-2026-cli-sessions-and-rest-api)
+<ReleaseUpdate label="02.27.2026" href="/docs/phoenix/release-notes/02-2026/02-27-2026-cli-sessions-and-rest-api" title="Sessions API and CLI Support">
 REST API endpoints for listing and getting sessions (`GET /v1/sessions`, `GET /v1/sessions/{id}`) and CLI commands (`px sessions`, `px session <id>`) for exploring multi-turn conversations from the terminal.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="02.24.2026" href="/docs/phoenix/integrations/typescript/claude-agent-sdk">
-## 02.24.2026: Claude Agent SDK Integration
-
+<ReleaseUpdate label="02.24.2026" href="/docs/phoenix/integrations/typescript/claude-agent-sdk" title="Claude Agent SDK Integration">
 Phoenix now supports tracing for [Anthropic's Claude Agent SDK](https://docs.anthropic.com/en/docs/agents/claude-agent-sdk) via a new OpenInference instrumentation package. The integration automatically captures **AGENT** and **TOOL** spans, giving you full visibility into your Claude Agent SDK applications.
 
 - Install `@arizeai/openinference-instrumentation-claude-agent-sdk` alongside `@arizeai/phoenix-otel`
@@ -558,8 +502,7 @@ Phoenix now supports tracing for [Anthropic's Claude Agent SDK](https://docs.ant
 - [Get started →](/docs/phoenix/integrations/typescript/claude-agent-sdk)
 </ReleaseUpdate>
 
-<ReleaseUpdate label="02.14.2026" href="/docs/phoenix/release-notes/02-2026/02-14-2026-phoenix-13-0">
-## [02.14.2026: Phoenix 13.0](/docs/phoenix/release-notes/02-2026/02-14-2026-phoenix-13-0)
+<ReleaseUpdate label="02.14.2026" href="/docs/phoenix/release-notes/02-2026/02-14-2026-phoenix-13-0" title="Phoenix 13.0">
 **Phoenix 13.0** is a major release centered on **Dataset Evaluators**, with support for **custom model providers**, **OpenAI Responses API type selection**, and extensive **Playground** and **dataset/experiment UX** improvements.
 
 Highlights include:
@@ -571,8 +514,7 @@ Highlights include:
 - Get expanded dataset and experiment ergonomics, model/provider updates (including Claude Opus 4.6 and Azure OpenAI v1 migration), and infrastructure improvements like a session ID index for spans.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="02.12.2026" href="/docs/phoenix/release-notes/02-2026/02-12-2026-openai-responses-api-support">
-## [02.12.2026: OpenAI Responses API Type Support](/docs/phoenix/release-notes/02-2026/02-12-2026-openai-responses-api-support)
+<ReleaseUpdate label="02.12.2026" href="/docs/phoenix/release-notes/02-2026/02-12-2026-openai-responses-api-support" title="OpenAI Responses API Type Support">
 Phoenix now supports selecting the **OpenAI API type** for OpenAI and Azure OpenAI calls in the Playground and custom providers. Choose **Chat Completions** (`chat.completions.create`) or **Responses** (`responses.create`) depending on the model and features you want to use.
 
 **Key capabilities:**
@@ -584,8 +526,7 @@ Phoenix now supports selecting the **OpenAI API type** for OpenAI and Azure Open
 To get started, open the Playground model configuration panel and select an **OpenAI API type**, or set it in **Settings → AI Providers → Custom Providers** for server-managed routing.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="02.12.2026" href="/docs/phoenix/release-notes/02-2026/02-12-2026-dataset-evaluators">
-## [02.12.2026: Dataset Evaluators](/docs/phoenix/release-notes/02-2026/02-12-2026-dataset-evaluators)
+<ReleaseUpdate label="02.12.2026" href="/docs/phoenix/release-notes/02-2026/02-12-2026-dataset-evaluators" title="Dataset Evaluators">
 **Requires Phoenix 13.x.**
 **Dataset evaluators** let you attach evaluators directly to a dataset so they automatically run server-side whenever you execute experiments from the Phoenix UI (for example, from the Playground). This turns your dataset into a reusable evaluation suite and removes the need to reconfigure evaluators for every experiment.
 
@@ -598,8 +539,7 @@ To get started, open the Playground model configuration panel and select an **Op
 To get started, open a dataset, navigate to the **Evaluators** tab, click **Add evaluator**, configure your input mapping, and run an experiment from the Playground to see server-side scores and traces.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="02.11.2026" href="/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers">
-## [02.11.2026: Custom Providers for Playground and Prompts](/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers)
+<ReleaseUpdate label="02.11.2026" href="/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers" title="Custom Providers for Playground and Prompts">
 Phoenix now supports **custom providers** for OpenAI, Azure OpenAI, Anthropic, AWS Bedrock, and Google GenAI. Custom providers let you store provider credentials and routing configuration on the server and reuse them across the playground and saved prompt versions.
 
 ![Custom provider configuration in Phoenix](https://storage.googleapis.com/arize-phoenix-assets/assets/images/custom-provider-config.png)
@@ -614,8 +554,7 @@ Phoenix now supports **custom providers** for OpenAI, Azure OpenAI, Anthropic, A
 To get started, open **Settings → AI Providers → Custom Providers**, create a provider configuration, and select it from the model menu in the playground.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="02.09.2026" href="/docs/phoenix/release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support">
-## [02.09.2026: Claude Opus 4.6 Model Support](/docs/phoenix/release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support)
+<ReleaseUpdate label="02.09.2026" href="/docs/phoenix/release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support" title="Claude Opus 4.6 Model Support">
 Phoenix playground now supports Claude Opus 4.6, Anthropic's latest flagship model. Select `claude-opus-4-6` in the Anthropic provider or `anthropic.claude-opus-4-6-v1` in AWS Bedrock to start using the model with full extended thinking parameter support and accurate cost tracking.
 
 **Key capabilities:**
@@ -627,8 +566,7 @@ Phoenix playground now supports Claude Opus 4.6, Anthropic's latest flagship mod
 The model appears in playground dropdowns alongside other Claude models and inherits the same reasoning capabilities as other Claude 4.x models.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="01.31.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
-## [01.31.2026: Tool Selection and Tool Invocation Evaluators](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+<ReleaseUpdate label="01.31.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators" title="Tool Selection and Tool Invocation Evaluators">
 **Available in arize-phoenix-evals 0.16.0+ (Python) and @arizeai/phoenix-evals 1.3.0+ (TypeScript)**
 
 Phoenix now provides two specialized evaluators for assessing AI agent tool usage. The **Tool Selection Evaluator** judges whether an agent correctly chose the most appropriate tool from its available toolkit to answer a user's question, without evaluating the parameters passed. The **Tool Invocation Evaluator** assesses whether the agent correctly invoked a tool with proper parameters, JSON formatting, and safe values.
@@ -642,8 +580,7 @@ These evaluators help developers:
 Both evaluators are available as `ToolSelectionEvaluator` and `ToolInvocationEvaluator` in Python's `phoenix.evals.metrics` module, and as `createToolSelectionEvaluator` and `createToolInvocationEvaluator` in TypeScript.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="01.28.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
-## [01.28.2026: Configurable Email Extraction for OAuth2 Providers](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+<ReleaseUpdate label="01.28.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators" title="Configurable Email Extraction for OAuth2 Providers">
 **Available in Phoenix 12.33.1+**
 
 Phoenix now supports custom email extraction from OAuth2 identity providers through the `PHOENIX_OAUTH2_{IDP}_EMAIL_ATTRIBUTE_PATH` environment variable. This solves authentication issues with providers like Azure AD/Entra ID where the standard `email` claim may be null but alternative claims like `preferred_username` contain the user's identity.
@@ -653,21 +590,18 @@ Configure email extraction using JMESPath expressions:
 ```bash
 </ReleaseUpdate>
 
-<ReleaseUpdate label="02.01.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
-## [02.01.2026: Extract from Azure AD preferred_username claim](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+<ReleaseUpdate label="02.01.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators" title="Extract from Azure AD preferred_username claim">
 PHOENIX_OAUTH2_AZURE_AD_EMAIL_ATTRIBUTE_PATH=preferred_username
 </ReleaseUpdate>
 
-<ReleaseUpdate label="02.01.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
-## [02.01.2026: Extract from nested claims](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+<ReleaseUpdate label="02.01.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators" title="Extract from nested claims">
 PHOENIX_OAUTH2_CUSTOM_IDP_EMAIL_ATTRIBUTE_PATH=user.contact.email
 ```
 
 The default behavior remains unchanged, using the standard OIDC `email` claim when no custom path is specified. JMESPath expressions are validated at startup for immediate feedback on configuration errors.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="01.22.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
-## [01.22.2026: CLI Commands for Prompts, Datasets, and Experiments](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+<ReleaseUpdate label="01.22.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators" title="CLI Commands for Prompts, Datasets, and Experiments">
 **Available in @arizeai/phoenix-cli 0.4.0+**
 
 The Phoenix CLI now provides comprehensive commands for managing prompts, datasets, and experiments directly from your terminal. Access version-controlled prompts, create evaluation datasets, and run experiments—all without leaving your development environment.
@@ -690,15 +624,13 @@ The Phoenix CLI now provides comprehensive commands for managing prompts, datase
 These commands integrate seamlessly with AI coding assistants and enable systematic testing of LLM applications through terminal-based workflows.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="01.23.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
-## [01.23.2026: CLI Authentication Configuration](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+<ReleaseUpdate label="01.23.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators" title="CLI Authentication Configuration">
 **Available in @arizeai/phoenix-cli 0.4.0+**
 
 The Phoenix CLI now includes enhanced authentication configuration commands, resolving database race conditions and improving connection reliability. Users can configure authentication settings directly through the CLI for more predictable and stable connections to Phoenix servers.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="01.21.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
-## [01.21.2026: Create Datasets from Traces with Span Associations](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+<ReleaseUpdate label="01.21.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators" title="Create Datasets from Traces with Span Associations">
 **Available in arize-phoenix-client 1.28.0+ (Python) and @arizeai/phoenix-client 2.0.0+ (TypeScript)**
 
 Phoenix now enables converting production traces into curated datasets while preserving bidirectional links back to source spans. Use the new `span_id_key` parameter to maintain traceability from evaluation examples to their original production executions.
@@ -739,8 +671,7 @@ Key capabilities:
 - **Bidirectional navigation** between evaluation results and production traces
 </ReleaseUpdate>
 
-<ReleaseUpdate label="01.19.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators">
-## [01.19.2026: Export Annotations with Traces](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+<ReleaseUpdate label="01.19.2026" href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators" title="Export Annotations with Traces">
 **Available in @arizeai/phoenix-cli 0.3.0+**
 
 The Phoenix CLI now supports exporting annotations alongside traces using the `--include-annotations` flag. Annotations—including manual labels, LLM evaluation scores, and programmatic feedback—are now preserved when exporting traces for offline analysis, backup, or migration workflows.
@@ -752,104 +683,104 @@ px traces export --include-annotations > traces_with_feedback.jsonl
 This enables teams to maintain complete evaluation history when moving data between environments or conducting retrospective analysis of model performance.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="01.22.2026" href="/docs/phoenix/release-notes/01-2026/01-22-2026-cli-prompt-commands">
-## [01.22.2026: CLI Prompt Commands: Pipe Prompts to AI Assistants](/docs/phoenix/release-notes/01-2026/01-22-2026-cli-prompt-commands) 📝
+<ReleaseUpdate label="01.22.2026" href="/docs/phoenix/release-notes/01-2026/01-22-2026-cli-prompt-commands" title="CLI Prompt Commands: Pipe Prompts to AI Assistants">
+📝
 
 **Available in @arizeai/phoenix-cli 0.4.0+**
 
 Phoenix CLI now supports prompt introspection with `px prompts` and `px prompt`. List prompts, view their content, and pipe them directly to AI assistants like Claude Code for optimization suggestions. The `--format text` option outputs prompts with XML-style role tags, ideal for analysis workflows.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="01.21.2026" href="/docs/phoenix/release-notes/01-2026/01-21-2026-create-datasets-from-traces">
-## [01.21.2026: Create Datasets from Traces with Span Associations](/docs/phoenix/release-notes/01-2026/01-21-2026-create-datasets-from-traces) 🔗
+<ReleaseUpdate label="01.21.2026" href="/docs/phoenix/release-notes/01-2026/01-21-2026-create-datasets-from-traces" title="Create Datasets from Traces with Span Associations">
+🔗
 
 **Available in arize-phoenix-client 1.28.0+ (Python) and @arizeai/phoenix-client 2.0.0+ (TypeScript)**
 
 The Phoenix client now enables converting production traces into curated datasets while preserving associations back to source spans. Query spans using client methods, then create datasets with span associations to maintain bidirectional links. Use this to build golden datasets from validated interactions, curate edge cases from failed traces, or create regression test suites from critical user flows.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="01.21.2026" href="/docs/phoenix/release-notes/01-2026/01-21-2026-cli-datasets-experiments-annotations">
-## [01.21.2026: Phoenix CLI: Datasets, Experiments & Annotations](/docs/phoenix/release-notes/01-2026/01-21-2026-cli-datasets-experiments-annotations) 🧪
+<ReleaseUpdate label="01.21.2026" href="/docs/phoenix/release-notes/01-2026/01-21-2026-cli-datasets-experiments-annotations" title="Phoenix CLI: Datasets, Experiments & Annotations">
+🧪
 
 **Available in @arizeai/phoenix-cli 0.2.0+**
 
 The Phoenix CLI now supports datasets, experiments, and annotations. Pull evaluation data, export experiment results, and access human feedback directly from the terminal. Works well with AI coding assistants for analyzing test cases and reviewing results.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="01.17.2026" href="/docs/phoenix/release-notes/01-2026/01-17-2026-phoenix-cli-ai-agent-debugging">
-## [01.17.2026: Phoenix CLI: Terminal Access for AI Coding Assistants](/docs/phoenix/release-notes/01-2026/01-17-2026-phoenix-cli-ai-agent-debugging) 🖥️
+<ReleaseUpdate label="01.17.2026" href="/docs/phoenix/release-notes/01-2026/01-17-2026-phoenix-cli-ai-agent-debugging" title="Phoenix CLI: Terminal Access for AI Coding Assistants">
+🖥️
 
 **Available in @arizeai/phoenix-cli 0.1.0+**
 
 AI coding assistants operate through terminals and files—they run shell commands, read output, and process data. The new Phoenix CLI makes trace data accessible through these interfaces, enabling tools like Claude Code, Cursor, and Windsurf to query your Phoenix instance directly. Export traces to JSON, pipe to `jq`, or save to disk for analysis.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="01.05.2026" href="/docs/phoenix/release-notes/01-2026/01-05-2026-appended-messages-for-playground-experiments">
-## [01.05.2026: Appended Messages for Playground Experiments](/docs/phoenix/release-notes/01-2026/01-05-2026-appended-messages-for-playground-experiments) 💬
+<ReleaseUpdate label="01.05.2026" href="/docs/phoenix/release-notes/01-2026/01-05-2026-appended-messages-for-playground-experiments" title="Appended Messages for Playground Experiments">
+💬
 
 **Available in Phoenix 13.0+**
 
 The Prompt Playground now supports appending conversation history from dataset examples to your prompts. This enables powerful A/B testing workflows for comparing models and system prompts against the same conversation threads. Specify a dot-notation path to messages in your dataset (e.g., `messages` or `input.messages`) and run experiments across all prompt variants.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="12.20.2025" href="/docs/phoenix/release-notes/12-2025/12-20-2025-improved-user-preferences">
-## [12.20.2025: Improved User Preferences](/docs/phoenix/release-notes/12-2025/12-20-2025-improved-user-preferences) ⚙️
+<ReleaseUpdate label="12.20.2025" href="/docs/phoenix/release-notes/12-2025/12-20-2025-improved-user-preferences" title="Improved User Preferences">
+⚙️
 
 **Available in Phoenix 12.27+**
 
 Phoenix now offers enhanced user preference settings, giving you more control over your experience. This update includes theme selection in viewer preferences and programming language preference.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="12.12.2025" href="/docs/phoenix/release-notes/12-2025/12-12-2025-support-for-gemini-tool-calls">
-## [12.12.2025: Support for Gemini Tool Calls](/docs/phoenix/release-notes/12-2025/12-12-2025-support-for-gemini-tool-calls) 🤖
+<ReleaseUpdate label="12.12.2025" href="/docs/phoenix/release-notes/12-2025/12-12-2025-support-for-gemini-tool-calls" title="Support for Gemini Tool Calls">
+🤖
 
 **Available in Phoenix 12.25+**
 
 Phoenix now supports Gemini tool calls, enabling enhanced integration capabilities with Google's Gemini models. This update allows for more robust and feature-complete interactions with Gemini, including improved request/response translation and advanced conversation handling with tool calls.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="12.09.2025" href="/docs/phoenix/release-notes/12-2025/12-09-2025-span-notes-api">
-## [12.09.2025: Span Notes API](/docs/phoenix/release-notes/12-2025/12-09-2025-span-notes-api) 📝
+<ReleaseUpdate label="12.09.2025" href="/docs/phoenix/release-notes/12-2025/12-09-2025-span-notes-api" title="Span Notes API">
+📝
 
 **Available in Phoenix 12.21+**
 
 New dedicated endpoints for span notes enable open coding and seamless annotation integrations. Add notes to spans programmatically using the Phoenix client in both Python and TypeScript—perfect for debugging sessions, human feedback, and building custom annotation pipelines.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="12.06.2025" href="/docs/phoenix/release-notes/12-2025/12-06-2025-ldap-authentication-support">
-## [12.06.2025: LDAP Authentication Support](/docs/phoenix/release-notes/12-2025/12-06-2025-ldap-authentication-support) 🔐
+<ReleaseUpdate label="12.06.2025" href="/docs/phoenix/release-notes/12-2025/12-06-2025-ldap-authentication-support" title="LDAP Authentication Support">
+🔐
 
 **Available in Phoenix 12.20+**
 
 Phoenix now supports authentication against LDAP directories, enabling integration with enterprise identity infrastructure including Microsoft Active Directory, OpenLDAP, and any LDAP v3 compliant directory. Key features include group-based role mapping, multi-server failover, TLS encryption, and automatic user provisioning.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="12.04.2025" href="/docs/phoenix/release-notes/12-2025/12-04-2025-evaluator-message-formats">
-## [12.04.2025: Evaluator Message Formats](/docs/phoenix/release-notes/12-2025/12-04-2025-evaluator-message-formats) 💬
+<ReleaseUpdate label="12.04.2025" href="/docs/phoenix/release-notes/12-2025/12-04-2025-evaluator-message-formats" title="Evaluator Message Formats">
+💬
 
 **Available in phoenix-evals 0.22+ (Python) and @arizeai/phoenix-evals 2.0+ (TypeScript)**
 
 Phoenix evaluators now support flexible prompt formats including simple string templates and OpenAI-style message arrays for multi-turn prompts. Python supports both f-string and mustache syntax, while TypeScript uses mustache syntax. Adapters handle provider-specific transformations automatically.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="12.03.2025" href="/docs/phoenix/release-notes/12-2025/12-03-2025-typescript-create-evaluator">
-## [12.03.2025: TypeScript createEvaluator](/docs/phoenix/release-notes/12-2025/12-03-2025-typescript-create-evaluator) 🧪
+<ReleaseUpdate label="12.03.2025" href="/docs/phoenix/release-notes/12-2025/12-03-2025-typescript-create-evaluator" title="TypeScript createEvaluator">
+🧪
 
 **Available in @arizeai/phoenix-evals 2.0+**
 
 The `createEvaluator` utility provides a type-safe way to build custom code evaluators for experiments in TypeScript. Define evaluators with full type inference, access `input`, `output`, `expected`, and `metadata` parameters, and integrate seamlessly with `runExperiment`.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="12.01.2025" href="/docs/phoenix/release-notes/12-2025/12-01-2025-splits-on-experiments-table">
-## [12.01.2025: Splits on Experiments Table](/docs/phoenix/release-notes/12-2025/12-01-2025-splits-on-experiments-table) 📊
+<ReleaseUpdate label="12.01.2025" href="/docs/phoenix/release-notes/12-2025/12-01-2025-splits-on-experiments-table" title="Splits on Experiments Table">
+📊
 
 **Available in Phoenix 12.20+**
 
 You can now view and filter experiment results by data splits directly in the experiments table. This enhancement makes it easier to analyze performance across different data subsets (such as train, validation, and test) and compare how your models perform on each split.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="11.29.2025" href="/docs/phoenix/release-notes/11-2025/11-29-2025-add-support-for-claude-opus-4-5">
-## [11.29.2025: Add support for Claude Opus 4-5](/docs/phoenix/release-notes/11-2025/11-29-2025-add-support-for-claude-opus-4-5) 🤖
+<ReleaseUpdate label="11.29.2025" href="/docs/phoenix/release-notes/11-2025/11-29-2025-add-support-for-claude-opus-4-5" title="Add support for Claude Opus 4-5">
+🤖
 
 **Available in Phoenix 12.18+**
 
@@ -860,8 +791,8 @@ You can now view and filter experiment results by data splits directly in the ex
 Phoenix now supports Claude Opus 4 and 4-5 as models you can invoke from the Playground.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="11.27.2025" href="/docs/phoenix/release-notes/11-2025/11-27-2025-show-server-credential-setup-in-playground-api-keys">
-## [11.27.2025: Show Server Credential Setup in Playground API Keys](/docs/phoenix/release-notes/11-2025/11-27-2025-show-server-credential-setup-in-playground-api-keys) 🔐
+<ReleaseUpdate label="11.27.2025" href="/docs/phoenix/release-notes/11-2025/11-27-2025-show-server-credential-setup-in-playground-api-keys" title="Show Server Credential Setup in Playground API Keys">
+🔐
 
 **Available in Phoenix 12.18+**
 
@@ -872,8 +803,8 @@ Phoenix now supports Claude Opus 4 and 4-5 as models you can invoke from the Pla
 The Playground now clearly indicates when server credentials are configured.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="11.25.2025" href="/docs/phoenix/release-notes/11-2025/11-25-2025-split-assignments-when-uploading-a-dataset">
-## [11.25.2025: Split Assignments When Uploading a Dataset](/docs/phoenix/release-notes/11-2025/11-25-2025-split-assignments-when-uploading-a-dataset) 🗂️
+<ReleaseUpdate label="11.25.2025" href="/docs/phoenix/release-notes/11-2025/11-25-2025-split-assignments-when-uploading-a-dataset" title="Split Assignments When Uploading a Dataset">
+🗂️
 
 **Available in Phoenix 12.18+**
 
@@ -884,8 +815,8 @@ The Playground now clearly indicates when server credentials are configured.
 You can now assign data splits (ex: train/test/validation) directly when uploading a dataset into Arize Phoenix.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="11.23.2025" href="/docs/phoenix/release-notes/11-2025/11-23-2025-repetitions-for-manual-playground-invocations">
-## [11.23.2025: Repetitions for Manual Playground Invocations](/docs/phoenix/release-notes/11-2025/11-23-2025-repetitions-for-manual-playground-invocations) 🛝
+<ReleaseUpdate label="11.23.2025" href="/docs/phoenix/release-notes/11-2025/11-23-2025-repetitions-for-manual-playground-invocations" title="Repetitions for Manual Playground Invocations">
+🛝
 
 **Available in Phoenix 12.17+**
 
@@ -896,24 +827,24 @@ You can now assign data splits (ex: train/test/validation) directly when uploadi
 This update adds an easy way to run several repetitions of the same prompt directly from the Playground.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="11.14.2025" href="/docs/phoenix/release-notes/11-2025/11-19-2025-expanded-provider-support-with-openai-5-1-+-gemini-3">
-## [11.14.2025: Expanded Provider Support with OpenAI 5.1 + Gemini 3](/docs/phoenix/release-notes/11-2025/11-19-2025-expanded-provider-support-with-openai-5-1-+-gemini-3) 🔧
+<ReleaseUpdate label="11.14.2025" href="/docs/phoenix/release-notes/11-2025/11-19-2025-expanded-provider-support-with-openai-5-1-+-gemini-3" title="Expanded Provider Support with OpenAI 5.1 + Gemini 3">
+🔧
 
 **Available in Phoenix 12.15+**
 
 This update enhances LLM provider support by adding **OpenAI v5.1** compatibility (including reasoning capabilities), expanding support for **Google DeepMind/Gemini** models, and introducing the **gemini-3** model variant.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="11.12.2025" href="/docs/phoenix/release-notes/11-2025/11-12-2025-updated-anthropic-model-list">
-## [11.12.2025: Updated Anthropic Model List](/docs/phoenix/release-notes/11-2025/11-12-2025-updated-anthropic-model-list) 🧠
+<ReleaseUpdate label="11.12.2025" href="/docs/phoenix/release-notes/11-2025/11-12-2025-updated-anthropic-model-list" title="Updated Anthropic Model List">
+🧠
 
 **Available in Phoenix 12.15+**
 
 This update enhances the Anthropic model registrations in Arize Phoenix by adding support for the **4.5 Sonnet/Haiku variants** and removing several legacy **3.x Sonnet/Opus entries.**
 </ReleaseUpdate>
 
-<ReleaseUpdate label="11.09.2025" href="/docs/phoenix/release-notes/11-2025/11-09-2025-openinference-typescript-2-0">
-## [11.09.2025: OpenInference TypeScript 2.0](/docs/phoenix/release-notes/11-2025/11-09-2025-openinference-typescript-2-0) 💻
+<ReleaseUpdate label="11.09.2025" href="/docs/phoenix/release-notes/11-2025/11-09-2025-openinference-typescript-2-0" title="OpenInference TypeScript 2.0">
+💻
 
 <Frame>
   <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/traced_agent.mp4" alt="traced agent" />
@@ -926,8 +857,8 @@ This update enhances the Anthropic model registrations in Arize Phoenix by addin
 * Overall, tracing workflows, agent behavior, and external tool calls is now significantly simpler and more consistent across languages.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="11.07.2025" href="/docs/phoenix/release-notes/11-2025/11-07-2025-timezone-preference">
-## [11.07.2025: Timezone Preference](/docs/phoenix/release-notes/11-2025/11-07-2025-timezone-preference) 🌍
+<ReleaseUpdate label="11.07.2025" href="/docs/phoenix/release-notes/11-2025/11-07-2025-timezone-preference" title="Timezone Preference">
+🌍
 
 **Available in Phoenix 12.11+**
 
@@ -938,8 +869,8 @@ This update enhances the Anthropic model registrations in Arize Phoenix by addin
 This update adds a new **display timezone preference** feature for users: you can now specify how timestamps are shown across the UI, making time-based data more intuitive and aligned with your locale.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="11.05.2025" href="/docs/phoenix/release-notes/11-2025/11-05-2025-metadata-for-prompts">
-## [11.05.2025: Metadata for Prompts](/docs/phoenix/release-notes/11-2025/11-05-2025-metadata-for-prompts) 🗂️
+<ReleaseUpdate label="11.05.2025" href="/docs/phoenix/release-notes/11-2025/11-05-2025-metadata-for-prompts" title="Metadata for Prompts">
+🗂️
 
 **Available in Phoenix 12.10+**
 
@@ -950,8 +881,8 @@ This update adds a new **display timezone preference** feature for users: you ca
 Added full prompt-level metadata support across API, UI, and clients: you can now create, clone, patch, and display a JSON `metadata` field for prompts.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="11.03.2025" href="/docs/phoenix/release-notes/11-2025/11-03-2025-playground-dataset-label-display">
-## [11.03.2025: Playground Dataset Label Display](/docs/phoenix/release-notes/11-2025/11-03-2025-playground-dataset-label-display) 🏷️
+<ReleaseUpdate label="11.03.2025" href="/docs/phoenix/release-notes/11-2025/11-03-2025-playground-dataset-label-display" title="Playground Dataset Label Display">
+🏷️
 
 **Available in Phoenix 12.10+**
 
@@ -962,16 +893,16 @@ Added full prompt-level metadata support across API, UI, and clients: you can no
 You can now view dataset labels as you load datasets into the Playground. This enhancement makes it easier to identify and select your desired dataset.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="11.01.2025" href="/docs/phoenix/release-notes/11-2025/11-01-2025-resume-experiments-and-evaluations">
-## [11.01.2025: Resume Experiments and Evaluations](/docs/phoenix/release-notes/11-2025/11-01-2025-resume-experiments-and-evaluations) 🔄
+<ReleaseUpdate label="11.01.2025" href="/docs/phoenix/release-notes/11-2025/11-01-2025-resume-experiments-and-evaluations" title="Resume Experiments and Evaluations">
+🔄
 
 **Available in Phoenix 12.10+**
 
 This release allows you to resume your experiments and evaluations at your convenience. If certain examples fail, there is no need to repeat an entire task you already completed. This feature provides you with new management capabilities across servers and clients. It's designed to save effort, making your experimentation workflow more flexible.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="10.30.2025" href="/docs/phoenix/release-notes/10-2025/10-30-2025-metadata-support-for-experiment-run-annotations">
-## [10.30.2025: Metadata Support for Experiment Run Annotations](/docs/phoenix/release-notes/10-2025/10-30-2025-metadata-support-for-experiment-run-annotations) 🧩
+<ReleaseUpdate label="10.30.2025" href="/docs/phoenix/release-notes/10-2025/10-30-2025-metadata-support-for-experiment-run-annotations" title="Metadata Support for Experiment Run Annotations">
+🧩
 
 **Available in Phoenix 12.9+**
 
@@ -982,16 +913,16 @@ This release allows you to resume your experiments and evaluations at your conve
 Added **metadata support for experiment run annotations**, with GraphQL updates to fetch and expose this information. The annotation details view now displays formatted JSON metadata across both **compare** and **example** views for easier inspection and debugging.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="10.28.2025" href="/docs/phoenix/release-notes/10-2025/10-28-2025-enable-aws-iam-auth-for-db-configuration">
-## [10.28.2025: Enable AWS IAM Auth for DB Configuration](/docs/phoenix/release-notes/10-2025/10-28-2025-enable-aws-iam-auth-for-db-configuration) 🔐
+<ReleaseUpdate label="10.28.2025" href="/docs/phoenix/release-notes/10-2025/10-28-2025-enable-aws-iam-auth-for-db-configuration" title="Enable AWS IAM Auth for DB Configuration">
+🔐
 
 **Available in Phoenix 12.9+**
 
 Added support for **AWS IAM–based authentication** for PostgreSQL connections to **AWS Aurora and RDS**. This enhancement enables the use of **short-lived IAM tokens** instead of static passwords, improving security and compliance for database access.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="10.26.2025" href="/docs/phoenix/release-notes/10-2025/10-26-2025-add-split-edit-menu-to-examples">
-## [10.26.2025: Add Split Edit Menu to Examples](/docs/phoenix/release-notes/10-2025/10-26-2025-add-split-edit-menu-to-examples) ䷖
+<ReleaseUpdate label="10.26.2025" href="/docs/phoenix/release-notes/10-2025/10-26-2025-add-split-edit-menu-to-examples" title="Add Split Edit Menu to Examples">
+䷖
 
 **Available in Phoenix 12.8+**
 
@@ -1002,8 +933,8 @@ Added support for **AWS IAM–based authentication** for PostgreSQL connections 
 Added a new **"Split"** dropdown to single-example view on the dataset pages, allowing users to update the data split classification (e.g., train/validation/test) directly from the example level. This improvement makes it easier to correct or adjust split assignments dynamically.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="10.24.2025" href="/docs/phoenix/release-notes/10-2025/10-24-2025-filter-prompts-page-by-label">
-## [10.24.2025: Filter Prompts Page by Label](/docs/phoenix/release-notes/10-2025/10-24-2025-filter-prompts-page-by-label) 🏷️
+<ReleaseUpdate label="10.24.2025" href="/docs/phoenix/release-notes/10-2025/10-24-2025-filter-prompts-page-by-label" title="Filter Prompts Page by Label">
+🏷️
 
 **Available in Phoenix 12.7+**
 
@@ -1014,16 +945,16 @@ Added a new **"Split"** dropdown to single-example view on the dataset pages, al
 Added filtering by label on the Prompts page—users can now pick one or more labels to narrow the prompts list.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="10.20.2025" href="/docs/phoenix/release-notes/10-2025/10-20-2025-splits">
-## [10.20.2025: Splits](/docs/phoenix/release-notes/10-2025/10-20-2025-splits) ䷖
+<ReleaseUpdate label="10.20.2025" href="/docs/phoenix/release-notes/10-2025/10-20-2025-splits" title="Splits">
+䷖
 
 **Available in Phoenix 12.7+**
 
 In Arize Phoenix, _splits_ let you categorize your dataset into distinct subsets—such as **train**, **validation**, or **test**—enabling structured workflows for experiments and evaluations. This capability offers more flexibility in how you organize, filter, and compare your data across different stages or experimental conditions.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="10.18.2025" href="/docs/phoenix/release-notes/10-2025/10-18-2025-filter-annotations-in-compare-experiments-slideover">
-## [10.18.2025: Filter Annotations in Compare Experiments Slideover](/docs/phoenix/release-notes/10-2025/10-18-2025-filter-annotations-in-compare-experiments-slideover) ✍️
+<ReleaseUpdate label="10.18.2025" href="/docs/phoenix/release-notes/10-2025/10-18-2025-filter-annotations-in-compare-experiments-slideover" title="Filter Annotations in Compare Experiments Slideover">
+✍️
 
 **Available in Phoenix 12.7+**
 
@@ -1034,8 +965,8 @@ In Arize Phoenix, _splits_ let you categorize your dataset into distinct subsets
 Added filtering of annotations in the experiment compare slideover so that only annotations present on the selected experiment runs are displayed. This ensures a cleaner UI and avoids filters for annotations that don't appear in the comparison set.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="10.15.2025" href="/docs/phoenix/release-notes/10-2025/10-15-2025-enhanced-filtering-for-examples-table">
-## [10.15.2025: Enhanced Filtering for Examples Table](/docs/phoenix/release-notes/10-2025/10-15-2025-enhanced-filtering-for-examples-table) 🔍
+<ReleaseUpdate label="10.15.2025" href="/docs/phoenix/release-notes/10-2025/10-15-2025-enhanced-filtering-for-examples-table" title="Enhanced Filtering for Examples Table">
+🔍
 
 **Available in Phoenix 12.5+**
 
@@ -1046,8 +977,8 @@ Added filtering of annotations in the experiment compare slideover so that only 
 Added filtering capabilities to the **Dataset Examples table**, allowing users to search examples by text or split ID. Additionally, the split-management filter menu has been reorganized to separate filtering by splits from split management actions.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="10.13.2025" href="/docs/phoenix/release-notes/10-2025/10-13-2025-view-traces-in-compare-experiments">
-## [10.13.2025: View Traces in Compare Experiments](/docs/phoenix/release-notes/10-2025/10-13-2025-view-traces-in-compare-experiments) 🧪
+<ReleaseUpdate label="10.13.2025" href="/docs/phoenix/release-notes/10-2025/10-13-2025-view-traces-in-compare-experiments" title="View Traces in Compare Experiments">
+🧪
 
 **Available in Phoenix 12.5+**
 
@@ -1058,16 +989,16 @@ Added filtering capabilities to the **Dataset Examples table**, allowing users t
 We've added trace-links to the experiment compare slideover for runs and annotations. Clicking the new trace icons opens the Trace View.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="10.10.2025" href="/docs/phoenix/release-notes/10-2025/10-10-2025-viewer-role">
-## [10.10.2025: Viewer Role](/docs/phoenix/release-notes/10-2025/10-10-2025-viewer-role) 👀
+<ReleaseUpdate label="10.10.2025" href="/docs/phoenix/release-notes/10-2025/10-10-2025-viewer-role" title="Viewer Role">
+👀
 
 **Available in Phoenix 12.5+**
 
 Introduced a new **VIEWER role** with enforced read-only permissions across both GraphQL and REST APIs, improving access control and security.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="10.08.2025" href="/docs/phoenix/release-notes/10-2025/10-08-2025-dataset-labels">
-## [10.08.2025: Dataset Labels](/docs/phoenix/release-notes/10-2025/10-08-2025-dataset-labels) 🏷️
+<ReleaseUpdate label="10.08.2025" href="/docs/phoenix/release-notes/10-2025/10-08-2025-dataset-labels" title="Dataset Labels">
+🏷️
 
 **Available in Phoenix 12.3+**
 
@@ -1078,8 +1009,8 @@ Introduced a new **VIEWER role** with enforced read-only permissions across both
 Added support for **dataset labels** — you can now label datasets and view these labels in a dedicated column on the dataset list page, making it easier to **filter and group datasets**. All dataset labels can also be managed and viewed in the **"Datasets" tab** on the Settings page.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="10.06.2025" href="/docs/phoenix/release-notes/10-2025/10-06-2025-paginate-compare-experiments">
-## [10.06.2025: Paginate Compare Experiments](/docs/phoenix/release-notes/10-2025/10-06-2025-paginate-compare-experiments) 📃
+<ReleaseUpdate label="10.06.2025" href="/docs/phoenix/release-notes/10-2025/10-06-2025-paginate-compare-experiments" title="Paginate Compare Experiments">
+📃
 
 **Available in Phoenix 12.3+**
 
@@ -1090,8 +1021,8 @@ Added support for **dataset labels** — you can now label datasets and view the
 We added pagination to the **experiment comparison slideover** on the list page for smoother navigation through results. We also introduced a new **repetition number column**, visible only when the base experiment includes multiple repetitions.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="10.05.2025" href="/docs/phoenix/release-notes/10-2025/10-05-2025-load-prompt-by-tag-into-playground">
-## [10.05.2025: Load Prompt by Tag into Playground](/docs/phoenix/release-notes/10-2025/10-05-2025-load-prompt-by-tag-into-playground) 🛝
+<ReleaseUpdate label="10.05.2025" href="/docs/phoenix/release-notes/10-2025/10-05-2025-load-prompt-by-tag-into-playground" title="Load Prompt by Tag into Playground">
+🛝
 
 **Available in Phoenix 12.2+**
 
@@ -1102,8 +1033,8 @@ We added pagination to the **experiment comparison slideover** on the list page 
 We have added support for **selecting and loading prompts by tag** in the Playground. Users can now open specific prompts tagged for easier comparison and reproducibility.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="10.03.2025" href="/docs/phoenix/release-notes/10-2025/10-03-2025-prompt-version-editing-in-playground">
-## [10.03.2025: Prompt Version Editing in Playground](/docs/phoenix/release-notes/10-2025/10-03-2025-prompt-version-editing-in-playground) 🛝
+<ReleaseUpdate label="10.03.2025" href="/docs/phoenix/release-notes/10-2025/10-03-2025-prompt-version-editing-in-playground" title="Prompt Version Editing in Playground">
+🛝
 
 **Available in Phoenix 12.2+**
 
@@ -1114,8 +1045,8 @@ We have added support for **selecting and loading prompts by tag** in the Playgr
 We added support for **prompt versioning in the Playground** — users can now select, edit, and experiment with specific prompt versions directly. This update improves traceability and reproducibility for prompt iterations, making it easier to manage and compare different versions.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="09.29.2025" href="/docs/phoenix/release-notes/09-2025/09-29-2025-day-0-support-for-claude-sonnet-4.5">
-## [09.29.2025: Day 0 support for Claude Sonnet 4.5](/docs/phoenix/release-notes/09-2025/09-29-2025-day-0-support-for-claude-sonnet-4.5) ⚡
+<ReleaseUpdate label="09.29.2025" href="/docs/phoenix/release-notes/09-2025/09-29-2025-day-0-support-for-claude-sonnet-4.5" title="Day 0 support for Claude Sonnet 4.5">
+⚡
 
 **Available in Phoenix 12.1+**
 
@@ -1126,8 +1057,8 @@ We added support for **prompt versioning in the Playground** — users can now s
 Day-0 support for Claude Sonnet 4.5.
 </ReleaseUpdate>
 
-<ReleaseUpdate label="09.27.2025" href="/docs/phoenix/release-notes/09-2025/09-27-2025-dataset-splits">
-## [09.27.2025: Dataset Splits ](/docs/phoenix/release-notes/09-2025/09-27-2025-dataset-splits)📊
+<ReleaseUpdate label="09.27.2025" href="/docs/phoenix/release-notes/09-2025/09-27-2025-dataset-splits" title="Dataset Splits">
+📊
 
 **Available in Phoenix 12.0+**
 
@@ -1135,8 +1066,8 @@ Add support for custom dataset splits to organize examples by category.
 
 </ReleaseUpdate>
 
-<ReleaseUpdate label="09.26.2025" href="/docs/phoenix/release-notes/09-2025/09-26-2025-session-annotations">
-## [09.26.2025: Session Annotations 🗂️](/docs/phoenix/release-notes/09-2025/09-26-2025-session-annotations)&#x20;
+<ReleaseUpdate label="09.26.2025" href="/docs/phoenix/release-notes/09-2025/09-26-2025-session-annotations" title="Session Annotations 🗂️">
+&#x20;
 
 **Available in Phoenix 12.0+**
 
@@ -1148,8 +1079,8 @@ You can now annotate sessions with conversational evaluations like coherency and
 
 </ReleaseUpdate>
 
-<ReleaseUpdate label="09.25.2025" href="/docs/phoenix/release-notes/09-2025/09-25-2025-repetitions">
-## [09.25.2025: Repetitions](/docs/phoenix/release-notes/09-2025/09-25-2025-repetitions) 🔁
+<ReleaseUpdate label="09.25.2025" href="/docs/phoenix/release-notes/09-2025/09-25-2025-repetitions" title="Repetitions">
+🔁
 
 **Available in Phoenix 11.38+**
 
@@ -1161,8 +1092,8 @@ Support for repetitions is now enabled in Playground and SDK workflows.
 
 </ReleaseUpdate>
 
-<ReleaseUpdate label="09.24.2025" href="/docs/phoenix/release-notes/09-2025/09-24-2025-custom-http-headers-for-requests-in-playground">
-## [09.24.2025: Custom HTTP headers for requests in Playground](/docs/phoenix/release-notes/09-2025/09-24-2025-custom-http-headers-for-requests-in-playground) 🛠️
+<ReleaseUpdate label="09.24.2025" href="/docs/phoenix/release-notes/09-2025/09-24-2025-custom-http-headers-for-requests-in-playground" title="Custom HTTP headers for requests in Playground">
+🛠️
 
 **Available in Phoenix 11.36+**
 
@@ -1174,8 +1105,8 @@ Enable configuring custom HTTP headers for playground requests.
 
 </ReleaseUpdate>
 
-<ReleaseUpdate label="09.23.2025" href="/docs/phoenix/release-notes/09-2025/09-23-2025-repetitions-in-experiment-compare-slideover">
-## [09.23.2025: Repetitions in experiment compare slideover ](/docs/phoenix/release-notes/09-2025/09-23-2025-repetitions-in-experiment-compare-slideover)🔄
+<ReleaseUpdate label="09.23.2025" href="/docs/phoenix/release-notes/09-2025/09-23-2025-repetitions-in-experiment-compare-slideover" title="Repetitions in experiment compare slideover">
+🔄
 
 **Available in Phoenix 11.36+**
 
@@ -1187,14 +1118,14 @@ Show experiment repetitions as separate cards in the compare slideover 🔄
 
 </ReleaseUpdate>
 
-<ReleaseUpdate label="09.22.2025" href="/docs/phoenix/release-notes/09-2025/09-22-2025-helm-configurable-image-registry-and-ipv6-support">
-## [09.22.2025: Helm configurable image registry & IPv6 support ](/docs/phoenix/release-notes/09-2025/09-22-2025-helm-configurable-image-registry-and-ipv6-support)🌐
+<ReleaseUpdate label="09.22.2025" href="/docs/phoenix/release-notes/09-2025/09-22-2025-helm-configurable-image-registry-and-ipv6-support" title="Helm configurable image registry & IPv6 support">
+🌐
 
 **Available in Phoenix 11.35+**
 </ReleaseUpdate>
 
-<ReleaseUpdate label="09.17.2025" href="/docs/phoenix/release-notes/09-2025/09-17-2025-experiment-compare-details-slideover-in-list-view">
-## [09.17.2025: Experiment compare details slideover in list view](/docs/phoenix/release-notes/09-2025/09-17-2025-experiment-compare-details-slideover-in-list-view) 🔍
+<ReleaseUpdate label="09.17.2025" href="/docs/phoenix/release-notes/09-2025/09-17-2025-experiment-compare-details-slideover-in-list-view" title="Experiment compare details slideover in list view">
+🔍
 
 **Available in Phoenix 11.34+**
 
@@ -1207,8 +1138,7 @@ Added a slideover in the experiments list view to show compare details inline.
 
 </ReleaseUpdate>
 
-<ReleaseUpdate label="09.15.2025" href="/docs/phoenix/release-notes/09-2025/09-15-2025-prompt-labels">
-## [09.15.2025: Prompt Labels 🏷️](/docs/phoenix/release-notes/09-2025/09-15-2025-prompt-labels)
+<ReleaseUpdate label="09.15.2025" href="/docs/phoenix/release-notes/09-2025/09-15-2025-prompt-labels" title="Prompt Labels 🏷️">
 
 **Available in Phoenix 11.33+**
 
@@ -1220,8 +1150,7 @@ We’ve added support for labeling prompts so you can categorize them by use-cas
 
 </ReleaseUpdate>
 
-<ReleaseUpdate label="09.12.2025" href="/docs/phoenix/release-notes/09-2025/09-12-2025-enable-paging-in-experiment-compare-details">
-## [09.12.2025: Enable Paging in Experiment Compare Details 📄](/docs/phoenix/release-notes/09-2025/09-12-2025-enable-paging-in-experiment-compare-details)
+<ReleaseUpdate label="09.12.2025" href="/docs/phoenix/release-notes/09-2025/09-12-2025-enable-paging-in-experiment-compare-details" title="Enable Paging in Experiment Compare Details 📄">
 
 **Available in Phoenix 11.33+**
 

--- a/docs/snippets/ReleaseUpdate.jsx
+++ b/docs/snippets/ReleaseUpdate.jsx
@@ -1,0 +1,10 @@
+export const ReleaseUpdate = ({ label, href, children }) => {
+  return (
+    <Update label={label}>
+      {children}
+      <a href={href} className="release-update-read-more">
+        Read the full update →
+      </a>
+    </Update>
+  );
+};

--- a/docs/snippets/ReleaseUpdate.jsx
+++ b/docs/snippets/ReleaseUpdate.jsx
@@ -1,6 +1,9 @@
-export const ReleaseUpdate = ({ label, href, children }) => {
+export const ReleaseUpdate = ({ label, href, title, children }) => {
   return (
     <Update label={label}>
+      <h2>
+        <a href={href}>{label}: {title}</a>
+      </h2>
       {children}
       <a href={href} className="release-update-read-more">
         Read the full update →

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,38 +1,47 @@
 /* sr-only: Visually hidden but accessible to screen readers and AI agents */
 /* Used for AI context blocks that should be in DOM but not visible to users */
 .sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 .card-group .card img {
-  max-height: 197px !important;
+    max-height: 197px !important;
 }
 
 .card-group[class$="-2"] .card img {
-  height: 160px !important;
+    height: 160px !important;
 }
 
 .card-group[class$="-3"] .card img {
-  height: 150px !important;
+    height: 150px !important;
 }
 
 table {
-  display: table !important;
+    display: table !important;
 }
 
 .step-title {
-  font-size: 1.5rem !important;
+    font-size: 1.5rem !important;
 }
 
 /* Invert monochrome-black logos in dark mode (e.g. vendor SVGs with hardcoded fill="#000"). */
 .dark .invert-on-dark {
-  filter: invert(1);
+    filter: invert(1);
+}
+
+/* Read more link styling for release notes */
+.release-update-read-more {
+    display: inline-block;
+    margin-top: 0.75rem;
+    font-weight: 500;
+    color: var(--primary);
+    text-decoration: none;
 }


### PR DESCRIPTION
## Summary

View here: https://arizeai-433a7140-docs-release-notes-read-more.mintlify.app/docs/phoenix/release-notes

<img width="1254" height="498" alt="Screenshot 2026-06-01 at 3 34 51 PM" src="https://github.com/user-attachments/assets/279ec3d3-c75f-4084-8721-6878f4dfbb52" />

- Adds a custom `ReleaseUpdate` component that wraps Mintlify's `Update` component and includes a "Read the full update →" link at the bottom of each entry
- The component accepts `label`, `href`, and `title` props, and generates the H2 heading internally (eliminating duplicate link URLs)
- Converts all 114 existing release note entries to use the new component
- Updates the `phoenix-release-notes` skill to use `ReleaseUpdate` for future automated releases

### Usage

```mdx
<ReleaseUpdate label="05.27.2026" href="/docs/phoenix/release-notes/05-2026/05-27-2026-drag-to-zoom" title="Drag-to-Zoom on Project Metric Charts">
**Available in arize-phoenix 16.3.0+**

Brief summary of the feature...
</ReleaseUpdate>
```

## Test plan

- [x] Run `mint dev` and verify release notes page renders correctly
- [x] Verify each entry shows the "Read the full update →" link
- [x] Click a few links to confirm they navigate to the correct pages