### PR TITLE
docs(tutorials): level up trace-level evaluation cookbook (beyond input/output checks)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1187,6 +1187,7 @@
             "pages": [
               "docs/phoenix/cookbook/evaluation/openai-agents-sdk-cookbook",
               "docs/phoenix/cookbook/evaluation/evaluate-an-agent",
+              "docs/phoenix/cookbook/evaluation/trace-level-evaluation",
               "docs/phoenix/cookbook/evaluation/evaluate-rag",
               "docs/phoenix/cookbook/evaluation/code-readability-evaluation",
               "docs/phoenix/cookbook/evaluation/relevance-classification-evaluation",

--- a/docs/phoenix/cookbook/evaluation/trace-level-evaluation.mdx
+++ b/docs/phoenix/cookbook/evaluation/trace-level-evaluation.mdx
@@ -1,0 +1,299 @@
+---
+title: "Trace-level Evaluation: Beyond Input/Output Checks"
+description: Evaluate an agent's intermediate reasoning, tool selection, and decision path — not just its final answer.
+---
+
+<Card title="Google Colab" href="https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/evals/trace_level_evals.ipynb" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/gc.ico" horizontal>
+colab.research.google.com
+</Card>
+
+The most common way to evaluate an LLM application is **end-to-end**: take the user's request, take the final answer, and judge whether the answer is good. That works for a single model call. It breaks down for **agents**, because an agent isn't one call — it's a *sequence of decisions*: which tools to call, in what order, with what arguments, and how to reason over the results.
+
+End-to-end eval only inspects the two **endpoints** — the input and the final output. The interesting failures happen in the middle, where you can't see them:
+
+* **Reasoning** — did the agent reason coherently toward the goal, or get there by luck?
+* **Tool selection** — did it pick the right tools (and *skip* the wrong ones)?
+* **Decision path** — did it call those tools in a sensible order, with sensible arguments?
+
+A **correct-looking answer can come from a broken path** — the right result for the wrong reasons, which fails the next time the inputs shift. This cookbook shows how to capture the full trace, reconstruct the agent's intermediate signals from its spans, and evaluate those — using a movie recommendation agent as the worked example.
+
+This cookbook shows examples of:
+
+* Reconstructing an agent's **decision path** (`tool_path`) and **tool I/O** (`tool_io`) from its spans
+* Running an *endpoint* check (recommendation relevance) alongside two *intermediate* checks (decision path and reasoning/support)
+* Seeing each evaluator catch a distinct failure the endpoint check misses
+* Logging trace-level evaluations back to Phoenix
+
+## Notebook Walkthrough
+
+We will go through key code snippets on this page. To follow the full tutorial, check out the [full notebook](https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/evals/trace_level_evals.ipynb).
+
+After configuring tracing with `phoenix.otel.register(...)` and building a movie recommendation agent with three tools (`movie_selector_llm`, `reviewer_llm`, `preview_summarizer_llm`), run it against a handful of questions to generate traces, then pull the spans with `px_client.spans.get_spans_dataframe(...)` into `primary_df`. See the notebook for the full agent and tool definitions.
+
+## Separate the endpoints from the trace
+
+First pull the **endpoints** — the user's question and the agent's *final* answer. Take the final answer only, not a concatenation of every span's output: folding in tool outputs would blur the line between "what the user saw" and "what happened inside the trace."
+
+<Note>
+With the OpenAI Agents instrumentation, the root `AGENT` span doesn't record `input.value` / `output.value` — those attributes live on the underlying `LLM` spans, so we read the question and final reply from there with two small helpers. With an instrumentation that populates the root span, you could read `input.value` / `output.value` off the agent root directly.
+</Note>
+
+```python expandable
+import json
+
+
+def _as_list(value):
+    """Span attributes can arrive as a JSON string or an already-parsed list."""
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return []
+    return value if isinstance(value, list) else []
+
+
+def user_query(input_messages):
+    """The first user message in an LLM span's input."""
+    for message in _as_list(input_messages):
+        if message.get("message.role") == "user":
+            contents = message.get("message.contents") or []
+            return message.get("message.content") or "".join(
+                c.get("message_content.text", "") for c in contents
+            )
+    return None
+
+
+def assistant_text(output_messages):
+    """The assistant's text reply in an LLM span (empty on tool-calling turns)."""
+    texts = []
+    for message in _as_list(output_messages):
+        if message.get("message.role") == "assistant":
+            if message.get("message.content"):
+                texts.append(message["message.content"])
+            for c in message.get("message.contents") or []:
+                if c.get("message_content.type") == "text":
+                    texts.append(c.get("message_content.text", ""))
+    return " ".join(t for t in texts if t).strip() or None
+
+
+# agent_trace_ids = the trace ids whose root span has span_kind == "AGENT"
+# (filtering out the evaluators' own LLM traces). See the notebook.
+llm_spans = primary_df[
+    (primary_df["span_kind"] == "LLM") & (primary_df["context.trace_id"].isin(agent_trace_ids))
+].sort_values("start_time")
+
+# Endpoint input  = the user's question (first user message).
+# Endpoint output = the agent's FINAL answer only (its last text turn).
+trace_df = pd.DataFrame(
+    {
+        "input": llm_spans.groupby("context.trace_id")["attributes.llm.input_messages"].apply(
+            lambda s: next((q for q in s.map(user_query) if q), None)
+        ),
+        "output": llm_spans.groupby("context.trace_id")["attributes.llm.output_messages"].apply(
+            lambda s: next((a for a in reversed(list(s.map(assistant_text))) if a), None)
+        ),
+    }
+).dropna(subset=["input", "output"])
+```
+
+## Reconstruct the intermediate signals
+
+To evaluate the agent's *process*, reconstruct two signals the endpoints never show, both from the trace's `TOOL` spans (sorted by `start_time`):
+
+* **`tool_path`** — the ordered tool calls the agent made, *with their arguments*. This is the decision path: tool selection, order, and the arguments each tool was called with.
+* **`tool_io`** — what each tool was called *with* and what it *returned*, so an evaluator can check whether the final answer is grounded in real tool results.
+
+```python expandable
+tool_spans = primary_df[primary_df["span_kind"] == "TOOL"].sort_values("start_time")
+
+
+# tool_path: the ordered tool calls WITH their arguments (selection, order, args).
+def format_decision_path(group):
+    return " -> ".join(
+        f"{row['name']}({row['attributes.input.value']})" for _, row in group.iterrows()
+    )
+
+
+trace_df["tool_path"] = (
+    tool_spans.groupby("context.trace_id")[["name", "attributes.input.value"]]
+    .apply(format_decision_path)
+    .reindex(trace_df.index)
+    .fillna("No tools called")
+)
+
+
+# tool_io: each tool call's input AND output.
+def format_tool_calls(group):
+    lines = []
+    for i, (_, row) in enumerate(group.iterrows(), start=1):
+        lines.append(
+            f"{i}. {row['name']} | input: {row['attributes.input.value']} "
+            f"| output: {row['attributes.output.value']}"
+        )
+    return "\n".join(lines)
+
+
+trace_df["tool_io"] = (
+    tool_spans.groupby("context.trace_id")[["name", "attributes.input.value", "attributes.output.value"]]
+    .apply(format_tool_calls)
+    .reindex(trace_df.index)
+    .fillna("No tools called")
+)
+```
+
+## Define the three evaluators
+
+Each evaluator reads a different column and answers a different question:
+
+1. **Relevance** — an *endpoint* check on `input` + `output` (exactly what end-to-end eval does).
+2. **Decision path** — an *intermediate* check on `input` + `tool_path` (right tools, right order, *sensible arguments*?).
+3. **Reasoning / support** — an *intermediate* check on `input` + `tool_io` + `output` (is the answer grounded in the actual tool results, or does it invent facts no tool produced?).
+
+Each prompt is written to judge only its own concern:
+
+```python expandable
+RECOMMENDATION_RELEVANCE = """
+You are evaluating the relevance of movie recommendations provided by an LLM application.
+
+You will be given:
+1. The user input that initiated the trace
+2. The list of movie recommendations output by the system
+
+##
+User Input:
+{input}
+
+Recommendations:
+{output}
+##
+
+Respond with exactly one word: `correct` or `incorrect`.
+1. `correct` →
+- All recommended movies match the requested genre or criteria in the user input.
+- The recommendations are relevant to the user's request and are not repetitive.
+2. `incorrect` →
+- One or more recommendations do not match the requested genre or criteria, or the
+  recommendations are repetitive.
+"""
+
+DECISION_PATH = """
+You are evaluating an agent's DECISION PATH: the ordered tool calls it made to
+answer a request — which tools, in what order, and with what arguments. You are
+NOT judging the final answer text, and you are NOT judging whether each tool's
+output was correct — only whether the agent's choices were sensible.
+
+The agent has three tools available:
+- movie_selector_llm(genre): returns candidate movies. Must come FIRST, because the
+  other tools operate on the selected movies.
+- reviewer_llm(movies): reviews and sorts movies. Only meaningful AFTER selection,
+  and should be called with the movies that were actually selected.
+- preview_summarizer_llm(movie): summarizes a movie. Only meaningful AFTER selection.
+
+You will be given:
+1. The user input that initiated the trace
+2. The ordered tool calls the agent executed, with their arguments
+
+##
+User Input:
+{input}
+
+Decision Path (ordered tool calls with arguments):
+{tool_path}
+##
+
+Respond with exactly one word: `correct` or `incorrect`.
+1. `correct` →
+- movie_selector_llm is called before reviewer_llm or preview_summarizer_llm, AND
+- each tool is called with sensible arguments (e.g. reviewer_llm receives the
+  movies that were selected, not an empty or unrelated list).
+2. `incorrect` →
+- a tool that operates on movies (reviewer_llm / preview_summarizer_llm) runs
+  before any movies have been selected, the selection step is missing, OR a tool is
+  called with nonsensical arguments (empty/placeholder inputs, or movies that were
+  never selected).
+"""
+
+REASONING_SUPPORT = """
+You are checking whether an agent's FINAL ANSWER is SUPPORTED by the actual
+results its tools returned.
+
+You are NOT judging tool order (that's the decision-path check) or genre match
+(that's the relevance check). Judge ONLY whether every concrete claim in the final
+answer — titles, ratings, scores, review quotes, plot facts — is grounded in the
+tool outputs below. An answer that asserts a fact no tool produced (for example a
+specific rating) is unsupported, even if it sounds plausible.
+
+##
+User Input:
+{input}
+
+Tool calls and their results (in order):
+{tool_io}
+
+Final Answer:
+{output}
+##
+
+Respond with exactly one word: `correct` or `incorrect`.
+1. `correct` → every concrete claim in the final answer is supported by the tool
+   results above.
+2. `incorrect` → the final answer asserts at least one concrete fact (a rating,
+   score, review, or title) that does not appear in the tool results.
+"""
+```
+
+Wrap the run in `suppress_tracing()` so the judges' own LLM calls don't get traced into the same project, then log the results back onto each trace's root span:
+
+```python expandable
+from phoenix.trace import suppress_tracing
+from phoenix.evals import LLM, ClassificationEvaluator, async_evaluate_dataframe
+
+llm = LLM(provider="openai", model="gpt-4o-mini")
+
+relevance_evaluator = ClassificationEvaluator(
+    name="relevance", llm=llm, prompt_template=RECOMMENDATION_RELEVANCE,
+    choices={"correct": 1.0, "incorrect": 0.0},
+)
+path_evaluator = ClassificationEvaluator(
+    name="decision path", llm=llm, prompt_template=DECISION_PATH,
+    choices={"correct": 1.0, "incorrect": 0.0},
+)
+reasoning_evaluator = ClassificationEvaluator(
+    name="reasoning", llm=llm, prompt_template=REASONING_SUPPORT,
+    choices={"correct": 1.0, "incorrect": 0.0},
+)
+
+with suppress_tracing():
+    results_df = await async_evaluate_dataframe(
+        dataframe=trace_df,
+        evaluators=[relevance_evaluator, path_evaluator, reasoning_evaluator],
+    )
+```
+
+## Seeing what each evaluator catches
+
+On well-behaved traces the three evaluators agree. The point of trace-level evaluation is what happens when they *don't*. Running the three judges on controlled cases that mirror the real schema — each with a relevant-looking answer, so the endpoint check passes every time — shows each intermediate check catching a distinct failure:
+
+| case | relevance (endpoint) | decision path | reasoning / support |
+| :--- | :--- | :--- | :--- |
+| clean run | correct | correct | correct |
+| broken order (reviews before selecting) | correct | **incorrect** | correct |
+| unsupported claim (cites a rating no tool returned) | correct | correct | **incorrect** |
+
+Two intermediate failures, two different lenses — and both invisible to the endpoint check.
+
+After logging the evaluations, each trace's root span carries all three labels in Phoenix:
+
+<Frame>
+![Trace-level evaluations in Phoenix](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/trace_level_all_correct.png)
+</Frame>
+
+## Takeaway
+
+We ran three evaluators over the same traces, each asking a different question and reading a different signal:
+
+* **relevance** (endpoint) — *did the final answer look right?* Reads only `input` and `output`.
+* **decision path** (intermediate) — *did the agent pick the right tools, in the right order, with sensible arguments?* Reads `tool_path`.
+* **reasoning / support** (intermediate) — *is the answer grounded in what the tools returned?* Reads `tool_io`.
+
+The lesson: **a good-looking answer can hide a broken process, and only intermediate evals — reading signals reconstructed from spans — can see it.** The pattern generalizes: for any intermediate step you care about, reconstruct the relevant signal from spans into a column, write a judge that reads that column, and run it alongside your endpoint eval.

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -651,6 +651,7 @@
 - [Code Readability Evaluation](https://arize.com/docs/phoenix/cookbook/evaluation/code-readability-evaluation): >-
 - [More Cookbooks](https://arize.com/docs/phoenix/cookbook/evaluation/cookbooks): Use Phoenix Evals to evaluate your application for faithfulness, toxicity, relevance of retrieved documents
 - [Evaluate a Talk-to-Your-Data Agent](https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-an-agent): Evaluate a Talk-to-Your-Data Agent
+- [Trace-level Evaluation: Beyond Input/Output Checks](https://arize.com/docs/phoenix/cookbook/evaluation/trace-level-evaluation): Evaluate an agent's intermediate reasoning, tool selection, and decision path — not just its final answer.
 - [Evaluate RAG](https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-rag): Building a RAG pipeline and evaluating it with Phoenix Evals
 - [OpenAI Agents SDK Cookbook](https://arize.com/docs/phoenix/cookbook/evaluation/openai-agents-sdk-cookbook): This guide shows you how to create and evaluate agents with Phoenix to improve performance
 - [Relevance Classification Evaluation](https://arize.com/docs/phoenix/cookbook/evaluation/relevance-classification-evaluation): Evaluate the relevance of documents retrieved by RAG applications using Phoenix's evaluation framework

--- a/docs/phoenix/sitemap.xml
+++ b/docs/phoenix/sitemap.xml
@@ -1793,6 +1793,10 @@
     <lastmod>2026-01-27T22:36:31+00:00</lastmod>
   </url>
   <url>
+    <loc>https://arize.com/docs/phoenix/cookbook/evaluation/trace-level-evaluation</loc>
+    <lastmod>2026-06-11T04:55:25+00:00</lastmod>
+  </url>
+  <url>
     <loc>https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-rag</loc>
     <lastmod>2026-01-27T22:36:31+00:00</lastmod>
   </url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1793,6 +1793,10 @@
     <lastmod>2026-01-27T22:36:31+00:00</lastmod>
   </url>
   <url>
+    <loc>https://arize.com/docs/phoenix/cookbook/evaluation/trace-level-evaluation</loc>
+    <lastmod>2026-06-11T04:55:25+00:00</lastmod>
+  </url>
+  <url>
     <loc>https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-rag</loc>
     <lastmod>2026-01-27T22:36:31+00:00</lastmod>
   </url>

--- a/tutorials/evals/trace_level_evals.ipynb
+++ b/tutorials/evals/trace_level_evals.ipynb
@@ -34,9 +34,7 @@
    "metadata": {
     "id": "1c2c8e6f"
    },
-   "source": [
-    "# Trace-Level Evals for a Movie Recommendation Agent\n"
-   ]
+   "source": "# Trace-level evaluation: beyond input/output checks\n\n*Worked example: a movie recommendation agent.*"
   },
   {
    "cell_type": "markdown",
@@ -44,18 +42,7 @@
    "metadata": {
     "id": "a68d55ab"
    },
-   "source": [
-    "This notebook demonstrates how to run trace-level evaluations for a movie recommendation agent. By analyzing individual traces, each representing a single user request, you can gain insights into how well the system is performing on a per-interaction basis. Trace-level evaluations are particularly valuable for identifying successes and failures for end-to-end performance.\n",
-    "\n",
-    "In this notebook, you will:\n",
-    "\n",
-    "- Build and capture interactions (traces) from your movie recommendation agent\n",
-    "- Evaluate each trace across key dimensions such as Recommendation Relevance and Tool Usage\n",
-    "- Format the evaluation outputs to match Arize’s schema and log them to the platform\n",
-    "- Learn a robust pipeline for assessing trace-level performance\n",
-    "\n",
-    "✅ You will need a free [Phoenix Cloud account](https://app.arize.com/auth/phoenix/login) and an OpenAI API key to run this notebook.\n"
-   ]
+   "source": "## Why input/output checks aren't enough\n\nThe most common way to evaluate an LLM application is **end-to-end**: take the user's request, take the final answer, and judge whether the answer is good. That works for a single model call. It breaks down for **agents**, because an agent isn't one call — it's a *sequence of decisions*: which tools to call, in what order, with what arguments, and how to reason over the results.\n\nEnd-to-end eval only inspects the two **endpoints** — the input and the final output. The interesting failures happen in the middle, where you can't see them:\n\n- **Reasoning** — did the agent reason coherently toward the goal, or get there by luck?\n- **Tool selection** — did it pick the right tools (and *skip* the wrong ones)?\n- **Decision path** — did it call those tools in a sensible order, with sensible arguments?\n\nThe reason endpoints lie cuts both ways. A **correct-looking answer can come from a broken path** — the right result for the wrong reasons, which will fail the next time the inputs shift. And when an answer *is* wrong, the endpoints tell you *that* it's wrong but not *why* — the root cause is invisible unless you look inside the trace.\n\n**The method:** capture the full trace, reconstruct the agent's *decision path* from its spans, and evaluate the intermediate steps — not just `input → output`.\n\nWe'll demonstrate each idea on a movie recommendation agent. In this notebook, you will:\n\n- Build and capture interactions (traces) from a movie recommendation agent\n- Reconstruct the agent's **decision path** (the ordered tool calls and their arguments) from its spans\n- Run **three evaluators**: an *endpoint* check (recommendation relevance) plus two *intermediate* checks — decision path (tool selection, order, and arguments) and reasoning (is the answer grounded in the tools' results?)\n- See each evaluator catch a failure the endpoint check misses\n- Format the evaluation outputs to match Phoenix's schema and log them back to the platform\n\n✅ You will need a free [Phoenix Cloud account](https://app.arize.com/auth/phoenix/login) and an OpenAI API key to run this notebook."
   },
   {
    "cell_type": "markdown",
@@ -137,15 +124,7 @@
    "metadata": {
     "id": "7c81c9bb"
    },
-   "source": [
-    "First, we need to define the tools that our recommendation system will use. For this example, we will define 3 tools:\n",
-    "\n",
-    "1. Movie Selector: Based on the desired genre indicated by the user, choose up to 5 recent movies availabtle for streaming\n",
-    "2. Reviewer: Find reviews for a movie. If given a list of movies, sort movies in order of highest to lowest ratings.\n",
-    "3. Preview Summarizer: For each movie, return a 1-2 sentence description\n",
-    "\n",
-    "Our most ideal flow involves a user simply giving the system a type of movie they are looking for, and in return, the user gets a list of options returned with descriptions and reviews.\n"
-   ]
+   "source": "First, we need to define the tools that our recommendation system will use. For this example, we will define 3 tools:\n\n1. Movie Selector: Based on the desired genre indicated by the user, choose up to 5 recent movies available for streaming\n2. Reviewer: Find reviews for a movie. If given a list of movies, sort movies in order of highest to lowest ratings.\n3. Preview Summarizer: For each movie, return a 1-2 sentence description\n\nOur most ideal flow involves a user simply giving the system a type of movie they are looking for, and in return, the user gets a list of options returned with descriptions and reviews.\n\nEach tool call the agent makes is a **decision point** — and every one of them is recorded as a span in the trace. That sequence of spans *is* the decision path we'll reconstruct and evaluate later, the part end-to-end eval never sees."
   },
   {
    "cell_type": "markdown",
@@ -153,9 +132,7 @@
    "metadata": {
     "id": "c64844a7"
    },
-   "source": [
-    "Let's test our agent & view traces in Arize\n"
-   ]
+   "source": "Let's test our agent and view the traces in Phoenix."
   },
   {
    "cell_type": "code",
@@ -277,6 +254,8 @@
    },
    "outputs": [],
    "source": [
+    "import time\n",
+    "\n",
     "questions = [\n",
     "    \"Which Batman movie should I watch?\",\n",
     "    \"I want to watch a good romcom\",\n",
@@ -287,7 +266,12 @@
     "]\n",
     "\n",
     "for question in questions:\n",
-    "    result = await Runner.run(agent, question)"
+    "    result = await Runner.run(agent, question)\n",
+    "\n",
+    "# Spans are exported in the background, so force a flush (and give Phoenix a\n",
+    "# moment to ingest) before we query them in the next section.\n",
+    "tracer_provider.force_flush()\n",
+    "time.sleep(5)"
    ]
   },
   {
@@ -306,9 +290,7 @@
    "metadata": {
     "id": "0de0363e"
    },
-   "source": [
-    "Before running our evaluations, we first retrieve the span data from Arize. We then group the spans by trace and separate the input and output values.\n"
-   ]
+   "source": "Before running our evaluations, we retrieve the span data from Phoenix and assemble what each evaluator needs.\n\nWe start with the **endpoints** — the user's question (`input`) and the agent's *final answer* (`output`). We take the final answer **only**, not a concatenation of every span's output: folding in tool outputs would blur the line between \"what the user saw\" and \"what happened inside the trace,\" and quietly weaken the endpoint-vs-trace contrast this notebook is about.\n\n> **Why read the LLM spans instead of the root span?** With the OpenAI Agents instrumentation, the root `AGENT` span doesn't record `input.value` / `output.value` — those attributes live on the underlying `LLM` spans. So we read the user's question from the first LLM call and the agent's final reply from its last text turn, using OpenInference's standard `llm.input_messages` / `llm.output_messages` attributes. (With an instrumentation that *does* populate the root span — many do — you could read `input.value` / `output.value` off `agent_roots` directly.)\n\nThe endpoints are all that end-to-end eval ever sees. In the next step we reconstruct the intermediate signals it misses."
   },
   {
    "cell_type": "code",
@@ -333,23 +315,21 @@
     "id": "91b78eee"
    },
    "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "\n",
-    "trace_df = primary_df.groupby(\"context.trace_id\").agg(\n",
-    "    {\n",
-    "        \"attributes.input.value\": \"first\",\n",
-    "        \"attributes.output.value\": lambda x: \" \".join(x.dropna()),\n",
-    "    }\n",
-    ")\n",
-    "trace_df = trace_df.rename(\n",
-    "    columns={\n",
-    "        \"attributes.input.value\": \"input\",\n",
-    "        \"attributes.output.value\": \"output\",\n",
-    "    }\n",
-    ")\n",
-    "trace_df.head()"
-   ]
+   "source": "import json\n\nimport pandas as pd\n\n\ndef _as_list(value):\n    \"\"\"Span attributes can arrive as a JSON string or an already-parsed list.\"\"\"\n    if isinstance(value, str):\n        try:\n            return json.loads(value)\n        except json.JSONDecodeError:\n            return []\n    return value if isinstance(value, list) else []\n\n\ndef user_query(input_messages):\n    \"\"\"The first user message in an LLM span's input.\"\"\"\n    for message in _as_list(input_messages):\n        if message.get(\"message.role\") == \"user\":\n            contents = message.get(\"message.contents\") or []\n            return message.get(\"message.content\") or \"\".join(\n                c.get(\"message_content.text\", \"\") for c in contents\n            )\n    return None\n\n\ndef assistant_text(output_messages):\n    \"\"\"The assistant's text reply in an LLM span (empty on tool-calling turns).\"\"\"\n    texts = []\n    for message in _as_list(output_messages):\n        if message.get(\"message.role\") == \"assistant\":\n            if message.get(\"message.content\"):\n                texts.append(message[\"message.content\"])\n            for c in message.get(\"message.contents\") or []:\n                if c.get(\"message_content.type\") == \"text\":\n                    texts.append(c.get(\"message_content.text\", \"\"))\n    return \" \".join(t for t in texts if t).strip() or None\n\n\n# Restrict to the agent's own traces: each has a root span (no parent) of kind\n# AGENT. This keeps the evaluators' own LLM calls — which are also traced into\n# this project once you run the cells below — out of our evaluation set.\nagent_roots = primary_df[(primary_df[\"parent_id\"].isna()) & (primary_df[\"span_kind\"] == \"AGENT\")]\nagent_trace_ids = agent_roots[\"context.trace_id\"].unique()\n\nllm_spans = primary_df[\n    (primary_df[\"span_kind\"] == \"LLM\") & (primary_df[\"context.trace_id\"].isin(agent_trace_ids))\n].sort_values(\"start_time\")\n\n# Endpoint input  = the user's question (first user message in the trace).\n# Endpoint output = the agent's FINAL answer only (its last text turn) — NOT a\n# concatenation of every span's output, which would leak intermediate tool results\n# into what is supposed to represent \"what the user saw.\"\ntrace_df = pd.DataFrame(\n    {\n        \"input\": llm_spans.groupby(\"context.trace_id\")[\"attributes.llm.input_messages\"].apply(\n            lambda s: next((q for q in s.map(user_query) if q), None)\n        ),\n        \"output\": llm_spans.groupby(\"context.trace_id\")[\"attributes.llm.output_messages\"].apply(\n            lambda s: next((a for a in reversed(list(s.map(assistant_text))) if a), None)\n        ),\n    }\n)\n# Drop traces where we couldn't recover both endpoints, so no evaluator runs on a\n# null input or output.\ntrace_df = trace_df.dropna(subset=[\"input\", \"output\"])\ntrace_df.head()"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af3437e5",
+   "metadata": {},
+   "source": "## Reconstruct the intermediate signals\n\nThe `output` above is an endpoint — the agent's final answer. To evaluate the agent's *process*, we reconstruct two intermediate signals the endpoints never show, both from the trace's spans (`span_kind == \"TOOL\"`, sorted by `start_time`):\n\n- **`tool_path`** — the ordered tool calls the agent made, *with their arguments*. This is the decision path: tool selection, order, and the arguments each tool was called with.\n- **`tool_io`** — what each tool was called *with* and what it *returned*. This is what lets us check whether the final answer is genuinely grounded in real tool results, rather than plausibly invented.\n\nThese two columns are exactly the signal end-to-end eval throws away."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84dab68d",
+   "metadata": {},
+   "outputs": [],
+   "source": "tool_spans = primary_df[primary_df[\"span_kind\"] == \"TOOL\"].sort_values(\"start_time\")\n\n\n# tool_path: the ordered tool calls WITH their arguments — the decision path,\n# capturing tool selection, order, AND what each tool was asked to do.\ndef format_decision_path(group):\n    return \" -> \".join(\n        f\"{row['name']}({row['attributes.input.value']})\" for _, row in group.iterrows()\n    )\n\n\ntrace_df[\"tool_path\"] = (\n    tool_spans.groupby(\"context.trace_id\")[[\"name\", \"attributes.input.value\"]]\n    .apply(format_decision_path)\n    .reindex(trace_df.index)\n    .fillna(\"No tools called\")\n)\n\n\n# tool_io: each tool call's input AND output, so an evaluator can check whether the\n# final answer is grounded in what the tools actually returned.\ndef format_tool_calls(group):\n    lines = []\n    for i, (_, row) in enumerate(group.iterrows(), start=1):\n        lines.append(\n            f\"{i}. {row['name']} | input: {row['attributes.input.value']} \"\n            f\"| output: {row['attributes.output.value']}\"\n        )\n    return \"\\n\".join(lines)\n\n\ntrace_df[\"tool_io\"] = (\n    tool_spans.groupby(\"context.trace_id\")[\n        [\"name\", \"attributes.input.value\", \"attributes.output.value\"]\n    ]\n    .apply(format_tool_calls)\n    .reindex(trace_df.index)\n    .fillna(\"No tools called\")\n)\ntrace_df[[\"input\", \"tool_path\", \"tool_io\"]].head()"
   },
   {
    "cell_type": "markdown",
@@ -367,9 +347,7 @@
    "metadata": {
     "id": "a426e4ca"
    },
-   "source": [
-    "In this tutorial, we will evaluate two aspects: tool usage and relevance. You can add any additional evaluation templates you like. We will then run the evaluations using an LLM as the judge.\n"
-   ]
+   "source": "We'll now run **three evaluators** — one endpoint check and two intermediate checks, each reading a different column:\n\n1. **Recommendation relevance — an *endpoint* check.** Reads `input` and the final `output` and asks whether the recommendations match the request. This is exactly what end-to-end eval does.\n2. **Decision path — an *intermediate* check.** Reads `input` and `tool_path` (the ordered tool calls *with their arguments*) and asks whether the agent selected the right tools, in a sensible order, with sensible arguments. It never looks at the final output — it judges *how* the agent got there.\n3. **Reasoning / support — an *intermediate* check.** Reads `input`, `tool_io`, and `output`, and asks whether the final answer is actually *grounded in the tool results* — catching answers that assert facts (a rating, a review, a title) that no tool produced.\n\nThe contrast is the point of this notebook: a trace can **pass the endpoint check and still fail an intermediate one** — a good-looking answer reached through a broken tool order, or one that invents a fact the tools never returned. All three run as LLM-as-a-judge classifiers."
   },
   {
    "cell_type": "code",
@@ -379,29 +357,7 @@
     "id": "d0f1768d"
    },
    "outputs": [],
-   "source": [
-    "TOOL_CALLING_ORDER = \"\"\"\n",
-    "You are evaluating the correctness of the tool calling order in an LLM application's trace.\n",
-    "\n",
-    "You will be given:\n",
-    "1. The user input that initiated the trace\n",
-    "2. The full trace output, including the sequence of tool calls made by the agent\n",
-    "\n",
-    "##\n",
-    "User Input:\n",
-    "{input}\n",
-    "\n",
-    "Trace Output:\n",
-    "{output}\n",
-    "##\n",
-    "\n",
-    "Respond with exactly one word: `correct` or `incorrect`.\n",
-    "1. `correct` →\n",
-    "- The tool calls occur in the appropriate order to fulfill the user's request logically and effectively.\n",
-    "- A proper answer involves calls to reviews, summaries, and recommendations where relevant.\n",
-    "2. `incorrect` → The tool calls are out of order, missing, or do not follow a coherent sequence for the given input.\n",
-    "\"\"\""
-   ]
+   "source": "DECISION_PATH = \"\"\"\nYou are evaluating an agent's DECISION PATH: the ordered tool calls it made to\nanswer a request — which tools, in what order, and with what arguments. You are\nNOT judging the final answer text, and you are NOT judging whether each tool's\noutput was correct — only whether the agent's choices were sensible.\n\nThe agent has three tools available:\n- movie_selector_llm(genre): returns candidate movies. Must come FIRST, because the\n  other tools operate on the selected movies.\n- reviewer_llm(movies): reviews and sorts movies. Only meaningful AFTER selection,\n  and should be called with the movies that were actually selected.\n- preview_summarizer_llm(movie): summarizes a movie. Only meaningful AFTER selection.\n\nYou will be given:\n1. The user input that initiated the trace\n2. The ordered tool calls the agent executed, with their arguments\n\n##\nUser Input:\n{input}\n\nDecision Path (ordered tool calls with arguments):\n{tool_path}\n##\n\nRespond with exactly one word: `correct` or `incorrect`.\n1. `correct` →\n- movie_selector_llm is called before reviewer_llm or preview_summarizer_llm, AND\n- each tool is called with sensible arguments (e.g. reviewer_llm receives the\n  movies that were selected, not an empty or unrelated list).\n2. `incorrect` →\n- a tool that operates on movies (reviewer_llm / preview_summarizer_llm) runs\n  before any movies have been selected, the selection step is missing, OR a tool is\n  called with nonsensical arguments (empty/placeholder inputs, or movies that were\n  never selected).\n\"\"\""
   },
   {
    "cell_type": "code",
@@ -411,27 +367,41 @@
     "id": "131a5e7f"
    },
    "outputs": [],
+   "source": "RECOMMENDATION_RELEVANCE = \"\"\"\nYou are evaluating the relevance of movie recommendations provided by an LLM application.\n\nYou will be given:\n1. The user input that initiated the trace\n2. The list of movie recommendations output by the system\n\n##\nUser Input:\n{input}\n\nRecommendations:\n{output}\n##\n\nRespond with exactly one word: `correct` or `incorrect`.\n1. `correct` →\n- All recommended movies match the requested genre or criteria in the user input.\n- The recommendations are relevant to the user's request and are not repetitive.\n2. `incorrect` →\n- One or more recommendations do not match the requested genre or criteria, or the\n  recommendations are repetitive.\n\"\"\""
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "378137d9",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "RECOMMENDATION_RELEVANCE = \"\"\"\n",
-    "You are evaluating the relevance of movie recommendations provided by an LLM application.\n",
+    "REASONING_SUPPORT = \"\"\"\n",
+    "You are checking whether an agent's FINAL ANSWER is SUPPORTED by the actual\n",
+    "results its tools returned.\n",
     "\n",
-    "You will be given:\n",
-    "1. The user input that initiated the trace\n",
-    "2. The list of movie recommendations output by the system\n",
+    "You are NOT judging tool order (that's the decision-path check) or genre match\n",
+    "(that's the relevance check). Judge ONLY whether every concrete claim in the final\n",
+    "answer — titles, ratings, scores, review quotes, plot facts — is grounded in the\n",
+    "tool outputs below. An answer that asserts a fact no tool produced (for example a\n",
+    "specific rating) is unsupported, even if it sounds plausible.\n",
     "\n",
     "##\n",
     "User Input:\n",
     "{input}\n",
     "\n",
-    "Recommendations:\n",
+    "Tool calls and their results (in order):\n",
+    "{tool_io}\n",
+    "\n",
+    "Final Answer:\n",
     "{output}\n",
     "##\n",
     "\n",
     "Respond with exactly one word: `correct` or `incorrect`.\n",
-    "1. `correct` →\n",
-    "- All recommended movies match the requested genre or criteria in the user input.\n",
-    "- The recommendations should be relevant to the user's request and shouldn't be repetitive.\n",
-    "- `incorrect` → one or more recommendations do not match the requested genre or criteria.\n",
+    "1. `correct` → every concrete claim in the final answer is supported by the tool\n",
+    "   results above.\n",
+    "2. `incorrect` → the final answer asserts at least one concrete fact (a rating,\n",
+    "   score, review, or title) that does not appear in the tool results.\n",
     "\"\"\""
    ]
   },
