### PR TITLE
feat: Add token detail metrics charts

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -4365,6 +4365,11 @@ type TraceTokenCostTimeSeriesDataPoint {
   totalCost: Float
 }
 
+type TraceTokenCountDetailsTimeSeriesEntry {
+  tokenType: String!
+  tokenCount: Float
+}
+
 type TraceTokenCountTimeSeries {
   data: [TraceTokenCountTimeSeriesDataPoint!]!
 }
@@ -4374,6 +4379,8 @@ type TraceTokenCountTimeSeriesDataPoint {
   promptTokenCount: Float
   completionTokenCount: Float
   totalTokenCount: Float
+  promptTokenCountDetails: [TraceTokenCountDetailsTimeSeriesEntry!]!
+  completionTokenCountDetails: [TraceTokenCountDetailsTimeSeriesEntry!]!
 }
 
 type UnparsableConfig {

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -304,7 +304,7 @@ export const appRouteObjects = createRoutesFromElements(
                   agentRoute: {
                     label: "Project Metrics",
                     description:
-                      "View time-series metrics and observability charts for a project.",
+                      "View project time-series metrics, token usage breakdowns, cache read/write token charts, and observability panels.",
                   },
                 }}
               />

--- a/app/src/pages/project/metrics/ProjectMetricsPage.tsx
+++ b/app/src/pages/project/metrics/ProjectMetricsPage.tsx
@@ -25,7 +25,11 @@ import { TraceAnnotationScoreTimeSeries } from "./TraceAnnotationScoreTimeSeries
 import { TraceCountTimeSeries } from "./TraceCountTimeSeries";
 import { TraceLatencyPercentilesTimeSeries } from "./TraceLatencyPercentilesTimeSeries";
 import { TraceTokenCostTimeSeries } from "./TraceTokenCostTimeSeries";
