### PR TITLE
feat(evals): agent-readable failure reports for PXI eval harness

### DIFF
--- a/.github/workflows/pxi-evals.yml
+++ b/.github/workflows/pxi-evals.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   group: pxi-evals-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -51,11 +51,42 @@ jobs:
             exit 0
           fi
 
+          # Pre-flight: verify Phoenix is reachable before touching any
+          # datasets. The runner retries internally (3x / 10s), so a transient
+          # blip won't fail here; but if Phoenix is genuinely down this exits
+          # once cleanly rather than burning through every dataset in the loop.
+          phoenix_url="${PHOENIX_COLLECTOR_ENDPOINT:-http://localhost:6006}"
+          phoenix_url="${phoenix_url%/}"
+          echo "Checking Phoenix connectivity at ${phoenix_url}..."
+          phoenix_ok=0
+          for attempt in 1 2 3; do
+            if curl -sf --max-time 5 "${phoenix_url}/healthz" > /dev/null 2>&1; then
+              echo "Phoenix reachable (attempt ${attempt})"
+              phoenix_ok=1
+              break
+            fi
+            if [[ "${attempt}" -lt 3 ]]; then
+              echo "Phoenix not reachable (attempt ${attempt}/3), retrying in 10s..." >&2
+              sleep 10
+            fi
+          done
+          if [[ "${phoenix_ok}" -eq 0 ]]; then
+            echo "::error::Phoenix unavailable at ${phoenix_url} after 3 attempts — aborting all dataset runs. Check PHOENIX_COLLECTOR_ENDPOINT."
+            exit 1
+          fi
+
+          report_dir="${RUNNER_TEMP}/pxi-eval-reports"
+          mkdir -p "${report_dir}"
+
           failed=0
           failed_datasets=()
           short_sha="${GITHUB_SHA::7}"
           branch_slug="${GITHUB_REF_NAME//\//-}"
           step_summary="${GITHUB_STEP_SUMMARY:-/dev/null}"
+          # Cumulative budget for embedding full reports in the step summary:
+          # GitHub caps the whole summary at 1 MiB, so the budget is shared
+          # across ALL failed datasets, not per report.
+          summary_embed_budget=786432
 
           {
             echo "## PXI Regression Evals"
@@ -63,6 +94,62 @@ jobs:
             echo "| Dataset | Result |"
             echo "| --- | --- |"
           } >> "${step_summary}"
