### PR TITLE
fix: wait for in-memory sqlite schema initialization

### DIFF
--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -156,6 +156,32 @@ def aio_sqlite_engine(
 
 
 def _init_memory_models(engine: AsyncEngine) -> None:
+    """
+    Create the tables for an in-memory SQLite engine, returning only
+    after they exist so the engine is safe to query immediately.
+
+    This is a sync function, so it cannot await ``init_models``. There
+    are two cases:
+
+    - No event loop is running in this thread (e.g. server startup):
+      ``asyncio.run`` executes the coroutine right here.
+    - A loop is already running (e.g. ``launch_app`` in a notebook):
+      ``asyncio.run`` would raise, and scheduling ``init_models`` as a
+      task on the caller's loop would not run it until the caller next
+      yields — the engine could be queried before its tables exist. So
+      a short-lived helper thread runs the coroutine on its own fresh
+      loop, and we block on ``join()``. Blocking the caller's loop is
+      acceptable: this happens once, at engine creation, and creating
+      tables in an in-memory database is fast.
+
+    In both cases the StaticPool's single aiosqlite connection is
+    created on an event loop that is closed by the time the application
+    uses the engine on its own loop. That is safe because aiosqlite
+    does not bind a connection to the loop it was created on: each
+    operation creates a fresh future on whatever loop is current at
+    call time, and the actual SQLite work runs on aiosqlite's dedicated
+    worker thread either way.
+    """
     try:
         asyncio.get_running_loop()
     except RuntimeError:
@@ -171,7 +197,7 @@ def _init_memory_models(engine: AsyncEngine) -> None:
         except BaseException as error:
             exc = error
 
-    thread = Thread(target=run)
+    thread = Thread(target=run, name="sqlite-init-models")
     thread.start()
     thread.join()
     if exc is not None:

--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from enum import Enum
 from sqlite3 import Connection
+from threading import Thread
 from typing import Any
 
 import aiosqlite
@@ -141,12 +142,7 @@ def aio_sqlite_engine(
     if not migrate:
         return engine
     if database.startswith(":memory:"):
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            asyncio.run(init_models(engine))
-        else:
-            asyncio.create_task(init_models(engine))
+        _init_memory_models(engine)
     else:
         migration_engine = create_async_engine(
             url=url,
@@ -157,6 +153,29 @@ def aio_sqlite_engine(
         )
         migrate_in_thread(migration_engine, log_migrations=log_migrations)
     return engine
+
+
+def _init_memory_models(engine: AsyncEngine) -> None:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(init_models(engine))
+        return
+
+    exc: BaseException | None = None
+
+    def run() -> None:
+        nonlocal exc
+        try:
+            asyncio.run(init_models(engine))
+        except BaseException as error:
+            exc = error
+
+    thread = Thread(target=run)
+    thread.start()
+    thread.join()
+    if exc is not None:
+        raise exc
 
 
 def aio_postgresql_engine(

--- a/tests/unit/db/test_engines.py
+++ b/tests/unit/db/test_engines.py
@@ -1,5 +1,6 @@
-import asyncio
+from unittest import mock
 
+import pytest
 from sqlalchemy import text
 
 from phoenix.db.engines import aio_sqlite_engine, get_async_db_url
@@ -34,19 +35,23 @@ def test_get_async_postgresql_db_url() -> None:
     assert url.query["password"] == "password"
 
 
-def test_memory_sqlite_models_are_ready_when_created_inside_running_loop() -> None:
-    async def run() -> None:
-        engine = aio_sqlite_engine(get_async_db_url("sqlite:///:memory:"), migrate=True)
-        try:
-            async with engine.connect() as conn:
-                table = await conn.scalar(
-                    text(
-                        "select name from sqlite_master "
-                        "where type = 'table' and name = 'generative_model_custom_providers'"
-                    )
-                )
-            assert table == "generative_model_custom_providers"
-        finally:
-            await engine.dispose()
+async def test_memory_sqlite_models_are_ready_when_created_inside_running_loop() -> None:
+    engine = aio_sqlite_engine(get_async_db_url("sqlite:///:memory:"), migrate=True)
+    try:
+        async with engine.connect() as conn:
+            # The default project row is inserted at the end of init_models,
+            # so its presence proves initialization ran to completion before
+            # the engine was returned.
+            name = await conn.scalar(text("select name from projects"))
+        assert name == "default"
+    finally:
+        await engine.dispose()
 
-    asyncio.run(run())
+
+async def test_memory_sqlite_init_failure_propagates_to_caller() -> None:
+    async def fail(_engine: object) -> None:
+        raise RuntimeError("init failed")
+
+    with mock.patch("phoenix.db.engines.init_models", fail):
+        with pytest.raises(RuntimeError, match="init failed"):
+            aio_sqlite_engine(get_async_db_url("sqlite:///:memory:"), migrate=True)

--- a/tests/unit/db/test_engines.py
+++ b/tests/unit/db/test_engines.py
@@ -1,4 +1,8 @@
-from phoenix.db.engines import get_async_db_url
+import asyncio
+
+from sqlalchemy import text
+
+from phoenix.db.engines import aio_sqlite_engine, get_async_db_url
 
 
 def test_get_async_sqlite_db_url() -> None:
@@ -28,3 +32,21 @@ def test_get_async_postgresql_db_url() -> None:
     # NB(mikeldking): No idea why this fails to authenticate
     assert url.query["user"] == "user"
     assert url.query["password"] == "password"
+
+
+def test_memory_sqlite_models_are_ready_when_created_inside_running_loop() -> None:
+    async def run() -> None:
+        engine = aio_sqlite_engine(get_async_db_url("sqlite:///:memory:"), migrate=True)
+        try:
+            async with engine.connect() as conn:
+                table = await conn.scalar(
+                    text(
+                        "select name from sqlite_master "
+                        "where type = 'table' and name = 'generative_model_custom_providers'"
+                    )
+                )
+            assert table == "generative_model_custom_providers"
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

`aio_sqlite_engine(..., migrate=True)` could return an in-memory SQLite engine before `init_models()` finished when it was called while an event loop was already running. In that branch the current code schedules `init_models(engine)` with `asyncio.create_task(...)` and immediately returns the engine, so the first caller can observe an empty schema.

This makes the in-memory path initialize models synchronously before returning in both sync and async caller contexts. The async-caller case runs the initialization in a short helper thread, matching the existing sync path's behavior of using a temporary event loop before the engine is used by the server/application loop.

Related to #12746, but scoped to the concrete schema-readiness race in `aio_sqlite_engine`.

## Validation

- `ruff check src/phoenix/db/engines.py tests/unit/db/test_engines.py`
- `git diff --check upstream/main...HEAD`
- `PYTHONNOUSERSITE=1 PYTHONPATH=src python -m py_compile src/phoenix/db/engines.py tests/unit/db/test_engines.py`
- Minimal isolated script: create `aio_sqlite_engine(get_async_db_url("sqlite:///:memory:"), migrate=True)` inside `asyncio.run(...)`, then query `sqlite_master` for `generative_model_custom_providers`; it now returns the table name.

I also tried `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/unit/db/test_engines.py -q` locally, but this checkout's Python environment is missing test/runtime dependencies (`aiosqlite` in the isolated path; the normal pytest path fails earlier on a missing `werkzeug` plugin dependency). The added regression test is included for CI.
