### PR TITLE
fix(client): match experiment runs to examples with custom example ids

### DIFF
--- a/js/.changeset/phoenix-client-evaluate-custom-example-ids.md
+++ b/js/.changeset/phoenix-client-evaluate-custom-example-ids.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+Fix `evaluateExperiment` failing to match experiment runs to dataset examples when the dataset was uploaded with custom example ids. Runs now consistently identify examples by node GlobalID in `datasetExampleId` — previously runs created in-process recorded the custom example id while runs fetched from the server recorded the GlobalID — and the evaluation example lookup is keyed by the GlobalID to match. Run recording also falls back to the example `id` field on servers that predate node ids (where that field carries the GlobalID), instead of posting an empty `dataset_example_id`.

--- a/js/packages/phoenix-client/src/experiments/helpers/getExampleGlobalId.ts
+++ b/js/packages/phoenix-client/src/experiments/helpers/getExampleGlobalId.ts
@@ -1,0 +1,12 @@
+import type { ExampleWithId } from "../../types/datasets";
+
+/**
+ * The example's node GlobalID, which experiment runs record as their
+ * `dataset_example_id`. Servers that predate the `nodeId` field deliver the
+ * GlobalID in the `id` field instead.
+ */
+export function getExampleGlobalId(
+  example: Pick<ExampleWithId, "id"> & Partial<Pick<ExampleWithId, "nodeId">>
+): string {
+  return example.nodeId ?? example.id;
+}

--- a/js/packages/phoenix-client/src/experiments/resumeEvaluation.ts
+++ b/js/packages/phoenix-client/src/experiments/resumeEvaluation.ts
@@ -29,6 +29,7 @@ import { ensureString } from "../utils/ensureString";
 import { toObjectHeaders } from "../utils/toObjectHeaders";
 import { getExperimentInfo } from "./getExperimentInfo.js";
 import { getExperimentEvaluators } from "./helpers";
+import { getExampleGlobalId } from "./helpers/getExampleGlobalId";
 import { logEvalResumeSummary, PROGRESS_PREFIX } from "./logging";
 import { cleanupOwnedTracerProvider } from "./tracing";
 
@@ -729,7 +730,7 @@ async function runSingleEvaluation({
         ...objectAsAttributes({
           experiment_id: experimentId,
           experiment_run_id: experimentRun.id,
-          dataset_example_id: datasetExample.nodeId,
+          dataset_example_id: getExampleGlobalId(datasetExample),
         }),
       });
 

--- a/js/packages/phoenix-client/src/experiments/resumeExperiment.ts
+++ b/js/packages/phoenix-client/src/experiments/resumeExperiment.ts
@@ -28,6 +28,7 @@ import { isHttpErrorWithStatus } from "../utils/isHttpError";
 import { toObjectHeaders } from "../utils/toObjectHeaders";
 import { getDatasetExperimentsUrl, getExperimentUrl } from "../utils/urlUtils";
 import { getExperimentInfo } from "./getExperimentInfo.js";