-import { TraceTokenCountTimeSeries } from "./TraceTokenCountTimeSeries";
+import {
+  TraceCompletionTokenDetailsTimeSeries,
+  TracePromptTokenDetailsTimeSeries,
+  TraceTokenCountTimeSeries,
+} from "./TraceTokenCountTimeSeries";
 
 interface MetricPanelHeaderProps {
   title: string;
@@ -266,6 +270,28 @@ const MetricPanels = memo(function MetricPanels({
         </MetricPanel>
         <MetricPanel title="Top models by tokens">
           <TopModelsByToken projectId={projectId} timeRange={timeRange} />
+        </MetricPanel>
+      </Flex>
+      <Flex direction="row" gap="size-200">
+        <MetricPanel
+          title="Prompt token details"
+          subtitle="Prompt tokens by input, cache, and audio parts"
+        >
+          <TracePromptTokenDetailsTimeSeries
+            projectId={projectId}
+            timeRange={timeRange}
+            onTimeRangeSelected={onTimeRangeSelected}
+          />
+        </MetricPanel>
+        <MetricPanel
+          title="Completion token details"
+          subtitle="Completion tokens by output, reasoning, and audio parts"
+        >
+          <TraceCompletionTokenDetailsTimeSeries
+            projectId={projectId}
+            timeRange={timeRange}
+            onTimeRangeSelected={onTimeRangeSelected}
+          />
         </MetricPanel>
       </Flex>
       <Flex direction="row" gap="size-200">

--- a/app/src/pages/project/metrics/TraceTokenCountTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceTokenCountTimeSeries.tsx
@@ -32,9 +32,174 @@ import type { ProjectMetricViewProps } from "@phoenix/pages/project/metrics/type
 import {
   intFormatter,
   intShortFormatter,
+  percentFormatter,
 } from "@phoenix/utils/numberFormatUtils";
 
 import type { TraceTokenCountTimeSeriesQuery } from "./__generated__/TraceTokenCountTimeSeriesQuery.graphql";
+
+type TokenCountTimeSeriesDatum = NonNullable<
+  NonNullable<
+    NonNullable<
+      TraceTokenCountTimeSeriesQuery["response"]["project"]
+    >["traceTokenCountTimeSeries"]
+  >["data"]
+>[number];
+type TokenDetailsKind = "prompt" | "completion";
+type TokenDetailsChartDatum = {
+  timestamp: number;
+  total: number | null;
+  [key: string]: number | null;
+};
+
+const TOKEN_DETAIL_DATA_KEY_PREFIX = "tokenDetail:";
+const TOKEN_DETAIL_SORT_ORDER: Record<string, number> = {
+  input: 0,
+  output: 0,
+  cache_read: 1,
+  cache_write: 2,
+  reasoning: 3,
+  audio: 4,
+};
+
+function getTokenDetailDataKey(tokenType: string) {
+  return `${TOKEN_DETAIL_DATA_KEY_PREFIX}${encodeURIComponent(tokenType)}`;
+}
+
+function getTokenDetailLabel(tokenType: string) {
+  if (tokenType === "cache_read") {
+    return "Cache read";
+  }
+  if (tokenType === "cache_write") {
+    return "Cache write";
+  }
+  return tokenType
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function compareTokenTypes(left: string, right: string) {
+  const leftOrder = TOKEN_DETAIL_SORT_ORDER[left] ?? 100;
+  const rightOrder = TOKEN_DETAIL_SORT_ORDER[right] ?? 100;
+  if (leftOrder !== rightOrder) {
+    return leftOrder - rightOrder;
+  }
+  return left.localeCompare(right);
+}
+
+function getTokenDetailColor({
+  colors,
+  index,
+  tokenType,
+}: {
+  colors: ReturnType<typeof useCategoryChartColors>;
+  index: number;
+  tokenType: string;
+}) {
+  if (tokenType === "input") {
+    return colors.category1;
+  }
+  if (tokenType === "output") {
+    return colors.category2;
+  }
+  if (tokenType === "cache_read") {
+    return colors.category9;
+  }
+  if (tokenType === "cache_write") {
+    return colors.category7;
+  }
+  if (tokenType === "reasoning") {
+    return colors.category4;
+  }
+  if (tokenType === "audio") {
+    return colors.category3;
+  }
+  const fallbackColors = [
+    colors.category5,
+    colors.category6,
+    colors.category8,
+    colors.category10,
+    colors.category11,
+    colors.category12,
+  ];
+  return fallbackColors[index % fallbackColors.length];
+}
+
+function getTokenDetails(
+  datum: TokenCountTimeSeriesDatum,
+  tokenKind: TokenDetailsKind
+) {
+  return tokenKind === "prompt"
+    ? datum.promptTokenCountDetails
+    : datum.completionTokenCountDetails;
+}
+
+function getTokenTotal(
+  datum: TokenCountTimeSeriesDatum,
+  tokenKind: TokenDetailsKind
+) {
+  return tokenKind === "prompt"
+    ? datum.promptTokenCount
+    : datum.completionTokenCount;
+}
+
+function useTraceTokenCountTimeSeriesData({
+  projectId,
+  timeRange,
+}: Pick<ProjectMetricViewProps, "projectId" | "timeRange">) {
+  const scale = useTimeBinScale({ timeRange });
+  const utcOffsetMinutes = useUTCOffsetMinutes();
+
+  const data = useLazyLoadQuery<TraceTokenCountTimeSeriesQuery>(
+    graphql`
+      query TraceTokenCountTimeSeriesQuery(
+        $projectId: ID!
+        $timeRange: TimeRange!
+        $timeBinConfig: TimeBinConfig!
+      ) {
+        project: node(id: $projectId) {
+          ... on Project {
+            traceTokenCountTimeSeries(
+              timeRange: $timeRange
+              timeBinConfig: $timeBinConfig
+            ) {
+              data {
+                timestamp
+                promptTokenCount
+                completionTokenCount
+                totalTokenCount
+                promptTokenCountDetails {
+                  tokenType
+                  tokenCount
+                }
+                completionTokenCountDetails {
+                  tokenType
+                  tokenCount
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      projectId,
+      timeRange: {
+        start: timeRange.start?.toISOString(),
+        end: timeRange.end?.toISOString(),
+      },
+      timeBinConfig: {
+        scale,
+        utcOffsetMinutes,
+      },
+    }
+  );
+
+  return {
+    data: data.project.traceTokenCountTimeSeries?.data ?? [],
+    scale,
+  };
+}
 
 function TooltipContent({ active, payload, label }: TooltipContentProps) {
   const { fullTimeFormatter } = useTimeFormatters();
@@ -69,59 +234,61 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
   return null;
 }
 
+function TokenDetailsTooltipContent({
+  active,
+  payload,
+  label,
+}: TooltipContentProps) {
+  const { fullTimeFormatter } = useTimeFormatters();
+  if (active && payload && payload.length) {
+    const total = payload[0]?.payload?.total;
+    return (
+      <ChartTooltip>
+        {label && (
+          <Text weight="heavy" size="S">{`${fullTimeFormatter(
+            new Date(Number(label))
+          )}`}</Text>
+        )}
+        {payload.map((entry) => {
+          const name = String(entry.name ?? entry.dataKey ?? "unknown");
+          const value =
+            typeof entry.value === "number" ? entry.value : undefined;
+          const share =
+            value != null && typeof total === "number" && total > 0
+              ? ` (${percentFormatter((value / total) * 100)})`
+              : "";
+          return (
+            <ChartTooltipItem
+              color={entry.color ?? "transparent"}
+              key={String(entry.dataKey ?? entry.name)}
+              shape="circle"
+              name={name}
+              value={value != null ? `${intFormatter(value)}${share}` : "--"}
+            />
+          );
+        })}
+      </ChartTooltip>
+    );
+  }
+
+  return null;
+}
+
 export function TraceTokenCountTimeSeries({
   projectId,
   timeRange,
   onTimeRangeSelected,
 }: ProjectMetricViewProps) {
-  const scale = useTimeBinScale({ timeRange });
-  const utcOffsetMinutes = useUTCOffsetMinutes();
-
-  const data = useLazyLoadQuery<TraceTokenCountTimeSeriesQuery>(
-    graphql`
-      query TraceTokenCountTimeSeriesQuery(
-        $projectId: ID!
-        $timeRange: TimeRange!
-        $timeBinConfig: TimeBinConfig!
-      ) {
-        project: node(id: $projectId) {
-          ... on Project {
-            traceTokenCountTimeSeries(
-              timeRange: $timeRange
-              timeBinConfig: $timeBinConfig
-            ) {
-              data {
-                timestamp
-                promptTokenCount
-                completionTokenCount
-                totalTokenCount
-              }
-            }
-          }
-        }
-      }
-    `,
-    {
-      projectId,
-      timeRange: {
-        start: timeRange.start?.toISOString(),
-        end: timeRange.end?.toISOString(),
-      },
-      timeBinConfig: {
-        scale,
-        utcOffsetMinutes,
-      },
-    }
-  );
-
-  const chartData = (data.project.traceTokenCountTimeSeries?.data ?? []).map(
-    (datum) => ({
-      timestamp: new Date(datum.timestamp).getTime(),
-      prompt: datum.promptTokenCount ?? 0,
-      completion: datum.completionTokenCount ?? 0,
-      total: datum.totalTokenCount,
-    })
-  );
+  const { data, scale } = useTraceTokenCountTimeSeriesData({
+    projectId,
+    timeRange,
+  });
+  const chartData = data.map((datum) => ({
+    timestamp: new Date(datum.timestamp).getTime(),
+    prompt: datum.promptTokenCount ?? 0,
+    completion: datum.completionTokenCount ?? 0,
+    total: datum.totalTokenCount,
+  }));
   const hasData = chartData.some((datum) => typeof datum.total === "number");
 
   const timeTickFormatter = useBinTimeTickFormatter({ scale });
@@ -197,4 +364,136 @@ export function TraceTokenCountTimeSeries({
       )}
     </TimeRangeChartBrush>
   );
+}
+
+function TraceTokenDetailsTimeSeries({
+  projectId,
+  timeRange,
+  onTimeRangeSelected,
+  tokenKind,
+}: ProjectMetricViewProps & { tokenKind: TokenDetailsKind }) {
+  const { data, scale } = useTraceTokenCountTimeSeriesData({
+    projectId,
+    timeRange,
+  });
+  const tokenTypes = Array.from(
+    data.reduce((types, datum) => {
+      getTokenDetails(datum, tokenKind).forEach((detail) => {
+        if ((detail.tokenCount ?? 0) > 0) {
+          types.add(detail.tokenType);
+        }
+      });
+      return types;
+    }, new Set<string>())
+  ).sort(compareTokenTypes);
+  const chartData: TokenDetailsChartDatum[] = data.map((datum) => {
+    const chartDatum: TokenDetailsChartDatum = {
+      timestamp: new Date(datum.timestamp).getTime(),
+      total: getTokenTotal(datum, tokenKind),
+    };
+    const tokenCountsByType = new Map(
+      getTokenDetails(datum, tokenKind).map((detail) => [
+        detail.tokenType,
+        detail.tokenCount ?? 0,
+      ])
+    );
+    tokenTypes.forEach((tokenType) => {
+      chartDatum[getTokenDetailDataKey(tokenType)] =
+        tokenCountsByType.get(tokenType) ?? 0;
+    });
+    return chartDatum;
+  });
+  const hasData = chartData.some((datum) => typeof datum.total === "number");
+
+  const timeTickFormatter = useBinTimeTickFormatter({ scale });
+
+  const colors = useCategoryChartColors();
+  const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
+    useInteractiveLegend();
+  return (
+    <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
+      {({ chartProps }) => (
+        <ChartEmptyStateOverlay
+          isEmpty={!hasData}
+          message="No data in this time range"
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={chartData}
+              margin={{ top: 0, right: 18, left: 8, bottom: 0 }}
+              barSize={10}
+              syncId={"projectMetrics"}
+              {...chartProps}
+            >
+              <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+              <XAxis
+                {...defaultTimeXAxisProps}
+                domain={[timeRange.start.getTime(), timeRange.end.getTime()]}
+                tickFormatter={(x) => timeTickFormatter(new Date(x))}
+              />
+              <YAxis
+                {...defaultYAxisProps}
+                width={70}
+                tickFormatter={(x) => intShortFormatter(x)}
+                label={{
+                  value:
+                    tokenKind === "prompt"
+                      ? "Prompt tokens"
+                      : "Completion tokens",
+                  angle: -90,
+                  dx: -28,
+                  style: {
+                    textAnchor: "middle",
+                    fill: "var(--chart-axis-label-color)",
+                  },
+                }}
+                style={{ fill: "var(--global-text-color-700)" }}
+              />
+              <Tooltip
+                content={TokenDetailsTooltipContent}
+                // TODO formalize this
+                cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+              />
+              {tokenTypes.map((tokenType, index) => {
+                const dataKey = getTokenDetailDataKey(tokenType);
+                return (
+                  <Bar
+                    dataKey={dataKey}
+                    fill={getTokenDetailColor({ colors, index, tokenType })}
+                    hide={isDataKeyHidden(dataKey)}
+                    key={dataKey}
+                    name={getTokenDetailLabel(tokenType)}
+                    radius={
+                      index === tokenTypes.length - 1 ? [2, 2, 0, 0] : undefined
+                    }
+                    stackId="a"
+                  />
+                );
+              })}
+
+              <InteractiveLegend
+                {...defaultLegendProps}
+                hiddenDataKeys={hiddenDataKeys}
+                iconType="circle"
+                iconSize={8}
+                onToggleDataKey={toggleDataKey}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartEmptyStateOverlay>
+      )}
+    </TimeRangeChartBrush>
+  );
+}
+
+export function TracePromptTokenDetailsTimeSeries(
+  props: ProjectMetricViewProps
+) {
+  return <TraceTokenDetailsTimeSeries {...props} tokenKind="prompt" />;
+}
+
+export function TraceCompletionTokenDetailsTimeSeries(
+  props: ProjectMetricViewProps
+) {
+  return <TraceTokenDetailsTimeSeries {...props} tokenKind="completion" />;
 }

--- a/app/src/pages/project/metrics/__generated__/TraceTokenCountTimeSeriesQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/TraceTokenCountTimeSeriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b9a71be1b9de3cc66178cbf77bfae5d9>>
+ * @generated SignedSource<<9826cd3e7eb2a30630fb88a248a3508e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -28,7 +28,15 @@ export type TraceTokenCountTimeSeriesQuery$data = {
     readonly traceTokenCountTimeSeries?: {
       readonly data: ReadonlyArray<{
         readonly completionTokenCount: number | null;
+        readonly completionTokenCountDetails: ReadonlyArray<{
+          readonly tokenCount: number | null;
+          readonly tokenType: string;
+        }>;
         readonly promptTokenCount: number | null;
+        readonly promptTokenCountDetails: ReadonlyArray<{
+          readonly tokenCount: number | null;
+          readonly tokenType: string;
+        }>;
         readonly timestamp: string;
         readonly totalTokenCount: number | null;
       }>;
@@ -63,7 +71,23 @@ v3 = [
     "variableName": "projectId"
   }
 ],
-v4 = {
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "tokenType",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "tokenCount",
+    "storageKey": null
+  }
+],
+v5 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -120,6 +144,26 @@ v4 = {
               "kind": "ScalarField",
               "name": "totalTokenCount",
               "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "TraceTokenCountDetailsTimeSeriesEntry",
+              "kind": "LinkedField",
+              "name": "promptTokenCountDetails",
+              "plural": true,
+              "selections": (v4/*: any*/),
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "TraceTokenCountDetailsTimeSeriesEntry",
+              "kind": "LinkedField",
+              "name": "completionTokenCountDetails",
+              "plural": true,
+              "selections": (v4/*: any*/),
+              "storageKey": null
             }
           ],
           "storageKey": null
@@ -150,7 +194,7 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": null
       }
@@ -183,7 +227,7 @@ return {
             "name": "__typename",
             "storageKey": null
           },
-          (v4/*: any*/),
+          (v5/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -197,16 +241,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e123a97bd485838cd5cb2b534eabd0d5",
+    "cacheID": "271dd9a2039761542883d47969aa23f1",
     "id": null,
     "metadata": {},
     "name": "TraceTokenCountTimeSeriesQuery",
     "operationKind": "query",
-    "text": "query TraceTokenCountTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      traceTokenCountTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          promptTokenCount\n          completionTokenCount\n          totalTokenCount\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query TraceTokenCountTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      traceTokenCountTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          promptTokenCount\n          completionTokenCount\n          totalTokenCount\n          promptTokenCountDetails {\n            tokenType\n            tokenCount\n          }\n          completionTokenCountDetails {\n            tokenType\n            tokenCount\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "04ca506080201401409afce5ef6eb89d";
+(node as any).hash = "e03579d83337bb96055dc138e0477b40";
 
 export default node;

--- a/scripts/generate_spans/generate_token_detail_spans.py
+++ b/scripts/generate_spans/generate_token_detail_spans.py
@@ -1,0 +1,446 @@
+# /// script
+# dependencies = [
+#   "openinference-semantic-conventions",
+#   "opentelemetry-exporter-otlp",
+#   "opentelemetry-sdk",
+# ]
+# ///
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Mapping
+
+from openinference.semconv.resource import ResourceAttributes
+from openinference.semconv.trace import (
+    ImageAttributes,
+    MessageAttributes,
+    MessageContentAttributes,
+    OpenInferenceLLMProviderValues,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import Status, StatusCode
+
+PROMPT_DETAILS_IMAGE = f"{SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS}.image"
+COMPLETION_DETAILS = "llm.token_count.completion_details"
+COMPLETION_DETAILS_IMAGE = f"{COMPLETION_DETAILS}.image"
+IMAGE_DATA_URL = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+AUDIO_DATA_URL = (
+    "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA="
+)
+
+
+@dataclass(frozen=True)
+class TokenBudget:
+    prompt_text: int
+    completion_text: int
+    cache_read: int = 0
+    cache_write: int = 0
+    prompt_image: int = 0
+    prompt_audio: int = 0
+    completion_image: int = 0
+    completion_audio: int = 0
+    reasoning: int = 0
+
+    @property
+    def prompt_total(self) -> int:
+        return (
+            self.prompt_text
+            + self.cache_read
+            + self.cache_write
+            + self.prompt_image
+            + self.prompt_audio
+        )
+
+    @property
+    def completion_total(self) -> int:
+        return self.completion_text + self.completion_image + self.completion_audio + self.reasoning
+
+    @property
+    def total(self) -> int:
+        return self.prompt_total + self.completion_total
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    provider: str
+    model_name: str
+    system_message: str
+    user_message: str
+    assistant_message: str
+    budget: TokenBudget
+    has_input_image: bool = False
+    has_input_audio: bool = False
+    has_output_image: bool = False
+    has_output_audio: bool = False
+
+
+def _scaled(value: int, day_index: int, scenario_index: int) -> int:
+    multiplier = 1.0 + (day_index * 0.06) + (scenario_index * 0.025)
+    return round(value * multiplier)
+
+
+def _scale_budget(budget: TokenBudget, day_index: int, scenario_index: int) -> TokenBudget:
+    return TokenBudget(
+        prompt_text=_scaled(budget.prompt_text, day_index, scenario_index),
+        completion_text=_scaled(budget.completion_text, day_index, scenario_index),
+        cache_read=_scaled(budget.cache_read, day_index, scenario_index),
+        cache_write=_scaled(budget.cache_write, day_index, scenario_index),
+        prompt_image=_scaled(budget.prompt_image, day_index, scenario_index),
+        prompt_audio=_scaled(budget.prompt_audio, day_index, scenario_index),
+        completion_image=_scaled(budget.completion_image, day_index, scenario_index),
+        completion_audio=_scaled(budget.completion_audio, day_index, scenario_index),
+        reasoning=_scaled(budget.reasoning, day_index, scenario_index),
+    )
+
+
+def _daily_scenarios(day_index: int) -> list[Scenario]:
+    base: list[Scenario] = [
+        Scenario(
+            name="cache-write-primer",
+            provider=OpenInferenceLLMProviderValues.ANTHROPIC.value,
+            model_name="claude-sonnet-4-20250514",
+            system_message="Use the cached policy and product catalog context.",
+            user_message="Prime the support cache with the latest enterprise account context.",
+            assistant_message="The cache is warm and ready for follow-up support questions.",
+            budget=TokenBudget(
+                prompt_text=940,
+                cache_read=80,
+                cache_write=3400,
+                completion_text=510,
+                reasoning=130,
+            ),
+        ),
+        Scenario(
+            name="cache-read-hit",
+            provider=OpenInferenceLLMProviderValues.ANTHROPIC.value,
+            model_name="claude-sonnet-4-20250514",
+            system_message="Reuse cached product and account context when possible.",
+            user_message="Answer a support question that should mostly hit the prompt cache.",
+            assistant_message="The cached context was used to answer the question directly.",
+            budget=TokenBudget(
+                prompt_text=620,
+                cache_read=3900,
+                cache_write=120,
+                completion_text=420,
+                reasoning=95,
+            ),
+        ),
+        Scenario(
+            name="vision-cache-analysis",
+            provider=OpenInferenceLLMProviderValues.OPENAI.value,
+            model_name="gpt-4o-2024-08-06",
+            system_message="Inspect the screenshot and compare it with cached UI guidelines.",
+            user_message="Review this dashboard screenshot and call out layout regressions.",
+            assistant_message="The chart alignment is correct, but the legend density changed.",
+            budget=TokenBudget(
+                prompt_text=520,
+                cache_read=1150,
+                cache_write=260,
+                prompt_image=1480,
+                completion_text=710,
+                reasoning=210,
+            ),
+            has_input_image=True,
+        ),
+        Scenario(
+            name="audio-summary",
+            provider=OpenInferenceLLMProviderValues.OPENAI.value,
+            model_name="gpt-4o-audio-preview",
+            system_message="Summarize support calls with text and audio context.",
+            user_message="Summarize this audio clip and preserve the account action items.",
+            assistant_message="The call summary and audio response were generated.",
+            budget=TokenBudget(
+                prompt_text=360,
+                cache_read=420,
+                prompt_audio=940,
+                completion_text=300,
+                completion_audio=780,
+            ),
+            has_input_audio=True,
+            has_output_audio=True,
+        ),
+        Scenario(
+            name="multimodal-output",
+            provider=OpenInferenceLLMProviderValues.OPENAI.value,
+            model_name="gpt-image-1.5",
+            system_message="Generate a concise visual follow-up using cached campaign context.",
+            user_message="Use the screenshot and audio notes to generate a visual campaign brief.",
+            assistant_message="A visual brief and text rationale were generated.",
+            budget=TokenBudget(
+                prompt_text=700,
+                cache_read=1280,
+                cache_write=540,
+                prompt_image=980,
+                prompt_audio=460,
+                completion_text=560,
+                completion_image=1240,
+                completion_audio=220,
+                reasoning=360,
+            ),
+            has_input_image=True,
+            has_input_audio=True,
+            has_output_image=True,
+            has_output_audio=True,
+        ),
+    ]
+    return [
+        Scenario(
+            name=scenario.name,
+            provider=scenario.provider,
+            model_name=scenario.model_name,
+            system_message=scenario.system_message,
+            user_message=scenario.user_message,
+            assistant_message=scenario.assistant_message,
+            budget=_scale_budget(scenario.budget, day_index, scenario_index),
+            has_input_image=scenario.has_input_image,
+            has_input_audio=scenario.has_input_audio,
+            has_output_image=scenario.has_output_image,
+            has_output_audio=scenario.has_output_audio,
+        )
+        for scenario_index, scenario in enumerate(base)
+    ]
+
+
+def _trace_endpoint(endpoint: str) -> str:
+    endpoint = endpoint.rstrip("/")
+    if endpoint.endswith("/v1/traces"):
+        return endpoint
+    return f"{endpoint}/v1/traces"
+
+
+def _set_content_blocks(
+    attributes: dict[str, str | int],
+    message_prefix: str,
+    text: str,
+    *,
+    include_image: bool,
+    include_audio: bool,
+) -> None:
+    if not include_image and not include_audio:
+        attributes[f"{message_prefix}.{MessageAttributes.MESSAGE_CONTENT}"] = text
+        return
+
+    contents = MessageAttributes.MESSAGE_CONTENTS
+    content_type = MessageContentAttributes.MESSAGE_CONTENT_TYPE
+    attributes[f"{message_prefix}.{contents}.0.{content_type}"] = "text"
+    attributes[f"{message_prefix}.{contents}.0.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}"] = (
+        text
+    )
+    index = 1
+    if include_image:
+        image = MessageContentAttributes.MESSAGE_CONTENT_IMAGE
+        attributes[f"{message_prefix}.{contents}.{index}.{content_type}"] = "image"
+        attributes[f"{message_prefix}.{contents}.{index}.{image}.{ImageAttributes.IMAGE_URL}"] = (
+            IMAGE_DATA_URL
+        )
+        index += 1
+    if include_audio:
+        attributes[f"{message_prefix}.{contents}.{index}.{content_type}"] = "audio"
+        attributes[
+            f"{message_prefix}.{contents}.{index}.{MessageContentAttributes.MESSAGE_CONTENT_DATA}"
+        ] = AUDIO_DATA_URL
+
+
+def _scenario_attributes(scenario: Scenario, run_id: str) -> Mapping[str, str | int]:
+    budget = scenario.budget
+    prompt_detail_sum = (
+        budget.cache_read + budget.cache_write + budget.prompt_image + budget.prompt_audio
+    )
+    completion_detail_sum = budget.completion_image + budget.completion_audio + budget.reasoning
+    if budget.prompt_text + prompt_detail_sum != budget.prompt_total:
+        raise ValueError(f"{scenario.name} prompt tokens do not sum to the aggregate total")
+    if budget.completion_text + completion_detail_sum != budget.completion_total:
+        raise ValueError(f"{scenario.name} completion tokens do not sum to the aggregate total")
+
+    attributes: dict[str, str | int] = {
+        SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.LLM.value,
+        SpanAttributes.INPUT_MIME_TYPE: OpenInferenceMimeTypeValues.TEXT.value,
+        SpanAttributes.INPUT_VALUE: scenario.user_message,
+        SpanAttributes.OUTPUT_MIME_TYPE: OpenInferenceMimeTypeValues.TEXT.value,
+        SpanAttributes.OUTPUT_VALUE: scenario.assistant_message,
+        SpanAttributes.METADATA: json.dumps({"fixture": "token_details", "run_id": run_id}),
+        SpanAttributes.LLM_PROVIDER: scenario.provider,
+        SpanAttributes.LLM_MODEL_NAME: scenario.model_name,
+        SpanAttributes.LLM_INVOCATION_PARAMETERS: json.dumps(
+            {
+                "cache": {"read": budget.cache_read, "write": budget.cache_write},
+                "modalities": [
+                    modality
+                    for modality, count in (
+                        ("text", budget.prompt_text + budget.completion_text),
+                        ("image", budget.prompt_image + budget.completion_image),
+                        ("audio", budget.prompt_audio + budget.completion_audio),
+                    )
+                    if count
+                ],
+                "temperature": 0.2,
+            },
+            sort_keys=True,
+        ),
+        SpanAttributes.LLM_TOKEN_COUNT_PROMPT: budget.prompt_total,
+        SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: budget.completion_total,
+        SpanAttributes.LLM_TOKEN_COUNT_TOTAL: budget.total,
+        SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ: budget.cache_read,
+        SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE: budget.cache_write,
+        SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_AUDIO: budget.prompt_audio,
+        PROMPT_DETAILS_IMAGE: budget.prompt_image,
+        SpanAttributes.LLM_TOKEN_COUNT_COMPLETION_DETAILS_AUDIO: budget.completion_audio,
+        SpanAttributes.LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING: budget.reasoning,
+        COMPLETION_DETAILS_IMAGE: budget.completion_image,
+    }
+    attributes = {key: value for key, value in attributes.items() if value != 0}
+
+    input_message = f"{SpanAttributes.LLM_INPUT_MESSAGES}.0"
+    attributes[f"{input_message}.{MessageAttributes.MESSAGE_ROLE}"] = "system"
+    attributes[f"{input_message}.{MessageAttributes.MESSAGE_CONTENT}"] = scenario.system_message
+    input_message = f"{SpanAttributes.LLM_INPUT_MESSAGES}.1"
+    attributes[f"{input_message}.{MessageAttributes.MESSAGE_ROLE}"] = "user"
+    _set_content_blocks(
+        attributes,
+        input_message,
+        scenario.user_message,
+        include_image=scenario.has_input_image,
+        include_audio=scenario.has_input_audio,
+    )
+
+    output_message = f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0"
+    attributes[f"{output_message}.{MessageAttributes.MESSAGE_ROLE}"] = "assistant"
+    _set_content_blocks(
+        attributes,
+        output_message,
+        scenario.assistant_message,
+        include_image=scenario.has_output_image,
+        include_audio=scenario.has_output_audio,
+    )
+    return attributes
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate Phoenix token detail fixture spans for cache, image, and audio data."
+    )
+    parser.add_argument(
+        "--endpoint",
+        default="http://localhost:6006",
+        help="Phoenix base URL or OTLP trace endpoint. Defaults to http://localhost:6006.",
+    )
+    parser.add_argument(
+        "--project-name",
+        default="token-detail-fixtures",
+        help="Phoenix project name to write fixture spans into.",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=7,
+        help="Number of daily fixture slices to generate.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and summarize spans without exporting them.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.days < 1:
+        raise ValueError("--days must be at least 1")
+
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    tracer_provider = TracerProvider(
+        resource=Resource.create({ResourceAttributes.PROJECT_NAME: args.project_name})
+    )
+    if not args.dry_run:
+        tracer_provider.add_span_processor(
+            SimpleSpanProcessor(OTLPSpanExporter(endpoint=_trace_endpoint(args.endpoint)))
+        )
+    tracer = tracer_provider.get_tracer(__name__)
+
+    now = datetime.now(timezone.utc)
+    start_day = now.replace(hour=9, minute=0, second=0, microsecond=0) - timedelta(
+        days=args.days - 1
+    )
+    span_count = 0
+    totals: dict[str, int] = {
+        "prompt": 0,
+        "completion": 0,
+        "prompt_input": 0,
+        "completion_output": 0,
+    }
+    detail_totals: dict[str, int] = {}
+
+    for day_index in range(args.days):
+        day_start = start_day + timedelta(days=day_index)
+        for scenario_index, scenario in enumerate(_daily_scenarios(day_index)):
+            start_time = day_start + timedelta(
+                hours=2 * scenario_index,
+                minutes=(day_index * 7 + scenario_index * 11) % 50,
+            )
+            start_time_ns = int(start_time.timestamp() * 1_000_000_000)
+            end_time_ns = start_time_ns + (scenario_index + 1) * 250_000_000
+            attributes = _scenario_attributes(scenario, run_id)
+
+            budget = scenario.budget
+            totals["prompt"] += budget.prompt_total
+            totals["completion"] += budget.completion_total
+            totals["prompt_input"] += budget.prompt_text
+            totals["completion_output"] += budget.completion_text
+            for key, value in (
+                ("prompt.cache_read", budget.cache_read),
+                ("prompt.cache_write", budget.cache_write),
+                ("prompt.image", budget.prompt_image),
+                ("prompt.audio", budget.prompt_audio),
+                ("completion.image", budget.completion_image),
+                ("completion.audio", budget.completion_audio),
+                ("completion.reasoning", budget.reasoning),
+            ):
+                detail_totals[key] = detail_totals.get(key, 0) + value
+
+            if not args.dry_run:
+                span = tracer.start_span(
+                    scenario.name,
+                    start_time=start_time_ns,
+                    attributes=attributes,
+                )
+                span.set_status(Status(StatusCode.OK))
+                span.end(end_time=end_time_ns)
+            span_count += 1
+
+    if not args.dry_run:
+        tracer_provider.force_flush()
+        tracer_provider.shutdown()
+
+    print(f"project={args.project_name}")
+    print(f"run_id={run_id}")
+    print(f"spans={span_count}")
+    print(f"prompt_total={totals['prompt']}")
+    print(f"completion_total={totals['completion']}")
+    print(f"prompt_input_remainder={totals['prompt_input']}")
+    print(f"completion_output_remainder={totals['completion_output']}")
+    for key in sorted(detail_totals):
+        print(f"{key}={detail_totals[key]}")
+    if args.dry_run:
+        print("dry_run=true")
+    else:
+        print(f"exported_to={_trace_endpoint(args.endpoint)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -54,8 +54,58 @@ from phoenix.server.types import DbSessionFactory
 from phoenix.trace.dsl import SpanFilter
 
 DEFAULT_PAGE_SIZE = 30
+_TOKEN_COUNT_DETAIL_EPSILON = 1e-9
+_TOKEN_COUNT_DETAIL_SORT_ORDER = {
+    "input": 0,
+    "output": 0,
+    "cache_read": 1,
+    "cache_write": 2,
+    "reasoning": 3,
+    "audio": 4,
+}
 if TYPE_CHECKING:
     from phoenix.server.api.types.ProjectTraceRetentionPolicy import ProjectTraceRetentionPolicy
+
+
+def _merge_token_count_detail(
+    details: list["TraceTokenCountDetailsTimeSeriesEntry"],
+    token_type: str,
+    token_count: float,
+) -> None:
+    if token_count <= _TOKEN_COUNT_DETAIL_EPSILON:
+        return
+    for detail in details:
+        if detail.token_type == token_type:
+            detail.token_count = (detail.token_count or 0) + token_count
+            return
+    details.append(
+        TraceTokenCountDetailsTimeSeriesEntry(
+            token_type=token_type,
+            token_count=token_count,
+        )
+    )
+
+
+def _ensure_token_count_details_total(
+    details: list["TraceTokenCountDetailsTimeSeriesEntry"],
+    total_token_count: Optional[float],
+    default_token_type: str,
+) -> None:
+    if total_token_count is None:
+        return
+    detail_token_count = sum(detail.token_count or 0 for detail in details)
+    remainder = total_token_count - detail_token_count
+    if remainder > _TOKEN_COUNT_DETAIL_EPSILON:
+        _merge_token_count_detail(details, default_token_type, remainder)
+
+
+def _sort_token_count_details(details: list["TraceTokenCountDetailsTimeSeriesEntry"]) -> None:
+    details.sort(
+        key=lambda detail: (
+            _TOKEN_COUNT_DETAIL_SORT_ORDER.get(detail.token_type, 100),
+            detail.token_type,
+        )
+    )
 
 
 @strawberry.type
@@ -1171,6 +1221,35 @@ class Project(Node):
                 stmt = stmt.where(time_range.start <= models.Trace.start_time)
             if time_range.end:
                 stmt = stmt.where(models.Trace.start_time < time_range.end)
+        details_stmt = (
+            select(
+                bucket,
+                models.SpanCostDetail.is_prompt,
+                models.SpanCostDetail.token_type,
+                func.sum(func.coalesce(models.SpanCostDetail.tokens, 0)),
+            )
+            .join_from(
+                models.Trace,
+                models.SpanCost,
+                onclause=models.SpanCost.trace_rowid == models.Trace.id,
+            )
+            .join(
+                models.SpanCostDetail,
+                models.SpanCostDetail.span_cost_id == models.SpanCost.id,
+            )
+            .where(models.Trace.project_rowid == self.id)
+            .group_by(bucket, models.SpanCostDetail.is_prompt, models.SpanCostDetail.token_type)
+            .order_by(
+                bucket,
+                models.SpanCostDetail.is_prompt.desc(),
+                models.SpanCostDetail.token_type,
+            )
+        )
+        if time_range:
+            if time_range.start:
+                details_stmt = details_stmt.where(time_range.start <= models.Trace.start_time)
+            if time_range.end:
+                details_stmt = details_stmt.where(models.Trace.start_time < time_range.end)
         data: dict[datetime, TraceTokenCountTimeSeriesDataPoint] = {}
         async with info.context.db.read() as session:
             async for (
@@ -1186,6 +1265,37 @@ class Project(Node):
                     completion_token_count=completion_tokens,
                     total_token_count=total_tokens,
                 )
+            async for (
+                t,
+                is_prompt,
+                token_type,
+                token_count,
+            ) in await session.stream(details_stmt):
+                timestamp = _as_datetime(t)
+                data_point = data.setdefault(
+                    timestamp,
+                    TraceTokenCountTimeSeriesDataPoint(timestamp=timestamp),
+                )
+                details = (
+                    data_point.prompt_token_count_details
+                    if is_prompt
+                    else data_point.completion_token_count_details
+                )
+                _merge_token_count_detail(details, token_type, token_count)
+
+        for data_point in data.values():
+            _ensure_token_count_details_total(
+                data_point.prompt_token_count_details,
+                data_point.prompt_token_count,
+                "input",
+            )
+            _ensure_token_count_details_total(
+                data_point.completion_token_count_details,
+                data_point.completion_token_count,
+                "output",
+            )
+            _sort_token_count_details(data_point.prompt_token_count_details)
+            _sort_token_count_details(data_point.completion_token_count_details)
 
         data_timestamps: list[datetime] = [data_point.timestamp for data_point in data.values()]
         min_time = min([*data_timestamps, time_range.start])
@@ -1570,11 +1680,23 @@ class TraceLatencyPercentileTimeSeries:
 
 
 @strawberry.type
+class TraceTokenCountDetailsTimeSeriesEntry:
+    token_type: str
+    token_count: Optional[float] = None
+
+
+@strawberry.type
 class TraceTokenCountTimeSeriesDataPoint:
     timestamp: datetime
     prompt_token_count: Optional[float] = None
     completion_token_count: Optional[float] = None
     total_token_count: Optional[float] = None
+    prompt_token_count_details: list[TraceTokenCountDetailsTimeSeriesEntry] = strawberry.field(
+        default_factory=list
+    )
+    completion_token_count_details: list[TraceTokenCountDetailsTimeSeriesEntry] = strawberry.field(
+        default_factory=list
+    )
 
 
 @strawberry.type

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -102,7 +102,9 @@ def _ensure_token_count_details_total(
 def _sort_token_count_details(details: list["TraceTokenCountDetailsTimeSeriesEntry"]) -> None:
     details.sort(
         key=lambda detail: (
-            _TOKEN_COUNT_DETAIL_SORT_ORDER.get(detail.token_type, 100),
+            _TOKEN_COUNT_DETAIL_SORT_ORDER.get(
+                detail.token_type, len(_TOKEN_COUNT_DETAIL_SORT_ORDER)
+            ),
             detail.token_type,
         )
     )

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -72,6 +72,13 @@ def _merge_token_count_detail(
     token_type: str,
     token_count: float,
 ) -> None:
+    """Add ``token_count`` tokens of ``token_type`` into ``details`` in place.
+
+    If an entry for ``token_type`` already exists, its count is incremented;
+    otherwise a new entry is appended. Contributions at or below
+    ``_TOKEN_COUNT_DETAIL_EPSILON`` are ignored so the breakdown does not
+    accumulate entries that round to zero.
+    """
     if token_count <= _TOKEN_COUNT_DETAIL_EPSILON:
         return
     for detail in details:
@@ -91,6 +98,14 @@ def _ensure_token_count_details_total(
     total_token_count: Optional[float],
     default_token_type: str,
 ) -> None:
+    """Reconcile the per-type breakdown against the authoritative total.
+
+    The detail rows may not account for every token in ``total_token_count``
+    (the totals query is the source of truth, the breakdown only refines it).
+    Any unaccounted remainder is folded into ``default_token_type`` (e.g.
+    ``"input"`` for prompts, ``"output"`` for completions) so the entries sum
+    to the total. Does nothing when the total is unknown or already covered.
+    """
     if total_token_count is None:
         return
     detail_token_count = sum(detail.token_count or 0 for detail in details)
@@ -100,6 +115,11 @@ def _ensure_token_count_details_total(
 
 
 def _sort_token_count_details(details: list["TraceTokenCountDetailsTimeSeriesEntry"]) -> None:
+    """Sort ``details`` in place into display order.
+
+    Entries are ordered by the rank in ``_TOKEN_COUNT_DETAIL_SORT_ORDER``;
+    unrecognized token types sort last and are then ordered alphabetically.
+    """
     details.sort(
         key=lambda detail: (
             _TOKEN_COUNT_DETAIL_SORT_ORDER.get(

--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -81,6 +81,26 @@ async def _add_span_cost(
     return span_cost
 
 
+async def _add_span_cost_detail(
+    session: AsyncSession,
+    span_cost: models.SpanCost,
+    token_type: str,
+    is_prompt: bool,
+    tokens: Optional[float],
+) -> models.SpanCostDetail:
+    span_cost_detail = models.SpanCostDetail(
+        span_cost_id=span_cost.id,
+        token_type=token_type,
+        is_prompt=is_prompt,
+        tokens=tokens,
+        cost=None,
+        cost_per_token=None,
+    )
+    session.add(span_cost_detail)
+    await session.flush()
+    return span_cost_detail
+
+
 @dataclass
 class _CostTestData:
     project: models.Project
@@ -450,6 +470,170 @@ class TestTopModels:
         assert not empty_cost_response.errors
         assert (empty_cost_data := empty_cost_response.data) is not None
         assert len(empty_cost_data["node"]["topModelsByCost"]) == 0
+
+
+class TestTraceTokenCountTimeSeries:
+    _QUERY = """
+        query ($projectId: ID!, $timeRange: TimeRange!, $timeBinConfig: TimeBinConfig!) {
+            node(id: $projectId) {
+                ... on Project {
+                    traceTokenCountTimeSeries(
+                        timeRange: $timeRange
+                        timeBinConfig: $timeBinConfig
+                    ) {
+                        data {
+                            timestamp
+                            promptTokenCount
+                            completionTokenCount
+                            totalTokenCount
+                            promptTokenCountDetails {
+                                tokenType
+                                tokenCount
+                            }
+                            completionTokenCountDetails {
+                                tokenType
+                                tokenCount
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """
+
+    async def test_token_detail_breakdowns_match_prompt_and_completion_totals(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        base_time = datetime.fromisoformat("2024-01-01T00:00:00+00:00")
+        async with db() as session:
+            project = await _add_project(session, name="token-detail-time-series-project")
+            model = await _add_generative_model(session, name="gpt-4o-mini", provider="openai")
+
+            trace_with_details = await _add_trace(
+                session,
+                project,
+                start_time=base_time + timedelta(minutes=10),
+                end_time=base_time + timedelta(minutes=12),
+            )
+            span_with_details = await _add_span(
+                session,
+                trace=trace_with_details,
+                start_time=trace_with_details.start_time,
+                end_time=trace_with_details.end_time,
+            )
+            span_cost_with_details = await _add_span_cost(
+                session,
+                span=span_with_details,
+                trace=trace_with_details,
+                model=model,
+                total_tokens=170,
+                prompt_tokens=120,
+                completion_tokens=50,
+                span_start_time=span_with_details.start_time,
+            )
+            await _add_span_cost_detail(
+                session,
+                span_cost=span_cost_with_details,
+                token_type="input",
+                is_prompt=True,
+                tokens=50,
+            )
+            await _add_span_cost_detail(
+                session,
+                span_cost=span_cost_with_details,
+                token_type="cache_read",
+                is_prompt=True,
+                tokens=40,
+            )
+            await _add_span_cost_detail(
+                session,
+                span_cost=span_cost_with_details,
+                token_type="cache_write",
+                is_prompt=True,
+                tokens=30,
+            )
+            await _add_span_cost_detail(
+                session,
+                span_cost=span_cost_with_details,
+                token_type="output",
+                is_prompt=False,
+                tokens=45,
+            )
+            await _add_span_cost_detail(
+                session,
+                span_cost=span_cost_with_details,
+                token_type="reasoning",
+                is_prompt=False,
+                tokens=5,
+            )
+
+            trace_without_details = await _add_trace(
+                session,
+                project,
+                start_time=base_time + timedelta(minutes=35),
+                end_time=base_time + timedelta(minutes=37),
+            )
+            span_without_details = await _add_span(
+                session,
+                trace=trace_without_details,
+                start_time=trace_without_details.start_time,
+                end_time=trace_without_details.end_time,
+            )
+            await _add_span_cost(
+                session,
+                span=span_without_details,
+                trace=trace_without_details,
+                model=model,
+                total_tokens=80,
+                prompt_tokens=60,
+                completion_tokens=20,
+                span_start_time=span_without_details.start_time,
+            )
+            await session.commit()
+
+        response = await gql_client.execute(
+            query=self._QUERY,
+            variables={
+                "projectId": str(GlobalID(type_name="Project", node_id=str(project.id))),
+                "timeRange": {
+                    "start": base_time.isoformat(),
+                    "end": (base_time + timedelta(hours=2)).isoformat(),
+                },
+                "timeBinConfig": {"scale": "HOUR", "utcOffsetMinutes": 0},
+            },
+        )
+        assert not response.errors
+        assert response.data is not None
+
+        data = response.data["node"]["traceTokenCountTimeSeries"]["data"]
+        bucket = next(data_point for data_point in data if data_point["totalTokenCount"] == 250)
+        assert bucket["promptTokenCount"] == 180
+        assert bucket["completionTokenCount"] == 70
+
+        prompt_details = {
+            detail["tokenType"]: detail["tokenCount"]
+            for detail in bucket["promptTokenCountDetails"]
+        }
+        completion_details = {
+            detail["tokenType"]: detail["tokenCount"]
+            for detail in bucket["completionTokenCountDetails"]
+        }
+        assert prompt_details == {
+            "input": 110,
+            "cache_read": 40,
+            "cache_write": 30,
+        }
+        assert completion_details == {
+            "output": 65,
+            "reasoning": 5,
+        }
+        assert sum(prompt_details.values()) == bucket["promptTokenCount"]
+        assert sum(completion_details.values()) == bucket["completionTokenCount"]
+        assert (
+            bucket["promptTokenCount"] + bucket["completionTokenCount"] == bucket["totalTokenCount"]
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

<img width="1727" height="934" alt="Screenshot 2026-06-15 at 2 59 36 PM" src="https://github.com/user-attachments/assets/1df51d50-3237-44d9-beff-29568131337a" />

resolves #13756
## Summary
- add prompt/completion token detail fields to the project token time-series GraphQL response
- reconcile detail buckets back to aggregate prompt/completion totals with input/output fallback buckets
- add two project Metrics stacked bar charts for prompt and completion token details, including legend toggles and tooltip percentage shares
