### PR TITLE
docs: Audit and update llms.txt

### DIFF
--- a/.github/workflows/check-dependabot-uv-version.yml
+++ b/.github/workflows/check-dependabot-uv-version.yml
@@ -97,16 +97,16 @@ jobs:
       - name: Run Claude Code
         if: steps.dependabot.outputs.version != steps.repo.outputs.version && steps.existing_pr.outputs.count == '0'
         id: claude
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Surface the full Claude SDK message stream in the step log instead of
-          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
-          # inputs are public repo/PR/issue content, registered secrets stay masked,
-          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs
+          # are public repo/PR/issue content, and GitHub masks registered secrets.
+          # Note: logs are public.
           show_full_output: 'true'
           prompt: |
             Bump the pinned uv CLI version across this repo from `${{ steps.repo.outputs.version }}` to `${{ steps.dependabot.outputs.version }}` so it matches the version Dependabot supports.

--- a/.github/workflows/check-dependabot-uv-version.yml
+++ b/.github/workflows/check-dependabot-uv-version.yml
@@ -14,14 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      # contents: read is all Claude can reach: the read-only workflow token is
+      # passed to the action below (so no write-scoped App token is minted via
+      # OIDC), and publishing is done by later steps with a PAT.
       contents: read
-      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          # Shallow clone: nothing here reads git history, and origin/main at
+          # the tip is enough for the publish step's blocked-file restore.
+          fetch-depth: 1
           persist-credentials: false
 
       - name: Get uv version supported by Dependabot
@@ -102,6 +106,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Hand the action the read-only workflow token instead of letting it
+          # mint a write-scoped Claude App token via OIDC. Claude never writes
+          # to GitHub here (a later step publishes with a PAT), so the GH_TOKEN
+          # in its environment stays read-only.
+          github_token: ${{ github.token }}
 
           # Surface the full Claude SDK message stream in the step log instead of
           # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs

--- a/.github/workflows/check-dependabot-uv-version.yml
+++ b/.github/workflows/check-dependabot-uv-version.yml
@@ -82,10 +82,17 @@ jobs:
         with:
           version: ${{ steps.dependabot.outputs.version }}
 
-      - name: Install bubblewrap
+      - name: Install subprocess isolation deps
         if: steps.dependabot.outputs.version != steps.repo.outputs.version && steps.existing_pr.outputs.count == '0'
-        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 for subprocess isolation.
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+        # Required by CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1. The Claude CLI sandbox
+        # needs both bubblewrap AND socat, and Ubuntu 24.04+ blocks the unprivileged
+        # user namespaces it relies on by default.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bubblewrap socat
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Run Claude Code
         if: steps.dependabot.outputs.version != steps.repo.outputs.version && steps.existing_pr.outputs.count == '0'
@@ -95,6 +102,17 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Surface the full Claude SDK message stream in the step log instead of
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
+          # inputs are public repo/PR/issue content, registered secrets stay masked,
+          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          show_full_output: 'true'
+          # Mints an OIDC app token with contents/pull_requests/issues: write,
+          # which the post-action "Commit and open pull request" step uses via
+          # steps.claude.outputs.github_token instead of a long-lived PAT.
+          additional_permissions: |
+            contents: write
           prompt: |
             Bump the pinned uv CLI version across this repo from `${{ steps.repo.outputs.version }}` to `${{ steps.dependabot.outputs.version }}` so it matches the version Dependabot supports.
 
@@ -113,7 +131,9 @@ jobs:
       - name: Commit and open pull request
         if: steps.dependabot.outputs.version != steps.repo.outputs.version && steps.existing_pr.outputs.count == '0' && steps.claude.outcome == 'success'
         env:
-          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          # OIDC app token minted by the claude-code-action step above — short-lived,
+          # auto-revoked at job end, and (unlike GITHUB_TOKEN) triggers downstream CI.
+          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
           UV_VERSION: ${{ steps.dependabot.outputs.version }}
         run: |
           if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then

--- a/.github/workflows/check-dependabot-uv-version.yml
+++ b/.github/workflows/check-dependabot-uv-version.yml
@@ -108,11 +108,6 @@ jobs:
           # inputs are public repo/PR/issue content, registered secrets stay masked,
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
-          # Mints an OIDC app token with write access for the Claude action while
-          # it runs. The action revokes this token during cleanup, so later steps
-          # must use a separate publishing token.
-          additional_permissions: |
-            contents: write
           prompt: |
             Bump the pinned uv CLI version across this repo from `${{ steps.repo.outputs.version }}` to `${{ steps.dependabot.outputs.version }}` so it matches the version Dependabot supports.
 

--- a/.github/workflows/check-dependabot-uv-version.yml
+++ b/.github/workflows/check-dependabot-uv-version.yml
@@ -108,9 +108,9 @@ jobs:
           # inputs are public repo/PR/issue content, registered secrets stay masked,
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
-          # Mints an OIDC app token with contents/pull_requests/issues: write,
-          # which the post-action "Commit and open pull request" step uses via
-          # steps.claude.outputs.github_token instead of a long-lived PAT.
+          # Mints an OIDC app token with write access for the Claude action while
+          # it runs. The action revokes this token during cleanup, so later steps
+          # must use a separate publishing token.
           additional_permissions: |
             contents: write
           prompt: |
@@ -131,9 +131,9 @@ jobs:
       - name: Commit and open pull request
         if: steps.dependabot.outputs.version != steps.repo.outputs.version && steps.existing_pr.outputs.count == '0' && steps.claude.outcome == 'success'
         env:
-          # OIDC app token minted by the claude-code-action step above — short-lived,
-          # auto-revoked at job end, and (unlike GITHUB_TOKEN) triggers downstream CI.
-          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
+          # Separate publishing token; the claude-code-action app token has
+          # already been revoked by this point.
+          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
           UV_VERSION: ${{ steps.dependabot.outputs.version }}
         run: |
           if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then

