### PR TITLE
test: fix pytest 9.1 duplicate parametrization of 'dialect' in test_serve

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -44,11 +44,21 @@ from tests.unit.graphql import AsyncGraphQLClient
 from tests.unit.vcr import CustomVCR
 
 
+def pytest_configure(config: Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "postgres_only: mark a test as requiring PostgreSQL (skipped under --db sqlite)",
+    )
+
+
 def pytest_collection_modifyitems(config: Config, items: list[Any]) -> None:
     db = config.getoption("--db")
     if db == "sqlite":
         skip_marker = pytest.mark.skip(reason="Skipping Postgres tests (--db sqlite)")
         for item in items:
+            if item.get_closest_marker("postgres_only") is not None:
+                item.add_marker(skip_marker)
+                continue
             if "dialect" in item.fixturenames:
                 if "postgresql" in item.callspec.params.values():
                     item.add_marker(skip_marker)

--- a/tests/unit/server/cli/commands/test_serve.py
+++ b/tests/unit/server/cli/commands/test_serve.py
@@ -90,9 +90,8 @@ def postgresql_primary_and_replica_urls(
         janitor.drop()
 
 
-@pytest.mark.parametrize("dialect", ["postgresql"], indirect=True)
+@pytest.mark.postgres_only
 async def test_create_db_session_factory_routes_reads_to_replica_for_postgres(
-    dialect: str,
     postgresql_primary_and_replica_urls: PostgresPrimaryAndReplicaUrls,
 ) -> None:
     factory, shutdown_callbacks = _create_db_session_factory(
@@ -117,9 +116,8 @@ async def test_create_db_session_factory_routes_reads_to_replica_for_postgres(
         await _run_shutdown_callbacks(shutdown_callbacks)
 
 
-@pytest.mark.parametrize("dialect", ["postgresql"], indirect=True)
+@pytest.mark.postgres_only
 async def test_create_db_session_factory_uses_primary_when_replica_not_configured_for_postgres(
-    dialect: str,
     postgresql_primary_and_replica_urls: PostgresPrimaryAndReplicaUrls,
 ) -> None:
     factory, shutdown_callbacks = _create_db_session_factory(

--- a/tests/unit/server/sandbox/test_sandbox_config_validation.py
+++ b/tests/unit/server/sandbox/test_sandbox_config_validation.py
@@ -54,13 +54,13 @@ class TestConfigModelValidation:
             adapter.config_model.model_validate({})
 
 
-@pytest.mark.parametrize(
-    "model_cls,payload",
-    [
-        (InternetAccessConfig, {"mode": "allow", "extra": "bad"}),
-        (DependenciesConfig, {"packages": [], "unknown": "x"}),
-    ],
-)
+_NESTED_LEAF_EXTRA_FIELD_CASES: list[tuple[type[BaseModel], dict[str, Any]]] = [
+    (InternetAccessConfig, {"mode": "allow", "extra": "bad"}),
+    (DependenciesConfig, {"packages": [], "unknown": "x"}),
+]
+
+
+@pytest.mark.parametrize("model_cls,payload", _NESTED_LEAF_EXTRA_FIELD_CASES)
 def test_nested_leaf_models_forbid_extra_fields(
     model_cls: type[BaseModel], payload: dict[str, Any]
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -5940,7 +5940,7 @@ html = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -5951,9 +5951,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What's failing

The scheduled **Main Python All Platforms** workflow is red on every Unit Tests job (e.g. [this run](https://github.com/Arize-ai/phoenix/actions/runs/27644620604)). It's a pytest **collection** error, not a test failure:

```
ERROR collecting tests/unit/server/cli/commands/test_serve.py
test_create_db_session_factory_routes_reads_to_replica_for_postgres: duplicate parametrization of 'dialect'
```

## Root cause

`test_serve.py` applied `@pytest.mark.parametrize("dialect", ["postgresql"], indirect=True)` to two tests to restrict them to Postgres. But `dialect` is **already** a parametrized fixture in `tests/unit/conftest.py`:

```python
@pytest.fixture(params=["sqlite", "postgresql"])
def dialect(request): ...
```

Overriding a params-fixture via indirect parametrize was silently allowed through pytest **9.0.3** (the indirect parametrize won). **pytest 9.1.0** makes that combination a hard `duplicate parametrization` collection error.

## Why it only broke now

- The conflicting test code has been present since #12532 (read-replica routing, Apr 2026).
- No Phoenix commit broke it recently. The trigger was the release of **pytest 9.1.0**: the scheduled "All Platforms" job installs **unpinned** deps and picked it up. PR CI and local environments were still on 9.0.3, so it passed review and only the nightly went red.

Reproduced both ways: green on pytest 9.0.3, exact error on pytest 9.1.0.

## The fix

- Drop the `@pytest.mark.parametrize("dialect", …, indirect=True)` override (and the unused `dialect` param) from the two tests; replace with a `@pytest.mark.postgres_only` marker.
- Teach the existing `pytest_collection_modifyitems` hook in `tests/unit/conftest.py` to skip `postgres_only`-marked tests under `--db sqlite`, and register the marker via `pytest_configure`.
- Bump pytest `9.0.3 -> 9.1.0` in `uv.lock` so PR/local CI runs against the version that introduced the stricter check. This makes the fix self-validating and catches this class of breakage in PRs instead of only in the unpinned nightly.

A **collection-time marker** (not a skip fixture) is required: `postgresql_proc` is session-scoped and is set up before any function-scoped skip fixture, so a fixture-based skip runs too late and the tests *error* (trying to start Postgres) instead of skipping. The marker skips them before any fixture setup, preserving the original behavior.

## Verification

| pytest | mode | result |
| --- | --- | --- |
| 9.1.0 | `--db sqlite` | 3 passed, **2 skipped**, no errors |
| 9.1.0 | `--db postgresql` | all 5 collect, no error |
| 9.0.3 | `--db sqlite` | 3 passed, 2 skipped (unchanged) |

Full `unit/` collection (5792 tests) is clean under pytest 9.1.0 — `test_serve.py` was the only affected file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)