### PR TITLE
ci: drop --latest from weekly deps upgrade to survive minimumReleaseAge cooldown

### DIFF
--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -69,13 +69,13 @@ jobs:
       - name: Upgrade JavaScript (pnpm) — app
         working-directory: ./app
         run: |
-          pnpm update --recursive --latest
+          pnpm update --recursive
           pnpm install --frozen-lockfile
 
       - name: Upgrade JavaScript (pnpm) — js
         working-directory: ./js
         run: |
-          pnpm update --recursive --latest
+          pnpm update --recursive
           pnpm install --frozen-lockfile
 
       - name: Detect changes
@@ -173,7 +173,7 @@ jobs:
               --body "Automated weekly dependency upgrade.
 
           - \`uv lock --upgrade\` (Python)
-          - \`pnpm update --recursive --latest\` in \`app/\` and \`js/\`
+          - \`pnpm update --recursive\` in \`app/\` and \`js/\`
 
           All verification checks passed (typecheck, fmt, lint, test, build). Review and merge."
           fi
@@ -211,7 +211,7 @@ jobs:
             contents: write
           prompt: |
             You're on branch `${{ steps.branch.outputs.branch }}`. The weekly dependency upgrade
-            already ran (`uv lock --upgrade` for Python, `pnpm update -r --latest`
+            already ran (`uv lock --upgrade` for Python, `pnpm update -r`
             in `app/` and `js/`), but the verification step failed. The upgraded
             lockfiles and any package manifest changes are in the working tree
             (uncommitted). Your job is to fix the regressions in the working tree
@@ -275,9 +275,10 @@ jobs:
               the policy.
             - No pre-releases in production Python deps (CLAUDE.md policy). Dev
               groups may use them when necessary.
-            - `pnpm update --latest` intentionally allows dependency ranges to
-              move beyond the existing `package.json` ranges. Preserve those range
-              bumps unless you pin a package back to avoid a substantive migration.
+            - `pnpm update --recursive` upgrades within the existing
+              `package.json` semver ranges (it does not bump the ranges
+              themselves). Preserve those in-range updates unless you pin a
+              package back to avoid a substantive migration.
 
             ## When checks pass
             Write a summary of what you did to `.scratch/pr-body.md` — this file
@@ -312,7 +313,7 @@ jobs:
             echo "> Review the diff and fixes carefully before merging."
             echo ""
             echo "- \`uv lock --upgrade\` (Python)"
-            echo "- \`pnpm update --recursive --latest\` in \`app/\` and \`js/\`"
+            echo "- \`pnpm update --recursive\` in \`app/\` and \`js/\`"
             echo ""
             echo "## Fix summary"
             echo ""


### PR DESCRIPTION
## What

Change the weekly dependency upgrade workflow from `pnpm update --recursive --latest` to `pnpm update --recursive` in both `app/` and `js/`, and update the accompanying PR-body / Claude-handoff strings to match.

## Why

The [weekly upgrade run](https://github.com/Arize-ai/phoenix/actions/runs/26759534014/job/78868785817) failed with:

```
[ERR_PNPM_NO_MATURE_MATCHING_VERSION] 1 version does not meet the minimumReleaseAge constraint:
  @arizeai/openinference-semantic-conventions@2.5.0 was published at 2026-05-29T22:30:26.265Z,
  within the minimumReleaseAge cutoff (2026-05-29T13:59:33.057Z)
```

This is a collision between two policies that fight each other:

- **`minimumReleaseAge: 4320`** (a 3-day supply-chain cooldown) in `app/pnpm-workspace.yaml` and `js/pnpm-workspace.yaml` — don't install any version published less than 3 days ago.
- **`--latest`** — force every package to its single newest published version, regardless of the existing `package.json` range.

When a package's newest version is younger than the cooldown, `--latest` has nothing older to fall back to. And because an *explicit* `minimumReleaseAge` auto-enables `minimumReleaseAgeStrict` (pnpm ≥ 11.0.4), strict mode in CI (non-TTY) **aborts** with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` — this is [documented, intended pnpm behavior](https://github.com/pnpm/pnpm/issues/10100), not a bug to be fixed by upgrading pnpm (confirmed against the changelog through 11.5.0; we're on 11.3.0). The hard error also kills the job *before* the "Hand off to Claude (fix regressions)" step can run.

Across a large recursive dependency tree, the odds that *at least one* package published within the prior 3 days on any given week are high, so this is expected to break most weeks rather than being a one-off.

## The fix

Dropping `--latest` makes `pnpm update --recursive` upgrade within each package's existing `package.json` semver range and pick the newest **mature** in-range version — so a freshly-published version inside the cooldown window is simply skipped instead of hard-failing the job.

## Trade-off

This job no longer proposes range-crossing / major bumps (e.g. `^2.4.0` won't jump to `3.x`). Those continue to come from **Dependabot** (`.github/dependabot.yml`) and manual bumps. We traded upgrade reach for reliability; the alternative (`minimumReleaseAgeStrict: false`, which auto-excludes the racing package and proceeds) would keep range-crossing bumps but bypass the cooldown for whatever version tripped it.