### PR TITLE
refactor(pxi): rename agent store key to arize-phoenix-assistant and reset persist version

### DIFF
--- a/app/src/agent/extensions/__tests__/toolRegistry.test.ts
+++ b/app/src/agent/extensions/__tests__/toolRegistry.test.ts
@@ -20,7 +20,7 @@ import { createPlaygroundStore } from "@phoenix/store/playground";
 
 describe("toolRegistry", () => {
   beforeEach(() => {
-    localStorage.removeItem("arize-phoenix-pxi");
+    localStorage.removeItem("arize-phoenix-assistant");
   });
 
   it("skips server-executed tools without producing output", async () => {

--- a/app/src/agent/extensions/__tests__/toolRegistry.test.ts
+++ b/app/src/agent/extensions/__tests__/toolRegistry.test.ts
@@ -20,7 +20,7 @@ import { createPlaygroundStore } from "@phoenix/store/playground";
 
 describe("toolRegistry", () => {
   beforeEach(() => {
-    localStorage.removeItem("arize-phoenix-agent");
+    localStorage.removeItem("arize-phoenix-pxi");
   });
 
   it("skips server-executed tools without producing output", async () => {

--- a/app/src/agent/tools/playgroundPrompt/__tests__/playgroundPrompt.test.ts
+++ b/app/src/agent/tools/playgroundPrompt/__tests__/playgroundPrompt.test.ts
@@ -14,7 +14,7 @@ import {
 
 describe("playground prompt agent tools", () => {
   beforeEach(() => {
-    localStorage.removeItem("arize-phoenix-pxi");
+    localStorage.removeItem("arize-phoenix-assistant");
     _resetInstanceId();
     _resetMessageId();
   });

--- a/app/src/agent/tools/playgroundPrompt/__tests__/playgroundPrompt.test.ts
+++ b/app/src/agent/tools/playgroundPrompt/__tests__/playgroundPrompt.test.ts
@@ -14,7 +14,7 @@ import {
 
 describe("playground prompt agent tools", () => {
   beforeEach(() => {
-    localStorage.removeItem("arize-phoenix-agent");
+    localStorage.removeItem("arize-phoenix-pxi");
     _resetInstanceId();
     _resetMessageId();
   });

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -4,7 +4,7 @@ import { createAgentStore } from "../agentStore";
 
 describe("agentStore", () => {
   beforeEach(() => {
-    localStorage.removeItem("arize-phoenix-agent");
+    localStorage.removeItem("arize-phoenix-pxi");
   });
 
   describe("createSession", () => {
@@ -238,98 +238,6 @@ describe("agentStore", () => {
 
         expect(store.getState().capabilities[capabilityKey]).toBe(enabled);
       }
-    });
-  });
-
-  describe("persist migration", () => {
-    it("migrates legacy debug flags into capabilities", async () => {
-      localStorage.setItem(
-        "arize-phoenix-agent",
-        JSON.stringify({
-          state: {
-            isOpen: false,
-            position: "detached",
-            sessions: [],
-            activeSessionId: null,
-            sessionMap: {},
-            defaultModelConfig: {
-              provider: "ANTHROPIC",
-              modelName: "claude-opus-4-6",
-              invocationParameters: [],
-              supportedInvocationParameters: [],
-            },
-            debug: {
-              retainInactiveBashSessions: true,
-              dangerouslyEnableMutations: true,
-            },
-          },
-          version: 1,
-        })
-      );
-
-      const store = createAgentStore();
-      await store.persist.rehydrate();
-
-      expect(store.getState().capabilities).toEqual({
-        ...createDefaultAgentCapabilities(),
-        "bash.retainInactiveSessions": true,
-        "graphql.mutations": true,
-        "session.storeSessions": false,
-        "web.access": false,
-      });
-      expect(store.getState().observability).toEqual({
-        storeLocalTraces: true,
-        exportRemoteTraces: false,
-        hasAcknowledgedConsent: false,
-      });
-    });
-
-    it("drops legacy pending prompt edits during migration", async () => {
-      localStorage.setItem(
-        "arize-phoenix-agent",
-        JSON.stringify({
-          state: {
-            sessions: [],
-            sessionMap: {},
-            pendingPromptEditsByToolCallId: {
-              "tool-call-1": {
-                toolCallId: "tool-call-1",
-                sessionId: "session-1",
-                instanceId: 0,
-                expectedRevision: "prompt-old",
-                before: { messages: [] },
-                after: { messages: [] },
-                operations: [],
-              },
-            },
-          },
-          version: 5,
-        })
-      );
-
-      const store = createAgentStore();
-      await store.persist.rehydrate();
-
-      expect(store.getState().pendingPromptEditsByToolCallId).toEqual({});
-    });
-
-    it("migrates legacy detached position to pinned", async () => {
-      localStorage.setItem(
-        "arize-phoenix-agent",
-        JSON.stringify({
-          state: {
-            position: "detached",
-            sessions: [],
-            sessionMap: {},
-          },
-          version: 7,
-        })
-      );
-
-      const store = createAgentStore();
-      await store.persist.rehydrate();
-
-      expect(store.getState().position).toBe("pinned");
     });
   });
 });

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -4,7 +4,7 @@ import { createAgentStore } from "../agentStore";
 
 describe("agentStore", () => {
   beforeEach(() => {
-    localStorage.removeItem("arize-phoenix-pxi");
+    localStorage.removeItem("arize-phoenix-assistant");
   });
 
   describe("createSession", () => {

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -340,7 +340,7 @@ function buildSessionRetentionPatch({
  * Creates a Zustand store for managing agent UI state and conversation sessions.
  *
  * The store is wrapped with devtools (for Redux DevTools inspection) and
- * persist (to local storage under "arize-phoenix-pxi"). The `isOpen`
+ * persist (to local storage under "arize-phoenix-assistant"). The `isOpen`
  * property is excluded from persistence so the panel always starts closed.
  *
  * @param initialProps - Optional overrides for the default store properties.
@@ -811,7 +811,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
 
   return create<AgentState>()(
     persist(devtools(agentStore, { name: "agentStore" }), {
-      name: "arize-phoenix-pxi",
+      name: "arize-phoenix-assistant",
       version: 0,
       partialize: (state) => ({
         isOpen: state.isOpen,

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -63,18 +63,6 @@ export type AgentObservabilitySettings = {
 
 export type AgentEditPermissionMode = "manual" | "bypass";
 
-const AGENT_EDIT_PERMISSION_MODES: readonly AgentEditPermissionMode[] = [
-  "manual",
-  "bypass",
-];
-
-/** Narrows an unknown persisted value to a recognized edit-permission mode. */
-function isAgentEditPermissionMode(
-  value: unknown
-): value is AgentEditPermissionMode {
-  return AGENT_EDIT_PERMISSION_MODES.includes(value as AgentEditPermissionMode);
-}
-
 export type AgentPermissions = {
   /** How user-visible edit approvals should be resolved. */
   edits: AgentEditPermissionMode;
@@ -352,7 +340,7 @@ function buildSessionRetentionPatch({
  * Creates a Zustand store for managing agent UI state and conversation sessions.
  *
  * The store is wrapped with devtools (for Redux DevTools inspection) and
- * persist (to local storage under "arize-phoenix-agent"). The `isOpen`
+ * persist (to local storage under "arize-phoenix-pxi"). The `isOpen`
  * property is excluded from persistence so the panel always starts closed.
  *
  * @param initialProps - Optional overrides for the default store properties.
@@ -823,78 +811,8 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
 
   return create<AgentState>()(
     persist(devtools(agentStore, { name: "agentStore" }), {
-      name: "arize-phoenix-agent",
-      version: 8,
-      migrate: (persisted, version) => {
-        const state = persisted as Partial<AgentProps> & {
-          capabilities?: Partial<AgentCapabilities>;
-          observability?: Partial<AgentObservabilitySettings>;
-          permissions?: Partial<AgentPermissions>;
-          debug?: {
-            retainInactiveBashSessions?: boolean;
-            dangerouslyEnableMutations?: boolean;
-          };
-        };
-        const migratedSessionMap: Record<string, AgentSession> = {};
-
-        for (const [sessionId, session] of Object.entries(
-          state.sessionMap ?? {}
-        )) {
-          migratedSessionMap[sessionId] = {
-            ...session,
-            createdAt: (session as AgentSession).createdAt ?? 0,
-          };
-        }
-
-        const migratedCapabilities = {
-          ...createDefaultAgentCapabilities(),
-          ...(state.capabilities ?? {}),
-          ...(version <= 2
-            ? {
-                "bash.retainInactiveSessions":
-                  state.debug?.retainInactiveBashSessions ??
-                  state.capabilities?.["bash.retainInactiveSessions"] ??
-                  false,
-                "graphql.mutations":
-                  state.debug?.dangerouslyEnableMutations ??
-                  state.capabilities?.["graphql.mutations"] ??
-                  false,
-              }
-            : {}),
-        };
-
-        return {
-          ...state,
-          // `position` existed before it was wired into the UI, but the
-          // visible behavior was always the pinned side panel. Treat pre-v8
-          // persisted values as pinned so the new floating mode is opt-in.
-          position:
-            version <= 7
-              ? "pinned"
-              : state.position === "detached"
-                ? "detached"
-                : "pinned",
-          fabPlacement: state.fabPlacement ?? "bottom-end",
-          sessionMap: migratedSessionMap,
-          observability: {
-            ...DEFAULT_AGENT_OBSERVABILITY_SETTINGS,
-            ...(state.observability ?? {}),
-          },
-          permissions: {
-            ...DEFAULT_AGENT_PERMISSIONS,
-            ...(state.permissions ?? {}),
-            // Drop any persisted edit mode that is no longer recognized (e.g.
-            // the legacy "ask"/"auto_accept" values) so it resets to default.
-            edits: isAgentEditPermissionMode(state.permissions?.edits)
-              ? state.permissions.edits
-              : DEFAULT_AGENT_PERMISSIONS.edits,
-          },
-          capabilities: migratedCapabilities,
-          pendingPromptEditsByToolCallId: {},
-          pendingBatchSpanAnnotatesByToolCallId: {},
-          pendingSavePromptsByToolCallId: {},
-        } as AgentState;
-      },
+      name: "arize-phoenix-pxi",
+      version: 0,
       partialize: (state) => ({
         isOpen: state.isOpen,
         position: state.position,

--- a/app/tests/pxi/fixtures.ts
+++ b/app/tests/pxi/fixtures.ts
@@ -48,7 +48,7 @@ async function installAgentDefaults({ page }: { page: Page }) {
         JSON.stringify({ agents: true, tracing_ux: false })
       );
       localStorage.setItem(
-        "arize-phoenix-agent",
+        "arize-phoenix-pxi",
         JSON.stringify({
           state: {
             isOpen: false,
@@ -126,7 +126,7 @@ export class PxiDriver {
     await this.page.getByLabel("Message input").fill(message);
     await this.page.getByRole("button", { name: "Send message" }).click();
     const turnHandle = await this.page.waitForFunction(() => {
-      const stored = localStorage.getItem("arize-phoenix-agent");
+      const stored = localStorage.getItem("arize-phoenix-pxi");
       if (!stored) {
         return null;
       }
@@ -253,7 +253,7 @@ export class PxiDriver {
 
   async getActiveSessionId(): Promise<string> {
     const handle = await this.page.waitForFunction(() => {
-      const stored = localStorage.getItem("arize-phoenix-agent");
+      const stored = localStorage.getItem("arize-phoenix-pxi");
       if (!stored) return null;
       const parsed = JSON.parse(stored) as {
         state?: { activeSessionId?: string | null };

--- a/app/tests/pxi/fixtures.ts
+++ b/app/tests/pxi/fixtures.ts
@@ -48,7 +48,7 @@ async function installAgentDefaults({ page }: { page: Page }) {
         JSON.stringify({ agents: true, tracing_ux: false })
       );
       localStorage.setItem(
-        "arize-phoenix-pxi",
+        "arize-phoenix-assistant",
         JSON.stringify({
           state: {
             isOpen: false,
@@ -126,7 +126,7 @@ export class PxiDriver {
     await this.page.getByLabel("Message input").fill(message);
     await this.page.getByRole("button", { name: "Send message" }).click();
     const turnHandle = await this.page.waitForFunction(() => {
-      const stored = localStorage.getItem("arize-phoenix-pxi");
+      const stored = localStorage.getItem("arize-phoenix-assistant");
       if (!stored) {
         return null;
       }
@@ -253,7 +253,7 @@ export class PxiDriver {
 
   async getActiveSessionId(): Promise<string> {
     const handle = await this.page.waitForFunction(() => {
-      const stored = localStorage.getItem("arize-phoenix-pxi");
+      const stored = localStorage.getItem("arize-phoenix-assistant");
       if (!stored) return null;
       const parsed = JSON.parse(stored) as {
         state?: { activeSessionId?: string | null };

--- a/app/tests/pxi/ingest-traces-smoke.spec.ts
+++ b/app/tests/pxi/ingest-traces-smoke.spec.ts
@@ -87,7 +87,7 @@ test.describe("PXI ingest traces smoke", () => {
 
     const assistantTextHandle = await page.waitForFunction(
       () => {
-        const stored = localStorage.getItem("arize-phoenix-agent");
+        const stored = localStorage.getItem("arize-phoenix-pxi");
         if (!stored) return null;
         const parsed = JSON.parse(stored) as {
           state?: {

--- a/app/tests/pxi/ingest-traces-smoke.spec.ts
+++ b/app/tests/pxi/ingest-traces-smoke.spec.ts
@@ -87,7 +87,7 @@ test.describe("PXI ingest traces smoke", () => {
 
     const assistantTextHandle = await page.waitForFunction(
       () => {
-        const stored = localStorage.getItem("arize-phoenix-pxi");
+        const stored = localStorage.getItem("arize-phoenix-assistant");
         if (!stored) return null;
         const parsed = JSON.parse(stored) as {
           state?: {


### PR DESCRIPTION
## Summary

- Renames the Zustand persistence key from `arize-phoenix-agent` to `arize-phoenix-assistant`
- Resets the persist `version` to `0` and removes the now-obsolete `migrate` logic
- Drops the `isAgentEditPermissionMode` helper and `AGENT_EDIT_PERMISSION_MODES` constant that only the migration used
- Updates all test/fixture references (unit tests + PXI Playwright fixtures/specs) to the new key
- Removes the "persist migration" test suite, which only covered the deleted migration path

## Why

The store is being rebranded. Since there is no production data to migrate under the new key, the version is reset to `0` and the legacy migration code is removed.