--- a/.github/workflows/check-dependabot-uv-version.yml
+++ b/.github/workflows/check-dependabot-uv-version.yml
@@ -136,6 +136,11 @@ jobs:
             exit 0
           fi
           gh auth setup-git
+          # The Claude step rewrites origin to embed its app token in the URL
+          # and revokes that token when the step ends. URL-embedded credentials
+          # take precedence over gh's credential helper, so reset the remote to
+          # a clean URL to push with the PAT configured above.
+          git remote set-url origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # Allow .github/ (uv pins live in workflow files) but restore other

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,11 @@ jobs:
     # secrets (ANTHROPIC_API_KEY is empty) nor an OIDC token (id-token: write
     # is inert for forks), so the action's auth validation would fail the run
     # on every external contribution. Skip instead of failing red.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Also skip drafts: synchronize fires on every push to a draft, and
+    # ready_for_review already triggers a review when the PR leaves draft.
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     # Bound the run so a hung review can't hold the runner indefinitely;
     # a single-PR review finishes well under this.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,12 +18,11 @@ concurrency:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Same-repo PRs only: fork-origin pull_request runs get neither repository
+    # secrets (ANTHROPIC_API_KEY is empty) nor an OIDC token (id-token: write
+    # is inert for forks), so the action's auth validation would fail the run
+    # on every external contribution. Skip instead of failing red.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     # Bound the run so a hung review can't hold the runner indefinitely;
     # a single-PR review finishes well under this.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,12 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# One review per PR: a new push (synchronize) cancels the in-flight review of
+# the now-stale commit, so only the latest state is reviewed.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -19,6 +25,9 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    # Bound the run so a hung review can't hold the runner indefinitely;
+    # a single-PR review finishes well under this.
+    timeout-minutes: 30
     permissions:
       # PR/issue read+write goes through the Claude App token minted by the
       # OIDC exchange below — the workflow GITHUB_TOKEN is only used for the

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:

--- a/.github/workflows/claude-docs-gap-audit.yml
+++ b/.github/workflows/claude-docs-gap-audit.yml
@@ -54,9 +54,9 @@ jobs:
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
           # Setting additional_permissions triggers the action to explicitly request
-          # contents/pull_requests/issues: write on the OIDC-minted app token, which
-          # the post-action "Create docs gap issue" step uses via
-          # steps.claude.outputs.github_token.
+          # contents/pull_requests/issues: write on the OIDC-minted app token while
+          # Claude runs. The action revokes this token during cleanup, so later
+          # publishing steps use a separate token.
           additional_permissions: |
             contents: write
           prompt: |
@@ -84,9 +84,9 @@ jobs:
 
       - name: Create docs gap issue
         env:
-          # App token minted by the claude-code-action OIDC exchange — short-lived
-          # and auto-revoked at job end.
-          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
+          # Separate publishing token; the claude-code-action app token has
+          # already been revoked by this point.
+          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
         run: |
           if [ ! -s .scratch/docs-gap-issue.md ]; then
             echo "No docs gap issue body written — exiting cleanly."

--- a/.github/workflows/claude-docs-gap-audit.yml
+++ b/.github/workflows/claude-docs-gap-audit.yml
@@ -47,6 +47,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Surface the full Claude SDK message stream in the step log instead of
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
+          # inputs are public repo/PR/issue content, registered secrets stay masked,
+          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          show_full_output: 'true'
           # Setting additional_permissions triggers the action to explicitly request
           # contents/pull_requests/issues: write on the OIDC-minted app token, which
           # the post-action "Create docs gap issue" step uses via

--- a/.github/workflows/claude-docs-gap-audit.yml
+++ b/.github/workflows/claude-docs-gap-audit.yml
@@ -15,8 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      # contents: read is all Claude can reach: the read-only workflow token is
+      # passed to the action below (so no write-scoped App token is minted via
+      # OIDC), and publishing is done by later steps with a PAT.
       contents: read
-      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
 
     steps:
       - name: Checkout repository
@@ -47,6 +49,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Hand the action the read-only workflow token instead of letting it
+          # mint a write-scoped Claude App token via OIDC. Claude never writes
+          # to GitHub here (a later step publishes with a PAT), so the GH_TOKEN
+          # in its environment stays read-only.
+          github_token: ${{ github.token }}
 
           # Surface the full Claude SDK message stream in the step log instead of
           # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs

--- a/.github/workflows/claude-docs-gap-audit.yml
+++ b/.github/workflows/claude-docs-gap-audit.yml
@@ -53,12 +53,6 @@ jobs:
           # inputs are public repo/PR/issue content, registered secrets stay masked,
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
-          # Setting additional_permissions triggers the action to explicitly request
-          # contents/pull_requests/issues: write on the OIDC-minted app token while
-          # Claude runs. The action revokes this token during cleanup, so later
-          # publishing steps use a separate token.
-          additional_permissions: |
-            contents: write
           prompt: |
             /phoenix-docs-gap-audit
 

--- a/.github/workflows/claude-docs-gap-audit.yml
+++ b/.github/workflows/claude-docs-gap-audit.yml
@@ -42,16 +42,16 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Surface the full Claude SDK message stream in the step log instead of
-          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
-          # inputs are public repo/PR/issue content, registered secrets stay masked,
-          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs
+          # are public repo/PR/issue content, and GitHub masks registered secrets.
+          # Note: logs are public.
           show_full_output: 'true'
           prompt: |
             /phoenix-docs-gap-audit

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -18,8 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
+      # contents: read is all Claude can reach: the read-only workflow token is
+      # passed to the action below (so no write-scoped App token is minted via
+      # OIDC), and publishing is done by later steps with a PAT.
       contents: read
-      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
     env:
       GH_REPO: ${{ github.repository }}
       ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -100,6 +102,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Hand the action the read-only workflow token instead of letting it
