### PR TITLE
feat(server): add REST endpoint for cloning prompts

### DIFF
--- a/src/phoenix/server/api/routers/v1/prompts.py
+++ b/src/phoenix/server/api/routers/v1/prompts.py
@@ -4,8 +4,10 @@ from typing import Any, Optional, Union
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import ValidationError, field_validator, model_validator
 from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import Select
+from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
 from starlette.requests import Request
 from strawberry.relay import GlobalID
 from typing_extensions import Self, TypeAlias, assert_never
@@ -104,6 +106,16 @@ class CreatePromptRequestBody(V1RoutesBaseModel):
 
 
 class CreatePromptResponseBody(ResponseBody[PromptVersion]):
+    pass
+
+
+class ClonePromptRequestBody(V1RoutesBaseModel):
+    name: Identifier
+    description: Optional[str] = None
+    metadata: Optional[dict[str, Any]] = None
+
+
+class ClonePromptResponseBody(ResponseBody[Prompt]):
     pass
 
 
@@ -756,6 +768,125 @@ async def delete_prompt_version_tag(
             raise HTTPException(404)
         await session.delete(tag)
     return None
+
+
+@router.post(
+    "/prompts/{prompt_identifier}/clone",
+    dependencies=[Depends(is_not_locked)],
+    operation_id="clonePrompt",
+    summary="Clone a prompt",
+    description="Clone an existing prompt and all its versions into a new prompt with a different "
+    "name. Tags are not copied. If description or metadata are omitted, they are inherited from "
+    "the source prompt.",
+    response_description="The newly created prompt",
+    status_code=201,
+    responses=add_errors_to_responses(
+        [
+            404,
+            {"status_code": 409, "description": "A prompt with the given name already exists."},
+            422,
+        ]
+    ),
+)
+async def clone_prompt(
+    request: Request,
+    request_body: ClonePromptRequestBody,
+    prompt_identifier: str = Path(description="The identifier of the prompt to clone, i.e. name or ID."),
+) -> ClonePromptResponseBody:
+    """
+    Clone an existing prompt and all its versions.
+
+    Creates a new prompt with the given name, copying all versions from the source prompt.
+    Tags are not copied. Description and metadata are inherited from the source prompt
+    unless explicitly provided in the request body.
+
+    Args:
+        request (Request): The FastAPI request object.
+        request_body (ClonePromptRequestBody): The request body containing the new prompt name
+            and optional description/metadata overrides.
+        prompt_identifier (str): The identifier of the source prompt (name or GlobalID).
+
+    Returns:
+        ClonePromptResponseBody: Response containing the newly created prompt.
+
+    Raises:
+        HTTPException: If the source prompt is not found, the name is invalid,
+            or a prompt with the given name already exists.
+    """
+    identifier = _parse_prompt_identifier(prompt_identifier)
+    if isinstance(identifier, _PromptId):
+        where_clause = models.Prompt.id == int(identifier)
+    elif isinstance(identifier, Identifier):
+        where_clause = models.Prompt.name == identifier
+    else:
+        assert_never(identifier)
+
+    async with request.app.state.db() as session:
+        stmt = (
+            select(models.Prompt)
+            .options(joinedload(models.Prompt.prompt_versions))
+            .where(where_clause)
+        )
+        result = await session.execute(stmt)
+        source_prompt = result.unique().scalar_one_or_none()
+
+        if not source_prompt:
+            raise HTTPException(status_code=404, detail="Prompt not found")
+
+        if "description" in request_body.model_fields_set:
+            description = (
+                request_body.description.strip()
+                if request_body.description is not None
+                else None
+            )
+        else:
+            description = source_prompt.description
+
+        if "metadata" in request_body.model_fields_set:
+            metadata = request_body.metadata or {}
+        else:
+            metadata = source_prompt.metadata_
+
+        new_prompt = models.Prompt(
+            name=request_body.name,
+            source_prompt_id=source_prompt.id,
+            description=description,
+            metadata_=metadata,
+        )
+
+        new_versions = [
+            models.PromptVersion(
+                prompt=new_prompt,
+                user_id=version.user_id,
+                description=version.description,
+                template_type=version.template_type,
+                template_format=version.template_format,
+                template=version.template,
+                invocation_parameters=normalize_invocation_parameters_for_write(
+                    version.invocation_parameters
+                ),
+                tools=version.tools,
+                response_format=version.response_format,
+                model_provider=version.model_provider,
+                model_name=version.model_name,
+                custom_provider_id=version.custom_provider_id,
+            )
+            for version in source_prompt.prompt_versions
+        ]
+        new_prompt.prompt_versions = new_versions
+
+        session.add(new_prompt)
+
+        try:
+            await session.flush()
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            raise HTTPException(
+                status_code=409,
+                detail=f"A prompt named '{request_body.name}' already exists",
+            )
+
+    data = _prompt_from_orm_prompt(new_prompt)
+    return ClonePromptResponseBody(data=data)
 
 
 @router.delete(

--- a/tests/unit/server/api/routers/v1/test_prompts.py
+++ b/tests/unit/server/api/routers/v1/test_prompts.py
@@ -225,6 +225,264 @@ class TestPrompts:
         response = await httpx_client.delete(url)
         assert response.status_code == 404
 
+    async def test_clone_prompt_success(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        prompt, prompt_versions = await self._insert_prompt_versions(db)
+        clone_name = token_hex(16)
+        url = f"v1/prompts/{quote_plus(prompt.name.root)}/clone"
+        payload = {"name": clone_name}
+        response = await httpx_client.post(url, json=payload)
+        assert response.status_code == 201
+        data = response.json()["data"]
+        assert data["name"] == clone_name
+        assert data["description"] == prompt.description
+        assert data["source_prompt_id"] is not None
+
+        async with db() as session:
+            cloned_prompt = await session.scalar(
+                select(models.Prompt).filter_by(name=Identifier.model_validate(clone_name))
+            )
+            assert cloned_prompt is not None
+            cloned_versions = (
+                await session.scalars(
+                    select(models.PromptVersion).filter_by(prompt_id=cloned_prompt.id)
+                )
+            ).all()
+            assert len(cloned_versions) == len(prompt_versions)
+
+    async def test_clone_prompt_by_id(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        prompt, _ = await self._insert_prompt_versions(db)
+        prompt_id = str(GlobalID(Prompt.__name__, str(prompt.id)))
+        clone_name = token_hex(16)
+        url = f"v1/prompts/{quote_plus(prompt_id)}/clone"
+        payload = {"name": clone_name}
+        response = await httpx_client.post(url, json=payload)
+        assert response.status_code == 201
+        data = response.json()["data"]
+        assert data["name"] == clone_name
+
+    async def test_clone_prompt_not_found(
+        self,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        url = "v1/prompts/nonexistent-prompt-name/clone"
+        payload = {"name": token_hex(16)}
+        response = await httpx_client.post(url, json=payload)
+        assert response.status_code == 404
+
+    async def test_clone_prompt_duplicate_name(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        prompt, _ = await self._insert_prompt_versions(db)
+        url = f"v1/prompts/{quote_plus(prompt.name.root)}/clone"
+        payload = {"name": prompt.name.root}
+        response = await httpx_client.post(url, json=payload)
+        assert response.status_code == 409
+
+    async def test_clone_prompt_inherits_description(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        prompt_name = Identifier.model_validate(token_hex(16))
+        async with db() as session:
+            prompt = models.Prompt(
+                name=prompt_name,
+                description="Source description",
+                metadata_={"key": "value"},
+            )
+            session.add(prompt)
+            await session.flush()
+            version = models.PromptVersion(
+                prompt_id=prompt.id,
+                template_type=PromptTemplateType.CHAT,
+                template_format=PromptTemplateFormat.MUSTACHE,
+                template=PromptChatTemplate(
+                    type="chat",
+                    messages=[PromptMessage(role="user", content="hi")],
+                ),
+                invocation_parameters=PromptOpenAIInvocationParameters(
+                    type="openai",
+                    openai=PromptOpenAIInvocationParametersContent(),
+                ),
+                model_provider=ModelProvider.OPENAI,
+                model_name=token_hex(16),
+            )
+            session.add(version)
+
+        clone_name = token_hex(16)
+        url = f"v1/prompts/{quote_plus(prompt_name.root)}/clone"
+        payload = {"name": clone_name}
+        response = await httpx_client.post(url, json=payload)
+        assert response.status_code == 201
+        data = response.json()["data"]
+        assert data["description"] == "Source description"
+
+    async def test_clone_prompt_inherits_metadata(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        prompt_name = Identifier.model_validate(token_hex(16))
+        async with db() as session:
+            prompt = models.Prompt(
+                name=prompt_name,
+                description="Source description",
+                metadata_={"inherited": "yes"},
+            )
+            session.add(prompt)
+            await session.flush()
+            version = models.PromptVersion(
+                prompt_id=prompt.id,
+                template_type=PromptTemplateType.CHAT,
+                template_format=PromptTemplateFormat.MUSTACHE,
+                template=PromptChatTemplate(
+                    type="chat",
+                    messages=[PromptMessage(role="user", content="hi")],
+                ),
+                invocation_parameters=PromptOpenAIInvocationParameters(
+                    type="openai",
+                    openai=PromptOpenAIInvocationParametersContent(),
+                ),
+                model_provider=ModelProvider.OPENAI,
+                model_name=token_hex(16),
+            )
+            session.add(version)
+
+        clone_name = token_hex(16)
+        url = f"v1/prompts/{quote_plus(prompt_name.root)}/clone"
+        payload = {"name": clone_name}
+        response = await httpx_client.post(url, json=payload)
+        assert response.status_code == 201
+        data = response.json()["data"]
+        assert data["metadata"] == {"inherited": "yes"}
+
+    async def test_clone_prompt_explicit_null_description(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        prompt_name = Identifier.model_validate(token_hex(16))
+        async with db() as session:
+            prompt = models.Prompt(
+                name=prompt_name,
+                description="Source description",
+                metadata_={"key": "value"},
+            )
+            session.add(prompt)
+            await session.flush()
+            version = models.PromptVersion(
+                prompt_id=prompt.id,
+                template_type=PromptTemplateType.CHAT,
+                template_format=PromptTemplateFormat.MUSTACHE,
+                template=PromptChatTemplate(
+                    type="chat",
+                    messages=[PromptMessage(role="user", content="hi")],
+                ),
+                invocation_parameters=PromptOpenAIInvocationParameters(
+                    type="openai",
+                    openai=PromptOpenAIInvocationParametersContent(),
+                ),
+                model_provider=ModelProvider.OPENAI,
+                model_name=token_hex(16),
+            )
+            session.add(version)
+
+        clone_name = token_hex(16)
+        url = f"v1/prompts/{quote_plus(prompt_name.root)}/clone"
+        payload = {"name": clone_name, "description": None}
+        response = await httpx_client.post(url, json=payload)
+        assert response.status_code == 201
+        data = response.json()["data"]
+        assert data["description"] is None
+        assert data["metadata"] == {"key": "value"}
+
+    async def test_clone_prompt_explicit_null_metadata(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        prompt_name = Identifier.model_validate(token_hex(16))
+        async with db() as session:
+            prompt = models.Prompt(
+                name=prompt_name,
+                description="Source description",
+                metadata_={"key": "value"},
+            )
+            session.add(prompt)
+            await session.flush()
+            version = models.PromptVersion(
+                prompt_id=prompt.id,
+                template_type=PromptTemplateType.CHAT,
+                template_format=PromptTemplateFormat.MUSTACHE,
+                template=PromptChatTemplate(
+                    type="chat",
+                    messages=[PromptMessage(role="user", content="hi")],
+                ),
+                invocation_parameters=PromptOpenAIInvocationParameters(
+                    type="openai",
+                    openai=PromptOpenAIInvocationParametersContent(),
+                ),
+                model_provider=ModelProvider.OPENAI,
+                model_name=token_hex(16),
+            )
+            session.add(version)
+
+        clone_name = token_hex(16)
+        url = f"v1/prompts/{quote_plus(prompt_name.root)}/clone"
+        payload = {"name": clone_name, "metadata": None}
+        response = await httpx_client.post(url, json=payload)
+        assert response.status_code == 201
+        data = response.json()["data"]
+        assert data["description"] == "Source description"
+        assert data["metadata"] == {}
+
+    async def test_clone_prompt_does_not_copy_tags(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        prompt, prompt_versions = await self._insert_prompt_versions(db)
+        await self._tag_prompt_version(db, prompt_versions[0])
+
+        clone_name = token_hex(16)
+        url = f"v1/prompts/{quote_plus(prompt.name.root)}/clone"
+        payload = {"name": clone_name}
+        response = await httpx_client.post(url, json=payload)
+        assert response.status_code == 201
+
+        async with db() as session:
+            cloned_prompt = await session.scalar(
+                select(models.Prompt).filter_by(name=Identifier.model_validate(clone_name))
+            )
+            assert cloned_prompt is not None
+            tags = (
+                await session.scalars(
+                    select(models.PromptVersionTag).filter_by(prompt_id=cloned_prompt.id)
+                )
+            ).all()
+            assert len(tags) == 0
+
+    async def test_clone_prompt_invalid_name(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        prompt, _ = await self._insert_prompt_versions(db)
+        url = f"v1/prompts/{quote_plus(prompt.name.root)}/clone"
+        payload = {"name": "invalid name with spaces"}
+        response = await httpx_client.post(url, json=payload)
+        assert response.status_code == 422
+
     @pytest.mark.parametrize(
         "name",
         [


### PR DESCRIPTION
resolves #12422
## Summary
Adds `POST /prompts/{prompt_identifier}/clone` to provide REST parity with the existing GraphQL `clonePrompt` mutation.

## Changes
* Added `POST /prompts/{prompt_identifier}/clone`
* Supports prompt lookup by both name and GlobalID via the existing `_parse_prompt_identifier()` helper
* Mirrors the current GraphQL `clonePrompt` behavior:

  * Inherits `description` and `metadata` from the source prompt when those fields are omitted from the request
  * Treats explicit `null` values for `description` and `metadata` as overrides rather than inheritance
  * Sets `source_prompt_id` on the cloned prompt
  * Deep-copies all prompt versions associated with the source prompt
  * Does not copy prompt version tags, matching the existing GraphQL implementation

## Tests
Added test coverage for:

* Cloning by prompt name
* Cloning by GlobalID
* Duplicate target name (`409`)
* Missing source prompt (`404`)
* Description inheritance and explicit `null` handling
* Metadata inheritance and explicit `null` handling
* Invalid prompt name/identifier (`422`)
* Verification that prompt version tags are not copied
