### PR TITLE
feat: Make trace time range URLs shareable

### DIFF
--- a/app/src/components/datetime/TimeRangeContext.tsx
+++ b/app/src/components/datetime/TimeRangeContext.tsx
@@ -3,22 +3,32 @@ import React, {
   startTransition,
   useEffect,
   useEffectEvent,
+  useRef,
   useState,
 } from "react";
+import { useSearchParams } from "react-router";
 
 import {
   SET_TIME_RANGE_TOOL_NAME,
   type SetTimeRangeInput,
 } from "@phoenix/agent/tools/timeRange";
+import {
+  LEGACY_TIME_RANGE_PARAM,
+  TIME_RANGE_END_PARAM,
+  TIME_RANGE_KEY_PARAM,
+  TIME_RANGE_START_PARAM,
+} from "@phoenix/constants/searchParams";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 import type { AgentClientActionResult } from "@phoenix/store/agentStore";
 
-import type { OpenTimeRangeWithKey } from "./types";
+import type { LastNTimeRangeKey, OpenTimeRangeWithKey } from "./types";
 import {
   getMillisecondsUntilNextLastNTimeRangeRefresh,
+  getTimeRangeFromSearchParams,
   getTimeRangeFromLastNTimeRangeKey,
   isLastNTimeRangeKey,
+  setTimeRangeSearchParams,
 } from "./utils";
 
 export type TimeRangeContextType = {
@@ -54,7 +64,45 @@ export function useTimeRange() {
   return context;
 }
 
+function getStoredTimeRange({
+  storedLastNTimeRangeKey,
+  now,
+}: {
+  storedLastNTimeRangeKey: unknown;
+  now: number;
+}): OpenTimeRangeWithKey {
+  // Just to be safe, we check if the stored time range key is valid
+  if (isLastNTimeRangeKey(storedLastNTimeRangeKey)) {
+    return {
+      timeRangeKey: storedLastNTimeRangeKey,
+      ...getTimeRangeFromLastNTimeRangeKey(storedLastNTimeRangeKey, now),
+    };
+  }
+  // Fall back to the default time range
+  return {
+    timeRangeKey: "7d",
+    ...getTimeRangeFromLastNTimeRangeKey("7d", now),
+  };
+}
+
+function getTimeRangeSearchSignature(searchParams: URLSearchParams) {
+  const scopedSearchParams = new URLSearchParams();
+  for (const param of [
+    LEGACY_TIME_RANGE_PARAM,
+    TIME_RANGE_KEY_PARAM,
+    TIME_RANGE_START_PARAM,
+    TIME_RANGE_END_PARAM,
+  ]) {
+    const value = searchParams.get(param);
+    if (value != null) {
+      scopedSearchParams.set(param, value);
+    }
+  }
+  return scopedSearchParams.toString();
+}
+
 export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
+  const [searchParams, setSearchParams] = useSearchParams();
   /**
    * Load in the last N time range key from preferences
    */
@@ -66,35 +114,72 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
     (state) => state.setLastNTimeRangeKey
   );
 
-  // Default to the last N time range stored in preferences
-  const [timeRange, _setTimeRange] = useState<OpenTimeRangeWithKey>(() => {
-    // Just to be safe, we check if the stored time range key is valid
-    if (isLastNTimeRangeKey(storedLastNTimeRangeKey)) {
-      return {
-        timeRangeKey: storedLastNTimeRangeKey,
-        ...getTimeRangeFromLastNTimeRangeKey(storedLastNTimeRangeKey),
-      };
-    } else {
-      // Fall back to the default time range
-      return {
-        timeRangeKey: "7d",
-        ...getTimeRangeFromLastNTimeRangeKey("7d"),
-      };
+  const [timeRangeNow, setTimeRangeNow] = useState(() => Date.now());
+  const liveTimeRangeKeyRef = useRef<LastNTimeRangeKey | null>(null);
+  const lastWrittenTimeRangeSearchRef = useRef<string | null>(null);
+  const currentTimeRangeSearch = getTimeRangeSearchSignature(searchParams);
+  const urlTimeRangeKey =
+    searchParams.get(TIME_RANGE_KEY_PARAM) ??
+    searchParams.get(LEGACY_TIME_RANGE_PARAM);
+  const hasUrlTimeRangeBounds =
+    searchParams.has(TIME_RANGE_START_PARAM) ||
+    searchParams.has(TIME_RANGE_END_PARAM);
+  const isLiveUrlTimeRange =
+    isLastNTimeRangeKey(urlTimeRangeKey) &&
+    liveTimeRangeKeyRef.current === urlTimeRangeKey &&
+    lastWrittenTimeRangeSearchRef.current === currentTimeRangeSearch;
+  const urlTimeRange = getTimeRangeFromSearchParams(
+    searchParams,
+    timeRangeNow,
+    {
+      preferConcreteBounds: !isLiveUrlTimeRange,
     }
+  );
+  const storedTimeRange = getStoredTimeRange({
+    storedLastNTimeRangeKey,
+    now: timeRangeNow,
   });
+  const timeRange = urlTimeRange ?? storedTimeRange;
+  const timeRangeStartMs = timeRange.start?.getTime();
+  const isRelativeUrlTimeRange =
+    isLastNTimeRangeKey(urlTimeRangeKey) && !hasUrlTimeRangeBounds;
+  const isLiveLastNTimeRange =
+    isLastNTimeRangeKey(timeRange.timeRangeKey) &&
+    (liveTimeRangeKeyRef.current === timeRange.timeRangeKey ||
+      isRelativeUrlTimeRange ||
+      urlTimeRange == null);
 
   const setTimeRange = (timeRange: OpenTimeRangeWithKey) => {
+    const now = Date.now();
     const nextTimeRange = isLastNTimeRangeKey(timeRange.timeRangeKey)
       ? {
           timeRangeKey: timeRange.timeRangeKey,
-          ...getTimeRangeFromLastNTimeRangeKey(timeRange.timeRangeKey),
+          ...getTimeRangeFromLastNTimeRangeKey(timeRange.timeRangeKey, now),
         }
       : timeRange;
+    if (isLastNTimeRangeKey(timeRange.timeRangeKey)) {
+      liveTimeRangeKeyRef.current = timeRange.timeRangeKey;
+    } else {
+      liveTimeRangeKeyRef.current = null;
+    }
     startTransition(() => {
-      _setTimeRange(nextTimeRange);
+      setSearchParams(
+        (currentSearchParams) => {
+          const nextSearchParams = setTimeRangeSearchParams({
+            searchParams: currentSearchParams,
+            timeRange: nextTimeRange,
+            now: new Date(now),
+          });
+          lastWrittenTimeRangeSearchRef.current =
+            getTimeRangeSearchSignature(nextSearchParams);
+          return nextSearchParams;
+        },
+        { replace: true }
+      );
       // Store the last N time range key in preferences
       if (isLastNTimeRangeKey(timeRange.timeRangeKey)) {
         setStoredLastNTimeRangeKey(timeRange.timeRangeKey);
+        setTimeRangeNow(now);
       }
     });
   };
@@ -108,24 +193,40 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
   };
 
   useEffect(() => {
-    if (!isLastNTimeRangeKey(timeRange.timeRangeKey)) {
+    if (isLiveLastNTimeRange) {
+      liveTimeRangeKeyRef.current = timeRange.timeRangeKey as LastNTimeRangeKey;
+    }
+    const nextSearchParams = setTimeRangeSearchParams({
+      searchParams,
+      timeRange,
+      now: new Date(timeRangeNow),
+    });
+    if (nextSearchParams.toString() === searchParams.toString()) {
       return;
     }
+    lastWrittenTimeRangeSearchRef.current =
+      getTimeRangeSearchSignature(nextSearchParams);
+    setSearchParams(nextSearchParams, { replace: true });
+  }, [
+    isLiveLastNTimeRange,
+    searchParams,
+    setSearchParams,
+    timeRange,
+    timeRangeNow,
+  ]);
+
+  useEffect(() => {
+    if (!isLiveLastNTimeRange || !isLastNTimeRangeKey(timeRange.timeRangeKey)) {
+      return;
+    }
+    const timeRangeKey = timeRange.timeRangeKey;
     const timeoutId = window.setTimeout(() => {
-      _setTimeRange((currentTimeRange) => {
-        if (!isLastNTimeRangeKey(currentTimeRange.timeRangeKey)) {
-          return currentTimeRange;
-        }
-        return {
-          timeRangeKey: currentTimeRange.timeRangeKey,
-          ...getTimeRangeFromLastNTimeRangeKey(currentTimeRange.timeRangeKey),
-        };
-      });
-    }, getMillisecondsUntilNextLastNTimeRangeRefresh(timeRange.timeRangeKey));
+      setTimeRangeNow(Date.now());
+    }, getMillisecondsUntilNextLastNTimeRangeRefresh(timeRangeKey));
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [timeRange]);
+  }, [isLiveLastNTimeRange, timeRange.timeRangeKey, timeRangeStartMs]);
 
   useRegisterSetTimeRangeClientAction({ setTimeRange });
 

