### PR TITLE
fix(phoenix-mcp): send explicit User-Agent to avoid undici HTML redirect (#13742)

### DIFF
--- a/js/packages/phoenix-mcp/src/client.ts
+++ b/js/packages/phoenix-mcp/src/client.ts
@@ -1,5 +1,6 @@
 import { createClient, type PhoenixClient } from "@arizeai/phoenix-client";
 
+import { USER_AGENT } from "./constants.js";
 import type { PhoenixMcpConfig } from "./config.js";
 
 export interface CreatePhoenixClientOptions {
@@ -16,6 +17,10 @@ export function createPhoenixClient({
   config,
 }: CreatePhoenixClientOptions): PhoenixClient {
   const headers: Record<string, string> = {
+    // Node's global fetch (undici) defaults to `User-Agent: undici`, which some
+    // Phoenix Cloud edges 302-redirect to HTML, breaking JSON parsing (#13742).
+    // Set an explicit User-Agent first so caller-supplied headers can override it.
+    "User-Agent": USER_AGENT,
     ...(config.headers || {}),
   };
 

--- a/js/packages/phoenix-mcp/src/client.ts
+++ b/js/packages/phoenix-mcp/src/client.ts
@@ -1,7 +1,7 @@
 import { createClient, type PhoenixClient } from "@arizeai/phoenix-client";
 
-import { USER_AGENT } from "./constants.js";
 import type { PhoenixMcpConfig } from "./config.js";
+import { USER_AGENT } from "./constants.js";
 
 export interface CreatePhoenixClientOptions {
   config: PhoenixMcpConfig;
@@ -17,9 +17,8 @@ export function createPhoenixClient({
   config,
 }: CreatePhoenixClientOptions): PhoenixClient {
   const headers: Record<string, string> = {
-    // Node's global fetch (undici) defaults to `User-Agent: undici`, which some
-    // Phoenix Cloud edges 302-redirect to HTML, breaking JSON parsing (#13742).
-    // Set an explicit User-Agent first so caller-supplied headers can override it.
+    // Set an explicit User-Agent first so caller-supplied headers can override
+    // it. See USER_AGENT in constants.ts for why this is required (#13742).
     "User-Agent": USER_AGENT,
     ...(config.headers || {}),
   };

--- a/js/packages/phoenix-mcp/src/constants.ts
+++ b/js/packages/phoenix-mcp/src/constants.ts
@@ -46,3 +46,13 @@ export const MS_PER_MINUTE = 60_000;
 
 /** Provenance tag applied to dataset examples created through the MCP server. */
 export const MCP_SYNTHETIC_SOURCE = "Synthetic Example added via MCP";
+
+/**
+ * User-Agent sent with Phoenix REST requests.
+ *
+ * Node's global `fetch` (undici) sends `User-Agent: undici` by default. Some
+ * Phoenix Cloud edges 302-redirect requests carrying that User-Agent to an HTML
+ * landing page, so the client receives `<!DOCTYPE html…>` and fails to parse the
+ * response as JSON (see #13742). Sending an explicit User-Agent avoids the redirect.
+ */
+export const USER_AGENT = "phoenix-mcp";

--- a/js/packages/phoenix-mcp/test/client.test.ts
+++ b/js/packages/phoenix-mcp/test/client.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(() => ({}) as unknown),
+}));
+
+vi.mock("@arizeai/phoenix-client", () => ({
+  createClient: createClientMock,
+}));
+
+import { createPhoenixClient } from "../src/client";
+import { USER_AGENT } from "../src/constants";
+
+type CreateClientArg = { options: { headers: Record<string, string> } };
+
+const headersFromLastCall = (): Record<string, string> =>
+  (createClientMock.mock.calls.at(-1)![0] as CreateClientArg).options.headers;
+
+describe("createPhoenixClient", () => {
+  afterEach(() => {
+    createClientMock.mockClear();
+  });
+
+  it("sets an explicit User-Agent so requests are not sent as undici (#13742)", () => {
+    createPhoenixClient({
+      config: { baseUrl: "https://app.phoenix.arize.com" },
+    });
+
+    expect(createClientMock).toHaveBeenCalledTimes(1);
+    expect(headersFromLastCall()["User-Agent"]).toBe(USER_AGENT);
+  });
+
+  it("lets caller-supplied headers override the default User-Agent", () => {
+    createPhoenixClient({
+      config: {
+        baseUrl: "https://app.phoenix.arize.com",
+        headers: { "User-Agent": "custom-agent/1.0" },
+      },
+    });
+
+    expect(headersFromLastCall()["User-Agent"]).toBe("custom-agent/1.0");
+  });
+
+  it("preserves auth headers alongside the User-Agent", () => {
+    createPhoenixClient({
+      config: { baseUrl: "https://app.phoenix.arize.com", apiKey: "secret" },
+    });
+
+    const headers = headersFromLastCall();
+    expect(headers["User-Agent"]).toBe(USER_AGENT);
+    expect(headers.Authorization).toBe("Bearer secret");
+    expect(headers.api_key).toBe("secret");
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #13742 — every `@arizeai/phoenix-mcp` tool call against Phoenix Cloud fails with `Unexpected token < in JSON at position 9`.

**Root cause:** phoenix-mcp uses Node's global `fetch` (undici), which sends `User-Agent: undici`. Phoenix Cloud's edge **302-redirects that User-Agent to an HTML page**, so the client receives `<!DOCTYPE html…>` and fails to parse it as JSON. The request is bounced on User-Agent before it reaches the API (auth/URL are correct).

## Fix
`createPhoenixClient` now sets an explicit `User-Agent` header (`USER_AGENT = "phoenix-mcp"`, defined in `constants.ts`). It is placed **before** the spread of caller-supplied `config.headers`, so a user-provided `User-Agent` still takes precedence, and the existing `Authorization`/`api_key` headers are unaffected.

```ts
const headers: Record<string, string> = {
  "User-Agent": USER_AGENT,
  ...(config.headers || {}),
};
```

## Testing
- New `test/client.test.ts` covers: default User-Agent is sent, caller override wins, and auth headers coexist.
- `pnpm test` → 21 passed (6 files) · `pnpm typecheck` clean · `oxlint` clean.