### PR TITLE
fix: expire prompt tool diffs on provider change

### DIFF
--- a/app/src/agent/tools/playgroundPromptTools/__tests__/playgroundPromptTools.test.ts
+++ b/app/src/agent/tools/playgroundPromptTools/__tests__/playgroundPromptTools.test.ts
@@ -903,6 +903,53 @@ describe("playground prompt tools agent tools", () => {
       ).toEqual(["added_later"]);
     });
 
+    it("rejects the accept if the provider changed after the diff was proposed", async () => {
+      const playgroundStore = newStore();
+      const agentStore = createAgentStore();
+      const write = makeWriteAction(playgroundStore, agentStore);
+      const addToolOutput = vi.fn().mockResolvedValue(undefined);
+
+      await write(
+        {
+          instanceId: 0,
+          expectedRevision: revisionOf(playgroundStore),
+          tools: [{ name: "get_weather" }],
+        },
+        { toolCallId: "tc-provider-stale", sessionId: "s-1", addToolOutput }
+      );
+      const pending =
+        agentStore.getState().pendingPromptToolWritesByToolCallId[
+          "tc-provider-stale"
+        ];
+      playgroundStore.getState().updateInstance({
+        instanceId: 0,
+        patch: {
+          model: {
+            ...playgroundStore.getState().instances[0]!.model,
+            provider: "ANTHROPIC",
+          },
+        },
+        dirty: false,
+      });
+
+      await pending!.accept!();
+
+      expect(addToolOutput).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: "output-error",
+          tool: WRITE_PROMPT_TOOLS_TOOL_NAME,
+          toolCallId: "tc-provider-stale",
+          errorText: expect.stringContaining("provider changed"),
+        })
+      );
+      expect(playgroundStore.getState().instances[0]!.tools).toHaveLength(0);
+      expect(
+        agentStore.getState().pendingPromptToolWritesByToolCallId[
+          "tc-provider-stale"
+        ]
+      ).toBeUndefined();
+    });
+
     it("requires tool call context", async () => {
       const playgroundStore = newStore();
       const agentStore = createAgentStore();

--- a/app/src/agent/tools/playgroundPromptTools/clientActions.ts
+++ b/app/src/agent/tools/playgroundPromptTools/clientActions.ts
@@ -98,6 +98,7 @@ export function createWritePromptToolsClientAction({
         sessionId: writeContext.sessionId,
         instanceId,
         expectedRevision: parsed.expectedRevision,
+        provider,
         input: parsed,
         before,
         after,

--- a/app/src/agent/tools/playgroundPromptTools/pendingPromptToolWrite.ts
+++ b/app/src/agent/tools/playgroundPromptTools/pendingPromptToolWrite.ts
@@ -25,6 +25,22 @@ export function bindPendingPromptToolWriteActions({
     ...pendingWrite,
     accept: async ({ approvalSource = "user" } = {}) => {
       setPendingPromptToolWrite(pendingWrite.toolCallId, null);
+      const currentInstance = playgroundStore
+        .getState()
+        .instances.find((instance) => instance.id === pendingWrite.instanceId);
+      if (
+        currentInstance != null &&
+        currentInstance.model.provider !== pendingWrite.provider
+      ) {
+        await addToolOutput({
+          state: "output-error",
+          tool: WRITE_PROMPT_TOOLS_TOOL_NAME,
+          toolCallId: pendingWrite.toolCallId,
+          errorText:
+            "The playground provider changed after this prompt tool diff was proposed. Please run write_prompt_tools again so the diff can be reviewed in the current provider format.",
+        });
+        return;
+      }
       const result = applyWritePromptTools({
         playgroundStore,
         input: pendingWrite.input,

--- a/app/src/agent/tools/playgroundPromptTools/types.ts
+++ b/app/src/agent/tools/playgroundPromptTools/types.ts
@@ -157,6 +157,8 @@ export type PendingPromptToolWrite = {
   sessionId: string;
   instanceId: number;
   expectedRevision: string;
+  /** Provider whose display format the user reviewed in the diff. */
+  provider: ModelProvider;
   /** The validated batch re-applied on accept. */
   input: WritePromptToolsInput;
   before: PromptToolsDisplaySnapshot;


### PR DESCRIPTION
## Summary
- store the provider used to render a pending `write_prompt_tools` approval diff
- reject accept when the playground provider has changed before the user approves the diff
- add regression coverage for provider drift between proposal and accept

Fixes #13626.

## To verify
- git diff --check
- Select-String -Path app/src/agent/tools/playgroundPromptTools/*.ts,app/src/agent/tools/playgroundPromptTools/__tests__/playgroundPromptTools.test.ts -Pattern 'sk-[A-Za-z0-9_-]+'

## Not run
- `pnpm exec vitest run src/agent/tools/playgroundPromptTools/__tests__/playgroundPromptTools.test.ts --runInBand`
- `pnpm exec oxlint ...`

The local Windows install could not finish because registry downloads repeatedly timed out and then a partial install hit a Windows rename `EPERM` under `app/node_modules/.pnpm`. I removed the incomplete `node_modules` afterward because the C: drive is below the local warning threshold.
