### PR TITLE
fix: Preserve HTTP collector path prefixes

### DIFF
--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -731,7 +731,8 @@ def _construct_http_endpoint(parsed_endpoint: ParseResult) -> ParseResult:
     traces_suffix = "/v1/traces"
     if parsed_endpoint.path.endswith(traces_suffix):
         return parsed_endpoint
-    return parsed_endpoint._replace(path=traces_suffix)
+    path_prefix = parsed_endpoint.path.rstrip("/")
+    return parsed_endpoint._replace(path=f"{path_prefix}{traces_suffix}")
 
 
 def _construct_phoenix_cloud_endpoint(parsed_endpoint: ParseResult) -> ParseResult:

--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -726,13 +726,13 @@ def _construct_http_endpoint(parsed_endpoint: ParseResult) -> ParseResult:
         parsed_endpoint (ParseResult): Parsed URL endpoint.
 
     Returns:
-        ParseResult: Modified endpoint with "/v1/traces" path.
+        ParseResult: Endpoint with "/v1/traces" appended to any existing path prefix.
     """
     traces_suffix = "/v1/traces"
-    if parsed_endpoint.path.endswith(traces_suffix):
-        return parsed_endpoint
-    path_prefix = parsed_endpoint.path.rstrip("/")
-    return parsed_endpoint._replace(path=f"{path_prefix}{traces_suffix}")
+    path = parsed_endpoint.path.rstrip("/")
+    if path.endswith(traces_suffix):
+        return parsed_endpoint._replace(path=path)
+    return parsed_endpoint._replace(path=f"{path}{traces_suffix}")
 
 
 def _construct_phoenix_cloud_endpoint(parsed_endpoint: ParseResult) -> ParseResult:

--- a/packages/phoenix-otel/tests/test_otel.py
+++ b/packages/phoenix-otel/tests/test_otel.py
@@ -17,6 +17,7 @@ from phoenix.otel.otel import (
     OTLPTransportProtocol,
     SimpleSpanProcessor,
     TracerProvider,
+    _construct_http_endpoint,
     _construct_phoenix_cloud_endpoint,
     register,
 )
@@ -527,6 +528,13 @@ class TestEndpointNormalization:
                 parsed, endpoint = _normalized_endpoint(None, use_http=False)
                 assert parsed.scheme == "http"
                 assert parsed.netloc == "localhost:4317"
+
+    def test_construct_http_endpoint_preserves_path_prefix(self) -> None:
+        parsed = urlparse("http://example.com/phoenix")
+
+        result = _construct_http_endpoint(parsed)
+
+        assert result.geturl() == "http://example.com/phoenix/v1/traces"
 
 
 class TestPhoenixCloudEndpoint:

--- a/packages/phoenix-otel/tests/test_otel.py
+++ b/packages/phoenix-otel/tests/test_otel.py
@@ -536,6 +536,34 @@ class TestEndpointNormalization:
 
         assert result.geturl() == "http://example.com/phoenix/v1/traces"
 
+    def test_construct_http_endpoint_preserves_path_prefix_with_trailing_slash(self) -> None:
+        parsed = urlparse("http://example.com/phoenix/")
+
+        result = _construct_http_endpoint(parsed)
+
+        assert result.geturl() == "http://example.com/phoenix/v1/traces"
+
+    def test_construct_http_endpoint_keeps_existing_traces_path(self) -> None:
+        parsed = urlparse("http://example.com/v1/traces")
+
+        result = _construct_http_endpoint(parsed)
+
+        assert result.geturl() == "http://example.com/v1/traces"
+
+    def test_construct_http_endpoint_normalizes_traces_path_with_trailing_slash(self) -> None:
+        parsed = urlparse("http://example.com/v1/traces/")
+
+        result = _construct_http_endpoint(parsed)
+
+        assert result.geturl() == "http://example.com/v1/traces"
+
+    def test_construct_http_endpoint_keeps_prefixed_traces_path(self) -> None:
+        parsed = urlparse("http://example.com/phoenix/v1/traces/")
+
+        result = _construct_http_endpoint(parsed)
+
+        assert result.geturl() == "http://example.com/phoenix/v1/traces"
+
 
 class TestPhoenixCloudEndpoint:
     def test_space_path_basic(self) -> None:


### PR DESCRIPTION
Fixes #13776

## Summary

- Preserve an existing HTTP collector path prefix when appending `/v1/traces`
- Keep already-normalized `/v1/traces` endpoints unchanged
- Add endpoint normalization regression coverage for prefixed HTTP collector URLs

## Validation

- `PYTHONPYCACHEPREFIX=/Users/luochen/Desktop/3d_upload_assets_test/api-work/.pycache python3 -m py_compile ...`