+
+          # Append a per-dataset failure section to the step summary: a digest
+          # table built from the JSON report plus the full agent-readable
+          # Markdown report inside a <details> block (browser copy-paste into
+          # any coding agent is select-all on the expanded section).
+          append_failure_summary() {
+            local dataset="$1"
+            local report_json="${report_dir}/${dataset}.report.json"
+            local report_md="${report_dir}/${dataset}.report.md"
+            {
+              echo ""
+              echo "### ❌ \`${dataset}\`"
+              echo ""
+              if [[ -f "${report_json}" ]]; then
+                local experiment_url
+                experiment_url="$(jq -r '.experiment_url // empty' "${report_json}")"
+                if [[ -n "${experiment_url}" ]]; then
+                  echo "Experiment: ${experiment_url}"
+                  echo ""
+                fi
+                echo "| Example | Evaluator | Score | Explanation |"
+                echo "| --- | --- | --- | --- |"
+                jq -r '
+                  .failures[] | . as $f
+                  | ((if .task_error != null
+                      then [{name: "(task)", score: "error", text: .task_error}]
+                      else [] end)
+                     + [.evaluations[] | select(.passed | not)
+                        | {name,
+                           score: (if .error != null then "error"
+                                   elif .score == null then "missing"
+                                   else (.score | tostring) end),
+                           text: (.error // .explanation // "")}])[]
+                  | "| `\($f.example_id)` | `\(.name)` | \(.score) | \(.text | gsub("[|]"; "\\|") | gsub("\n"; " ") | .[0:200]) |"
+                ' "${report_json}"
+              fi
+              if [[ -f "${report_md}" ]]; then
+                local report_bytes
+                report_bytes="$(wc -c < "${report_md}")"
+                if [[ "${report_bytes}" -lt "${summary_embed_budget}" ]]; then
+                  summary_embed_budget=$((summary_embed_budget - report_bytes))
+                  echo ""
+                  echo "<details><summary>Full failure report (paste into a coding agent)</summary>"
+                  echo ""
+                  cat "${report_md}"
+                  echo ""
+                  echo "</details>"
+                else
+                  echo ""
+                  echo "Full report too large to embed here — fetch it with" \
+                    "\`gh run view ${GITHUB_RUN_ID} --log-failed\` or" \
+                    "\`gh run download ${GITHUB_RUN_ID} -n pxi-eval-reports-${GITHUB_RUN_ID}\`."
+                fi
+              fi
+            } >> "${step_summary}"
+          }
 
           for dataset_file in "${dataset_files[@]}"; do
             dataset="$(basename "${dataset_file}" .yaml)"
@@ -74,6 +161,7 @@ jobs:
               --dataset "${dataset}" \
               --splits regression \
               --fail-on-regression \
+              --report-dir "${report_dir}" \
               --experiment-name "${experiment_name}"; then
               dataset_result=0
             else
@@ -84,8 +172,29 @@ jobs:
             if [[ "${dataset_result}" -ne 0 ]]; then
               failed=1
               failed_datasets+=("${dataset}")
-              echo "❌ ${dataset}: regressions detected — expand above for details"
-              echo "::error title=PXI eval regression failure::Dataset '${dataset}' had regression failures. Expand the '${dataset}' group above for the full failure table."
+              # Embed the full agent-readable report in the job log under its
+              # own collapsed group. The sentinel markers inside the report
+              # (===== BEGIN/END PXI EVAL REPORT: <dataset> =====) make it
+              # greppable from `gh run view <run-id> --log-failed`. The report
+              # embeds untrusted model output, so suspend workflow-command
+              # processing while printing it: a payload line starting with
+              # '::' must not close the group or spoof annotations.
+              # A missing report file means the runner crashed before writing
+              # one (e.g. an infrastructure error), not a confirmed regression.
+              report_md="${report_dir}/${dataset}.report.md"
+              if [[ -f "${report_md}" ]]; then
+                echo "❌ ${dataset}: regressions detected — see the failure report group below"
+                stop_token="pxi-report-${GITHUB_RUN_ID}-${RANDOM}${RANDOM}"
+                echo "::group::PXI EVAL FAILURE REPORT (agent-readable): ${dataset}"
+                echo "::stop-commands::${stop_token}"
+                cat "${report_md}"
+                echo "::${stop_token}::"
+                echo "::endgroup::"
+                echo "::error title=PXI eval regression failure::Dataset '${dataset}' had regression failures. Expand 'PXI EVAL FAILURE REPORT (agent-readable): ${dataset}' above, or fetch it with: gh run view ${GITHUB_RUN_ID} --log-failed"
+              else
+                echo "❌ ${dataset}: run failed before a report could be written — expand above for details"
+                echo "::error title=PXI eval failure::Dataset '${dataset}' failed before a report could be written. Expand the '${dataset}' group above for the runner output."
+              fi
               echo "| \`${dataset}\` | ❌ FAILED |" >> "${step_summary}"
             else
               echo "✅ ${dataset}: all passed"
@@ -105,7 +214,16 @@ jobs:
               echo "**Result: ❌ ${n_failed} of ${total} datasets failed**"
               echo ""
               echo "Failed: $(IFS=', '; echo "${failed_datasets[*]}")"
+              echo ""
+              echo "Agent-readable reports: \`gh run view ${GITHUB_RUN_ID} --log-failed\`" \
+                "(full reports are in the failed step log between" \
+                "\`===== BEGIN PXI EVAL REPORT\` markers) or" \
+                "\`gh run download ${GITHUB_RUN_ID} -n pxi-eval-reports-${GITHUB_RUN_ID}\`" \
+                "for the JSON artifacts."
             } >> "${step_summary}"
+            for dataset in "${failed_datasets[@]}"; do
+              append_failure_summary "${dataset}"
+            done
           else
             echo "RESULT: all ${total} dataset(s) passed"
             {
@@ -115,3 +233,10 @@ jobs:
           fi
 
           exit "${failed}"
+      - name: Upload eval failure reports
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: pxi-eval-reports-${{ github.run_id }}
+          path: ${{ runner.temp }}/pxi-eval-reports/
+          if-no-files-found: ignore

--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -39,6 +39,62 @@ uv run python -m evals.pxi.harness.run_experiment --dataset set_spans_filter --s
 `regression` example. The runner prints a stdout summary and the Phoenix
 experiment URL.
 
+## Failure Reports
+
+The console summary keeps its compact, truncated tables -- that is the
+glance tier. For full-fidelity output there are two flags:
+
+### `--print-report` (local use)
+
+Pass `--print-report` to dump the full Markdown failure report to stdout at
+the end of the run. No-op when all examples pass.
+
+```bash
+uv run python -m evals.pxi.harness.run_experiment \
+  --dataset set_spans_filter --print-report
+```
+
+This is the recommended way to see full failure details locally: inputs,
+expected outputs, the agent's actual tool calls, per-evaluator
+scores/labels/explanations, and a Phoenix trace link -- all in one place in
+your terminal without writing any files.
+
+### `--report-dir DIR` (CI / artifact use)
+
+Pass `--report-dir` to write two files per dataset run:
+
+- **`<dataset>.report.json`** -- machine-readable: run metadata (experiment
+  name and URL, git sha/branch, model, provider, splits, timestamp) plus one
+  record per *failed or errored* example with the full untruncated `input`,
+  `expected`, `actual_output` (including every tool call the agent made),
+  per-evaluator score/label/explanation/error, any `task_error`, and a
+  per-example trace URL (`<base-url>/redirects/traces/<trace_id>`) when the
+  run was traced. Passing examples contribute to counts only.
+- **`<dataset>.report.md`** -- the same content as agent-friendly Markdown:
+  a digest table up top, one section per failed example (message histories
+  collapsed under `<details>`), and a repro footer with the exact local
+  command. The whole report is wrapped in sentinel markers
+  (`===== BEGIN PXI EVAL REPORT: <dataset> =====` / `===== END ... =====`)
+  so it can be grepped out of a CI log. Paste this into a coding agent to
+  diagnose and fix the failure -- it is self-sufficient context.
+
+In CI the workflow passes `--report-dir` rather than `--print-report` because
+GitHub Actions interprets any log line starting with `::` as a workflow
+command (e.g. `::endgroup::` closes a log group, `::error::` creates an
+annotation). Model output in the report can contain such lines, so the
+workflow writes to a file first and then `cat`s the file inside a
+`::stop-commands::` block to suspend command processing while the untrusted
+content is being logged. See `.github/workflows/pxi-evals.yml` for the full
+pattern.
+
+If a report would exceed GitHub's embedding limits (~1 MiB for step
+summaries, ~64 KiB per log line), the Markdown tier falls back to its digest
+plus a pointer at the JSON artifact; the JSON file never truncates example
+data. The one deliberate redaction in both tiers: the static system prompt
+that pydantic_ai repeats under `messages[].instructions` (~55 KB per model
+request) is replaced with a placeholder -- it is product prompt, not example
+data, and the full text is always viewable via the trace URL.
+
 The runner checks `/healthz` against whichever Phoenix URL is configured
 (default `http://localhost:6006`, or `PHOENIX_COLLECTOR_ENDPOINT` /
 `OTEL_EXPORTER_OTLP_ENDPOINT` if set) before uploading anything. To use a
@@ -285,8 +341,38 @@ Phoenix Cloud. It runs on PRs that change `evals/**` or
 the Actions tab.
 
 The workflow invokes the runner for every YAML file in
-`evals/pxi/datasets/*.yaml` with `--splits regression` and
-`--fail-on-regression`. The runner skips datasets when the requested split has
-no regression examples. Each dataset run is printed as its own log group with
-the dataset file and CI experiment name. The workflow keeps going after
-individual dataset failures, and the final status is red if any dataset fails.
+`evals/pxi/datasets/*.yaml` with `--splits regression`,
+`--fail-on-regression`, and `--report-dir`. The runner skips datasets when
+the requested split has no regression examples. Each dataset run is printed
+as its own log group with the dataset file and CI experiment name. The
+workflow keeps going after individual dataset failures, and the final status
+is red if any dataset fails.
+
+### Reading a CI failure
+
+Failure output is published through three channels, ranked by how you (or a
+coding agent) consume it:
+
+1. **Job log (primary, agents).** Each failed dataset's full Markdown report
+   is embedded in the log under a collapsed
+   `PXI EVAL FAILURE REPORT (agent-readable): <dataset>` group, wrapped in
+   `===== BEGIN/END PXI EVAL REPORT: <dataset> =====` sentinels. Retrieval
+   from a red check is two commands:
+
+   ```bash
+   gh pr checks <pr-number>           # find the failing run id from its URL
+   gh run view <run-id> --log-failed  # full agent-readable reports
+   ```
+
+   Paste the report between the sentinels into a coding agent; the repro
+   footer and experiment URL make it self-sufficient.
+2. **Step summary (humans).** The run's summary page shows the dataset
+   pass/fail table, a digest table per failed dataset (example id,
+   evaluator, score, one-line explanation, experiment link), and the full
+   report inside a `<details>` block for browser copy-paste.
+3. **JSON artifact (programmatic).** Both report files for every dataset are
+   uploaded as the `pxi-eval-reports-<run-id>` artifact on every run:
+
+   ```bash
+   gh run download <run-id> -n pxi-eval-reports-<run-id>
+   ```

--- a/evals/pxi/harness/reporting.py
+++ b/evals/pxi/harness/reporting.py
@@ -1,0 +1,709 @@
+"""Reporting helpers for the PXI eval experiment runner.
+
+Pure functions over :class:`RanExperiment` and :class:`EvalDataset` -- no
+Phoenix network calls -- so the console summary and failure reports stay
+unit-testable without a live server.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from urllib.parse import urljoin
+
+from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
+
+from evals.pxi.harness.datasets import DATASETS_DIR, EvalDataset
+
+PASSING_SCORE = 1.0
+MAX_TABLE_CELL_WIDTH = 80
+
+# Repo-relative datasets dir for report links and repro commands, derived
+# from the same constant the loader uses so a relocation updates both.
+_DATASETS_DIR_RELATIVE = DATASETS_DIR.relative_to(DATASETS_DIR.parents[2])
+
+REPORT_SCHEMA_VERSION = 1
+# GitHub step summaries cap at 1 MiB and log lines at ~64 KiB. Keep the
+# rendered Markdown comfortably under the summary cap; fall back to a
+# digest-only report when a pathological dataset-wide failure would blow
+# past it.
+MAX_REPORT_MD_BYTES = 800_000
+MAX_REPORT_LINE_CHARS = 16_000
+_DIGEST_EXPLANATION_CHARS = 200
+
+
+def _format_table(headers: tuple[str, ...], rows: Sequence[tuple[str, ...]]) -> str:
+    widths = [
+        max(len(header), *(len(row[index]) for row in rows)) for index, header in enumerate(headers)
+    ]
+    rule = "+" + "+".join("-" * (width + 2) for width in widths) + "+"
+
+    def format_row(row: tuple[str, ...]) -> str:
+        cells = [value.ljust(widths[index]) for index, value in enumerate(row)]
+        return "| " + " | ".join(cells) + " |"
+
+    lines = [rule, format_row(headers), rule]
+    lines.extend(format_row(row) for row in rows)
+    lines.append(rule)
+    return "\n".join(lines)
+
+
+def _truncate_cell(value: Any) -> str:
+    text = str(value)
+    if len(text) <= MAX_TABLE_CELL_WIDTH:
+        return text
+    return text[: MAX_TABLE_CELL_WIDTH - 3] + "..."
+
+
+def _result_field(evaluation_run: ExperimentEvaluationRun, key: str) -> str:
+    result = evaluation_run.result
+    if not isinstance(result, dict):
+        return ""
+    value = result.get(key)
+    return "" if value is None else _truncate_cell(value)
+
+
+def _task_error_rows(experiment: RanExperiment) -> list[tuple[str, str]]:
+    rows: list[tuple[str, str]] = []
+    for task_run in experiment.get("task_runs", []):
+        error = _task_run_error(task_run)
+        if not error:
+            continue
+        rows.append((_truncate_cell(_stable_example_id(task_run)), _truncate_cell(error)))
+    return rows
+
+
+def _score_display(error: str | None, score: float | None) -> str:
+    """Single source of truth for rendering an evaluation's score state."""
+    if error is not None:
+        return "error"
+    if score is None:
+        return "missing"
+    return f"{score:g}"
+
+
+def _failed_evaluation_rows(
+    experiment: RanExperiment,
+    evaluation_runs: Sequence[ExperimentEvaluationRun],
+) -> list[tuple[str, str, str, str, str]]:
+    task_runs_by_id = {
+        str(task_run["id"]): task_run
+        for task_run in experiment.get("task_runs", [])
+        if "id" in task_run
+    }
+    rows: list[tuple[str, str, str, str, str]] = []
+    for evaluation_run in evaluation_runs:
+        if not _is_failed_evaluation(evaluation_run):
+            continue
+        task_run = task_runs_by_id.get(str(evaluation_run.experiment_run_id))
+        example_id = (
+            _stable_example_id(task_run) if task_run else str(evaluation_run.experiment_run_id)
+        )
+        rows.append(
+            (
+                _truncate_cell(example_id),
+                _truncate_cell(evaluation_run.name or "unknown"),
+                _score_display(evaluation_run.error, _score(evaluation_run)),
+                _result_field(evaluation_run, "label"),
+                _truncate_cell(
+                    evaluation_run.error or _result_field(evaluation_run, "explanation")
+                ),
+            )
+        )
+    return rows
+
+
+def _score(evaluation_run: ExperimentEvaluationRun) -> float | None:
+    result = evaluation_run.result
+    if not isinstance(result, dict):
+        return None
+    value = result.get("score")
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def _example_splits_by_id(dataset: EvalDataset) -> dict[str, set[str]]:
+    return {
+        str(example["id"]): {str(split) for split in example["splits"]}
+        for example in dataset.examples
+    }
+
+
+def _is_failed_evaluation(evaluation_run: ExperimentEvaluationRun) -> bool:
+    score = _score(evaluation_run)
+    return evaluation_run.error is not None or score is None or score < PASSING_SCORE
+
+
+def _evaluator_summary_rows(
+    evaluation_runs: Sequence[ExperimentEvaluationRun],
+) -> list[tuple[str, dict[str, int]]]:
+    by_evaluator: dict[str, dict[str, int]] = {}
+    for evaluation_run in evaluation_runs:
+        name = str(evaluation_run.name or "unknown")
+        summary = by_evaluator.setdefault(
+            name,
+            {"total": 0, "passing": 0, "failing": 0, "missing_score": 0, "errors": 0},
+        )
+        summary["total"] += 1
+        score = _score(evaluation_run)
+        if evaluation_run.error is not None:
+            summary["errors"] += 1
+            summary["failing"] += 1
+        elif score is None:
+            summary["missing_score"] += 1
+            summary["failing"] += 1
+        elif score >= PASSING_SCORE:
+            summary["passing"] += 1
+        else:
+            summary["failing"] += 1
+    return sorted(by_evaluator.items())
+
+
+def _has_regression_evaluator_failure(
+    dataset: EvalDataset,
+    experiment: RanExperiment,
+    evaluation_runs: Sequence[ExperimentEvaluationRun],
+) -> bool:
+    splits_by_id = _example_splits_by_id(dataset)
+    task_runs_by_id = {
+        str(task_run["id"]): task_run
+        for task_run in experiment.get("task_runs", [])
+        if "id" in task_run
+    }
+    for evaluation_run in evaluation_runs:
+        if not _is_failed_evaluation(evaluation_run):
+            continue
+        task_run = task_runs_by_id.get(str(evaluation_run.experiment_run_id))
+        if task_run is None:
+            continue
+        example_id = _stable_example_id(task_run)
+        if "regression" in splits_by_id.get(example_id, set()):
+            return True
+    return False
+
+
+def _print_score_summary(dataset: EvalDataset, experiment: RanExperiment, *, base_url: str) -> bool:
+    experiment_url = _experiment_url(experiment, base_url)
+    if experiment_url:
+        print(f"Experiment: {experiment_url}")
+    evaluation_runs = list(experiment.get("evaluation_runs") or [])
+    evaluator_summaries = _evaluator_summary_rows(evaluation_runs)
+
+    print(f"Dataset: {dataset.dataset_name} ({len(experiment.get('task_runs', []))} examples run)")
+    task_error_rows = _task_error_rows(experiment)
+    if task_error_rows:
+        print(f"Task errors: {len(task_error_rows)}/{len(experiment.get('task_runs', []))}")
+        print(_format_table(("Example", "Error"), task_error_rows))
+    if evaluator_summaries:
+        rows = []
+        for name, summary in evaluator_summaries:
+            total = int(summary["total"])
+            passing = int(summary["passing"])
+            pass_rate = f"{passing / total:.0%}" if total else "n/a"
+            rows.append(
+                (
+                    name,
+                    str(total),
+                    str(passing),
+                    str(summary["failing"]),
+                    str(summary["errors"]),
+                    str(summary["missing_score"]),
+                    pass_rate,
+                )
+            )
+        print(f"Evaluator results (passing score >= {PASSING_SCORE:g}):")
+        print(
+            _format_table(
+                ("Evaluator", "Total", "Passed", "Failed", "Errors", "Missing", "Pass Rate"),
+                rows,
+            )
+        )
+        failed_rows = _failed_evaluation_rows(experiment, evaluation_runs)
+        if failed_rows:
+            print("Failed evaluations:")
+            print(_format_table(("Example", "Evaluator", "Score", "Label", "Details"), failed_rows))
+    return _has_regression_evaluator_failure(dataset, experiment, evaluation_runs)
+
+
+# ---------------------------------------------------------------------------
+# Failure reports (closes #13668)
+#
+# Two output tiers per dataset run:
+#   <dataset>.report.json  -- machine/agent-readable, full fidelity
+#   <dataset>.report.md    -- human/agent-friendly; the "paste into a coding
+#                             agent" artifact, embedded in the CI job log
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EvaluationRecord:
+    """One evaluator's verdict on a single example, untruncated."""
+
+    name: str
+    score: float | None
+    label: str | None
+    explanation: str | None
+    error: str | None
+    passed: bool
+
+
+@dataclass(frozen=True)
+class ExampleFailure:
+    """A failed or errored example with everything an agent needs to act."""
+
+    example_id: str
+    splits: list[str]
+    trace_id: str | None
+    trace_url: str | None
+    input: Any
+    expected: Any
+    actual_output: Any
+    task_error: str | None
+    evaluations: list[EvaluationRecord]
+
+
+@dataclass(frozen=True)
+class Report:
+    """Full failure report for one dataset run."""
+
+    dataset_name: str
+    # CLI stem (``--dataset <stem>``): keys the report file names, sentinel
+    # markers, and repro command, matching how CI iterates dataset files.
+    dataset_stem: str
+    dataset_file: str
+    experiment_name: str | None
+    experiment_url: str | None
+    git_sha: str
+    git_branch: str
+    assistant_provider: str
+    assistant_model: str
+    splits: list[str]
+    generated_at: str
+    examples_run: int
+    examples_passed: int
+    evaluator_summary: list[dict[str, Any]]
+    failures: list[ExampleFailure]
+    repro_command: str
+    schema_version: int = REPORT_SCHEMA_VERSION
+    notes: list[str] = field(default_factory=list)
+
+
+def _experiment_url(experiment: RanExperiment, base_url: str) -> str | None:
+    if not experiment.get("experiment_id"):
+        return None
+    return urljoin(
+        base_url.rstrip("/") + "/",
+        f"datasets/{experiment['dataset_id']}/compare?experimentId={experiment['experiment_id']}",
+    )
+
+
+def _trace_url(trace_id: str | None, base_url: str) -> str | None:
+    """Per-trace deep link via Phoenix's OTEL-id redirect route.
+
+    ``/redirects/traces/<trace_otel_id>`` resolves a bare OTEL trace id to
+    the project trace page without needing the project node id.
+    """
+    if not trace_id:
+        return None
+    return urljoin(base_url.rstrip("/") + "/", f"redirects/traces/{trace_id}")
+
+
+def _task_run_error(task_run: Mapping[str, Any]) -> str | None:
+    output = task_run.get("output")
+    output_error = output.get("error") if isinstance(output, dict) else None
+    error = task_run.get("error") or output_error
+    return str(error) if error else None
+
+
+def _stable_example_id(task_run: Mapping[str, Any]) -> str:
+    output = task_run.get("output")
+    if isinstance(output, dict) and isinstance(output.get("stable_example_id"), str):
+        return str(output["stable_example_id"])
+    return str(task_run.get("dataset_example_id", ""))
+
+
+# The serialized pydantic_ai messages repeat the full static system prompt
+# (~55 KB) on every model request under ``instructions``. That is product
+# prompt, not example data -- it dominates report size and drowns the signal
+# when pasted into an agent. Replace anything past this threshold with a
+# placeholder; the untouched prompt is viewable via the trace URL.
+_MAX_INLINE_INSTRUCTIONS_CHARS = 2_000
+
+
+def _strip_static_instructions(actual_output: Any) -> tuple[Any, bool]:
+    """Replace oversized static ``instructions`` fields in the task output's
+    serialized messages with a placeholder. Returns the (possibly copied)
+    output and whether anything was replaced."""
+    if not isinstance(actual_output, dict) or not isinstance(actual_output.get("messages"), list):
+        return actual_output, False
+    stripped = False
+    messages: list[Any] = []
+    for message in actual_output["messages"]:
+        instructions = message.get("instructions") if isinstance(message, dict) else None
+        if isinstance(instructions, str) and len(instructions) > _MAX_INLINE_INSTRUCTIONS_CHARS:
+            message = {
+                **message,
+                "instructions": (
+                    f"<static system instructions omitted ({len(instructions)} chars); "
+                    "see the trace URL for the full prompt>"
+                ),
+            }
+            stripped = True
+        messages.append(message)
+    if not stripped:
+        return actual_output, False
+    return {**actual_output, "messages": messages}, True
+
+
+def _evaluation_record(evaluation_run: ExperimentEvaluationRun) -> EvaluationRecord:
+    result = evaluation_run.result if isinstance(evaluation_run.result, dict) else {}
+    label = result.get("label")
+    explanation = result.get("explanation")
+    return EvaluationRecord(
+        name=str(evaluation_run.name or "unknown"),
+        score=_score(evaluation_run),
+        label=str(label) if label is not None else None,
+        explanation=str(explanation) if explanation is not None else None,
+        error=evaluation_run.error,
+        passed=not _is_failed_evaluation(evaluation_run),
+    )
+
+
+def build_report(
+    dataset: EvalDataset,
+    experiment: RanExperiment,
+    *,
+    base_url: str,
+    splits: Sequence[str],
+    experiment_name: str | None = None,
+    generated_at: str | None = None,
+    dataset_arg: str | None = None,
+) -> Report:
+    """Build a failure report from a completed experiment.
+
+    Pure function over ``RanExperiment`` + ``EvalDataset`` -- no Phoenix
+    calls. Only failed or errored examples carry full payloads; passing
+    examples contribute to counts only, keeping artifacts small.
+    """
+    metadata = dict(experiment.get("experiment_metadata") or {})
+    examples_by_id = {str(example["id"]): example for example in dataset.examples}
+    evaluations_by_run_id: dict[str, list[ExperimentEvaluationRun]] = {}
+    for evaluation_run in experiment.get("evaluation_runs") or []:
+        evaluations_by_run_id.setdefault(str(evaluation_run.experiment_run_id), []).append(
+            evaluation_run
+        )
+
+    failures: list[ExampleFailure] = []
+    instructions_stripped = False
+    task_runs = list(experiment.get("task_runs") or [])
+    for task_run in task_runs:
+        task_error = _task_run_error(task_run)
+        evaluations = [
+            _evaluation_record(run)
+            for run in evaluations_by_run_id.get(str(task_run.get("id", "")), [])
+        ]
+        if task_error is None and all(record.passed for record in evaluations):
+            continue
+        example_id = _stable_example_id(task_run)
+        example = examples_by_id.get(example_id, {})
+        trace_id = task_run.get("trace_id")
+        actual_output, stripped = _strip_static_instructions(task_run.get("output"))
+        instructions_stripped = instructions_stripped or stripped
+        failures.append(
+            ExampleFailure(
+                example_id=example_id,
+                splits=[str(split) for split in example.get("splits", [])],
+                trace_id=str(trace_id) if trace_id else None,
+                trace_url=_trace_url(str(trace_id) if trace_id else None, base_url),
+                input=example.get("input"),
+                expected=example.get("expected"),
+                actual_output=actual_output,
+                task_error=task_error,
+                evaluations=evaluations,
+            )
+        )
+
+    evaluator_summary = [
+        {"name": name, **summary}
+        for name, summary in _evaluator_summary_rows(list(experiment.get("evaluation_runs") or []))
+    ]
+    # ``dataset_arg`` is the CLI stem (``--dataset <stem>``), which is what
+    # both the YAML path and the repro command actually need; the YAML's
+    # ``dataset_name`` is only a fallback that usually matches the stem.
+    dataset_stem = dataset_arg or dataset.dataset_name
+    return Report(
+        dataset_name=dataset.dataset_name,
+        dataset_stem=dataset_stem,
+        dataset_file=str(_DATASETS_DIR_RELATIVE / f"{dataset_stem}.yaml"),
+        experiment_name=experiment_name,
+        experiment_url=_experiment_url(experiment, base_url),
+        git_sha=str(metadata.get("git_sha", "unknown")),
+        git_branch=str(metadata.get("git_branch", "unknown")),
+        assistant_provider=str(metadata.get("assistant_provider", "unknown")),
+        assistant_model=str(metadata.get("assistant_model", "unknown")),
+        splits=[str(split) for split in splits],
+        generated_at=generated_at or datetime.now(timezone.utc).isoformat(),
+        examples_run=len(task_runs),
+        examples_passed=len(task_runs) - len(failures),
+        evaluator_summary=evaluator_summary,
+        failures=failures,
+        repro_command=(
+            "uv run python -m evals.pxi.harness.run_experiment "
+            f"--dataset {dataset_stem} --splits {' '.join(str(s) for s in splits)}"
+        ),
+        notes=(
+            [
+                "Static system instructions were replaced with a placeholder in "
+                "actual_output.messages; open the trace URL for the full prompt."
+            ]
+            if instructions_stripped
+            else []
+        ),
+    )
+
+
+def report_to_json(report: Report) -> str:
+    """Serialize the full-fidelity report as indented JSON (untruncated)."""
+    return json.dumps(dataclasses.asdict(report), indent=2, default=str)
+
+
+def _first_line(text: str | None, limit: int = _DIGEST_EXPLANATION_CHARS) -> str:
+    if not text:
+        return ""
+    line = text.strip().splitlines()[0] if text.strip() else ""
+    if len(line) > limit:
+        return line[: limit - 1] + "…"
+    return line
+
+
+def _wrap_long_lines(text: str, width: int = MAX_REPORT_LINE_CHARS) -> str:
+    """Soft-wrap pathological single-line payloads so log lines stay under
+    GitHub's ~64 KiB per-line cap."""
+    lines = text.splitlines()
+    if all(len(line) <= width for line in lines):
+        return text
+    wrapped: list[str] = []
+    for line in lines:
+        if len(line) <= width:
+            wrapped.append(line)
+        else:
+            wrapped.extend(line[start : start + width] for start in range(0, len(line), width))
+    return "\n".join(wrapped)
+
+
+def _fenced_block(text: str, lang: str = "") -> str:
+    """Fence ``text`` with enough backticks that no backtick run inside it
+    (e.g. an evaluator explanation quoting a code fence) can close the block
+    early and corrupt the rest of the report."""
+    longest_run = max((len(match.group(0)) for match in re.finditer(r"`+", text)), default=0)
+    fence = "`" * max(3, longest_run + 1)
+    return f"{fence}{lang}\n{text}\n{fence}"
+
+
+def _json_block(value: Any) -> str:
+    return _fenced_block(json.dumps(value, indent=2, default=str), "json")
+
+
+def _payload_section(title: str, value: Any) -> list[str]:
+    """Render an input/output payload, collapsing message histories (which can
+    be very long post-#13474) under ``<details>`` while keeping everything
+    else open."""
+    lines = [f"**{title}:**", ""]
+    if isinstance(value, dict) and isinstance(value.get("messages"), list):
+        rest = {key: val for key, val in value.items() if key != "messages"}
+        if rest:
+            lines.extend([_json_block(rest), ""])
+        messages = value["messages"]
+        lines.extend(
+            [
+                "<details>",
+                f"<summary>{title.lower()} messages ({len(messages)})</summary>",
+                "",
+                _json_block(messages),
+                "",
+                "</details>",
+                "",
+            ]
+        )
+    else:
+        lines.extend([_json_block(value), ""])
+    return lines
+
+
+def _tool_calls_from_output(actual_output: Any) -> list[dict[str, Any]]:
+    """Extract ``tool-call`` parts from the serialized pydantic_ai messages in
+    the task output, so the report surfaces what the agent actually did."""
+    if not isinstance(actual_output, dict):
+        return []
+    calls: list[dict[str, Any]] = []
+    for message in actual_output.get("messages") or []:
+        if not isinstance(message, dict):
+            continue
+        for part in message.get("parts") or []:
+            if isinstance(part, dict) and part.get("part_kind") == "tool-call":
+                calls.append({"tool_name": part.get("tool_name"), "args": part.get("args")})
+    return calls
+
+
+def _digest_rows(report: Report) -> list[tuple[str, str, str, str]]:
+    rows: list[tuple[str, str, str, str]] = []
+    for failure in report.failures:
+        if failure.task_error is not None:
+            rows.append((failure.example_id, "(task)", "error", _first_line(failure.task_error)))
+        for record in failure.evaluations:
+            if record.passed:
+                continue
+            rows.append(
+                (
+                    failure.example_id,
+                    record.name,
+                    _score_display(record.error, record.score),
+                    _first_line(record.error or record.explanation),
+                )
+            )
+    return rows
+
+
+def _md_header(report: Report) -> list[str]:
+    failed = len(report.failures)
+    lines = [
+        f"# PXI Eval Failure Report: {report.dataset_name}",
+        "",
+        f"- **Experiment**: {report.experiment_name or 'unknown'}"
+        + (f" — {report.experiment_url}" if report.experiment_url else ""),
+        f"- **Dataset file**: `{report.dataset_file}`",
+        f"- **Git**: `{report.git_branch}` @ `{report.git_sha}`",
+        f"- **Model**: {report.assistant_provider}/{report.assistant_model}",
+        f"- **Splits**: {', '.join(report.splits)}",
+        f"- **Generated**: {report.generated_at}",
+        f"- **Examples**: {report.examples_run} run, "
+        f"{report.examples_passed} passed, {failed} failed",
+        "",
+    ]
+    digest = _digest_rows(report)
+    if digest:
+        lines.extend(
+            [
+                "## Digest",
+                "",
+                "| Example | Evaluator | Score | Explanation |",
+                "| --- | --- | --- | --- |",
+            ]
+        )
+        lines.extend(
+            f"| `{example}` | `{evaluator}` | {score} | {_md_escape_cell(explanation)} |"
+            for example, evaluator, score, explanation in digest
+        )
+        lines.append("")
+    return lines
+
+
+def _md_escape_cell(text: str) -> str:
+    return text.replace("|", "\\|").replace("\n", " ")
+
+
+def _md_failure_section(failure: ExampleFailure) -> list[str]:
+    lines = [f"### Example: `{failure.example_id}`", ""]
+    if failure.splits:
+        lines.append(f"- **Splits**: {', '.join(failure.splits)}")
+    if failure.trace_url:
+        lines.append(f"- **Trace**: {failure.trace_url}")
+    lines.append("")
+    if failure.task_error is not None:
+        lines.extend(["**Task error:**", "", _fenced_block(failure.task_error, "text"), ""])
+    failed_evaluations = [record for record in failure.evaluations if not record.passed]
+    for record in failed_evaluations:
+        token = _score_display(record.error, record.score)
+        score = {"error": "error", "missing": "missing score"}.get(token, f"score {token}")
+        label = f" — label `{record.label}`" if record.label else ""
+        lines.extend([f"#### `{record.name}` — {score}{label}", ""])
+        detail = record.error or record.explanation
+        if detail:
+            lines.extend([_fenced_block(detail, "text"), ""])
+    tool_calls = _tool_calls_from_output(failure.actual_output)
+    if tool_calls:
+        lines.extend(["**Tool calls made:**", "", _json_block(tool_calls), ""])
+    if failure.input is not None:
+        lines.extend(_payload_section("Input", failure.input))
+    if failure.expected is not None:
+        lines.extend(_payload_section("Expected", failure.expected))
+    if failure.actual_output is not None:
+        lines.extend(_payload_section("Actual output", failure.actual_output))
+    return lines
+
+
+def _md_footer(report: Report) -> list[str]:
+    lines = [
+        "## Repro",
+        "",
+        "Run this dataset locally:",
+        "",
+        "```bash",
+        report.repro_command,
+        "```",
+        "",
+    ]
+    if report.experiment_url:
+        lines.extend([f"Experiment (Phoenix): {report.experiment_url}", ""])
+    return lines
+
+
+def report_to_markdown(report: Report, *, max_bytes: int = MAX_REPORT_MD_BYTES) -> str:
+    """Render the Markdown report, wrapped in sentinel markers so it can be
+    grepped out of a CI job log.
+
+    If the full render would exceed ``max_bytes`` (GitHub step-summary /
+    log-embedding limits), fall back to the digest plus a pointer at the
+    JSON artifact instead of truncating fields silently.
+    """
+    begin = f"===== BEGIN PXI EVAL REPORT: {report.dataset_stem} ====="
+    end = f"===== END PXI EVAL REPORT: {report.dataset_stem} ====="
+
+    def render(include_failures: bool, notes: Sequence[str]) -> str:
+        lines = [begin, ""]
+        lines.extend(_md_header(report))
+        for note in notes:
+            lines.extend([f"> **Note**: {note}", ""])
+        if include_failures and report.failures:
+            lines.append("## Failures")
+            lines.append("")
+            for failure in report.failures:
+                lines.extend(_md_failure_section(failure))
+        lines.extend(_md_footer(report))
+        lines.append(end)
+        return _wrap_long_lines("\n".join(lines))
+
+    full = render(True, report.notes)
+    if len(full.encode("utf-8")) <= max_bytes:
+        return full
+    return render(
+        False,
+        [
+            *report.notes,
+            "Full failure payloads exceeded the report size limit and were "
+            f"omitted ({len(report.failures)} failed examples). Download the "
+            f"untruncated JSON report ({report.dataset_stem}.report.json) from "
+            "the `pxi-eval-reports-<run-id>` workflow artifact: "
+            "`gh run download <run-id> -n pxi-eval-reports-<run-id>`.",
+        ],
+    )
+
+
+def write_reports(report: Report, report_dir: Path) -> tuple[Path, Path]:
+    """Write ``<stem>.report.json`` and ``<stem>.report.md`` under
+    ``report_dir`` (created if missing). Returns the two paths.
+
+    File names are keyed by ``dataset_stem`` (the ``--dataset`` CLI value),
+    NOT the YAML's free-form ``dataset_name``: the CI workflow looks reports
+    up by the dataset file stem, and nothing forces the two to match.
+    """
+    report_dir.mkdir(parents=True, exist_ok=True)
+    json_path = report_dir / f"{report.dataset_stem}.report.json"
+    md_path = report_dir / f"{report.dataset_stem}.report.md"
+    json_path.write_text(report_to_json(report) + "\n")
+    md_path.write_text(report_to_markdown(report) + "\n")
+    return json_path, md_path

--- a/evals/pxi/harness/run_experiment.py
+++ b/evals/pxi/harness/run_experiment.py
@@ -5,6 +5,7 @@ import asyncio
 import os
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.request
 from contextlib import AsyncExitStack
@@ -12,13 +13,14 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Sequence, cast
-from urllib.parse import urljoin
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
+from urllib.parse import urljoin
+
 from phoenix.client import AsyncClient
-from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
+from phoenix.client.resources.experiments.types import RanExperiment
 from phoenix.client.utils.config import get_base_url, get_env_phoenix_api_key
 
 from evals.pxi.evaluators import EVALUATORS_BY_NAME
@@ -34,10 +36,14 @@ from evals.pxi.harness.datasets import (
     EvalDataset,
     load_dataset,
 )
+from evals.pxi.harness.reporting import (
+    _print_score_summary,
+    build_report,
+    report_to_markdown,
+    write_reports,
+)
 
 DEFAULT_BASE_URL = "http://localhost:6006"
-PASSING_SCORE = 1.0
-MAX_TABLE_CELL_WIDTH = 80
 
 
 @dataclass(frozen=True)
@@ -52,6 +58,8 @@ class ExperimentConfig:
     fail_on_regression: bool
     splits: tuple[str, ...]
     evaluator_override: tuple[str, ...] | None
+    report_dir: Path | None = None
+    print_report: bool = False
 
 
 def _resolve_evaluators(dataset: EvalDataset, override: tuple[str, ...] | None) -> list[Any]:
@@ -75,19 +83,41 @@ def _configured_base_url() -> tuple[str, bool]:
     return value.rstrip("/"), value.rstrip("/") != DEFAULT_BASE_URL
 
 
+_HEALTHZ_RETRIES = 3
+_HEALTHZ_RETRY_DELAY = 10  # seconds between attempts
+
+
 def _check_phoenix_healthz(base_url: str) -> None:
-    """Verify the configured Phoenix is reachable before uploading anything."""
-    try:
-        with urllib.request.urlopen(urljoin(base_url + "/", "healthz"), timeout=2) as response:
-            if response.status >= 400:
-                raise RuntimeError(
-                    f"Phoenix health check failed with HTTP {response.status}: {base_url}"
+    """Verify the configured Phoenix is reachable before uploading anything.
+
+    Retries up to ``_HEALTHZ_RETRIES`` times with a fixed delay so transient
+    blips (e.g. a 30-second Phoenix Cloud hiccup) don't permanently fail a
+    dataset run. Each attempt uses a short per-request timeout; the total wait
+    is at most ``_HEALTHZ_RETRIES * _HEALTHZ_RETRY_DELAY`` seconds.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(1, _HEALTHZ_RETRIES + 1):
+        try:
+            with urllib.request.urlopen(urljoin(base_url + "/", "healthz"), timeout=5) as response:
+                if response.status >= 400:
+                    raise RuntimeError(
+                        f"Phoenix health check failed with HTTP {response.status}: {base_url}"
+                    )
+                return  # success
+        except (OSError, urllib.error.URLError) as exc:
+            last_exc = exc
+            if attempt < _HEALTHZ_RETRIES:
+                print(
+                    f"Phoenix not reachable at {base_url} "
+                    f"(attempt {attempt}/{_HEALTHZ_RETRIES}), "
+                    f"retrying in {_HEALTHZ_RETRY_DELAY}s...",
+                    file=sys.stderr,
                 )
-    except (OSError, urllib.error.URLError) as exc:
-        raise RuntimeError(
-            f"Phoenix is unavailable at {base_url}. "
-            "Start Phoenix or fix PHOENIX_COLLECTOR_ENDPOINT."
-        ) from exc
+                time.sleep(_HEALTHZ_RETRY_DELAY)
+    raise RuntimeError(
+        f"Phoenix is unavailable at {base_url} after {_HEALTHZ_RETRIES} attempts. "
+        "Start Phoenix or fix PHOENIX_COLLECTOR_ENDPOINT."
+    ) from last_exc
 
 
 def _git_value(*args: str) -> str:
@@ -107,157 +137,6 @@ def _experiment_name(dataset: EvalDataset, config: ExperimentConfig) -> str:
     return "-".join(parts)
 
 
-def _format_table(headers: tuple[str, ...], rows: Sequence[tuple[str, ...]]) -> str:
-    widths = [
-        max(len(header), *(len(row[index]) for row in rows)) for index, header in enumerate(headers)
-    ]
-    rule = "+" + "+".join("-" * (width + 2) for width in widths) + "+"
-
-    def format_row(row: tuple[str, ...]) -> str:
-        cells = [value.ljust(widths[index]) for index, value in enumerate(row)]
-        return "| " + " | ".join(cells) + " |"
-
-    lines = [rule, format_row(headers), rule]
-    lines.extend(format_row(row) for row in rows)
-    lines.append(rule)
-    return "\n".join(lines)
-
-
-def _truncate_cell(value: Any) -> str:
-    text = str(value)
-    if len(text) <= MAX_TABLE_CELL_WIDTH:
-        return text
-    return text[: MAX_TABLE_CELL_WIDTH - 3] + "..."
-
-
-def _result_field(evaluation_run: ExperimentEvaluationRun, key: str) -> str:
-    result = evaluation_run.result
-    if not isinstance(result, dict):
-        return ""
-    value = result.get(key)
-    return "" if value is None else _truncate_cell(value)
-
-
-def _task_error_rows(experiment: RanExperiment) -> list[tuple[str, str]]:
-    rows: list[tuple[str, str]] = []
-    for task_run in experiment.get("task_runs", []):
-        output = task_run.get("output")
-        output_error = output.get("error") if isinstance(output, dict) else None
-        error = task_run.get("error") or output_error
-        if not error:
-            continue
-        stable_example_id = output.get("stable_example_id") if isinstance(output, dict) else None
-        example_id = stable_example_id or task_run["dataset_example_id"]
-        rows.append((_truncate_cell(example_id), _truncate_cell(error)))
-    return rows
-
-
-def _failed_evaluation_rows(
-    experiment: RanExperiment,
-    evaluation_runs: Sequence[ExperimentEvaluationRun],
-) -> list[tuple[str, str, str, str, str]]:
-    task_runs_by_id = {
-        str(task_run["id"]): task_run
-        for task_run in experiment.get("task_runs", [])
-        if "id" in task_run
-    }
-    rows: list[tuple[str, str, str, str, str]] = []
-    for evaluation_run in evaluation_runs:
-        score = _score(evaluation_run)
-        if evaluation_run.error is None and score is not None and score >= PASSING_SCORE:
-            continue
-        task_run = task_runs_by_id.get(str(evaluation_run.experiment_run_id))
-        example_id = (
-            task_run["dataset_example_id"] if task_run else str(evaluation_run.experiment_run_id)
-        )
-        rows.append(
-            (
-                _truncate_cell(example_id),
-                _truncate_cell(evaluation_run.name or "unknown"),
-                (
-                    "error"
-                    if evaluation_run.error is not None
-                    else "missing"
-                    if score is None
-                    else f"{score:g}"
-                ),
-                _result_field(evaluation_run, "label"),
-                _truncate_cell(
-                    evaluation_run.error or _result_field(evaluation_run, "explanation")
-                ),
-            )
-        )
-    return rows
-
-
-def _score(evaluation_run: ExperimentEvaluationRun) -> float | None:
-    result = evaluation_run.result
-    if not isinstance(result, dict):
-        return None
-    value = result.get("score")
-    return float(value) if isinstance(value, (int, float)) else None
-
-
-def _example_splits_by_id(dataset: EvalDataset) -> dict[str, set[str]]:
-    return {
-        str(example["id"]): {str(split) for split in example["splits"]}
-        for example in dataset.examples
-    }
-
-
-def _is_failed_evaluation(evaluation_run: ExperimentEvaluationRun) -> bool:
-    score = _score(evaluation_run)
-    return evaluation_run.error is not None or score is None or score < PASSING_SCORE
-
-
-def _evaluator_summary_rows(
-    evaluation_runs: Sequence[ExperimentEvaluationRun],
-) -> list[tuple[str, dict[str, int]]]:
-    by_evaluator: dict[str, dict[str, int]] = {}
-    for evaluation_run in evaluation_runs:
-        name = str(evaluation_run.name or "unknown")
-        summary = by_evaluator.setdefault(
-            name,
-            {"total": 0, "passing": 0, "failing": 0, "missing_score": 0, "errors": 0},
-        )
-        summary["total"] += 1
-        score = _score(evaluation_run)
-        if evaluation_run.error is not None:
-            summary["errors"] += 1
-            summary["failing"] += 1
-        elif score is None:
-            summary["missing_score"] += 1
-            summary["failing"] += 1
-        elif score >= PASSING_SCORE:
-            summary["passing"] += 1
-        else:
-            summary["failing"] += 1
-    return sorted(by_evaluator.items())
-
-
-def _has_regression_evaluator_failure(
-    dataset: EvalDataset,
-    experiment: RanExperiment,
-    evaluation_runs: Sequence[ExperimentEvaluationRun],
-) -> bool:
-    splits_by_id = _example_splits_by_id(dataset)
-    task_runs_by_id = {
-        str(task_run["id"]): task_run
-        for task_run in experiment.get("task_runs", [])
-        if "id" in task_run
-    }
-    for evaluation_run in evaluation_runs:
-        if not _is_failed_evaluation(evaluation_run):
-            continue
-        task_run = task_runs_by_id.get(str(evaluation_run.experiment_run_id))
-        if task_run is None:
-            continue
-        example_id = str(task_run["dataset_example_id"])
-        if "regression" in splits_by_id.get(example_id, set()):
-            return True
-    return False
-
-
 def _empty_experiment(phoenix_dataset: Any) -> RanExperiment:
     return {
         "experiment_id": "",
@@ -268,52 +147,6 @@ def _empty_experiment(phoenix_dataset: Any) -> RanExperiment:
         "experiment_metadata": {},
         "project_name": None,
     }
-
-
-def _print_score_summary(dataset: EvalDataset, experiment: RanExperiment, *, base_url: str) -> bool:
-    if experiment["experiment_id"]:
-        experiment_url = urljoin(
-            base_url.rstrip("/") + "/",
-            f"datasets/{experiment['dataset_id']}/compare?experimentId={experiment['experiment_id']}",
-        )
-        print(f"Experiment: {experiment_url}")
-    evaluation_runs = list(experiment.get("evaluation_runs") or [])
-    evaluator_summaries = _evaluator_summary_rows(evaluation_runs)
-
-    print(f"Dataset: {dataset.dataset_name} ({len(experiment.get('task_runs', []))} examples run)")
-    task_error_rows = _task_error_rows(experiment)
-    if task_error_rows:
-        print(f"Task errors: {len(task_error_rows)}/{len(experiment.get('task_runs', []))}")
-        print(_format_table(("Example", "Error"), task_error_rows))
-    if evaluator_summaries:
-        rows = []
-        for name, summary in evaluator_summaries:
-            total = int(summary["total"])
-            passing = int(summary["passing"])
-            pass_rate = f"{passing / total:.0%}" if total else "n/a"
-            rows.append(
-                (
-                    name,
-                    str(total),
-                    str(passing),
-                    str(summary["failing"]),
-                    str(summary["errors"]),
-                    str(summary["missing_score"]),
-                    pass_rate,
-                )
-            )
-        print(f"Evaluator results (passing score >= {PASSING_SCORE:g}):")
-        print(
-            _format_table(
-                ("Evaluator", "Total", "Passed", "Failed", "Errors", "Missing", "Pass Rate"),
-                rows,
-            )
-        )
-        failed_rows = _failed_evaluation_rows(experiment, evaluation_runs)
-        if failed_rows:
-            print("Failed evaluations:")
-            print(_format_table(("Example", "Evaluator", "Score", "Label", "Details"), failed_rows))
-    return _has_regression_evaluator_failure(dataset, experiment, evaluation_runs)
 
 
 def _phoenix_examples(dataset: EvalDataset) -> list[dict[str, Any]]:
@@ -346,6 +179,48 @@ async def _get_split_filtered_dataset(
         dataset=phoenix_dataset,
         splits=list(splits),
     )
+
+
+def _check_evaluations_ran(experiment: RanExperiment) -> None:
+    """Fail loudly when examples ran but zero evaluations executed.
+
+    The client pairs evaluators with examples via the example node GlobalID
+    and silently skips runs whose lookup misses. If that pairing ever breaks
+    again (it did once: rewriting example ids before evaluation), every
+    example would count as vacuously passed -- a false green this guard turns
+    into an infrastructure error instead.
+    """
+    if experiment.get("task_runs") and not experiment.get("evaluation_runs"):
+        raise RuntimeError(
+            "experiment ran "
+            f"{len(experiment['task_runs'])} task(s) but zero evaluations executed; "
+            "evaluator/example pairing is broken (refusing to report a vacuous pass)"
+        )
+
+
+def _rewrite_stable_example_ids(experiment: RanExperiment, experiment_dataset: Any) -> None:
+    """Replace Phoenix's relay dataset example GlobalIDs with stable YAML ids.
+
+    Resolves via the uploaded dataset's GlobalID->stable-id mapping first --
+    which also covers task runs whose ``output`` is ``None`` (e.g. the
+    phoenix-client's own timeout fired before the task could return its error
+    payload) -- falling back to ``output.stable_example_id``.
+    """
+    stable_by_global_id: dict[str, str] = {}
+    for example in getattr(experiment_dataset, "examples", None) or []:
+        if not isinstance(example, dict):
+            continue
+        stable_id = example.get("id")
+        global_id = example.get("node_id") or stable_id
+        if isinstance(stable_id, str) and isinstance(global_id, str):
+            stable_by_global_id[global_id] = stable_id
+    for task_run in experiment["task_runs"]:
+        mapped = stable_by_global_id.get(str(task_run.get("dataset_example_id", "")))
+        output = task_run.get("output")
+        from_output = output.get("stable_example_id") if isinstance(output, dict) else None
+        stable = mapped or (from_output if isinstance(from_output, str) else None)
+        if stable:
+            task_run["dataset_example_id"] = stable
 
 
 async def _run_async(config: ExperimentConfig) -> int:
@@ -407,15 +282,15 @@ async def _run_async(config: ExperimentConfig) -> int:
             name = _experiment_name(dataset, config)
             metadata = {
                 "git_sha": _git_value("rev-parse", "HEAD"),
-                "git_branch": _git_value("rev-parse", "--abbrev-ref", "HEAD"),
+                # In CI, git is in a detached HEAD state so git rev-parse returns
+                # "HEAD". Prefer GITHUB_HEAD_REF (the PR branch name) when set.
+                "git_branch": os.getenv("GITHUB_HEAD_REF")
+                or _git_value("rev-parse", "--abbrev-ref", "HEAD"),
                 "assistant_provider": os.getenv(ENV_ASSISTANT_PROVIDER, DEFAULT_ASSISTANT_PROVIDER),
                 "assistant_model": os.getenv(ENV_ASSISTANT_MODEL, DEFAULT_ASSISTANT_MODEL),
                 "started_at": datetime.now(timezone.utc).isoformat(),
             }
             print(f"Running experiment: {name}")
-            # Run task first, then evaluate explicitly after replacing Phoenix's
-            # relay dataset example ID with the stable YAML example ID expected
-            # by the client-side evaluator lookup.
             experiment = await client.experiments.run_experiment(
                 dataset=experiment_dataset,
                 task=make_task(docs_mcp_server=docs_mcp_server),
@@ -427,10 +302,6 @@ async def _run_async(config: ExperimentConfig) -> int:
                 timeout=180,
                 retries=0,
             )
-            for task_run in experiment["task_runs"]:
-                output = task_run.get("output")
-                if isinstance(output, dict) and isinstance(output.get("stable_example_id"), str):
-                    task_run["dataset_example_id"] = output["stable_example_id"]
             experiment = await client.experiments.evaluate_experiment(
                 experiment=experiment,
                 evaluators=cast(Any, evaluators),
@@ -439,6 +310,14 @@ async def _run_async(config: ExperimentConfig) -> int:
                 timeout=180,
                 retries=0,
             )
+            _check_evaluations_ran(experiment)
+            # Replace Phoenix's relay dataset example ID with the stable YAML
+            # example ID for summary/report rendering. This MUST happen after
+            # ``evaluate_experiment``: the client pairs evaluators with
+            # examples via the example node GlobalID, so rewriting first makes
+            # every lookup miss and silently skips all evaluations (the
+            # false-green failure mode this ordering previously caused).
+            _rewrite_stable_example_ids(experiment, experiment_dataset)
         finally:
             # ``AsyncClient`` does not yet expose a public ``aclose``; reach for
             # the underlying httpx client and tolerate it disappearing in a
@@ -454,6 +333,24 @@ async def _run_async(config: ExperimentConfig) -> int:
                         file=sys.stderr,
                     )
     has_regressions = _print_score_summary(dataset, experiment, base_url=config.base_url)
+    if config.report_dir is not None or config.print_report:
+        report = build_report(
+            dataset,
+            experiment,
+            base_url=config.base_url,
+            splits=requested,
+            experiment_name=name,
+            dataset_arg=config.dataset,
+        )
+        md_path = None
+        if config.report_dir is not None:
+            json_path, md_path = write_reports(report, config.report_dir)
+            if report.failures:
+                print(f"Report (JSON): {json_path}")
+                print(f"Report (MD):   {md_path}")
+        if config.print_report and report.failures:
+            # Reuse the already-rendered file instead of rendering twice.
+            print(md_path.read_text() if md_path is not None else report_to_markdown(report))
     return 1 if has_regressions and config.fail_on_regression else 0
 
 
@@ -491,6 +388,24 @@ def build_parser() -> argparse.ArgumentParser:
         default=["regression"],
         help="Dataset split names to run (default: regression)",
     )
+    parser.add_argument(
+        "--report-dir",
+        type=Path,
+        help=(
+            "Directory to write failure reports to (created if missing). "
+            "Writes <dataset>.report.json (machine-readable, full fidelity) "
+            "and <dataset>.report.md (agent-pasteable Markdown)."
+        ),
+    )
+    parser.add_argument(
+        "--print-report",
+        action="store_true",
+        help=(
+            "Print the full Markdown failure report to stdout after the "
+            "summary (no-op when all examples pass). For local/manual runs; "
+            "CI embeds the written report file instead."
+        ),
+    )
     # The dataset YAML's ``evaluators:`` field is the source of truth for
     # what gets scored in normal use. This flag is a transient per-run
     # override -- useful for iterating on a single evaluator (halves eval
@@ -525,6 +440,8 @@ def main(argv: list[str] | None = None) -> int:
         fail_on_regression=args.fail_on_regression,
         splits=tuple(args.splits),
         evaluator_override=tuple(args.evaluators) if args.evaluators else None,
+        report_dir=args.report_dir,
+        print_report=args.print_report,
     )
     try:
         return run(config)

--- a/tests/unit/pxi/evals/test_reporting.py
+++ b/tests/unit/pxi/evals/test_reporting.py
@@ -1,0 +1,416 @@
+"""Unit tests for the PXI eval failure report builders.
+
+Synthetic ``RanExperiment`` fixtures only -- no Phoenix calls.
+
+Run directly:
+
+    uv run pytest tests/unit/pxi/evals/test_reporting.py
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from phoenix.client.resources.experiments.types import (
+    ExperimentEvaluation,
+    ExperimentEvaluationRun,
+    ExperimentRun,
+    RanExperiment,
+)
+
+from evals.pxi.harness.datasets import EvalDataset
+from evals.pxi.harness.reporting import (
+    build_report,
+    report_to_json,
+    report_to_markdown,
+    write_reports,
+)
+
+BASE_URL = "http://phoenix.example.com"
+NOW = datetime.now(timezone.utc)
+
+
+def _dataset() -> EvalDataset:
+    return EvalDataset.model_validate(
+        {
+            "dataset_name": "example_suite",
+            "evaluators": ["correct_tools_called"],
+            "examples": [
+                {
+                    "id": "passing-example",
+                    "splits": ["regression"],
+                    "input": {"messages": [{"role": "user", "content": "list LLM spans"}]},
+                    "expected": {"tools": {"required": ["set_spans_filter"]}},
+                },
+                {
+                    "id": "failing-example",
+                    "splits": ["regression"],
+                    "input": {
+                        "messages": [{"role": "user", "content": "show errors"}],
+                        "contexts": [{"type": "project", "projectNodeId": "UHJvamVjdDox"}],
+                    },
+                    "expected": {"tools": {"required": ["set_spans_filter"]}},
+                },
+                {
+                    "id": "task-error-example",
+                    "splits": ["dev"],
+                    "input": {"messages": [{"role": "user", "content": "boom"}]},
+                    "expected": {"tools": {"required": []}},
+                },
+                {
+                    "id": "missing-score-example",
+                    "splits": ["regression"],
+                    "input": {"messages": [{"role": "user", "content": "hmm"}]},
+                    "expected": {"tools": {"required": []}},
+                },
+            ],
+        }
+    )
+
+
+def _task_run(
+    run_id: str,
+    example_id: str,
+    *,
+    output: Any = None,
+    error: str | None = None,
+    trace_id: str | None = None,
+) -> ExperimentRun:
+    task_run: ExperimentRun = {
+        "id": run_id,
+        "dataset_example_id": example_id,
+        "output": output if output is not None else {"assistant_text": "ok", "messages": []},
+        "repetition_number": 1,
+        "start_time": NOW.isoformat(),
+        "end_time": NOW.isoformat(),
+        "experiment_id": "experiment-1",
+    }
+    if error is not None:
+        task_run["error"] = error
+    if trace_id is not None:
+        task_run["trace_id"] = trace_id
+    return task_run
+
+
+def _evaluation(
+    run_id: str,
+    *,
+    name: str = "correct_tools_called",
+    score: float | None = None,
+    label: str | None = None,
+    explanation: str | None = None,
+    error: str | None = None,
+) -> ExperimentEvaluationRun:
+    result: ExperimentEvaluation | None = None
+    if error is None:
+        result = {}
+        if score is not None:
+            result["score"] = score
+        if label is not None:
+            result["label"] = label
+        if explanation is not None:
+            result["explanation"] = explanation
+    return ExperimentEvaluationRun(
+        experiment_run_id=run_id,
+        start_time=NOW,
+        end_time=NOW,
+        name=name,
+        annotator_kind="CODE",
+        result=result,
+        error=error,
+    )
+
+
+def _experiment() -> RanExperiment:
+    """One passing, one eval-fail (with trace), one task-error, one
+    missing-score example."""
+    return {
+        "experiment_id": "RXhwZXJpbWVudDox",
+        "dataset_id": "RGF0YXNldDox",
+        "dataset_version_id": "version-1",
+        "task_runs": [
+            _task_run("run-pass", "passing-example"),
+            _task_run(
+                "run-fail",
+                "failing-example",
+                output={
+                    "assistant_text": "done",
+                    "messages": [
+                        {
+                            "parts": [
+                                {
+                                    "part_kind": "tool-call",
+                                    "tool_name": "set_time_range",
+                                    "args": {"preset": "7d"},
+                                }
+                            ]
+                        }
+                    ],
+                    "stable_example_id": "failing-example",
+                },
+                trace_id="abc123def456",
+            ),
+            _task_run(
+                "run-error",
+                "task-error-example",
+                error="TimeoutError: task timed out",
+            ),
+            _task_run("run-missing", "missing-score-example"),
+        ],
+        "evaluation_runs": [
+            _evaluation("run-pass", score=1.0, label="pass"),
+            _evaluation(
+                "run-fail",
+                score=0.0,
+                label="fail",
+                explanation="expected set_spans_filter, agent called set_time_range",
+            ),
+            _evaluation("run-missing", label="indeterminate"),
+        ],
+        "experiment_metadata": {
+            "git_sha": "deadbeef",
+            "git_branch": "ehutt/eval-harness",
+            "assistant_provider": "OPENAI",
+            "assistant_model": "gpt-5.4",
+            "started_at": NOW.isoformat(),
+        },
+        "project_name": None,
+    }
+
+
+def _report() -> Any:
+    return build_report(
+        _dataset(),
+        _experiment(),
+        base_url=BASE_URL,
+        splits=["regression", "dev"],
+        experiment_name="ci-pxi-eval-example_suite",
+        generated_at="2026-06-12T00:00:00+00:00",
+    )
+
+
+def test_report_counts_and_metadata() -> None:
+    report = _report()
+
+    assert report.dataset_name == "example_suite"
+    assert report.examples_run == 4
+    assert report.examples_passed == 1
+    assert len(report.failures) == 3
+    assert report.git_sha == "deadbeef"
+    assert report.git_branch == "ehutt/eval-harness"
+    assert report.assistant_provider == "OPENAI"
+    assert report.assistant_model == "gpt-5.4"
+    assert report.experiment_url == (
+        f"{BASE_URL}/datasets/RGF0YXNldDox/compare?experimentId=RXhwZXJpbWVudDox"
+    )
+    assert report.repro_command == (
+        "uv run python -m evals.pxi.harness.run_experiment "
+        "--dataset example_suite --splits regression dev"
+    )
+    assert report.dataset_file == "evals/pxi/datasets/example_suite.yaml"
+
+
+def test_report_uses_cli_dataset_stem_when_it_differs_from_dataset_name() -> None:
+    report = build_report(
+        _dataset(),
+        _experiment(),
+        base_url=BASE_URL,
+        splits=["regression"],
+        dataset_arg="example_suite_v2",
+    )
+
+    assert report.dataset_file == "evals/pxi/datasets/example_suite_v2.yaml"
+    assert "--dataset example_suite_v2" in report.repro_command
+    # Sentinels are keyed by the stem too, matching the CI lookup.
+    markdown = report_to_markdown(report)
+    assert markdown.startswith("===== BEGIN PXI EVAL REPORT: example_suite_v2 =====")
+
+
+def test_write_reports_names_files_by_cli_stem(tmp_path: Path) -> None:
+    """CI looks reports up by the dataset file stem; file names must follow
+    the stem even when the YAML dataset_name differs."""
+    report = build_report(
+        _dataset(),
+        _experiment(),
+        base_url=BASE_URL,
+        splits=["regression"],
+        dataset_arg="example_suite_v2",
+    )
+
+    json_path, md_path = write_reports(report, tmp_path)
+
+    assert json_path.name == "example_suite_v2.report.json"
+    assert md_path.name == "example_suite_v2.report.md"
+
+
+def test_markdown_fences_survive_embedded_backtick_runs() -> None:
+    """An explanation quoting a code fence must not terminate the report's
+    own fenced block early."""
+    dataset = _dataset()
+    experiment = _experiment()
+    experiment["evaluation_runs"][1] = _evaluation(
+        "run-fail",
+        score=0.0,
+        label="fail",
+        explanation='agent emitted:\n```json\n{"bad": true}\n```\nwhich is wrong',
+    )
+
+    markdown = report_to_markdown(
+        build_report(dataset, experiment, base_url=BASE_URL, splits=["regression"])
+    )
+
+    # The fence wrapping the explanation must be longer than the embedded one.
+    assert "````text" in markdown
+    assert 'agent emitted:\n```json\n{"bad": true}\n```\nwhich is wrong\n````' in markdown
+
+
+def test_report_excludes_passing_examples_from_failures() -> None:
+    report = _report()
+
+    assert "passing-example" not in {failure.example_id for failure in report.failures}
+
+
+def test_eval_failure_record_has_full_untruncated_fields() -> None:
+    report = _report()
+    failure = next(f for f in report.failures if f.example_id == "failing-example")
+
+    assert failure.splits == ["regression"]
+    assert failure.input == {
+        "messages": [{"role": "user", "content": "show errors"}],
+        "contexts": [{"type": "project", "projectNodeId": "UHJvamVjdDox"}],
+    }
+    assert failure.expected == {"tools": {"required": ["set_spans_filter"]}}
+    assert failure.actual_output["assistant_text"] == "done"
+    assert failure.task_error is None
+    assert failure.trace_id == "abc123def456"
+    assert failure.trace_url == f"{BASE_URL}/redirects/traces/abc123def456"
+    [evaluation] = failure.evaluations
+    assert evaluation.name == "correct_tools_called"
+    assert evaluation.score == 0.0
+    assert evaluation.label == "fail"
+    assert evaluation.explanation == ("expected set_spans_filter, agent called set_time_range")
+    assert evaluation.error is None
+    assert evaluation.passed is False
+
+
+def test_task_error_record() -> None:
+    report = _report()
+    failure = next(f for f in report.failures if f.example_id == "task-error-example")
+
+    assert failure.task_error == "TimeoutError: task timed out"
+    assert failure.trace_id is None
+    assert failure.trace_url is None
+
+
+def test_missing_score_counts_as_failure() -> None:
+    report = _report()
+    failure = next(f for f in report.failures if f.example_id == "missing-score-example")
+
+    [evaluation] = failure.evaluations
+    assert evaluation.score is None
+    assert evaluation.passed is False
+
+
+def test_json_round_trips_with_schema_fields() -> None:
+    payload = json.loads(report_to_json(_report()))
+
+    assert payload["schema_version"] == 1
+    assert payload["dataset_name"] == "example_suite"
+    assert payload["examples_run"] == 4
+    assert payload["examples_passed"] == 1
+    assert {f["example_id"] for f in payload["failures"]} == {
+        "failing-example",
+        "task-error-example",
+        "missing-score-example",
+    }
+    failing = next(f for f in payload["failures"] if f["example_id"] == "failing-example")
+    assert failing["evaluations"][0]["explanation"] == (
+        "expected set_spans_filter, agent called set_time_range"
+    )
+    assert payload["evaluator_summary"][0]["name"] == "correct_tools_called"
+
+
+def test_markdown_has_sentinels_digest_payloads_and_repro_footer() -> None:
+    markdown = report_to_markdown(_report())
+
+    assert markdown.startswith("===== BEGIN PXI EVAL REPORT: example_suite =====")
+    assert markdown.endswith("===== END PXI EVAL REPORT: example_suite =====")
+    assert "## Digest" in markdown
+    assert "expected set_spans_filter, agent called set_time_range" in markdown
+    assert "### Example: `failing-example`" in markdown
+    assert "**Task error:**" in markdown
+    assert "TimeoutError: task timed out" in markdown
+    # Tool calls the agent actually made are surfaced openly.
+    assert "set_time_range" in markdown
+    # Message histories are collapsed, not dumped inline.
+    assert "<details>" in markdown
+    # Repro footer makes a pasted report self-sufficient.
+    assert "uv run python -m evals.pxi.harness.run_experiment" in markdown
+    assert f"{BASE_URL}/datasets/RGF0YXNldDox/compare" in markdown
+    assert f"{BASE_URL}/redirects/traces/abc123def456" in markdown
+
+
+def test_static_instructions_replaced_with_placeholder() -> None:
+    dataset = _dataset()
+    experiment = _experiment()
+    big_prompt = "you are a helpful assistant " * 1_000
+    experiment["task_runs"][1]["output"]["messages"][0]["instructions"] = big_prompt
+
+    report = build_report(dataset, experiment, base_url=BASE_URL, splits=["regression"])
+
+    failure = next(f for f in report.failures if f.example_id == "failing-example")
+    instructions = failure.actual_output["messages"][0]["instructions"]
+    assert big_prompt not in instructions
+    assert "static system instructions omitted" in instructions
+    assert f"({len(big_prompt)} chars)" in instructions
+    assert any("Static system instructions" in note for note in report.notes)
+    assert "Static system instructions" in report_to_markdown(report)
+    # The experiment dict itself is not mutated.
+    assert experiment["task_runs"][1]["output"]["messages"][0]["instructions"] == big_prompt
+
+
+def test_short_instructions_kept_inline() -> None:
+    dataset = _dataset()
+    experiment = _experiment()
+    experiment["task_runs"][1]["output"]["messages"][0]["instructions"] = "be brief"
+
+    report = build_report(dataset, experiment, base_url=BASE_URL, splits=["regression"])
+
+    failure = next(f for f in report.failures if f.example_id == "failing-example")
+    assert failure.actual_output["messages"][0]["instructions"] == "be brief"
+    assert report.notes == []
+
+
+def test_markdown_falls_back_to_digest_when_oversized() -> None:
+    markdown = report_to_markdown(_report(), max_bytes=2_000)
+
+    assert "## Failures" not in markdown
+    assert "## Digest" in markdown
+    assert "pxi-eval-reports-<run-id>" in markdown
+    assert markdown.startswith("===== BEGIN PXI EVAL REPORT: example_suite =====")
+
+
+def test_markdown_wraps_pathologically_long_lines() -> None:
+    dataset = _dataset()
+    experiment = _experiment()
+    experiment["task_runs"][1]["output"]["assistant_text"] = "x" * 70_000
+
+    markdown = report_to_markdown(
+        build_report(dataset, experiment, base_url=BASE_URL, splits=["regression"])
+    )
+
+    assert all(len(line) <= 16_000 for line in markdown.splitlines())
+
+
+def test_write_reports_writes_both_files(tmp_path: Path) -> None:
+    report = _report()
+
+    json_path, md_path = write_reports(report, tmp_path / "reports")
+
+    assert json_path == tmp_path / "reports" / "example_suite.report.json"
+    assert md_path == tmp_path / "reports" / "example_suite.report.md"
+    assert json.loads(json_path.read_text())["dataset_name"] == "example_suite"
+    assert "===== BEGIN PXI EVAL REPORT: example_suite =====" in md_path.read_text()

--- a/tests/unit/pxi/evals/test_run_experiment.py
+++ b/tests/unit/pxi/evals/test_run_experiment.py
@@ -13,15 +13,19 @@ import pytest
 from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
 
 from evals.pxi.harness.datasets import EvalDataset
-from evals.pxi.harness.run_experiment import (
-    ExperimentConfig,
+from evals.pxi.harness.reporting import (
     _failed_evaluation_rows,
     _format_table,
-    _get_split_filtered_dataset,
     _has_regression_evaluator_failure,
-    _phoenix_examples,
     _print_score_summary,
     _task_error_rows,
+)
+from evals.pxi.harness.run_experiment import (
+    ExperimentConfig,
+    _check_evaluations_ran,
+    _get_split_filtered_dataset,
+    _phoenix_examples,
+    _rewrite_stable_example_ids,
     main,
 )
 
@@ -181,6 +185,47 @@ def test_main_defaults_to_regression_split(monkeypatch: pytest.MonkeyPatch) -> N
     assert captured[0].splits == ("regression",)
 
 
+def test_main_forwards_report_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    from pathlib import Path
+
+    captured: list[ExperimentConfig] = []
+
+    def fake_run(config: ExperimentConfig) -> int:
+        captured.append(config)
+        return 0
+
+    monkeypatch.setattr("evals.pxi.harness.run_experiment.run", fake_run)
+
+    assert (
+        main(
+            [
+                "--dataset",
+                "set_spans_filter",
+                "--report-dir",
+                "/tmp/reports",
+                "--print-report",
+            ]
+        )
+        == 0
+    )
+    assert captured[0].report_dir == Path("/tmp/reports")
+    assert captured[0].print_report is True
+
+
+def test_main_defaults_report_flags_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[ExperimentConfig] = []
+
+    def fake_run(config: ExperimentConfig) -> int:
+        captured.append(config)
+        return 0
+
+    monkeypatch.setattr("evals.pxi.harness.run_experiment.run", fake_run)
+
+    assert main(["--dataset", "set_spans_filter"]) == 0
+    assert captured[0].report_dir is None
+    assert captured[0].print_report is False
+
+
 def test_main_forwards_explicit_splits(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: list[ExperimentConfig] = []
 
@@ -242,6 +287,110 @@ async def test_split_filtered_dataset_forwards_requested_splits() -> None:
 
     assert result == "filtered-dataset"
     assert client.datasets.calls == [{"dataset": "uploaded-dataset", "splits": ["dev", "val"]}]
+
+
+def test_check_evaluations_ran_raises_on_vacuous_pass() -> None:
+    now = datetime.now(timezone.utc)
+    experiment = _ran_experiment()
+    experiment["task_runs"] = [
+        {
+            "id": "run-1",
+            "dataset_example_id": "regression-example",
+            "output": {},
+            "repetition_number": 1,
+            "start_time": now.isoformat(),
+            "end_time": now.isoformat(),
+            "experiment_id": "experiment-1",
+        }
+    ]
+
+    with pytest.raises(RuntimeError, match="zero evaluations"):
+        _check_evaluations_ran(experiment)
+
+
+def test_check_evaluations_ran_accepts_empty_experiment_and_real_evaluations() -> None:
+    now = datetime.now(timezone.utc)
+    empty = _ran_experiment()
+    _check_evaluations_ran(empty)  # no task runs -> nothing expected
+
+    evaluated = _ran_experiment()
+    evaluated["task_runs"] = [
+        {
+            "id": "run-1",
+            "dataset_example_id": "regression-example",
+            "output": {},
+            "repetition_number": 1,
+            "start_time": now.isoformat(),
+            "end_time": now.isoformat(),
+            "experiment_id": "experiment-1",
+        }
+    ]
+    evaluated["evaluation_runs"] = [
+        ExperimentEvaluationRun(
+            experiment_run_id="run-1",
+            start_time=now,
+            end_time=now,
+            name="correct_tools_called",
+            annotator_kind="CODE",
+            result={"score": 1.0},
+        )
+    ]
+    _check_evaluations_ran(evaluated)
+
+
+class _FakeDatasetWithExamples:
+    def __init__(self, examples: list[dict[str, object]]) -> None:
+        self.examples = examples
+
+
+def test_rewrite_stable_example_ids_maps_global_ids_even_without_output() -> None:
+    """Task runs whose output is None (e.g. client-level timeout) must still
+    resolve to stable YAML ids via the dataset GlobalID mapping."""
+    now = datetime.now(timezone.utc)
+    experiment = _ran_experiment()
+    experiment["task_runs"] = [
+        {
+            "id": "run-1",
+            "dataset_example_id": "RGF0YXNldEV4YW1wbGU6MQ==",
+            "output": None,
+            "repetition_number": 1,
+            "start_time": now.isoformat(),
+            "end_time": now.isoformat(),
+            "experiment_id": "experiment-1",
+            "error": "TimeoutError()",
+        },
+        {
+            "id": "run-2",
+            "dataset_example_id": "RGF0YXNldEV4YW1wbGU6Mg==",
+            "output": {"stable_example_id": "from-output-example"},
+            "repetition_number": 1,
+            "start_time": now.isoformat(),
+            "end_time": now.isoformat(),
+            "experiment_id": "experiment-1",
+        },
+        {
+            "id": "run-3",
+            "dataset_example_id": "unmapped-global-id",
+            "output": None,
+            "repetition_number": 1,
+            "start_time": now.isoformat(),
+            "end_time": now.isoformat(),
+            "experiment_id": "experiment-1",
+        },
+    ]
+    dataset = _FakeDatasetWithExamples(
+        [
+            {"id": "regression-example", "node_id": "RGF0YXNldEV4YW1wbGU6MQ=="},
+            {"id": "dev-example", "node_id": "RGF0YXNldEV4YW1wbGU6Mg=="},
+        ]
+    )
+
+    _rewrite_stable_example_ids(experiment, dataset)
+
+    assert experiment["task_runs"][0]["dataset_example_id"] == "regression-example"
+    assert experiment["task_runs"][1]["dataset_example_id"] == "dev-example"
+    # Unmapped ids without output fall through unchanged rather than crashing.
+    assert experiment["task_runs"][2]["dataset_example_id"] == "unmapped-global-id"
 
 
 def test_fail_on_regression_detects_only_regression_failures() -> None:


### PR DESCRIPTION
## What and why

Fixes the two biggest problems with the PXI eval harness as a CI gate:

1. **False-green bug (pre-existing):** The harness was rewriting dataset example IDs *before* calling `evaluate_experiment`. The Phoenix client pairs evaluators with examples via the example's node GlobalID — so the rewrite caused every lookup to miss, all evaluations were silently skipped, and CI always reported green regardless of agent behavior. This PR moves the rewrite to *after* evaluation and adds a `_check_evaluations_ran` guard that turns a vacuous pass into an exit-2 infrastructure error.

2. **Unreadable failure output (#13668):** When an example did fail, the only output was a truncated 80-character table cell. There was no way to see what the agent actually did, what was expected, or where to look in Phoenix. This PR adds full-fidelity failure reports.

## Changes

### New: `evals/pxi/harness/reporting.py`

Pure functions over `RanExperiment` + `EvalDataset` (no Phoenix calls, fully unit-testable). Builds two output tiers per failed dataset run:

- **`<dataset>.report.json`** — machine-readable: run metadata + one record per failed/errored example with the full untruncated `input`, `expected`, `actual_output` (every tool call the agent made), per-evaluator score/label/explanation/error, task error if any, and a per-example trace URL (`/redirects/traces/<otel_id>`). Passing examples contribute to counts only, keeping files small.
- **`<dataset>.report.md`** — agent-pasteable Markdown: digest table up top, one section per failed example (message histories collapsed under `<details>` to avoid bloat from the ~55 KB system prompt repeated on every request), and a repro footer. Wrapped in `===== BEGIN/END PXI EVAL REPORT: <dataset> =====` sentinels so it can be grepped out of CI logs.

### Runner: two new flags

- **`--print-report`** — dumps the Markdown report to stdout at the end of a run when any example failed. This is the recommended mode for local debugging.
- **`--report-dir DIR`** — writes both report files to `DIR`. Used by CI rather than `--print-report` because GitHub Actions interprets lines starting with `::` as workflow commands; the workflow writes to a file first, then `cat`s it inside a `::stop-commands::` block to safely log untrusted model output.

### Bug fixes in the runner

- **Stable example ID rewrite** now happens after `evaluate_experiment`, fixing the false-green bug.
- **`_rewrite_stable_example_ids`** maps GlobalID → stable YAML ID via the uploaded dataset's example list (covers `output=None` task runs from client-level timeouts, which previously kept the relay GlobalID).
- **`_check_evaluations_ran`** raises `RuntimeError` (exit 2) if task runs executed but zero evaluations ran — turns any recurrence of the false-green class into a loud infra error.
- **Phoenix healthz retry:** 3 attempts / 10 s delay before giving up, so a transient 30-second Phoenix Cloud blip doesn't permanently fail a dataset run.
- **Branch name in reports:** uses `GITHUB_HEAD_REF` when set (CI detached-HEAD checkout) instead of `HEAD`.
- **Report paths suppressed on green runs** — no noise when all examples pass.

### CI: `pxi-evals.yml`

- Pre-flight `curl` healthz check (3 retries) before the dataset loop — if Phoenix is genuinely down, one clean error instead of N dataset failures.
- Per failed dataset: full Markdown report embedded in the job log inside `::stop-commands::` (a new collapsed group, sentinel-marked, safe to grep with `gh run view <id> --log-failed`), digest table in the step summary, full report in a `<details>` block with a cumulative 768 KB budget across all failed datasets (respects GitHub's 1 MiB step-summary cap).
- Always-uploaded `pxi-eval-reports-<run_id>` artifact (`if: always()`) for programmatic access.
- `cancel-in-progress: true` — new pushes cancel in-progress runs.
- `::error` annotation on failure correctly distinguishes "regressions detected (report exists)" from "runner crashed before writing a report" and points to the right log group in each case.

### README

Documents both flags with the reason `--report-dir` exists in CI (the `::` workflow command injection risk), and the three channels for accessing failure output from a red check: job log, step summary, JSON artifact.

## Note on CI status

This PR's CI check will show failures on some datasets. Those failures are **pre-existing** — they were hidden by the false-green bug this PR fixes (evaluations were never actually running, so CI was always green regardless of agent behavior). They are not regressions introduced by this change.

## More coming soon

Closes #13668. Part of #13664.
