### PR TITLE
chore: add changeset for phoenix-mcp User-Agent fix (#13743)

### DIFF
--- a/js/.changeset/phoenix-mcp-user-agent.md
+++ b/js/.changeset/phoenix-mcp-user-agent.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-mcp": patch
+---
+
+Send an explicit `User-Agent: phoenix-mcp` header on Phoenix REST requests. Node's global `fetch` (undici) defaults to `User-Agent: undici`, which some Phoenix Cloud edges 302-redirect to an HTML landing page, causing tool calls to fail with `Unexpected token < in JSON`. Caller-supplied headers still take precedence (#13742).


### PR DESCRIPTION
Follow-up to #13743, which merged the `@arizeai/phoenix-mcp` User-Agent fix without a changeset.

This adds the missing `patch` changeset so the fix is captured in the next `@arizeai/phoenix-mcp` release and changelog.

No code changes — changeset only.