### PR TITLE
fix(app): scope assistant chat history to deployment root path

### DIFF
--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -4,6 +4,7 @@ import { createDefaultAgentCapabilities } from "@phoenix/agent/extensions/capabi
 import {
   createAgentStore,
   hasAcknowledgedCurrentTraceConsent,
+  resolveAssistantStorageKey,
 } from "../agentStore";
 
 installTestStorage();
@@ -11,6 +12,32 @@ installTestStorage();
 describe("agentStore", () => {
   beforeEach(() => {
     localStorage.removeItem("arize-phoenix-assistant");
+  });
+
+  describe("resolveAssistantStorageKey", () => {
+    const originalBasename = window.Config.basename;
+    afterEach(() => {
+      window.Config.basename = originalBasename;
+    });
+
+    it("uses the base unscoped key when there is no root path", () => {
+      window.Config.basename = "/";
+      expect(resolveAssistantStorageKey()).toBe("arize-phoenix-assistant");
+      window.Config.basename = "";
+      expect(resolveAssistantStorageKey()).toBe("arize-phoenix-assistant");
+    });
+
+    it("scopes the key to the deployment root path", () => {
+      window.Config.basename = "/s/phoenix-devs";
+      expect(resolveAssistantStorageKey()).toBe(
+        "arize-phoenix-assistant:/s/phoenix-devs"
+      );
+      // Trailing slashes are normalized so the key is stable.
+      window.Config.basename = "/s/phoenix-devs/";
+      expect(resolveAssistantStorageKey()).toBe(
+        "arize-phoenix-assistant:/s/phoenix-devs"
+      );
+    });
   });
 
   describe("createSession", () => {

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -481,11 +481,41 @@ function buildSessionRetentionPatch({
 }
 
 /**
+ * Base local-storage key for the persisted assistant state. Used verbatim for
+ * single-tenant deployments and as a prefix when scoping by root path.
+ */
+const BASE_ASSISTANT_STORAGE_KEY = "arize-phoenix-assistant";
+
+/**
+ * Resolves the local-storage key for the persisted assistant state, scoped to
+ * the deployment's root path.
+ *
+ * `localStorage` is origin-scoped and path-blind. In multi-tenant deployments
+ * (e.g. Phoenix Cloud) many workspaces are served from distinct root paths on
+ * the SAME browser origin, so a single shared key would let one workspace's
+ * chat history load in another. Scoping by the root-path basename aligns this
+ * with the per-deployment isolation boundary already enforced server-side by
+ * PHOENIX_COOKIES_PATH (which is set to the same root path).
+ *
+ * Deployments without a root path (the common single-tenant case, e.g. OSS)
+ * use the base key unchanged so existing history is preserved on upgrade.
+ * Under a root path the new scoped key simply leaves the old unscoped blob
+ * untouched; nothing reads it once the key changes.
+ */
+export function resolveAssistantStorageKey(): string {
+  const basename = (window.Config?.basename ?? "").replace(/\/+$/, "");
+  return basename
+    ? `${BASE_ASSISTANT_STORAGE_KEY}:${basename}`
+    : BASE_ASSISTANT_STORAGE_KEY;
+}
+
+/**
  * Creates a Zustand store for managing agent UI state and conversation sessions.
  *
  * The store is wrapped with devtools (for Redux DevTools inspection) and
- * persist (to local storage under "arize-phoenix-assistant"). The `isOpen`
- * property is excluded from persistence so the panel always starts closed.
+ * persist (to local storage under a per-deployment key derived from the root
+ * path; see {@link resolveAssistantStorageKey}). The `isOpen` property is
+ * excluded from persistence so the panel always starts closed.
  *
  * @param initialProps - Optional overrides for the default store properties.
  */
@@ -1101,7 +1131,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
 
   return create<AgentState>()(
     persist(devtools(agentStore, { name: "agentStore" }), {
-      name: "arize-phoenix-assistant",
+      name: resolveAssistantStorageKey(),
       version: 0,
       partialize: (state) => ({
         isOpen: state.isOpen,


### PR DESCRIPTION
## Summary

Fixes #13613. In Phoenix Cloud, PXI chat history was shared across workspaces: opening a chat in one workspace (`/s/phoenix-devs`) and then another (`/s/design-shared`) showed the first workspace's history in the second.

## Background

Each cloud workspace is a separate Phoenix deployment mounted at its own `PHOENIX_HOST_ROOT_PATH`, but all are served from the same browser origin (`app.phoenix.arize.com`). PXI persists its chat history in `localStorage` under a single key, `"arize-phoenix-assistant"`. `localStorage` is origin-scoped and path-blind, so every workspace on that origin resolved to the same entry.

This is consistent with the other behavior in the report: auth cookies are path-scoped via `PHOENIX_COOKIES_PATH` (set to the root path), so credentials are isolated per workspace, while the browser-storage layer had no equivalent scoping.

| Layer | Scoping | Path-aware? | Behavior across workspaces |
|---|---|---|---|
| Auth cookies | `PHOENIX_COOKIES_PATH` = root path | Yes | Isolated |
| PXI `localStorage` | single key, origin only | No | Shared |

## Change

Scope the zustand `persist` key by the deployment root path (`window.Config.basename`, the same value cloud sets as `PHOENIX_COOKIES_PATH`):

- **No root path** (single-tenant / OSS) → base key unchanged, so existing history is preserved.
- **Under a root path** → `arize-phoenix-assistant:/s/<handle>`, aligning storage with the per-deployment boundary already used by cookies.

`resolveAssistantStorageKey()` is a pure key resolver. The previous unscoped entry is simply no longer read once the key changes; no migration or cleanup code is added.

This applies to the whole persisted blob, so the PXI consent acknowledgment and the other per-user prefs (`permissions`, `capabilities`, model config) are scoped by the same change.

No new tenant concept is needed — the discriminator already flows from `PHOENIX_HOST_ROOT_PATH` → `window.Config.basename`. Frontend-only (OSS) change.

## Behavior change to note

After deploy, cloud users will see the PXI trace-consent gate once per workspace (the prior acknowledgment lived under the old key). This is the expected behavior for separate per-workspace deployments.

## Testing

- Regression tests for key resolution: base key, scoped key, and trailing-slash normalization.
- `pnpm test` for the store passes; `tsc --noEmit` and `oxlint` clean for the edited files.