### PR TITLE
feat: preserve place and auto truncate for large tools

### DIFF
--- a/app/src/components/agent/BashToolDetails.tsx
+++ b/app/src/components/agent/BashToolDetails.tsx
@@ -6,6 +6,7 @@ import {
 
 import {
   ToolPartCodeBlock,
+  ToolPartExpandableSection,
   ToolPartLabel,
   ToolPartMeta,
 } from "./ToolPartPrimitives";
@@ -44,13 +45,17 @@ export function BashToolDetails({ part }: { part: ToolInvocationPart }) {
   return (
     <div className="tool-part__body">
       <ToolPartLabel>Command</ToolPartLabel>
-      <ToolPartCodeBlock>{command}</ToolPartCodeBlock>
+      <ToolPartExpandableSection>
+        <ToolPartCodeBlock>{command}</ToolPartCodeBlock>
+      </ToolPartExpandableSection>
       {part.state === "output-available" ? (
         <>
           {stdout ? (
             <>
               <ToolPartLabel>Output</ToolPartLabel>
-              <ToolPartCodeBlock>{stdout}</ToolPartCodeBlock>
+              <ToolPartExpandableSection>
+                <ToolPartCodeBlock>{stdout}</ToolPartCodeBlock>
+              </ToolPartExpandableSection>
             </>
           ) : null}
           <ToolPartMeta items={metaItems} />
@@ -59,7 +64,9 @@ export function BashToolDetails({ part }: { part: ToolInvocationPart }) {
       {part.state === "output-error" ? (
         <>
           <ToolPartLabel variant="danger">Error</ToolPartLabel>
-          <ToolPartCodeBlock>{part.errorText ?? ""}</ToolPartCodeBlock>
+          <ToolPartExpandableSection>
+            <ToolPartCodeBlock>{part.errorText ?? ""}</ToolPartCodeBlock>
+          </ToolPartExpandableSection>
         </>
       ) : null}
     </div>

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -12,6 +12,8 @@ import {
 import { useHotkeys } from "react-hotkeys-hook";
 import { useStickToBottom } from "use-stick-to-bottom";
 
+import { ChatScrollContext } from "./ChatScrollContext";
+
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import { useAgentQuickActions } from "@phoenix/agent/quickActions/quickActions";
 import type {
@@ -362,10 +364,12 @@ export function ChatView({
   emptyStateQuickActions?: EmptyStateQuickAction[];
 }>) {
   const { theme } = useTheme();
-  const { contentRef, scrollRef, scrollToBottom } = useStickToBottom({
-    initial: "instant",
-    resize: "instant",
-  });
+  const { contentRef, scrollRef, scrollToBottom, stopScroll } =
+    useStickToBottom({
+      initial: "instant",
+      resize: "instant",
+    });
+  const chatScrollContextValue = useMemo(() => ({ stopScroll }), [stopScroll]);
   const handleScrollRef = useCallback(
     (element: HTMLElement | null) => {
       scrollRef(element);
@@ -502,9 +506,10 @@ export function ChatView({
         }
       >
         <ChatLantern isVisible={showsEmptyState} />
-        <div className="chat__scroll-frame">
-          <div className="chat__scroll" ref={handleScrollRef}>
-            <div className="chat__messages" ref={contentRef}>
+        <ChatScrollContext.Provider value={chatScrollContextValue}>
+          <div className="chat__scroll-frame">
+            <div className="chat__scroll" ref={handleScrollRef}>
+              <div className="chat__messages" ref={contentRef}>
               {showsEmptyState && (
                 <ChatEmptyState
                   key={theme}
@@ -558,6 +563,7 @@ export function ChatView({
             </div>
           </div>
         </div>
+        </ChatScrollContext.Provider>
         <div className="chat__input">
           {!hasAcknowledgedConsent ? (
             <PromptInput status={status} isDisabled mode="elicitation">

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -12,8 +12,6 @@ import {
 import { useHotkeys } from "react-hotkeys-hook";
 import { useStickToBottom } from "use-stick-to-bottom";
 
-import { ChatScrollContext } from "./ChatScrollContext";
-
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import { useAgentQuickActions } from "@phoenix/agent/quickActions/quickActions";
 import type {
@@ -56,6 +54,7 @@ import {
   type MessageRewindRequest,
   UserMessage,
 } from "./ChatMessage";
+import { ChatScrollContext } from "./ChatScrollContext";
 import {
   ElicitationDraftProvider,
   type PendingElicitationDraft,
@@ -510,59 +509,59 @@ export function ChatView({
           <div className="chat__scroll-frame">
             <div className="chat__scroll" ref={handleScrollRef}>
               <div className="chat__messages" ref={contentRef}>
-              {showsEmptyState && (
-                <ChatEmptyState
-                  key={theme}
-                  subtext={emptyStateSubtext}
-                  quickActions={quickActions}
-                  onQuickAction={handleQuickAction}
-                >
-                  {missingCredentialsProvider ? (
-                    <AgentModelCredentialForm
-                      modelName={modelMenuValue.modelName}
-                      onCredentialsUpdated={refreshCredentialStatus}
-                      provider={missingCredentialsProvider}
-                    />
-                  ) : undefined}
-                </ChatEmptyState>
-              )}
-              {messages.map((message, index) => {
-                if (message.role === "user") {
+                {showsEmptyState && (
+                  <ChatEmptyState
+                    key={theme}
+                    subtext={emptyStateSubtext}
+                    quickActions={quickActions}
+                    onQuickAction={handleQuickAction}
+                  >
+                    {missingCredentialsProvider ? (
+                      <AgentModelCredentialForm
+                        modelName={modelMenuValue.modelName}
+                        onCredentialsUpdated={refreshCredentialStatus}
+                        provider={missingCredentialsProvider}
+                      />
+                    ) : undefined}
+                  </ChatEmptyState>
+                )}
+                {messages.map((message, index) => {
+                  if (message.role === "user") {
+                    return (
+                      <UserMessage
+                        key={message.id}
+                        message={message}
+                        onRewindRequest={onRewindRequest}
+                      />
+                    );
+                  }
+                  // Only the last assistant message can still be streaming — hide
+                  // its actions until the chat reports it is settled.
+                  const isLast = index === messages.length - 1;
+                  const showActions = !isLast || status === "ready";
+                  // Pin the most recent assistant turn's toolbar so its actions
+                  // stay visible; other turns reveal their toolbars on hover to
+                  // cut down on stacked-toolbar clutter.
+                  const pinToolbar = isLast && status === "ready";
+                  // Rewinding to the last assistant turn is a no-op: nothing
+                  // follows it to truncate and, once settled, it has no pending
+                  // tool calls to clear. Hide the rewind control there.
                   return (
-                    <UserMessage
+                    <AssistantMessage
                       key={message.id}
                       message={message}
+                      showActions={showActions}
+                      pinToolbar={pinToolbar}
                       onRewindRequest={onRewindRequest}
+                      allowRewind={!isLast}
                     />
                   );
-                }
-                // Only the last assistant message can still be streaming — hide
-                // its actions until the chat reports it is settled.
-                const isLast = index === messages.length - 1;
-                const showActions = !isLast || status === "ready";
-                // Pin the most recent assistant turn's toolbar so its actions
-                // stay visible; other turns reveal their toolbars on hover to
-                // cut down on stacked-toolbar clutter.
-                const pinToolbar = isLast && status === "ready";
-                // Rewinding to the last assistant turn is a no-op: nothing
-                // follows it to truncate and, once settled, it has no pending
-                // tool calls to clear. Hide the rewind control there.
-                return (
-                  <AssistantMessage
-                    key={message.id}
-                    message={message}
-                    showActions={showActions}
-                    pinToolbar={pinToolbar}
-                    onRewindRequest={onRewindRequest}
-                    allowRewind={!isLast}
-                  />
-                );
-              })}
-              {showThinkingIndicator && <Loading />}
-              {error && <ErrorMessage error={error} />}
+                })}
+                {showThinkingIndicator && <Loading />}
+                {error && <ErrorMessage error={error} />}
+              </div>
             </div>
           </div>
-        </div>
         </ChatScrollContext.Provider>
         <div className="chat__input">
           {!hasAcknowledgedConsent ? (

--- a/app/src/components/agent/ChatScrollContext.tsx
+++ b/app/src/components/agent/ChatScrollContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from "react";
+
+export type ChatScrollContextValue = {
+  stopScroll: () => void;
+};
+
+export const ChatScrollContext = createContext<ChatScrollContextValue | null>(
+  null
+);
+
+export function useChatScrollContext(): ChatScrollContextValue | null {
+  return useContext(ChatScrollContext);
+}

--- a/app/src/components/agent/DocsToolDetails.tsx
+++ b/app/src/components/agent/DocsToolDetails.tsx
@@ -8,7 +8,11 @@ import {
   parseDocsSearchInput,
 } from "@phoenix/agent/tools/docs";
 
-import { ToolPartCodeBlock, ToolPartLabel } from "./ToolPartPrimitives";
+import {
+  ToolPartCodeBlock,
+  ToolPartExpandableSection,
+  ToolPartLabel,
+} from "./ToolPartPrimitives";
 import type { ToolInvocationPart, ToolUIPartState } from "./toolPartTypes";
 import { formatToolState, stringifyToolValue } from "./toolPartTypes";
 
@@ -67,22 +71,29 @@ export function DocsToolDetails({ part }: { part: ToolInvocationPart }) {
 
   const inputLabel = isSearch ? "Query" : "Command";
   const inputText = getInputText(part, isSearch);
-  const outputText = getOutputText(part);
+  const outputText = getOutputText(part) || "(no output)";
+  const errorText = part.errorText ?? "";
 
   return (
     <div className="tool-part__body">
       <ToolPartLabel>{inputLabel}</ToolPartLabel>
-      <ToolPartCodeBlock>{inputText}</ToolPartCodeBlock>
+      <ToolPartExpandableSection>
+        <ToolPartCodeBlock>{inputText}</ToolPartCodeBlock>
+      </ToolPartExpandableSection>
       {part.state === "output-available" ? (
         <>
           <ToolPartLabel>{isSearch ? "Results" : "Output"}</ToolPartLabel>
-          <ToolPartCodeBlock>{outputText || "(no output)"}</ToolPartCodeBlock>
+          <ToolPartExpandableSection>
+            <ToolPartCodeBlock>{outputText}</ToolPartCodeBlock>
+          </ToolPartExpandableSection>
         </>
       ) : null}
       {part.state === "output-error" ? (
         <>
           <ToolPartLabel variant="danger">Error</ToolPartLabel>
-          <ToolPartCodeBlock>{part.errorText ?? ""}</ToolPartCodeBlock>
+          <ToolPartExpandableSection>
+            <ToolPartCodeBlock>{errorText}</ToolPartCodeBlock>
+          </ToolPartExpandableSection>
         </>
       ) : null}
     </div>

--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -27,7 +27,6 @@ import {
   formatBatchSpanAnnotateState,
   getBatchSpanAnnotateToolPreview,
 } from "./BatchSpanAnnotateToolDetails";
-import { useChatScrollContext } from "./ChatScrollContext";
 import {
   DocsToolDetails,
   formatDocsToolState,
@@ -72,6 +71,7 @@ import {
   getSavePromptToolPreview,
   SavePromptToolDetails,
 } from "./SavePromptToolDetails";
+import { getScrollableParent, useScrollAnchor } from "./scrollAnchor";
 import {
   TOOL_PART_ENTRY_KEYFRAMES,
   TOOL_CALL_SUMMARY_LANE_RULES,
@@ -420,28 +420,6 @@ export function ToolPart({
 }
 
 /**
- * Walks up the DOM from `element` to find the closest ancestor that can scroll
- * vertically — i.e. one whose `overflow-y` is `auto`/`scroll` and whose content
- * actually overflows. This is the container we want to move when revealing a
- * descendant, rather than letting the browser scroll every ancestor.
- *
- * @param element - The element whose scroll container to locate.
- * @returns The nearest vertically scrollable ancestor, or `null` if none exists.
- */
-function getScrollableParent(element: HTMLElement): HTMLElement | null {
-  let current = element.parentElement;
-  while (current) {
-    const { overflowY } = getComputedStyle(current);
-    const isScrollable = overflowY === "auto" || overflowY === "scroll";
-    if (isScrollable && current.scrollHeight > current.clientHeight) {
-      return current;
-    }
-    current = current.parentElement;
-  }
-  return null;
-}
-
-/**
  * Smoothly scrolls `element` to the top of its nearest scrollable ancestor,
  * scrolling only that container.
  *
@@ -481,7 +459,7 @@ function ToolInvocationPartDetails({
   const hasAutoOpenedRef = useRef(false);
   const [manualOpen, setManualOpen] = useState<boolean | null>(null);
   const [isHeaderActive, setIsHeaderActive] = useState(false);
-  const chatScrollContext = useChatScrollContext();
+  const scrollAnchor = useScrollAnchor();
   const {
     preview,
     stateLabel,
@@ -531,38 +509,13 @@ function ToolInvocationPartDetails({
           // natively can race the auto-open/manual override state during tool
           // streaming updates and make the disclosure feel stuck.
           event.preventDefault();
-          const wasOpen = isRenderedOpen;
 
-          // Record the tool's visual position before expanding so we can
-          // restore it after the content grows.
-          const scrollParent = getScrollableParent(event.currentTarget);
-          const elementRect = detailsRef.current?.getBoundingClientRect();
-          const parentRect = scrollParent?.getBoundingClientRect();
-          const offsetFromParentTop =
-            elementRect && parentRect ? elementRect.top - parentRect.top : null;
-
-          // Stop the stick-to-bottom library from fighting our scroll restore.
-          if (!wasOpen) {
-            chatScrollContext?.stopScroll();
-          }
-
+          // Record the tool's position before it grows/shrinks, flip the open
+          // state, then restore the header to the same spot once the DOM has
+          // updated so opening a tool doesn't jump the transcript.
+          scrollAnchor.capture(detailsRef.current);
           setManualOpen(!isRenderedOpen);
-
-          // After React renders the expanded/collapsed content, restore the
-          // tool header to its original visual position.
-          if (scrollParent && offsetFromParentTop !== null) {
-            requestAnimationFrame(() => {
-              const newElementRect =
-                detailsRef.current?.getBoundingClientRect();
-              const newParentRect = scrollParent.getBoundingClientRect();
-              if (newElementRect) {
-                const newOffsetFromParentTop =
-                  newElementRect.top - newParentRect.top;
-                const delta = newOffsetFromParentTop - offsetFromParentTop;
-                scrollParent.scrollTop += delta;
-              }
-            });
-          }
+          requestAnimationFrame(() => scrollAnchor.restore(detailsRef.current));
         }}
       >
         <div className="tool-part__summary">

--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -533,16 +533,36 @@ function ToolInvocationPartDetails({
           // streaming updates and make the disclosure feel stuck.
           event.preventDefault();
           const wasOpen = isRenderedOpen;
-          setManualOpen(!isRenderedOpen);
 
-          // When manually expanding a tool, stop the stick-to-bottom library
-          // from scrolling, then scroll the tool header into view so the user
-          // can read from the top.
+          // Record the tool's visual position before expanding so we can
+          // restore it after the content grows.
+          const scrollParent = getScrollableParent(event.currentTarget);
+          const elementRect = detailsRef.current?.getBoundingClientRect();
+          const parentRect = scrollParent?.getBoundingClientRect();
+          const offsetFromParentTop =
+            elementRect && parentRect
+              ? elementRect.top - parentRect.top
+              : null;
+
+          // Stop the stick-to-bottom library from fighting our scroll restore.
           if (!wasOpen) {
             chatScrollContext?.stopScroll();
+          }
+
+          setManualOpen(!isRenderedOpen);
+
+          // After React renders the expanded/collapsed content, restore the
+          // tool header to its original visual position.
+          if (scrollParent && offsetFromParentTop !== null) {
             requestAnimationFrame(() => {
-              if (detailsRef.current) {
-                scrollElementIntoViewWithinScrollParent(detailsRef.current);
+              const newElementRect =
+                detailsRef.current?.getBoundingClientRect();
+              const newParentRect = scrollParent.getBoundingClientRect();
+              if (newElementRect) {
+                const newOffsetFromParentTop =
+                  newElementRect.top - newParentRect.top;
+                const delta = newOffsetFromParentTop - offsetFromParentTop;
+                scrollParent.scrollTop += delta;
               }
             });
           }

--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -2,8 +2,6 @@ import { css } from "@emotion/react";
 import { getToolName } from "ai";
 import { useEffect, useRef, useState } from "react";
 
-import { useChatScrollContext } from "./ChatScrollContext";
-
 import { getAgentToolUIBehavior } from "@phoenix/agent/extensions/toolRegistry";
 import { BATCH_SPAN_ANNOTATE_TOOL_NAME } from "@phoenix/agent/tools/batchSpanAnnotate";
 import { EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME } from "@phoenix/agent/tools/codeEvaluatorDraft";
@@ -29,6 +27,7 @@ import {
   formatBatchSpanAnnotateState,
   getBatchSpanAnnotateToolPreview,
 } from "./BatchSpanAnnotateToolDetails";
+import { useChatScrollContext } from "./ChatScrollContext";
 import {
   DocsToolDetails,
   formatDocsToolState,
@@ -540,9 +539,7 @@ function ToolInvocationPartDetails({
           const elementRect = detailsRef.current?.getBoundingClientRect();
           const parentRect = scrollParent?.getBoundingClientRect();
           const offsetFromParentTop =
-            elementRect && parentRect
-              ? elementRect.top - parentRect.top
-              : null;
+            elementRect && parentRect ? elementRect.top - parentRect.top : null;
 
           // Stop the stick-to-bottom library from fighting our scroll restore.
           if (!wasOpen) {

--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -2,6 +2,8 @@ import { css } from "@emotion/react";
 import { getToolName } from "ai";
 import { useEffect, useRef, useState } from "react";
 
+import { useChatScrollContext } from "./ChatScrollContext";
+
 import { getAgentToolUIBehavior } from "@phoenix/agent/extensions/toolRegistry";
 import { BATCH_SPAN_ANNOTATE_TOOL_NAME } from "@phoenix/agent/tools/batchSpanAnnotate";
 import { EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME } from "@phoenix/agent/tools/codeEvaluatorDraft";
@@ -75,6 +77,7 @@ import {
   TOOL_PART_ENTRY_KEYFRAMES,
   TOOL_CALL_SUMMARY_LANE_RULES,
   ToolPartCodeBlock,
+  ToolPartExpandableSection,
   ToolPartLabel,
   ToolPartStatus,
 } from "./ToolPartPrimitives";
@@ -440,8 +443,8 @@ function getScrollableParent(element: HTMLElement): HTMLElement | null {
 }
 
 /**
- * Smoothly scrolls `element` to the vertical center of its nearest scrollable
- * ancestor, scrolling only that container.
+ * Smoothly scrolls `element` to the top of its nearest scrollable ancestor,
+ * scrolling only that container.
  *
  * Unlike the native `Element.scrollIntoView`, which scrolls every scrollable
  * ancestor (and can move the whole page/layout), this confines the scroll to
@@ -459,11 +462,10 @@ function scrollElementIntoViewWithinScrollParent(element: HTMLElement): void {
   }
   const parentRect = scrollParent.getBoundingClientRect();
   const elementRect = element.getBoundingClientRect();
-  // Distance to scroll so the element sits centered in the scroll viewport.
-  const delta =
-    elementRect.top -
-    parentRect.top -
-    (scrollParent.clientHeight - elementRect.height) / 2;
+  // Distance to scroll so the element's top sits near the top of the viewport
+  // with a small margin for context.
+  const topMargin = 16;
+  const delta = elementRect.top - parentRect.top - topMargin;
   scrollParent.scrollBy({ top: delta, behavior: "smooth" });
 }
 
@@ -480,6 +482,7 @@ function ToolInvocationPartDetails({
   const hasAutoOpenedRef = useRef(false);
   const [manualOpen, setManualOpen] = useState<boolean | null>(null);
   const [isHeaderActive, setIsHeaderActive] = useState(false);
+  const chatScrollContext = useChatScrollContext();
   const {
     preview,
     stateLabel,
@@ -529,7 +532,20 @@ function ToolInvocationPartDetails({
           // natively can race the auto-open/manual override state during tool
           // streaming updates and make the disclosure feel stuck.
           event.preventDefault();
+          const wasOpen = isRenderedOpen;
           setManualOpen(!isRenderedOpen);
+
+          // When manually expanding a tool, stop the stick-to-bottom library
+          // from scrolling, then scroll the tool header into view so the user
+          // can read from the top.
+          if (!wasOpen) {
+            chatScrollContext?.stopScroll();
+            requestAnimationFrame(() => {
+              if (detailsRef.current) {
+                scrollElementIntoViewWithinScrollParent(detailsRef.current);
+              }
+            });
+          }
         }}
       >
         <div className="tool-part__summary">
@@ -837,6 +853,7 @@ function getToolPresentation(
         part.state === "output-available"
           ? JSON.stringify(part.output, null, 2)
           : "";
+      const errorStr = part.errorText ?? "";
       return {
         preview: getNativeWebToolPreview(toolName, part),
         stateLabel: formatToolState(part.state),
@@ -844,17 +861,23 @@ function getToolPresentation(
         details: (
           <div className="tool-part__body">
             <ToolPartLabel>Input</ToolPartLabel>
-            <ToolPartCodeBlock>{inputStr}</ToolPartCodeBlock>
+            <ToolPartExpandableSection>
+              <ToolPartCodeBlock>{inputStr}</ToolPartCodeBlock>
+            </ToolPartExpandableSection>
             {part.state === "output-available" ? (
               <>
                 <ToolPartLabel>Output</ToolPartLabel>
-                <ToolPartCodeBlock>{outputStr}</ToolPartCodeBlock>
+                <ToolPartExpandableSection>
+                  <ToolPartCodeBlock>{outputStr}</ToolPartCodeBlock>
+                </ToolPartExpandableSection>
               </>
             ) : null}
             {part.state === "output-error" ? (
               <>
                 <ToolPartLabel variant="danger">Error</ToolPartLabel>
-                <ToolPartCodeBlock>{part.errorText ?? ""}</ToolPartCodeBlock>
+                <ToolPartExpandableSection>
+                  <ToolPartCodeBlock>{errorStr}</ToolPartCodeBlock>
+                </ToolPartExpandableSection>
               </>
             ) : null}
           </div>
@@ -875,6 +898,7 @@ function getToolPresentation(
         part.state === "output-available"
           ? JSON.stringify(part.output, null, 2)
           : "";
+      const errorStr = part.errorText ?? "";
       return {
         preview: "",
         stateLabel: formatToolState(part.state),
@@ -882,17 +906,23 @@ function getToolPresentation(
         details: (
           <div className="tool-part__body">
             <ToolPartLabel>Input</ToolPartLabel>
-            <ToolPartCodeBlock>{inputStr}</ToolPartCodeBlock>
+            <ToolPartExpandableSection>
+              <ToolPartCodeBlock>{inputStr}</ToolPartCodeBlock>
+            </ToolPartExpandableSection>
             {part.state === "output-available" ? (
               <>
                 <ToolPartLabel>Output</ToolPartLabel>
-                <ToolPartCodeBlock>{outputStr}</ToolPartCodeBlock>
+                <ToolPartExpandableSection>
+                  <ToolPartCodeBlock>{outputStr}</ToolPartCodeBlock>
+                </ToolPartExpandableSection>
               </>
             ) : null}
             {part.state === "output-error" ? (
               <>
                 <ToolPartLabel variant="danger">Error</ToolPartLabel>
-                <ToolPartCodeBlock>{part.errorText ?? ""}</ToolPartCodeBlock>
+                <ToolPartExpandableSection>
+                  <ToolPartCodeBlock>{errorStr}</ToolPartCodeBlock>
+                </ToolPartExpandableSection>
               </>
             ) : null}
           </div>

--- a/app/src/components/agent/ToolPartPrimitives.tsx
+++ b/app/src/components/agent/ToolPartPrimitives.tsx
@@ -1,11 +1,11 @@
 import { css, keyframes } from "@emotion/react";
 import type { ReactNode } from "react";
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { CopyToClipboardButton } from "@phoenix/components";
 import { ExpandableContent } from "@phoenix/components/core/content/ExpandableContent";
 
-import { useChatScrollContext } from "./ChatScrollContext";
+import { useScrollAnchor } from "./scrollAnchor";
 
 export const TOOL_PART_ENTRY_KEYFRAMES = keyframes`
   from {
@@ -61,7 +61,9 @@ export function ToolPartCodeBlock({
 }) {
   return (
     <div
-      className={`tool-part__line${allowCopy ? " tool-part__line--copyable" : ""}`}
+      className={`tool-part__line${
+        allowCopy ? " tool-part__line--copyable" : ""
+      }`}
     >
       <code className="tool-part__code">{children || "(empty)"}</code>
       {allowCopy ? (
@@ -122,24 +124,13 @@ const expandableSectionCSS = css`
 `;
 
 /**
- * Finds the nearest scrollable parent element.
- */
-function getScrollableParent(element: HTMLElement): HTMLElement | null {
-  let current = element.parentElement;
-  while (current) {
-    const { overflowY } = getComputedStyle(current);
-    const isScrollable = overflowY === "auto" || overflowY === "scroll";
-    if (isScrollable && current.scrollHeight > current.clientHeight) {
-      return current;
-    }
-    current = current.parentElement;
-  }
-  return null;
-}
-
-/**
  * Wrapper for tool part input/output sections. Automatically collapses content
  * that exceeds the collapsed height, showing an expand/collapse button.
+ *
+ * Drives `ExpandableContent` in controlled mode so we can bracket each toggle
+ * with scroll anchoring — recording the section's position before it grows or
+ * shrinks and restoring it afterward — without `ExpandableContent` needing to
+ * know anything about the surrounding scroll container.
  */
 export function ToolPartExpandableSection({
   children,
@@ -147,51 +138,25 @@ export function ToolPartExpandableSection({
   children: ReactNode;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const scrollAnchorRef = useRef<{
-    scrollParent: HTMLElement;
-    offsetFromParentTop: number;
-  } | null>(null);
-  const chatScrollContext = useChatScrollContext();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const scrollAnchor = useScrollAnchor();
 
-  const handleBeforeExpandedChange = useCallback(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const scrollParent = getScrollableParent(container);
-    if (!scrollParent) return;
-
-    const containerRect = container.getBoundingClientRect();
-    const parentRect = scrollParent.getBoundingClientRect();
-    const offsetFromParentTop = containerRect.top - parentRect.top;
-
-    // Stop the stick-to-bottom library from fighting our scroll restore
-    chatScrollContext?.stopScroll();
-
-    scrollAnchorRef.current = { scrollParent, offsetFromParentTop };
-  }, [chatScrollContext]);
-
-  const handleAfterExpandedChange = useCallback(() => {
-    const anchor = scrollAnchorRef.current;
-    const container = containerRef.current;
-    if (!anchor || !container) return;
-
-    const { scrollParent, offsetFromParentTop } = anchor;
-    const newContainerRect = container.getBoundingClientRect();
-    const newParentRect = scrollParent.getBoundingClientRect();
-    const newOffsetFromParentTop = newContainerRect.top - newParentRect.top;
-    const delta = newOffsetFromParentTop - offsetFromParentTop;
-
-    scrollParent.scrollTop += delta;
-    scrollAnchorRef.current = null;
-  }, []);
+  const handleExpandedChange = useCallback(
+    (nextIsExpanded: boolean) => {
+      scrollAnchor.capture(containerRef.current);
+      setIsExpanded(nextIsExpanded);
+      requestAnimationFrame(() => scrollAnchor.restore(containerRef.current));
+    },
+    [scrollAnchor]
+  );
 
   return (
     <div ref={containerRef} css={expandableSectionCSS}>
       <ExpandableContent
         height={COLLAPSED_HEIGHT_PX}
         expandedBehavior="grow"
-        onBeforeExpandedChange={handleBeforeExpandedChange}
-        onAfterExpandedChange={handleAfterExpandedChange}
+        isExpanded={isExpanded}
+        onExpandedChange={handleExpandedChange}
       >
         {children}
       </ExpandableContent>

--- a/app/src/components/agent/ToolPartPrimitives.tsx
+++ b/app/src/components/agent/ToolPartPrimitives.tsx
@@ -122,7 +122,11 @@ const expandableSectionCSS = css`
  * Wrapper for tool part input/output sections. Automatically collapses content
  * that exceeds the collapsed height, showing an expand/collapse button.
  */
-export function ToolPartExpandableSection({ children }: { children: ReactNode }) {
+export function ToolPartExpandableSection({
+  children,
+}: {
+  children: ReactNode;
+}) {
   return (
     <div css={expandableSectionCSS}>
       <ExpandableContent height={COLLAPSED_HEIGHT_PX} expandedBehavior="grow">

--- a/app/src/components/agent/ToolPartPrimitives.tsx
+++ b/app/src/components/agent/ToolPartPrimitives.tsx
@@ -1,8 +1,11 @@
 import { css, keyframes } from "@emotion/react";
 import type { ReactNode } from "react";
+import { useCallback, useRef } from "react";
 
 import { CopyToClipboardButton } from "@phoenix/components";
 import { ExpandableContent } from "@phoenix/components/core/content/ExpandableContent";
+
+import { useChatScrollContext } from "./ChatScrollContext";
 
 export const TOOL_PART_ENTRY_KEYFRAMES = keyframes`
   from {
@@ -119,6 +122,22 @@ const expandableSectionCSS = css`
 `;
 
 /**
+ * Finds the nearest scrollable parent element.
+ */
+function getScrollableParent(element: HTMLElement): HTMLElement | null {
+  let current = element.parentElement;
+  while (current) {
+    const { overflowY } = getComputedStyle(current);
+    const isScrollable = overflowY === "auto" || overflowY === "scroll";
+    if (isScrollable && current.scrollHeight > current.clientHeight) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+/**
  * Wrapper for tool part input/output sections. Automatically collapses content
  * that exceeds the collapsed height, showing an expand/collapse button.
  */
@@ -127,9 +146,53 @@ export function ToolPartExpandableSection({
 }: {
   children: ReactNode;
 }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const scrollAnchorRef = useRef<{
+    scrollParent: HTMLElement;
+    offsetFromParentTop: number;
+  } | null>(null);
+  const chatScrollContext = useChatScrollContext();
+
+  const handleBeforeExpandedChange = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scrollParent = getScrollableParent(container);
+    if (!scrollParent) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const parentRect = scrollParent.getBoundingClientRect();
+    const offsetFromParentTop = containerRect.top - parentRect.top;
+
+    // Stop the stick-to-bottom library from fighting our scroll restore
+    chatScrollContext?.stopScroll();
+
+    scrollAnchorRef.current = { scrollParent, offsetFromParentTop };
+  }, [chatScrollContext]);
+
+  const handleAfterExpandedChange = useCallback(() => {
+    const anchor = scrollAnchorRef.current;
+    const container = containerRef.current;
+    if (!anchor || !container) return;
+
+    const { scrollParent, offsetFromParentTop } = anchor;
+    const newContainerRect = container.getBoundingClientRect();
+    const newParentRect = scrollParent.getBoundingClientRect();
+    const newOffsetFromParentTop = newContainerRect.top - newParentRect.top;
+    const delta = newOffsetFromParentTop - offsetFromParentTop;
+
+    scrollParent.scrollTop += delta;
+    scrollAnchorRef.current = null;
+  }, []);
+
   return (
-    <div css={expandableSectionCSS}>
-      <ExpandableContent height={COLLAPSED_HEIGHT_PX} expandedBehavior="grow">
+    <div ref={containerRef} css={expandableSectionCSS}>
+      <ExpandableContent
+        height={COLLAPSED_HEIGHT_PX}
+        expandedBehavior="grow"
+        onBeforeExpandedChange={handleBeforeExpandedChange}
+        onAfterExpandedChange={handleAfterExpandedChange}
+      >
         {children}
       </ExpandableContent>
     </div>

--- a/app/src/components/agent/ToolPartPrimitives.tsx
+++ b/app/src/components/agent/ToolPartPrimitives.tsx
@@ -1,6 +1,9 @@
 import { keyframes } from "@emotion/react";
+import type { ReactNode } from "react";
 
 import { CopyToClipboardButton } from "@phoenix/components";
+// TODO: Re-enable after scroll fix is complete
+// import { ExpandableContent } from "@phoenix/components/core/content/ExpandableContent";
 
 export const TOOL_PART_ENTRY_KEYFRAMES = keyframes`
   from {
@@ -106,4 +109,29 @@ export function ToolPartMeta({
       ))}
     </div>
   );
+}
+
+// TODO: Re-enable after scroll fix is complete
+// const COLLAPSED_HEIGHT_PX = 320;
+
+// const expandableSectionCSS = css`
+//   --expandable-content-overlay-background-color: var(
+//     --tool-call-body-background-color
+//   );
+// `;
+
+/**
+ * Wrapper for tool part input/output sections. Automatically collapses content
+ * that exceeds the collapsed height, showing an expand/collapse button.
+ */
+export function ToolPartExpandableSection({ children }: { children: ReactNode }) {
+  // TODO: Re-enable after scroll fix is complete
+  return <>{children}</>;
+  // return (
+  //   <div css={expandableSectionCSS}>
+  //     <ExpandableContent height={COLLAPSED_HEIGHT_PX} expandedBehavior="grow">
+  //       {children}
+  //     </ExpandableContent>
+  //   </div>
+  // );
 }

--- a/app/src/components/agent/ToolPartPrimitives.tsx
+++ b/app/src/components/agent/ToolPartPrimitives.tsx
@@ -1,9 +1,8 @@
-import { keyframes } from "@emotion/react";
+import { css, keyframes } from "@emotion/react";
 import type { ReactNode } from "react";
 
 import { CopyToClipboardButton } from "@phoenix/components";
-// TODO: Re-enable after scroll fix is complete
-// import { ExpandableContent } from "@phoenix/components/core/content/ExpandableContent";
+import { ExpandableContent } from "@phoenix/components/core/content/ExpandableContent";
 
 export const TOOL_PART_ENTRY_KEYFRAMES = keyframes`
   from {
@@ -111,27 +110,24 @@ export function ToolPartMeta({
   );
 }
 
-// TODO: Re-enable after scroll fix is complete
-// const COLLAPSED_HEIGHT_PX = 320;
+const COLLAPSED_HEIGHT_PX = 320;
 
-// const expandableSectionCSS = css`
-//   --expandable-content-overlay-background-color: var(
-//     --tool-call-body-background-color
-//   );
-// `;
+const expandableSectionCSS = css`
+  --expandable-content-overlay-background-color: var(
+    --tool-call-body-background-color
+  );
+`;
 
 /**
  * Wrapper for tool part input/output sections. Automatically collapses content
  * that exceeds the collapsed height, showing an expand/collapse button.
  */
 export function ToolPartExpandableSection({ children }: { children: ReactNode }) {
-  // TODO: Re-enable after scroll fix is complete
-  return <>{children}</>;
-  // return (
-  //   <div css={expandableSectionCSS}>
-  //     <ExpandableContent height={COLLAPSED_HEIGHT_PX} expandedBehavior="grow">
-  //       {children}
-  //     </ExpandableContent>
-  //   </div>
-  // );
+  return (
+    <div css={expandableSectionCSS}>
+      <ExpandableContent height={COLLAPSED_HEIGHT_PX} expandedBehavior="grow">
+        {children}
+      </ExpandableContent>
+    </div>
+  );
 }

--- a/app/src/components/agent/__tests__/scrollAnchor.test.tsx
+++ b/app/src/components/agent/__tests__/scrollAnchor.test.tsx
@@ -1,0 +1,110 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ChatScrollContext } from "../ChatScrollContext";
+import { useScrollAnchor } from "../scrollAnchor";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+type Anchor = ReturnType<typeof useScrollAnchor>;
+
+/**
+ * Renders the hook inside a chat scroll context and returns its (stable)
+ * `capture`/`restore` callbacks for direct invocation.
+ */
+function renderScrollAnchor(stopScroll: () => void): Anchor {
+  let value: Anchor | null = null;
+  function Harness() {
+    value = useScrollAnchor();
+    return null;
+  }
+  act(() => {
+    root.render(
+      <ChatScrollContext.Provider value={{ stopScroll }}>
+        <Harness />
+      </ChatScrollContext.Provider>
+    );
+  });
+  if (!value) {
+    throw new Error("useScrollAnchor did not render");
+  }
+  return value;
+}
+
+describe("useScrollAnchor", () => {
+  it("stops stick-to-bottom on capture even when there is no scrollable ancestor", () => {
+    // This is the regression guard: a section whose expansion is what first
+    // creates overflow has no scrollable ancestor at capture time, but we must
+    // still stop stick-to-bottom so it can't snap the transcript to the bottom.
+    const stopScroll = vi.fn();
+    const anchor = renderScrollAnchor(stopScroll);
+
+    const el = document.createElement("div");
+    document.body.appendChild(el); // body is not a scroll container
+
+    anchor.capture(el);
+
+    expect(stopScroll).toHaveBeenCalledTimes(1);
+    // With no anchor recorded, restore must be a safe no-op.
+    expect(() => anchor.restore(el)).not.toThrow();
+  });
+
+  it("restores the anchored element to its prior position after a reflow", () => {
+    const stopScroll = vi.fn();
+    const anchor = renderScrollAnchor(stopScroll);
+
+    const scrollParent = document.createElement("div");
+    Object.defineProperty(scrollParent, "scrollHeight", {
+      value: 1000,
+      configurable: true,
+    });
+    Object.defineProperty(scrollParent, "clientHeight", {
+      value: 500,
+      configurable: true,
+    });
+    scrollParent.scrollTop = 100;
+    const el = document.createElement("div");
+    scrollParent.appendChild(el);
+    document.body.appendChild(scrollParent);
+
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      (node: Element) =>
+        ({
+          overflowY: node === scrollParent ? "auto" : "visible",
+        }) as unknown as CSSStyleDeclaration
+    );
+    vi.spyOn(scrollParent, "getBoundingClientRect").mockReturnValue({
+      top: 0,
+    } as unknown as DOMRect);
+    const elementRect = vi.spyOn(el, "getBoundingClientRect");
+    elementRect.mockReturnValue({ top: 200 } as unknown as DOMRect);
+
+    anchor.capture(el);
+    expect(stopScroll).toHaveBeenCalledTimes(1);
+
+    // Simulate content above the element growing by 60px after expansion.
+    elementRect.mockReturnValue({ top: 260 } as unknown as DOMRect);
+    anchor.restore(el);
+
+    // scrollTop advances by the 60px delta so the element stays visually put.
+    expect(scrollParent.scrollTop).toBe(160);
+  });
+});

--- a/app/src/components/agent/scrollAnchor.ts
+++ b/app/src/components/agent/scrollAnchor.ts
@@ -1,0 +1,87 @@
+import { useCallback, useRef } from "react";
+
+import { useChatScrollContext } from "./ChatScrollContext";
+
+/**
+ * Walks up the DOM from `element` to find the closest ancestor that can scroll
+ * vertically — i.e. one whose `overflow-y` is `auto`/`scroll` and whose content
+ * actually overflows. This is the container we want to move when revealing or
+ * resizing a descendant, rather than letting the browser scroll every ancestor.
+ *
+ * @param element - The element whose scroll container to locate.
+ * @returns The nearest vertically scrollable ancestor, or `null` if none exists.
+ */
+export function getScrollableParent(element: HTMLElement): HTMLElement | null {
+  let current = element.parentElement;
+  while (current) {
+    const { overflowY } = getComputedStyle(current);
+    const isScrollable = overflowY === "auto" || overflowY === "scroll";
+    if (isScrollable && current.scrollHeight > current.clientHeight) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Scroll anchoring for expand/collapse interactions inside the chat transcript.
+ *
+ * `capture(element)` records where `element` sits within its scroll container
+ * just before its content grows or shrinks; `restore(element)` — run after the
+ * DOM updates — scrolls the container so the element stays visually put.
+ *
+ * `capture` always stops the stick-to-bottom controller, even when no scroll
+ * container is overflowing yet. Expanding a section can be precisely what first
+ * creates the overflow; if we gated the stop on finding a scrollable ancestor
+ * (as an earlier version did), the controller would snap the transcript to the
+ * bottom in that case and fight the restore. Stopping unconditionally keeps a
+ * single, predictable policy for both the tool disclosure and inner sections.
+ */
+export function useScrollAnchor() {
+  const chatScrollContext = useChatScrollContext();
+  const anchorRef = useRef<{
+    scrollParent: HTMLElement;
+    offsetFromParentTop: number;
+  } | null>(null);
+
+  const capture = useCallback(
+    (element: HTMLElement | null) => {
+      // Stop stick-to-bottom unconditionally — see the note above for why this
+      // must run even before we know whether a scroll container exists.
+      chatScrollContext?.stopScroll();
+      anchorRef.current = null;
+      if (!element) {
+        return;
+      }
+      const scrollParent = getScrollableParent(element);
+      if (!scrollParent) {
+        // Nothing is scrolling yet, so there is no position to anchor against;
+        // the element keeps its place naturally once the content grows.
+        return;
+      }
+      const elementRect = element.getBoundingClientRect();
+      const parentRect = scrollParent.getBoundingClientRect();
+      anchorRef.current = {
+        scrollParent,
+        offsetFromParentTop: elementRect.top - parentRect.top,
+      };
+    },
+    [chatScrollContext]
+  );
+
+  const restore = useCallback((element: HTMLElement | null) => {
+    const anchor = anchorRef.current;
+    anchorRef.current = null;
+    if (!anchor || !element) {
+      return;
+    }
+    const { scrollParent, offsetFromParentTop } = anchor;
+    const newElementRect = element.getBoundingClientRect();
+    const newParentRect = scrollParent.getBoundingClientRect();
+    const newOffsetFromParentTop = newElementRect.top - newParentRect.top;
+    scrollParent.scrollTop += newOffsetFromParentTop - offsetFromParentTop;
+  }, []);
+
+  return { capture, restore };
+}

--- a/app/src/components/core/content/ExpandableContent.tsx
+++ b/app/src/components/core/content/ExpandableContent.tsx
@@ -169,7 +169,7 @@ export function ExpandableContent({
           aria-label="Show more"
           aria-expanded={false}
         >
-          <span>expand</span>
+          <span>Expand</span>
           <Icon svg={<Icons.ArrowIosDownwardOutline />} />
         </button>
       )}
@@ -181,7 +181,7 @@ export function ExpandableContent({
           aria-label="Show less"
           aria-expanded={true}
         >
-          <span>collapse</span>
+          <span>Collapse</span>
           <Icon svg={<Icons.ArrowIosUpwardOutline />} />
         </button>
       )}

--- a/app/src/components/core/content/ExpandableContent.tsx
+++ b/app/src/components/core/content/ExpandableContent.tsx
@@ -107,16 +107,6 @@ export interface ExpandableContentProps extends PropsWithChildren {
    * Use this with `isExpanded` for controlled mode.
    */
   onExpandedChange?: (isExpanded: boolean) => void;
-  /**
-   * Called before the expanded state changes. Use this to prepare for scroll
-   * anchoring by recording the current scroll position.
-   */
-  onBeforeExpandedChange?: () => void;
-  /**
-   * Called after the expanded state changes and the DOM has updated. Use this
-   * to restore scroll position for scroll anchoring.
-   */
-  onAfterExpandedChange?: () => void;
 }
 
 export function ExpandableContent({
@@ -126,8 +116,6 @@ export function ExpandableContent({
   overlayBackgroundColor = "var(--global-background-color-default)",
   isExpanded: controlledExpanded,
   onExpandedChange,
-  onBeforeExpandedChange,
-  onAfterExpandedChange,
 }: ExpandableContentProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -144,14 +132,10 @@ export function ExpandableContent({
   const isExpanded = isControlled ? controlledExpanded : internalExpanded;
 
   const setExpanded = (nextIsExpanded: boolean) => {
-    onBeforeExpandedChange?.();
     if (!isControlled) {
       setInternalExpanded(nextIsExpanded);
     }
     onExpandedChange?.(nextIsExpanded);
-    if (onAfterExpandedChange) {
-      requestAnimationFrame(onAfterExpandedChange);
-    }
   };
   const shouldUseNaturalHeight = expandedBehavior === "grow" && isExpanded;
   const canCollapse =

--- a/app/src/components/core/content/ExpandableContent.tsx
+++ b/app/src/components/core/content/ExpandableContent.tsx
@@ -107,6 +107,16 @@ export interface ExpandableContentProps extends PropsWithChildren {
    * Use this with `isExpanded` for controlled mode.
    */
   onExpandedChange?: (isExpanded: boolean) => void;
+  /**
+   * Called before the expanded state changes. Use this to prepare for scroll
+   * anchoring by recording the current scroll position.
+   */
+  onBeforeExpandedChange?: () => void;
+  /**
+   * Called after the expanded state changes and the DOM has updated. Use this
+   * to restore scroll position for scroll anchoring.
+   */
+  onAfterExpandedChange?: () => void;
 }
 
 export function ExpandableContent({
@@ -116,6 +126,8 @@ export function ExpandableContent({
   overlayBackgroundColor = "var(--global-background-color-default)",
   isExpanded: controlledExpanded,
   onExpandedChange,
+  onBeforeExpandedChange,
+  onAfterExpandedChange,
 }: ExpandableContentProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -132,10 +144,14 @@ export function ExpandableContent({
   const isExpanded = isControlled ? controlledExpanded : internalExpanded;
 
   const setExpanded = (nextIsExpanded: boolean) => {
+    onBeforeExpandedChange?.();
     if (!isControlled) {
       setInternalExpanded(nextIsExpanded);
     }
     onExpandedChange?.(nextIsExpanded);
+    if (onAfterExpandedChange) {
+      requestAnimationFrame(onAfterExpandedChange);
+    }
   };
   const shouldUseNaturalHeight = expandedBehavior === "grow" && isExpanded;
   const canCollapse =

--- a/app/src/components/core/content/__tests__/ExpandableContent.test.tsx
+++ b/app/src/components/core/content/__tests__/ExpandableContent.test.tsx
@@ -1,0 +1,141 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ExpandableContent } from "../ExpandableContent";
+
+let container: HTMLDivElement;
+let root: Root;
+let originalScrollHeight: PropertyDescriptor | undefined;
+
+// jsdom has no layout, so `scrollHeight` is always 0. Stub it with a mutable
+// backing value so a test can simulate content growing/shrinking. Note jsdom
+// defines `scrollHeight` on `Element.prototype` (not `HTMLElement.prototype`),
+// so we capture/restore the descriptor there to avoid leaking the stub.
+let scrollHeightValue = 0;
+
+function mockScrollHeight(value: number) {
+  scrollHeightValue = value;
+}
+
+beforeEach(() => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  scrollHeightValue = 0;
+  originalScrollHeight = Object.getOwnPropertyDescriptor(
+    Element.prototype,
+    "scrollHeight"
+  );
+  Object.defineProperty(Element.prototype, "scrollHeight", {
+    configurable: true,
+    get() {
+      return scrollHeightValue;
+    },
+  });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  if (originalScrollHeight) {
+    Object.defineProperty(
+      Element.prototype,
+      "scrollHeight",
+      originalScrollHeight
+    );
+  } else {
+    // Defensive: if a future jsdom stops defining scrollHeight, drop our stub
+    // rather than leaving it installed for later tests in this process.
+    delete (Element.prototype as { scrollHeight?: number }).scrollHeight;
+  }
+  vi.restoreAllMocks();
+});
+
+function renderExpandable(props: {
+  isExpanded?: boolean;
+  onExpandedChange?: (next: boolean) => void;
+}) {
+  act(() => {
+    root.render(
+      <ExpandableContent height={320} expandedBehavior="grow" {...props}>
+        <div>content</div>
+      </ExpandableContent>
+    );
+  });
+}
+
+describe("ExpandableContent", () => {
+  it("shows an expand affordance when content exceeds the collapsed height", () => {
+    mockScrollHeight(500);
+    renderExpandable({});
+    expect(container.querySelector('[aria-label="Show more"]')).not.toBeNull();
+  });
+
+  it("hides the expand affordance when content fits", () => {
+    mockScrollHeight(100);
+    renderExpandable({});
+    expect(container.querySelector('[aria-label="Show more"]')).toBeNull();
+  });
+
+  it("reports changes and swaps the affordance in controlled mode", () => {
+    mockScrollHeight(500);
+    const onExpandedChange = vi.fn();
+
+    renderExpandable({ isExpanded: false, onExpandedChange });
+    const expandButton = container.querySelector(
+      '[aria-label="Show more"]'
+    ) as HTMLButtonElement | null;
+    expect(expandButton).not.toBeNull();
+
+    act(() => {
+      expandButton?.click();
+    });
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+
+    // Controlled mode: the parent drives the expanded prop. Once expanded, the
+    // expand affordance is replaced by a collapse affordance.
+    renderExpandable({ isExpanded: true, onExpandedChange });
+    expect(container.querySelector('[aria-label="Show less"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Show more"]')).toBeNull();
+  });
+
+  it("re-checks overflow when the observed content resizes", () => {
+    // Production relies on a ResizeObserver to catch async reflow (CodeMirror
+    // init, image load) after the initial synchronous check. Capture the
+    // observer callback so we can drive a later resize by hand.
+    let resizeCallback: ResizeObserverCallback | null = null;
+    const realResizeObserver = globalThis.ResizeObserver;
+    class CapturingResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    globalThis.ResizeObserver =
+      CapturingResizeObserver as unknown as typeof ResizeObserver;
+
+    try {
+      mockScrollHeight(100);
+      renderExpandable({});
+      expect(container.querySelector('[aria-label="Show more"]')).toBeNull();
+      expect(resizeCallback).not.toBeNull();
+
+      // Content grows past the collapsed height, then the observer fires.
+      mockScrollHeight(500);
+      act(() => {
+        resizeCallback?.([], {} as ResizeObserver);
+      });
+      expect(
+        container.querySelector('[aria-label="Show more"]')
+      ).not.toBeNull();
+    } finally {
+      globalThis.ResizeObserver = realResizeObserver;
+    }
+  });
+});

--- a/app/vitest.setup.ts
+++ b/app/vitest.setup.ts
@@ -4,6 +4,13 @@ import "vitest-canvas-mock";
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock;
+
 export const baseWindowConfig = {
   authenticationEnabled: true,
   basename: "/",


### PR DESCRIPTION
* When expanding a tool, keep scroll position relative to that tool's top, rather than jumping to bottom
* Wrap tool IO in existing truncation utils to avoid giant outputs

Before:
https://github.com/user-attachments/assets/71486b4c-aa87-4083-92e6-f7f842c60c61

With place preservation:
https://github.com/user-attachments/assets/a16f85c0-852f-4f6d-8430-4f4a666a7629

With place preservation and truncation:
https://github.com/user-attachments/assets/6dade398-b65d-4b66-9891-3978932ecf55

