### PR TITLE
fix(agents): show streaming PXI bash summary

### DIFF
--- a/app/src/agent/tools/bash/__tests__/bashToolSchema.test.ts
+++ b/app/src/agent/tools/bash/__tests__/bashToolSchema.test.ts
@@ -22,11 +22,11 @@ describe("getBashToolSummary", () => {
 describe("getBashToolInput", () => {
   it("requires command to be a string", () => {
     expect(getBashToolInput({ summary: "Listing files" })).toBeNull();
-    expect(getBashToolInput({ command: "ls", summary: "Listing files" })).toEqual(
-      {
-        command: "ls",
-        summary: "Listing files",
-      }
-    );
+    expect(
+      getBashToolInput({ command: "ls", summary: "Listing files" })
+    ).toEqual({
+      command: "ls",
+      summary: "Listing files",
+    });
   });
 });

--- a/app/src/agent/tools/bash/__tests__/bashToolSchema.test.ts
+++ b/app/src/agent/tools/bash/__tests__/bashToolSchema.test.ts
@@ -1,0 +1,32 @@
+import {
+  getBashToolInput,
+  getBashToolSummary,
+} from "@phoenix/agent/tools/bash/bashToolSchema";
+
+describe("getBashToolSummary", () => {
+  it("returns the summary from a complete input", () => {
+    expect(
+      getBashToolSummary({ command: "ls -la", summary: "Listing files" })
+    ).toBe("Listing files");
+  });
+
+  it("returns the summary while still streaming, before command arrives", () => {
+    // The model emits `summary` before `command`, so during streaming the
+    // partial input has a summary but no command yet.
+    expect(getBashToolSummary({ summary: "Listing files" })).toBe(
+      "Listing files"
+    );
+  });
+});
+
+describe("getBashToolInput", () => {
+  it("requires command to be a string", () => {
+    expect(getBashToolInput({ summary: "Listing files" })).toBeNull();
+    expect(getBashToolInput({ command: "ls", summary: "Listing files" })).toEqual(
+      {
+        command: "ls",
+        summary: "Listing files",
+      }
+    );
+  });
+});

--- a/app/src/agent/tools/bash/bashToolSchema.ts
+++ b/app/src/agent/tools/bash/bashToolSchema.ts
@@ -19,3 +19,18 @@ export function getBashToolInput(input: unknown): BashToolInput | null {
     ...(typeof summary === "string" ? { summary } : {}),
   };
 }
+
+/**
+ * Read the `summary` from a partial (still-streaming) bash tool input. Unlike
+ * {@link getBashToolInput}, it does not require `command`, which streams in
+ * after `summary`.
+ */
+export function getBashToolSummary(input: unknown): string | null {
+  if (!input || typeof input !== "object") {
+    return null;
+  }
+
+  const { summary } = input as Partial<BashToolInput>;
+
+  return typeof summary === "string" && summary.length > 0 ? summary : null;
+}

--- a/app/src/agent/tools/bash/index.ts
+++ b/app/src/agent/tools/bash/index.ts
@@ -1,5 +1,5 @@
 // --- Bash tool ---
-export { getBashToolInput } from "./bashToolSchema";
+export { getBashToolInput, getBashToolSummary } from "./bashToolSchema";
 export {
   applyBashToolFilesystemPolicy,
   BASH_TOOL_READONLY_ROOT,

--- a/app/src/components/agent/BashToolDetails.tsx
+++ b/app/src/components/agent/BashToolDetails.tsx
@@ -1,6 +1,7 @@
 import {
   getBashToolCommandDisplayResult,
   getBashToolInput,
+  getBashToolSummary,
 } from "@phoenix/agent/tools/bash";
 
 import {
@@ -15,11 +16,11 @@ import { stringifyToolValue } from "./toolPartTypes";
  * Returns the preview text for the collapsed bash tool summary.
  */
 export function getBashToolPreview(part: ToolInvocationPart): string {
-  const input = getBashToolInput(part.input);
-  if (input?.summary) {
-    return input.summary;
+  const summary = getBashToolSummary(part.input);
+  if (summary) {
+    return summary;
   }
-  const command = input?.command ?? stringifyToolValue(part.input);
+  const command = getBashToolInput(part.input)?.command;
   return command ? command.split("\n")[0] : "";
 }
 

--- a/app/src/components/agent/__tests__/BashToolDetails.test.tsx
+++ b/app/src/components/agent/__tests__/BashToolDetails.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { getBashToolPreview } from "../BashToolDetails";
+import type { ToolInvocationPart } from "../toolPartTypes";
+
+function createBashPart(
+  overrides: Partial<ToolInvocationPart> = {}
+): ToolInvocationPart {
+  return {
+    type: "tool-bash",
+    toolCallId: "tool-call-1",
+    state: "input-streaming",
+    input: {},
+    output: undefined,
+    errorText: undefined,
+    ...overrides,
+  } as ToolInvocationPart;
+}
+
+describe("getBashToolPreview", () => {
+  it("shows the summary while it is still streaming, before the command arrives", () => {
+    // The model emits `summary` before `command`, so mid-stream the parsed
+    // input has a summary but no command yet. The preview must surface the
+    // summary rather than the partial-JSON "{".
+    const part = createBashPart({
+      state: "input-streaming",
+      input: { summary: "Listing your traces" },
+    });
+
+    expect(getBashToolPreview(part)).toBe("Listing your traces");
+  });
+
+  it("prefers the summary once the full input is available", () => {
+    const part = createBashPart({
+      state: "input-available",
+      input: { command: "ls -la /phoenix", summary: "Listing your traces" },
+    });
+
+    expect(getBashToolPreview(part)).toBe("Listing your traces");
+  });
+});


### PR DESCRIPTION
## Summary

The PXI bash collapsed preview showed a lone `{` while the tool's `summary` was streaming in.

`getBashToolPreview` routed through `getBashToolInput`, which returns `null` until `command` is a string. Since `summary` now streams *before* `command` (#13501), the preview fell back to pretty-printing the partial input and took its first line — a lone `{` — until `command` arrived and it flipped to the real summary.

## Fix

- Add `getBashToolSummary`, which reads `summary` from a partial/streaming input **without** requiring `command`.
- Use it in `getBashToolPreview`, and drop the partial-JSON fallback that produced the brace. The summary now shows as soon as it streams; before it has any characters, the preview is empty instead of `{`.

## Test plan

- [x] `vitest run` — new tests cover streaming (summary-only) and complete inputs
- [x] `pnpm typecheck`
- [x] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
