### PR TITLE
fix: integration route coverage for FastAPI 0.137

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
   "python-multipart",  # see https://www.starlette.io/#dependencies
   "arize-phoenix-evals>=3.1.0",
   "arize-phoenix-otel>=0.16.1",
-  "fastapi>=0.135.2",  # older versions raise AssertionError on 204 routes, see https://github.com/Arize-ai/phoenix/issues/12384
+  "fastapi>=0.137.0",  # 0.137 keeps included routers as a lazy _IncludedRouter tree; older versions raise AssertionError on 204 routes, see https://github.com/Arize-ai/phoenix/issues/12384
   "pydantic>=2.1.0", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
   "pydantic-ai-slim[anthropic,bedrock,google,mcp,openai,ui]>=1.95.0",
   "authlib>=1.7.0",

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -50,6 +50,7 @@ import jwt
 import pytest
 import smtpdfix
 from fastapi import FastAPI
+from fastapi.routing import APIRoute, _IncludedRouter
 from httpx import Headers, HTTPStatusError
 from jwt import DecodeError
 from openinference.semconv.resource import ResourceAttributes
@@ -68,6 +69,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import NullPool
 from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse, Response
+from starlette.routing import BaseRoute
 from strawberry.relay import GlobalID
 from typing_extensions import Self, TypeAlias, assert_never, override
 
@@ -89,6 +91,7 @@ from phoenix.db.engines import get_async_db_url
 from phoenix.server.api.auth import IsAdmin
 from phoenix.server.api.exceptions import Unauthorized
 from phoenix.server.api.input_types.UserRoleInput import UserRoleInput
+from phoenix.server.api.routers.v1 import create_v1_router
 from phoenix.server.thread_server import ThreadServer
 
 _DB_BACKEND: TypeAlias = Literal["sqlite", "postgresql"]
@@ -101,6 +104,8 @@ _ProjectName: TypeAlias = str
 _SpanName: TypeAlias = str
 _Headers: TypeAlias = dict[str, Any]
 _Name: TypeAlias = str
+_HttpMethod: TypeAlias = str
+_RoutePath: TypeAlias = str
 
 _Secret: TypeAlias = str
 _Email: TypeAlias = str
@@ -2270,42 +2275,35 @@ _VIEWER_BLOCKED_WRITE_OPERATIONS = (
 )
 
 
+def _join_paths(prefix: _RoutePath, path: _RoutePath) -> _RoutePath:
+    if not prefix:
+        return path
+    return f"{prefix.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _get_api_route_methods_and_paths(
+    routes: Iterable[BaseRoute], prefix: _RoutePath = ""
+) -> Iterator[tuple[_HttpMethod, _RoutePath]]:
+    for route in routes:
+        if isinstance(route, APIRoute):
+            for method in route.methods or ():
+                yield method, _join_paths(prefix, route.path)
+        elif isinstance(route, _IncludedRouter):
+            include_prefix = route.include_context.prefix
+            yield from _get_api_route_methods_and_paths(
+                route.original_router.routes, _join_paths(prefix, include_prefix)
+            )
+
+
 def _ensure_endpoint_coverage_is_exhaustive() -> None:
     """Verify that test constants cover all actual v1 API routes.
 
     This runs at module import time as a prerequisite check. If endpoint
     coverage is incomplete, all tests that import this module will fail fast.
     """
-    import re
-
-    from fastapi.routing import APIRoute
-
-    from phoenix.server.api.routers.v1 import create_v1_router
-
-    def join_paths(prefix: str, path: str) -> str:
-        if not prefix:
-            return path
-        return f"{prefix.rstrip('/')}/{path.lstrip('/')}"
-
-    def iter_api_routes(routes: Iterable[Any], prefix: str = "") -> Iterator[tuple[str, str]]:
-        for route in routes:
-            if isinstance(route, APIRoute):
-                for method in route.methods:
-                    yield method, join_paths(prefix, route.path)
-                continue
-
-            # FastAPI 0.137+ keeps included routers lazy as private _IncludedRouter
-            # entries instead of flattening them into APIRoute entries immediately.
-            included_router = getattr(route, "original_router", None)
-            if included_router is None:
-                continue
-            include_context = getattr(route, "include_context", None)
-            include_prefix = getattr(include_context, "prefix", "")
-            yield from iter_api_routes(included_router.routes, join_paths(prefix, include_prefix))
-
     # Get all actual routes from the v1 router
     router = create_v1_router(authentication_enabled=False)