@@ -446,16 +416,12 @@
    "source": [
     "from phoenix.evals import LLM, ClassificationEvaluator, async_evaluate_dataframe\n",
     "\n",
+    "from phoenix.trace import suppress_tracing\n",
+    "\n",
     "llm = LLM(provider=\"openai\", model=\"gpt-4o-mini\")\n",
     "\n",
     "\n",
-    "tone_evaluator = ClassificationEvaluator(\n",
-    "    name=\"tool calling\",\n",
-    "    llm=llm,\n",
-    "    prompt_template=TOOL_CALLING_ORDER,\n",
-    "    choices={\"correct\": 1.0, \"incorrect\": 0.0},\n",
-    ")\n",
-    "\n",
+    "# Endpoint check: input -> final answer only (what end-to-end eval sees).\n",
     "relevance_evaluator = ClassificationEvaluator(\n",
     "    name=\"relevance\",\n",
     "    llm=llm,\n",
@@ -463,13 +429,47 @@
     "    choices={\"correct\": 1.0, \"incorrect\": 0.0},\n",
     ")\n",
     "\n",
-    "\n",
-    "results_df = await async_evaluate_dataframe(\n",
-    "    dataframe=trace_df,\n",
-    "    evaluators=[tone_evaluator, relevance_evaluator],\n",
+    "# Intermediate check: did the agent pick the right tools in the right order?\n",
+    "path_evaluator = ClassificationEvaluator(\n",
+    "    name=\"decision path\",\n",
+    "    llm=llm,\n",
+    "    prompt_template=DECISION_PATH,\n",
+    "    choices={\"correct\": 1.0, \"incorrect\": 0.0},\n",
     ")\n",
+    "\n",
+    "# Intermediate check: is the final answer actually grounded in the tool results?\n",
+    "reasoning_evaluator = ClassificationEvaluator(\n",
+    "    name=\"reasoning\",\n",
+    "    llm=llm,\n",
+    "    prompt_template=REASONING_SUPPORT,\n",
+    "    choices={\"correct\": 1.0, \"incorrect\": 0.0},\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# The judges are themselves LLM calls, which auto-instrumentation would trace into\n",
+    "# this same project. suppress_tracing keeps those evaluator spans out, so the\n",
+    "# project stays just the agent's traces.\n",
+    "with suppress_tracing():\n",
+    "    results_df = await async_evaluate_dataframe(\n",
+    "        dataframe=trace_df,\n",
+    "        evaluators=[relevance_evaluator, path_evaluator, reasoning_evaluator],\n",
+    "    )\n",
     "results_df.head()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48ca3f0b",
+   "metadata": {},
+   "source": "## Seeing what each evaluator catches\n\nOn well-behaved traces the three evaluators agree. The point of trace-level evaluation is what happens when they *don't*. Below we run the three judges on three controlled cases that **mirror the real trace schema** (`input`, `output`, `tool_path`, `tool_io`) — each with a relevant-looking answer, so the **endpoint (relevance) check passes every time**:\n\n- **Clean run** — selects, reviews, summarizes; the answer matches the tool results. Everything passes.\n- **Broken order** — reviews a movie before any movie has been selected. The **decision path** check catches it; relevance and support cannot.\n- **Unsupported claim** — good tool order, but the answer cites a *\"9.2/10\"* rating that appears in no tool output. The **reasoning / support** check catches it; relevance and decision path cannot.\n\nTwo intermediate failures, two different lenses — and both invisible to the endpoint check."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3aacaf4",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Controlled cases that mirror the real trace schema (input, output, tool_path,\n# tool_io). Each answer looks relevant, so the endpoint check passes — the\n# failures live in the intermediate signals. tool_path shows the calls + arguments;\n# tool_io adds the results. Each transcript matches its path, broken-order included.\nclean_path = (\n    'movie_selector_llm({\"genre\":\"comedy\"}) -> '\n    'reviewer_llm({\"movies\":[\"The Grand Budapest Hotel\",\"Superbad\"]}) -> '\n    'preview_summarizer_llm({\"movie\":\"Superbad\"})'\n)\nclean_io = (\n    '1. movie_selector_llm | input: {\"genre\":\"comedy\"} | output: [\"The Grand Budapest Hotel\", \"Superbad\"]\\n'\n    '2. reviewer_llm | input: {\"movies\":[\"The Grand Budapest Hotel\",\"Superbad\"]} | output: The Grand Budapest Hotel — witty and stylish; Superbad — raunchy coming-of-age comedy.\\n'\n    '3. preview_summarizer_llm | input: {\"movie\":\"Superbad\"} | output: Two friends navigate one wild night before graduation.'\n)\nbroken_order_path = 'reviewer_llm({\"movies\":[]}) -> movie_selector_llm({\"genre\":\"comedy\"})'\nbroken_order_io = (\n    '1. reviewer_llm | input: {\"movies\":[]} | output: No movies were provided to review.\\n'\n    '2. movie_selector_llm | input: {\"genre\":\"comedy\"} | output: [\"The Grand Budapest Hotel\", \"Superbad\"]'\n)\nunsupported_path = (\n    'movie_selector_llm({\"genre\":\"comedy\"}) -> '\n    'reviewer_llm({\"movies\":[\"Superbad\"]}) -> '\n    'preview_summarizer_llm({\"movie\":\"Superbad\"})'\n)\nno_rating_io = (\n    '1. movie_selector_llm | input: {\"genre\":\"comedy\"} | output: [\"The Grand Budapest Hotel\", \"Superbad\"]\\n'\n    '2. reviewer_llm | input: {\"movies\":[\"Superbad\"]} | output: Superbad — a funny, heartfelt coming-of-age comedy.\\n'\n    '3. preview_summarizer_llm | input: {\"movie\":\"Superbad\"} | output: Two friends navigate one wild night.'\n)\n\ndemo_df = pd.DataFrame(\n    {\n        \"case\": [\"clean run\", \"broken order\", \"unsupported claim\"],\n        \"input\": [\"Which comedy movie should I watch?\"] * 3,\n        \"output\": [\n            \"Two great comedy picks: 'The Grand Budapest Hotel' and 'Superbad'.\",\n            \"Two great comedy picks: 'The Grand Budapest Hotel' and 'Superbad'.\",\n            \"Watch 'Superbad' — critics rated it 9.2/10.\",  # no tool produced this rating\n        ],\n        \"tool_path\": [clean_path, broken_order_path, unsupported_path],\n        \"tool_io\": [clean_io, broken_order_io, no_rating_io],\n    }\n)\n\nwith suppress_tracing():\n    demo_results = await async_evaluate_dataframe(\n        dataframe=demo_df,\n        evaluators=[relevance_evaluator, path_evaluator, reasoning_evaluator],\n    )\n\n\ndef label_of(score):\n    \"\"\"Pull the classification label out of a Phoenix score cell.\"\"\"\n    if isinstance(score, str):\n        score = json.loads(score)\n    if isinstance(score, dict):\n        return score.get(\"label\")\n    return getattr(score, \"label\", None)\n\n\npd.DataFrame(\n    {\n        \"case\": demo_df[\"case\"],\n        \"relevance\": demo_results[\"relevance_score\"].apply(label_of),\n        \"decision path\": demo_results[\"decision path_score\"].apply(label_of),\n        \"reasoning\": demo_results[\"reasoning_score\"].apply(label_of),\n    }\n)"
   },
   {
    "cell_type": "markdown",
@@ -487,9 +487,7 @@
    "metadata": {
     "id": "afd4401d"
    },
-   "source": [
-    "The final step is to log our results back to Arize. After running the cell below, you’ll be able to view your trace-level evaluations on the platform, complete with relevant labels, scores, and explanations.\n"
-   ]
+   "source": "The final step is to log our results back to Phoenix. After running the cell below, you'll be able to view your trace-level evaluations on the platform, complete with relevant labels, scores, and explanations."
   },
   {
    "cell_type": "code",
@@ -502,11 +500,12 @@
    "source": [
     "from phoenix.evals.utils import to_annotation_dataframe\n",
     "\n",
-    "root_spans = primary_df[primary_df[\"parent_id\"].isna()][[\"context.trace_id\", \"context.span_id\"]]\n",
+    "# Map each trace to its root (AGENT) span so the evals attach to the root span.\n",
+    "root_spans = agent_roots[[\"context.trace_id\", \"context.span_id\"]]\n",
     "\n",
     "# Merge results with root spans to align on trace_id\n",
     "results_with_spans = pd.merge(\n",
-    "    results_df.reset_index(), root_spans, on=\"context.trace_id\", how=\"left\"\n",
+    "    results_df.reset_index(), root_spans, on=\"context.trace_id\", how=\"inner\"\n",
     ").set_index(\"context.span_id\", drop=False)\n",
     "\n",
     "# Format for Phoenix logging\n",
@@ -524,9 +523,13 @@
    "metadata": {
     "id": "xVG-DsKlWb6c"
    },
-   "source": [
-    "![Results](https://storage.googleapis.com/arize-phoenix-assets/assets/images/trace_level_evals_phoenix.png)\n"
-   ]
+   "source": "The three trace-level evaluations — `relevance`, `decision path`, and `reasoning` — logged back onto a real agent trace in Phoenix, each with the judge's label, score, and explanation. Here all three pass (and the `decision path` explanation confirms the agent selected, then reviewed, then summarized — in the right order); the controlled cases above show what it looks like when an intermediate check fails.\n\n![Results](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/trace_level_all_correct.png)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94f543b4",
+   "metadata": {},
+   "source": "## Takeaway\n\nWe ran three evaluators over the same traces, each asking a different question and reading a different signal:\n\n- **relevance** (endpoint) — *did the final answer look right?* Reads only `input` and `output` — exactly what end-to-end eval sees.\n- **decision path** (intermediate) — *did the agent pick the right tools, in the right order, with sensible arguments?* Reads `tool_path`.\n- **reasoning / support** (intermediate) — *is the final answer actually grounded in what the tools returned?* Reads `tool_io`.\n\nThe controlled cases show why all three matter: every answer looked relevant, yet the decision-path check caught a broken tool order and the support check caught a fabricated rating — two *different* failures, both invisible at the endpoints. That's the core lesson: **a good-looking answer can hide a broken process, and only intermediate evals — reading signals reconstructed from spans — can see it.**\n\nThe pattern generalizes. For any intermediate step you care about, reconstruct the relevant signal from spans into a column (`tool_path`, `tool_io`, retrieved context, a sub-agent's handoff, …), write a judge that reads that column, and run it alongside your endpoint eval."
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
Level-up of the trace-level evals cookbook into a concept-first cookbook — **Trace-level evaluation: beyond input/output checks** (DEV-354) — and ships it as a docs-site cookbook page. Keeps the movie-recommendation worked example. PX only.

## Notebook (`tutorials/evals/trace_level_evals.ipynb`)
- **Leads with the concept:** why end-to-end (input/output) eval misses agent failures.
- **Separates endpoint from trace:** clean endpoints (user question + final answer) vs. intermediate signals reconstructed from spans — `tool_path` (decision path, *including tool arguments*) and `tool_io` (per-tool inputs/outputs).
- **Three evaluators:** `relevance` (endpoint), `decision path` (tool selection, order, **and argument sensibility**), `reasoning` (is the answer grounded in actual tool results?).
- **Controlled demo** where each intermediate eval catches a distinct failure the endpoint check misses; evaluator tracing suppressed; eval results logged back onto agent root spans.

## Docs
- New cookbook page `docs/phoenix/cookbook/evaluation/trace-level-evaluation.mdx` + `docs.json` nav entry (Evaluation group).
- Regenerated `sitemap.xml` / `docs/phoenix/sitemap.xml` and added the `llms.txt` entry.

## Verification
Runs end-to-end against Phoenix (local + Cloud); demo diagonal stable; lint/format pass; docs render via `mint dev` with no broken links.