### PR TITLE
fix(ui): pass project id to trace sparkline

### DIFF
--- a/app/src/pages/project/ProjectTraceCountSparkline.tsx
+++ b/app/src/pages/project/ProjectTraceCountSparkline.tsx
@@ -1,7 +1,6 @@
 import { css } from "@emotion/react";
 import { useMemo, useRef } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
-import { useParams } from "react-router";
 import type { TooltipContentProps } from "recharts";
 import {
   Bar,
@@ -121,8 +120,11 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
   );
 }
 
-export function ProjectTraceCountSparkline() {
-  const { projectId } = useParams();
+export function ProjectTraceCountSparkline({
+  projectId,
+}: {
+  projectId: string;
+}) {
   const { timeRange, setCustomTimeRange } = useTimeRange();
   const startBoundedTimeRange = useMemo(
     () => getStartBoundedTimeRange(timeRange),
@@ -158,7 +160,7 @@ export function ProjectTraceCountSparkline() {
       }
     `,
     {
-      projectId: projectId as string,
+      projectId,
       timeRange: {
         start: startBoundedTimeRange.start.toISOString(),
         end: startBoundedTimeRange.end?.toISOString(),

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -882,7 +882,7 @@ export function SpansTable(props: SpansTableProps) {
             zIndex={2}
           >
             <Suspense fallback={<ProjectTraceCountSparklineSkeleton />}>
-              <ProjectTraceCountSparkline />
+              <ProjectTraceCountSparkline projectId={projectId} />
             </Suspense>
           </View>
           <View


### PR DESCRIPTION
## Summary
- Pass the active tracing project id into `ProjectTraceCountSparkline` instead of reading it from route params
- Preserve the sparkline on dataset evaluator spans pages by using the evaluator project already provided by `TracingProvider`

## Testing
- `pnpm --dir app typecheck`
- `pnpm --dir app exec oxlint src/pages/project/ProjectTraceCountSparkline.tsx src/pages/project/SpansTable.tsx`
- pre-commit: oxfmt/oxlint app hooks passed

Related issue: N/A