### PR TITLE
fix(pxi): treat /dev/null as a discard sink in bash tool filesystem policy

### DIFF
--- a/app/src/agent/tools/bash/__tests__/bashToolFilesystemPolicy.test.ts
+++ b/app/src/agent/tools/bash/__tests__/bashToolFilesystemPolicy.test.ts
@@ -1,0 +1,44 @@
+import { createBashToolRuntime } from "@phoenix/agent/tools/bash/bashToolRuntime";
+
+describe("bash tool filesystem policy", () => {
+  it("discards writes redirected to /dev/null without aborting the command", async () => {
+    const runtime = await createBashToolRuntime();
+
+    const result = await runtime.executeCommand(
+      "printf 'noise' >/dev/null 2>&1; printf 'done'"
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("done");
+    expect(result.stderr).toBe("");
+  });
+
+  it("discards appends to /dev/null and never persists content there", async () => {
+    const runtime = await createBashToolRuntime();
+
+    const result = await runtime.executeCommand(
+      "printf 'a' >>/dev/null; printf 'b' >>/dev/null; cat /dev/null; printf 'ok'"
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("ok");
+  });
+
+  it("still blocks writes outside the workspace", async () => {
+    const runtime = await createBashToolRuntime();
+
+    await expect(
+      runtime.executeCommand("printf 'nope' > /etc/passwd")
+    ).rejects.toThrow("Writes outside the workspace are blocked");
+  });
+
+  it("still allows workspace writes", async () => {
+    const runtime = await createBashToolRuntime();
+
+    const result = await runtime.executeCommand(
+      "printf 'ok' > /home/user/workspace/note.txt && cat /home/user/workspace/note.txt"
+    );
+
+    expect(result.stdout).toContain("ok");
+  });
+});

--- a/app/src/agent/tools/bash/bashToolFilesystemPolicy.ts
+++ b/app/src/agent/tools/bash/bashToolFilesystemPolicy.ts
@@ -43,6 +43,17 @@ export const BASH_TOOL_READONLY_ROOT = "/phoenix";
 export const BASH_TOOL_WORKSPACE_ROOT = "/home/user/workspace";
 
 /**
+ * Null-sink device paths. just-bash has no real device files, so a redirect
+ * like `cmd >/dev/null 2>&1` resolves to an ordinary `writeFile("/dev/null")`.
+ * That idiom is ubiquitous in model-authored commands, so rather than block it
+ * (which aborts the whole command), we treat writes to these paths as silent
+ * discards — matching POSIX `/dev/null` semantics.
+ */
+export const BASH_TOOL_DISCARD_DEVICE_PATHS: ReadonlySet<string> = new Set([
+  "/dev/null",
+]);
+
+/**
  * Captures the current writable filesystem methods so internal setup code can
  * temporarily bypass policy wrappers and then restore them.
  */
@@ -63,6 +74,14 @@ function normalizeVirtualPath(fs: IFileSystem, path: string) {
 
 function isWithinRoot(path: string, root: string) {
   return path === root || path.startsWith(`${root}/`);
+}
+
+/**
+ * Returns true when `path` resolves to a null-sink device whose writes should
+ * be discarded rather than enforced against the workspace policy.
+ */
+function isDiscardDevicePath(fs: IFileSystem, path: string) {
+  return BASH_TOOL_DISCARD_DEVICE_PATHS.has(normalizeVirtualPath(fs, path));
 }
 
 function assertWritablePath(fs: IFileSystem, path: string, operation: string) {
@@ -109,23 +128,31 @@ export function applyBashToolFilesystemPolicy(fs: IFileSystem) {
     path: string,
     content: FileContent,
     options?: WriteFileOptions | BufferEncoding
-  ) =>
-    originalWriteFile(
+  ) => {
+    if (isDiscardDevicePath(fs, path)) {
+      return Promise.resolve();
+    }
+    return originalWriteFile(
       assertWritablePath(fs, path, "writeFile"),
       content,
       options
     );
+  };
 
   fs.appendFile = (
     path: string,
     content: FileContent,
     options?: WriteFileOptions | BufferEncoding
-  ) =>
-    originalAppendFile(
+  ) => {
+    if (isDiscardDevicePath(fs, path)) {
+      return Promise.resolve();
+    }
+    return originalAppendFile(
       assertWritablePath(fs, path, "appendFile"),
       content,
       options
     );
+  };
 
   fs.mkdir = (path: string, options?: MkdirOptions) =>
     originalMkdir(assertWritablePath(fs, path, "mkdir"), options);

--- a/src/phoenix/server/agents/capabilities/tools/external/bash.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/bash.py
@@ -18,6 +18,8 @@ Run a shell command in the browser virtual filesystem.
 Runs inside a browser-only just-bash virtual shell, not a host machine or container.
 Read Phoenix context from /phoenix; writes there are blocked.
 Write scratch files only under /home/user/workspace; mutations elsewhere are blocked.
+Redirect unwanted output to /dev/null (e.g. `cmd >/dev/null 2>&1`); it is the only \
+writable path outside the workspace.
 General purpose network access is disabled, so curl/wget and remote package installs \
 should not be assumed to work.
 Built-in just-bash commands are available; do not assume apt, brew, pnpm, uv, git, \

--- a/src/phoenix/server/agents/prompts/tools/BASH_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/BASH_TOOL_INSTRUCTIONS.xml.j2
@@ -4,6 +4,7 @@
     - Runs inside a browser-only just-bash virtual shell, not a host machine or container.
     - Read Phoenix context from /phoenix; writes there are blocked.
     - Write scratch files only under /home/user/workspace; mutations elsewhere are blocked.
+    - Redirect unwanted output to /dev/null (e.g. `cmd >/dev/null 2>&1`); it is the only writable path outside the workspace.
     - General purpose network access is disabled, so curl/wget and remote package installs should not be assumed to work.
     - Built-in just-bash commands are available; do not assume apt, brew, pnpm, uv, git, or other host binaries exist unless the sandbox reports them.
     - Language runtimes such as python, python3, and node are not available.


### PR DESCRIPTION
## Problem

Model-authored bash commands frequently redirect output with `cmd >/dev/null 2>&1`. The PXI bash tool runs in a `just-bash` virtual filesystem that has no real device files, so this idiom resolves to a literal `writeFile("/dev/null")`. The workspace write policy rejected that path and **aborted the entire command**, breaking a very common shell pattern.

## Fix

Treat writes and appends to `/dev/null` as silent discards (matching POSIX semantics) rather than enforcing them against the workspace policy. The prompt instructions are updated so the model knows the redirect is available.

## Changes

| File | Change |
|---|---|
| `bashToolFilesystemPolicy.ts` | Add `BASH_TOOL_DISCARD_DEVICE_PATHS` + `isDiscardDevicePath`; `writeFile`/`appendFile` short-circuit to a no-op for `/dev/null` |
| `__tests__/bashToolFilesystemPolicy.test.ts` | New tests: discard on write, discard on append, still-blocked outside workspace, still-allowed in workspace |
| `bash.py` (tool DESCRIPTION) | Document the `/dev/null` redirect |
| `BASH_TOOL_INSTRUCTIONS.xml.j2` | Same guidance in the XML prompt |

## Verification

- All 11 bash-tool tests pass (4 new)
- `oxfmt --check`, `oxlint`, and `tsc --noEmit` all clean

## Screenshot

Trace view showing the `bash` span (with its policy-driven error indicator) in the `assistant_agent` project:

![bash span trace](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/13590-bash-span-trace.png)
