### PR TITLE
feat(playground): add PXI load_dataset tool

### DIFF
--- a/app/src/agent/extensions/toolRegistry.ts
+++ b/app/src/agent/extensions/toolRegistry.ts
@@ -34,6 +34,12 @@ import { parseElicitToolInput } from "@phoenix/agent/tools/elicit";
 import type { ElicitToolInput } from "@phoenix/agent/tools/elicit";
 import { parseEmptyToolInput } from "@phoenix/agent/tools/emptyToolInput";
 import {
+  LOAD_DATASET_TOOL_NAME,
+  parseLoadDatasetInput,
+  type LoadDatasetActionContext,
+  type LoadDatasetInput,
+} from "@phoenix/agent/tools/playgroundLoadDataset";
+import {
   LIST_PLAYGROUND_MODEL_TARGETS_TOOL_NAME,
   parseListPlaygroundModelTargetsInput,
   parseSetPlaygroundModelInput,
@@ -41,12 +47,6 @@ import {
   type ListPlaygroundModelTargetsInput,
   type SetPlaygroundModelInput,
 } from "@phoenix/agent/tools/playgroundModel";
-import {
-  LOAD_DATASET_TOOL_NAME,
-  parseLoadDatasetInput,
-  type LoadDatasetActionContext,
-  type LoadDatasetInput,
-} from "@phoenix/agent/tools/playgroundLoadDataset";
 import {
   parseReadPlaygroundOutputInput,
   READ_PLAYGROUND_OUTPUT_TOOL_NAME,

--- a/app/src/agent/extensions/toolRegistry.ts
+++ b/app/src/agent/extensions/toolRegistry.ts
@@ -42,6 +42,12 @@ import {
   type SetPlaygroundModelInput,
 } from "@phoenix/agent/tools/playgroundModel";
 import {
+  LOAD_DATASET_TOOL_NAME,
+  parseLoadDatasetInput,
+  type LoadDatasetActionContext,
+  type LoadDatasetInput,
+} from "@phoenix/agent/tools/playgroundLoadDataset";
+import {
   parseReadPlaygroundOutputInput,
   READ_PLAYGROUND_OUTPUT_TOOL_NAME,
   type ReadPlaygroundOutputInput,
@@ -707,6 +713,59 @@ const savePromptAgentTool = createRegisteredAgentTool<SavePromptInput>({
   },
 });
 
+const loadDatasetAgentTool = createRegisteredAgentTool<LoadDatasetInput>({
+  name: LOAD_DATASET_TOOL_NAME,
+  parseInput: parseLoadDatasetInput,
+  invalidInputErrorText: `Invalid ${LOAD_DATASET_TOOL_NAME} input. Expected { datasetName: string, splitName?: string }.`,
+  uiBehavior: {
+    autoOpen: true,
+    scrollIntoViewOnMount: true,
+  },
+  execute: async ({
+    toolCall,
+    input,
+    sessionId,
+    addToolOutput,
+    agentStore,
+  }) => {
+    const action =
+      agentStore.getState().registeredClientActions[LOAD_DATASET_TOOL_NAME];
+    if (!action) {
+      await addToolOutput({
+        state: "output-error",
+        tool: LOAD_DATASET_TOOL_NAME,
+        toolCallId: toolCall.toolCallId,
+        errorText:
+          "The playground is not mounted; cannot load a dataset into the playground.",
+      });
+      return;
+    }
+    if (!sessionId) {
+      await addToolOutput({
+        state: "output-error",
+        tool: LOAD_DATASET_TOOL_NAME,
+        toolCallId: toolCall.toolCallId,
+        errorText: "Cannot load a dataset without an active session.",
+      });
+      return;
+    }
+    const context: LoadDatasetActionContext = {
+      toolCallId: toolCall.toolCallId,
+      sessionId,
+      addToolOutput,
+    };
+    const result = await action(input, context);
+    if (!result.ok) {
+      await addToolOutput({
+        state: "output-error",
+        tool: LOAD_DATASET_TOOL_NAME,
+        toolCallId: toolCall.toolCallId,
+        errorText: result.error,
+      });
+    }
+  },
+});
+
 const runPlaygroundAgentTool = createRegisteredAgentTool<RunPlaygroundInput>({
   name: RUN_PLAYGROUND_TOOL_NAME,
   parseInput: parseRunPlaygroundInput,
@@ -1147,6 +1206,7 @@ const agentToolRegistry: RegisteredAgentTool<unknown>[] = [
   savePromptAgentTool as RegisteredAgentTool<unknown>,
   readPromptToolsAgentTool as RegisteredAgentTool<unknown>,
   writePromptToolsAgentTool as RegisteredAgentTool<unknown>,
+  loadDatasetAgentTool as RegisteredAgentTool<unknown>,
   runPlaygroundAgentTool as RegisteredAgentTool<unknown>,
   readPlaygroundOutputAgentTool as RegisteredAgentTool<unknown>,
   setVariableValuesAgentTool as RegisteredAgentTool<unknown>,

--- a/app/src/agent/tools/playgroundLoadDataset/__generated__/loadPlaygroundDatasetExampleCountQuery.graphql.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/__generated__/loadPlaygroundDatasetExampleCountQuery.graphql.ts
@@ -1,0 +1,136 @@
+/**
+ * @generated SignedSource<<482868eabb611949e0e5c14adac972a0>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type loadPlaygroundDatasetExampleCountQuery$variables = {
+  id: string;
+  splitIds: ReadonlyArray<string>;
+};
+export type loadPlaygroundDatasetExampleCountQuery$data = {
+  readonly node: {
+    readonly exampleCount?: number;
+  };
+};
+export type loadPlaygroundDatasetExampleCountQuery = {
+  response: loadPlaygroundDatasetExampleCountQuery$data;
+  variables: loadPlaygroundDatasetExampleCountQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "splitIds"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "splitIds",
+          "variableName": "splitIds"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "exampleCount",
+      "storageKey": null
+    }
+  ],
+  "type": "Dataset",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "loadPlaygroundDatasetExampleCountQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "loadPlaygroundDatasetExampleCountQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "c492fb79e2cb26c8aefd6cae506133b6",
+    "id": null,
+    "metadata": {},
+    "name": "loadPlaygroundDatasetExampleCountQuery",
+    "operationKind": "query",
+    "text": "query loadPlaygroundDatasetExampleCountQuery(\n  $id: ID!\n  $splitIds: [ID!]!\n) {\n  node(id: $id) {\n    __typename\n    ... on Dataset {\n      exampleCount(splitIds: $splitIds)\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "33337e2099eee1fc003dc12f6d948015";
+
+export default node;

--- a/app/src/agent/tools/playgroundLoadDataset/__generated__/loadPlaygroundDatasetResolveQuery.graphql.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/__generated__/loadPlaygroundDatasetResolveQuery.graphql.ts
@@ -1,0 +1,176 @@
+/**
+ * @generated SignedSource<<0c59d437d89c4f6af8cd0416e2819461>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type loadPlaygroundDatasetResolveQuery$variables = {
+  first: number;
+  name: string;
+};
+export type loadPlaygroundDatasetResolveQuery$data = {
+  readonly datasets: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly exampleCount: number;
+        readonly id: string;
+        readonly name: string;
+        readonly splits: ReadonlyArray<{
+          readonly id: string;
+          readonly name: string;
+        }>;
+      };
+    }>;
+  };
+};
+export type loadPlaygroundDatasetResolveQuery = {
+  response: loadPlaygroundDatasetResolveQuery$data;
+  variables: loadPlaygroundDatasetResolveQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "first"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "name"
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "fields": [
+          {
+            "kind": "Literal",
+            "name": "col",
+            "value": "name"
+          },
+          {
+            "kind": "Variable",
+            "name": "value",
+            "variableName": "name"
+          }
+        ],
+        "kind": "ObjectValue",
+        "name": "filter"
+      },
+      {
+        "kind": "Variable",
+        "name": "first",
+        "variableName": "first"
+      }
+    ],
+    "concreteType": "DatasetConnection",
+    "kind": "LinkedField",
+    "name": "datasets",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "DatasetEdge",
+        "kind": "LinkedField",
+        "name": "edges",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Dataset",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "exampleCount",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "DatasetSplit",
+                "kind": "LinkedField",
+                "name": "splits",
+                "plural": true,
+                "selections": [
+                  (v2/*: any*/),
+                  (v3/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "loadPlaygroundDatasetResolveQuery",
+    "selections": (v4/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "loadPlaygroundDatasetResolveQuery",
+    "selections": (v4/*: any*/)
+  },
+  "params": {
+    "cacheID": "0ee3f0d398602326eb7fe7ac93b87a10",
+    "id": null,
+    "metadata": {},
+    "name": "loadPlaygroundDatasetResolveQuery",
+    "operationKind": "query",
+    "text": "query loadPlaygroundDatasetResolveQuery(\n  $name: String!\n  $first: Int!\n) {\n  datasets(filter: {col: name, value: $name}, first: $first) {\n    edges {\n      node {\n        id\n        name\n        exampleCount\n        splits {\n          id\n          name\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "36b7707a45c509d5e0203d856f315b56";
+
+export default node;

--- a/app/src/agent/tools/playgroundLoadDataset/__tests__/playgroundLoadDataset.test.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/__tests__/playgroundLoadDataset.test.ts
@@ -15,11 +15,7 @@ import {
   createPlaygroundStore,
 } from "@phoenix/store/playground";
 
-/**
- * Builds a mutable URL-search-params test harness. `setSearchParams` applies the
- * router updater against the current params so accept-time writes are
- * observable, and `params` can be reassigned to simulate selection drift.
- */
+// Mutable URL-search-params harness; `setDrift` reassigns params to simulate selection drift.
 function createSearchParamsHarness(initial?: string) {
   let params = new URLSearchParams(initial);
   const setSearchParams = vi.fn<SetURLSearchParams>((next) => {
@@ -35,12 +31,8 @@ function createSearchParamsHarness(initial?: string) {
   };
 }
 
-/**
- * Applying a selection writes the playground store, which persists to
- * localStorage. Some jsdom configs expose an opaque-origin window whose
- * localStorage lacks `setItem`; install an in-memory shim so the dual-write
- * assertions are hermetic.
- */
+// Some jsdom configs expose an opaque-origin localStorage with no `setItem`; shim it
+// so the store dual-write (which persists to localStorage) is hermetic.
 function ensureWorkingLocalStorage() {
   if (typeof window.localStorage?.setItem === "function") {
     return;

--- a/app/src/agent/tools/playgroundLoadDataset/__tests__/playgroundLoadDataset.test.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/__tests__/playgroundLoadDataset.test.ts
@@ -1,0 +1,348 @@
+import type { SetURLSearchParams } from "react-router";
+
+import {
+  buildDatasetSelectionSnapshot,
+  buildSelectionRevision,
+  createLoadDatasetClientAction,
+  parseLoadDatasetInput,
+  type DatasetTargetResolution,
+  type PendingLoadDataset,
+  type ResolveDatasetTarget,
+} from "@phoenix/agent/tools/playgroundLoadDataset";
+import {
+  _resetInstanceId,
+  _resetMessageId,
+  createPlaygroundStore,
+} from "@phoenix/store/playground";
+
+/**
+ * Builds a mutable URL-search-params test harness. `setSearchParams` applies the
+ * router updater against the current params so accept-time writes are
+ * observable, and `params` can be reassigned to simulate selection drift.
+ */
+function createSearchParamsHarness(initial?: string) {
+  let params = new URLSearchParams(initial);
+  const setSearchParams = vi.fn<SetURLSearchParams>((next) => {
+    const resolved = typeof next === "function" ? next(params) : next;
+    params = new URLSearchParams(resolved as Record<string, string>);
+  });
+  return {
+    getSearchParams: () => params,
+    setSearchParams,
+    setDrift: (search: string) => {
+      params = new URLSearchParams(search);
+    },
+  };
+}
+
+/**
+ * Applying a selection writes the playground store, which persists to
+ * localStorage. Some jsdom configs expose an opaque-origin window whose
+ * localStorage lacks `setItem`; install an in-memory shim so the dual-write
+ * assertions are hermetic.
+ */
+function ensureWorkingLocalStorage() {
+  if (typeof window.localStorage?.setItem === "function") {
+    return;
+  }
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => void store.set(key, value),
+    removeItem: (key: string) => void store.delete(key),
+    clear: () => store.clear(),
+    key: (index: number) => [...store.keys()][index] ?? null,
+    get length() {
+      return store.size;
+    },
+  });
+}
+
+const toolCallContext = {
+  toolCallId: "call-1",
+  sessionId: "session-1",
+  addToolOutput: vi.fn().mockResolvedValue(undefined),
+};
+
+function resolverFor(
+  resolution: DatasetTargetResolution
+): ResolveDatasetTarget {
+  return vi.fn().mockResolvedValue(resolution);
+}
+
+describe("playground load dataset agent tool", () => {
+  beforeEach(() => {
+    _resetInstanceId();
+    _resetMessageId();
+    vi.clearAllMocks();
+    ensureWorkingLocalStorage();
+  });
+
+  it("parses common load_dataset input aliases", () => {
+    expect(
+      parseLoadDatasetInput({
+        dataset_name: "Support Tickets",
+        split_name: "train",
+      })
+    ).toEqual({ datasetName: "Support Tickets", splitName: "train" });
+  });
+
+  it("requires a non-empty dataset name", () => {
+    expect(parseLoadDatasetInput({})).toBeNull();
+    expect(parseLoadDatasetInput({ datasetName: "   " })).toBeNull();
+  });
+
+  it("treats a null split name as loading the whole dataset", () => {
+    expect(
+      parseLoadDatasetInput({ datasetName: "Support", splitName: null })
+    ).toEqual({ datasetName: "Support" });
+  });
+
+  it("derives a revision independent of split ordering", () => {
+    expect(
+      buildSelectionRevision({ datasetId: "d1", splitIds: ["a", "b"] })
+    ).toEqual(
+      buildSelectionRevision({ datasetId: "d1", splitIds: ["b", "a"] })
+    );
+    expect(
+      buildSelectionRevision({ datasetId: "d1", splitIds: ["a"] })
+    ).not.toEqual(buildSelectionRevision({ datasetId: "d2", splitIds: ["a"] }));
+  });
+
+  it("snapshots only the selected split id and names", () => {
+    expect(
+      buildDatasetSelectionSnapshot({
+        datasetId: "d1",
+        datasetName: "Support",
+        splitId: "s1",
+        splitName: "train",
+      })
+    ).toEqual({
+      datasetId: "d1",
+      splitIds: ["s1"],
+      datasetName: "Support",
+      splitNames: ["train"],
+    });
+    expect(
+      buildDatasetSelectionSnapshot({
+        datasetId: "d1",
+        datasetName: "Support",
+        splitId: null,
+        splitName: null,
+      })
+    ).toEqual({ datasetId: "d1", splitIds: [], datasetName: "Support" });
+  });
+
+  it("surfaces propose-time resolution errors and registers no pending load", async () => {
+    const playgroundStore = createPlaygroundStore({
+      datasetId: null,
+      modelConfigByProvider: {},
+    });
+    const setPendingLoadDataset = vi.fn();
+    const harness = createSearchParamsHarness();
+    const action = createLoadDatasetClientAction({
+      playgroundStore,
+      setSearchParams: harness.setSearchParams,
+      getSearchParams: harness.getSearchParams,
+      setPendingLoadDataset,
+      resolveDatasetTarget: resolverFor({
+        ok: false,
+        error: 'No dataset named "Ghost" was found.',
+      }),
+    });
+
+    const result = await action({ datasetName: "Ghost" }, toolCallContext);
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'No dataset named "Ghost" was found.',
+    });
+    expect(setPendingLoadDataset).not.toHaveBeenCalled();
+  });
+
+  it("registers a pending load and dual-writes store + URL on accept", async () => {
+    const playgroundStore = createPlaygroundStore({
+      datasetId: null,
+      modelConfigByProvider: {},
+    });
+    const setPendingLoadDataset = vi.fn();
+    const harness = createSearchParamsHarness("exampleId=ex-old");
+    const action = createLoadDatasetClientAction({
+      playgroundStore,
+      setSearchParams: harness.setSearchParams,
+      getSearchParams: harness.getSearchParams,
+      setPendingLoadDataset,
+      resolveDatasetTarget: resolverFor({
+        ok: true,
+        output: {
+          datasetId: "d1",
+          datasetName: "Support",
+          splitId: "s1",
+          splitName: "train",
+        },
+      }),
+    });
+
+    await action(
+      { datasetName: "Support", splitName: "train" },
+      toolCallContext
+    );
+
+    expect(setPendingLoadDataset).toHaveBeenCalledTimes(1);
+    const pendingLoad = setPendingLoadDataset.mock
+      .calls[0]![1] as PendingLoadDataset;
+    expect(pendingLoad.snapshot).toEqual({
+      datasetId: "d1",
+      splitIds: ["s1"],
+      datasetName: "Support",
+      splitNames: ["train"],
+    });
+
+    await pendingLoad.accept?.();
+
+    // Pending state cleared before the write.
+    expect(setPendingLoadDataset).toHaveBeenLastCalledWith("call-1", null);
+    // Store write flips dataset mode for the experiment path.
+    expect(playgroundStore.getState().datasetId).toBe("d1");
+    // URL write sets datasetId + repeated splitId and clears the stale exampleId.
+    const written = harness.getSearchParams();
+    expect(written.get("datasetId")).toBe("d1");
+    expect(written.getAll("splitId")).toEqual(["s1"]);
+    expect(written.get("exampleId")).toBeNull();
+    expect(toolCallContext.addToolOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        state: "output-available",
+        tool: "load_dataset",
+        toolCallId: "call-1",
+        output: expect.objectContaining({ status: "loaded", datasetId: "d1" }),
+      })
+    );
+  });
+
+  it("rejects on accept when the selection drifted since propose", async () => {
+    const playgroundStore = createPlaygroundStore({
+      datasetId: null,
+      modelConfigByProvider: {},
+    });
+    const setPendingLoadDataset = vi.fn();
+    const harness = createSearchParamsHarness();
+    const resolveDatasetTarget = resolverFor({
+      ok: true,
+      output: {
+        datasetId: "d1",
+        datasetName: "Support",
+        splitId: null,
+        splitName: null,
+      },
+    });
+    const action = createLoadDatasetClientAction({
+      playgroundStore,
+      setSearchParams: harness.setSearchParams,
+      getSearchParams: harness.getSearchParams,
+      setPendingLoadDataset,
+      resolveDatasetTarget,
+    });
+
+    await action({ datasetName: "Support" }, toolCallContext);
+    const pendingLoad = setPendingLoadDataset.mock
+      .calls[0]![1] as PendingLoadDataset;
+
+    // The user picked a different dataset after the proposal.
+    harness.setDrift("datasetId=other");
+    await pendingLoad.accept?.();
+
+    expect(harness.setSearchParams).not.toHaveBeenCalled();
+    expect(playgroundStore.getState().datasetId).toBeNull();
+    expect(toolCallContext.addToolOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        state: "output-error",
+        tool: "load_dataset",
+        errorText: expect.stringContaining("selection changed"),
+      })
+    );
+  });
+
+  it("rejects on accept when the target no longer resolves", async () => {
+    const playgroundStore = createPlaygroundStore({
+      datasetId: null,
+      modelConfigByProvider: {},
+    });
+    const setPendingLoadDataset = vi.fn();
+    const harness = createSearchParamsHarness();
+    const resolveDatasetTarget = vi
+      .fn<ResolveDatasetTarget>()
+      .mockResolvedValueOnce({
+        ok: true,
+        output: {
+          datasetId: "d1",
+          datasetName: "Support",
+          splitId: null,
+          splitName: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: 'No dataset named "Support" was found.',
+      });
+    const action = createLoadDatasetClientAction({
+      playgroundStore,
+      setSearchParams: harness.setSearchParams,
+      getSearchParams: harness.getSearchParams,
+      setPendingLoadDataset,
+      resolveDatasetTarget,
+    });
+
+    await action({ datasetName: "Support" }, toolCallContext);
+    const pendingLoad = setPendingLoadDataset.mock
+      .calls[0]![1] as PendingLoadDataset;
+
+    await pendingLoad.accept?.();
+
+    expect(resolveDatasetTarget).toHaveBeenCalledTimes(2);
+    expect(harness.setSearchParams).not.toHaveBeenCalled();
+    expect(toolCallContext.addToolOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        state: "output-error",
+        tool: "load_dataset",
+        errorText: 'No dataset named "Support" was found.',
+      })
+    );
+  });
+
+  it("auto-accepts when shouldAutoAccept is true", async () => {
+    const playgroundStore = createPlaygroundStore({
+      datasetId: null,
+      modelConfigByProvider: {},
+    });
+    const setPendingLoadDataset = vi.fn();
+    const harness = createSearchParamsHarness();
+    const action = createLoadDatasetClientAction({
+      playgroundStore,
+      setSearchParams: harness.setSearchParams,
+      getSearchParams: harness.getSearchParams,
+      setPendingLoadDataset,
+      shouldAutoAccept: () => true,
+      resolveDatasetTarget: resolverFor({
+        ok: true,
+        output: {
+          datasetId: "d1",
+          datasetName: "Support",
+          splitId: null,
+          splitName: null,
+        },
+      }),
+    });
+
+    await action({ datasetName: "Support" }, toolCallContext);
+
+    expect(playgroundStore.getState().datasetId).toBe("d1");
+    expect(toolCallContext.addToolOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        output: expect.objectContaining({
+          status: "loaded",
+          acceptedBy: "auto",
+        }),
+      })
+    );
+  });
+});

