### PR TITLE
feat(ui): search and free-form durations in time range selector

### DIFF
--- a/app/src/components/datetime/TimeRangeSelector.tsx
+++ b/app/src/components/datetime/TimeRangeSelector.tsx
@@ -1,7 +1,8 @@
 import { css } from "@emotion/react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
-import { useInteractOutside } from "react-aria";
+import { useFilter, useInteractOutside } from "react-aria";
+import { Autocomplete, Input } from "react-aria-components";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import { usePreferencesContext } from "@phoenix/contexts";
@@ -14,15 +15,18 @@ import { getLocale, getTimeZone } from "@phoenix/utils/timeUtils";
 
 import { Badge } from "../core/badge";
 import { Text } from "../core/content";
+import { SearchField, SearchIcon } from "../core/field";
 import { ListBox, ListBoxItem } from "../core/listbox";
 import { Popover } from "../core/overlay";
 import type { ComponentSize } from "../core/types";
-import { LAST_N_TIME_RANGES, LAST_N_TIME_RANGES_MAP } from "./constants";
+import { LAST_N_TIME_RANGES } from "./constants";
 import { TimeRangeFields } from "./TimeRangeFields";
 import type { TimeRangeFieldsHandle } from "./TimeRangeFields";
 import type { OpenTimeRangeWithKey } from "./types";
 import {
+  getLastNTimeRangeLabel,
   getTimeRangeFromLastNTimeRangeKey,
+  getTimeRangeSearchSuggestions,
   isLastNTimeRangeKey,
 } from "./utils";
 
@@ -173,6 +177,16 @@ const presetListBoxCSS = css`
   width: 100%;
 `;
 
