### PR TITLE
fix: Validate malformed ATIF fields before conversion

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/helpers/atif/_validate.py
+++ b/packages/phoenix-client/src/phoenix/client/helpers/atif/_validate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import re
+from datetime import datetime
 from typing import Any, List, Mapping, Optional, Set
 
 logger = logging.getLogger(__name__)
@@ -20,6 +21,19 @@ _AGENT_ONLY_FIELDS = {
     "reasoning_effort",
 }
 _SCHEMA_VERSION_PATTERN = re.compile(r"^ATIF-v\d+\.\d+$")
+_STEP_NUMERIC_METRIC_FIELDS = {
+    "prompt_tokens",
+    "completion_tokens",
+    "cached_tokens",
+    "cost_usd",
+}
+_FINAL_NUMERIC_METRIC_FIELDS = {
+    "total_prompt_tokens",
+    "total_completion_tokens",
+    "total_cached_tokens",
+    "total_cost_usd",
+    "total_steps",
+}
 
 
 def _parse_schema_version(schema_version: object) -> Optional[tuple[int, int]]:
@@ -28,6 +42,18 @@ def _parse_schema_version(schema_version: object) -> Optional[tuple[int, int]]:
     version_part = schema_version.split("-v")[1]
     major_str, minor_str = version_part.split(".")
     return int(major_str), int(minor_str)
+
+
+def _is_numeric(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _is_iso_8601_timestamp(value: str) -> bool:
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
 
 
 def _validate_atif_trajectory(
@@ -119,6 +145,18 @@ def _validate_atif_trajectory(
         # model_name is optional but if present must be a string
         if "model_name" in agent and not isinstance(agent["model_name"], str):
             errors.append("agent.model_name must be a string if provided")
+        if "extra" in agent and agent["extra"] is not None and not isinstance(agent["extra"], dict):
+            errors.append("agent.extra must be a dict if provided")
+
+    final_metrics = trajectory.get("final_metrics")
+    if final_metrics is not None:
+        if not isinstance(final_metrics, dict):
+            errors.append("final_metrics must be a dict if provided")
+        else:
+            for field in _FINAL_NUMERIC_METRIC_FIELDS:
+                value = final_metrics.get(field)
+                if value is not None and not _is_numeric(value):
+                    errors.append(f"final_metrics.{field} must be numeric if provided")
 
     # Steps validation
     raw_steps: object = trajectory["steps"]
@@ -181,6 +219,11 @@ def _validate_atif_trajectory(
         if source not in _VALID_SOURCES:
             errors.append(f"{prefix}: source '{source}' must be one of {_VALID_SOURCES}")
 
+        timestamp: object = step_dict.get("timestamp")
+        if timestamp is not None:
+            if not isinstance(timestamp, str) or not _is_iso_8601_timestamp(timestamp):
+                errors.append(f"{prefix}: timestamp must be ISO 8601 if provided")
+
         # Message required for user/system steps. ATIF v1.7 requires it for
         # all steps, including agent steps with an intentionally empty string.
         if source in ("user", "system") or (minor is not None and minor >= 7):
@@ -210,6 +253,16 @@ def _validate_atif_trajectory(
                 llm_zero_tool_calls = step_dict.get("tool_calls")
                 if not isinstance(llm_zero_tool_calls, list) or not llm_zero_tool_calls:
                     errors.append(f"{prefix}: tool_calls are required when llm_call_count is 0")
+
+        metrics = step_dict.get("metrics")
+        if metrics is not None:
+            if not isinstance(metrics, dict):
+                errors.append(f"{prefix}: metrics must be a dict if provided")
+            else:
+                for field in _STEP_NUMERIC_METRIC_FIELDS:
+                    value = metrics.get(field)
+                    if value is not None and not _is_numeric(value):
+                        errors.append(f"{prefix}: metrics.{field} must be numeric if provided")
 
         # Tool call validation
         tool_call_ids: Set[str] = set()

--- a/packages/phoenix-client/tests/client/helpers/atif/test_validate.py
+++ b/packages/phoenix-client/tests/client/helpers/atif/test_validate.py
@@ -190,6 +190,18 @@ class TestAgentValidation:
         with pytest.raises(ValueError, match="model_name must be a string"):
             _validate_atif_trajectory(simple_trajectory)
 
+    def test_extra_must_be_dict_if_present(self, simple_trajectory: Dict[str, Any]) -> None:
+        simple_trajectory["agent"]["extra"] = "oops"
+        with pytest.raises(ValueError, match="agent.extra must be a dict"):
+            _validate_atif_trajectory(simple_trajectory)
+
+
+class TestFinalMetricsValidation:
+    def test_final_metrics_must_be_dict_if_present(self, simple_trajectory: Dict[str, Any]) -> None:
+        simple_trajectory["final_metrics"] = "oops"
+        with pytest.raises(ValueError, match="final_metrics must be a dict"):
+            _validate_atif_trajectory(simple_trajectory)
+
 
 class TestV17Validation:
     def test_session_id_optional(self, v17_embedded_subagents: Dict[str, Any]) -> None:
@@ -392,6 +404,21 @@ class TestStepValidation:
         for step in simple_trajectory["steps"]:
             step.pop("timestamp", None)
         _validate_atif_trajectory(simple_trajectory)  # should not raise
+
+    def test_timestamp_must_be_iso_8601_if_present(self, simple_trajectory: Dict[str, Any]) -> None:
+        simple_trajectory["steps"][0]["timestamp"] = "not-a-date"
+        with pytest.raises(ValueError, match="timestamp must be ISO 8601"):
+            _validate_atif_trajectory(simple_trajectory)
+
+    def test_metrics_must_be_dict_if_present(self, simple_trajectory: Dict[str, Any]) -> None:
+        simple_trajectory["steps"][1]["metrics"] = "oops"
+        with pytest.raises(ValueError, match="metrics must be a dict"):
+            _validate_atif_trajectory(simple_trajectory)
+
+    def test_token_metrics_must_be_numeric(self, simple_trajectory: Dict[str, Any]) -> None:
+        simple_trajectory["steps"][1]["metrics"] = {"prompt_tokens": "abc"}
+        with pytest.raises(ValueError, match="metrics.prompt_tokens must be numeric"):
+            _validate_atif_trajectory(simple_trajectory)
 
     def test_observation_allowed_on_system_step(self, simple_trajectory: Dict[str, Any]) -> None:
         """observation is allowed on any source since ATIF v1.2."""


### PR DESCRIPTION
## Summary

- reject malformed ATIF timestamps during validation
- validate object-shaped agent metadata, step metrics, and final metrics before conversion
- add regression tests for validation gaps that previously crashed conversion

Closes #13777
Closes #13778
Closes #13779
Closes #13780

## Tests

- .venv/bin/python -m pytest packages/phoenix-client/tests/client/helpers/atif -q
- .venv/bin/ruff check packages/phoenix-client/src/phoenix/client/helpers/atif/_validate.py packages/phoenix-client/tests/client/helpers/atif/test_validate.py