### PR TITLE
fix(agent): focus PXI input on open

### DIFF
--- a/app/src/components/agent/AgentChatPanel.tsx
+++ b/app/src/components/agent/AgentChatPanel.tsx
@@ -263,6 +263,7 @@ function AgentChatController({
           forkFromMessage={forkFromMessage}
           modelMenuValue={menuValue}
           onModelChange={handleModelChange}
+          autoFocusInput
         >
           {activeSessionId ? (
             <ChatSessionUsage sessionId={activeSessionId} />

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -6,6 +6,7 @@ import {
   type ReactNode,
   useMemo,
   useRef,
+  useLayoutEffect,
   type PropsWithChildren,
   useState,
 } from "react";
@@ -340,6 +341,7 @@ export function ChatView({
   children,
   emptyStateSubtext,
   emptyStateQuickActions,
+  autoFocusInput = false,
 }: PropsWithChildren<{
   sessionId?: string | null;
   messages: AgentUIMessage[];
@@ -361,6 +363,7 @@ export function ChatView({
   onModelChange: (model: ModelMenuValue) => void;
   emptyStateSubtext?: ReactNode;
   emptyStateQuickActions?: EmptyStateQuickAction[];
+  autoFocusInput?: boolean;
 }>) {
   const { theme } = useTheme();
   const { contentRef, scrollRef, scrollToBottom, stopScroll } =
@@ -492,6 +495,23 @@ export function ChatView({
       }
     }
   };
+
+  useLayoutEffect(() => {
+    if (
+      !autoFocusInput ||
+      !hasAcknowledgedConsent ||
+      pendingElicitation ||
+      rewindRequest
+    ) {
+      return;
+    }
+    textareaRef.current?.focus();
+  }, [
+    autoFocusInput,
+    hasAcknowledgedConsent,
+    pendingElicitation,
+    rewindRequest,
+  ]);
 
   return (
     <ElicitationDraftProvider draft={resolvedElicitationDraft}>

--- a/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/app/src/components/agent/__tests__/Chat.test.tsx
@@ -1,0 +1,150 @@
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentProvider } from "@phoenix/contexts/AgentContext";
+import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
+
+import { ChatView } from "../Chat";
+
+vi.mock("@phoenix/agent/quickActions/quickActions", () => ({
+  useAgentQuickActions: () => [],
+}));
+
+vi.mock("../AgentContextPills", () => ({
+  AgentContextPills: () => null,
+}));
+
+vi.mock("../AgentEditPermissionMenu", () => ({
+  AgentEditPermissionMenu: () => null,
+  getNextEditPermissionMode: () => "bypass",
+}));
+
+vi.mock("../AgentModelCredentialForm", () => ({
+  AgentModelCredentialForm: () => null,
+  useAgentModelCredentialStatus: () => ({
+    missingCredentialsProvider: null,
+    refreshCredentialStatus: () => undefined,
+  }),
+}));
+
+vi.mock("../AgentModelMenu", () => ({
+  AgentModelMenu: () => <button type="button">Model</button>,
+}));
+
+vi.mock("../AgentWebSearchToggle", () => ({
+  AgentWebSearchToggle: () => <button type="button">Web</button>,
+}));
+
+vi.mock("../ChatEmptyState", () => ({
+  ChatEmptyState: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("../ChatLantern", () => ({
+  ChatLantern: () => null,
+}));
+
+vi.mock("../ChatMessage", () => ({
+  AssistantMessage: () => null,
+  UserMessage: () => null,
+}));
+
+function renderChatView(root: Root, { autoFocusInput = false } = {}) {
+  act(() => {
+    root.render(
+      <ThemeProvider themeMode="light" disableBodyTheme>
+        <AgentProvider
+          agentsConfig={{
+            collectorEndpoint: null,
+            assistantProjectName: "assistant_agent",
+            webAccessEnabled: false,
+            assistantEnabled: true,
+            allowLocalTraces: true,
+            allowRemoteExport: false,
+          }}
+          observability={{
+            storeLocalTraces: true,
+            exportRemoteTraces: false,
+            acknowledgedTraceConsent: {
+              allowLocalTraces: true,
+              allowRemoteExport: false,
+            },
+          }}
+        >
+          <ChatView
+            sessionId="session-1"
+            messages={[]}
+            sendMessage={vi.fn()}
+            stop={async () => undefined}
+            status="ready"
+            error={undefined}
+            pendingElicitation={null}
+            handleElicitationSubmit={vi.fn()}
+            handleElicitationCancel={vi.fn()}
+            modelMenuValue={{ provider: "ANTHROPIC", modelName: "claude" }}
+            onModelChange={vi.fn()}
+            autoFocusInput={autoFocusInput}
+          />
+        </AgentProvider>
+      </ThemeProvider>
+    );
+  });
+}
+
+describe("ChatView", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }))
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("focuses the prompt textarea when requested", () => {
+    renderChatView(root, { autoFocusInput: true });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Message input"]'
+    );
+
+    expect(textarea).not.toBeNull();
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  it("does not focus the prompt textarea by default", () => {
+    renderChatView(root);
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Message input"]'
+    );
+
+    expect(textarea).not.toBeNull();
+    expect(document.activeElement).not.toBe(textarea);
+  });
+});


### PR DESCRIPTION
Fixes #13627

## What changed
- Focus the PXI prompt textarea when the assistant panel opens. The panel controller unmounts the chat view while closed, so a mount-time effect fires exactly on open; a plain `useEffect` is sufficient since no other focus management competes with it.
- Keep the behavior opt-in (`autoFocusInput`) at the panel controller so other ChatView surfaces do not steal focus.
- Skip autofocus while the consent gate, elicitation UI, or rewind confirmation is shown; when one of those surfaces clears, the effect re-fires and returns focus to the input.

## To verify
- pnpm exec oxfmt --check src/components/agent/Chat.tsx src/components/agent/AgentChatPanel.tsx src/components/agent/__tests__/Chat.test.tsx
- pnpm exec oxlint src/components/agent/Chat.tsx src/components/agent/AgentChatPanel.tsx src/components/agent/__tests__/Chat.test.tsx
- pnpm exec vitest run src/components/agent/__tests__/Chat.test.tsx --no-file-parallelism --maxWorkers 1
- pnpm exec tsc --noEmit --pretty false
- pnpm run build