### PR TITLE
fix(graphql): return prompt label name as plain string

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2999,7 +2999,7 @@ input PromptInvocationParametersInput @oneOf {
 type PromptLabel implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
-  name: Identifier!
+  name: String!
   description: String
   color: String
 }

--- a/src/phoenix/server/api/types/PromptLabel.py
+++ b/src/phoenix/server/api/types/PromptLabel.py
@@ -5,7 +5,6 @@ from strawberry.relay import Node, NodeID
 from strawberry.types import Info
 
 from phoenix.db import models
-from phoenix.db.types.identifier import Identifier
 from phoenix.server.api.context import Context
 
 
@@ -22,14 +21,14 @@ class PromptLabel(Node):
     async def name(
         self,
         info: Info[Context, None],
-    ) -> Identifier:
+    ) -> str:
         if self.db_record:
             val = self.db_record.name
         else:
             val = await info.context.data_loaders.prompt_label_fields.load(
                 (self.id, models.PromptLabel.name),
             )
-        return Identifier(val)
+        return val
 
     @strawberry.field
     async def description(


### PR DESCRIPTION
## Summary

Fixes #13561 — a prompt label whose name contains uppercase letters, spaces, or punctuation breaks the **entire** prompts list page with `"an unexpected error occurred"` at GraphQL path `prompts.edges[…].prompt.labels[…].name`.

### Root cause

`PromptLabel.name` was typed as `Identifier` and coerced its value through `Identifier(val)`, which enforces the strict pattern `^[a-z0-9]([_a-z0-9-]*[a-z0-9])?$`. But prompt label names are **free-form display strings**, not identifiers:

- the DB column is a plain `Mapped[str]` (`models.py`),
- the `create`/`patch` mutations accept any `str`,
- the UI form (`NewLabelForm.tsx`) only constrains length (1–30 chars), placeholder `"e.g., classifier"`.

So a label like `My Label` persists fine but fails pydantic validation on read, and a single bad label name takes down the whole `promptsLoaderQuery`. This is the same class of issue a prior fix (#10849, "make graphql prompt label type honest to db model") addressed for `color`/`description` nullability — it just missed `name`.

### Fix

Return the raw column value so the field type is honest to the model (`str`). This also fixes existing databases retroactively — no migration needed.

Notably this lets the **type checker** guard the boundary: because `db_record.name` is `str`, returning the value under an `-> Identifier` annotation is now a static `mypy` error. The original bug only slipped through because the value was laundered through `Identifier(val)`, deferring the failure to runtime.

## Changes

- `src/phoenix/server/api/types/PromptLabel.py` — return `str`, drop the `Identifier` coercion + unused import
- `app/schema.graphql` — regenerated: `PromptLabel.name: Identifier!` → `String!` (Relay artifacts unchanged; the scalar already maps to `string` in TS)

## Test plan

- [x] `mypy` clean; confirmed it flags the mismatch if the `Identifier` annotation is reintroduced without coercion
- [x] Manually verified labels with spaces/uppercase/punctuation now serialize verbatim instead of erroring