### PR TITLE
fix(graphql): batch dataset exampleCount resolution with a dataloader

### DIFF
--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -20,6 +20,7 @@ from .dataset_dataset_splits import DatasetDatasetSplitsDataLoader
 from .dataset_evaluators import DatasetEvaluatorsDataLoader
 from .dataset_evaluators_by_evaluator import DatasetEvaluatorsByEvaluatorDataLoader
 from .dataset_evaluators_by_id import DatasetEvaluatorsByIdDataLoader
+from .dataset_example_counts import DatasetExampleCountsDataLoader
 from .dataset_example_revisions import DatasetExampleRevisionsDataLoader
 from .dataset_example_spans import DatasetExampleSpansDataLoader
 from .dataset_example_splits import DatasetExampleSplitsDataLoader
@@ -155,6 +156,7 @@ class DataLoaders:
     dataset_evaluators_by_id: DatasetEvaluatorsByIdDataLoader
     dataset_evaluators: DatasetEvaluatorsDataLoader
     datasets_by_evaluator: DatasetsByEvaluatorDataLoader
+    dataset_example_counts: DatasetExampleCountsDataLoader
     dataset_example_fields: TableFieldsDataLoader
     dataset_example_revisions: DatasetExampleRevisionsDataLoader
     dataset_example_spans: DatasetExampleSpansDataLoader
