### PR TITLE
fix(ui): encode trace IDs when building trace/span routes

### DIFF
--- a/app/src/components/agent/AssistantMessageActions.tsx
+++ b/app/src/components/agent/AssistantMessageActions.tsx
@@ -154,7 +154,9 @@ export function AssistantMessageActions({
       return;
     }
     window.open(
-      prependBasename(`/redirects/traces/${metadata.trace.traceId}`),
+      prependBasename(
+        `/redirects/traces/${encodeURIComponent(metadata.trace.traceId)}`
+      ),
       "_blank",
       "noopener,noreferrer"
     );

--- a/app/src/pages/auth/OAuth2Login.tsx
+++ b/app/src/pages/auth/OAuth2Login.tsx
@@ -43,7 +43,7 @@ export function OAuth2Login({
     <form
       ref={ref}
       action={prependBasename(
-        `/oauth2/${idpName}/login${returnUrl ? `?returnUrl=${returnUrl}` : ""}`
+        `/oauth2/${idpName}/login${returnUrl ? `?returnUrl=${encodeURIComponent(returnUrl)}` : ""}`
       )}
       method="post"
       css={loginCSS}

--- a/app/src/pages/example/ExampleDetailsDialog.tsx
+++ b/app/src/pages/example/ExampleDetailsDialog.tsx
@@ -256,7 +256,7 @@ function ExampleDetailsDialogContent({
           {sourceSpanInfo ? (
             <LinkButton
               size="S"
-              to={`/projects/${sourceSpanInfo.projectId}/traces/${sourceSpanInfo.traceId}?${SELECTED_SPAN_NODE_ID_PARAM}=${sourceSpanInfo.id}`}
+              to={`/projects/${sourceSpanInfo.projectId}/traces/${encodeURIComponent(sourceSpanInfo.traceId)}?${SELECTED_SPAN_NODE_ID_PARAM}=${encodeURIComponent(sourceSpanInfo.id)}`}
             >
               View Source Span
             </LinkButton>

--- a/app/src/pages/example/ExampleExperimentRunsTable.tsx
+++ b/app/src/pages/example/ExampleExperimentRunsTable.tsx
@@ -186,7 +186,7 @@ export function ExampleExperimentRunsTable({
                     onClick={() => {
                       if (annotation.trace) {
                         navigate(
-                          `/projects/${annotation.trace.projectId}/traces/${annotation.trace.traceId}`
+                          `/projects/${annotation.trace.projectId}/traces/${encodeURIComponent(annotation.trace.traceId)}`
                         );
                       }
                     }}
@@ -209,7 +209,7 @@ export function ExampleExperimentRunsTable({
               leadingVisual={<Icon svg={<Icons.Trace />} />}
               onPress={() => {
                 navigate(
-                  `/projects/${trace.projectId}/traces/${trace.traceId}`
+                  `/projects/${trace.projectId}/traces/${encodeURIComponent(trace.traceId)}`
                 );
               }}
               aria-label="view trace"

--- a/app/src/pages/experiment/TraceDetailsDialog.tsx
+++ b/app/src/pages/experiment/TraceDetailsDialog.tsx
@@ -31,7 +31,7 @@ export function TraceDetailsDialog({
           <DialogTitleExtra>
             <LinkButton
               size="S"
-              to={`/projects/${projectId}/traces/${traceId}`}
+              to={`/projects/${projectId}/traces/${encodeURIComponent(traceId)}`}
             >
               View Trace in Project
             </LinkButton>

--- a/app/src/pages/playground/PlaygroundRunTraceDialog.tsx
+++ b/app/src/pages/playground/PlaygroundRunTraceDialog.tsx
@@ -28,7 +28,7 @@ export function PlaygroundRunTraceDetailsDialog({
             <DialogTitleExtra>
               <LinkButton
                 size="S"
-                to={`/projects/${projectId}/traces/${traceId}`}
+                to={`/projects/${projectId}/traces/${encodeURIComponent(traceId)}`}
               >
                 View Trace in Project
               </LinkButton>

--- a/app/src/pages/playground/SpanPlaygroundPage.tsx
+++ b/app/src/pages/playground/SpanPlaygroundPage.tsx
@@ -77,7 +77,7 @@ function SpanPlaygroundBanners({
               leadingVisual={<Icon svg={<Icons.ArrowBack />} />}
               onPress={() => {
                 navigate(
-                  `/projects/${span.project.id}/traces/${span.trace.traceId}?${SELECTED_SPAN_NODE_ID_PARAM}=${span.id}`
+                  `/projects/${span.project.id}/traces/${encodeURIComponent(span.trace.traceId)}?${SELECTED_SPAN_NODE_ID_PARAM}=${encodeURIComponent(span.id)}`
                 );
               }}
             >

--- a/app/src/pages/redirects/spanRedirectLoader.ts
+++ b/app/src/pages/redirects/spanRedirectLoader.ts
@@ -35,8 +35,11 @@ export async function spanRedirectLoader({ params }: LoaderFunctionArgs) {
 
   if (response?.span) {
     const { id: spanId, trace, project } = response.span;
+    // encode the trace ID because the ingested value is not guaranteed to be
+    // path-safe; a path- or protocol-relative value would otherwise escape the
+    // intended route
     return redirect(
-      `/projects/${project.id}/spans/${trace.traceId}?selectedSpanNodeId=${spanId}`
+      `/projects/${project.id}/spans/${encodeURIComponent(trace.traceId)}?selectedSpanNodeId=${encodeURIComponent(spanId)}`
     );
   } else {
     throw new Error(`Span with id "${span_otel_id}" not found`);

--- a/app/src/pages/redirects/traceRedirectLoader.ts
+++ b/app/src/pages/redirects/traceRedirectLoader.ts
@@ -31,7 +31,12 @@ export async function traceRedirectLoader({ params }: LoaderFunctionArgs) {
 
   if (response?.trace) {
     const { project } = response.trace;
-    return redirect(`/projects/${project.id}/traces/${trace_otel_id}`);
+    // encode the trace ID because the ingested value is not guaranteed to be
+    // path-safe; a path- or protocol-relative value would otherwise escape the
+    // intended route
+    return redirect(
+      `/projects/${project.id}/traces/${encodeURIComponent(trace_otel_id)}`
+    );
   } else {
     throw new Error(`Trace with id "${trace_otel_id}" not found`);
   }

--- a/app/src/pages/trace/TracePaginationContext.tsx
+++ b/app/src/pages/trace/TracePaginationContext.tsx
@@ -76,8 +76,10 @@ export const makeTraceUrls = (
     .split("/")
     .filter((part) => part !== "");
   const makeUrl = (traceId: string, currentSpanId?: string) => {
-    // we always navigate directly to a traceId
-    const path = `/${projects}/${projectId}/${resource}/${traceId}`;
+    // we always navigate directly to a traceId; encode it because the ingested
+    // ID is not guaranteed to be path-safe and a path- or protocol-relative
+    // value would otherwise escape the intended route
+    const path = `/${projects}/${projectId}/${resource}/${encodeURIComponent(traceId)}`;
     const search = withSearchParams(location.search, (params) => {
       if (currentSpanId) {
         params.set(SELECTED_SPAN_NODE_ID_PARAM, currentSpanId);

--- a/app/src/utils/__tests__/urlUtils.test.ts
+++ b/app/src/utils/__tests__/urlUtils.test.ts
@@ -25,4 +25,33 @@ describe("urlUtils", () => {
       })
     ).toBe("trace-2?timeRangeKey=7d&selectedSpanNodeId=span-2");
   });
+
+  describe("getTraceDetailsPath encodes the trace ID into a same-origin segment", () => {
+    const encode = (traceId: string) =>
+      getTraceDetailsPath({ traceId, searchParams: new URLSearchParams() });
+
+    it("encodes a protocol-relative trace ID into a single same-origin segment", () => {
+      // Without encoding, React Router/the browser would resolve this as a
+      // cross-origin protocol-relative href.
+      expect(encode("//attacker.example/x")).toBe("%2F%2Fattacker.example%2Fx");
+    });
+
+    it("encodes absolute-path-shaped trace IDs", () => {
+      expect(encode("/settings")).toBe("%2Fsettings");
+    });
+
+    it("encodes relative-path-shaped trace IDs", () => {
+      expect(encode("../settings")).toBe("..%2Fsettings");
+    });
+
+    it("encodes whitespace and query/fragment characters", () => {
+      expect(encode("trace id with spaces")).toBe("trace%20id%20with%20spaces");
+      expect(encode("trace?x=y#frag")).toBe("trace%3Fx%3Dy%23frag");
+    });
+
+    it("leaves a legitimate 32-hex OpenTelemetry trace ID unchanged", () => {
+      const hexTraceId = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4";
+      expect(encode(hexTraceId)).toBe(hexTraceId);
+    });
+  });
 });

--- a/app/src/utils/urlUtils.ts
+++ b/app/src/utils/urlUtils.ts
@@ -49,6 +49,12 @@ export function clearSelectionScopedParams(
  * Build a relative path to a trace's details, preserving recreatable URL state
  * (such as the selected time range) while setting or clearing the selected
  * span.
+ *
+ * The trace ID is URL-encoded because it originates from ingested span data
+ * and is not guaranteed to be a path-safe value. Encoding collapses it into a
+ * single same-origin path segment, so a value beginning with `//` cannot be
+ * resolved by React Router or the browser as a protocol-relative, cross-origin
+ * `href`.
  */
 export function getTraceDetailsPath({
   traceId,
@@ -59,7 +65,7 @@ export function getTraceDetailsPath({
   spanNodeId?: string | null;
   searchParams: URLSearchParams;
 }): string {
-  return `${traceId}${withSearchParams(
+  return `${encodeURIComponent(traceId)}${withSearchParams(
     clearSelectionScopedParams(searchParams),
     (params) => {
       if (spanNodeId) {


### PR DESCRIPTION
## Summary

Trace IDs originate from ingested span data and are not guaranteed to be path-safe. The trace/span route builders concatenated them directly into router paths, so a trace ID beginning with `//` was resolved by React Router and the browser as a **protocol-relative, cross-origin href** — a stored client-side open redirect. Any caller with span-ingest permission could plant a trace whose ID is `//attacker.example/…`, and a project viewer clicking that row's link would be silently navigated off-origin.

## Fix

- **`getTraceDetailsPath`** (`app/src/utils/urlUtils.ts`) — the shared builder behind both trace and span tables (`<Link>` and `navigate()` sinks) — now encodes the trace ID into a single same-origin path segment, mirroring the existing `encodeURIComponent` in the sibling `getSessionDetailsPath`. **This is the change that closes the redirect.**
- **Defense in depth** — the same encoding applied to every other trace-path builder so trace links are safe by construction:
  - `TracePaginationContext` and the trace/span **redirect loaders** (`traceRedirectLoader`, `spanRedirectLoader`).
  - The absolute-path builders that embed the trace ID after a leading `/projects/…` or `/redirects/…` segment: `AssistantMessageActions`, `SpanPlaygroundPage`, `PlaygroundRunTraceDialog`, `ExampleExperimentRunsTable` (×2), `ExampleDetailsDialog`, `TraceDetailsDialog`. A `//`-prefixed value stays same-origin in these (so not exploitable as a redirect), but an unencoded `/`, `?`, or `#` would otherwise break the intended route.
  - The OAuth2 login `returnUrl` query value is URL-encoded. The backend already rejects non-relative return URLs (`_is_relative_url`), so this is hardening only — it prevents reserved characters from mangling the URL or injecting extra query params.

Legitimate 32-char hex OpenTelemetry trace IDs pass through `encodeURIComponent` unchanged, so existing navigation is unaffected.

## Tests

Adds regression coverage in `urlUtils.test.ts` for protocol-relative (`//attacker.example/x`), absolute-path (`/settings`), relative-path (`../settings`), whitespace, and query/fragment-shaped trace IDs, plus a guard that a hex trace ID is left unchanged.

```
✓ 7 tests passed (app/src/utils/__tests__/urlUtils.test.ts)
```

## Notes

- A codebase-wide audit of navigation sinks (relative `<Link>`/`navigate()`, `window.location`/`window.open`, dynamic `<a href>`, router `redirect()` loaders, and backend `RedirectResponse`) surfaced **no other exploitable open redirects**. The auth return-URL flow is guarded on both ends: the frontend (`isValidRedirectUrl`/`sanitizeUrl`) and the backend (`_is_relative_url`, checked against the unquoted value).
- Server-side ingest validation of trace IDs was considered but intentionally **not** included — the frontend encoding fully closes the redirect, and rejecting non-hex IDs at ingest would be a behavior change that could break clients sending non-standard trace IDs.
