### PR TITLE
docs: June 10-11 release notes; allow PXI in release-notes skill

### DIFF
--- a/.agents/skills/phoenix-release-notes/SKILL.md
+++ b/.agents/skills/phoenix-release-notes/SKILL.md
@@ -15,6 +15,15 @@ Create and publish release documentation for Phoenix. This skill walks through a
 workflow: identify undocumented releases, analyze commits by reading the actual code, draft MDX
 files, and update all the documentation touchpoints.
 
+## Hard Rules
+
+- Do not exclude a change just because it is PXI-related or beta. PXI is a user-facing Phoenix
+  product surface, so PXI releases should go out when they add visible capabilities.
+- Distinguish product PXI skills from internal Codex/agent skills. Changes under
+  `src/phoenix/server/agents/prompts/skills/` are PXI product behavior; changes under
+  `.agents/skills/` are internal agent workflow unless they are accompanied by a Phoenix product
+  change.
+
 ## Tone and Style
 
 Write for a developer who uses Phoenix daily. The voice is technical, friendly, and informative
@@ -43,6 +52,10 @@ without being verbose.
 | @arizeai/phoenix-evals (TS evals) | Check `js/packages/phoenix-evals/package.json` |
 | @arizeai/phoenix-mcp (TS MCP) | Check `js/packages/phoenix-mcp/package.json` |
 | @arizeai/phoenix-otel (TS OTel) | Check `js/packages/phoenix-otel/package.json` |
+
+PXI features usually ship as part of `arize-phoenix` because the server, GraphQL/API surface, and
+frontend app own the built-in agent experience. Use the server version line unless the PXI release
+also changes a public Python or TypeScript SDK package.
 
 ## Step 1: Identify Undocumented Releases
 
@@ -87,6 +100,11 @@ feature actually does. Commit messages are often terse — the code tells the re
 - **Evaluators**: `packages/phoenix-evals/src/phoenix/evals/`
 - **CLI**: `packages/phoenix-client/src/phoenix/client/cli/`
 - **Models/providers**: playground and model configuration code
+- **PXI frontend**: `app/src/agent/`, `app/src/components/agent/`, and settings/playground pages
+  that expose agent controls
+- **PXI server/runtime**: `src/phoenix/server/agents/`, `src/phoenix/server/api/types/AgentsConfig.py`,
+  and related configuration in `src/phoenix/config.py`
+- **PXI product docs**: `docs/phoenix/pxi.mdx` and PXI-specific release-note pages
 
 ### Classify each change
 
@@ -98,6 +116,10 @@ feature actually does. Commit messages are often terse — the code tells the re
 - New CLI commands or flags
 - New evaluator types or capabilities
 - Performance improvements with visible user impact
+- PXI agent features — new PXI tools, skills, slash commands, and agent capabilities are
+  user-facing and should be announced
+- PXI controls, observability, approval flows, sandbox/runtime capabilities, web access settings,
+  model configuration, and context-aware page integrations
 
 **EXCLUDE** — internal housekeeping:
 - Dependency bumps (`chore(deps):`, `fix(deps):`)
@@ -105,20 +127,9 @@ feature actually does. Commit messages are often terse — the code tells the re
 - Test additions or fixes
 - CI/CD and build changes
 - Code style or formatting changes
-- Internal tooling, skills, or dev workflows
+- Internal tooling, `.agents/skills/` changes, eval harnesses, or dev workflows with no Phoenix
+  product behavior change
 - Reverts that cancel out a feature within the same release
-
-**EXCLUDE — beta features (hard rule):**
-- **PXI agent** — anything under the `phoenix-pxi` namespace, the PXI runtime, or PXI tool
-  wiring. PXI is still in beta and is not announced in release notes.
-- **Phoenix AI Assistant** — the in-app assistant widget, its settings page
-  (`Settings → Agents`), system prompt customization, enable/disable toggle, and response
-  feedback (thumbs up/down, copy, open-trace). The assistant is still in beta.
-
-If a commit, PR, or feature touches PXI or the assistant, skip it entirely — do not mention it
-in individual MDX files, the aggregate `release-notes.mdx`, the year overview, or `docs.json`
-navigation. This exclusion stands even if the change is user-visible. Revisit only when the
-user explicitly says these features are GA.
 
 If a release contains only excluded changes, skip it — no release note needed.
 