@@ -289,6 +291,7 @@ def build_data_loaders(
         dataset_evaluators=DatasetEvaluatorsDataLoader(db),
         datasets_by_evaluator=DatasetsByEvaluatorDataLoader(db),
         dataset_dataset_splits=DatasetDatasetSplitsDataLoader(db),
+        dataset_example_counts=DatasetExampleCountsDataLoader(db),
         dataset_example_fields=TableFieldsDataLoader(db, models.DatasetExample),
         dataset_example_revisions=DatasetExampleRevisionsDataLoader(db),
         dataset_example_spans=DatasetExampleSpansDataLoader(db),

--- a/src/phoenix/server/api/dataloaders/dataset_example_counts.py
+++ b/src/phoenix/server/api/dataloaders/dataset_example_counts.py
@@ -11,7 +11,7 @@ from phoenix.server.types import DbSessionFactory
 
 DatasetId: TypeAlias = int
 VersionId: TypeAlias = Optional[int]
-SplitIds: TypeAlias = Optional[tuple[int, ...]]
+SplitIds: TypeAlias = tuple[int, ...]  # empty means no split filter
 Key: TypeAlias = tuple[DatasetId, VersionId, SplitIds]
 Result: TypeAlias = int
 
@@ -27,20 +27,28 @@ class DatasetExampleCountsDataLoader(DataLoader[Key, Result]):
         groups: defaultdict[tuple[VersionId, SplitIds], set[DatasetId]] = defaultdict(set)
         for dataset_id, version_id, split_ids in keys:
             groups[(version_id, split_ids)].add(dataset_id)
+        version_ids = {version_id for version_id, _ in groups if version_id is not None}
         counts: dict[Key, int] = {}
         async with self._db.read() as session:
+            version_owners: dict[int, int] = {}
+            if version_ids:
+                version_owners = {
+                    version_id: dataset_id
+                    for version_id, dataset_id in await session.execute(
+                        select(models.DatasetVersion.id, models.DatasetVersion.dataset_id).where(
+                            models.DatasetVersion.id.in_(version_ids)
+                        )
+                    )
+                }
             for (version_id, split_ids), dataset_ids in groups.items():
                 target_dataset_ids = dataset_ids
                 if version_id is not None:
-                    version_dataset_id = await session.scalar(
-                        select(models.DatasetVersion.dataset_id).where(
-                            models.DatasetVersion.id == version_id
-                        )
-                    )
                     # A version belongs to exactly one dataset; any other dataset
                     # queried with this version has zero examples in it.
                     target_dataset_ids = {
-                        dataset_id for dataset_id in dataset_ids if dataset_id == version_dataset_id
+                        dataset_id
+                        for dataset_id in dataset_ids
+                        if dataset_id == version_owners.get(version_id)
                     }
                 if not target_dataset_ids:
                     continue

--- a/src/phoenix/server/api/dataloaders/dataset_example_counts.py
+++ b/src/phoenix/server/api/dataloaders/dataset_example_counts.py
@@ -1,0 +1,100 @@
+from collections import defaultdict
+from typing import Optional
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.sql.functions import count
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+DatasetId: TypeAlias = int
+VersionId: TypeAlias = Optional[int]
+SplitIds: TypeAlias = Optional[tuple[int, ...]]
+Key: TypeAlias = tuple[DatasetId, VersionId, SplitIds]
+Result: TypeAlias = int
+
+
+class DatasetExampleCountsDataLoader(DataLoader[Key, Result]):
+    """Batches dataset example-count lookups to avoid one session per dataset."""
+
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: list[Key]) -> list[Result]:
+        groups: defaultdict[tuple[VersionId, SplitIds], set[DatasetId]] = defaultdict(set)
+        for dataset_id, version_id, split_ids in keys:
+            groups[(version_id, split_ids)].add(dataset_id)
+        counts: dict[Key, int] = {}
+        async with self._db.read() as session:
+            for (version_id, split_ids), dataset_ids in groups.items():
+                target_dataset_ids = dataset_ids
+                if version_id is not None:
+                    version_dataset_id = await session.scalar(
+                        select(models.DatasetVersion.dataset_id).where(
+                            models.DatasetVersion.id == version_id
+                        )
+                    )
+                    # A version belongs to exactly one dataset; any other dataset
+                    # queried with this version has zero examples in it.
+                    target_dataset_ids = {
+                        dataset_id for dataset_id in dataset_ids if dataset_id == version_dataset_id
+                    }
+                if not target_dataset_ids:
+                    continue
+                stmt = _count_statement(target_dataset_ids, version_id, split_ids)
+                for dataset_id, example_count in await session.execute(stmt):
+                    counts[(dataset_id, version_id, split_ids)] = example_count
+        return [counts.get(key, 0) for key in keys]
+
+
+def _count_statement(
+    dataset_ids: set[DatasetId],
+    version_id: VersionId,
+    split_ids: SplitIds,
+) -> Select[tuple[int, int]]:
+    revision_ids = (
+        select(func.max(models.DatasetExampleRevision.id))
+        .join(models.DatasetExample)
+        .where(models.DatasetExample.dataset_id.in_(dataset_ids))
+        .group_by(models.DatasetExampleRevision.dataset_example_id)
+    )
+    if version_id is not None:
+        revision_ids = revision_ids.where(
+            models.DatasetExampleRevision.dataset_version_id <= version_id
+        )
+    if split_ids:
+        stmt = (
+            select(
+                models.DatasetExample.dataset_id,
+                count(models.DatasetExample.id.distinct()),
+            )
+            .join(
+                models.DatasetExampleRevision,
+                onclause=(
+                    models.DatasetExample.id == models.DatasetExampleRevision.dataset_example_id
+                ),
+            )
+            .join(
+                models.DatasetSplitDatasetExample,
+                onclause=(
+                    models.DatasetExample.id == models.DatasetSplitDatasetExample.dataset_example_id
+                ),
+            )
+            .where(models.DatasetSplitDatasetExample.dataset_split_id.in_(split_ids))
+        )
+    else:
+        stmt = select(
+            models.DatasetExample.dataset_id,
+            count(models.DatasetExampleRevision.id),
+        ).join(
+            models.DatasetExampleRevision,
+            onclause=(models.DatasetExample.id == models.DatasetExampleRevision.dataset_example_id),
+        )
+    return (
+        stmt.where(models.DatasetExampleRevision.id.in_(revision_ids))
+        .where(models.DatasetExampleRevision.revision_kind != "DELETE")
+        .group_by(models.DatasetExample.dataset_id)
+    )

--- a/src/phoenix/server/api/types/Dataset.py
+++ b/src/phoenix/server/api/types/Dataset.py
@@ -178,54 +178,13 @@ class Dataset(Node):
                 except Exception:
                     raise BadRequest(f"Invalid split ID: {split_id}")
 
