### PR TITLE
fix(ui): backfill stale PXI capability state and add Playwright coverage

### DIFF
--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -543,4 +543,53 @@ describe("agentStore", () => {
       }
     });
   });
+
+  describe("capability hydration", () => {
+    it("backfills capability keys missing from stale persisted state", () => {
+      // Simulate a browser whose persisted assistant state predates a newer
+      // capability key. The stale blob omits "subagents.enabled" entirely.
+      const staleCapabilities = Object.fromEntries(
+        Object.entries(createDefaultAgentCapabilities()).filter(
+          ([key]) => key !== "subagents.enabled"
+        )
+      );
+      localStorage.setItem(
+        "arize-phoenix-assistant",
+        JSON.stringify({
+          state: { capabilities: staleCapabilities },
+          version: 0,
+        })
+      );
+
+      const store = createAgentStore();
+
+      // The missing key must hydrate to its default boolean rather than
+      // `undefined` (which `toBe(false)` would reject via Object.is). Otherwise
+      // request-context serialization drops the field and the backend rejects
+      // the chat request with a 422.
+      expect(store.getState().capabilities["subagents.enabled"]).toBe(false);
+    });
+
+    it("preserves explicitly persisted capability values", () => {
+      localStorage.setItem(
+        "arize-phoenix-assistant",
+        JSON.stringify({
+          state: {
+            capabilities: {
+              ...createDefaultAgentCapabilities(),
+              "web.access": true,
+            },
+          },
+          version: 0,
+        })
+      );
+
+      const store = createAgentStore();
+
+      // User-toggled values survive the backfill; only absent keys fall back to
+      // their defaults.
+      expect(store.getState().capabilities["web.access"]).toBe(true);
+      expect(store.getState().capabilities["subagents.enabled"]).toBe(false);
+    });
+  });
 });

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -1353,6 +1353,27 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         permissions: state.permissions,
         capabilities: state.capabilities,
       }),
+      // Custom merge that backfills capability keys added after a given browser
+      // last persisted its state. Zustand's default merge is a shallow spread,
+      // so a persisted `capabilities` blob written before a new key existed
+      // (e.g. "subagents.enabled") would replace the defaults wholesale and
+      // leave that key `undefined`. Request-context builders then serialize a
+      // context whose required boolean field is dropped by JSON, which the
+      // backend rejects with a 422. Layering the persisted snapshot over a fresh
+      // default capability set guarantees every known key resolves to a real
+      // boolean while still honoring values the user explicitly toggled. See
+      // issue #13789 and the related fix in #13788.
+      merge: (persistedState, currentState) => {
+        const persisted = (persistedState ?? {}) as Partial<AgentProps>;
+        return {
+          ...currentState,
+          ...persisted,
+          capabilities: {
+            ...createDefaultAgentCapabilities(),
+            ...persisted.capabilities,
+          },
+        };
+      },
     })
   );
 };

--- a/app/tests/pxi/constants.ts
+++ b/app/tests/pxi/constants.ts
@@ -2,3 +2,40 @@ export const DEFAULT_ASSISTANT_PROVIDER = "OPENAI";
 export const DEFAULT_ASSISTANT_MODEL = "gpt-5.4";
 export const DEFAULT_ASSISTANT_PROJECT_NAME = "assistant_agent";
 export const DEFAULT_JUDGE_MODEL = "openai/gpt-4.1";
