### PR TITLE
feat: pre-load background color respects saved theme and os prefs

### DIFF
--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -62,26 +62,31 @@
       // app/src/contexts/ThemeContext.tsx and the gray-75 background tokens in
       // app/src/GlobalStyles.tsx; keep the values below in sync with those.
       (function () {
-        var STORAGE_KEY = "arize-phoenix-theme";
-        var DEFAULT_THEME = "dark";
-        var BACKGROUND = { dark: "#0e0e0e", light: "#fdfdfd" };
+        try {
+          var STORAGE_KEY = "arize-phoenix-theme";
+          var DEFAULT_THEME = "dark";
+          var BACKGROUND = { dark: "#0e0e0e", light: "#fdfdfd" };
 
-        var saved = localStorage.getItem(STORAGE_KEY);
-        var mode =
-          saved === "light" || saved === "dark" || saved === "system"
-            ? saved
-            : DEFAULT_THEME;
-        var theme =
-          mode === "system"
-            ? window.matchMedia("(prefers-color-scheme: dark)").matches
-              ? "dark"
-              : "light"
-            : mode;
+          var saved = localStorage.getItem(STORAGE_KEY);
+          var mode =
+            saved === "light" || saved === "dark" || saved === "system"
+              ? saved
+              : DEFAULT_THEME;
+          var theme =
+            mode === "system"
+              ? window.matchMedia("(prefers-color-scheme: dark)").matches
+                ? "dark"
+                : "light"
+              : mode;
 
-        var color = BACKGROUND[theme];
-        document.documentElement.style.backgroundColor = color;
-        var meta = document.querySelector('meta[name="theme-color"]');
-        if (meta) meta.content = color;
+          var color = BACKGROUND[theme];
+          document.documentElement.style.backgroundColor = color;
+          var meta = document.querySelector('meta[name="theme-color"]');
+          if (meta) meta.content = color;
+        } catch (e) {
+          // localStorage/matchMedia can throw in sandboxed iframes or when
+          // site data is blocked; fall back to the static dark theme-color.
+        }
       })();
     </script>
     {% if allow_external_resources %}

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -55,7 +55,35 @@
     <meta property="og:description" content="AI Observability & Evaluation" />
     <meta property="og:image" content="https://raw.githubusercontent.com/Arize-ai/phoenix-assets/main/images/socal/social-preview-horizontal.jpg" />
     <meta name="theme-color" content="#0e0e0e" />
-    <script>!function(){var s=localStorage.getItem('arize-phoenix-theme'),d=s==='light'?false:s==='dark'?true:s==='system'?window.matchMedia('(prefers-color-scheme: dark)').matches:true;document.documentElement.style.backgroundColor=d?'rgb(14,14,14)':'rgb(253,253,253)';var m=document.querySelector('meta[name="theme-color"]');if(m)m.content=d?'#0e0e0e':'#fdfdfd'}()</script>
+    <script>
+      // Apply the page background and theme-color before the app's CSS loads so
+      // the first paint matches the user's saved theme (avoids a flash of the
+      // wrong color). This mirrors the theme resolution in
+      // app/src/contexts/ThemeContext.tsx and the gray-75 background tokens in
+      // app/src/GlobalStyles.tsx; keep the values below in sync with those.
+      (function () {
+        var STORAGE_KEY = "arize-phoenix-theme";
+        var DEFAULT_THEME = "dark";
+        var BACKGROUND = { dark: "#0e0e0e", light: "#fdfdfd" };
+
+        var saved = localStorage.getItem(STORAGE_KEY);
+        var mode =
+          saved === "light" || saved === "dark" || saved === "system"
+            ? saved
+            : DEFAULT_THEME;
+        var theme =
+          mode === "system"
+            ? window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light"
+            : mode;
+
+        var color = BACKGROUND[theme];
+        document.documentElement.style.backgroundColor = color;
+        var meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) meta.content = color;
+      })();
+    </script>
     {% if allow_external_resources %}
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -54,7 +54,8 @@
     <meta property="og:title" content="Arize Phoenix" />
     <meta property="og:description" content="AI Observability & Evaluation" />
     <meta property="og:image" content="https://raw.githubusercontent.com/Arize-ai/phoenix-assets/main/images/socal/social-preview-horizontal.jpg" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta name="theme-color" content="#0e0e0e" />
+    <script>!function(){var s=localStorage.getItem('arize-phoenix-theme'),d=s==='light'?false:s==='dark'?true:s==='system'?window.matchMedia('(prefers-color-scheme: dark)').matches:true;document.documentElement.style.backgroundColor=d?'rgb(14,14,14)':'rgb(253,253,253)';var m=document.querySelector('meta[name="theme-color"]');if(m)m.content=d?'#0e0e0e':'#fdfdfd'}()</script>
     {% if allow_external_resources %}
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary

Sets the page background color and `theme-color` meta before the app's CSS loads, so the first paint matches the user's saved theme (avoids a flash of the wrong color on load). The resolved theme respects the saved preference in `localStorage` and OS preferences for `system` mode.

## Changes

- Rebased onto `main`, dropping the now-redundant FastAPI 0.137 endpoint-coverage CI fix — that fix already landed on `main` via #13807.
- Reworked the inline theme bootstrap to be more scalable / less hard-coded:
  - De-minified into a readable IIFE.
  - Pulled the storage key, default theme, and background colors into named constants / a single `{ dark, light }` map.
  - Resolves the theme the same way as `ThemeContext.getCurrentTheme()`.
  - Unified the duplicated `rgb()` / hex color literals into one hex value per theme.
  - Documented the TS/CSS source of truth (`app/src/contexts/ThemeContext.tsx`, `app/src/GlobalStyles.tsx`) to keep values in sync.

## Notes

The literal color values still mirror the `--global-color-gray-75` design tokens by necessity — this script must run before any CSS (including the design tokens) loads, so it can't read them at runtime. The values are now centralized in one place with a comment pointing back to the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSW13vuPnURkWJwxuxV6oD)_