### PR TITLE
fix(pxi): reject stale prompt tool provider approvals

### DIFF
--- a/app/src/agent/tools/playgroundPromptTools/__tests__/playgroundPromptTools.test.ts
+++ b/app/src/agent/tools/playgroundPromptTools/__tests__/playgroundPromptTools.test.ts
@@ -903,6 +903,53 @@ describe("playground prompt tools agent tools", () => {
       ).toEqual(["added_later"]);
     });
 
+    it("rejects the accept if the provider changed after the diff was proposed", async () => {
+      const playgroundStore = newStore();
+      const agentStore = createAgentStore();
+      const write = makeWriteAction(playgroundStore, agentStore);
+      const addToolOutput = vi.fn().mockResolvedValue(undefined);
+
+      await write(
+        {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [{ name: "get_weather" }],
+        },
+        {
+          toolCallId: "tc-stale-provider",
+          sessionId: "s-1",
+          addToolOutput,
+        }
+      );
+      const model = playgroundStore.getState().instances[0]!.model;
+      playgroundStore.getState().updateInstance({
+        instanceId: 0,
+        patch: { model: { ...model, provider: "ANTHROPIC" } },
+        dirty: false,
+      });
+
+      const pending =
+        agentStore.getState().pendingPromptToolWritesByToolCallId[
+          "tc-stale-provider"
+        ];
+      await pending!.accept!();
+
+      expect(addToolOutput).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: "output-error",
+          tool: WRITE_PROMPT_TOOLS_TOOL_NAME,
+          toolCallId: "tc-stale-provider",
+          errorText: expect.stringContaining("provider changed"),
+        })
+      );
+      expect(playgroundStore.getState().instances[0]!.tools).toHaveLength(0);
+      expect(
+        agentStore.getState().pendingPromptToolWritesByToolCallId[
+          "tc-stale-provider"
+        ]
+      ).toBeUndefined();
+    });
+
     it("requires tool call context", async () => {
       const playgroundStore = newStore();
       const agentStore = createAgentStore();

--- a/app/src/agent/tools/playgroundPromptTools/clientActions.ts
+++ b/app/src/agent/tools/playgroundPromptTools/clientActions.ts
@@ -97,6 +97,7 @@ export function createWritePromptToolsClientAction({
         toolCallId: writeContext.toolCallId,
         sessionId: writeContext.sessionId,
         instanceId,
+        provider,
         expectedRevision: parsed.expectedRevision,
         input: parsed,
         before,

--- a/app/src/agent/tools/playgroundPromptTools/pendingPromptToolWrite.ts
+++ b/app/src/agent/tools/playgroundPromptTools/pendingPromptToolWrite.ts
@@ -25,6 +25,22 @@ export function bindPendingPromptToolWriteActions({
     ...pendingWrite,
     accept: async ({ approvalSource = "user" } = {}) => {
       setPendingPromptToolWrite(pendingWrite.toolCallId, null);
+      const currentInstance = playgroundStore
+        .getState()
+        .instances.find((instance) => instance.id === pendingWrite.instanceId);
+      if (
+        currentInstance != null &&
+        currentInstance.model.provider !== pendingWrite.provider
+      ) {
+        await addToolOutput({
+          state: "output-error",
+          tool: WRITE_PROMPT_TOOLS_TOOL_NAME,
+          toolCallId: pendingWrite.toolCallId,
+          errorText:
+            "The playground provider changed since PXI proposed these prompt tool changes. Ask PXI to re-read the prompt tools and propose the change again.",
+        });
+        return;
+      }
       const result = applyWritePromptTools({
         playgroundStore,
         input: pendingWrite.input,

--- a/app/src/agent/tools/playgroundPromptTools/types.ts
+++ b/app/src/agent/tools/playgroundPromptTools/types.ts
@@ -156,6 +156,8 @@ export type PendingPromptToolWrite = {
   /** Agent session that owns the unresolved write_prompt_tools tool call. */
   sessionId: string;
   instanceId: number;
+  /** Provider used to render the approval diff. */
+  provider: ModelProvider;
   expectedRevision: string;
   /** The validated batch re-applied on accept. */
   input: WritePromptToolsInput;


### PR DESCRIPTION
resolves #13626

## Summary
- stores the provider used to render the pending `write_prompt_tools` approval diff
- rejects accept if the playground provider changed before approval is accepted
- covers proposal -> provider switch -> accept with a regression test

## To verify
- [x] `pnpm test src/agent/tools/playgroundPromptTools/__tests__/playgroundPromptTools.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm lint src/agent/tools/playgroundPromptTools/types.ts src/agent/tools/playgroundPromptTools/clientActions.ts src/agent/tools/playgroundPromptTools/pendingPromptToolWrite.ts src/agent/tools/playgroundPromptTools/__tests__/playgroundPromptTools.test.ts`
- [x] `pnpm fmt:check src/agent/tools/playgroundPromptTools/types.ts src/agent/tools/playgroundPromptTools/clientActions.ts src/agent/tools/playgroundPromptTools/pendingPromptToolWrite.ts src/agent/tools/playgroundPromptTools/__tests__/playgroundPromptTools.test.ts`
- [x] `git diff --check`