@@ -127,6 +138,10 @@ If a release contains only excluded changes, skip it — no release note needed.
 Multiple commits often implement a single feature across server + client + UI. A REST endpoint
 commit, a Python client wrapper, and a TypeScript client wrapper should become one release note
 entry that mentions all relevant package versions — not three separate entries.
+
+For PXI, group the full user capability. A tool definition, client action renderer, server prompt
+skill, GraphQL/config change, and documentation update that all enable one agent behavior should be
+one PXI release-note entry, usually versioned as `arize-phoenix X.Y.Z+`.
 
 ## Step 3: Draft Individual MDX Files
 
@@ -231,6 +246,7 @@ Match the version line to which packages are involved:
 **Available in arize-phoenix 13.14.0+**
 **Available in arize-phoenix-client 2.0.0+ (Python) and @arizeai/phoenix-client 6.4.0+ (TypeScript)**
 **Available in arize-phoenix 13.13.0+ (server), arize-phoenix-client 1.31.0+ (Python)**
+**Available in arize-phoenix 15.1.0+ (PXI beta)**
 **Breaking change in arize-phoenix-client 2.0.0**
 ```
 

--- a/.agents/skills/phoenix-release-notes/SKILL.md
+++ b/.agents/skills/phoenix-release-notes/SKILL.md
@@ -15,15 +15,6 @@ Create and publish release documentation for Phoenix. This skill walks through a
 workflow: identify undocumented releases, analyze commits by reading the actual code, draft MDX
 files, and update all the documentation touchpoints.
 
-## Hard Rules
-
-- Do not exclude a change just because it is PXI-related or beta. PXI is a user-facing Phoenix
-  product surface, so PXI releases should go out when they add visible capabilities.
-- Distinguish product PXI skills from internal Codex/agent skills. Changes under
-  `src/phoenix/server/agents/prompts/skills/` are PXI product behavior; changes under
-  `.agents/skills/` are internal agent workflow unless they are accompanied by a Phoenix product
-  change.
-
 ## Tone and Style
 
 Write for a developer who uses Phoenix daily. The voice is technical, friendly, and informative
@@ -52,10 +43,6 @@ without being verbose.
 | @arizeai/phoenix-evals (TS evals) | Check `js/packages/phoenix-evals/package.json` |
 | @arizeai/phoenix-mcp (TS MCP) | Check `js/packages/phoenix-mcp/package.json` |
 | @arizeai/phoenix-otel (TS OTel) | Check `js/packages/phoenix-otel/package.json` |
-
-PXI features usually ship as part of `arize-phoenix` because the server, GraphQL/API surface, and
-frontend app own the built-in agent experience. Use the server version line unless the PXI release
-also changes a public Python or TypeScript SDK package.
 
 ## Step 1: Identify Undocumented Releases
 
@@ -100,11 +87,6 @@ feature actually does. Commit messages are often terse — the code tells the re
 - **Evaluators**: `packages/phoenix-evals/src/phoenix/evals/`
 - **CLI**: `packages/phoenix-client/src/phoenix/client/cli/`
 - **Models/providers**: playground and model configuration code
-- **PXI frontend**: `app/src/agent/`, `app/src/components/agent/`, and settings/playground pages
-  that expose agent controls
-- **PXI server/runtime**: `src/phoenix/server/agents/`, `src/phoenix/server/api/types/AgentsConfig.py`,
-  and related configuration in `src/phoenix/config.py`
-- **PXI product docs**: `docs/phoenix/pxi.mdx` and PXI-specific release-note pages
 
 ### Classify each change
 
@@ -116,10 +98,6 @@ feature actually does. Commit messages are often terse — the code tells the re
 - New CLI commands or flags
 - New evaluator types or capabilities
 - Performance improvements with visible user impact
-- PXI agent features — new PXI tools, skills, slash commands, and agent capabilities are
-  user-facing and should be announced
-- PXI controls, observability, approval flows, sandbox/runtime capabilities, web access settings,
-  model configuration, and context-aware page integrations
 
 **EXCLUDE** — internal housekeeping:
 - Dependency bumps (`chore(deps):`, `fix(deps):`)
@@ -127,7 +105,7 @@ feature actually does. Commit messages are often terse — the code tells the re
 - Test additions or fixes
 - CI/CD and build changes
 - Code style or formatting changes
-- Internal tooling, `.agents/skills/` changes, eval harnesses, or dev workflows with no Phoenix
+- Internal tooling, repo-internal agent skills (`.agents/skills/`), or dev workflows with no
   product behavior change
 - Reverts that cancel out a feature within the same release
 
@@ -138,10 +116,6 @@ If a release contains only excluded changes, skip it — no release note needed.
 Multiple commits often implement a single feature across server + client + UI. A REST endpoint
 commit, a Python client wrapper, and a TypeScript client wrapper should become one release note
 entry that mentions all relevant package versions — not three separate entries.
-
-For PXI, group the full user capability. A tool definition, client action renderer, server prompt
-skill, GraphQL/config change, and documentation update that all enable one agent behavior should be
-one PXI release-note entry, usually versioned as `arize-phoenix X.Y.Z+`.
 
 ## Step 3: Draft Individual MDX Files
 
@@ -246,7 +220,7 @@ Match the version line to which packages are involved:
 **Available in arize-phoenix 13.14.0+**
 **Available in arize-phoenix-client 2.0.0+ (Python) and @arizeai/phoenix-client 6.4.0+ (TypeScript)**
 **Available in arize-phoenix 13.13.0+ (server), arize-phoenix-client 1.31.0+ (Python)**
-**Available in arize-phoenix 15.1.0+ (PXI beta)**
+**Available in arize-phoenix 15.1.0+ (beta)**
 **Breaking change in arize-phoenix-client 2.0.0**
 ```
 