+const presetEmptyStateCSS = css`
+  padding: var(--global-dimension-size-200) var(--global-dimension-size-150);
+`;
+
+const presetSearchCSS = css`
+  width: 100%;
+  border-bottom: var(--global-border-size-thin) solid
+    var(--global-menu-border-color);
+`;
+
 const badgeCSS = css`
   flex: none;
   font-variant-numeric: tabular-nums;
@@ -185,23 +199,28 @@ const OPEN_VALUE_MIN_WIDTH = "var(--global-dimension-size-4000)";
  * compact preset label until the control receives focus, then swaps to editable
  * start/end date fields. Typing into the dates forks the active preset into a
  * custom range, while focusing the control opens the list of quick presets
- * right below it. The leading badge surfaces the active preset's shorthand and
- * the trailing label shows the time zone the range is displayed in.
+ * right below it. A search field at the top of the presets filters the list
+ * and parses free-form durations ("25m", "2 hours") into ad-hoc last-N
+ * options. The leading badge surfaces the active preset's shorthand and the
+ * trailing label shows the time zone the range is displayed in.
  */
 export function TimeRangeSelector(props: TimeRangeSelectorProps) {
   const { value, isDisabled, onChange, size = "S" } = props;
   const { timeRangeKey, start, end } = value;
   const containerRef = useRef<HTMLDivElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
-  const presetListBoxRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const valueMeasureRef = useRef<HTMLDivElement>(null);
   const valueButtonRef = useRef<HTMLButtonElement>(null);
   const timeRangeFieldsRef = useRef<TimeRangeFieldsHandle | null>(null);
   const [isPresetsOpen, setIsPresetsOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [popoverWidth, setPopoverWidth] = useState<string | undefined>();
+  const [searchText, setSearchText] = useState("");
+  const { contains } = useFilter({ sensitivity: "base" });
   const closePresets = useCallback(() => {
     setIsPresetsOpen(false);
+    setSearchText("");
   }, []);
   // The focused element belongs to this control if it lives inside the trigger
   // or its popover. Used to decide whether losing focus should stop editing.
@@ -265,6 +284,12 @@ export function TimeRangeSelector(props: TimeRangeSelectorProps) {
     "escape",
     (event) => {
       event.stopPropagation();
+      // Escape from a non-empty search clears the search before a second
+      // press closes the control, matching standard search field behavior.
+      if (searchText && document.activeElement === searchInputRef.current) {
+        setSearchText("");
+        return;
+      }
       commitAndBlurTimeRangeField();
     },
     {
@@ -293,8 +318,17 @@ export function TimeRangeSelector(props: TimeRangeSelectorProps) {
   const badgeLabel = isCustom ? "Custom" : timeRangeKey;
   const timeRangeFormatter = createTimeRangeFormatter({ locale, timeZone });
   const valueLabel = isLastNTimeRangeKey(timeRangeKey)
-    ? (LAST_N_TIME_RANGES_MAP[timeRangeKey]?.label ?? timeRangeKey)
+    ? getLastNTimeRangeLabel(timeRangeKey)
     : timeRangeFormatter({ start, end });
+
+  // A duration typed into the search (e.g. "25m") becomes a selectable
+  // "Last 25 minutes" option ahead of the presets, and a bare quantity
+  // ("25") suggests it in every unit. Colliding presets are dropped so each
+  // option appears once.
+  const searchSuggestions = getTimeRangeSearchSuggestions(searchText);
+  const presetItems = LAST_N_TIME_RANGES.filter(
+    ({ key }) => !searchSuggestions.includes(key)
+  );
 
   // Forces the inline fields to reset whenever the committed range or the
   // display time zone changes from the outside (e.g. selecting a preset).
@@ -341,7 +375,7 @@ export function TimeRangeSelector(props: TimeRangeSelectorProps) {
     if (!isPopoverReady) {
       return;
     }
-    presetListBoxRef.current?.focus();
+    searchInputRef.current?.focus();
   }, [isPopoverReady]);
 
   return (
@@ -444,40 +478,67 @@ export function TimeRangeSelector(props: TimeRangeSelectorProps) {
           opacity: 1,
         }}
       >
-        <ListBox
-          ref={presetListBoxRef}
-          aria-label="time range preset selection"
-          selectionMode="single"
-          selectedKeys={isCustom ? [] : [timeRangeKey]}
-          css={presetListBoxCSS}
-          onSelectionChange={(selection) => {
-            const selectedKey =
-              selection === "all" ? undefined : selection.keys().next().value;
-            // Re-clicking the active preset toggles single-selection off,
-            // firing this with an empty selection; fall back to the active
-            // preset so that clicking any preset — even the current one —
-            // commits its (recomputed) range.
-            const keyToApply = isLastNTimeRangeKey(selectedKey)
-              ? selectedKey
-              : isLastNTimeRangeKey(timeRangeKey)
-                ? timeRangeKey
-                : undefined;
-            setIsEditing(false);
-            if (!keyToApply) {
-              setIsPresetsOpen(false);
-              return;
-            }
-            const nextRange = getTimeRangeFromLastNTimeRangeKey(keyToApply);
-            setIsPresetsOpen(false);
-            onChange({ timeRangeKey: keyToApply, ...nextRange });
-          }}
-        >
-          {LAST_N_TIME_RANGES.map(({ key, label }) => (
-            <ListBoxItem key={key} id={key}>
-              {label}
-            </ListBoxItem>
-          ))}
-        </ListBox>
+        <Autocomplete filter={contains}>
+          <SearchField
+            aria-label="Search time range presets"
+            size="M"
+            variant="quiet"
+            value={searchText}
+            onChange={setSearchText}
+            css={presetSearchCSS}
+          >
+            <SearchIcon />
+            <Input ref={searchInputRef} placeholder='Search or type "25m"' />
+          </SearchField>
+          <ListBox
+            aria-label="time range preset selection"
+            selectionMode="single"
+            selectedKeys={isCustom ? [] : [timeRangeKey]}
+            css={presetListBoxCSS}
+            renderEmptyState={() => (
+              <div css={presetEmptyStateCSS}>No matching time ranges</div>
+            )}
+            onSelectionChange={(selection) => {
+              const selectedKey =
+                selection === "all" ? undefined : selection.keys().next().value;
+              // Re-clicking the active preset toggles single-selection off,
+              // firing this with an empty selection; fall back to the active
+              // preset so that clicking any preset — even the current one —
+              // commits its (recomputed) range.
+              const keyToApply = isLastNTimeRangeKey(selectedKey)
+                ? selectedKey
+                : isLastNTimeRangeKey(timeRangeKey)
+                  ? timeRangeKey
+                  : undefined;
+              setIsEditing(false);
+              if (!keyToApply) {
+                closePresets();
+                return;
+              }
+              const nextRange = getTimeRangeFromLastNTimeRangeKey(keyToApply);
+              closePresets();
+              onChange({ timeRangeKey: keyToApply, ...nextRange });
+            }}
+          >
+            {searchSuggestions.map((suggestedKey) => (
+              // The search text itself is the text value so suggestions always
+              // survive the autocomplete filter (their labels may not contain
+              // the raw input, e.g. "25m" vs "Last 25 minutes").
+              <ListBoxItem
+                key={suggestedKey}
+                id={suggestedKey}
+                textValue={searchText}
+              >
+                {getLastNTimeRangeLabel(suggestedKey)}
+              </ListBoxItem>
+            ))}
+            {presetItems.map(({ key, label }) => (
+              <ListBoxItem key={key} id={key}>
+                {label}
+              </ListBoxItem>
+            ))}
+          </ListBox>
+        </Autocomplete>
       </Popover>
     </>
   );

--- a/app/src/components/datetime/__tests__/TimeRangeSelector.test.tsx
+++ b/app/src/components/datetime/__tests__/TimeRangeSelector.test.tsx
@@ -1,0 +1,171 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PreferencesProvider } from "@phoenix/contexts/PreferencesContext";
+import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
+
+import { TimeRangeSelector } from "../TimeRangeSelector";
+import type { OpenTimeRangeWithKey } from "../types";
+import { getTimeRangeFromLastNTimeRangeKey } from "../utils";
+
+describe("TimeRangeSelector", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const originalMatchMedia = window.matchMedia;
+  const originalOffsetWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "offsetWidth"
+  );
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T10:00:30.000Z"));
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    });
+    // The presets popover only mounts once the trigger has a measurable width
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      get: () => 400,
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+    if (originalOffsetWidth) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "offsetWidth",
+        originalOffsetWidth
+      );
+    }
+    vi.useRealTimers();
+  });
+
+  async function renderSelector(onChange: (value: unknown) => void) {
+    const timeRange: OpenTimeRangeWithKey = {
+      timeRangeKey: "15m",
+      ...getTimeRangeFromLastNTimeRangeKey("15m"),
+    };
+    await act(async () => {
+      root.render(
+        <ThemeProvider themeMode="light" disableBodyTheme>
+          <PreferencesProvider>
+            <TimeRangeSelector value={timeRange} onChange={onChange} />
+          </PreferencesProvider>
+        </ThemeProvider>
+      );
+    });
+  }
+
+  /** Focuses the trigger, which opens the presets popover with its search. */
+  async function openPresets() {
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(".time-range-selector__value")
+        ?.focus();
+    });
+    // The popover is portaled, so search the document
+    const searchInput = document.querySelector<HTMLInputElement>(
+      'input[type="search"]'
+    );
+    expect(searchInput).not.toBeNull();
+    return searchInput as HTMLInputElement;
+  }
+
+  async function typeIntoSearch(searchInput: HTMLInputElement, text: string) {
+    await act(async () => {
+      const setValue = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value"
+      )?.set;
+      setValue?.call(searchInput, text);
+      searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+
+  function getOptionLabels() {
+    return Array.from(document.querySelectorAll('[role="option"]')).map(
+      (option) => option.textContent
+    );
+  }
+
+  it("keeps the inline time fields mounted when the selector receives focus", async () => {
+    await renderSelector(() => undefined);
+
+    const valueButton = container.querySelector<HTMLButtonElement>(
+      ".time-range-selector__value"
+    );
+    expect(valueButton).not.toBeNull();
+
+    await act(async () => {
+      valueButton?.focus();
+    });
+
+    expect(container.querySelector('[aria-label="Start time"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="End time"]')).not.toBeNull();
+  });
+
+  it("commits a typed duration as an open last-N range", async () => {
+    const onChange = vi.fn();
+    await renderSelector(onChange);
+    const searchInput = await openPresets();
+    await typeIntoSearch(searchInput, "25m");
+
+    expect(getOptionLabels()).toEqual(["Last 25 minutes"]);
+
+    // Move virtual focus onto the (only) option, then commit it
+    for (const key of ["ArrowDown", "Enter"]) {
+      await act(async () => {
+        searchInput.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key,
+            code: key,
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+      });
+    }
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const committed = onChange.mock.calls[0][0];
+    expect(committed.timeRangeKey).toBe("25m");
+    expect(committed.start?.toISOString()).toBe("2026-06-09T09:35:00.000Z");
+    expect(committed.end).toBeNull();
+  });
+
+  it("suggests every unit for a bare quantity, deduped against presets", async () => {
+    await renderSelector(() => undefined);
+    const searchInput = await openPresets();
+    // "1" collides with the "1h" and "1d" preset keys, which keep their
+    // curated labels, and also text-matches the "15m" and "12h" presets
+    await typeIntoSearch(searchInput, "1");
+
+    expect(getOptionLabels()).toEqual([
+      "Last 1 minute",
+      "Last Hour",
+      "Last Day",
+      "Last 15 Min",
+      "Last 12 Hours",
+    ]);
+  });
+});

--- a/app/src/components/datetime/__tests__/TimeRangeSelector.test.tsx
+++ b/app/src/components/datetime/__tests__/TimeRangeSelector.test.tsx
@@ -108,22 +108,6 @@ describe("TimeRangeSelector", () => {
     );
   }
 
-  it("keeps the inline time fields mounted when the selector receives focus", async () => {
-    await renderSelector(() => undefined);
-
-    const valueButton = container.querySelector<HTMLButtonElement>(
-      ".time-range-selector__value"
-    );
-    expect(valueButton).not.toBeNull();
-
-    await act(async () => {
-      valueButton?.focus();
-    });
-
-    expect(container.querySelector('[aria-label="Start time"]')).not.toBeNull();
-    expect(container.querySelector('[aria-label="End time"]')).not.toBeNull();
-  });
-
   it("commits a typed duration as an open last-N range", async () => {
     const onChange = vi.fn();
     await renderSelector(onChange);

--- a/app/src/components/datetime/__tests__/utils.test.ts
+++ b/app/src/components/datetime/__tests__/utils.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  getLastNTimeRangeLabel,
   getMillisecondsUntilNextLastNTimeRangeRefresh,
   getTimeRangeFromLastNTimeRangeKey,
+  getTimeRangeSearchSuggestions,
+  isLastNTimeRangeKey,
+  parseTimeRangeSearchText,
 } from "../utils";
 
 describe("datetime utils", () => {
@@ -36,5 +40,65 @@ describe("datetime utils", () => {
       2_670_000
     );
     expect(getMillisecondsUntilNextLastNTimeRangeRefresh("7d")).toBe(2_670_000);
+  });
+
+  it("computes arbitrary last-N keys, snapping by window length", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T10:20:30.000Z"));
+
+    // Windows up to an hour snap to the minute
+    const minutes = getTimeRangeFromLastNTimeRangeKey("25m");
+    expect(minutes.start?.toISOString()).toBe("2026-06-09T09:55:00.000Z");
+    expect(minutes.end).toBeNull();
+
+    // Longer windows snap to the hour
+    const hours = getTimeRangeFromLastNTimeRangeKey("2h");
+    expect(hours.start?.toISOString()).toBe("2026-06-09T08:00:00.000Z");
+    expect(hours.end).toBeNull();
+
+    expect(getMillisecondsUntilNextLastNTimeRangeRefresh("25m")).toBe(30_000);
+    expect(getMillisecondsUntilNextLastNTimeRangeRefresh("2h")).toBe(2_370_000);
+  });
+
+  it("recognizes arbitrary last-N keys and rejects malformed ones", () => {
+    expect(isLastNTimeRangeKey("25m")).toBe(true);
+    expect(isLastNTimeRangeKey("3d")).toBe(true);
+    expect(isLastNTimeRangeKey("0m")).toBe(false);
+    expect(isLastNTimeRangeKey("25")).toBe(false);
+    expect(isLastNTimeRangeKey("m")).toBe(false);
+    expect(isLastNTimeRangeKey("custom")).toBe(false);
+  });
+
+  it("labels presets with their curated labels and other keys spelled out", () => {
+    expect(getLastNTimeRangeLabel("15m")).toBe("Last 15 Min");
+    expect(getLastNTimeRangeLabel("1h")).toBe("Last Hour");
+    expect(getLastNTimeRangeLabel("25m")).toBe("Last 25 minutes");
+    expect(getLastNTimeRangeLabel("2h")).toBe("Last 2 hours");
+    expect(getLastNTimeRangeLabel("3d")).toBe("Last 3 days");
+    expect(getLastNTimeRangeLabel("90m")).toBe("Last 90 minutes");
+  });
+
+  it("parses free-form search text into last-N keys", () => {
+    expect(parseTimeRangeSearchText("25m")).toBe("25m");
+    expect(parseTimeRangeSearchText(" 25 min ")).toBe("25m");
+    expect(parseTimeRangeSearchText("Last 25 Minutes")).toBe("25m");
+    expect(parseTimeRangeSearchText("2 hr")).toBe("2h");
+    expect(parseTimeRangeSearchText("last 2 hours")).toBe("2h");
+    expect(parseTimeRangeSearchText("3 days")).toBe("3d");
+    expect(parseTimeRangeSearchText("")).toBeNull();
+    expect(parseTimeRangeSearchText("25")).toBeNull();
+    expect(parseTimeRangeSearchText("0m")).toBeNull();
+    expect(parseTimeRangeSearchText("25x")).toBeNull();
+    expect(parseTimeRangeSearchText("last")).toBeNull();
+  });
+
+  it("suggests every unit for a bare quantity and the exact key for a duration", () => {
+    expect(getTimeRangeSearchSuggestions("25")).toEqual(["25m", "25h", "25d"]);
+    expect(getTimeRangeSearchSuggestions("last 3")).toEqual(["3m", "3h", "3d"]);
+    expect(getTimeRangeSearchSuggestions("25m")).toEqual(["25m"]);
+    expect(getTimeRangeSearchSuggestions("2 hours")).toEqual(["2h"]);
+    expect(getTimeRangeSearchSuggestions("")).toEqual([]);
+    expect(getTimeRangeSearchSuggestions("0")).toEqual([]);
+    expect(getTimeRangeSearchSuggestions("hour")).toEqual([]);
   });
 });

--- a/app/src/components/datetime/__tests__/utils.test.ts
+++ b/app/src/components/datetime/__tests__/utils.test.ts
@@ -14,49 +14,21 @@ describe("datetime utils", () => {
     vi.useRealTimers();
   });
 
-  it("keeps last-N ranges open-ended", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-09T10:00:30.000Z"));
-
-    const timeRange = getTimeRangeFromLastNTimeRangeKey("15m");
-
-    expect(timeRange.start?.toISOString()).toBe("2026-06-09T09:45:00.000Z");
-    expect(timeRange.end).toBeNull();
-  });
-
-  it("refreshes minute-based last-N ranges at the next minute boundary", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-09T10:00:30.000Z"));
-
-    expect(getMillisecondsUntilNextLastNTimeRangeRefresh("15m")).toBe(30_000);
-    expect(getMillisecondsUntilNextLastNTimeRangeRefresh("1h")).toBe(30_000);
-  });
-
-  it("refreshes hour-based last-N ranges at the next hour boundary", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-09T10:15:30.000Z"));
-
-    expect(getMillisecondsUntilNextLastNTimeRangeRefresh("12h")).toBe(
-      2_670_000
-    );
-    expect(getMillisecondsUntilNextLastNTimeRangeRefresh("7d")).toBe(2_670_000);
-  });
-
-  it("computes arbitrary last-N keys, snapping by window length", () => {
+  it("computes open-ended last-N ranges, snapping and refreshing by window length", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-09T10:20:30.000Z"));
 
-    // Windows up to an hour snap to the minute
+    // Windows up to an hour (inclusive) snap and refresh to the minute
     const minutes = getTimeRangeFromLastNTimeRangeKey("25m");
     expect(minutes.start?.toISOString()).toBe("2026-06-09T09:55:00.000Z");
     expect(minutes.end).toBeNull();
+    expect(getMillisecondsUntilNextLastNTimeRangeRefresh("25m")).toBe(30_000);
+    expect(getMillisecondsUntilNextLastNTimeRangeRefresh("1h")).toBe(30_000);
 
-    // Longer windows snap to the hour
+    // Longer windows snap and refresh to the hour
     const hours = getTimeRangeFromLastNTimeRangeKey("2h");
     expect(hours.start?.toISOString()).toBe("2026-06-09T08:00:00.000Z");
     expect(hours.end).toBeNull();
-
-    expect(getMillisecondsUntilNextLastNTimeRangeRefresh("25m")).toBe(30_000);
     expect(getMillisecondsUntilNextLastNTimeRangeRefresh("2h")).toBe(2_370_000);
   });
 

--- a/app/src/components/datetime/types.ts
+++ b/app/src/components/datetime/types.ts
@@ -1,4 +1,11 @@
-export type LastNTimeRangeKey = "15m" | "1h" | "12h" | "1d" | "7d" | "30d";
+export type LastNTimeRangeUnit = "m" | "h" | "d";
+
+/**
+ * A relative, open-ended time window expressed as a quantity and unit, e.g.
+ * "15m", "12h", "30d". A fixed set of these is offered as presets
+ * (see LAST_N_TIME_RANGES) but any positive quantity is a valid key.
+ */
+export type LastNTimeRangeKey = `${number}${LastNTimeRangeUnit}`;
 
 export type CustomTimeRangeKey = "custom";
 

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -8,56 +8,95 @@ import {
 
 import { assertUnreachable } from "@phoenix/typeUtils";
 
-import { LAST_N_TIME_RANGES } from "./constants";
-import type { LastNTimeRangeKey, TimeRangeKey } from "./types";
+import { LAST_N_TIME_RANGES_MAP } from "./constants";
+import type {
+  LastNTimeRangeKey,
+  LastNTimeRangeUnit,
+  TimeRangeKey,
+} from "./types";
 
 const MINUTE_IN_MS = 60 * 1000;
 const HOUR_IN_MS = 60 * MINUTE_IN_MS;
+const DAY_IN_MS = 24 * HOUR_IN_MS;
+
+const LAST_N_TIME_RANGE_KEY_REGEX = /^(\d+)([mhd])$/;
+
+type ParsedLastNTimeRange = {
+  quantity: number;
+  unit: LastNTimeRangeUnit;
+};
+
+function parseLastNTimeRangeKey(key: unknown): ParsedLastNTimeRange | null {
+  if (typeof key !== "string") {
+    return null;
+  }
+  const match = LAST_N_TIME_RANGE_KEY_REGEX.exec(key);
+  if (!match) {
+    return null;
+  }
+  const quantity = parseInt(match[1], 10);
+  if (quantity < 1) {
+    return null;
+  }
+  return { quantity, unit: match[2] as LastNTimeRangeUnit };
+}
+
+function getLastNTimeRangeDurationMs({
+  quantity,
+  unit,
+}: ParsedLastNTimeRange): number {
+  switch (unit) {
+    case "m":
+      return quantity * MINUTE_IN_MS;
+    case "h":
+      return quantity * HOUR_IN_MS;
+    case "d":
+      return quantity * DAY_IN_MS;
+    default:
+      assertUnreachable(unit);
+  }
+}
 
 export function getTimeRangeFromLastNTimeRangeKey(
   key: LastNTimeRangeKey
 ): OpenTimeRange {
-  const now = Date.now();
-  switch (key) {
-    case "15m":
-      return {
-        start: startOfMinute(subMinutes(now, 15)),
-        end: null,
-      };
-    case "1h":
-      return {
-        start: startOfMinute(subHours(now, 1)),
-        end: null,
-      };
-    case "12h":
-      return {
-        start: startOfHour(subHours(now, 12)),
-        end: null,
-      };
-    case "1d":
-      return {
-        start: startOfHour(subDays(now, 1)),
-        end: null,
-      };
-    case "7d":
-      return {
-        start: startOfHour(subDays(now, 7)),
-        end: null,
-      };
-    case "30d":
-      return {
-        start: startOfHour(subDays(now, 30)),
-        end: null,
-      };
-    default:
-      assertUnreachable(key);
+  const parsed = parseLastNTimeRangeKey(key);
+  if (!parsed) {
+    throw new Error(`Invalid last N time range key: ${key}`);
   }
+  const now = Date.now();
+  const { quantity, unit } = parsed;
+  let start: Date;
+  switch (unit) {
+    case "m":
+      start = subMinutes(now, quantity);
+      break;
+    case "h":
+      start = subHours(now, quantity);
+      break;
+    case "d":
+      start = subDays(now, quantity);
+      break;
+    default:
+      assertUnreachable(unit);
+  }
+  // Windows up to an hour snap to the minute so the range tracks closely;
+  // anything longer snaps to the hour.
+  const snap =
+    getLastNTimeRangeDurationMs(parsed) <= HOUR_IN_MS
+      ? startOfMinute
+      : startOfHour;
+  return { start: snap(start), end: null };
 }
 
 export function getMillisecondsUntilNextLastNTimeRangeRefresh(
   key: LastNTimeRangeKey
 ): number {
-  const interval = key === "15m" || key === "1h" ? MINUTE_IN_MS : HOUR_IN_MS;
+  const parsed = parseLastNTimeRangeKey(key);
+  const interval =
+    parsed && getLastNTimeRangeDurationMs(parsed) <= HOUR_IN_MS
+      ? MINUTE_IN_MS
+      : HOUR_IN_MS;
   const elapsed = Date.now() % interval;
   return elapsed === 0 ? interval : interval - elapsed;
 }
@@ -66,11 +105,88 @@ export function getMillisecondsUntilNextLastNTimeRangeRefresh(
  * Type guard for the last N time range key
  */
 export function isLastNTimeRangeKey(key: unknown): key is LastNTimeRangeKey {
-  return LAST_N_TIME_RANGES.some((range) => range.key === key);
+  return parseLastNTimeRangeKey(key) !== null;
 }
 /**
  * Type guard for the time range key
  */
 export function isTimeRangeKey(key: unknown): key is TimeRangeKey {
   return isLastNTimeRangeKey(key) || key === "custom";
+}
+
+const LAST_N_UNIT_LABELS: Record<
+  LastNTimeRangeUnit,
+  { singular: string; plural: string }
+> = {
+  m: { singular: "minute", plural: "minutes" },
+  h: { singular: "hour", plural: "hours" },
+  d: { singular: "day", plural: "days" },
+};
+
+/**
+ * Human-readable label for a last N time range key. Presets keep their curated
+ * labels (e.g. "Last 15 Min"); arbitrary keys are spelled out (e.g. "25m" →
+ * "Last 25 minutes").
+ */
+export function getLastNTimeRangeLabel(key: LastNTimeRangeKey): string {
+  const preset = LAST_N_TIME_RANGES_MAP[key];
+  if (preset) {
+    return preset.label;
+  }
+  const parsed = parseLastNTimeRangeKey(key);
+  if (!parsed) {
+    return key;
+  }
+  const { quantity, unit } = parsed;
+  const { singular, plural } = LAST_N_UNIT_LABELS[unit];
+  return `Last ${quantity} ${quantity === 1 ? singular : plural}`;
+}
+
+const TIME_RANGE_SEARCH_REGEX =
+  /^(?:last\s+)?(\d+)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$/;
+
+const TIME_RANGE_QUANTITY_SEARCH_REGEX = /^(?:last\s+)?(\d+)$/;
+
+/**
+ * Parse free-form search text like "25m", "25 min", or "last 2 hours" into a
+ * last N time range key. Returns null when the text is not a duration.
+ */
+export function parseTimeRangeSearchText(
+  text: string
+): LastNTimeRangeKey | null {
+  const match = TIME_RANGE_SEARCH_REGEX.exec(text.trim().toLowerCase());
+  if (!match) {
+    return null;
+  }
+  const quantity = parseInt(match[1], 10);
+  if (quantity < 1) {
+    return null;
+  }
+  const unit = match[2][0] as LastNTimeRangeUnit;
+  return `${quantity}${unit}` as LastNTimeRangeKey;
+}
+
+/**
+ * Last N time range keys suggested by free-form search text. A full duration
+ * ("25m") suggests exactly that key; a bare quantity ("25") suggests it in
+ * every unit; anything else suggests nothing.
+ */
+export function getTimeRangeSearchSuggestions(
+  text: string
+): LastNTimeRangeKey[] {
+  const exactKey = parseTimeRangeSearchText(text);
+  if (exactKey) {
+    return [exactKey];
+  }
+  const match = TIME_RANGE_QUANTITY_SEARCH_REGEX.exec(
+    text.trim().toLowerCase()
+  );
+  if (!match) {
+    return [];
+  }
+  const quantity = parseInt(match[1], 10);
+  if (quantity < 1) {
+    return [];
+  }
+  return [`${quantity}m`, `${quantity}h`, `${quantity}d`];
 }

--- a/app/stories/TimeRangeSelector.stories.tsx
+++ b/app/stories/TimeRangeSelector.stories.tsx
@@ -70,6 +70,20 @@ export const Custom = {
   },
 };
 
+/**
+ * Any duration typed into the preset search (e.g. "25m") becomes an ad-hoc
+ * open-ended last-N range with a spelled-out label.
+ */
+export const ArbitraryDuration = {
+  render: Template,
+  args: {
+    initialValue: {
+      timeRangeKey: "25m",
+      start: new Date("2024-01-15T10:00:00Z"),
+    },
+  },
+};
+
 export const Disabled = {
   render: Template,
   args: {

--- a/app/vitest.setup.ts
+++ b/app/vitest.setup.ts
@@ -11,6 +11,15 @@ class ResizeObserverMock {
 }
 globalThis.ResizeObserver = ResizeObserverMock;
 
+// jsdom does not expose CSS.escape, which react-aria uses to build selectors
+// for virtually focused collection items
+if (typeof globalThis.CSS === "undefined") {
+  globalThis.CSS = {
+    escape: (value: string) =>
+      String(value).replace(/[^a-zA-Z0-9_-]/g, (char) => `\\${char}`),
+  } as typeof CSS;
+}
+
 export const baseWindowConfig = {
   authenticationEnabled: true,
   basename: "/",


### PR DESCRIPTION
https://www.loom.com/share/d693e0a54c964535a08092ea5749a8ec
Adds a search field to the `TimeRangeSelector` preset popover. The search filters the existing presets and also parses free-form durations into ad-hoc "last N" options:

- A full duration — `25m`, `25 min`, `last 2 hours` — surfaces exactly that option (e.g. **Last 25 minutes**) ahead of the presets.
- A bare quantity — `25` — suggests it in every unit (**Last 25 minutes / hours / days**).