-        revision_ids = (
-            select(func.max(models.DatasetExampleRevision.id))
-            .join(models.DatasetExample)
-            .where(models.DatasetExample.dataset_id == dataset_id)
-            .group_by(models.DatasetExampleRevision.dataset_example_id)
+        return await info.context.data_loaders.dataset_example_counts.load(
+            (
+                dataset_id,
+                version_id,
+                tuple(sorted(set(split_rowids))) if split_rowids else None,
+            )
         )
-        if version_id:
-            version_id_subquery = (
-                select(models.DatasetVersion.id)
-                .where(models.DatasetVersion.dataset_id == dataset_id)
-                .where(models.DatasetVersion.id == version_id)
-                .scalar_subquery()
-            )
-            revision_ids = revision_ids.where(
-                models.DatasetExampleRevision.dataset_version_id <= version_id_subquery
-            )
-
-        # Build the count query
-        if split_rowids:
-            # When filtering by splits, count distinct examples that belong to those splits
-            stmt = (
-                select(count(models.DatasetExample.id.distinct()))
-                .join(
-                    models.DatasetExampleRevision,
-                    onclause=(
-                        models.DatasetExample.id == models.DatasetExampleRevision.dataset_example_id
-                    ),
-                )
-                .join(
-                    models.DatasetSplitDatasetExample,
-                    onclause=(
-                        models.DatasetExample.id
-                        == models.DatasetSplitDatasetExample.dataset_example_id
-                    ),
-                )
-                .where(models.DatasetExampleRevision.id.in_(revision_ids))
-                .where(models.DatasetExampleRevision.revision_kind != "DELETE")
-                .where(models.DatasetSplitDatasetExample.dataset_split_id.in_(split_rowids))
-            )
-        else:
-            stmt = (
-                select(count(models.DatasetExampleRevision.id))
-                .where(models.DatasetExampleRevision.id.in_(revision_ids))
-                .where(models.DatasetExampleRevision.revision_kind != "DELETE")
-            )
-
-        async with info.context.db.read() as session:
-            return (await session.scalar(stmt)) or 0
 
     @strawberry.field
     async def examples(

--- a/src/phoenix/server/api/types/Dataset.py
+++ b/src/phoenix/server/api/types/Dataset.py
@@ -182,7 +182,7 @@ class Dataset(Node):
             (
                 dataset_id,
                 version_id,
-                tuple(sorted(set(split_rowids))) if split_rowids else None,
+                tuple(sorted(set(split_rowids))) if split_rowids else (),
             )
         )
 

--- a/tests/unit/server/api/types/test_Dataset.py
+++ b/tests/unit/server/api/types/test_Dataset.py
@@ -209,6 +209,71 @@ class TestDatasetExampleCountResolver:
         assert not response.errors
         assert response.data == {"node": {"exampleCount": 1}}
 
+    async def test_count_is_zero_when_version_belongs_to_another_dataset(
+        self,
+        gql_client: AsyncGraphQLClient,
+        many_datasets_with_examples: Mapping[str, int],
+    ) -> None:
+        response = await gql_client.execute(
+            query=self.QUERY,
+            variables={
+                "datasetId": str(GlobalID("Dataset", str(2))),
+                "datasetVersionId": str(GlobalID("DatasetVersion", str(1))),
+            },
+        )
+        assert not response.errors
+        assert response.data == {"node": {"exampleCount": 0}}
+
+    async def test_bulk_query_returns_count_for_every_dataset(
+        self,
+        gql_client: AsyncGraphQLClient,
+        many_datasets_with_examples: Mapping[str, int],
+    ) -> None:
+        query = """
+          query {
+            datasets(first: 50) {
+              edges {
+                node {
+                  id
+                  exampleCount
+                }
+              }
+            }
+          }
+        """
+        response = await gql_client.execute(query=query)
+        assert not response.errors
+        assert response.data
+        counts = {
+            edge["node"]["id"]: edge["node"]["exampleCount"]
+            for edge in response.data["datasets"]["edges"]
+        }
+        assert counts == dict(many_datasets_with_examples)
+
+    async def test_count_with_split_filter(
+        self,
+        gql_client: AsyncGraphQLClient,
+        many_datasets_with_examples: Mapping[str, int],
+    ) -> None:
+        query = """
+          query ($datasetId: ID!, $splitIds: [ID!]) {
+            node(id: $datasetId) {
+              ... on Dataset {
+                exampleCount(splitIds: $splitIds)
+              }
+            }
+          }
+        """
+        response = await gql_client.execute(
+            query=query,
+            variables={
+                "datasetId": str(GlobalID("Dataset", str(3))),
+                "splitIds": [str(GlobalID("DatasetSplit", str(1)))],
+            },
+        )
+        assert not response.errors
+        assert response.data == {"node": {"exampleCount": 2}}
+
 
 class TestDatasetExamplesResolver:
     QUERY = """
@@ -1317,6 +1382,100 @@ async def dataset_with_three_versions(db: DbSessionFactory) -> None:
         )
         session.add(dataset_example_revision_3)
         await session.flush()
+
+
+@pytest.fixture
+async def many_datasets_with_examples(db: DbSessionFactory) -> Mapping[str, int]:
+    """
+    Twelve datasets where dataset i contains i active examples plus one deleted
+    example that must not be counted. The first two examples of dataset 3 are
+    assigned to dataset split 1. Returns a mapping from dataset global ID to its
+    expected active example count.
+    """
+    expected_counts: dict[str, int] = {}
+    async with db() as session:
+        split = models.DatasetSplit(
+            id=1,
+            name="train",
+            description=None,
+            color="#0000FF",
+            metadata_={},
+        )
+        session.add(split)
+        example_id = 0
+        revision_id = 0
+        for dataset_index in range(1, 13):
+            session.add(
+                models.Dataset(
+                    id=dataset_index,
+                    name=f"dataset-{dataset_index}",
+                    description=None,
+                    metadata_={},
+                )
+            )
+            await session.flush()
+            session.add(
+                models.DatasetVersion(
+                    id=dataset_index,
+                    dataset_id=dataset_index,
+                    description=None,
+                    metadata_={},
+                )
+            )
+            await session.flush()
+            for example_index in range(dataset_index):
+                example_id += 1
+                session.add(models.DatasetExample(id=example_id, dataset_id=dataset_index))
+                await session.flush()
+                revision_id += 1
+                session.add(
+                    models.DatasetExampleRevision(
+                        id=revision_id,
+                        dataset_example_id=example_id,
+                        dataset_version_id=dataset_index,
+                        input={},
+                        output={},
+                        metadata_={},
+                        revision_kind="CREATE",
+                    )
+                )
+                if dataset_index == 3 and example_index < 2:
+                    session.add(
+                        models.DatasetSplitDatasetExample(
+                            dataset_split_id=1,
+                            dataset_example_id=example_id,
+                        )
+                    )
+            session.add(
+                models.DatasetVersion(
+                    id=dataset_index + 100,
+                    dataset_id=dataset_index,
+                    description=None,
+                    metadata_={},
+                )
+            )
+            example_id += 1
+            session.add(models.DatasetExample(id=example_id, dataset_id=dataset_index))
+            await session.flush()
+            for version_id, revision_kind in (
+                (dataset_index, "CREATE"),
+                (dataset_index + 100, "DELETE"),
+            ):
+                revision_id += 1
+                session.add(
+                    models.DatasetExampleRevision(
+                        id=revision_id,
+                        dataset_example_id=example_id,
+                        dataset_version_id=version_id,
+                        input={},
+                        output={},
+                        metadata_={},
+                        revision_kind=revision_kind,
+                    )
+                )
+            await session.flush()
+            expected_counts[str(GlobalID("Dataset", str(dataset_index)))] = dataset_index
+    return expected_counts
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #13688
Fixes #13567

## Problem

Listing ~6+ datasets with `exampleCount` on the Datasets page fails with a generic `"an unexpected error occurred"` GraphQL error.

`Dataset.example_count` opened its own database session per invocation, and Strawberry resolves connection nodes concurrently — so a list of N datasets produced N parallel session checkouts, exhausting SQLAlchemy's default async pool (`pool_size=5, max_overflow=10`). The same field queried per-dataset via `node(id:)` worked fine, confirming the failure was concurrency-related rather than data-related (see #13567 for the detailed repro).

## Fix

- Add `DatasetExampleCountsDataLoader`, keyed on `(dataset_id, version_id, split_ids)`. Keys are grouped by filter combination and each group is counted with a single grouped SQL query inside one session — the common Datasets-page case (no version, no splits) becomes exactly one query regardless of dataset count.
- Resolve `Dataset.example_count` through the loader, preserving existing semantics: latest-revision-per-example counting, `DELETE` exclusion, version cutoff, distinct-example counting under split filters, and a count of 0 when the requested version belongs to a different dataset.

## Testing

- New tests: bulk query over 12 datasets with varying counts and deleted examples, split-filtered count, and a cross-dataset version check (these paths previously had no bulk coverage).
- `tests/unit/server/api/types/test_Dataset.py` and `tests/unit/server/api/dataloaders` pass; `make typecheck-python` is clean.
- No GraphQL schema change.