+          # mint a write-scoped Claude App token via OIDC. Claude never writes
+          # to GitHub here (a later step publishes with a PAT), so the GH_TOKEN
+          # in its environment stays read-only.
+          github_token: ${{ github.token }}
 
           # Surface the full Claude SDK message stream in the step log instead of
           # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -107,9 +107,9 @@ jobs:
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
           # Setting additional_permissions triggers the action to explicitly request
-          # contents/pull_requests/issues: write on the OIDC-minted app token, which
-          # the post-action "Commit and open PR" step uses via
-          # steps.claude.outputs.github_token.
+          # contents/pull_requests/issues: write on the OIDC-minted app token while
+          # Claude runs. The action revokes this token during cleanup, so later
+          # publishing steps use a separate token.
           additional_permissions: |
             contents: write
           prompt: |
@@ -178,9 +178,9 @@ jobs:
       - name: Commit and open PR
         if: steps.guard.outputs.ready == 'true' && steps.claude.outcome == 'success'
         env:
-          # App token minted by the claude-code-action OIDC exchange — short-lived,
-          # auto-revoked at job end, and (unlike GITHUB_TOKEN) triggers downstream CI.
-          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
+          # Separate publishing token; the claude-code-action app token has
+          # already been revoked by this point.
+          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
         run: |
           gh auth setup-git
           git config user.name "github-actions[bot]"

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -13,8 +13,18 @@ concurrency:
 
 jobs:
   implement:
-    # Only run when good-agent-issue label is added
-    if: github.event.label.name == 'good-agent-issue'
+    # Only run when the good-agent-issue label is added by someone on the
+    # explicit allowlist of GitHub usernames — the same list (and rationale)
+    # as claude.yml: author_association misclassifies private org members,
+    # github.actor is always the user who triggered the event, and `contains`
+    # compares case-insensitively. Keep the two lists in sync.
+    if: |
+      github.event.label.name == 'good-agent-issue' &&
+      contains(fromJSON('[
+        "anticorrelator", "axiomofjoy", "cephalization", "ehutt", "jimbobbennett",
+        "mikeldking", "Nancy-Chauhan", "PatriciaArnedo", "rickarize", "RogerHYang",
+        "seldo", "yfrigui2"
+      ]'), github.actor)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -27,19 +37,12 @@ jobs:
       ISSUE_NUMBER: ${{ github.event.issue.number }}
 
     steps:
-      - name: Guard – check permissions and duplicates
+      - name: Guard – check duplicates
         id: guard
         env:
           GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
-          REPO: ${{ github.repository }}
-          SENDER: ${{ github.event.sender.login }}
         run: |
-          # Verify sender has write access
-          PERMISSION=$(gh api "repos/$REPO/collaborators/$SENDER/permission" -q '.permission')
-          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "maintain" && "$PERMISSION" != "write" ]]; then
-            echo "Sender $SENDER has '$PERMISSION' permission, skipping"
-            exit 0
-          fi
+          # The labeler is already vetted by the job-level username allowlist.
 
           # Skip if already assigned
           ASSIGNEES=$(gh issue view "$ISSUE_NUMBER" --json assignees -q '.assignees | length')

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -177,6 +177,11 @@ jobs:
           GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
         run: |
           gh auth setup-git
+          # The Claude step rewrites origin to embed its app token in the URL
+          # and revokes that token when the step ends. URL-embedded credentials
+          # take precedence over gh's credential helper, so reset the remote to
+          # a clean URL to push with the PAT configured above.
+          git remote set-url origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -4,6 +4,13 @@ on:
   issues:
     types: [labeled]
 
+# One implementation per issue. cancel-in-progress is false so an in-flight
+# run (which may already be committing/pushing a PR) is never killed mid-work;
+# a duplicate trigger queues behind it and the guard step then no-ops.
+concurrency:
+  group: claude-implement-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   implement:
     # Only run when good-agent-issue label is added
@@ -93,6 +100,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Surface the full Claude SDK message stream in the step log instead of
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
+          # inputs are public repo/PR/issue content, registered secrets stay masked,
+          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          show_full_output: 'true'
           # Setting additional_permissions triggers the action to explicitly request
           # contents/pull_requests/issues: write on the OIDC-minted app token, which
           # the post-action "Commit and open PR" step uses via

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -106,12 +106,6 @@ jobs:
           # inputs are public repo/PR/issue content, registered secrets stay masked,
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
-          # Setting additional_permissions triggers the action to explicitly request
-          # contents/pull_requests/issues: write on the OIDC-minted app token while
-          # Claude runs. The action revokes this token during cleanup, so later
-          # publishing steps use a separate token.
-          additional_permissions: |
-            contents: write
           prompt: |
             Implement GitHub issue #${{ github.event.issue.number }} end-to-end in the working tree.
             A separate workflow step will commit, push, and open the PR; do NOT attempt

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -95,16 +95,16 @@ jobs:
       - name: Run Claude Code
         if: steps.guard.outputs.ready == 'true'
         id: claude
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Surface the full Claude SDK message stream in the step log instead of
-          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
-          # inputs are public repo/PR/issue content, registered secrets stay masked,
-          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs
+          # are public repo/PR/issue content, and GitHub masks registered secrets.
+          # Note: logs are public.
           show_full_output: 'true'
           prompt: |
             Implement GitHub issue #${{ github.event.issue.number }} end-to-end in the working tree.

--- a/.github/workflows/claude-llms-txt.yml
+++ b/.github/workflows/claude-llms-txt.yml
@@ -59,9 +59,9 @@ jobs:
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
           # Setting additional_permissions triggers the action to explicitly request
-          # contents/pull_requests/issues: write on the OIDC-minted app token, which
-          # the post-action "Commit and open pull request" step uses to git push and
-          # open the PR via steps.claude.outputs.github_token.
+          # contents/pull_requests/issues: write on the OIDC-minted app token while
+          # Claude runs. The action revokes this token during cleanup, so later
+          # publishing steps use a separate token.
           additional_permissions: |
             contents: write
           prompt: |
