### PR TITLE
feat(ui): pan and zoom time range controls with live streaming toggle

### DIFF
--- a/.agents/skills/phoenix-design/rules/icons.md
+++ b/.agents/skills/phoenix-design/rules/icons.md
@@ -19,6 +19,10 @@ Phoenix has a curated icon set in `app/src/components/core/icon/Icons.tsx`. Use 
 | Context (generic) | `Icons.InfoOutline` | Default for an `AttachmentContextData` whose category has no canonical icon yet. |
 | Bypass / unguarded approvals | `Icons.ShieldOutline` | Warning shield for bypass/auto-approval modes where approvals are skipped. |
 | Undo / rewind | `Icons.RotateCcwOutline` | Counterclockwise arrow for reverting/undoing an action (e.g. rewinding a chat). Distinct from `HistoryOutline` (clock = history/session list). |
+| Play / resume live | `Icons.PlayOutline` | Lucide play triangle for resuming a live/streaming view. Distinct from `PlayCircleOutline` (video attachments). |
+| Pause | `Icons.PauseOutline` | Lucide pause bars for pausing a live/streaming view. |
+| Zoom in / out | `Icons.PlusOutline` / `Icons.MinusOutline` | Bare plus/minus for stepping a range narrower or wider (e.g. time range controls). |
+| Pan / step left, right | `Icons.ChevronLeftOutline` / `Icons.ChevronRightOutline` | Lucide chevrons for directional stepping through a range or list. |
 
 ## When you need an icon
 

--- a/.agents/skills/phoenix-design/rules/icons.md
+++ b/.agents/skills/phoenix-design/rules/icons.md
@@ -19,10 +19,8 @@ Phoenix has a curated icon set in `app/src/components/core/icon/Icons.tsx`. Use 
 | Context (generic) | `Icons.InfoOutline` | Default for an `AttachmentContextData` whose category has no canonical icon yet. |
 | Bypass / unguarded approvals | `Icons.ShieldOutline` | Warning shield for bypass/auto-approval modes where approvals are skipped. |
 | Undo / rewind | `Icons.RotateCcwOutline` | Counterclockwise arrow for reverting/undoing an action (e.g. rewinding a chat). Distinct from `HistoryOutline` (clock = history/session list). |
-| Play / resume live | `Icons.PlayOutline` | Lucide play triangle for resuming a live/streaming view. Distinct from `PlayCircleOutline` (video attachments). |
-| Pause | `Icons.PauseOutline` | Lucide pause bars for pausing a live/streaming view. |
-| Zoom in / out | `Icons.PlusOutline` / `Icons.MinusOutline` | Bare plus/minus for stepping a range narrower or wider (e.g. time range controls). |
-| Pan / step left, right | `Icons.ChevronLeftOutline` / `Icons.ChevronRightOutline` | Lucide chevrons for directional stepping through a range or list. |
+| Resume / play | `Icons.PlayOutline` | Start or resume a paused activity (e.g. resume live streaming). Distinct from `PlayCircleOutline` (used for video attachments). |
+| Pause | `Icons.PauseOutline` | Pause an in-progress activity (e.g. pause live streaming). |
 
 ## When you need an icon
 

--- a/.agents/skills/phoenix-typescript/SKILL.md
+++ b/.agents/skills/phoenix-typescript/SKILL.md
@@ -47,6 +47,37 @@ const isDisabled = !hasPermission || isSubmitting;
 - Object parameters should be documented with JSDoc using `@param` dot notation so editors surface descriptions on hover and during autocomplete.
 - Behavior should be built from composition (functions and hooks), not inheritance.
 - Transforms should prefer functional purity over mutation — use `map` not `reduce` for element-wise transforms, return new objects instead of mutating.
+- Pure utilities must not reach for hardcoded module constants or ambient state (`Date.now()`, `new Date()`, config singletons) deep inside their bodies. Expose every such value as an optional parameter whose default is the constant, so callers — and especially tests — can override it and the function's output depends only on its inputs. The module constant becomes the default, prefixed `DEFAULT_`.
+
+```ts
+const DEFAULT_ZOOM_FACTOR = 2;
+const DEFAULT_MIN_WINDOW_MS = 60_000;
+
+// Bad — reads a module constant and the clock internally; output isn't
+// determined by inputs, so tests can't pin the window or the factor.
+function zoomOut(value: TimeRange): TimeRange {
+  const now = new Date();
+  return widen(value, ZOOM_FACTOR, now);
+}
+
+// Good — constants are overridable defaults; pass `now` to make it pure.
+function zoomOut({
+  value,
+  now = new Date(),
+  zoomFactor = DEFAULT_ZOOM_FACTOR,
+  minWindowMs = DEFAULT_MIN_WINDOW_MS,
+}: {
+  value: TimeRange;
+  /** Reference "now". Defaults to the current time. */
+  now?: Date;
+  /** Multiplier applied to the window duration. */
+  zoomFactor?: number;
+  /** Smallest window the zoom will produce. */
+  minWindowMs?: number;
+}): TimeRange {
+  return widen(value, zoomFactor, now, minWindowMs);
+}
+```
 
 ```ts
 /**

--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -928,13 +928,14 @@ const baseTokensCSS = (theme: Theme) => css`
 
     --highlight-foreground: var(--global-text-color-900);
     --highlight-background: var(--global-color-primary-100);
