### PR TITLE
feat(agents): Add session context

### DIFF
--- a/app/src/agent/context/__tests__/deriveRouteContexts.test.ts
+++ b/app/src/agent/context/__tests__/deriveRouteContexts.test.ts
@@ -1,7 +1,10 @@
 import type { UIMatch } from "react-router";
 import { describe, expect, it } from "vitest";
 
-import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
+import {
+  SELECTED_SPAN_NODE_ID_PARAM,
+  SELECTED_TRACE_ID_PARAM,
+} from "@phoenix/constants/searchParams";
 
 import { deriveRouteContexts } from "../deriveRouteContexts";
 
@@ -57,5 +60,33 @@ describe("deriveRouteContexts", () => {
     );
 
     expect(contexts).toEqual([{ type: "span", spanNodeId: "S1" }]);
+  });
+
+  it("derives session context from a project session route", () => {
+    const contexts = deriveRouteContexts(
+      [match({ projectId: "P1" }), match({ sessionId: "SESSION1" })],
+      new URLSearchParams()
+    );
+
+    expect(contexts).toEqual([
+      { type: "project", projectNodeId: "P1" },
+      { type: "session", projectNodeId: "P1", sessionNodeId: "SESSION1" },
+    ]);
+  });
+
+  it("derives selected trace and span contexts on a project session route", () => {
+    const contexts = deriveRouteContexts(
+      [match({ projectId: "P1" }), match({ sessionId: "SESSION1" })],
+      new URLSearchParams(
+        `${SELECTED_TRACE_ID_PARAM}=TRACE1&${SELECTED_SPAN_NODE_ID_PARAM}=SPAN1`
+      )
+    );
+
+    expect(contexts).toEqual([
+      { type: "project", projectNodeId: "P1" },
+      { type: "trace", projectNodeId: "P1", otelTraceId: "TRACE1" },
+      { type: "session", projectNodeId: "P1", sessionNodeId: "SESSION1" },
+      { type: "span", projectNodeId: "P1", spanNodeId: "SPAN1" },
+    ]);
   });
 });

