### PR TITLE
fix(ui): use design system tooltip for project view mode toggle

### DIFF
--- a/app/src/pages/projects/ProjectViewModeToggle.tsx
+++ b/app/src/pages/projects/ProjectViewModeToggle.tsx
@@ -1,13 +1,12 @@
 import { css } from "@emotion/react";
-import { Tooltip, TooltipTrigger } from "react-aria-components";
 
 import {
   Icon,
   Icons,
-  Text,
   ToggleButton,
   ToggleButtonGroup,
-  View,
+  Tooltip,
+  TooltipTrigger,
 } from "@phoenix/components";
 import { usePreferencesContext } from "@phoenix/contexts";
 import type { ProjectViewMode } from "@phoenix/store/preferencesStore";
@@ -41,16 +40,7 @@ export const ProjectViewModeToggle = () => {
           aria-label="Grid view"
           leadingVisual={<Icon svg={<Icons.Grid />} />}
         />
-        <Tooltip offset={10}>
-          <View
-            padding="size-100"
-            borderColor="default"
-            borderWidth="thin"
-            borderRadius="small"
-          >
-            <Text>View projects in a grid</Text>
-          </View>
-        </Tooltip>
+        <Tooltip>View projects in a grid</Tooltip>
       </TooltipTrigger>
       <TooltipTrigger delay={100}>
         <ToggleButton
@@ -58,16 +48,7 @@ export const ProjectViewModeToggle = () => {
           aria-label="Table view"
           leadingVisual={<Icon svg={<Icons.ListOutline />} />}
         />
-        <Tooltip offset={10}>
-          <View
-            padding="size-100"
-            borderColor="default"
-            borderWidth="thin"
-            borderRadius="small"
-          >
-            <Text>View projects in a table</Text>
-          </View>
-        </Tooltip>
+        <Tooltip>View projects in a table</Tooltip>
       </TooltipTrigger>
     </ToggleButtonGroup>
   );


### PR DESCRIPTION
## Summary

The grid/list view toggle on the projects page rendered its tooltips as unstyled, transparent boxes floating away from the buttons.

The cause: `ProjectViewModeToggle` imported `Tooltip`/`TooltipTrigger` from raw `react-aria-components` and hand-rolled the tooltip body with a `View` wrapper, instead of using the Phoenix design system tooltip which carries the proper background, padding, and positioning.

## Changes

- Swap `Tooltip`/`TooltipTrigger` imports from `react-aria-components` to `@phoenix/components`
- Drop the manual `View`/`Text` wrapper and `offset` overrides in favor of the design system defaults