### PR TITLE
fix(evals): compute macro/weighted F-score per class to match sklearn semantics

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/metrics/precision_recall.py
+++ b/packages/phoenix-evals/src/phoenix/evals/metrics/precision_recall.py
@@ -185,11 +185,11 @@ class PrecisionRecallFScore(Evaluator):
                 class_counts.true_positive, class_counts.true_positive + class_counts.false_negative
             )
             suffix = ""
+            # Binary one-vs-rest: F is computed from this class's precision/recall.
+            f_score = self._compute_f_score(precision, recall, self.beta)
         else:
-            precision, recall = self._aggregate_precision_recall(counts_by_label)
+            precision, recall, f_score = self._aggregate_precision_recall(counts_by_label)
             suffix = "" if self.average == "macro" else f"_{self.average}"
-
-        f_score = self._compute_f_score(precision, recall, self.beta)
 
         beta_name = _format_beta_for_name(self.beta)
 
@@ -316,14 +316,20 @@ class PrecisionRecallFScore(Evaluator):
 
     def _aggregate_precision_recall(
         self, counts_by_label: Mapping[Hashable, _ClassCounts]
-    ) -> Tuple[float, float]:
-        """Aggregate precision and recall across all classes.
+    ) -> Tuple[float, float, float]:
+        """Aggregate precision, recall, and F-beta across all classes.
+
+        Mirrors scikit-learn's ``average`` semantics: for ``macro``/``weighted``
+        the F-beta is computed per class and then averaged (not derived from the
+        aggregated precision/recall). For ``micro`` the per-class confusion
+        counts are pooled first, so F-beta is computed from the pooled
+        precision/recall.
 
         Args:
             counts_by_label (Mapping[Hashable, _ClassCounts]): Counts for each label.
 
         Returns:
-            Tuple[float, float]: A tuple of (precision, recall).
+            Tuple[float, float, float]: A tuple of (precision, recall, f_score).
         """
         if self.average == "micro":
             tp = sum(c.true_positive for c in counts_by_label.values())
@@ -331,31 +337,35 @@ class PrecisionRecallFScore(Evaluator):
             fn = sum(c.false_negative for c in counts_by_label.values())
             precision = self._safe_div(tp, tp + fp)
             recall = self._safe_div(tp, tp + fn)
-            return precision, recall
+            return precision, recall, self._compute_f_score(precision, recall, self.beta)
 
         # per-class metrics
         per_class_precision: List[float] = []
         per_class_recall: List[float] = []
+        per_class_f: List[float] = []
         supports: List[int] = []
         for c in counts_by_label.values():
             p = self._safe_div(c.true_positive, c.true_positive + c.false_positive)
             r = self._safe_div(c.true_positive, c.true_positive + c.false_negative)
             per_class_precision.append(p)
             per_class_recall.append(r)
+            per_class_f.append(self._compute_f_score(p, r, self.beta))
             supports.append(c.support)
 
         if self.average == "macro":
             precision = sum(per_class_precision) / len(per_class_precision)
             recall = sum(per_class_recall) / len(per_class_recall)
-            return precision, recall
+            f_score = sum(per_class_f) / len(per_class_f)
+            return precision, recall, f_score
 
         # weighted
         total = sum(supports)
         if total == 0:
-            return float(self.zero_division), float(self.zero_division)
+            return float(self.zero_division), float(self.zero_division), float(self.zero_division)
         precision = sum(p * s for p, s in zip(per_class_precision, supports)) / total
         recall = sum(r * s for r, s in zip(per_class_recall, supports)) / total
-        return precision, recall
+        f_score = sum(f * s for f, s in zip(per_class_f, supports)) / total
+        return precision, recall, f_score
 
     def _compute_f_score(self, precision: float, recall: float, beta: float) -> float:
         """Compute the F-beta score from precision and recall.

--- a/packages/phoenix-evals/tests/phoenix/evals/metrics/test_precision_recall.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/metrics/test_precision_recall.py
@@ -38,7 +38,10 @@ def _scores_by_name(scores: List[Any]) -> Dict[str, float]:
             ["a", "b", "a", "c"],
             ["a", "a", "a", "c"],
             ["precision", "recall", "f1"],