--- a/docs.json
+++ b/docs.json
@@ -1220,6 +1220,8 @@
               {
                 "group": "06.2026",
                 "pages": [
+                  "docs/phoenix/release-notes/06-2026/06-11-2026-time-range-and-pxi-slash-commands",
+                  "docs/phoenix/release-notes/06-2026/06-10-2026-pxi-agent-update",
                   "docs/phoenix/release-notes/06-2026/06-02-2026-pxi-agent"
                 ]
               },

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -13,6 +13,42 @@ GitHub
 **We want to hear from you!** The DevRel team wants to hear from the Phoenix community. If you're building with Phoenix and want to tell us what's working, what's painful, or what you wish existed, [grab 25 minutes with us](https://cal.com/team/arize-devrel/user-interview).
 </Info>
 
+<ReleaseUpdate label="06.11.2026" href="/docs/phoenix/release-notes/06-2026/06-11-2026-time-range-and-pxi-slash-commands" title="Time Range Selector — Search and Free-Form Durations">
+**Available in arize-phoenix 17.4.0+**
+
+Search the time range selector and type free-form durations to land on exactly the window you want.
+
+- **Search presets** — filter the preset list as you type
+- **Free-form durations** — `25m`, `2h`, `3d`, or `last 2 hours` create custom windows on the fly
+- **Inline editing** — type start and end dates directly in the navbar selector
+</ReleaseUpdate>
+
+<ReleaseUpdate label="06.11.2026" href="/docs/phoenix/release-notes/06-2026/06-11-2026-time-range-and-pxi-slash-commands" title="PXI Slash Commands and Dataset Evaluator Editing">
+**Available in arize-phoenix 17.4.0+ (PXI beta)**
+
+The `/` menu in PXI chat now includes local commands like `/clear`, and PXI can manage a dataset's evaluators.
+
+- **`/clear`** — reset the conversation into a fresh session from the chat input
+- **Dataset evaluators** — PXI reads evaluator definitions, selects which run on the next playground experiment, and edits existing evaluators as accept/reject diffs
+</ReleaseUpdate>
+
+<ReleaseUpdate label="06.10.2026" href="/docs/phoenix/release-notes/06-2026/06-10-2026-pxi-agent-update" title="PXI Skills Menu, Subagents, and Playground Orchestration">
+**Available in arize-phoenix 17.3.0+ (PXI beta)**
+
+PXI can now drive much more of Phoenix for you — invoke skills with `/`, fan out parallel subagents, and run full prompt-iteration loops in the playground.
+
+- **Skills menu** — type `/` to invoke skills like `/debug-trace` and `/llm-evaluator-authoring`
+- **Subagents** — parallel, read-only data retrieval that keeps big lookups out of the main context
+- **Playground orchestration** — load datasets, switch models, set repetitions, manage comparison instances, toggle experiment recording, and cancel runs
+- **Evaluator authoring and dataset management** — draft LLM-judge and code evaluators, create datasets, and import spans as examples, all as reviewable diffs
+</ReleaseUpdate>
+
+<ReleaseUpdate label="06.10.2026" href="/docs/phoenix/release-notes/06-2026/06-10-2026-pxi-agent-update" title="Claude Fable 5 in the Playground">
+**Available in arize-phoenix 17.3.0+**
+
+The playground now supports Anthropic's Claude Fable 5 — `claude-fable-5` on Anthropic and `anthropic.claude-fable-5` on AWS Bedrock — with cost tracking included.
+</ReleaseUpdate>
+
 <ReleaseUpdate label="06.02.2026" href="/docs/phoenix/release-notes/06-2026/06-02-2026-pxi-agent" title="Introducing PXI">
 **Available in arize-phoenix 17.0.0+ (beta)**
 

