### PR TITLE
fix(json): drop None-valued Optional dataclass fields in jsonify

### DIFF
--- a/src/phoenix/utilities/json.py
+++ b/src/phoenix/utilities/json.py
@@ -47,8 +47,8 @@ def jsonify(obj: Any) -> Any:
             for field in dataclasses.fields(obj)
             if not (
                 (v := getattr(obj, (k := field.name))) is None
-                and get_origin(field) is Union
-                and type(None) in get_args(field)
+                and get_origin(field.type) is Union
+                and type(None) in get_args(field.type)
             )
         }
     if isinstance(obj, (datetime.date, datetime.datetime, datetime.time)):

--- a/tests/unit/utilities/test_json.py
+++ b/tests/unit/utilities/test_json.py
@@ -1,10 +1,12 @@
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import Optional
 
 import numpy as np
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
-from phoenix.utilities.json import decode_df_from_json_string, encode_df_as_json_string
+from phoenix.utilities.json import decode_df_from_json_string, encode_df_as_json_string, jsonify
 
 
 class TestDataFrameJSONRoundtrip:
@@ -131,3 +133,17 @@ class TestDataFrameJSONRoundtrip:
         payload = encode_df_as_json_string(expected)
         received = decode_df_from_json_string(payload)
         assert_frame_equal(received, expected)
+
+
+class TestJsonify:
+    def test_drops_none_valued_optional_dataclass_fields(self) -> None:
+        @dataclass
+        class Record:
+            a: int
+            b: Optional[str] = None
+
+        # The None-valued Optional field `b` should be omitted, while the
+        # required field `a` is kept.
+        assert jsonify(Record(a=1)) == {"a": 1}
+        # A non-None Optional value is kept.
+        assert jsonify(Record(a=1, b="x")) == {"a": 1, "b": "x"}


### PR DESCRIPTION
## What's broken
`jsonify()` intends to omit `None`-valued `Optional[...]` dataclass fields, but it called `get_origin()`/`get_args()` on the `dataclasses.Field` object instead of `field.type`. `get_origin(Field)` is always `None`, so the guard was always `False` and the `None` fields were never dropped — they leaked into the serialized output as `"field": null`.

```python
jsonify(Record(a=1))   # -> {'a': 1, 'b': None}   (expected {'a': 1})
```

## Why it happens
`get_origin`/`get_args` must receive a type annotation, not a `Field`. `field.type` holds the annotation; `field` is metadata, so the `is Union` check never matched.

## Fix
Pass `field.type` to `get_origin`/`get_args` so `Optional` fields set to `None` are correctly omitted.

## Test
Adds a `TestJsonify` unit test asserting None-Optionals are dropped and non-None kept. Fails before, passes after.
