### PR TITLE
fix(agent): scroll grouped auto-open tools

### DIFF
--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -432,7 +432,9 @@ export function ToolPart({
  *
  * @param element - The element to bring into view within its scroll container.
  */
-function scrollElementIntoViewWithinScrollParent(element: HTMLElement): void {
+export function scrollElementIntoViewWithinScrollParent(
+  element: HTMLElement
+): void {
   const scrollParent = getScrollableParent(element);
   if (!scrollParent) {
     return;

--- a/app/src/components/agent/ToolPartGroup.tsx
+++ b/app/src/components/agent/ToolPartGroup.tsx
@@ -1,11 +1,19 @@
 import { css, keyframes } from "@emotion/react";
 import { getToolName, isToolUIPart } from "ai";
-import { type CSSProperties, useMemo, useState } from "react";
+import {
+  type CSSProperties,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
+import { getAgentToolUIBehavior } from "@phoenix/agent/extensions/toolRegistry";
 import { Icon, Icons } from "@phoenix/components";
 
 import {
   getToolPartPreview,
+  scrollElementIntoViewWithinScrollParent,
   shouldAutoOpenToolPart,
   ToolPart,
   type ToolPartType,
@@ -263,17 +271,50 @@ function formatPoolStatus({
  */
 export function ToolPartGroup({ parts }: { parts: ToolPartType[] }) {
   const stats = useToolPoolStats(parts);
-  const hasAutoOpenTool = parts.some(
-    (part) =>
-      isToolUIPart(part) &&
-      shouldAutoOpenToolPart(part, getToolPartPreview(part))
-  );
+  const groupRef = useRef<HTMLDivElement>(null);
+  const hasAutoScrolledRef = useRef(false);
+  const { hasAutoOpenTool, hasAutoScrollTool } = useMemo(() => {
+    let hasAutoOpenTool = false;
+    let hasAutoScrollTool = false;
+
+    for (const part of parts) {
+      if (!isToolUIPart(part)) continue;
+      const preview = getToolPartPreview(part);
+      if (!shouldAutoOpenToolPart(part, preview)) continue;
+
+      hasAutoOpenTool = true;
+      if (
+        getAgentToolUIBehavior(getToolName(part))?.scrollIntoViewOnMount ===
+        true
+      ) {
+        hasAutoScrollTool = true;
+      }
+    }
+
+    return { hasAutoOpenTool, hasAutoScrollTool };
+  }, [parts]);
   const [manualExpanded, setManualExpanded] = useState<boolean | null>(null);
   // Auto-open is only the initial/default state. Once the user toggles the
   // group, their manual choice must win even if a child tool still requests
   // auto-open (for example, an edit_prompt_instance diff that remains previewable).
   const isRenderedExpanded = manualExpanded ?? hasAutoOpenTool;
   const [isHeaderActive, setIsHeaderActive] = useState(false);
+
+  useEffect(() => {
+    if (
+      !isRenderedExpanded ||
+      !hasAutoScrollTool ||
+      hasAutoScrolledRef.current
+    ) {
+      return;
+    }
+    hasAutoScrolledRef.current = true;
+    requestAnimationFrame(() => {
+      if (groupRef.current) {
+        scrollElementIntoViewWithinScrollParent(groupRef.current);
+      }
+    });
+  }, [hasAutoScrollTool, isRenderedExpanded]);
 
   const { text: statusText, variant: statusVariant } = formatPoolStatus(stats);
   const breakdownText = Array.from(stats.byName.entries())
@@ -288,6 +329,7 @@ export function ToolPartGroup({ parts }: { parts: ToolPartType[] }) {
 
   return (
     <div
+      ref={groupRef}
       className="tool-pool"
       css={toolPoolCSS}
       data-header-active={isHeaderActive}

--- a/app/src/components/agent/__tests__/ToolPartDisclosure.test.tsx
+++ b/app/src/components/agent/__tests__/ToolPartDisclosure.test.tsx
@@ -1,6 +1,6 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   EDIT_PROMPT_TOOL_NAME,
@@ -27,6 +27,8 @@ afterEach(() => {
     root.unmount();
   });
   container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 function createToolPart(
@@ -208,6 +210,57 @@ describe("tool disclosure controls", () => {
 
     click(header);
     expect(container.querySelector(".tool-pool__body")).not.toBeNull();
+  });
+
+  it("scrolls an auto-open tool group into view", () => {
+    const scrollBy = vi.fn();
+    Object.defineProperty(container, "scrollHeight", {
+      value: 1000,
+      configurable: true,
+    });
+    Object.defineProperty(container, "clientHeight", {
+      value: 400,
+      configurable: true,
+    });
+    Object.defineProperty(container, "scrollBy", {
+      value: scrollBy,
+      configurable: true,
+    });
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      (node: Element) =>
+        ({
+          overflowY: node === container ? "auto" : "visible",
+        }) as unknown as CSSStyleDeclaration
+    );
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        const className =
+          typeof this.className === "string" ? this.className : "";
+        if (this === container) {
+          return { top: 0 } as DOMRect;
+        }
+        if (className.includes("tool-pool")) {
+          return { top: 100 } as DOMRect;
+        }
+        if (className.includes("tool-part")) {
+          return { top: 200 } as DOMRect;
+        }
+        return { top: 0 } as DOMRect;
+      }
+    );
+
+    renderToolPartGroup([
+      createToolPart({ toolCallId: "tool-call-1" }),
+      createToolPart({ toolCallId: "tool-call-2" }),
+      createAutoOpenToolPart({ toolCallId: "tool-call-3" }),
+    ]);
+
+    expect(container.querySelector(".tool-pool__body")).not.toBeNull();
+    expect(scrollBy).toHaveBeenCalledWith({ top: 84, behavior: "smooth" });
   });
 
   it("keeps an auto-open tool group collapsed after streaming updates", () => {


### PR DESCRIPTION
Fixes #13580

## What changed
- Reuse the existing tool-part scroll helper for grouped tool calls.
- When a grouped tool requests both auto-open and scroll-on-mount, scroll the expanded group into the chat scroll container once.
- Add a regression test that distinguishes group scrolling from the child tool-part scroll path.

## To verify
- pnpm exec oxfmt --check src\components\agent\ToolPart.tsx src\components\agent\ToolPartGroup.tsx src\components\agent\__tests__\ToolPartDisclosure.test.tsx
- pnpm exec oxlint src\components\agent\ToolPart.tsx src\components\agent\ToolPartGroup.tsx src\components\agent\__tests__\ToolPartDisclosure.test.tsx
- pnpm exec vitest run src\components\agent\__tests__\ToolPartDisclosure.test.tsx --no-file-parallelism --maxWorkers 1
- pnpm exec tsc --noEmit --pretty false
