### PR TITLE
feat(pxi): annotation-config form authoring scaffolding for the PXI agent

### DIFF
--- a/app/src/agent/context/agentContextTypes.ts
+++ b/app/src/agent/context/agentContextTypes.ts
@@ -60,6 +60,10 @@ export function agentContextKey(context: AgentContext): string {
       return context.evaluatorNodeId
         ? `llm_evaluator:${context.evaluatorNodeId}`
         : "llm_evaluator:create";
+    case "annotation_config":
+      return context.annotationConfigNodeId
+        ? `annotation_config:${context.annotationConfigNodeId}`
+        : "annotation_config:create";
     case "dataset":
       return context.datasetVersionNodeId
         ? `dataset:${context.datasetNodeId}:${context.datasetVersionNodeId}`

--- a/app/src/agent/extensions/toolRegistry.ts
+++ b/app/src/agent/extensions/toolRegistry.ts
@@ -12,6 +12,7 @@ import { bashAgentTool } from "@phoenix/agent/tools/bash";
  * in `./registry/defineTool` or `./registry/defineClientActionTool`, then list
  * it in the appropriate array below.
  */
+import { openAnnotationConfigFormAgentTool } from "@phoenix/agent/tools/annotationConfigDraft";
 import { batchSpanAnnotateAgentTool } from "@phoenix/agent/tools/batchSpanAnnotate";
 import {
   editCodeEvaluatorDraftAgentTool,
@@ -128,6 +129,7 @@ const clientActionTools: AgentToolDefinition[] = [
   setDatasetEvaluatorSelectionAgentTool,
   openDatasetEvaluatorForEditAgentTool,
   readDatasetEvaluatorDefinitionAgentTool,
+  openAnnotationConfigFormAgentTool,
   openCodeEvaluatorFormAgentTool,
   readCodeEvaluatorDraftAgentTool,
   editCodeEvaluatorDraftAgentTool,

--- a/app/src/agent/extensions/toolRegistry.ts
+++ b/app/src/agent/extensions/toolRegistry.ts
@@ -12,7 +12,11 @@ import { bashAgentTool } from "@phoenix/agent/tools/bash";
  * in `./registry/defineTool` or `./registry/defineClientActionTool`, then list
  * it in the appropriate array below.
  */
-import { openAnnotationConfigFormAgentTool } from "@phoenix/agent/tools/annotationConfigDraft";
+import {
+  editAnnotationConfigDraftAgentTool,
+  openAnnotationConfigFormAgentTool,
+  readAnnotationConfigDraftAgentTool,
+} from "@phoenix/agent/tools/annotationConfigDraft";
 import { batchSpanAnnotateAgentTool } from "@phoenix/agent/tools/batchSpanAnnotate";
 import {
   editCodeEvaluatorDraftAgentTool,
@@ -130,6 +134,8 @@ const clientActionTools: AgentToolDefinition[] = [
   openDatasetEvaluatorForEditAgentTool,
   readDatasetEvaluatorDefinitionAgentTool,
   openAnnotationConfigFormAgentTool,
+  readAnnotationConfigDraftAgentTool,
+  editAnnotationConfigDraftAgentTool,
   openCodeEvaluatorFormAgentTool,
   readCodeEvaluatorDraftAgentTool,
   editCodeEvaluatorDraftAgentTool,

--- a/app/src/agent/tools/annotationConfigDraft/__tests__/annotationConfigDraft.test.ts
+++ b/app/src/agent/tools/annotationConfigDraft/__tests__/annotationConfigDraft.test.ts
@@ -1,0 +1,177 @@
+import {
+  type AnnotationConfigDraftHost,
+  type AnnotationConfigDraftSnapshot,
+  applyDraftOperations,
+  createEditAnnotationConfigDraftClientAction,
+  createReadAnnotationConfigDraftClientAction,
+  type EditAnnotationConfigDraftOperation,
+  parseEditAnnotationConfigDraftInput,
+  parseOpenAnnotationConfigFormInput,
+} from "@phoenix/agent/tools/annotationConfigDraft";
+
+function makeSnapshot(
+  overrides: Partial<AnnotationConfigDraftSnapshot> = {}
+): AnnotationConfigDraftSnapshot {
+  return {
+    mode: "create",
+    annotationConfigNodeId: null,
+    annotationType: "CATEGORICAL",
+    name: "",
+    description: null,
+    optimizationDirection: "MAXIMIZE",
+    values: [
+      { label: "", score: null },
+      { label: "", score: null },
+    ],
+    lowerBound: null,
+    upperBound: null,
+    ...overrides,
+  };
+}
+
+/** Mutable in-memory host so client-action tests can observe applied edits. */
+function makeHost(initial: AnnotationConfigDraftSnapshot): {
+  host: AnnotationConfigDraftHost;
+  get: () => AnnotationConfigDraftSnapshot;
+} {
+  let current = initial;
+  const host: AnnotationConfigDraftHost = {
+    getSnapshot: () => current,
+    previewOperations: (snapshot, operations) =>
+      applyDraftOperations({ snapshot, operations }),
+    applyOperations: (operations) => {
+      const result = applyDraftOperations({ snapshot: current, operations });
+      if (result.ok) current = result.output;
+      return result;
+    },
+  };
+  return { host, get: () => current };
+}
+
+describe("applyDraftOperations", () => {
+  it("sets scalar fields", () => {
+    const result = applyDraftOperations({
+      snapshot: makeSnapshot(),
+      operations: [
+        { type: "set_name", name: "correctness" },
+        { type: "set_description", description: "is it correct" },
+        { type: "set_optimization_direction", optimizationDirection: "MINIMIZE" },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.output.name).toBe("correctness");
+    expect(result.output.description).toBe("is it correct");
+    expect(result.output.optimizationDirection).toBe("MINIMIZE");
+  });
+
+  it("replaces categorical values", () => {
+    const result = applyDraftOperations({
+      snapshot: makeSnapshot(),
+      operations: [
+        {
+          type: "set_values",
+          values: [
+            { label: "correct", score: 1 },
+            { label: "incorrect", score: 0 },
+          ],
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.output.values).toEqual([
+      { label: "correct", score: 1 },
+      { label: "incorrect", score: 0 },
+    ]);
+  });
+
+  it("rejects changing annotation type in edit mode", () => {
+    const result = applyDraftOperations({
+      snapshot: makeSnapshot({ mode: "edit", annotationConfigNodeId: "Q29uZmlnOjE" }),
+      operations: [{ type: "set_annotation_type", annotationType: "CONTINUOUS" }],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/immutable/i);
+  });
+});
+
+describe("parseEditAnnotationConfigDraftInput", () => {
+  it("normalizes a single bare snake_case operation into the operations array", () => {
+    const parsed = parseEditAnnotationConfigDraftInput({
+      type: "set_optimization_direction",
+      optimization_direction: "MINIMIZE",
+    });
+    expect(parsed).not.toBeNull();
+    const operations = parsed?.operations as
+      | EditAnnotationConfigDraftOperation[]
+      | undefined;
+    expect(operations?.[0]).toEqual({
+      type: "set_optimization_direction",
+      optimizationDirection: "MINIMIZE",
+    });
+  });
+
+  it("rejects an empty operations list", () => {
+    expect(parseEditAnnotationConfigDraftInput({ operations: [] })).toBeNull();
+  });
+});
+
+describe("parseOpenAnnotationConfigFormInput", () => {
+  it("defaults to create mode when no id is given", () => {
+    expect(parseOpenAnnotationConfigFormInput(undefined)).toEqual({
+      annotationConfigId: null,
+    });
+    expect(parseOpenAnnotationConfigFormInput({})).toEqual({
+      annotationConfigId: null,
+    });
+  });
+
+  it("keeps a provided config id", () => {
+    expect(
+      parseOpenAnnotationConfigFormInput({ annotationConfigId: "Q29uZmlnOjE" })
+    ).toEqual({ annotationConfigId: "Q29uZmlnOjE" });
+  });
+
+  it("normalizes a snake_case id", () => {
+    expect(
+      parseOpenAnnotationConfigFormInput({ annotation_config_id: "Q29uZmlnOjE" })
+    ).toEqual({ annotationConfigId: "Q29uZmlnOjE" });
+  });
+});
+
+describe("annotation-config draft client actions", () => {
+  it("reads the current snapshot as formatted JSON", async () => {
+    const { host } = makeHost(makeSnapshot({ name: "correctness" }));
+    const read = createReadAnnotationConfigDraftClientAction({
+      getDraftHost: () => host,
+    });
+    const result = await read({});
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(JSON.parse(result.output ?? "").name).toBe("correctness");
+  });
+
+  it("applies edits directly to the draft", async () => {
+    const { host, get } = makeHost(makeSnapshot());
+    const edit = createEditAnnotationConfigDraftClientAction({
+      getDraftHost: () => host,
+    });
+    const result = await edit({
+      operations: [{ type: "set_name", name: "relevance" }],
+    });
+    expect(result.ok).toBe(true);
+    expect(get().name).toBe("relevance");
+  });
+
+  it("errors when the form is not mounted", async () => {
+    const edit = createEditAnnotationConfigDraftClientAction({
+      getDraftHost: () => null,
+    });
+    const result = await edit({
+      operations: [{ type: "set_name", name: "relevance" }],
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/app/src/agent/tools/annotationConfigDraft/agentTools.ts
+++ b/app/src/agent/tools/annotationConfigDraft/agentTools.ts
@@ -1,21 +1,55 @@
 import { defineClientActionTool } from "@phoenix/agent/extensions/registry/defineClientActionTool";
-import {
-  parseEmptyToolInput,
-  type EmptyToolInput,
-} from "@phoenix/agent/tools/emptyToolInput";
 
-import { OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME } from "./constants";
+import {
+  EDIT_ANNOTATION_CONFIG_DRAFT_TOOL_NAME,
+  OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME,
+  READ_ANNOTATION_CONFIG_DRAFT_TOOL_NAME,
+} from "./constants";
+import {
+  parseEditAnnotationConfigDraftInput,
+  parseOpenAnnotationConfigFormInput,
+  parseReadAnnotationConfigDraftInput,
+} from "./parsers";
+import type {
+  EditAnnotationConfigDraftInput,
+  OpenAnnotationConfigFormInput,
+  ReadAnnotationConfigDraftInput,
+} from "./types";
 
 /**
  * Opens the annotation-config form slideover mounted on the focused project
- * page. Delegates to the client action the slideover registers while open.
+ * page. With an `annotationConfigId`, opens the existing config for editing;
+ * otherwise opens a blank create form. Delegates to the client action the
+ * slideover registers while open.
  */
 export const openAnnotationConfigFormAgentTool =
-  defineClientActionTool<EmptyToolInput>({
+  defineClientActionTool<OpenAnnotationConfigFormInput>({
     name: OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME,
-    parseInput: parseEmptyToolInput,
-    invalidInputErrorText: `Invalid ${OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME} input. Expected {}.`,
+    parseInput: parseOpenAnnotationConfigFormInput,
+    invalidInputErrorText: `Invalid ${OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME} input. Expected { annotationConfigId?: string }.`,
     notMountedErrorText:
       "No project page is mounted; cannot open the annotation-config form.",
     defaultSuccessOutput: "Annotation-config form opened.",
+  });
+
+/** Reads the current annotation-config draft from the mounted form. */
+export const readAnnotationConfigDraftAgentTool =
+  defineClientActionTool<ReadAnnotationConfigDraftInput>({
+    name: READ_ANNOTATION_CONFIG_DRAFT_TOOL_NAME,
+    parseInput: parseReadAnnotationConfigDraftInput,
+    invalidInputErrorText: `Invalid ${READ_ANNOTATION_CONFIG_DRAFT_TOOL_NAME} input. Expected {}.`,
+    notMountedErrorText:
+      "The annotation-config form is not mounted; cannot read the draft.",
+    defaultSuccessOutput: "Annotation-config draft read.",
+  });
+
+/** Applies edit operations to the mounted annotation-config draft. */
+export const editAnnotationConfigDraftAgentTool =
+  defineClientActionTool<EditAnnotationConfigDraftInput>({
+    name: EDIT_ANNOTATION_CONFIG_DRAFT_TOOL_NAME,
+    parseInput: parseEditAnnotationConfigDraftInput,
+    invalidInputErrorText: `Invalid ${EDIT_ANNOTATION_CONFIG_DRAFT_TOOL_NAME} input. Expected { operations: EditAnnotationConfigDraftOperation[] }.`,
+    notMountedErrorText:
+      "The annotation-config form is not mounted; cannot edit the draft.",
+    defaultSuccessOutput: "Annotation-config draft updated.",
   });

--- a/app/src/agent/tools/annotationConfigDraft/agentTools.ts
+++ b/app/src/agent/tools/annotationConfigDraft/agentTools.ts
@@ -1,0 +1,21 @@
+import { defineClientActionTool } from "@phoenix/agent/extensions/registry/defineClientActionTool";
+import {
+  parseEmptyToolInput,
+  type EmptyToolInput,
+} from "@phoenix/agent/tools/emptyToolInput";
+
+import { OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME } from "./constants";
+
+/**
+ * Opens the annotation-config form slideover mounted on the focused project
+ * page. Delegates to the client action the slideover registers while open.
+ */
+export const openAnnotationConfigFormAgentTool =
+  defineClientActionTool<EmptyToolInput>({
+    name: OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME,
+    parseInput: parseEmptyToolInput,
+    invalidInputErrorText: `Invalid ${OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME} input. Expected {}.`,
+    notMountedErrorText:
+      "No project page is mounted; cannot open the annotation-config form.",
+    defaultSuccessOutput: "Annotation-config form opened.",
+  });

--- a/app/src/agent/tools/annotationConfigDraft/clientActions.ts
+++ b/app/src/agent/tools/annotationConfigDraft/clientActions.ts
@@ -1,0 +1,61 @@
+import type { AgentClientActionResult } from "@phoenix/store/agentStore";
+
+import {
+  parseEditAnnotationConfigDraftInput,
+  parseReadAnnotationConfigDraftInput,
+} from "./parsers";
+import type { AnnotationConfigDraftHost } from "./types";
+
+export function createReadAnnotationConfigDraftClientAction({
+  getDraftHost,
+}: {
+  getDraftHost: () => AnnotationConfigDraftHost | null;
+}) {
+  return async (input: unknown): Promise<AgentClientActionResult> => {
+    const parsed = parseReadAnnotationConfigDraftInput(input);
+    if (!parsed) {
+      return {
+        ok: false,
+        error: "Invalid read_annotation_config_draft input.",
+      };
+    }
+    const host = getDraftHost();
+    if (!host) {
+      return {
+        ok: false,
+        error:
+          "The annotation-config form is not mounted; cannot read the draft.",
+      };
+    }
+    return { ok: true, output: JSON.stringify(host.getSnapshot(), null, 2) };
+  };
+}
+
+export function createEditAnnotationConfigDraftClientAction({
+  getDraftHost,
+}: {
+  getDraftHost: () => AnnotationConfigDraftHost | null;
+}) {
+  return async (input: unknown): Promise<AgentClientActionResult> => {
+    const parsed = parseEditAnnotationConfigDraftInput(input);
+    if (!parsed) {
+      return {
+        ok: false,
+        error: "Invalid edit_annotation_config_draft input.",
+      };
+    }
+    const host = getDraftHost();
+    if (!host) {
+      return {
+        ok: false,
+        error:
+          "The annotation-config form is not mounted; cannot edit the draft.",
+      };
+    }
+    // The edit applies directly to the form draft (no approval diff card); the
+    // returned snapshot lets the agent confirm the resulting state.
+    const result = host.applyOperations(parsed.operations);
+    if (!result.ok) return result;
+    return { ok: true, output: JSON.stringify(result.output, null, 2) };
+  };
+}

--- a/app/src/agent/tools/annotationConfigDraft/constants.ts
+++ b/app/src/agent/tools/annotationConfigDraft/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Tool name shared between the server `ToolDefinition` advertisement and the
+ * browser client-action dispatch for opening the annotation-config form.
+ */
+export const OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME =
+  "open_annotation_config_form";

--- a/app/src/agent/tools/annotationConfigDraft/constants.ts
+++ b/app/src/agent/tools/annotationConfigDraft/constants.ts
@@ -1,6 +1,12 @@
 /**
- * Tool name shared between the server `ToolDefinition` advertisement and the
- * browser client-action dispatch for opening the annotation-config form.
+ * Tool names shared between the server `ToolDefinition` advertisements and the
+ * browser client-action dispatch for the annotation-config form.
  */
 export const OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME =
   "open_annotation_config_form";
+
+export const READ_ANNOTATION_CONFIG_DRAFT_TOOL_NAME =
+  "read_annotation_config_draft";
+
+export const EDIT_ANNOTATION_CONFIG_DRAFT_TOOL_NAME =
+  "edit_annotation_config_draft";

--- a/app/src/agent/tools/annotationConfigDraft/draftOperations.ts
+++ b/app/src/agent/tools/annotationConfigDraft/draftOperations.ts
@@ -1,0 +1,70 @@
+import type {
+  AnnotationConfigActionResult,
+  AnnotationConfigDraftSnapshot,
+  EditAnnotationConfigDraftOperation,
+} from "./types";
+
+/**
+ * Pure reducer that applies edit operations to an annotation-config draft
+ * snapshot. Mirrors the code-evaluator draft reducer: it never mutates the
+ * form directly — callers preview or commit the returned snapshot. Honors the
+ * edit-mode lock on `annotationType` (immutable once a config exists).
+ */
+export function applyDraftOperations({
+  snapshot,
+  operations,
+}: {
+  snapshot: AnnotationConfigDraftSnapshot;
+  operations: EditAnnotationConfigDraftOperation[];
+}): AnnotationConfigActionResult<AnnotationConfigDraftSnapshot> {
+  let next: AnnotationConfigDraftSnapshot = { ...snapshot };
+  for (const operation of operations) {
+    switch (operation.type) {
+      case "set_name": {
+        next = { ...next, name: operation.name };
+        break;
+      }
+      case "set_description": {
+        next = { ...next, description: operation.description };
+        break;
+      }
+      case "set_annotation_type": {
+        if (next.mode === "edit") {
+          return {
+            ok: false,
+            error:
+              "Annotation type is immutable on an existing annotation config; remove the `set_annotation_type` operation.",
+          };
+        }
+        next = { ...next, annotationType: operation.annotationType };
+        break;
+      }
+      case "set_optimization_direction": {
+        next = {
+          ...next,
+          optimizationDirection: operation.optimizationDirection,
+        };
+        break;
+      }
+      case "set_lower_bound": {
+        next = { ...next, lowerBound: operation.lowerBound };
+        break;
+      }
+      case "set_upper_bound": {
+        next = { ...next, upperBound: operation.upperBound };
+        break;
+      }
+      case "set_values": {
+        next = {
+          ...next,
+          values: operation.values.map((value) => ({
+            label: value.label,
+            score: value.score ?? null,
+          })),
+        };
+        break;
+      }
+    }
+  }
+  return { ok: true, output: next };
+}

--- a/app/src/agent/tools/annotationConfigDraft/index.ts
+++ b/app/src/agent/tools/annotationConfigDraft/index.ts
@@ -1,0 +1,4 @@
+// Annotation-config form co-pilot tools: open the project-scoped
+// annotation-config slideover the PXI agent authors into.
+export * from "./agentTools";
+export * from "./constants";

--- a/app/src/agent/tools/annotationConfigDraft/index.ts
+++ b/app/src/agent/tools/annotationConfigDraft/index.ts
@@ -1,4 +1,10 @@
 // Annotation-config form co-pilot tools: open the project-scoped
-// annotation-config slideover the PXI agent authors into.
+// annotation-config slideover the PXI agent authors into, and read/edit the
+// open draft (the propose → accept/reject lifecycle).
 export * from "./agentTools";
+export * from "./clientActions";
 export * from "./constants";
+export * from "./draftOperations";
+export * from "./parsers";
+export * from "./schemas";
+export * from "./types";

--- a/app/src/agent/tools/annotationConfigDraft/parsers.ts
+++ b/app/src/agent/tools/annotationConfigDraft/parsers.ts
@@ -1,0 +1,28 @@
+import {
+  editAnnotationConfigDraftInputSchema,
+  openAnnotationConfigFormInputSchema,
+  readAnnotationConfigDraftInputSchema,
+} from "./schemas";
+import type {
+  EditAnnotationConfigDraftInput,
+  OpenAnnotationConfigFormInput,
+  ReadAnnotationConfigDraftInput,
+} from "./types";
+
+export function parseReadAnnotationConfigDraftInput(
+  input: unknown
+): ReadAnnotationConfigDraftInput | null {
+  return readAnnotationConfigDraftInputSchema.safeParse(input).data ?? null;
+}
+
+export function parseOpenAnnotationConfigFormInput(
+  input: unknown
+): OpenAnnotationConfigFormInput | null {
+  return openAnnotationConfigFormInputSchema.safeParse(input).data ?? null;
+}
+
+export function parseEditAnnotationConfigDraftInput(
+  input: unknown
+): EditAnnotationConfigDraftInput | null {
+  return editAnnotationConfigDraftInputSchema.safeParse(input).data ?? null;
+}

--- a/app/src/agent/tools/annotationConfigDraft/schemas.ts
+++ b/app/src/agent/tools/annotationConfigDraft/schemas.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+
+import { emptyToolInputSchema } from "@phoenix/agent/tools/emptyToolInput";
+import { normalizeAliases } from "@phoenix/agent/tools/playgroundPrompt";
+
+// The Python tool schema (agents/tools/*) is the model-facing source of truth
+// for these enums; this TS layer only validates what the client dispatches.
+const annotationTypeSchema = z.enum(["CATEGORICAL", "CONTINUOUS", "FREEFORM"]);
+const optimizationDirectionSchema = z.enum(["MAXIMIZE", "MINIMIZE", "NONE"]);
+
+const categoricalValueSchema = z.object({
+  label: z.string(),
+  score: z
+    .number()
+    .nullish()
+    .transform((value) => value ?? null),
+});
+
+export const readAnnotationConfigDraftInputSchema = emptyToolInputSchema;
+
+// `open_annotation_config_form` takes an optional config id: omitted/null opens
+// the create form; a node id opens that existing config for editing. Coalesces
+// a missing payload to `{}` like the empty-input parser, but keeps the id.
+export const openAnnotationConfigFormInputSchema = z
+  .preprocess(
+    (input) =>
+      normalizeAliases(input == null ? {} : input, {
+        annotationConfigId: ["annotation_config_id"],
+      }),
+    z
+      .object({
+        annotationConfigId: z
+          .string()
+          .nullish()
+          .transform((value) => value ?? null),
+      })
+      .passthrough()
+  )
+  .transform((input) => ({ annotationConfigId: input.annotationConfigId }));
+
+const setNameOperationSchema = z.object({
+  type: z.literal("set_name"),
+  name: z.string(),
+});
+
+const setDescriptionOperationSchema = z.object({
+  type: z.literal("set_description"),
+  description: z.string().nullable(),
+});
+
+const setAnnotationTypeOperationSchema = z.object({
+  type: z.literal("set_annotation_type"),
+  annotationType: annotationTypeSchema,
+});
+
+const setOptimizationDirectionOperationSchema = z.object({
+  type: z.literal("set_optimization_direction"),
+  optimizationDirection: optimizationDirectionSchema,
+});
+
+const setLowerBoundOperationSchema = z.object({
+  type: z.literal("set_lower_bound"),
+  lowerBound: z.number().nullable(),
+});
+
+const setUpperBoundOperationSchema = z.object({
+  type: z.literal("set_upper_bound"),
+  upperBound: z.number().nullable(),
+});
+
+const setValuesOperationSchema = z.object({
+  type: z.literal("set_values"),
+  values: z.array(categoricalValueSchema),
+});
+
+export const editAnnotationConfigDraftOperationSchema = z.preprocess(
+  (input) =>
+    normalizeAliases(input, {
+      annotationType: ["annotation_type"],
+      optimizationDirection: ["optimization_direction"],
+      lowerBound: ["lower_bound"],
+      upperBound: ["upper_bound"],
+    }),
+  z.discriminatedUnion("type", [
+    setNameOperationSchema,
+    setDescriptionOperationSchema,
+    setAnnotationTypeOperationSchema,
+    setOptimizationDirectionOperationSchema,
+    setLowerBoundOperationSchema,
+    setUpperBoundOperationSchema,
+    setValuesOperationSchema,
+  ])
+);
+
+// The `normalize*` helpers map the model's snake_case keys and a single bare
+// operation onto the canonical `{ operations: [...] }` shape these schemas
+// expect (see normalizeAliases).
+function normalizeEditAnnotationConfigDraftInput(input: unknown): unknown {
+  const normalized = normalizeAliases(input, { operations: ["operation"] });
+  if (
+    typeof normalized !== "object" ||
+    normalized === null ||
+    Array.isArray(normalized)
+  ) {
+    return normalized;
+  }
+  const candidate = normalized as Record<string, unknown>;
+  if (candidate.operations === undefined && typeof candidate.type === "string") {
+    return { operations: [candidate] };
+  }
+  return normalized;
+}
+
+const editAnnotationConfigDraftOperationsSchema = z.preprocess((input) => {
+  if (Array.isArray(input)) return input;
+  return typeof input === "object" && input !== null ? [input] : input;
+}, z.array(editAnnotationConfigDraftOperationSchema).min(1));
+
+export const editAnnotationConfigDraftInputSchema = z
+  .preprocess(
+    normalizeEditAnnotationConfigDraftInput,
+    z.object({
+      operations: editAnnotationConfigDraftOperationsSchema,
+    })
+  )
+  .transform((input) => input);

--- a/app/src/agent/tools/annotationConfigDraft/types.ts
+++ b/app/src/agent/tools/annotationConfigDraft/types.ts
@@ -1,0 +1,50 @@
+import type { z } from "zod";
+
+import type { AnnotationConfigDraftValues } from "@phoenix/store/annotationConfigDraftStore";
+
+import type {
+  editAnnotationConfigDraftInputSchema,
+  editAnnotationConfigDraftOperationSchema,
+  openAnnotationConfigFormInputSchema,
+  readAnnotationConfigDraftInputSchema,
+} from "./schemas";
+
+export type ReadAnnotationConfigDraftInput = z.output<
+  typeof readAnnotationConfigDraftInputSchema
+>;
+
+export type OpenAnnotationConfigFormInput = z.output<
+  typeof openAnnotationConfigFormInputSchema
+>;
+
+export type EditAnnotationConfigDraftOperation = z.output<
+  typeof editAnnotationConfigDraftOperationSchema
+>;
+
+export type EditAnnotationConfigDraftInput = z.output<
+  typeof editAnnotationConfigDraftInputSchema
+>;
+
+/**
+ * The agent-facing view of the open form: the flat draft values plus the form
+ * mode and (in edit mode) the relay node id of the config being edited.
+ */
+export type AnnotationConfigDraftSnapshot = {
+  mode: "create" | "edit";
+  annotationConfigNodeId: string | null;
+} & AnnotationConfigDraftValues;
+
+export type AnnotationConfigActionResult<TOutput> =
+  | { ok: true; output: TOutput }
+  | { ok: false; error: string };
+
+export type AnnotationConfigDraftHost = {
+  getSnapshot: () => AnnotationConfigDraftSnapshot;
+  applyOperations: (
+    operations: EditAnnotationConfigDraftOperation[]
+  ) => AnnotationConfigActionResult<AnnotationConfigDraftSnapshot>;
+  previewOperations: (
+    snapshot: AnnotationConfigDraftSnapshot,
+    operations: EditAnnotationConfigDraftOperation[]
+  ) => AnnotationConfigActionResult<AnnotationConfigDraftSnapshot>;
+};

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1451,6 +1451,22 @@ export interface components {
             /** Data */
             data: components["schemas"]["InsertedTraceAnnotation"][];
         };
+        /**
+         * AnnotationConfigContext
+         * @description Annotation-config create/edit form mounted in the current browser route.
+         *
+         *     ``annotation_config_node_id`` is ``None`` when the form is creating a new
+         *     config and carries the config's relay node id when editing an existing one.
+         */
+        AnnotationConfigContext: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "annotation_config";
+            /** Annotationconfignodeid */
+            annotationConfigNodeId?: string | null;
+        };
         /** AnnotationResult */
         AnnotationResult: {
             /**
@@ -1614,7 +1630,7 @@ export interface components {
          * ChatContext
          * @description Discriminated union of every UI-state context the agent understands.
          */
-        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["SessionContext"] | components["schemas"]["PromptContext"] | components["schemas"]["PromptVersionContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["CodeEvaluatorContext"] | components["schemas"]["LlmEvaluatorContext"] | components["schemas"]["DatasetContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"] | components["schemas"]["SubagentsContext"];
+        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["SessionContext"] | components["schemas"]["PromptContext"] | components["schemas"]["PromptVersionContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["CodeEvaluatorContext"] | components["schemas"]["LlmEvaluatorContext"] | components["schemas"]["AnnotationConfigContext"] | components["schemas"]["DatasetContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"] | components["schemas"]["SubagentsContext"];
         /**
          * ChatRegenerateMessage
          * @description Regenerate message extended with Phoenix-specific fields.

--- a/app/src/components/agent/AgentContextPills.tsx
+++ b/app/src/components/agent/AgentContextPills.tsx
@@ -53,6 +53,8 @@ function contextLabel(context: AgentContext): string {
       return "Code Evaluator";
     case "llm_evaluator":
       return "LLM Evaluator";
+    case "annotation_config":
+      return "Annotation Config";
     case "dataset":
       return "Dataset";
   }
@@ -81,6 +83,10 @@ function contextDetail(context: AgentContext): string | undefined {
       return context.evaluatorNodeId
         ? `Editing evaluator: ${truncateId(context.evaluatorNodeId)}`
         : "New evaluator";
+    case "annotation_config":
+      return context.annotationConfigNodeId
+        ? `Editing config: ${truncateId(context.annotationConfigNodeId)}`
+        : "New config";
     case "dataset":
       return truncateId(context.datasetNodeId);
     default:

--- a/app/src/components/ai/attachment/utils.tsx
+++ b/app/src/components/ai/attachment/utils.tsx
@@ -70,6 +70,8 @@ function getContextCategoryIcon(category: string | undefined): ReactNode {
       return <Icon svg={<Icons.Edit />} />;
     case "llm_evaluator":
       return <Icon svg={<Icons.Scale />} />;
+    case "annotation_config":
+      return <Icon svg={<Icons.PriceTagsOutline />} />;
     default:
       return <Icon svg={<Icons.Info />} />;
   }

--- a/app/src/components/annotation/AnnotationConfigDialog.tsx
+++ b/app/src/components/annotation/AnnotationConfigDialog.tsx
@@ -21,6 +21,7 @@ import {
   TextField,
   View,
 } from "@phoenix/components";
+import { DialogCloseButton } from "@phoenix/components/core/dialog";
 import { useNotifySuccess } from "@phoenix/contexts";
 import {
   AnnotationConfigDraftProvider,
@@ -64,9 +65,15 @@ type OnAddAnnotationConfig = (
 export const AnnotationConfigDialog = ({
   onAddAnnotationConfig,
   initialAnnotationConfig,
+  fillContainer = false,
 }: {
   onAddAnnotationConfig: OnAddAnnotationConfig;
   initialAnnotationConfig?: Partial<AnnotationConfig>;
+  /**
+   * Fill the parent's width instead of the fixed 700px centered-modal width.
+   * Set when rendering inside a resizable container such as a Drawer.
+   */
+  fillContainer?: boolean;
 }) => {
   const initialProps = initialDraftPropsFromConfig(initialAnnotationConfig);
   return (
@@ -76,15 +83,20 @@ export const AnnotationConfigDialog = ({
       key={initialAnnotationConfig?.id ?? "new"}
       {...initialProps}
     >
-      <AnnotationConfigDialogForm onAddAnnotationConfig={onAddAnnotationConfig} />
+      <AnnotationConfigDialogForm
+        onAddAnnotationConfig={onAddAnnotationConfig}
+        fillContainer={fillContainer}
+      />
     </AnnotationConfigDraftProvider>
   );
 };
 
 const AnnotationConfigDialogForm = ({
   onAddAnnotationConfig,
+  fillContainer,
 }: {
   onAddAnnotationConfig: OnAddAnnotationConfig;
+  fillContainer: boolean;
 }) => {
   const [error, setError] = useState<string | null>(null);
   const [showErrors, setShowErrors] = useState(false);
@@ -123,17 +135,28 @@ const AnnotationConfigDialogForm = ({
 
   return (
     <Dialog
-      css={css`
-        border: none;
-        width: 700px;
-        max-width: 90%;
-      `}
+      css={
+        fillContainer
+          ? css`
+              border: none;
+              width: 100%;
+              height: 100%;
+            `
+          : css`
+              border: none;
+              width: 700px;
+              max-width: 90%;
+            `
+      }
     >
       {({ close }) => (
         <Card
           title={
             mode === "create" ? "New Annotation Config" : "Edit Annotation Config"
           }
+          // In the drawer, surface the minimize control in the header like the
+          // trace drawer (the button renders the collapse arrow in a Drawer).
+          extra={fillContainer ? <DialogCloseButton close={close} /> : undefined}
         >
           <Form
             onSubmit={(e) => {

--- a/app/src/components/annotation/AnnotationConfigDialog.tsx
+++ b/app/src/components/annotation/AnnotationConfigDialog.tsx
@@ -21,7 +21,6 @@ import {
   TextField,
   View,
 } from "@phoenix/components";
-import { DialogCloseButton } from "@phoenix/components/core/dialog";
 import { useNotifySuccess } from "@phoenix/contexts";
 import {
   AnnotationConfigDraftProvider,
@@ -65,15 +64,9 @@ type OnAddAnnotationConfig = (
 export const AnnotationConfigDialog = ({
   onAddAnnotationConfig,
   initialAnnotationConfig,
-  fillContainer = false,
 }: {
   onAddAnnotationConfig: OnAddAnnotationConfig;
   initialAnnotationConfig?: Partial<AnnotationConfig>;
-  /**
-   * Fill the parent's width instead of the fixed 700px centered-modal width.
-   * Set when rendering inside a resizable container such as a Drawer.
-   */
-  fillContainer?: boolean;
 }) => {
   const initialProps = initialDraftPropsFromConfig(initialAnnotationConfig);
   return (
@@ -83,20 +76,15 @@ export const AnnotationConfigDialog = ({
       key={initialAnnotationConfig?.id ?? "new"}
       {...initialProps}
     >
-      <AnnotationConfigDialogForm
-        onAddAnnotationConfig={onAddAnnotationConfig}
-        fillContainer={fillContainer}
-      />
+      <AnnotationConfigDialogForm onAddAnnotationConfig={onAddAnnotationConfig} />
     </AnnotationConfigDraftProvider>
   );
 };
 
 const AnnotationConfigDialogForm = ({
   onAddAnnotationConfig,
-  fillContainer,
 }: {
   onAddAnnotationConfig: OnAddAnnotationConfig;
-  fillContainer: boolean;
 }) => {
   const [error, setError] = useState<string | null>(null);
   const [showErrors, setShowErrors] = useState(false);
@@ -135,28 +123,17 @@ const AnnotationConfigDialogForm = ({
 
   return (
     <Dialog
-      css={
-        fillContainer
-          ? css`
-              border: none;
-              width: 100%;
-              height: 100%;
-            `
-          : css`
-              border: none;
-              width: 700px;
-              max-width: 90%;
-            `
-      }
+      css={css`
+        border: none;
+        width: 700px;
+        max-width: 90%;
+      `}
     >
       {({ close }) => (
         <Card
           title={
             mode === "create" ? "New Annotation Config" : "Edit Annotation Config"
           }
-          // In the drawer, surface the minimize control in the header like the
-          // trace drawer (the button renders the collapse arrow in a Drawer).
-          extra={fillContainer ? <DialogCloseButton close={close} /> : undefined}
         >
           <Form
             onSubmit={(e) => {

--- a/app/src/components/annotation/AnnotationConfigDialog.tsx
+++ b/app/src/components/annotation/AnnotationConfigDialog.tsx
@@ -38,6 +38,8 @@ import {
   validateAnnotationConfigDraft,
 } from "@phoenix/store/annotationConfigDraftStore";
 
+import { useAnnotationConfigDraftRegistration } from "./useAnnotationConfigDraftRegistration";
+
 const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
 
 const optimizationDirections = [
@@ -92,6 +94,9 @@ const AnnotationConfigDialogForm = ({
     number | null
   >(null);
   const notifySuccess = useNotifySuccess();
+
+  // Register the agent read/edit draft client actions for the form's lifetime.
+  useAnnotationConfigDraftRegistration();
 
   const store = useAnnotationConfigDraftStoreInstance();
   const mode = useAnnotationConfigDraftStore((s) => s.mode);

--- a/app/src/components/annotation/AnnotationConfigDialog.tsx
+++ b/app/src/components/annotation/AnnotationConfigDialog.tsx
@@ -1,6 +1,5 @@
 import { css } from "@emotion/react";
 import { useState } from "react";
-import { Controller, useFieldArray, useForm, useWatch } from "react-hook-form";
 
 import {
   Alert,
@@ -23,14 +22,21 @@ import {
   View,
 } from "@phoenix/components";
 import { useNotifySuccess } from "@phoenix/contexts";
+import {
+  AnnotationConfigDraftProvider,
+  useAnnotationConfigDraftStore,
+  useAnnotationConfigDraftStoreInstance,
+} from "@phoenix/contexts/AnnotationConfigDraftContext";
 import type {
   AnnotationConfig,
-  AnnotationConfigCategorical,
-  AnnotationConfigContinuous,
-  AnnotationConfigFreeform,
   AnnotationConfigOptimizationDirection,
   AnnotationConfigType,
 } from "@phoenix/pages/settings/types";
+import {
+  initialDraftPropsFromConfig,
+  toAnnotationConfig,
+  validateAnnotationConfigDraft,
+} from "@phoenix/store/annotationConfigDraftStore";
 
 const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
 
@@ -46,92 +52,75 @@ const types = [
   "FREEFORM",
 ] satisfies AnnotationConfigType[];
 
+/** Coerce a store number|null into the number|undefined React Aria wants. */
+const toNumberFieldValue = (value: number | null): number | undefined =>
+  typeof value === "number" && !Number.isNaN(value) ? value : undefined;
+
+type OnAddAnnotationConfig = (
+  config: AnnotationConfig,
+  args?: { onCompleted?: () => void; onError?: (error: string) => void }
+) => void;
+
 export const AnnotationConfigDialog = ({
   onAddAnnotationConfig,
   initialAnnotationConfig,
 }: {
-  onAddAnnotationConfig: (
-    config: AnnotationConfig,
-    {
-      onCompleted,
-      onError,
-    }?: { onCompleted?: () => void; onError?: (error: string) => void }
-  ) => void;
+  onAddAnnotationConfig: OnAddAnnotationConfig;
   initialAnnotationConfig?: Partial<AnnotationConfig>;
 }) => {
+  const initialProps = initialDraftPropsFromConfig(initialAnnotationConfig);
+  return (
+    // Key on the target config so the store re-seeds if this stays mounted
+    // while the edit target changes ("new" key for the create flow).
+    <AnnotationConfigDraftProvider
+      key={initialAnnotationConfig?.id ?? "new"}
+      {...initialProps}
+    >
+      <AnnotationConfigDialogForm onAddAnnotationConfig={onAddAnnotationConfig} />
+    </AnnotationConfigDraftProvider>
+  );
+};
+
+const AnnotationConfigDialogForm = ({
+  onAddAnnotationConfig,
+}: {
+  onAddAnnotationConfig: OnAddAnnotationConfig;
+}) => {
   const [error, setError] = useState<string | null>(null);
-  const notifySuccess = useNotifySuccess();
-  const mode: "new" | "edit" = initialAnnotationConfig ? "edit" : "new";
-  const { control, handleSubmit } = useForm<AnnotationConfig>({
-    defaultValues: initialAnnotationConfig || {
-      annotationType: "CATEGORICAL",
-      values: [
-        { label: "", score: null },
-        { label: "", score: null },
-      ],
-      optimizationDirection: "MAXIMIZE",
-    },
-  });
-  const { fields, append, remove } = useFieldArray({
-    control,
-    name: "values",
-  });
+  const [showErrors, setShowErrors] = useState(false);
   const [autoFocusedCategoryIndex, setAutoFocusedCategoryIndex] = useState<
     number | null
   >(null);
-  const annotationType = useWatch({ control, name: "annotationType" });
-  const lowerBound = useWatch({ control, name: "lowerBound" });
-  const onSubmit = (data: AnnotationConfig, close: () => void) => {
-    const onCompleted = () => {
-      notifySuccess({
-        title:
-          mode === "new"
-            ? "Annotation config created!"
-            : "Annotation config updated!",
-      });
-      close();
-    };
-    const onError = (error: string) => {
-      setError(error);
-    };
-    switch (data.annotationType) {
-      case "CATEGORICAL": {
-        const config: AnnotationConfigCategorical = {
-          annotationType: "CATEGORICAL",
-          name: data.name,
-          values: data.values,
-          id: initialAnnotationConfig?.id || "",
-          optimizationDirection: data.optimizationDirection,
-          description: data.description,
-        };
-        onAddAnnotationConfig(config, { onCompleted, onError });
-        break;
-      }
-      case "CONTINUOUS": {
-        const config: AnnotationConfigContinuous = {
-          annotationType: "CONTINUOUS",
-          name: data.name,
-          lowerBound: data.lowerBound,
-          upperBound: data.upperBound,
-          id: initialAnnotationConfig?.id || "",
-          optimizationDirection: data.optimizationDirection,
-          description: data.description,
-        };
-        onAddAnnotationConfig(config, { onCompleted, onError });
-        break;
-      }
-      case "FREEFORM": {
-        const config: AnnotationConfigFreeform = {
-          annotationType: "FREEFORM",
-          name: data.name,
-          id: initialAnnotationConfig?.id || "",
-          description: data.description,
-        };
-        onAddAnnotationConfig(config, { onCompleted, onError });
-        break;
-      }
+  const notifySuccess = useNotifySuccess();
+
+  const store = useAnnotationConfigDraftStoreInstance();
+  const mode = useAnnotationConfigDraftStore((s) => s.mode);
+  const draft = useAnnotationConfigDraftStore((s) => s.draft);
+  const { annotationType } = draft;
+  const errors = validateAnnotationConfigDraft(draft);
+  const errorFor = (key: string) => (showErrors ? errors[key] : undefined);
+
+  const onSubmit = (close: () => void) => {
+    const { draft: current, configId } = store.getState();
+    if (Object.keys(validateAnnotationConfigDraft(current)).length > 0) {
+      setShowErrors(true);
+      return;
     }
+    const config = toAnnotationConfig(current, configId ?? "");
+    onAddAnnotationConfig(config, {
+      onCompleted: () => {
+        notifySuccess({
+          title:
+            mode === "create"
+              ? "Annotation config created!"
+              : "Annotation config updated!",
+        });
+        close();
+      },
+      onError: (err) => setError(err),
+    });
   };
+
   return (
     <Dialog
       css={css`
@@ -143,14 +132,13 @@ export const AnnotationConfigDialog = ({
       {({ close }) => (
         <Card
           title={
-            mode === "new" ? "New Annotation Config" : "Edit Annotation Config"
+            mode === "create" ? "New Annotation Config" : "Edit Annotation Config"
           }
         >
           <Form
             onSubmit={(e) => {
-              handleSubmit((data) => {
-                onSubmit(data, close);
-              })(e);
+              e.preventDefault();
+              onSubmit(close);
             }}
           >
             {error && (
@@ -164,109 +152,98 @@ export const AnnotationConfigDialog = ({
                 gap="size-200"
                 className="new-annotation-dialog-container"
               >
-                <Controller
-                  name="name"
-                  control={control}
-                  rules={{
-                    required: "Name is required",
-                  }}
-                  render={({ field, fieldState: { error } }) => (
-                    <TextField {...field} isInvalid={!!error} autoFocus>
-                      <Label>Annotation Name</Label>
-                      <Input placeholder="e.g. correctness" />
-                      <FieldError>{error?.message}</FieldError>
-                    </TextField>
-                  )}
-                />
-                <Controller
-                  name="description"
-                  control={control}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      value={field.value ?? undefined}
-                      css={css`
-                        & .react-aria-TextArea {
-                          resize: vertical;
-                          transition: none;
-                        }
-                      `}
-                    >
-                      <Label>Description</Label>
-                      <TextArea
-                        rows={2}
-                        placeholder="A description of the annotation configuration"
-                      />
-                    </TextField>
-                  )}
-                />
-                <Controller
-                  control={control}
-                  name="annotationType"
-                  render={({ field }) => (
-                    <RadioGroup
-                      {...field}
-                      aria-label="Type"
-                      data-testid="type-picker"
-                      isReadOnly={mode === "edit"}
-                    >
-                      <Label>Annotation Type</Label>
-                      {types
-                        .filter((type) =>
-                          mode === "edit" ? type === field.value : type
-                        )
-                        .map((type) => (
-                          <Radio key={type} value={type}>
-                            {type.charAt(0).toUpperCase() +
-                              type.slice(1).toLowerCase()}
-                          </Radio>
-                        ))}
-                      <Text slot="description">
-                        Categorical - assign a category - e.g. grade, A, B, C
-                        <br />
-                        Continuous - assign a score within a range - e.g. 0-1,
-                        0.5
-                        <br />
-                        Freeform - assign a freeform text comment, e.g.
-                        &quot;good&quot;
-                      </Text>
-                    </RadioGroup>
-                  )}
-                />
+                <TextField
+                  value={draft.name}
+                  onChange={(value) => store.getState().setName(value)}
+                  isInvalid={!!errorFor("name")}
+                  autoFocus
+                >
+                  <Label>Annotation Name</Label>
+                  <Input placeholder="e.g. correctness" />
+                  <FieldError>{errorFor("name")}</FieldError>
+                </TextField>
+                <TextField
+                  value={draft.description ?? ""}
+                  onChange={(value) =>
+                    store.getState().setDescription(value || null)
+                  }
+                  css={css`
+                    & .react-aria-TextArea {
+                      resize: vertical;
+                      transition: none;
+                    }
+                  `}
+                >
+                  <Label>Description</Label>
+                  <TextArea
+                    rows={2}
+                    placeholder="A description of the annotation configuration"
+                  />
+                </TextField>
+                <RadioGroup
+                  value={annotationType}
+                  onChange={(value) =>
+                    store
+                      .getState()
+                      .setAnnotationType(value as AnnotationConfigType)
+                  }
+                  aria-label="Type"
+                  data-testid="type-picker"
+                  isReadOnly={mode === "edit"}
+                >
+                  <Label>Annotation Type</Label>
+                  {types
+                    .filter((type) =>
+                      mode === "edit" ? type === annotationType : type
+                    )
+                    .map((type) => (
+                      <Radio key={type} value={type}>
+                        {type.charAt(0).toUpperCase() +
+                          type.slice(1).toLowerCase()}
+                      </Radio>
+                    ))}
+                  <Text slot="description">
+                    Categorical - assign a category - e.g. grade, A, B, C
+                    <br />
+                    Continuous - assign a score within a range - e.g. 0-1, 0.5
+                    <br />
+                    Freeform - assign a freeform text comment, e.g.
+                    &quot;good&quot;
+                  </Text>
+                </RadioGroup>
                 {(annotationType === "CONTINUOUS" ||
                   annotationType === "CATEGORICAL") && (
-                  <Controller
-                    control={control}
-                    name="optimizationDirection"
-                    render={({ field }) => (
-                      <RadioGroup
-                        {...field}
-                        aria-label="Optimization Direction"
-                        data-testid="optimization-direction-picker"
-                        css={css`
-                          height: 100%;
-                        `}
-                      >
-                        <Label>Optimization Direction</Label>
-                        {optimizationDirections.map((direction) => (
-                          <Radio key={direction} value={direction}>
-                            {direction.charAt(0).toUpperCase() +
-                              direction.slice(1).toLowerCase()}
-                          </Radio>
-                        ))}
-                        <Text marginTop="auto" slot="description">
-                          Maximize - higher the score the better - e.g.,
-                          correctness
-                          <br />
-                          Minimize - lower the score the better - e.g.,
-                          hallucinations
-                          <br />
-                          None - higher is not better or worse
-                          <br />
-                        </Text>
-                      </RadioGroup>
-                    )}
-                  />
+                  <RadioGroup
+                    value={draft.optimizationDirection}
+                    onChange={(value) =>
+                      store
+                        .getState()
+                        .setOptimizationDirection(
+                          value as AnnotationConfigOptimizationDirection
+                        )
+                    }
+                    aria-label="Optimization Direction"
+                    data-testid="optimization-direction-picker"
+                    css={css`
+                      height: 100%;
+                    `}
+                  >
+                    <Label>Optimization Direction</Label>
+                    {optimizationDirections.map((direction) => (
+                      <Radio key={direction} value={direction}>
+                        {direction.charAt(0).toUpperCase() +
+                          direction.slice(1).toLowerCase()}
+                      </Radio>
+                    ))}
+                    <Text marginTop="auto" slot="description">
+                      Maximize - higher the score the better - e.g., correctness
+                      <br />
+                      Minimize - lower the score the better - e.g., hallucinations
+                      <br />
+                      None - higher is not better or worse
+                      <br />
+                    </Text>
+                  </RadioGroup>
                 )}
                 {annotationType === "CONTINUOUS" && (
                   <Flex
@@ -278,69 +255,33 @@ export const AnnotationConfigDialog = ({
                       }
                     `}
                   >
-                    <Controller
-                      control={control}
-                      name="lowerBound"
-                      rules={{
-                        required: "Min is required",
-                      }}
-                      render={({
-                        field: { value, ...field },
-                        fieldState: { error },
-                      }) => (
-                        <NumberField
-                          {...field}
-                          value={typeof value === "number" ? value : undefined}
-                          isInvalid={!!error}
-                        >
-                          <Label>Min</Label>
-                          <Input placeholder="0" />
-                          <FieldError>{error?.message}</FieldError>
-                        </NumberField>
-                      )}
-                    />
-                    <Controller
-                      control={control}
-                      name="upperBound"
-                      rules={{
-                        validate: (value) => {
-                          if (
-                            lowerBound != null &&
-                            value != null &&
-                            value <= lowerBound
-                          ) {
-                            return "Max must be greater than min";
-                          }
-                          if (value != null && isNaN(value)) {
-                            return "Max is required";
-                          }
-                          return true;
-                        },
-                      }}
-                      render={({
-                        field: { value, ...field },
-                        fieldState: { error },
-                      }) => {
-                        return (
-                          <NumberField
-                            {...field}
-                            value={
-                              typeof value === "number" ? value : undefined
-                            }
-                            isInvalid={!!error}
-                            minValue={
-                              typeof lowerBound === "number"
-                                ? lowerBound
-                                : undefined
-                            }
-                          >
-                            <Label>Max</Label>
-                            <Input placeholder="1" />
-                            <FieldError>{error?.message}</FieldError>
-                          </NumberField>
-                        );
-                      }}
-                    />
+                    <NumberField
+                      value={toNumberFieldValue(draft.lowerBound)}
+                      onChange={(value) =>
+                        store
+                          .getState()
+                          .setLowerBound(Number.isNaN(value) ? null : value)
+                      }
+                      isInvalid={!!errorFor("lowerBound")}
+                    >
+                      <Label>Min</Label>
+                      <Input placeholder="0" />
+                      <FieldError>{errorFor("lowerBound")}</FieldError>
+                    </NumberField>
+                    <NumberField
+                      value={toNumberFieldValue(draft.upperBound)}
+                      onChange={(value) =>
+                        store
+                          .getState()
+                          .setUpperBound(Number.isNaN(value) ? null : value)
+                      }
+                      isInvalid={!!errorFor("upperBound")}
+                      minValue={toNumberFieldValue(draft.lowerBound)}
+                    >
+                      <Label>Max</Label>
+                      <Input placeholder="1" />
+                      <FieldError>{errorFor("upperBound")}</FieldError>
+                    </NumberField>
                   </Flex>
                 )}
                 {annotationType === "CATEGORICAL" && (
@@ -348,65 +289,53 @@ export const AnnotationConfigDialog = ({
                     <Text size="XS" weight="heavy">
                       Categories
                     </Text>
-                    {fields.map((item, index) => (
+                    {draft.values.map((value, index) => (
                       <Flex
-                        key={item.id}
+                        key={index}
                         direction="row"
                         gap="size-100"
                         alignItems="start"
                       >
-                        <Controller
-                          control={control}
-                          name={`values.${index}.label`}
-                          rules={{
-                            required: "Category label is required",
-                          }}
-                          render={({ field, fieldState: { error } }) => (
-                            <TextField
-                              {...field}
-                              aria-label={`Value ${index + 1}`}
-                              isInvalid={!!error}
-                              autoFocus={autoFocusedCategoryIndex === index}
-                            >
-                              <Input
-                                placeholder={`e.g. ${ALPHABET[index % ALPHABET.length]}`}
-                              />
-                              <FieldError>{error?.message}</FieldError>
-                            </TextField>
-                          )}
-                        />
-                        <Controller
-                          control={control}
-                          name={`values.${index}.score`}
-                          render={({ field, fieldState: { error } }) => (
-                            <NumberField
-                              {...field}
-                              value={
-                                typeof field.value === "number"
-                                  ? field.value
-                                  : undefined
-                              }
-                              aria-label={`Score ${index + 1}`}
-                              isInvalid={!!error}
-                            >
-                              <Flex
-                                direction="row"
-                                gap="size-100"
-                                alignItems="center"
-                              >
-                                <Input
-                                  placeholder={`e.g. ${index} (optional)`}
-                                />
-                              </Flex>
-                              <FieldError>{error?.message}</FieldError>
-                            </NumberField>
-                          )}
-                        />
+                        <TextField
+                          value={value.label}
+                          onChange={(label) =>
+                            store.getState().updateValue(index, { label })
+                          }
+                          aria-label={`Value ${index + 1}`}
+                          isInvalid={!!errorFor(`values.${index}.label`)}
+                          autoFocus={autoFocusedCategoryIndex === index}
+                        >
+                          <Input
+                            placeholder={`e.g. ${ALPHABET[index % ALPHABET.length]}`}
+                          />
+                          <FieldError>
+                            {errorFor(`values.${index}.label`)}
+                          </FieldError>
+                        </TextField>
+                        <NumberField
+                          value={toNumberFieldValue(value.score)}
+                          onChange={(score) =>
+                            store
+                              .getState()
+                              .updateValue(index, {
+                                score: Number.isNaN(score) ? null : score,
+                              })
+                          }
+                          aria-label={`Score ${index + 1}`}
+                        >
+                          <Flex
+                            direction="row"
+                            gap="size-100"
+                            alignItems="center"
+                          >
+                            <Input placeholder={`e.g. ${index} (optional)`} />
+                          </Flex>
+                        </NumberField>
                         <Button
                           type="button"
                           leadingVisual={<Icon svg={<Icons.Trash />} />}
                           aria-label="Remove category"
-                          onPress={() => remove(index)}
+                          onPress={() => store.getState().removeValue(index)}
                         />
                       </Flex>
                     ))}
@@ -414,8 +343,8 @@ export const AnnotationConfigDialog = ({
                       <Button
                         type="button"
                         onPress={() => {
-                          append({ label: "", score: null });
-                          const newIndex = fields.length;
+                          const newIndex = draft.values.length;
+                          store.getState().addValue();
                           setAutoFocusedCategoryIndex(newIndex);
                         }}
                         leadingVisual={<Icon svg={<Icons.Plus />} />}
@@ -438,7 +367,7 @@ export const AnnotationConfigDialog = ({
                   Cancel
                 </Button>
                 <Button type="submit" variant="primary">
-                  {mode === "new"
+                  {mode === "create"
                     ? "Create Annotation Config"
                     : "Update Annotation Config"}
                 </Button>

--- a/app/src/components/annotation/AnnotationConfigSlideover.tsx
+++ b/app/src/components/annotation/AnnotationConfigSlideover.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useState } from "react";
-import { graphql, useMutation } from "react-relay";
+import { fetchQuery, graphql, useMutation } from "react-relay";
 
 import { Modal, ModalOverlay } from "@phoenix/components";
 import { AnnotationConfigDialog } from "@phoenix/components/annotation/AnnotationConfigDialog";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
 import { OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME } from "@phoenix/agent/tools/annotationConfigDraft/constants";
 import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
+import RelayEnvironment from "@phoenix/RelayEnvironment";
 import type { AnnotationConfig } from "@phoenix/pages/settings/types";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
+import type { AnnotationConfigSlideoverConfigQuery } from "./__generated__/AnnotationConfigSlideoverConfigQuery.graphql";
 import type { AnnotationConfigSlideoverCreateMutation } from "./__generated__/AnnotationConfigSlideoverCreateMutation.graphql";
 import type { AnnotationConfigSlideoverUpdateMutation } from "./__generated__/AnnotationConfigSlideoverUpdateMutation.graphql";
 import type { AnnotationConfigSlideoverAddToProjectMutation } from "./__generated__/AnnotationConfigSlideoverAddToProjectMutation.graphql";
@@ -17,6 +19,129 @@ import type { AnnotationConfigSlideoverAddToProjectMutation } from "./__generate
 type AnnotationConfigFormState = {
   mode: "create" | "edit";
   config?: AnnotationConfig;
+};
+
+// Annotation-config nodes are not resolvable through the top-level `node(id:)`
+// field, so we read them through the project's `annotationConfigs` connection
+// (the same path the settings table uses) and match by id. This also scopes the
+// edit flow to configs associated with the focused project.
+const projectAnnotationConfigsQuery = graphql`
+  query AnnotationConfigSlideoverConfigQuery($projectId: ID!) {
+    node(id: $projectId) {
+      __typename
+      ... on Project {
+        annotationConfigs {
+          edges {
+            annotationConfig: node {
+              __typename
+              ... on CategoricalAnnotationConfig {
+                id
+                name
+                description
+                annotationType
+                optimizationDirection
+                values {
+                  label
+                  score
+                }
+              }
+              ... on ContinuousAnnotationConfig {
+                id
+                name
+                description
+                annotationType
+                optimizationDirection
+                lowerBound
+                upperBound
+              }
+              ... on FreeformAnnotationConfig {
+                id
+                name
+                description
+                annotationType
+                optimizationDirection
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+type ProjectNode = Extract<
+  AnnotationConfigSlideoverConfigQuery["response"]["node"],
+  { readonly __typename: "Project" }
+>;
+type AnnotationConfigNode =
+  ProjectNode["annotationConfigs"]["edges"][number]["annotationConfig"];
+
+/**
+ * Map a config node from the project's `annotationConfigs` connection into the
+ * discriminated {@link AnnotationConfig} shape the dialog seeds its draft from.
+ * Returns null for an unrecognized node type.
+ */
+const toAnnotationConfig = (
+  node: AnnotationConfigNode
+): AnnotationConfig | null => {
+  switch (node.__typename) {
+    case "CategoricalAnnotationConfig":
+      return {
+        id: node.id,
+        annotationType: "CATEGORICAL",
+        name: node.name,
+        description: node.description,
+        optimizationDirection: node.optimizationDirection,
+        values: node.values.map((value) => ({
+          label: value.label,
+          score: value.score,
+        })),
+      };
+    case "ContinuousAnnotationConfig":
+      return {
+        id: node.id,
+        annotationType: "CONTINUOUS",
+        name: node.name,
+        description: node.description,
+        optimizationDirection: node.optimizationDirection,
+        lowerBound: node.lowerBound,
+        upperBound: node.upperBound,
+      };
+    case "FreeformAnnotationConfig":
+      return {
+        id: node.id,
+        annotationType: "FREEFORM",
+        name: node.name,
+        description: node.description,
+        optimizationDirection: node.optimizationDirection,
+      };
+    default:
+      return null;
+  }
+};
+
+/**
+ * Resolve an annotation config associated with the project by its node id.
+ * Returns null when no config on the project matches.
+ */
+const fetchAnnotationConfigById = async (
+  projectId: string,
+  annotationConfigId: string
+): Promise<AnnotationConfig | null> => {
+  const data = await fetchQuery<AnnotationConfigSlideoverConfigQuery>(
+    RelayEnvironment,
+    projectAnnotationConfigsQuery,
+    { projectId }
+  ).toPromise();
+  const project =
+    data?.node?.__typename === "Project" ? data.node : null;
+  for (const edge of project?.annotationConfigs.edges ?? []) {
+    const config = toAnnotationConfig(edge.annotationConfig);
+    if (config?.id === annotationConfigId) {
+      return config;
+    }
+  }
+  return null;
 };
 
 /**
@@ -96,12 +221,43 @@ export const AnnotationConfigSlideover = ({
   useEffect(() => {
     const { registerClientAction, unregisterClientAction } =
       agentStore.getState();
-    registerClientAction(OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME, async () => {
-      setFormState({ mode: "create" });
-      return { ok: true, output: "Annotation-config form opened." };
+    registerClientAction(OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME, async (input) => {
+      const annotationConfigId =
+        (input as { annotationConfigId?: string | null } | null)
+          ?.annotationConfigId ?? null;
+      if (annotationConfigId == null) {
+        setFormState({ mode: "create" });
+        return {
+          ok: true,
+          output: "Annotation-config form opened to create a new config.",
+        };
+      }
+      try {
+        const config = await fetchAnnotationConfigById(
+          projectId,
+          annotationConfigId
+        );
+        if (!config) {
+          return {
+            ok: false,
+            error: `No annotation config found for id ${annotationConfigId}.`,
+          };
+        }
+        setFormState({ mode: "edit", config });
+        return {
+          ok: true,
+          output: `Annotation-config form opened to edit "${config.name}".`,
+        };
+      } catch (error) {
+        const messages = getErrorMessagesFromRelayMutationError(error as Error);
+        return {
+          ok: false,
+          error: messages?.[0] ?? "Failed to load the annotation config.",
+        };
+      }
     });
     return () => unregisterClientAction(OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME);
-  }, [agentStore]);
+  }, [agentStore, projectId]);
 
   const [createConfig] =
     useMutation<AnnotationConfigSlideoverCreateMutation>(graphql`
@@ -203,7 +359,7 @@ export const AnnotationConfigSlideover = ({
         }
       }}
     >
-      <Modal variant="slideover" size="L">
+      <Modal>
         <AnnotationConfigDialog
           initialAnnotationConfig={formState?.config}
           onAddAnnotationConfig={handleSubmit}

--- a/app/src/components/annotation/AnnotationConfigSlideover.tsx
+++ b/app/src/components/annotation/AnnotationConfigSlideover.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useState } from "react";
+import { graphql, useMutation } from "react-relay";
+
+import { Modal, ModalOverlay } from "@phoenix/components";
+import { AnnotationConfigDialog } from "@phoenix/components/annotation/AnnotationConfigDialog";
+import { useAgentStore } from "@phoenix/contexts/AgentContext";
+import { OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME } from "@phoenix/agent/tools/annotationConfigDraft/constants";
+import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
+import type { AnnotationConfig } from "@phoenix/pages/settings/types";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
+
+import type { AnnotationConfigSlideoverCreateMutation } from "./__generated__/AnnotationConfigSlideoverCreateMutation.graphql";
+import type { AnnotationConfigSlideoverUpdateMutation } from "./__generated__/AnnotationConfigSlideoverUpdateMutation.graphql";
+import type { AnnotationConfigSlideoverAddToProjectMutation } from "./__generated__/AnnotationConfigSlideoverAddToProjectMutation.graphql";
+
+/** The form's open state: create (no config) or edit (seeded with a config). */
+type AnnotationConfigFormState = {
+  mode: "create" | "edit";
+  config?: AnnotationConfig;
+};
+
+/**
+ * Shape the discriminated config into the GraphQL `AnnotationConfigInput`. The
+ * `AnnotationConfig` type is derived from a GraphQL fragment and so types these
+ * fields loosely; the values are well-formed by construction (the form's store
+ * always sets them), so the nullish fallbacks only satisfy the compiler.
+ */
+const buildAnnotationConfigInput = (config: AnnotationConfig) => {
+  switch (config.annotationType) {
+    case "CATEGORICAL":
+      return {
+        categorical: {
+          name: config.name,
+          description: config.description,
+          optimizationDirection: config.optimizationDirection ?? "MAXIMIZE",
+          values: (config.values ?? []).map((value) => ({
+            label: value.label,
+            score: value.score ?? null,
+          })),
+        },
+      };
+    case "CONTINUOUS":
+      return {
+        continuous: {
+          name: config.name,
+          description: config.description,
+          optimizationDirection: config.optimizationDirection ?? "MAXIMIZE",
+          lowerBound: config.lowerBound,
+          upperBound: config.upperBound,
+        },
+      };
+    case "FREEFORM":
+      return {
+        freeform: {
+          name: config.name,
+          description: config.description,
+        },
+      };
+  }
+};
+
+/**
+ * Hosts the annotation-config create/edit form as a project-scoped slideover.
+ *
+ * Self-contained: it owns its open state, registers the PXI
+ * `open_annotation_config_form` client action so the agent can open it while a
+ * project is focused, advertises the `annotation_config` context while open
+ * (which gates the read/edit draft tools), and owns the create / update /
+ * project-association mutations. Newly created configs are attached to the
+ * current project.
+ */
+export const AnnotationConfigSlideover = ({
+  projectId,
+}: {
+  /** Relay node id of the focused project. */
+  projectId: string;
+}) => {
+  const agentStore = useAgentStore();
+  const [formState, setFormState] = useState<AnnotationConfigFormState | null>(
+    null
+  );
+
+  // Advertise the form context only while open so the read/edit draft tools
+  // are gated to the open dialog; null clears the advertisement when closed.
+  useAdvertiseAgentContext(
+    formState
+      ? {
+          type: "annotation_config",
+          annotationConfigNodeId: formState.config?.id ?? null,
+        }
+      : null
+  );
+
+  // Register the open client action for the lifetime of the project page. The
+  // agent's open tool dispatches here; today it opens the create form.
+  useEffect(() => {
+    const { registerClientAction, unregisterClientAction } =
+      agentStore.getState();
+    registerClientAction(OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME, async () => {
+      setFormState({ mode: "create" });
+      return { ok: true, output: "Annotation-config form opened." };
+    });
+    return () => unregisterClientAction(OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME);
+  }, [agentStore]);
+
+  const [createConfig] =
+    useMutation<AnnotationConfigSlideoverCreateMutation>(graphql`
+      mutation AnnotationConfigSlideoverCreateMutation(
+        $input: CreateAnnotationConfigInput!
+      ) {
+        createAnnotationConfig(input: $input) {
+          annotationConfig {
+            ... on Node {
+              id
+            }
+          }
+        }
+      }
+    `);
+
+  const [updateConfig] =
+    useMutation<AnnotationConfigSlideoverUpdateMutation>(graphql`
+      mutation AnnotationConfigSlideoverUpdateMutation(
+        $input: UpdateAnnotationConfigInput!
+      ) {
+        updateAnnotationConfig(input: $input) {
+          query {
+            ...AnnotationConfigTableFragment
+          }
+        }
+      }
+    `);
+
+  const [addConfigToProject] =
+    useMutation<AnnotationConfigSlideoverAddToProjectMutation>(graphql`
+      mutation AnnotationConfigSlideoverAddToProjectMutation(
+        $projectId: ID!
+        $annotationConfigId: ID!
+      ) {
+        addAnnotationConfigToProject(
+          input: {
+            projectId: $projectId
+            annotationConfigId: $annotationConfigId
+          }
+        ) {
+          query {
+            node(id: $projectId) {
+              ... on Project {
+                id
+              }
+            }
+          }
+        }
+      }
+    `);
+
+  const handleSubmit = (
+    config: AnnotationConfig,
+    {
+      onCompleted,
+      onError,
+    }: { onCompleted?: () => void; onError?: (error: string) => void } = {}
+  ) => {
+    const reportError = (error: Error) => {
+      const messages = getErrorMessagesFromRelayMutationError(error);
+      onError?.(messages?.[0] ?? "Failed to save annotation config");
+    };
+    const annotationConfig = buildAnnotationConfigInput(config);
+    if (formState?.mode === "edit") {
+      updateConfig({
+        variables: { input: { id: config.id ?? "", annotationConfig } },
+        onCompleted: () => onCompleted?.(),
+        onError: reportError,
+      });
+      return;
+    }
+    // Create, then attach the new config to the current project.
+    createConfig({
+      variables: { input: { annotationConfig } },
+      onCompleted: (response) => {
+        const annotationConfigId =
+          response.createAnnotationConfig.annotationConfig.id;
+        if (annotationConfigId == null) {
+          onError?.("Created annotation config is missing an id");
+          return;
+        }
+        addConfigToProject({
+          variables: { projectId, annotationConfigId },
+          onCompleted: () => onCompleted?.(),
+          onError: reportError,
+        });
+      },
+      onError: reportError,
+    });
+  };
+
+  return (
+    <ModalOverlay
+      isOpen={formState != null}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          setFormState(null);
+        }
+      }}
+    >
+      <Modal variant="slideover" size="L">
+        <AnnotationConfigDialog
+          initialAnnotationConfig={formState?.config}
+          onAddAnnotationConfig={handleSubmit}
+        />
+      </Modal>
+    </ModalOverlay>
+  );
+};

--- a/app/src/components/annotation/AnnotationConfigSlideover.tsx
+++ b/app/src/components/annotation/AnnotationConfigSlideover.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useState } from "react";
 import { graphql, useMutation } from "react-relay";
 
-import { Drawer } from "@phoenix/components";
+import { Modal, ModalOverlay } from "@phoenix/components";
 import { AnnotationConfigDialog } from "@phoenix/components/annotation/AnnotationConfigDialog";
-import { DRAWER_DEFAULT_MIN_SIZE } from "@phoenix/components/core/overlay/constants";
-import { useDefaultDrawerSize } from "@phoenix/components/core/overlay/useDefaultDrawerSize";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
 import { OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME } from "@phoenix/agent/tools/annotationConfigDraft/constants";
 import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
@@ -81,9 +79,6 @@ export const AnnotationConfigSlideover = ({
   const [formState, setFormState] = useState<AnnotationConfigFormState | null>(
     null
   );
-  const { defaultSize, onSizeChange } = useDefaultDrawerSize({
-    id: "annotation-config",
-  });
 
   // Advertise the form context only while open so the read/edit draft tools
   // are gated to the open dialog; null clears the advertisement when closed.
@@ -199,22 +194,21 @@ export const AnnotationConfigSlideover = ({
     });
   };
 
-  // Non-modal Drawer (like the trace detail panel): overlaps the project page
-  // while it stays interactive behind, resizable with persisted width. The
-  // Drawer unmounts its children when closed, so the dialog re-seeds per open.
   return (
-    <Drawer
+    <ModalOverlay
       isOpen={formState != null}
-      onClose={() => setFormState(null)}
-      defaultSize={defaultSize}
-      minSize={DRAWER_DEFAULT_MIN_SIZE}
-      onResize={onSizeChange}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          setFormState(null);
+        }
+      }}
     >
-      <AnnotationConfigDialog
-        fillContainer
-        initialAnnotationConfig={formState?.config}
-        onAddAnnotationConfig={handleSubmit}
-      />
-    </Drawer>
+      <Modal variant="slideover" size="L">
+        <AnnotationConfigDialog
+          initialAnnotationConfig={formState?.config}
+          onAddAnnotationConfig={handleSubmit}
+        />
+      </Modal>
+    </ModalOverlay>
   );
 };

--- a/app/src/components/annotation/AnnotationConfigSlideover.tsx
+++ b/app/src/components/annotation/AnnotationConfigSlideover.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import { graphql, useMutation } from "react-relay";
 
-import { Modal, ModalOverlay } from "@phoenix/components";
+import { Drawer } from "@phoenix/components";
 import { AnnotationConfigDialog } from "@phoenix/components/annotation/AnnotationConfigDialog";
+import { DRAWER_DEFAULT_MIN_SIZE } from "@phoenix/components/core/overlay/constants";
+import { useDefaultDrawerSize } from "@phoenix/components/core/overlay/useDefaultDrawerSize";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
 import { OPEN_ANNOTATION_CONFIG_FORM_TOOL_NAME } from "@phoenix/agent/tools/annotationConfigDraft/constants";
 import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
@@ -79,6 +81,9 @@ export const AnnotationConfigSlideover = ({
   const [formState, setFormState] = useState<AnnotationConfigFormState | null>(
     null
   );
+  const { defaultSize, onSizeChange } = useDefaultDrawerSize({
+    id: "annotation-config",
+  });
 
   // Advertise the form context only while open so the read/edit draft tools
   // are gated to the open dialog; null clears the advertisement when closed.
@@ -194,21 +199,22 @@ export const AnnotationConfigSlideover = ({
     });
   };
 
+  // Non-modal Drawer (like the trace detail panel): overlaps the project page
+  // while it stays interactive behind, resizable with persisted width. The
+  // Drawer unmounts its children when closed, so the dialog re-seeds per open.
   return (
-    <ModalOverlay
+    <Drawer
       isOpen={formState != null}
-      onOpenChange={(isOpen) => {
-        if (!isOpen) {
-          setFormState(null);
-        }
-      }}
+      onClose={() => setFormState(null)}
+      defaultSize={defaultSize}
+      minSize={DRAWER_DEFAULT_MIN_SIZE}
+      onResize={onSizeChange}
     >
-      <Modal variant="slideover" size="L">
-        <AnnotationConfigDialog
-          initialAnnotationConfig={formState?.config}
-          onAddAnnotationConfig={handleSubmit}
-        />
-      </Modal>
-    </ModalOverlay>
+      <AnnotationConfigDialog
+        fillContainer
+        initialAnnotationConfig={formState?.config}
+        onAddAnnotationConfig={handleSubmit}
+      />
+    </Drawer>
   );
 };

--- a/app/src/components/annotation/__generated__/AnnotationConfigSlideoverAddToProjectMutation.graphql.ts
+++ b/app/src/components/annotation/__generated__/AnnotationConfigSlideoverAddToProjectMutation.graphql.ts
@@ -1,0 +1,193 @@
+/**
+ * @generated SignedSource<<872640e2f524d44e21b4b4b75e26018b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AnnotationConfigSlideoverAddToProjectMutation$variables = {
+  annotationConfigId: string;
+  projectId: string;
+};
+export type AnnotationConfigSlideoverAddToProjectMutation$data = {
+  readonly addAnnotationConfigToProject: {
+    readonly query: {
+      readonly node: {
+        readonly id?: string;
+      };
+    };
+  };
+};
+export type AnnotationConfigSlideoverAddToProjectMutation = {
+  response: AnnotationConfigSlideoverAddToProjectMutation$data;
+  variables: AnnotationConfigSlideoverAddToProjectMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "annotationConfigId"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "projectId"
+},
+v2 = [
+  {
+    "fields": [
+      {
+        "kind": "Variable",
+        "name": "annotationConfigId",
+        "variableName": "annotationConfigId"
+      },
+      {
+        "kind": "Variable",
+        "name": "projectId",
+        "variableName": "projectId"
+      }
+    ],
+    "kind": "ObjectValue",
+    "name": "input"
+  }
+],
+v3 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AnnotationConfigSlideoverAddToProjectMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "AddAnnotationConfigToProjectPayload",
+        "kind": "LinkedField",
+        "name": "addAnnotationConfigToProject",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Query",
+            "kind": "LinkedField",
+            "name": "query",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": (v3/*: any*/),
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v4/*: any*/)
+                    ],
+                    "type": "Project",
+                    "abstractKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "AnnotationConfigSlideoverAddToProjectMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "AddAnnotationConfigToProjectPayload",
+        "kind": "LinkedField",
+        "name": "addAnnotationConfigToProject",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Query",
+            "kind": "LinkedField",
+            "name": "query",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": (v3/*: any*/),
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  (v4/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "9e7980d628fb47e6fed603fa3232b5eb",
+    "id": null,
+    "metadata": {},
+    "name": "AnnotationConfigSlideoverAddToProjectMutation",
+    "operationKind": "mutation",
+    "text": "mutation AnnotationConfigSlideoverAddToProjectMutation(\n  $projectId: ID!\n  $annotationConfigId: ID!\n) {\n  addAnnotationConfigToProject(input: {projectId: $projectId, annotationConfigId: $annotationConfigId}) {\n    query {\n      node(id: $projectId) {\n        __typename\n        ... on Project {\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "d489848d0a77497d7e40ed0769755f33";
+
+export default node;

--- a/app/src/components/annotation/__generated__/AnnotationConfigSlideoverConfigQuery.graphql.ts
+++ b/app/src/components/annotation/__generated__/AnnotationConfigSlideoverConfigQuery.graphql.ts
@@ -1,0 +1,352 @@
+/**
+ * @generated SignedSource<<2c90202cb941b1609998904c354a24c9>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AnnotationType = "CATEGORICAL" | "CONTINUOUS" | "FREEFORM";
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
+export type AnnotationConfigSlideoverConfigQuery$variables = {
+  projectId: string;
+};
+export type AnnotationConfigSlideoverConfigQuery$data = {
+  readonly node: {
+    readonly __typename: "Project";
+    readonly annotationConfigs: {
+      readonly edges: ReadonlyArray<{
+        readonly annotationConfig: {
+          readonly __typename: "CategoricalAnnotationConfig";
+          readonly annotationType: AnnotationType;
+          readonly description: string | null;
+          readonly id: string;
+          readonly name: string;
+          readonly optimizationDirection: OptimizationDirection;
+          readonly values: ReadonlyArray<{
+            readonly label: string;
+            readonly score: number | null;
+          }>;
+        } | {
+          readonly __typename: "ContinuousAnnotationConfig";
+          readonly annotationType: AnnotationType;
+          readonly description: string | null;
+          readonly id: string;
+          readonly lowerBound: number | null;
+          readonly name: string;
+          readonly optimizationDirection: OptimizationDirection;
+          readonly upperBound: number | null;
+        } | {
+          readonly __typename: "FreeformAnnotationConfig";
+          readonly annotationType: AnnotationType;
+          readonly description: string | null;
+          readonly id: string;
+          readonly name: string;
+          readonly optimizationDirection: OptimizationDirection;
+        } | {
+          // This will never be '%other', but we need some
+          // value in case none of the concrete values match.
+          readonly __typename: "%other";
+        };
+      }>;
+    };
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  };
+};
+export type AnnotationConfigSlideoverConfigQuery = {
+  response: AnnotationConfigSlideoverConfigQuery$data;
+  variables: AnnotationConfigSlideoverConfigQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "projectId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "annotationType",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v8 = {
+  "kind": "InlineFragment",
+  "selections": [
+    (v3/*: any*/),
+    (v4/*: any*/),
+    (v5/*: any*/),
+    (v6/*: any*/),
+    (v7/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CategoricalAnnotationValue",
+      "kind": "LinkedField",
+      "name": "values",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "label",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "score",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "CategoricalAnnotationConfig",
+  "abstractKey": null
+},
+v9 = {
+  "kind": "InlineFragment",
+  "selections": [
+    (v3/*: any*/),
+    (v4/*: any*/),
+    (v5/*: any*/),
+    (v6/*: any*/),
+    (v7/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "lowerBound",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "upperBound",
+      "storageKey": null
+    }
+  ],
+  "type": "ContinuousAnnotationConfig",
+  "abstractKey": null
+},
+v10 = {
+  "kind": "InlineFragment",
+  "selections": [
+    (v3/*: any*/),
+    (v4/*: any*/),
+    (v5/*: any*/),
+    (v6/*: any*/),
+    (v7/*: any*/)
+  ],
+  "type": "FreeformAnnotationConfig",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AnnotationConfigSlideoverConfigQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "annotationConfig",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v8/*: any*/),
+                          (v9/*: any*/),
+                          (v10/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AnnotationConfigSlideoverConfigQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "annotationConfig",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v8/*: any*/),
+                          (v9/*: any*/),
+                          (v10/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v3/*: any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "Project",
+            "abstractKey": null
+          },
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "e8e301ad1d173b98c4a24fb43f2be105",
+    "id": null,
+    "metadata": {},
+    "name": "AnnotationConfigSlideoverConfigQuery",
+    "operationKind": "query",
+    "text": "query AnnotationConfigSlideoverConfigQuery(\n  $projectId: ID!\n) {\n  node(id: $projectId) {\n    __typename\n    ... on Project {\n      annotationConfigs {\n        edges {\n          annotationConfig: node {\n            __typename\n            ... on CategoricalAnnotationConfig {\n              id\n              name\n              description\n              annotationType\n              optimizationDirection\n              values {\n                label\n                score\n              }\n            }\n            ... on ContinuousAnnotationConfig {\n              id\n              name\n              description\n              annotationType\n              optimizationDirection\n              lowerBound\n              upperBound\n            }\n            ... on FreeformAnnotationConfig {\n              id\n              name\n              description\n              annotationType\n              optimizationDirection\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e14e21113107cb8ca1d8a6619dcbf73d";
+
+export default node;

--- a/app/src/components/annotation/__generated__/AnnotationConfigSlideoverCreateMutation.graphql.ts
+++ b/app/src/components/annotation/__generated__/AnnotationConfigSlideoverCreateMutation.graphql.ts
@@ -1,0 +1,175 @@
+/**
+ * @generated SignedSource<<ba8df3b3ddbd605f656ba17b9c599d44>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
+export type CreateAnnotationConfigInput = {
+  annotationConfig: AnnotationConfigInput;
+};
+export type AnnotationConfigInput = {
+  categorical?: CategoricalAnnotationConfigInput | null;
+  continuous?: ContinuousAnnotationConfigInput | null;
+  freeform?: FreeformAnnotationConfigInput | null;
+};
+export type CategoricalAnnotationConfigInput = {
+  description?: string | null;
+  name: string;
+  optimizationDirection: OptimizationDirection;
+  values: ReadonlyArray<CategoricalAnnotationConfigValueInput>;
+};
+export type CategoricalAnnotationConfigValueInput = {
+  label: string;
+  score?: number | null;
+};
+export type ContinuousAnnotationConfigInput = {
+  description?: string | null;
+  lowerBound?: number | null;
+  name: string;
+  optimizationDirection: OptimizationDirection;
+  upperBound?: number | null;
+};
+export type FreeformAnnotationConfigInput = {
+  description?: string | null;
+  lowerBound?: number | null;
+  name: string;
+  optimizationDirection?: OptimizationDirection | null;
+  threshold?: number | null;
+  upperBound?: number | null;
+};
+export type AnnotationConfigSlideoverCreateMutation$variables = {
+  input: CreateAnnotationConfigInput;
+};
+export type AnnotationConfigSlideoverCreateMutation$data = {
+  readonly createAnnotationConfig: {
+    readonly annotationConfig: {
+      readonly id?: string;
+    };
+  };
+};
+export type AnnotationConfigSlideoverCreateMutation = {
+  response: AnnotationConfigSlideoverCreateMutation$data;
+  variables: AnnotationConfigSlideoverCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    }
+  ],
+  "type": "Node",
+  "abstractKey": "__isNode"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AnnotationConfigSlideoverCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "CreateAnnotationConfigPayload",
+        "kind": "LinkedField",
+        "name": "createAnnotationConfig",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "annotationConfig",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AnnotationConfigSlideoverCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "CreateAnnotationConfigPayload",
+        "kind": "LinkedField",
+        "name": "createAnnotationConfig",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "annotationConfig",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "9c7648b36c9c1d5733a8ac0e94389b1d",
+    "id": null,
+    "metadata": {},
+    "name": "AnnotationConfigSlideoverCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation AnnotationConfigSlideoverCreateMutation(\n  $input: CreateAnnotationConfigInput!\n) {\n  createAnnotationConfig(input: $input) {\n    annotationConfig {\n      __typename\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "8ac2ba21b95466275eb9dadd2fe91f71";
+
+export default node;

--- a/app/src/components/annotation/__generated__/AnnotationConfigSlideoverUpdateMutation.graphql.ts
+++ b/app/src/components/annotation/__generated__/AnnotationConfigSlideoverUpdateMutation.graphql.ts
@@ -1,0 +1,324 @@
+/**
+ * @generated SignedSource<<c74677416be00870c2d8d1ded2f2c59e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
+export type UpdateAnnotationConfigInput = {
+  annotationConfig: AnnotationConfigInput;
+  id: string;
+};
+export type AnnotationConfigInput = {
+  categorical?: CategoricalAnnotationConfigInput | null;
+  continuous?: ContinuousAnnotationConfigInput | null;
+  freeform?: FreeformAnnotationConfigInput | null;
+};
+export type CategoricalAnnotationConfigInput = {
+  description?: string | null;
+  name: string;
+  optimizationDirection: OptimizationDirection;
+  values: ReadonlyArray<CategoricalAnnotationConfigValueInput>;
+};
+export type CategoricalAnnotationConfigValueInput = {
+  label: string;
+  score?: number | null;
+};
+export type ContinuousAnnotationConfigInput = {
+  description?: string | null;
+  lowerBound?: number | null;
+  name: string;
+  optimizationDirection: OptimizationDirection;
+  upperBound?: number | null;
+};
+export type FreeformAnnotationConfigInput = {
+  description?: string | null;
+  lowerBound?: number | null;
+  name: string;
+  optimizationDirection?: OptimizationDirection | null;
+  threshold?: number | null;
+  upperBound?: number | null;
+};
+export type AnnotationConfigSlideoverUpdateMutation$variables = {
+  input: UpdateAnnotationConfigInput;
+};
+export type AnnotationConfigSlideoverUpdateMutation$data = {
+  readonly updateAnnotationConfig: {
+    readonly query: {
+      readonly " $fragmentSpreads": FragmentRefs<"AnnotationConfigTableFragment">;
+    };
+  };
+};
+export type AnnotationConfigSlideoverUpdateMutation = {
+  response: AnnotationConfigSlideoverUpdateMutation$data;
+  variables: AnnotationConfigSlideoverUpdateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "annotationType",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AnnotationConfigSlideoverUpdateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateAnnotationConfigPayload",
+        "kind": "LinkedField",
+        "name": "updateAnnotationConfig",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Query",
+            "kind": "LinkedField",
+            "name": "query",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "AnnotationConfigTableFragment"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AnnotationConfigSlideoverUpdateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateAnnotationConfigPayload",
+        "kind": "LinkedField",
+        "name": "updateAnnotationConfig",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Query",
+            "kind": "LinkedField",
+            "name": "query",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "annotationConfig",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "__typename",
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v2/*: any*/),
+                              (v3/*: any*/),
+                              (v4/*: any*/),
+                              (v5/*: any*/),
+                              (v6/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "label",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "score",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v2/*: any*/),
+                              (v3/*: any*/),
+                              (v4/*: any*/),
+                              (v5/*: any*/),
+                              (v6/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "upperBound",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "lowerBound",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "ContinuousAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v2/*: any*/),
+                              (v3/*: any*/),
+                              (v4/*: any*/),
+                              (v5/*: any*/),
+                              (v6/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "threshold",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "FreeformAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v2/*: any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "9163d981ea349f03d4634d6b79d369fc",
+    "id": null,
+    "metadata": {},
+    "name": "AnnotationConfigSlideoverUpdateMutation",
+    "operationKind": "mutation",
+    "text": "mutation AnnotationConfigSlideoverUpdateMutation(\n  $input: UpdateAnnotationConfigInput!\n) {\n  updateAnnotationConfig(input: $input) {\n    query {\n      ...AnnotationConfigTableFragment\n    }\n  }\n}\n\nfragment AnnotationConfigTableFragment on Query {\n  annotationConfigs {\n    edges {\n      annotationConfig: node {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          id\n          name\n          description\n          annotationType\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          id\n          name\n          description\n          annotationType\n          optimizationDirection\n          upperBound\n          lowerBound\n        }\n        ... on FreeformAnnotationConfig {\n          id\n          name\n          description\n          annotationType\n          optimizationDirection\n          threshold\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "c6ab4478fba6f8e8ea4e1a743f8c7c4d";
+
+export default node;

--- a/app/src/components/annotation/useAnnotationConfigDraftRegistration.ts
+++ b/app/src/components/annotation/useAnnotationConfigDraftRegistration.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from "react";
+
+import {
+  applyDraftOperations,
+  createEditAnnotationConfigDraftClientAction,
+  createReadAnnotationConfigDraftClientAction,
+  EDIT_ANNOTATION_CONFIG_DRAFT_TOOL_NAME,
+  READ_ANNOTATION_CONFIG_DRAFT_TOOL_NAME,
+  type AnnotationConfigDraftHost,
+  type AnnotationConfigDraftSnapshot,
+  type EditAnnotationConfigDraftOperation,
+} from "@phoenix/agent/tools/annotationConfigDraft";
+import { useAgentStore } from "@phoenix/contexts/AgentContext";
+import { useAnnotationConfigDraftStoreInstance } from "@phoenix/contexts/AnnotationConfigDraftContext";
+
+/**
+ * Wires the open annotation-config form up to the agent: builds a draft host
+ * backed by the live draft store, then registers the read/edit client actions
+ * for the agent to drive. Edits apply directly to the draft (no approval diff
+ * card). The actions are unregistered on unmount, so they only resolve while a
+ * form is mounted — which is also when the server advertises the matching
+ * `annotation_config`-gated tools.
+ */
+export const useAnnotationConfigDraftRegistration = () => {
+  const store = useAnnotationConfigDraftStoreInstance();
+  const agentStore = useAgentStore();
+  const draftHostRef = useRef<AnnotationConfigDraftHost | null>(null);
+
+  useEffect(() => {
+    const buildSnapshot = (): AnnotationConfigDraftSnapshot => {
+      const state = store.getState();
+      return {
+        mode: state.mode,
+        annotationConfigNodeId: state.configId,
+        ...state.draft,
+      };
+    };
+
+    const previewOperations = (
+      snapshot: AnnotationConfigDraftSnapshot,
+      operations: EditAnnotationConfigDraftOperation[]
+    ) => applyDraftOperations({ snapshot, operations });
+
+    const applyOperations = (operations: EditAnnotationConfigDraftOperation[]) => {
+      const current = buildSnapshot();
+      const proposed = previewOperations(current, operations);
+      if (!proposed.ok) return proposed;
+      const next = proposed.output;
+      store.getState().replaceDraft({
+        annotationType: next.annotationType,
+        name: next.name,
+        description: next.description,
+        optimizationDirection: next.optimizationDirection,
+        values: next.values,
+        lowerBound: next.lowerBound,
+        upperBound: next.upperBound,
+      });
+      return { ok: true as const, output: buildSnapshot() };
+    };
+
+    const host: AnnotationConfigDraftHost = {
+      getSnapshot: buildSnapshot,
+      previewOperations,
+      applyOperations,
+    };
+    draftHostRef.current = host;
+
+    const { registerClientAction, unregisterClientAction } =
+      agentStore.getState();
+    const getDraftHost = () => draftHostRef.current;
+    registerClientAction(
+      READ_ANNOTATION_CONFIG_DRAFT_TOOL_NAME,
+      createReadAnnotationConfigDraftClientAction({ getDraftHost })
+    );
+    registerClientAction(
+      EDIT_ANNOTATION_CONFIG_DRAFT_TOOL_NAME,
+      createEditAnnotationConfigDraftClientAction({ getDraftHost })
+    );
+    return () => {
+      draftHostRef.current = null;
+      unregisterClientAction(READ_ANNOTATION_CONFIG_DRAFT_TOOL_NAME);
+      unregisterClientAction(EDIT_ANNOTATION_CONFIG_DRAFT_TOOL_NAME);
+    };
+  }, [agentStore, store]);
+};

--- a/app/src/contexts/AnnotationConfigDraftContext.tsx
+++ b/app/src/contexts/AnnotationConfigDraftContext.tsx
@@ -1,0 +1,45 @@
+import type { PropsWithChildren } from "react";
+import { createContext, useContext, useState } from "react";
+import { useZustand } from "use-zustand";
+
+import type {
+  AnnotationConfigDraftStore,
+  AnnotationConfigDraftStoreInstance,
+  InitialAnnotationConfigDraftStoreProps,
+} from "@phoenix/store/annotationConfigDraftStore";
+import { createAnnotationConfigDraftStore } from "@phoenix/store/annotationConfigDraftStore";
+
+export const AnnotationConfigDraftContext =
+  createContext<AnnotationConfigDraftStoreInstance | null>(null);
+
+export function AnnotationConfigDraftProvider({
+  children,
+  ...props
+}: PropsWithChildren<InitialAnnotationConfigDraftStoreProps>) {
+  const [store] = useState<AnnotationConfigDraftStoreInstance>(() =>
+    createAnnotationConfigDraftStore(props)
+  );
+  return (
+    <AnnotationConfigDraftContext.Provider value={store}>
+      {children}
+    </AnnotationConfigDraftContext.Provider>
+  );
+}
+
+/** Access the raw store instance — for imperative reads/writes in handlers. */
+export function useAnnotationConfigDraftStoreInstance() {
+  const store = useContext(AnnotationConfigDraftContext);
+  if (!store) {
+    throw new Error("Missing AnnotationConfigDraftProvider in the tree");
+  }
+  return store;
+}
+
+/** Subscribe to a slice of the draft store. */
+export function useAnnotationConfigDraftStore<T>(
+  selector: (state: AnnotationConfigDraftStore) => T,
+  equalityFn?: (left: T, right: T) => boolean
+): T {
+  const store = useAnnotationConfigDraftStoreInstance();
+  return useZustand(store, selector, equalityFn);
+}

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -11,6 +11,7 @@ import { graphql, useLazyLoadQuery, useQueryLoader } from "react-relay";
 import { Outlet, useLocation, useNavigate, useParams } from "react-router";
 
 import { LazyTabPanel, Loading, Tab, TabList, Tabs } from "@phoenix/components";
+import { AnnotationConfigSlideover } from "@phoenix/components/annotation/AnnotationConfigSlideover";
 import {
   ConnectedTimeRangeSelector,
   useTimeRange,
@@ -265,6 +266,7 @@ function ProjectPageContentBody({
           </LazyTabPanel>
         </Tabs>
       </ProjectPageQueryReferenceContext.Provider>
+      <AnnotationConfigSlideover projectId={projectId} />
     </main>
   );
 }

--- a/app/src/store/annotationConfigDraftStore.tsx
+++ b/app/src/store/annotationConfigDraftStore.tsx
@@ -1,0 +1,304 @@
+import { createStore } from "zustand";
+import { devtools } from "zustand/middleware";
+
+import type {
+  AnnotationConfig,
+  AnnotationConfigOptimizationDirection,
+  AnnotationConfigType,
+} from "@phoenix/pages/settings/types";
+
+/**
+ * A single category in a categorical annotation config.
+ */
+export type AnnotationConfigDraftValue = {
+  label: string;
+  score: number | null;
+};
+
+/**
+ * A flat superset of every annotation-config type's fields. Holding all fields
+ * at once (rather than a discriminated union) means switching `annotationType`
+ * never discards data the user — or the agent — has already staged for another
+ * type. The union is reconstructed on submit via {@link toAnnotationConfig}.
+ */
+export type AnnotationConfigDraftValues = {
+  annotationType: AnnotationConfigType;
+  name: string;
+  description: string | null;
+  optimizationDirection: AnnotationConfigOptimizationDirection;
+  /** CATEGORICAL only. */
+  values: AnnotationConfigDraftValue[];
+  /** CONTINUOUS only. */
+  lowerBound: number | null;
+  /** CONTINUOUS only. */
+  upperBound: number | null;
+};
+
+export type AnnotationConfigDraftStoreProps = {
+  /** "create" makes a new config; "edit" updates an existing one (type is locked). */
+  mode: "create" | "edit";
+  /** GlobalID of the config being edited, or null when creating. */
+  configId: string | null;
+  draft: AnnotationConfigDraftValues;
+  /** True once the draft has been mutated away from its initial state. */
+  isDirty: boolean;
+};
+
+export type AnnotationConfigDraftStoreActions = {
+  setName: (name: string) => void;
+  setDescription: (description: string | null) => void;
+  setAnnotationType: (annotationType: AnnotationConfigType) => void;
+  setOptimizationDirection: (
+    optimizationDirection: AnnotationConfigOptimizationDirection
+  ) => void;
+  setLowerBound: (lowerBound: number | null) => void;
+  setUpperBound: (upperBound: number | null) => void;
+  addValue: () => void;
+  removeValue: (index: number) => void;
+  updateValue: (
+    index: number,
+    patch: Partial<AnnotationConfigDraftValue>
+  ) => void;
+  replaceDraft: (draft: AnnotationConfigDraftValues) => void;
+  reset: () => void;
+};
+
+export type AnnotationConfigDraftStore = AnnotationConfigDraftStoreProps &
+  AnnotationConfigDraftStoreActions;
+
+/**
+ * Factory (not a shared constant) so every store instance — and every `reset` —
+ * gets its own object and its own `values` array. Sharing one module-level
+ * default would alias mutable state across draft stores.
+ */
+export const createDefaultAnnotationConfigDraft =
+  (): AnnotationConfigDraftValues => ({
+    annotationType: "CATEGORICAL",
+    name: "",
+    description: null,
+    optimizationDirection: "MAXIMIZE",
+    values: [
+      { label: "", score: null },
+      { label: "", score: null },
+    ],
+    lowerBound: null,
+    upperBound: null,
+  });
+
+export type InitialAnnotationConfigDraftStoreProps = {
+  mode: "create" | "edit";
+  configId?: string | null;
+  draft?: AnnotationConfigDraftValues;
+};
+
+export const createAnnotationConfigDraftStore = (
+  init: InitialAnnotationConfigDraftStoreProps
+) =>
+  createStore<AnnotationConfigDraftStore>()(
+    devtools(
+      (set, get) => {
+        const patchDraft = (
+          patch: Partial<AnnotationConfigDraftValues>,
+          action: string
+        ) =>
+          set(
+            (state) => ({ draft: { ...state.draft, ...patch }, isDirty: true }),
+            false,
+            action
+          );
+
+        return {
+          mode: init.mode,
+          configId: init.configId ?? null,
+          draft: init.draft ?? createDefaultAnnotationConfigDraft(),
+          isDirty: false,
+
+          setName: (name) => patchDraft({ name }, "setName"),
+          setDescription: (description) =>
+            patchDraft({ description }, "setDescription"),
+          setOptimizationDirection: (optimizationDirection) =>
+            patchDraft({ optimizationDirection }, "setOptimizationDirection"),
+          setLowerBound: (lowerBound) =>
+            patchDraft({ lowerBound }, "setLowerBound"),
+          setUpperBound: (upperBound) =>
+            patchDraft({ upperBound }, "setUpperBound"),
+
+          
+          setAnnotationType: (annotationType) => {
+            if (get().mode === "edit") return; // The annotation type cannot change once a config exists
+            patchDraft({ annotationType }, "setAnnotationType");
+          },
+
+          addValue: () =>
+            set(
+              (state) => ({
+                draft: {
+                  ...state.draft,
+                  values: [...state.draft.values, { label: "", score: null }],
+                },
+                isDirty: true,
+              }),
+              false,
+              "addValue"
+            ),
+          removeValue: (index) =>
+            set(
+              (state) => ({
+                draft: {
+                  ...state.draft,
+                  values: state.draft.values.filter((_, i) => i !== index),
+                },
+                isDirty: true,
+              }),
+              false,
+              "removeValue"
+            ),
+          updateValue: (index, patch) =>
+            set(
+              (state) => ({
+                draft: {
+                  ...state.draft,
+                  values: state.draft.values.map((value, i) =>
+                    i === index ? { ...value, ...patch } : value
+                  ),
+                },
+                isDirty: true,
+              }),
+              false,
+              "updateValue"
+            ),
+
+          replaceDraft: (draft) =>
+            set({ draft, isDirty: true }, false, "replaceDraft"),
+          reset: () =>
+            set(
+              {
+                draft: init.draft ?? createDefaultAnnotationConfigDraft(),
+                isDirty: false,
+              },
+              false,
+              "reset"
+            ),
+        };
+      },
+      { name: "annotationConfigDraftStore" }
+    )
+  );
+
+export type AnnotationConfigDraftStoreInstance = ReturnType<
+  typeof createAnnotationConfigDraftStore
+>;
+
+/**
+ * Build the initial store props from an existing config (edit) or nothing
+ * (create). Lives next to the store so both the dialog and any agent host
+ * seed the draft identically.
+ */
+export const initialDraftPropsFromConfig = (
+  initialConfig?: Partial<AnnotationConfig>
+): InitialAnnotationConfigDraftStoreProps => {
+  if (!initialConfig) {
+    return { mode: "create", configId: null };
+  }
+  // Read across the union without per-type narrowing; absent fields fall back
+  // to defaults below.
+  const anyConfig = initialConfig as {
+    values?: readonly { label: string; score?: number | null }[];
+    lowerBound?: number | null;
+    upperBound?: number | null;
+  };
+  return {
+    mode: "edit",
+    configId: initialConfig.id ?? null,
+    draft: {
+      annotationType: initialConfig.annotationType ?? "CATEGORICAL",
+      name: initialConfig.name ?? "",
+      description: initialConfig.description ?? null,
+      optimizationDirection: initialConfig.optimizationDirection ?? "MAXIMIZE",
+      values:
+        anyConfig.values?.map((value) => ({
+          label: value.label,
+          score: value.score ?? null,
+        })) ?? createDefaultAnnotationConfigDraft().values,
+      lowerBound: anyConfig.lowerBound ?? null,
+      upperBound: anyConfig.upperBound ?? null,
+    },
+  };
+};
+
+/**
+ * Discriminate the flat draft into the {@link AnnotationConfig} union expected
+ * by the create/update mutations. Mirrors the per-type shaping the dialog used
+ * to do inline on submit.
+ */
+export const toAnnotationConfig = (
+  draft: AnnotationConfigDraftValues,
+  id: string
+): AnnotationConfig => {
+  switch (draft.annotationType) {
+    case "CATEGORICAL":
+      return {
+        id,
+        annotationType: "CATEGORICAL",
+        name: draft.name,
+        description: draft.description,
+        optimizationDirection: draft.optimizationDirection,
+        values: draft.values,
+      };
+    case "CONTINUOUS":
+      return {
+        id,
+        annotationType: "CONTINUOUS",
+        name: draft.name,
+        description: draft.description,
+        optimizationDirection: draft.optimizationDirection,
+        lowerBound: draft.lowerBound,
+        upperBound: draft.upperBound,
+      };
+    case "FREEFORM":
+      return {
+        id,
+        annotationType: "FREEFORM",
+        name: draft.name,
+        description: draft.description,
+      };
+  }
+};
+
+/**
+ * Pure validation shared by the form's submit gate and (eventually) the agent
+ * edit gate. Returns a map of field key → error message; an empty map is valid.
+ * Field keys match the form controls: "name", "lowerBound", "upperBound", and
+ * `values.${index}.label`.
+ */
+export const validateAnnotationConfigDraft = (
+  draft: AnnotationConfigDraftValues
+): Record<string, string> => {
+  const errors: Record<string, string> = {};
+  if (!draft.name.trim()) {
+    errors.name = "Name is required";
+  } else if (draft.name === "note") {
+    errors.name = "'note' is a reserved name";
+  }
+  if (draft.annotationType === "CONTINUOUS") {
+    if (draft.lowerBound == null || isNaN(draft.lowerBound)) {
+      errors.lowerBound = "Min is required";
+    }
+    if (draft.upperBound == null || isNaN(draft.upperBound)) {
+      errors.upperBound = "Max is required";
+    } else if (draft.lowerBound != null && draft.upperBound <= draft.lowerBound) {
+      errors.upperBound = "Max must be greater than min";
+    }
+  }
+  if (draft.annotationType === "CATEGORICAL") {
+    if (draft.values.length === 0) {
+      errors.values = "At least one category is required";
+    }
+    draft.values.forEach((value, index) => {
+      if (!value.label.trim()) {
+        errors[`values.${index}.label`] = "Category label is required";
+      }
+    });
+  }
+  return errors;
+};

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1451,6 +1451,22 @@ export interface components {
             /** Data */
             data: components["schemas"]["InsertedTraceAnnotation"][];
         };
+        /**
+         * AnnotationConfigContext
+         * @description Annotation-config create/edit form mounted in the current browser route.
+         *
+         *     ``annotation_config_node_id`` is ``None`` when the form is creating a new
+         *     config and carries the config's relay node id when editing an existing one.
+         */
+        AnnotationConfigContext: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "annotation_config";
+            /** Annotationconfignodeid */
+            annotationConfigNodeId?: string | null;
+        };
         /** AnnotationResult */
         AnnotationResult: {
             /**
@@ -1614,7 +1630,7 @@ export interface components {
          * ChatContext
          * @description Discriminated union of every UI-state context the agent understands.
          */
-        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["SessionContext"] | components["schemas"]["PromptContext"] | components["schemas"]["PromptVersionContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["CodeEvaluatorContext"] | components["schemas"]["LlmEvaluatorContext"] | components["schemas"]["DatasetContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"] | components["schemas"]["SubagentsContext"];
+        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["SessionContext"] | components["schemas"]["PromptContext"] | components["schemas"]["PromptVersionContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["CodeEvaluatorContext"] | components["schemas"]["LlmEvaluatorContext"] | components["schemas"]["AnnotationConfigContext"] | components["schemas"]["DatasetContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"] | components["schemas"]["SubagentsContext"];
         /**
          * ChatRegenerateMessage
          * @description Regenerate message extended with Phoenix-specific fields.

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -15,6 +15,11 @@ class AgentSpanContext(TypedDict):
     otelSpanId: NotRequired[str]
 
 
+class AnnotationConfigContext(TypedDict):
+    type: Literal["annotation_config"]
+    annotationConfigNodeId: NotRequired[str]
+
+
 class AnnotationResult(TypedDict):
     label: NotRequired[str]
     score: NotRequired[float]
@@ -1570,6 +1575,7 @@ class ChatRegenerateMessage(TypedDict):
                 PlaygroundContext,
                 CodeEvaluatorContext,
                 LlmEvaluatorContext,
+                AnnotationConfigContext,
                 DatasetContext,
                 GraphQLContext,
                 WebAccessContext,
@@ -1601,6 +1607,7 @@ class ChatSubmitMessage(TypedDict):
                 PlaygroundContext,
                 CodeEvaluatorContext,
                 LlmEvaluatorContext,
+                AnnotationConfigContext,
                 DatasetContext,
                 GraphQLContext,
                 WebAccessContext,

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -6909,6 +6909,32 @@
         ],
         "title": "AnnotateTracesResponseBody"
       },
+      "AnnotationConfigContext": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "annotation_config",
+            "title": "Type"
+          },
+          "annotationConfigNodeId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Annotationconfignodeid"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "title": "AnnotationConfigContext",
+        "description": "Annotation-config create/edit form mounted in the current browser route.\n\n``annotation_config_node_id`` is ``None`` when the form is creating a new\nconfig and carries the config's relay node id when editing an existing one."
+      },
       "AnnotationResult": {
         "properties": {
           "label": {
@@ -7391,6 +7417,9 @@
             "$ref": "#/components/schemas/LlmEvaluatorContext"
           },
           {
+            "$ref": "#/components/schemas/AnnotationConfigContext"
+          },
+          {
             "$ref": "#/components/schemas/DatasetContext"
           },
           {
@@ -7408,6 +7437,7 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
+            "annotation_config": "#/components/schemas/AnnotationConfigContext",
             "app": "#/components/schemas/AppContext",
             "code_evaluator": "#/components/schemas/CodeEvaluatorContext",
             "dataset": "#/components/schemas/DatasetContext",

--- a/src/phoenix/server/agents/capabilities/tools/external/__init__.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/__init__.py
@@ -24,6 +24,7 @@ from phoenix.server.agents.capabilities.tools.external import (
     delete_dataset_examples,
     delete_dataset_labels,
     delete_dataset_splits,
+    edit_annotation_config_draft,
     edit_code_evaluator_draft,
     edit_llm_evaluator_draft,
     edit_prompt_instance,
@@ -44,6 +45,7 @@ from phoenix.server.agents.capabilities.tools.external import (
     patch_dataset_examples,
     patch_dataset_split,
     patch_experiment,
+    read_annotation_config_draft,
     read_code_evaluator_draft,
     read_dataset_evaluator_definition,
     read_llm_evaluator_draft,
@@ -112,6 +114,9 @@ from phoenix.server.agents.capabilities.tools.external.delete_dataset_labels imp
 from phoenix.server.agents.capabilities.tools.external.delete_dataset_splits import (
     DeleteDatasetSplitsCapability,
 )
+from phoenix.server.agents.capabilities.tools.external.edit_annotation_config_draft import (
+    EditAnnotationConfigDraftCapability,
+)
 from phoenix.server.agents.capabilities.tools.external.edit_code_evaluator_draft import (
     EditCodeEvaluatorDraftCapability,
 )
@@ -171,6 +176,9 @@ from phoenix.server.agents.capabilities.tools.external.patch_dataset_split impor
 )
 from phoenix.server.agents.capabilities.tools.external.patch_experiment import (
     PatchExperimentCapability,
+)
+from phoenix.server.agents.capabilities.tools.external.read_annotation_config_draft import (
+    ReadAnnotationConfigDraftCapability,
 )
 from phoenix.server.agents.capabilities.tools.external.read_code_evaluator_draft import (
     ReadCodeEvaluatorDraftCapability,
@@ -280,6 +288,7 @@ _EXTERNAL_TOOL_DEFINITIONS_BY_NAME: dict[str, ToolDefinition] = {
         bash.TOOL_DEFINITION,
         cancel_playground_run.TOOL_DEFINITION,
         clone_prompt_instance.TOOL_DEFINITION,
+        edit_annotation_config_draft.TOOL_DEFINITION,
         edit_code_evaluator_draft.TOOL_DEFINITION,
         edit_llm_evaluator_draft.TOOL_DEFINITION,
         edit_prompt_instance.TOOL_DEFINITION,
@@ -290,6 +299,7 @@ _EXTERNAL_TOOL_DEFINITIONS_BY_NAME: dict[str, ToolDefinition] = {
         open_dataset_evaluator_for_edit.TOOL_DEFINITION,
         open_llm_evaluator_form.TOOL_DEFINITION,
         patch_experiment.TOOL_DEFINITION,
+        read_annotation_config_draft.TOOL_DEFINITION,
         read_code_evaluator_draft.TOOL_DEFINITION,
         read_dataset_evaluator_definition.TOOL_DEFINITION,
         read_llm_evaluator_draft.TOOL_DEFINITION,
@@ -396,6 +406,8 @@ def get_external_tool_capability_function(
         ),
         PatchExperimentCapability(instructions=prompts.patch_experiment_tool),
         OpenAnnotationConfigFormCapability(instructions=prompts.open_annotation_config_form_tool),
+        ReadAnnotationConfigDraftCapability(instructions=prompts.read_annotation_config_draft_tool),
+        EditAnnotationConfigDraftCapability(instructions=prompts.edit_annotation_config_draft_tool),
         OpenCodeEvaluatorFormCapability(instructions=prompts.open_code_evaluator_form_tool),
         OpenLlmEvaluatorFormCapability(instructions=prompts.open_llm_evaluator_form_tool),
         ReadCodeEvaluatorDraftCapability(instructions=prompts.read_code_evaluator_draft_tool),
@@ -442,6 +454,7 @@ __all__ = [
     "BashCapability",
     "CancelPlaygroundRunCapability",
     "ClonePromptInstanceCapability",
+    "EditAnnotationConfigDraftCapability",
     "EditCodeEvaluatorDraftCapability",
     "EditLlmEvaluatorDraftCapability",
     "EditPromptInstanceCapability",
@@ -453,6 +466,7 @@ __all__ = [
     "OpenDatasetEvaluatorForEditCapability",
     "OpenLlmEvaluatorFormCapability",
     "PatchExperimentCapability",
+    "ReadAnnotationConfigDraftCapability",
     "ReadCodeEvaluatorDraftCapability",
     "ReadDatasetEvaluatorDefinitionCapability",
     "ReadLlmEvaluatorDraftCapability",

--- a/src/phoenix/server/agents/capabilities/tools/external/__init__.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/__init__.py
@@ -36,6 +36,7 @@ from phoenix.server.agents.capabilities.tools.external import (
     list_playground_model_targets,
     list_splits,
     load_dataset,
+    open_annotation_config_form,
     open_code_evaluator_form,
     open_dataset_evaluator_for_edit,
     open_llm_evaluator_form,
@@ -146,6 +147,9 @@ from phoenix.server.agents.capabilities.tools.external.list_splits import (
 )
 from phoenix.server.agents.capabilities.tools.external.load_dataset import (
     LoadDatasetCapability,
+)
+from phoenix.server.agents.capabilities.tools.external.open_annotation_config_form import (
+    OpenAnnotationConfigFormCapability,
 )
 from phoenix.server.agents.capabilities.tools.external.open_code_evaluator_form import (
     OpenCodeEvaluatorFormCapability,
@@ -281,6 +285,7 @@ _EXTERNAL_TOOL_DEFINITIONS_BY_NAME: dict[str, ToolDefinition] = {
         edit_prompt_instance.TOOL_DEFINITION,
         get_route_info.TOOL_DEFINITION,
         load_dataset.TOOL_DEFINITION,
+        open_annotation_config_form.TOOL_DEFINITION,
         open_code_evaluator_form.TOOL_DEFINITION,
         open_dataset_evaluator_for_edit.TOOL_DEFINITION,
         open_llm_evaluator_form.TOOL_DEFINITION,
@@ -390,6 +395,7 @@ def get_external_tool_capability_function(
             instructions=prompts.read_dataset_evaluator_definition_tool
         ),
         PatchExperimentCapability(instructions=prompts.patch_experiment_tool),
+        OpenAnnotationConfigFormCapability(instructions=prompts.open_annotation_config_form_tool),
         OpenCodeEvaluatorFormCapability(instructions=prompts.open_code_evaluator_form_tool),
         OpenLlmEvaluatorFormCapability(instructions=prompts.open_llm_evaluator_form_tool),
         ReadCodeEvaluatorDraftCapability(instructions=prompts.read_code_evaluator_draft_tool),
@@ -442,6 +448,7 @@ __all__ = [
     "GetRouteInfoCapability",
     "ListPlaygroundModelTargetsCapability",
     "LoadDatasetCapability",
+    "OpenAnnotationConfigFormCapability",
     "OpenCodeEvaluatorFormCapability",
     "OpenDatasetEvaluatorForEditCapability",
     "OpenLlmEvaluatorFormCapability",

--- a/src/phoenix/server/agents/capabilities/tools/external/edit_annotation_config_draft.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/edit_annotation_config_draft.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from jinja2 import Template
+from pydantic_ai import RunContext
+from pydantic_ai.tools import SystemPromptFunc, ToolDefinition
+from pydantic_ai.toolsets import AgentToolset
+from pydantic_ai.toolsets.external import ExternalToolset
+
+from phoenix.server.agents.capabilities.base import AbstractDynamicCapability
+from phoenix.server.agents.types import AgentDependencies
+
+NAME = "edit_annotation_config_draft"
+
+ANNOTATION_TYPE_ENUM = ["CATEGORICAL", "CONTINUOUS", "FREEFORM"]
+OPTIMIZATION_DIRECTION_ENUM = ["MAXIMIZE", "MINIMIZE", "NONE"]
+
+DESCRIPTION = (
+    "Edit the open annotation-config draft. The edit applies to the form "
+    "immediately; the user still creates or updates the config with the form's "
+    "own Create/Update action. Call `read_annotation_config_draft` first to see "
+    "the current draft. Use camelCase field names exactly as shown. Common valid "
+    "examples: "
+    '{"type":"set_name","name":"correctness"}; '
+    '{"type":"set_annotation_type","annotationType":"CATEGORICAL"}; '
+    '{"type":"set_optimization_direction","optimizationDirection":"MAXIMIZE"}; '
+    '{"type":"set_values","values":[{"label":"correct","score":1},'
+    '{"label":"incorrect","score":0}]}; '
+    '{"type":"set_lower_bound","lowerBound":0}; '
+    '{"type":"set_upper_bound","upperBound":1}. '
+    "`set_annotation_type` is rejected in `edit` mode (the type is immutable once "
+    "a config exists). Use `set_values` for CATEGORICAL configs and "
+    "`set_lower_bound`/`set_upper_bound` for CONTINUOUS configs."
+)
+
+OPERATION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "One annotation-config draft edit operation. Required fields by type: "
+        "set_name requires name; set_description requires description (may be "
+        "null to clear); set_annotation_type requires annotationType (rejected "
+        "in edit mode); set_optimization_direction requires optimizationDirection; "
+        "set_lower_bound requires lowerBound; set_upper_bound requires upperBound; "
+        "set_values requires values (whole-list replace of categorical values)."
+    ),
+    "properties": {
+        "type": {
+            "type": "string",
+            "enum": [
+                "set_name",
+                "set_description",
+                "set_annotation_type",
+                "set_optimization_direction",
+                "set_lower_bound",
+                "set_upper_bound",
+                "set_values",
+            ],
+            "description": "The operation kind.",
+        },
+        "name": {
+            "type": "string",
+            "description": "Replacement annotation name (e.g. `correctness`).",
+        },
+        "description": {
+            "type": ["string", "null"],
+            "description": "Replacement description; pass null to clear it.",
+        },
+        "annotationType": {
+            "type": "string",
+            "enum": ANNOTATION_TYPE_ENUM,
+            "description": (
+                "Annotation type. Only valid in `create` mode; rejected in `edit` "
+                "mode since the type is immutable post-create."
+            ),
+        },
+        "optimizationDirection": {
+            "type": "string",
+            "enum": OPTIMIZATION_DIRECTION_ENUM,
+            "description": "Whether a higher score is better, worse, or neither.",
+        },
+        "lowerBound": {
+            "type": ["number", "null"],
+            "description": "Minimum score for a CONTINUOUS config.",
+        },
+        "upperBound": {
+            "type": ["number", "null"],
+            "description": "Maximum score for a CONTINUOUS config.",
+        },
+        "values": {
+            "type": "array",
+            "description": (
+                "Whole-list replacement of the CATEGORICAL config's categories. "
+                "Each entry has a label and an optional numeric score."
+            ),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "label": {"type": "string"},
+                    "score": {"type": ["number", "null"]},
+                },
+                "required": ["label"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["type"],
+    "additionalProperties": False,
+}
+
+PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "operations": {
+            "type": "array",
+            "description": "Ordered edit operations to apply to the draft.",
+            "items": OPERATION_SCHEMA,
+            "minItems": 1,
+        },
+    },
+    "required": ["operations"],
+    "additionalProperties": False,
+}
+
+TOOL_DEFINITION = ToolDefinition(
+    name=NAME,
+    description=DESCRIPTION,
+    parameters_json_schema=PARAMETERS,
+    kind="external",
+)
+
+
+@dataclass
+class EditAnnotationConfigDraftCapability(AbstractDynamicCapability[AgentDependencies]):
+    instructions: Template
+
+    def get_toolset(self) -> AgentToolset[AgentDependencies] | None:
+        return ExternalToolset[AgentDependencies]([TOOL_DEFINITION])
+
+    def get_dynamic_instructions(self) -> SystemPromptFunc[AgentDependencies]:
+        instructions = self.instructions
+
+        def _instructions(ctx: RunContext[AgentDependencies]) -> str:
+            return instructions.render()
+
+        return _instructions
+
+    def include_for_run(self, ctx: RunContext[AgentDependencies]) -> bool:
+        return ctx.deps.contexts.annotation_config is not None and not ctx.deps.is_viewer

--- a/src/phoenix/server/agents/capabilities/tools/external/open_annotation_config_form.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/open_annotation_config_form.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from jinja2 import Template
+from pydantic_ai import RunContext
+from pydantic_ai.tools import SystemPromptFunc, ToolDefinition
+from pydantic_ai.toolsets import AgentToolset
+from pydantic_ai.toolsets.external import ExternalToolset
+
+from phoenix.server.agents.capabilities.base import AbstractDynamicCapability
+from phoenix.server.agents.types import AgentDependencies
+
+NAME = "open_annotation_config_form"
+
+DESCRIPTION = (
+    "Open the annotation-config form on the current project page without navigating "
+    "away. Use this when a project is focused and the user wants to define a new "
+    "annotation config (categorical, continuous, or freeform) for labeling spans. "
+    "This opens the existing create form; it does not persist or create a config."
+)
+
+PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+TOOL_DEFINITION = ToolDefinition(
+    name=NAME,
+    description=DESCRIPTION,
+    parameters_json_schema=PARAMETERS,
+    kind="external",
+)
+
+
+@dataclass
+class OpenAnnotationConfigFormCapability(AbstractDynamicCapability[AgentDependencies]):
+    instructions: Template
+
+    def get_toolset(self) -> AgentToolset[AgentDependencies] | None:
+        return ExternalToolset[AgentDependencies]([TOOL_DEFINITION])
+
+    def get_dynamic_instructions(self) -> SystemPromptFunc[AgentDependencies]:
+        instructions = self.instructions
+
+        def _instructions(ctx: RunContext[AgentDependencies]) -> str:
+            return instructions.render()
+
+        return _instructions
+
+    def include_for_run(self, ctx: RunContext[AgentDependencies]) -> bool:
+        return (
+            ctx.deps.contexts.project is not None
+            and ctx.deps.contexts.annotation_config is None
+            and not ctx.deps.is_viewer
+        )

--- a/src/phoenix/server/agents/capabilities/tools/external/read_annotation_config_draft.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/read_annotation_config_draft.py
@@ -12,30 +12,19 @@ from pydantic_ai.toolsets.external import ExternalToolset
 from phoenix.server.agents.capabilities.base import AbstractDynamicCapability
 from phoenix.server.agents.types import AgentDependencies
 
-NAME = "open_annotation_config_form"
+NAME = "read_annotation_config_draft"
 
 DESCRIPTION = (
-    "Open the annotation-config form on the current project page without navigating "
-    "away. Use this when a project is focused and the user wants to define a new "
-    "annotation config (categorical, continuous, or freeform) for labeling spans, or "
-    "to edit an existing one. Omit `annotationConfigId` to open the create form; pass "
-    "an existing config's node id to open it for editing. Resolve a config's node id "
-    "from the project's annotation configs (e.g. the project-annotation-configs "
-    "recipe). This only opens the form; it does not persist, create, or update a "
-    "config."
+    "Read the open annotation-config draft. Returns the draft's mode "
+    "(`create` or `edit`), annotationType (CATEGORICAL, CONTINUOUS, or "
+    "FREEFORM), name, description, optimizationDirection, categorical values, "
+    "and continuous lowerBound/upperBound. Call this before "
+    "`edit_annotation_config_draft` to see the current draft."
 )
 
 PARAMETERS: dict[str, Any] = {
     "type": "object",
-    "properties": {
-        "annotationConfigId": {
-            "type": "string",
-            "description": (
-                "Relay node id of an existing annotation config to open for editing. "
-                "Omit to open the create form instead."
-            ),
-        },
-    },
+    "properties": {},
     "additionalProperties": False,
 }
 
@@ -48,7 +37,7 @@ TOOL_DEFINITION = ToolDefinition(
 
 
 @dataclass
-class OpenAnnotationConfigFormCapability(AbstractDynamicCapability[AgentDependencies]):
+class ReadAnnotationConfigDraftCapability(AbstractDynamicCapability[AgentDependencies]):
     instructions: Template
 
     def get_toolset(self) -> AgentToolset[AgentDependencies] | None:
@@ -63,8 +52,4 @@ class OpenAnnotationConfigFormCapability(AbstractDynamicCapability[AgentDependen
         return _instructions
 
     def include_for_run(self, ctx: RunContext[AgentDependencies]) -> bool:
-        return (
-            ctx.deps.contexts.project is not None
-            and ctx.deps.contexts.annotation_config is None
-            and not ctx.deps.is_viewer
-        )
+        return ctx.deps.contexts.annotation_config is not None

--- a/src/phoenix/server/agents/context.py
+++ b/src/phoenix/server/agents/context.py
@@ -221,6 +221,17 @@ class LlmEvaluatorContext(_ChatContextBase):
     evaluator_node_id: str | None = Field(default=None, alias="evaluatorNodeId")
 
 
+class AnnotationConfigContext(_ChatContextBase):
+    """Annotation-config create/edit form mounted in the current browser route.
+
+    ``annotation_config_node_id`` is ``None`` when the form is creating a new
+    config and carries the config's relay node id when editing an existing one.
+    """
+
+    type: Literal["annotation_config"]
+    annotation_config_node_id: str | None = Field(default=None, alias="annotationConfigNodeId")
+
+
 class DatasetContext(_ChatContextBase):
     """Dataset the user is currently viewing or has bound to a workflow.
 
@@ -269,6 +280,7 @@ class ChatContext(
             | PlaygroundContext
             | CodeEvaluatorContext
             | LlmEvaluatorContext
+            | AnnotationConfigContext
             | DatasetContext
             | GraphQLContext
             | WebAccessContext
@@ -292,6 +304,7 @@ class ResolvedContexts:
     playground: PlaygroundContext | None = None
     code_evaluator: CodeEvaluatorContext | None = None
     llm_evaluator: LlmEvaluatorContext | None = None
+    annotation_config: AnnotationConfigContext | None = None
     dataset: DatasetContext | None = None
     graphql: GraphQLContext | None = None
     web_access: WebAccessContext | None = None
@@ -310,6 +323,8 @@ def resolve_contexts(contexts: list[ChatContext]) -> ResolvedContexts:
             resolved.code_evaluator = context_value
         elif isinstance(context_value, LlmEvaluatorContext):
             resolved.llm_evaluator = context_value
+        elif isinstance(context_value, AnnotationConfigContext):
+            resolved.annotation_config = context_value
         elif isinstance(context_value, DatasetContext):
             resolved.dataset = context_value
         elif isinstance(context_value, ProjectContext):

--- a/src/phoenix/server/agents/prompts/__init__.py
+++ b/src/phoenix/server/agents/prompts/__init__.py
@@ -166,6 +166,12 @@ _SUBMIT_LLM_EVALUATOR_DRAFT_TOOL_INSTRUCTIONS = get_template(
 _OPEN_ANNOTATION_CONFIG_FORM_TOOL_INSTRUCTIONS = get_template(
     "tools/OPEN_ANNOTATION_CONFIG_FORM_TOOL_INSTRUCTIONS.xml.j2"
 )
+_READ_ANNOTATION_CONFIG_DRAFT_TOOL_INSTRUCTIONS = get_template(
+    "tools/READ_ANNOTATION_CONFIG_DRAFT_TOOL_INSTRUCTIONS.xml.j2"
+)
+_EDIT_ANNOTATION_CONFIG_DRAFT_TOOL_INSTRUCTIONS = get_template(
+    "tools/EDIT_ANNOTATION_CONFIG_DRAFT_TOOL_INSTRUCTIONS.xml.j2"
+)
 _APP_CONTEXT_TEMPLATE = get_template("context/APP_CONTEXT_INSTRUCTIONS.xml.j2")
 _PROJECT_CONTEXT_TEMPLATE = get_template("context/PROJECT_CONTEXT_INSTRUCTIONS.xml.j2")
 _TRACE_CONTEXT_TEMPLATE = get_template("context/TRACE_CONTEXT_INSTRUCTIONS.xml.j2")
@@ -269,6 +275,8 @@ class AgentPrompts:
     open_llm_evaluator_form_tool: Template = _OPEN_LLM_EVALUATOR_FORM_TOOL_INSTRUCTIONS
     submit_llm_evaluator_draft_tool: Template = _SUBMIT_LLM_EVALUATOR_DRAFT_TOOL_INSTRUCTIONS
     open_annotation_config_form_tool: Template = _OPEN_ANNOTATION_CONFIG_FORM_TOOL_INSTRUCTIONS
+    read_annotation_config_draft_tool: Template = _READ_ANNOTATION_CONFIG_DRAFT_TOOL_INSTRUCTIONS
+    edit_annotation_config_draft_tool: Template = _EDIT_ANNOTATION_CONFIG_DRAFT_TOOL_INSTRUCTIONS
     app_context: Template = _APP_CONTEXT_TEMPLATE
     project_context: Template = _PROJECT_CONTEXT_TEMPLATE
     trace_context: Template = _TRACE_CONTEXT_TEMPLATE

--- a/src/phoenix/server/agents/prompts/__init__.py
+++ b/src/phoenix/server/agents/prompts/__init__.py
@@ -163,6 +163,9 @@ _SUBMIT_CODE_EVALUATOR_DRAFT_TOOL_INSTRUCTIONS = get_template(
 _SUBMIT_LLM_EVALUATOR_DRAFT_TOOL_INSTRUCTIONS = get_template(
     "tools/SUBMIT_LLM_EVALUATOR_DRAFT_TOOL_INSTRUCTIONS.xml.j2"
 )
+_OPEN_ANNOTATION_CONFIG_FORM_TOOL_INSTRUCTIONS = get_template(
+    "tools/OPEN_ANNOTATION_CONFIG_FORM_TOOL_INSTRUCTIONS.xml.j2"
+)
 _APP_CONTEXT_TEMPLATE = get_template("context/APP_CONTEXT_INSTRUCTIONS.xml.j2")
 _PROJECT_CONTEXT_TEMPLATE = get_template("context/PROJECT_CONTEXT_INSTRUCTIONS.xml.j2")
 _TRACE_CONTEXT_TEMPLATE = get_template("context/TRACE_CONTEXT_INSTRUCTIONS.xml.j2")
@@ -265,6 +268,7 @@ class AgentPrompts:
     test_llm_evaluator_draft_tool: Template = _TEST_LLM_EVALUATOR_DRAFT_TOOL_INSTRUCTIONS
     open_llm_evaluator_form_tool: Template = _OPEN_LLM_EVALUATOR_FORM_TOOL_INSTRUCTIONS
     submit_llm_evaluator_draft_tool: Template = _SUBMIT_LLM_EVALUATOR_DRAFT_TOOL_INSTRUCTIONS
+    open_annotation_config_form_tool: Template = _OPEN_ANNOTATION_CONFIG_FORM_TOOL_INSTRUCTIONS
     app_context: Template = _APP_CONTEXT_TEMPLATE
     project_context: Template = _PROJECT_CONTEXT_TEMPLATE
     trace_context: Template = _TRACE_CONTEXT_TEMPLATE

--- a/src/phoenix/server/agents/prompts/tools/EDIT_ANNOTATION_CONFIG_DRAFT_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/EDIT_ANNOTATION_CONFIG_DRAFT_TOOL_INSTRUCTIONS.xml.j2
@@ -1,0 +1,17 @@
+<tool name="edit_annotation_config_draft">
+  <description>Apply edits to the open annotation-config form draft. Each operation updates one field of the draft and takes effect in the form immediately.</description>
+  <when_to_use>
+    - The user asks you to fill in or change the annotation config (its name, description, type, optimization direction, categories, or score bounds).
+    - Call `read_annotation_config_draft` first to see the current draft before proposing edits.
+  </when_to_use>
+  <user_facing_language>
+    - The tool name is internal. In replies to users, describe this as updating the annotation-config form.
+    - Editing the draft does not create or save the config. The user persists it with the form's own Create/Update action.
+  </user_facing_language>
+  <guidelines>
+    - Use `set_values` (whole-list replace) for CATEGORICAL configs; each category has a label and an optional numeric score.
+    - Use `set_lower_bound` and `set_upper_bound` for CONTINUOUS configs.
+    - `set_annotation_type` only works in `create` mode; the type is immutable once a config exists.
+    - Do not promise the config has been created or saved — that stays behind the form's Create/Update action.
+  </guidelines>
+</tool>

--- a/src/phoenix/server/agents/prompts/tools/OPEN_ANNOTATION_CONFIG_FORM_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/OPEN_ANNOTATION_CONFIG_FORM_TOOL_INSTRUCTIONS.xml.j2
@@ -1,15 +1,17 @@
 <tool name="open_annotation_config_form">
-  <description>Open the annotation-config form on the current project page in place. The browser stays on the project route; the form mounts as a slideover. A config created from this form is attached to the focused project.</description>
+  <description>Open the annotation-config form on the current project page in place. The browser stays on the project route; the form mounts as a modal dialog. A config created from this form is attached to the focused project.</description>
   <when_to_use>
     - The user is viewing a project and asks to create or define an annotation config — a categorical, continuous, or freeform schema used to label spans.
+    - The user asks to edit or change an existing annotation config on the project. Pass that config's node id as `annotationConfigId`.
     - The annotation-config form is not already mounted.
   </when_to_use>
   <user_facing_language>
     - The tool name is internal. In replies to users, call the opened surface the annotation-config form.
-    - Do not describe creating as approving a diff. The user creates with the form's Create action when ready.
+    - Do not describe creating or updating as approving a diff. The user commits with the form's Create/Update action when ready.
   </user_facing_language>
   <workflow>
-    - Call open_annotation_config_form to mount the form, then let the user fill it in.
-    - Do not promise that the config has been created. Persistence stays behind the user-visible Create action in the form.
+    - To create: call open_annotation_config_form with no arguments, then fill in the form (e.g. via edit_annotation_config_draft) or let the user complete it.
+    - To edit an existing config: first resolve its node id (e.g. from the project-annotation-configs recipe), then call open_annotation_config_form with that `annotationConfigId`. The annotation type is locked once a config exists.
+    - Do not promise that the config has been created or updated. Persistence stays behind the user-visible Create/Update action in the form.
   </workflow>
 </tool>

--- a/src/phoenix/server/agents/prompts/tools/OPEN_ANNOTATION_CONFIG_FORM_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/OPEN_ANNOTATION_CONFIG_FORM_TOOL_INSTRUCTIONS.xml.j2
@@ -1,0 +1,15 @@
+<tool name="open_annotation_config_form">
+  <description>Open the annotation-config form on the current project page in place. The browser stays on the project route; the form mounts as a slideover. A config created from this form is attached to the focused project.</description>
+  <when_to_use>
+    - The user is viewing a project and asks to create or define an annotation config — a categorical, continuous, or freeform schema used to label spans.
+    - The annotation-config form is not already mounted.
+  </when_to_use>
+  <user_facing_language>
+    - The tool name is internal. In replies to users, call the opened surface the annotation-config form.
+    - Do not describe creating as approving a diff. The user creates with the form's Create action when ready.
+  </user_facing_language>
+  <workflow>
+    - Call open_annotation_config_form to mount the form, then let the user fill it in.
+    - Do not promise that the config has been created. Persistence stays behind the user-visible Create action in the form.
+  </workflow>
+</tool>

--- a/src/phoenix/server/agents/prompts/tools/READ_ANNOTATION_CONFIG_DRAFT_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/READ_ANNOTATION_CONFIG_DRAFT_TOOL_INSTRUCTIONS.xml.j2
@@ -1,0 +1,11 @@
+<tool name="read_annotation_config_draft">
+  <description>Read the current state of the open annotation-config form draft, including its mode, annotation type, name, description, optimization direction, categorical values, and continuous bounds.</description>
+  <when_to_use>
+    - Before calling `edit_annotation_config_draft` — to see the current draft contents before proposing edits.
+    - Whenever the user asks what the draft currently contains or wants a review of the in-progress annotation config.
+  </when_to_use>
+  <guidelines>
+    - The `mode` field is either `create` (a new config is being authored) or `edit` (an existing config is being modified). In `edit` mode, `annotationType` is immutable and a `set_annotation_type` op will be rejected.
+    - `values` apply only to CATEGORICAL configs; `lowerBound`/`upperBound` apply only to CONTINUOUS configs.
+  </guidelines>
+</tool>

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -31,6 +31,7 @@ from phoenix.server.agents.capabilities import (
 )
 from phoenix.server.agents.context import (
     AgentSpanContext,
+    AnnotationConfigContext,
     CodeEvaluatorContext,
     DatasetContext,
     LlmEvaluatorContext,
@@ -1415,6 +1416,86 @@ class TestLlmEvaluatorFormToolGates:
         assert "edit_llm_evaluator_draft" not in tool_names
         assert "test_llm_evaluator_draft" not in tool_names
         assert "submit_llm_evaluator_draft" not in tool_names
+
+
+class TestAnnotationConfigFormToolGates:
+    async def test_open_form_advertised_for_project(
+        self,
+        anthropic_model: AnthropicModel,
+        captured_request: CapturedRequest,
+    ) -> None:
+        agent = build_agent(model=anthropic_model)
+        deps = AgentDependencies(
+            contexts=ResolvedContexts(
+                project=ProjectContext(
+                    type="project",
+                    project_node_id="UHJvamVjdDox",
+                ),
+            ),
+        )
+
+        await agent.run("hello", deps=deps)
+
+        tool_names = _get_tool_names(captured_request.body)
+        assert "open_annotation_config_form" in tool_names
+
+    async def test_open_form_hidden_for_viewer(
+        self,
+        anthropic_model: AnthropicModel,
+        captured_request: CapturedRequest,
+    ) -> None:
+        agent = build_agent(model=anthropic_model)
+        deps = AgentDependencies(
+            contexts=ResolvedContexts(
+                project=ProjectContext(
+                    type="project",
+                    project_node_id="UHJvamVjdDox",
+                ),
+            ),
+            is_viewer=True,
+        )
+
+        await agent.run("hello", deps=deps)
+
+        tool_names = _get_tool_names(captured_request.body)
+        assert "open_annotation_config_form" not in tool_names
+
+    async def test_open_form_hidden_without_project(
+        self,
+        anthropic_model: AnthropicModel,
+        captured_request: CapturedRequest,
+    ) -> None:
+        agent = build_agent(model=anthropic_model)
+        deps = AgentDependencies(contexts=ResolvedContexts())
+
+        await agent.run("hello", deps=deps)
+
+        tool_names = _get_tool_names(captured_request.body)
+        assert "open_annotation_config_form" not in tool_names
+
+    async def test_open_form_hidden_when_annotation_config_form_mounted(
+        self,
+        anthropic_model: AnthropicModel,
+        captured_request: CapturedRequest,
+    ) -> None:
+        agent = build_agent(model=anthropic_model)
+        deps = AgentDependencies(
+            contexts=ResolvedContexts(
+                project=ProjectContext(
+                    type="project",
+                    project_node_id="UHJvamVjdDox",
+                ),
+                annotation_config=AnnotationConfigContext(
+                    type="annotation_config",
+                    annotation_config_node_id=None,
+                ),
+            ),
+        )
+
+        await agent.run("hello", deps=deps)
+
+        tool_names = _get_tool_names(captured_request.body)
+        assert "open_annotation_config_form" not in tool_names
 
 
 class TestEvaluatorsSkillLoadContract:

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -1473,6 +1473,72 @@ class TestAnnotationConfigFormToolGates:
         tool_names = _get_tool_names(captured_request.body)
         assert "open_annotation_config_form" not in tool_names
 
+    async def test_draft_tools_advertised_for_mounted_annotation_config_form(
+        self,
+        anthropic_model: AnthropicModel,
+        captured_request: CapturedRequest,
+    ) -> None:
+        agent = build_agent(model=anthropic_model)
+        deps = AgentDependencies(
+            contexts=ResolvedContexts(
+                annotation_config=AnnotationConfigContext(
+                    type="annotation_config",
+                    annotation_config_node_id=None,
+                ),
+            ),
+        )
+
+        await agent.run("hello", deps=deps)
+
+        tool_names = _get_tool_names(captured_request.body)
+        assert "open_annotation_config_form" not in tool_names
+        assert "read_annotation_config_draft" in tool_names
+        assert "edit_annotation_config_draft" in tool_names
+
+    async def test_draft_tools_absent_without_annotation_config_context(
+        self,
+        anthropic_model: AnthropicModel,
+        captured_request: CapturedRequest,
+    ) -> None:
+        agent = build_agent(model=anthropic_model)
+        deps = AgentDependencies(
+            contexts=ResolvedContexts(
+                project=ProjectContext(
+                    type="project",
+                    project_node_id="UHJvamVjdDox",
+                ),
+            ),
+        )
+
+        await agent.run("hello", deps=deps)
+
+        tool_names = _get_tool_names(captured_request.body)
+        assert "read_annotation_config_draft" not in tool_names
+        assert "edit_annotation_config_draft" not in tool_names
+
+    async def test_edit_draft_tool_hidden_for_viewer(
+        self,
+        anthropic_model: AnthropicModel,
+        captured_request: CapturedRequest,
+    ) -> None:
+        agent = build_agent(model=anthropic_model)
+        deps = AgentDependencies(
+            contexts=ResolvedContexts(
+                annotation_config=AnnotationConfigContext(
+                    type="annotation_config",
+                    annotation_config_node_id=None,
+                ),
+            ),
+            is_viewer=True,
+        )
+
+        await agent.run("hello", deps=deps)
+
+        tool_names = _get_tool_names(captured_request.body)
+        # Reading the draft stays available to viewers; editing does not.
+        assert "read_annotation_config_draft" in tool_names
+        assert "edit_annotation_config_draft" not in tool_names
+
     async def test_open_form_hidden_when_annotation_config_form_mounted(
         self,
         anthropic_model: AnthropicModel,


### PR DESCRIPTION
## Summary

Lets the PXI agent open an annotation-config create/edit form from a project page, and rebuilds the form's state so it's agent-drivable. This is the **scaffolding** for agent-authored annotation configs — the agent can open the form today; agent-driven field population (read/edit draft tools) is the next step.

## What's here

**Form state (Zustand)**
- New per-instance `annotationConfigDraftStore` (+ `AnnotationConfigDraftContext`) holding a flat superset draft, serialized to the GraphQL union on submit via `toAnnotationConfig` and validated by `validateAnnotationConfigDraft`.
- `AnnotationConfigDialog` lifted off `react-hook-form` onto the store; public props unchanged, so the settings-page create/edit call sites are untouched.

**Project-scoped slideover**
- `AnnotationConfigSlideover` mounted on the project page: owns its open state, the `createAnnotationConfig` → `addAnnotationConfigToProject` and `updateAnnotationConfig` mutations, advertises the `annotation_config` context while open, and registers the `open_annotation_config_form` client action.

**Agent context + tool**
- New `annotation_config` agent context (server `ChatContext` + `ResolvedContexts`, regenerated OpenAPI clients, client context key + pills).
- New `open_annotation_config_form` external tool, gated on a focused project with no annotation-config form already open, with prompt instructions and gating tests.

## Verification

- `TestAnnotationConfigFormToolGates` (4 new) + the evaluator gating tests pass; frontend `tsc` and `oxlint` clean; Python `ruff` clean.
- **Manual e2e (agent-browser):** on a project page, asked PXI to create a categorical config → it called `open_annotation_config_form`, the slideover opened and rendered correctly, and the composer context chip flipped `Project` → `Annotation Config` (confirming the full gating chain).

## Not yet done (follow-ups)

- **Read/edit draft tools** so the agent can populate the form (it currently opens it and the user fills it in), plus the `waitForRegisteredClientActions` open→read/edit handshake.
- **Edit via the agent** (the open action only does create; edit needs resolving a config by id).
- **Project "Config" tab live refresh** after create+associate (the associate mutation returns a minimal project node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)