### PR TITLE
fix(js): run package docs cleanup in postpublish instead of postpack

### DIFF
--- a/.agents/skills/phoenix-typescript-package-docs/SKILL.md
+++ b/.agents/skills/phoenix-typescript-package-docs/SKILL.md
@@ -75,7 +75,7 @@ Each supported package must have:
 - a canonical Mintlify package-doc folder
 - a `docs` entry in `files`
 - a `prepack` hook that runs the sync script for that package
-- a `postpack` hook that removes staged package docs
+- a `postpublish` hook that removes staged package docs (not `postpack` — `pnpm publish` stats the package files after the pack lifecycle, so a `postpack` clean deletes them mid-publish and fails with ENOENT)
 - visible navigation in `docs.json`
 
 ## Authoring Rules

--- a/js/packages/phoenix-client/package.json
+++ b/js/packages/phoenix-client/package.json
@@ -77,7 +77,7 @@
     "clean": "rimraf dist",
     "generate": "openapi-typescript --empty-objects-unknown=true --default-non-nullable=false ../../../schemas/openapi.json -o ./src/__generated__/api/v1.ts",
     "postbuild": "echo '{\"type\": \"module\"}' > ./dist/esm/package.json",
-    "postpack": "node ../../scripts/sync-package-docs.mjs clean phoenix-client",
+    "postpublish": "node ../../scripts/sync-package-docs.mjs clean phoenix-client",
     "prebuild": "pnpm run clean && pnpm run generate",
     "prepack": "node ../../scripts/sync-package-docs.mjs phoenix-client",
     "test": "vitest run",

--- a/js/packages/phoenix-evals/package.json
+++ b/js/packages/phoenix-evals/package.json
@@ -63,7 +63,7 @@
     "docs": "typedoc",
     "docs:preview": "pnpx http-server ./docs -p 8080 -o",
     "postbuild": "echo '{\"type\": \"module\"}' > ./dist/esm/package.json",
-    "postpack": "node ../../scripts/sync-package-docs.mjs clean phoenix-evals",
+    "postpublish": "node ../../scripts/sync-package-docs.mjs clean phoenix-evals",
     "prebuild": "pnpm run clean",
     "prepack": "node ../../scripts/sync-package-docs.mjs phoenix-evals",
     "test": "vitest run",

--- a/js/packages/phoenix-otel/package.json
+++ b/js/packages/phoenix-otel/package.json
@@ -45,7 +45,7 @@
     "build": "tsc --build tsconfig.json tsconfig.esm.json && tsc-alias -p tsconfig.esm.json",
     "clean": "rimraf dist",
     "postbuild": "echo '{\"type\": \"module\"}' > ./dist/esm/package.json",
-    "postpack": "node ../../scripts/sync-package-docs.mjs clean phoenix-otel",
+    "postpublish": "node ../../scripts/sync-package-docs.mjs clean phoenix-otel",
     "prebuild": "pnpm run clean",
     "prepack": "node ../../scripts/sync-package-docs.mjs phoenix-otel",
     "test": "vitest run",


### PR DESCRIPTION
## Problem

`pnpm -r publish` on main fails with:

```
[ENOENT] ENOENT: no such file or directory, stat '.../js/packages/phoenix-client/docs/annotations.mdx'
```

pnpm computes the package file list during the pack lifecycle, runs `postpack`, and then stats each listed file to upload it. The `postpack` hook that removes the staged `docs/` folder therefore deleted the files mid-publish.

Reproduced locally with `pnpm publish --dry-run --no-git-checks` in `js/packages/phoenix-client` (same ENOENT).

## Fix

Move the docs cleanup from `postpack` to `postpublish` in `phoenix-client`, `phoenix-evals`, and `phoenix-otel`, so it runs after the upload completes. The staged docs are gitignored (`/js/**/docs`), so nothing leaks into the tree if a publish aborts before the hook runs. Also updated the `phoenix-typescript-package-docs` skill, which prescribed the `postpack` hook.

## Verification

- `pnpm publish --dry-run --no-git-checks` now succeeds for all three packages; pnpm still runs the `postpublish` cleanup afterward
- `npm pack --dry-run` confirms the tarball still bundles all `docs/*.mdx` pages