### PR TITLE
chore(db): align ORM index declarations with migrations for traces/sessions

### DIFF
--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -734,14 +734,20 @@ class ProjectSession(HasId):
     project_id: Mapped[int] = mapped_column(
         ForeignKey("projects.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
     )
-    start_time: Mapped[datetime] = mapped_column(UtcTimeStamp, index=True, nullable=False)
+    start_time: Mapped[datetime] = mapped_column(UtcTimeStamp, nullable=False)
     end_time: Mapped[datetime] = mapped_column(UtcTimeStamp, index=True, nullable=False)
     traces: Mapped[list["Trace"]] = relationship(
         "Trace",
         back_populates="project_session",
         uselist=True,
+    )
+    __table_args__ = (
+        Index(
+            "ix_project_sessions_project_id_start_time",
+            "project_id",
+            text("start_time DESC"),
+        ),
     )
 
 
@@ -750,14 +756,13 @@ class Trace(HasId):
     project_rowid: Mapped[int] = mapped_column(
         ForeignKey("projects.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
     )
     trace_id: Mapped[str]
     project_session_rowid: Mapped[Optional[int]] = mapped_column(
         ForeignKey("project_sessions.id", ondelete="CASCADE"),
         index=True,
     )
-    start_time: Mapped[datetime] = mapped_column(UtcTimeStamp, index=True)
+    start_time: Mapped[datetime] = mapped_column(UtcTimeStamp)
     end_time: Mapped[datetime] = mapped_column(UtcTimeStamp)
 
     @hybrid_property
@@ -796,6 +801,11 @@ class Trace(HasId):
     __table_args__ = (
         UniqueConstraint(
             "trace_id",
+        ),
+        Index(
+            "ix_traces_project_rowid_start_time",
+            "project_rowid",
+            text("start_time DESC"),
         ),
     )
 


### PR DESCRIPTION
## Summary
Aligns the ORM model's index declarations with what the migrations actually produce for the `traces` and `project_sessions` tables.

Migrations `272b66ff50f8` (drop single indices) and `735d3d93c33e` (add composite indices) replaced the standalone single-column indices with composites:

| Table | Dropped (single) | Added (composite) |
|---|---|---|
| `traces` | `ix_traces_project_rowid`, `ix_traces_start_time` | `ix_traces_project_rowid_start_time (project_rowid, start_time DESC)` |
| `project_sessions` | `ix_project_sessions_project_id`, `ix_project_sessions_start_time` | `ix_project_sessions_project_id_start_time (project_id, start_time DESC)` |

The ORM model in `models.py` was never updated to match — it still declared `index=True` on the dropped columns and never declared the composites.

## Why it matters
The canonical DDL (`scripts/ddl/postgresql_schema.sql`) is generated by running Alembic migrations, so production and the DDL were always correct. But schemas built directly from ORM metadata via `Base.metadata.create_all` — the **unit test fixtures** (`tests/unit/conftest.py`) — diverged from production: they recreated the dropped single-column indices and lacked the composites. Tests were running against a different index topology than production.

## Changes
- Drop stale `index=True` on `traces.project_rowid`, `traces.start_time`, `project_sessions.project_id`, `project_sessions.start_time`.
- Add the two composite indices to each table's `__table_args__`.
- `project_sessions.end_time`'s index is kept (`ix_project_sessions_end_time` is still in the migrated schema).

## Verification
- `create_all` on SQLite now produces exactly the migrated index set for both tables (stale singles gone, composites present).
- `make schema-ddl` produces no diff (DDL is migration-driven and already correct).

## Notes / scope
- Standalone, no migration required — this only changes ORM metadata used by `create_all`; the migrated schema is unchanged.
- Overlaps slightly with #13752, which also drops `index=True` on `traces.project_rowid`/`start_time` (but does not add the composite). Once #13752 merges, this branch rebases cleanly (identical deletions).
- Out of scope (separate, pre-existing drift found while auditing): the `spans` expression indices (`ix_latency`, `ix_cumulative_llm_token_count_total`, `ix_spans_session_id`) are declared in the model but absent from the migrated DDL, and `dataset_labels` has `ix_dataset_labels_user_id` in the DDL but not the model. These are left for a dedicated follow-up.