-            dict(precision=5 / 9, recall=2 / 3, f1=60 / 99),
+            # Macro F1 averages per-class F1 (sklearn semantics), not F1 of the
+            # aggregated P/R. Per class: a P=2/3 R=1 F1=0.8; b P=0 R=0 F1=0;
+            # c P=1 R=1 F1=1 -> mean = (0.8 + 0 + 1) / 3 = 0.6.
+            dict(precision=5 / 9, recall=2 / 3, f1=0.6),
             False,
             id="multiclass-macro",
         ),
@@ -58,7 +61,10 @@ def _scores_by_name(scores: List[Any]) -> Dict[str, float]:
             ["a", "b", "a", "c"],
             ["a", "a", "a", "c"],
             ["precision_weighted", "recall_weighted", "f1_weighted"],
-            dict(precision_weighted=7 / 12, recall_weighted=3 / 4, f1_weighted=21 / 32),
+            # Weighted F1 is the support-weighted mean of per-class F1 (sklearn
+            # semantics). Supports a=2, b=1, c=1; per-class F1 0.8, 0, 1 ->
+            # (0.8*2 + 0*1 + 1*1) / 4 = 0.65.
+            dict(precision_weighted=7 / 12, recall_weighted=3 / 4, f1_weighted=0.65),
             False,
             id="multiclass-weighted",
         ),
@@ -69,9 +75,11 @@ def _scores_by_name(scores: List[Any]) -> Dict[str, float]:
             ["a", "a"],
             ["precision", "recall", "f1"],
             # For class 'b': precision undefined -> 1.0, recall = 0.0
-            # Per-class precision: a=0.5? Here a: TP=1, FP=1 -> 1/(1+1)=0.5; b: 1.0
-            # Macro P=(0.5+1.0)/2=0.75; Macro R=(1.0+0.0)/2=0.5; F1 from aggregated P,R: 2*0.75*0.5/(0.75+0.5)=0.6
-            dict(precision=0.75, recall=0.5, f1=0.6),
+            # Per-class precision: a: TP=1, FP=1 -> 1/(1+1)=0.5; b: 1.0
+            # Macro P=(0.5+1.0)/2=0.75; Macro R=(1.0+0.0)/2=0.5.
+            # Macro F1 averages per-class F1 (sklearn semantics):
+            # a: F1=2*0.5*1/(0.5+1)=2/3; b: F1=0 (recall 0) -> mean=1/3.
+            dict(precision=0.75, recall=0.5, f1=1 / 3),
             False,
             id="zero-division-custom",
         ),
@@ -85,6 +93,47 @@ def _scores_by_name(scores: List[Any]) -> Dict[str, float]:
             dict(precision_micro=2 / 3, recall_micro=2 / 3, f2_micro=2 / 3),
             False,
             id="beta-2-micro-naming",
+        ),
+        # The following three cases lock in scikit-learn `average` semantics for
+        # macro/weighted F: F is averaged per class, not derived from the
+        # aggregated precision/recall. Expected values match
+        # sklearn.metrics.precision_recall_fscore_support (verified offline; no
+        # sklearn dependency is added to the test).
+        pytest.param(
+            "multiclass macro F matches sklearn (per-class F averaged)",
+            dict(beta=1.0, average="macro"),
+            ["cat", "dog", "cat", "bird"],
+            ["cat", "cat", "cat", "bird"],
+            ["precision", "recall", "f1"],
+            # Per class: cat P=2/3 R=1 F1=0.8; dog P=0 R=0 F1=0; bird P=1 R=1 F1=1
+            # macro P=5/9, R=2/3, F1=(0.8+0+1)/3=0.6 (sklearn: 0.6).
+            dict(precision=5 / 9, recall=2 / 3, f1=0.6),
+            False,
+            id="multiclass-macro-sklearn-parity",
+        ),
+        pytest.param(
+            "multiclass weighted F matches sklearn (support-weighted per-class F)",
+            dict(beta=1.0, average="weighted"),
+            ["cat", "dog", "cat", "bird"],
+            ["cat", "cat", "cat", "bird"],
+            ["precision_weighted", "recall_weighted", "f1_weighted"],
+            # Supports cat=2, dog=1, bird=1; per-class F1 0.8, 0, 1
+            # weighted F1=(0.8*2+0*1+1*1)/4=0.65 (sklearn: 0.65).
+            dict(precision_weighted=7 / 12, recall_weighted=3 / 4, f1_weighted=0.65),
+            False,
+            id="multiclass-weighted-sklearn-parity",
+        ),
+        pytest.param(
+            "multiclass macro F-beta (beta=2) matches sklearn",
+            dict(beta=2.0, average="macro"),
+            ["cat", "dog", "cat", "bird"],
+            ["cat", "cat", "cat", "bird"],
+            ["precision", "recall", "f2"],
+            # Per-class F2: cat=(5*(2/3)*1)/(4*(2/3)+1)=10/11; dog=0; bird=1
+            # macro F2=(10/11+0+1)/3=7/11 (sklearn: 0.6363636...).
+            dict(precision=5 / 9, recall=2 / 3, f2=7 / 11),
+            False,
+            id="multiclass-macro-beta2-sklearn-parity",
         ),
     ],
 )


