### PR TITLE
docs: Audit and update llms.txt

### DIFF
--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -8,6 +8,7 @@
 - [User Guide](https://arize.com/docs/phoenix/user-guide): End-to-end workflows for development, production, and optimization
 - [Production Guide](https://arize.com/docs/phoenix/production-guide): Deploy Phoenix in production with best practices for scale and reliability
 - [Environments](https://arize.com/docs/phoenix/environments): Configure Phoenix across development, staging, and production environments
+- [PXI Agent](https://arize.com/docs/phoenix/pxi): Hand investigations to Phoenix Intelligence, the built-in AI agent that inspects traces, iterates prompts, and runs experiments
 
 ## Quick Start
 
@@ -394,6 +395,23 @@
 - [Translating Conventions](https://arize.com/docs/phoenix/tracing/concepts-tracing/translating-conventions): Map framework-specific conventions to Phoenix's trace structure
 - [Tracing FAQs](https://arize.com/docs/phoenix/tracing/concepts-tracing/faqs-tracing): Troubleshoot trace collection, local vs remote setup, and common configuration issues
 
+### OpenTelemetry & OpenInference
+
+- [OTel & OpenInference Overview](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/overview): How Phoenix tracing builds on the OpenTelemetry and OpenInference open standards
+- [Signals, Spans, Traces, and Sessions](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/signals): Understand the data shapes OpenTelemetry produces and how they form a trace tree
+- [Tracing Resource](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/resource): Set service name, environment, and attributes that route spans to your project
+- [Exporter and OTLP](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter): Ship spans out of your app over OTLP via gRPC or HTTP
+- [Span Processor](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor): Choose between BatchSpanProcessor and SimpleSpanProcessor and tune span batching
+- [Tracer Provider and Tracer](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/tracer-provider): Configure the central OpenTelemetry tracing object and handle shutdown on Lambda and Node.js
+- [phoenix.otel Helpers](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers): Collapse OpenTelemetry setup into one register() call with arize-phoenix-otel
+- [OpenInference Semantic Conventions](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/semantic-conventions): Standardized span attribute names that make AI trace data portable across tools and languages
+- [OpenInference Span Kinds](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds): The eleven span kinds — LLM, Tool, Agent, Chain, Retriever — and their canonical attributes
+- [Instrumentation Approaches](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/instrumentation-approaches): Compare auto, manual, and hybrid instrumentation and the custom span processor pattern
+- [OpenInference Context Managers](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers): Attach session IDs, user IDs, metadata, tags, and prompt templates to spans in scope
+- [Context Propagation](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-propagation): Carry trace context across async boundaries, threads, and microservices
+- [Trace Sampling](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/sampling): Reduce telemetry volume with head and tail sampling without losing visibility
+- [OpenTelemetry Collector](https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/otel-collector): Receive, process, and export spans through an optional intermediate collector service
+
 ### Prompts
 
 - [Prompts Concepts](https://arize.com/docs/phoenix/prompt-engineering/concepts-prompts/prompts-concepts): Understand prompt templates, versioning, tagging, and invocation parameters
@@ -734,6 +752,11 @@
 - [05.13.2026 Playground Thinking Controls for Anthropic and Google](https://arize.com/docs/phoenix/release-notes/05-2026/05-13-2026-playground-thinking-controls): Configure Anthropic extended thinking and Google thinking in the Playground — token budgets, effort levels, and display toggles
 - [05.15.2026 OTel GenAI Semantic Convention Auto-Conversion](https://arize.com/docs/phoenix/release-notes/05-2026/05-15-2026-otel-semconv-conversion): Phoenix auto-converts gen_ai.* OTel attributes to OpenInference at ingest — OTel-native traces render with full message I/O and token counts without code changes
 - [05.15.2026 Session Trace Feedback and ATIF v1.7](https://arize.com/docs/phoenix/release-notes/05-2026/05-15-2026-session-feedback-and-atif): Thumbs-up/down feedback toolbar on session turns; ATIF v1.7 trajectory upload with embedded subagents and deterministic dispatch steps
+- [05.21.2026 Code Evaluators](https://arize.com/docs/phoenix/release-notes/05-2026/05-21-2026-code-evaluators): Write Python or TypeScript evaluate() functions in the UI and run them server-side on every experiment
+- [05.27.2026 Drag-to-Zoom on Project Metric Charts](https://arize.com/docs/phoenix/release-notes/05-2026/05-27-2026-drag-to-zoom): Click and drag across any project metric chart or spans sparkline to zoom into a time window
+- [06.02.2026 Introducing PXI](https://arize.com/docs/phoenix/release-notes/06-2026/06-02-2026-pxi-agent): Phoenix Intelligence, the built-in AI engineering agent, debuts in beta in arize-phoenix 17.0.0+
+- [06.10.2026 PXI Agent Update](https://arize.com/docs/phoenix/release-notes/06-2026/06-10-2026-pxi-agent-update): PXI gains a skills menu, parallel subagents, playground orchestration, evaluator authoring, and dataset management
+- [06.11.2026 Time Range Selector and PXI Slash Commands](https://arize.com/docs/phoenix/release-notes/06-2026/06-11-2026-time-range-and-pxi-slash-commands): Search presets and type free-form durations in the time range selector; PXI adds local slash commands
 
 ### 2025
 


### PR DESCRIPTION
## Audit `llms.txt` coverage against the docs tree

Audited `docs/phoenix/llms.txt` against the intersection of `docs.json` navigation and the `.mdx` files on disk. Added missing nav-published pages and verified descriptions stay concise and action-oriented.

### Added

**Overview**
- `pxi` — PXI (Phoenix Intelligence) agent page, a substantial feature doc that was published in nav but missing from the index.

**Concepts → new `OpenTelemetry & OpenInference` subsection (14 pages)**
- `tracing/concepts-tracing/otel-openinference/{overview, signals, resource, exporter, span-processor, tracer-provider, phoenix-otel-helpers, semantic-conventions, span-kinds, instrumentation-approaches, context-managers, context-propagation, sampling, otel-collector}` — an entire conceptual subsection that exists in nav and on disk but had no entries in `llms.txt`. Titles were made unique (e.g. "OTel & OpenInference Overview", "Tracing Resource", "Trace Sampling") and descriptions trimmed to 5–20 words.

**Release Notes → 2026**
- `05-2026/05-21-2026-code-evaluators`
- `05-2026/05-27-2026-drag-to-zoom`
- `06-2026/06-02-2026-pxi-agent`
- `06-2026/06-10-2026-pxi-agent-update`
- `06-2026/06-11-2026-time-range-and-pxi-slash-commands`

### Intentionally skipped (exclusion rules)
- `evaluation/pre-built-metrics/hallucination` — in `docs.json` nav but **no `.mdx` file on disk** (broken nav entry); would 404, so not indexed.
- `resources/typescript-api`, `resources/python-api` — bare redirect stubs (`url:` frontmatter only) pointing to pages already indexed under SDK & API Reference.
- `resources/github`, `resources/openinference` — bare external GitHub links with no docs page behind them.

### ⚠️ Flagged for maintainer review — `docs.json` nav gap (no `llms.txt` change made)
Nine release-note `.mdx` files exist on disk **and** are already in `llms.txt`, but are **absent from `docs.json` navigation**:

- `release-notes/01-2026/01-05-2026-appended-messages-for-playground-experiments`
- `release-notes/01-2026/01-21-2026-cli-datasets-experiments-annotations`
- `release-notes/01-2026/01-21-2026-create-datasets-from-traces`
- `release-notes/01-2026/01-22-2026-cli-prompt-commands`
- `release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators`
- `release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support`
- `release-notes/02-2026/02-11-2026-custom-providers`
- `release-notes/02-2026/02-12-2026-openai-responses-api-support`
- `release-notes/02-2026/02-12-2026-dataset-evaluators`

`docs.json` lists only `01-17-2026` for 01-2026 and `02-14-2026`/`02-27-2026` for 02-2026, while every other 2025/2026 month is listed in full. This asymmetry looks like an **accidental nav regression in `docs.json`** rather than deliberate curation. Per the skill's stale-removal criterion (remove only when the `.mdx` was deleted or renamed), these files still exist, so they were **kept** in `llms.txt`. Recommended fix is to restore the missing entries to `docs.json` navigation rather than delete them from the index — please confirm.

### Verification
- No duplicate `[Title]` entries introduced (each new title appears exactly once).
- All additions follow the `- [Title](url): description` spec format.
- The `phoenix-cli` docs parser test could not be run in this environment (the sandbox blocks `pnpm`); additions mirror the existing line format exactly.
