### PR TITLE
fix(server): don't let docs MCP init failure abort server startup

### DIFF
--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -719,7 +719,17 @@ def _lifespan(
             await stack.enter_async_context(sandbox_session_manager)
             await stack.enter_async_context(experiment_runner)
             if docs_mcp_server is not None:
-                await stack.enter_async_context(docs_mcp_server)
+                # The docs MCP server connects to an external host during
+                # startup. Never let its initialization (which can hang until a
+                # deadline when egress is blocked) abort server startup; degrade
+                # to the assistant running without docs tools instead.
+                try:
+                    await stack.enter_async_context(docs_mcp_server)
+                except Exception:
+                    logger.warning(
+                        "Failed to initialize docs MCP server; continuing without docs capability.",
+                        exc_info=True,
+                    )
             if scaffolder_config:
                 scaffolder = Scaffolder(
                     config=scaffolder_config,

--- a/tests/unit/server/test_app_docs_mcp_lifespan.py
+++ b/tests/unit/server/test_app_docs_mcp_lifespan.py
@@ -1,0 +1,59 @@
+"""Regression test for the docs MCP server's effect on application startup.
+
+The docs MCP capability (``MintlifyDocsMCPServer``) connects to an external
+Mintlify host during the FastAPI lifespan. When that host is unreachable -- e.g.
+a pod whose egress policy blocks the connection -- the MCP ``initialize()``
+handshake hangs until its deadline and raises. That failure must NOT abort
+startup: the docs capability is best-effort, so the app must boot and degrade
+(assistant without docs tools) rather than crash-loop.
+"""
+
+from __future__ import annotations
+
+from contextlib import AsyncExitStack
+
+import pytest
+from asgi_lifespan import LifespanManager
+
+from phoenix.server.agents.capabilities import MintlifyDocsMCPServer
+from phoenix.server.app import create_app
+from phoenix.server.types import DbSessionFactory
+from tests.unit.conftest import (
+    TestBulkInserter,
+    patch_batched_caller,
+    patch_grpc_server,
+)
+
+
+class _ExplodingDocsMCPServer(MintlifyDocsMCPServer):
+    """Docs MCP server whose handshake fails like a blocked/timed-out egress."""
+
+    async def __aenter__(self) -> "_ExplodingDocsMCPServer":
+        raise TimeoutError("deadline exceeded")
+
+
+async def test_app_starts_up_when_docs_mcp_server_init_fails(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A docs MCP server whose handshake fails must not abort startup."""
+    # Force the gate open so ``create_app`` constructs the docs MCP server
+    # regardless of the ambient test environment.
+    monkeypatch.setattr("phoenix.server.app.get_env_disable_agent_assistant", lambda: False)
+    monkeypatch.setattr("phoenix.server.app.get_env_allow_external_resources", lambda: True)
+    monkeypatch.setattr("phoenix.server.app.MintlifyDocsMCPServer", _ExplodingDocsMCPServer)
+
+    async with AsyncExitStack() as stack:
+        await stack.enter_async_context(patch_batched_caller())
+        await stack.enter_async_context(patch_grpc_server())
+        app = create_app(
+            db=db,
+            authentication_enabled=False,
+            serve_ui=False,
+            bulk_inserter_factory=TestBulkInserter,
+        )
+        # The path under test is actually exercised: the gate built our
+        # exploding server, not ``None``.
+        assert isinstance(app.state.docs_mcp_server, _ExplodingDocsMCPServer)
+        # Lifespan startup must not raise even though docs MCP init fails.
+        await stack.enter_async_context(LifespanManager(app))


### PR DESCRIPTION
## Problem

`phoenix-demo` returned **HTTP 502** because the backend pod was in CrashLoopBackOff. The 17.0.0 assistant gate flipped on-by-default, which exposed a latent bug: the docs MCP server connects to an external Mintlify host (`arizeai-*.mintlify.app`) during the FastAPI **lifespan**, and the enter was **unguarded**. On the demo pod, egress to that host is blocked, so the MCP `initialize()` handshake hangs to its deadline and raises — aborting startup → CrashLoopBackOff → 502 for the **entire product** (projects, tracing, UI), not just the assistant.

Production traceback confirmed the chain: `pydantic_ai/mcp.py __aenter__` → `client.initialize()` → `anyio.fail_after` → `TimeoutError`.

## Fix

Wrap the lifespan enter in `try/except`. A docs MCP init failure now logs a warning and the server boots normally (without docs tools), instead of crash-looping.