### PR TITLE
fix: PXI capability hydration

### DIFF
--- a/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
+++ b/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { createDefaultAgentCapabilities } from "@phoenix/agent/extensions/capabilities";
+import {
+  createDefaultAgentCapabilities,
+  type AgentCapabilities,
+} from "@phoenix/agent/extensions/capabilities";
 
 import { buildAgentChatRequestBody } from "../buildAgentChatRequestBody";
 import type { AgentUIMessage } from "../types";
@@ -86,6 +89,43 @@ describe("buildAgentChatRequestBody", () => {
     expect(body.contexts).toContainEqual({
       type: "web_access",
       enabled: true,
+    });
+  });
+
+  it("defaults missing capability flags before serializing contexts", () => {
+    const body = buildAgentChatRequestBody({
+      body: undefined,
+      id: "session-1",
+      messages: [] as AgentUIMessage[],
+      trigger: "submit-message",
+      messageId: undefined,
+      capabilities: {} as AgentCapabilities,
+      observability: {
+        storeLocalTraces: false,
+        exportRemoteTraces: false,
+        acknowledgedTraceConsent: null,
+      },
+      agentsConfig,
+      permissions: { edits: "bypass" },
+      contexts: [],
+      modelSelection: {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-4o-mini",
+      },
+    });
+
+    expect(body.contexts).toContainEqual({
+      type: "graphql",
+      mutationsEnabled: false,
+    });
+    expect(body.contexts).toContainEqual({
+      type: "web_access",
+      enabled: false,
+    });
+    expect(body.contexts).toContainEqual({
+      type: "subagents",
+      enabled: false,
     });
   });
 

--- a/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -69,7 +69,7 @@ function buildCurrentAppContext(): AgentContext {
 function buildGraphQLContext(capabilities: AgentCapabilities): AgentContext {
   return {
     type: "graphql",
-    mutationsEnabled: capabilities["graphql.mutations"],
+    mutationsEnabled: capabilities["graphql.mutations"] ?? false,
   };
 }
 
@@ -81,7 +81,7 @@ function buildGraphQLContext(capabilities: AgentCapabilities): AgentContext {
 function buildWebAccessContext(capabilities: AgentCapabilities): AgentContext {
   return {
     type: "web_access",
-    enabled: capabilities["web.access"],
+    enabled: capabilities["web.access"] ?? false,
   };
 }
 
@@ -91,7 +91,7 @@ function buildWebAccessContext(capabilities: AgentCapabilities): AgentContext {
 function buildSubagentsContext(capabilities: AgentCapabilities): AgentContext {
   return {
     type: "subagents",
-    enabled: capabilities["subagents.enabled"],
+    enabled: capabilities["subagents.enabled"] ?? false,
   };
 }
 

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -1,5 +1,8 @@
 import { installTestStorage } from "@phoenix/__tests__/installTestStorage";
-import { createDefaultAgentCapabilities } from "@phoenix/agent/extensions/capabilities";
+import {
+  createDefaultAgentCapabilities,
+  type AgentCapabilities,
+} from "@phoenix/agent/extensions/capabilities";
 
 import {
   createAgentStore,
@@ -514,6 +517,30 @@ describe("agentStore", () => {
           observability: store.getState().observability,
         })
       ).toBe(false);
+    });
+  });
+
+  describe("persisted capabilities", () => {
+    it("backfills missing capability keys when rehydrating persisted state", () => {
+      const persistedCapabilities: Partial<AgentCapabilities> = {
+        "graphql.mutations": true,
+        "web.access": true,
+      };
+      localStorage.setItem(
+        resolveAssistantStorageKey(),
+        JSON.stringify({
+          state: { capabilities: persistedCapabilities },
+          version: 0,
+        })
+      );
+
+      const store = createAgentStore();
+
+      expect(store.getState().capabilities).toEqual({
+        ...createDefaultAgentCapabilities(),
+        "graphql.mutations": true,
+        "web.access": true,
+      });
     });
   });
 

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -463,6 +463,50 @@ export interface AgentState extends AgentProps {
   ) => void;
 }
 
+function normalizeAgentCapabilities({
+  capabilities,
+  defaultCapabilities = createDefaultAgentCapabilities(),
+}: {
+  capabilities: unknown;
+  defaultCapabilities?: AgentCapabilities;
+}): AgentCapabilities {
+  if (!capabilities || typeof capabilities !== "object") {
+    return { ...defaultCapabilities };
+  }
+  const persistedCapabilities = capabilities as Partial<
+    Record<AgentCapabilityKey, unknown>
+  >;
+  return Object.fromEntries(
+    (Object.keys(defaultCapabilities) as AgentCapabilityKey[]).map((key) => {
+      const persistedValue = persistedCapabilities[key];
+      return [
+        key,
+        typeof persistedValue === "boolean"
+          ? persistedValue
+          : defaultCapabilities[key],
+      ];
+    })
+  ) as AgentCapabilities;
+}
+
+function mergeAgentPersistedState(
+  persistedState: unknown,
+  currentState: AgentState
+): AgentState {
+  if (!persistedState || typeof persistedState !== "object") {
+    return currentState;
+  }
+  const persisted = persistedState as Partial<AgentState>;
+  return {
+    ...currentState,
+    ...persisted,
+    capabilities: normalizeAgentCapabilities({
+      capabilities: persisted.capabilities,
+      defaultCapabilities: currentState.capabilities,
+    }),
+  };
+}
+
 /**
  * Handler for a server-advertised, client-executed agent tool. Receives the
  * raw `input` object the model produced (handlers are responsible for
@@ -1353,6 +1397,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         permissions: state.permissions,
         capabilities: state.capabilities,
       }),
+      merge: mergeAgentPersistedState,
     })
   );
 };


### PR DESCRIPTION
## Summary

- backfill missing PXI capability keys when rehydrating persisted agent store state
- default missing request capability flags to false before serializing agent contexts
- add regression coverage for stale persisted capabilities and missing request flags

## Root Cause

Browsers with older PXI localStorage could rehydrate a capabilities object that did not include newly added keys such as `subagents.enabled`. That made the request builder produce `enabled: undefined`, which JSON serialization omitted, so the backend rejected the `subagents` context as missing the required `enabled` field.

## Impact

Existing users with stale PXI local state can continue using PXI without manually clearing localStorage. Future capability additions also get default backfills during hydration.

## Validation

- `make typecheck-frontend`
- `make lint-frontend`
- `make test-frontend`