### PR TITLE
docs(tutorials): level up email model-comparison into eval-harness cookbook (DEV-357)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1205,6 +1205,7 @@
               "docs/phoenix/cookbook/datasets-and-experiments/comparing-llamaindex-query-engines-with-a-pairwise-evaluator",
               "docs/phoenix/cookbook/datasets-and-experiments/summarization",
               "docs/phoenix/cookbook/datasets-and-experiments/text2sql",
+              "docs/phoenix/cookbook/datasets-and-experiments/building-your-own-eval-harness",
               "docs/phoenix/cookbook/datasets-and-experiments/cookbooks"
             ]
           }

--- a/docs/phoenix/cookbook/datasets-and-experiments/building-your-own-eval-harness.mdx
+++ b/docs/phoenix/cookbook/datasets-and-experiments/building-your-own-eval-harness.mdx
@@ -1,0 +1,257 @@
+---
+title: "Why Public Benchmarks Lie: Building Your Own Eval Harness"
+description: A model that wins on MMLU can lose on your task. Build a domain-specific harness and compare models fairly on your own data and metric.
+---
+
+<Card title="Google Colab" href="https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/experiments/building_your_own_eval_harness.ipynb" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/gc.ico" horizontal>
+colab.research.google.com
+</Card>
+
+When a new model tops MMLU, GPQA, or the latest leaderboard, it's tempting to assume it's the right choice for *your* application. It usually isn't — at least not for the reason you think. Public benchmarks measure **generic capabilities** on **generic data** with a **generic metric**: broad academic knowledge, scored as multiple-choice accuracy, averaged over thousands of questions that look nothing like your production traffic.
+
+Your task is narrow and specific. You aren't asking the model trivia — you're asking it to pull a handful of exact fields out of a customer email, every time, in a schema your downstream code can parse. A model that wins MMLU by two points can lose *your* task by twenty, because:
+
+* **The data is different** — your inputs are your customers' emails, not exam questions.
+* **The metric is different** — you care whether the `due_date` field is *exactly* right, not whether the prose sounds smart.
+* **The failure modes are different** — a confident, plausible-sounding wrong answer is worse for you than an "I don't know," the opposite of what a knowledge benchmark rewards.
+
+The only benchmark that predicts how a model performs on your task is **a benchmark built from your task** — and Phoenix experiments are exactly that harness. This cookbook builds one for an email text-extraction service and uses it to compare two models fairly.
+
+This cookbook shows examples of:
+
+* Building a small **domain dataset** of emails + correct extractions — your benchmark, not a public one
+* Defining an **extraction task** with a fixed schema and prompt, parameterized only by model
+* Defining **two evaluators** — string similarity *and* field-level accuracy — and seeing how they can rank the models differently
+* Running the **same harness** across `gpt-4o` and `gpt-4o-mini` and comparing them fairly
+
+## What makes a benchmark trustworthy
+
+Before trusting *any* number — public or your own — ask whether the benchmark behind it has these four properties:
+
+1. **Representative data.** The examples are drawn from your real inputs, covering the cases you actually see (including the messy and ambiguous ones), not a clean toy sample.
+2. **A metric that measures what you care about.** The score moves when the output gets better *for your purpose* and stays flat when it doesn't. The wrong metric can rank a worse model first — we'll show exactly this below.
+3. **Enough examples to be stable.** Two examples can't distinguish two models; the score has to be more signal than noise.
+4. **Reproducible and fair.** Every model is judged on the *same* dataset, with the *same* metric, under the *same* prompt — so a difference in the score reflects a difference in the model, not the setup.
+
+A Phoenix **experiment** is this harness: a fixed **dataset**, a **task** you vary, and one or more **evaluators**. Hold the dataset and evaluators constant, swap only the model, and the comparison is fair by construction.
+
+## Notebook Walkthrough
+
+We will go through key code snippets on this page. To follow the full tutorial, check out the [full notebook](https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/experiments/building_your_own_eval_harness.ipynb).
+
+After configuring tracing with `phoenix.otel.register(...)` and instrumenting OpenAI, we build a small hand-labeled dataset, define a model-parameterized extraction task, score it two ways, and run the same harness across two models.
+
+## Set up tracing
+
+Register a tracer provider so every extraction call shows up as a span in Phoenix — the experiment results link back to the exact calls that produced them. `auto_instrument=True` activates the installed OpenInference instrumentors (here, OpenAI), so there's no need to call `OpenAIInstrumentor().instrument(...)` yourself. Use `AsyncClient` because the experiment task makes network-bound LLM calls.
+
+```python
+from phoenix.client import AsyncClient
+from phoenix.otel import register
+
+register(project_name="email-extraction-eval-harness", auto_instrument=True)
+
+px_client = AsyncClient()
+```
+
+## Build a domain dataset
+
+This is the part public benchmarks can't do for you. Hand-label a handful of emails the way your service actually sees them — a meeting request, an invoice, a support escalation — each paired with the **exact** structured output you want back. In production you'd build this from real traffic (export traces from Phoenix, sample, and label); here we inline a small set so the example is self-contained.
+
+The mix of free-text fields (`summary`) and categorical fields (`category`, `due_date`) is deliberate: it's what lets two reasonable metrics *disagree* later.
+
+<Note>
+This is a **demonstration harness**. Eight examples is enough to show the workflow, not to draw stable conclusions (recall property 3 above). A production harness needs a larger, representative sample drawn from your real traffic before you'd trust the ranking.
+</Note>
+
+```python expandable
+import pandas as pd
+from datetime import datetime, timezone
+
+# EMAILS = [{"email": "...", "expected": {"sender": ..., "category": ..., "summary": ...,
+#            "action_required": ..., "due_date": ...}}, ...]  — see the notebook for the full set.
+
+# Flatten each example's expected extraction into top-level columns, so the dataset's
+# output IS the extraction dict the evaluators compare against — not a nested wrapper.
+rows = [{"email": e["email"], **e["expected"]} for e in EMAILS]
+df = pd.DataFrame(rows)
+OUTPUT_KEYS = ["sender", "category", "summary", "action_required", "due_date"]
+
+dataset = await px_client.datasets.create_dataset(
+    name=f"email-extraction-{datetime.now(timezone.utc):%Y%m%d-%H%M%S}",
+    dataframe=df,
+    input_keys=["email"],
+    output_keys=OUTPUT_KEYS,
+)
+```
+
+## Define the extraction task
+
+The task is what we hold *almost* constant: the same schema, the same prompt, the same parsing — **only the model changes**. Using structured outputs forces every model to return the exact same shape, so the comparison is about extraction quality rather than formatting luck.
+
+<Note>
+`make_task(model)` returns a task function bound to one model. The experiment calls it once per dataset example; the `input` it receives is that example's input dict (`{"email": ...}`).
+</Note>
+
+```python expandable
+from typing import Literal
+
+from openai import AsyncOpenAI
+from pydantic import BaseModel
+
+openai_client = AsyncOpenAI()
+
+
+class EmailExtraction(BaseModel):
+    sender: str
+    category: Literal["meeting", "invoice", "support_request", "sales", "internal_update"]
+    summary: str
+    action_required: bool
+    due_date: str  # ISO date (YYYY-MM-DD) or the literal string "none"
+
+
+PROMPT = (
+    "Extract structured fields from the email below. "
+    "category must be one of: meeting, invoice, support_request, sales, internal_update. "
+    'due_date must be an ISO date (YYYY-MM-DD) or the literal string "none". '
+    "action_required is true if the email asks the recipient to do something.\n\nEMAIL:\n{email}"
+)
+
+
+def make_task(model: str):
+    async def task(input) -> dict:
+        response = await openai_client.beta.chat.completions.parse(
+            model=model,
+            messages=[{"role": "user", "content": PROMPT.format(email=input["email"])}],
+            response_format=EmailExtraction,
+            temperature=0,  # deterministic — a fair comparison varies only the model
+        )
+        return response.choices[0].message.parsed.model_dump()
+
+    return task
+```
+
+## Choose metrics that measure what you care about
+
+This is where benchmarks quietly lie. Score the **same** outputs two ways:
+
+* **`jaro_winkler`** — string similarity over the JSON of the output vs. the expected output. Cheap and forgiving — the kind of "looks about right" metric people reach for first — and the right tool for the free-text `summary`, which can be correct while worded differently.
+* **`field_accuracy`** — the fraction of the **operational** fields (`sender`, `category`, `action_required`, `due_date`) that match *exactly* (case-insensitive). This is what downstream code depends on: a `due_date` that's "close" is still a wrong date. `summary` is deliberately left out — exact-matching a summary would punish good extractions for harmless rewording.
+
+The two metrics measure genuinely different things, so they *can* rank the models differently: a model might write better summaries (higher `jaro_winkler`) while miscategorizing more emails (lower `field_accuracy`), or vice versa. When they disagree, the metric that should decide is the one tied to your downstream needs — here, `field_accuracy`.
+
+```python
+import json
+
+import jarowinkler
+
+# The free-text summary is scored by jaro_winkler; field_accuracy judges only the
+# operational fields downstream code actually depends on.
+OPERATIONAL_FIELDS = ["sender", "category", "action_required", "due_date"]
+
+
+def jaro_winkler(output, expected) -> float:
+    """Forgiving string similarity over the serialized JSON (captures summary wording)."""
+    return jarowinkler.jarowinkler_similarity(
+        json.dumps(output, sort_keys=True),
+        json.dumps(expected, sort_keys=True),
+    )
+
+
+def field_accuracy(output, expected) -> float:
+    """Fraction of OPERATIONAL fields that match exactly (case-insensitive)."""
+    matches = sum(
+        1
+        for k in OPERATIONAL_FIELDS
+        if str(output.get(k)).strip().lower() == str(expected[k]).strip().lower()
+    )
+    return matches / len(OPERATIONAL_FIELDS)
+
+
+EVALUATORS = [jaro_winkler, field_accuracy]
+```
+
+The two metrics can rank the same outputs in opposite order. Made deterministic — two candidate extractions for one invoice email: one with the right operational fields but a reworded `summary`, one that looks almost identical but has the `due_date` off by a day:
+
+```python
+expected = {
+    "sender": "billing@cloudhost.com", "category": "invoice", "action_required": True,
+    "due_date": "2025-06-30", "summary": "CloudHost invoice #88231 for $4,200 is due June 30.",
+}
+# A: every operational field right, but the summary is fully reworded (harmless).
+candidate_a = {**expected, "summary": "Please arrange payment for the recent cloud hosting charges before the close of the current billing period."}
+# B: summary identical, but the due_date is off by a day.
+candidate_b = {**expected, "due_date": "2025-07-01"}
+
+# field_accuracy prefers A (1.000 vs 0.750 — all operational fields correct).
+# jaro_winkler prefers B (0.980 vs 0.897 — it looks almost identical).
+# But B's one-day date slip is exactly what breaks downstream code: same outputs,
+# opposite rankings, and the strict metric is the one that's right.
+```
+
+## Run the same harness across models
+
+Same dataset, same evaluators, same prompt — change only the `model` argument. That's what makes this a fair comparison instead of an anecdote.
+
+```python
+experiment_4o = await px_client.experiments.run_experiment(
+    dataset=dataset, task=make_task("gpt-4o"), evaluators=EVALUATORS, experiment_name="gpt-4o"
+)
+experiment_4o_mini = await px_client.experiments.run_experiment(
+    dataset=dataset, task=make_task("gpt-4o-mini"), evaluators=EVALUATORS, experiment_name="gpt-4o-mini"
+)
+```
+
+## Compare fairly
+
+Phoenix prints a per-experiment summary and lets you compare both runs example-by-example in the UI. Rolling the scores up per metric makes the disagreement explicit:
+
+```python
+from collections import defaultdict
+
+
+def average_scores(experiment) -> dict:
+    sums, counts = defaultdict(float), defaultdict(int)
+    for run in experiment["evaluation_runs"]:
+        result = run.result
+        if result and result.get("score") is not None:
+            sums[run.name] += result["score"]
+            counts[run.name] += 1
+    return {name: sums[name] / counts[name] for name in sums}
+```
+
+With only eight examples the two models may or may not separate cleanly on a given run — that's exactly why you *look* rather than assume. The lesson holds regardless: if the two metrics **rank the models differently**, the public-leaderboard instinct ("just take the higher-scoring model") could have led you to the wrong choice — *which* model is "better" depends on the metric, and the metric that should win is the one that reflects your downstream needs (here, `field_accuracy`). If they **agree**, you now have evidence grounded in *your* data and *your* metric. Either way, you trust the result because you built the harness.
+
+## Reading the results in Phoenix
+
+Open the dataset's **Experiments** tab to see the runs side by side. Each experiment is a row; each evaluator becomes its own **score column** (so `field_accuracy` sits next to `jaro_winkler`), alongside operational columns — average **latency**, **cost**, and **error rate** — that matter for a real model choice but never show up on a public leaderboard.
+
+<Frame>
+![Comparing the gpt-4o and gpt-4o-mini experiments in Phoenix — field_accuracy, jaro_winkler, latency, cost, and error rate side by side.](https://storage.googleapis.com/arize-phoenix-assets/assets/images/email-eval-harness-experiments.png)
+</Frame>
+
+Notice the two metrics can disagree on the headline question: here `gpt-4o` leads on `field_accuracy` while `gpt-4o-mini` edges ahead on `jaro_winkler`. Sort by the metric tied to your downstream needs (`field_accuracy`) rather than the forgiving one, and click any row to drop into the example-level view: the input email, the model's extraction, and each evaluator's score for that single example. That's where you *see why* one model wins — a `due_date` the model dropped, a sender it over-captured — instead of trusting an aggregate.
+
+<Frame>
+![The example-level compare view in Phoenix: the input email, the reference extraction, and the model's output with per-example field_accuracy and jaro_winkler scores.](https://storage.googleapis.com/arize-phoenix-assets/assets/images/email-eval-harness-example-level.png)
+</Frame>
+
+## Where to go next
+
+The harness is reusable — everything below holds the dataset and evaluators constant and changes one thing at a time, so each comparison stays fair:
+
+* **Iterate the prompt.** Vary `PROMPT` instead of `model` to find the wording that extracts most reliably.
+* **Add models and providers.** Drop another model name — or another provider's client — into `make_task` and rerun. The leaderboard ranking rarely survives contact with your task.
+* **Grow the dataset.** Move from eight inline examples to a representative sample exported from your real traffic, so the scores become stable enough to trust (property 3).
+* **Make it a standing benchmark.** Rerun the same harness on every model upgrade or prompt change to catch regressions before they reach production.
+
+## Takeaway
+
+A public benchmark tells you how a model does on *someone else's* task, with *someone else's* metric. That number rarely transfers to production. The fix isn't a better leaderboard — it's a small, trustworthy harness of your own:
+
+* **Representative data** — a dataset built from your real inputs.
+* **A metric that measures what you care about** — and the discipline to notice when a convenient metric (string similarity) disagrees with the real one (field accuracy).
+* **Enough examples** to make the score stable.
+* **A fair, reproducible setup** — same dataset, same evaluators, same prompt; vary only the model.
+
+A Phoenix experiment gives you all four. Once you have it, comparing models — or prompts, or providers — is just swapping one argument and reading a number you can actually defend.

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -649,6 +649,7 @@
 - [Experiment with a Customer Support Agent](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/experiment-with-a-customer-support-agent): This guide shows you how to create and evaluate agents with Phoenix to improve performance
 - [Prompt Template Iteration for a Summarization Service](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/summarization): Imagine you're deploying a service for your media company's summarization model that condenses daily news
 - [Text2SQL Experiments](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/text2sql): Building effective text-to-SQL systems requires rigorous evaluation and systematic experimentation. In this
+- [Why Public Benchmarks Lie: Building Your Own Eval Harness](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/building-your-own-eval-harness): A model that wins on MMLU can lose on your task. Build a domain-specific harness and compare models fairly on your own data and metric.
 - [Code Readability Evaluation](https://arize.com/docs/phoenix/cookbook/evaluation/code-readability-evaluation): >-
 - [More Cookbooks](https://arize.com/docs/phoenix/cookbook/evaluation/cookbooks): Use Phoenix Evals to evaluate your application for faithfulness, toxicity, relevance of retrieved documents
 - [Evaluate a Talk-to-Your-Data Agent](https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-an-agent): Evaluate a Talk-to-Your-Data Agent

--- a/docs/phoenix/sitemap.xml
+++ b/docs/phoenix/sitemap.xml
@@ -1841,6 +1841,10 @@
     <lastmod>2026-01-27T22:36:31+00:00</lastmod>
   </url>
   <url>
+    <loc>https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/building-your-own-eval-harness</loc>
+    <lastmod>2026-06-11T00:00:00+00:00</lastmod>
+  </url>
+  <url>
     <loc>https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/cookbooks</loc>
     <lastmod>2026-01-27T22:36:31+00:00</lastmod>
   </url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1841,6 +1841,10 @@
     <lastmod>2026-01-27T22:36:31+00:00</lastmod>
   </url>
   <url>
+    <loc>https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/building-your-own-eval-harness</loc>
+    <lastmod>2026-06-11T00:00:00+00:00</lastmod>
+  </url>
+  <url>
     <loc>https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/cookbooks</loc>
     <lastmod>2026-01-27T22:36:31+00:00</lastmod>
   </url>

--- a/tutorials/experiments/building_your_own_eval_harness.ipynb
+++ b/tutorials/experiments/building_your_own_eval_harness.ipynb
@@ -1,0 +1,624 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b2d1f0a0",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/experiments/building_your_own_eval_harness.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8a2f2d0",
+   "metadata": {},
+   "source": [
+    "<center>\n",
+    "    <p style=\"text-align:center\">\n",
+    "        <img alt=\"phoenix logo\" src=\"https://storage.googleapis.com/arize-phoenix-assets/assets/phoenix-logo-light.svg\" width=\"200\"/>\n",
+    "        <br>\n",
+    "        <a href=\"https://docs.arize.com/phoenix/\">Docs</a>\n",
+    "        |\n",
+    "        <a href=\"https://github.com/Arize-ai/phoenix\">GitHub</a>\n",
+    "        |\n",
+    "        <a href=\"https://join.slack.com/t/arize-ai/shared_invite/zt-1px8dcmlf-fmThhDFD_V_48oU7ALan4Q\">Community</a>\n",
+    "    </p>\n",
+    "</center>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea7cf46e",
+   "metadata": {},
+   "source": [
+    "# Why public benchmarks lie: building your own eval harness\n",
+    "\n",
+    "*Worked example: an email text-extraction service.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b91508db",
+   "metadata": {},
+   "source": [
+    "## A leaderboard winner can lose on your task\n",
+    "\n",
+    "When a new model tops MMLU, GPQA, or the latest leaderboard, it's tempting to assume it's the right choice for *your* application. It usually isn't — at least not for the reason you think. Public benchmarks measure **generic capabilities** on **generic data** with a **generic metric**: broad academic knowledge, scored as multiple-choice accuracy, averaged over thousands of questions that look nothing like your production traffic.\n",
+    "\n",
+    "Your task is narrow and specific. You aren't asking the model trivia — you're asking it to pull five exact fields out of a customer email, every time, in a schema your downstream code can parse. A model that wins MMLU by two points can lose *your* task by twenty, because:\n",
+    "\n",
+    "- **The data is different.** Your inputs are your customers' emails, not exam questions.\n",
+    "- **The metric is different.** You care whether the `due_date` field is exactly right, not whether the prose sounds smart.\n",
+    "- **The failure modes are different.** A confident, plausible-sounding wrong answer is worse for you than an \"I don't know\" — the opposite of what a knowledge benchmark rewards.\n",
+    "\n",
+    "The only benchmark that predicts how a model performs on your task is **a benchmark built from your task.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "170a7a5c",
+   "metadata": {},
+   "source": [
+    "## What makes a benchmark trustworthy\n",
+    "\n",
+    "Before trusting *any* number — public or your own — ask whether the benchmark behind it has these four properties:\n",
+    "\n",
+    "1. **Representative data.** The examples are drawn from your real inputs, covering the cases you actually see (including the messy and ambiguous ones), not a clean toy sample.\n",
+    "2. **A metric that measures what you care about.** The score moves when the output gets better *for your purpose* and stays flat when it doesn't. The wrong metric can rank a worse model first — we'll show exactly this below.\n",
+    "3. **Enough examples to be stable.** Two examples can't distinguish two models; the score has to be more signal than noise.\n",
+    "4. **Reproducible and fair.** Every model is judged on the *same* dataset, with the *same* metric, under the *same* prompt — so a difference in the score reflects a difference in the model, not the setup.\n",
+    "\n",
+    "A Phoenix **experiment** is exactly this harness: a fixed **dataset**, a **task** you vary, and one or more **evaluators**. Hold the dataset and evaluators constant, swap only the model, and the comparison is fair by construction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6204d0f9",
+   "metadata": {},
+   "source": [
+    "**In this notebook, you will:**\n",
+    "\n",
+    "- Build a small **domain dataset** of emails + their correct extractions — your benchmark, not a public one\n",
+    "- Define an **extraction task** with a fixed schema and prompt, parameterized only by model\n",
+    "- Define **two evaluators** — string similarity *and* field-level accuracy — and see how they can rank the models differently\n",
+    "- Run the **same harness** across `gpt-4o` and `gpt-4o-mini` and compare them fairly in Phoenix\n",
+    "\n",
+    "✅ You will need a free [Phoenix Cloud account](https://app.arize.com/auth/phoenix/login) and an OpenAI API key to run this notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60da3c0f",
+   "metadata": {},
+   "source": [
+    "# Set Up Keys & Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24291ef8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install arize-phoenix arize-phoenix-otel arize-phoenix-client openai openinference-instrumentation-openai jarowinkler nest_asyncio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f36359fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from getpass import getpass\n",
+    "\n",
+    "if not (phoenix_endpoint := os.getenv(\"PHOENIX_COLLECTOR_ENDPOINT\")):\n",
+    "    phoenix_endpoint = getpass(\"🔑 Enter your Phoenix Collector Endpoint: \")\n",
+    "os.environ[\"PHOENIX_COLLECTOR_ENDPOINT\"] = phoenix_endpoint\n",
+    "\n",
+    "if not (phoenix_api_key := os.getenv(\"PHOENIX_API_KEY\")):\n",
+    "    phoenix_api_key = getpass(\"🔑 Enter your Phoenix API key: \")\n",
+    "os.environ[\"PHOENIX_API_KEY\"] = phoenix_api_key\n",
+    "\n",
+    "if not (openai_api_key := os.getenv(\"OPENAI_API_KEY\")):\n",
+    "    openai_api_key = getpass(\"🔑 Enter your OpenAI API key: \")\n",
+    "os.environ[\"OPENAI_API_KEY\"] = openai_api_key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd68096e",
+   "metadata": {},
+   "source": [
+    "# Configure Tracing\n",
+    "\n",
+    "Register a tracer provider and auto-instrument OpenAI so every extraction call shows up as a span in Phoenix. With tracing on, the experiment results link back to the exact calls that produced them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a61f5d0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nest_asyncio\n",
+    "from phoenix.otel import register\n",
+    "\n",
+    "nest_asyncio.apply()  # allow running async experiment code inside the notebook\n",
+    "\n",
+    "# auto_instrument=True activates the installed OpenInference instrumentors (here, OpenAI),\n",
+    "# so there's no need to call OpenAIInstrumentor().instrument(...) separately.\n",
+    "register(project_name=\"email-extraction-eval-harness\", auto_instrument=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a9ea99e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from phoenix.client import AsyncClient\n",
+    "\n",
+    "px_client = AsyncClient()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab31e075",
+   "metadata": {},
+   "source": [
+    "# Build a domain dataset\n",
+    "\n",
+    "This is the part public benchmarks can't do for you. We hand-label a handful of emails the way our service actually sees them — a meeting request, an invoice, a support escalation, a sales reply — each paired with the **exact** structured output we want back.\n",
+    "\n",
+    "In production you'd build this from real traffic (export traces from Phoenix, sample, and label). Here we inline a small set so the notebook is self-contained. Each example has an `email` input and an `expected` extraction with five fields:\n",
+    "\n",
+    "- `sender` — who sent it (free text)\n",
+    "- `category` — one of a fixed set (categorical)\n",
+    "- `summary` — a one-line gist (free text)\n",
+    "- `action_required` — does this need a human to act? (boolean)\n",
+    "- `due_date` — an ISO date, or `\"none\"` (categorical-ish)\n",
+    "\n",
+    "The mix of free-text and categorical fields matters: it's what lets two reasonable metrics *disagree* later.\n",
+    "\n",
+    "> **This is a demonstration harness.** Eight examples is enough to illustrate the workflow, not to draw stable conclusions — recall property 3 above. A production harness needs a larger, representative sample drawn from your real traffic before you'd trust the ranking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71875ce5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EMAILS = [\n",
+    "    {\n",
+    "        \"email\": \"From: Dana Whitfield <dana@acme.co>\\nSubject: Kickoff for Q3 redesign\\n\\nHi team, can we lock in the kickoff for the Q3 site redesign? I'm proposing Thursday July 10 at 2pm PT. Please confirm by end of week so I can send invites.\",\n",
+    "        \"expected\": {\n",
+    "            \"sender\": \"Dana Whitfield\",\n",
+    "            \"category\": \"meeting\",\n",
+    "            \"summary\": \"Proposes a Q3 redesign kickoff meeting on July 10 at 2pm PT.\",\n",
+    "            \"action_required\": True,\n",
+    "            \"due_date\": \"2025-07-10\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"email\": \"From: billing@cloudhost.com\\nSubject: Invoice #88231 due\\n\\nYour CloudHost invoice #88231 for $4,200.00 is due on 2025-06-30. Please remit payment to avoid a service interruption.\",\n",
+    "        \"expected\": {\n",
+    "            \"sender\": \"billing@cloudhost.com\",\n",
+    "            \"category\": \"invoice\",\n",
+    "            \"summary\": \"CloudHost invoice #88231 for $4,200 is due June 30.\",\n",
+    "            \"action_required\": True,\n",
+    "            \"due_date\": \"2025-06-30\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"email\": \"From: Marcus Lee <m.lee@biotechlabs.org>\\nSubject: URGENT: dashboard down\\n\\nOur production dashboard has been returning 500 errors since this morning and our analysts are blocked. We need this resolved today. Ticket #4471 already open.\",\n",
+    "        \"expected\": {\n",
+    "            \"sender\": \"Marcus Lee\",\n",
+    "            \"category\": \"support_request\",\n",
+    "            \"summary\": \"Production dashboard is down with 500 errors; needs resolution today.\",\n",
+    "            \"action_required\": True,\n",
+    "            \"due_date\": \"none\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"email\": \"From: Priya Nair <priya@growthpartners.io>\\nSubject: Re: enterprise pricing\\n\\nThanks for the deck. Leadership is interested but wants to see SOC 2 docs before we go further. No rush on timing.\",\n",
+    "        \"expected\": {\n",
+    "            \"sender\": \"Priya Nair\",\n",
+    "            \"category\": \"sales\",\n",
+    "            \"summary\": \"Interested in enterprise plan but needs SOC 2 docs before proceeding.\",\n",
+    "            \"action_required\": True,\n",
+    "            \"due_date\": \"none\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"email\": \"From: HR <people@acme.co>\\nSubject: Office closed Monday\\n\\nReminder: the office will be closed Monday for the holiday. No action needed, just a heads up. Enjoy the long weekend!\",\n",
+    "        \"expected\": {\n",
+    "            \"sender\": \"HR\",\n",
+    "            \"category\": \"internal_update\",\n",
+    "            \"summary\": \"Office is closed Monday for the holiday; informational only.\",\n",
+    "            \"action_required\": False,\n",
+    "            \"due_date\": \"none\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"email\": \"From: Tom Briggs <tom@vendorworks.com>\\nSubject: Contract renewal by Aug 1\\n\\nOur MSA is up for renewal. To keep continuity, please sign and return the renewal addendum no later than August 1, 2025. Reach out with redlines.\",\n",
+    "        \"expected\": {\n",
+    "            \"sender\": \"Tom Briggs\",\n",
+    "            \"category\": \"sales\",\n",
+    "            \"summary\": \"MSA renewal addendum must be signed and returned by August 1.\",\n",
+    "            \"action_required\": True,\n",
+    "            \"due_date\": \"2025-08-01\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"email\": \"From: alerts@statuspage.io\\nSubject: All systems operational\\n\\nThis is your weekly status digest. All monitored services were operational over the past 7 days with 100% uptime. No incidents reported.\",\n",
+    "        \"expected\": {\n",
+    "            \"sender\": \"alerts@statuspage.io\",\n",
+    "            \"category\": \"internal_update\",\n",
+    "            \"summary\": \"Weekly status digest: all services operational, 100% uptime, no incidents.\",\n",
+    "            \"action_required\": False,\n",
+    "            \"due_date\": \"none\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"email\": \"From: Sofia Reyes <sofia@designco.studio>\\nSubject: Need feedback on mockups\\n\\nDropped v2 of the mockups in the shared drive. Could you review and send comments before our sync on June 25? Want to finalize before the build phase.\",\n",
+    "        \"expected\": {\n",
+    "            \"sender\": \"Sofia Reyes\",\n",
+    "            \"category\": \"support_request\",\n",
+    "            \"summary\": \"Requests review of v2 mockups before the June 25 sync.\",\n",
+    "            \"action_required\": True,\n",
+    "            \"due_date\": \"2025-06-25\",\n",
+    "        },\n",
+    "    },\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b2a2fc3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime, timezone\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Flatten each example's expected extraction into top-level columns, so the dataset's\n",
+    "# output IS the extraction dict the evaluators compare against — not a nested wrapper.\n",
+    "rows = [{\"email\": e[\"email\"], **e[\"expected\"]} for e in EMAILS]\n",
+    "df = pd.DataFrame(rows)\n",
+    "OUTPUT_KEYS = [\"sender\", \"category\", \"summary\", \"action_required\", \"due_date\"]\n",
+    "\n",
+    "dataset = await px_client.datasets.create_dataset(\n",
+    "    name=f\"email-extraction-{datetime.now(timezone.utc):%Y%m%d-%H%M%S}\",\n",
+    "    dataframe=df,\n",
+    "    input_keys=[\"email\"],\n",
+    "    output_keys=OUTPUT_KEYS,\n",
+    ")\n",
+    "print(f\"Uploaded {len(df)} examples to dataset '{dataset.name}'\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ed616cd",
+   "metadata": {},
+   "source": [
+    "# Define the extraction task\n",
+    "\n",
+    "The task is what we hold *almost* constant: the same schema, the same prompt, the same parsing — **only the model changes**. We use OpenAI's structured outputs so every model is forced to return the exact same shape, which keeps the comparison about extraction quality rather than formatting luck.\n",
+    "\n",
+    "`make_task(model)` returns a task function bound to one model. The experiment calls it once per example; the `input` it receives is the dataset example's input dict (`{\"email\": ...}`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77ac2fee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Literal\n",
+    "\n",
+    "from openai import AsyncOpenAI\n",
+    "from pydantic import BaseModel\n",
+    "\n",
+    "openai_client = AsyncOpenAI()\n",
+    "\n",
+    "\n",
+    "class EmailExtraction(BaseModel):\n",
+    "    sender: str\n",
+    "    category: Literal[\"meeting\", \"invoice\", \"support_request\", \"sales\", \"internal_update\"]\n",
+    "    summary: str\n",
+    "    action_required: bool\n",
+    "    due_date: str  # ISO date (YYYY-MM-DD) or the literal string \"none\"\n",
+    "\n",
+    "\n",
+    "PROMPT = (\n",
+    "    \"Extract structured fields from the email below. \"\n",
+    "    \"category must be one of: meeting, invoice, support_request, sales, internal_update. \"\n",
+    "    \"due_date must be an ISO date (YYYY-MM-DD) if the email states a concrete deadline, \"\n",
+    "    'otherwise the literal string \"none\". '\n",
+    "    \"action_required is true if the email asks the recipient to do something.\\n\\nEMAIL:\\n{email}\"\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def make_task(model: str):\n",
+    "    async def task(input) -> dict:\n",
+    "        response = await openai_client.beta.chat.completions.parse(\n",
+    "            model=model,\n",
+    "            messages=[{\"role\": \"user\", \"content\": PROMPT.format(email=input[\"email\"])}],\n",
+    "            response_format=EmailExtraction,\n",
+    "            temperature=0,  # deterministic — a fair comparison varies only the model\n",
+    "        )\n",
+    "        return response.choices[0].message.parsed.model_dump()\n",
+    "\n",
+    "    return task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27c398a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sanity-check the task on a single example before running the full experiment.\n",
+    "await make_task(\"gpt-4o-mini\")(dataset.examples[0][\"input\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "254ed3ad",
+   "metadata": {},
+   "source": [
+    "# Choose metrics that measure what you care about\n",
+    "\n",
+    "This is where benchmarks quietly lie. We score the **same** outputs two ways:\n",
+    "\n",
+    "- **`jaro_winkler`** — string similarity over the JSON of the output vs. the expected output. It's cheap and forgiving — the kind of \"looks about right\" metric people reach for first — and it's the right tool for the free-text `summary`, which can be correct while worded differently.\n",
+    "- **`field_accuracy`** — the fraction of the **operational** fields (`sender`, `category`, `action_required`, `due_date`) that match *exactly* (case-insensitive). This is what downstream code depends on: a `due_date` that's \"close\" is still a wrong date. We deliberately leave `summary` out of this one — exact-matching a summary would punish good extractions for harmless rewording.\n",
+    "\n",
+    "The two metrics measure genuinely different things, so they *can* rank the models differently: a model might write better summaries (higher `jaro_winkler`) while miscategorizing more emails (lower `field_accuracy`), or vice versa. When they disagree, the metric that should decide is the one tied to your downstream needs — here, `field_accuracy`. We make this concrete with a deterministic example below, then look at how the two real models actually land."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "544bfcd4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "import jarowinkler\n",
+    "\n",
+    "# The free-text summary is scored by jaro_winkler; field_accuracy judges only the\n",
+    "# operational fields downstream code actually depends on.\n",
+    "OPERATIONAL_FIELDS = [\"sender\", \"category\", \"action_required\", \"due_date\"]\n",
+    "\n",
+    "\n",
+    "def jaro_winkler(output, expected) -> float:\n",
+    "    \"\"\"Forgiving string similarity over the serialized JSON (captures summary wording).\"\"\"\n",
+    "    return jarowinkler.jarowinkler_similarity(\n",
+    "        json.dumps(output, sort_keys=True),\n",
+    "        json.dumps(expected, sort_keys=True),\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def field_accuracy(output, expected) -> float:\n",
+    "    \"\"\"Fraction of OPERATIONAL fields that match exactly (case-insensitive).\"\"\"\n",
+    "    matches = sum(\n",
+    "        1\n",
+    "        for k in OPERATIONAL_FIELDS\n",
+    "        if str(output.get(k)).strip().lower() == str(expected[k]).strip().lower()\n",
+    "    )\n",
+    "    return matches / len(OPERATIONAL_FIELDS)\n",
+    "\n",
+    "\n",
+    "EVALUATORS = [jaro_winkler, field_accuracy]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a574bb5",
+   "metadata": {},
+   "source": [
+    "Before running the models, here's the disagreement made deterministic. Two candidate extractions for the same invoice email — one with the right operational fields but a reworded `summary`, one that looks almost identical but has the `due_date` off by a day:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1e1716e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expected = {\n",
+    "    \"sender\": \"billing@cloudhost.com\",\n",
+    "    \"category\": \"invoice\",\n",
+    "    \"action_required\": True,\n",
+    "    \"due_date\": \"2025-06-30\",\n",
+    "    \"summary\": \"CloudHost invoice #88231 for $4,200 is due June 30.\",\n",
+    "}\n",
+    "# A: every operational field right, but the summary is fully reworded (harmless).\n",
+    "candidate_a = {\n",
+    "    **expected,\n",
+    "    \"summary\": \"Please arrange payment for the recent cloud hosting charges before the close of the current billing period.\",\n",
+    "}\n",
+    "# B: summary identical, but the due_date is off by a day.\n",
+    "candidate_b = {**expected, \"due_date\": \"2025-07-01\"}\n",
+    "\n",
+    "for name, cand in [\n",
+    "    (\"A (right fields, reworded summary)\", candidate_a),\n",
+    "    (\"B (identical summary, due_date off by a day)\", candidate_b),\n",
+    "]:\n",
+    "    print(\n",
+    "        f\"{name}: jaro_winkler={jaro_winkler(cand, expected):.3f}  \"\n",
+    "        f\"field_accuracy={field_accuracy(cand, expected):.3f}\"\n",
+    "    )\n",
+    "\n",
+    "# field_accuracy prefers A (all operational fields correct); jaro_winkler prefers B\n",
+    "# (it looks almost identical). But B's one-day date slip is exactly what breaks\n",
+    "# downstream code — same outputs, opposite rankings, and the strict metric is right."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa4236b1",
+   "metadata": {},
+   "source": [
+    "# Run the same harness across models\n",
+    "\n",
+    "Same dataset, same evaluators, same prompt — we change only the `model` argument. That's what makes this a fair comparison instead of an anecdote."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81c51493",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment_4o = await px_client.experiments.run_experiment(\n",
+    "    dataset=dataset,\n",
+    "    task=make_task(\"gpt-4o\"),\n",
+    "    evaluators=EVALUATORS,\n",
+    "    experiment_name=\"gpt-4o\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6250b129",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment_4o_mini = await px_client.experiments.run_experiment(\n",
+    "    dataset=dataset,\n",
+    "    task=make_task(\"gpt-4o-mini\"),\n",
+    "    evaluators=EVALUATORS,\n",
+    "    experiment_name=\"gpt-4o-mini\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5dc1400",
+   "metadata": {},
+   "source": [
+    "# Compare fairly\n",
+    "\n",
+    "Phoenix prints a per-experiment summary, and the UI lets you compare both runs example-by-example. Here we also roll the scores up per metric so the disagreement is explicit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f550ecdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import defaultdict\n",
+    "\n",
+    "\n",
+    "def average_scores(experiment) -> dict:\n",
+    "    sums, counts = defaultdict(float), defaultdict(int)\n",
+    "    for run in experiment[\"evaluation_runs\"]:\n",
+    "        result = run.result\n",
+    "        if result and result.get(\"score\") is not None:\n",
+    "            sums[run.name] += result[\"score\"]\n",
+    "            counts[run.name] += 1\n",
+    "    return {name: sums[name] / counts[name] for name in sums}\n",
+    "\n",
+    "\n",
+    "summary = pd.DataFrame(\n",
+    "    {\"gpt-4o\": average_scores(experiment_4o), \"gpt-4o-mini\": average_scores(experiment_4o_mini)}\n",
+    ")\n",
+    "print(summary)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81dd6317",
+   "metadata": {},
+   "source": [
+    "Open the experiment comparison in Phoenix to see the per-example detail behind these averages. With only eight examples the two models may or may not separate cleanly on this run — that's exactly why you *look* rather than assume. The headline lesson holds regardless:\n",
+    "\n",
+    "- If the two metrics **rank the models differently**, the public-leaderboard instinct (\"just take the higher-scoring model\") could have led you to the wrong choice — *which* model is \"better\" depends on the metric, and the metric that should win is the one tied to your downstream needs (here, `field_accuracy`).\n",
+    "- If they **agree**, you now have evidence grounded in *your* data and *your* metric — not a borrowed number from a benchmark that never saw your task.\n",
+    "\n",
+    "Either way, you trust the result because you built the harness."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d8fd6bb",
+   "metadata": {},
+   "source": [
+    "# Reading the results in Phoenix\n",
+    "\n",
+    "Open the dataset's **Experiments** tab to see the runs side by side. Each experiment is a row; each evaluator becomes its own **score column** (so `field_accuracy` sits next to `jaro_winkler`), alongside operational columns — average **latency**, **cost**, and **error rate** — that matter for a real model choice but never show up on a public leaderboard.\n",
+    "\n",
+    "![Comparing the gpt-4o and gpt-4o-mini experiments in Phoenix.](https://storage.googleapis.com/arize-phoenix-assets/assets/images/email-eval-harness-experiments.png)\n",
+    "\n",
+    "Notice the two metrics can disagree on the headline question: here `gpt-4o` leads on `field_accuracy` while `gpt-4o-mini` edges ahead on `jaro_winkler`. Sort by the metric tied to your downstream needs (`field_accuracy`) rather than the forgiving one, and click any row to drop into the example-level view: the input email, the model's extraction, and each evaluator's score for that single example. That's where you *see why* one model wins — a `due_date` the model dropped, a sender it over-captured — instead of trusting an aggregate.\n",
+    "\n",
+    "![The example-level compare view in Phoenix showing input, reference, and model output with per-example scores.](https://storage.googleapis.com/arize-phoenix-assets/assets/images/email-eval-harness-example-level.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "096fb6c6",
+   "metadata": {},
+   "source": [
+    "# Where to go next\n",
+    "\n",
+    "The harness is reusable — each step below holds the dataset and evaluators constant and changes one thing at a time, so every comparison stays fair:\n",
+    "\n",
+    "- **Iterate the prompt.** Vary `PROMPT` instead of `model` to find the wording that extracts most reliably.\n",
+    "- **Add models and providers.** Drop another model name — or another provider's client — into `make_task` and rerun. The leaderboard ranking rarely survives contact with your task.\n",
+    "- **Grow the dataset.** Move from eight inline examples to a representative sample exported from your real traffic, so the scores become stable enough to trust (property 3).\n",
+    "- **Make it a standing benchmark.** Rerun the same harness on every model upgrade or prompt change to catch regressions before they reach production."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f27164b",
+   "metadata": {},
+   "source": [
+    "# Takeaway\n",
+    "\n",
+    "A public benchmark tells you how a model does on *someone else's* task, with *someone else's* metric. That number rarely transfers to production.\n",
+    "\n",
+    "The fix isn't a better leaderboard — it's a small, trustworthy harness of your own:\n",
+    "\n",
+    "1. **Representative data** — a dataset built from your real inputs.\n",
+    "2. **A metric that measures what you care about** — and the discipline to notice when a convenient metric (string similarity) disagrees with the real one (field accuracy).\n",
+    "3. **Enough examples** to make the score stable.\n",
+    "4. **A fair, reproducible setup** — same dataset, same evaluators, same prompt; vary only the model.\n",
+    "\n",
+    "A Phoenix experiment gives you all four. Once you have it, comparing models — or prompts, or providers — is just swapping one argument and reading a number you can actually defend."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
Level-up of the **Model Comparison for an Email Text Extraction Service** cookbook into a concept-first cookbook — **Why public benchmarks lie: building your own eval harness** (DEV-357) — and ships it as a docs-site cookbook page. Keeps the email text-extraction worked example. PX only.

The original notebook (`tutorials/experiments/langchain_email_extraction.ipynb`) and its cookbook page were removed in the LangChain 1.x migration (#12103) because they depended on `langchain-benchmarks`. This is a fresh, **LangChain-free** rewrite that keeps the email-extraction example and the Jaro-Winkler metric.

## Notebook (`tutorials/experiments/building_your_own_eval_harness.ipynb`)
- **Leads with the concept:** a model that tops MMLU can lose on your task; what makes a benchmark trustworthy (representative data, a metric that measures what you care about, enough examples, a fair/reproducible setup); how to compare models fairly.
- **Self-contained:** an inline hand-labeled email dataset + OpenAI **structured outputs**; the task is parameterized only by model (`gpt-4o` vs `gpt-4o-mini`) with `temperature=0` so the comparison varies only the model.
- **Two evaluators:** `jaro_winkler` (forgiving string similarity, captures the free-text summary) and `field_accuracy` (exact match on the operational fields downstream code relies on) — plus a **deterministic example** where the two metrics rank the same outputs in *opposite* order.
- **Tracing & experiments:** `register(..., auto_instrument=True)`; dataset upload, `run_experiment`, and `evaluate_experiment` via `phoenix.client.AsyncClient`; results rolled up per metric and read back in the Phoenix UI.

## Docs
- New cookbook page `docs/phoenix/cookbook/datasets-and-experiments/building-your-own-eval-harness.mdx` with a "Set up tracing" section, a "Reading the results in Phoenix" section (two screenshots), and a "Where to go next" section.
- `docs.json` nav entry (Datasets & Experiments cookbook group), `llms.txt` entry, and `sitemap.xml` / `docs/phoenix/sitemap.xml` refresh.