@@ -78,9 +78,9 @@ jobs:
       - name: Commit and open pull request
         if: steps.claude.outcome == 'success'
         env:
-          # App token minted by the claude-code-action OIDC exchange — short-lived,
-          # auto-revoked at job end, and (unlike GITHUB_TOKEN) triggers downstream CI.
-          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
+          # Separate publishing token; the claude-code-action app token has
+          # already been revoked by this point.
+          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
         run: |
           if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
             echo "No llms.txt changes — exiting cleanly."

--- a/.github/workflows/claude-llms-txt.yml
+++ b/.github/workflows/claude-llms-txt.yml
@@ -58,12 +58,6 @@ jobs:
           # inputs are public repo/PR/issue content, registered secrets stay masked,
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
-          # Setting additional_permissions triggers the action to explicitly request
-          # contents/pull_requests/issues: write on the OIDC-minted app token while
-          # Claude runs. The action revokes this token during cleanup, so later
-          # publishing steps use a separate token.
-          additional_permissions: |
-            contents: write
           prompt: |
             /phoenix-llms-txt
 

--- a/.github/workflows/claude-llms-txt.yml
+++ b/.github/workflows/claude-llms-txt.yml
@@ -103,6 +103,10 @@ jobs:
               fi
             done <<< "$blocked_files"
           fi
+          if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+            echo "Only blocked files changed; restored them and skipping PR."
+            exit 0
+          fi
           git add -A
           git commit -m "docs: audit and update llms.txt"
           git push -u origin "$BRANCH"

--- a/.github/workflows/claude-llms-txt.yml
+++ b/.github/workflows/claude-llms-txt.yml
@@ -81,6 +81,11 @@ jobs:
             exit 0
           fi
           gh auth setup-git