-    actual_routes = set(iter_api_routes(router.routes))
+    actual_routes = set(_get_api_route_methods_and_paths(router.routes))
 
     # Get all routes from test constants
     test_routes = {

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2282,14 +2282,30 @@ def _ensure_endpoint_coverage_is_exhaustive() -> None:
 
     from phoenix.server.api.routers.v1 import create_v1_router
 
+    def join_paths(prefix: str, path: str) -> str:
+        if not prefix:
+            return path
+        return f"{prefix.rstrip('/')}/{path.lstrip('/')}"
+
+    def iter_api_routes(routes: Iterable[Any], prefix: str = "") -> Iterator[tuple[str, str]]:
+        for route in routes:
+            if isinstance(route, APIRoute):
+                for method in route.methods:
+                    yield method, join_paths(prefix, route.path)
+                continue
+
+            # FastAPI 0.137+ keeps included routers lazy as private _IncludedRouter
+            # entries instead of flattening them into APIRoute entries immediately.
+            included_router = getattr(route, "original_router", None)
+            if included_router is None:
+                continue
+            include_context = getattr(route, "include_context", None)
+            include_prefix = getattr(include_context, "prefix", "")
+            yield from iter_api_routes(included_router.routes, join_paths(prefix, include_prefix))
+
     # Get all actual routes from the v1 router
     router = create_v1_router(authentication_enabled=False)
-    actual_routes = {
-        (method, route.path)
-        for route in router.routes
-        if isinstance(route, APIRoute)
-        for method in route.methods
-    }
+    actual_routes = set(iter_api_routes(router.routes))
 
     # Get all routes from test constants
     test_routes = {

--- a/uv.lock
+++ b/uv.lock
@@ -695,7 +695,7 @@ requires-dist = [
     { name = "e2b-code-interpreter", marker = "extra == 'container'", specifier = ">=0.0.12" },
     { name = "e2b-code-interpreter", marker = "extra == 'e2b'", specifier = ">=0.0.12" },
     { name = "email-validator" },
-    { name = "fastapi", specifier = ">=0.135.2" },
+    { name = "fastapi", specifier = ">=0.137.0" },
     { name = "google-genai", marker = "python_full_version >= '3.10' and extra == 'container'", specifier = ">=1.50.0" },
     { name = "google-genai", marker = "python_full_version < '3.10' and extra == 'container'" },
     { name = "grpc-interceptor" },
@@ -2107,7 +2107,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.137.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -2116,9 +2116,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/fe/fb25c287ff7e0f79fc6acf2e8b812725dad28d2a1446c0410bab1422ac90/fastapi-0.137.0.tar.gz", hash = "sha256:d0565d551f65a803ecff245390840867186f456ef98971f750724eed16e1541c", size = 408023, upload-time = "2026-06-14T12:51:30.672Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f1/b38481428e50131e5345b535414d11d196f14990122fe69c9020c64e5683/fastapi-0.137.0-py3-none-any.whl", hash = "sha256:6dcbde8d464f92117c1accb9e42720f8e423fa9b86cb563b1f5862f785a06498", size = 121777, upload-time = "2026-06-14T12:51:29.067Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Recursively collect v1 API routes in the integration endpoint coverage helper.
- Preserve router prefixes while walking included routers so the coverage check works with both flattened and lazy FastAPI route lists.

## Root Cause

FastAPI 0.137 changed `APIRouter.include_router()` behavior: included routers now remain in `router.routes` as lazy private `_IncludedRouter` entries instead of being immediately flattened into direct `APIRoute` objects.

The integration helper was doing a direct `isinstance(route, APIRoute)` scan over `create_v1_router(...).routes`. In a fresh tox environment, CI resolved `fastapi==0.137.0`, so that direct scan found zero v1 server routes. The exhaustive coverage guard then treated every endpoint test constant as stale and failed during `tests/integration/conftest.py` import.

FastAPI/OpenAPI generation can handle the lazy include entries, but our custom test helper needed to expand included routers recursively.