--- a/docs/phoenix/release-notes/06-2026/06-10-2026-pxi-agent-update.mdx
+++ b/docs/phoenix/release-notes/06-2026/06-10-2026-pxi-agent-update.mdx
@@ -1,0 +1,81 @@
+---
+title: "06.10.2026: PXI Agent Update"
+description: "PXI gains a skills menu, parallel subagents, full playground orchestration, evaluator authoring, and dataset management — plus Claude Fable 5 in the playground."
+---
+
+# PXI Skills Menu, Subagents, and Playground Orchestration
+
+June 10, 2026
+
+**Available in arize-phoenix 17.3.0+ (PXI beta)**
+
+PXI can now drive much more of Phoenix on your behalf. This release adds a skills menu in chat, parallel subagents for data retrieval, end-to-end playground orchestration, evaluator authoring, and dataset management — all behind the same accept/reject approval flows introduced at launch.
+
+## Skills menu
+
+Type `/` in the PXI chat input to browse and invoke PXI's skill library directly. Each skill packages a methodology PXI follows for a specific job:
+
+- **`/debug-trace`** — investigate traces to identify failure modes, root causes, and prioritized fixes
+- **`/llm-evaluator-authoring`** — design or refine an LLM-as-a-judge evaluator, including labels, rubric, and test cases
+- **`/playground`** — author, edit, run, compare, and improve prompts in the playground
+- **`/datasets`** — reason about dataset examples, outputs, splits, and labels
+- **`/annotate-spans`** — create consistent annotations and design feedback taxonomies
+
+Combine multiple skills in one message, and watch each skill load in the transcript as PXI picks it up.
+
+## Subagents
+
+<video controls autoPlay={false} loop={false} width="100%">
+  <source src="https://storage.googleapis.com/arize-phoenix-assets/assets/videos/pxi/sub_agents.mp4" type="video/mp4" />
+</video>
+
+PXI can delegate data retrieval to parallel subagents. Each subagent runs read-only queries against your Phoenix data with your identity and permissions, so large lookups happen alongside the main investigation instead of crowding its context. Subagent calls appear as expandable entries in the chat transcript.
+
+## Playground orchestration
+
+PXI can now run a full prompt-iteration loop in the playground:
+
+- **Load a dataset** into the playground, optionally scoped to a single split
+- **Switch the model** on any prompt instance, across built-in and custom providers
+- **Add or remove comparison instances** to set up side-by-side prompt variants
+- **Set repetitions** to repeat runs and surface flaky outputs
+- **Point template variables and appended message history** at specific dataset fields
+- **Toggle experiment recording** to decide whether dataset runs are saved as experiments or kept ephemeral
+- **Cancel a running playground run** and pick up the experiment results once a dataset run completes
+
+## Evaluator authoring
+
+Ask PXI to write an evaluator and it works inside the same forms you use:
+
+- **LLM-as-a-judge evaluators** — PXI drafts the judge prompt, labels, and model configuration, proposing every change as an accept/reject diff
+- **Code evaluators** — PXI writes the `evaluate()` source, configures outputs, and tests it in the sandbox before saving
+- **Validated saves** — evaluators persist through the same validation as the Create button, and results report whether changes were accepted by you or auto-accepted
+
+## Dataset management
+
+PXI can create and maintain evaluation datasets from chat: create or rename datasets, add and edit examples, organize splits and labels, and import spans from your projects as new examples. Dataset writes render as diffs for approval before they apply.
+
+## Chat refinements
+
+- **Reviewable tool edits** — playground tool-definition changes are gated behind an accept/reject diff
+- **Readable transcripts** — long tool outputs auto-collapse with an expand control, and the transcript keeps your scroll position while sections open and close
+- **Copy trace IDs** directly from PXI responses
+
+<CardGroup cols={2}>
+  <Card title="PXI Agent" icon="robot" href="/docs/phoenix/pxi">
+    Learn how to enable and use PXI in your Phoenix deployment.
+  </Card>
+</CardGroup>
+
+# Claude Fable 5 in the Playground
+
+June 10, 2026
+
+**Available in arize-phoenix 17.3.0+**
+
+The playground now supports Anthropic's Claude Fable 5:
+
+- **Anthropic** — `claude-fable-5`
+- **AWS Bedrock** — `anthropic.claude-fable-5`
+
+Select it from the model picker in the playground and prompts, with cost tracking included.