+          # The Claude step rewrites origin to embed its app token in the URL
+          # and revokes that token when the step ends. URL-embedded credentials
+          # take precedence over gh's credential helper, so reset the remote to
+          # a clean URL to push with the PAT configured above.
+          git remote set-url origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           blocked_files=$(git diff --name-only | awk '

--- a/.github/workflows/claude-llms-txt.yml
+++ b/.github/workflows/claude-llms-txt.yml
@@ -52,6 +52,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Surface the full Claude SDK message stream in the step log instead of
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
+          # inputs are public repo/PR/issue content, registered secrets stay masked,
+          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          show_full_output: 'true'
           # Setting additional_permissions triggers the action to explicitly request
           # contents/pull_requests/issues: write on the OIDC-minted app token, which
           # the post-action "Commit and open pull request" step uses to git push and

--- a/.github/workflows/claude-llms-txt.yml
+++ b/.github/workflows/claude-llms-txt.yml
@@ -15,14 +15,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      # contents: read is all Claude can reach: the read-only workflow token is
+      # passed to the action below (so no write-scoped App token is minted via
+      # OIDC), and publishing is done by later steps with a PAT.
       contents: read
-      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          # Shallow clone: the audit compares llms.txt against the current docs
+          # tree and never reads git history, and origin/main at the tip is
+          # enough for the publish step's blocked-file restore.
+          fetch-depth: 1
           persist-credentials: false
 
       - name: Create branch
@@ -52,6 +57,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Hand the action the read-only workflow token instead of letting it
+          # mint a write-scoped Claude App token via OIDC. Claude never writes
+          # to GitHub here (a later step publishes with a PAT), so the GH_TOKEN
+          # in its environment stays read-only.
+          github_token: ${{ github.token }}
 
           # Surface the full Claude SDK message stream in the step log instead of
           # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs

--- a/.github/workflows/claude-llms-txt.yml
+++ b/.github/workflows/claude-llms-txt.yml
@@ -47,16 +47,16 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Surface the full Claude SDK message stream in the step log instead of
-          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
-          # inputs are public repo/PR/issue content, registered secrets stay masked,
-          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs
+          # are public repo/PR/issue content, and GitHub masks registered secrets.
+          # Note: logs are public.
           show_full_output: 'true'
           prompt: |
             /phoenix-llms-txt

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -58,12 +58,6 @@ jobs:
           # inputs are public repo/PR/issue content, registered secrets stay masked,
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
-          # Setting additional_permissions triggers the action to explicitly request
-          # contents/pull_requests/issues: write on the OIDC-minted app token while
-          # Claude runs. The action revokes this token during cleanup, so later
-          # publishing steps use a separate token.
-          additional_permissions: |
-            contents: write
           prompt: |
             /phoenix-release-notes
 

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -103,6 +103,10 @@ jobs:
               fi
             done <<< "$blocked_files"
           fi
+          if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+            echo "Only blocked files changed; restored them and skipping PR."
+            exit 0
+          fi
           git add -A
           git commit -m "docs: add Phoenix release notes"
           git push -u origin "$BRANCH"

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -47,16 +47,16 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Surface the full Claude SDK message stream in the step log instead of
-          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
-          # inputs are public repo/PR/issue content, registered secrets stay masked,
-          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs
+          # are public repo/PR/issue content, and GitHub masks registered secrets.
+          # Note: logs are public.
           show_full_output: 'true'
           prompt: |
             /phoenix-release-notes

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -59,9 +59,9 @@ jobs:
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
           # Setting additional_permissions triggers the action to explicitly request
-          # contents/pull_requests/issues: write on the OIDC-minted app token, which
-          # the post-action "Commit and open pull request" step uses to git push and
-          # open the PR via steps.claude.outputs.github_token.
+          # contents/pull_requests/issues: write on the OIDC-minted app token while
+          # Claude runs. The action revokes this token during cleanup, so later
+          # publishing steps use a separate token.
           additional_permissions: |
             contents: write
           prompt: |
@@ -77,9 +77,9 @@ jobs:
       - name: Commit and open pull request
         if: steps.claude.outcome == 'success'
         env:
-          # App token minted by the claude-code-action OIDC exchange — short-lived,
-          # auto-revoked at job end, and (unlike GITHUB_TOKEN) triggers downstream CI.
-          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
+          # Separate publishing token; the claude-code-action app token has
+          # already been revoked by this point.
+          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
         run: |
           if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
             echo "No release notes changes — exiting cleanly."

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -52,6 +52,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Surface the full Claude SDK message stream in the step log instead of
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
+          # inputs are public repo/PR/issue content, registered secrets stay masked,
+          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          show_full_output: 'true'
           # Setting additional_permissions triggers the action to explicitly request
           # contents/pull_requests/issues: write on the OIDC-minted app token, which
           # the post-action "Commit and open pull request" step uses to git push and

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -81,6 +81,11 @@ jobs:
           fi
           TODAY=$(date -u +%Y-%m-%d)
           gh auth setup-git
+          # The Claude step rewrites origin to embed its app token in the URL
+          # and revokes that token when the step ends. URL-embedded credentials
+          # take precedence over gh's credential helper, so reset the remote to
+          # a clean URL to push with the PAT configured above.
+          git remote set-url origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           blocked_files=$(git diff --name-only | awk '

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -15,8 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      # contents: read is all Claude can reach: the read-only workflow token is
+      # passed to the action below (so no write-scoped App token is minted via
+      # OIDC), and publishing is done by later steps with a PAT.
       contents: read
-      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
 
     steps:
       - name: Checkout repository
@@ -52,6 +54,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Hand the action the read-only workflow token instead of letting it
+          # mint a write-scoped Claude App token via OIDC. Claude never writes
+          # to GitHub here (a later step publishes with a PAT), so the GH_TOKEN
+          # in its environment stays read-only.
+          github_token: ${{ github.token }}
 
           # Surface the full Claude SDK message stream in the step log instead of
           # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs

--- a/.github/workflows/claude-skills-audit.yml
+++ b/.github/workflows/claude-skills-audit.yml
@@ -129,6 +129,11 @@ jobs:
           AUDIT_BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
           gh auth setup-git
+          # The Claude step rewrites origin to embed its app token in the URL
+          # and revokes that token when the step ends. URL-embedded credentials
+          # take precedence over gh's credential helper, so reset the remote to
+          # a clean URL to push with the PAT configured above.
+          git remote set-url origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           git add .agents/skills/phoenix-tracing .agents/skills/phoenix-cli .agents/skills/phoenix-evals
           git commit -m "docs(skills): weekly audit — $AUDIT_DATE"
           git push origin "$AUDIT_BRANCH"

--- a/.github/workflows/claude-skills-audit.yml
+++ b/.github/workflows/claude-skills-audit.yml
@@ -20,8 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      # contents: read is all Claude can reach: the read-only workflow token is
+      # passed to the action below (so no write-scoped App token is minted via
+      # OIDC), and publishing is done by later steps with a PAT.
       contents: read
-      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
     env:
       AUDIT_WINDOW: ${{ inputs.window || '7 days ago' }}
 
@@ -70,6 +72,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Hand the action the read-only workflow token instead of letting it
+          # mint a write-scoped Claude App token via OIDC. Claude never writes
+          # to GitHub here (a later step publishes with a PAT), so the GH_TOKEN
+          # in its environment stays read-only.
+          github_token: ${{ github.token }}
 
           # Surface the full Claude SDK message stream in the step log instead of
           # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs

--- a/.github/workflows/claude-skills-audit.yml
+++ b/.github/workflows/claude-skills-audit.yml
@@ -76,12 +76,6 @@ jobs:
           # inputs are public repo/PR/issue content, registered secrets stay masked,
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
-          # Setting additional_permissions triggers the action to explicitly request
-          # contents/pull_requests/issues: write on the OIDC-minted app token while
-          # Claude runs. The action revokes this token during cleanup, so later
-          # publishing steps use a separate token.
-          additional_permissions: |
-            contents: write
           prompt: |
             /phoenix-skills-audit
 

--- a/.github/workflows/claude-skills-audit.yml
+++ b/.github/workflows/claude-skills-audit.yml
@@ -65,16 +65,16 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Surface the full Claude SDK message stream in the step log instead of
-          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
-          # inputs are public repo/PR/issue content, registered secrets stay masked,
-          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs
+          # are public repo/PR/issue content, and GitHub masks registered secrets.
+          # Note: logs are public.
           show_full_output: 'true'
           prompt: |
             /phoenix-skills-audit

--- a/.github/workflows/claude-skills-audit.yml
+++ b/.github/workflows/claude-skills-audit.yml
@@ -70,6 +70,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Surface the full Claude SDK message stream in the step log instead of
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
+          # inputs are public repo/PR/issue content, registered secrets stay masked,
+          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          show_full_output: 'true'
           # Setting additional_permissions triggers the action to explicitly request
           # contents/pull_requests/issues: write on the OIDC-minted app token, which
           # the post-action "Commit and push" / "Open pull request" steps use via

--- a/.github/workflows/claude-skills-audit.yml
+++ b/.github/workflows/claude-skills-audit.yml
@@ -77,9 +77,9 @@ jobs:
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
           # Setting additional_permissions triggers the action to explicitly request
-          # contents/pull_requests/issues: write on the OIDC-minted app token, which
-          # the post-action "Commit and push" / "Open pull request" steps use via
-          # steps.claude.outputs.github_token.
+          # contents/pull_requests/issues: write on the OIDC-minted app token while
+          # Claude runs. The action revokes this token during cleanup, so later
+          # publishing steps use a separate token.
           additional_permissions: |
             contents: write
           prompt: |
@@ -128,9 +128,9 @@ jobs:
       - name: Commit and push
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          # App token minted by the claude-code-action OIDC exchange — short-lived,
-          # auto-revoked at job end, and (unlike GITHUB_TOKEN) triggers downstream CI.
-          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
+          # Separate publishing token; the claude-code-action app token has
+          # already been revoked by this point.
+          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
           AUDIT_DATE: ${{ steps.branch.outputs.date }}
           AUDIT_BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
@@ -142,7 +142,7 @@ jobs:
       - name: Open pull request
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
+          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
           AUDIT_DATE: ${{ steps.branch.outputs.date }}
           AUDIT_BRANCH: ${{ steps.branch.outputs.branch }}
           SUMMARY_FILE: ${{ steps.summary.outputs.path }}

--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -14,8 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
+      # contents: read is all Claude can reach: the read-only workflow token is
+      # passed to the action below (so no write-scoped App token is minted via
+      # OIDC), and publishing is done by later steps with a PAT.
       contents: read
-      id-token: write # Required: claude-code-action requests a GitHub OIDC token at startup
     env:
       CI: "true"
 
@@ -199,6 +201,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Hand the action the read-only workflow token instead of letting it
+          # mint a write-scoped Claude App token via OIDC. Claude never writes
+          # to GitHub here (a later step publishes with a PAT), so the GH_TOKEN
+          # in its environment stays read-only.
+          github_token: ${{ github.token }}
 
           # Surface the full Claude SDK message stream in the step log instead of
           # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs

--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -295,6 +295,11 @@ jobs:
           GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
         run: |
           gh auth setup-git
+          # The Claude step rewrites origin to embed its app token in the URL
+          # and revokes that token when the step ends. URL-embedded credentials
+          # take precedence over gh's credential helper, so reset the remote to
+          # a clean URL to push with the PAT configured above.
+          git remote set-url origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # Compose the PR body: fixed header (non-injectable) + Claude's

--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -199,6 +199,12 @@ jobs:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Surface the full Claude SDK message stream in the step log instead of
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
+          # inputs are public repo/PR/issue content, registered secrets stay masked,
+          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          show_full_output: 'true'
           # additional_permissions triggers an OIDC exchange that mints a
           # short-lived app token with contents:write, exposed to subsequent
           # steps as steps.claude_fix.outputs.github_token. Claude itself

--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -205,12 +205,6 @@ jobs:
           # inputs are public repo/PR/issue content, registered secrets stay masked,
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
-          # additional_permissions triggers an OIDC exchange that mints a
-          # short-lived app token with contents:write for the Claude action while
-          # it runs. The action revokes this token during cleanup, so the
-          # post-step commit/push uses a separate publishing token.
-          additional_permissions: |
-            contents: write
           prompt: |
             You're on branch `${{ steps.branch.outputs.branch }}`. The weekly dependency upgrade
             already ran (`uv lock --upgrade` for Python, `pnpm update -r --latest`

--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -194,16 +194,16 @@ jobs:
       - name: Hand off to Claude (fix regressions)
         id: claude_fix
         if: steps.changes.outputs.changed == 'true' && steps.verify.outcome == 'failure'
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Surface the full Claude SDK message stream in the step log instead of
-          # the sanitized summary (denied-tool detail, tool calls, reasoning). Safe:
-          # inputs are public repo/PR/issue content, registered secrets stay masked,
-          # and the OIDC app token is never in Claude's context. Note: logs are public.
+          # the sanitized summary (denied-tool detail, tool calls, reasoning). Inputs
+          # are public repo/PR/issue content, and GitHub masks registered secrets.
+          # Note: logs are public.
           show_full_output: 'true'
           prompt: |
             You're on branch `${{ steps.branch.outputs.branch }}`. The weekly dependency upgrade

--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -206,13 +206,9 @@ jobs:
           # and the OIDC app token is never in Claude's context. Note: logs are public.
           show_full_output: 'true'
           # additional_permissions triggers an OIDC exchange that mints a
-          # short-lived app token with contents:write, exposed to subsequent
-          # steps as steps.claude_fix.outputs.github_token. Claude itself
-          # never sees the token — outputs are written after the step exits,
-          # and Claude's Bash allowlist excludes git remote/config, so prompt
-          # injection from a malicious dep cannot reach it from inside this
-          # step. The post-step commit/push uses the minted token instead of
-          # a long-lived PAT.
+          # short-lived app token with contents:write for the Claude action while
+          # it runs. The action revokes this token during cleanup, so the
+          # post-step commit/push uses a separate publishing token.
           additional_permissions: |
             contents: write
           prompt: |
@@ -300,12 +296,9 @@ jobs:
       - name: Commit & open PR (after Claude fix)
         if: steps.changes.outputs.changed == 'true' && steps.verify.outcome == 'failure' && steps.claude_fix.outcome == 'success'
         env:
-          # OIDC-minted app token from the claude-code-action step above.
-          # Short-lived, auto-revoked at job end, and triggers downstream CI
-          # (unlike GITHUB_TOKEN). The claude-code-action step embedded this
-          # same token into the origin remote URL, so the git push below
-          # picks it up.
-          GH_TOKEN: ${{ steps.claude_fix.outputs.github_token }}
+          # Separate publishing token; the claude-code-action app token has
+          # already been revoked by this point.
+          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
         run: |
           gh auth setup-git
           git config user.name "github-actions[bot]"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -88,11 +88,11 @@ jobs:
           # Note: logs are public.
           show_full_output: 'true'
 
-          # Lets Claude read CI results on PRs. NOTE: the OIDC app token already
-          # gets contents/pull_requests/issues: write — the action's token
-          # exchange merges those DEFAULT_PERMISSIONS in whenever
-          # additional_permissions is non-empty (see claude-code-action
-          # src/github/token.ts). So write access is NOT the thing to add here.
+          # Request actions:read on the Claude App token. The non-empty
+          # additional_permissions input also makes the action request its
+          # DEFAULT_PERMISSIONS (contents/pull_requests/issues: write), which tag
+          # mode needs for comments and branch pushes. The github_ci MCP server
+          # uses the workflow GITHUB_TOKEN instead, enabled by job permissions above.
           additional_permissions: |
             actions: read
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,7 +6,10 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    # No `assigned` here: the action only honors assigned events via its
+    # assignee_trigger input (unset for us); its @claude body/title check
+    # applies only to `opened`, so an assigned run would always no-op.
+    types: [opened]
   pull_request_review:
     types: [submitted]
 
@@ -97,7 +100,7 @@ jobs:
             actions: read
 
           # Enable the file-editing tools. In tag mode the action omits
-          # Edit/Write/MultiEdit from its auto-generated --allowedTools and relies
+          # Edit/Write from its auto-generated --allowedTools and relies
           # on `--permission-mode acceptEdits` to allow edits inside the workspace.
           # The headless SDK has no interactive approval handler, so any tool that
           # is neither on the allowlist nor covered by the permission mode falls
@@ -106,5 +109,5 @@ jobs:
           # Listing the edit tools explicitly guarantees they are allowed
           # independent of permission mode; the action merges them with its own
           # git/Read/Grep tools.
-          claude_args: '--allowedTools Edit,MultiEdit,Write'
+          claude_args: '--allowedTools Edit,Write'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,6 +43,11 @@ jobs:
         "seldo", "yfrigui2"
       ]'), github.actor)
     runs-on: ubuntu-latest
+    # Bound the interactive run so a hung/looping agent can't hold the runner
+    # indefinitely — which, with the queue concurrency above, would also block
+    # every later @claude on this PR. Higher than the read-only workflows since
+    # @claude may be asked to implement larger changes.
+    timeout-minutes: 60
     permissions:
       # Writes to PRs/issues and pushes from Claude go through the App token
       # minted by the OIDC exchange below — the workflow GITHUB_TOKEN is only

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -76,17 +76,16 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Surface the full Claude SDK message stream in the step log (denied-tool
-          # details, tool calls, reasoning) instead of the sanitized summary. Safe
-          # here: inputs are public repo/PR/issue content, registered secrets are
-          # masked, and the OIDC app token is written to step outputs after this
-          # step exits — it is never in Claude's context. Note: logs are public.
+          # details, tool calls, reasoning) instead of the sanitized summary. Inputs
+          # are public repo/PR/issue content, and GitHub masks registered secrets.
+          # Note: logs are public.
           show_full_output: 'true'
 
           # Lets Claude read CI results on PRs. NOTE: the OIDC app token already

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -8,6 +8,7 @@
 - [User Guide](https://arize.com/docs/phoenix/user-guide): End-to-end workflows for development, production, and optimization
 - [Production Guide](https://arize.com/docs/phoenix/production-guide): Deploy Phoenix in production with best practices for scale and reliability
 - [Environments](https://arize.com/docs/phoenix/environments): Configure Phoenix across development, staging, and production environments
+- [PXI Agent](https://arize.com/docs/phoenix/pxi): Hand investigations to the built-in AI agent that inspects traces, iterates on prompts, runs experiments, and authors evaluators
 
 ## Quick Start
 
@@ -344,7 +345,7 @@
 - [CrewAI](https://arize.com/docs/phoenix/integrations/python/crewai): CrewAI is an open-source Python framework for orchestrating role-playing, autonomous AI agents into
 - [DSPy](https://arize.com/docs/phoenix/integrations/python/dspy): DSPy is an open-source Python framework for declaratively programming modular LLM pipelines and automatically
 - [Google ADK](https://arize.com/docs/phoenix/integrations/python/google-adk): Google ADK is a Python SDK for building AI applications with Google's Gemini models and agent framework
-- [Graphite](https://arize.com/docs/phoenix/integrations/python/graphite): >-
+- [Graphite](https://arize.com/docs/phoenix/integrations/python/graphite): Instrument Graphite distributed agent workflows for tracing and observability in Phoenix
 - [Guardrails AI](https://arize.com/docs/phoenix/integrations/python/guardrails-ai): Guardrails is an open-source Python framework for adding programmable input/output validators to LLM
 - [Haystack](https://arize.com/docs/phoenix/integrations/python/haystack): Haystack is an open-source framework for building scalable semantic search and QA pipelines with document
 - [Hugging Face Smolagents](https://arize.com/docs/phoenix/integrations/python/hugging-face-smolagents): Hugging Face smolagents is a minimalist Python library for building powerful AI agents with simple
@@ -649,7 +650,7 @@
 - [Experiment with a Customer Support Agent](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/experiment-with-a-customer-support-agent): This guide shows you how to create and evaluate agents with Phoenix to improve performance
 - [Prompt Template Iteration for a Summarization Service](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/summarization): Imagine you're deploying a service for your media company's summarization model that condenses daily news
 - [Text2SQL Experiments](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/text2sql): Building effective text-to-SQL systems requires rigorous evaluation and systematic experimentation. In this
-- [Code Readability Evaluation](https://arize.com/docs/phoenix/cookbook/evaluation/code-readability-evaluation): >-
+- [Code Readability Evaluation](https://arize.com/docs/phoenix/cookbook/evaluation/code-readability-evaluation): Classify LLM-generated code as readable or unreadable using a benchmark dataset with ground-truth labels
 - [More Cookbooks](https://arize.com/docs/phoenix/cookbook/evaluation/cookbooks): Use Phoenix Evals to evaluate your application for faithfulness, toxicity, relevance of retrieved documents
 - [Evaluate a Talk-to-Your-Data Agent](https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-an-agent): Evaluate a Talk-to-Your-Data Agent
 - [Trace-level Evaluation: Beyond Input/Output Checks](https://arize.com/docs/phoenix/cookbook/evaluation/trace-level-evaluation): Evaluate an agent's intermediate reasoning, tool selection, and decision path — not just its final answer.
@@ -667,7 +668,7 @@
 - [Optimizing Prompts for LLM Classification - Prompt Learning](https://arize.com/docs/phoenix/cookbook/prompt-engineering/prompt-learning-optimizing-prompts-for-classification): Using Prompt Learning to boost accuracy on a classification dataset
 - [Prompt Optimization Techniques](https://arize.com/docs/phoenix/cookbook/prompt-engineering/prompt-optimization): This tutorial will use Phoenix to compare the performance of different prompt optimization techniques
 - [ReAct Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/react-prompting): **ReAct (Reasoning + Acting)** is a prompting technique that enables LLMs to think step-by-step before taking
-- [Agentic RAG Tracing](https://arize.com/docs/phoenix/cookbook/tracing/agentic-rag-tracing): >-
+- [Agentic RAG Tracing](https://arize.com/docs/phoenix/cookbook/tracing/agentic-rag-tracing): Trace a LlamaIndex ReAct agent that combines vector and SQL query tools
 - [More Cookbooks](https://arize.com/docs/phoenix/cookbook/tracing/cookbooks): Trace through the execution of your LLM application to understand its internal structure and to troubleshoot
 - [Generating Synthetic Datasets for LLM Evaluators & Agents](https://arize.com/docs/phoenix/cookbook/tracing/generating-synthetic-datasets-for-llm-evaluators-and-agents): Learn different strategies for dataset generation and show how they can be used to run experiments and test
 - [Product Recommendation Agent: Google Agent Engine & LangGraph](https://arize.com/docs/phoenix/cookbook/tracing/product-recommendation-agent-google-agent-engine-and-langgraph): This notebook is adapted from Google's \"Building and Deploying a LangGraph Application with Agent Engine in
@@ -733,6 +734,11 @@
 - [05.13.2026 Playground Thinking Controls for Anthropic and Google](https://arize.com/docs/phoenix/release-notes/05-2026/05-13-2026-playground-thinking-controls): Configure Anthropic extended thinking and Google thinking in the Playground — token budgets, effort levels, and display toggles
 - [05.15.2026 OTel GenAI Semantic Convention Auto-Conversion](https://arize.com/docs/phoenix/release-notes/05-2026/05-15-2026-otel-semconv-conversion): Phoenix auto-converts gen_ai.* OTel attributes to OpenInference at ingest — OTel-native traces render with full message I/O and token counts without code changes
 - [05.15.2026 Session Trace Feedback and ATIF v1.7](https://arize.com/docs/phoenix/release-notes/05-2026/05-15-2026-session-feedback-and-atif): Thumbs-up/down feedback toolbar on session turns; ATIF v1.7 trajectory upload with embedded subagents and deterministic dispatch steps
+- [05.21.2026 Code Evaluators](https://arize.com/docs/phoenix/release-notes/05-2026/05-21-2026-code-evaluators): Write Python or TypeScript evaluate() functions in the UI and run them server-side on every experiment — no SDK or deploy step
+- [05.27.2026 Drag-to-Zoom on Project Metric Charts](https://arize.com/docs/phoenix/release-notes/05-2026/05-27-2026-drag-to-zoom): Click and drag across any project metric chart or spans sparkline to zoom into a custom time window
+- [06.02.2026 Introducing PXI](https://arize.com/docs/phoenix/release-notes/06-2026/06-02-2026-pxi-agent): Hand investigations to PXI, the AI engineering agent built into Phoenix that inspects traces, prompts, and experiments for you
+- [06.10.2026 PXI Agent Update](https://arize.com/docs/phoenix/release-notes/06-2026/06-10-2026-pxi-agent-update): PXI gains a skills menu, parallel subagents, playground orchestration, evaluator authoring, and dataset management
+- [06.11.2026 Time Range Selector and PXI Slash Commands](https://arize.com/docs/phoenix/release-notes/06-2026/06-11-2026-time-range-and-pxi-slash-commands): Search presets and type free-form durations in the time range selector; PXI adds local slash commands and dataset evaluator editing
 
 ### 2025
 


### PR DESCRIPTION
## Summary

Audited `docs/phoenix/llms.txt` for coverage against the docs tree (`docs.json` nav ∩ on-disk `.mdx` files) and fixed the gaps found.

## Changes

### Added missing pages (6)

- **PXI Agent** (`/pxi`) — a substantial, nav-published page for Phoenix Intelligence, the built-in AI engineering agent. Added under **Overview**.
- **5 recent release notes** that shipped after the last `llms.txt` update — the 2026 section previously stopped at 05.15.2026. Added under **Release Notes → 2026**:
  - `05.21.2026` Code Evaluators
  - `05.27.2026` Drag-to-Zoom on Project Metric Charts
  - `06.02.2026` Introducing PXI
  - `06.10.2026` PXI Agent Update
  - `06.11.2026` Time Range Selector and PXI Slash Commands

### Fixed broken descriptions (3)

These had a leaked YAML block-scalar indicator (`>-`) where frontmatter extraction failed, carrying zero signal. Rewrote them as concise, action-oriented descriptions:

- **Graphite** (`integrations/python/graphite`)
- **Code Readability Evaluation** (`cookbook/evaluation/...`)
- **Agentic RAG Tracing** (`cookbook/tracing/...`)

## Verified — no action needed

- **Redirect stubs correctly excluded**: `resources/typescript-api`, `resources/python-api`, `resources/github`, and `resources/openinference` are `url:`-only redirect pages (no content) pointing to already-indexed SDK docs or bare external URLs — they remain excluded per the exclusion rules.
- **No stale entries from deleted/renamed files**: every URL in `llms.txt` still maps to an on-disk page or an expected non-filesystem resource (OpenAPI spec, external TypeScript API docs).
- **Provider `-evals` pages and other on-disk `.mdx` not in `docs.json` nav** (e.g. `evaluation/server-evals/builtin-evaluators`, `tracing/how-to-tracing/advanced/constructing-urls`) remain excluded as orphans.

## Notes

The CLI parser test (`js/packages/phoenix-cli` `pnpm test -- --grep "docs"`) could not be run in this environment (tooling not permitted). All edits use the standard `- [Title](url): description` format, preserving the file's structure.