### PR DESCRIPTION
resolves #13739

Thanks for `phoenix-evals` — `PrecisionRecallFScore` is a handy, dependency-free way to get classification metrics, and this PR is a small fix to align one corner of it with the scikit-learn `average` semantics the class already documents.

## Problem

`PrecisionRecallFScore` computed `macro`/`weighted` F-beta from the **aggregated** precision and recall, instead of computing F-beta **per class and then averaging** — which is what scikit-learn's `average` parameter does. Precision, recall, and micro F were already correct; only macro and weighted F diverged.

This is framed as completing an existing convention rather than new behavior: `_aggregate_precision_recall` already loops per class and averages precision and recall with the chosen strategy — the per-class F-beta was simply not collected and averaged the same way.

## Before / After (vs scikit-learn 1.9.0)

Inputs `expected = ["cat","dog","cat","bird"]`, `output = ["cat","cat","cat","bird"]` (per class: cat F1=0.8, dog F1=0, bird F1=1):

| Item | Before | After (== sklearn) |
|------|--------|--------------------|
| macro F1 | 0.606061 (60/99) ❌ | **0.600000** ✅ |
| weighted F1 | 0.656250 (21/32) ❌ | **0.650000** ✅ |
| macro F2 (beta=2) | 0.641026 ❌ | **0.636364** (7/11) ✅ |
| macro F1 w/ `zero_division=1.0`, `["a","b"]→["a","a"]` | 0.600000 ❌ | **0.333333** (1/3) ✅ |
| micro F1 | 0.750000 ✅ | 0.750000 ✅ (unchanged) |
| precision / recall (all averages) | correct ✅ | correct ✅ (unchanged) |
| binary `positive_label` F | correct ✅ | correct ✅ (unchanged) |
| public API / metric names / Score ordering | — | unchanged ✅ |

## Change

- In `_aggregate_precision_recall`, collect per-class F-beta in the existing per-class loop and average it with the same strategy as precision/recall (macro = mean, weighted = support-weighted mean). The method now returns `(precision, recall, f_score)`.
- `micro` F is still computed from the pooled precision/recall (correct, since micro P == R), and the binary `positive_label` path still computes F from that class's P/R — both unchanged.

It's a private helper, so the return-shape change is internal only.

## Tests

Three existing assertions baked in the previous (aggregated-P/R) values; they're corrected to the scikit-learn values, with the per-class arithmetic spelled out in comments. Added three parametrized cases that lock in scikit-learn parity for macro F1, weighted F1, and macro F2 (no `scikit-learn` dependency added — expected values are written as exact fractions and were verified offline against `sklearn.metrics.precision_recall_fscore_support` 1.9.0).

To show the tests actually catch the bug, I reverted only the source change (keeping the corrected tests):

```
$ git stash push -- .../precision_recall.py   # source back to current main
$ pytest tests/phoenix/evals/metrics/test_precision_recall.py -q
E  assert 0.606060606060606 == 0.6 ± 6.0e-07        # multiclass-macro
E  assert 0.65625 == 0.65 ± 6.5e-07                 # multiclass-weighted
E  assert 0.6 == 0.3333333333333333 ± 3.3e-07       # zero-division-custom
E  assert 0.606060606060606 == 0.6 ± 6.0e-07        # multiclass-macro-sklearn-parity
E  assert 0.65625 == 0.65 ± 6.5e-07                 # multiclass-weighted-sklearn-parity
E  assert 0.641025641025641 == 0.6363636363636364   # multiclass-macro-beta2-sklearn-parity
6 failed, 9 passed
```

With the fix restored:

```
$ pytest tests/phoenix/evals/metrics/test_precision_recall.py -q
15 passed
```

Local checks on the changed files: `ruff check` clean, `ruff format --check` clean, `mypy -p phoenix.evals.metrics.precision_recall` → `Success: no issues found`.

---
*This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, the scikit-learn comparison, and the test results before submitting.*