-    /* Accent variant of the highlight used for actively-edited fields: white
-       text on a strong brand blue. The blue ramp is inverted between themes
-       (blue-500 is a dark blue in dark mode but a pale tint in light mode), so
-       each theme picks the step that keeps white text legible rather than
-       pinning a single ramp value. */
-    --highlight-accent-foreground: var(--global-static-color-white-900);
-    --highlight-accent-background: ${theme === "dark"
+    /* The actively-edited field: white text on a strong brand blue, used to
+       mark the segment the user is currently editing (e.g. a focused date
+       segment). The blue ramp is inverted between themes (blue-500 is a dark
+       blue in dark mode but a pale tint in light mode), so each theme picks
+       the step that keeps white text legible rather than pinning a single
+       ramp value. */
+    --field-editing-foreground: var(--global-static-color-white-900);
+    --field-editing-background: ${theme === "dark"
       ? "var(--global-color-blue-500)"
       : "var(--global-color-blue-900)"};
     --hover-background: var(--global-color-gray-100);

--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -928,6 +928,15 @@ const baseTokensCSS = (theme: Theme) => css`
 
     --highlight-foreground: var(--global-text-color-900);
     --highlight-background: var(--global-color-primary-100);
+    /* Accent variant of the highlight used for actively-edited fields: white
+       text on a strong brand blue. The blue ramp is inverted between themes
+       (blue-500 is a dark blue in dark mode but a pale tint in light mode), so
+       each theme picks the step that keeps white text legible rather than
+       pinning a single ramp value. */
+    --highlight-accent-foreground: var(--global-static-color-white-900);
+    --highlight-accent-background: ${theme === "dark"
+      ? "var(--global-color-blue-500)"
+      : "var(--global-color-blue-900)"};
     --hover-background: var(--global-color-gray-100);
     --focus-ring-color: var(--global-color-primary-500);
     --focus-ring-offset: var(--global-dimension-static-size-25);

--- a/app/src/components/core/icon/Icons.tsx
+++ b/app/src/components/core/icon/Icons.tsx
@@ -696,19 +696,35 @@ export const ChevronRight = () => (
   </svg>
 );
 
+export const ChevronLeftOutline = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="m15 18-6-6 6-6" fill="none" />
+  </svg>
+);
+
 export const ChevronRightOutline = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-    <g data-name="Layer 2">
-      <g data-name="chevron-right">
-        <rect
-          width="24"
-          height="24"
-          transform="rotate(-90 12 12)"
-          opacity="0"
-        />
-        <path d="M10.5 17a1 1 0 0 1-.71-.29 1 1 0 0 1 0-1.42L13.1 12 9.92 8.69a1 1 0 0 1 0-1.41 1 1 0 0 1 1.42 0l3.86 4a1 1 0 0 1 0 1.4l-4 4a1 1 0 0 1-.7.32z" />
-      </g>
-    </g>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="m9 18 6-6-6-6" fill="none" />
   </svg>
 );
 
@@ -1942,6 +1958,23 @@ export const PaperPlaneOutline = () => (
   </svg>
 );
 
+export const PauseOutline = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="14" y="4" width="4" height="16" rx="1" fill="none" />
+    <rect x="6" y="4" width="4" height="16" rx="1" fill="none" />
+  </svg>
+);
+
 export const PersonOutline = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g data-name="Layer 2">
@@ -1975,6 +2008,22 @@ export const PlayCircleOutline = () => (
         <path d="M12.34 7.45a1.7 1.7 0 0 0-1.85-.3 1.6 1.6 0 0 0-1 1.48v6.74a1.6 1.6 0 0 0 1 1.48 1.68 1.68 0 0 0 .69.15 1.74 1.74 0 0 0 1.16-.45L16 13.18a1.6 1.6 0 0 0 0-2.36zm-.84 7.15V9.4l2.81 2.6z" />
       </g>
     </g>
+  </svg>
+);
+
+export const PlayOutline = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polygon points="6 3 20 12 6 21 6 3" fill="none" />
   </svg>
 );
 

--- a/app/src/components/core/icon/Icons.tsx
+++ b/app/src/components/core/icon/Icons.tsx
@@ -696,35 +696,19 @@ export const ChevronRight = () => (
   </svg>
 );
 
-export const ChevronLeftOutline = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="20"
-    height="20"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="m15 18-6-6 6-6" fill="none" />
-  </svg>
-);
-
 export const ChevronRightOutline = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="20"
-    height="20"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="m9 18 6-6-6-6" fill="none" />
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <g data-name="Layer 2">
+      <g data-name="chevron-right">
+        <rect
+          width="24"
+          height="24"
+          transform="rotate(-90 12 12)"
+          opacity="0"
+        />
+        <path d="M10.5 17a1 1 0 0 1-.71-.29 1 1 0 0 1 0-1.42L13.1 12 9.92 8.69a1 1 0 0 1 0-1.41 1 1 0 0 1 1.42 0l3.86 4a1 1 0 0 1 0 1.4l-4 4a1 1 0 0 1-.7.32z" />
+      </g>
+    </g>
   </svg>
 );
 
@@ -1970,8 +1954,8 @@ export const PauseOutline = () => (
     strokeLinecap="round"
     strokeLinejoin="round"
   >
-    <rect x="14" y="4" width="4" height="16" rx="1" fill="none" />
-    <rect x="6" y="4" width="4" height="16" rx="1" fill="none" />
+    <rect x="14" y="3" width="5" height="18" rx="1" fill="none" />
+    <rect x="5" y="3" width="5" height="18" rx="1" fill="none" />
   </svg>
 );
 
@@ -1999,18 +1983,6 @@ export const PieChartOutline = () => (
   </svg>
 );
 
-export const PlayCircleOutline = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-    <g data-name="Layer 2">
-      <g data-name="play-circle">
-        <rect width="24" height="24" opacity="0" />
-        <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8z" />
-        <path d="M12.34 7.45a1.7 1.7 0 0 0-1.85-.3 1.6 1.6 0 0 0-1 1.48v6.74a1.6 1.6 0 0 0 1 1.48 1.68 1.68 0 0 0 .69.15 1.74 1.74 0 0 0 1.16-.45L16 13.18a1.6 1.6 0 0 0 0-2.36zm-.84 7.15V9.4l2.81 2.6z" />
-      </g>
-    </g>
-  </svg>
-);
-
 export const PlayOutline = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -2023,7 +1995,22 @@ export const PlayOutline = () => (
     strokeLinecap="round"
     strokeLinejoin="round"
   >
-    <polygon points="6 3 20 12 6 21 6 3" fill="none" />
+    <path
+      d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z"
+      fill="none"
+    />
+  </svg>
+);
+
+export const PlayCircleOutline = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <g data-name="Layer 2">
+      <g data-name="play-circle">
+        <rect width="24" height="24" opacity="0" />
+        <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8z" />
+        <path d="M12.34 7.45a1.7 1.7 0 0 0-1.85-.3 1.6 1.6 0 0 0-1 1.48v6.74a1.6 1.6 0 0 0 1 1.48 1.68 1.68 0 0 0 .69.15 1.74 1.74 0 0 0 1.16-.45L16 13.18a1.6 1.6 0 0 0 0-2.36zm-.84 7.15V9.4l2.81 2.6z" />
+      </g>
+    </g>
   </svg>
 );
 

--- a/app/src/components/datetime/ConnectedTimeRangeControls.tsx
+++ b/app/src/components/datetime/ConnectedTimeRangeControls.tsx
@@ -1,9 +1,6 @@
-import { startTransition, useCallback } from "react";
-
 import { useTimeRange } from "./TimeRangeContext";
 import type { TimeRangeControlsProps } from "./TimeRangeControls";
 import { TimeRangeControls } from "./TimeRangeControls";
-import type { OpenTimeRangeWithKey } from "./types";
 
 /**
  * Time range controls wired to the shared time range context, for use beside
@@ -13,16 +10,12 @@ import type { OpenTimeRangeWithKey } from "./types";
 export function ConnectedTimeRangeControls(
   props: Omit<TimeRangeControlsProps, "value" | "onChange">
 ) {
-  const { timeRange, setTimeRange: _setTimeRange } = useTimeRange();
-  const setTimeRange = useCallback(
-    (timeRange: OpenTimeRangeWithKey) => {
-      startTransition(() => {
-        _setTimeRange(timeRange);
-      });
-    },
-    [_setTimeRange]
-  );
+  const { timeRange, setTimeRangeInTransition } = useTimeRange();
   return (
-    <TimeRangeControls {...props} value={timeRange} onChange={setTimeRange} />
+    <TimeRangeControls
+      {...props}
+      value={timeRange}
+      onChange={setTimeRangeInTransition}
+    />
   );
 }

--- a/app/src/components/datetime/ConnectedTimeRangeControls.tsx
+++ b/app/src/components/datetime/ConnectedTimeRangeControls.tsx
@@ -12,10 +12,6 @@ export function ConnectedTimeRangeControls(
 ) {
   const { timeRange, setTimeRange } = useTimeRange();
   return (
-    <TimeRangeControls
-      {...props}
-      value={timeRange}
-      onChange={setTimeRange}
-    />
+    <TimeRangeControls {...props} value={timeRange} onChange={setTimeRange} />
   );
 }

--- a/app/src/components/datetime/ConnectedTimeRangeControls.tsx
+++ b/app/src/components/datetime/ConnectedTimeRangeControls.tsx
@@ -1,0 +1,28 @@
+import { startTransition, useCallback } from "react";
+
+import { useTimeRange } from "./TimeRangeContext";
+import type { TimeRangeControlsProps } from "./TimeRangeControls";
+import { TimeRangeControls } from "./TimeRangeControls";
+import type { OpenTimeRangeWithKey } from "./types";
+
+/**
+ * Time range controls wired to the shared time range context, for use beside
+ * a ConnectedTimeRangeSelector. Live-streaming props pass through; omit them
+ * for a pure pan/zoom strip.
+ */
+export function ConnectedTimeRangeControls(
+  props: Omit<TimeRangeControlsProps, "value" | "onChange">
+) {
+  const { timeRange, setTimeRange: _setTimeRange } = useTimeRange();
+  const setTimeRange = useCallback(
+    (timeRange: OpenTimeRangeWithKey) => {
+      startTransition(() => {
+        _setTimeRange(timeRange);
+      });
+    },
+    [_setTimeRange]
+  );
+  return (
+    <TimeRangeControls {...props} value={timeRange} onChange={setTimeRange} />
+  );
+}

--- a/app/src/components/datetime/ConnectedTimeRangeControls.tsx
+++ b/app/src/components/datetime/ConnectedTimeRangeControls.tsx
@@ -10,12 +10,12 @@ import { TimeRangeControls } from "./TimeRangeControls";
 export function ConnectedTimeRangeControls(
   props: Omit<TimeRangeControlsProps, "value" | "onChange">
 ) {
-  const { timeRange, setTimeRangeInTransition } = useTimeRange();
+  const { timeRange, setTimeRange } = useTimeRange();
   return (
     <TimeRangeControls
       {...props}
       value={timeRange}
-      onChange={setTimeRangeInTransition}
+      onChange={setTimeRange}
     />
   );
 }

--- a/app/src/components/datetime/ConnectedTimeRangeSelector.tsx
+++ b/app/src/components/datetime/ConnectedTimeRangeSelector.tsx
@@ -10,10 +10,6 @@ export function ConnectedTimeRangeSelector({
 }) {
   const { timeRange, setTimeRange } = useTimeRange();
   return (
-    <TimeRangeSelector
-      value={timeRange}
-      onChange={setTimeRange}
-      size={size}
-    />
+    <TimeRangeSelector value={timeRange} onChange={setTimeRange} size={size} />
   );
 }

--- a/app/src/components/datetime/ConnectedTimeRangeSelector.tsx
+++ b/app/src/components/datetime/ConnectedTimeRangeSelector.tsx
@@ -1,26 +1,19 @@
-import { startTransition, useCallback } from "react";
-
 import type { ComponentSize } from "@phoenix/components/core/types";
 
 import { useTimeRange } from "./TimeRangeContext";
 import { TimeRangeSelector } from "./TimeRangeSelector";
-import type { OpenTimeRangeWithKey } from "./types";
 
 export function ConnectedTimeRangeSelector({
   size = "S",
 }: {
   size?: ComponentSize;
 }) {
-  const { timeRange, setTimeRange: _setTimeRange } = useTimeRange();
-  const setTimeRange = useCallback(
-    (timeRange: OpenTimeRangeWithKey) => {
-      startTransition(() => {
-        _setTimeRange(timeRange);
-      });
-    },
-    [_setTimeRange]
-  );
+  const { timeRange, setTimeRangeInTransition } = useTimeRange();
   return (
-    <TimeRangeSelector value={timeRange} onChange={setTimeRange} size={size} />
+    <TimeRangeSelector
+      value={timeRange}
+      onChange={setTimeRangeInTransition}
+      size={size}
+    />
   );
 }

--- a/app/src/components/datetime/ConnectedTimeRangeSelector.tsx
+++ b/app/src/components/datetime/ConnectedTimeRangeSelector.tsx
@@ -8,11 +8,11 @@ export function ConnectedTimeRangeSelector({
 }: {
   size?: ComponentSize;
 }) {
-  const { timeRange, setTimeRangeInTransition } = useTimeRange();
+  const { timeRange, setTimeRange } = useTimeRange();
   return (
     <TimeRangeSelector
       value={timeRange}
-      onChange={setTimeRangeInTransition}
+      onChange={setTimeRange}
       size={size}
     />
   );

--- a/app/src/components/datetime/TimeRangeContext.tsx
+++ b/app/src/components/datetime/TimeRangeContext.tsx
@@ -1,7 +1,6 @@
 import React, {
   createContext,
   startTransition,
-  useCallback,
   useEffect,
   useEffectEvent,
   useState,
@@ -24,13 +23,12 @@ import {
 
 export type TimeRangeContextType = {
   timeRange: OpenTimeRangeWithKey;
-  setTimeRange: (timeRange: OpenTimeRangeWithKey) => void;
   /**
    * Set the time range with the state write wrapped in a transition so
    * steering interactions (preset picks, pan/zoom) do not block the input
    * event.
    */
-  setTimeRangeInTransition: (timeRange: OpenTimeRangeWithKey) => void;
+  setTimeRange: (timeRange: OpenTimeRangeWithKey) => void;
   /**
    * Apply a closed time range as a custom selection. Wraps the state write in
    * a transition so brush-driven updates do not block the input event.
@@ -85,44 +83,29 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
     }
   });
 
-  const setTimeRange = useCallback(
-    (timeRange: OpenTimeRangeWithKey) => {
-      const nextTimeRange = isLastNTimeRangeKey(timeRange.timeRangeKey)
-        ? {
-            timeRangeKey: timeRange.timeRangeKey,
-            ...getTimeRangeFromLastNTimeRangeKey(timeRange.timeRangeKey),
-          }
-        : timeRange;
+  const setTimeRange = (timeRange: OpenTimeRangeWithKey) => {
+    const nextTimeRange = isLastNTimeRangeKey(timeRange.timeRangeKey)
+      ? {
+          timeRangeKey: timeRange.timeRangeKey,
+          ...getTimeRangeFromLastNTimeRangeKey(timeRange.timeRangeKey),
+        }
+      : timeRange;
+    startTransition(() => {
       _setTimeRange(nextTimeRange);
       // Store the last N time range key in preferences
       if (isLastNTimeRangeKey(timeRange.timeRangeKey)) {
         setStoredLastNTimeRangeKey(timeRange.timeRangeKey);
       }
-    },
-    [setStoredLastNTimeRangeKey]
-  );
+    });
+  };
 
-  const setTimeRangeInTransition = useCallback(
-    (timeRange: OpenTimeRangeWithKey) => {
-      startTransition(() => {
-        setTimeRange(timeRange);
-      });
-    },
-    [setTimeRange]
-  );
-
-  const setCustomTimeRange = useCallback(
-    (timeRange: TimeRange) => {
-      startTransition(() => {
-        setTimeRange({
-          timeRangeKey: "custom",
-          start: timeRange.start,
-          end: timeRange.end,
-        });
-      });
-    },
-    [setTimeRange]
-  );
+  const setCustomTimeRange = (timeRange: TimeRange) => {
+    setTimeRange({
+      timeRangeKey: "custom",
+      start: timeRange.start,
+      end: timeRange.end,
+    });
+  };
 
   useEffect(() => {
     if (!isLastNTimeRangeKey(timeRange.timeRangeKey)) {
@@ -151,7 +134,6 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
       value={{
         timeRange,
         setTimeRange,
-        setTimeRangeInTransition,
         setCustomTimeRange,
       }}
     >

--- a/app/src/components/datetime/TimeRangeContext.tsx
+++ b/app/src/components/datetime/TimeRangeContext.tsx
@@ -26,6 +26,12 @@ export type TimeRangeContextType = {
   timeRange: OpenTimeRangeWithKey;
   setTimeRange: (timeRange: OpenTimeRangeWithKey) => void;
   /**
+   * Set the time range with the state write wrapped in a transition so
+   * steering interactions (preset picks, pan/zoom) do not block the input
+   * event.
+   */
+  setTimeRangeInTransition: (timeRange: OpenTimeRangeWithKey) => void;
+  /**
    * Apply a closed time range as a custom selection. Wraps the state write in
    * a transition so brush-driven updates do not block the input event.
    */
@@ -96,6 +102,15 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
     [setStoredLastNTimeRangeKey]
   );
 
+  const setTimeRangeInTransition = useCallback(
+    (timeRange: OpenTimeRangeWithKey) => {
+      startTransition(() => {
+        setTimeRange(timeRange);
+      });
+    },
+    [setTimeRange]
+  );
+
   const setCustomTimeRange = useCallback(
     (timeRange: TimeRange) => {
       startTransition(() => {
@@ -136,6 +151,7 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
       value={{
         timeRange,
         setTimeRange,
+        setTimeRangeInTransition,
         setCustomTimeRange,
       }}
     >

--- a/app/src/components/datetime/TimeRangeControls.tsx
+++ b/app/src/components/datetime/TimeRangeControls.tsx
@@ -20,9 +20,12 @@ export type TimeRangeControlsProps = {
   /** Called when a pan or zoom commits a new range. */
   onChange: (value: OpenTimeRangeWithKey) => void;
   /** Whether the view is live (streaming in new data). */
-  isLive: boolean;
-  /** Called when the user presses the play/pause toggle. */
-  onIsLiveChange: (isLive: boolean) => void;
+  isLive?: boolean;
+  /**
+   * Called when the user presses the play/pause toggle. When omitted, the
+   * toggle is not rendered and the strip is a pure pan/zoom control.
+   */
+  onIsLiveChange?: (isLive: boolean) => void;
   /** Disables every control. */
   isDisabled?: boolean;
   /** Visual size for the buttons. */
@@ -167,18 +170,18 @@ function ControlButton(props: {
 /**
  * A compact toolbar of icon buttons for steering the active time range,
  * designed to sit beside the time range selector and share its chrome.
- * Reading outward from the play/pause toggle in the center: minus/plus zoom
- * the window wider or narrower (live ranges stay live, anchored to now), and
- * the chevrons pan the window back or forward by half its width. Panning
- * forward is capped at the present and unavailable while the range is
- * open-ended (already at the live edge). While live, the toggle carries a
- * gently pulsing success tint.
+ * Minus/plus zoom the window wider or narrower (live ranges stay live,
+ * anchored to now), and the chevrons pan the window back or forward by half
+ * its width. Panning forward is capped at the present and unavailable while
+ * the range is open-ended (already at the live edge). When live-streaming
+ * props are provided a play/pause toggle sits in the center, carrying a
+ * gently pulsing success tint while live.
  */
 export function TimeRangeControls(props: TimeRangeControlsProps) {
   const {
     value,
     onChange,
-    isLive,
+    isLive = false,
     onIsLiveChange,
     isDisabled,
     size = "S",
@@ -217,25 +220,29 @@ export function TimeRangeControls(props: TimeRangeControlsProps) {
         isDisabled={isDisabled || !hasWindow}
         onPress={() => applyChange(zoomTimeRangeOut(value))}
       />
-      <TooltipTrigger>
-        <ToggleButton
-          size={size}
-          className="time-range-controls__live-toggle"
-          css={controlButtonCSS}
-          aria-label={isLive ? "Pause live streaming" : "Resume live streaming"}
-          isSelected={isLive}
-          isDisabled={isDisabled}
-          leadingVisual={
-            <Icon
-              svg={isLive ? <Icons.PauseOutline /> : <Icons.PlayOutline />}
-            />
-          }
-          onChange={onIsLiveChange}
-        />
-        <Tooltip>
-          {isLive ? "Pause live streaming" : "Resume live streaming"}
-        </Tooltip>
-      </TooltipTrigger>
+      {onIsLiveChange && (
+        <TooltipTrigger>
+          <ToggleButton
+            size={size}
+            className="time-range-controls__live-toggle"
+            css={controlButtonCSS}
+            aria-label={
+              isLive ? "Pause live streaming" : "Resume live streaming"
+            }
+            isSelected={isLive}
+            isDisabled={isDisabled}
+            leadingVisual={
+              <Icon
+                svg={isLive ? <Icons.PauseOutline /> : <Icons.PlayOutline />}
+              />
+            }
+            onChange={onIsLiveChange}
+          />
+          <Tooltip>
+            {isLive ? "Pause live streaming" : "Resume live streaming"}
+          </Tooltip>
+        </TooltipTrigger>
+      )}
       <ControlButton
         label="Zoom in"
         icon={<Icons.PlusOutline />}

--- a/app/src/components/datetime/TimeRangeControls.tsx
+++ b/app/src/components/datetime/TimeRangeControls.tsx
@@ -116,21 +116,24 @@ const controlButtonCSS = css`
     fill: currentColor;
   }
 
-  /* Streaming live reads as a quiet success tint that gently pulses rather
-     than a heavy primary fill. The tint lives on an overlay so the pulse
-     composes from the static token instead of animating between raw colors. */
+  /* Streaming live uses a gently pulsing neutral tint so the pause icon
+     doesn't compete with status colors elsewhere. The tint lives on an
+     overlay so the pulse composes from the static token instead of
+     animating between raw colors. */
   &[data-selected="true"] {
+    isolation: isolate;
     background-color: transparent;
-    color: var(--global-color-success);
+    color: var(--global-text-color-900);
     &:hover:not([data-disabled]) {
-      background-color: var(--global-color-success-100);
+      background-color: var(--global-input-field-background-color-active);
     }
     &::before {
       content: "";
       position: absolute;
       inset: 0;
+      z-index: -1;
       border-radius: inherit;
-      background-color: var(--global-color-success-100);
+      background-color: var(--global-input-field-background-color-active);
       animation: ${livePulseKeyframes} 3s ease-in-out infinite;
     }
   }

--- a/app/src/components/datetime/TimeRangeControls.tsx
+++ b/app/src/components/datetime/TimeRangeControls.tsx
@@ -104,6 +104,12 @@ const controlButtonCSS = css`
     font-size: var(--global-font-size-s);
   }
 
+  /* Solid play/pause glyphs give the center control a media-transport feel
+     and anchor it against the stroked pan/zoom icons around it. */
+  &.time-range-controls__live-toggle .icon-wrap svg :is(path, rect) {
+    fill: currentColor;
+  }
+
   &:hover:not([disabled]),
   &[data-hovered]:not([data-disabled]):not([data-selected="true"]) {
     background-color: var(--global-input-field-background-color-active);
@@ -224,6 +230,7 @@ export function TimeRangeControls(props: TimeRangeControlsProps) {
         <TooltipTrigger>
           <ToggleButton
             size={size}
+            className="time-range-controls__live-toggle"
             css={controlButtonCSS}
             aria-label={liveToggleLabel}
             isSelected={isLive}

--- a/app/src/components/datetime/TimeRangeControls.tsx
+++ b/app/src/components/datetime/TimeRangeControls.tsx
@@ -22,7 +22,7 @@ export type TimeRangeControlsProps = {
   /** Whether the view is live (streaming in new data). */
   isLive?: boolean;
   /**
-   * Called when the user presses the play/pause toggle. When omitted, the
+   * Called when the user presses the live play/stop toggle. When omitted, the
    * toggle is not rendered and the strip is a pure pan/zoom control.
    */
   onIsLiveChange?: (isLive: boolean) => void;
@@ -110,13 +110,7 @@ const controlButtonCSS = css`
     color: var(--global-text-color-900);
   }
 
-  /* Solid play/pause glyphs give the center control a media-transport feel
-     and anchor it against the stroked icons around it. */
-  &.time-range-controls__live-toggle .icon-wrap svg :is(polygon, rect) {
-    fill: currentColor;
-  }
-
-  /* Streaming live uses a gently pulsing neutral tint so the pause icon
+  /* Streaming live uses a gently pulsing neutral tint so the center control
      doesn't compete with status colors elsewhere. The tint lives on an
      overlay so the pulse composes from the static token instead of
      animating between raw colors. */