+
+/**
+ * Capability snapshot seeded into persisted PXI state by the Playwright
+ * fixtures. This is intentionally a flat `Record<string, boolean>` that mirrors
+ * the on-disk `capabilities` blob shape rather than importing the app's
+ * `AgentCapabilities` type, so specs can seed *stale* state that omits keys a
+ * newer Phoenix build would write (TypeScript would otherwise reject a partial
+ * literal). Keep this aligned with the app's capability catalog in
+ * `app/src/agent/extensions/capabilities.ts`.
+ */
+export const DEFAULT_FIXTURE_CAPABILITIES: Record<string, boolean> = {
+  "bash.retainInactiveSessions": false,
+  "graphql.mutations": false,
+  "session.storeSessions": false,
+  "subagents.enabled": false,
+  "web.access": false,
+};
+
+/**
+ * A deliberately stale capability snapshot that omits `subagents.enabled`,
+ * reproducing localStorage written by a Phoenix build from before that key
+ * existed. Hydrating this must backfill the missing key to a boolean so the
+ * `/chat` request still serializes a valid `subagents` context instead of
+ * dropping the field and triggering a backend 422 (see issue #13789 / #13788).
+ *
+ * To extend this regression fixture when a future capability key is added:
+ * derive a new stale snapshot from {@link DEFAULT_FIXTURE_CAPABILITIES} that
+ * omits the newly added key, and assert the hydrated `/chat` request still
+ * includes that key's context with an explicit boolean in
+ * `stale-capabilities.spec.ts`.
+ */
+export const STALE_CAPABILITIES_MISSING_SUBAGENTS: Record<string, boolean> =
+  Object.fromEntries(
+    Object.entries(DEFAULT_FIXTURE_CAPABILITIES).filter(
+      ([key]) => key !== "subagents.enabled"
+    )
+  );

--- a/app/tests/pxi/fixtures.ts
+++ b/app/tests/pxi/fixtures.ts
@@ -1,14 +1,24 @@
 import { expect, test as base } from "@playwright/test";
-import type { APIRequestContext, Page, TestInfo } from "@playwright/test";
+import type {
+  APIRequestContext,
+  Page,
+  Request,
+  TestInfo,
+} from "@playwright/test";
 
 import { DOCS_TOOL_NAMES } from "../../src/agent/tools/docs";
 import {
   DEFAULT_ASSISTANT_MODEL,
   DEFAULT_ASSISTANT_PROJECT_NAME,
   DEFAULT_ASSISTANT_PROVIDER,
+  DEFAULT_FIXTURE_CAPABILITIES,
   DEFAULT_JUDGE_MODEL,
 } from "./constants";
-import type { PxiTurn } from "./types";
+import type {
+  PxiCapturedChatRequest,
+  PxiChatRequestBody,
+  PxiTurn,
+} from "./types";
 import { expectOK, getSpanToolName, getUiMessageToolNames } from "./utils";
 
 export type { PxiTurn } from "./types";
@@ -41,11 +51,23 @@ function getAssistantProjectName() {
   );
 }
 
