### PR TITLE
fix(client): drop Google top_k instead of mapping it to OpenAI top_logprobs

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/helpers/sdk/openai/chat.py
+++ b/packages/phoenix-client/src/phoenix/client/helpers/sdk/openai/chat.py
@@ -355,8 +355,9 @@ class _InvocationParametersConversion:
                 ans["temperature"] = google_params["temperature"]
             if "top_p" in google_params:
                 ans["top_p"] = google_params["top_p"]
-            if "top_k" in google_params:
-                ans["top_logprobs"] = google_params["top_k"]
+            # Google `top_k` is a sampling parameter with no OpenAI chat-completion
+            # equivalent; it must not be written to `top_logprobs` (an unrelated
+            # output-formatting field). Drop it, like the other reverse converters.
             if "presence_penalty" in google_params:
                 ans["presence_penalty"] = google_params["presence_penalty"]
             if "frequency_penalty" in google_params:

--- a/packages/phoenix-client/tests/canary/sdk/openai/test_chat.py
+++ b/packages/phoenix-client/tests/canary/sdk/openai/test_chat.py
@@ -489,6 +489,8 @@ def test_google_top_k_is_not_mapped_to_openai_top_logprobs() -> None:
     }
     result = _InvocationParametersConversion.to_openai(obj)
     assert "top_logprobs" not in result
-    # The other fields still convert correctly.
-    assert result["temperature"] == 0.5
-    assert result["max_completion_tokens"] == 128
+    # The other fields still convert correctly. Use .get() because temperature /
+    # max_completion_tokens are NotRequired keys on the _InvocationParameters
+    # TypedDict (direct subscript trips pyright's reportTypedDictNotRequiredAccess).
+    assert result.get("temperature") == 0.5
+    assert result.get("max_completion_tokens") == 128

--- a/packages/phoenix-client/tests/canary/sdk/openai/test_chat.py
+++ b/packages/phoenix-client/tests/canary/sdk/openai/test_chat.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 from phoenix.client.__generated__ import v1
 from phoenix.client.helpers.sdk.openai.chat import (
     _FunctionToolConversion,
+    _InvocationParametersConversion,
     _MessageConversion,
     _ResponseFormatConversion,
     _TextContentPartConversion,
@@ -476,3 +477,18 @@ class TestCompletionCreateParamsBase:
 class _MockFormatter:
     def format(self, _: str, /, *, variables: Mapping[str, str]) -> str:
         return json.dumps(variables)
+
+
+def test_google_top_k_is_not_mapped_to_openai_top_logprobs() -> None:
+    # Google `top_k` is a sampling parameter and has no OpenAI chat-completion equivalent.
+    # OpenAI `top_logprobs` is the number of logprobs to return (0-20, requires logprobs=True),
+    # so mapping top_k -> top_logprobs is wrong. Drop it, as the other reverse converters do.
+    obj: Any = {
+        "type": "google",
+        "google": {"top_k": 40, "temperature": 0.5, "max_output_tokens": 128},
+    }
+    result = _InvocationParametersConversion.to_openai(obj)
+    assert "top_logprobs" not in result
+    # The other fields still convert correctly.
+    assert result["temperature"] == 0.5
+    assert result["max_completion_tokens"] == 128


### PR DESCRIPTION
## Summary

In `_InvocationParametersConversion.to_openai` (`packages/phoenix-client/.../openai/chat.py`), the `google` branch maps Google's `top_k` to OpenAI's `top_logprobs`:

```python
if "top_k" in google_params:
    ans["top_logprobs"] = google_params["top_k"]
```

These are unrelated parameters:
- Google `top_k` is a **sampling** parameter (limit the candidate token pool to the K most-likely tokens).
- OpenAI `top_logprobs` is the **number of logprobs to return** per position — an integer 0–20, valid only when `logprobs=True` is also set.

So converting a stored Google-provider prompt to OpenAI kwargs writes e.g. `top_k=40` into `top_logprobs`, which is out of OpenAI's valid range (and is sent without `logprobs=True`) → the OpenAI API rejects the request, or the semantics are nonsense when the value happens to be in range. Every other field in this google branch maps to its correct OpenAI equivalent (`max_output_tokens → max_completion_tokens`, `temperature`, `top_p`, `presence_penalty`, `frequency_penalty`, `stop_sequences → stop`); `top_logprobs` was the lone mistranslation.

Google `top_k` has no OpenAI chat-completion equivalent, so it should be dropped — which is exactly what the sibling Anthropic reverse converter does in its `google` branch (it omits `top_k`). There is no reverse `top_logprobs → top_k` mapping, so dropping introduces no asymmetry.

## Fix

Remove the `top_k → top_logprobs` mapping (drop `top_k` for the OpenAI target).

## Verification

Added `test_google_top_k_is_not_mapped_to_openai_top_logprobs` in `tests/canary/sdk/openai/test_chat.py`: converts a `google` invocation-parameters object containing `top_k` and asserts the result has no `top_logprobs` (and that the other fields still convert). Verified it fails before the fix and passes after. Full `test_chat.py` suite green (34 passed); `ruff check` and `ruff format --check` clean.