@@ -177,8 +171,8 @@ function ControlButton(props: {
  * anchored to now), and the chevrons pan the window back or forward by half
  * its width. Panning forward is capped at the present and unavailable while
  * the range is open-ended (already at the live edge). When live-streaming
- * props are provided a play/pause toggle sits in the center, carrying a
- * gently pulsing success tint while live.
+ * props are provided a play/stop toggle sits in the center, carrying a gently
+ * pulsing active tint while live.
  */
 export function TimeRangeControls(props: TimeRangeControlsProps) {
   const {
@@ -192,7 +186,7 @@ export function TimeRangeControls(props: TimeRangeControlsProps) {
   // Without a start there is no window to pan or zoom by.
   const hasWindow = value.start != null;
   const liveToggleLabel = isLive
-    ? "Pause live streaming"
+    ? "Stop live streaming"
     : "Resume live streaming";
   // An open-ended range is already at the live edge.
   const isAtLiveEdge = value.end == null;
@@ -214,7 +208,7 @@ export function TimeRangeControls(props: TimeRangeControlsProps) {
     >
       <ControlButton
         label="Pan back in time"
-        icon={<Icons.ChevronLeftOutline />}
+        icon={<Icons.ChevronLeft />}
         size={size}
         isDisabled={isDisabled || !hasWindow}
         onPress={() => applyChange(panTimeRangeLeft(value))}
@@ -230,14 +224,15 @@ export function TimeRangeControls(props: TimeRangeControlsProps) {
         <TooltipTrigger>
           <ToggleButton
             size={size}
-            className="time-range-controls__live-toggle"
             css={controlButtonCSS}
             aria-label={liveToggleLabel}
             isSelected={isLive}
             isDisabled={isDisabled}
             leadingVisual={
               <Icon
-                svg={isLive ? <Icons.PauseOutline /> : <Icons.PlayOutline />}
+                svg={
+                  isLive ? <Icons.PauseOutline /> : <Icons.PlayOutline />
+                }
               />
             }
             onChange={onIsLiveChange}
@@ -254,7 +249,7 @@ export function TimeRangeControls(props: TimeRangeControlsProps) {
       />
       <ControlButton
         label="Pan forward in time"
-        icon={<Icons.ChevronRightOutline />}
+        icon={<Icons.ChevronRight />}
         size={size}
         isDisabled={isDisabled || !hasWindow || isAtLiveEdge}
         onPress={() => applyChange(panTimeRangeRight(value))}

--- a/app/src/components/datetime/TimeRangeControls.tsx
+++ b/app/src/components/datetime/TimeRangeControls.tsx
@@ -211,14 +211,14 @@ export function TimeRangeControls(props: TimeRangeControlsProps) {
         icon={<Icons.ChevronLeft />}
         size={size}
         isDisabled={isDisabled || !hasWindow}
-        onPress={() => applyChange(panTimeRangeLeft(value))}
+        onPress={() => applyChange(panTimeRangeLeft({ value }))}
       />
       <ControlButton
         label="Zoom out"
         icon={<Icons.MinusOutline />}
         size={size}
         isDisabled={isDisabled || !hasWindow}
-        onPress={() => applyChange(zoomTimeRangeOut(value))}
+        onPress={() => applyChange(zoomTimeRangeOut({ value }))}
       />
       {onIsLiveChange && (
         <TooltipTrigger>
@@ -230,9 +230,7 @@ export function TimeRangeControls(props: TimeRangeControlsProps) {
             isDisabled={isDisabled}
             leadingVisual={
               <Icon
-                svg={
-                  isLive ? <Icons.PauseOutline /> : <Icons.PlayOutline />
-                }
+                svg={isLive ? <Icons.PauseOutline /> : <Icons.PlayOutline />}
               />
             }
             onChange={onIsLiveChange}
@@ -245,14 +243,14 @@ export function TimeRangeControls(props: TimeRangeControlsProps) {
         icon={<Icons.PlusOutline />}
         size={size}
         isDisabled={isDisabled || !hasWindow}
-        onPress={() => applyChange(zoomTimeRangeIn(value))}
+        onPress={() => applyChange(zoomTimeRangeIn({ value }))}
       />
       <ControlButton
         label="Pan forward in time"
         icon={<Icons.ChevronRight />}
         size={size}
         isDisabled={isDisabled || !hasWindow || isAtLiveEdge}
-        onPress={() => applyChange(panTimeRangeRight(value))}
+        onPress={() => applyChange(panTimeRangeRight({ value }))}
       />
     </div>
   );

--- a/app/src/components/datetime/TimeRangeControls.tsx
+++ b/app/src/components/datetime/TimeRangeControls.tsx
@@ -188,6 +188,9 @@ export function TimeRangeControls(props: TimeRangeControlsProps) {
   } = props;
   // Without a start there is no window to pan or zoom by.
   const hasWindow = value.start != null;
+  const liveToggleLabel = isLive
+    ? "Pause live streaming"
+    : "Resume live streaming";
   // An open-ended range is already at the live edge.
   const isAtLiveEdge = value.end == null;
 
@@ -226,9 +229,7 @@ export function TimeRangeControls(props: TimeRangeControlsProps) {
             size={size}
             className="time-range-controls__live-toggle"
             css={controlButtonCSS}
-            aria-label={
-              isLive ? "Pause live streaming" : "Resume live streaming"
-            }
+            aria-label={liveToggleLabel}
             isSelected={isLive}
             isDisabled={isDisabled}
             leadingVisual={
@@ -238,9 +239,7 @@ export function TimeRangeControls(props: TimeRangeControlsProps) {
             }
             onChange={onIsLiveChange}
           />
-          <Tooltip>
-            {isLive ? "Pause live streaming" : "Resume live streaming"}
-          </Tooltip>
+          <Tooltip>{liveToggleLabel}</Tooltip>
         </TooltipTrigger>
       )}
       <ControlButton

--- a/app/src/components/datetime/TimeRangeControls.tsx
+++ b/app/src/components/datetime/TimeRangeControls.tsx
@@ -1,0 +1,255 @@
+import { css, keyframes } from "@emotion/react";
+import type { ReactNode } from "react";
+
+import { Button } from "../core/button";
+import { Icon, Icons } from "../core/icon";
+import { ToggleButton } from "../core/toggleButtonGroup";
+import { Tooltip, TooltipTrigger } from "../core/tooltip";
+import type { ComponentSize } from "../core/types";
+import type { OpenTimeRangeWithKey } from "./types";
+import {
+  panTimeRangeLeft,
+  panTimeRangeRight,
+  zoomTimeRangeIn,
+  zoomTimeRangeOut,
+} from "./utils";
+
+export type TimeRangeControlsProps = {
+  /** The currently committed range, including its preset key. */
+  value: OpenTimeRangeWithKey;
+  /** Called when a pan or zoom commits a new range. */
+  onChange: (value: OpenTimeRangeWithKey) => void;
+  /** Whether the view is live (streaming in new data). */
+  isLive: boolean;
+  /** Called when the user presses the play/pause toggle. */
+  onIsLiveChange: (isLive: boolean) => void;
+  /** Disables every control. */
+  isDisabled?: boolean;
+  /** Visual size for the buttons. */
+  size?: Exclude<ComponentSize, "L">;
+};
+
+const livePulseKeyframes = keyframes`
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+`;
+
+/**
+ * A single input-styled shell so the strip reads as one control and shares
+ * the height, border, and background of the time range selector beside it.
+ */
+const timeRangeControlsCSS = css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--global-dimension-static-size-50);
+  width: fit-content;
+  box-sizing: border-box;
+  /* Uniform inset so each button's hover pill floats evenly in the shell. */
+  padding: var(--global-dimension-static-size-50);
+  background-color: var(--global-input-field-background-color);
+  border: var(--global-border-size-thin) solid
+    var(--global-input-field-border-color);
+  border-radius: var(--global-rounding-small);
+
+  &[data-size="S"] {
+    height: var(--global-input-height-s);
+  }
+  &[data-size="M"] {
+    height: var(--global-input-height-m);
+  }
+
+  /* Fade the whole shell as one unit, not each button twice over. */
+  &[data-disabled] {
+    opacity: var(--global-opacity-disabled);
+    button[disabled] {
+      opacity: 1;
+    }
+  }
+`;
+
+/**
+ * Buttons sit inset within the shell as borderless squares whose rounding is
+ * concentric with the shell's. Geometry overrides are scoped to the same
+ * data-attributes the base button styles use so they win the cascade.
+ */
+const controlButtonCSS = css`
+  position: relative;
+  border: none;
+  background-color: transparent;
+  border-radius: var(--global-rounding-xsmall);
+  color: var(--global-text-color-700);
+  transition:
+    background-color 0.2s ease-in-out,
+    color 0.2s ease-in-out;
+
+  &[data-size] {
+    align-self: stretch;
+    height: auto;
+    aspect-ratio: 1 / 1;
+  }
+  &[data-size][data-childless] {
+    padding: 0;
+  }
+
+  /* One optical size for glyphs from both icon families. */
+  .icon-wrap {
+    font-size: var(--global-font-size-s);
+  }
+
+  &:hover:not([disabled]),
+  &[data-hovered]:not([data-disabled]):not([data-selected="true"]) {
+    background-color: var(--global-input-field-background-color-active);
+    color: var(--global-text-color-900);
+  }
+
+  /* Solid play/pause glyphs give the center control a media-transport feel
+     and anchor it against the stroked icons around it. */
+  &.time-range-controls__live-toggle .icon-wrap svg :is(polygon, rect) {
+    fill: currentColor;
+  }
+
+  /* Streaming live reads as a quiet success tint that gently pulses rather
+     than a heavy primary fill. The tint lives on an overlay so the pulse
+     composes from the static token instead of animating between raw colors. */
+  &[data-selected="true"] {
+    background-color: transparent;
+    color: var(--global-color-success);
+    &:hover:not([data-disabled]) {
+      background-color: var(--global-color-success-100);
+    }
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background-color: var(--global-color-success-100);
+      animation: ${livePulseKeyframes} 3s ease-in-out infinite;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &[data-selected="true"]::before {
+      animation: none;
+    }
+  }
+`;
+
+/** A quiet icon button in the shell whose tooltip doubles as its label. */
+function ControlButton(props: {
+  label: string;
+  icon: ReactNode;
+  size: TimeRangeControlsProps["size"];
+  isDisabled?: boolean;
+  onPress: () => void;
+}) {
+  const { label, icon, size, isDisabled, onPress } = props;
+  return (
+    <TooltipTrigger>
+      <Button
+        size={size}
+        variant="quiet"
+        css={controlButtonCSS}
+        aria-label={label}
+        isDisabled={isDisabled}
+        leadingVisual={<Icon svg={icon} />}
+        onPress={onPress}
+      />
+      <Tooltip>{label}</Tooltip>
+    </TooltipTrigger>
+  );
+}
+
+/**
+ * A compact toolbar of icon buttons for steering the active time range,
+ * designed to sit beside the time range selector and share its chrome.
+ * Reading outward from the play/pause toggle in the center: minus/plus zoom
+ * the window wider or narrower (live ranges stay live, anchored to now), and
+ * the chevrons pan the window back or forward by half its width. Panning
+ * forward is capped at the present and unavailable while the range is
+ * open-ended (already at the live edge). While live, the toggle carries a
+ * gently pulsing success tint.
+ */
+export function TimeRangeControls(props: TimeRangeControlsProps) {
+  const {
+    value,
+    onChange,
+    isLive,
+    onIsLiveChange,
+    isDisabled,
+    size = "S",
+  } = props;
+  // Without a start there is no window to pan or zoom by.
+  const hasWindow = value.start != null;
+  // An open-ended range is already at the live edge.
+  const isAtLiveEdge = value.end == null;
+
+  const applyChange = (next: OpenTimeRangeWithKey | null) => {
+    if (next) {
+      onChange(next);
+    }
+  };
+
+  return (
+    <div
+      className="time-range-controls"
+      css={timeRangeControlsCSS}
+      role="group"
+      aria-label="Time range controls"
+      data-size={size}
+      data-disabled={isDisabled || undefined}
+    >
+      <ControlButton
+        label="Pan back in time"
+        icon={<Icons.ChevronLeftOutline />}
+        size={size}
+        isDisabled={isDisabled || !hasWindow}
+        onPress={() => applyChange(panTimeRangeLeft(value))}
+      />
+      <ControlButton
+        label="Zoom out"
+        icon={<Icons.MinusOutline />}
+        size={size}
+        isDisabled={isDisabled || !hasWindow}
+        onPress={() => applyChange(zoomTimeRangeOut(value))}
+      />
+      <TooltipTrigger>
+        <ToggleButton
+          size={size}
+          className="time-range-controls__live-toggle"
+          css={controlButtonCSS}
+          aria-label={isLive ? "Pause live streaming" : "Resume live streaming"}
+          isSelected={isLive}
+          isDisabled={isDisabled}
+          leadingVisual={
+            <Icon
+              svg={isLive ? <Icons.PauseOutline /> : <Icons.PlayOutline />}
+            />
+          }
+          onChange={onIsLiveChange}
+        />
+        <Tooltip>
+          {isLive ? "Pause live streaming" : "Resume live streaming"}
+        </Tooltip>
+      </TooltipTrigger>
+      <ControlButton
+        label="Zoom in"
+        icon={<Icons.PlusOutline />}
+        size={size}
+        isDisabled={isDisabled || !hasWindow}
+        onPress={() => applyChange(zoomTimeRangeIn(value))}
+      />
+      <ControlButton
+        label="Pan forward in time"
+        icon={<Icons.ChevronRightOutline />}
+        size={size}
+        isDisabled={isDisabled || !hasWindow || isAtLiveEdge}
+        onPress={() => applyChange(panTimeRangeRight(value))}
+      />
+    </div>
+  );
+}

--- a/app/src/components/datetime/TimeRangeSelector.tsx
+++ b/app/src/components/datetime/TimeRangeSelector.tsx
@@ -152,8 +152,8 @@ const timeRangeSelectorCSS = css`
       color: var(--global-text-color-500);
     }
     &:focus {
-      color: var(--highlight-accent-foreground);
-      background: var(--highlight-accent-background);
+      color: var(--field-editing-foreground);
+      background: var(--field-editing-background);
       outline: none;
       caret-color: transparent;
     }

--- a/app/src/components/datetime/TimeRangeSelector.tsx
+++ b/app/src/components/datetime/TimeRangeSelector.tsx
@@ -151,7 +151,8 @@ const timeRangeSelectorCSS = css`
     &:focus {
       color: var(--highlight-foreground);
       background: var(--highlight-background);
-      outline: none;
+      outline: 1px solid var(--global-color-primary);
+      outline-offset: -1px;
       caret-color: transparent;
     }
   }

--- a/app/src/components/datetime/TimeRangeSelector.tsx
+++ b/app/src/components/datetime/TimeRangeSelector.tsx
@@ -135,7 +135,9 @@ const timeRangeSelectorCSS = css`
     font-variant-numeric: tabular-nums;
     color: var(--global-text-color-900);
     border-radius: var(--global-rounding-xsmall);
-    transition: color 0.1s ease-out;
+    transition:
+      color 0.1s ease-out,
+      background-color 0.1s ease-out;
 
     &[data-type="literal"] {
       padding: 0;
@@ -150,9 +152,8 @@ const timeRangeSelectorCSS = css`
       color: var(--global-text-color-500);
     }
     &:focus {
-      color: var(--global-static-color-white-900);
-      background: var(--global-color-blue-500);
-      border-radius: var(--global-rounding-small);
+      color: var(--highlight-accent-foreground);
+      background: var(--highlight-accent-background);
       outline: none;
       caret-color: transparent;
     }

--- a/app/src/components/datetime/TimeRangeSelector.tsx
+++ b/app/src/components/datetime/TimeRangeSelector.tsx
@@ -149,10 +149,9 @@ const timeRangeSelectorCSS = css`
       color: var(--global-text-color-500);
     }
     &:focus {
-      color: var(--highlight-foreground);
-      background: var(--highlight-background);
-      outline: 1px solid var(--global-color-primary);
-      outline-offset: -1px;
+      color: var(--global-text-color-900);
+      background: var(--global-color-primary-200);
+      outline: none;
       caret-color: transparent;
     }
   }

--- a/app/src/components/datetime/TimeRangeSelector.tsx
+++ b/app/src/components/datetime/TimeRangeSelector.tsx
@@ -135,6 +135,7 @@ const timeRangeSelectorCSS = css`
     font-variant-numeric: tabular-nums;
     color: var(--global-text-color-900);
     border-radius: var(--global-rounding-xsmall);
+    transition: color 0.1s ease-out;
 
     &[data-type="literal"] {
       padding: 0;
@@ -149,8 +150,9 @@ const timeRangeSelectorCSS = css`
       color: var(--global-text-color-500);
     }
     &:focus {
-      color: var(--global-text-color-900);
-      background: var(--global-color-primary-200);
+      color: var(--global-static-color-white-900);
+      background: var(--global-color-blue-500);
+      border-radius: var(--global-rounding-small);
       outline: none;
       caret-color: transparent;
     }

--- a/app/src/components/datetime/__tests__/utils.test.ts
+++ b/app/src/components/datetime/__tests__/utils.test.ts
@@ -233,23 +233,11 @@ describe("time range pan and zoom", () => {
     ).toBe("90m");
   });
 
-  it("snaps zoomed live windows to the nearest curated duration", () => {
+  it("rounds large zoomed live windows to days instead of accumulating hours", () => {
     vi.useFakeTimers();
     vi.setSystemTime(now);
 
-    // Pure 2x zoom would land on 32m; curated snapping prefers 30m.
-    expect(
-      zoomTimeRangeOut(
-        {
-          timeRangeKey: "16m",
-          start: new Date(now.getTime() - 16 * 60 * 1000),
-          end: null,
-        },
-        now
-      )?.timeRangeKey
-    ).toBe("30m");
-    // Very large hour windows snap to curated day durations instead of
-    // accumulating odd rounded day counts.
+    // Doubling out of "2048h" reads as days, not "4096h".
     expect(
       zoomTimeRangeOut(
         {
@@ -259,18 +247,34 @@ describe("time range pan and zoom", () => {
         },
         now
       )?.timeRangeKey
-    ).toBe("180d");
-    // Curated snapping also applies when zooming in.
+    ).toBe("171d");
+    // And once in days, zooming stays in days.
     expect(
-      zoomTimeRangeIn(
+      zoomTimeRangeOut(
         {
-          timeRangeKey: "16m",
-          start: new Date(now.getTime() - 16 * 60 * 1000),
+          timeRangeKey: "171d",
+          start: new Date(now.getTime() - 171 * 24 * 60 * 60 * 1000),
           end: null,
         },
         now
       )?.timeRangeKey
-    ).toBe("10m");
+    ).toBe("342d");
+  });
+
+  it("zooms a closed range by the exact factor, preserving its span", () => {
+    // A 50-minute custom window doubles to exactly 100 minutes around its
+    // center; custom windows show concrete datetimes, so the span is exact.
+    const fiftyMinutes = {
+      timeRangeKey: "custom" as const,
+      start: new Date("2026-06-09T10:00:00.000Z"),
+      end: new Date("2026-06-09T10:50:00.000Z"),
+    };
+    expect(zoomTimeRangeOut(fiftyMinutes, now)).toEqual({
+      timeRangeKey: "custom",
+      // Center 10:25 ± 50m → 09:35–11:15, fully before now (12:00).
+      start: new Date("2026-06-09T09:35:00.000Z"),
+      end: new Date("2026-06-09T11:15:00.000Z"),
+    });
   });
 
   it("stops zooming in at the one minute floor", () => {

--- a/app/src/components/datetime/__tests__/utils.test.ts
+++ b/app/src/components/datetime/__tests__/utils.test.ts
@@ -83,14 +83,14 @@ describe("time range pan and zoom", () => {
   const now = new Date("2026-06-09T12:00:00.000Z");
 
   it("pans a closed range back by half its window", () => {
-    const next = panTimeRangeLeft(
-      {
+    const next = panTimeRangeLeft({
+      value: {
         timeRangeKey: "custom",
         start: new Date("2026-06-09T10:00:00.000Z"),
         end: new Date("2026-06-09T11:00:00.000Z"),
       },
-      now
-    );
+      now,
+    });
     expect(next).toEqual({
       timeRangeKey: "custom",
       start: new Date("2026-06-09T09:30:00.000Z"),
@@ -99,14 +99,14 @@ describe("time range pan and zoom", () => {
   });
 
   it("pans a live range back into a closed custom range", () => {
-    const next = panTimeRangeLeft(
-      {
+    const next = panTimeRangeLeft({
+      value: {
         timeRangeKey: "1h",
         start: new Date("2026-06-09T11:00:00.000Z"),
         end: null,
       },
-      now
-    );
+      now,
+    });
     expect(next).toEqual({
       timeRangeKey: "custom",
       start: new Date("2026-06-09T10:30:00.000Z"),
@@ -115,28 +115,28 @@ describe("time range pan and zoom", () => {
   });
 
   it("pans a closed range forward, clamped to now", () => {
-    const halfStep = panTimeRangeRight(
-      {
+    const halfStep = panTimeRangeRight({
+      value: {
         timeRangeKey: "custom",
         start: new Date("2026-06-09T09:00:00.000Z"),
         end: new Date("2026-06-09T10:00:00.000Z"),
       },
-      now
-    );
+      now,
+    });
     expect(halfStep).toEqual({
       timeRangeKey: "custom",
       start: new Date("2026-06-09T09:30:00.000Z"),
       end: new Date("2026-06-09T10:30:00.000Z"),
     });
 
-    const clamped = panTimeRangeRight(
-      {
+    const clamped = panTimeRangeRight({
+      value: {
         timeRangeKey: "custom",
         start: new Date("2026-06-09T10:45:00.000Z"),
         end: new Date("2026-06-09T11:45:00.000Z"),
       },
-      now
-    );
+      now,
+    });
     expect(clamped).toEqual({
       timeRangeKey: "custom",
       start: new Date("2026-06-09T11:00:00.000Z"),
@@ -146,20 +146,23 @@ describe("time range pan and zoom", () => {
 
   it("does not pan forward past now or pan a live range forward", () => {
     expect(
-      panTimeRangeRight(
-        {
+      panTimeRangeRight({
+        value: {
           timeRangeKey: "custom",
           start: new Date("2026-06-09T11:00:00.000Z"),
           end: now,
         },
-        now
-      )
+        now,
+      })
     ).toBeNull();
     expect(
-      panTimeRangeRight(
-        { timeRangeKey: "1h", start: new Date("2026-06-09T11:00:00.000Z") },
-        now
-      )
+      panTimeRangeRight({
+        value: {
+          timeRangeKey: "1h",
+          start: new Date("2026-06-09T11:00:00.000Z"),
+        },
+        now,
+      })
     ).toBeNull();
   });
 
@@ -169,12 +172,12 @@ describe("time range pan and zoom", () => {
       start: new Date("2026-06-09T08:00:00.000Z"),
       end: new Date("2026-06-09T10:00:00.000Z"),
     };
-    expect(zoomTimeRangeIn(value, now)).toEqual({
+    expect(zoomTimeRangeIn({ value, now })).toEqual({
       timeRangeKey: "custom",
       start: new Date("2026-06-09T08:30:00.000Z"),
       end: new Date("2026-06-09T09:30:00.000Z"),
     });
-    expect(zoomTimeRangeOut(value, now)).toEqual({
+    expect(zoomTimeRangeOut({ value, now })).toEqual({
       timeRangeKey: "custom",
       start: new Date("2026-06-09T07:00:00.000Z"),
       end: new Date("2026-06-09T11:00:00.000Z"),
@@ -182,14 +185,14 @@ describe("time range pan and zoom", () => {
   });
 
   it("slides a zoom-out back when it would extend past now", () => {
-    const next = zoomTimeRangeOut(
-      {
+    const next = zoomTimeRangeOut({
+      value: {
         timeRangeKey: "custom",
         start: new Date("2026-06-09T10:00:00.000Z"),
         end: new Date("2026-06-09T12:00:00.000Z"),
       },
-      now
-    );
+      now,
+    });
     // Doubling around the center would end at 13:00; the overflow is pushed
     // back so the window still doubles but ends at now.
     expect(next).toEqual({
@@ -208,28 +211,34 @@ describe("time range pan and zoom", () => {
       start: new Date("2026-06-09T11:00:00.000Z"),
       end: null,
     };
-    expect(zoomTimeRangeIn(lastHour, now)).toEqual({
+    expect(zoomTimeRangeIn({ value: lastHour, now })).toEqual({
       timeRangeKey: "30m",
       ...getTimeRangeFromLastNTimeRangeKey("30m"),
     });
-    expect(zoomTimeRangeOut(lastHour, now)).toEqual({
+    expect(zoomTimeRangeOut({ value: lastHour, now })).toEqual({
       timeRangeKey: "2h",
       ...getTimeRangeFromLastNTimeRangeKey("2h"),
     });
     // Half of 7 days is 3.5 days — at two-plus days the key snaps to the
     // nearest whole day instead of dropping to "84h".
     expect(
-      zoomTimeRangeIn(
-        { timeRangeKey: "7d", start: new Date("2026-06-02T12:00:00.000Z") },
-        now
-      )?.timeRangeKey
+      zoomTimeRangeIn({
+        value: {
+          timeRangeKey: "7d",
+          start: new Date("2026-06-02T12:00:00.000Z"),
+        },
+        now,
+      })?.timeRangeKey
     ).toBe("4d");
     // A fraction below two of the next unit keeps the smaller unit.
     expect(
-      zoomTimeRangeIn(
-        { timeRangeKey: "3h", start: new Date("2026-06-09T09:00:00.000Z") },
-        now
-      )?.timeRangeKey
+      zoomTimeRangeIn({
+        value: {
+          timeRangeKey: "3h",
+          start: new Date("2026-06-09T09:00:00.000Z"),
+        },
+        now,
+      })?.timeRangeKey
     ).toBe("90m");
   });
 
@@ -239,25 +248,25 @@ describe("time range pan and zoom", () => {
 
     // Doubling out of "2048h" reads as days, not "4096h".
     expect(
-      zoomTimeRangeOut(
-        {
+      zoomTimeRangeOut({
+        value: {
           timeRangeKey: "2048h",
           start: new Date(now.getTime() - 2048 * 60 * 60 * 1000),
           end: null,
         },
-        now
-      )?.timeRangeKey
+        now,
+      })?.timeRangeKey
     ).toBe("171d");
     // And once in days, zooming stays in days.
     expect(
-      zoomTimeRangeOut(
-        {
+      zoomTimeRangeOut({
+        value: {
           timeRangeKey: "171d",
           start: new Date(now.getTime() - 171 * 24 * 60 * 60 * 1000),
           end: null,
         },
-        now
-      )?.timeRangeKey
+        now,
+      })?.timeRangeKey
     ).toBe("342d");
   });
 
@@ -269,7 +278,7 @@ describe("time range pan and zoom", () => {
       start: new Date("2026-06-09T10:00:00.000Z"),
       end: new Date("2026-06-09T10:50:00.000Z"),
     };
-    expect(zoomTimeRangeOut(fiftyMinutes, now)).toEqual({
+    expect(zoomTimeRangeOut({ value: fiftyMinutes, now })).toEqual({
       timeRangeKey: "custom",
       // Center 10:25 ± 50m → 09:35–11:15, fully before now (12:00).
       start: new Date("2026-06-09T09:35:00.000Z"),
@@ -279,28 +288,31 @@ describe("time range pan and zoom", () => {
 
   it("stops zooming in at the one minute floor", () => {
     expect(
-      zoomTimeRangeIn(
-        { timeRangeKey: "1m", start: new Date("2026-06-09T11:59:00.000Z") },
-        now
-      )
+      zoomTimeRangeIn({
+        value: {
+          timeRangeKey: "1m",
+          start: new Date("2026-06-09T11:59:00.000Z"),
+        },
+        now,
+      })
     ).toBeNull();
     expect(
-      zoomTimeRangeIn(
-        {
+      zoomTimeRangeIn({
+        value: {
           timeRangeKey: "custom",
           start: new Date("2026-06-09T11:59:00.000Z"),
           end: now,
         },
-        now
-      )
+        now,
+      })
     ).toBeNull();
   });
 
   it("returns null when the range has no resolvable window", () => {
     const startless = { timeRangeKey: "custom" as const, end: now };
-    expect(panTimeRangeLeft(startless, now)).toBeNull();
-    expect(panTimeRangeRight(startless, now)).toBeNull();
-    expect(zoomTimeRangeIn(startless, now)).toBeNull();
-    expect(zoomTimeRangeOut(startless, now)).toBeNull();
+    expect(panTimeRangeLeft({ value: startless, now })).toBeNull();
+    expect(panTimeRangeRight({ value: startless, now })).toBeNull();
+    expect(zoomTimeRangeIn({ value: startless, now })).toBeNull();
+    expect(zoomTimeRangeOut({ value: startless, now })).toBeNull();
   });
 });

--- a/app/src/components/datetime/__tests__/utils.test.ts
+++ b/app/src/components/datetime/__tests__/utils.test.ts
@@ -233,11 +233,23 @@ describe("time range pan and zoom", () => {
     ).toBe("90m");
   });
 
-  it("snaps large zoomed windows to days instead of accumulating hours", () => {
+  it("snaps zoomed live windows to the nearest curated duration", () => {
     vi.useFakeTimers();
     vi.setSystemTime(now);
 
-    // Doubling out of "2048h" reads as days, not "4096h".
+    // Pure 2x zoom would land on 32m; curated snapping prefers 30m.
+    expect(
+      zoomTimeRangeOut(
+        {
+          timeRangeKey: "16m",
+          start: new Date(now.getTime() - 16 * 60 * 1000),
+          end: null,
+        },
+        now
+      )?.timeRangeKey
+    ).toBe("30m");
+    // Very large hour windows snap to curated day durations instead of
+    // accumulating odd rounded day counts.
     expect(
       zoomTimeRangeOut(
         {
@@ -247,18 +259,18 @@ describe("time range pan and zoom", () => {
         },
         now
       )?.timeRangeKey
-    ).toBe("171d");
-    // And once in days, zooming stays in days.
+    ).toBe("180d");
+    // Curated snapping also applies when zooming in.
     expect(
-      zoomTimeRangeOut(
+      zoomTimeRangeIn(
         {
-          timeRangeKey: "171d",
-          start: new Date(now.getTime() - 171 * 24 * 60 * 60 * 1000),
+          timeRangeKey: "16m",
+          start: new Date(now.getTime() - 16 * 60 * 1000),
           end: null,
         },
         now
       )?.timeRangeKey
-    ).toBe("342d");
+    ).toBe("10m");
   });
 
   it("stops zooming in at the one minute floor", () => {

--- a/app/src/components/datetime/__tests__/utils.test.ts
+++ b/app/src/components/datetime/__tests__/utils.test.ts
@@ -6,7 +6,11 @@ import {
   getTimeRangeFromLastNTimeRangeKey,
   getTimeRangeSearchSuggestions,
   isLastNTimeRangeKey,
+  panTimeRangeLeft,
+  panTimeRangeRight,
   parseTimeRangeSearchText,
+  zoomTimeRangeIn,
+  zoomTimeRangeOut,
 } from "../utils";
 
 describe("datetime utils", () => {
@@ -72,5 +76,215 @@ describe("datetime utils", () => {
     expect(getTimeRangeSearchSuggestions("")).toEqual([]);
     expect(getTimeRangeSearchSuggestions("0")).toEqual([]);
     expect(getTimeRangeSearchSuggestions("hour")).toEqual([]);
+  });
+});
+
+describe("time range pan and zoom", () => {
+  const now = new Date("2026-06-09T12:00:00.000Z");
+
+  it("pans a closed range back by half its window", () => {
+    const next = panTimeRangeLeft(
+      {
+        timeRangeKey: "custom",
+        start: new Date("2026-06-09T10:00:00.000Z"),
+        end: new Date("2026-06-09T11:00:00.000Z"),
+      },
+      now
+    );
+    expect(next).toEqual({
+      timeRangeKey: "custom",
+      start: new Date("2026-06-09T09:30:00.000Z"),
+      end: new Date("2026-06-09T10:30:00.000Z"),
+    });
+  });
+
+  it("pans a live range back into a closed custom range", () => {
+    const next = panTimeRangeLeft(
+      {
+        timeRangeKey: "1h",
+        start: new Date("2026-06-09T11:00:00.000Z"),
+        end: null,
+      },
+      now
+    );
+    expect(next).toEqual({
+      timeRangeKey: "custom",
+      start: new Date("2026-06-09T10:30:00.000Z"),
+      end: new Date("2026-06-09T11:30:00.000Z"),
+    });
+  });
+
+  it("pans a closed range forward, clamped to now", () => {
+    const halfStep = panTimeRangeRight(
+      {
+        timeRangeKey: "custom",
+        start: new Date("2026-06-09T09:00:00.000Z"),
+        end: new Date("2026-06-09T10:00:00.000Z"),
+      },
+      now
+    );
+    expect(halfStep).toEqual({
+      timeRangeKey: "custom",
+      start: new Date("2026-06-09T09:30:00.000Z"),
+      end: new Date("2026-06-09T10:30:00.000Z"),
+    });
+
+    const clamped = panTimeRangeRight(
+      {
+        timeRangeKey: "custom",
+        start: new Date("2026-06-09T10:45:00.000Z"),
+        end: new Date("2026-06-09T11:45:00.000Z"),
+      },
+      now
+    );
+    expect(clamped).toEqual({
+      timeRangeKey: "custom",
+      start: new Date("2026-06-09T11:00:00.000Z"),
+      end: new Date("2026-06-09T12:00:00.000Z"),
+    });
+  });
+
+  it("does not pan forward past now or pan a live range forward", () => {
+    expect(
+      panTimeRangeRight(
+        {
+          timeRangeKey: "custom",
+          start: new Date("2026-06-09T11:00:00.000Z"),
+          end: now,
+        },
+        now
+      )
+    ).toBeNull();
+    expect(
+      panTimeRangeRight(
+        { timeRangeKey: "1h", start: new Date("2026-06-09T11:00:00.000Z") },
+        now
+      )
+    ).toBeNull();
+  });
+
+  it("zooms a closed range around its center", () => {
+    const value = {
+      timeRangeKey: "custom" as const,
+      start: new Date("2026-06-09T08:00:00.000Z"),
+      end: new Date("2026-06-09T10:00:00.000Z"),
+    };
+    expect(zoomTimeRangeIn(value, now)).toEqual({
+      timeRangeKey: "custom",
+      start: new Date("2026-06-09T08:30:00.000Z"),
+      end: new Date("2026-06-09T09:30:00.000Z"),
+    });
+    expect(zoomTimeRangeOut(value, now)).toEqual({
+      timeRangeKey: "custom",
+      start: new Date("2026-06-09T07:00:00.000Z"),
+      end: new Date("2026-06-09T11:00:00.000Z"),
+    });
+  });
+
+  it("slides a zoom-out back when it would extend past now", () => {
+    const next = zoomTimeRangeOut(
+      {
+        timeRangeKey: "custom",
+        start: new Date("2026-06-09T10:00:00.000Z"),
+        end: new Date("2026-06-09T12:00:00.000Z"),
+      },
+      now
+    );
+    // Doubling around the center would end at 13:00; the overflow is pushed
+    // back so the window still doubles but ends at now.
+    expect(next).toEqual({
+      timeRangeKey: "custom",
+      start: new Date("2026-06-09T08:00:00.000Z"),
+      end: new Date("2026-06-09T12:00:00.000Z"),
+    });
+  });
+
+  it("keeps live ranges live, mapping zoom to the equivalent last-N key", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    const lastHour = {
+      timeRangeKey: "1h" as const,
+      start: new Date("2026-06-09T11:00:00.000Z"),
+      end: null,
+    };
+    expect(zoomTimeRangeIn(lastHour, now)).toEqual({
+      timeRangeKey: "30m",
+      ...getTimeRangeFromLastNTimeRangeKey("30m"),
+    });
+    expect(zoomTimeRangeOut(lastHour, now)).toEqual({
+      timeRangeKey: "2h",
+      ...getTimeRangeFromLastNTimeRangeKey("2h"),
+    });
+    // Half of 7 days is 3.5 days — at two-plus days the key snaps to the
+    // nearest whole day instead of dropping to "84h".
+    expect(
+      zoomTimeRangeIn(
+        { timeRangeKey: "7d", start: new Date("2026-06-02T12:00:00.000Z") },
+        now
+      )?.timeRangeKey
+    ).toBe("4d");
+    // A fraction below two of the next unit keeps the smaller unit.
+    expect(
+      zoomTimeRangeIn(
+        { timeRangeKey: "3h", start: new Date("2026-06-09T09:00:00.000Z") },
+        now
+      )?.timeRangeKey
+    ).toBe("90m");
+  });
+
+  it("snaps large zoomed windows to days instead of accumulating hours", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    // Doubling out of "2048h" reads as days, not "4096h".
+    expect(
+      zoomTimeRangeOut(
+        {
+          timeRangeKey: "2048h",
+          start: new Date(now.getTime() - 2048 * 60 * 60 * 1000),
+          end: null,
+        },
+        now
+      )?.timeRangeKey
+    ).toBe("171d");
+    // And once in days, zooming stays in days.
+    expect(
+      zoomTimeRangeOut(
+        {
+          timeRangeKey: "171d",
+          start: new Date(now.getTime() - 171 * 24 * 60 * 60 * 1000),
+          end: null,
+        },
+        now
+      )?.timeRangeKey
+    ).toBe("342d");
+  });
+
+  it("stops zooming in at the one minute floor", () => {
+    expect(
+      zoomTimeRangeIn(
+        { timeRangeKey: "1m", start: new Date("2026-06-09T11:59:00.000Z") },
+        now
+      )
+    ).toBeNull();
+    expect(
+      zoomTimeRangeIn(
+        {
+          timeRangeKey: "custom",
+          start: new Date("2026-06-09T11:59:00.000Z"),
+          end: now,
+        },
+        now
+      )
+    ).toBeNull();
+  });
+
+  it("returns null when the range has no resolvable window", () => {
+    const startless = { timeRangeKey: "custom" as const, end: now };
+    expect(panTimeRangeLeft(startless, now)).toBeNull();
+    expect(panTimeRangeRight(startless, now)).toBeNull();
+    expect(zoomTimeRangeIn(startless, now)).toBeNull();
+    expect(zoomTimeRangeOut(startless, now)).toBeNull();
   });
 });

--- a/app/src/components/datetime/index.tsx
+++ b/app/src/components/datetime/index.tsx
@@ -6,5 +6,6 @@ export * from "./TimeRangeContext";
 export * from "./TimeRangeSelector";
 export * from "./TimeRangeControls";
 export * from "./ConnectedTimeRangeSelector";
+export * from "./ConnectedTimeRangeControls";
 export * from "./TimeRangeForm";
 export type { TimeRangeKey, OpenTimeRangeWithKey } from "./types";

--- a/app/src/components/datetime/index.tsx
+++ b/app/src/components/datetime/index.tsx
@@ -4,7 +4,7 @@ export { TimeField } from "../core/datetime/TimeField";
 export * from "./TimeRangeCalendarPicker";
 export * from "./TimeRangeContext";
 export * from "./TimeRangeSelector";
+export * from "./TimeRangeControls";
 export * from "./ConnectedTimeRangeSelector";
 export * from "./TimeRangeForm";
-export * from "./TimeRangeSelector";
 export type { TimeRangeKey, OpenTimeRangeWithKey } from "./types";

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -14,6 +14,7 @@ import { LAST_N_TIME_RANGES_MAP } from "./constants";
 import type {
   LastNTimeRangeKey,
   LastNTimeRangeUnit,
+  OpenTimeRangeWithKey,
   TimeRangeKey,
 } from "./types";
 
@@ -191,6 +192,181 @@ export function getTimeRangeSearchSuggestions(
     return [];
   }
   return [`${quantity}m`, `${quantity}h`, `${quantity}d`];
+}
+
+const PAN_SHIFT_FRACTION = 0.5;
+const ZOOM_FACTOR = 2;
+/** The smallest window zooming in will produce. */
+const MIN_ZOOM_WINDOW_MS = MINUTE_IN_MS;
+
+/**
+ * Resolve a (possibly open-ended) time range into a concrete window. An open
+ * end resolves to `now`. A range with no start (or an inverted window) has no
+ * duration to pan or zoom by, so it resolves to null.
+ */
+function getResolvedWindow(
+  value: OpenTimeRange,
+  now: Date
+): { startMs: number; endMs: number; durationMs: number } | null {
+  if (!value.start) {
+    return null;
+  }
+  const startMs = value.start.getTime();
+  const endMs = (value.end ?? now).getTime();
+  const durationMs = endMs - startMs;
+  if (durationMs <= 0) {
+    return null;
+  }
+  return { startMs, endMs, durationMs };
+}
+
+/**
+ * The last-N key matching the given duration, expressed in the largest
+ * readable unit (e.g. 90 minutes → "90m", 120 minutes → "2h", 48 hours →
+ * "2d"). Once a duration spans at least two of a unit it is rounded to that
+ * unit ("85d", not "2048h") — repeated zooming rarely lands on exact
+ * multiples, so windows would otherwise stay in small units forever. Below
+ * that, only exact multiples switch units. Durations are rounded to the
+ * nearest minute, with a one minute floor.
+ */
+function getLastNTimeRangeKeyFromDurationMs(ms: number): LastNTimeRangeKey {
+  const minutes = Math.max(1, Math.round(ms / MINUTE_IN_MS));
+  const days = minutes / (24 * 60);
+  if (days >= 2 || Number.isInteger(days)) {
+    return `${Math.round(days)}d`;
+  }
+  const hours = minutes / 60;
+  if (hours >= 2 || Number.isInteger(hours)) {
+    return `${Math.round(hours)}h`;
+  }
+  return `${minutes}m`;
+}
+
+/**
+ * Shift the window back in time by half its duration. Panning steps off the
+ * live edge, so the result is always a closed custom range. Returns null when
+ * the range has no resolvable window.
+ */
+export function panTimeRangeLeft(
+  value: OpenTimeRangeWithKey,
+  now: Date = new Date()
+): OpenTimeRangeWithKey | null {
+  const window = getResolvedWindow(value, now);
+  if (!window) {
+    return null;
+  }
+  const shiftMs = window.durationMs * PAN_SHIFT_FRACTION;
+  return {
+    timeRangeKey: "custom",
+    start: new Date(window.startMs - shiftMs),
+    end: new Date(window.endMs - shiftMs),
+  };
+}
+
+/**
+ * Shift the window forward in time by half its duration, clamped so it never
+ * extends past `now`. Returns null when the range is already live
+ * (open-ended) or there is no room left to shift.
+ */
+export function panTimeRangeRight(
+  value: OpenTimeRangeWithKey,
+  now: Date = new Date()
+): OpenTimeRangeWithKey | null {
+  if (!value.end) {
+    return null;
+  }
+  const window = getResolvedWindow(value, now);
+  if (!window) {
+    return null;
+  }
+  const shiftMs = Math.min(
+    window.durationMs * PAN_SHIFT_FRACTION,
+    now.getTime() - window.endMs
+  );
+  if (shiftMs <= 0) {
+    return null;
+  }
+  return {
+    timeRangeKey: "custom",
+    start: new Date(window.startMs + shiftMs),
+    end: new Date(window.endMs + shiftMs),
+  };
+}
+
+/**
+ * Halve the window duration, down to a one minute floor. Live (open-ended)
+ * ranges stay live and zoom toward `now`, mapping to the equivalent last-N
+ * key; closed ranges zoom around their center. Returns null when there is
+ * nothing to zoom.
+ */
+export function zoomTimeRangeIn(
+  value: OpenTimeRangeWithKey,
+  now: Date = new Date()
+): OpenTimeRangeWithKey | null {
+  return zoomTimeRange(value, now, 1 / ZOOM_FACTOR);
+}
+
+/**
+ * Double the window duration. Live (open-ended) ranges stay live and zoom
+ * out from `now`, mapping to the equivalent last-N key; closed ranges zoom
+ * around their center, sliding back any portion that would extend past `now`.
+ * Returns null when there is nothing to zoom.
+ */
+export function zoomTimeRangeOut(
+  value: OpenTimeRangeWithKey,
+  now: Date = new Date()
+): OpenTimeRangeWithKey | null {
+  return zoomTimeRange(value, now, ZOOM_FACTOR);
+}
+
+function zoomTimeRange(
+  value: OpenTimeRangeWithKey,
+  now: Date,
+  factor: number
+): OpenTimeRangeWithKey | null {
+  // For last-N presets the key is the duration's source of truth — the
+  // resolved start is snapped to the minute/hour, so deriving the duration
+  // from it would drift.
+  const parsedKey = parseLastNTimeRangeKey(value.timeRangeKey);
+  const window = getResolvedWindow(value, now);
+  const durationMs = parsedKey
+    ? getLastNTimeRangeDurationMs(parsedKey)
+    : window?.durationMs;
+  if (durationMs == null) {
+    return null;
+  }
+  const newDurationMs = Math.max(durationMs * factor, MIN_ZOOM_WINDOW_MS);
+  // Zooming in at (or below) the minimum window has nothing left to reveal.
+  if (factor < 1 ? newDurationMs >= durationMs : newDurationMs === durationMs) {
+    return null;
+  }
+  if (!value.end) {
+    // Live ranges stay live: re-anchor the new duration to now.
+    const timeRangeKey = getLastNTimeRangeKeyFromDurationMs(newDurationMs);
+    if (timeRangeKey === value.timeRangeKey) {
+      return null;
+    }
+    return {
+      timeRangeKey,
+      ...getTimeRangeFromLastNTimeRangeKey(timeRangeKey),
+    };
+  }
+  if (!window) {
+    return null;
+  }
+  const centerMs = (window.startMs + window.endMs) / 2;
+  let startMs = centerMs - newDurationMs / 2;
+  let endMs = centerMs + newDurationMs / 2;
+  const overflowMs = endMs - now.getTime();
+  if (overflowMs > 0) {
+    startMs -= overflowMs;
+    endMs -= overflowMs;
+  }
+  return {
+    timeRangeKey: "custom",
+    start: new Date(startMs),
+    end: new Date(endMs),
+  };
 }
 
 /**

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -200,6 +200,60 @@ const ZOOM_FACTOR = 2;
 const MIN_ZOOM_WINDOW_MS = MINUTE_IN_MS;
 
 /**
+ * Human-friendly durations that zooming snaps to. This prevents awkward
+ * values like 32m or 64m that arise from pure 2x multiplication.
+ */
+const EVEN_DURATIONS_MS = [
+  1, // 1m
+  2, // 2m
+  5, // 5m
+  10, // 10m
+  15, // 15m
+  30, // 30m
+  45, // 45m
+  60, // 1h
+  90, // 1.5h
+  120, // 2h
+  180, // 3h
+  240, // 4h
+  360, // 6h
+  480, // 8h
+  720, // 12h
+  1440, // 1d
+  2880, // 2d
+  4320, // 3d
+  5760, // 4d
+  7200, // 5d
+  10080, // 7d
+  14400, // 10d
+  21600, // 15d
+  43200, // 30d
+  64800, // 45d
+  86400, // 60d
+  129600, // 90d
+  259200, // 180d
+  525600, // 365d
+].map((m) => m * MINUTE_IN_MS);
+
+/**
+ * Snap a duration to the nearest value in EVEN_DURATIONS_MS. When
+ * equidistant between two values, prefers the larger one.
+ */
+function snapToEvenDuration(ms: number): number {
+  let closest = EVEN_DURATIONS_MS[0];
+  let minDiff = Math.abs(ms - closest);
+  for (const candidate of EVEN_DURATIONS_MS) {
+    const diff = Math.abs(ms - candidate);
+    // Use <= to prefer the larger value when equidistant.
+    if (diff <= minDiff) {
+      minDiff = diff;
+      closest = candidate;
+    }
+  }
+  return closest;
+}
+
+/**
  * Resolve a (possibly open-ended) time range into a concrete window. An open
  * end resolves to `now`. A range with no start (or an inverted window) has no
  * duration to pan or zoom by, so it resolves to null.
@@ -335,9 +389,10 @@ function zoomTimeRange(
   if (durationMs == null) {
     return null;
   }
-  const newDurationMs = Math.max(durationMs * factor, MIN_ZOOM_WINDOW_MS);
+  const rawDurationMs = Math.max(durationMs * factor, MIN_ZOOM_WINDOW_MS);
+  const newDurationMs = snapToEvenDuration(rawDurationMs);
   // Zooming in at (or below) the minimum window has nothing left to reveal.
-  if (factor < 1 ? newDurationMs >= durationMs : newDurationMs === durationMs) {
+  if (newDurationMs === snapToEvenDuration(durationMs)) {
     return null;
   }
   if (!value.end) {

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -194,10 +194,30 @@ export function getTimeRangeSearchSuggestions(
   return [`${quantity}m`, `${quantity}h`, `${quantity}d`];
 }
 
-const PAN_SHIFT_FRACTION = 0.5;
-const ZOOM_FACTOR = 2;
-/** The smallest window zooming in will produce. */
-const MIN_ZOOM_WINDOW_MS = MINUTE_IN_MS;
+/** Default fraction of the window a pan step shifts by. */
+const DEFAULT_PAN_SHIFT_FRACTION = 0.5;
+/** Default multiplier applied to the window duration when zooming. */
+const DEFAULT_ZOOM_FACTOR = 2;
+/** Default smallest window zooming in will produce. */
+const DEFAULT_MIN_ZOOM_WINDOW_MS = MINUTE_IN_MS;
+
+type PanTimeRangeParams = {
+  value: OpenTimeRangeWithKey;
+  /** Reference "now" for resolving open-ended ranges. Defaults to the current time. */
+  now?: Date;
+  /** Fraction of the window to shift by. */
+  shiftFraction?: number;
+};
+
+type ZoomTimeRangeParams = {
+  value: OpenTimeRangeWithKey;
+  /** Reference "now" for resolving open-ended ranges. Defaults to the current time. */
+  now?: Date;
+  /** Multiplier applied to the window duration. */
+  zoomFactor?: number;
+  /** Smallest window zooming in will produce. */
+  minWindowMs?: number;
+};
 
 /**
  * Resolve a (possibly open-ended) time range into a concrete window. An open
@@ -247,15 +267,16 @@ function getLastNTimeRangeKeyFromDurationMs(ms: number): LastNTimeRangeKey {
  * live edge, so the result is always a closed custom range. Returns null when
  * the range has no resolvable window.
  */
-export function panTimeRangeLeft(
-  value: OpenTimeRangeWithKey,
-  now: Date = new Date()
-): OpenTimeRangeWithKey | null {
+export function panTimeRangeLeft({
+  value,
+  now = new Date(),
+  shiftFraction = DEFAULT_PAN_SHIFT_FRACTION,
+}: PanTimeRangeParams): OpenTimeRangeWithKey | null {
   const window = getResolvedWindow(value, now);
   if (!window) {
     return null;
   }
-  const shiftMs = window.durationMs * PAN_SHIFT_FRACTION;
+  const shiftMs = window.durationMs * shiftFraction;
   return {
     timeRangeKey: "custom",
     start: new Date(window.startMs - shiftMs),
@@ -268,10 +289,11 @@ export function panTimeRangeLeft(
  * extends past `now`. Returns null when the range is already live
  * (open-ended) or there is no room left to shift.
  */
-export function panTimeRangeRight(
-  value: OpenTimeRangeWithKey,
-  now: Date = new Date()
-): OpenTimeRangeWithKey | null {
+export function panTimeRangeRight({
+  value,
+  now = new Date(),
+  shiftFraction = DEFAULT_PAN_SHIFT_FRACTION,
+}: PanTimeRangeParams): OpenTimeRangeWithKey | null {
   if (!value.end) {
     return null;
   }
@@ -280,7 +302,7 @@ export function panTimeRangeRight(
     return null;
   }
   const shiftMs = Math.min(
-    window.durationMs * PAN_SHIFT_FRACTION,
+    window.durationMs * shiftFraction,
     now.getTime() - window.endMs
   );
   if (shiftMs <= 0) {
@@ -299,11 +321,13 @@ export function panTimeRangeRight(
  * key; closed ranges zoom around their center. Returns null when there is
  * nothing to zoom.
  */
-export function zoomTimeRangeIn(
-  value: OpenTimeRangeWithKey,
-  now: Date = new Date()
-): OpenTimeRangeWithKey | null {
-  return zoomTimeRange(value, now, 1 / ZOOM_FACTOR);
+export function zoomTimeRangeIn({
+  value,
+  now = new Date(),
+  zoomFactor = DEFAULT_ZOOM_FACTOR,
+  minWindowMs = DEFAULT_MIN_ZOOM_WINDOW_MS,
+}: ZoomTimeRangeParams): OpenTimeRangeWithKey | null {
+  return zoomTimeRange({ value, now, factor: 1 / zoomFactor, minWindowMs });
 }
 
 /**
@@ -312,18 +336,26 @@ export function zoomTimeRangeIn(
  * around their center, sliding back any portion that would extend past `now`.
  * Returns null when there is nothing to zoom.
  */
-export function zoomTimeRangeOut(
-  value: OpenTimeRangeWithKey,
-  now: Date = new Date()
-): OpenTimeRangeWithKey | null {
-  return zoomTimeRange(value, now, ZOOM_FACTOR);
+export function zoomTimeRangeOut({
+  value,
+  now = new Date(),
+  zoomFactor = DEFAULT_ZOOM_FACTOR,
+  minWindowMs = DEFAULT_MIN_ZOOM_WINDOW_MS,
+}: ZoomTimeRangeParams): OpenTimeRangeWithKey | null {
+  return zoomTimeRange({ value, now, factor: zoomFactor, minWindowMs });
 }
 
-function zoomTimeRange(
-  value: OpenTimeRangeWithKey,
-  now: Date,
-  factor: number
-): OpenTimeRangeWithKey | null {
+function zoomTimeRange({
+  value,
+  now,
+  factor,
+  minWindowMs,
+}: {
+  value: OpenTimeRangeWithKey;
+  now: Date;
+  factor: number;
+  minWindowMs: number;
+}): OpenTimeRangeWithKey | null {
   if (!value.end) {
     // Live (open-ended) ranges stay live and re-anchor to now. The duration
     // comes from the last-N key — its resolved start is snapped to the
@@ -335,7 +367,7 @@ function zoomTimeRange(
     if (liveDurationMs == null) {
       return null;
     }
-    const newDurationMs = Math.max(liveDurationMs * factor, MIN_ZOOM_WINDOW_MS);
+    const newDurationMs = Math.max(liveDurationMs * factor, minWindowMs);
     // Zooming in at (or below) the minimum window has nothing left to reveal.
     if (factor < 1 && newDurationMs >= liveDurationMs) {
       return null;
@@ -355,10 +387,7 @@ function zoomTimeRange(
   if (!window) {
     return null;
   }
-  const newDurationMs = Math.max(
-    window.durationMs * factor,
-    MIN_ZOOM_WINDOW_MS
-  );
+  const newDurationMs = Math.max(window.durationMs * factor, minWindowMs);
   // Zooming in at (or below) the minimum window has nothing left to reveal.
   if (
     factor < 1

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -224,10 +224,13 @@ type ZoomTimeRangeParams = {
  * end resolves to `now`. A range with no start (or an inverted window) has no
  * duration to pan or zoom by, so it resolves to null.
  */
-function getResolvedWindow(
-  value: OpenTimeRange,
-  now: Date
-): { startMs: number; endMs: number; durationMs: number } | null {
+function getResolvedWindow({
+  value,
+  now,
+}: {
+  value: OpenTimeRange;
+  now: Date;
+}): { startMs: number; endMs: number; durationMs: number } | null {
   if (!value.start) {
     return null;
   }
@@ -263,16 +266,16 @@ function getLastNTimeRangeKeyFromDurationMs(ms: number): LastNTimeRangeKey {
 }
 
 /**
- * Shift the window back in time by half its duration. Panning steps off the
- * live edge, so the result is always a closed custom range. Returns null when
- * the range has no resolvable window.
+ * Shift the window back in time by `shiftFraction` of its duration (half by
+ * default). Panning steps off the live edge, so the result is always a closed
+ * custom range. Returns null when the range has no resolvable window.
  */
 export function panTimeRangeLeft({
   value,
   now = new Date(),
   shiftFraction = DEFAULT_PAN_SHIFT_FRACTION,
 }: PanTimeRangeParams): OpenTimeRangeWithKey | null {
-  const window = getResolvedWindow(value, now);
+  const window = getResolvedWindow({ value, now });
   if (!window) {
     return null;
   }
@@ -285,9 +288,9 @@ export function panTimeRangeLeft({
 }
 
 /**
- * Shift the window forward in time by half its duration, clamped so it never
- * extends past `now`. Returns null when the range is already live
- * (open-ended) or there is no room left to shift.
+ * Shift the window forward in time by `shiftFraction` of its duration (half by
+ * default), clamped so it never extends past `now`. Returns null when the
+ * range is already live (open-ended) or there is no room left to shift.
  */
 export function panTimeRangeRight({
   value,
@@ -297,7 +300,7 @@ export function panTimeRangeRight({
   if (!value.end) {
     return null;
   }
-  const window = getResolvedWindow(value, now);
+  const window = getResolvedWindow({ value, now });
   if (!window) {
     return null;
   }
@@ -316,10 +319,10 @@ export function panTimeRangeRight({
 }
 
 /**
- * Halve the window duration, down to a one minute floor. Live (open-ended)
- * ranges stay live and zoom toward `now`, mapping to the equivalent last-N
- * key; closed ranges zoom around their center. Returns null when there is
- * nothing to zoom.
+ * Narrow the window by `zoomFactor` (halving it by default), down to a
+ * `minWindowMs` floor. Live (open-ended) ranges stay live and zoom toward
+ * `now`, mapping to the equivalent last-N key; closed ranges zoom around their
+ * center. Returns null when there is nothing to zoom.
  */
 export function zoomTimeRangeIn({
   value,
@@ -331,10 +334,10 @@ export function zoomTimeRangeIn({
 }
 
 /**
- * Double the window duration. Live (open-ended) ranges stay live and zoom
- * out from `now`, mapping to the equivalent last-N key; closed ranges zoom
- * around their center, sliding back any portion that would extend past `now`.
- * Returns null when there is nothing to zoom.
+ * Widen the window by `zoomFactor` (doubling it by default). Live (open-ended)
+ * ranges stay live and zoom out from `now`, mapping to the equivalent last-N
+ * key; closed ranges zoom around their center, sliding back any portion that
+ * would extend past `now`. Returns null when there is nothing to zoom.
  */
 export function zoomTimeRangeOut({
   value,
@@ -363,7 +366,7 @@ function zoomTimeRange({
     const parsedKey = parseLastNTimeRangeKey(value.timeRangeKey);
     const liveDurationMs = parsedKey
       ? getLastNTimeRangeDurationMs(parsedKey)
-      : getResolvedWindow(value, now)?.durationMs;
+      : getResolvedWindow({ value, now })?.durationMs;
     if (liveDurationMs == null) {
       return null;
     }
@@ -383,7 +386,7 @@ function zoomTimeRange({
   }
 
   // Closed (custom) ranges zoom around their center by the exact factor.
-  const window = getResolvedWindow(value, now);
+  const window = getResolvedWindow({ value, now });
   if (!window) {
     return null;
   }

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -200,60 +200,6 @@ const ZOOM_FACTOR = 2;
 const MIN_ZOOM_WINDOW_MS = MINUTE_IN_MS;
 
 /**
- * Human-friendly durations that zooming snaps to. This prevents awkward
- * values like 32m or 64m that arise from pure 2x multiplication.
- */
-const EVEN_DURATIONS_MS = [
-  1, // 1m
-  2, // 2m
-  5, // 5m
-  10, // 10m
-  15, // 15m
-  30, // 30m
-  45, // 45m
-  60, // 1h
-  90, // 1.5h
-  120, // 2h
-  180, // 3h
-  240, // 4h
-  360, // 6h
-  480, // 8h
-  720, // 12h
-  1440, // 1d
-  2880, // 2d
-  4320, // 3d
-  5760, // 4d
-  7200, // 5d
-  10080, // 7d
-  14400, // 10d
-  21600, // 15d
-  43200, // 30d
-  64800, // 45d
-  86400, // 60d
-  129600, // 90d
-  259200, // 180d
-  525600, // 365d
-].map((m) => m * MINUTE_IN_MS);
-
-/**
- * Snap a duration to the nearest value in EVEN_DURATIONS_MS. When
- * equidistant between two values, prefers the larger one.
- */
-function snapToEvenDuration(ms: number): number {
-  let closest = EVEN_DURATIONS_MS[0];
-  let minDiff = Math.abs(ms - closest);
-  for (const candidate of EVEN_DURATIONS_MS) {
-    const diff = Math.abs(ms - candidate);
-    // Use <= to prefer the larger value when equidistant.
-    if (diff <= minDiff) {
-      minDiff = diff;
-      closest = candidate;
-    }
-  }
-  return closest;
-}
-
-/**
  * Resolve a (possibly open-ended) time range into a concrete window. An open
  * end resolves to `now`. A range with no start (or an inverted window) has no
  * duration to pan or zoom by, so it resolves to null.
@@ -378,25 +324,22 @@ function zoomTimeRange(
   now: Date,
   factor: number
 ): OpenTimeRangeWithKey | null {
-  // For last-N presets the key is the duration's source of truth — the
-  // resolved start is snapped to the minute/hour, so deriving the duration
-  // from it would drift.
-  const parsedKey = parseLastNTimeRangeKey(value.timeRangeKey);
-  const window = getResolvedWindow(value, now);
-  const durationMs = parsedKey
-    ? getLastNTimeRangeDurationMs(parsedKey)
-    : window?.durationMs;
-  if (durationMs == null) {
-    return null;
-  }
-  const rawDurationMs = Math.max(durationMs * factor, MIN_ZOOM_WINDOW_MS);
-  const newDurationMs = snapToEvenDuration(rawDurationMs);
-  // Zooming in at (or below) the minimum window has nothing left to reveal.
-  if (newDurationMs === snapToEvenDuration(durationMs)) {
-    return null;
-  }
   if (!value.end) {
-    // Live ranges stay live: re-anchor the new duration to now.
+    // Live (open-ended) ranges stay live and re-anchor to now. The duration
+    // comes from the last-N key — its resolved start is snapped to the
+    // minute/hour, so deriving the duration from the window would drift.
+    const parsedKey = parseLastNTimeRangeKey(value.timeRangeKey);
+    const liveDurationMs = parsedKey
+      ? getLastNTimeRangeDurationMs(parsedKey)
+      : getResolvedWindow(value, now)?.durationMs;
+    if (liveDurationMs == null) {
+      return null;
+    }
+    const newDurationMs = Math.max(liveDurationMs * factor, MIN_ZOOM_WINDOW_MS);
+    // Zooming in at (or below) the minimum window has nothing left to reveal.
+    if (factor < 1 && newDurationMs >= liveDurationMs) {
+      return null;
+    }
     const timeRangeKey = getLastNTimeRangeKeyFromDurationMs(newDurationMs);
     if (timeRangeKey === value.timeRangeKey) {
       return null;
@@ -406,7 +349,22 @@ function zoomTimeRange(
       ...getTimeRangeFromLastNTimeRangeKey(timeRangeKey),
     };
   }
+
+  // Closed (custom) ranges zoom around their center by the exact factor.
+  const window = getResolvedWindow(value, now);
   if (!window) {
+    return null;
+  }
+  const newDurationMs = Math.max(
+    window.durationMs * factor,
+    MIN_ZOOM_WINDOW_MS
+  );
+  // Zooming in at (or below) the minimum window has nothing left to reveal.
+  if (
+    factor < 1
+      ? newDurationMs >= window.durationMs
+      : newDurationMs === window.durationMs
+  ) {
     return null;
   }
   const centerMs = (window.startMs + window.endMs) / 2;

--- a/app/src/pages/dashboards/DashboardsPage.tsx
+++ b/app/src/pages/dashboards/DashboardsPage.tsx
@@ -10,7 +10,10 @@ import {
 import invariant from "tiny-invariant";
 
 import { Empty, Flex, Loading } from "@phoenix/components";
-import { ConnectedTimeRangeSelector } from "@phoenix/components/datetime";
+import {
+  ConnectedTimeRangeControls,
+  ConnectedTimeRangeSelector,
+} from "@phoenix/components/datetime";
 import { ProjectMenu } from "@phoenix/components/project";
 import { usePreferencesContext } from "@phoenix/contexts";
 import { useOwnedPreloadedQuery } from "@phoenix/hooks";
@@ -77,7 +80,10 @@ export function DashboardsPage() {
             navigate(`/dashboards/projects/${projectId}`);
           }}
         />
-        <ConnectedTimeRangeSelector size="S" />
+        <Flex direction="row" alignItems="center" gap="size-100">
+          <ConnectedTimeRangeSelector size="S" />
+          <ConnectedTimeRangeControls size="S" />
+        </Flex>
       </div>
       <div css={contentCSS}>
         <Suspense fallback={<Loading />}>

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -32,7 +32,7 @@ import {
   ProjectPageQueriesTracesQuery,
   ProjectPageQueryReferenceContext,
 } from "./ProjectPageQueries";
-import { StreamToggle } from "./StreamToggle";
+import { ProjectTimeRangeControls } from "./ProjectTimeRangeControls";
 
 const mainCSS = css`
   flex: 1 1 auto;
@@ -137,7 +137,7 @@ function ProjectPageContentBody({
         project: node(id: $id) {
           ... on Project {
             ...ProjectStats_project
-            ...StreamToggle_data
+            ...ProjectTimeRangeControls_data
           }
         }
       }
@@ -225,8 +225,8 @@ function ProjectPageContentBody({
 
   return (
     <main css={mainCSS}>
-      <TopNavActions order={-1}>
-        <StreamToggle project={data.project} />
+      <TopNavActions order={1}>
+        <ProjectTimeRangeControls project={data.project} />
       </TopNavActions>
       <ProjectPageQueryReferenceContext.Provider
         value={{

--- a/app/src/pages/project/ProjectTimeRangeControls.tsx
+++ b/app/src/pages/project/ProjectTimeRangeControls.tsx
@@ -2,7 +2,7 @@ import { startTransition, useCallback, useEffect, useRef } from "react";
 import { graphql, useRefetchableFragment } from "react-relay";
 import { useLocation } from "react-router";
 
-import { TimeRangeControls, useTimeRange } from "@phoenix/components/datetime";
+import { ConnectedTimeRangeControls } from "@phoenix/components/datetime";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useInterval } from "@phoenix/hooks/useInterval";
 
@@ -32,7 +32,6 @@ export function ProjectTimeRangeControls(props: {
     setIsStreaming,
     setFetchKey,
   } = useStreamState();
-  const { timeRange, setTimeRange } = useTimeRange();
   const location = useLocation();
   const currentPathTail = location.pathname.split("/").pop() || "";
   // Take into account both the current path and the streaming state for whether streaming is enabled
@@ -80,13 +79,7 @@ export function ProjectTimeRangeControls(props: {
   useInterval(refetchCountsIfStreaming, REFRESH_INTERVAL_MS);
 
   return (
-    <TimeRangeControls
-      value={timeRange}
-      onChange={(nextTimeRange) => {
-        startTransition(() => {
-          setTimeRange(nextTimeRange);
-        });
-      }}
+    <ConnectedTimeRangeControls
       isLive={isStreamingState}
       onIsLiveChange={setIsStreaming}
     />

--- a/app/src/pages/project/ProjectTimeRangeControls.tsx
+++ b/app/src/pages/project/ProjectTimeRangeControls.tsx
@@ -2,11 +2,11 @@ import { startTransition, useCallback, useEffect, useRef } from "react";
 import { graphql, useRefetchableFragment } from "react-relay";
 import { useLocation } from "react-router";
 
-import { Switch } from "@phoenix/components";
+import { TimeRangeControls, useTimeRange } from "@phoenix/components/datetime";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useInterval } from "@phoenix/hooks/useInterval";
 
-import type { StreamToggle_data$key } from "./__generated__/StreamToggle_data.graphql";
+import type { ProjectTimeRangeControls_data$key } from "./__generated__/ProjectTimeRangeControls_data.graphql";
 
 /**
  * Check every few seconds for new data
@@ -18,12 +18,21 @@ const REFRESH_INTERVAL_MS = 2000;
  */
 const STREAMING_ENABLED_ROUTE_TAILS = ["spans", "traces", "sessions"];
 
-export function StreamToggle(props: { project: StreamToggle_data$key }) {
+/**
+ * The project page's time range control strip: pan/zoom buttons around a
+ * play/pause toggle for live streaming, rendered beside the time range
+ * selector. While streaming is playing, polls the project's last-updated
+ * timestamp and bumps the shared fetch key when new data lands.
+ */
+export function ProjectTimeRangeControls(props: {
+  project: ProjectTimeRangeControls_data$key;
+}) {
   const {
     isStreaming: isStreamingState,
     setIsStreaming,
     setFetchKey,
   } = useStreamState();
+  const { timeRange, setTimeRange } = useTimeRange();
   const location = useLocation();
   const currentPathTail = location.pathname.split("/").pop() || "";
   // Take into account both the current path and the streaming state for whether streaming is enabled
@@ -33,8 +42,8 @@ export function StreamToggle(props: { project: StreamToggle_data$key }) {
 
   const [lastUpdatedAt, refetchLastUpdatedAt] = useRefetchableFragment(
     graphql`
-      fragment StreamToggle_data on Project
-      @refetchable(queryName: "StreamToggleRefetchQuery") {
+      fragment ProjectTimeRangeControls_data on Project
+      @refetchable(queryName: "ProjectTimeRangeControlsRefetchQuery") {
         streamingLastUpdatedAt
       }
     `,
@@ -45,7 +54,7 @@ export function StreamToggle(props: { project: StreamToggle_data$key }) {
     lastUpdatedAt.streamingLastUpdatedAt
   );
 
-  // Refetch lastUpdatedAt if the streaming toggle is on to detect when the underlying data changes
+  // Refetch lastUpdatedAt if streaming is playing to detect when the underlying data changes
   const refetchCountsIfStreaming = useCallback(() => {
     if (isStreamingEnabled) {
       startTransition(() => {
@@ -71,14 +80,15 @@ export function StreamToggle(props: { project: StreamToggle_data$key }) {
   useInterval(refetchCountsIfStreaming, REFRESH_INTERVAL_MS);
 
   return (
-    <Switch
-      labelPlacement="start"
-      isSelected={isStreamingState}
-      onChange={() => {
-        setIsStreaming(!isStreamingState);
+    <TimeRangeControls
+      value={timeRange}
+      onChange={(nextTimeRange) => {
+        startTransition(() => {
+          setTimeRange(nextTimeRange);
+        });
       }}
-    >
-      Stream
-    </Switch>
+      isLive={isStreamingState}
+      onIsLiveChange={setIsStreaming}
+    />
   );
 }

--- a/app/src/pages/project/ProjectTimeRangeControls.tsx
+++ b/app/src/pages/project/ProjectTimeRangeControls.tsx
@@ -1,10 +1,10 @@
-import { startTransition, useCallback, useEffect, useRef } from "react";
+import { startTransition, useEffect, useRef } from "react";
 import { graphql, useRefetchableFragment } from "react-relay";
-import { useLocation } from "react-router";
 
 import { ConnectedTimeRangeControls } from "@phoenix/components/datetime";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useInterval } from "@phoenix/hooks/useInterval";
+import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
 
 import type { ProjectTimeRangeControls_data$key } from "./__generated__/ProjectTimeRangeControls_data.graphql";
 
@@ -14,15 +14,15 @@ import type { ProjectTimeRangeControls_data$key } from "./__generated__/ProjectT
 const REFRESH_INTERVAL_MS = 2000;
 
 /**
- * Routes where streaming is enabled
+ * Project tabs where live streaming is available.
  */
-const STREAMING_ENABLED_ROUTE_TAILS = ["spans", "traces", "sessions"];
+const STREAMING_ENABLED_TABS = ["spans", "traces", "sessions"];
 
 /**
  * The project page's time range control strip: pan/zoom buttons around a
- * play/pause toggle for live streaming, rendered beside the time range
- * selector. While streaming is playing, polls the project's last-updated
- * timestamp and bumps the shared fetch key when new data lands.
+ * live streaming toggle, rendered beside the time range selector. While
+ * streaming is playing on a streamable tab, polls the project's
+ * last-updated timestamp and bumps the shared fetch key when new data lands.
  */
 export function ProjectTimeRangeControls(props: {
   project: ProjectTimeRangeControls_data$key;
@@ -32,12 +32,9 @@ export function ProjectTimeRangeControls(props: {
     setIsStreaming,
     setFetchKey,
   } = useStreamState();
-  const location = useLocation();
-  const currentPathTail = location.pathname.split("/").pop() || "";
-  // Take into account both the current path and the streaming state for whether streaming is enabled
-  // E.g. we don't want to stream when there is a sub-route active
-  const isStreamingEnabled =
-    STREAMING_ENABLED_ROUTE_TAILS.includes(currentPathTail) && isStreamingState;
+  const { tab } = useProjectRootPath();
+  const isStreamingTab = STREAMING_ENABLED_TABS.includes(tab);
+  const isLiveStreaming = isStreamingTab && isStreamingState;
 
   const [lastUpdatedAt, refetchLastUpdatedAt] = useRefetchableFragment(
     graphql`
@@ -53,14 +50,14 @@ export function ProjectTimeRangeControls(props: {
     lastUpdatedAt.streamingLastUpdatedAt
   );
 
-  // Refetch lastUpdatedAt if streaming is playing to detect when the underlying data changes
-  const refetchCountsIfStreaming = useCallback(() => {
-    if (isStreamingEnabled) {
+  useInterval(
+    () => {
       startTransition(() => {
         refetchLastUpdatedAt({}, { fetchPolicy: "store-and-network" });
       });
-    }
-  }, [isStreamingEnabled, refetchLastUpdatedAt]);
+    },
+    isLiveStreaming ? REFRESH_INTERVAL_MS : null
+  );
 
   // We want to refetch higher up the render tree when lastUpdatedAt changes
   const currentLastUpdatedAt = lastUpdatedAt.streamingLastUpdatedAt;
@@ -76,12 +73,10 @@ export function ProjectTimeRangeControls(props: {
     }
   }, [setFetchKey, currentLastUpdatedAt]);
 
-  useInterval(refetchCountsIfStreaming, REFRESH_INTERVAL_MS);
-
   return (
     <ConnectedTimeRangeControls
-      isLive={isStreamingState}
-      onIsLiveChange={setIsStreaming}
+      isLive={isLiveStreaming}
+      onIsLiveChange={isStreamingTab ? setIsStreaming : undefined}
     />
   );
 }

--- a/app/src/pages/project/__generated__/ProjectPageQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4014015c4649f623e7f7ef8ac96a24b9>>
+ * @generated SignedSource<<ade5f64efc505f5f612b9bd5b525c48f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,7 +20,7 @@ export type ProjectPageQuery$variables = {
 };
 export type ProjectPageQuery$data = {
   readonly project: {
-    readonly " $fragmentSpreads": FragmentRefs<"ProjectStats_project" | "StreamToggle_data">;
+    readonly " $fragmentSpreads": FragmentRefs<"ProjectStats_project" | "ProjectTimeRangeControls_data">;
   };
 };
 export type ProjectPageQuery = {
@@ -91,7 +91,7 @@ return {
               {
                 "args": null,
                 "kind": "FragmentSpread",
-                "name": "StreamToggle_data"
+                "name": "ProjectTimeRangeControls_data"
               }
             ],
             "type": "Project",
@@ -242,16 +242,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d2ceed800a251dd00827f1f0c94223d0",
+    "cacheID": "1bf378cde90c188de27f484c754e0bab",
     "id": null,
     "metadata": {},
     "name": "ProjectPageQuery",
     "operationKind": "query",
-    "text": "query ProjectPageQuery(\n  $id: ID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      ...ProjectStats_project\n      ...StreamToggle_data\n    }\n    id\n  }\n}\n\nfragment ProjectStats_project on Project {\n  timeRangeTraceCount: traceCount(timeRange: $timeRange)\n  costSummary(timeRange: $timeRange) {\n    total {\n      cost\n    }\n    prompt {\n      cost\n    }\n    completion {\n      cost\n    }\n  }\n  latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n  latencyMsP99: latencyMsQuantile(probability: 0.99, timeRange: $timeRange)\n  spanAnnotationNames\n  documentEvaluationNames\n  id\n}\n\nfragment StreamToggle_data on Project {\n  streamingLastUpdatedAt\n  id\n}\n"
+    "text": "query ProjectPageQuery(\n  $id: ID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      ...ProjectStats_project\n      ...ProjectTimeRangeControls_data\n    }\n    id\n  }\n}\n\nfragment ProjectStats_project on Project {\n  timeRangeTraceCount: traceCount(timeRange: $timeRange)\n  costSummary(timeRange: $timeRange) {\n    total {\n      cost\n    }\n    prompt {\n      cost\n    }\n    completion {\n      cost\n    }\n  }\n  latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n  latencyMsP99: latencyMsQuantile(probability: 0.99, timeRange: $timeRange)\n  spanAnnotationNames\n  documentEvaluationNames\n  id\n}\n\nfragment ProjectTimeRangeControls_data on Project {\n  streamingLastUpdatedAt\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "30878d78c8f1aa980cb72fce40ab5b03";
+(node as any).hash = "2e3a897c38827a7d1840f89802bf05b9";
 
 export default node;

--- a/app/src/pages/project/__generated__/ProjectTimeRangeControlsRefetchQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectTimeRangeControlsRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9eb3eacba7aee412fa43e126660b9ec8>>
+ * @generated SignedSource<<6b8f70c7fef756f3b6d0e9853c40b49d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,17 +10,17 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type StreamToggleRefetchQuery$variables = {
+export type ProjectTimeRangeControlsRefetchQuery$variables = {
   id: string;
 };
-export type StreamToggleRefetchQuery$data = {
+export type ProjectTimeRangeControlsRefetchQuery$data = {
   readonly node: {
-    readonly " $fragmentSpreads": FragmentRefs<"StreamToggle_data">;
+    readonly " $fragmentSpreads": FragmentRefs<"ProjectTimeRangeControls_data">;
   };
 };
-export type StreamToggleRefetchQuery = {
-  response: StreamToggleRefetchQuery$data;
-  variables: StreamToggleRefetchQuery$variables;
+export type ProjectTimeRangeControlsRefetchQuery = {
+  response: ProjectTimeRangeControlsRefetchQuery$data;
+  variables: ProjectTimeRangeControlsRefetchQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -43,7 +43,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "StreamToggleRefetchQuery",
+    "name": "ProjectTimeRangeControlsRefetchQuery",
     "selections": [
       {
         "alias": null,
@@ -56,7 +56,7 @@ return {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "StreamToggle_data"
+            "name": "ProjectTimeRangeControls_data"
           }
         ],
         "storageKey": null
@@ -69,7 +69,7 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "StreamToggleRefetchQuery",
+    "name": "ProjectTimeRangeControlsRefetchQuery",
     "selections": [
       {
         "alias": null,
@@ -113,16 +113,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "70bebe4abe808b13c94decf17c7cd90d",
+    "cacheID": "0b8a37799ef4da27d1fd19012ab0bd24",
     "id": null,
     "metadata": {},
-    "name": "StreamToggleRefetchQuery",
+    "name": "ProjectTimeRangeControlsRefetchQuery",
     "operationKind": "query",
-    "text": "query StreamToggleRefetchQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...StreamToggle_data\n    id\n  }\n}\n\nfragment StreamToggle_data on Project {\n  streamingLastUpdatedAt\n  id\n}\n"
+    "text": "query ProjectTimeRangeControlsRefetchQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ProjectTimeRangeControls_data\n    id\n  }\n}\n\nfragment ProjectTimeRangeControls_data on Project {\n  streamingLastUpdatedAt\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "30a8f0bcf1aa6021b2c9a47866f5dc49";
+(node as any).hash = "401b5dd6a1381f66c736661d739d069e";
 
 export default node;

--- a/app/src/pages/project/__generated__/ProjectTimeRangeControls_data.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectTimeRangeControls_data.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<db47499276d3678b075fb071e7f6f1c2>>
+ * @generated SignedSource<<7b52fb3ca77407545e5165045a13a719>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,17 +10,17 @@
 
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type StreamToggle_data$data = {
+export type ProjectTimeRangeControls_data$data = {
   readonly id: string;
   readonly streamingLastUpdatedAt: string | null;
-  readonly " $fragmentType": "StreamToggle_data";
+  readonly " $fragmentType": "ProjectTimeRangeControls_data";
 };
-export type StreamToggle_data$key = {
-  readonly " $data"?: StreamToggle_data$data;
-  readonly " $fragmentSpreads": FragmentRefs<"StreamToggle_data">;
+export type ProjectTimeRangeControls_data$key = {
+  readonly " $data"?: ProjectTimeRangeControls_data$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ProjectTimeRangeControls_data">;
 };
 
-import StreamToggleRefetchQuery_graphql from './StreamToggleRefetchQuery.graphql';
+import ProjectTimeRangeControlsRefetchQuery_graphql from './ProjectTimeRangeControlsRefetchQuery.graphql';
 
 const node: ReaderFragment = {
   "argumentDefinitions": [],
@@ -31,14 +31,14 @@ const node: ReaderFragment = {
       "fragmentPathInResult": [
         "node"
       ],
-      "operation": StreamToggleRefetchQuery_graphql,
+      "operation": ProjectTimeRangeControlsRefetchQuery_graphql,
       "identifierInfo": {
         "identifierField": "id",
         "identifierQueryVariableName": "id"
       }
     }
   },
-  "name": "StreamToggle_data",
+  "name": "ProjectTimeRangeControls_data",
   "selections": [
     {
       "alias": null,
@@ -59,6 +59,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "30a8f0bcf1aa6021b2c9a47866f5dc49";
+(node as any).hash = "401b5dd6a1381f66c736661d739d069e";
 
 export default node;

--- a/app/stories/TimeRangeControls.stories.tsx
+++ b/app/stories/TimeRangeControls.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryFn } from "@storybook/react";
+import { useState } from "react";
+
+import type {
+  OpenTimeRangeWithKey,
+  TimeRangeControlsProps,
+} from "@phoenix/components";
+import { TimeRangeControls, TimeRangeSelector } from "@phoenix/components";
+import { PreferencesProvider } from "@phoenix/contexts";
+
+const meta: Meta = {
+  title: "DateTime/Time Range Controls",
+  component: TimeRangeControls,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+
+const Template: StoryFn<
+  TimeRangeControlsProps & {
+    initialValue: OpenTimeRangeWithKey;
+    withSelector?: boolean;
+  }
+> = ({ initialValue, withSelector, ...args }) => {
+  const [timeRange, setTimeRange] =
+    useState<OpenTimeRangeWithKey>(initialValue);
+  const [isLive, setIsLive] = useState(true);
+  const controls = (
+    <TimeRangeControls
+      {...args}
+      value={timeRange}
+      onChange={setTimeRange}
+      isLive={isLive}
+      onIsLiveChange={setIsLive}
+    />
+  );
+  return (
+    <PreferencesProvider>
+      {withSelector ? (
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          {controls}
+        </div>
+      ) : (
+        controls
+      )}
+    </PreferencesProvider>
+  );
+};
+
+/**
+ * The composite strip on its own: pan back, zoom out, play/pause, zoom in,
+ * pan forward. The range starts live (open-ended), so panning forward is
+ * unavailable until a pan or zoom steps off the live edge.
+ */
+export const Default = {
+  render: Template,
+  args: {
+    initialValue: {
+      timeRangeKey: "1h",
+      start: new Date(Date.now() - 60 * 60 * 1000),
+    },
+  },
+};
+
+/**
+ * A closed custom range (e.g. after zooming into a chart) can pan in both
+ * directions and zooms around its center.
+ */
+export const ClosedRange = {
+  render: Template,
+  args: {
+    initialValue: {
+      timeRangeKey: "custom",
+      start: new Date(Date.now() - 4 * 60 * 60 * 1000),
+      end: new Date(Date.now() - 2 * 60 * 60 * 1000),
+    },
+  },
+};
+
+/**
+ * The intended composition: the controls sit directly to the right of the
+ * time range selector, sharing its height and border treatment.
+ */
+export const BesideTimeRangeSelector = {
+  render: Template,
+  args: {
+    withSelector: true,
+    initialValue: {
+      timeRangeKey: "7d",
+      start: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+    },
+  },
+};
+
+export const Disabled = {
+  render: Template,
+  args: {
+    isDisabled: true,
+    initialValue: {
+      timeRangeKey: "1h",
+      start: new Date(Date.now() - 60 * 60 * 1000),
+    },
+  },
+};

--- a/app/stories/TimeRangeControls.stories.tsx
+++ b/app/stories/TimeRangeControls.stories.tsx
@@ -22,8 +22,9 @@ const Template: StoryFn<
   TimeRangeControlsProps & {
     initialValue: OpenTimeRangeWithKey;
     withSelector?: boolean;
+    withoutLiveToggle?: boolean;
   }
-> = ({ initialValue, withSelector, ...args }) => {
+> = ({ initialValue, withSelector, withoutLiveToggle, ...args }) => {
   const [timeRange, setTimeRange] =
     useState<OpenTimeRangeWithKey>(initialValue);
   const [isLive, setIsLive] = useState(true);
@@ -32,8 +33,8 @@ const Template: StoryFn<
       {...args}
       value={timeRange}
       onChange={setTimeRange}
-      isLive={isLive}
-      onIsLiveChange={setIsLive}
+      isLive={withoutLiveToggle ? undefined : isLive}
+      onIsLiveChange={withoutLiveToggle ? undefined : setIsLive}
     />
   );
   return (
@@ -91,6 +92,22 @@ export const BesideTimeRangeSelector = {
     initialValue: {
       timeRangeKey: "7d",
       start: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+    },
+  },
+};
+
+/**
+ * Without live-streaming props the play/pause toggle is omitted and the strip
+ * is a pure pan/zoom control (e.g. the dashboards page).
+ */
+export const PanZoomOnly = {
+  render: Template,
+  args: {
+    withoutLiveToggle: true,
+    initialValue: {
+      timeRangeKey: "custom",
+      start: new Date(Date.now() - 4 * 60 * 60 * 1000),
+      end: new Date(Date.now() - 2 * 60 * 60 * 1000),
     },
   },
 };

--- a/app/stories/TimeRangeControls.stories.tsx
+++ b/app/stories/TimeRangeControls.stories.tsx
@@ -52,7 +52,7 @@ const Template: StoryFn<
 };
 
 /**
- * The composite strip on its own: pan back, zoom out, play/pause, zoom in,
+ * The composite strip on its own: pan back, zoom out, play/stop, zoom in,
  * pan forward. The range starts live (open-ended), so panning forward is
  * unavailable until a pan or zoom steps off the live edge.
  */
@@ -97,7 +97,7 @@ export const BesideTimeRangeSelector = {
 };
 
 /**
- * Without live-streaming props the play/pause toggle is omitted and the strip
+ * Without live-streaming props the play/stop toggle is omitted and the strip
  * is a pure pan/zoom control (e.g. the dashboards page).
  */
 export const PanZoomOnly = {


### PR DESCRIPTION
## Summary

Adds a compact time-steering toolbar beside the time range selector: **pan back / zoom out / play-stop / zoom in / pan forward**. On the project page it replaces the streaming `Switch`; on the dashboards page it renders as a pure pan/zoom strip (no live toggle).

## Screenshots

> Note: screenshots predate the latest visual polish (filled play/stop glyphs, subtler neutral streaming tint, swapped chevron icons).

**Project page — live streaming on.** The strip sits beside the time range selector; the center toggle carries a gently pulsing tint while streaming, and pan-forward is disabled because the live range is already pinned to *now*:

![Project page with live streaming controls](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/13725-project-live.png)

**Zoom out while live.** Zooming out from a live `Last 7 Days` range maps to the equivalent live last-N key (`Last 14 days`) instead of converting to a frozen custom range — streaming stays on:

![Project page after zooming out, still live](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/13725-project-zoom-out.png)

**Dashboards page — pan/zoom only.** The live toggle props are omitted, so the strip renders without the play/stop control:

![Dashboards page with pan/zoom controls](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/13725-dashboards.png)

### Design
- The strip renders as a single input-styled shell matching the time range selector's chrome (height, border, background, rounding), with quiet inset icon buttons and uniform 4px insets so hover pills float evenly.
- The center play/stop toggle uses solid (filled) glyphs to read as a media-transport control and anchor it against the stroked pan/zoom icons around it; while streaming it carries a gently pulsing neutral tint so it doesn't compete with status colors elsewhere (`prefers-reduced-motion` respected).
- Tooltips on every control; full `aria-label` coverage ("Resume / Stop live streaming") and a `role=group` wrapper.

### Behavior
- **Pan** shifts the window by half its width; forward panning is clamped at *now* and disabled while the range is open-ended (already at the live edge).
- **Zoom** halves/doubles the window. Live last-N ranges stay live and map to the equivalent last-N key; closed ranges zoom around their center, sliding back if they would extend past now. One-minute floor on zoom-in.
- Large zoomed windows snap to readable units once they span 2+ of a larger unit (e.g. `85d`, not `2048h`).
- The play/stop toggle is optional — omit the live props for a pure pan/zoom control (dashboards).
- `ProjectTimeRangeControls` gates streaming on the active project tab (`spans`/`traces`/`sessions`) and carries over the old `StreamToggle` polling (2s interval, `store-and-network`), bumping the shared fetch key when `streamingLastUpdatedAt` advances.

### Notes
- New generic `TimeRangeControls` + `ConnectedTimeRangeControls` (wired to the shared time range context) in `components/datetime`, with Storybook stories (default, closed range, beside-selector composition, pan/zoom-only, disabled).
- The pan/zoom utilities are pure functions taking object params, with their shift fraction, zoom factor, and minimum window exposed as overridable defaults.
- Icon updates: pan uses the filled `ChevronLeft`/`ChevronRight`; the `PlayOutline`/`PauseOutline` glyphs were reworked and are filled within the live toggle. Icon mapping table updated.
- 16 unit tests cover the pan/zoom math.

## Test plan
- `pnpm test` — unit tests for the pan/zoom math in `components/datetime/__tests__/utils.test.ts` (16 cases: clamping at now, live last-N mapping, zoom floor, unit snapping).
- Storybook stories for visual states (default, closed range, beside-selector, pan/zoom-only, disabled); Chromatic passed.
- Manually verified against the `demo_llama_index` fixture: pan/zoom from both live and closed ranges, resume/stop streaming, and the dashboards-page strip.