+import { getExampleGlobalId } from "./helpers/getExampleGlobalId";
 import {
   logExperimentResumeSummary,
   logLinks,
@@ -619,7 +620,7 @@ async function recordTaskResult({
         },
       },
       body: {
-        dataset_example_id: example.nodeId,
+        dataset_example_id: getExampleGlobalId(example),
         repetition_number: repetitionNumber,
         output: output as Record<string, unknown>,
         start_time: startTime.toISOString(),
@@ -695,7 +696,7 @@ async function runSingleTask({
         [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
         ...objectAsAttributes({
           experiment_id: experimentId,
-          dataset_example_id: example.nodeId,
+          dataset_example_id: getExampleGlobalId(example),
           repetition_number: repetitionNumber,
         }),
       });

--- a/js/packages/phoenix-client/src/experiments/runExperiment.ts
+++ b/js/packages/phoenix-client/src/experiments/runExperiment.ts
@@ -47,6 +47,7 @@ import {
 } from "../utils/urlUtils";
 import { getExperimentInfo } from "./getExperimentInfo";
 import { getExperimentEvaluators } from "./helpers";
+import { getExampleGlobalId } from "./helpers/getExampleGlobalId";
 import {
   logEvalSummary,
   logLinks,
@@ -485,7 +486,7 @@ function runTaskWithExamples({
         id: localId(), // initialized with local id, will be replaced with server-assigned id when dry run is false
         traceId,
         experimentId,
-        datasetExampleId: example.id,
+        datasetExampleId: getExampleGlobalId(example),
         startTime: new Date(),
         endTime: new Date(), // will get replaced with actual end time
         output: null,
@@ -509,7 +510,7 @@ function runTaskWithExamples({
             },
           },
           body: {
-            dataset_example_id: example.nodeId,
+            dataset_example_id: getExampleGlobalId(example),
             output: thisRun.output,
             repetition_number: repetitionNumber,
             start_time: thisRun.startTime.toISOString(),
@@ -681,9 +682,11 @@ export async function evaluateExperiment({
     type EvaluationId = string;
     const evaluationRuns: Record<EvaluationId, ExperimentEvaluationRun> = {};
 
+    // Index examples by node GlobalID, matching how runs record
+    // datasetExampleId.
     const examplesById: Record<string, Example> = {};
     for (const example of dataset.examples) {
-      examplesById[example.id] = example;
+      examplesById[getExampleGlobalId(example)] = example;
     }
 
     const onEvaluationComplete = (run: ExperimentEvaluationRun) => {

--- a/js/packages/phoenix-client/test/experiments/evaluateExperiment.test.ts
+++ b/js/packages/phoenix-client/test/experiments/evaluateExperiment.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as getDatasetModule from "../../src/datasets/getDataset";
+import { asExperimentEvaluator } from "../../src/experiments/helpers/asExperimentEvaluator";
+import { evaluateExperiment } from "../../src/experiments/runExperiment";
+import type {
+  EvaluatorParams,
+  RanExperiment,
+} from "../../src/types/experiments";
+
+// A dataset uploaded with custom example ids: "id" carries the custom id
+// while "nodeId" carries the server-generated node GlobalID.
+const mockDataset = {
+  id: "dataset-1",
+  name: "mock-dataset",
+  description: "A mock dataset",
+  versionId: "v1",
+  metadata: {},
+  examples: [
+    {
+      id: "custom-1",
+      nodeId: "RGF0YXNldEV4YW1wbGU6MQ==",
+      input: { name: "Alice" },
+      output: { text: "Hello, Alice!" },
+      metadata: {},
+      updatedAt: new Date(),
+    },
+    {
+      id: "custom-2",
+      nodeId: "RGF0YXNldEV4YW1wbGU6Mg==",
+      input: { name: "Bob" },
+      output: { text: "Hello, Bob!" },
+      metadata: {},
+      updatedAt: new Date(),
+    },
+  ],
+};
+
+function makeRanExperiment(
+  runs: Record<string, { id: string; datasetExampleId: string }>
+): RanExperiment {
+  return {
+    id: "experiment-1",
+    datasetId: mockDataset.id,
+    datasetVersionId: mockDataset.versionId,
+    repetitions: 1,
+    metadata: {},
+    projectName: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    exampleCount: Object.keys(runs).length,
+    successfulRunCount: Object.keys(runs).length,
+    failedRunCount: 0,
+    missingRunCount: 0,
+    runs: Object.fromEntries(
+      Object.entries(runs).map(([runId, run]) => [
+        runId,
+        {
+          ...run,
+          experimentId: "experiment-1",
+          startTime: new Date(),
+          endTime: new Date(),
+          output: "Hello!",
+          error: null,
+          traceId: null,
+        },
+      ])
+    ),
+  };
+}
+
+describe("evaluateExperiment (dryRun)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(getDatasetModule, "getDataset").mockResolvedValue(mockDataset);
+  });
+
+  it("matches runs that reference examples by node GlobalID", async () => {
+    // Runs fetched from the server identify examples by node GlobalID,
+    // not by the custom example id.
+    const experiment = makeRanExperiment({
+      "run-1": { id: "run-1", datasetExampleId: "RGF0YXNldEV4YW1wbGU6MQ==" },
+      "run-2": { id: "run-2", datasetExampleId: "RGF0YXNldEV4YW1wbGU6Mg==" },
+    });
+    const evaluateFn = vi.fn(async ({ input }: EvaluatorParams) => ({
+      label: "ok",
+      score: 1,
+      explanation: `input name was ${(input as { name?: string }).name}`,
+      metadata: {},
+    }));
+    const evaluator = asExperimentEvaluator({
+      name: "dummy",
+      kind: "CODE",
+      evaluate: evaluateFn,
+    });
+
+    const result = await evaluateExperiment({
+      experiment,
+      evaluators: [evaluator],
+      dryRun: true,
+    });
+
+    expect(result.evaluationRuns).toHaveLength(2);
+    expect(result.evaluationRuns?.every((run) => run.error === null)).toBe(
+      true
+    );
+    const evaluatedNames = evaluateFn.mock.calls
+      .map((call) => (call[0].input as { name?: string }).name)
+      .sort();
+    expect(evaluatedNames).toEqual(["Alice", "Bob"]);
+  });
+
+  it("matches runs against servers that predate node ids", async () => {
+    // Older servers omit nodeId from the examples response and deliver the
+    // GlobalID in the id field; runs recorded against them carry that value.
+    const legacyDataset = {
+      ...mockDataset,
+      examples: mockDataset.examples.map(({ nodeId: _nodeId, ...example }) => ({
+        ...example,
+        id: _nodeId,
+      })),
+    };
+    vi.spyOn(getDatasetModule, "getDataset").mockResolvedValue(legacyDataset);
+    const experiment = makeRanExperiment({
+      "run-1": { id: "run-1", datasetExampleId: "RGF0YXNldEV4YW1wbGU6MQ==" },
+      "run-2": { id: "run-2", datasetExampleId: "RGF0YXNldEV4YW1wbGU6Mg==" },
+    });
+    const evaluator = asExperimentEvaluator({
+      name: "dummy",
+      kind: "CODE",
+      evaluate: async () => ({
+        label: "ok",
+        score: 1,
+        explanation: "",
+        metadata: {},
+      }),
+    });
+
+    const result = await evaluateExperiment({
+      experiment,
+      evaluators: [evaluator],
+      dryRun: true,
+    });
+
+    expect(result.evaluationRuns).toHaveLength(2);
+    expect(result.evaluationRuns?.every((run) => run.error === null)).toBe(
+      true
+    );
+  });
+});

--- a/js/packages/phoenix-client/test/experiments/runExperiment.test.ts
+++ b/js/packages/phoenix-client/test/experiments/runExperiment.test.ts
@@ -34,6 +34,30 @@ const mockDataset = {
   ],
 };
 
+// A dataset uploaded with custom example ids: "id" carries the custom id
+// while "nodeId" carries the server-generated node GlobalID.
+const mockCustomIdDataset = {
+  ...mockDataset,
+  examples: [
+    {
+      id: "custom-1",
+      nodeId: "RGF0YXNldEV4YW1wbGU6MQ==",
+      input: { name: "Alice" },
+      output: { text: "Hello, Alice!" },
+      metadata: {},
+      updatedAt: new Date(),
+    },
+    {
+      id: "custom-2",
+      nodeId: "RGF0YXNldEV4YW1wbGU6Mg==",
+      input: { name: "Bob" },
+      output: { text: "Hello, Bob!" },
+      metadata: {},
+      updatedAt: new Date(),
+    },
+  ],
+};
+
 describe("runExperiment (dryRun)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -204,6 +228,28 @@ describe("runExperiment (dryRun)", () => {
       ),
     });
   });
+  it("records runs against the node GlobalID on custom-id datasets", async () => {
+    vi.spyOn(getDatasetModule, "getDataset").mockResolvedValue(
+      mockCustomIdDataset
+    );
+    const task = (example: Example) => `Hi, ${example.input.name}`;
+
+    const experiment = await runExperiment({
+      dataset: { datasetId: mockCustomIdDataset.id },
+      task,
+      dryRun: true,
+    });
+
+    // Runs identify their example by node GlobalID, not by the custom id
+    const exampleIds = Object.values(experiment.runs)
+      .map((run) => run.datasetExampleId)
+      .sort();
+    expect(exampleIds).toEqual([
+      "RGF0YXNldEV4YW1wbGU6MQ==",
+      "RGF0YXNldEV4YW1wbGU6Mg==",
+    ]);
+  });
+
   it("passes traceId to evaluators", async () => {
     const task = async (example: Example) => `Hello, ${example.input.name}!`;
     const evaluateFn = vi.fn(async () => ({

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -329,6 +329,15 @@ def _print_experiment_error(
     print("\033[91m" + formatted_exception + "\033[0m")  # prints in red
 
 
+def _example_global_id(example: v1.DatasetExample) -> str:
+    """
+    The example's node GlobalID, which experiment runs record as
+    ``dataset_example_id``. Servers that predate the ``node_id`` field
+    deliver the GlobalID in ``id`` instead.
+    """
+    return example.get("node_id") or example["id"]
+
+
 def _build_evaluation_tasks(
     task_runs: Sequence[ExperimentRun],
     evaluators_by_name: Mapping[EvaluatorName, Evaluator],
@@ -1606,7 +1615,7 @@ class Experiments:
             print("🌵️ This is a dry-run evaluation.")
 
         # Build evaluation tasks
-        examples_by_id = {ex["id"]: ex for ex in dataset.examples}
+        examples_by_id = {_example_global_id(ex): ex for ex in dataset.examples}
         evaluation_tasks = _build_evaluation_tasks(
             task_runs,
             evaluators_by_name,
@@ -1768,7 +1777,7 @@ class Experiments:
             trace_id = _str_trace_id(span_context.trace_id)
 
         exp_run: ExperimentRun = {
-            "dataset_example_id": example["node_id"],
+            "dataset_example_id": _example_global_id(example),
             "output": output,
             "repetition_number": repetition_number,
             "start_time": start_time.isoformat(),
@@ -3359,7 +3368,7 @@ class AsyncExperiments:
             print("🌵️ This is a dry-run evaluation.")
 
         # Build evaluation tasks
-        examples_by_id = {ex["id"]: ex for ex in dataset.examples}
+        examples_by_id = {_example_global_id(ex): ex for ex in dataset.examples}
         evaluation_tasks = _build_evaluation_tasks(
             task_runs,
             evaluators_by_name,
@@ -3519,7 +3528,7 @@ class AsyncExperiments:
             trace_id = _str_trace_id(span_context.trace_id)
 
         exp_run: ExperimentRun = {
-            "dataset_example_id": example["node_id"],
+            "dataset_example_id": _example_global_id(example),
             "output": output,
             "repetition_number": repetition_number,
             "start_time": start_time.isoformat(),

--- a/packages/phoenix-client/tests/client/resources/experiments/test_evaluation_tasks.py
+++ b/packages/phoenix-client/tests/client/resources/experiments/test_evaluation_tasks.py
@@ -1,0 +1,83 @@
+# pyright: reportPrivateUsage=false
+from typing import Any, cast
+
+from phoenix.client.__generated__ import v1
+from phoenix.client.resources.experiments import (
+    _build_evaluation_tasks,
+    _evaluators_by_name,
+    _example_global_id,
+)
+
+
+def _example(id_: str, node_id: str) -> v1.DatasetExample:
+    return {
+        "id": id_,
+        "node_id": node_id,
+        "input": {"question": "q"},
+        "output": {"answer": "a"},
+        "metadata": {},
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+
+def _run(dataset_example_id: str) -> v1.ExperimentRun:
+    return {
+        "dataset_example_id": dataset_example_id,
+        "output": "task output",
+        "repetition_number": 1,
+        "start_time": "2026-01-01T00:00:00+00:00",
+        "end_time": "2026-01-01T00:00:01+00:00",
+        "id": "ExperimentRun:1",
+        "experiment_id": "Experiment:1",
+    }
+
+
+def _evaluator(output: Any) -> float:
+    return 1.0
+
+
+class TestExampleGlobalId:
+    def test_returns_node_id_not_custom_id(self) -> None:
+        example = _example("my-custom-id", "RGF0YXNldEV4YW1wbGU6MQ==")
+        assert _example_global_id(example) == "RGF0YXNldEV4YW1wbGU6MQ=="
+
+    def test_falls_back_to_id_when_node_id_is_absent(self) -> None:
+        example = cast(
+            v1.DatasetExample,
+            {
+                "id": "RGF0YXNldEV4YW1wbGU6MQ==",
+                "input": {},
+                "output": {},
+                "metadata": {},
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            },
+        )
+        assert _example_global_id(example) == "RGF0YXNldEV4YW1wbGU6MQ=="
+
+
+class TestBuildEvaluationTasks:
+    def test_runs_keyed_by_node_id_match_examples_with_custom_ids(self) -> None:
+        examples = [
+            _example("custom-1", "RGF0YXNldEV4YW1wbGU6MQ=="),
+            _example("custom-2", "RGF0YXNldEV4YW1wbGU6Mg=="),
+        ]
+        task_runs = [_run("RGF0YXNldEV4YW1wbGU6MQ=="), _run("RGF0YXNldEV4YW1wbGU6Mg==")]
+        evaluation_tasks = _build_evaluation_tasks(
+            task_runs,
+            _evaluators_by_name({"evaluator": _evaluator}),
+            {_example_global_id(ex): ex for ex in examples},
+        )
+        assert [(ex["id"], run["dataset_example_id"]) for ex, run, _ in evaluation_tasks] == [
+            ("custom-1", "RGF0YXNldEV4YW1wbGU6MQ=="),
+            ("custom-2", "RGF0YXNldEV4YW1wbGU6Mg=="),
+        ]
+
+    def test_unmatched_runs_are_skipped(self) -> None:
+        examples = [_example("custom-1", "RGF0YXNldEV4YW1wbGU6MQ==")]
+        task_runs = [_run("RGF0YXNldEV4YW1wbGU6MQ=="), _run("RGF0YXNldEV4YW1wbGU6OTk=")]
+        evaluation_tasks = _build_evaluation_tasks(
+            task_runs,
+            _evaluators_by_name({"evaluator": _evaluator}),
+            {_example_global_id(ex): ex for ex in examples},
+        )
+        assert len(evaluation_tasks) == 1


### PR DESCRIPTION
resolves #13695

Experiment task runs record an example's node GlobalID as `dataset_example_id`, but the evaluation phase in `run_experiment` / `evaluate_experiment` built its example lookup keyed by the example's `id` field. The v1 examples endpoint fills `id` with the user-supplied custom id when one exists (falling back to the GlobalID otherwise), so for datasets uploaded with custom example ids every lookup missed and the silent skip produced `N task runs, 0 evaluations` with no error.

The fix converges both clients on a single identifier: `dataset_example_id` always means the node GlobalID, read through one helper per client (`_example_global_id` / `getExampleGlobalId`) that falls back to the example `id` field on servers that predate `node_id` (where that field carries the GlobalID).

## Python client

- `evaluate_experiment` (sync and async) keys its example lookup by node GlobalID via `_example_global_id`, matching what runs record.
- Run construction reads the GlobalID through `_example_global_id` instead of `example["node_id"]`, which raised `KeyError` against servers that predate the field (including in dry runs).
- Unit tests for the indexing and matching behavior, including the custom-id dataset case from the issue and the old-server fallback.
- Note for callers who worked around this bug by remapping `dataset_example_id` to custom example ids before evaluating: those runs no longer resolve; drop the remap when upgrading.

## TypeScript client

The TS client had the same id-namespace split: runs fetched from the server (`getExperiment`) identify examples by node GlobalID, while runs created in-process recorded `datasetExampleId: example.id` — a leftover from before custom example ids split that field away from the GlobalID. `evaluateExperiment`'s example lookup was keyed only by the example id, so evaluating a re-fetched experiment on a custom-id dataset failed every lookup (loudly, via `invariant`).

- In-process runs record the node GlobalID in `datasetExampleId`, so the field means the same thing regardless of how the run object was obtained.
- The `evaluateExperiment` example lookup is keyed by node GlobalID to match.
- All `dataset_example_id` reads (run POSTs and span attributes across `runExperiment` / `resumeExperiment` / `resumeEvaluation`) go through `getExampleGlobalId`; previously they read `example.nodeId` unconditionally, so against servers that predate the field the run POST body silently omitted `dataset_example_id` and the server rejected every run.
- Changeset and unit tests covering GlobalID matching on custom-id datasets, the old-server fallback, and the GlobalID recording.

## Testing

- Python: `tox -e phoenix_client` (pyright, mypy --strict, pytest) passes.
- TypeScript: `pnpm --filter @arizeai/phoenix-client test` (356 tests) and `typecheck` pass.