--- a/app/src/agent/context/agentContextTypes.ts
+++ b/app/src/agent/context/agentContextTypes.ts
@@ -68,6 +68,8 @@ export function agentContextKey(context: AgentContext): string {
       return `project:${context.projectNodeId}`;
     case "trace":
       return `trace:${context.projectNodeId}:${context.otelTraceId}`;
+    case "session":
+      return `session:${context.projectNodeId}:${context.sessionNodeId}`;
     case "span": {
       const project = context.projectNodeId ?? "";
       const span = context.spanNodeId

--- a/app/src/agent/context/deriveRouteContexts.ts
+++ b/app/src/agent/context/deriveRouteContexts.ts
@@ -1,6 +1,9 @@
 import type { UIMatch } from "react-router";
 
-import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
+import {
+  SELECTED_SPAN_NODE_ID_PARAM,
+  SELECTED_TRACE_ID_PARAM,
+} from "@phoenix/constants/searchParams";
 
 import type { AgentContext } from "./agentContextTypes";
 
@@ -22,7 +25,7 @@ function collectRouteParams(matches: UIMatch[]): Record<string, string> {
  * route and URL.
  *
  * Route params are flattened across all matched routes, and contexts are
- * emitted in natural containment order: project → trace → span. The selected
+ * emitted in natural containment order: project → trace/session → span. The selected
  * span search param (from the spans table) takes precedence over a `spanId`
  * in the route, since it reflects the user's most recent selection.
  *
@@ -43,15 +46,26 @@ export function deriveRouteContexts(
   // agentContextTypes.ts for the format conventions.
   const projectNodeId = params["projectId"];
   const otelTraceId = params["traceId"];
+  const sessionNodeId = params["sessionId"];
   const routeSpanNodeId = params["spanId"];
   const selectedSpanNodeId = searchParams.get(SELECTED_SPAN_NODE_ID_PARAM);
+  const selectedTraceId = searchParams.get(SELECTED_TRACE_ID_PARAM);
+  const activeOtelTraceId = otelTraceId ?? selectedTraceId;
 
   if (projectNodeId) {
     contexts.push({ type: "project", projectNodeId });
   }
 
-  if (projectNodeId && otelTraceId) {
-    contexts.push({ type: "trace", projectNodeId, otelTraceId });
+  if (projectNodeId && activeOtelTraceId) {
+    contexts.push({
+      type: "trace",
+      projectNodeId,
+      otelTraceId: activeOtelTraceId,
+    });
+  }
+
+  if (projectNodeId && sessionNodeId) {
+    contexts.push({ type: "session", projectNodeId, sessionNodeId });
   }
 
   if (selectedSpanNodeId) {

--- a/app/src/agent/quickActions/__tests__/quickActions.test.tsx
+++ b/app/src/agent/quickActions/__tests__/quickActions.test.tsx
@@ -33,6 +33,14 @@ describe("buildAgentQuickActions", () => {
     expect(actions).toContain("Explain this trace");
   });
 
+  it("surfaces session-specific actions on a session page", () => {
+    expect(labels(buildAgentQuickActions(["project", "session"]))).toEqual([
+      "Summarize this session",
+      "Find session issues",
+      "Find critical issues",
+    ]);
+  });
+
   it("caps the number of actions and dedupes shared labels", () => {
     const actions = buildAgentQuickActions(["project", "trace", "span"]);
     expect(actions.length).toBeLessThanOrEqual(3);

--- a/app/src/agent/quickActions/quickActions.tsx
+++ b/app/src/agent/quickActions/quickActions.tsx
@@ -30,6 +30,7 @@ const MAX_QUICK_ACTIONS = 3;
 const CONTEXT_SPECIFICITY: AgentContextType[] = [
   "span",
   "trace",
+  "session",
   "project",
   "playground",
 ];
@@ -90,6 +91,18 @@ const QUICK_ACTIONS_BY_CONTEXT: Partial<
       icon: <Icons.Trace />,
       label: "Find what went wrong",
       prompt: "Find what went wrong in this trace.",
+    },
+  ],
+  session: [
+    {
+      icon: <Icons.MessageSquareOutline />,
+      label: "Summarize this session",
+      prompt: "Summarize what happened in this session.",
+    },
+    {
+      icon: <Icons.Trace />,
+      label: "Find session issues",
+      prompt: "Find the most important issues in this session.",
     },
   ],
   span: [

--- a/app/src/agent/tools/bash/context/filesystem/fileBuilders/buildGraphqlContextFiles.ts
+++ b/app/src/agent/tools/bash/context/filesystem/fileBuilders/buildGraphqlContextFiles.ts
@@ -19,6 +19,10 @@ import {
   buildPromptRecipeFiles,
   buildPromptStarterFiles,
 } from "./graphql/prompt";
+import {
+  buildSessionRecipeFiles,
+  buildSessionStarterFiles,
+} from "./graphql/session";
 import { PHOENIX_GQL_GUIDE } from "./graphql/shared";
 import { buildTraceRecipeFiles, buildTraceStarterFiles } from "./graphql/trace";
 import type { GeneratedContextFile } from "./types";
@@ -89,10 +93,15 @@ function buildFallbackStarterFiles(): GeneratedContextFile[] {
 function buildStarterFiles(
   pageContext: AgentPageContext
 ): GeneratedContextFile[] {
-  const { projectId, traceId, datasetId, promptId } = pageContext.params;
+  const { projectId, traceId, sessionId, datasetId, promptId } =
+    pageContext.params;
 
   if (projectId && traceId) {
     return buildTraceStarterFiles(projectId, traceId);
+  }
+
+  if (projectId && sessionId) {
+    return buildSessionStarterFiles(sessionId);
   }
 
   if (projectId) {
@@ -113,10 +122,15 @@ function buildStarterFiles(
 function buildRecipeFiles(
   pageContext: AgentPageContext
 ): GeneratedContextFile[] {
-  const { projectId, traceId, datasetId, promptId } = pageContext.params;
+  const { projectId, traceId, sessionId, datasetId, promptId } =
+    pageContext.params;
 
   if (projectId && traceId) {
     return buildTraceRecipeFiles({ projectId, traceId });
+  }
+
+  if (projectId && sessionId) {
+    return buildSessionRecipeFiles(pageContext);
   }
 
   if (projectId) {

--- a/app/src/agent/tools/bash/context/filesystem/fileBuilders/graphql/__generated__/sessionPageContextByIdQuery.graphql.ts
+++ b/app/src/agent/tools/bash/context/filesystem/fileBuilders/graphql/__generated__/sessionPageContextByIdQuery.graphql.ts
@@ -1,0 +1,283 @@
+/**
+ * @generated SignedSource<<9fcd74be92bc662aa95368e0583837d5>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type sessionPageContextByIdQuery$variables = {
+  id: string;
+};
+export type sessionPageContextByIdQuery$data = {
+  readonly node: {
+    readonly __typename: "ProjectSession";
+    readonly costSummary: {
+      readonly completion: {
+        readonly cost: number | null;
+        readonly tokens: number | null;
+      };
+      readonly prompt: {
+        readonly cost: number | null;
+        readonly tokens: number | null;
+      };
+      readonly total: {
+        readonly cost: number | null;
+        readonly tokens: number | null;
+      };
+    };
+    readonly endTime: string;
+    readonly id: string;
+    readonly latencyP50: number | null;
+    readonly numTraces: number;
+    readonly sessionId: string;
+    readonly startTime: string;
+    readonly tokenUsage: {
+      readonly total: number;
+    };
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  };
+};
+export type sessionPageContextByIdQuery = {
+  response: sessionPageContextByIdQuery$data;
+  variables: sessionPageContextByIdQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "sessionId",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "startTime",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endTime",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "numTraces",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "TokenUsage",
+  "kind": "LinkedField",
+  "name": "tokenUsage",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "total",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v9 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "cost",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "tokens",
+    "storageKey": null
+  }
+],
+v10 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "SpanCostSummary",
+  "kind": "LinkedField",
+  "name": "costSummary",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CostBreakdown",
+      "kind": "LinkedField",
+      "name": "total",
+      "plural": false,
+      "selections": (v9/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CostBreakdown",
+      "kind": "LinkedField",
+      "name": "prompt",
+      "plural": false,
+      "selections": (v9/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CostBreakdown",
+      "kind": "LinkedField",
+      "name": "completion",
+      "plural": false,
+      "selections": (v9/*: any*/),
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v11 = {
+  "alias": "latencyP50",
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "probability",
+      "value": 0.5
+    }
+  ],
+  "kind": "ScalarField",
+  "name": "traceLatencyMsQuantile",
+  "storageKey": "traceLatencyMsQuantile(probability:0.5)"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "sessionPageContextByIdQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/)
+            ],
+            "type": "ProjectSession",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "sessionPageContextByIdQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/)
+            ],
+            "type": "ProjectSession",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "44ae8795525d17fe611eb02d1702be25",
+    "id": null,
+    "metadata": {},
+    "name": "sessionPageContextByIdQuery",
+    "operationKind": "query",
+    "text": "query sessionPageContextByIdQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      id\n      sessionId\n      startTime\n      endTime\n      numTraces\n      tokenUsage {\n        total\n      }\n      costSummary {\n        total {\n          cost\n          tokens\n        }\n        prompt {\n          cost\n          tokens\n        }\n        completion {\n          cost\n          tokens\n        }\n      }\n      latencyP50: traceLatencyMsQuantile(probability: 0.5)\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1dc9aa924f0ae388d2c9ae134af669b9";
+
+export default node;

--- a/app/src/agent/tools/bash/context/filesystem/fileBuilders/graphql/__generated__/sessionPageContextSelectedTraceQuery.graphql.ts
+++ b/app/src/agent/tools/bash/context/filesystem/fileBuilders/graphql/__generated__/sessionPageContextSelectedTraceQuery.graphql.ts
@@ -1,0 +1,392 @@
+/**
+ * @generated SignedSource<<69b2e49f4cd540e4bd7d2ee15f8c5d1a>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type MimeType = "json" | "text";
+export type SpanKind = "agent" | "chain" | "embedding" | "evaluator" | "guardrail" | "llm" | "prompt" | "reranker" | "retriever" | "tool" | "unknown";
+export type SpanStatusCode = "ERROR" | "OK" | "UNSET";
+export type sessionPageContextSelectedTraceQuery$variables = {
+  projectId: string;
+  traceId: string;
+};
+export type sessionPageContextSelectedTraceQuery$data = {
+  readonly node: {
+    readonly __typename: "Project";
+    readonly id: string;
+    readonly name: string;
+    readonly trace: {
+      readonly id: string;
+      readonly latencyMs: number | null;
+      readonly projectSessionId: string | null;
+      readonly rootSpan: {
+        readonly cumulativeTokenCountTotal: number | null;
+        readonly endTime: string | null;
+        readonly id: string;
+        readonly input: {
+          readonly mimeType: MimeType;
+          readonly truncatedValue: string;
+          readonly value: string;
+        } | null;
+        readonly latencyMs: number | null;
+        readonly name: string;
+        readonly output: {
+          readonly mimeType: MimeType;
+          readonly truncatedValue: string;
+          readonly value: string;
+        } | null;
+        readonly spanId: string;
+        readonly spanKind: SpanKind;
+        readonly startTime: string;
+        readonly statusCode: SpanStatusCode;
+      } | null;
+      readonly spans: {
+        readonly edges: ReadonlyArray<{
+          readonly node: {
+            readonly endTime: string | null;
+            readonly id: string;
+            readonly latencyMs: number | null;
+            readonly name: string;
+            readonly parentId: string | null;
+            readonly spanId: string;
+            readonly spanKind: SpanKind;
+            readonly startTime: string;
+            readonly statusCode: SpanStatusCode;
+          };
+        }>;
+      };
+      readonly traceId: string;
+    } | null;
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  };
+};
+export type sessionPageContextSelectedTraceQuery = {
+  response: sessionPageContextSelectedTraceQuery$data;
+  variables: sessionPageContextSelectedTraceQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "projectId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "traceId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "latencyMs",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "spanId",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "spanKind",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "startTime",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endTime",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "statusCode",
+  "storageKey": null
+},
+v11 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "value",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "truncatedValue",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "mimeType",
+    "storageKey": null
+  }
+],
+v12 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "traceId",
+      "variableName": "traceId"
+    }
+  ],
+  "concreteType": "Trace",
+  "kind": "LinkedField",
+  "name": "trace",
+  "plural": false,
+  "selections": [
+    (v3/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "traceId",
+      "storageKey": null
+    },
+    (v5/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "projectSessionId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Span",
+      "kind": "LinkedField",
+      "name": "rootSpan",
+      "plural": false,
+      "selections": [
+        (v3/*: any*/),
+        (v6/*: any*/),
+        (v4/*: any*/),
+        (v7/*: any*/),
+        (v8/*: any*/),
+        (v9/*: any*/),
+        (v5/*: any*/),
+        (v10/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "cumulativeTokenCountTotal",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SpanIOValue",
+          "kind": "LinkedField",
+          "name": "input",
+          "plural": false,
+          "selections": (v11/*: any*/),
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SpanIOValue",
+          "kind": "LinkedField",
+          "name": "output",
+          "plural": false,
+          "selections": (v11/*: any*/),
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 20
+        }
+      ],
+      "concreteType": "SpanConnection",
+      "kind": "LinkedField",
+      "name": "spans",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SpanEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Span",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v3/*: any*/),
+                (v6/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "parentId",
+                  "storageKey": null
+                },
+                (v4/*: any*/),
+                (v7/*: any*/),
+                (v8/*: any*/),
+                (v9/*: any*/),
+                (v5/*: any*/),
+                (v10/*: any*/)
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "spans(first:20)"
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "sessionPageContextSelectedTraceQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v12/*: any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "sessionPageContextSelectedTraceQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v4/*: any*/),
+              (v12/*: any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "5fda35fbf0d5ae57f0ccb728f521861e",
+    "id": null,
+    "metadata": {},
+    "name": "sessionPageContextSelectedTraceQuery",
+    "operationKind": "query",
+    "text": "query sessionPageContextSelectedTraceQuery(\n  $projectId: ID!\n  $traceId: ID!\n) {\n  node(id: $projectId) {\n    __typename\n    ... on Project {\n      id\n      name\n      trace(traceId: $traceId) {\n        id\n        traceId\n        latencyMs\n        projectSessionId\n        rootSpan {\n          id\n          spanId\n          name\n          spanKind\n          startTime\n          endTime\n          latencyMs\n          statusCode\n          cumulativeTokenCountTotal\n          input {\n            value\n            truncatedValue\n            mimeType\n          }\n          output {\n            value\n            truncatedValue\n            mimeType\n          }\n        }\n        spans(first: 20) {\n          edges {\n            node {\n              id\n              spanId\n              parentId\n              name\n              spanKind\n              startTime\n              endTime\n              latencyMs\n              statusCode\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "065a4c0056731e12dd575865f5cc7c00";
+
+export default node;

--- a/app/src/agent/tools/bash/context/filesystem/fileBuilders/graphql/__generated__/sessionPageContextTracesQuery.graphql.ts
+++ b/app/src/agent/tools/bash/context/filesystem/fileBuilders/graphql/__generated__/sessionPageContextTracesQuery.graphql.ts
@@ -1,0 +1,431 @@
+/**
+ * @generated SignedSource<<e7219cb1c5514ae26ef329af324b5ef2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type MimeType = "json" | "text";
+export type SpanKind = "agent" | "chain" | "embedding" | "evaluator" | "guardrail" | "llm" | "prompt" | "reranker" | "retriever" | "tool" | "unknown";
+export type SpanStatusCode = "ERROR" | "OK" | "UNSET";
+export type sessionPageContextTracesQuery$variables = {
+  first?: number | null;
+  id: string;
+};
+export type sessionPageContextTracesQuery$data = {
+  readonly node: {
+    readonly __typename: "ProjectSession";
+    readonly id: string;
+    readonly numTraces: number;
+    readonly sessionId: string;
+    readonly traces: {
+      readonly edges: ReadonlyArray<{
+        readonly trace: {
+          readonly id: string;
+          readonly rootSpan: {
+            readonly cumulativeTokenCountTotal: number | null;
+            readonly endTime: string | null;
+            readonly id: string;
+            readonly input: {
+              readonly mimeType: MimeType;
+              readonly truncatedValue: string;
+              readonly value: string;
+            } | null;
+            readonly latencyMs: number | null;
+            readonly name: string;
+            readonly output: {
+              readonly mimeType: MimeType;
+              readonly truncatedValue: string;
+              readonly value: string;
+            } | null;
+            readonly spanId: string;
+            readonly spanKind: SpanKind;
+            readonly startTime: string;
+            readonly statusCode: SpanStatusCode;
+            readonly trace: {
+              readonly costSummary: {
+                readonly total: {
+                  readonly cost: number | null;
+                };
+              };
+              readonly id: string;
+            };
+          } | null;
+          readonly traceId: string;
+        };
+      }>;
+      readonly pageInfo: {
+        readonly endCursor: string | null;
+        readonly hasNextPage: boolean;
+      };
+    };
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  };
+};
+export type sessionPageContextTracesQuery = {
+  response: sessionPageContextTracesQuery$data;
+  variables: sessionPageContextTracesQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": 10,
+  "kind": "LocalArgument",
+  "name": "first"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "id"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "sessionId",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "numTraces",
+  "storageKey": null
+},
+v7 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "value",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "truncatedValue",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "mimeType",
+    "storageKey": null
+  }
+],
+v8 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "first",
+      "variableName": "first"
+    }
+  ],
+  "concreteType": "TraceConnection",
+  "kind": "LinkedField",
+  "name": "traces",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "TraceEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": "trace",
+          "args": null,
+          "concreteType": "Trace",
+          "kind": "LinkedField",
+          "name": "node",
+          "plural": false,
+          "selections": [
+            (v4/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "traceId",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Span",
+              "kind": "LinkedField",
+              "name": "rootSpan",
+              "plural": false,
+              "selections": [
+                (v4/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "spanId",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "spanKind",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "startTime",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "endTime",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "latencyMs",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "statusCode",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "cumulativeTokenCountTotal",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "SpanIOValue",
+                  "kind": "LinkedField",
+                  "name": "input",
+                  "plural": false,
+                  "selections": (v7/*: any*/),
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "SpanIOValue",
+                  "kind": "LinkedField",
+                  "name": "output",
+                  "plural": false,
+                  "selections": (v7/*: any*/),
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Trace",
+                  "kind": "LinkedField",
+                  "name": "trace",
+                  "plural": false,
+                  "selections": [
+                    (v4/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "SpanCostSummary",
+                      "kind": "LinkedField",
+                      "name": "costSummary",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "CostBreakdown",
+                          "kind": "LinkedField",
+                          "name": "total",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "cost",
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "PageInfo",
+      "kind": "LinkedField",
+      "name": "pageInfo",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "endCursor",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "hasNextPage",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "sessionPageContextTracesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v8/*: any*/)
+            ],
+            "type": "ProjectSession",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "sessionPageContextTracesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          (v4/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v8/*: any*/)
+            ],
+            "type": "ProjectSession",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "36cd8344b6fb057743fee1dfcc08887f",
+    "id": null,
+    "metadata": {},
+    "name": "sessionPageContextTracesQuery",
+    "operationKind": "query",
+    "text": "query sessionPageContextTracesQuery(\n  $id: ID!\n  $first: Int = 10\n) {\n  node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      id\n      sessionId\n      numTraces\n      traces(first: $first) {\n        edges {\n          trace: node {\n            id\n            traceId\n            rootSpan {\n              id\n              spanId\n              name\n              spanKind\n              startTime\n              endTime\n              latencyMs\n              statusCode\n              cumulativeTokenCountTotal\n              input {\n                value\n                truncatedValue\n                mimeType\n              }\n              output {\n                value\n                truncatedValue\n                mimeType\n              }\n              trace {\n                id\n                costSummary {\n                  total {\n                    cost\n                  }\n                }\n              }\n            }\n          }\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "8f54b78983d198a261ad9b8b8daf04bf";
+
+export default node;

--- a/app/src/agent/tools/bash/context/filesystem/fileBuilders/graphql/session.ts
+++ b/app/src/agent/tools/bash/context/filesystem/fileBuilders/graphql/session.ts
@@ -1,0 +1,217 @@
+import { graphql } from "relay-runtime";
+
+import { PHOENIX_ROOT } from "@phoenix/agent/tools/bash/context/filesystem/pathConstants";
+import type { AgentPageContext } from "@phoenix/agent/tools/bash/context/pageContextTypes";
+import { SELECTED_TRACE_ID_PARAM } from "@phoenix/constants/searchParams";
+
+import type { GeneratedContextFile } from "../types";
+import { createGraphqlContextFile, createJsonContextFile } from "./shared";
+
+const sessionByIdQuery = graphql`
+  query sessionPageContextByIdQuery($id: ID!) {
+    node(id: $id) {
+      __typename
+      ... on ProjectSession {
+        id
+        sessionId
+        startTime
+        endTime
+        numTraces
+        tokenUsage {
+          total
+        }
+        costSummary {
+          total {
+            cost
+            tokens
+          }
+          prompt {
+            cost
+            tokens
+          }
+          completion {
+            cost
+            tokens
+          }
+        }
+        latencyP50: traceLatencyMsQuantile(probability: 0.5)
+      }
+    }
+  }
+`;
+
+const sessionTracesQuery = graphql`
+  query sessionPageContextTracesQuery($id: ID!, $first: Int = 10) {
+    node(id: $id) {
+      __typename
+      ... on ProjectSession {
+        id
+        sessionId
+        numTraces
+        traces(first: $first) {
+          edges {
+            trace: node {
+              id
+              traceId
+              rootSpan {
+                id
+                spanId
+                name
+                spanKind
+                startTime
+                endTime
+                latencyMs
+                statusCode
+                cumulativeTokenCountTotal
+                input {
+                  value
+                  truncatedValue
+                  mimeType
+                }
+                output {
+                  value
+                  truncatedValue
+                  mimeType
+                }
+                trace {
+                  id
+                  costSummary {
+                    total {
+                      cost
+                    }
+                  }
+                }
+              }
+            }
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+    }
+  }
+`;
+
+const sessionSelectedTraceQuery = graphql`
+  query sessionPageContextSelectedTraceQuery($projectId: ID!, $traceId: ID!) {
+    node(id: $projectId) {
+      __typename
+      ... on Project {
+        id
+        name
+        trace(traceId: $traceId) {
+          id
+          traceId
+          latencyMs
+          projectSessionId
+          rootSpan {
+            id
+            spanId
+            name
+            spanKind
+            startTime
+            endTime
+            latencyMs
+            statusCode
+            cumulativeTokenCountTotal
+            input {
+              value
+              truncatedValue
+              mimeType
+            }
+            output {
+              value
+              truncatedValue
+              mimeType
+            }
+          }
+          spans(first: 20) {
+            edges {
+              node {
+                id
+                spanId
+                parentId
+                name
+                spanKind
+                startTime
+                endTime
+                latencyMs
+                statusCode
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+function getSearchParam(
+  pageContext: AgentPageContext,
+  name: string
+): string | undefined {
+  const value = pageContext.searchParams[name];
+  return typeof value === "string" ? value : undefined;
+}
+
+export function buildSessionStarterFiles(
+  sessionId: string
+): GeneratedContextFile[] {
+  return [
+    createGraphqlContextFile({
+      path: `${PHOENIX_ROOT}/graphql/examples/session-by-id.graphql`,
+      request: sessionByIdQuery,
+      requestName: "sessionPageContextByIdQuery",
+    }),
+    createJsonContextFile({
+      path: `${PHOENIX_ROOT}/graphql/examples/session-by-id.variables.json`,
+      value: { id: sessionId },
+    }),
+  ];
+}
+
+export function buildSessionRecipeFiles(
+  pageContext: AgentPageContext
+): GeneratedContextFile[] {
+  const { projectId, sessionId } = pageContext.params;
+  const selectedTraceId = getSearchParam(pageContext, SELECTED_TRACE_ID_PARAM);
+
+  if (!sessionId) {
+    return [];
+  }
+
+  const files: GeneratedContextFile[] = [
+    createGraphqlContextFile({
+      path: `${PHOENIX_ROOT}/graphql/recipes/session-summary.graphql`,
+      request: sessionByIdQuery,
+      requestName: "sessionPageContextByIdQuery",
+    }),
+    createGraphqlContextFile({
+      path: `${PHOENIX_ROOT}/graphql/recipes/session-traces.graphql`,
+      request: sessionTracesQuery,
+      requestName: "sessionPageContextTracesQuery",
+    }),
+    createJsonContextFile({
+      path: `${PHOENIX_ROOT}/graphql/recipes/session-recipes.variables.json`,
+      value: { id: sessionId, first: 10 },
+    }),
+  ];
+
+  if (projectId && selectedTraceId) {
+    files.push(
+      createGraphqlContextFile({
+        path: `${PHOENIX_ROOT}/graphql/recipes/session-selected-trace.graphql`,
+        request: sessionSelectedTraceQuery,
+        requestName: "sessionPageContextSelectedTraceQuery",
+      }),
+      createJsonContextFile({
+        path: `${PHOENIX_ROOT}/graphql/recipes/session-selected-trace.variables.json`,
+        value: { projectId, traceId: selectedTraceId },
+      })
+    );
+  }
+
+  return files;
+}

--- a/app/src/agent/tools/getRouteInfo/routeParams.ts
+++ b/app/src/agent/tools/getRouteInfo/routeParams.ts
@@ -46,6 +46,9 @@ export function buildParamsFromContexts(
     } else if (context.type === "trace") {
       params.projectId = context.projectNodeId;
       params.traceId = context.otelTraceId;
+    } else if (context.type === "session") {
+      params.projectId = context.projectNodeId;
+      params.sessionId = context.sessionNodeId;
     } else if (context.type === "span" && context.spanNodeId) {
       params.spanId = context.spanNodeId;
       if (context.projectNodeId) {

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -4207,6 +4207,21 @@ export interface components {
             /** Next Cursor */
             next_cursor: string | null;
         };
+        /**
+         * SessionContext
+         * @description Session the user is currently viewing.
+         */
+        SessionContext: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "session";
+            /** Projectnodeid */
+            projectNodeId: string;
+            /** Sessionnodeid */
+            sessionNodeId: string;
+        };
         /** SessionData */
         SessionData: {
             /** Id */
@@ -5059,18 +5074,6 @@ export interface components {
             projectNodeId: string;
             /** Oteltraceid */
             otelTraceId: string;
-        };
-        /** SessionContext */
-        SessionContext: {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            type: "session";
-            /** Projectnodeid */
-            projectNodeId: string;
-            /** Sessionnodeid */
-            sessionNodeId: string;
         };
         /** TraceData */
         TraceData: {

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1614,7 +1614,7 @@ export interface components {
          * ChatContext
          * @description Discriminated union of every UI-state context the agent understands.
          */
-        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["CodeEvaluatorContext"] | components["schemas"]["LlmEvaluatorContext"] | components["schemas"]["DatasetContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"] | components["schemas"]["SubagentsContext"];
+        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["SessionContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["CodeEvaluatorContext"] | components["schemas"]["LlmEvaluatorContext"] | components["schemas"]["DatasetContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"] | components["schemas"]["SubagentsContext"];
         /**
          * ChatRegenerateMessage
          * @description Regenerate message extended with Phoenix-specific fields.
@@ -5059,6 +5059,18 @@ export interface components {
             projectNodeId: string;
             /** Oteltraceid */
             otelTraceId: string;
+        };
+        /** SessionContext */
+        SessionContext: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "session";
+            /** Projectnodeid */
+            projectNodeId: string;
+            /** Sessionnodeid */
+            sessionNodeId: string;
         };
         /** TraceData */
         TraceData: {

--- a/app/src/components/agent/AgentContextPills.tsx
+++ b/app/src/components/agent/AgentContextPills.tsx
@@ -41,6 +41,8 @@ function contextLabel(context: AgentContext): string {
       return "Project";
     case "trace":
       return "Trace";
+    case "session":
+      return "Session";
     case "span":
       return "Span";
     case "code_evaluator":
@@ -57,6 +59,8 @@ function contextDetail(context: AgentContext): string | undefined {
   switch (context.type) {
     case "trace":
       return truncateId(context.otelTraceId);
+    case "session":
+      return truncateId(context.sessionNodeId);
     case "span": {
       const spanId = context.spanNodeId ?? context.otelSpanId;
       if (spanId == null) {

--- a/app/src/components/ai/attachment/utils.tsx
+++ b/app/src/components/ai/attachment/utils.tsx
@@ -56,6 +56,8 @@ function getContextCategoryIcon(category: string | undefined): ReactNode {
       return <Icon svg={<Icons.Trace />} />;
     case "trace":
       return <Icon svg={<Icons.Trace />} />;
+    case "session":
+      return <Icon svg={<Icons.MessageSquareOutline />} />;
     case "span":
       return <Icon svg={<Icons.WorkflowOutline />} />;
     case "span_filter":

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -4207,6 +4207,21 @@ export interface components {
             /** Next Cursor */
             next_cursor: string | null;
         };
+        /**
+         * SessionContext
+         * @description Session the user is currently viewing.
+         */
+        SessionContext: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "session";
+            /** Projectnodeid */
+            projectNodeId: string;
+            /** Sessionnodeid */
+            sessionNodeId: string;
+        };
         /** SessionData */
         SessionData: {
             /** Id */
@@ -5059,18 +5074,6 @@ export interface components {
             projectNodeId: string;
             /** Oteltraceid */
             otelTraceId: string;
-        };
-        /** SessionContext */
-        SessionContext: {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            type: "session";
-            /** Projectnodeid */
-            projectNodeId: string;
-            /** Sessionnodeid */
-            sessionNodeId: string;
         };
         /** TraceData */
         TraceData: {

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1614,7 +1614,7 @@ export interface components {
          * ChatContext
          * @description Discriminated union of every UI-state context the agent understands.
          */
-        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["CodeEvaluatorContext"] | components["schemas"]["LlmEvaluatorContext"] | components["schemas"]["DatasetContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"] | components["schemas"]["SubagentsContext"];
+        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["SessionContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["CodeEvaluatorContext"] | components["schemas"]["LlmEvaluatorContext"] | components["schemas"]["DatasetContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"] | components["schemas"]["SubagentsContext"];
         /**
          * ChatRegenerateMessage
          * @description Regenerate message extended with Phoenix-specific fields.
@@ -5059,6 +5059,18 @@ export interface components {
             projectNodeId: string;
             /** Oteltraceid */
             otelTraceId: string;
+        };
+        /** SessionContext */
+        SessionContext: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "session";
+            /** Projectnodeid */
+            projectNodeId: string;
+            /** Sessionnodeid */
+            sessionNodeId: string;
         };
         /** TraceData */
         TraceData: {

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -645,6 +645,12 @@ class SessionAnnotationsResponseBody(TypedDict):
     next_cursor: Optional[str]
 
 
+class SessionContext(TypedDict):
+    type: Literal["session"]
+    projectNodeId: str
+    sessionNodeId: str
+
+
 class SessionNoteData(TypedDict):
     session_id: str
     note: str
@@ -864,12 +870,6 @@ class TraceContext(TypedDict):
     type: Literal["trace"]
     projectNodeId: str
     otelTraceId: str
-
-
-class SessionContext(TypedDict):
-    type: Literal["session"]
-    projectNodeId: str
-    sessionNodeId: str
 
 
 class TraceNoteData(TypedDict):

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -866,6 +866,12 @@ class TraceContext(TypedDict):
     otelTraceId: str
 
 
+class SessionContext(TypedDict):
+    type: Literal["session"]
+    projectNodeId: str
+    sessionNodeId: str
+
+
 class TraceNoteData(TypedDict):
     trace_id: str
     note: str
@@ -1541,6 +1547,7 @@ class ChatRegenerateMessage(TypedDict):
                 AppContext,
                 ProjectContext,
                 TraceContext,
+                SessionContext,
                 AgentSpanContext,
                 PlaygroundContext,
                 CodeEvaluatorContext,
@@ -1568,6 +1575,7 @@ class ChatSubmitMessage(TypedDict):
                 AppContext,
                 ProjectContext,
                 TraceContext,
+                SessionContext,
                 AgentSpanContext,
                 PlaygroundContext,
                 CodeEvaluatorContext,

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -7370,6 +7370,9 @@
             "$ref": "#/components/schemas/TraceContext"
           },
           {
+            "$ref": "#/components/schemas/SessionContext"
+          },
+          {
             "$ref": "#/components/schemas/AgentSpanContext"
           },
           {
@@ -7406,6 +7409,7 @@
             "llm_evaluator": "#/components/schemas/LlmEvaluatorContext",
             "playground": "#/components/schemas/PlaygroundContext",
             "project": "#/components/schemas/ProjectContext",
+            "session": "#/components/schemas/SessionContext",
             "span": "#/components/schemas/AgentSpanContext",
             "subagents": "#/components/schemas/SubagentsContext",
             "trace": "#/components/schemas/TraceContext",
@@ -15586,6 +15590,30 @@
           "otelTraceId"
         ],
         "title": "TraceContext"
+      },
+      "SessionContext": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session",
+            "title": "Type"
+          },
+          "projectNodeId": {
+            "type": "string",
+            "title": "Projectnodeid"
+          },
+          "sessionNodeId": {
+            "type": "string",
+            "title": "Sessionnodeid"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "projectNodeId",
+          "sessionNodeId"
+        ],
+        "title": "SessionContext"
       },
       "TraceData": {
         "properties": {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -13772,6 +13772,31 @@
         ],
         "title": "SessionAnnotationsResponseBody"
       },
+      "SessionContext": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session",
+            "title": "Type"
+          },
+          "projectNodeId": {
+            "type": "string",
+            "title": "Projectnodeid"
+          },
+          "sessionNodeId": {
+            "type": "string",
+            "title": "Sessionnodeid"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "projectNodeId",
+          "sessionNodeId"
+        ],
+        "title": "SessionContext",
+        "description": "Session the user is currently viewing."
+      },
       "SessionData": {
         "properties": {
           "id": {
@@ -15590,30 +15615,6 @@
           "otelTraceId"
         ],
         "title": "TraceContext"
-      },
-      "SessionContext": {
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session",
-            "title": "Type"
-          },
-          "projectNodeId": {
-            "type": "string",
-            "title": "Projectnodeid"
-          },
-          "sessionNodeId": {
-            "type": "string",
-            "title": "Sessionnodeid"
-          }
-        },
-        "type": "object",
-        "required": [
-          "type",
-          "projectNodeId",
-          "sessionNodeId"
-        ],
-        "title": "SessionContext"
       },
       "TraceData": {
         "properties": {

--- a/src/phoenix/server/agents/capabilities/contexts/__init__.py
+++ b/src/phoenix/server/agents/capabilities/contexts/__init__.py
@@ -17,6 +17,7 @@ from phoenix.server.agents.capabilities.contexts.llm_evaluator import (
 )
 from phoenix.server.agents.capabilities.contexts.playground import PlaygroundContextCapability
 from phoenix.server.agents.capabilities.contexts.project import ProjectContextCapability
+from phoenix.server.agents.capabilities.contexts.session import SessionContextCapability
 from phoenix.server.agents.capabilities.contexts.span import SpanContextCapability
 from phoenix.server.agents.capabilities.contexts.trace import TraceContextCapability
 from phoenix.server.agents.prompts import AgentPrompts
@@ -38,6 +39,7 @@ def get_context_capability_function(
         AppContextCapability(instructions=prompts.app_context),
         ProjectContextCapability(instructions=prompts.project_context),
         TraceContextCapability(instructions=prompts.trace_context),
+        SessionContextCapability(instructions=prompts.session_context),
         SpanContextCapability(instructions=prompts.span_context),
         PlaygroundContextCapability(instructions=prompts.playground_context),
         CodeEvaluatorContextCapability(instructions=prompts.code_evaluator_context),
@@ -61,6 +63,7 @@ __all__ = [
     "LlmEvaluatorContextCapability",
     "PlaygroundContextCapability",
     "ProjectContextCapability",
+    "SessionContextCapability",
     "SpanContextCapability",
     "TraceContextCapability",
     "get_context_capability_function",

--- a/src/phoenix/server/agents/capabilities/contexts/session.py
+++ b/src/phoenix/server/agents/capabilities/contexts/session.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from jinja2 import Template
+from pydantic_ai import RunContext
+from pydantic_ai.tools import SystemPromptFunc
+
+from phoenix.server.agents.capabilities.base import AbstractDynamicCapability
+from phoenix.server.agents.types import AgentDependencies
+
+
+@dataclass
+class SessionContextCapability(AbstractDynamicCapability[AgentDependencies]):
+    instructions: Template
+
+    def get_dynamic_instructions(self) -> SystemPromptFunc[AgentDependencies]:
+        instructions = self.instructions
+
+        def _instructions(ctx: RunContext[AgentDependencies]) -> str | None:
+            session = ctx.deps.contexts.session
+            if session is None:
+                return None
+            return instructions.render(session=session)
+
+        return _instructions
+
+    def include_for_run(self, ctx: RunContext[AgentDependencies]) -> bool:
+        return ctx.deps.contexts.session is not None

--- a/src/phoenix/server/agents/capabilities/tools/internal/run_graphql_query.py
+++ b/src/phoenix/server/agents/capabilities/tools/internal/run_graphql_query.py
@@ -30,6 +30,17 @@ Useful introspection patterns (run these before guessing):
 `{ __type(name: "Project") { fields { name args { name } type { name kind } } } }`
 - Available root queries: `{ __schema { queryType { fields { name } } } }`
 
+GraphQL query-shaping rules:
+- If selecting the same field more than once with different arguments, use aliases. \
+For example: `{ traceType: __type(name: "Trace") { fields { name } } spanType: \
+__type(name: "Span") { fields { name } } }`.
+- Do not batch repeated unaliased `__type(...)` fields.
+- For aggregate/list object fields, introspect the concrete child type before selecting \
+child fields.
+- If a generic error says `an unexpected error occurred`, assume the query may be \
+invalid or too broad. Simplify, introspect the exact type/field, and retry with \
+corrected fields.
+
 Args:
     query: A GraphQL query document string (a normal query or an introspection query).
     variable_values: Optional mapping of GraphQL variable names to values.
@@ -40,7 +51,7 @@ the query and retry. When errors indicate an unknown or misused field/argument, 
 introspection query to confirm the schema rather than guessing again.
 """
 
-RUN_GRAPHQL_QUERY_MAX_RETRIES = 15
+RUN_GRAPHQL_QUERY_MAX_RETRIES = 3
 
 
 class RunGraphQLQueryToolset(FunctionToolset[None]):

--- a/src/phoenix/server/agents/capabilities/tools/internal/run_graphql_query.py
+++ b/src/phoenix/server/agents/capabilities/tools/internal/run_graphql_query.py
@@ -40,6 +40,8 @@ the query and retry. When errors indicate an unknown or misused field/argument, 
 introspection query to confirm the schema rather than guessing again.
 """
 
+RUN_GRAPHQL_QUERY_MAX_RETRIES = 15
+
 
 class RunGraphQLQueryToolset(FunctionToolset[None]):
     """Toolset exposing a tool to execute GraphQL queries, but not over the network."""
@@ -73,13 +75,14 @@ class RunGraphQLQueryToolset(FunctionToolset[None]):
             return {"data": result.data}
 
         super().__init__(
+            max_retries=RUN_GRAPHQL_QUERY_MAX_RETRIES,
             tools=[
                 Tool(
                     run_graphql_query,
                     takes_ctx=False,
                     description=RUN_GRAPHQL_QUERY_TOOL_DESCRIPTION,
                 )
-            ]
+            ],
         )
 
 

--- a/src/phoenix/server/agents/context.py
+++ b/src/phoenix/server/agents/context.py
@@ -67,6 +67,14 @@ class TraceContext(_ChatContextBase):
     otel_trace_id: str = Field(alias="otelTraceId")
 
 
+class SessionContext(_ChatContextBase):
+    """Session the user is currently viewing."""
+
+    type: Literal["session"]
+    project_node_id: str = Field(alias="projectNodeId")
+    session_node_id: str = Field(alias="sessionNodeId")
+
+
 class AgentSpanContext(_ChatContextBase):
     """Span the user has selected.
 
@@ -239,6 +247,7 @@ class ChatContext(
             AppContext
             | ProjectContext
             | TraceContext
+            | SessionContext
             | AgentSpanContext
             | PlaygroundContext
             | CodeEvaluatorContext
@@ -259,6 +268,7 @@ class ResolvedContexts:
     app: AppContext | None = None
     project: ProjectContext | None = None
     trace: TraceContext | None = None
+    session: SessionContext | None = None
     span: AgentSpanContext | None = None
     playground: PlaygroundContext | None = None
     code_evaluator: CodeEvaluatorContext | None = None
@@ -287,6 +297,8 @@ def resolve_contexts(contexts: list[ChatContext]) -> ResolvedContexts:
             resolved.project = context_value
         elif isinstance(context_value, TraceContext):
             resolved.trace = context_value
+        elif isinstance(context_value, SessionContext):
+            resolved.session = context_value
         elif isinstance(context_value, AgentSpanContext):
             resolved.span = context_value
         elif isinstance(context_value, GraphQLContext):

--- a/src/phoenix/server/agents/prompts/__init__.py
+++ b/src/phoenix/server/agents/prompts/__init__.py
@@ -166,6 +166,7 @@ _SUBMIT_LLM_EVALUATOR_DRAFT_TOOL_INSTRUCTIONS = get_template(
 _APP_CONTEXT_TEMPLATE = get_template("context/APP_CONTEXT_INSTRUCTIONS.xml.j2")
 _PROJECT_CONTEXT_TEMPLATE = get_template("context/PROJECT_CONTEXT_INSTRUCTIONS.xml.j2")
 _TRACE_CONTEXT_TEMPLATE = get_template("context/TRACE_CONTEXT_INSTRUCTIONS.xml.j2")
+_SESSION_CONTEXT_TEMPLATE = get_template("context/SESSION_CONTEXT_INSTRUCTIONS.xml.j2")
 _SPAN_CONTEXT_TEMPLATE = get_template("context/SPAN_CONTEXT_INSTRUCTIONS.xml.j2")
 _PLAYGROUND_CONTEXT_TEMPLATE = get_template("context/PLAYGROUND_CONTEXT_INSTRUCTIONS.xml.j2")
 _CODE_EVALUATOR_CONTEXT_TEMPLATE = get_template(
@@ -265,6 +266,7 @@ class AgentPrompts:
     app_context: Template = _APP_CONTEXT_TEMPLATE
     project_context: Template = _PROJECT_CONTEXT_TEMPLATE
     trace_context: Template = _TRACE_CONTEXT_TEMPLATE
+    session_context: Template = _SESSION_CONTEXT_TEMPLATE
     span_context: Template = _SPAN_CONTEXT_TEMPLATE
     playground_context: Template = _PLAYGROUND_CONTEXT_TEMPLATE
     code_evaluator_context: Template = _CODE_EVALUATOR_CONTEXT_TEMPLATE

--- a/src/phoenix/server/agents/prompts/context/SESSION_CONTEXT_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/context/SESSION_CONTEXT_INSTRUCTIONS.xml.j2
@@ -1,0 +1,6 @@
+<phoenix_session_context>
+  <description>The session the user is currently viewing.</description>
+  <project_node_id format="phoenix_node_id">{{ session.project_node_id }}</project_node_id>
+  <session_node_id format="phoenix_node_id">{{ session.session_node_id }}</session_node_id>
+  <guidance>Use this session context to answer questions about the session's traces, turns, spans, and metadata. If a phoenix_trace_context is also present, it is the currently selected trace within this session.</guidance>
+</phoenix_session_context>

--- a/src/phoenix/server/agents/prompts/tools/RUN_GRAPHQL_QUERY_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/RUN_GRAPHQL_QUERY_TOOL_INSTRUCTIONS.xml.j2
@@ -4,7 +4,11 @@
     - This tool is read-only: only `query` operations are permitted. Mutations and subscriptions are rejected, so do not attempt to write, delete, or otherwise modify data with it.
     - Do not guess field, type, or argument names. When you are not certain the schema matches what you intend to query, run an introspection query first (e.g. `{ __type(name: "Project") { fields { name args { name } type { name kind } } } }`) and write your query against what it returns.
     - Write a single GraphQL query that retrieves exactly what is needed and pass query variables via `variable_values` rather than string interpolation.
+    - If a query selects the same field more than once with different arguments, every repeated selection must use a unique alias. This is especially important for introspection: bad: `{ __type(name: "Trace") { fields { name } } __type(name: "Span") { fields { name } } }`; good: `{ traceType: __type(name: "Trace") { fields { name } } spanType: __type(name: "Span") { fields { name } } }`.
+    - Prefer small introspection queries over broad schema-discovery queries. If you need multiple types, either query them one at a time or use aliases for each `__type` selection.
+    - For fields returning object lists, introspect the returned object type before selecting child fields. Do not assume common names like `name`; some Phoenix aggregate types use fields such as `exceptionType` or `spanKind` instead.
     - On success the tool returns a dict with the query `data`. If the query has errors the tool raises and you receive the error messages back — read them, introspect the schema if a field or argument may be wrong, correct the query, and retry.
+    - Treat generic GraphQL errors such as `an unexpected error occurred` as possible validation errors. Do not keep retrying the same query. First simplify the query or introspect the exact parent type and field names, then retry with a corrected query.
     - Return a concise, factual answer grounded in the data you retrieved.
   </guidelines>
 </tool>

--- a/tests/unit/server/agents/capabilities/contexts/test_capabilities.py
+++ b/tests/unit/server/agents/capabilities/contexts/test_capabilities.py
@@ -15,6 +15,7 @@ from phoenix.server.agents.capabilities.contexts.llm_evaluator import (
 )
 from phoenix.server.agents.capabilities.contexts.playground import PlaygroundContextCapability
 from phoenix.server.agents.capabilities.contexts.project import ProjectContextCapability
+from phoenix.server.agents.capabilities.contexts.session import SessionContextCapability
 from phoenix.server.agents.capabilities.tools.external.patch_experiment import (
     PatchExperimentCapability,
 )
@@ -30,6 +31,7 @@ from phoenix.server.agents.context import (
     PlaygroundInstanceContext,
     ProjectContext,
     ResolvedContexts,
+    SessionContext,
 )
 from phoenix.server.agents.prompts import AgentPrompts
 from phoenix.server.agents.types import (
@@ -151,6 +153,28 @@ class TestProjectContextCapabilityRender:
         content = _render(capability, ctx)
         assert "… [truncated]" in content
         assert long_condition not in content
+
+
+class TestSessionContextCapabilityRender:
+    def test_renders_session_context(self) -> None:
+        capability = SessionContextCapability(instructions=_DEFAULT_PROMPTS.session_context)
+        ctx = _get_run_context(
+            ResolvedContexts(
+                session=SessionContext(
+                    type="session",
+                    project_node_id="UHJvamVjdDox",
+                    session_node_id="UHJvamVjdFNlc3Npb246MQ==",
+                ),
+            )
+        )
+
+        content = _render(capability, ctx)
+
+        assert content.startswith("<phoenix_session_context>")
+        assert '<project_node_id format="phoenix_node_id">UHJvamVjdDox</project_node_id>' in content
+        assert (
+            '<session_node_id format="phoenix_node_id">UHJvamVjdFNlc3Npb246MQ==</session_node_id>'
+        ) in content
 
 
 class TestDatasetContextCapabilityRender:


### PR DESCRIPTION
## Summary
- Add session UI context for PXI, including route-derived session and selected trace/span context.
- Render session context in agent prompts and expose session pills, quick actions, and route params.
- Add session-focused phoenix-gql starter/recipe files for bash context.

## Tests
- pnpm --dir app test src/agent/context/__tests__/deriveRouteContexts.test.ts src/agent/quickActions/__tests__/quickActions.test.tsx --run
- pnpm --dir app typecheck
- pnpm --dir app build:relay
- uv run pytest tests/unit/server/agents/capabilities/contexts/test_capabilities.py -q
- uv run pytest tests/unit/server/agents/test_agent_factory.py -q