--- a/app/src/components/datetime/TimeRangeContext.tsx
+++ b/app/src/components/datetime/TimeRangeContext.tsx
@@ -13,7 +13,6 @@ import {
   type SetTimeRangeInput,
 } from "@phoenix/agent/tools/timeRange";
 import {
-  LEGACY_TIME_RANGE_PARAM,
   TIME_RANGE_END_PARAM,
   TIME_RANGE_KEY_PARAM,
   TIME_RANGE_START_PARAM,
@@ -88,7 +87,6 @@ function getStoredTimeRange({
 function getTimeRangeSearchSignature(searchParams: URLSearchParams) {
   const scopedSearchParams = new URLSearchParams();
   for (const param of [
-    LEGACY_TIME_RANGE_PARAM,
     TIME_RANGE_KEY_PARAM,
     TIME_RANGE_START_PARAM,
     TIME_RANGE_END_PARAM,
@@ -118,9 +116,7 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
   const liveTimeRangeKeyRef = useRef<LastNTimeRangeKey | null>(null);
   const lastWrittenTimeRangeSearchRef = useRef<string | null>(null);
   const currentTimeRangeSearch = getTimeRangeSearchSignature(searchParams);
-  const urlTimeRangeKey =
-    searchParams.get(TIME_RANGE_KEY_PARAM) ??
-    searchParams.get(LEGACY_TIME_RANGE_PARAM);
+  const urlTimeRangeKey = searchParams.get(TIME_RANGE_KEY_PARAM);
   const hasUrlTimeRangeBounds =
     searchParams.has(TIME_RANGE_START_PARAM) ||
     searchParams.has(TIME_RANGE_END_PARAM);

--- a/app/src/components/datetime/TimeRangeContext.tsx
+++ b/app/src/components/datetime/TimeRangeContext.tsx
@@ -63,6 +63,11 @@ export function useTimeRange() {
   return context;
 }
 
+/**
+ * Resolve the time range to fall back to when the URL carries none, from the
+ * user's stored last-N preference. Defaults to the last 7 days when the stored
+ * value is missing or invalid.
+ */
 function getStoredTimeRange({
   storedLastNTimeRangeKey,
   now,
@@ -70,7 +75,7 @@ function getStoredTimeRange({
   storedLastNTimeRangeKey: unknown;
   now: number;
 }): OpenTimeRangeWithKey {
-  // Just to be safe, we check if the stored time range key is valid
+  // Guard against a malformed stored value before trusting it.
   if (isLastNTimeRangeKey(storedLastNTimeRangeKey)) {
     return {
       timeRangeKey: storedLastNTimeRangeKey,
@@ -84,6 +89,21 @@ function getStoredTimeRange({
   };
 }
 
+/**
+ * Builds a stable string signature of just the time-range-related search
+ * params ({@link TIME_RANGE_KEY_PARAM}, {@link TIME_RANGE_START_PARAM},
+ * {@link TIME_RANGE_END_PARAM}), ignoring all other params in the URL.
+ *
+ * The params are collected in a fixed order so the resulting string is
+ * deterministic regardless of how they happen to be ordered in the URL. This
+ * lets callers cheaply compare whether the time range encoded in the URL has
+ * changed (e.g. against `lastWrittenTimeRangeSearchRef`) without reacting to
+ * unrelated search param updates.
+ *
+ * @param searchParams - The current URL search params.
+ * @returns A normalized query string containing only the present time-range
+ *   params, or an empty string if none are set.
+ */
 function getTimeRangeSearchSignature(searchParams: URLSearchParams) {
   const scopedSearchParams = new URLSearchParams();
   for (const param of [
@@ -99,31 +119,62 @@ function getTimeRangeSearchSignature(searchParams: URLSearchParams) {
   return scopedSearchParams.toString();
 }
 
+/**
+ * Provides the active tracing time range to the app and keeps it in sync with
+ * the URL.
+ *
+ * The active range takes one of two shapes:
+ * - **Live (last-N):** a relative window like "7d" that always ends at "now"
+ *   and refreshes on a timer (see {@link LastNTimeRangeKey}).
+ * - **Custom:** a fixed, closed window with concrete start/end bounds.
+ *
+ * State is sourced with the following precedence:
+ * 1. The URL search params — the canonical, shareable source of truth.
+ * 2. The user's stored last-N preference — used when the URL carries no time
+ *    range (e.g. a fresh visit).
+ *
+ * The subtle part is telling a *live* last-N range that we wrote ourselves
+ * (which should keep tracking "now") apart from a *shared or restored* URL that
+ * pins concrete bounds (which must be honored verbatim). Two refs disambiguate:
+ * - `liveTimeRangeKeyRef`: the last-N key currently ticking live, or null.
+ * - `lastWrittenTimeRangeSearchRef`: a signature of the time-range params we
+ *   last wrote, so a URL matching it is known to be ours rather than external.
+ */
 export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
   const [searchParams, setSearchParams] = useSearchParams();
-  /**
-   * Load in the last N time range key from preferences
-   */
   const storedLastNTimeRangeKey = usePreferencesContext(
     (state) => state.lastNTimeRangeKey
   );
-
   const setStoredLastNTimeRangeKey = usePreferencesContext(
     (state) => state.setLastNTimeRangeKey
   );
 
+  // The "now" anchor for resolving relative (last-N) windows. Bumped on a timer
+  // so live windows slide forward, and reset whenever a new last-N range is set.
   const [timeRangeNow, setTimeRangeNow] = useState(() => Date.now());
+  // The last-N key currently tracking "now" live, or null when the active range
+  // is a fixed custom window.
   const liveTimeRangeKeyRef = useRef<LastNTimeRangeKey | null>(null);
+  // Signature of the time-range params we last wrote, used to recognize our own
+  // URL writes versus an externally supplied (shared/restored) range.
   const lastWrittenTimeRangeSearchRef = useRef<string | null>(null);
+
   const currentTimeRangeSearch = getTimeRangeSearchSignature(searchParams);
   const urlTimeRangeKey = searchParams.get(TIME_RANGE_KEY_PARAM);
   const hasUrlTimeRangeBounds =
     searchParams.has(TIME_RANGE_START_PARAM) ||
     searchParams.has(TIME_RANGE_END_PARAM);
+
+  // The URL range is "live" only when it is a last-N key that we wrote and have
+  // been ticking — i.e. its params still match our last write. We then recompute
+  // the window from the key rather than honoring any now-stale bounds in the URL.
   const isLiveUrlTimeRange =
     isLastNTimeRangeKey(urlTimeRangeKey) &&
     liveTimeRangeKeyRef.current === urlTimeRangeKey &&
     lastWrittenTimeRangeSearchRef.current === currentTimeRangeSearch;
+
+  // A shared/restored URL keeps its concrete bounds; a live one re-derives them
+  // from the key against `timeRangeNow`.
   const urlTimeRange = getTimeRangeFromSearchParams(
     searchParams,
     timeRangeNow,
@@ -135,16 +186,31 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
     storedLastNTimeRangeKey,
     now: timeRangeNow,
   });
+  // The URL wins when it carries a usable range; otherwise fall back to the
+  // stored preference.
   const timeRange = urlTimeRange ?? storedTimeRange;
   const timeRangeStartMs = timeRange.start?.getTime();
+
+  // A relative URL range is a last-N key with no concrete bounds pinned.
   const isRelativeUrlTimeRange =
     isLastNTimeRangeKey(urlTimeRangeKey) && !hasUrlTimeRangeBounds;
+  // Whether the active range should keep ticking live against "now": a last-N
+  // key that we are already tracking, that came from a relative URL, or that
+  // came from the stored preference (no URL range at all).
   const isLiveLastNTimeRange =
     isLastNTimeRangeKey(timeRange.timeRangeKey) &&
     (liveTimeRangeKeyRef.current === timeRange.timeRangeKey ||
       isRelativeUrlTimeRange ||
       urlTimeRange == null);
 
+  /**
+   * Set the active time range and reflect it in the URL.
+   *
+   * Last-N keys are resolved to a concrete window at call time (anchored to
+   * "now") and marked live so they keep refreshing; custom ranges are written
+   * as-is. The URL write replaces history (no new entry per change) and any
+   * last-N key is persisted as the user's preference.
+   */
   const setTimeRange = (timeRange: OpenTimeRangeWithKey) => {
     const now = Date.now();
     const nextTimeRange = isLastNTimeRangeKey(timeRange.timeRangeKey)
@@ -153,11 +219,11 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
           ...getTimeRangeFromLastNTimeRangeKey(timeRange.timeRangeKey, now),
         }
       : timeRange;
-    if (isLastNTimeRangeKey(timeRange.timeRangeKey)) {
-      liveTimeRangeKeyRef.current = timeRange.timeRangeKey;
-    } else {
-      liveTimeRangeKeyRef.current = null;
-    }
+    // Track (last-N) or clear (custom) the live key so the URL sync can tell
+    // this write apart from an externally supplied range.
+    liveTimeRangeKeyRef.current = isLastNTimeRangeKey(timeRange.timeRangeKey)
+      ? timeRange.timeRangeKey
+      : null;
     startTransition(() => {
       setSearchParams(
         (currentSearchParams) => {
@@ -172,7 +238,7 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
         },
         { replace: true }
       );
-      // Store the last N time range key in preferences
+      // Persist the preset and re-anchor "now" so the live window refreshes.
       if (isLastNTimeRangeKey(timeRange.timeRangeKey)) {
         setStoredLastNTimeRangeKey(timeRange.timeRangeKey);
         setTimeRangeNow(now);
@@ -188,6 +254,11 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
     });
   };
 
+  // Keep the URL in sync with the active range. This covers the cases that
+  // `setTimeRange` does not write directly: seeding a fresh URL from the stored
+  // preference on first load, and advancing a live window's end on each refresh.
+  // The write is skipped when the params already match to avoid redundant
+  // history updates.
   useEffect(() => {
     if (isLiveLastNTimeRange) {
       liveTimeRangeKeyRef.current = timeRange.timeRangeKey as LastNTimeRangeKey;
@@ -211,6 +282,9 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
     timeRangeNow,
   ]);
 
+  // Drive live refreshes. While a last-N range is live, schedule a bump of
+  // `timeRangeNow` for when its window next rolls over (the start of the next
+  // minute or hour) so the displayed window keeps tracking "now".
   useEffect(() => {
     if (!isLiveLastNTimeRange || !isLastNTimeRangeKey(timeRange.timeRangeKey)) {
       return;

--- a/app/src/components/datetime/TimeRangeContext.tsx
+++ b/app/src/components/datetime/TimeRangeContext.tsx
@@ -118,13 +118,11 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
   const [timeRangeNow, setTimeRangeNow] = useState(() => Date.now());
 
   // The URL wins when it carries a usable range; otherwise fall back to the
-  // stored preference.
+  // stored preference (computed lazily, only when the URL carries no range).
   const urlTimeRange = getTimeRangeFromSearchParams(searchParams, timeRangeNow);
-  const storedTimeRange = getStoredTimeRange({
-    storedLastNTimeRangeKey,
-    now: timeRangeNow,
-  });
-  const timeRange = urlTimeRange ?? storedTimeRange;
+  const timeRange =
+    urlTimeRange ??
+    getStoredTimeRange({ storedLastNTimeRangeKey, now: timeRangeNow });
   const timeRangeStartMs = timeRange.start?.getTime();
 
   /**

--- a/app/src/components/datetime/TimeRangeContext.tsx
+++ b/app/src/components/datetime/TimeRangeContext.tsx
@@ -3,7 +3,6 @@ import React, {
   startTransition,
   useEffect,
   useEffectEvent,
-  useRef,
   useState,
 } from "react";
 import { useSearchParams } from "react-router";
@@ -12,16 +11,11 @@ import {
   SET_TIME_RANGE_TOOL_NAME,
   type SetTimeRangeInput,
 } from "@phoenix/agent/tools/timeRange";
-import {
-  TIME_RANGE_END_PARAM,
-  TIME_RANGE_KEY_PARAM,
-  TIME_RANGE_START_PARAM,
-} from "@phoenix/constants/searchParams";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 import type { AgentClientActionResult } from "@phoenix/store/agentStore";
 
-import type { LastNTimeRangeKey, OpenTimeRangeWithKey } from "./types";
+import type { OpenTimeRangeWithKey } from "./types";
 import {
   getMillisecondsUntilNextLastNTimeRangeRefresh,
   getTimeRangeFromSearchParams,
@@ -90,55 +84,25 @@ function getStoredTimeRange({
 }
 
 /**
- * Builds a stable string signature of just the time-range-related search
- * params ({@link TIME_RANGE_KEY_PARAM}, {@link TIME_RANGE_START_PARAM},
- * {@link TIME_RANGE_END_PARAM}), ignoring all other params in the URL.
- *
- * The params are collected in a fixed order so the resulting string is
- * deterministic regardless of how they happen to be ordered in the URL. This
- * lets callers cheaply compare whether the time range encoded in the URL has
- * changed (e.g. against `lastWrittenTimeRangeSearchRef`) without reacting to
- * unrelated search param updates.
- *
- * @param searchParams - The current URL search params.
- * @returns A normalized query string containing only the present time-range
- *   params, or an empty string if none are set.
- */
-function getTimeRangeSearchSignature(searchParams: URLSearchParams) {
-  const scopedSearchParams = new URLSearchParams();
-  for (const param of [
-    TIME_RANGE_KEY_PARAM,
-    TIME_RANGE_START_PARAM,
-    TIME_RANGE_END_PARAM,
-  ]) {
-    const value = searchParams.get(param);
-    if (value != null) {
-      scopedSearchParams.set(param, value);
-    }
-  }
-  return scopedSearchParams.toString();
-}
-
-/**
  * Provides the active tracing time range to the app and keeps it in sync with
  * the URL.
  *
- * The active range takes one of two shapes:
- * - **Live (last-N):** a relative window like "7d" that always ends at "now"
- *   and refreshes on a timer (see {@link LastNTimeRangeKey}).
- * - **Custom:** a fixed, closed window with concrete start/end bounds.
+ * The active range takes one of two shapes, mirroring the URL's two mutually
+ * exclusive representations (see {@link getTimeRangeFromSearchParams}):
+ * - **Live (last-N):** a `timeRangeKey` like "7d" with no bounds. It always
+ *   ends at "now" and refreshes on a timer (see {@link LastNTimeRangeKey}).
+ * - **Custom:** explicit start/end bounds with no key — a fixed window honored
+ *   verbatim.
+ *
+ * Because the URL is declarative — a key XOR explicit bounds — "is this range
+ * live?" is a pure function of its shape: a last-N key is always live, a custom
+ * range never is. No provenance tracking is needed to tell a self-authored URL
+ * apart from a shared/restored one.
  *
  * State is sourced with the following precedence:
  * 1. The URL search params — the canonical, shareable source of truth.
  * 2. The user's stored last-N preference — used when the URL carries no time
- *    range (e.g. a fresh visit).
- *
- * The subtle part is telling a *live* last-N range that we wrote ourselves
- * (which should keep tracking "now") apart from a *shared or restored* URL that
- * pins concrete bounds (which must be honored verbatim). Two refs disambiguate:
- * - `liveTimeRangeKeyRef`: the last-N key currently ticking live, or null.
- * - `lastWrittenTimeRangeSearchRef`: a signature of the time-range params we
- *   last wrote, so a URL matching it is known to be ours rather than external.
+ *    range (e.g. a fresh visit), and then seeded into the URL.
  */
 export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -152,96 +116,39 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
   // The "now" anchor for resolving relative (last-N) windows. Bumped on a timer
   // so live windows slide forward, and reset whenever a new last-N range is set.
   const [timeRangeNow, setTimeRangeNow] = useState(() => Date.now());
-  // The last-N key currently tracking "now" live, or null when the active range
-  // is a fixed custom window.
-  const liveTimeRangeKeyRef = useRef<LastNTimeRangeKey | null>(null);
-  // Signature of the time-range params we last wrote, used to recognize our own
-  // URL writes versus an externally supplied (shared/restored) range.
-  const lastWrittenTimeRangeSearchRef = useRef<string | null>(null);
 
-  const currentTimeRangeSearch = getTimeRangeSearchSignature(searchParams);
-  const urlTimeRangeKey = searchParams.get(TIME_RANGE_KEY_PARAM);
-  const hasUrlTimeRangeBounds =
-    searchParams.has(TIME_RANGE_START_PARAM) ||
-    searchParams.has(TIME_RANGE_END_PARAM);
-
-  // The URL range is "live" only when it is a last-N key that we wrote and have
-  // been ticking — i.e. its params still match our last write. We then recompute
-  // the window from the key rather than honoring any now-stale bounds in the URL.
-  const isLiveUrlTimeRange =
-    isLastNTimeRangeKey(urlTimeRangeKey) &&
-    liveTimeRangeKeyRef.current === urlTimeRangeKey &&
-    lastWrittenTimeRangeSearchRef.current === currentTimeRangeSearch;
-
-  // A shared/restored URL keeps its concrete bounds; a live one re-derives them
-  // from the key against `timeRangeNow`.
-  const urlTimeRange = getTimeRangeFromSearchParams(
-    searchParams,
-    timeRangeNow,
-    {
-      preferConcreteBounds: !isLiveUrlTimeRange,
-    }
-  );
+  // The URL wins when it carries a usable range; otherwise fall back to the
+  // stored preference.
+  const urlTimeRange = getTimeRangeFromSearchParams(searchParams, timeRangeNow);
   const storedTimeRange = getStoredTimeRange({
     storedLastNTimeRangeKey,
     now: timeRangeNow,
   });
-  // The URL wins when it carries a usable range; otherwise fall back to the
-  // stored preference.
   const timeRange = urlTimeRange ?? storedTimeRange;
   const timeRangeStartMs = timeRange.start?.getTime();
-
-  // A relative URL range is a last-N key with no concrete bounds pinned.
-  const isRelativeUrlTimeRange =
-    isLastNTimeRangeKey(urlTimeRangeKey) && !hasUrlTimeRangeBounds;
-  // Whether the active range should keep ticking live against "now": a last-N
-  // key that we are already tracking, that came from a relative URL, or that
-  // came from the stored preference (no URL range at all).
-  const isLiveLastNTimeRange =
-    isLastNTimeRangeKey(timeRange.timeRangeKey) &&
-    (liveTimeRangeKeyRef.current === timeRange.timeRangeKey ||
-      isRelativeUrlTimeRange ||
-      urlTimeRange == null);
 
   /**
    * Set the active time range and reflect it in the URL.
    *
-   * Last-N keys are resolved to a concrete window at call time (anchored to
-   * "now") and marked live so they keep refreshing; custom ranges are written
-   * as-is. The URL write replaces history (no new entry per change) and any
-   * last-N key is persisted as the user's preference.
+   * The URL write is declarative: a last-N key is written as just the key
+   * (clearing any bounds) and a custom range as just its bounds. The write
+   * replaces history (no new entry per change) and any last-N key is persisted
+   * as the user's preference.
    */
   const setTimeRange = (timeRange: OpenTimeRangeWithKey) => {
-    const now = Date.now();
-    const nextTimeRange = isLastNTimeRangeKey(timeRange.timeRangeKey)
-      ? {
-          timeRangeKey: timeRange.timeRangeKey,
-          ...getTimeRangeFromLastNTimeRangeKey(timeRange.timeRangeKey, now),
-        }
-      : timeRange;
-    // Track (last-N) or clear (custom) the live key so the URL sync can tell
-    // this write apart from an externally supplied range.
-    liveTimeRangeKeyRef.current = isLastNTimeRangeKey(timeRange.timeRangeKey)
-      ? timeRange.timeRangeKey
-      : null;
     startTransition(() => {
       setSearchParams(
-        (currentSearchParams) => {
-          const nextSearchParams = setTimeRangeSearchParams({
+        (currentSearchParams) =>
+          setTimeRangeSearchParams({
             searchParams: currentSearchParams,
-            timeRange: nextTimeRange,
-            now: new Date(now),
-          });
-          lastWrittenTimeRangeSearchRef.current =
-            getTimeRangeSearchSignature(nextSearchParams);
-          return nextSearchParams;
-        },
+            timeRange,
+          }),
         { replace: true }
       );
       // Persist the preset and re-anchor "now" so the live window refreshes.
       if (isLastNTimeRangeKey(timeRange.timeRangeKey)) {
         setStoredLastNTimeRangeKey(timeRange.timeRangeKey);
-        setTimeRangeNow(now);
+        setTimeRangeNow(Date.now());
       }
     });
   };
@@ -254,39 +161,29 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
     });
   };
 
-  // Keep the URL in sync with the active range. This covers the cases that
-  // `setTimeRange` does not write directly: seeding a fresh URL from the stored
-  // preference on first load, and advancing a live window's end on each refresh.
-  // The write is skipped when the params already match to avoid redundant
-  // history updates.
+  // Seed a fresh URL from the stored preference on first load. Once the URL
+  // carries a range it is canonical, so this no-ops. A live window's refresh
+  // needs no URL write: the URL holds only the key, and the window is
+  // recomputed from `timeRangeNow` on each render.
   useEffect(() => {
-    if (isLiveLastNTimeRange) {
-      liveTimeRangeKeyRef.current = timeRange.timeRangeKey as LastNTimeRangeKey;
+    if (urlTimeRange != null) {
+      return;
     }
     const nextSearchParams = setTimeRangeSearchParams({
       searchParams,
       timeRange,
-      now: new Date(timeRangeNow),
     });
     if (nextSearchParams.toString() === searchParams.toString()) {
       return;
     }
-    lastWrittenTimeRangeSearchRef.current =
-      getTimeRangeSearchSignature(nextSearchParams);
     setSearchParams(nextSearchParams, { replace: true });
-  }, [
-    isLiveLastNTimeRange,
-    searchParams,
-    setSearchParams,
-    timeRange,
-    timeRangeNow,
-  ]);
+  }, [urlTimeRange, searchParams, setSearchParams, timeRange]);
 
   // Drive live refreshes. While a last-N range is live, schedule a bump of
   // `timeRangeNow` for when its window next rolls over (the start of the next
   // minute or hour) so the displayed window keeps tracking "now".
   useEffect(() => {
-    if (!isLiveLastNTimeRange || !isLastNTimeRangeKey(timeRange.timeRangeKey)) {
+    if (!isLastNTimeRangeKey(timeRange.timeRangeKey)) {
       return;
     }
     const timeRangeKey = timeRange.timeRangeKey;
@@ -296,7 +193,7 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [isLiveLastNTimeRange, timeRange.timeRangeKey, timeRangeStartMs]);
+  }, [timeRange.timeRangeKey, timeRangeStartMs]);
 
   useRegisterSetTimeRangeClientAction({ setTimeRange });
 

--- a/app/src/components/datetime/__tests__/TimeRangeContext.test.tsx
+++ b/app/src/components/datetime/__tests__/TimeRangeContext.test.tsx
@@ -1,7 +1,14 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import {
+  MemoryRouter,
+  type NavigateFunction,
+  useLocation,
+  useNavigate,
+} from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { AgentProvider } from "@phoenix/contexts/AgentContext";
 import { PreferencesProvider } from "@phoenix/contexts/PreferencesContext";
 
@@ -10,19 +17,64 @@ import {
   TimeRangeProvider,
   useTimeRange,
 } from "../TimeRangeContext";
-import type { OpenTimeRangeWithKey } from "../types";
+import type { LastNTimeRangeKey, OpenTimeRangeWithKey } from "../types";
 
 function TimeRangeReader({
   onRender,
   onSetTimeRange,
+  onLocation,
+  onNavigate,
 }: {
   onRender: (timeRange: OpenTimeRangeWithKey) => void;
   onSetTimeRange?: (setTimeRange: TimeRangeContextType["setTimeRange"]) => void;
+  onLocation?: (search: string) => void;
+  onNavigate?: (navigate: NavigateFunction) => void;
 }) {
   const { timeRange, setTimeRange } = useTimeRange();
+  const location = useLocation();
+  const navigate = useNavigate();
   onRender(timeRange);
   onSetTimeRange?.(setTimeRange);
+  onLocation?.(location.search);
+  onNavigate?.(navigate);
   return null;
+}
+
+function renderTimeRangeProvider({
+  root,
+  initialEntry = "/projects/project-1/traces",
+  lastNTimeRangeKey = "15m",
+  onRender,
+  onSetTimeRange,
+  onLocation,
+  onNavigate,
+}: {
+  root: Root;
+  initialEntry?: string;
+  lastNTimeRangeKey?: LastNTimeRangeKey;
+  onRender: (timeRange: OpenTimeRangeWithKey) => void;
+  onSetTimeRange?: (setTimeRange: TimeRangeContextType["setTimeRange"]) => void;
+  onLocation?: (search: string) => void;
+  onNavigate?: (navigate: NavigateFunction) => void;
+}) {
+  act(() => {
+    root.render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <PreferencesProvider lastNTimeRangeKey={lastNTimeRangeKey}>
+          <AgentProvider>
+            <TimeRangeProvider>
+              <TimeRangeReader
+                onRender={onRender}
+                onSetTimeRange={onSetTimeRange}
+                onLocation={onLocation}
+                onNavigate={onNavigate}
+              />
+            </TimeRangeProvider>
+          </AgentProvider>
+        </PreferencesProvider>
+      </MemoryRouter>
+    );
+  });
 }
 
 describe("TimeRangeProvider", () => {
@@ -50,20 +102,11 @@ describe("TimeRangeProvider", () => {
   it("keeps last-N ranges open-ended and advances them at refresh boundaries", () => {
     const renderedTimeRanges: OpenTimeRangeWithKey[] = [];
 
-    act(() => {
-      root.render(
-        <PreferencesProvider lastNTimeRangeKey="15m">
-          <AgentProvider>
-            <TimeRangeProvider>
-              <TimeRangeReader
-                onRender={(timeRange) => {
-                  renderedTimeRanges.push(timeRange);
-                }}
-              />
-            </TimeRangeProvider>
-          </AgentProvider>
-        </PreferencesProvider>
-      );
+    renderTimeRangeProvider({
+      root,
+      onRender: (timeRange) => {
+        renderedTimeRanges.push(timeRange);
+      },
     });
 
     expect(renderedTimeRanges.at(-1)?.timeRangeKey).toBe("15m");
@@ -89,23 +132,14 @@ describe("TimeRangeProvider", () => {
     const start = new Date("2026-06-09T09:00:00.000Z");
     const end = new Date("2026-06-09T11:00:00.000Z");
 
-    act(() => {
-      root.render(
-        <PreferencesProvider lastNTimeRangeKey="15m">
-          <AgentProvider>
-            <TimeRangeProvider>
-              <TimeRangeReader
-                onRender={(timeRange) => {
-                  renderedTimeRanges.push(timeRange);
-                }}
-                onSetTimeRange={(nextSetTimeRange) => {
-                  setTimeRange = nextSetTimeRange;
-                }}
-              />
-            </TimeRangeProvider>
-          </AgentProvider>
-        </PreferencesProvider>
-      );
+    renderTimeRangeProvider({
+      root,
+      onRender: (timeRange) => {
+        renderedTimeRanges.push(timeRange);
+      },
+      onSetTimeRange: (nextSetTimeRange) => {
+        setTimeRange = nextSetTimeRange;
+      },
     });
 
     act(() => {
@@ -113,7 +147,7 @@ describe("TimeRangeProvider", () => {
     });
 
     expect(renderedTimeRanges.at(-1)?.timeRangeKey).toBe("custom");
-    expect(renderedTimeRanges.at(-1)?.start).toBe(start);
+    expect(renderedTimeRanges.at(-1)?.start).toStrictEqual(start);
     expect(renderedTimeRanges.at(-1)?.end).toBeNull();
 
     act(() => {
@@ -122,6 +156,168 @@ describe("TimeRangeProvider", () => {
 
     expect(renderedTimeRanges.at(-1)?.timeRangeKey).toBe("custom");
     expect(renderedTimeRanges.at(-1)?.start).toBeNull();
-    expect(renderedTimeRanges.at(-1)?.end).toBe(end);
+    expect(renderedTimeRanges.at(-1)?.end).toStrictEqual(end);
+  });
+
+  it("initializes from URL search params before stored preferences", () => {
+    const renderedTimeRanges: OpenTimeRangeWithKey[] = [];
+
+    renderTimeRangeProvider({
+      root,
+      initialEntry: "/projects/project-1/traces?timeRange=1h",
+      lastNTimeRangeKey: "15m",
+      onRender: (timeRange) => {
+        renderedTimeRanges.push(timeRange);
+      },
+    });
+
+    expect(renderedTimeRanges.at(-1)?.timeRangeKey).toBe("1h");
+    expect(renderedTimeRanges.at(-1)?.start?.toISOString()).toBe(
+      "2026-06-09T09:00:00.000Z"
+    );
+    expect(renderedTimeRanges.at(-1)?.end).toBeNull();
+  });
+
+  it("initializes from concrete last-N URL bounds before stored preferences", () => {
+    const renderedTimeRanges: OpenTimeRangeWithKey[] = [];
+
+    renderTimeRangeProvider({
+      root,
+      initialEntry:
+        "/projects/project-1/traces?timeRangeKey=1h&timeRangeStart=2026-06-09T08%3A00%3A00.000Z&timeRangeEnd=2026-06-09T09%3A00%3A00.000Z",
+      lastNTimeRangeKey: "15m",
+      onRender: (timeRange) => {
+        renderedTimeRanges.push(timeRange);
+      },
+    });
+
+    expect(renderedTimeRanges.at(-1)?.timeRangeKey).toBe("1h");
+    expect(renderedTimeRanges.at(-1)?.start?.toISOString()).toBe(
+      "2026-06-09T08:00:00.000Z"
+    );
+    expect(renderedTimeRanges.at(-1)?.end?.toISOString()).toBe(
+      "2026-06-09T09:00:00.000Z"
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(renderedTimeRanges.at(-1)?.start?.toISOString()).toBe(
+      "2026-06-09T08:00:00.000Z"
+    );
+    expect(renderedTimeRanges.at(-1)?.end?.toISOString()).toBe(
+      "2026-06-09T09:00:00.000Z"
+    );
+  });
+
+  it("canonicalizes relative last-N URLs with concrete bounds", () => {
+    const renderedLocations: string[] = [];
+
+    renderTimeRangeProvider({
+      root,
+      initialEntry: "/projects/project-1/traces?timeRange=7d",
+      lastNTimeRangeKey: "15m",
+      onRender: () => null,
+      onLocation: (search) => {
+        renderedLocations.push(search);
+      },
+    });
+
+    const latestSearchParams = new URLSearchParams(
+      renderedLocations.at(-1) ?? ""
+    );
+    expect(latestSearchParams.get("timeRange")).toBeNull();
+    expect(latestSearchParams.get("timeRangeKey")).toBe("7d");
+    expect(latestSearchParams.get("timeRangeStart")).toBe(
+      "2026-06-02T10:00:00.000Z"
+    );
+    expect(latestSearchParams.get("timeRangeEnd")).toBe(
+      "2026-06-09T10:00:30.000Z"
+    );
+  });
+
+  it("keeps locally selected last-N ranges live when unrelated params change", () => {
+    const renderedTimeRanges: OpenTimeRangeWithKey[] = [];
+    const renderedLocations: string[] = [];
+    let navigate: NavigateFunction | null = null;
+
+    renderTimeRangeProvider({
+      root,
+      onRender: (timeRange) => {
+        renderedTimeRanges.push(timeRange);
+      },
+      onLocation: (search) => {
+        renderedLocations.push(search);
+      },
+      onNavigate: (nextNavigate) => {
+        navigate = nextNavigate;
+      },
+    });
+
+    act(() => {
+      const nextSearchParams = new URLSearchParams(
+        renderedLocations.at(-1) ?? ""
+      );
+      nextSearchParams.set(SELECTED_SPAN_NODE_ID_PARAM, "span-1");
+      navigate?.({ search: `?${nextSearchParams.toString()}` });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    const latestSearchParams = new URLSearchParams(
+      renderedLocations.at(-1) ?? ""
+    );
+    expect(renderedTimeRanges.at(-1)?.timeRangeKey).toBe("15m");
+    expect(renderedTimeRanges.at(-1)?.start?.toISOString()).toBe(
+      "2026-06-09T09:46:00.000Z"
+    );
+    expect(renderedTimeRanges.at(-1)?.end).toBeNull();
+    expect(latestSearchParams.get(SELECTED_SPAN_NODE_ID_PARAM)).toBe("span-1");
+    expect(latestSearchParams.get("timeRangeStart")).toBe(
+      "2026-06-09T09:46:00.000Z"
+    );
+    expect(latestSearchParams.get("timeRangeEnd")).toBe(
+      "2026-06-09T10:01:00.000Z"
+    );
+  });
+
+  it("writes selected time ranges to the URL while preserving unrelated params", () => {
+    const renderedLocations: string[] = [];
+    let setTimeRange: TimeRangeContextType["setTimeRange"] | null = null;
+    const start = new Date("2026-06-09T09:00:00.000Z");
+    const end = new Date("2026-06-09T11:00:00.000Z");
+
+    renderTimeRangeProvider({
+      root,
+      initialEntry:
+        "/projects/project-1/traces?selectedSpanNodeId=span-1&timeRange=15m",
+      onRender: () => null,
+      onLocation: (search) => {
+        renderedLocations.push(search);
+      },
+      onSetTimeRange: (nextSetTimeRange) => {
+        setTimeRange = nextSetTimeRange;
+      },
+    });
+
+    act(() => {
+      setTimeRange?.({ timeRangeKey: "custom", start, end });
+    });
+
+    const latestSearchParams = new URLSearchParams(
+      renderedLocations.at(-1) ?? ""
+    );
+    expect(latestSearchParams.get("selectedSpanNodeId")).toBe("span-1");
+    expect(latestSearchParams.get("timeRange")).toBeNull();
+    expect(latestSearchParams.get("timeRangeKey")).toBeNull();
+    expect(latestSearchParams.get("timeRangeStart")).toBe(
+      "2026-06-09T09:00:00.000Z"
+    );
+    expect(latestSearchParams.get("timeRangeEnd")).toBe(
+      "2026-06-09T11:00:00.000Z"
+    );
   });
 });

--- a/app/src/components/datetime/__tests__/TimeRangeContext.test.tsx
+++ b/app/src/components/datetime/__tests__/TimeRangeContext.test.tsx
@@ -178,7 +178,7 @@ describe("TimeRangeProvider", () => {
     expect(renderedTimeRanges.at(-1)?.end).toBeNull();
   });
 
-  it("initializes from concrete last-N URL bounds before stored preferences", () => {
+  it("treats a last-N URL key as live, ignoring any bounds it carries", () => {
     const renderedTimeRanges: OpenTimeRangeWithKey[] = [];
 
     renderTimeRangeProvider({
@@ -191,27 +191,26 @@ describe("TimeRangeProvider", () => {
       },
     });
 
+    // The preset key wins: the window resolves live against "now", not the
+    // (stale) bounds carried in the URL. This keeps legacy URLs working.
     expect(renderedTimeRanges.at(-1)?.timeRangeKey).toBe("1h");
     expect(renderedTimeRanges.at(-1)?.start?.toISOString()).toBe(
-      "2026-06-09T08:00:00.000Z"
-    );
-    expect(renderedTimeRanges.at(-1)?.end?.toISOString()).toBe(
       "2026-06-09T09:00:00.000Z"
     );
+    expect(renderedTimeRanges.at(-1)?.end).toBeNull();
 
     act(() => {
       vi.advanceTimersByTime(60_000);
     });
 
+    // And it keeps ticking forward like any live preset.
     expect(renderedTimeRanges.at(-1)?.start?.toISOString()).toBe(
-      "2026-06-09T08:00:00.000Z"
+      "2026-06-09T09:01:00.000Z"
     );
-    expect(renderedTimeRanges.at(-1)?.end?.toISOString()).toBe(
-      "2026-06-09T09:00:00.000Z"
-    );
+    expect(renderedTimeRanges.at(-1)?.end).toBeNull();
   });
 
-  it("canonicalizes relative last-N URLs with concrete bounds", () => {
+  it("keeps a relative last-N URL declarative, without adding bounds", () => {
     const renderedLocations: string[] = [];
 
     renderTimeRangeProvider({
@@ -224,19 +223,16 @@ describe("TimeRangeProvider", () => {
       },
     });
 
+    // A live preset is represented by its key alone; no bounds are written.
     const latestSearchParams = new URLSearchParams(
       renderedLocations.at(-1) ?? ""
     );
     expect(latestSearchParams.get("timeRangeKey")).toBe("7d");
-    expect(latestSearchParams.get("timeRangeStart")).toBe(
-      "2026-06-02T10:00:00.000Z"
-    );
-    expect(latestSearchParams.get("timeRangeEnd")).toBe(
-      "2026-06-09T10:00:30.000Z"
-    );
+    expect(latestSearchParams.get("timeRangeStart")).toBeNull();
+    expect(latestSearchParams.get("timeRangeEnd")).toBeNull();
   });
 
-  it("keeps locally selected last-N ranges live when unrelated params change", () => {
+  it("keeps locally selected last-N ranges live and key-only when unrelated params change", () => {
     const renderedTimeRanges: OpenTimeRangeWithKey[] = [];
     const renderedLocations: string[] = [];
     let navigate: NavigateFunction | null = null;
@@ -275,12 +271,11 @@ describe("TimeRangeProvider", () => {
     );
     expect(renderedTimeRanges.at(-1)?.end).toBeNull();
     expect(latestSearchParams.get(SELECTED_SPAN_NODE_ID_PARAM)).toBe("span-1");
-    expect(latestSearchParams.get("timeRangeStart")).toBe(
-      "2026-06-09T09:46:00.000Z"
-    );
-    expect(latestSearchParams.get("timeRangeEnd")).toBe(
-      "2026-06-09T10:01:00.000Z"
-    );
+    // The live preset stays declarative: only the key is in the URL, never
+    // bounds, even as the window advances on refresh.
+    expect(latestSearchParams.get("timeRangeKey")).toBe("15m");
+    expect(latestSearchParams.get("timeRangeStart")).toBeNull();
+    expect(latestSearchParams.get("timeRangeEnd")).toBeNull();
   });
 
   it("writes selected time ranges to the URL while preserving unrelated params", () => {

--- a/app/src/components/datetime/__tests__/TimeRangeContext.test.tsx
+++ b/app/src/components/datetime/__tests__/TimeRangeContext.test.tsx
@@ -164,7 +164,7 @@ describe("TimeRangeProvider", () => {
 
     renderTimeRangeProvider({
       root,
-      initialEntry: "/projects/project-1/traces?timeRange=1h",
+      initialEntry: "/projects/project-1/traces?timeRangeKey=1h",
       lastNTimeRangeKey: "15m",
       onRender: (timeRange) => {
         renderedTimeRanges.push(timeRange);
@@ -216,7 +216,7 @@ describe("TimeRangeProvider", () => {
 
     renderTimeRangeProvider({
       root,
-      initialEntry: "/projects/project-1/traces?timeRange=7d",
+      initialEntry: "/projects/project-1/traces?timeRangeKey=7d",
       lastNTimeRangeKey: "15m",
       onRender: () => null,
       onLocation: (search) => {
@@ -227,7 +227,6 @@ describe("TimeRangeProvider", () => {
     const latestSearchParams = new URLSearchParams(
       renderedLocations.at(-1) ?? ""
     );
-    expect(latestSearchParams.get("timeRange")).toBeNull();
     expect(latestSearchParams.get("timeRangeKey")).toBe("7d");
     expect(latestSearchParams.get("timeRangeStart")).toBe(
       "2026-06-02T10:00:00.000Z"
@@ -293,7 +292,7 @@ describe("TimeRangeProvider", () => {
     renderTimeRangeProvider({
       root,
       initialEntry:
-        "/projects/project-1/traces?selectedSpanNodeId=span-1&timeRange=15m",
+        "/projects/project-1/traces?selectedSpanNodeId=span-1&timeRangeKey=15m",
       onRender: () => null,
       onLocation: (search) => {
         renderedLocations.push(search);
@@ -311,7 +310,6 @@ describe("TimeRangeProvider", () => {
       renderedLocations.at(-1) ?? ""
     );
     expect(latestSearchParams.get("selectedSpanNodeId")).toBe("span-1");
-    expect(latestSearchParams.get("timeRange")).toBeNull();
     expect(latestSearchParams.get("timeRangeKey")).toBeNull();
     expect(latestSearchParams.get("timeRangeStart")).toBe(
       "2026-06-09T09:00:00.000Z"

--- a/app/src/components/datetime/__tests__/utils.test.ts
+++ b/app/src/components/datetime/__tests__/utils.test.ts
@@ -84,6 +84,7 @@ describe("datetime utils", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-09T10:20:30.000Z"));
 
+    // A preset key is always live, resolved against "now" with no bounds.
     const lastN = getTimeRangeFromSearchParams(
       new URLSearchParams("timeRangeKey=15m")
     );
@@ -91,25 +92,19 @@ describe("datetime utils", () => {
     expect(lastN?.start?.toISOString()).toBe("2026-06-09T10:05:00.000Z");
     expect(lastN?.end).toBeNull();
 
-    const concreteLastN = getTimeRangeFromSearchParams(
+    // A preset key wins over any bounds in the URL, re-resolving live rather
+    // than honoring the (now-stale) bounds. This also keeps legacy URLs that
+    // carry both working as live presets.
+    const presetWithStaleBounds = getTimeRangeFromSearchParams(
       new URLSearchParams(
         "timeRangeKey=15m&timeRangeStart=2026-06-09T09%3A00%3A00.000Z&timeRangeEnd=2026-06-09T10%3A00%3A00.000Z"
       )
     );
-    expect(concreteLastN).toEqual({
-      timeRangeKey: "15m",
-      start: new Date("2026-06-09T09:00:00.000Z"),
-      end: new Date("2026-06-09T10:00:00.000Z"),
-    });
-
-    const liveLastN = getTimeRangeFromSearchParams(
-      new URLSearchParams(
-        "timeRangeKey=15m&timeRangeStart=2026-06-09T09%3A00%3A00.000Z&timeRangeEnd=2026-06-09T10%3A00%3A00.000Z"
-      ),
-      Date.now(),
-      { preferConcreteBounds: false }
+    expect(presetWithStaleBounds?.timeRangeKey).toBe("15m");
+    expect(presetWithStaleBounds?.start?.toISOString()).toBe(
+      "2026-06-09T10:05:00.000Z"
     );
-    expect(liveLastN?.start?.toISOString()).toBe("2026-06-09T10:05:00.000Z");
+    expect(presetWithStaleBounds?.end).toBeNull();
 
     const custom = getTimeRangeFromSearchParams(
       new URLSearchParams(
@@ -147,6 +142,7 @@ describe("datetime utils", () => {
     const searchParams = new URLSearchParams(
       "timeRangeKey=7d&selectedSpanNodeId=span-1"
     );
+    // A custom range is written as its bounds only, clearing any preset key.
     const customParams = setTimeRangeSearchParams({
       searchParams,
       timeRange: {
@@ -154,25 +150,27 @@ describe("datetime utils", () => {
         start: new Date("2026-06-09T09:00:00.000Z"),
         end: null,
       },
-      now: new Date("2026-06-09T10:20:30.000Z"),
     });
     expect(customParams.get("timeRangeKey")).toBeNull();
     expect(customParams.get("timeRangeStart")).toBe("2026-06-09T09:00:00.000Z");
     expect(customParams.get("timeRangeEnd")).toBeNull();
     expect(customParams.get("selectedSpanNodeId")).toBe("span-1");
 
-    const presetNow = new Date("2026-06-09T10:20:30.000Z");
+    // A preset is written as just the key, clearing any bounds, so the URL is
+    // unambiguously a live range.
     const presetParams = setTimeRangeSearchParams({
       searchParams: customParams,
       timeRange: {
         timeRangeKey: "1h",
-        ...getTimeRangeFromLastNTimeRangeKey("1h", presetNow.getTime()),
+        ...getTimeRangeFromLastNTimeRangeKey(
+          "1h",
+          new Date("2026-06-09T10:20:30.000Z").getTime()
+        ),
       },
-      now: presetNow,
     });
     expect(presetParams.get("timeRangeKey")).toBe("1h");
-    expect(presetParams.get("timeRangeStart")).toBe("2026-06-09T09:20:00.000Z");
-    expect(presetParams.get("timeRangeEnd")).toBe("2026-06-09T10:20:30.000Z");
+    expect(presetParams.get("timeRangeStart")).toBeNull();
+    expect(presetParams.get("timeRangeEnd")).toBeNull();
     expect(presetParams.get("selectedSpanNodeId")).toBe("span-1");
   });
 });

--- a/app/src/components/datetime/__tests__/utils.test.ts
+++ b/app/src/components/datetime/__tests__/utils.test.ts
@@ -91,13 +91,6 @@ describe("datetime utils", () => {
     expect(lastN?.start?.toISOString()).toBe("2026-06-09T10:05:00.000Z");
     expect(lastN?.end).toBeNull();
 
-    const legacyLastN = getTimeRangeFromSearchParams(
-      new URLSearchParams("timeRange=15m")
-    );
-    expect(legacyLastN?.timeRangeKey).toBe("15m");
-    expect(legacyLastN?.start?.toISOString()).toBe("2026-06-09T10:05:00.000Z");
-    expect(legacyLastN?.end).toBeNull();
-
     const concreteLastN = getTimeRangeFromSearchParams(
       new URLSearchParams(
         "timeRangeKey=15m&timeRangeStart=2026-06-09T09%3A00%3A00.000Z&timeRangeEnd=2026-06-09T10%3A00%3A00.000Z"
@@ -152,7 +145,7 @@ describe("datetime utils", () => {
 
   it("serializes selected time ranges to URL search params", () => {
     const searchParams = new URLSearchParams(
-      "timeRange=7d&selectedSpanNodeId=span-1"
+      "timeRangeKey=7d&selectedSpanNodeId=span-1"
     );
     const customParams = setTimeRangeSearchParams({
       searchParams,
@@ -163,7 +156,6 @@ describe("datetime utils", () => {
       },
       now: new Date("2026-06-09T10:20:30.000Z"),
     });
-    expect(customParams.get("timeRange")).toBeNull();
     expect(customParams.get("timeRangeKey")).toBeNull();
     expect(customParams.get("timeRangeStart")).toBe("2026-06-09T09:00:00.000Z");
     expect(customParams.get("timeRangeEnd")).toBeNull();
@@ -178,7 +170,6 @@ describe("datetime utils", () => {
       },
       now: presetNow,
     });
-    expect(presetParams.get("timeRange")).toBeNull();
     expect(presetParams.get("timeRangeKey")).toBe("1h");
     expect(presetParams.get("timeRangeStart")).toBe("2026-06-09T09:20:00.000Z");
     expect(presetParams.get("timeRangeEnd")).toBe("2026-06-09T10:20:30.000Z");

--- a/app/src/components/datetime/__tests__/utils.test.ts
+++ b/app/src/components/datetime/__tests__/utils.test.ts
@@ -3,12 +3,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getLastNTimeRangeLabel,
   getMillisecondsUntilNextLastNTimeRangeRefresh,
+  getTimeRangeFromSearchParams,
   getTimeRangeFromLastNTimeRangeKey,
   getTimeRangeSearchSuggestions,
   isLastNTimeRangeKey,
   panTimeRangeLeft,
   panTimeRangeRight,
   parseTimeRangeSearchText,
+  setTimeRangeSearchParams,
   zoomTimeRangeIn,
   zoomTimeRangeOut,
 } from "../utils";
@@ -76,6 +78,111 @@ describe("datetime utils", () => {
     expect(getTimeRangeSearchSuggestions("")).toEqual([]);
     expect(getTimeRangeSearchSuggestions("0")).toEqual([]);
     expect(getTimeRangeSearchSuggestions("hour")).toEqual([]);
+  });
+
+  it("parses selected time ranges from URL search params", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T10:20:30.000Z"));
+
+    const lastN = getTimeRangeFromSearchParams(
+      new URLSearchParams("timeRangeKey=15m")
+    );
+    expect(lastN?.timeRangeKey).toBe("15m");
+    expect(lastN?.start?.toISOString()).toBe("2026-06-09T10:05:00.000Z");
+    expect(lastN?.end).toBeNull();
+
+    const legacyLastN = getTimeRangeFromSearchParams(
+      new URLSearchParams("timeRange=15m")
+    );
+    expect(legacyLastN?.timeRangeKey).toBe("15m");
+    expect(legacyLastN?.start?.toISOString()).toBe("2026-06-09T10:05:00.000Z");
+    expect(legacyLastN?.end).toBeNull();
+
+    const concreteLastN = getTimeRangeFromSearchParams(
+      new URLSearchParams(
+        "timeRangeKey=15m&timeRangeStart=2026-06-09T09%3A00%3A00.000Z&timeRangeEnd=2026-06-09T10%3A00%3A00.000Z"
+      )
+    );
+    expect(concreteLastN).toEqual({
+      timeRangeKey: "15m",
+      start: new Date("2026-06-09T09:00:00.000Z"),
+      end: new Date("2026-06-09T10:00:00.000Z"),
+    });
+
+    const liveLastN = getTimeRangeFromSearchParams(
+      new URLSearchParams(
+        "timeRangeKey=15m&timeRangeStart=2026-06-09T09%3A00%3A00.000Z&timeRangeEnd=2026-06-09T10%3A00%3A00.000Z"
+      ),
+      Date.now(),
+      { preferConcreteBounds: false }
+    );
+    expect(liveLastN?.start?.toISOString()).toBe("2026-06-09T10:05:00.000Z");
+
+    const custom = getTimeRangeFromSearchParams(
+      new URLSearchParams(
+        "timeRangeStart=2026-06-09T09%3A00%3A00.000Z&timeRangeEnd=2026-06-09T10%3A00%3A00.000Z"
+      )
+    );
+    expect(custom).toEqual({
+      timeRangeKey: "custom",
+      start: new Date("2026-06-09T09:00:00.000Z"),
+      end: new Date("2026-06-09T10:00:00.000Z"),
+    });
+
+    expect(
+      getTimeRangeFromSearchParams(new URLSearchParams("timeRange=bogus"))
+    ).toBeNull();
+    expect(
+      getTimeRangeFromSearchParams(
+        new URLSearchParams(
+          "timeRangeKey=bogus&timeRangeStart=2026-06-09T09%3A00%3A00.000Z&timeRangeEnd=2026-06-09T10%3A00%3A00.000Z"
+        )
+      )
+    ).toEqual({
+      timeRangeKey: "custom",
+      start: new Date("2026-06-09T09:00:00.000Z"),
+      end: new Date("2026-06-09T10:00:00.000Z"),
+    });
+    expect(
+      getTimeRangeFromSearchParams(
+        new URLSearchParams("timeRangeStart=not-a-date")
+      )
+    ).toBeNull();
+  });
+
+  it("serializes selected time ranges to URL search params", () => {
+    const searchParams = new URLSearchParams(
+      "timeRange=7d&selectedSpanNodeId=span-1"
+    );
+    const customParams = setTimeRangeSearchParams({
+      searchParams,
+      timeRange: {
+        timeRangeKey: "custom",
+        start: new Date("2026-06-09T09:00:00.000Z"),
+        end: null,
+      },
+      now: new Date("2026-06-09T10:20:30.000Z"),
+    });
+    expect(customParams.get("timeRange")).toBeNull();
+    expect(customParams.get("timeRangeKey")).toBeNull();
+    expect(customParams.get("timeRangeStart")).toBe("2026-06-09T09:00:00.000Z");
+    expect(customParams.get("timeRangeEnd")).toBeNull();
+    expect(customParams.get("selectedSpanNodeId")).toBe("span-1");
+
+    const presetNow = new Date("2026-06-09T10:20:30.000Z");
+    const presetParams = setTimeRangeSearchParams({
+      searchParams: customParams,
+      timeRange: {
+        timeRangeKey: "1h",
+        ...getTimeRangeFromLastNTimeRangeKey("1h", presetNow.getTime()),
+      },
+      now: presetNow,
+    });
+    expect(presetParams.get("timeRange")).toBeNull();
+    expect(presetParams.get("timeRangeKey")).toBe("1h");
+    expect(presetParams.get("timeRangeStart")).toBe("2026-06-09T09:20:00.000Z");
+    expect(presetParams.get("timeRangeEnd")).toBe("2026-06-09T10:20:30.000Z");
+    expect(presetParams.get("selectedSpanNodeId")).toBe("span-1");
   });
 });
 

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -195,6 +195,13 @@ export function setTimeRangeSearchParams({
   timeRange: OpenTimeRangeWithKey;
 }): URLSearchParams {
   const nextSearchParams = new URLSearchParams(searchParams);
+  const setOrDelete = (param: string, value: Date | null | undefined) => {
+    if (value != null) {
+      nextSearchParams.set(param, value.toISOString());
+    } else {
+      nextSearchParams.delete(param);
+    }
+  };
   if (isLastNTimeRangeKey(timeRange.timeRangeKey)) {
     nextSearchParams.set(TIME_RANGE_KEY_PARAM, timeRange.timeRangeKey);
     nextSearchParams.delete(TIME_RANGE_START_PARAM);
@@ -202,16 +209,8 @@ export function setTimeRangeSearchParams({
     return nextSearchParams;
   }
   nextSearchParams.delete(TIME_RANGE_KEY_PARAM);
-  if (timeRange.start != null) {
-    nextSearchParams.set(TIME_RANGE_START_PARAM, timeRange.start.toISOString());
-  } else {
-    nextSearchParams.delete(TIME_RANGE_START_PARAM);
-  }
-  if (timeRange.end != null) {
-    nextSearchParams.set(TIME_RANGE_END_PARAM, timeRange.end.toISOString());
-  } else {
-    nextSearchParams.delete(TIME_RANGE_END_PARAM);
-  }
+  setOrDelete(TIME_RANGE_START_PARAM, timeRange.start);
+  setOrDelete(TIME_RANGE_END_PARAM, timeRange.end);
   return nextSearchParams;
 }
 

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -9,7 +9,6 @@ import {
 import type { DateValue } from "react-aria-components";
 
 import {
-  LEGACY_TIME_RANGE_PARAM,
   TIME_RANGE_END_PARAM,
   TIME_RANGE_KEY_PARAM,
   TIME_RANGE_START_PARAM,
@@ -145,9 +144,7 @@ export function getTimeRangeFromSearchParams(
     preferConcreteBounds?: boolean;
   } = {}
 ): OpenTimeRangeWithKey | null {
-  const urlTimeRangeKey =
-    searchParams.get(TIME_RANGE_KEY_PARAM) ??
-    searchParams.get(LEGACY_TIME_RANGE_PARAM);
+  const urlTimeRangeKey = searchParams.get(TIME_RANGE_KEY_PARAM);
   const hasCustomBounds =
     searchParams.has(TIME_RANGE_START_PARAM) ||
     searchParams.has(TIME_RANGE_END_PARAM);
@@ -203,7 +200,6 @@ export function setTimeRangeSearchParams({
 }): URLSearchParams {
   const nextSearchParams = new URLSearchParams(searchParams);
   const isLastNTimeRange = isLastNTimeRangeKey(timeRange.timeRangeKey);
-  nextSearchParams.delete(LEGACY_TIME_RANGE_PARAM);
   if (isLastNTimeRange) {
     nextSearchParams.set(TIME_RANGE_KEY_PARAM, timeRange.timeRangeKey);
   } else {

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -8,6 +8,12 @@ import {
 } from "date-fns";
 import type { DateValue } from "react-aria-components";
 
+import {
+  LEGACY_TIME_RANGE_PARAM,
+  TIME_RANGE_END_PARAM,
+  TIME_RANGE_KEY_PARAM,
+  TIME_RANGE_START_PARAM,
+} from "@phoenix/constants/searchParams";
 import { assertUnreachable } from "@phoenix/typeUtils";
 
 import { LAST_N_TIME_RANGES_MAP } from "./constants";
@@ -61,13 +67,13 @@ function getLastNTimeRangeDurationMs({
 }
 
 export function getTimeRangeFromLastNTimeRangeKey(
-  key: LastNTimeRangeKey
+  key: LastNTimeRangeKey,
+  now = Date.now()
 ): OpenTimeRange {
   const parsed = parseLastNTimeRangeKey(key);
   if (!parsed) {
     throw new Error(`Invalid last N time range key: ${key}`);
   }
-  const now = Date.now();
   const { quantity, unit } = parsed;
   let start: Date;
   switch (unit) {
@@ -115,6 +121,107 @@ export function isLastNTimeRangeKey(key: unknown): key is LastNTimeRangeKey {
  */
 export function isTimeRangeKey(key: unknown): key is TimeRangeKey {
   return isLastNTimeRangeKey(key) || key === "custom";
+}
+
+function getDateFromSearchParamValue(value: string | null) {
+  if (value == null || value.trim() === "") {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+/**
+ * Parses a selected time range from URL search params. Invalid or incomplete
+ * params return null so callers can fall back to the user's stored preference.
+ */
+export function getTimeRangeFromSearchParams(
+  searchParams: URLSearchParams,
+  now = Date.now(),
+  {
+    preferConcreteBounds = true,
+  }: {
+    /** Whether concrete URL bounds should override a relative last-N key. */
+    preferConcreteBounds?: boolean;
+  } = {}
+): OpenTimeRangeWithKey | null {
+  const urlTimeRangeKey =
+    searchParams.get(TIME_RANGE_KEY_PARAM) ??
+    searchParams.get(LEGACY_TIME_RANGE_PARAM);
+  const hasCustomBounds =
+    searchParams.has(TIME_RANGE_START_PARAM) ||
+    searchParams.has(TIME_RANGE_END_PARAM);
+  const start = getDateFromSearchParamValue(
+    searchParams.get(TIME_RANGE_START_PARAM)
+  );
+  const end = getDateFromSearchParamValue(
+    searchParams.get(TIME_RANGE_END_PARAM)
+  );
+  if (start === undefined || end === undefined) {
+    return null;
+  }
+  if (start != null && end != null && start > end) {
+    return null;
+  }
+  const hasConcreteBounds = start != null || end != null;
+  if (isLastNTimeRangeKey(urlTimeRangeKey)) {
+    if (preferConcreteBounds && hasConcreteBounds) {
+      return {
+        timeRangeKey: urlTimeRangeKey,
+        start,
+        end,
+      };
+    }
+    return {
+      timeRangeKey: urlTimeRangeKey,
+      ...getTimeRangeFromLastNTimeRangeKey(urlTimeRangeKey, now),
+    };
+  }
+  if (!hasCustomBounds || !hasConcreteBounds) {
+    return null;
+  }
+  return {
+    timeRangeKey: "custom",
+    start,
+    end,
+  };
+}
+
+/**
+ * Writes the selected time range to URL search params while preserving
+ * unrelated params such as selected span/session state.
+ */
+export function setTimeRangeSearchParams({
+  searchParams,
+  timeRange,
+  now = new Date(),
+}: {
+  searchParams: URLSearchParams;
+  timeRange: OpenTimeRangeWithKey;
+  /** Reference end time for open-ended last-N ranges. Defaults to now. */
+  now?: Date;
+}): URLSearchParams {
+  const nextSearchParams = new URLSearchParams(searchParams);
+  const isLastNTimeRange = isLastNTimeRangeKey(timeRange.timeRangeKey);
+  nextSearchParams.delete(LEGACY_TIME_RANGE_PARAM);
+  if (isLastNTimeRange) {
+    nextSearchParams.set(TIME_RANGE_KEY_PARAM, timeRange.timeRangeKey);
+  } else {
+    nextSearchParams.delete(TIME_RANGE_KEY_PARAM);
+  }
+  if (timeRange.start != null) {
+    nextSearchParams.set(TIME_RANGE_START_PARAM, timeRange.start.toISOString());
+  } else {
+    nextSearchParams.delete(TIME_RANGE_START_PARAM);
+  }
+  const end =
+    timeRange.end ?? (isLastNTimeRange && timeRange.start != null ? now : null);
+  if (end != null) {
+    nextSearchParams.set(TIME_RANGE_END_PARAM, end.toISOString());
+  } else {
+    nextSearchParams.delete(TIME_RANGE_END_PARAM);
+  }
+  return nextSearchParams;
 }
 
 const LAST_N_UNIT_LABELS: Record<

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -131,50 +131,45 @@ function getDateFromSearchParamValue(value: string | null) {
 }
 
 /**
- * Parses a selected time range from URL search params. Invalid or incomplete
- * params return null so callers can fall back to the user's stored preference.
+ * Parses a selected time range from URL search params.
+ *
+ * The URL encodes exactly one representation of the range (see
+ * {@link setTimeRangeSearchParams}):
+ * - a preset key ({@link TIME_RANGE_KEY_PARAM}), which is always live and
+ *   re-resolves against `now`, owning no bounds; or
+ * - an explicit (custom) range defined purely by its
+ *   {@link TIME_RANGE_START_PARAM}/{@link TIME_RANGE_END_PARAM} bounds.
+ *
+ * A preset key therefore always wins — bounds are only consulted when no preset
+ * key is present, which also means a legacy URL carrying both is read as a live
+ * preset. Invalid or incomplete params return null so callers can fall back to
+ * the user's stored preference.
  */
 export function getTimeRangeFromSearchParams(
   searchParams: URLSearchParams,
-  now = Date.now(),
-  {
-    preferConcreteBounds = true,
-  }: {
-    /** Whether concrete URL bounds should override a relative last-N key. */
-    preferConcreteBounds?: boolean;
-  } = {}
+  now = Date.now()
 ): OpenTimeRangeWithKey | null {
   const urlTimeRangeKey = searchParams.get(TIME_RANGE_KEY_PARAM);
-  const hasCustomBounds =
-    searchParams.has(TIME_RANGE_START_PARAM) ||
-    searchParams.has(TIME_RANGE_END_PARAM);
+  if (isLastNTimeRangeKey(urlTimeRangeKey)) {
+    return {
+      timeRangeKey: urlTimeRangeKey,
+      ...getTimeRangeFromLastNTimeRangeKey(urlTimeRangeKey, now),
+    };
+  }
   const start = getDateFromSearchParamValue(
     searchParams.get(TIME_RANGE_START_PARAM)
   );
   const end = getDateFromSearchParamValue(
     searchParams.get(TIME_RANGE_END_PARAM)
   );
+  // Non-parseable bounds, no bounds at all, or an inverted window are unusable.
   if (start === undefined || end === undefined) {
     return null;
   }
-  if (start != null && end != null && start > end) {
+  if (start == null && end == null) {
     return null;
   }
-  const hasConcreteBounds = start != null || end != null;
-  if (isLastNTimeRangeKey(urlTimeRangeKey)) {
-    if (preferConcreteBounds && hasConcreteBounds) {
-      return {
-        timeRangeKey: urlTimeRangeKey,
-        start,
-        end,
-      };
-    }
-    return {
-      timeRangeKey: urlTimeRangeKey,
-      ...getTimeRangeFromLastNTimeRangeKey(urlTimeRangeKey, now),
-    };
-  }
-  if (!hasCustomBounds || !hasConcreteBounds) {
+  if (start != null && end != null && start > end) {
     return null;
   }
   return {
@@ -187,33 +182,33 @@ export function getTimeRangeFromSearchParams(
 /**
  * Writes the selected time range to URL search params while preserving
  * unrelated params such as selected span/session state.
+ *
+ * Exactly one representation is written and the other is cleared, so the URL is
+ * never ambiguous (see {@link getTimeRangeFromSearchParams}): a preset key is
+ * live and carries no bounds; a custom range is defined solely by its bounds.
  */
 export function setTimeRangeSearchParams({
   searchParams,
   timeRange,
-  now = new Date(),
 }: {
   searchParams: URLSearchParams;
   timeRange: OpenTimeRangeWithKey;
-  /** Reference end time for open-ended last-N ranges. Defaults to now. */
-  now?: Date;
 }): URLSearchParams {
   const nextSearchParams = new URLSearchParams(searchParams);
-  const isLastNTimeRange = isLastNTimeRangeKey(timeRange.timeRangeKey);
-  if (isLastNTimeRange) {
+  if (isLastNTimeRangeKey(timeRange.timeRangeKey)) {
     nextSearchParams.set(TIME_RANGE_KEY_PARAM, timeRange.timeRangeKey);
-  } else {
-    nextSearchParams.delete(TIME_RANGE_KEY_PARAM);
+    nextSearchParams.delete(TIME_RANGE_START_PARAM);
+    nextSearchParams.delete(TIME_RANGE_END_PARAM);
+    return nextSearchParams;
   }
+  nextSearchParams.delete(TIME_RANGE_KEY_PARAM);
   if (timeRange.start != null) {
     nextSearchParams.set(TIME_RANGE_START_PARAM, timeRange.start.toISOString());
   } else {
     nextSearchParams.delete(TIME_RANGE_START_PARAM);
   }
-  const end =
-    timeRange.end ?? (isLastNTimeRange && timeRange.start != null ? now : null);
-  if (end != null) {
-    nextSearchParams.set(TIME_RANGE_END_PARAM, end.toISOString());
+  if (timeRange.end != null) {
+    nextSearchParams.set(TIME_RANGE_END_PARAM, timeRange.end.toISOString());
   } else {
     nextSearchParams.delete(TIME_RANGE_END_PARAM);
   }

--- a/app/src/constants/searchParams.ts
+++ b/app/src/constants/searchParams.ts
@@ -17,6 +17,29 @@ export const SESSION_VIEW_PARAM = "sessionView";
  */
 export const SELECTED_TRACE_ID_PARAM = "selectedTraceId";
 
+/**
+ * Legacy search param that contained the selected tracing time range key.
+ * Retained for parsing existing links and canonicalizing them to the
+ * bounds-first URL contract.
+ */
+export const LEGACY_TIME_RANGE_PARAM = "timeRange";
+
+/**
+ * Optional search param that contains UI metadata for the selected tracing
+ * time range key. Canonical URL state lives in the start/end params below.
+ */
+export const TIME_RANGE_KEY_PARAM = "timeRangeKey";
+
+/**
+ * The canonical ISO datetime lower bound for the tracing time range.
+ */
+export const TIME_RANGE_START_PARAM = "timeRangeStart";
+
+/**
+ * The canonical ISO datetime upper bound for the tracing time range.
+ */
+export const TIME_RANGE_END_PARAM = "timeRangeEnd";
+
 export const CREATE_CODE_EVALUATOR_PARAM = "createCodeEvaluator";
 
 export const CREATE_LLM_EVALUATOR_PARAM = "createLlmEvaluator";

--- a/app/src/constants/searchParams.ts
+++ b/app/src/constants/searchParams.ts
@@ -18,11 +18,14 @@ export const SESSION_VIEW_PARAM = "sessionView";
 export const SELECTED_TRACE_ID_PARAM = "selectedTraceId";
 
 /**
- * Legacy search param that contained the selected tracing time range key.
- * Retained for parsing existing links and canonicalizing them to the
- * bounds-first URL contract.
+ * Search params scoped to a specific selection within trace/session detail
+ * views. These are dropped when navigating away from a selection while
+ * recreatable params (such as the time range) are preserved.
  */
-export const LEGACY_TIME_RANGE_PARAM = "timeRange";
+export const SELECTION_SCOPED_SEARCH_PARAMS = [
+  SELECTED_TRACE_ID_PARAM,
+  SELECTED_SPAN_NODE_ID_PARAM,
+] as const;
 
 /**
  * Optional search param that contains UI metadata for the selected tracing

--- a/app/src/pages/project/ProjectIndexPage.tsx
+++ b/app/src/pages/project/ProjectIndexPage.tsx
@@ -1,8 +1,18 @@
-import { Navigate } from "react-router";
+import { Navigate, useLocation } from "react-router";
 
 import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 
 export const ProjectIndexPage = () => {
   const defaultTab = useProjectContext((state) => state.defaultTab);
-  return <Navigate to={defaultTab} replace />;
+  const location = useLocation();
+  return (
+    <Navigate
+      to={{
+        pathname: defaultTab,
+        search: location.search,
+        hash: location.hash,
+      }}
+      replace
+    />
+  );
 };

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -8,7 +8,7 @@ import {
   useMemo,
 } from "react";
 import { graphql, useLazyLoadQuery, useQueryLoader } from "react-relay";
-import { Outlet, useNavigate, useParams } from "react-router";
+import { Outlet, useLocation, useNavigate, useParams } from "react-router";
 
 import { LazyTabPanel, Loading, Tab, TabList, Tabs } from "@phoenix/components";
 import {
@@ -16,6 +16,10 @@ import {
   useTimeRange,
 } from "@phoenix/components/datetime";
 import { TopNavActions } from "@phoenix/components/nav";
+import {
+  SELECTED_SPAN_NODE_ID_PARAM,
+  SELECTED_TRACE_ID_PARAM,
+} from "@phoenix/constants/searchParams";
 import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 import { StreamStateProvider } from "@phoenix/contexts/StreamStateContext";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
@@ -164,6 +168,7 @@ function ProjectPageContentBody({
       ProjectPageQueriesProjectConfigQuery
     );
   const tabIndex = isTab(tab) ? TAB_INDEX_MAP[tab] : 0;
+  const location = useLocation();
   useEffect(() => {
     startTransition(() => {
       if (tabIndex === TAB_INDEX_MAP.spans) {
@@ -202,25 +207,50 @@ function ProjectPageContentBody({
   const onTabChange = useCallback(
     (index: number) => {
       startTransition(() => {
+        const nextSearchParams = new URLSearchParams(location.search);
+        nextSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
+        nextSearchParams.delete(SELECTED_TRACE_ID_PARAM);
+        const nextSearch = nextSearchParams.toString();
+        const search = nextSearch ? `?${nextSearch}` : "";
         if (index === 1) {
           // navigate to the traces tab
-          navigate(`${rootPath}/traces`);
+          navigate({
+            pathname: `${rootPath}/traces`,
+            search,
+            hash: location.hash,
+          });
         } else if (index === 2) {
           // navigate to the sessions tab
-          navigate(`${rootPath}/sessions`);
+          navigate({
+            pathname: `${rootPath}/sessions`,
+            search,
+            hash: location.hash,
+          });
         } else if (index === 3) {
           // navigate to the metrics tab
-          navigate(`${rootPath}/metrics`);
+          navigate({
+            pathname: `${rootPath}/metrics`,
+            search,
+            hash: location.hash,
+          });
         } else if (index === 4) {
           // navigate to the config tab
-          navigate(`${rootPath}/config`);
+          navigate({
+            pathname: `${rootPath}/config`,
+            search,
+            hash: location.hash,
+          });
         } else {
           // navigate to the spans tab
-          navigate(`${rootPath}/spans`);
+          navigate({
+            pathname: `${rootPath}/spans`,
+            search,
+            hash: location.hash,
+          });
         }
       });
     },
-    [navigate, rootPath]
+    [location.hash, location.search, navigate, rootPath]
   );
 
   return (

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -16,11 +16,10 @@ import {
   useTimeRange,
 } from "@phoenix/components/datetime";
 import { TopNavActions } from "@phoenix/components/nav";
-import { SELECTION_SCOPED_SEARCH_PARAMS } from "@phoenix/constants/searchParams";
 import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 import { StreamStateProvider } from "@phoenix/contexts/StreamStateContext";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
-import { withSearchParams } from "@phoenix/utils/urlUtils";
+import { clearSelectionScopedParams } from "@phoenix/utils/urlUtils";
 
 import type { ProjectPageQueriesProjectConfigQuery as ProjectPageProjectConfigQueryType } from "./__generated__/ProjectPageQueriesProjectConfigQuery.graphql";
 import type { ProjectPageQueriesSessionsQuery as ProjectPageSessionsQueryType } from "./__generated__/ProjectPageQueriesSessionsQuery.graphql";
@@ -209,11 +208,7 @@ function ProjectPageContentBody({
   const onTabChange = useCallback(
     (index: number) => {
       startTransition(() => {
-        const search = withSearchParams(location.search, (params) => {
-          for (const param of SELECTION_SCOPED_SEARCH_PARAMS) {
-            params.delete(param);
-          }
-        });
+        const search = clearSelectionScopedParams(location.search);
         const tab = TAB_PATH_BY_INDEX[index] ?? "spans";
         navigate({
           pathname: `${rootPath}/${tab}`,

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -16,13 +16,11 @@ import {
   useTimeRange,
 } from "@phoenix/components/datetime";
 import { TopNavActions } from "@phoenix/components/nav";
-import {
-  SELECTED_SPAN_NODE_ID_PARAM,
-  SELECTED_TRACE_ID_PARAM,
-} from "@phoenix/constants/searchParams";
+import { SELECTION_SCOPED_SEARCH_PARAMS } from "@phoenix/constants/searchParams";
 import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 import { StreamStateProvider } from "@phoenix/contexts/StreamStateContext";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
+import { withSearchParams } from "@phoenix/utils/urlUtils";
 
 import type { ProjectPageQueriesProjectConfigQuery as ProjectPageProjectConfigQueryType } from "./__generated__/ProjectPageQueriesProjectConfigQuery.graphql";
 import type { ProjectPageQueriesSessionsQuery as ProjectPageSessionsQueryType } from "./__generated__/ProjectPageQueriesSessionsQuery.graphql";
@@ -102,6 +100,10 @@ const TAB_INDEX_MAP: Record<(typeof TABS)[number], number> = {
   metrics: 3,
   config: 4,
 };
+
+const TAB_PATH_BY_INDEX = Object.fromEntries(
+  Object.entries(TAB_INDEX_MAP).map(([tab, index]) => [index, tab])
+) as Record<number, (typeof TABS)[number]>;
 
 export function ProjectPageContent({
   projectId,
@@ -207,47 +209,17 @@ function ProjectPageContentBody({
   const onTabChange = useCallback(
     (index: number) => {
       startTransition(() => {
-        const nextSearchParams = new URLSearchParams(location.search);
-        nextSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
-        nextSearchParams.delete(SELECTED_TRACE_ID_PARAM);
-        const nextSearch = nextSearchParams.toString();
-        const search = nextSearch ? `?${nextSearch}` : "";
-        if (index === 1) {
-          // navigate to the traces tab
-          navigate({
-            pathname: `${rootPath}/traces`,
-            search,
-            hash: location.hash,
-          });
-        } else if (index === 2) {
-          // navigate to the sessions tab
-          navigate({
-            pathname: `${rootPath}/sessions`,
-            search,
-            hash: location.hash,
-          });
-        } else if (index === 3) {
-          // navigate to the metrics tab
-          navigate({
-            pathname: `${rootPath}/metrics`,
-            search,
-            hash: location.hash,
-          });
-        } else if (index === 4) {
-          // navigate to the config tab
-          navigate({
-            pathname: `${rootPath}/config`,
-            search,
-            hash: location.hash,
-          });
-        } else {
-          // navigate to the spans tab
-          navigate({
-            pathname: `${rootPath}/spans`,
-            search,
-            hash: location.hash,
-          });
-        }
+        const search = withSearchParams(location.search, (params) => {
+          for (const param of SELECTION_SCOPED_SEARCH_PARAMS) {
+            params.delete(param);
+          }
+        });
+        const tab = TAB_PATH_BY_INDEX[index] ?? "spans";
+        navigate({
+          pathname: `${rootPath}/${tab}`,
+          search,
+          hash: location.hash,
+        });
       });
     },
     [location.hash, location.search, navigate, rootPath]

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -20,7 +20,7 @@ import React, {
   useState,
 } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
-import { useNavigate, useParams } from "react-router";
+import { useNavigate, useParams, useSearchParams } from "react-router";
 
 import {
   ContextualHelp,
@@ -40,6 +40,10 @@ import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SessionTokenCosts } from "@phoenix/components/trace/SessionTokenCosts";
 import { SessionTokenCount } from "@phoenix/components/trace/SessionTokenCount";
+import {
+  SELECTED_SPAN_NODE_ID_PARAM,
+  SELECTED_TRACE_ID_PARAM,
+} from "@phoenix/constants/searchParams";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { SummaryValueLabels } from "@phoenix/pages/project/AnnotationSummary";
@@ -73,6 +77,20 @@ const defaultColumnSettings = {
   minSize: 100,
 } satisfies Partial<ColumnDef<unknown>>;
 
+function getSessionDetailsPath({
+  sessionId,
+  searchParams,
+}: {
+  sessionId: string;
+  searchParams: URLSearchParams;
+}) {
+  const nextSearchParams = new URLSearchParams(searchParams);
+  nextSearchParams.delete(SELECTED_TRACE_ID_PARAM);
+  nextSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
+  const nextSearch = nextSearchParams.toString();
+  return `${encodeURIComponent(sessionId)}${nextSearch ? `?${nextSearch}` : ""}`;
+}
+
 const TableBody = <T extends { id: string }>({
   table,
 }: {
@@ -81,6 +99,7 @@ const TableBody = <T extends { id: string }>({
   "use no memo";
   const navigate = useNavigate();
   const { sessionId } = useParams();
+  const [searchParams] = useSearchParams();
   return (
     <tbody>
       {table.getRowModel().rows.map((row) => {
@@ -89,7 +108,14 @@ const TableBody = <T extends { id: string }>({
           <tr
             key={row.id}
             data-selected={isSelected}
-            onClick={() => navigate(`${encodeURIComponent(row.original.id)}`)}
+            onClick={() =>
+              navigate(
+                getSessionDetailsPath({
+                  sessionId: row.original.id,
+                  searchParams,
+                })
+              )
+            }
           >
             {row.getVisibleCells().map((cell) => {
               return (

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -40,14 +40,11 @@ import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SessionTokenCosts } from "@phoenix/components/trace/SessionTokenCosts";
 import { SessionTokenCount } from "@phoenix/components/trace/SessionTokenCount";
-import {
-  SELECTED_SPAN_NODE_ID_PARAM,
-  SELECTED_TRACE_ID_PARAM,
-} from "@phoenix/constants/searchParams";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { SummaryValueLabels } from "@phoenix/pages/project/AnnotationSummary";
 import { useSessionPagination } from "@phoenix/pages/trace/SessionPaginationContext";
+import { getSessionDetailsPath } from "@phoenix/utils/urlUtils";
 
 import {
   CellWithControlsWrap,
@@ -76,20 +73,6 @@ const PAGE_SIZE = DEFAULT_PAGE_SIZE;
 const defaultColumnSettings = {
   minSize: 100,
 } satisfies Partial<ColumnDef<unknown>>;
-
-function getSessionDetailsPath({
-  sessionId,
-  searchParams,
-}: {
-  sessionId: string;
-  searchParams: URLSearchParams;
-}) {
-  const nextSearchParams = new URLSearchParams(searchParams);
-  nextSearchParams.delete(SELECTED_TRACE_ID_PARAM);
-  nextSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
-  const nextSearch = nextSearchParams.toString();
-  return `${encodeURIComponent(sessionId)}${nextSearch ? `?${nextSearch}` : ""}`;
-}
 
 const TableBody = <T extends { id: string }>({
   table,

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -67,6 +67,7 @@ import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { SummaryValueLabels } from "@phoenix/pages/project/AnnotationSummary";
 import { MetadataTableCell } from "@phoenix/pages/project/MetadataTableCell";
 import { useTracePagination } from "@phoenix/pages/trace/TracePaginationContext";
+import { getTraceDetailsPath } from "@phoenix/utils/urlUtils";
 
 import type {
   SpansTable_spans$key,
@@ -108,25 +109,6 @@ type RootSpanFilterValue = "root" | "all";
 const defaultColumnSettings = {
   minSize: 100,
 } satisfies Partial<ColumnDef<unknown>>;
-
-function getTraceDetailsPath({
-  traceId,
-  spanNodeId,
-  searchParams,
-}: {
-  traceId: string;
-  spanNodeId?: string;
-  searchParams: URLSearchParams;
-}) {
-  const nextSearchParams = new URLSearchParams(searchParams);
-  if (spanNodeId) {
-    nextSearchParams.set(SELECTED_SPAN_NODE_ID_PARAM, spanNodeId);
-  } else {
-    nextSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
-  }
-  const nextSearch = nextSearchParams.toString();
-  return `${traceId}${nextSearch ? `?${nextSearch}` : ""}`;
-}
 
 function isRootSpanFilterValue(val: unknown): val is RootSpanFilterValue {
   return val === "root" || val === "all";

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -109,6 +109,25 @@ const defaultColumnSettings = {
   minSize: 100,
 } satisfies Partial<ColumnDef<unknown>>;
 
+function getTraceDetailsPath({
+  traceId,
+  spanNodeId,
+  searchParams,
+}: {
+  traceId: string;
+  spanNodeId?: string;
+  searchParams: URLSearchParams;
+}) {
+  const nextSearchParams = new URLSearchParams(searchParams);
+  if (spanNodeId) {
+    nextSearchParams.set(SELECTED_SPAN_NODE_ID_PARAM, spanNodeId);
+  } else {
+    nextSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
+  }
+  const nextSearch = nextSearchParams.toString();
+  return `${traceId}${nextSearch ? `?${nextSearch}` : ""}`;
+}
+
 function isRootSpanFilterValue(val: unknown): val is RootSpanFilterValue {
   return val === "root" || val === "all";
 }
@@ -141,7 +160,11 @@ const TableBody = <T extends { trace: { traceId: string }; id: string }>({
             data-selected={isSelected}
             onClick={() =>
               navigate(
-                `${row.original.trace.traceId}?${SELECTED_SPAN_NODE_ID_PARAM}=${row.original.id}`
+                getTraceDetailsPath({
+                  traceId: row.original.trace.traceId,
+                  spanNodeId: row.original.id,
+                  searchParams,
+                })
               )
             }
           >
@@ -202,6 +225,7 @@ function SpansTableAsideSkeleton() {
 }
 
 export function SpansTable(props: SpansTableProps) {
+  const [searchParams] = useSearchParams();
   const { fetchKey } = useStreamState();
   //we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -602,7 +626,13 @@ export function SpansTable(props: SpansTableProps) {
         const span = row.original;
         const { traceId } = span.trace;
         return (
-          <Link to={`${traceId}?${SELECTED_SPAN_NODE_ID_PARAM}=${span.id}`}>
+          <Link
+            to={getTraceDetailsPath({
+              traceId,
+              spanNodeId: span.id,
+              searchParams,
+            })}
+          >
             {getValue() as string}
           </Link>
         );

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -55,12 +55,12 @@ import { TraceTokenCount } from "@phoenix/components/trace/TraceTokenCount";
 import type { ISpanItem } from "@phoenix/components/trace/types";
 import type { SpanTreeNode } from "@phoenix/components/trace/utils";
 import { createSpanTree } from "@phoenix/components/trace/utils";
-import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { SummaryValueLabels } from "@phoenix/pages/project/AnnotationSummary";
 import { MetadataTableCell } from "@phoenix/pages/project/MetadataTableCell";
 import { useTracePagination } from "@phoenix/pages/trace/TracePaginationContext";
+import { getTraceDetailsPath } from "@phoenix/utils/urlUtils";
 
 import type {
   SpanStatusCode,
@@ -88,25 +88,6 @@ type TracesTableProps = {
 
 const PAGE_SIZE = DEFAULT_PAGE_SIZE;
 const NUM_DESCENDANTS = 50;
-
-function getTraceDetailsPath({
-  traceId,
-  spanNodeId,
-  searchParams,
-}: {
-  traceId: string;
-  spanNodeId?: string | null;
-  searchParams: URLSearchParams;
-}) {
-  const nextSearchParams = new URLSearchParams(searchParams);
-  if (spanNodeId) {
-    nextSearchParams.set(SELECTED_SPAN_NODE_ID_PARAM, spanNodeId);
-  } else {
-    nextSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
-  }
-  const nextSearch = nextSearchParams.toString();
-  return `${traceId}${nextSearch ? `?${nextSearch}` : ""}`;
-}
 
 interface IAdditionalSpansIndicator {
   /**

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -25,7 +25,7 @@ import React, {
   useState,
 } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
-import { useNavigate, useParams } from "react-router";
+import { useNavigate, useParams, useSearchParams } from "react-router";
 
 import {
   CopyToClipboardButton,
@@ -89,6 +89,25 @@ type TracesTableProps = {
 const PAGE_SIZE = DEFAULT_PAGE_SIZE;
 const NUM_DESCENDANTS = 50;
 
+function getTraceDetailsPath({
+  traceId,
+  spanNodeId,
+  searchParams,
+}: {
+  traceId: string;
+  spanNodeId?: string | null;
+  searchParams: URLSearchParams;
+}) {
+  const nextSearchParams = new URLSearchParams(searchParams);
+  if (spanNodeId) {
+    nextSearchParams.set(SELECTED_SPAN_NODE_ID_PARAM, spanNodeId);
+  } else {
+    nextSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
+  }
+  const nextSearch = nextSearchParams.toString();
+  return `${traceId}${nextSearch ? `?${nextSearch}` : ""}`;
+}
+
 interface IAdditionalSpansIndicator {
   /**
    * A flag that if set, indicates that this row is just there to show that there are N more spans under this span
@@ -119,6 +138,7 @@ const TableBody = <
   "use no memo";
   const navigate = useNavigate();
   const { traceId } = useParams();
+  const [searchParams] = useSearchParams();
   return (
     <tbody>
       {table.getRowModel().rows.map((row) => {
@@ -126,7 +146,14 @@ const TableBody = <
         return (
           <tr
             key={row.id}
-            onClick={() => navigate(`${row.original.trace.traceId}`)}
+            onClick={() =>
+              navigate(
+                getTraceDetailsPath({
+                  traceId: row.original.trace.traceId,
+                  searchParams,
+                })
+              )
+            }
             data-is-additional-row={row.original.__additionalRow}
             data-selected={isSelected}
             css={css(trCSS)}
@@ -200,6 +227,7 @@ function spanTreeToNestedSpanTableRows<TSpan extends ISpanItem>(params: {
 }
 
 export function TracesTable(props: TracesTableProps) {
+  const [searchParams] = useSearchParams();
   //we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const isFirstRender = useRef<boolean>(true);
@@ -716,7 +744,11 @@ export function TracesTable(props: TracesTableProps) {
           const spanId = row.original.__additionalRow ? null : row.original.id;
           return (
             <Link
-              to={`${traceId}${spanId ? `?${SELECTED_SPAN_NODE_ID_PARAM}=${spanId}` : ""}`}
+              to={getTraceDetailsPath({
+                traceId,
+                spanNodeId: spanId,
+                searchParams,
+              })}
             >
               {getValue() as string}
             </Link>
@@ -847,7 +879,7 @@ export function TracesTable(props: TracesTableProps) {
         },
       },
     ],
-    [annotationColumns]
+    [annotationColumns, searchParams]
   );
 
   useEffect(() => {

--- a/app/src/pages/trace/SessionPage.tsx
+++ b/app/src/pages/trace/SessionPage.tsx
@@ -19,13 +19,11 @@ import {
 } from "@phoenix/components";
 import { DRAWER_DEFAULT_MIN_SIZE } from "@phoenix/components/core/overlay/constants";
 import { useDefaultDrawerSize } from "@phoenix/components/core/overlay/useDefaultDrawerSize";
-import {
-  SELECTED_SPAN_NODE_ID_PARAM,
-  SELECTED_TRACE_ID_PARAM,
-} from "@phoenix/constants/searchParams";
+import { SELECTION_SCOPED_SEARCH_PARAMS } from "@phoenix/constants/searchParams";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
 import { SessionDetailsPaginator } from "@phoenix/pages/trace/SessionDetailsPaginator";
 import type { sessionLoader } from "@phoenix/pages/trace/sessionLoader";
+import { withSearchParams } from "@phoenix/utils/urlUtils";
 
 import { SessionDetails } from "./SessionDetails";
 
@@ -39,10 +37,11 @@ export function SessionPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const { rootPath, tab } = useProjectRootPath();
-  const parentSearchParams = new URLSearchParams(location.search);
-  parentSearchParams.delete(SELECTED_TRACE_ID_PARAM);
-  parentSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
-  const parentSearch = parentSearchParams.toString();
+  const parentSearch = withSearchParams(location.search, (params) => {
+    for (const param of SELECTION_SCOPED_SEARCH_PARAMS) {
+      params.delete(param);
+    }
+  });
   const { defaultSize, onSizeChange } = useDefaultDrawerSize({
     id: "session-details",
   });
@@ -53,7 +52,7 @@ export function SessionPage() {
       onClose={() =>
         navigate({
           pathname: `${rootPath}/${tab}`,
-          search: parentSearch ? `?${parentSearch}` : "",
+          search: parentSearch,
           hash: location.hash,
         })
       }

--- a/app/src/pages/trace/SessionPage.tsx
+++ b/app/src/pages/trace/SessionPage.tsx
@@ -1,4 +1,9 @@
-import { useLoaderData, useNavigate, useParams } from "react-router";
+import {
+  useLoaderData,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router";
 import invariant from "tiny-invariant";
 
 import {
@@ -14,6 +19,10 @@ import {
 } from "@phoenix/components";
 import { DRAWER_DEFAULT_MIN_SIZE } from "@phoenix/components/core/overlay/constants";
 import { useDefaultDrawerSize } from "@phoenix/components/core/overlay/useDefaultDrawerSize";
+import {
+  SELECTED_SPAN_NODE_ID_PARAM,
+  SELECTED_TRACE_ID_PARAM,
+} from "@phoenix/constants/searchParams";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
 import { SessionDetailsPaginator } from "@phoenix/pages/trace/SessionDetailsPaginator";
 import type { sessionLoader } from "@phoenix/pages/trace/sessionLoader";
@@ -28,7 +37,12 @@ export function SessionPage() {
   invariant(loaderData, "loaderData is required");
   const { sessionId } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const { rootPath, tab } = useProjectRootPath();
+  const parentSearchParams = new URLSearchParams(location.search);
+  parentSearchParams.delete(SELECTED_TRACE_ID_PARAM);
+  parentSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
+  const parentSearch = parentSearchParams.toString();
   const { defaultSize, onSizeChange } = useDefaultDrawerSize({
     id: "session-details",
   });
@@ -36,7 +50,13 @@ export function SessionPage() {
   return (
     <Drawer
       isOpen
-      onClose={() => navigate(`${rootPath}/${tab}`)}
+      onClose={() =>
+        navigate({
+          pathname: `${rootPath}/${tab}`,
+          search: parentSearch ? `?${parentSearch}` : "",
+          hash: location.hash,
+        })
+      }
       defaultSize={defaultSize}
       minSize={DRAWER_DEFAULT_MIN_SIZE}
       onResize={onSizeChange}

--- a/app/src/pages/trace/SessionPage.tsx
+++ b/app/src/pages/trace/SessionPage.tsx
@@ -19,11 +19,10 @@ import {
 } from "@phoenix/components";
 import { DRAWER_DEFAULT_MIN_SIZE } from "@phoenix/components/core/overlay/constants";
 import { useDefaultDrawerSize } from "@phoenix/components/core/overlay/useDefaultDrawerSize";
-import { SELECTION_SCOPED_SEARCH_PARAMS } from "@phoenix/constants/searchParams";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
 import { SessionDetailsPaginator } from "@phoenix/pages/trace/SessionDetailsPaginator";
 import type { sessionLoader } from "@phoenix/pages/trace/sessionLoader";
-import { withSearchParams } from "@phoenix/utils/urlUtils";
+import { clearSelectionScopedParams } from "@phoenix/utils/urlUtils";
 
 import { SessionDetails } from "./SessionDetails";
 
@@ -37,11 +36,7 @@ export function SessionPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const { rootPath, tab } = useProjectRootPath();
-  const parentSearch = withSearchParams(location.search, (params) => {
-    for (const param of SELECTION_SCOPED_SEARCH_PARAMS) {
-      params.delete(param);
-    }
-  });
+  const parentSearch = clearSelectionScopedParams(location.search);
   const { defaultSize, onSizeChange } = useDefaultDrawerSize({
     id: "session-details",
   });

--- a/app/src/pages/trace/SessionPaginationContext.tsx
+++ b/app/src/pages/trace/SessionPaginationContext.tsx
@@ -2,10 +2,8 @@ import type { PropsWithChildren } from "react";
 import { createContext, useCallback, useContext, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 
-import {
-  SELECTED_SPAN_NODE_ID_PARAM,
-  SELECTED_TRACE_ID_PARAM,
-} from "@phoenix/constants/searchParams";
+import { SELECTION_SCOPED_SEARCH_PARAMS } from "@phoenix/constants/searchParams";
+import { withSearchParams } from "@phoenix/utils/urlUtils";
 
 /**
  * A sequence of session node IDs used to navigate between sessions.
@@ -26,19 +24,12 @@ export const useSessionPagination = () => {
   return useContext(SessionPaginationContext);
 };
 
-const SESSION_DETAILS_SEARCH_PARAMS_TO_CLEAR = [
-  SELECTED_TRACE_ID_PARAM,
-  SELECTED_SPAN_NODE_ID_PARAM,
-];
-
-const getPreservedSearch = (search: string) => {
-  const searchParams = new URLSearchParams(search);
-  for (const searchParam of SESSION_DETAILS_SEARCH_PARAMS_TO_CLEAR) {
-    searchParams.delete(searchParam);
-  }
-  const nextSearch = searchParams.toString();
-  return nextSearch ? `?${nextSearch}` : "";
-};
+const getPreservedSearch = (search: string) =>
+  withSearchParams(search, (params) => {
+    for (const param of SELECTION_SCOPED_SEARCH_PARAMS) {
+      params.delete(param);
+    }
+  });
 
 /**
  * Get the next and previous sessionIds based on the current sessionId.

--- a/app/src/pages/trace/SessionPaginationContext.tsx
+++ b/app/src/pages/trace/SessionPaginationContext.tsx
@@ -2,8 +2,7 @@ import type { PropsWithChildren } from "react";
 import { createContext, useCallback, useContext, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 
-import { SELECTION_SCOPED_SEARCH_PARAMS } from "@phoenix/constants/searchParams";
-import { withSearchParams } from "@phoenix/utils/urlUtils";
+import { clearSelectionScopedParams } from "@phoenix/utils/urlUtils";
 
 /**
  * A sequence of session node IDs used to navigate between sessions.
@@ -23,13 +22,6 @@ export const SessionPaginationContext =
 export const useSessionPagination = () => {
   return useContext(SessionPaginationContext);
 };
-
-const getPreservedSearch = (search: string) =>
-  withSearchParams(search, (params) => {
-    for (const param of SELECTION_SCOPED_SEARCH_PARAMS) {
-      params.delete(param);
-    }
-  });
 
 /**
  * Get the next and previous sessionIds based on the current sessionId.
@@ -63,7 +55,7 @@ export const makeSessionUrls = (
   const [projects, projectId, resource] = location.pathname
     .split("/")
     .filter((part) => part !== "");
-  const preservedSearch = getPreservedSearch(location.search);
+  const preservedSearch = clearSelectionScopedParams(location.search);
   const makeUrl = (sessionId: string) =>
     `/${projects}/${projectId}/${resource}/${encodeURIComponent(sessionId)}${preservedSearch}${location.hash}`;
   return {

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -28,9 +28,8 @@ import { SpanStatusBadge } from "@phoenix/components/trace/SpanStatusBadge";
 import { TraceTreeProvider } from "@phoenix/components/trace/TraceTree";
 import { TraceTreeToolbar } from "@phoenix/components/trace/TraceTreeToolbar";
 import type { SpanStatusCodeType } from "@phoenix/components/trace/types";
-import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { costFormatter } from "@phoenix/utils/numberFormatUtils";
-import { withSearchParams } from "@phoenix/utils/urlUtils";
+import { clearSelectionScopedParams } from "@phoenix/utils/urlUtils";
 
 import { RichTokenBreakdown } from "../../components/RichTokenCostBreakdown";
 import type {
@@ -197,9 +196,7 @@ function TraceHeader({
 }) {
   const [searchParams] = useSearchParams();
   const statusCode = (rootSpan?.statusCode ?? "UNSET") as SpanStatusCodeType;
-  const sessionSearch = withSearchParams(searchParams, (params) => {
-    params.delete(SELECTED_SPAN_NODE_ID_PARAM);
-  });
+  const sessionSearch = clearSelectionScopedParams(searchParams);
   return (
     <View
       paddingTop="size-100"

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -30,6 +30,7 @@ import { TraceTreeToolbar } from "@phoenix/components/trace/TraceTreeToolbar";
 import type { SpanStatusCodeType } from "@phoenix/components/trace/types";
 import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { costFormatter } from "@phoenix/utils/numberFormatUtils";
+import { withSearchParams } from "@phoenix/utils/urlUtils";
 
 import { RichTokenBreakdown } from "../../components/RichTokenCostBreakdown";
 import type {
@@ -196,9 +197,9 @@ function TraceHeader({
 }) {
   const [searchParams] = useSearchParams();
   const statusCode = (rootSpan?.statusCode ?? "UNSET") as SpanStatusCodeType;
-  const sessionSearchParams = new URLSearchParams(searchParams);
-  sessionSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
-  const sessionSearch = sessionSearchParams.toString();
+  const sessionSearch = withSearchParams(searchParams, (params) => {
+    params.delete(SELECTED_SPAN_NODE_ID_PARAM);
+  });
   return (
     <View
       paddingTop="size-100"
@@ -294,7 +295,7 @@ function TraceHeader({
               variant="primary"
               to={{
                 pathname: `/projects/${projectId}/sessions/${sessionId}`,
-                search: sessionSearch ? `?${sessionSearch}` : "",
+                search: sessionSearch,
               }}
             >
               View Session

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -23,6 +23,7 @@ import {
   View,
 } from "@phoenix/components";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanStatusBadge } from "@phoenix/components/trace/SpanStatusBadge";
 import { TraceTreeProvider } from "@phoenix/components/trace/TraceTree";

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -23,12 +23,12 @@ import {
   View,
 } from "@phoenix/components";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
-import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanStatusBadge } from "@phoenix/components/trace/SpanStatusBadge";
 import { TraceTreeProvider } from "@phoenix/components/trace/TraceTree";
 import { TraceTreeToolbar } from "@phoenix/components/trace/TraceTreeToolbar";
 import type { SpanStatusCodeType } from "@phoenix/components/trace/types";
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { costFormatter } from "@phoenix/utils/numberFormatUtils";
 import { clearSelectionScopedParams } from "@phoenix/utils/urlUtils";
 

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -194,7 +194,11 @@ function TraceHeader({
   sessionId?: string | null;
   projectId: string;
 }) {
+  const [searchParams] = useSearchParams();
   const statusCode = (rootSpan?.statusCode ?? "UNSET") as SpanStatusCodeType;
+  const sessionSearchParams = new URLSearchParams(searchParams);
+  sessionSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
+  const sessionSearch = sessionSearchParams.toString();
   return (
     <View
       paddingTop="size-100"
@@ -288,7 +292,10 @@ function TraceHeader({
             <LinkButton
               size="S"
               variant="primary"
-              to={`/projects/${projectId}/sessions/${sessionId}`}
+              to={{
+                pathname: `/projects/${projectId}/sessions/${sessionId}`,
+                search: sessionSearch ? `?${sessionSearch}` : "",
+              }}
             >
               View Session
             </LinkButton>

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -1,5 +1,10 @@
 import { Suspense } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router";
+import {
+  useLocation,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router";
 
 import {
   Dialog,
@@ -31,8 +36,12 @@ export function TracePage() {
   const { traceId, projectId } = useParams();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const { rootPath, tab } = useProjectRootPath();
   const selectedSpanNodeId = searchParams.get(SELECTED_SPAN_NODE_ID_PARAM);
+  const parentSearchParams = new URLSearchParams(searchParams);
+  parentSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
+  const parentSearch = parentSearchParams.toString();
   const { defaultSize, onSizeChange } = useDefaultDrawerSize({
     id: "trace-details",
   });
@@ -44,7 +53,13 @@ export function TracePage() {
   return (
     <Drawer
       isOpen
-      onClose={() => navigate(`${rootPath}/${tab}`)}
+      onClose={() =>
+        navigate({
+          pathname: `${rootPath}/${tab}`,
+          search: parentSearch ? `?${parentSearch}` : "",
+          hash: location.hash,
+        })
+      }
       defaultSize={defaultSize}
       minSize={DRAWER_DEFAULT_MIN_SIZE}
       onResize={onSizeChange}

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -26,6 +26,7 @@ import { ShareLinkButton } from "@phoenix/components/ShareLinkButton";
 import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
 import { TraceDetailsPaginator } from "@phoenix/pages/trace/TraceDetailsPaginator";
+import { withSearchParams } from "@phoenix/utils/urlUtils";
 
 import { TraceDetails } from "./TraceDetails";
 
@@ -39,9 +40,9 @@ export function TracePage() {
   const location = useLocation();
   const { rootPath, tab } = useProjectRootPath();
   const selectedSpanNodeId = searchParams.get(SELECTED_SPAN_NODE_ID_PARAM);
-  const parentSearchParams = new URLSearchParams(searchParams);
-  parentSearchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
-  const parentSearch = parentSearchParams.toString();
+  const parentSearch = withSearchParams(searchParams, (params) => {
+    params.delete(SELECTED_SPAN_NODE_ID_PARAM);
+  });
   const { defaultSize, onSizeChange } = useDefaultDrawerSize({
     id: "trace-details",
   });
@@ -56,7 +57,7 @@ export function TracePage() {
       onClose={() =>
         navigate({
           pathname: `${rootPath}/${tab}`,
-          search: parentSearch ? `?${parentSearch}` : "",
+          search: parentSearch,
           hash: location.hash,
         })
       }

--- a/app/src/pages/trace/TracePaginationContext.tsx
+++ b/app/src/pages/trace/TracePaginationContext.tsx
@@ -3,6 +3,7 @@ import { createContext, useCallback, useContext, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 
 import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
+import { withSearchParams } from "@phoenix/utils/urlUtils";
 
 /**
  * A sequence of traceId/spanId pairs that represent the trace sequence.
@@ -77,14 +78,14 @@ export const makeTraceUrls = (
   const makeUrl = (traceId: string, currentSpanId?: string) => {
     // we always navigate directly to a traceId
     const path = `/${projects}/${projectId}/${resource}/${traceId}`;
-    const searchParams = new URLSearchParams(location.search);
-    if (currentSpanId) {
-      searchParams.set(SELECTED_SPAN_NODE_ID_PARAM, currentSpanId);
-    } else {
-      searchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
-    }
-    const nextSearch = searchParams.toString();
-    return `${path}${nextSearch ? `?${nextSearch}` : ""}${location.hash}`;
+    const search = withSearchParams(location.search, (params) => {
+      if (currentSpanId) {
+        params.set(SELECTED_SPAN_NODE_ID_PARAM, currentSpanId);
+      } else {
+        params.delete(SELECTED_SPAN_NODE_ID_PARAM);
+      }
+    });
+    return `${path}${search}${location.hash}`;
   };
   const hasNext = !!nextTraceId;
   const hasPrevious = !!previousTraceId;

--- a/app/src/pages/trace/TracePaginationContext.tsx
+++ b/app/src/pages/trace/TracePaginationContext.tsx
@@ -76,12 +76,15 @@ export const makeTraceUrls = (
     .filter((part) => part !== "");
   const makeUrl = (traceId: string, currentSpanId?: string) => {
     // we always navigate directly to a traceId
-    let path = `/${projects}/${projectId}/${resource}/${traceId}`;
-    // we add a selected span node id if provided to makeUrl
+    const path = `/${projects}/${projectId}/${resource}/${traceId}`;
+    const searchParams = new URLSearchParams(location.search);
     if (currentSpanId) {
-      path += `?${SELECTED_SPAN_NODE_ID_PARAM}=${currentSpanId}`;
+      searchParams.set(SELECTED_SPAN_NODE_ID_PARAM, currentSpanId);
+    } else {
+      searchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
     }
-    return path;
+    const nextSearch = searchParams.toString();
+    return `${path}${nextSearch ? `?${nextSearch}` : ""}${location.hash}`;
   };
   const hasNext = !!nextTraceId;
   const hasPrevious = !!previousTraceId;

--- a/app/src/pages/trace/__tests__/SessionPaginationContext.test.ts
+++ b/app/src/pages/trace/__tests__/SessionPaginationContext.test.ts
@@ -7,7 +7,7 @@ describe("makeSessionUrls", () => {
     const location = {
       pathname: "/projects/project-1/sessions/current-session",
       search:
-        "?sessionView=traces&timeRange=7d&selectedTraceId=trace-1&selectedSpanNodeId=span-1",
+        "?sessionView=traces&timeRangeKey=7d&timeRangeStart=2026-06-02T10%3A00%3A00.000Z&timeRangeEnd=2026-06-09T10%3A00%3A30.000Z&selectedTraceId=trace-1&selectedSpanNodeId=span-1",
       hash: "#details",
     } as Parameters<typeof makeSessionUrls>[0];
 
@@ -20,7 +20,7 @@ describe("makeSessionUrls", () => {
       makeSessionUrls(location, sessionSequence, "current-session")
         .nextSessionPath
     ).toBe(
-      "/projects/project-1/sessions/next-session?sessionView=traces&timeRange=7d#details"
+      "/projects/project-1/sessions/next-session?sessionView=traces&timeRangeKey=7d&timeRangeStart=2026-06-02T10%3A00%3A00.000Z&timeRangeEnd=2026-06-09T10%3A00%3A30.000Z#details"
     );
   });
 

--- a/app/src/pages/trace/__tests__/TracePaginationContext.test.ts
+++ b/app/src/pages/trace/__tests__/TracePaginationContext.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { makeTraceUrls } from "../TracePaginationContext";
+
+describe("makeTraceUrls", () => {
+  it("preserves recreatable URL state while replacing selected span", () => {
+    const location = {
+      pathname: "/projects/project-1/spans/current-trace",
+      search:
+        "?timeRangeStart=2026-06-09T09%3A00%3A00.000Z&timeRangeEnd=2026-06-09T10%3A00%3A00.000Z&selectedSpanNodeId=current-span",
+      hash: "#details",
+    } as Parameters<typeof makeTraceUrls>[0];
+
+    const traceSequence = [
+      { traceId: "current-trace", spanId: "current-span" },
+      { traceId: "next-trace", spanId: "next-span" },
+    ];
+
+    expect(
+      makeTraceUrls(location, traceSequence, "current-span").nextTracePath
+    ).toBe(
+      "/projects/project-1/spans/next-trace?timeRangeStart=2026-06-09T09%3A00%3A00.000Z&timeRangeEnd=2026-06-09T10%3A00%3A00.000Z&selectedSpanNodeId=next-span#details"
+    );
+  });
+
+  it("adds the selected span when there is no other search state to preserve", () => {
+    const location = {
+      pathname: "/projects/project-1/traces/current-trace",
+      search: "",
+      hash: "",
+    } as Parameters<typeof makeTraceUrls>[0];
+
+    const traceSequence = [
+      { traceId: "previous-trace", spanId: "previous-span" },
+      { traceId: "current-trace", spanId: "current-span" },
+    ];
+
+    expect(
+      makeTraceUrls(location, traceSequence, "current-trace").previousTracePath
+    ).toBe(
+      "/projects/project-1/traces/previous-trace?selectedSpanNodeId=previous-span"
+    );
+  });
+});

--- a/app/src/utils/__tests__/urlUtils.test.ts
+++ b/app/src/utils/__tests__/urlUtils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clearSelectionScopedParams,
+  getTraceDetailsPath,
+} from "@phoenix/utils/urlUtils";
+
+describe("urlUtils", () => {
+  it("clears selection-scoped params while preserving recreatable state", () => {
+    expect(
+      clearSelectionScopedParams(
+        "?timeRangeKey=7d&selectedTraceId=trace-1&selectedSpanNodeId=span-1"
+      )
+    ).toBe("?timeRangeKey=7d");
+  });
+
+  it("builds trace details paths without leaking stale selection params", () => {
+    expect(
+      getTraceDetailsPath({
+        traceId: "trace-2",
+        spanNodeId: "span-2",
+        searchParams: new URLSearchParams(
+          "timeRangeKey=7d&selectedTraceId=trace-1&selectedSpanNodeId=span-1"
+        ),
+      })
+    ).toBe("trace-2?timeRangeKey=7d&selectedSpanNodeId=span-2");
+  });
+});

--- a/app/src/utils/urlUtils.ts
+++ b/app/src/utils/urlUtils.ts
@@ -59,13 +59,14 @@ export function getTraceDetailsPath({
   spanNodeId?: string | null;
   searchParams: URLSearchParams;
 }): string {
-  return `${traceId}${withSearchParams(searchParams, (params) => {
-    if (spanNodeId) {
-      params.set(SELECTED_SPAN_NODE_ID_PARAM, spanNodeId);
-    } else {
-      params.delete(SELECTED_SPAN_NODE_ID_PARAM);
+  return `${traceId}${withSearchParams(
+    clearSelectionScopedParams(searchParams),
+    (params) => {
+      if (spanNodeId) {
+        params.set(SELECTED_SPAN_NODE_ID_PARAM, spanNodeId);
+      }
     }
-  })}`;
+  )}`;
 }
 
 /**

--- a/app/src/utils/urlUtils.ts
+++ b/app/src/utils/urlUtils.ts
@@ -30,6 +30,22 @@ export function withSearchParams(
 }
 
 /**
+ * Drop the selection-scoped params (such as the selected trace/span) from the
+ * given search, preserving everything else. Used to build navigation targets
+ * that leave a detail selection while keeping recreatable state like the time
+ * range.
+ */
+export function clearSelectionScopedParams(
+  search: string | URLSearchParams
+): string {
+  return withSearchParams(search, (params) => {
+    for (const param of SELECTION_SCOPED_SEARCH_PARAMS) {
+      params.delete(param);
+    }
+  });
+}
+
+/**
  * Build a relative path to a trace's details, preserving recreatable URL state
  * (such as the selected time range) while setting or clearing the selected
  * span.
@@ -63,12 +79,7 @@ export function getSessionDetailsPath({
   sessionId: string;
   searchParams: URLSearchParams;
 }): string {
-  return `${encodeURIComponent(sessionId)}${withSearchParams(
-    searchParams,
-    (params) => {
-      for (const param of SELECTION_SCOPED_SEARCH_PARAMS) {
-        params.delete(param);
-      }
-    }
+  return `${encodeURIComponent(sessionId)}${clearSelectionScopedParams(
+    searchParams
   )}`;
 }

--- a/app/src/utils/urlUtils.ts
+++ b/app/src/utils/urlUtils.ts
@@ -1,3 +1,8 @@
+import {
+  SELECTED_SPAN_NODE_ID_PARAM,
+  SELECTION_SCOPED_SEARCH_PARAMS,
+} from "@phoenix/constants/searchParams";
+
 const videoUrlRegex = /\.(mp4|mov|webm|ogg)(\?|$)/i;
 const audioUrlRegex = /\.(mp3|wav)(\?|$)/i;
 export function isVideoUrl(url: string): boolean {
@@ -6,4 +11,64 @@ export function isVideoUrl(url: string): boolean {
 
 export function isAudioUrl(url: string): boolean {
   return audioUrlRegex.test(url);
+}
+
+/**
+ * Clone the given search, apply a mutation, and serialize back to a query
+ * string with a leading "?" (or "" when empty). Centralizes the
+ * clone/mutate/stringify boilerplate used to build navigation targets that
+ * preserve unrelated URL state.
+ */
+export function withSearchParams(
+  search: string | URLSearchParams,
+  mutate: (params: URLSearchParams) => void
+): string {
+  const params = new URLSearchParams(search);
+  mutate(params);
+  const nextSearch = params.toString();
+  return nextSearch ? `?${nextSearch}` : "";
+}
+
+/**
+ * Build a relative path to a trace's details, preserving recreatable URL state
+ * (such as the selected time range) while setting or clearing the selected
+ * span.
+ */
+export function getTraceDetailsPath({
+  traceId,
+  spanNodeId,
+  searchParams,
+}: {
+  traceId: string;
+  spanNodeId?: string | null;
+  searchParams: URLSearchParams;
+}): string {
+  return `${traceId}${withSearchParams(searchParams, (params) => {
+    if (spanNodeId) {
+      params.set(SELECTED_SPAN_NODE_ID_PARAM, spanNodeId);
+    } else {
+      params.delete(SELECTED_SPAN_NODE_ID_PARAM);
+    }
+  })}`;
+}
+
+/**
+ * Build a relative path to a session's details, preserving recreatable URL
+ * state while clearing the selection-scoped params.
+ */
+export function getSessionDetailsPath({
+  sessionId,
+  searchParams,
+}: {
+  sessionId: string;
+  searchParams: URLSearchParams;
+}): string {
+  return `${encodeURIComponent(sessionId)}${withSearchParams(
+    searchParams,
+    (params) => {
+      for (const param of SELECTION_SCOPED_SEARCH_PARAMS) {
+        params.delete(param);
+      }
+    }
+  )}`;
 }

--- a/app/tests/auth-refresh.spec.ts
+++ b/app/tests/auth-refresh.spec.ts
@@ -12,13 +12,15 @@ async function loginAsMember(page: Page) {
   await page.getByLabel("Email").fill("member@localhost.com");
   await page.getByLabel("Password").fill("member123");
   await page.getByRole("button", { name: "Log In", exact: true }).click();
-  await page.waitForURL("**/projects");
+  // The projects route seeds a recreatable time range (e.g. ?timeRangeKey=7d)
+  // into the URL, so match the path and tolerate any query string.
+  await page.waitForURL(/\/projects(\?|$)/);
 }
 
 async function openProjectsPage(page: Page) {
   await loginAsMember(page);
   await page.goto("/projects");
-  await page.waitForURL("**/projects");
+  await page.waitForURL(/\/projects(\?|$)/);
   await expect(page.getByRole("button", { name: "New Project" })).toBeVisible();
 }
 
@@ -49,7 +51,7 @@ test("recovers from an expired session by refreshing auth", async ({
   });
 
   await page.reload();
-  await page.waitForURL("**/projects");
+  await page.waitForURL(/\/projects(\?|$)/);
 
   await expect(page.getByRole("button", { name: "New Project" })).toBeVisible();
   await expect.poll(() => refreshRequests).toBeGreaterThan(0);
@@ -83,7 +85,9 @@ test("redirects to login when session refresh fails", async ({ page }) => {
   });
 
   await page.reload();
-  await page.waitForURL("**/login?returnUrl=%2Fprojects");
+  // returnUrl round-trips the projects URL, which may carry a recreatable time
+  // range (e.g. an encoded ?timeRangeKey=7d), so match the returnUrl prefix.
+  await page.waitForURL(/\/login\?returnUrl=%2Fprojects/);
 });
 
 test("redirects to login when session refresh times out", async ({ page }) => {
@@ -116,5 +120,5 @@ test("redirects to login when session refresh times out", async ({ page }) => {
   });
 
   await page.reload();
-  await page.waitForURL("**/login?returnUrl=%2Fprojects");
+  await page.waitForURL(/\/login\?returnUrl=%2Fprojects/);
 });


### PR DESCRIPTION
resolves #13687

Persist the trace time range in the URL as a **declarative, shareable** value. The URL encodes exactly **one** representation of the range — never both:

- **Preset (live):** `timeRangeKey=7d` and no bounds. Always relative; re-resolves against the viewer's "now" and refreshes on a timer.
- **Custom (fixed):** explicit `timeRangeStart`/`timeRangeEnd` bounds and no key. Honored verbatim.

Because the URL is a key **XOR** explicit bounds, "is this range live?" is a pure function of the URL's shape — a preset key is always live, a custom range never is. No provenance tracking is needed to tell a self-authored URL apart from a shared/restored one.

### Sharing semantics
- Sharing a **preset** link shows the recipient their own "last N" relative to when they open it.
- Sharing an **exact window** is done by selecting a **custom** range, whose explicit bounds travel in the URL.
- Legacy URLs carrying both a key and bounds are read as a live preset (the key wins), so old links keep working.

### Notes
This supersedes the earlier approach of always persisting resolved bounds alongside the key. That made a `?timeRangeKey=7d` URL ambiguous (live preset vs. frozen snapshot) and required two refs, a search-param signature, and a `preferConcreteBounds` flag in the reader to disambiguate — all removed here.
