### PR TITLE
feat(agents): Agent GraphQL skill

### DIFF
--- a/app/src/agent/tools/bash/__tests__/bashToolFilesystemPolicy.test.ts
+++ b/app/src/agent/tools/bash/__tests__/bashToolFilesystemPolicy.test.ts
@@ -24,12 +24,23 @@ describe("bash tool filesystem policy", () => {
     expect(result.stdout).toBe("ok");
   });
 
-  it("still blocks writes outside the workspace", async () => {
+  it("allows writes to /tmp", async () => {
+    const runtime = await createBashToolRuntime();
+
+    const result = await runtime.executeCommand(
+      "printf 'help' > /tmp/help && cat /tmp/help"
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("help");
+  });
+
+  it("still blocks writes outside scratch directories", async () => {
     const runtime = await createBashToolRuntime();
 
     await expect(
       runtime.executeCommand("printf 'nope' > /etc/passwd")
-    ).rejects.toThrow("Writes outside the workspace are blocked");
+    ).rejects.toThrow("Writes outside scratch directories are blocked");
   });
 
   it("still allows workspace writes", async () => {

--- a/app/src/agent/tools/bash/bashToolFilesystemPolicy.ts
+++ b/app/src/agent/tools/bash/bashToolFilesystemPolicy.ts
@@ -43,6 +43,11 @@ export const BASH_TOOL_READONLY_ROOT = "/phoenix";
 export const BASH_TOOL_WORKSPACE_ROOT = "/home/user/workspace";
 
 /**
+ * Virtual temp directory for familiar shell scratch-file workflows.
+ */
+export const BASH_TOOL_TMP_ROOT = "/tmp";
+
+/**
  * Null-sink device paths. just-bash has no real device files, so a redirect
  * like `cmd >/dev/null 2>&1` resolves to an ordinary `writeFile("/dev/null")`.
  * That idiom is ubiquitous in model-authored commands, so rather than block it
@@ -87,7 +92,10 @@ function isDiscardDevicePath(fs: IFileSystem, path: string) {
 function assertWritablePath(fs: IFileSystem, path: string, operation: string) {
   const normalizedPath = normalizeVirtualPath(fs, path);
 
-  if (isWithinRoot(normalizedPath, BASH_TOOL_WORKSPACE_ROOT)) {
+  if (
+    isWithinRoot(normalizedPath, BASH_TOOL_WORKSPACE_ROOT) ||
+    isWithinRoot(normalizedPath, BASH_TOOL_TMP_ROOT)
+  ) {
     return normalizedPath;
   }
 
@@ -99,8 +107,8 @@ function assertWritablePath(fs: IFileSystem, path: string, operation: string) {
   }
 
   throw new Error(
-    `${operation} is only allowed in ${BASH_TOOL_WORKSPACE_ROOT}. ` +
-      `Writes outside the workspace are blocked.`
+    `${operation} is only allowed in ${BASH_TOOL_WORKSPACE_ROOT} or ${BASH_TOOL_TMP_ROOT}. ` +
+      `Writes outside scratch directories are blocked.`
   );
 }
 
@@ -110,8 +118,8 @@ function assertWritablePath(fs: IFileSystem, path: string, operation: string) {
 export function applyBashToolFilesystemPolicy(fs: IFileSystem) {
   /**
    * Wrap filesystem mutation methods with a Phoenix-specific path policy.
-   * Writes are allowed under `/home/user/workspace`, denied under `/phoenix`,
-   * and rejected everywhere else with a clear error.
+   * Writes are allowed under `/home/user/workspace` and `/tmp`, denied under
+   * `/phoenix`, and rejected everywhere else with a clear error.
    */
   const originalWriteFile = fs.writeFile.bind(fs);
   const originalAppendFile = fs.appendFile.bind(fs);

--- a/app/src/agent/tools/bash/bashToolRuntime.ts
+++ b/app/src/agent/tools/bash/bashToolRuntime.ts
@@ -8,6 +8,7 @@ import {
 import {
   applyBashToolFilesystemPolicy,
   BASH_TOOL_READONLY_ROOT,
+  BASH_TOOL_TMP_ROOT,
   BASH_TOOL_WORKSPACE_ROOT,
   captureBashToolFilesystemMutationMethods,
   type BashToolFilesystemMutationMethods,
@@ -223,6 +224,7 @@ export async function createBashToolRuntime({
   const originalMutationMethods = captureBashToolFilesystemMutationMethods(
     bash.fs as InMemoryFs
   );
+  await originalMutationMethods.mkdir(BASH_TOOL_TMP_ROOT, { recursive: true });
   applyBashToolFilesystemPolicy(bash.fs);
 
   const runtime: BashToolRuntime = {

--- a/app/src/agent/tools/bash/context/filesystem/fileBuilders/buildGraphqlContextFiles.ts
+++ b/app/src/agent/tools/bash/context/filesystem/fileBuilders/buildGraphqlContextFiles.ts
@@ -23,7 +23,6 @@ import {
   buildSessionRecipeFiles,
   buildSessionStarterFiles,
 } from "./graphql/session";
-import { PHOENIX_GQL_GUIDE } from "./graphql/shared";
 import { buildTraceRecipeFiles, buildTraceStarterFiles } from "./graphql/trace";
 import type { GeneratedContextFile } from "./types";
 
@@ -159,7 +158,6 @@ export async function buildGraphqlContextFiles(pageContext: AgentPageContext) {
       `${PHOENIX_ROOT}/agent-start.md`,
       buildAgentStartGuide({ pageContext, recipePaths }),
     ],
-    [`${PHOENIX_ROOT}/graphql/README.md`, PHOENIX_GQL_GUIDE],
     [
       `${PHOENIX_ROOT}/graphql/current-page.md`,
       buildCurrentPageGuide({ pageContext, recipePaths }),

--- a/app/src/agent/tools/bash/context/filesystem/fileBuilders/graphql/pageDocs.ts
+++ b/app/src/agent/tools/bash/context/filesystem/fileBuilders/graphql/pageDocs.ts
@@ -39,7 +39,9 @@ Use this file for initial orientation.
 Helpful files:
 - ${PHOENIX_ROOT}/page-context.json
 - ${PHOENIX_ROOT}/graphql/current-page.md
-- ${PHOENIX_ROOT}/graphql/README.md
+- ${PHOENIX_ROOT}/graphql/schema.json (full introspection — prefer the phoenix-graphql skill over reading this)
+
+For GraphQL guidance (schema entrypoints, pagination, filters, query patterns), load the \`phoenix-graphql\` skill instead of exploring the schema.
 
 Relevant recipe files:
 ${recipePaths.length > 0 ? recipePaths.map((path) => `- ${path}`).join("\n") : "- (none)"}

--- a/app/src/agent/tools/bash/context/filesystem/fileBuilders/graphql/shared.ts
+++ b/app/src/agent/tools/bash/context/filesystem/fileBuilders/graphql/shared.ts
@@ -1,37 +1,6 @@
 import type { ConcreteRequest, GraphQLTaggedNode } from "relay-runtime";
 
-import { PHOENIX_ROOT } from "@phoenix/agent/tools/bash/context/filesystem/pathConstants";
-
 import type { GeneratedContextFile } from "../types";
-
-export const PHOENIX_GQL_GUIDE = `# phoenix-gql
-
-Use \`phoenix-gql\` to execute GraphQL operations against Phoenix from the bash sandbox.
-This command is built into the bash environment; you can execute it directly.
-Run \`phoenix-gql --help\` to see current permissions and usage.
-
-Tips:
-- Prefer \`node(id: ...)\` with inline fragments when page context already gives you an entity id.
-- Use page context and any route-specific recipe files to find likely ids and entrypoints.
-- Verify argument names and enum values in \`${PHOENIX_ROOT}/graphql/schema.json\` before guessing.
-- Use \`--data-only\` when piping into \`jq\`.
-- Use \`--output\` for larger results you want to inspect in multiple steps.
-
-Examples:
-
-\`\`\`bash
-phoenix-gql '{ projects { edges { node { name } } } }' | jq '.data'
-cat query.graphql | phoenix-gql --vars '{"id":"UHJvamVjdDox"}' --data-only
-phoenix-gql query.graphql --vars-file vars.json | jq '.data'
-phoenix-gql big-query.graphql --output /home/user/workspace/result.json
-\`\`\`
-
-Notes:
-- Allowed operation types (queries, mutations) depend on runtime permissions. The tool reports its current permissions on stderr with every invocation and in its --help output.
-- Subscriptions are never supported.
-- Large responses may spill to a workspace file unless you pass \`--stdout\`.
-- The GraphQL schema introspection is available at \`${PHOENIX_ROOT}/graphql/schema.json\`.
-`;
 
 export function formatJsonBlock(value: unknown) {
   return JSON.stringify(value, null, 2);

--- a/app/src/agent/tools/bash/phoenixGqlCommand.ts
+++ b/app/src/agent/tools/bash/phoenixGqlCommand.ts
@@ -20,8 +20,8 @@ Execute GraphQL operations against Phoenix.
 ${permissionsLine}
 
 Recommended flow:
-  1. cat /phoenix/agent-start.md
-  2. if needed, cat /phoenix/graphql/current-page.md
+  1. load the phoenix-graphql skill (load_skill) for schema entrypoints and query patterns
+  2. cat /phoenix/agent-start.md to orient to the current page
   3. start with a tiny query or a file from /phoenix/graphql/recipes/ or /phoenix/graphql/examples/
   4. add filters, sorting, and deeper fields only after the base query works
 

--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -44,7 +44,7 @@ def get_skills_capability_function(
 ) -> CapabilityFunc[AgentDependencies]:
     def _build(ctx: RunContext[AgentDependencies]) -> AbstractCapability[AgentDependencies]:
         return SkillsCapability(
-            toolset=SkillsToolset(
+            toolset=SkillsToolset[AgentDependencies](
                 skills=get_skills_for_contexts(ctx.deps.contexts),
                 load_skill_template=prompts.load_skill,
                 load_skill_tool_template=prompts.load_skill_tool,

--- a/src/phoenix/server/agents/capabilities/skills/skill.py
+++ b/src/phoenix/server/agents/capabilities/skills/skill.py
@@ -17,7 +17,7 @@ class Skill:
     summary: str
     content: str
     path: Path
-    resources: list[SkillResource] = field(default_factory=list)
+    resources: list[SkillResource[Any]] = field(default_factory=list)
     metadata: dict[str, Any] | None = None
 
     @classmethod
@@ -25,7 +25,7 @@ class Skill:
         cls,
         path: Path,
         *,
-        resources: list[SkillResource] | None = None,
+        resources: list[SkillResource[Any]] | None = None,
     ) -> Skill:
         skill_file = path.expanduser().resolve()
         if skill_file.name != "SKILL.md":

--- a/src/phoenix/server/agents/capabilities/skills/skill_capability.py
+++ b/src/phoenix/server/agents/capabilities/skills/skill_capability.py
@@ -3,21 +3,25 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from jinja2 import Template
+from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AgentToolset
 
 from phoenix.server.agents.capabilities.base import AbstractStaticCapability
 from phoenix.server.agents.capabilities.skills.toolset import SkillsToolset
-from phoenix.server.agents.types import AgentDependencies
 
 
 @dataclass
-class SkillsCapability(AbstractStaticCapability[AgentDependencies]):
-    """Capability that wraps a skills toolset with a static instructions template."""
+class SkillsCapability(AbstractStaticCapability[AgentDepsT]):
+    """Capability that wraps a skills toolset with a static instructions template.
 
-    toolset: SkillsToolset
+    Generic over the agent's dependency type so the same capability serves both
+    the main assistant agent and sub-agents with different (or no) deps.
+    """
+
+    toolset: SkillsToolset[AgentDepsT]
     instructions: Template
 
-    def get_toolset(self) -> AgentToolset[AgentDependencies] | None:
+    def get_toolset(self) -> AgentToolset[AgentDepsT] | None:
         return self.toolset
 
     def get_static_instructions(self) -> str:

--- a/src/phoenix/server/agents/capabilities/skills/skill_capability.py
+++ b/src/phoenix/server/agents/capabilities/skills/skill_capability.py
@@ -12,11 +12,7 @@ from phoenix.server.agents.capabilities.skills.toolset import SkillsToolset
 
 @dataclass
 class SkillsCapability(AbstractStaticCapability[AgentDepsT]):
-    """Capability that wraps a skills toolset with a static instructions template.
-
-    Generic over the agent's dependency type so the same capability serves both
-    the main assistant agent and sub-agents with different (or no) deps.
-    """
+    """Capability that wraps a skills toolset with a static instructions template."""
 
     toolset: SkillsToolset[AgentDepsT]
     instructions: Template

--- a/src/phoenix/server/agents/capabilities/skills/skill_resource.py
+++ b/src/phoenix/server/agents/capabilities/skills/skill_resource.py
@@ -7,8 +7,6 @@ from typing import Any, TypeAlias
 
 from pydantic_ai import RunContext, _function_schema
 
-from phoenix.server.agents.types import AgentDependencies
-
 ResourceFunction: TypeAlias = Callable[..., Any | Awaitable[Any]]
 """A resource function: any callable, sync or async, returning anything."""
 
@@ -23,7 +21,7 @@ class SkillResource(ABC):
     @abstractmethod
     async def load(
         self,
-        ctx: RunContext[AgentDependencies],
+        ctx: RunContext[Any],
         args: dict[str, Any] | None = None,
     ) -> Any:
         """Load and return the resource's value.
@@ -45,7 +43,7 @@ class ContentSkillResource(SkillResource):
 
     async def load(
         self,
-        ctx: RunContext[AgentDependencies],
+        ctx: RunContext[Any],
         args: dict[str, Any] | None = None,
     ) -> Any:
         return self.content
@@ -65,7 +63,7 @@ class FunctionSkillResource(SkillResource):
 
     async def load(
         self,
-        ctx: RunContext[AgentDependencies],
+        ctx: RunContext[Any],
         args: dict[str, Any] | None = None,
     ) -> Any:
         return await self.function_schema.call(args or {}, ctx)

--- a/src/phoenix/server/agents/capabilities/skills/skill_resource.py
+++ b/src/phoenix/server/agents/capabilities/skills/skill_resource.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any, TypeAlias
+from typing import Any, Generic, TypeAlias, TypeVar
 
 from pydantic_ai import RunContext, _function_schema
+
+ResourceDepsT = TypeVar("ResourceDepsT")
 
 ResourceFunction: TypeAlias = Callable[..., Any | Awaitable[Any]]
 """A resource function: any callable, sync or async, returning anything."""
 
 
 @dataclass(kw_only=True)
-class SkillResource(ABC):
+class SkillResource(ABC, Generic[ResourceDepsT]):
     """Abstract base for skill resources."""
 
     name: str
@@ -21,7 +23,7 @@ class SkillResource(ABC):
     @abstractmethod
     async def load(
         self,
-        ctx: RunContext[Any],
+        ctx: RunContext[ResourceDepsT],
         args: dict[str, Any] | None = None,
     ) -> Any:
         """Load and return the resource's value.
@@ -36,21 +38,21 @@ class SkillResource(ABC):
 
 
 @dataclass(kw_only=True)
-class ContentSkillResource(SkillResource):
+class ContentSkillResource(SkillResource[ResourceDepsT]):
     """A skill resource that returns static content."""
 
     content: str
 
     async def load(
         self,
-        ctx: RunContext[Any],
+        ctx: RunContext[ResourceDepsT],
         args: dict[str, Any] | None = None,
     ) -> Any:
         return self.content
 
 
 @dataclass(kw_only=True)
-class FunctionSkillResource(SkillResource):
+class FunctionSkillResource(SkillResource[ResourceDepsT]):
     """A skill resource backed by a callable.
 
     Attributes:
@@ -63,7 +65,7 @@ class FunctionSkillResource(SkillResource):
 
     async def load(
         self,
-        ctx: RunContext[Any],
+        ctx: RunContext[ResourceDepsT],
         args: dict[str, Any] | None = None,
     ) -> Any:
         return await self.function_schema.call(args or {}, ctx)

--- a/src/phoenix/server/agents/capabilities/skills/toolset.py
+++ b/src/phoenix/server/agents/capabilities/skills/toolset.py
@@ -13,11 +13,7 @@ from phoenix.server.agents.capabilities.skills.skill_resource import SkillResour
 
 
 class SkillsToolset(FunctionToolset[AgentDepsT]):
-    """Pydantic AI toolset for automatic skill discovery and integration.
-
-    Generic over the agent's dependency type so the same toolset serves both
-    the main assistant agent and sub-agents with different (or no) deps.
-    """
+    """Pydantic AI toolset for automatic skill discovery and integration."""
 
     def __init__(
         self,

--- a/src/phoenix/server/agents/capabilities/skills/toolset.py
+++ b/src/phoenix/server/agents/capabilities/skills/toolset.py
@@ -86,7 +86,7 @@ class SkillsToolset(FunctionToolset[AgentDepsT]):
         return list(self._skills.values())
 
 
-def _find_skill_resource(skill: Skill, resource_name: str) -> SkillResource | None:
+def _find_skill_resource(skill: Skill, resource_name: str) -> SkillResource[Any] | None:
     if not skill.resources:
         return None
     for resource in skill.resources:

--- a/src/phoenix/server/agents/capabilities/skills/toolset.py
+++ b/src/phoenix/server/agents/capabilities/skills/toolset.py
@@ -5,15 +5,19 @@ from typing import Any
 from jinja2 import Template
 from pydantic_ai import ModelRetry, Tool
 from pydantic_ai._run_context import RunContext
+from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import FunctionToolset
 
 from phoenix.server.agents.capabilities.skills.skill import Skill
 from phoenix.server.agents.capabilities.skills.skill_resource import SkillResource
-from phoenix.server.agents.types import AgentDependencies
 
 
-class SkillsToolset(FunctionToolset[AgentDependencies]):
-    """Pydantic AI toolset for automatic skill discovery and integration."""
+class SkillsToolset(FunctionToolset[AgentDepsT]):
+    """Pydantic AI toolset for automatic skill discovery and integration.
+
+    Generic over the agent's dependency type so the same toolset serves both
+    the main assistant agent and sub-agents with different (or no) deps.
+    """
 
     def __init__(
         self,
@@ -43,7 +47,7 @@ class SkillsToolset(FunctionToolset[AgentDependencies]):
             return self._load_skill_template.render(skill=self._skills[skill_name])
 
         async def read_skill_resource(
-            ctx: RunContext[AgentDependencies],
+            ctx: RunContext[AgentDepsT],
             skill_name: str,
             resource_name: str,
             args: dict[str, Any] | None = None,

--- a/src/phoenix/server/agents/capabilities/tools/external/bash.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/bash.py
@@ -17,9 +17,10 @@ DESCRIPTION = """\
 Run a shell command in the browser virtual filesystem.
 Runs inside a browser-only just-bash virtual shell, not a host machine or container.
 Read Phoenix context from /phoenix; writes there are blocked.
-Write scratch files only under /home/user/workspace; mutations elsewhere are blocked.
-Redirect unwanted output to /dev/null (e.g. `cmd >/dev/null 2>&1`); it is the only \
-writable path outside the workspace.
+Write scratch files only under /home/user/workspace or /tmp; mutations elsewhere are \
+blocked.
+Redirect unwanted output to /dev/null (e.g. `cmd >/dev/null 2>&1`); it is a \
+discard-only path.
 General purpose network access is disabled, so curl/wget and remote package installs \
 should not be assumed to work.
 Built-in just-bash commands are available; do not assume apt, brew, pnpm, uv, git, \
@@ -29,7 +30,7 @@ The user has no access to the filesystem. You can use the filesystem for your ow
 purposes, but if you want to share something with the user, you must display the \
 content in the rich markdown rendered chat.
 phoenix-gql is available for GraphQL operations against the Phoenix GraphQL API. \
-Run phoenix-gql --help for usage and current permissions.\
+If CLI usage is unclear, run `phoenix-gql --help` directly.\
 """
 
 PARAMETERS: dict[str, Any] = {

--- a/src/phoenix/server/agents/prompts/__init__.py
+++ b/src/phoenix/server/agents/prompts/__init__.py
@@ -287,6 +287,10 @@ class ServerAgentPrompts:
     base: Template = _BASE_SUBAGENT_INSTRUCTIONS
     run_graphql_query_tool: Template = _RUN_GRAPHQL_QUERY_TOOL_INSTRUCTIONS
     docs_tool: Template = _DOCS_TOOL_INSTRUCTIONS
+    skills: Template = _SKILLS_TEMPLATE
+    load_skill: Template = _LOAD_SKILL_TEMPLATE
+    load_skill_tool: Template = _LOAD_SKILL_TOOL_TEMPLATE
+    read_skill_resource_tool: Template = _READ_SKILL_RESOURCE_TOOL_TEMPLATE
 
 
 __all__ = [

--- a/src/phoenix/server/agents/prompts/skills/debug-trace/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/debug-trace/SKILL.md
@@ -56,7 +56,7 @@ Use this journal as the input to axial-coding.
 
 Prefer linking to the specific span that exhibits the issue over the parent trace whenever possible — span links land the user on the exact node, while a trace link forces them to hunt for the relevant span. Fall back to a trace link only when no single span captures the issue (e.g., a trajectory problem spanning many spans).
 
-Use Phoenix's root-relative redirect URLs with the OpenTelemetry IDs returned by GraphQL — no project lookup required. Read the OTel IDs from the `spanId` and `traceId` GraphQL fields (the hex OTel IDs), **not** the `id` field (which is a Relay node ID and will not resolve):
+Use Phoenix's root-relative redirect URLs with the OpenTelemetry IDs returned by GraphQL — no project lookup required. Read the hex OTel IDs from `Span.spanId` and `Trace.traceId`, **not** the `id` field (which is a Relay node ID and will not resolve). A `Span` has no `traceId` field — read it via the nested `trace { traceId }`:
 
 - Span: `[short description](/redirects/spans/<spanId>)`
 - Trace: `[short description](/redirects/traces/<traceId>)`

--- a/src/phoenix/server/agents/prompts/skills/phoenix-graphql/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/phoenix-graphql/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: phoenix-graphql
+description: >
+  Write efficient GraphQL queries against the Phoenix API. Load this skill in two cases:
+  (1) before composing any non-trivial GraphQL query yourself for data analysis (via
+  `phoenix-gql` or `run_graphql_query`) — it contains schema entrypoints and patterns
+  that eliminate the need for introspection; (2) when the user asks for help writing
+  GraphQL queries for their own scripts, tools, or integrations against Phoenix —
+  it covers the endpoint, authentication, and client examples.
+summary: Answer data questions with efficient GraphQL queries, or get working GraphQL for your own scripts and integrations against the Phoenix API.
+---
+
+### Two modes
+
+- **Internal data analysis** — you are querying Phoenix yourself to answer a question. Apply the schema facts, efficiency rules, and patterns below directly.
+- **Helping the user integrate** — the user wants GraphQL queries for their own code or tools. Use the same schema facts and patterns, plus the "External API usage" section for endpoint, auth, and client examples. Queries you hand to the user should use variables and include pagination handling.
+
+### Schema essentials
+
+Top-level `Query` fields you will use most:
+
+- `projects(first, after, sort: ProjectSort, filter: ProjectFilter)` → connection of `Project`
+- `getProjectByName(name: String!)` → `Project` (skip the connection when you know the name)
+- `node(id: ID!)` — global lookup for any entity; resolve with an inline fragment, e.g. `node(id: $id) { ... on Project { name } }`
+- `getSpanByOtelId(...)`, `getTraceByOtelId(...)`, `getProjectSessionById(...)` — lookups by OTel/session identifiers
+- `datasets(...)`, `prompts(...)`, `evaluators(...)` → connections
+- `viewer` → the authenticated `User`
+- `projectCount`, `datasetCount`, `promptCount` — cheap counts
+
+Key `Project` fields:
+
+- `spans(timeRange, first, after, sort: SpanSort, rootSpansOnly: Boolean, filterCondition: String)` → connection of `Span`. There is **no `traces` connection on `Project`** — use `spans(rootSpansOnly: true)` for one row per trace.
+- `trace(traceId: ID!)` → `Trace` — lookup by OTel hex trace id.
+- `sessions(timeRange, first, after, sort, filterIoSubstring, sessionId)` → connection of `ProjectSession`.
+- Aggregates, most accepting `timeRange` and `filterCondition`: `traceCount`, `recordCount` (span count), `tokenCountTotal`, `tokenCountPrompt`, `tokenCountCompletion`, `costSummary`, `latencyMsQuantile(probability: Float!)`, `spanLatencyMsQuantile(probability: Float!)`.
+- `spanAnnotationNames`, `traceAnnotationsNames`, `spanAnnotationSummary`, `documentEvaluationNames` — discover what evals/annotations exist before querying them.
+- `validateSpanFilterCondition(condition: String!)` — check a filter string without running it.
+
+Conventions:
+
+- **Pagination** is Relay-style: `first`/`after` args; responses have `edges { node { ... } }` and `pageInfo { hasNextPage endCursor }`. Cursors are opaque strings. Some connections (e.g. `Project.spans`) are forward-only.
+- **IDs**: the `id` field on any node is a Relay global ID (base64 of `TypeName:rowId`) — use it with `node(id:)`. The `spanId` and `traceId` fields are OpenTelemetry hex IDs — use those for OTel lookups and `/redirects/spans/<spanId>` / `/redirects/traces/<traceId>` links. Never mix the two.
+- **`TimeRange`** input: `{ start: DateTime, end: DateTime }` — ISO 8601 strings; `end` is exclusive; both optional.
+- **`SpanSort`** input: `{ col: SpanColumn, dir: SortDir }`, e.g. `{ col: startTime, dir: desc }`. Useful `SpanColumn` values: `startTime`, `latencyMs`, `tokenCountTotal`, `cumulativeTokenCountTotal`, `tokenCostTotal`.
+- **`filterCondition`** is a Python-like DSL string over span fields, e.g. `span_kind == 'LLM'`, `status_code == 'ERROR'`, `latency_ms > 1000`, `'timeout' in output.value`, `evals['Hallucination'].label == 'hallucinated'`, `annotations['note'].score < 0.5`. Combine with `and`/`or`.
+
+### Efficiency rules
+
+- **Do not run full schema introspection.** The facts above cover most analysis queries. When you genuinely need to verify a field or argument, introspect one type at a time: `{ __type(name: "Project") { fields { name args { name type { name kind } } } } }`.
+- **Batch independent lookups with aliases** in one query instead of multiple round trips, e.g. `p50: latencyMsQuantile(probability: 0.5) p99: latencyMsQuantile(probability: 0.99)`.
+- Select only the fields you need; keep page sizes small (10–50) and paginate only when necessary.
+- Pass values via query variables, never string interpolation.
+- Span `input`/`output` payloads can be huge — request `input { truncatedValue }` (first 100 chars) when surveying; fetch `input { value }` (full payload) only for spans you intend to read closely.
+
+### Common patterns
+
+Project overview in one round trip:
+
+```graphql
+query Overview($name: String!, $timeRange: TimeRange) {
+  getProjectByName(name: $name) {
+    id
+    traceCount(timeRange: $timeRange)
+    recordCount(timeRange: $timeRange)
+    tokenCountTotal(timeRange: $timeRange)
+    p50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)
+    p99: latencyMsQuantile(probability: 0.99, timeRange: $timeRange)
+    errorCount: recordCount(timeRange: $timeRange, filterCondition: "status_code == 'ERROR'")
+    spanAnnotationNames
+  }
+}
+```
+
+Recent root spans (one per trace), slowest first:
+
+```graphql
+query RecentTraces($id: ID!, $first: Int = 20) {
+  node(id: $id) {
+    ... on Project {
+      spans(first: $first, rootSpansOnly: true, sort: { col: latencyMs, dir: desc }) {
+        edges {
+          node { spanId traceId name latencyMs statusCode startTime cumulativeTokenCountTotal }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+```
+
+Filtered spans (error LLM spans):
+
+```graphql
+query ErrorSpans($id: ID!) {
+  node(id: $id) {
+    ... on Project {
+      spans(first: 20, filterCondition: "span_kind == 'LLM' and status_code == 'ERROR'") {
+        edges { node { spanId traceId name statusCode } }
+      }
+    }
+  }
+}
+```
+
+### Execution surfaces (internal mode)
+
+- `phoenix-gql` (bash): run `phoenix-gql --help` for flags and current permissions. Use `--data-only` when piping to `jq`, `--output <file>` for large results, `--vars '<json>'` for variables. Mutations are allowed only when runtime permissions say so; the tool reports its permissions on every invocation. If a bash filesystem is available, `/phoenix/graphql/` contains a live `schema.json` plus route-specific recipe `.graphql` files and prefetched starter data — prefer recipes over writing queries from scratch.
+- `run_graphql_query` (server sub-agent): strictly read-only — queries only, no mutations or subscriptions. Pass variables via `variable_values`.
+
+### External API usage (user-facing mode)
+
+Facts users need to call the API themselves:
+
+- **Endpoint**: `POST <phoenix-host>/graphql` with a JSON body `{ "query": "...", "variables": { ... } }`. A GraphiQL IDE is served on GET at the same path.
+- **Auth**: send a Phoenix API key as a bearer token: `Authorization: Bearer <API_KEY>`. API keys are created in Phoenix settings.
+- The GraphQL schema is primarily designed for the Phoenix UI and may change between versions; for stable programmatic access, recommend the REST API (`/v1/...`) and the `arize-phoenix-client` Python / `@arizeai/phoenix-client` TypeScript packages where they cover the need, and GraphQL for everything else.
+
+curl:
+
+```bash
+curl -s "$PHOENIX_HOST/graphql" \
+  -H "Authorization: Bearer $PHOENIX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "query($n: String!) { getProjectByName(name: $n) { traceCount } }", "variables": {"n": "default"}}'
+```
+
+Python:
+
+```python
+import httpx
+
+resp = httpx.post(
+    f"{host}/graphql",
+    headers={"Authorization": f"Bearer {api_key}"},
+    json={"query": query, "variables": variables},
+)
+resp.raise_for_status()
+data = resp.json()["data"]
+```
+
+When handing users a query, include: the full operation with variable definitions, an example variables payload, and a note on paginating via `pageInfo { hasNextPage endCursor }` → pass `endCursor` as `after`.

--- a/src/phoenix/server/agents/prompts/skills/phoenix-graphql/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/phoenix-graphql/SKILL.md
@@ -15,89 +15,68 @@ summary: Answer data questions with efficient GraphQL queries, or get working Gr
 - **Internal data analysis** — you are querying Phoenix yourself to answer a question. Apply the schema facts, efficiency rules, and patterns below directly.
 - **Helping the user integrate** — the user wants GraphQL queries for their own code or tools. Use the same schema facts and patterns, plus the "External API usage" section for endpoint, auth, and client examples. Queries you hand to the user should use variables and include pagination handling.
 
-### Schema essentials
+### Entrypoints
 
-Top-level `Query` fields you will use most:
+Top-level `Query` entrypoints get you to a starting entity; per-entity schema details live in the resources listed under "Schema map" below.
 
-- `projects(first, after, sort: ProjectSort, filter: ProjectFilter)` → connection of `Project`
-- `getProjectByName(name: String!)` → `Project` (skip the connection when you know the name)
-- `node(id: ID!)` — global lookup for any entity; resolve with an inline fragment, e.g. `node(id: $id) { ... on Project { name } }`
-- `getSpanByOtelId(...)`, `getTraceByOtelId(...)`, `getProjectSessionById(...)` — lookups by OTel/session identifiers
-- `datasets(...)`, `prompts(...)`, `evaluators(...)` → connections
-- `viewer` → the authenticated `User`
-- `projectCount`, `datasetCount`, `promptCount` — cheap counts
+- `node(id: ID!)` — global lookup for **any** entity by its Relay global id; resolve with an inline fragment, e.g. `node(id: $id) { ... on Dataset { name } }`. This is the primary way to fetch datasets, prompts, experiments, sessions, and annotations, which have **no** by-name/by-id helpers.
+- `projects(...)`, `datasets(...)`, `prompts(...)`, `evaluators(...)` → Relay connections, each with `filter`/`sort` inputs to find an entity when you only have a name.
+- By-X helpers (the only ones that exist): `getProjectByName(name: String!)`, `getProjectSessionById(sessionId: String!)`, `getDatasetExampleByExternalId(datasetId: GlobalID!, externalId: String!)`, `getSpanByOtelId(spanId: String!)`, `getTraceByOtelId(traceId: String!)`. There is **no** `getDatasetByName`, `getPromptByName`, or `getExperimentById` — use `node(id:)` or a connection `filter` instead.
+- `viewer` → the authenticated `User`; `projectCount`, `datasetCount`, `promptCount` — cheap counts.
+- `compareExperiments(baseExperimentId: GlobalID!, compareExperimentIds: [GlobalID!]!, first, after, filterCondition)` → experiment comparison.
 
-Key `Project` fields:
+### Schema map
 
-- `spans(timeRange, first, after, sort: SpanSort, rootSpansOnly: Boolean, filterCondition: String)` → connection of `Span`. There is **no `traces` connection on `Project`** — use `spans(rootSpansOnly: true)` for one row per trace.
-- `trace(traceId: ID!)` → `Trace` — lookup by OTel hex trace id.
-- `sessions(timeRange, first, after, sort, filterIoSubstring, sessionId)` → connection of `ProjectSession`.
-- Aggregates, most accepting `timeRange` and `filterCondition`: `traceCount`, `recordCount` (span count), `tokenCountTotal`, `tokenCountPrompt`, `tokenCountCompletion`, `costSummary`, `latencyMsQuantile(probability: Float!)`, `spanLatencyMsQuantile(probability: Float!)`.
-- `spanAnnotationNames`, `traceAnnotationsNames`, `spanAnnotationSummary`, `documentEvaluationNames` — discover what evals/annotations exist before querying them.
-- `validateSpanFilterCondition(condition: String!)` — check a filter string without running it.
+Per-entity field references and examples are split into resources. Read **only** the one(s) you need with `read_skill_resource`, after loading this skill:
 
-Conventions:
+- `project-spans-traces` — Project aggregates and `spans`; Span and Trace fields. The starting point for most trace analysis.
+- `sessions` — ProjectSession: multi-turn session metrics, token/cost, session traces.
+- `datasets` — Dataset and DatasetExample: examples, versions, splits, labels.
+- `experiments` — Experiment and ExperimentRun: runs, aggregate metrics, comparison.
+- `prompts` — Prompt and PromptVersion: versions, templates, tags.
+- `annotations` — Span/Trace/ExperimentRun annotation fields and how to read them.
 
-- **Pagination** is Relay-style: `first`/`after` args; responses have `edges { node { ... } }` and `pageInfo { hasNextPage endCursor }`. Cursors are opaque strings. Some connections (e.g. `Project.spans`) are forward-only.
-- **IDs**: the `id` field on any node is a Relay global ID (base64 of `TypeName:rowId`) — use it with `node(id:)`. The `spanId` and `traceId` fields are OpenTelemetry hex IDs — use those for OTel lookups and `/redirects/spans/<spanId>` / `/redirects/traces/<traceId>` links. Never mix the two.
+### Conventions
+
+These apply to every entity:
+
+- **Pagination** is Relay-style: `first`/`after` args; responses have `edges { node { ... } }` and `pageInfo { hasNextPage endCursor }`. Cursors are opaque strings. Some connections (e.g. `Project.spans`, `Experiment.runs`, `ProjectSession.traces`) are forward-only.
+- **IDs**: the `id` field on any node is a Relay global ID (base64 of `TypeName:rowId`) — use it with `node(id:)`. OpenTelemetry hex IDs come from `Span.spanId` and `Trace.traceId` — use those for OTel lookups and `/redirects/spans/<spanId>` / `/redirects/traces/<traceId>` links. Note a `Span` has **no** `traceId` field; read it via the nested `trace { traceId }`. Never mix global IDs with OTel IDs.
 - **`TimeRange`** input: `{ start: DateTime, end: DateTime }` — ISO 8601 strings; `end` is exclusive; both optional.
 - **`SpanSort`** input: `{ col: SpanColumn, dir: SortDir }`, e.g. `{ col: startTime, dir: desc }`. Useful `SpanColumn` values: `startTime`, `latencyMs`, `tokenCountTotal`, `cumulativeTokenCountTotal`, `tokenCostTotal`.
 - **`filterCondition`** is a Python-like DSL string over span fields, e.g. `span_kind == 'LLM'`, `status_code == 'ERROR'`, `latency_ms > 1000`, `'timeout' in output.value`, `evals['Hallucination'].label == 'hallucinated'`, `annotations['note'].score < 0.5`. Combine with `and`/`or`.
 
 ### Efficiency rules
 
-- **Do not run full schema introspection.** The facts above cover most analysis queries. When you genuinely need to verify a field or argument, introspect one type at a time: `{ __type(name: "Project") { fields { name args { name type { name kind } } } } }`.
+- **Do not run full schema introspection.** Read the relevant `Schema map` resource instead; it covers the fields and arguments for that entity. Only when a resource does not cover a field you need, introspect a single type: `{ __type(name: "Project") { fields { name args { name type { name kind } } } } }`.
 - **Batch independent lookups with aliases** in one query instead of multiple round trips, e.g. `p50: latencyMsQuantile(probability: 0.5) p99: latencyMsQuantile(probability: 0.99)`.
 - Select only the fields you need; keep page sizes small (10–50) and paginate only when necessary.
 - Pass values via query variables, never string interpolation.
 - Span `input`/`output` payloads can be huge — request `input { truncatedValue }` (first 100 chars) when surveying; fetch `input { value }` (full payload) only for spans you intend to read closely.
 
-### Common patterns
+### Patterns
 
-Project overview in one round trip:
+Two canonical shapes to orient you; entity-specific examples live in each resource.
+
+Reach an entity and read fields via `node(id:)` + an inline fragment:
+
+```graphql
+query GetEntity($id: ID!) {
+  node(id: $id) {
+    ... on Dataset { name exampleCount }
+  }
+}
+```
+
+Batch independent project aggregates with aliases in one round trip:
 
 ```graphql
 query Overview($name: String!, $timeRange: TimeRange) {
   getProjectByName(name: $name) {
-    id
     traceCount(timeRange: $timeRange)
-    recordCount(timeRange: $timeRange)
-    tokenCountTotal(timeRange: $timeRange)
     p50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)
     p99: latencyMsQuantile(probability: 0.99, timeRange: $timeRange)
     errorCount: recordCount(timeRange: $timeRange, filterCondition: "status_code == 'ERROR'")
-    spanAnnotationNames
-  }
-}
-```
-
-Recent root spans (one per trace), slowest first:
-
-```graphql
-query RecentTraces($id: ID!, $first: Int = 20) {
-  node(id: $id) {
-    ... on Project {
-      spans(first: $first, rootSpansOnly: true, sort: { col: latencyMs, dir: desc }) {
-        edges {
-          node { spanId traceId name latencyMs statusCode startTime cumulativeTokenCountTotal }
-        }
-        pageInfo { hasNextPage endCursor }
-      }
-    }
-  }
-}
-```
-
-Filtered spans (error LLM spans):
-
-```graphql
-query ErrorSpans($id: ID!) {
-  node(id: $id) {
-    ... on Project {
-      spans(first: 20, filterCondition: "span_kind == 'LLM' and status_code == 'ERROR'") {
-        edges { node { spanId traceId name statusCode } }
-      }
-    }
   }
 }
 ```

--- a/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/annotations.md
+++ b/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/annotations.md
@@ -1,0 +1,42 @@
+# Annotations
+
+Annotations are named labels/scores attached to spans, traces, or experiment runs by humans, code, or LLM judges.
+
+## Fields
+
+`SpanAnnotation` and `TraceAnnotation` share these fields:
+
+- `name`, `label`, `score`, `explanation`
+- `annotatorKind` (`AnnotatorKind` enum: human / LLM / code)
+- `metadata`, `identifier`, `createdAt`, `updatedAt`
+
+`SpanAnnotation` additionally has `spanId: GlobalID!` and `span`; `TraceAnnotation` has `trace` (but no `traceId` global-id field).
+
+`ExperimentRunAnnotation` has the same scalar shape plus `error: String`, and uses `startTime`/`endTime` instead of `createdAt`/`updatedAt`.
+
+## Reading annotations
+
+- Per span: `Span.spanAnnotations { name label score explanation annotatorKind }`.
+- Project-wide discovery and rollups: `Project.spanAnnotationNames`, `Project.spanAnnotationSummary`, `Project.traceAnnotationsNames`, `Project.traceAnnotationSummary` — use these to learn which annotation names exist before drilling in.
+- In a span `filterCondition`, reference annotations as `annotations['<name>'].label` / `.score` (or the legacy `evals['<name>']`).
+
+## Example
+
+Spans that an LLM judge labelled as hallucinated, with the annotation detail:
+
+```graphql
+query Hallucinations($id: ID!) {
+  node(id: $id) {
+    ... on Project {
+      spans(first: 20, filterCondition: "annotations['Hallucination'].label == 'hallucinated'") {
+        edges {
+          node {
+            spanId
+            spanAnnotations { name label score explanation }
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/datasets.md
+++ b/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/datasets.md
@@ -1,0 +1,45 @@
+# Dataset, DatasetExample
+
+## Reaching a dataset
+
+There is **no `getDatasetByName`** — fetch via `node(id:) { ... on Dataset { ... } }` or the `datasets(filter: DatasetFilter, sort)` connection.
+
+## Dataset fields
+
+- `name`, `description`, `metadata`
+- `exampleCount(datasetVersionId)`
+- `examples(datasetVersionId, splitIds, first, after, filter: String, filterIds)` → `DatasetExampleConnection`
+- `versions(first, after, sort)` → `DatasetVersionConnection`
+- `splits`, `labels`
+- `experiments(first, after, filterCondition, filterIds)`, `experimentCount`
+
+Gotchas:
+
+- **The version argument is `datasetVersionId` everywhere** (not `versionId`); omit it to get the latest version.
+- `examples` has two distinct filter args: `filter: String` (free-text search over input/output/metadata) and `filterIds: [GlobalID!]` (membership lookup).
+- `experiments` uses `filterCondition: String` (not `filter`).
+
+## DatasetExample fields
+
+- `externalId`
+- `revision(datasetVersionId) { input output metadata revisionKind }` — `input`/`output`/`metadata` are `JSON`; `revisionKind` is `CREATE`/`PATCH`/`DELETE`.
+- `span`
+- `datasetSplits`
+- `experimentRuns(experimentIds, first, after)`
+
+## Example
+
+```graphql
+query DatasetExamples($id: ID!, $first: Int = 20) {
+  node(id: $id) {
+    ... on Dataset {
+      name
+      exampleCount
+      examples(first: $first) {
+        edges { node { id externalId revision { input output metadata } } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+```

--- a/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/experiments.md
+++ b/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/experiments.md
@@ -1,0 +1,37 @@
+# Experiment, ExperimentRun
+
+An experiment is one run of a prompt or pipeline over every example in a dataset.
+
+## Reaching an experiment
+
+There is **no `getExperimentById`** — reach an `Experiment` via `node(id:)`, `Dataset.experiments`, or `compareExperiments`.
+
+## Experiment fields
+
+- `name`, `description`, `sequenceNumber`, `repetitions`, `isEphemeral`
+- `dataset`, `datasetVersion`, `project`
+- `runs(first, after, sort: ExperimentRunSort)` — **forward-only** (no `last`/`before`)
+- `runCount`, `expectedRunCount`
+- `errorRate`, `averageRunLatencyMs`, `costSummary`, `costDetailSummaryEntries`
+- `annotationSummaries { annotationName meanScore minScore maxScore count errorCount }`
+
+## Comparison
+
+For candidate comparison prefer `compareExperiments(baseExperimentId: GlobalID!, compareExperimentIds: [GlobalID!]!, first, after, filterCondition)` over fetching each experiment's runs separately. Related: `experimentRunMetricComparisons(baseExperimentId, compareExperimentIds)` and `validateExperimentRunFilterCondition(condition, experimentIds)`.
+
+## Example
+
+```graphql
+query ExperimentMetrics($id: ID!) {
+  node(id: $id) {
+    ... on Experiment {
+      name
+      sequenceNumber
+      runCount
+      errorRate
+      averageRunLatencyMs
+      annotationSummaries { annotationName meanScore count errorCount }
+    }
+  }
+}
+```

--- a/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/project-spans-traces.md
+++ b/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/project-spans-traces.md
@@ -1,0 +1,58 @@
+# Project, Span, Trace
+
+## Project
+
+- `Project.spans(timeRange, first, after, sort: SpanSort, rootSpansOnly: Boolean, filterCondition: String)` → connection of `Span`. There is **no `traces` connection on `Project`** — use `spans(rootSpansOnly: true)` for one row per trace.
+- `Project.trace(traceId: ID!)` → `Trace` — lookup by OTel hex trace id.
+- Aggregates, most accepting `timeRange` and `filterCondition`: `traceCount`, `recordCount` (span count), `tokenCountTotal`, `tokenCountPrompt`, `tokenCountCompletion`, `costSummary`, `latencyMsQuantile(probability: Float!)`, `spanLatencyMsQuantile(probability: Float!)`.
+- Discovery fields: `spanAnnotationNames`, `traceAnnotationsNames`, `spanAnnotationSummary`, `documentEvaluationNames` — check which evals/annotations exist before querying them.
+- `validateSpanFilterCondition(condition: String!)` — check a filter string without running it.
+
+## Span
+
+Key fields: `spanId` (OTel hex), `name`, `spanKind`, `statusCode`, `startTime`, `latencyMs`, `cumulativeTokenCountTotal`, `input { truncatedValue value }`, `output { truncatedValue value }`, `spanAnnotations { name label score }`, `trace { traceId }`. **`Span` has no `traceId` field** — read the OTel trace id via the nested `trace { traceId }`.
+
+## Trace
+
+Key fields: `traceId`, `latencyMs`, `numSpans`, `spans(first, after)`, `projectSessionId`.
+
+## Examples
+
+Recent root spans (one per trace), slowest first:
+
+```graphql
+query RecentTraces($id: ID!, $first: Int = 20) {
+  node(id: $id) {
+    ... on Project {
+      spans(first: $first, rootSpansOnly: true, sort: { col: latencyMs, dir: desc }) {
+        edges {
+          node {
+            spanId
+            name
+            latencyMs
+            statusCode
+            startTime
+            cumulativeTokenCountTotal
+            trace { traceId }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+```
+
+Filtered spans (error LLM spans):
+
+```graphql
+query ErrorSpans($id: ID!) {
+  node(id: $id) {
+    ... on Project {
+      spans(first: 20, filterCondition: "span_kind == 'LLM' and status_code == 'ERROR'") {
+        edges { node { spanId name statusCode trace { traceId } } }
+      }
+    }
+  }
+}
+```

--- a/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/project-spans-traces.md
+++ b/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/project-spans-traces.md
@@ -14,7 +14,7 @@ Key fields: `spanId` (OTel hex), `name`, `spanKind`, `statusCode`, `startTime`, 
 
 ## Trace
 
-Key fields: `traceId`, `latencyMs`, `numSpans`, `spans(first, after)`, `projectSessionId`.
+Key fields: `traceId`, `latencyMs`, `numSpans`, `rootSpan { ... }` (the entry span — use it for a one-line turn/trace summary), `spans(first, after)`, `projectSessionId`.
 
 ## Examples
 

--- a/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/prompts.md
+++ b/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/prompts.md
@@ -1,0 +1,40 @@
+# Prompt, PromptVersion
+
+## Reaching a prompt
+
+There is **no `getPromptByName`** — fetch via `node(id:)` or the `prompts(filter: PromptFilter, labelIds)` connection.
+
+## Prompt fields
+
+- `name`, `description`, `metadata`
+- `version(versionId: GlobalID, tagName: Identifier)` → `PromptVersion` — **call with no args to get the latest version**; pass `versionId` or `tagName` to pin one.
+- `promptVersions(first, after)` → `PromptVersionConnection`
+- `versionTags`, `labels`
+
+## PromptVersion fields
+
+- `modelName`, `modelProvider`
+- `templateType`, `templateFormat`
+- `template` — union `PromptStringTemplate | PromptChatTemplate`. Chat templates expose `messages { role content { ... } }`; string templates expose `template`.
+- `invocationParameters`, `tools`, `responseFormat`
+- `tags`, `isLatest`, `sequenceNumber`, `previousVersion`
+
+## Example
+
+```graphql
+query LatestPrompt($id: ID!) {
+  node(id: $id) {
+    ... on Prompt {
+      name
+      version {
+        modelName
+        modelProvider
+        template {
+          ... on PromptChatTemplate { messages { role } }
+          ... on PromptStringTemplate { template }
+        }
+      }
+    }
+  }
+}
+```

--- a/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/sessions.md
+++ b/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/sessions.md
@@ -12,13 +12,15 @@ A session groups the traces of one multi-turn conversation.
 - `sessionId`, `startTime`, `endTime`, `project`
 - `numTraces`, `numTracesWithError`
 - `firstInput { value }`, `lastOutput { value }`
-- `tokenUsage { prompt completion }`
-- `costSummary`, `costDetailSummaryEntries`
+- `tokenUsage { prompt completion total }` — each is a `Float`
+- `costSummary { total { cost tokens } prompt { cost tokens } completion { cost tokens } }`, `costDetailSummaryEntries`
 - `traceLatencyMsQuantile(probability: Float!)` — the percentile field (not `latency`)
-- `traces(first, after)` — forward-only; `first` is effectively required
+- `traces(first, after)` — forward-only; `first` is effectively required. Summarize each turn via the trace's `rootSpan { name input { truncatedValue } output { truncatedValue } }`.
 - `sessionAnnotations { name label score }`, `sessionAnnotationSummaries(filter)`
 
 ## Example
+
+One round trip: session rollups plus a per-turn summary read from each trace's root span.
 
 ```graphql
 query SessionDetail($id: ID!) {
@@ -27,10 +29,24 @@ query SessionDetail($id: ID!) {
       sessionId
       numTraces
       numTracesWithError
-      tokenUsage { prompt completion }
+      tokenUsage { total }
+      costSummary { total { cost tokens } }
       p50: traceLatencyMsQuantile(probability: 0.5)
       traces(first: 20) {
-        edges { node { traceId latencyMs numSpans } }
+        edges {
+          node {
+            traceId
+            latencyMs
+            numSpans
+            rootSpan {
+              spanId
+              name
+              statusCode
+              input { truncatedValue }
+              output { truncatedValue }
+            }
+          }
+        }
         pageInfo { hasNextPage endCursor }
       }
     }

--- a/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/sessions.md
+++ b/src/phoenix/server/agents/prompts/skills/phoenix-graphql/resources/sessions.md
@@ -1,0 +1,39 @@
+# ProjectSession
+
+A session groups the traces of one multi-turn conversation.
+
+## Reaching a session
+
+- `Project.sessions(timeRange, first, after, sort, filterIoSubstring, sessionId)` → connection of `ProjectSession`.
+- `getProjectSessionById(sessionId: String!)` → `ProjectSession` — `sessionId` is the raw session string, not a global id.
+
+## Fields
+
+- `sessionId`, `startTime`, `endTime`, `project`
+- `numTraces`, `numTracesWithError`
+- `firstInput { value }`, `lastOutput { value }`
+- `tokenUsage { prompt completion }`
+- `costSummary`, `costDetailSummaryEntries`
+- `traceLatencyMsQuantile(probability: Float!)` — the percentile field (not `latency`)
+- `traces(first, after)` — forward-only; `first` is effectively required
+- `sessionAnnotations { name label score }`, `sessionAnnotationSummaries(filter)`
+
+## Example
+
+```graphql
+query SessionDetail($id: ID!) {
+  node(id: $id) {
+    ... on ProjectSession {
+      sessionId
+      numTraces
+      numTracesWithError
+      tokenUsage { prompt completion }
+      p50: traceLatencyMsQuantile(probability: 0.5)
+      traces(first: 20) {
+        edges { node { traceId latencyMs numSpans } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+```

--- a/src/phoenix/server/agents/prompts/tools/BASH_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/BASH_TOOL_INSTRUCTIONS.xml.j2
@@ -9,7 +9,7 @@
     - Built-in just-bash commands are available; do not assume apt, brew, pnpm, uv, git, or other host binaries exist unless the sandbox reports them.
     - Language runtimes such as python, python3, and node are not available.
     - The user has no access to the filesystem. You can use the filesystem for your own purposes, but if you want to share something with the user, you must display the content in the rich markdown rendered chat.
-    - phoenix-gql is available for GraphQL operations against the Phoenix GraphQL API. Run phoenix-gql --help for usage and current permissions.
+    - phoenix-gql is available for GraphQL operations against the Phoenix GraphQL API. Run phoenix-gql --help for usage and current permissions. Before composing non-trivial GraphQL, load the `phoenix-graphql` skill for schema entrypoints and query patterns.
   </constraints>
   <orientation>
     - The /phoenix directory contains the current page context and may be refreshed on navigation, time-range changes, or a /refresh command.

--- a/src/phoenix/server/agents/prompts/tools/BASH_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/BASH_TOOL_INSTRUCTIONS.xml.j2
@@ -3,13 +3,13 @@
   <constraints>
     - Runs inside a browser-only just-bash virtual shell, not a host machine or container.
     - Read Phoenix context from /phoenix; writes there are blocked.
-    - Write scratch files only under /home/user/workspace; mutations elsewhere are blocked.
-    - Redirect unwanted output to /dev/null (e.g. `cmd >/dev/null 2>&1`); it is the only writable path outside the workspace.
+    - Write scratch files only under /home/user/workspace or /tmp; mutations elsewhere are blocked.
+    - Redirect unwanted output to /dev/null (e.g. `cmd >/dev/null 2>&1`); it is a discard-only path.
     - General purpose network access is disabled, so curl/wget and remote package installs should not be assumed to work.
     - Built-in just-bash commands are available; do not assume apt, brew, pnpm, uv, git, or other host binaries exist unless the sandbox reports them.
     - Language runtimes such as python, python3, and node are not available.
     - The user has no access to the filesystem. You can use the filesystem for your own purposes, but if you want to share something with the user, you must display the content in the rich markdown rendered chat.
-    - phoenix-gql is available for GraphQL operations against the Phoenix GraphQL API. Run phoenix-gql --help for usage and current permissions. Before composing non-trivial GraphQL, load the `phoenix-graphql` skill for schema entrypoints and query patterns.
+    - phoenix-gql is available for GraphQL operations against the Phoenix GraphQL API. If CLI usage is unclear, run `phoenix-gql --help` directly. Before composing non-trivial GraphQL, load the `phoenix-graphql` skill for schema entrypoints and query patterns.
   </constraints>
   <orientation>
     - The /phoenix directory contains the current page context and may be refreshed on navigation, time-range changes, or a /refresh command.

--- a/src/phoenix/server/agents/prompts/tools/RUN_GRAPHQL_QUERY_TOOL_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/tools/RUN_GRAPHQL_QUERY_TOOL_INSTRUCTIONS.xml.j2
@@ -2,12 +2,12 @@
   <description>Execute a read-only GraphQL query against the Phoenix server and return its result, for example fetching project data, retrieving traces, or inspecting the schema via introspection.</description>
   <guidelines>
     - This tool is read-only: only `query` operations are permitted. Mutations and subscriptions are rejected, so do not attempt to write, delete, or otherwise modify data with it.
-    - Do not guess field, type, or argument names. When you are not certain the schema matches what you intend to query, run an introspection query first (e.g. `{ __type(name: "Project") { fields { name args { name } type { name kind } } } }`) and write your query against what it returns.
-    - Write a single GraphQL query that retrieves exactly what is needed and pass query variables via `variable_values` rather than string interpolation.
+    - Before composing a non-trivial query, load the `phoenix-graphql` skill — it documents the schema entrypoints, pagination, ID semantics, filter syntax, and ready-to-use query patterns, so you rarely need introspection.
+    - Do not run full schema introspection. If the skill does not cover a field you need, introspect a single type (e.g. `{ __type(name: "Project") { fields { name args { name } type { name kind } } } }`) and write your query against what it returns.
+    - Write a single GraphQL query that retrieves exactly what is needed — batch independent lookups with aliases — and pass query variables via `variable_values` rather than string interpolation.
     - If a query selects the same field more than once with different arguments, every repeated selection must use a unique alias. This is especially important for introspection: bad: `{ __type(name: "Trace") { fields { name } } __type(name: "Span") { fields { name } } }`; good: `{ traceType: __type(name: "Trace") { fields { name } } spanType: __type(name: "Span") { fields { name } } }`.
-    - Prefer small introspection queries over broad schema-discovery queries. If you need multiple types, either query them one at a time or use aliases for each `__type` selection.
     - For fields returning object lists, introspect the returned object type before selecting child fields. Do not assume common names like `name`; some Phoenix aggregate types use fields such as `exceptionType` or `spanKind` instead.
-    - On success the tool returns a dict with the query `data`. If the query has errors the tool raises and you receive the error messages back — read them, introspect the schema if a field or argument may be wrong, correct the query, and retry.
+    - On success the tool returns a dict with the query `data`. If the query has errors the tool raises and you receive the error messages back — read them, correct the query (introspect the exact parent type and field names if needed), and retry.
     - Treat generic GraphQL errors such as `an unexpected error occurred` as possible validation errors. Do not keep retrying the same query. First simplify the query or introspect the exact parent type and field names, then retry with a corrected query.
     - Return a concise, factual answer grounded in the data you retrieved.
   </guidelines>

--- a/src/phoenix/server/agents/server_agents.py
+++ b/src/phoenix/server/agents/server_agents.py
@@ -12,7 +12,7 @@ from pydantic_ai.mcp import MCPServerStreamableHTTP
 from pydantic_ai.models import Model
 
 from phoenix.server.agents.capabilities import MintlifyDocsMCPCapability
-from phoenix.server.agents.capabilities.skills import Skill, SkillsCapability, SkillsToolset
+from phoenix.server.agents.capabilities.skills import SkillsCapability, SkillsToolset
 from phoenix.server.agents.capabilities.tools.internal.run_graphql_query import (
     RunGraphQLQueryCapability,
 )
@@ -21,6 +21,7 @@ from phoenix.server.agents.pydantic_ai import (
     OpenInferenceAgentWrapper,
     OpenInferenceCapabilityWrapper,
 )
+from phoenix.server.agents.skills.phoenix_graphql import PHOENIX_GRAPHQL_SKILL
 from phoenix.server.agents.web_access import (
     build_web_fetch_capability,
     build_web_search_capability,
@@ -37,7 +38,6 @@ def build_server_agent(
     docs_mcp_server: MCPServerStreamableHTTP | None = None,
     enable_web_access: bool = False,
     tracer_provider: TracerProvider | None = None,
-    skills: list[Skill] | None = None,
 ) -> AbstractAgent[None, str]:
     """Construct server agent.
 
@@ -45,8 +45,8 @@ def build_server_agent(
     they are for the main agent, so the sub-agent gains the docs MCP and web
     search/fetch tools under the same conditions.
 
-    ``skills`` are exposed through the same progressive-disclosure skills toolset
-    the main agent uses (``load_skill`` / ``read_skill_resource``).
+    The server agent always receives the GraphQL skill through the same
+    progressive-disclosure skills toolset the main agent uses.
     """
     resolved_prompts = prompts or ServerAgentPrompts()
     provider = tracer_provider or NoOpTracerProvider()
@@ -61,18 +61,17 @@ def build_server_agent(
             instructions=resolved_prompts.run_graphql_query_tool.render(),
         ),
     ]
-    if skills:
-        capabilities.append(
-            SkillsCapability(
-                toolset=SkillsToolset[None](
-                    skills=skills,
-                    load_skill_template=resolved_prompts.load_skill,
-                    load_skill_tool_template=resolved_prompts.load_skill_tool,
-                    read_skill_resource_tool_template=resolved_prompts.read_skill_resource_tool,
-                ),
-                instructions=resolved_prompts.skills,
-            )
+    capabilities.append(
+        SkillsCapability(
+            toolset=SkillsToolset[None](
+                skills=[PHOENIX_GRAPHQL_SKILL],
+                load_skill_template=resolved_prompts.load_skill,
+                load_skill_tool_template=resolved_prompts.load_skill_tool,
+                read_skill_resource_tool_template=resolved_prompts.read_skill_resource_tool,
+            ),
+            instructions=resolved_prompts.skills,
         )
+    )
     if docs_mcp_server is not None:
         capabilities.append(
             MintlifyDocsMCPCapability(

--- a/src/phoenix/server/agents/server_agents.py
+++ b/src/phoenix/server/agents/server_agents.py
@@ -12,6 +12,7 @@ from pydantic_ai.mcp import MCPServerStreamableHTTP
 from pydantic_ai.models import Model
 
 from phoenix.server.agents.capabilities import MintlifyDocsMCPCapability
+from phoenix.server.agents.capabilities.skills import Skill, SkillsCapability, SkillsToolset
 from phoenix.server.agents.capabilities.tools.internal.run_graphql_query import (
     RunGraphQLQueryCapability,
 )
@@ -36,12 +37,16 @@ def build_server_agent(
     docs_mcp_server: MCPServerStreamableHTTP | None = None,
     enable_web_access: bool = False,
     tracer_provider: TracerProvider | None = None,
+    skills: list[Skill] | None = None,
 ) -> AbstractAgent[None, str]:
     """Construct server agent.
 
     ``docs_mcp_server`` and ``enable_web_access`` are gated by the caller exactly as
     they are for the main agent, so the sub-agent gains the docs MCP and web
     search/fetch tools under the same conditions.
+
+    ``skills`` are exposed through the same progressive-disclosure skills toolset
+    the main agent uses (``load_skill`` / ``read_skill_resource``).
     """
     resolved_prompts = prompts or ServerAgentPrompts()
     provider = tracer_provider or NoOpTracerProvider()
@@ -56,6 +61,18 @@ def build_server_agent(
             instructions=resolved_prompts.run_graphql_query_tool.render(),
         ),
     ]
+    if skills:
+        capabilities.append(
+            SkillsCapability(
+                toolset=SkillsToolset[None](
+                    skills=skills,
+                    load_skill_template=resolved_prompts.load_skill,
+                    load_skill_tool_template=resolved_prompts.load_skill_tool,
+                    read_skill_resource_tool_template=resolved_prompts.read_skill_resource_tool,
+                ),
+                instructions=resolved_prompts.skills,
+            )
+        )
     if docs_mcp_server is not None:
         capabilities.append(
             MintlifyDocsMCPCapability(

--- a/src/phoenix/server/agents/skills/__init__.py
+++ b/src/phoenix/server/agents/skills/__init__.py
@@ -31,15 +31,6 @@ def build_skills(
     return skills
 
 
-def get_server_agent_skills() -> list[Skill]:
-    """Return the skills available to the server sub-agent.
-
-    The sub-agent answers data questions exclusively through GraphQL, so it
-    receives the GraphQL skill regardless of UI context.
-    """
-    return [PHOENIX_GRAPHQL_SKILL]
-
-
 def get_skills_for_contexts(contexts: ResolvedContexts) -> list[Skill]:
     """Return the skills the assistant agent would have given a resolved context set.
 
@@ -96,7 +87,6 @@ def get_skills(
 
 __all__ = [
     "build_skills",
-    "get_server_agent_skills",
     "get_skills",
     "get_skills_for_contexts",
 ]

--- a/src/phoenix/server/agents/skills/__init__.py
+++ b/src/phoenix/server/agents/skills/__init__.py
@@ -7,6 +7,7 @@ from phoenix.server.agents.skills.datasets import DATASETS_SKILL
 from phoenix.server.agents.skills.debug_trace import DEBUG_TRACE_SKILL
 from phoenix.server.agents.skills.evaluators import EVALUATORS_SKILL
 from phoenix.server.agents.skills.experiments import EXPERIMENTS_SKILL
+from phoenix.server.agents.skills.phoenix_graphql import PHOENIX_GRAPHQL_SKILL
 from phoenix.server.agents.skills.playground import PLAYGROUND_SKILL
 
 
@@ -18,7 +19,7 @@ def build_skills(
     include_evaluators: bool = False,
 ) -> list[Skill]:
     """Return the skills bundled with the assistant agent."""
-    skills = [DEBUG_TRACE_SKILL, ANNOTATE_SPANS_SKILL]
+    skills = [DEBUG_TRACE_SKILL, ANNOTATE_SPANS_SKILL, PHOENIX_GRAPHQL_SKILL]
     if include_playground:
         skills.append(PLAYGROUND_SKILL)
     if include_datasets:
@@ -28,6 +29,15 @@ def build_skills(
     if include_evaluators:
         skills.append(EVALUATORS_SKILL)
     return skills
+
+
+def get_server_agent_skills() -> list[Skill]:
+    """Return the skills available to the server sub-agent.
+
+    The sub-agent answers data questions exclusively through GraphQL, so it
+    receives the GraphQL skill regardless of UI context.
+    """
+    return [PHOENIX_GRAPHQL_SKILL]
 
 
 def get_skills_for_contexts(contexts: ResolvedContexts) -> list[Skill]:
@@ -84,4 +94,9 @@ def get_skills(
     )
 
 
-__all__ = ["build_skills", "get_skills", "get_skills_for_contexts"]
+__all__ = [
+    "build_skills",
+    "get_server_agent_skills",
+    "get_skills",
+    "get_skills_for_contexts",
+]

--- a/src/phoenix/server/agents/skills/phoenix_graphql.py
+++ b/src/phoenix/server/agents/skills/phoenix_graphql.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from phoenix.server.agents.capabilities.skills import Skill
+
+_SKILL_PATH = (
+    Path(__file__).resolve().parent.parent / "prompts" / "skills" / "phoenix-graphql" / "SKILL.md"
+)
+
+PHOENIX_GRAPHQL_SKILL = Skill.from_file(_SKILL_PATH)

--- a/src/phoenix/server/agents/skills/phoenix_graphql.py
+++ b/src/phoenix/server/agents/skills/phoenix_graphql.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 from phoenix.server.agents.capabilities.skills import (
     ContentSkillResource,
@@ -52,8 +52,8 @@ _RESOURCE_SPECS: tuple[ResourceSpec, ...] = (
 )
 
 
-def _load_resources() -> list[SkillResource]:
-    resources: list[SkillResource] = []
+def _load_resources() -> list[SkillResource[Any]]:
+    resources: list[SkillResource[Any]] = []
     for name, description, filename in _RESOURCE_SPECS:
         content = (_RESOURCES_DIR / filename).read_text(encoding="utf-8").strip()
         resources.append(ContentSkillResource(name=name, description=description, content=content))

--- a/src/phoenix/server/agents/skills/phoenix_graphql.py
+++ b/src/phoenix/server/agents/skills/phoenix_graphql.py
@@ -2,10 +2,59 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from phoenix.server.agents.capabilities.skills import Skill
-
-_SKILL_PATH = (
-    Path(__file__).resolve().parent.parent / "prompts" / "skills" / "phoenix-graphql" / "SKILL.md"
+from phoenix.server.agents.capabilities.skills import (
+    ContentSkillResource,
+    Skill,
+    SkillResource,
 )
 
-PHOENIX_GRAPHQL_SKILL = Skill.from_file(_SKILL_PATH)
+_SKILL_DIR = Path(__file__).resolve().parent.parent / "prompts" / "skills" / "phoenix-graphql"
+_SKILL_PATH = _SKILL_DIR / "SKILL.md"
+_RESOURCES_DIR = _SKILL_DIR / "resources"
+
+# Per-domain schema references, surfaced as on-demand skill resources so the
+# top-level skill body stays small. Each entry is (resource name, short
+# description shown in the load_skill manifest, resource markdown filename).
+_RESOURCE_SPECS: tuple[tuple[str, str, str], ...] = (
+    (
+        "project-spans-traces",
+        "Project aggregates and spans; Span and Trace fields. Start here for trace analysis.",
+        "project-spans-traces.md",
+    ),
+    (
+        "sessions",
+        "ProjectSession: multi-turn session metrics, token/cost, and session traces.",
+        "sessions.md",
+    ),
+    (
+        "datasets",
+        "Dataset and DatasetExample: examples, versions, splits, and labels.",
+        "datasets.md",
+    ),
+    (
+        "experiments",
+        "Experiment and ExperimentRun: runs, aggregate metrics, and comparison.",
+        "experiments.md",
+    ),
+    (
+        "prompts",
+        "Prompt and PromptVersion: versions, templates, and tags.",
+        "prompts.md",
+    ),
+    (
+        "annotations",
+        "Span/Trace/ExperimentRun annotation fields and how to read them.",
+        "annotations.md",
+    ),
+)
+
+
+def _load_resources() -> list[SkillResource]:
+    resources: list[SkillResource] = []
+    for name, description, filename in _RESOURCE_SPECS:
+        content = (_RESOURCES_DIR / filename).read_text(encoding="utf-8").strip()
+        resources.append(ContentSkillResource(name=name, description=description, content=content))
+    return resources
+
+
+PHOENIX_GRAPHQL_SKILL = Skill.from_file(_SKILL_PATH, resources=_load_resources())

--- a/src/phoenix/server/agents/skills/phoenix_graphql.py
+++ b/src/phoenix/server/agents/skills/phoenix_graphql.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TypeAlias
 
 from phoenix.server.agents.capabilities.skills import (
     ContentSkillResource,
     Skill,
     SkillResource,
 )
+
+ResourceSpec: TypeAlias = tuple[str, str, str]
 
 _SKILL_DIR = Path(__file__).resolve().parent.parent / "prompts" / "skills" / "phoenix-graphql"
 _SKILL_PATH = _SKILL_DIR / "SKILL.md"
@@ -15,7 +18,7 @@ _RESOURCES_DIR = _SKILL_DIR / "resources"
 # Per-domain schema references, surfaced as on-demand skill resources so the
 # top-level skill body stays small. Each entry is (resource name, short
 # description shown in the load_skill manifest, resource markdown filename).
-_RESOURCE_SPECS: tuple[tuple[str, str, str], ...] = (
+_RESOURCE_SPECS: tuple[ResourceSpec, ...] = (
     (
         "project-spans-traces",
         "Project aggregates and spans; Span and Trace fields. Start here for trace analysis.",

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -61,7 +61,7 @@ from phoenix.server.agents.skill_requests import (
     iter_requested_skill_response_chunks,
     resolve_requested_skills,
 )
-from phoenix.server.agents.skills import get_skills_for_contexts
+from phoenix.server.agents.skills import get_server_agent_skills, get_skills_for_contexts
 from phoenix.server.agents.summarization import summarize_messages
 from phoenix.server.agents.types import (
     AgentDependencies,
@@ -622,6 +622,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 docs_mcp_server=request.app.state.docs_mcp_server,
                 enable_web_access=web_access_enabled,
                 tracer_provider=tracer_provider,
+                skills=get_server_agent_skills(),
             )
             if subagents_enabled
             else None

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -61,7 +61,7 @@ from phoenix.server.agents.skill_requests import (
     iter_requested_skill_response_chunks,
     resolve_requested_skills,
 )
-from phoenix.server.agents.skills import get_server_agent_skills, get_skills_for_contexts
+from phoenix.server.agents.skills import get_skills_for_contexts
 from phoenix.server.agents.summarization import summarize_messages
 from phoenix.server.agents.types import (
     AgentDependencies,
@@ -622,7 +622,6 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 docs_mcp_server=request.app.state.docs_mcp_server,
                 enable_web_access=web_access_enabled,
                 tracer_provider=tracer_provider,
-                skills=get_server_agent_skills(),
             )
             if subagents_enabled
             else None

--- a/tests/unit/server/agents/capabilities/skills/test_skill_capability.py
+++ b/tests/unit/server/agents/capabilities/skills/test_skill_capability.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, cast
+from typing import Any, Callable, cast
 
 from phoenix.server.agents.capabilities.skills import (
     ContentSkillResource,
@@ -32,7 +32,7 @@ def _make_skill(
     name: str,
     description: str,
     content: str,
-    resources: list[SkillResource] | None = None,
+    resources: list[SkillResource[Any]] | None = None,
 ) -> Skill:
     return Skill(
         name=name,

--- a/tests/unit/server/agents/skills/test_phoenix_graphql.py
+++ b/tests/unit/server/agents/skills/test_phoenix_graphql.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+from graphql import parse, validate
+
+from phoenix.server.agents.capabilities.skills import ContentSkillResource
+from phoenix.server.agents.skills.phoenix_graphql import PHOENIX_GRAPHQL_SKILL
+from phoenix.server.api.schema import build_graphql_schema
+
+_GRAPHQL_BLOCK = re.compile(r"```graphql\n(.*?)```", re.DOTALL)
+
+
+def _iter_graphql_examples() -> list[tuple[str, str]]:
+    """Yield (source_label, query_text) for every ```graphql block in the skill.
+
+    Covers the skill body and every resource so a renamed schema field fails the
+    suite instead of silently rotting the documented examples.
+    """
+    sources: list[tuple[str, str]] = [("SKILL.md body", PHOENIX_GRAPHQL_SKILL.content)]
+    for resource in PHOENIX_GRAPHQL_SKILL.resources:
+        assert isinstance(resource, ContentSkillResource)
+        sources.append((f"resource:{resource.name}", resource.content))
+
+    examples: list[tuple[str, str]] = []
+    for label, text in sources:
+        for idx, match in enumerate(_GRAPHQL_BLOCK.finditer(text)):
+            examples.append((f"{label}#{idx}", match.group(1).strip()))
+    return examples
+
+
+_EXPECTED_RESOURCE_NAMES = {
+    "project-spans-traces",
+    "sessions",
+    "datasets",
+    "experiments",
+    "prompts",
+    "annotations",
+}
+
+
+def test_skill_metadata() -> None:
+    assert PHOENIX_GRAPHQL_SKILL.name == "phoenix-graphql"
+    assert PHOENIX_GRAPHQL_SKILL.description.strip()
+    assert PHOENIX_GRAPHQL_SKILL.summary.strip()
+
+
+def test_exposes_one_resource_per_schema_domain() -> None:
+    names = {resource.name for resource in PHOENIX_GRAPHQL_SKILL.resources}
+    assert names == _EXPECTED_RESOURCE_NAMES
+
+
+def test_every_resource_has_a_manifest_description_and_content() -> None:
+    for resource in PHOENIX_GRAPHQL_SKILL.resources:
+        assert isinstance(resource, ContentSkillResource)
+        assert resource.description, f"{resource.name} is missing a manifest description"
+        assert resource.content.strip(), f"{resource.name} has empty content"
+
+
+def test_body_points_at_resources_instead_of_inlining_schema() -> None:
+    body = PHOENIX_GRAPHQL_SKILL.content
+    # The body advertises the schema map and the read mechanism...
+    assert "Schema map" in body
+    assert "read_skill_resource" in body
+    # ...and every resource is named in the map so the model knows what to request.
+    for name in _EXPECTED_RESOURCE_NAMES:
+        assert name in body, f"resource '{name}' is not referenced in the skill body"
+
+
+@pytest.mark.parametrize(
+    "resource_name, expected_substring",
+    [
+        ("datasets", "datasetVersionId"),
+        ("experiments", "compareExperiments"),
+        ("prompts", "call with no args to get the latest version"),
+        ("sessions", "traceLatencyMsQuantile"),
+        ("annotations", "annotatorKind"),
+        ("project-spans-traces", "rootSpansOnly"),
+    ],
+)
+def test_resource_content_covers_key_facts(resource_name: str, expected_substring: str) -> None:
+    resource = next(r for r in PHOENIX_GRAPHQL_SKILL.resources if r.name == resource_name)
+    assert isinstance(resource, ContentSkillResource)
+    assert expected_substring in resource.content
+
+
+_GRAPHQL_EXAMPLES = _iter_graphql_examples()
+
+
+def test_skill_documents_graphql_examples() -> None:
+    # Guard against the extractor silently matching nothing.
+    assert _GRAPHQL_EXAMPLES, "expected at least one ```graphql example in the skill"
+
+
+@pytest.mark.parametrize(
+    "label, query",
+    _GRAPHQL_EXAMPLES,
+    ids=[label for label, _ in _GRAPHQL_EXAMPLES],
+)
+def test_example_queries_validate_against_live_schema(label: str, query: str) -> None:
+    """Every documented example must parse and validate against the real schema.
+
+    This is the anti-rot guard: if a field or argument is renamed in the
+    GraphQL schema, the corresponding skill example fails here.
+    """
+    schema = build_graphql_schema()
+    errors = validate(schema._schema, parse(query))
+    assert not errors, f"{label} failed schema validation: {[str(e) for e in errors]}"

--- a/tests/unit/server/agents/skills/test_phoenix_graphql.py
+++ b/tests/unit/server/agents/skills/test_phoenix_graphql.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from typing import TypeAlias
 
 import pytest
 from graphql import parse, validate
@@ -10,79 +11,26 @@ from phoenix.server.agents.skills.phoenix_graphql import PHOENIX_GRAPHQL_SKILL
 from phoenix.server.api.schema import build_graphql_schema
 
 _GRAPHQL_BLOCK = re.compile(r"```graphql\n(.*?)```", re.DOTALL)
+GraphQLExample: TypeAlias = tuple[str, str]
+SkillContentSource: TypeAlias = tuple[str, str]
 
 
-def _iter_graphql_examples() -> list[tuple[str, str]]:
+def _iter_graphql_examples() -> list[GraphQLExample]:
     """Yield (source_label, query_text) for every ```graphql block in the skill.
 
     Covers the skill body and every resource so a renamed schema field fails the
     suite instead of silently rotting the documented examples.
     """
-    sources: list[tuple[str, str]] = [("SKILL.md body", PHOENIX_GRAPHQL_SKILL.content)]
+    sources: list[SkillContentSource] = [("SKILL.md body", PHOENIX_GRAPHQL_SKILL.content)]
     for resource in PHOENIX_GRAPHQL_SKILL.resources:
         assert isinstance(resource, ContentSkillResource)
         sources.append((f"resource:{resource.name}", resource.content))
 
-    examples: list[tuple[str, str]] = []
+    examples: list[GraphQLExample] = []
     for label, text in sources:
         for idx, match in enumerate(_GRAPHQL_BLOCK.finditer(text)):
             examples.append((f"{label}#{idx}", match.group(1).strip()))
     return examples
-
-
-_EXPECTED_RESOURCE_NAMES = {
-    "project-spans-traces",
-    "sessions",
-    "datasets",
-    "experiments",
-    "prompts",
-    "annotations",
-}
-
-
-def test_skill_metadata() -> None:
-    assert PHOENIX_GRAPHQL_SKILL.name == "phoenix-graphql"
-    assert PHOENIX_GRAPHQL_SKILL.description.strip()
-    assert PHOENIX_GRAPHQL_SKILL.summary.strip()
-
-
-def test_exposes_one_resource_per_schema_domain() -> None:
-    names = {resource.name for resource in PHOENIX_GRAPHQL_SKILL.resources}
-    assert names == _EXPECTED_RESOURCE_NAMES
-
-
-def test_every_resource_has_a_manifest_description_and_content() -> None:
-    for resource in PHOENIX_GRAPHQL_SKILL.resources:
-        assert isinstance(resource, ContentSkillResource)
-        assert resource.description, f"{resource.name} is missing a manifest description"
-        assert resource.content.strip(), f"{resource.name} has empty content"
-
-
-def test_body_points_at_resources_instead_of_inlining_schema() -> None:
-    body = PHOENIX_GRAPHQL_SKILL.content
-    # The body advertises the schema map and the read mechanism...
-    assert "Schema map" in body
-    assert "read_skill_resource" in body
-    # ...and every resource is named in the map so the model knows what to request.
-    for name in _EXPECTED_RESOURCE_NAMES:
-        assert name in body, f"resource '{name}' is not referenced in the skill body"
-
-
-@pytest.mark.parametrize(
-    "resource_name, expected_substring",
-    [
-        ("datasets", "datasetVersionId"),
-        ("experiments", "compareExperiments"),
-        ("prompts", "call with no args to get the latest version"),
-        ("sessions", "traceLatencyMsQuantile"),
-        ("annotations", "annotatorKind"),
-        ("project-spans-traces", "rootSpansOnly"),
-    ],
-)
-def test_resource_content_covers_key_facts(resource_name: str, expected_substring: str) -> None:
-    resource = next(r for r in PHOENIX_GRAPHQL_SKILL.resources if r.name == resource_name)
-    assert isinstance(resource, ContentSkillResource)
-    assert expected_substring in resource.content
 
 
 _GRAPHQL_EXAMPLES = _iter_graphql_examples()

--- a/tests/unit/server/agents/test_server_agents.py
+++ b/tests/unit/server/agents/test_server_agents.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+import strawberry
+from pydantic_ai.models.test import TestModel
+
+from phoenix.server.agents.server_agents import build_server_agent
+from phoenix.server.agents.skills import get_server_agent_skills
+from phoenix.server.api.context import Context
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def hello(self) -> str:
+        return "world"
+
+
+@pytest.fixture
+def schema() -> strawberry.Schema:
+    return strawberry.Schema(query=Query)
+
+
+@pytest.fixture
+def model() -> TestModel:
+    """Model that advertises tools without calling any of them."""
+    return TestModel(call_tools=[])
+
+
+async def test_skills_toolset_advertised_when_skills_provided(
+    model: TestModel,
+    schema: strawberry.Schema,
+) -> None:
+    agent = build_server_agent(
+        model=model,
+        schema=schema,
+        build_graphql_context=lambda: Mock(spec=Context),
+        skills=get_server_agent_skills(),
+    )
+    await agent.run("hi")
+
+    assert model.last_model_request_parameters is not None
+    tool_names = {tool.name for tool in model.last_model_request_parameters.function_tools}
+    assert "run_graphql_query" in tool_names
+    assert "load_skill" in tool_names
+    assert "read_skill_resource" in tool_names
+
+
+async def test_skill_catalog_rendered_into_instructions(
+    model: TestModel,
+    schema: strawberry.Schema,
+) -> None:
+    agent = build_server_agent(
+        model=model,
+        schema=schema,
+        build_graphql_context=lambda: Mock(spec=Context),
+        skills=get_server_agent_skills(),
+    )
+    result = await agent.run("hi")
+
+    instructions = result.all_messages()[0].instructions  # type: ignore[union-attr]
+    assert instructions is not None
+    assert "<available_skills>" in instructions
+    assert "phoenix-graphql" in instructions
+
+
+async def test_no_skills_tools_without_skills(
+    model: TestModel,
+    schema: strawberry.Schema,
+) -> None:
+    agent = build_server_agent(
+        model=model,
+        schema=schema,
+        build_graphql_context=lambda: Mock(spec=Context),
+    )
+    await agent.run("hi")
+
+    assert model.last_model_request_parameters is not None
+    tool_names = {tool.name for tool in model.last_model_request_parameters.function_tools}
+    assert "run_graphql_query" in tool_names
+    assert "load_skill" not in tool_names
+    assert "read_skill_resource" not in tool_names

--- a/tests/unit/server/agents/test_server_agents.py
+++ b/tests/unit/server/agents/test_server_agents.py
@@ -7,7 +7,6 @@ import strawberry
 from pydantic_ai.models.test import TestModel
 
 from phoenix.server.agents.server_agents import build_server_agent
-from phoenix.server.agents.skills import get_server_agent_skills
 from phoenix.server.api.context import Context
 
 
@@ -29,7 +28,7 @@ def model() -> TestModel:
     return TestModel(call_tools=[])
 
 
-async def test_skills_toolset_advertised_when_skills_provided(
+async def test_skills_toolset_advertised(
     model: TestModel,
     schema: strawberry.Schema,
 ) -> None:
@@ -37,7 +36,6 @@ async def test_skills_toolset_advertised_when_skills_provided(
         model=model,
         schema=schema,
         build_graphql_context=lambda: Mock(spec=Context),
-        skills=get_server_agent_skills(),
     )
     await agent.run("hi")
 
@@ -56,7 +54,6 @@ async def test_skill_catalog_rendered_into_instructions(
         model=model,
         schema=schema,
         build_graphql_context=lambda: Mock(spec=Context),
-        skills=get_server_agent_skills(),
     )
     result = await agent.run("hi")
 
@@ -64,21 +61,3 @@ async def test_skill_catalog_rendered_into_instructions(
     assert instructions is not None
     assert "<available_skills>" in instructions
     assert "phoenix-graphql" in instructions
-
-
-async def test_no_skills_tools_without_skills(
-    model: TestModel,
-    schema: strawberry.Schema,
-) -> None:
-    agent = build_server_agent(
-        model=model,
-        schema=schema,
-        build_graphql_context=lambda: Mock(spec=Context),
-    )
-    await agent.run("hi")
-
-    assert model.last_model_request_parameters is not None
-    tool_names = {tool.name for tool in model.last_model_request_parameters.function_tools}
-    assert "run_graphql_query" in tool_names
-    assert "load_skill" not in tool_names
-    assert "read_skill_resource" not in tool_names

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -2799,7 +2799,7 @@ async def test_available_agent_skills_base_catalog(
     assert response.data is not None
     names = [skill["name"] for skill in response.data["availableAgentSkills"]]
     # No context mounted: only the always-on skills, in catalog order, no gated ones.
-    assert names == ["debug-trace", "annotate-spans"]
+    assert names == ["debug-trace", "annotate-spans", "phoenix-graphql"]
     # progressive-disclosure header is populated
     assert all(skill["description"] for skill in response.data["availableAgentSkills"])
     assert all(skill["summary"] for skill in response.data["availableAgentSkills"])
@@ -2816,7 +2816,7 @@ async def test_available_agent_skills_playground_context(
     assert response.data is not None
     names = [skill["name"] for skill in response.data["availableAgentSkills"]]
     # Playground context adds the playground skill on top of the always-on base.
-    assert names == ["debug-trace", "annotate-spans", "playground"]
+    assert names == ["debug-trace", "annotate-spans", "phoenix-graphql", "playground"]
 
 
 async def test_available_agent_skills_dataset_context(
@@ -2830,7 +2830,14 @@ async def test_available_agent_skills_dataset_context(
     assert response.data is not None
     names = [skill["name"] for skill in response.data["availableAgentSkills"]]
     # Dataset context unlocks the dataset-backed trio: datasets, experiments, evaluators.
-    assert names == ["debug-trace", "annotate-spans", "datasets", "experiments", "evaluators"]
+    assert names == [
+        "debug-trace",
+        "annotate-spans",
+        "phoenix-graphql",
+        "datasets",
+        "experiments",
+        "evaluators",
+    ]
 
 
 async def test_available_agent_skills_llm_evaluator_context(
@@ -2844,7 +2851,7 @@ async def test_available_agent_skills_llm_evaluator_context(
     assert response.data is not None
     names = [skill["name"] for skill in response.data["availableAgentSkills"]]
     # An evaluator context (without a dataset) unlocks only the evaluators skill.
-    assert names == ["debug-trace", "annotate-spans", "evaluators"]
+    assert names == ["debug-trace", "annotate-spans", "phoenix-graphql", "evaluators"]
 
 
 async def test_available_agent_skills_code_evaluator_context(
@@ -2858,4 +2865,4 @@ async def test_available_agent_skills_code_evaluator_context(
     assert response.data is not None
     names = [skill["name"] for skill in response.data["availableAgentSkills"]]
     # An evaluator context (without a dataset) unlocks only the evaluators skill.
-    assert names == ["debug-trace", "annotate-spans", "evaluators"]
+    assert names == ["debug-trace", "annotate-spans", "phoenix-graphql", "evaluators"]


### PR DESCRIPTION
resolves #13583

## Summary

Moves the filesystem-based GraphQL guidance into an always-on `phoenix-graphql` skill accessible to both the primary PXI agent and the server sub-agent, eliminating the read-the-getting-started-MD hop and full-introspection round trips called out in the issue.

### The skill (two modes)

- **Internal data analysis** — verified schema entrypoints (`getProjectByName`, `node(id:)`, `Project.spans`/aggregates), Relay pagination, Relay-vs-OTel ID semantics, `filterCondition` DSL examples, `TimeRange`/`SpanSort` inputs, and ready-to-run query patterns so the agent rarely needs introspection. Explicit rules: never full-introspect (single-type `__type` only as fallback), batch independent lookups with aliases, prefer `truncatedValue` when surveying span IO.
- **User-facing integration help** — `POST /graphql` endpoint, `Authorization: Bearer <API_KEY>` auth, GraphiQL on GET, curl/Python examples, pagination contract, and guidance to prefer REST/clients for stable programmatic access.

Registered always-on in `build_skills()`, so it also appears in the prompt UI skill catalog (`/phoenix-graphql` slash command).

### Sub-agent access

- Genericized `SkillsToolset`/`SkillsCapability`/`SkillResource` over the agent deps type (pydantic-ai's `AgentDepsT` defaults to `None`, so existing call sites are unchanged)
- `build_server_agent()` accepts `skills=`; the chat router passes the GraphQL skill
- `run_graphql_query` tool prompt slimmed to point at the skill and forbid full schema introspection

### Browser virtual filesystem cleanup

- Removed the generic `/phoenix/graphql/README.md` guide (`PHOENIX_GQL_GUIDE`); route-specific recipes, starter data, `agent-start.md`, and `schema.json` remain
- `agent-start.md`, `phoenix-gql --help`, and the bash tool instructions now point at the skill

### Deferred follow-up

A `FunctionSkillResource` type-lookup resource (server-side SDL for named types) to eliminate introspection entirely.

## Testing

- New `tests/unit/server/agents/test_server_agents.py`: skills toolset advertised/absent on the sub-agent, skill catalog rendered into sub-agent instructions
- Updated skill catalog test in `test_queries.py`
- mypy strict, ruff, oxlint/oxfmt clean; 188 agent unit tests and 14 TS bash-tool tests pass