-async function installAgentDefaults({ page }: { page: Page }) {
+async function installAgentDefaults({
+  page,
+  capabilities = DEFAULT_FIXTURE_CAPABILITIES,
+}: {
+  page: Page;
+  /**
+   * Persisted `capabilities` blob to seed. Defaults to the current capability
+   * catalog; pass a stale snapshot (e.g.
+   * {@link STALE_CAPABILITIES_MISSING_SUBAGENTS}) to reproduce localStorage
+   * written by an older Phoenix build that predates a newer capability key.
+   */
+  capabilities?: Record<string, boolean>;
+}) {
   const assistantProvider = getAssistantProvider();
   const assistantModel = getAssistantModel();
   await page.addInitScript(
-    ({ provider, modelName }) => {
+    ({ provider, modelName, capabilities: seededCapabilities }) => {
       localStorage.clear();
       localStorage.setItem(
         "arize-phoenix-feature-flags",
@@ -78,12 +100,7 @@ async function installAgentDefaults({ page }: { page: Page }) {
               exportRemoteTraces: false,
               hasAcknowledgedConsent: false,
             },
-            capabilities: {
-              "bash.retainInactiveSessions": false,
-              "graphql.mutations": false,
-              "session.storeSessions": false,
-              "web.access": false,
-            },
+            capabilities: seededCapabilities,
           },
           version: 0,
         })
@@ -92,6 +109,7 @@ async function installAgentDefaults({ page }: { page: Page }) {
     {
       provider: assistantProvider,
       modelName: assistantModel,
+      capabilities,
     }
   );
 }
@@ -112,8 +130,19 @@ export class PxiDriver {
     this.request = request;
   }
 
-  async open() {
-    await installAgentDefaults({ page: this.page });
+  async open(options?: {
+    /**
+     * Persisted `capabilities` blob to seed before the app boots. Defaults to
+     * the current capability catalog. Pass a stale snapshot to exercise the
+     * older-localStorage compatibility path (see
+     * {@link STALE_CAPABILITIES_MISSING_SUBAGENTS}).
+     */
+    capabilities?: Record<string, boolean>;
+  }) {
+    await installAgentDefaults({
+      page: this.page,
+      capabilities: options?.capabilities,
+    });
     await this.page.goto("/projects");
     await this.page.getByRole("button", { name: "Open assistant" }).click();
     await expect(
@@ -121,6 +150,42 @@ export class PxiDriver {
         name: "Meet PXI, your Phoenix assistant",
       })
     ).toBeVisible();
+  }
+
+  /**
+   * Fills the PXI prompt input, submits it, and captures the outgoing `/chat`
+   * request together with the backend's HTTP response status.
+   *
+   * Protocol-level regression specs use this to assert on the serialized
+   * request body (e.g. that capability contexts carry explicit booleans) and on
+   * whether the backend accepted the request, without waiting for or depending
+   * on a real assistant answer.
+   */
+  async submitMessageAndCaptureChatRequest(
+    message: string
+  ): Promise<PxiCapturedChatRequest> {
+    const isChatRequest = (request: Request) => {
+      if (request.method() !== "POST") {
+        return false;
+      }
+      let pathname: string;
+      try {
+        pathname = new URL(request.url()).pathname;
+      } catch {
+        return false;
+      }
+      // Chat requests are session-scoped: /agents/{id}/sessions/{id}/chat.
+      return /\/sessions\/[^/]+\/chat$/.test(pathname);
+    };
+    const chatRequestPromise = this.page.waitForRequest(isChatRequest);
+    await this.page.getByLabel("Message input").fill(message);
+    await this.page.getByRole("button", { name: "Send message" }).click();
+    const request = await chatRequestPromise;
+    const requestBody = JSON.parse(
+      request.postData() ?? "{}"
+    ) as PxiChatRequestBody;
+    const response = await request.response();
+    return { requestBody, responseStatus: response?.status() ?? null };
   }
 
   async acknowledgeConsent() {

--- a/app/tests/pxi/stale-capabilities.spec.ts
+++ b/app/tests/pxi/stale-capabilities.spec.ts
@@ -1,0 +1,93 @@
+import { STALE_CAPABILITIES_MISSING_SUBAGENTS } from "./constants";
+import { expect, test } from "./fixtures";
+import type { PxiChatRequestBody, PxiChatRequestContext } from "./types";
+
+/**
+ * Browser-level regression coverage for persisted agent capability state that
+ * predates a newer capability key.
+ *
+ * PR #13788 fixed a bug where older PXI localStorage could rehydrate a
+ * `capabilities` object missing newly added keys such as `subagents.enabled`.
+ * Reading the absent key produced `enabled: undefined`, JSON serialization
+ * dropped the field, and the backend rejected the `subagents` context with a
+ * 422 missing-field response. This spec reproduces the real user path: stale
+ * localStorage, opening PXI, sending a message, and asserting the serialized
+ * `/chat` request still carries valid capability contexts and is not rejected
+ * with a 422.
+ *
+ * This is a deterministic protocol-level spec: it asserts on the serialized
+ * request body and the backend's HTTP status, so it does not require model
+ * credentials or the LLM-as-judge / experiment-persistence harness used by the
+ * answer-quality smoke specs.
+ *
+ * Extending this for future capability additions: when a new capability key is
+ * introduced, add a stale snapshot to `constants.ts` that omits it (mirroring
+ * {@link STALE_CAPABILITIES_MISSING_SUBAGENTS}) and assert its context below.
+ */
+
+const USER_PROMPT = "Hello, PXI.";
+
+/** Required capability contexts and the boolean field each must carry. */
+const REQUIRED_CAPABILITY_CONTEXTS: ReadonlyArray<{
+  type: string;
+  booleanField: string;
+}> = [
+  { type: "subagents", booleanField: "enabled" },
+  { type: "web_access", booleanField: "enabled" },
+  { type: "graphql", booleanField: "mutationsEnabled" },
+];
+
+function findContext(
+  body: PxiChatRequestBody,
+  type: string
+): PxiChatRequestContext | undefined {
+  return (body.contexts ?? []).find((context) => context.type === type);
+}
+
+test.describe("PXI stale capability state", () => {
+  test("submits a chat request with valid capability contexts after rehydrating stale persisted state", async ({
+    browserName,
+    pxi,
+  }) => {
+    test.skip(
+      browserName !== "chromium",
+      "PXI E2E specs run once in chromium."
+    );
+    test.skip(
+      process.env.PXI_E2E !== "true",
+      "Set PXI_E2E=true to run PXI E2E tests."
+    );
+
+    // Seed localStorage as an older Phoenix build would have written it: the
+    // persisted capabilities omit `subagents.enabled` entirely.
+    await pxi.open({ capabilities: STALE_CAPABILITIES_MISSING_SUBAGENTS });
+    await pxi.acknowledgeConsent();
+
+    const { requestBody, responseStatus } =
+      await pxi.submitMessageAndCaptureChatRequest(USER_PROMPT);
+
+    // Every required capability context must be present with an explicit
+    // boolean. Before the fix, the rehydrated `subagents` capability was
+    // `undefined`, so this context serialized as `{ type: "subagents" }` with
+    // the `enabled` field dropped.
+    for (const { type, booleanField } of REQUIRED_CAPABILITY_CONTEXTS) {
+      const context = findContext(requestBody, type);
+      expect(
+        context,
+        `Expected the /chat request to include a "${type}" capability context.`
+      ).toBeDefined();
+      const fieldValue = context?.[booleanField];
+      expect(
+        typeof fieldValue,
+        `Expected the "${type}" context field "${booleanField}" to be an explicit boolean, got ${typeof fieldValue}.`
+      ).toBe("boolean");
+    }
+
+    // The backend must accept the request body: a 422 is exactly the
+    // missing-field validation failure this regression guards against.
+    expect(
+      responseStatus,
+      `Expected the /chat request to avoid a 422 validation error, got status ${responseStatus}.`
+    ).not.toBe(422);
+  });
+});

--- a/app/tests/pxi/types.ts
+++ b/app/tests/pxi/types.ts
@@ -4,3 +4,27 @@ export type PxiTurn = {
   traceId: string;
   durationMs: number;
 };
+
+/**
+ * A single typed context entry within a serialized PXI `/chat` request body.
+ * Discriminated by `type` (e.g. "subagents", "web_access", "graphql"); the
+ * remaining fields are capability-specific (e.g. `enabled`, `mutationsEnabled`).
+ * Modeled loosely on purpose so protocol-level specs can assert on the raw
+ * over-the-wire shape rather than the app's internal context types.
+ */
+export type PxiChatRequestContext = {
+  type?: string;
+  [key: string]: unknown;
+};
+
+/** Minimal view of the serialized PXI `/chat` request body. */
+export type PxiChatRequestBody = {
+  contexts?: PxiChatRequestContext[];
+  [key: string]: unknown;
+};
+
+/** Outgoing `/chat` request paired with the backend's HTTP response status. */
+export type PxiCapturedChatRequest = {
+  requestBody: PxiChatRequestBody;
+  responseStatus: number | null;
+};


### PR DESCRIPTION
# Add PXI Playwright coverage for stale capability state

Closes #13789.

## What changed

Adds browser-level regression coverage for the persisted-capability compatibility bug, and fixes the root cause so that coverage passes.

### Fix: backfill capability keys on store hydration
`app/src/store/agentStore.ts`

The agent store persists its `capabilities` snapshot to `localStorage` under
`arize-phoenix-assistant`. Zustand's default `persist` merge is a **shallow**
spread, so a snapshot written by an older Phoenix build — before a new
capability key existed — replaced the in-memory defaults wholesale and left the
new key (e.g. `subagents.enabled`) `undefined`.

`buildAgentChatRequestBody` then serialized `{ type: "subagents", enabled: undefined }`;
`JSON.stringify` drops `undefined` fields, so the backend received
`{ type: "subagents" }`. The backend `SubagentsContext.enabled` is a required
`bool`, so the request was rejected with a **422**.

The fix adds a custom `merge` to the persist config that layers the persisted
snapshot over a fresh default capability set, guaranteeing every known
capability key hydrates to a real boolean while still honoring values the user
explicitly toggled.

### Regression coverage
- `app/tests/pxi/stale-capabilities.spec.ts` (new) — a deterministic,
  protocol-level PXI Playwright spec. It seeds stale `localStorage` that omits
  `subagents.enabled`, opens PXI, submits a message, and asserts the captured
  `/chat` request carries every required capability context (`subagents`,
  `web_access`, `graphql`) with an explicit boolean, and that the backend does
  not respond with a 422.
- `app/tests/pxi/fixtures.ts` — `pxi.open({ capabilities })` can now seed an
  arbitrary persisted capability blob, and a new
  `pxi.submitMessageAndCaptureChatRequest(message)` captures the outgoing
  `/chat` request body plus the backend response status without waiting for an
  assistant answer (no model credentials or judge required).
- `app/tests/pxi/constants.ts` — adds `DEFAULT_FIXTURE_CAPABILITIES` and
  `STALE_CAPABILITIES_MISSING_SUBAGENTS`, documented so future capability
  additions can extend the stale-state fixture.
- `app/tests/pxi/types.ts` — shared types for the captured `/chat` request.
- `app/src/store/__tests__/agentStore.test.ts` — fast unit tests for the
  hydration backfill (missing key fills to its default; explicitly persisted
  values survive).
- `.agents/skills/phoenix-pxi-playwright/SKILL.md` — documents the new
  deterministic protocol-spec pattern and how to extend the stale-state fixture.

## Why
This was ultimately a browser-persisted-state compatibility bug. Unit coverage
alone could not catch the real user path (stale `localStorage` → open PXI →
send → backend validation), so this adds the missing Playwright regression and
the hydration fix it depends on. Related fix: #13788.

## How to verify
- Fast unit suite: `make test-frontend` (covers the hydration backfill in
  `agentStore.test.ts`).
- PXI E2E (chromium, requires the PXI test server): `pnpm run test:e2e:pxi`.
  The new spec runs without model credentials because FastAPI validates the
  request body before any model call.
- To confirm the regression direction, temporarily revert the `merge` change in
  `agentStore.ts`: the new unit test fails (`subagents.enabled` hydrates to
  `undefined`) and `stale-capabilities.spec.ts` fails (the `subagents` context
  lacks an explicit boolean / the backend returns 422).

## Extending the fixture
When a new capability key is added, derive a new stale snapshot in
`app/tests/pxi/constants.ts` that omits it (mirroring
`STALE_CAPABILITIES_MISSING_SUBAGENTS`) and add it to the required-context list
in `stale-capabilities.spec.ts`.

## Validation note
The automated `make` lint/format/typecheck/test targets shell out to `pnpm`,
which is not installed in this agent's sandbox (and `corepack`/`node`/`tsc`/
`vitest` invocations are permission-gated here). Changes were reviewed manually
against Prettier (80-col) and the TypeScript types; CI runs the full suite.
