### PR TITLE
fix: Use sync timeout policy for async client

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/client.py
+++ b/packages/phoenix-client/src/phoenix/client/client.py
@@ -14,6 +14,8 @@ from phoenix.client.resources.traces import AsyncTraces, Traces
 from phoenix.client.utils.config import get_base_url, get_env_client_headers
 from phoenix.client.utils.server_requirements import AsyncServerVersionGuard, ServerVersionGuard
 
+_DEFAULT_CLIENT_TIMEOUT = httpx.Timeout(connect=10.0, read=30.0, write=10.0, pool=10.0)
+
 
 class Client:
     def __init__(
@@ -45,7 +47,7 @@ class Client:
             http_client = _WrappedClient(
                 base_url=base_url,
                 headers=_update_headers(headers, api_key),
-                timeout=httpx.Timeout(connect=10.0, read=30.0, write=10.0, pool=10.0),
+                timeout=_DEFAULT_CLIENT_TIMEOUT,
             )
         self._client = http_client
 
@@ -159,6 +161,7 @@ class AsyncClient:
             http_client = httpx.AsyncClient(
                 base_url=base_url,
                 headers=_update_headers(headers, api_key),
+                timeout=_DEFAULT_CLIENT_TIMEOUT,
             )
         self._client = http_client
 

--- a/packages/phoenix-client/tests/client/test_client.py
+++ b/packages/phoenix-client/tests/client/test_client.py
@@ -1,6 +1,6 @@
 import pytest
 
-from phoenix.client import Client
+from phoenix.client import AsyncClient, Client
 
 
 @pytest.mark.parametrize(
@@ -19,3 +19,14 @@ def test_url_sanitization(input: str, expected: str) -> None:
     """
     client = Client(base_url=input)
     assert str(client._client.base_url) == expected  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_async_client_uses_sync_client_default_timeout_policy() -> None:
+    client = Client(base_url="http://localhost:6006")
+    async_client = AsyncClient(base_url="http://localhost:6006")
+
+    try:
+        assert async_client._client.timeout == client._client.timeout  # pyright: ignore[reportPrivateUsage]
+    finally:
+        await async_client._client.aclose()  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
Fixes #13772

## Summary

- Extract the default Phoenix client timeout policy into a shared constant
- Pass the same timeout to the default `httpx.AsyncClient` used by `AsyncClient`
- Add regression coverage that sync and async clients use the same default timeout

## Validation

- `PYTHONPYCACHEPREFIX=/Users/luochen/Desktop/3d_upload_assets_test/api-work/.pycache python3 -m py_compile ...`
