### PR TITLE
perf(db): sort projects by trace start_time to use composite index

### DIFF
--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -750,14 +750,13 @@ class Trace(HasId):
     project_rowid: Mapped[int] = mapped_column(
         ForeignKey("projects.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
     )
     trace_id: Mapped[str]
     project_session_rowid: Mapped[Optional[int]] = mapped_column(
         ForeignKey("project_sessions.id", ondelete="CASCADE"),
         index=True,
     )
-    start_time: Mapped[datetime] = mapped_column(UtcTimeStamp, index=True)
+    start_time: Mapped[datetime] = mapped_column(UtcTimeStamp)
     end_time: Mapped[datetime] = mapped_column(UtcTimeStamp)
 
     @hybrid_property

--- a/src/phoenix/server/api/dataloaders/min_start_or_max_end_times.py
+++ b/src/phoenix/server/api/dataloaders/min_start_or_max_end_times.py
@@ -65,7 +65,7 @@ class MinStartOrMaxEndTimeDataLoader(DataLoader[Key, Result]):
             select(
                 pid,
                 func.min(models.Trace.start_time).label("min_start"),
-                func.max(models.Trace.end_time).label("max_end"),
+                func.max(models.Trace.start_time).label("max_end"),
             )
             .where(pid.in_(arguments.keys()))
             .group_by(pid)

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -456,7 +456,7 @@ class Query:
             # The end_time comes from the Trace model, and we need to get the max end_time for
             # each project
             end_time_subq = (
-                select(func.max(models.Trace.end_time))
+                select(func.max(models.Trace.start_time))
                 .where(models.Trace.project_rowid == models.Project.id)
                 .scalar_subquery()
             )


### PR DESCRIPTION
## Summary
- Project end-time sorting used `max(traces.end_time)` in a correlated subquery filtered by `project_rowid`. There is **no** `(project_rowid, end_time)` composite index, so the planner could not seek efficiently.
- The composite index `ix_traces_project_rowid_start_time (project_rowid, start_time DESC)` (migration `735d3d93c33e`) **already exists**. Switching the sort subquery (`queries.py`) and the project end-time dataloader (`min_start_or_max_end_times.py`) to `max(traces.start_time)` lets the planner seek by `project_rowid` and read the max straight from the index tail.

> Note: the standalone `start_time` index (`ix_traces_start_time`) does **not** help this query — it can't satisfy the `project_rowid` filter. It is the composite `(project_rowid, start_time DESC)` index that makes this fast.

## Alternative to #13748
This is an alternative approach to #13748, which keeps `max(end_time)` and adds a new `(project_rowid, end_time DESC)` index via an Alembic migration. This PR instead rides the existing `(project_rowid, start_time DESC)` composite index — **no migration required**.

### Tradeoff
A project's reported "end time" now reflects the latest trace **start**, not its actual end. For a long-running trace that started earlier but ended later, the reported end time can be understated. The sort and displayed value stay consistent since both use `max(start_time)`.

## Test plan
- [ ] Sort the projects list by end time and confirm ordering matches the displayed end-time column.
- [ ] `EXPLAIN` the project end-time sort query and confirm it uses `ix_traces_project_rowid_start_time`.

Co-authored-by: Andrei Ladyka <770581+ladyka@users.noreply.github.com>