--- a/app/src/agent/tools/playgroundLoadDataset/clientActions.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/clientActions.ts
@@ -20,11 +20,7 @@ import type {
   ResolveDatasetTarget,
 } from "./types";
 
-/**
- * Reads the live playground dataset selection from the URL search params. The
- * URL — not the store — is the source of truth for the rendered dataset mode,
- * so drift detection must read it too.
- */
+// The URL (not the store) is the source of truth for the rendered dataset mode.
 function getUrlSelection(searchParams: URLSearchParams): ExpectedSelection {
   return {
     datasetId: searchParams.get("datasetId"),
@@ -32,12 +28,7 @@ function getUrlSelection(searchParams: URLSearchParams): ExpectedSelection {
   };
 }
 
-/**
- * Applies a selection by replicating PlaygroundDatasetSelect.onSelectionChange:
- * write the store (keeps the experiment path + per-dataset config consistent)
- * and the URL (flips the visible mode), setting `datasetId` + one repeated
- * `splitId` per split and clearing the now-stale `exampleId`.
- */
+// Mirrors PlaygroundDatasetSelect.onSelectionChange: the URL write (not the store) flips the rendered mode.
 function applyDatasetSelection({
   snapshot,
   playgroundStore,
@@ -63,12 +54,7 @@ function applyDatasetSelection({
   });
 }
 
-/**
- * Creates the client action handler for the load_dataset tool. At propose time
- * it resolves the dataset/split names to ids, validates existence + emptiness,
- * snapshots the selection with a drift revision, and registers a pending
- * proposal for user approval before the playground switches into dataset mode.
- */
+/** Client action for load_dataset: resolves names to ids, validates, and registers a pending proposal for approval. */
 export function createLoadDatasetClientAction({
   playgroundStore,
   setSearchParams,

--- a/app/src/agent/tools/playgroundLoadDataset/clientActions.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/clientActions.ts
@@ -54,7 +54,6 @@ function applyDatasetSelection({
   });
 }
 
-/** Client action for load_dataset: resolves names to ids, validates, and registers a pending proposal for approval. */
 export function createLoadDatasetClientAction({
   playgroundStore,
   setSearchParams,
@@ -65,7 +64,6 @@ export function createLoadDatasetClientAction({
 }: {
   playgroundStore: PlaygroundStore;
   setSearchParams: SetURLSearchParams;
-  /** Reads the current URL search params (kept fresh across renders). */
   getSearchParams: () => URLSearchParams;
   setPendingLoadDataset: (
     toolCallId: string,

--- a/app/src/agent/tools/playgroundLoadDataset/clientActions.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/clientActions.ts
@@ -1,0 +1,139 @@
+import type { SetURLSearchParams } from "react-router";
+
+import type { AgentClientActionResult } from "@phoenix/store/agentStore";
+import type { PlaygroundStore } from "@phoenix/store/playground";
+
+import {
+  buildDatasetSelectionSnapshot,
+  buildSelectionRevision,
+  resolveLoadDatasetTarget,
+} from "./loadPlaygroundDataset";
+import {
+  parseLoadDatasetActionContext,
+  parseLoadDatasetInput,
+} from "./parsers";
+import { bindPendingLoadDatasetActions } from "./pendingLoadDataset";
+import type {
+  DatasetSelectionSnapshot,
+  ExpectedSelection,
+  PendingLoadDataset,
+  ResolveDatasetTarget,
+} from "./types";
+
+/**
+ * Reads the live playground dataset selection from the URL search params. The
+ * URL — not the store — is the source of truth for the rendered dataset mode,
+ * so drift detection must read it too.
+ */
+function getUrlSelection(searchParams: URLSearchParams): ExpectedSelection {
+  return {
+    datasetId: searchParams.get("datasetId"),
+    splitIds: searchParams.getAll("splitId"),
+  };
+}
+
+/**
+ * Applies a selection by replicating PlaygroundDatasetSelect.onSelectionChange:
+ * write the store (keeps the experiment path + per-dataset config consistent)
+ * and the URL (flips the visible mode), setting `datasetId` + one repeated
+ * `splitId` per split and clearing the now-stale `exampleId`.
+ */
+function applyDatasetSelection({
+  snapshot,
+  playgroundStore,
+  setSearchParams,
+}: {
+  snapshot: DatasetSelectionSnapshot;
+  playgroundStore: PlaygroundStore;
+  setSearchParams: SetURLSearchParams;
+}) {
+  playgroundStore.getState().setDatasetId(snapshot.datasetId);
+  setSearchParams((prev) => {
+    const next = new URLSearchParams(prev);
+    const hasDatasetChanged = snapshot.datasetId !== next.get("datasetId");
+    next.set("datasetId", snapshot.datasetId);
+    next.delete("splitId");
+    snapshot.splitIds.forEach((splitId) => {
+      next.append("splitId", splitId);
+    });
+    if (hasDatasetChanged) {
+      next.delete("exampleId");
+    }
+    return next;
+  });
+}
+
+/**
+ * Creates the client action handler for the load_dataset tool. At propose time
+ * it resolves the dataset/split names to ids, validates existence + emptiness,
+ * snapshots the selection with a drift revision, and registers a pending
+ * proposal for user approval before the playground switches into dataset mode.
+ */
+export function createLoadDatasetClientAction({
+  playgroundStore,
+  setSearchParams,
+  getSearchParams,
+  setPendingLoadDataset,
+  shouldAutoAccept = () => false,
+  resolveDatasetTarget = resolveLoadDatasetTarget,
+}: {
+  playgroundStore: PlaygroundStore;
+  setSearchParams: SetURLSearchParams;
+  /** Reads the current URL search params (kept fresh across renders). */
+  getSearchParams: () => URLSearchParams;
+  setPendingLoadDataset: (
+    toolCallId: string,
+    pendingLoad: PendingLoadDataset | null
+  ) => void;
+  shouldAutoAccept?: () => boolean;
+  resolveDatasetTarget?: ResolveDatasetTarget;
+}) {
+  const readSelectionRevision = () =>
+    buildSelectionRevision(getUrlSelection(getSearchParams()));
+
+  return async (
+    input: unknown,
+    context?: unknown
+  ): Promise<AgentClientActionResult> => {
+    const actionContext = parseLoadDatasetActionContext(context);
+    if (!actionContext) {
+      return {
+        ok: false,
+        error: "Cannot propose dataset load without tool call context.",
+      };
+    }
+    const parsed = parseLoadDatasetInput(input);
+    if (!parsed) {
+      return { ok: false, error: "Invalid load_dataset input." };
+    }
+
+    const resolution = await resolveDatasetTarget(parsed);
+    if (!resolution.ok) return resolution;
+
+    const expectedSelection = getUrlSelection(getSearchParams());
+    const pendingLoad = bindPendingLoadDatasetActions({
+      pendingLoad: {
+        toolCallId: actionContext.toolCallId,
+        sessionId: actionContext.sessionId,
+        input: parsed,
+        snapshot: buildDatasetSelectionSnapshot(resolution.output),
+        expectedSelection,
+        expectedRevision: buildSelectionRevision(expectedSelection),
+      },
+      resolveDatasetTarget,
+      readSelectionRevision,
+      applyDatasetSelection: (snapshot) =>
+        applyDatasetSelection({ snapshot, playgroundStore, setSearchParams }),
+      addToolOutput: actionContext.addToolOutput,
+      setPendingLoadDataset,
+    });
+
+    if (shouldAutoAccept()) {
+      await pendingLoad.accept?.({ approvalSource: "auto" });
+      return { ok: true };
+    }
+
+    setPendingLoadDataset(actionContext.toolCallId, pendingLoad);
+    return { ok: true };
+  };
+}

--- a/app/src/agent/tools/playgroundLoadDataset/constants.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/constants.ts
@@ -1,0 +1,7 @@
+// Must byte-match the server tool NAME advertised in
+// src/phoenix/server/agents/tools/external/load_dataset.py — the name is the
+// single contract between server advertisement and browser dispatch.
+export const LOAD_DATASET_TOOL_NAME = "load_dataset";
+
+export const LOAD_DATASET_NAVIGATION_CANCEL_ERROR =
+  "The playground was closed before this dataset load could be reviewed, so it was discarded.";

--- a/app/src/agent/tools/playgroundLoadDataset/constants.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/constants.ts
@@ -1,5 +1,4 @@
-// Must byte-match the server tool NAME advertised in
-// src/phoenix/server/agents/tools/external/load_dataset.py — the name is the
+// Must byte-match the server tool NAME (load_dataset.py) — the name is the
 // single contract between server advertisement and browser dispatch.
 export const LOAD_DATASET_TOOL_NAME = "load_dataset";
 

--- a/app/src/agent/tools/playgroundLoadDataset/index.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/index.ts
@@ -1,0 +1,7 @@
+export * from "./clientActions";
+export * from "./constants";
+export * from "./loadPlaygroundDataset";
+export * from "./parsers";
+export * from "./pendingLoadDataset";
+export * from "./schemas";
+export * from "./types";

--- a/app/src/agent/tools/playgroundLoadDataset/loadPlaygroundDataset.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/loadPlaygroundDataset.ts
@@ -1,0 +1,216 @@
+import { fetchQuery, graphql } from "react-relay";
+
+import RelayEnvironment from "@phoenix/RelayEnvironment";
+
+import type { loadPlaygroundDatasetExampleCountQuery } from "./__generated__/loadPlaygroundDatasetExampleCountQuery.graphql";
+import type { loadPlaygroundDatasetResolveQuery } from "./__generated__/loadPlaygroundDatasetResolveQuery.graphql";
+import type {
+  DatasetSelectionSnapshot,
+  DatasetTargetResolution,
+  ExpectedSelection,
+  LoadDatasetInput,
+  ResolvedDatasetTarget,
+} from "./types";
+
+// `datasets(filter:)` uses substring `ilike` matching, so a single name may
+// return multiple rows; the resolver exact-matches the supplied name against
+// them. Dataset names are unique, so a larger page only guards against an exact
+// match being pushed past the first page by similarly named datasets.
+const DATASET_RESOLVE_PAGE_SIZE = 100;
+
+const resolveDatasetQuery = graphql`
+  query loadPlaygroundDatasetResolveQuery($name: String!, $first: Int!) {
+    datasets(filter: { col: name, value: $name }, first: $first) {
+      edges {
+        node {
+          id
+          name
+          exampleCount
+          splits {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+
+const datasetExampleCountQuery = graphql`
+  query loadPlaygroundDatasetExampleCountQuery($id: ID!, $splitIds: [ID!]!) {
+    node(id: $id) {
+      ... on Dataset {
+        exampleCount(splitIds: $splitIds)
+      }
+    }
+  }
+`;
+
+type ResolvedDatasetRow = {
+  id: string;
+  name: string;
+  exampleCount: number;
+  splits: ReadonlyArray<{ id: string; name: string }>;
+};
+
+/**
+ * Resolves the dataset and (optional) split named in a load_dataset input to
+ * concrete ids, validating that the dataset exists, the split exists within it,
+ * and the targeted selection is non-empty. Emptiness is split-scoped: when a
+ * split is supplied the selected split's example count is checked, otherwise the
+ * dataset-level count. Returns `{ok:false,error}` on any failure so the caller
+ * can surface a propose-time error and show no card.
+ */
+export async function resolveLoadDatasetTarget(
+  input: LoadDatasetInput
+): Promise<DatasetTargetResolution> {
+  let datasetRow: ResolvedDatasetRow | null;
+  try {
+    datasetRow = await resolveDatasetRowByName(input.datasetName);
+  } catch (error) {
+    return { ok: false, error: getResolveFailureMessage(error) };
+  }
+  if (!datasetRow) {
+    return {
+      ok: false,
+      error: `No dataset named "${input.datasetName}" was found.`,
+    };
+  }
+
+  if (input.splitName === undefined) {
+    if (datasetRow.exampleCount <= 0) {
+      return {
+        ok: false,
+        error: `Dataset "${datasetRow.name}" has no examples to load.`,
+      };
+    }
+    return {
+      ok: true,
+      output: {
+        datasetId: datasetRow.id,
+        datasetName: datasetRow.name,
+        splitId: null,
+        splitName: null,
+      },
+    };
+  }
+
+  const split = datasetRow.splits.find(
+    (candidate) => candidate.name === input.splitName
+  );
+  if (!split) {
+    return {
+      ok: false,
+      error: `Dataset "${datasetRow.name}" has no split named "${input.splitName}".`,
+    };
+  }
+
+  let splitExampleCount: number;
+  try {
+    splitExampleCount = await fetchDatasetExampleCount({
+      datasetId: datasetRow.id,
+      splitIds: [split.id],
+    });
+  } catch (error) {
+    return { ok: false, error: getResolveFailureMessage(error) };
+  }
+  if (splitExampleCount <= 0) {
+    return {
+      ok: false,
+      error: `Split "${split.name}" in dataset "${datasetRow.name}" has no examples to load.`,
+    };
+  }
+
+  return {
+    ok: true,
+    output: {
+      datasetId: datasetRow.id,
+      datasetName: datasetRow.name,
+      splitId: split.id,
+      splitName: split.name,
+    },
+  };
+}
+
+async function resolveDatasetRowByName(
+  name: string
+): Promise<ResolvedDatasetRow | null> {
+  const data = await fetchQuery<loadPlaygroundDatasetResolveQuery>(
+    RelayEnvironment,
+    resolveDatasetQuery,
+    { name, first: DATASET_RESOLVE_PAGE_SIZE }
+  ).toPromise();
+  const edges = data?.datasets.edges ?? [];
+  const exactMatches = edges
+    .map((edge) => edge.node)
+    .filter((node) => node.name === name);
+  if (exactMatches.length === 0) {
+    if (edges.length >= DATASET_RESOLVE_PAGE_SIZE) {
+      throw new Error(
+        `Too many datasets match "${name}" to resolve an exact name; rename the dataset or use a more specific name.`
+      );
+    }
+    return null;
+  }
+  // Dataset names are unique, so an exact-name match is singular.
+  return {
+    id: exactMatches[0]!.id,
+    name: exactMatches[0]!.name,
+    exampleCount: exactMatches[0]!.exampleCount,
+    splits: exactMatches[0]!.splits.map((split) => ({
+      id: split.id,
+      name: split.name,
+    })),
+  };
+}
+
+async function fetchDatasetExampleCount({
+  datasetId,
+  splitIds,
+}: {
+  datasetId: string;
+  splitIds: string[];
+}): Promise<number> {
+  const data = await fetchQuery<loadPlaygroundDatasetExampleCountQuery>(
+    RelayEnvironment,
+    datasetExampleCountQuery,
+    { id: datasetId, splitIds }
+  ).toPromise();
+  return data?.node?.exampleCount ?? 0;
+}
+
+function getResolveFailureMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Failed to resolve dataset.";
+}
+
+/**
+ * Builds the JSON-safe selection snapshot the card shows and the accept handler
+ * applies verbatim.
+ */
+export function buildDatasetSelectionSnapshot(
+  target: ResolvedDatasetTarget
+): DatasetSelectionSnapshot {
+  return {
+    datasetId: target.datasetId,
+    splitIds: target.splitId != null ? [target.splitId] : [],
+    datasetName: target.datasetName,
+    ...(target.splitName != null ? { splitNames: [target.splitName] } : {}),
+  };
+}
+
+/**
+ * djb2 hash of a selection, used as an optimistic-concurrency revision (no
+ * native revision counter exists). Split ids are sorted so the revision depends
+ * on the selection, not on split ordering.
+ */
+export function buildSelectionRevision(selection: ExpectedSelection): string {
+  const serialized = JSON.stringify({
+    datasetId: selection.datasetId,
+    splitIds: [...selection.splitIds].sort(),
+  });
+  let hash = 5381;
+  for (let index = 0; index < serialized.length; index++) {
+    hash = (hash * 33) ^ serialized.charCodeAt(index);
+  }
+  return `load-dataset-${(hash >>> 0).toString(16)}`;
+}

--- a/app/src/agent/tools/playgroundLoadDataset/loadPlaygroundDataset.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/loadPlaygroundDataset.ts
@@ -12,10 +12,8 @@ import type {
   ResolvedDatasetTarget,
 } from "./types";
 
-// `datasets(filter:)` uses substring `ilike` matching, so a single name may
-// return multiple rows; the resolver exact-matches the supplied name against
-// them. Dataset names are unique, so a larger page only guards against an exact
-// match being pushed past the first page by similarly named datasets.
+// `datasets(filter:)` is a substring `ilike` match, so a name can return multiple rows;
+// the page size only guards against an exact match being pushed past the first page.
 const DATASET_RESOLVE_PAGE_SIZE = 100;
 
 const resolveDatasetQuery = graphql`
@@ -54,12 +52,9 @@ type ResolvedDatasetRow = {
 };
 
 /**
- * Resolves the dataset and (optional) split named in a load_dataset input to
- * concrete ids, validating that the dataset exists, the split exists within it,
- * and the targeted selection is non-empty. Emptiness is split-scoped: when a
- * split is supplied the selected split's example count is checked, otherwise the
- * dataset-level count. Returns `{ok:false,error}` on any failure so the caller
- * can surface a propose-time error and show no card.
+ * Resolves a load_dataset input's dataset/split names to ids. Emptiness is
+ * split-scoped (the selected split's count when a split is given, else the
+ * dataset total). Returns `{ok:false,error}` on any failure.
  */
 export async function resolveLoadDatasetTarget(
   input: LoadDatasetInput
@@ -183,10 +178,7 @@ function getResolveFailureMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Failed to resolve dataset.";
 }
 
-/**
- * Builds the JSON-safe selection snapshot the card shows and the accept handler
- * applies verbatim.
- */
+/** Builds the JSON-safe snapshot the card shows and the accept handler applies verbatim. */
 export function buildDatasetSelectionSnapshot(
   target: ResolvedDatasetTarget
 ): DatasetSelectionSnapshot {
@@ -198,11 +190,7 @@ export function buildDatasetSelectionSnapshot(
   };
 }
 
-/**
- * djb2 hash of a selection, used as an optimistic-concurrency revision (no
- * native revision counter exists). Split ids are sorted so the revision depends
- * on the selection, not on split ordering.
- */
+/** Optimistic-concurrency revision (djb2). Split ids are sorted so the revision is order-independent. */
 export function buildSelectionRevision(selection: ExpectedSelection): string {
   const serialized = JSON.stringify({
     datasetId: selection.datasetId,

--- a/app/src/agent/tools/playgroundLoadDataset/loadPlaygroundDataset.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/loadPlaygroundDataset.ts
@@ -51,7 +51,7 @@ type ResolvedDatasetRow = {
   splits: ReadonlyArray<{ id: string; name: string }>;
 };
 
-// Resolves names to ids; emptiness is split-scoped. Returns {ok:false,error} on any failure.
+// Emptiness is split-scoped: a supplied split's example count is checked, not the dataset total.
 export async function resolveLoadDatasetTarget(
   input: LoadDatasetInput
 ): Promise<DatasetTargetResolution> {
@@ -174,7 +174,6 @@ function getResolveFailureMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Failed to resolve dataset.";
 }
 
-/** Builds the JSON-safe snapshot the card shows and the accept handler applies verbatim. */
 export function buildDatasetSelectionSnapshot(
   target: ResolvedDatasetTarget
 ): DatasetSelectionSnapshot {
@@ -186,10 +185,10 @@ export function buildDatasetSelectionSnapshot(
   };
 }
 
-/** Optimistic-concurrency revision (djb2). Split ids are sorted so the revision is order-independent. */
 export function buildSelectionRevision(selection: ExpectedSelection): string {
   const serialized = JSON.stringify({
     datasetId: selection.datasetId,
+    // Sorted so the revision is order-independent.
     splitIds: [...selection.splitIds].sort(),
   });
   let hash = 5381;

--- a/app/src/agent/tools/playgroundLoadDataset/loadPlaygroundDataset.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/loadPlaygroundDataset.ts
@@ -51,11 +51,7 @@ type ResolvedDatasetRow = {
   splits: ReadonlyArray<{ id: string; name: string }>;
 };
 
-/**
- * Resolves a load_dataset input's dataset/split names to ids. Emptiness is
- * split-scoped (the selected split's count when a split is given, else the
- * dataset total). Returns `{ok:false,error}` on any failure.
- */
+// Resolves names to ids; emptiness is split-scoped. Returns {ok:false,error} on any failure.
 export async function resolveLoadDatasetTarget(
   input: LoadDatasetInput
 ): Promise<DatasetTargetResolution> {

--- a/app/src/agent/tools/playgroundLoadDataset/parsers.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/parsers.ts
@@ -1,0 +1,15 @@
+import {
+  loadDatasetActionContextSchema,
+  loadDatasetInputSchema,
+} from "./schemas";
+import type { LoadDatasetActionContext, LoadDatasetInput } from "./types";
+
+export function parseLoadDatasetInput(input: unknown): LoadDatasetInput | null {
+  return loadDatasetInputSchema.safeParse(input).data ?? null;
+}
+
+export function parseLoadDatasetActionContext(
+  context: unknown
+): LoadDatasetActionContext | null {
+  return loadDatasetActionContextSchema.safeParse(context).data ?? null;
+}

--- a/app/src/agent/tools/playgroundLoadDataset/pendingLoadDataset.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/pendingLoadDataset.ts
@@ -8,10 +8,9 @@ import type {
 } from "./types";
 
 /**
- * Attaches accept/reject callbacks to a pending load_dataset proposal. On
- * accept, the proposed target is re-resolved and the live selection re-checked
- * for drift before the dual-write, so the URL never receives stale ids the card
- * did not show.
+ * Attaches accept/reject/cancel to a pending load_dataset proposal. Accept
+ * re-resolves the target and re-checks selection drift before the dual-write, so
+ * the URL never receives stale ids the card did not show.
  */
 export function bindPendingLoadDatasetActions({
   pendingLoad,

--- a/app/src/agent/tools/playgroundLoadDataset/pendingLoadDataset.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/pendingLoadDataset.ts
@@ -1,0 +1,111 @@
+import {
+  LOAD_DATASET_NAVIGATION_CANCEL_ERROR,
+  LOAD_DATASET_TOOL_NAME,
+} from "./constants";
+import type {
+  BindPendingLoadDatasetOptions,
+  PendingLoadDataset,
+} from "./types";
+
+/**
+ * Attaches accept/reject callbacks to a pending load_dataset proposal. On
+ * accept, the proposed target is re-resolved and the live selection re-checked
+ * for drift before the dual-write, so the URL never receives stale ids the card
+ * did not show.
+ */
+export function bindPendingLoadDatasetActions({
+  pendingLoad,
+  resolveDatasetTarget,
+  readSelectionRevision,
+  applyDatasetSelection,
+  addToolOutput,
+  setPendingLoadDataset,
+}: BindPendingLoadDatasetOptions): PendingLoadDataset {
+  return {
+    ...pendingLoad,
+    accept: async ({ approvalSource = "user" } = {}) => {
+      setPendingLoadDataset(pendingLoad.toolCallId, null);
+
+      if (readSelectionRevision() !== pendingLoad.expectedRevision) {
+        await addToolOutput({
+          state: "output-error",
+          tool: LOAD_DATASET_TOOL_NAME,
+          toolCallId: pendingLoad.toolCallId,
+          errorText:
+            "The playground dataset selection changed after this load was proposed, so it can no longer be applied.",
+        });
+        return;
+      }
+
+      // The dataset and split are separate, deletable entities, so
+      // selection-drift detection alone is insufficient — re-resolve the target
+      // to confirm it still exists before writing its ids into the URL.
+      const resolution = await resolveDatasetTarget(pendingLoad.input);
+      if (!resolution.ok) {
+        await addToolOutput({
+          state: "output-error",
+          tool: LOAD_DATASET_TOOL_NAME,
+          toolCallId: pendingLoad.toolCallId,
+          errorText: resolution.error,
+        });
+        return;
+      }
+      const resolvedSplitId = resolution.output.splitId;
+      const proposedSplitId = pendingLoad.snapshot.splitIds[0] ?? null;
+      if (
+        resolution.output.datasetId !== pendingLoad.snapshot.datasetId ||
+        resolvedSplitId !== proposedSplitId
+      ) {
+        await addToolOutput({
+          state: "output-error",
+          tool: LOAD_DATASET_TOOL_NAME,
+          toolCallId: pendingLoad.toolCallId,
+          errorText:
+            "The proposed dataset or split changed after this load was proposed, so it can no longer be applied.",
+        });
+        return;
+      }
+
+      applyDatasetSelection(pendingLoad.snapshot);
+
+      await addToolOutput({
+        state: "output-available",
+        tool: LOAD_DATASET_TOOL_NAME,
+        toolCallId: pendingLoad.toolCallId,
+        output: {
+          status: "loaded",
+          acceptedBy: approvalSource,
+          datasetId: pendingLoad.snapshot.datasetId,
+          datasetName: pendingLoad.snapshot.datasetName ?? null,
+          splitIds: pendingLoad.snapshot.splitIds,
+          splitNames: pendingLoad.snapshot.splitNames ?? [],
+          message:
+            approvalSource === "auto"
+              ? "Dataset load auto-approved."
+              : "Playground switched to dataset mode.",
+        },
+      });
+    },
+    reject: async () => {
+      setPendingLoadDataset(pendingLoad.toolCallId, null);
+      await addToolOutput({
+        state: "output-available",
+        tool: LOAD_DATASET_TOOL_NAME,
+        toolCallId: pendingLoad.toolCallId,
+        output: {
+          status: "rejected",
+          message: "User rejected the proposed dataset load.",
+        },
+      });
+    },
+    cancel: async () => {
+      setPendingLoadDataset(pendingLoad.toolCallId, null);
+      await addToolOutput({
+        state: "output-error",
+        tool: LOAD_DATASET_TOOL_NAME,
+        toolCallId: pendingLoad.toolCallId,
+        errorText: LOAD_DATASET_NAVIGATION_CANCEL_ERROR,
+      });
+    },
+  };
+}

--- a/app/src/agent/tools/playgroundLoadDataset/pendingLoadDataset.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/pendingLoadDataset.ts
@@ -7,7 +7,6 @@ import type {
   PendingLoadDataset,
 } from "./types";
 
-/** Accept re-resolves the target and re-checks selection drift before the dual-write. */
 export function bindPendingLoadDatasetActions({
   pendingLoad,
   resolveDatasetTarget,

--- a/app/src/agent/tools/playgroundLoadDataset/pendingLoadDataset.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/pendingLoadDataset.ts
@@ -7,11 +7,7 @@ import type {
   PendingLoadDataset,
 } from "./types";
 
-/**
- * Attaches accept/reject/cancel to a pending load_dataset proposal. Accept
- * re-resolves the target and re-checks selection drift before the dual-write, so
- * the URL never receives stale ids the card did not show.
- */
+/** Accept re-resolves the target and re-checks selection drift before the dual-write. */
 export function bindPendingLoadDatasetActions({
   pendingLoad,
   resolveDatasetTarget,
@@ -36,9 +32,8 @@ export function bindPendingLoadDatasetActions({
         return;
       }
 
-      // The dataset and split are separate, deletable entities, so
-      // selection-drift detection alone is insufficient — re-resolve the target
-      // to confirm it still exists before writing its ids into the URL.
+      // Dataset/split are separately deletable, so drift detection alone is insufficient:
+      // re-resolve the target before writing its ids to the URL.
       const resolution = await resolveDatasetTarget(pendingLoad.input);
       if (!resolution.ok) {
         await addToolOutput({

--- a/app/src/agent/tools/playgroundLoadDataset/schemas.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/schemas.ts
@@ -1,0 +1,39 @@
+import type { Chat } from "@ai-sdk/react";
+import type { UIMessage } from "ai";
+import { z } from "zod";
+
+import { normalizeAliases } from "@phoenix/agent/tools/playgroundPrompt";
+
+export type LoadDatasetToolOutputSender = Chat<UIMessage>["addToolOutput"];
+
+/**
+ * Input schema for the load_dataset tool. Must agree with the server-owned
+ * PARAMETERS (the model-facing source of truth): `datasetName` is a required
+ * string and `splitName` is optional. v1 accepts at most one split.
+ */
+export const loadDatasetInputSchema = z
+  .preprocess(
+    (input) =>
+      normalizeAliases(input == null ? {} : input, {
+        datasetName: ["dataset_name"],
+        splitName: ["split_name"],
+      }),
+    z.object({
+      datasetName: z.string().trim().min(1),
+      // The model may emit an explicit null to mean "no split"; treat it the
+      // same as omitting the field, which loads the whole dataset.
+      splitName: z.string().trim().min(1).nullable().optional(),
+    })
+  )
+  .transform(({ datasetName, splitName }) => ({
+    datasetName,
+    ...(splitName != null ? { splitName } : {}),
+  }));
+
+export const loadDatasetActionContextSchema = z.object({
+  toolCallId: z.string(),
+  sessionId: z.string(),
+  addToolOutput: z.custom<LoadDatasetToolOutputSender>(
+    (value) => typeof value === "function"
+  ),
+});

--- a/app/src/agent/tools/playgroundLoadDataset/schemas.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/schemas.ts
@@ -6,11 +6,7 @@ import { normalizeAliases } from "@phoenix/agent/tools/playgroundPrompt";
 
 export type LoadDatasetToolOutputSender = Chat<UIMessage>["addToolOutput"];
 
-/**
- * Input schema for the load_dataset tool. Must agree with the server-owned
- * PARAMETERS (the model-facing source of truth): `datasetName` is a required
- * string and `splitName` is optional. v1 accepts at most one split.
- */
+// Must agree with the server-owned PARAMETERS: datasetName required, splitName optional.
 export const loadDatasetInputSchema = z
   .preprocess(
     (input) =>

--- a/app/src/agent/tools/playgroundLoadDataset/types.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/types.ts
@@ -17,10 +17,9 @@ export type LoadDatasetActionContext = z.output<
 >;
 
 /**
- * Stable, JSON-safe snapshot of a playground dataset selection. Owned by this
- * module rather than reusing a Relay/UI type so a pending entry can be
- * serialized and rebound. `splitIds` is kept as an array solely to preserve the
- * playground's repeated-`splitId` URL contract; v1 holds at most one split.
+ * JSON-safe snapshot of a playground dataset selection. `splitIds` is an array
+ * solely to preserve the playground's repeated-`splitId` URL contract; v1 holds
+ * at most one split.
  */
 export type DatasetSelectionSnapshot = {
   datasetId: string;
@@ -29,11 +28,7 @@ export type DatasetSelectionSnapshot = {
   splitNames?: string[];
 };
 
-/**
- * The current playground dataset selection captured at propose time, used to
- * detect drift before the accept-time dual-write. Holds the resolved
- * `datasetId`/`splitIds` and the revision derived from them.
- */
+/** Playground selection captured at propose time; re-checked for drift before the accept-time dual-write. */
 export type ExpectedSelection = {
   datasetId: string | null;
   splitIds: string[];

--- a/app/src/agent/tools/playgroundLoadDataset/types.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/types.ts
@@ -1,0 +1,93 @@
+import type { z } from "zod";
+
+import type { ApprovalSource } from "@phoenix/agent/tools/approval";
+
+import type {
+  loadDatasetActionContextSchema,
+  loadDatasetInputSchema,
+  LoadDatasetToolOutputSender,
+} from "./schemas";
+
+export type { LoadDatasetToolOutputSender } from "./schemas";
+
+export type LoadDatasetInput = z.output<typeof loadDatasetInputSchema>;
+
+export type LoadDatasetActionContext = z.output<
+  typeof loadDatasetActionContextSchema
+>;
+
+/**
+ * Stable, JSON-safe snapshot of a playground dataset selection. Owned by this
+ * module rather than reusing a Relay/UI type so a pending entry can be
+ * serialized and rebound. `splitIds` is kept as an array solely to preserve the
+ * playground's repeated-`splitId` URL contract; v1 holds at most one split.
+ */
+export type DatasetSelectionSnapshot = {
+  datasetId: string;
+  splitIds: string[];
+  datasetName?: string;
+  splitNames?: string[];
+};
+
+/**
+ * The current playground dataset selection captured at propose time, used to
+ * detect drift before the accept-time dual-write. Holds the resolved
+ * `datasetId`/`splitIds` and the revision derived from them.
+ */
+export type ExpectedSelection = {
+  datasetId: string | null;
+  splitIds: string[];
+};
+
+export type ResolvedDatasetTarget = {
+  datasetId: string;
+  datasetName: string;
+  /** Resolved split, present only when the input supplied a split name. */
+  splitId: string | null;
+  splitName: string | null;
+};
+
+export type DatasetTargetResolution =
+  | { ok: true; output: ResolvedDatasetTarget }
+  | { ok: false; error: string };
+
+/** Resolves a dataset/split name pair to ids, validating existence + emptiness. */
+export type ResolveDatasetTarget = (
+  input: LoadDatasetInput
+) => Promise<DatasetTargetResolution>;
+
+export type PendingLoadDataset = {
+  toolCallId: string;
+  /** Agent session that owns the unresolved load_dataset tool call. */
+  sessionId: string;
+  /** Parsed load_dataset input awaiting user approval. */
+  input: LoadDatasetInput;
+  /** Resolved target shown on the card and applied verbatim on accept. */
+  snapshot: DatasetSelectionSnapshot;
+  /** Selection at propose time, re-checked at accept to detect drift. */
+  expectedSelection: ExpectedSelection;
+  /** djb2 revision of `expectedSelection`, re-checked at accept. */
+  expectedRevision: string;
+  accept?: (options?: { approvalSource?: ApprovalSource }) => Promise<void>;
+  reject?: () => Promise<void>;
+  cancel?: () => Promise<void>;
+};
+
+export type ApplyDatasetSelection = (
+  snapshot: DatasetSelectionSnapshot
+) => void;
+
+export type BindPendingLoadDatasetOptions = {
+  pendingLoad: PendingLoadDataset;
+  /** Re-resolves the proposed target at accept to confirm it still exists. */
+  resolveDatasetTarget: ResolveDatasetTarget;
+  /** Reads the live selection to detect drift since propose time. */
+  readSelectionRevision: () => string;
+  /** Performs the store + URL dual-write that flips the playground into dataset mode. */
+  applyDatasetSelection: ApplyDatasetSelection;
+  addToolOutput: LoadDatasetToolOutputSender;
+  setPendingLoadDataset: (
+    toolCallId: string,
+    pendingLoad: PendingLoadDataset | null
+  ) => void;
+};

--- a/app/src/agent/tools/playgroundLoadDataset/types.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/types.ts
@@ -24,7 +24,6 @@ export type DatasetSelectionSnapshot = {
   splitNames?: string[];
 };
 
-/** Playground selection captured at propose time; re-checked for drift before the accept-time dual-write. */
 export type ExpectedSelection = {
   datasetId: string | null;
   splitIds: string[];
@@ -33,7 +32,6 @@ export type ExpectedSelection = {
 export type ResolvedDatasetTarget = {
   datasetId: string;
   datasetName: string;
-  /** Resolved split, present only when the input supplied a split name. */
   splitId: string | null;
   splitName: string | null;
 };
@@ -42,22 +40,16 @@ export type DatasetTargetResolution =
   | { ok: true; output: ResolvedDatasetTarget }
   | { ok: false; error: string };
 
-/** Resolves a dataset/split name pair to ids, validating existence + emptiness. */
 export type ResolveDatasetTarget = (
   input: LoadDatasetInput
 ) => Promise<DatasetTargetResolution>;
 
 export type PendingLoadDataset = {
   toolCallId: string;
-  /** Agent session that owns the unresolved load_dataset tool call. */
   sessionId: string;
-  /** Parsed load_dataset input awaiting user approval. */
   input: LoadDatasetInput;
-  /** Resolved target shown on the card and applied verbatim on accept. */
   snapshot: DatasetSelectionSnapshot;
-  /** Selection at propose time, re-checked at accept to detect drift. */
   expectedSelection: ExpectedSelection;
-  /** djb2 revision of `expectedSelection`, re-checked at accept. */
   expectedRevision: string;
   accept?: (options?: { approvalSource?: ApprovalSource }) => Promise<void>;
   reject?: () => Promise<void>;
@@ -70,11 +62,8 @@ export type ApplyDatasetSelection = (
 
 export type BindPendingLoadDatasetOptions = {
   pendingLoad: PendingLoadDataset;
-  /** Re-resolves the proposed target at accept to confirm it still exists. */
   resolveDatasetTarget: ResolveDatasetTarget;
-  /** Reads the live selection to detect drift since propose time. */
   readSelectionRevision: () => string;
-  /** Performs the store + URL dual-write that flips the playground into dataset mode. */
   applyDatasetSelection: ApplyDatasetSelection;
   addToolOutput: LoadDatasetToolOutputSender;
   setPendingLoadDataset: (

--- a/app/src/agent/tools/playgroundLoadDataset/types.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/types.ts
@@ -16,11 +16,7 @@ export type LoadDatasetActionContext = z.output<
   typeof loadDatasetActionContextSchema
 >;
 
-/**
- * JSON-safe snapshot of a playground dataset selection. `splitIds` is an array
- * solely to preserve the playground's repeated-`splitId` URL contract; v1 holds
- * at most one split.
- */
+// `splitIds` is an array to match the playground's repeated-`splitId` URL contract (v1: one split).
 export type DatasetSelectionSnapshot = {
   datasetId: string;
   splitIds: string[];

--- a/app/src/components/agent/LoadDatasetToolDetails.tsx
+++ b/app/src/components/agent/LoadDatasetToolDetails.tsx
@@ -141,16 +141,18 @@ function LoadDatasetResultDetails({ output }: { output: unknown }) {
 
   return (
     <>
-      <ToolPartLabel variant="success">Dataset loaded</ToolPartLabel>
+      <ToolPartLabel variant="success">
+        Loaded a dataset into the playground
+      </ToolPartLabel>
       <ul className="load-dataset__preview">
         <LoadDatasetPreviewRow label="Dataset">
           {result.datasetName ?? result.datasetId}
         </LoadDatasetPreviewRow>
-        {result.splitNames.length > 0 ? (
-          <LoadDatasetPreviewRow label="Split">
-            {result.splitNames.join(", ")}
-          </LoadDatasetPreviewRow>
-        ) : null}
+        <LoadDatasetPreviewRow label="Split">
+          {result.splitNames.length > 0
+            ? result.splitNames.join(", ")
+            : "All splits"}
+        </LoadDatasetPreviewRow>
       </ul>
     </>
   );

--- a/app/src/components/agent/LoadDatasetToolDetails.tsx
+++ b/app/src/components/agent/LoadDatasetToolDetails.tsx
@@ -1,0 +1,261 @@
+import { css } from "@emotion/react";
+import type { ReactNode } from "react";
+import { z } from "zod";
+
+import {
+  parseLoadDatasetInput,
+  type DatasetSelectionSnapshot,
+  type PendingLoadDataset,
+} from "@phoenix/agent/tools/playgroundLoadDataset";
+import { Button, Flex, View } from "@phoenix/components";
+import { useAgentContext } from "@phoenix/contexts/AgentContext";
+
+import { ToolPartCodeBlock, ToolPartLabel } from "./ToolPartPrimitives";
+import type { ToolInvocationPart } from "./toolPartTypes";
+import { formatToolState, stringifyToolValue } from "./toolPartTypes";
+
+const loadDatasetToolDetailsCSS = css`
+  && {
+    padding-bottom: 0;
+  }
+
+  .load-dataset__preview {
+    list-style: none;
+    margin: 0;
+    padding: var(--global-dimension-size-50) var(--global-dimension-size-250)
+      var(--global-dimension-size-125);
+    display: grid;
+    gap: var(--global-dimension-size-75);
+    font-family: var(--ac-global-font-family-sans);
+    white-space: normal;
+  }
+
+  .load-dataset__preview-row {
+    display: grid;
+    grid-template-columns: minmax(7rem, max-content) minmax(0, 1fr);
+    gap: var(--global-dimension-size-150);
+    align-items: baseline;
+    min-width: 0;
+  }
+
+  .load-dataset__preview-label {
+    color: var(--tool-call-secondary-color);
+    text-transform: uppercase;
+    font-size: var(--global-font-size-xs);
+    letter-spacing: 0.05em;
+    user-select: none;
+  }
+
+  .load-dataset__preview-value {
+    min-width: 0;
+    color: var(--global-text-color-900);
+    overflow-wrap: anywhere;
+  }
+`;
+
+export function getLoadDatasetToolPreview(part: ToolInvocationPart): string {
+  const result = parseLoadDatasetResult(part.output);
+  if (result?.datasetName) {
+    return result.splitNames.length > 0
+      ? `${result.datasetName} / ${result.splitNames.join(", ")}`
+      : result.datasetName;
+  }
+  const input = parseLoadDatasetInput(part.input);
+  if (!input) return "";
+  return input.splitName
+    ? `${input.datasetName} / ${input.splitName}`
+    : input.datasetName;
+}
+
+/**
+ * Semantic color for the collapsed tool-summary status pill, kept in sync with
+ * the body heading: a completed load reads success, a rejection reads warning,
+ * and a failure reads danger.
+ */
+export function getLoadDatasetStatusVariant(
+  part: ToolInvocationPart
+): "danger" | "warning" | "success" | undefined {
+  if (part.state === "output-error") return "danger";
+  if (part.state === "output-available") {
+    return getOutputStatus(part.output) === "rejected" ? "warning" : "success";
+  }
+  return undefined;
+}
+
+export function formatLoadDatasetState(part: ToolInvocationPart): string {
+  switch (part.state) {
+    case "input-available":
+      return "Awaiting approval";
+    case "output-available": {
+      const status = getOutputStatus(part.output);
+      if (status === "rejected") return "Rejected";
+      return isAutoAccepted(part.output) ? "Auto-approved" : "Accepted";
+    }
+    default:
+      return formatToolState(part.state);
+  }
+}
+
+export function LoadDatasetToolDetails({ part }: { part: ToolInvocationPart }) {
+  const pendingLoad = useAgentContext(
+    (state) => state.pendingLoadDatasetsByToolCallId[part.toolCallId] ?? null
+  );
+  const input = parseLoadDatasetInput(part.input);
+  const isResolved = part.state === "output-available";
+  const isRejected = isResolved && getOutputStatus(part.output) === "rejected";
+
+  return (
+    <div className="tool-part__body" css={loadDatasetToolDetailsCSS}>
+      {pendingLoad ? (
+        <PendingLoadDatasetDetails pendingLoad={pendingLoad} />
+      ) : null}
+      {isResolved && !isRejected ? (
+        <LoadDatasetResultDetails output={part.output} />
+      ) : null}
+      {isRejected ? (
+        <ToolPartLabel variant="warning">Load rejected</ToolPartLabel>
+      ) : null}
+      {part.state === "output-error" ? (
+        <>
+          <ToolPartLabel variant="danger">Error</ToolPartLabel>
+          <ToolPartCodeBlock>{part.errorText ?? ""}</ToolPartCodeBlock>
+        </>
+      ) : null}
+      {!pendingLoad && input && part.state === "input-available" ? (
+        <>
+          <ToolPartLabel>Load dataset</ToolPartLabel>
+          <ToolPartCodeBlock>
+            Preparing dataset load approval...
+          </ToolPartCodeBlock>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function LoadDatasetResultDetails({ output }: { output: unknown }) {
+  const result = parseLoadDatasetResult(output);
+  if (!result) {
+    return (
+      <>
+        <ToolPartLabel>Result</ToolPartLabel>
+        <ToolPartCodeBlock>{stringifyToolValue(output)}</ToolPartCodeBlock>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <ToolPartLabel variant="success">Dataset loaded</ToolPartLabel>
+      <ul className="load-dataset__preview">
+        <LoadDatasetPreviewRow label="Dataset">
+          {result.datasetName ?? result.datasetId}
+        </LoadDatasetPreviewRow>
+        {result.splitNames.length > 0 ? (
+          <LoadDatasetPreviewRow label="Split">
+            {result.splitNames.join(", ")}
+          </LoadDatasetPreviewRow>
+        ) : null}
+      </ul>
+    </>
+  );
+}
+
+function PendingLoadDatasetDetails({
+  pendingLoad,
+}: {
+  pendingLoad: PendingLoadDataset;
+}) {
+  const canRespond = Boolean(pendingLoad.accept && pendingLoad.reject);
+  return (
+    <Flex direction="column" gap="size-100" minHeight="0">
+      <ToolPartLabel>Load dataset</ToolPartLabel>
+      <LoadDatasetPreviewBlock snapshot={pendingLoad.snapshot} />
+      <View paddingX="size-200" paddingBottom="size-125">
+        <Flex direction="row-reverse" gap="size-100">
+          <Button
+            size="S"
+            variant="primary"
+            isDisabled={!canRespond}
+            onPress={() => void pendingLoad.accept?.()}
+          >
+            Accept
+          </Button>
+          <Button
+            size="S"
+            isDisabled={!canRespond}
+            onPress={() => void pendingLoad.reject?.()}
+          >
+            Reject
+          </Button>
+        </Flex>
+        {!canRespond ? (
+          <ToolPartCodeBlock>
+            This dataset load was proposed in an earlier session and can&apos;t
+            be applied here. Re-run your request to have PXI propose it again.
+          </ToolPartCodeBlock>
+        ) : null}
+      </View>
+    </Flex>
+  );
+}
+
+function LoadDatasetPreviewBlock({
+  snapshot,
+}: {
+  snapshot: DatasetSelectionSnapshot;
+}) {
+  const splitNames = snapshot.splitNames ?? [];
+  return (
+    <ul className="load-dataset__preview">
+      <LoadDatasetPreviewRow label="From">Manual input</LoadDatasetPreviewRow>
+      <LoadDatasetPreviewRow label="Dataset">
+        {snapshot.datasetName ?? snapshot.datasetId}
+      </LoadDatasetPreviewRow>
+      {splitNames.length > 0 ? (
+        <LoadDatasetPreviewRow label="Split">
+          {splitNames.join(", ")}
+        </LoadDatasetPreviewRow>
+      ) : (
+        <LoadDatasetPreviewRow label="Split">All splits</LoadDatasetPreviewRow>
+      )}
+    </ul>
+  );
+}
+
+function LoadDatasetPreviewRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <li className="load-dataset__preview-row">
+      <span className="load-dataset__preview-label">{label}</span>
+      <div className="load-dataset__preview-value">{children}</div>
+    </li>
+  );
+}
+
+const loadDatasetResultSchema = z.object({
+  status: z.literal("loaded"),
+  datasetId: z.string(),
+  datasetName: z.string().nullable(),
+  splitNames: z.array(z.string()),
+});
+
+function parseLoadDatasetResult(output: unknown) {
+  return loadDatasetResultSchema.safeParse(output).data ?? null;
+}
+
+const outputStatusSchema = z.object({ status: z.string() });
+const autoAcceptedSchema = z.object({ acceptedBy: z.literal("auto") });
+
+function getOutputStatus(output: unknown): string | null {
+  return outputStatusSchema.safeParse(output).data?.status ?? null;
+}
+
+function isAutoAccepted(output: unknown): boolean {
+  return autoAcceptedSchema.safeParse(output).success;
+}

--- a/app/src/components/agent/LoadDatasetToolDetails.tsx
+++ b/app/src/components/agent/LoadDatasetToolDetails.tsx
@@ -67,11 +67,6 @@ export function getLoadDatasetToolPreview(part: ToolInvocationPart): string {
     : input.datasetName;
 }
 
-/**
- * Semantic color for the collapsed tool-summary status pill, kept in sync with
- * the body heading: a completed load reads success, a rejection reads warning,
- * and a failure reads danger.
- */
 export function getLoadDatasetStatusVariant(
   part: ToolInvocationPart
 ): "danger" | "warning" | "success" | undefined {

--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { getAgentToolUIBehavior } from "@phoenix/agent/extensions/toolRegistry";
 import { BATCH_SPAN_ANNOTATE_TOOL_NAME } from "@phoenix/agent/tools/batchSpanAnnotate";
 import { EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME } from "@phoenix/agent/tools/codeEvaluatorDraft";
+import { LOAD_DATASET_TOOL_NAME } from "@phoenix/agent/tools/playgroundLoadDataset";
 import { EDIT_PROMPT_TOOL_NAME } from "@phoenix/agent/tools/playgroundPrompt";
 import { SAVE_PROMPT_TOOL_NAME } from "@phoenix/agent/tools/playgroundSavePrompt";
 import { Icon, Icons } from "@phoenix/components";
@@ -36,6 +37,12 @@ import {
   formatEditPromptState,
   getEditPromptToolPreview,
 } from "./EditPromptToolDetails";
+import {
+  formatLoadDatasetState,
+  getLoadDatasetStatusVariant,
+  getLoadDatasetToolPreview,
+  LoadDatasetToolDetails,
+} from "./LoadDatasetToolDetails";
 import {
   formatSavePromptState,
   getSavePromptStatusVariant,
@@ -643,6 +650,13 @@ function getToolPresentation(
         stateLabel: formatSavePromptState(part),
         statusVariant: getSavePromptStatusVariant(part) ?? statusVariant,
         details: <SavePromptToolDetails part={part} />,
+      };
+    case LOAD_DATASET_TOOL_NAME:
+      return {
+        preview: getLoadDatasetToolPreview(part),
+        stateLabel: formatLoadDatasetState(part),
+        statusVariant: getLoadDatasetStatusVariant(part) ?? statusVariant,
+        details: <LoadDatasetToolDetails part={part} />,
       };
     case BATCH_SPAN_ANNOTATE_TOOL_NAME:
       return {

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -20,6 +20,7 @@ import type {
   ElicitToolOutput,
   PendingElicitation,
 } from "@phoenix/agent/tools/elicit";
+import { LOAD_DATASET_TOOL_NAME } from "@phoenix/agent/tools/playgroundLoadDataset";
 import { EDIT_PROMPT_TOOL_NAME } from "@phoenix/agent/tools/playgroundPrompt";
 import { SAVE_PROMPT_TOOL_NAME } from "@phoenix/agent/tools/playgroundSavePrompt";
 import { authFetch } from "@phoenix/authFetch";
@@ -198,6 +199,9 @@ export function useAgentChat({
       }
       if (toolCall.tool === EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME) {
         store.getState().setPendingCodeEvaluatorEdit(toolCall.toolCallId, null);
+      }
+      if (toolCall.tool === LOAD_DATASET_TOOL_NAME) {
+        store.getState().setPendingLoadDataset(toolCall.toolCallId, null);
       }
     });
 

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
@@ -30,6 +31,10 @@ import {
   LIST_PLAYGROUND_MODEL_TARGETS_TOOL_NAME,
   SET_PLAYGROUND_MODEL_TOOL_NAME,
 } from "@phoenix/agent/tools/playgroundModel";
+import {
+  createLoadDatasetClientAction,
+  LOAD_DATASET_TOOL_NAME,
+} from "@phoenix/agent/tools/playgroundLoadDataset";
 import {
   createReadPlaygroundOutputClientAction,
   READ_PLAYGROUND_OUTPUT_TOOL_NAME,
@@ -277,6 +282,11 @@ function PlaygroundContent() {
   const playgroundStore = usePlaygroundStore();
   const templateFormat = usePlaygroundContext((state) => state.templateFormat);
   const [searchParams, setSearchParams] = useSearchParams();
+  // The load_dataset client action reads the live URL selection outside React
+  // (drift recheck), so keep the latest search params in a ref the
+  // mount-scoped registration effect can read without re-registering.
+  const searchParamsRef = useRef(searchParams);
+  searchParamsRef.current = searchParams;
   const storeDatasetId = usePlaygroundContext((state) => state.datasetId);
   const experimentId = searchParams.get("experimentId");
   const datasetId = experimentId
@@ -362,6 +372,7 @@ function PlaygroundContent() {
       unregisterClientAction,
       setPendingPromptEdit,
       setPendingSavePrompt,
+      setPendingLoadDataset,
     } = agentStore.getState();
     registerClientAction(
       READ_PROMPT_TOOL_NAME,
@@ -401,6 +412,17 @@ function PlaygroundContent() {
       SET_VARIABLE_VALUES_TOOL_NAME,
       createSetVariableValuesClientAction({ playgroundStore })
     );
+    registerClientAction(
+      LOAD_DATASET_TOOL_NAME,
+      createLoadDatasetClientAction({
+        playgroundStore,
+        setSearchParams,
+        getSearchParams: () => searchParamsRef.current,
+        setPendingLoadDataset,
+        shouldAutoAccept: () =>
+          agentStore.getState().permissions.edits === "bypass",
+      })
+    );
     return () => {
       unregisterClientAction(READ_PROMPT_TOOL_NAME);
       unregisterClientAction(CLONE_PROMPT_INSTANCE_TOOL_NAME);
@@ -409,6 +431,7 @@ function PlaygroundContent() {
       unregisterClientAction(RUN_PLAYGROUND_TOOL_NAME);
       unregisterClientAction(READ_PLAYGROUND_OUTPUT_TOOL_NAME);
       unregisterClientAction(SET_VARIABLE_VALUES_TOOL_NAME);
+      unregisterClientAction(LOAD_DATASET_TOOL_NAME);
       for (const pendingEdit of Object.values(
         agentStore.getState().pendingPromptEditsByToolCallId
       )) {
@@ -423,8 +446,15 @@ function PlaygroundContent() {
           void pendingSave.cancel?.();
         }
       }
+      for (const pendingLoad of Object.values(
+        agentStore.getState().pendingLoadDatasetsByToolCallId
+      )) {
+        if (pendingLoad) {
+          void pendingLoad.cancel?.();
+        }
+      }
     };
-  }, [agentStore, playgroundStore]);
+  }, [agentStore, playgroundStore, setSearchParams]);
 
   useEffect(() => {
     const { registerClientAction, unregisterClientAction } =

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -26,15 +26,15 @@ import {
   TEST_CODE_EVALUATOR_DRAFT_TOOL_NAME,
 } from "@phoenix/agent/tools/codeEvaluatorDraft";
 import {
+  createLoadDatasetClientAction,
+  LOAD_DATASET_TOOL_NAME,
+} from "@phoenix/agent/tools/playgroundLoadDataset";
+import {
   createListPlaygroundModelTargetsClientAction,
   createSetPlaygroundModelClientAction,
   LIST_PLAYGROUND_MODEL_TARGETS_TOOL_NAME,
   SET_PLAYGROUND_MODEL_TOOL_NAME,
 } from "@phoenix/agent/tools/playgroundModel";
-import {
-  createLoadDatasetClientAction,
-  LOAD_DATASET_TOOL_NAME,
-} from "@phoenix/agent/tools/playgroundLoadDataset";
 import {
   createReadPlaygroundOutputClientAction,
   READ_PLAYGROUND_OUTPUT_TOOL_NAME,

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -16,6 +16,7 @@ import {
 import type { PendingBatchSpanAnnotate } from "@phoenix/agent/tools/batchSpanAnnotate";
 import type { PendingCodeEvaluatorEdit } from "@phoenix/agent/tools/codeEvaluatorDraft";
 import type { PendingElicitation } from "@phoenix/agent/tools/elicit";
+import type { PendingLoadDataset } from "@phoenix/agent/tools/playgroundLoadDataset";
 import type { PendingPromptEdit } from "@phoenix/agent/tools/playgroundPrompt";
 import type { PendingSavePrompt } from "@phoenix/agent/tools/playgroundSavePrompt";
 import { getDefaultInvocationConfig } from "@phoenix/pages/playground/providerAdapters";
@@ -424,6 +425,11 @@ export interface AgentState extends AgentProps {
     toolCallId: string,
     edit: PendingCodeEvaluatorEdit | null
   ) => void;
+  pendingLoadDatasetsByToolCallId: Partial<Record<string, PendingLoadDataset>>;
+  setPendingLoadDataset: (
+    toolCallId: string,
+    pendingLoad: PendingLoadDataset | null
+  ) => void;
 }
 
 /**
@@ -533,6 +539,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
     pendingBatchSpanAnnotatesByToolCallId: {},
     pendingSavePromptsByToolCallId: {},
     pendingCodeEvaluatorEditsByToolCallId: {},
+    pendingLoadDatasetsByToolCallId: {},
     setIsOpen: (isOpen) => {
       set({ isOpen }, false, { type: "setIsOpen" });
     },
@@ -1082,6 +1089,22 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         },
         false,
         { type: "setPendingCodeEvaluatorEdit" }
+      );
+    },
+
+    setPendingLoadDataset: (toolCallId, pendingLoad) => {
+      set(
+        (state) => {
+          const next = { ...state.pendingLoadDatasetsByToolCallId };
+          if (pendingLoad) {
+            next[toolCallId] = pendingLoad;
+          } else {
+            delete next[toolCallId];
+          }
+          return { pendingLoadDatasetsByToolCallId: next };
+        },
+        false,
+        { type: "setPendingLoadDataset" }
       );
     },
 

--- a/src/phoenix/server/agents/capabilities/tools/external/__init__.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/__init__.py
@@ -16,6 +16,7 @@ from phoenix.server.agents.capabilities.tools.external import (
     edit_code_evaluator_draft,
     edit_prompt_instance,
     list_playground_model_targets,
+    load_dataset,
     open_code_evaluator_form,
     read_code_evaluator_draft,
     read_playground_output,
@@ -47,6 +48,9 @@ from phoenix.server.agents.capabilities.tools.external.edit_prompt_instance impo
 )
 from phoenix.server.agents.capabilities.tools.external.list_playground_model_targets import (
     ListPlaygroundModelTargetsCapability,
+)
+from phoenix.server.agents.capabilities.tools.external.load_dataset import (
+    LoadDatasetCapability,
 )
 from phoenix.server.agents.capabilities.tools.external.open_code_evaluator_form import (
     OpenCodeEvaluatorFormCapability,
@@ -100,6 +104,7 @@ _EXTERNAL_TOOL_DEFINITIONS_BY_NAME: dict[str, ToolDefinition] = {
         clone_prompt_instance.TOOL_DEFINITION,
         edit_code_evaluator_draft.TOOL_DEFINITION,
         edit_prompt_instance.TOOL_DEFINITION,
+        load_dataset.TOOL_DEFINITION,
         open_code_evaluator_form.TOOL_DEFINITION,
         read_code_evaluator_draft.TOOL_DEFINITION,
         read_prompt_instance.TOOL_DEFINITION,
@@ -154,6 +159,7 @@ def get_external_tool_capability_function(
         WritePromptToolsCapability(instructions=prompts.write_prompt_tools_tool),
         RunPlaygroundCapability(instructions=prompts.run_playground_tool),
         SetVariableValuesCapability(instructions=prompts.set_variable_values_tool),
+        LoadDatasetCapability(instructions=prompts.load_dataset_tool),
         OpenCodeEvaluatorFormCapability(instructions=prompts.open_code_evaluator_form_tool),
         ReadCodeEvaluatorDraftCapability(instructions=prompts.read_code_evaluator_draft_tool),
         EditCodeEvaluatorDraftCapability(instructions=prompts.edit_code_evaluator_draft_tool),
@@ -175,6 +181,7 @@ __all__ = [
     "EditCodeEvaluatorDraftCapability",
     "EditPromptInstanceCapability",
     "ListPlaygroundModelTargetsCapability",
+    "LoadDatasetCapability",
     "OpenCodeEvaluatorFormCapability",
     "ReadCodeEvaluatorDraftCapability",
     "ReadPromptInstanceCapability",

--- a/src/phoenix/server/agents/capabilities/tools/external/load_dataset.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/load_dataset.py
@@ -17,11 +17,9 @@ NAME = "load_dataset"
 DESCRIPTION = (
     "Load a dataset into the currently mounted playground, optionally scoped to a single "
     "split, so the prompt runs over the dataset's examples. Use this when the user asks to "
-    "load, open, switch to, or run against a dataset (or one split of it) in the "
-    "playground. This only switches the playground's dataset selection; it does not edit "
-    "prompts, set variables, or run the playground. In manual approval mode an inline "
-    "accept/reject card applies the change on approval (skipped when edit_permission is "
-    "bypass)."
+    "load, open, switch to, run against, or run an experiment over a dataset (or one split "
+    "of it) in the playground. This only switches the playground's dataset selection; it "
+    "does not edit prompts, set variables, or run the playground."
 )
 
 PARAMETERS: dict[str, Any] = {

--- a/src/phoenix/server/agents/capabilities/tools/external/load_dataset.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/load_dataset.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from jinja2 import Template
+from pydantic_ai import RunContext
+from pydantic_ai.tools import SystemPromptFunc, ToolDefinition
+from pydantic_ai.toolsets import AgentToolset
+from pydantic_ai.toolsets.external import ExternalToolset
+
+from phoenix.server.agents.capabilities.base import AbstractDynamicCapability
+from phoenix.server.agents.types import AgentDependencies
+
+NAME = "load_dataset"
+
+DESCRIPTION = (
+    "Load a dataset into the currently mounted playground so the user can run prompts "
+    "over it. Optionally scope the run to a single split. This tool does not switch the "
+    "playground immediately: the browser renders an inline accept/reject card and the "
+    "user must approve the change. Pass dataset and split names exactly as they appear in "
+    "Phoenix; the browser resolves the names to IDs. Use this when the user asks to load, "
+    "open, switch to, or run against a dataset (or a split of one) in the playground."
+)
+
+PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "datasetName": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the dataset to load, exactly as it appears in Phoenix.",
+        },
+        "splitName": {
+            "type": ["string", "null"],
+            "description": (
+                "The name of a single dataset split to scope the run to, exactly as it "
+                "appears in Phoenix. Use null or omit to load the whole dataset."
+            ),
+        },
+    },
+    "required": ["datasetName"],
+    "additionalProperties": False,
+}
+
+TOOL_DEFINITION = ToolDefinition(
+    name=NAME,
+    description=DESCRIPTION,
+    parameters_json_schema=PARAMETERS,
+    kind="external",
+)
+
+
+@dataclass
+class LoadDatasetCapability(AbstractDynamicCapability[AgentDependencies]):
+    instructions: Template
+
+    def get_toolset(self) -> AgentToolset[AgentDependencies] | None:
+        return ExternalToolset[AgentDependencies]([TOOL_DEFINITION])
+
+    def get_dynamic_instructions(self) -> SystemPromptFunc[AgentDependencies]:
+        instructions = self.instructions
+
+        def _instructions(ctx: RunContext[AgentDependencies]) -> str:
+            return instructions.render()
+
+        return _instructions
+
+    def include_for_run(self, ctx: RunContext[AgentDependencies]) -> bool:
+        return ctx.deps.contexts.playground is not None

--- a/src/phoenix/server/agents/capabilities/tools/external/load_dataset.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/load_dataset.py
@@ -15,12 +15,13 @@ from phoenix.server.agents.types import AgentDependencies
 NAME = "load_dataset"
 
 DESCRIPTION = (
-    "Load a dataset into the currently mounted playground so the user can run prompts "
-    "over it. Optionally scope the run to a single split. This tool does not switch the "
-    "playground immediately: the browser renders an inline accept/reject card and the "
-    "user must approve the change. Pass dataset and split names exactly as they appear in "
-    "Phoenix; the browser resolves the names to IDs. Use this when the user asks to load, "
-    "open, switch to, or run against a dataset (or a split of one) in the playground."
+    "Load a dataset into the currently mounted playground, optionally scoped to a single "
+    "split, so the prompt runs over the dataset's examples. Use this when the user asks to "
+    "load, open, switch to, or run against a dataset (or one split of it) in the "
+    "playground. This only switches the playground's dataset selection; it does not edit "
+    "prompts, set variables, or run the playground. In manual approval mode an inline "
+    "accept/reject card applies the change on approval (skipped when edit_permission is "
+    "bypass)."
 )
 
 PARAMETERS: dict[str, Any] = {

--- a/src/phoenix/server/agents/prompts/__init__.py
+++ b/src/phoenix/server/agents/prompts/__init__.py
@@ -46,6 +46,7 @@ _SAVE_PROMPT_TOOL_INSTRUCTIONS = get_template("tools/SAVE_PROMPT_TOOL_INSTRUCTIO
 _SET_VARIABLE_VALUES_TOOL_INSTRUCTIONS = get_template(
     "tools/SET_VARIABLE_VALUES_TOOL_INSTRUCTIONS.xml.j2"
 )
+_LOAD_DATASET_TOOL_INSTRUCTIONS = get_template("tools/LOAD_DATASET_TOOL_INSTRUCTIONS.xml.j2")
 _BATCH_SPAN_ANNOTATE_TOOL_INSTRUCTIONS = get_template(
     "tools/BATCH_SPAN_ANNOTATE_TOOL_INSTRUCTIONS.xml.j2"
 )
@@ -103,6 +104,7 @@ class AgentPrompts:
     write_prompt_tools_tool: Template = _WRITE_PROMPT_TOOLS_TOOL_INSTRUCTIONS
     run_playground_tool: Template = _RUN_PLAYGROUND_TOOL_INSTRUCTIONS
     set_variable_values_tool: Template = _SET_VARIABLE_VALUES_TOOL_INSTRUCTIONS
+    load_dataset_tool: Template = _LOAD_DATASET_TOOL_INSTRUCTIONS
     batch_span_annotate_tool: Template = _BATCH_SPAN_ANNOTATE_TOOL_INSTRUCTIONS
     read_code_evaluator_draft_tool: Template = _READ_CODE_EVALUATOR_DRAFT_TOOL_INSTRUCTIONS
     edit_code_evaluator_draft_tool: Template = _EDIT_CODE_EVALUATOR_DRAFT_TOOL_INSTRUCTIONS

--- a/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playground
-description: Author, edit, or iterate on prompts in the Phoenix prompt playground. Load before any playground tool call, including single-shot prompt rewrites.
+description: Author, edit, or iterate on prompts in the Phoenix prompt playground, including running experiments over a dataset. Load before any playground tool call, including single-shot prompt rewrites.
 ---
 
 # Prompt Playground
@@ -44,26 +44,29 @@ dataset-backed evaluation loop is in scope.
 Use this workflow when the user wants evidence that a prompt is improving across a dataset, or when
 they are comparing prompt variants using evaluator results.
 
-1. Confirm the dataset represents the task the prompt is meant to solve, including the important
+1. Load the dataset with `load_dataset` if it isn't already loaded. If the user named a dataset but
+   no split and the dataset has splits, name them and ask whether to scope to one or load the whole
+   dataset — then load once.
+2. Confirm the dataset represents the task the prompt is meant to solve, including the important
    input fields, expected outputs, and failure modes.
-2. Make sure the starting prompt is well formed before running it: it should define the task,
+3. Make sure the starting prompt is well formed before running it: it should define the task,
    relevant variables, output format, and any constraints needed for consistent evaluation.
-3. Run the playground over the dataset. Each prompt instance run over a dataset is captured as an
+4. Run the playground over the dataset. Each prompt instance run over a dataset is captured as an
    experiment, with outputs and evaluator annotations available for review.
-4. Review the experiment outputs and annotations to find recurring failure patterns. Use `bash` with
+5. Review the experiment outputs and annotations to find recurring failure patterns. Use `bash` with
    `phoenix-gql` to inspect dataset-backed experiment results when needed; `read_playground_output`
    only reads manual playground runs. Separate model randomness from prompt issues when possible.
-5. Use or add evaluators when they make issue detection more systematic, especially for failures
+6. Use or add evaluators when they make issue detection more systematic, especially for failures
    that are hard to spot by manual review alone.
-6. Form a specific hypothesis for improving the prompt, then use `edit_prompt_instance` or
+7. Form a specific hypothesis for improving the prompt, then use `edit_prompt_instance` or
    `clone_prompt_instance` to create the next candidate.
-7. Rerun the playground and compare experiments. Look for evaluator improvements, fewer repeated
+8. Rerun the playground and compare experiments. Look for evaluator improvements, fewer repeated
    failure modes, and acceptable tradeoffs in output quality.
-8. Use `save_prompt` to save a prompt as a new version only after the evidence shows an
+9. Use `save_prompt` to save a prompt as a new version only after the evidence shows an
    improvement or the user explicitly accepts the tradeoff. For unsaved prompts, the tool can
    create the Phoenix prompt directly without asking for a name unless the user cares about the
    exact name.
-9. Continue the hypothesis, edit, run, compare loop until the dataset-backed results satisfy the
+10. Continue the hypothesis, edit, run, compare loop until the dataset-backed results satisfy the
    user's goal.
 
 ## Workflow: Author, Refine, Or Remove A Function Tool

--- a/src/phoenix/server/agents/prompts/tools/LOAD_DATASET_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/LOAD_DATASET_TOOL_INSTRUCTIONS.xml.j2
@@ -1,7 +1,7 @@
 <tool name="load_dataset">
   <description>Load a dataset (optionally scoped to one split) into the mounted playground. In manual approval mode the browser renders an inline accept/reject card and the user approves the change; this tool does not switch the playground immediately. Approval is skipped only when edit_permission is bypass.</description>
   <when_to_use>
-    - The user asks to load, open, switch to, or run against a dataset in the playground.
+    - The user asks to load, open, switch to, run against, or run an experiment over a dataset in the playground.
     - The user wants to scope a playground run to a single split of a dataset.
   </when_to_use>
   <preflight>
@@ -9,10 +9,7 @@
     - When the user names a dataset directly and you are confident it exists, you may pass that name without a discovery query.
   </preflight>
   <rules>
-    - `datasetName` is required. `splitName` is optional and scopes the run to one split; use null or omit it to load the whole dataset. Only a single split is supported.
-    - Propose the load by calling this tool directly. The inline accept/reject card is the approval surface — do not ask the user a separate yes/no question (or call `ask_user`) to confirm before calling it.
-    - Approval is skipped only when edit_permission is bypass; in that mode the load applies immediately without a card.
-    - This tool only switches the playground dataset selection. It does not edit prompt messages, set variable values, or run the playground.
-    - After the load is applied (the user accepts, or it is auto-approved under bypass), call `run_playground` if the user wants to see results over the loaded dataset.
+    - Propose the load by calling this tool directly. The inline accept/reject card is the approval surface — do not ask the user a separate yes/no question (or call `ask_user`) to confirm before calling it. Asking which split to scope to is a content question and is fine.
+    - After the load is applied, call `run_playground` if the user wants to see results over the loaded dataset.
   </rules>
 </tool>

--- a/src/phoenix/server/agents/prompts/tools/LOAD_DATASET_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/LOAD_DATASET_TOOL_INSTRUCTIONS.xml.j2
@@ -1,0 +1,16 @@
+<tool name="load_dataset">
+  <description>Load a dataset (optionally scoped to one split) into the mounted playground. The browser renders an inline accept/reject card and the user approves the change — this tool does not switch the playground immediately.</description>
+  <when_to_use>
+    - The user asks to load, open, switch to, or run against a dataset in the playground.
+    - The user wants to scope a playground run to a single split of a dataset.
+  </when_to_use>
+  <preflight>
+    - If you are unsure the dataset or split exists, or which exact name to pass, discover it first with `bash` and `phoenix-gql` rather than guessing. Pass `datasetName` (and `splitName`) exactly as Phoenix reports them; the browser resolves names to IDs.
+    - When the user names a dataset directly and you are confident it exists, you may pass that name without a discovery query.
+  </preflight>
+  <rules>
+    - `datasetName` is required. `splitName` is optional and scopes the run to one split; use null or omit it to load the whole dataset. Only a single split is supported.
+    - This tool only switches the playground dataset selection. It does not edit prompt messages, set variable values, or run the playground.
+    - After the user accepts the change, call `run_playground` if the user wants to see results over the loaded dataset.
+  </rules>
+</tool>

--- a/src/phoenix/server/agents/prompts/tools/LOAD_DATASET_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/LOAD_DATASET_TOOL_INSTRUCTIONS.xml.j2
@@ -1,5 +1,5 @@
 <tool name="load_dataset">
-  <description>Load a dataset (optionally scoped to one split) into the mounted playground. The browser renders an inline accept/reject card and the user approves the change — this tool does not switch the playground immediately.</description>
+  <description>Load a dataset (optionally scoped to one split) into the mounted playground. In manual approval mode the browser renders an inline accept/reject card and the user approves the change; this tool does not switch the playground immediately. Approval is skipped only when edit_permission is bypass.</description>
   <when_to_use>
     - The user asks to load, open, switch to, or run against a dataset in the playground.
     - The user wants to scope a playground run to a single split of a dataset.
@@ -10,7 +10,9 @@
   </preflight>
   <rules>
     - `datasetName` is required. `splitName` is optional and scopes the run to one split; use null or omit it to load the whole dataset. Only a single split is supported.
+    - Propose the load by calling this tool directly. The inline accept/reject card is the approval surface — do not ask the user a separate yes/no question (or call `ask_user`) to confirm before calling it.
+    - Approval is skipped only when edit_permission is bypass; in that mode the load applies immediately without a card.
     - This tool only switches the playground dataset selection. It does not edit prompt messages, set variable values, or run the playground.
-    - After the user accepts the change, call `run_playground` if the user wants to see results over the loaded dataset.
+    - After the load is applied (the user accepts, or it is auto-approved under bypass), call `run_playground` if the user wants to see results over the loaded dataset.
   </rules>
 </tool>

--- a/tests/unit/server/agents/capabilities/test_external_tools.py
+++ b/tests/unit/server/agents/capabilities/test_external_tools.py
@@ -24,7 +24,7 @@ def test_load_dataset_instructions_expose_params_and_discovery_preflight() -> No
 def test_load_dataset_parameters_expose_only_dataset_name_and_optional_split_name() -> None:
     """Pin the ``load_dataset`` model-facing parameter contract.
 
-    The browser dispatch (Phase 2) resolves these names to IDs, so the advertised
+    The browser dispatch resolves these names to IDs, so the advertised
     schema is the integration contract: ``datasetName`` is a required string and
     ``splitName`` is an optional, nullable string. Nothing else is accepted.
     """

--- a/tests/unit/server/agents/capabilities/test_external_tools.py
+++ b/tests/unit/server/agents/capabilities/test_external_tools.py
@@ -1,4 +1,41 @@
-from phoenix.server.agents.capabilities.tools.external import _EXTERNAL_TOOL_DEFINITIONS_BY_NAME
+from phoenix.server.agents.capabilities.tools.external import (
+    _EXTERNAL_TOOL_DEFINITIONS_BY_NAME,
+    load_dataset,
+)
+from phoenix.server.agents.prompts import AgentPrompts
+
+
+def test_load_dataset_instructions_expose_params_and_discovery_preflight() -> None:
+    """Pin the rendered ``load_dataset`` instruction structure, not its prose.
+
+    The template must name both parameters and carry a ``<preflight>`` block that
+    routes name discovery through ``phoenix-gql`` rather than baking dataset
+    inventory into the static prompt.
+    """
+    rendered = AgentPrompts().load_dataset_tool.render()
+
+    assert '<tool name="load_dataset">' in rendered
+    assert "datasetName" in rendered
+    assert "splitName" in rendered
+    assert "<preflight>" in rendered
+    assert "phoenix-gql" in rendered
+
+
+def test_load_dataset_parameters_expose_only_dataset_name_and_optional_split_name() -> None:
+    """Pin the ``load_dataset`` model-facing parameter contract.
+
+    The browser dispatch (Phase 2) resolves these names to IDs, so the advertised
+    schema is the integration contract: ``datasetName`` is a required string and
+    ``splitName`` is an optional, nullable string. Nothing else is accepted.
+    """
+    schema = load_dataset.TOOL_DEFINITION.parameters_json_schema
+
+    assert load_dataset.NAME == "load_dataset"
+    assert set(schema["properties"]) == {"datasetName", "splitName"}
+    assert schema["required"] == ["datasetName"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["datasetName"]["type"] == "string"
+    assert schema["properties"]["splitName"]["type"] == ["string", "null"]
 
 
 def test_external_tool_schemas_avoid_provider_rejected_top_level_keywords() -> None:

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -66,6 +66,7 @@ DYNAMIC_TOOL_INSTRUCTIONS: frozenset[str] = frozenset(
         _DEFAULT_PROMPTS.save_prompt_tool.render(),
         _DEFAULT_PROMPTS.run_playground_tool.render(),
         _DEFAULT_PROMPTS.set_variable_values_tool.render(),
+        _DEFAULT_PROMPTS.load_dataset_tool.render(),
     }
 )
 
@@ -476,6 +477,7 @@ class TestPlaygroundTools:
         assert "set_variable_values" not in _get_tool_names(captured_request.body)
         assert "list_playground_model_targets" not in _get_tool_names(captured_request.body)
         assert "set_playground_model" not in _get_tool_names(captured_request.body)
+        assert "load_dataset" not in _get_tool_names(captured_request.body)
 
     async def test_run_playground_tool_is_advertised_with_playground_context(
         self,
@@ -509,6 +511,7 @@ class TestPlaygroundTools:
         assert "set_variable_values" in _get_tool_names(captured_request.body)
         assert "list_playground_model_targets" in _get_tool_names(captured_request.body)
         assert "set_playground_model" in _get_tool_names(captured_request.body)
+        assert "load_dataset" in _get_tool_names(captured_request.body)
 
 
 class TestDocsMCPToolset:


### PR DESCRIPTION
resolves #13419

The Phoenix playground can switch between manual-input mode and dataset mode, but the PXI agent previously had no way to drive that switch — it could edit and run prompts, but not change the dataset selection (`set_variable_values` explicitly doesn't touch it, and `run_playground` only reads it). This PR adds a `load_dataset` tool that proposes loading a dataset (and optionally one split) into the playground. The user approves through an inline accept/reject card, and on accept the playground flips into dataset mode so the prompt runs over the dataset's examples. The UX mirrors the existing prompt-edit propose+confirm flow.

The tool is browser-executed: the server advertises a `load_dataset` tool definition (`{datasetName, splitName?}`) gated on playground context, while the work happens client-side. The client resolves dataset/split names to IDs at propose time, validates that the dataset/split exists and is non-empty (split-scoped when a split is given), and renders a summary-grid card of the `manual → dataset / split` transition. Accepting **re-resolves the target and rechecks the current selection for drift** before committing — guarding against the dataset/split being deleted or the selection changing between propose and accept — then dual-writes the playground store and the URL search params (the URL is the source of truth for the rendered mode). Pending state is cleaned up if the turn is interrupted.

```
 MODEL TURN                      BROWSER (PXI client)                    PLAYGROUND
 ──────────                      ────────────────────                    ──────────
 calls load_dataset    ───────►  resolve names→IDs (datasets(filter))
 {datasetName,                   read current selection {datasetId,
  splitName?}                      splitIds} from URL
 (server advertises              validate: found? non-empty?
  ToolDefinition,                  └─ no ─► propose-time error (no card)
  gated on playground)           build revision + show card
                                          │
                                          ▼
                                 summary grid:  Manual → Dataset <name> / Split <name>
                                   [ Accept ]            [ Reject ]
                                       │                     │
                                       ▼                     ▼
                          re-resolve target +         emit rejected
                          recheck revision drift
                            └─ drift ─► accept-time error
                            └─ ok ───► DUAL-WRITE:
                                 setDatasetId(store) ──────► store.datasetId
                                 setSearchParams(URL) ─────► ?datasetId=&splitId=…
                                  (clear exampleId)          (URL drives rendered mode)
                                                                    │
                                                                    ▼
                                                            isDatasetMode = true →
                                                            examples load (fire-and-forget)
```

**Key design decisions**
- **Browser-executed propose+confirm** (not direct-apply, not server-executed): the entire effect is a browser store + URL change, and the inline accept/reject card is required.
- **Name-based input with client-side name→ID resolution; no companion server tool** — the browser already holds the dataset/split inventory, so the tool accepts `datasetName`/`splitName` and resolves them client-side.
- **Accept-time integrity:** re-check a derived selection revision **and** re-resolve the target, because the dataset/split is a separately-deletable entity — revision-drift detection alone would let the card commit stale IDs.
- **Apply via dual-write** (`setDatasetId` store + `setSearchParams` URL): the URL is the source of truth for the rendered mode, so a store-only write would not flip the visible mode.
- **Fire-and-forget apply** with propose-time existence/emptiness validation; examples stream in through the existing lazy-loading path, consistent with the manual dataset dropdown.

## Test plan
- [x] Server unit tests: `load_dataset` advertised with playground context and absent without; PARAMETERS contract; rendered instruction XML structure (21 tests).
- [x] Frontend unit tests: name/split alias parsing, null-split coalescing, revision order-independence, snapshot shape, propose-error shows no card, accept dual-write + `exampleId` clear, accept-time selection-drift reject, accept-time target re-resolution reject, auto-accept (10 tests).
- [x] `tsc --noEmit` clean; ruff + mypy clean (server); oxlint + oxfmt clean (frontend).
- [ ] Manual: invoke in the playground — confirm the card shows the manual→dataset transition; accept flips into dataset mode (URL shows `datasetId`/`splitId`, examples load); reject leaves manual mode unchanged.
- [ ] Manual: propose against a non-existent dataset, an empty dataset, or an empty selected split → propose-time error, no card.
