### PR TITLE
fix: skip malformed header segments in parse_env_headers (#13775)

### DIFF
--- a/packages/phoenix-otel/src/phoenix/otel/settings.py
+++ b/packages/phoenix-otel/src/phoenix/otel/settings.py
@@ -132,6 +132,13 @@ def parse_env_headers(s: str) -> Dict[str, str]:
         match = _HEADER_PATTERN.fullmatch(header.strip())
         if not match:
             parts = header.split("=", 1)
+            if len(parts) != 2:
+                logger.warning(
+                    "Header format invalid! Header values in environment variables must be "
+                    "URL encoded and in the form name=value: %s",
+                    "****",
+                )
+                continue
             name, value = parts
             encoded_header = f"{urllib.parse.quote(name)}={urllib.parse.quote(value)}"
             match = _HEADER_PATTERN.fullmatch(encoded_header.strip())

--- a/packages/phoenix-otel/src/phoenix/otel/settings.py
+++ b/packages/phoenix-otel/src/phoenix/otel/settings.py
@@ -135,8 +135,7 @@ def parse_env_headers(s: str) -> Dict[str, str]:
             if len(parts) != 2:
                 logger.warning(
                     "Header format invalid! Header values in environment variables must be "
-                    "URL encoded and in the form name=value: %s",
-                    "****",
+                    "URL encoded and in the form name=value."
                 )
                 continue
             name, value = parts

--- a/packages/phoenix-otel/tests/test_settings.py
+++ b/packages/phoenix-otel/tests/test_settings.py
@@ -53,7 +53,5 @@ def test_construct_http_endpoint(endpoint: str, expected: str) -> None:
         ("x=a,bad", {"x": "a"}),
     ],
 )
-def test_parse_env_headers_skips_malformed_segments(
-    headers: str, expected: dict[str, str]
-) -> None:
+def test_parse_env_headers_skips_malformed_segments(headers: str, expected: dict[str, str]) -> None:
     assert parse_env_headers(headers) == expected

--- a/packages/phoenix-otel/tests/test_settings.py
+++ b/packages/phoenix-otel/tests/test_settings.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 import pytest
 
 from phoenix.otel.otel import _construct_http_endpoint
-from phoenix.otel.settings import get_env_collector_endpoint
+from phoenix.otel.settings import get_env_collector_endpoint, parse_env_headers
 
 
 @pytest.mark.parametrize(
@@ -41,3 +41,19 @@ def test_construct_http_endpoint(endpoint: str, expected: str) -> None:
     parsed = urlparse(endpoint)
     result = _construct_http_endpoint(parsed)
     assert result.geturl() == expected
+
+
+@pytest.mark.parametrize(
+    "headers, expected",
+    [
+        ("x=a,y=b", {"x": "a", "y": "b"}),
+        # Malformed segment without "=" is skipped rather than crashing
+        ("Authorization", {}),
+        # Mixed valid/invalid: valid entries are kept, invalid ones skipped
+        ("x=a,bad", {"x": "a"}),
+    ],
+)
+def test_parse_env_headers_skips_malformed_segments(
+    headers: str, expected: dict[str, str]
+) -> None:
+    assert parse_env_headers(headers) == expected


### PR DESCRIPTION
Fixes #13775.

### Problem

`parse_env_headers` (`packages/phoenix-otel/src/phoenix/otel/settings.py`) crashes on a header segment that has no `=`. In the fallback branch for a non-matching segment it does `parts = header.split("=", 1)` then `name, value = parts`; a segment like `Authorization` produces a single-element list, so the unpack raises `ValueError: not enough values to unpack (expected 2, got 1)`. Because the whole header string is parsed in one loop, a single malformed segment poisons every header (e.g. `x=a,bad` raises instead of yielding `{"x": "a"}`). The function is documented to warn and skip invalid entries rather than crash.

### Fix

Guard the unpack: when the split does not yield two parts, log the same invalid-format warning the function already uses and `continue`, so malformed segments are skipped and valid ones still parse.

### Test

Added parametrized cases to `test_parse_env_headers...`: a segment with no `=` (skipped, yields `{}`) and a mixed `x=a,bad` string (keeps `x=a`, skips `bad`). Without the fix both fail with the `ValueError`; with it the full `test_settings.py` passes (10 passed).

Disclosure: I used AI assistance (Claude) to help locate and draft this fix, under my direction and review.