--- a/docs/phoenix/release-notes/06-2026/06-11-2026-time-range-and-pxi-slash-commands.mdx
+++ b/docs/phoenix/release-notes/06-2026/06-11-2026-time-range-and-pxi-slash-commands.mdx
@@ -1,0 +1,43 @@
+---
+title: "06.11.2026: Time Range Selector and PXI Slash Commands"
+description: "Search presets and type free-form durations in the time range selector; PXI adds local slash commands and dataset evaluator editing."
+---
+
+# Time Range Selector — Search and Free-Form Durations
+
+June 11, 2026
+
+**Available in arize-phoenix 17.4.0+**
+
+<video controls autoPlay={false} loop={false} width="100%">
+  <source src="https://storage.googleapis.com/arize-phoenix-assets/assets/videos/time_range.mp4" type="video/mp4" />
+</video>
+
+The time range selector across projects, dashboards, and evaluators is now searchable and accepts free-form durations — no more hunting through a fixed preset list.
+
+- **Search presets** — a search field at the top of the selector filters the preset list as you type
+- **Free-form durations** — type `25m`, `2h`, `3d`, or phrases like `last 2 hours` to create exactly the window you want; a bare number like `25` suggests minutes, hours, and days variants
+- **Inline editing** — the selector shows the active range directly in the navbar; focus it to type start and end dates, which forks the preset into a custom range (introduced in arize-phoenix 17.3.0)
+
+# PXI Slash Commands and Dataset Evaluator Editing
+
+June 11, 2026
+
+**Available in arize-phoenix 17.4.0+ (PXI beta)**
+
+<video controls autoPlay={false} loop={false} width="100%">
+  <source src="https://storage.googleapis.com/arize-phoenix-assets/assets/videos/pxi/slash_commands.mp4" type="video/mp4" />
+</video>
+
+The `/` menu in PXI chat now includes local commands alongside skills, and PXI can manage the evaluators attached to a dataset.
+
+- **`/clear`** — reset the conversation into a fresh session without leaving the chat input; commands show their keyboard shortcut in the menu
+- **Read evaluator definitions** — ask PXI what evaluators a dataset has and inspect their full source code or judge prompts
+- **Select evaluators for a run** — PXI can change which evaluators apply to the next playground experiment
+- **Edit existing evaluators** — PXI opens an existing code or LLM evaluator for editing, then proposes changes as accept/reject diffs
+
+<CardGroup cols={2}>
+  <Card title="PXI Agent" icon="robot" href="/docs/phoenix/pxi">
+    Learn how to enable and use PXI in your Phoenix deployment.
+  </Card>
+</CardGroup>

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/06-2026/06-11-2026-time-range-and-pxi-slash-commands" arrow="true" title="06.11.2026" icon="calendar" description="Searchable time range selector with free-form durations (25m, 2h, 3d); PXI slash commands and dataset evaluator editing"/>
+    <Card href="/docs/phoenix/release-notes/06-2026/06-10-2026-pxi-agent-update" arrow="true" title="06.10.2026" icon="calendar" description="PXI skills menu, parallel subagents, playground orchestration, evaluator authoring, and dataset management; Claude Fable 5 in the playground"/>
     <Card href="/docs/phoenix/release-notes/06-2026/06-02-2026-pxi-agent" arrow="true" title="06.02.2026" icon="calendar" description="Introducing PXI (beta) — the AI engineering agent built into Phoenix that investigates traces, iterates on prompts, and runs experiments on your observability data"/>
     <Card href="/docs/phoenix/release-notes/05-2026/05-27-2026-drag-to-zoom" arrow="true" title="05.27.2026" icon="calendar" description="Click-and-drag to zoom into a time window on project metric charts and the spans sparkline"/>
     <Card href="/docs/phoenix/release-notes/05-2026/05-21-2026-code-evaluators" arrow="true" title="05.21.2026" icon="calendar" description="Code Evaluators — write Python or TypeScript evaluate() functions in the Phoenix UI and run them server-side in an isolated sandbox"/>


