### PR TITLE
feat(playground): add support for claude-fable-5

### DIFF
--- a/app/src/components/agent/agentCuratedModels.ts
+++ b/app/src/components/agent/agentCuratedModels.ts
@@ -13,6 +13,7 @@ export type AgentPlaygroundModel = {
 
 export const AGENT_CURATED_BUILT_IN_MODELS: readonly AgentBuiltInModelSelection[] =
   [
+    { provider: "ANTHROPIC", modelName: "claude-fable-5" },
     { provider: "ANTHROPIC", modelName: "claude-opus-4-8" },
     { provider: "ANTHROPIC", modelName: "claude-opus-4-6" },
     { provider: "ANTHROPIC", modelName: "claude-sonnet-4-6" },

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1385,6 +1385,7 @@ class TogetherStreamingClient(OpenAIBaseStreamingClient):
     provider_key=GenerativeProviderKey.AWS,
     model_names=[
         PROVIDER_DEFAULT,
+        "anthropic.claude-fable-5",
         "anthropic.claude-opus-4-8",
         "anthropic.claude-opus-4-7",
         "anthropic.claude-opus-4-6-v1",

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -2170,6 +2170,7 @@ class AzureOpenAIReasoningNonStreamingClient(
     provider_key=GenerativeProviderKey.ANTHROPIC,
     model_names=[
         PROVIDER_DEFAULT,
+        "claude-fable-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
     ],

--- a/src/phoenix/server/cost_tracking/model_cost_manifest.json
+++ b/src/phoenix/server/cost_tracking/model_cost_manifest.json
@@ -396,6 +396,33 @@
       ]
     },
     {
+      "name": "claude-fable-5",
+      "name_pattern": "claude-fable-5",
+      "source": "litellm",
+      "token_prices": [
+        {
+          "base_rate": 1e-5,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 5e-5,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 1e-6,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 1.25e-5,
+          "is_prompt": true,
+          "token_type": "cache_write"
+        }
+      ]
+    },
+    {
       "name": "claude-opus-4-7",
       "name_pattern": "claude-opus-4-7",
       "source": "litellm",


### PR DESCRIPTION
## Summary

Adds support for the `claude-fable-5` Anthropic model (the tier above Opus) across the Phoenix playground and cost-tracking surfaces.

`claude-fable-5` shares the same request surface as Opus 4.7/4.8 (adaptive thinking only; sampling params and `budget_tokens` removed), so it is registered alongside `claude-opus-4-8` / `claude-opus-4-7` on the standard `AnthropicStreamingClient`.

## Changes

- **`playground_clients.py`** — register `claude-fable-5` in the `AnthropicStreamingClient` `model_names` list, making it routable/selectable in the playground.
- **`model_cost_manifest.json`** — add token pricing for `claude-fable-5`: input $10/1M, output $50/1M, cache read $1/1M (0.1×), cache write $12.50/1M (1.25×).
- **`agentCuratedModels.ts`** — surface `claude-fable-5` as the top curated Anthropic model in the agent builder.

## Testing

- `tests/unit/server/cost_tracking/test_regex_specificity.py` and `tests/unit/db/test_facilitator.py` pass (245 passed, 11 skipped).
- Cost manifest JSON validated and parses with the new entry present.

https://claude.ai/code/session_01FdmSeSvAL63JgxrkdiV1VH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdmSeSvAL63JgxrkdiV1VH)_