### PR DESCRIPTION
## Summary

Two related changes:

**1. Simplify the `phoenix-release-notes` skill** — removes the hard exclusion that kept PXI and assistant features out of release notes (they are now announceable like any other user-facing change). The skill stays generic with no PXI special-casing:
- Beta-exclusion block deleted — beta features are classified by the same user-facing test as everything else
- Internal-tooling exclusion clarified: repo-internal agent skills (`.agents/skills/`) and dev workflows with no product behavior change stay out
- Added a generic `(beta)` version-line example

**2. Add release notes for arize-phoenix 17.1.0–17.4.0:**

- **06.10.2026 — PXI Agent Update** (`17.3.0+`): skills slash menu (`/debug-trace`, `/llm-evaluator-authoring`, …), parallel read-only subagents, end-to-end playground orchestration (load datasets, switch models, repetitions, comparison instances, experiment recording, run cancellation), LLM-judge and code evaluator authoring with validated saves, dataset management tools, chat refinements; plus Claude Fable 5 in the playground (Anthropic `claude-fable-5`, Bedrock `anthropic.claude-fable-5`)
- **06.11.2026 — Time Range Selector and PXI Slash Commands** (`17.4.0+`): preset search and free-form durations (`25m`, `2h`, `3d`, `last 2 hours`), inline range editing; `/clear` local command and dataset evaluator read/select/edit via PXI

Touchpoints updated: individual MDX pages (with demo videos), `release-notes.mdx` aggregate (4 entries), `2026.mdx` year overview (2 cards), `docs.json` navigation.

Skipped: arize-phoenix-client 2.8.0 (no new public SDK surface — verified by diffing the package between tags), 17.2.0 (route-info tool folded into the orchestration entry), token-price and dataloader fixes (internal).

## Verification

- All claims verified against the actual code (skill names, duration parser syntax, model IDs, subagent semantics)
- Every aggregate href resolves to a real file; `docs.json` parses; entries are reverse-chronological; video URLs return 200/206
- Pre-existing aggregate-order violations (March/January 2026) and generic titles in old files predate this branch and are untouched