### PR TITLE
feat!: per-resource access control (strawman prototype)

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -53,6 +53,54 @@ input AWSBedrockCustomProviderConfigInput {
   awsBedrockClientKwargs: AWSBedrockClientKwargsInput!
 }
 
+type AccessGrant {
+  subjectKind: AccessSubjectKind!
+  subjectId: ID
+  subjectName: String!
+  roleId: ID
+  roleName: String!
+}
+
+input AccessGrantInput {
+  subject: AccessGrantSubjectInput!
+  object: AccessGrantObjectInput!
+  permissionSetId: ID
+}
+
+type AccessGrantMutationPayload {
+  query: Query!
+}
+
+input AccessGrantObjectInput @oneOf {
+  projectId: ID
+  datasetId: ID
+  promptId: ID
+}
+
+input AccessGrantSubjectInput @oneOf {
+  userId: ID
+  userGroupId: ID
+  isEveryone: Boolean
+}
+
+enum AccessObjectType {
+  PROJECT
+  DATASET
+  PROMPT
+}
+
+enum AccessSubjectKind {
+  USER
+  GROUP
+  EVERYONE
+}
+
+type AccessibleObjectRef {
+  kind: String!
+  id: ID!
+  name: String!
+}
+
 input AddAnnotationConfigToProjectInput {
   projectId: ID!
   annotationConfigId: ID!
@@ -335,6 +383,10 @@ interface ApiKey {
 
   """The date and time the API key will expire."""
   expiresAt: DateTime
+}
+
+enum ApiKeyScope {
+  INGEST
 }
 
 enum AuthMethod {
@@ -687,6 +739,7 @@ input CreateApiKeyInput {
   name: String!
   description: String
   expiresAt: DateTime
+  scope: ApiKeyScope
 }
 
 input CreateChatPromptInput {
@@ -827,6 +880,11 @@ type CreateModelMutationPayload {
   query: Query!
 }
 
+input CreatePermissionSetInput {
+  name: String!
+  permissions: [ObjectPermission!]!
+}
+
 input CreateProjectInput {
   name: String!
   description: String
@@ -916,6 +974,7 @@ input CreateUserApiKeyInput {
   name: String!
   description: String
   expiresAt: DateTime
+  scope: ApiKeyScope
 }
 
 type CreateUserApiKeyMutationPayload {
@@ -940,6 +999,7 @@ union CustomProviderConfig = OpenAICustomProviderConfig | AzureOpenAICustomProvi
 type Dataset implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
+  accessGrants: [AccessGrant!]!
   name: String!
   description: String
   metadata: JSON!
@@ -1364,6 +1424,10 @@ input DeleteModelMutationInput {
 type DeleteModelMutationPayload {
   model: GenerativeModel!
   query: Query!
+}
+
+input DeletePermissionSetInput {
+  id: ID!
 }
 
 type DeleteProjectAnnotationsByNamePayload {
@@ -2373,6 +2437,12 @@ input ModelsInput {
 }
 
 type Mutation {
+  grantAccess(input: AccessGrantInput!): AccessGrantMutationPayload!
+  revokeAccess(input: AccessGrantInput!): AccessGrantMutationPayload!
+  setResourceTag(input: ResourceTagInput!): AccessGrantMutationPayload!
+  removeResourceTag(input: ResourceTagInput!): AccessGrantMutationPayload!
+  grantTagAccess(input: TagAccessGrantInput!): AccessGrantMutationPayload!
+  revokeTagAccess(input: TagAccessGrantInput!): AccessGrantMutationPayload!
   createAnnotationConfig(input: CreateAnnotationConfigInput!): CreateAnnotationConfigPayload!
   updateAnnotationConfig(input: UpdateAnnotationConfigInput!): UpdateAnnotationConfigPayload!
   deleteAnnotationConfigs(input: DeleteAnnotationConfigsInput!): DeleteAnnotationConfigsPayload!
@@ -2434,6 +2504,9 @@ type Mutation {
   createModel(input: CreateModelMutationInput!): CreateModelMutationPayload!
   updateModel(input: UpdateModelMutationInput!): UpdateModelMutationPayload!
   deleteModel(input: DeleteModelMutationInput!): DeleteModelMutationPayload!
+  createPermissionSet(input: CreatePermissionSetInput!): PermissionSetMutationPayload!
+  patchPermissionSet(input: PatchPermissionSetInput!): PermissionSetMutationPayload!
+  deletePermissionSet(input: DeletePermissionSetInput!): PermissionSetMutationPayload!
 
   """
   Delete every span annotation with the given name in a project, optionally restricted to a time range. Admin only when auth is enabled.
@@ -2487,6 +2560,10 @@ type Mutation {
   deleteTraceAnnotations(input: DeleteAnnotationsInput!): TraceAnnotationMutationPayload!
   deleteTraces(traceIds: [ID!]!): Query!
   transferTracesToProject(traceIds: [ID!]!, projectId: ID!): Query!
+  createUserGroup(name: String!): UserGroupMutationPayload!
+  deleteUserGroup(groupId: Int!): UserGroupMutationPayload!
+  addUserGroupMember(groupId: Int!, userId: Int!): UserGroupMutationPayload!
+  removeUserGroupMember(groupId: Int!, userId: Int!): UserGroupMutationPayload!
   createUser(input: CreateUserInput!): UserMutationPayload!
   patchUser(input: PatchUserInput!): UserMutationPayload!
   patchViewer(input: PatchViewerInput!): UserMutationPayload!
@@ -2497,6 +2574,12 @@ type Mutation {
 interface Node {
   """The Globally Unique ID of this object"""
   id: ID!
+}
+
+enum ObjectPermission {
+  VIEW
+  EDIT
+  MANAGE_ACCESS
 }
 
 enum OpenAIApiType {
@@ -2653,6 +2736,12 @@ type PatchGenerativeModelCustomProviderMutationPayload {
   query: Query!
 }
 
+input PatchPermissionSetInput {
+  id: ID!
+  name: String
+  permissions: [ObjectPermission!]
+}
+
 input PatchProjectInput {
   id: ID!
   description: String
@@ -2694,6 +2783,19 @@ input PatchViewerInput {
   currentPassword: String
 }
 
+type PermissionSet implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+  name: String!
+  isBuiltIn: Boolean!
+  permissions: [ObjectPermission!]!
+}
+
+type PermissionSetMutationPayload {
+  permissionSet: PermissionSet
+  query: Query!
+}
+
 type PlaygroundConfig {
   templateVariablesPath: String
   appendedMessagesPath: String
@@ -2716,6 +2818,8 @@ type Project implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
   name: String!
+  accessGrants: [AccessGrant!]!
+  accessPosture: ProjectAccessPosture!
   description: String
   gradientStartColor: String!
   gradientEndColor: String!
@@ -2813,6 +2917,12 @@ type Project implements Node {
   sessionAnnotationScoreTimeSeries(timeRange: TimeRange!, timeBinConfig: TimeBinConfig): AnnotationScoreTimeSeries!
   topModelsByCost(timeRange: TimeRange!): [GenerativeModel!]!
   topModelsByTokenCount(timeRange: TimeRange!): [GenerativeModel!]!
+}
+
+enum ProjectAccessPosture {
+  ADMINS_ONLY
+  SHARED
+  ALL_USERS
 }
 
 enum ProjectColumn {
@@ -3031,6 +3141,7 @@ input ProjectTraceRetentionRuleMaxDaysOrCountInput {
 type Prompt implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
+  accessGrants: [AccessGrant!]!
   sourcePromptId: ID
   name: Identifier!
   description: String
@@ -3484,12 +3595,16 @@ type Query {
   secrets(keys: [String!] = null, first: Int = 50, last: Int, after: String, before: String): SecretConnection!
   generativeModels(first: Int = 50, last: Int, after: String, before: String): GenerativeModelConnection!
   playgroundModels(input: ModelsInput = null): [PlaygroundModel!]!
-  users(first: Int = 50, last: Int, after: String, before: String): UserConnection!
+  users(first: Int = 50, last: Int, after: String, before: String, filter: UserFilter): UserConnection!
   userRoles: [UserRole!]!
   userApiKeys: [UserApiKey!]!
   systemApiKeys: [SystemApiKey!]!
   projects(first: Int = 50, last: Int, after: String, before: String, sort: ProjectSort, filter: ProjectFilter): ProjectConnection!
   projectsLastUpdatedAt: DateTime
+  permissionSets: [PermissionSet!]!
+  resourceTags(objectType: AccessObjectType!, objectId: ID!): [ResourceTag!]!
+  tagGrants(objectType: AccessObjectType = null): [TagAccessGrant!]!
+  userGroups(localOnly: Boolean! = false): [UserGroup!]!
   datasets(first: Int = 50, last: Int, after: String, before: String, sort: DatasetSort, filter: DatasetFilter): DatasetConnection!
   datasetsLastUpdatedAt: DateTime
   compareExperiments(baseExperimentId: ID!, compareExperimentIds: [ID!]!, first: Int = 50, after: String, filterCondition: String): ExperimentComparisonConnection!
@@ -3573,6 +3688,17 @@ type RemoveAnnotationConfigFromProjectPayload {
 }
 
 union ResolvedSecret = DecryptedSecret | UnparsableSecret
+
+type ResourceTag {
+  key: String!
+  value: String!
+}
+
+input ResourceTagInput {
+  object: AccessGrantObjectInput!
+  key: String!
+  value: String
+}
 
 type ResumeExperimentPayload {
   job: ExperimentJob!
@@ -4147,6 +4273,25 @@ type SystemApiKey implements ApiKey & Node {
   id: ID!
 }
 
+type TagAccessGrant {
+  id: ID!
+  subjectKind: AccessSubjectKind!
+  subjectId: ID
+  subjectName: String!
+  objectType: AccessObjectType!
+  tagKey: String!
+  tagValue: String!
+  roleName: String
+}
+
+input TagAccessGrantInput {
+  subject: AccessGrantSubjectInput!
+  objectType: AccessObjectType!
+  tagKey: String!
+  tagValue: String!
+  permissionSetId: ID
+}
+
 type TaskWorkItemId {
   datasetExampleId: Int!
   repetitionNumber: Int!
@@ -4609,6 +4754,16 @@ type User implements Node {
   role: UserRole!
   apiKeys: [UserApiKey!]!
   isManagementUser: Boolean!
+  accessSummary: UserAccessSummary!
+}
+
+type UserAccessSummary {
+  enforced: Boolean!
+  isAdmin: Boolean!
+  allProjects: Boolean!
+  allDatasets: Boolean!
+  allPrompts: Boolean!
+  objects: [AccessibleObjectRef!]!
 }
 
 type UserApiKey implements ApiKey & Node {
@@ -4645,6 +4800,26 @@ type UserEdge {
 
   """The item at the end of the edge"""
   node: User!
+}
+
+"""A filter for users"""
+input UserFilter {
+  value: String = null
+}
+
+type UserGroup implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+  groupId: Int!
+  name: String!
+  provider: String!
+  isLocal: Boolean!
+  memberUserIds: [Int!]!
+}
+
+type UserGroupMutationPayload {
+  query: Query!
+  userGroup: UserGroup
 }
 
 type UserMutationPayload {

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -24,6 +24,7 @@ import { RootLayout } from "@phoenix/pages/RootLayout";
 import { settingsPromptsPageLoader } from "@phoenix/pages/settings/prompts/settingsPromptsPageLoader";
 import { SettingsSecretsPage } from "@phoenix/pages/settings/secrets/SettingsSecretsPage";
 import { settingsSecretsPageLoader } from "@phoenix/pages/settings/secrets/settingsSecretsPageLoader";
+import { SettingsAccessPage } from "@phoenix/pages/settings/SettingsAccessPage";
 import { SettingsAIProvidersPage } from "@phoenix/pages/settings/SettingsAIProvidersPage";
 import { settingsAIProvidersPageLoader } from "@phoenix/pages/settings/settingsAIProvidersPageLoader";
 import { SettingsAnnotationsPage } from "@phoenix/pages/settings/SettingsAnnotationsPage";
@@ -97,6 +98,7 @@ import { GraphQLPage } from "./pages/apis/GraphQLPage";
 import { RestAPIPage } from "./pages/apis/RestAPIPage";
 import { Layout } from "./pages/Layout";
 import { layoutLoader } from "./pages/layoutLoader";
+import { ProjectAccessPage } from "./pages/project/ProjectAccessPage";
 import { ProjectConfigPage } from "./pages/project/ProjectConfigPage";
 import { ProjectRoot } from "./pages/project/ProjectRoot";
 import { promptConfigLoader } from "./pages/prompt/promptConfigLoader";
@@ -305,6 +307,17 @@ export const appRouteObjects = createRoutesFromElements(
                     label: "Project Metrics",
                     description:
                       "View project time-series metrics, token usage breakdowns, cache read/write token charts, and observability panels.",
+                  },
+                }}
+              />
+              <Route
+                path="access"
+                element={<ProjectAccessPage />}
+                handle={{
+                  agentRoute: {
+                    label: "Project Access",
+                    description:
+                      "Manage which users and groups can access this project.",
                   },
                 }}
               />
@@ -730,6 +743,30 @@ export const appRouteObjects = createRoutesFromElements(
                   "Configure general Phoenix instance settings including hostname, platform version, database usage, users, system API keys, and the default project retention policy.",
               },
             }}
+          />
+          <Route
+            path="access"
+            element={<SettingsAccessPage />}
+            handle={{
+              crumb: () => "Access",
+              agentRoute: {
+                label: "Access Settings",
+                description:
+                  "Manage access-control groups and resource roles used to grant access to projects, datasets, and prompts.",
+              },
+            }}
+          />
+          <Route
+            path="groups"
+            element={<Navigate to="/settings/access" replace />}
+          />
+          <Route
+            path="people"
+            element={<Navigate to="/settings/access" replace />}
+          />
+          <Route
+            path="roles"
+            element={<Navigate to="/settings/access" replace />}
           />
           <Route
             path="secrets"

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -4,6 +4,278 @@
  */
 
 export interface paths {
+    "/v1/access/grants": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List access grants */
+        get: operations["listAccessGrants"];
+        put?: never;
+        /**
+         * Author an access grant (allow-only, idempotent)
+         * @description Grant a subject access to an object (or, with ``object_id`` omitted, to every
+         *     object of that type). Monotonic and allow-only: grants only ever *add* access.
+         *     Idempotent — re-granting the same subject+object updates only the role. Authoring a grant
+         *     on a specific object needs OBJ_MANAGE_ACCESS on it; a type-wide grant is admin-only.
+         */
+        post: operations["createAccessGrant"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/tag-grants": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List tag grants */
+        get: operations["listTagGrants"];
+        put?: never;
+        /**
+         * Author a tag grant (allow-only, idempotent)
+         * @description Grant a subject access to every object of a type carrying a given key=value tag.
+         *     Type-scoped and additive — admin-only, like other type-wide policy. Idempotent: re-granting
+         *     the same (subject, type, tag) updates only the role. A tag grant may confer view or edit,
+         *     never manage-access: a tag's reach is object-manager-mutable, so a manage-conferring tag
+         *     grant would let a non-admin strand an object; it is rejected here and the oracle refuses to
+         *     honor manage from a tag selector regardless.
+         */
+        post: operations["createTagGrant"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/tag-grants/{grant_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Revoke a tag grant
+         * @description Revoke a tag grant. Admin-only, like authoring one. No last-manager guard applies: a tag
+         *     grant is type-scoped and never confers manage, so it is never an object's last manager.
+         */
+        delete: operations["deleteTagGrant"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/object-roles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the permission sets a grant may confer
+         * @description The permission sets a grant may confer — viewer (visibility), editor (mutate), manager
+         *     (manage access). The oracle enforces each tier at its permission level.
+         */
+        get: operations["listPermissionSets"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/enforcement": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Whether access control is enforcing
+         * @description The DB-latched activation state — the source of truth for whether enforcement is on.
+         *     Read-only: there is intentionally no enable/disable endpoint (enabling is the one-way env
+         *     switch; disabling is a deliberate ops action).
+         */
+        get: operations["getAccessEnforcement"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/groups": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List local (admin-managed) groups */
+        get: operations["listLocalGroups"];
+        put?: never;
+        /** Create a local (admin-managed) group */
+        post: operations["createLocalGroup"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/groups/{group_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a local group (and sweep its grants) */
+        delete: operations["deleteLocalGroup"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/groups/{group_id}/members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Add a user to a local group */
+        post: operations["addLocalGroupMember"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/groups/{group_id}/members/{user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Remove a user from a local group */
+        delete: operations["removeLocalGroupMember"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/grants/{grant_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke an access grant */
+        delete: operations["deleteAccessGrant"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/objects/{object_type}/{object_id}/subjects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Who can access this object ("who can see X?")
+         * @description The audit read: the subjects currently granted access to the object (plus its
+         *     creator). Needs OBJ_MANAGE_ACCESS on the object. Administrators have
+         *     implicit access and are not enumerated.
+         */
+        get: operations["listObjectSubjects"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/objects/{object_type}/{object_id}/tags/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Set (or update) a curated tag on an object
+         * @description Apply or update a curated key=value tag on an object. A tag grant reads the tag as
+         *     policy, so setting one changes who can reach the object — it requires OBJ_MANAGE_ACCESS on
+         *     the target, the same authority as granting access. Idempotent: re-setting a key overwrites
+         *     its value.
+         */
+        put: operations["setResourceTag"];
+        post?: never;
+        /**
+         * Remove a curated tag from an object
+         * @description Remove a curated tag. A tag grant that reached the object via this key simply stops
+         *     matching — no grant is deleted (tag grants carry the strings, not a link to the tag row).
+         *     Requires OBJ_MANAGE_ACCESS on the object.
+         */
+        delete: operations["removeResourceTag"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/objects/{object_type}/{object_id}/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List an object's curated tags
+         * @description The curated tags on an object. Tags steer access, so reading them needs
+         *     OBJ_MANAGE_ACCESS on the object — the same gate as the "who can see X?" audit read.
+         */
+        get: operations["listResourceTags"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/annotation_configs": {
         parameters: {
             query?: never;
@@ -2569,6 +2841,17 @@ export interface components {
             /** Approval */
             approval?: components["schemas"]["ToolApprovalRequested"] | components["schemas"]["ToolApprovalResponded"] | null;
         };
+        /** Enforcement */
+        Enforcement: {
+            /** Enabled */
+            enabled: boolean;
+            /** Source */
+            source: string;
+        };
+        /** EnforcementResponseBody */
+        EnforcementResponseBody: {
+            data: components["schemas"]["Enforcement"];
+        };
         /** Experiment */
         Experiment: {
             /**
@@ -2896,6 +3179,49 @@ export interface components {
             /** Data */
             data: components["schemas"]["LocalUser"] | components["schemas"]["OAuth2User"] | components["schemas"]["LDAPUser"] | components["schemas"]["AnonymousUser"];
         };
+        /** Grant */
+        Grant: {
+            /** Id */
+            id: string;
+            subject: components["schemas"]["Subject"];
+            object_type: components["schemas"]["GrantObjectType"];
+            /** Object Id */
+            object_id: string | null;
+            /** Role */
+            role: string | null;
+        };
+        /** GrantCreate */
+        GrantCreate: {
+            subject: components["schemas"]["Subject"];
+            object_type: components["schemas"]["GrantObjectType"];
+            /** Object Id */
+            object_id?: string | null;
+            /** Role */
+            role?: string | null;
+        };
+        /**
+         * GrantObjectType
+         * @description The grantable access roots. Containment children and eval artifacts are
+         *     intentionally absent: their access is inherited from a parent, never granted directly.
+         * @enum {string}
+         */
+        GrantObjectType: "project" | "dataset" | "prompt";
+        /** GrantResponseBody */
+        GrantResponseBody: {
+            data: components["schemas"]["Grant"];
+        };
+        /**
+         * GrantSubjectKind
+         * @description Who a grant targets. ``everyone`` is the only kind with no id — a deliberate
+         *     'make this object visible to all' grant, not a seeded baseline.
+         * @enum {string}
+         */
+        GrantSubjectKind: "user" | "group" | "role" | "service_account" | "everyone";
+        /** GrantsResponseBody */
+        GrantsResponseBody: {
+            /** Data */
+            data: components["schemas"]["Grant"][];
+        };
         /**
          * GraphQLContext
          * @description GraphQL runtime state.
@@ -2908,6 +3234,29 @@ export interface components {
             type: "graphql";
             /** Mutationsenabled */
             mutationsEnabled: boolean;
+        };
+        /** GroupCreate */
+        GroupCreate: {
+            /** Name */
+            name: string;
+        };
+        /** GroupData */
+        GroupData: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Member User Ids */
+            member_user_ids: string[];
+        };
+        /** GroupResponseBody */
+        GroupResponseBody: {
+            data: components["schemas"]["GroupData"];
+        };
+        /** GroupsResponseBody */
+        GroupsResponseBody: {
+            /** Data */
+            data: components["schemas"]["GroupData"][];
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -3134,6 +3483,11 @@ export interface components {
             auth_method: "LOCAL";
             /** Password */
             password?: string;
+        };
+        /** MemberCreate */
+        MemberCreate: {
+            /** User Id */
+            user_id: string;
         };
         /**
          * ModelProvider
@@ -3403,6 +3757,22 @@ export interface components {
              * @description A developer-facing human readable error message.
              */
             message?: string | null;
+        };
+        /** PermissionSetData */
+        PermissionSetData: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Is Built In */
+            is_built_in: boolean;
+            /** Permissions */
+            permissions: string[];
+        };
+        /** PermissionSetsResponseBody */
+        PermissionSetsResponseBody: {
+            /** Data */
+            data: components["schemas"]["PermissionSetData"][];
         };
         /**
          * PlaygroundBuiltinModelContext
@@ -4374,6 +4744,30 @@ export interface components {
                 };
             } | null;
         };
+        /** ResourceTagBody */
+        ResourceTagBody: {
+            /** Value */
+            value: string;
+        };
+        /** ResourceTagData */
+        ResourceTagData: {
+            object_type: components["schemas"]["GrantObjectType"];
+            /** Object Id */
+            object_id: string;
+            /** Key */
+            key: string;
+            /** Value */
+            value: string;
+        };
+        /** ResourceTagResponseBody */
+        ResourceTagResponseBody: {
+            data: components["schemas"]["ResourceTagData"];
+        };
+        /** ResourceTagsResponseBody */
+        ResourceTagsResponseBody: {
+            /** Data */
+            data: components["schemas"]["ResourceTagData"][];
+        };
         /** ResponseBody[UpsertOrDeleteSecretsResult] */
         ResponseBody_UpsertOrDeleteSecretsResult_: {
             data: components["schemas"]["UpsertOrDeleteSecretsResult"];
@@ -4966,6 +5360,50 @@ export interface components {
             type: "subagents";
             /** Enabled */
             enabled: boolean;
+        };
+        /** Subject */
+        Subject: {
+            kind: components["schemas"]["GrantSubjectKind"];
+            /** Id */
+            id?: string | null;
+        };
+        /** SubjectsResponseBody */
+        SubjectsResponseBody: {
+            /** Data */
+            data: components["schemas"]["Subject"][];
+        };
+        /** TagGrant */
+        TagGrant: {
+            /** Id */
+            id: string;
+            subject: components["schemas"]["Subject"];
+            object_type: components["schemas"]["GrantObjectType"];
+            /** Tag Key */
+            tag_key: string;
+            /** Tag Value */
+            tag_value: string;
+            /** Role */
+            role: string | null;
+        };
+        /** TagGrantCreate */
+        TagGrantCreate: {
+            subject: components["schemas"]["Subject"];
+            object_type: components["schemas"]["GrantObjectType"];
+            /** Tag Key */
+            tag_key: string;
+            /** Tag Value */
+            tag_value: string;
+            /** Role */
+            role?: string | null;
+        };
+        /** TagGrantResponseBody */
+        TagGrantResponseBody: {
+            data: components["schemas"]["TagGrant"];
+        };
+        /** TagGrantsResponseBody */
+        TagGrantsResponseBody: {
+            /** Data */
+            data: components["schemas"]["TagGrant"][];
         };
         /** TextContentPart */
         TextContentPart: {
@@ -5726,6 +6164,792 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    listAccessGrants: {
+        parameters: {
+            query?: {
+                object_type?: components["schemas"]["GrantObjectType"] | null;
+                /** @description Filter to one object (requires object_type). */
+                object_id?: string | null;
+                subject_kind?: components["schemas"]["GrantSubjectKind"] | null;
+                /** @description Filter to one subject (requires subject_kind). */
+                subject_id?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GrantsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    createAccessGrant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GrantCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GrantResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listTagGrants: {
+        parameters: {
+            query?: {
+                object_type?: components["schemas"]["GrantObjectType"] | null;
+                subject_kind?: components["schemas"]["GrantSubjectKind"] | null;
+                /** @description Filter to one subject (requires subject_kind). */
+                subject_id?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TagGrantsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    createTagGrant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TagGrantCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TagGrantResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteTagGrant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The tag grant GlobalID */
+                grant_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listPermissionSets: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PermissionSetsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    getAccessEnforcement: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EnforcementResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listLocalGroups: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    createLocalGroup: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteLocalGroup: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The local group GlobalID */
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    addLocalGroupMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The local group GlobalID */
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MemberCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    removeLocalGroupMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The local group GlobalID */
+                group_id: string;
+                /** @description The user GlobalID to remove */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteAccessGrant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The access grant GlobalID */
+                grant_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listObjectSubjects: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                object_type: components["schemas"]["GrantObjectType"];
+                /** @description The object GlobalID */
+                object_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubjectsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    setResourceTag: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                object_type: components["schemas"]["GrantObjectType"];
+                /** @description The object GlobalID */
+                object_id: string;
+                /** @description The tag key */
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ResourceTagBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceTagResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    removeResourceTag: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                object_type: components["schemas"]["GrantObjectType"];
+                /** @description The object GlobalID */
+                object_id: string;
+                /** @description The tag key */
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listResourceTags: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                object_type: components["schemas"]["GrantObjectType"];
+                /** @description The object GlobalID */
+                object_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceTagsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
     list_annotation_configs_v1_annotation_configs_get: {
         parameters: {
             query?: {
@@ -8718,6 +9942,24 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Conflict */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/app/src/components/ConfirmButton.tsx
+++ b/app/src/components/ConfirmButton.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import type { ReactNode } from "react";
+
+import {
+  Button,
+  Dialog,
+  DialogCloseButton,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTitleExtra,
+  DialogTrigger,
+  Flex,
+  Icon,
+  Icons,
+  Modal,
+  ModalOverlay,
+  Text,
+  View,
+} from "@phoenix/components";
+
+/**
+ * A danger-styled button that requires explicit confirmation before running an
+ * irreversible action. The trigger shows `buttonText`; pressing it opens a modal that
+ * states the consequence and runs `onConfirm` only after the user confirms.
+ */
+export function ConfirmButton({
+  buttonText,
+  buttonAriaLabel,
+  title,
+  message,
+  confirmText = "Confirm",
+  isDisabled,
+  onConfirm,
+}: {
+  buttonText?: string;
+  buttonAriaLabel?: string;
+  title: string;
+  message: ReactNode;
+  confirmText?: string;
+  isDisabled?: boolean;
+  onConfirm: () => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <DialogTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
+      <Button
+        size="S"
+        variant="danger"
+        isDisabled={isDisabled}
+        aria-label={buttonAriaLabel}
+        leadingVisual={<Icon svg={<Icons.Trash />} />}
+      >
+        {buttonText}
+      </Button>
+      <ModalOverlay>
+        <Modal>
+          <Dialog>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>{title}</DialogTitle>
+                <DialogTitleExtra>
+                  <DialogCloseButton slot="close" />
+                </DialogTitleExtra>
+              </DialogHeader>
+              <View padding="size-200">
+                <Text color="danger">{message}</Text>
+              </View>
+              <View
+                paddingEnd="size-200"
+                paddingTop="size-100"
+                paddingBottom="size-100"
+                borderTopColor="default"
+                borderTopWidth="thin"
+              >
+                <Flex direction="row" justifyContent="end" gap="size-100">
+                  <Button
+                    size="S"
+                    variant="default"
+                    onPress={() => setIsOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size="S"
+                    variant="danger"
+                    onPress={() => {
+                      setIsOpen(false);
+                      onConfirm();
+                    }}
+                  >
+                    {confirmText}
+                  </Button>
+                </Flex>
+              </View>
+            </DialogContent>
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
+  );
+}

--- a/app/src/components/auth/CreateAPIKeyDialog.tsx
+++ b/app/src/components/auth/CreateAPIKeyDialog.tsx
@@ -14,6 +14,8 @@ import {
   Flex,
   Input,
   Label,
+  Radio,
+  RadioGroup,
   Text,
   TextArea,
   TextField,
@@ -27,10 +29,18 @@ import {
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
 
+/**
+ * The access scope of the key. "FULL" is the legacy behavior (the key acts
+ * with its owner's role) and is represented as a null scope in the API;
+ * "INGEST" keys can only send traces.
+ */
+export type APIKeyFormScope = "FULL" | "INGEST";
+
 export type APIKeyFormParams = {
   name: string;
   description: string | null;
   expiresAt: DateValue | null;
+  scope: APIKeyFormScope;
 };
 
 /**
@@ -51,6 +61,7 @@ export function CreateAPIKeyDialog(props: {
       name: defaultName ?? "New Key",
       description: "",
       expiresAt: null,
+      scope: "FULL",
     },
   });
 
@@ -117,6 +128,26 @@ export function CreateAPIKeyDialog(props: {
                       </Text>
                     )}
                   </TextField>
+                )}
+              />
+              <Controller
+                name="scope"
+                control={control}
+                render={({ field }) => (
+                  <RadioGroup
+                    {...field}
+                    aria-label="Access scope"
+                    data-testid="api-key-scope-picker"
+                  >
+                    <Label>Access Scope</Label>
+                    <Radio value="FULL">Full access</Radio>
+                    <Radio value="INGEST">Ingest only</Radio>
+                    <Text slot="description">
+                      Ingest-only keys can send traces but cannot read data or
+                      access any other API. The scope cannot be changed after
+                      the key is created.
+                    </Text>
+                  </RadioGroup>
                 )}
               />
               <Controller

--- a/app/src/components/auth/__generated__/GeneratePersonalAPIKeyButtonMutation.graphql.ts
+++ b/app/src/components/auth/__generated__/GeneratePersonalAPIKeyButtonMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ee9f7b5c87995aade65d4fe2eca2e466>>
+ * @generated SignedSource<<37e06abb24bfcbb2db3e3a2cc2995bf5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,10 +9,12 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+export type ApiKeyScope = "INGEST";
 export type CreateUserApiKeyInput = {
   description?: string | null;
   expiresAt?: string | null;
   name: string;
+  scope?: ApiKeyScope | null;
 };
 export type GeneratePersonalAPIKeyButtonMutation$variables = {
   input: CreateUserApiKeyInput;

--- a/app/src/contexts/FunctionalityContext.tsx
+++ b/app/src/contexts/FunctionalityContext.tsx
@@ -9,6 +9,11 @@ export type FunctionalityContextType = {
    * Will be set to true if the platform is deployed with authentication
    */
   authenticationEnabled: boolean;
+  /**
+   * Will be set to true if per-resource access control is enforcing. When false,
+   * grants are not enforced — every authenticated user can see everything.
+   */
+  accessControlEnabled: boolean;
 };
 
 export const FunctionalityContext =
@@ -29,6 +34,7 @@ export function FunctionalityProvider(props: PropsWithChildren) {
     <FunctionalityContext.Provider
       value={{
         authenticationEnabled: window.Config.authenticationEnabled,
+        accessControlEnabled: window.Config.accessControlEnabled,
       }}
     >
       {props.children}

--- a/app/src/contexts/ViewerContext.tsx
+++ b/app/src/contexts/ViewerContext.tsx
@@ -79,6 +79,19 @@ export function useViewerCanDeleteProjectAnnotations() {
   return useIsAdmin();
 }
 
+/**
+ * Returns true if the viewer can manage access control — user groups, object roles, and
+ * project sharing. These are administrator surfaces.
+ * Note: when the app is not configured with auth, we assume the user is an admin.
+ */
+export function useViewerCanManageAccessControl() {
+  const { viewer } = useViewer();
+  if (viewer && viewer?.role?.name !== "ADMIN") {
+    return false;
+  }
+  return true;
+}
+
 export function ViewerProvider({
   query,
   children,

--- a/app/src/pages/access/ResourceAccessForm.tsx
+++ b/app/src/pages/access/ResourceAccessForm.tsx
@@ -1,0 +1,647 @@
+import { css } from "@emotion/react";
+import { useState } from "react";
+import { graphql, useMutation } from "react-relay";
+
+import {
+  Alert,
+  Button,
+  Card,
+  ComboBox,
+  ComboBoxItem,
+  Flex,
+  Icon,
+  Icons,
+  Input,
+  Label,
+  ListBox,
+  Popover,
+  Select,
+  SelectChevronUpDownIcon,
+  SelectItem,
+  SelectValue,
+  Text,
+  TextField,
+  Token,
+  View,
+} from "@phoenix/components";
+import { ConfirmButton } from "@phoenix/components/ConfirmButton";
+import { tableCSS } from "@phoenix/components/table/styles";
+import { useNotifySuccess } from "@phoenix/contexts";
+
+import type { ResourceAccessFormGrantMutation } from "./__generated__/ResourceAccessFormGrantMutation.graphql";
+import type { ResourceAccessFormRemoveTagMutation } from "./__generated__/ResourceAccessFormRemoveTagMutation.graphql";
+import type { ResourceAccessFormRevokeMutation } from "./__generated__/ResourceAccessFormRevokeMutation.graphql";
+import type { ResourceAccessFormSetTagMutation } from "./__generated__/ResourceAccessFormSetTagMutation.graphql";
+
+const pageCSS = css`
+  overflow-y: auto;
+  padding: var(--global-dimension-size-400);
+`;
+
+const modalPageCSS = css`
+  overflow-y: auto;
+  padding: var(--global-dimension-size-200);
+`;
+
+const innerCSS = css`
+  max-width: 800px;
+  min-width: 500px;
+  width: 100%;
+  margin: 0 auto;
+  box-sizing: border-box;
+`;
+
+const addAccessRowCSS = css`
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) minmax(180px, 220px) auto;
+  gap: var(--global-dimension-size-200);
+  align-items: start;
+
+  @media (max-width: 700px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const roleFieldCSS = css`
+  min-width: 0;
+`;
+
+const addTagRowCSS = css`
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(160px, 1fr) auto;
+  gap: var(--global-dimension-size-200);
+  align-items: end;
+
+  @media (max-width: 700px) {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+`;
+
+const tagListCSS = css`
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--global-dimension-size-100);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+const tagTokenCSS = css`
+  font-variant-numeric: tabular-nums;
+  .tag-key {
+    font-weight: 600;
+  }
+  .tag-sep {
+    margin: 0 var(--global-dimension-size-75);
+    opacity: 0.5;
+  }
+`;
+
+const grantButtonCSS = css`
+  margin-top: var(--global-dimension-size-300);
+`;
+
+/**
+ * Which resource a grant targets. Exactly one key is set (the GraphQL input is `@oneOf`),
+ * which also selects the resource noun shown in the UI copy.
+ */
+export type AccessObjectInput =
+  | { projectId: string }
+  | { datasetId: string }
+  | { promptId: string };
+
+/**
+ * A grant subject. Users and groups are identified by their Relay global id; "All users"
+ * (everyone) carries no id. Mirrors the `@oneOf` GraphQL subject input.
+ */
+export type SubjectInput =
+  | { userId: string }
+  | { userGroupId: string }
+  | { isEveryone: true };
+
+export type SubjectItem = { id: string; label: string };
+
+type PermissionSet = {
+  readonly id: string;
+  readonly name: string;
+  readonly permissions: readonly string[];
+};
+
+type AccessGrant = {
+  readonly subjectKind: string;
+  readonly subjectId: string | null;
+  readonly subjectName: string;
+  readonly roleId: string | null;
+  readonly roleName: string;
+};
+
+type ResourceTag = {
+  readonly key: string;
+  readonly value: string;
+};
+
+const EVERYONE = "EVERYONE";
+
+function encodeSubject(kind: "USER" | "GROUP", id: string): string {
+  return `${kind}:${id}`;
+}
+
+/** Build the combobox options (everyone, then people, then groups) from query results. */
+export function buildSubjectItems(
+  users: ReadonlyArray<{
+    readonly id: string;
+    readonly username: string | null;
+    readonly email: string | null;
+  }>,
+  userGroups: ReadonlyArray<{ readonly id: string; readonly name: string }>
+): SubjectItem[] {
+  const items: SubjectItem[] = [
+    { id: EVERYONE, label: "All users · everyone" },
+  ];
+  for (const user of users) {
+    items.push({
+      id: encodeSubject("USER", user.id),
+      label: `${user.email || user.username || "user"} · person`,
+    });
+  }
+  for (const group of userGroups) {
+    items.push({
+      id: encodeSubject("GROUP", group.id),
+      label: `${group.name} · group`,
+    });
+  }
+  return items;
+}
+
+/** A plain-language summary of a permission set, derived from the permissions it confers. */
+function describeRole(permissions: readonly string[]): string {
+  if (permissions.includes("MANAGE_ACCESS")) {
+    return "Can view, edit, and manage who has access";
+  }
+  if (permissions.includes("EDIT")) {
+    return "Can view and edit";
+  }
+  return "Can view";
+}
+
+/** The `SubjectInput` for a stored subject kind + Relay id (e.g. re-identifying a grant). */
+export function subjectInputFromParts(
+  subjectKind: string,
+  subjectId: string | null
+): SubjectInput {
+  if (subjectKind === "EVERYONE") {
+    return { isEveryone: true };
+  }
+  if (subjectKind === "GROUP") {
+    return { userGroupId: subjectId as string };
+  }
+  return { userId: subjectId as string };
+}
+
+export function resolveSelectedSubject(
+  selectedSubject: string
+): SubjectInput | null {
+  if (selectedSubject === EVERYONE) {
+    return { isEveryone: true };
+  }
+  const separatorIndex = selectedSubject.indexOf(":");
+  if (separatorIndex < 0) {
+    return null;
+  }
+  const kind = selectedSubject.slice(0, separatorIndex);
+  const subjectId = selectedSubject.slice(separatorIndex + 1);
+  if (kind === "USER") {
+    return { userId: subjectId };
+  }
+  if (kind === "GROUP") {
+    return { userGroupId: subjectId };
+  }
+  return null;
+}
+
+/** The `SubjectInput` that re-identifies an existing grant for revoke / permission-set change. */
+function grantSubject(grant: AccessGrant): SubjectInput {
+  return subjectInputFromParts(grant.subjectKind, grant.subjectId);
+}
+
+/**
+ * The shared "manage access" surface for a project, dataset, or prompt. Renders the fail-closed
+ * sharing model — admins always have access; everyone else is added by explicit grant — over the
+ * unified access-grant mutations. The owning page supplies the resource, its current grants, the
+ * grantable subjects and permission sets, and search + refetch hooks; the resource noun is taken from `object`.
+ */
+export function ResourceAccessForm({
+  object,
+  grants,
+  tags,
+  permissionSets,
+  subjectItems,
+  onSubjectSearchChange,
+  onRefresh,
+  isModal = false,
+}: {
+  object: AccessObjectInput;
+  grants: ReadonlyArray<AccessGrant>;
+  tags: ReadonlyArray<ResourceTag>;
+  permissionSets: ReadonlyArray<PermissionSet>;
+  subjectItems: ReadonlyArray<SubjectItem>;
+  onSubjectSearchChange: (value: string) => void;
+  onRefresh: () => void;
+  isModal?: boolean;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [selectedSubject, setSelectedSubject] = useState<string | null>(null);
+  const [selectedRoleId, setSelectedRoleId] = useState<string | null>(null);
+  const [newTagKey, setNewTagKey] = useState("");
+  const [newTagValue, setNewTagValue] = useState("");
+  const notifySuccess = useNotifySuccess();
+
+  const [commitGrant, isGranting] =
+    useMutation<ResourceAccessFormGrantMutation>(graphql`
+      mutation ResourceAccessFormGrantMutation($input: AccessGrantInput!) {
+        grantAccess(input: $input) {
+          __typename
+        }
+      }
+    `);
+
+  const [commitRevoke, isRevoking] =
+    useMutation<ResourceAccessFormRevokeMutation>(graphql`
+      mutation ResourceAccessFormRevokeMutation($input: AccessGrantInput!) {
+        revokeAccess(input: $input) {
+          __typename
+        }
+      }
+    `);
+
+  const [commitSetTag, isSettingTag] =
+    useMutation<ResourceAccessFormSetTagMutation>(graphql`
+      mutation ResourceAccessFormSetTagMutation($input: ResourceTagInput!) {
+        setResourceTag(input: $input) {
+          __typename
+        }
+      }
+    `);
+
+  const [commitRemoveTag, isRemovingTag] =
+    useMutation<ResourceAccessFormRemoveTagMutation>(graphql`
+      mutation ResourceAccessFormRemoveTagMutation($input: ResourceTagInput!) {
+        removeResourceTag(input: $input) {
+          __typename
+        }
+      }
+    `);
+
+  const noun =
+    "projectId" in object
+      ? "project"
+      : "datasetId" in object
+        ? "dataset"
+        : "prompt";
+  const isMutating = isGranting || isRevoking;
+  const isMutatingTag = isSettingTag || isRemovingTag;
+  const selectedRole = permissionSets.find(
+    (role) => role.id === selectedRoleId
+  );
+  const selectedRoleDescription = selectedRole
+    ? describeRole(selectedRole.permissions)
+    : "Defaults to Viewer — can view";
+
+  const grantAccess = () => {
+    if (!selectedSubject) return;
+    const subject = resolveSelectedSubject(selectedSubject);
+    if (subject == null) {
+      setError("Could not resolve the selected subject.");
+      return;
+    }
+    setError(null);
+    commitGrant({
+      variables: {
+        input: { object, subject, permissionSetId: selectedRoleId || null },
+      },
+      onCompleted: () => {
+        notifySuccess({
+          title: "Access granted",
+          message: `The subject can now access this ${noun}.`,
+        });
+        setSelectedSubject(null);
+        setSelectedRoleId(null);
+        onRefresh();
+      },
+      onError: (e) => setError(e.message),
+    });
+  };
+
+  const revokeAccess = (subject: SubjectInput) => {
+    setError(null);
+    commitRevoke({
+      variables: { input: { object, subject } },
+      onCompleted: () => {
+        notifySuccess({
+          title: "Access revoked",
+          message: "Access has been removed.",
+        });
+        onRefresh();
+      },
+      onError: (e) => setError(e.message),
+    });
+  };
+
+  const changeRole = (subject: SubjectInput, roleId: string) => {
+    setError(null);
+    commitGrant({
+      variables: { input: { object, subject, permissionSetId: roleId } },
+      onCompleted: () => {
+        notifySuccess({
+          title: "Access updated",
+          message: "The permission set has been changed.",
+        });
+        onRefresh();
+      },
+      onError: (e) => setError(e.message),
+    });
+  };
+
+  const addTag = () => {
+    const key = newTagKey.trim();
+    const value = newTagValue.trim();
+    if (!key || !value) {
+      setError("A tag needs both a key and a value.");
+      return;
+    }
+    setError(null);
+    commitSetTag({
+      variables: { input: { object, key, value } },
+      onCompleted: () => {
+        notifySuccess({
+          title: "Tag added",
+          message: `Tagged this ${noun} with ${key} = ${value}.`,
+        });
+        setNewTagKey("");
+        setNewTagValue("");
+        onRefresh();
+      },
+      onError: (e) => setError(e.message),
+    });
+  };
+
+  const removeTag = (key: string) => {
+    setError(null);
+    commitRemoveTag({
+      variables: { input: { object, key } },
+      onCompleted: () => {
+        notifySuccess({
+          title: "Tag removed",
+          message: `Removed the ${key} tag from this ${noun}.`,
+        });
+        onRefresh();
+      },
+      onError: (e) => setError(e.message),
+    });
+  };
+
+  return (
+    <div css={isModal ? modalPageCSS : pageCSS}>
+      <div css={innerCSS}>
+        <Flex direction="column" gap="size-200">
+          {error && <Alert variant="danger">{error}</Alert>}
+          <Alert variant="info" banner>
+            A {noun} is visible to administrators only until it is shared. Grant
+            people or groups below to give them access; removing every grant
+            returns it to administrators only.
+          </Alert>
+          <Card title="Add access" titleSeparator={false}>
+            <View padding="size-200">
+              <Flex direction="column" gap="size-200">
+                <Text color="text-700">
+                  Choose who should get access, then select the level of access
+                  they should receive.
+                </Text>
+                <div css={addAccessRowCSS}>
+                  <ComboBox
+                    label="Person or group"
+                    placeholder="Search people and groups…"
+                    width="100%"
+                    selectedKey={selectedSubject}
+                    onSelectionChange={(key) =>
+                      setSelectedSubject(key == null ? null : String(key))
+                    }
+                    onInputChange={onSubjectSearchChange}
+                    renderEmptyState={() => "No people or groups found"}
+                  >
+                    {subjectItems.map((item) => (
+                      <ComboBoxItem
+                        key={item.id}
+                        id={item.id}
+                        textValue={item.label}
+                      >
+                        {item.label}
+                      </ComboBoxItem>
+                    ))}
+                  </ComboBox>
+                  <Flex direction="column" gap="size-50" css={roleFieldCSS}>
+                    <Select
+                      value={selectedRoleId ?? undefined}
+                      onChange={(key) =>
+                        setSelectedRoleId(key == null ? null : String(key))
+                      }
+                      placeholder="Viewer"
+                    >
+                      <Label>Permission set</Label>
+                      <Button>
+                        <SelectValue />
+                        <SelectChevronUpDownIcon />
+                      </Button>
+                      <Popover>
+                        <ListBox>
+                          {permissionSets.map((role) => (
+                            <SelectItem key={role.id} id={role.id}>
+                              {role.name}
+                            </SelectItem>
+                          ))}
+                        </ListBox>
+                      </Popover>
+                    </Select>
+                    <Text size="XS" color="text-700">
+                      {selectedRoleDescription}
+                    </Text>
+                  </Flex>
+                  <Button
+                    size="S"
+                    variant="primary"
+                    isDisabled={!selectedSubject || isMutating}
+                    leadingVisual={<Icon svg={<Icons.PlusCircle />} />}
+                    onPress={grantAccess}
+                    css={grantButtonCSS}
+                  >
+                    Grant access
+                  </Button>
+                </div>
+              </Flex>
+            </View>
+          </Card>
+          <Card title={`Who can access this ${noun}`} titleSeparator={false}>
+            <table css={tableCSS}>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Permission set</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <Flex direction="row" gap="size-100" alignItems="center">
+                      <Icon svg={<Icons.Shield />} />
+                      Administrators
+                    </Flex>
+                  </td>
+                  <td>Role</td>
+                  <td>Full access</td>
+                  <td>
+                    <Flex justifyContent="end">
+                      <Text size="XS" color="text-700">
+                        always
+                      </Text>
+                    </Flex>
+                  </td>
+                </tr>
+                {grants.length === 0 ? (
+                  <tr>
+                    <td colSpan={4}>
+                      <View padding="size-200">
+                        <Text color="text-700">
+                          No one else has been granted access — only
+                          administrators can see this {noun}.
+                        </Text>
+                      </View>
+                    </td>
+                  </tr>
+                ) : (
+                  grants.map((grant) => {
+                    const subject = grantSubject(grant);
+                    return (
+                      <tr key={`${grant.subjectKind}:${grant.subjectId}`}>
+                        <td>{grant.subjectName}</td>
+                        <td>
+                          {grant.subjectKind === "USER"
+                            ? "Person"
+                            : grant.subjectKind === "GROUP"
+                              ? "Group"
+                              : "Everyone"}
+                        </td>
+                        <td>
+                          <Select
+                            value={grant.roleId ?? undefined}
+                            onChange={(key) => {
+                              if (key == null) return;
+                              changeRole(subject, String(key));
+                            }}
+                          >
+                            <Label>Permission set</Label>
+                            <Button size="S">
+                              <SelectValue>{grant.roleName}</SelectValue>
+                              <SelectChevronUpDownIcon />
+                            </Button>
+                            <Popover>
+                              <ListBox>
+                                {permissionSets.map((role) => (
+                                  <SelectItem key={role.id} id={role.id}>
+                                    {role.name}
+                                  </SelectItem>
+                                ))}
+                              </ListBox>
+                            </Popover>
+                          </Select>
+                        </td>
+                        <td>
+                          <Flex justifyContent="end">
+                            <ConfirmButton
+                              buttonText="Remove"
+                              title="Remove access"
+                              message={`Remove ${grant.subjectName}'s access to this ${noun}?`}
+                              confirmText="Remove access"
+                              isDisabled={isMutating}
+                              onConfirm={() => revokeAccess(subject)}
+                            />
+                          </Flex>
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </Card>
+          <Card
+            title="Tags"
+            subTitle={`Curated key=value labels on this ${noun}. A tag grant (Settings › Access) can then grant a person or group access to every ${noun} carrying a given tag.`}
+            titleSeparator={false}
+          >
+            <View padding="size-200">
+              <Flex direction="column" gap="size-200">
+                <div css={addTagRowCSS}>
+                  <TextField value={newTagKey} onChange={setNewTagKey}>
+                    <Label>Key</Label>
+                    <Input placeholder="e.g. env" />
+                  </TextField>
+                  <TextField value={newTagValue} onChange={setNewTagValue}>
+                    <Label>Value</Label>
+                    <Input placeholder="e.g. prod" />
+                  </TextField>
+                  <Button
+                    size="S"
+                    variant="primary"
+                    isDisabled={
+                      !newTagKey.trim() || !newTagValue.trim() || isMutatingTag
+                    }
+                    leadingVisual={<Icon svg={<Icons.PlusCircle />} />}
+                    onPress={addTag}
+                  >
+                    Add tag
+                  </Button>
+                </div>
+                {tags.length === 0 ? (
+                  <Text color="text-700">
+                    No tags yet. Tags let a single grant cover many {noun}s at
+                    once.
+                  </Text>
+                ) : (
+                  <Flex direction="column" gap="size-100">
+                    <Text size="XS" color="text-500">
+                      {tags.length} tag{tags.length === 1 ? "" : "s"} on this{" "}
+                      {noun}
+                    </Text>
+                    <ul css={tagListCSS}>
+                      {tags.map((tag) => (
+                        <li key={tag.key}>
+                          <Token
+                            size="L"
+                            color="var(--global-color-blue-700)"
+                            css={tagTokenCSS}
+                            onRemove={
+                              isMutatingTag
+                                ? undefined
+                                : () => removeTag(tag.key)
+                            }
+                          >
+                            <span className="tag-key">{tag.key}</span>
+                            <span className="tag-sep">=</span>
+                            {tag.value}
+                          </Token>
+                        </li>
+                      ))}
+                    </ul>
+                  </Flex>
+                )}
+              </Flex>
+            </View>
+          </Card>
+        </Flex>
+      </div>
+    </div>
+  );
+}

--- a/app/src/pages/access/__generated__/ResourceAccessFormGrantMutation.graphql.ts
+++ b/app/src/pages/access/__generated__/ResourceAccessFormGrantMutation.graphql.ts
@@ -1,0 +1,104 @@
+/**
+ * @generated SignedSource<<b686c1b60afc73f12d69d4b3a117e418>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AccessGrantInput = {
+  object: AccessGrantObjectInput;
+  permissionSetId?: string | null;
+  subject: AccessGrantSubjectInput;
+};
+export type AccessGrantSubjectInput = {
+  isEveryone?: boolean | null;
+  userGroupId?: string | null;
+  userId?: string | null;
+};
+export type AccessGrantObjectInput = {
+  datasetId?: string | null;
+  projectId?: string | null;
+  promptId?: string | null;
+};
+export type ResourceAccessFormGrantMutation$variables = {
+  input: AccessGrantInput;
+};
+export type ResourceAccessFormGrantMutation$data = {
+  readonly grantAccess: {
+    readonly __typename: "AccessGrantMutationPayload";
+  };
+};
+export type ResourceAccessFormGrantMutation = {
+  response: ResourceAccessFormGrantMutation$data;
+  variables: ResourceAccessFormGrantMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "AccessGrantMutationPayload",
+    "kind": "LinkedField",
+    "name": "grantAccess",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ResourceAccessFormGrantMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ResourceAccessFormGrantMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "194a2ca9a6ad13cf41ec30f2753f6f80",
+    "id": null,
+    "metadata": {},
+    "name": "ResourceAccessFormGrantMutation",
+    "operationKind": "mutation",
+    "text": "mutation ResourceAccessFormGrantMutation(\n  $input: AccessGrantInput!\n) {\n  grantAccess(input: $input) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "a1b229182ea96a373c5f1ff4777009cf";
+
+export default node;

--- a/app/src/pages/access/__generated__/ResourceAccessFormRemoveTagMutation.graphql.ts
+++ b/app/src/pages/access/__generated__/ResourceAccessFormRemoveTagMutation.graphql.ts
@@ -1,0 +1,99 @@
+/**
+ * @generated SignedSource<<759ada9658f6eeb55d4b3c1396c48273>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ResourceTagInput = {
+  key: string;
+  object: AccessGrantObjectInput;
+  value?: string | null;
+};
+export type AccessGrantObjectInput = {
+  datasetId?: string | null;
+  projectId?: string | null;
+  promptId?: string | null;
+};
+export type ResourceAccessFormRemoveTagMutation$variables = {
+  input: ResourceTagInput;
+};
+export type ResourceAccessFormRemoveTagMutation$data = {
+  readonly removeResourceTag: {
+    readonly __typename: "AccessGrantMutationPayload";
+  };
+};
+export type ResourceAccessFormRemoveTagMutation = {
+  response: ResourceAccessFormRemoveTagMutation$data;
+  variables: ResourceAccessFormRemoveTagMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "AccessGrantMutationPayload",
+    "kind": "LinkedField",
+    "name": "removeResourceTag",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ResourceAccessFormRemoveTagMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ResourceAccessFormRemoveTagMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "e44c9eae1f9765beec1e83620392bf1e",
+    "id": null,
+    "metadata": {},
+    "name": "ResourceAccessFormRemoveTagMutation",
+    "operationKind": "mutation",
+    "text": "mutation ResourceAccessFormRemoveTagMutation(\n  $input: ResourceTagInput!\n) {\n  removeResourceTag(input: $input) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "2e3c6a3b6fd988ef233dfe2866da1615";
+
+export default node;

--- a/app/src/pages/access/__generated__/ResourceAccessFormRevokeMutation.graphql.ts
+++ b/app/src/pages/access/__generated__/ResourceAccessFormRevokeMutation.graphql.ts
@@ -1,0 +1,104 @@
+/**
+ * @generated SignedSource<<e4850e91d1fd53e060ec6749c14195d1>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AccessGrantInput = {
+  object: AccessGrantObjectInput;
+  permissionSetId?: string | null;
+  subject: AccessGrantSubjectInput;
+};
+export type AccessGrantSubjectInput = {
+  isEveryone?: boolean | null;
+  userGroupId?: string | null;
+  userId?: string | null;
+};
+export type AccessGrantObjectInput = {
+  datasetId?: string | null;
+  projectId?: string | null;
+  promptId?: string | null;
+};
+export type ResourceAccessFormRevokeMutation$variables = {
+  input: AccessGrantInput;
+};
+export type ResourceAccessFormRevokeMutation$data = {
+  readonly revokeAccess: {
+    readonly __typename: "AccessGrantMutationPayload";
+  };
+};
+export type ResourceAccessFormRevokeMutation = {
+  response: ResourceAccessFormRevokeMutation$data;
+  variables: ResourceAccessFormRevokeMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "AccessGrantMutationPayload",
+    "kind": "LinkedField",
+    "name": "revokeAccess",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ResourceAccessFormRevokeMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ResourceAccessFormRevokeMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "be144c62c36a69c7286bdf7bb532f946",
+    "id": null,
+    "metadata": {},
+    "name": "ResourceAccessFormRevokeMutation",
+    "operationKind": "mutation",
+    "text": "mutation ResourceAccessFormRevokeMutation(\n  $input: AccessGrantInput!\n) {\n  revokeAccess(input: $input) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "df533f0b158adcb6f6f80a404d562be9";
+
+export default node;

--- a/app/src/pages/access/__generated__/ResourceAccessFormSetTagMutation.graphql.ts
+++ b/app/src/pages/access/__generated__/ResourceAccessFormSetTagMutation.graphql.ts
@@ -1,0 +1,99 @@
+/**
+ * @generated SignedSource<<8cb99f57917ce508464c719753ac5c45>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ResourceTagInput = {
+  key: string;
+  object: AccessGrantObjectInput;
+  value?: string | null;
+};
+export type AccessGrantObjectInput = {
+  datasetId?: string | null;
+  projectId?: string | null;
+  promptId?: string | null;
+};
+export type ResourceAccessFormSetTagMutation$variables = {
+  input: ResourceTagInput;
+};
+export type ResourceAccessFormSetTagMutation$data = {
+  readonly setResourceTag: {
+    readonly __typename: "AccessGrantMutationPayload";
+  };
+};
+export type ResourceAccessFormSetTagMutation = {
+  response: ResourceAccessFormSetTagMutation$data;
+  variables: ResourceAccessFormSetTagMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "AccessGrantMutationPayload",
+    "kind": "LinkedField",
+    "name": "setResourceTag",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ResourceAccessFormSetTagMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ResourceAccessFormSetTagMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "c4ca65ad8f2be2fd5d0ab2df7bbbef20",
+    "id": null,
+    "metadata": {},
+    "name": "ResourceAccessFormSetTagMutation",
+    "operationKind": "mutation",
+    "text": "mutation ResourceAccessFormSetTagMutation(\n  $input: ResourceTagInput!\n) {\n  setResourceTag(input: $input) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "82fb5a6995b38554e2ea4256bfec3bcd";
+
+export default node;

--- a/app/src/pages/datasets/DatasetAccessPage.tsx
+++ b/app/src/pages/datasets/DatasetAccessPage.tsx
@@ -1,0 +1,79 @@
+import { useDeferredValue, useState } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+
+import {
+  buildSubjectItems,
+  ResourceAccessForm,
+} from "@phoenix/pages/access/ResourceAccessForm";
+
+import type { DatasetAccessPageQuery } from "./__generated__/DatasetAccessPageQuery.graphql";
+
+export function DatasetAccessPageContent({ datasetId }: { datasetId: string }) {
+  const [fetchKey, setFetchKey] = useState(0);
+  const [subjectSearch, setSubjectSearch] = useState("");
+  const deferredSubjectSearch = useDeferredValue(subjectSearch.trim());
+
+  const data = useLazyLoadQuery<DatasetAccessPageQuery>(
+    graphql`
+      query DatasetAccessPageQuery($datasetId: ID!, $userFilter: UserFilter) {
+        dataset: node(id: $datasetId) {
+          ... on Dataset {
+            id
+            accessGrants {
+              subjectKind
+              subjectId
+              subjectName
+              roleId
+              roleName
+            }
+          }
+        }
+        users(first: 25, filter: $userFilter) {
+          edges {
+            user: node {
+              id
+              username
+              email
+            }
+          }
+        }
+        userGroups {
+          id
+          name
+        }
+        permissionSets {
+          id
+          name
+          permissions
+        }
+        resourceTags(objectType: DATASET, objectId: $datasetId) {
+          key
+          value
+        }
+      }
+    `,
+    {
+      datasetId,
+      userFilter: deferredSubjectSearch
+        ? { value: deferredSubjectSearch }
+        : null,
+    },
+    { fetchKey, fetchPolicy: "store-and-network" }
+  );
+
+  return (
+    <ResourceAccessForm
+      object={{ datasetId }}
+      grants={data.dataset?.accessGrants ?? []}
+      tags={data.resourceTags}
+      permissionSets={data.permissionSets}
+      subjectItems={buildSubjectItems(
+        data.users.edges.map((edge) => edge.user),
+        data.userGroups
+      )}
+      onSubjectSearchChange={setSubjectSearch}
+      onRefresh={() => setFetchKey((key) => key + 1)}
+      isModal
+    />
+  );
+}

--- a/app/src/pages/datasets/DatasetActionMenu.tsx
+++ b/app/src/pages/datasets/DatasetActionMenu.tsx
@@ -4,6 +4,7 @@ import { SubmenuTrigger } from "react-aria-components";
 
 import {
   Button,
+  Dialog,
   Flex,
   Icon,
   Icons,
@@ -11,13 +12,25 @@ import {
   Menu,
   MenuItem,
   MenuTrigger,
+  Modal,
+  ModalOverlay,
   Popover,
   PopoverArrow,
   Text,
 } from "@phoenix/components";
+import {
+  DialogCloseButton,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTitleExtra,
+} from "@phoenix/components/core/dialog";
 import { DatasetLabelSelectionContent } from "@phoenix/components/dataset/DatasetLabelConfigButton";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
+import { useViewerCanManageAccessControl } from "@phoenix/contexts";
+import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
 
+import { DatasetAccessPageContent } from "./DatasetAccessPage";
 import { DeleteDatasetDialog } from "./DeleteDatasetDialog";
 import { EditDatasetDialog } from "./EditDatasetDialog";
 type DatasetActionMenuProps = {
@@ -33,6 +46,7 @@ enum DatasetAction {
   DELETE = "deleteDataset",
   EDIT = "editDataset",
   LABELS = "configureLabels",
+  MANAGE_ACCESS = "manageAccess",
 }
 
 export function DatasetActionMenu(props: DatasetActionMenuProps) {
@@ -44,6 +58,10 @@ export function DatasetActionMenu(props: DatasetActionMenuProps) {
     onDatasetDelete,
     onDatasetEdit,
   } = props;
+  const canManageAccessControl = useViewerCanManageAccessControl();
+  const { accessControlEnabled } = useFunctionality();
+  const canShowManageAccess = accessControlEnabled && canManageAccessControl;
+  const [showManageAccessDialog, setShowManageAccessDialog] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
 
@@ -64,6 +82,9 @@ export function DatasetActionMenu(props: DatasetActionMenuProps) {
                   break;
                 case DatasetAction.EDIT:
                   setIsEditOpen(true);
+                  break;
+                case DatasetAction.MANAGE_ACCESS:
+                  setShowManageAccessDialog(true);
                   break;
               }
             }}
@@ -113,6 +134,22 @@ export function DatasetActionMenu(props: DatasetActionMenuProps) {
                 </Suspense>
               </Popover>
             </SubmenuTrigger>
+            {canShowManageAccess ? (
+              <MenuItem
+                id={DatasetAction.MANAGE_ACCESS}
+                textValue="Manage access"
+              >
+                <Flex
+                  direction={"row"}
+                  gap="size-75"
+                  justifyContent={"start"}
+                  alignItems={"center"}
+                >
+                  <Icon svg={<Icons.Shield />} />
+                  <Text>Manage Access</Text>
+                </Flex>
+              </MenuItem>
+            ) : null}
             <MenuItem id={DatasetAction.DELETE}>
               <Flex
                 direction={"row"}
@@ -127,6 +164,27 @@ export function DatasetActionMenu(props: DatasetActionMenuProps) {
           </Menu>
         </Popover>
       </MenuTrigger>
+
+      <ModalOverlay
+        isOpen={showManageAccessDialog}
+        onOpenChange={setShowManageAccessDialog}
+      >
+        <Modal variant="slideover" size="L">
+          <Dialog>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Manage Access</DialogTitle>
+                <DialogTitleExtra>
+                  <DialogCloseButton />
+                </DialogTitleExtra>
+              </DialogHeader>
+              <Suspense fallback={<Loading />}>
+                <DatasetAccessPageContent datasetId={datasetId} />
+              </Suspense>
+            </DialogContent>
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
 
       {/* Delete Dataset Dialog */}
       <DeleteDatasetDialog

--- a/app/src/pages/datasets/__generated__/DatasetAccessPageQuery.graphql.ts
+++ b/app/src/pages/datasets/__generated__/DatasetAccessPageQuery.graphql.ts
@@ -1,0 +1,355 @@
+/**
+ * @generated SignedSource<<e2e8939b3d15a134a5471921e53859bc>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AccessSubjectKind = "EVERYONE" | "GROUP" | "USER";
+export type ObjectPermission = "EDIT" | "MANAGE_ACCESS" | "VIEW";
+export type UserFilter = {
+  value?: string | null;
+};
+export type DatasetAccessPageQuery$variables = {
+  datasetId: string;
+  userFilter?: UserFilter | null;
+};
+export type DatasetAccessPageQuery$data = {
+  readonly dataset: {
+    readonly accessGrants?: ReadonlyArray<{
+      readonly roleId: string | null;
+      readonly roleName: string;
+      readonly subjectId: string | null;
+      readonly subjectKind: AccessSubjectKind;
+      readonly subjectName: string;
+    }>;
+    readonly id?: string;
+  };
+  readonly permissionSets: ReadonlyArray<{
+    readonly id: string;
+    readonly name: string;
+    readonly permissions: ReadonlyArray<ObjectPermission>;
+  }>;
+  readonly resourceTags: ReadonlyArray<{
+    readonly key: string;
+    readonly value: string;
+  }>;
+  readonly userGroups: ReadonlyArray<{
+    readonly id: string;
+    readonly name: string;
+  }>;
+  readonly users: {
+    readonly edges: ReadonlyArray<{
+      readonly user: {
+        readonly email: string | null;
+        readonly id: string;
+        readonly username: string;
+      };
+    }>;
+  };
+};
+export type DatasetAccessPageQuery = {
+  response: DatasetAccessPageQuery$data;
+  variables: DatasetAccessPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "datasetId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "userFilter"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "datasetId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "AccessGrant",
+  "kind": "LinkedField",
+  "name": "accessGrants",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "subjectKind",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "subjectId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "subjectName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "roleId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "roleName",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "filter",
+      "variableName": "userFilter"
+    },
+    {
+      "kind": "Literal",
+      "name": "first",
+      "value": 25
+    }
+  ],
+  "concreteType": "UserConnection",
+  "kind": "LinkedField",
+  "name": "users",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "UserEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": "user",
+          "args": null,
+          "concreteType": "User",
+          "kind": "LinkedField",
+          "name": "node",
+          "plural": false,
+          "selections": [
+            (v2/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "username",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "email",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "UserGroup",
+  "kind": "LinkedField",
+  "name": "userGroups",
+  "plural": true,
+  "selections": [
+    (v2/*: any*/),
+    (v5/*: any*/)
+  ],
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PermissionSet",
+  "kind": "LinkedField",
+  "name": "permissionSets",
+  "plural": true,
+  "selections": [
+    (v2/*: any*/),
+    (v5/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "permissions",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "objectId",
+      "variableName": "datasetId"
+    },
+    {
+      "kind": "Literal",
+      "name": "objectType",
+      "value": "DATASET"
+    }
+  ],
+  "concreteType": "ResourceTag",
+  "kind": "LinkedField",
+  "name": "resourceTags",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "key",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "value",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "DatasetAccessPageQuery",
+    "selections": [
+      {
+        "alias": "dataset",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ],
+            "type": "Dataset",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      (v4/*: any*/),
+      (v6/*: any*/),
+      (v7/*: any*/),
+      (v8/*: any*/)
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "DatasetAccessPageQuery",
+    "selections": [
+      {
+        "alias": "dataset",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/)
+            ],
+            "type": "Dataset",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      (v4/*: any*/),
+      (v6/*: any*/),
+      (v7/*: any*/),
+      (v8/*: any*/)
+    ]
+  },
+  "params": {
+    "cacheID": "67886716fb99c0c1c3699c3ed315a944",
+    "id": null,
+    "metadata": {},
+    "name": "DatasetAccessPageQuery",
+    "operationKind": "query",
+    "text": "query DatasetAccessPageQuery(\n  $datasetId: ID!\n  $userFilter: UserFilter\n) {\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      id\n      accessGrants {\n        subjectKind\n        subjectId\n        subjectName\n        roleId\n        roleName\n      }\n    }\n    id\n  }\n  users(first: 25, filter: $userFilter) {\n    edges {\n      user: node {\n        id\n        username\n        email\n      }\n    }\n  }\n  userGroups {\n    id\n    name\n  }\n  permissionSets {\n    id\n    name\n    permissions\n  }\n  resourceTags(objectType: DATASET, objectId: $datasetId) {\n    key\n    value\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "bcbb5e9c8f11375c3b3ddfd31d2167c0";
+
+export default node;

--- a/app/src/pages/profile/ViewerAPIKeys.tsx
+++ b/app/src/pages/profile/ViewerAPIKeys.tsx
@@ -56,9 +56,11 @@ export function ViewerAPIKeys({
       commit({
         variables: {
           input: {
-            ...data,
+            name: data.name,
+            description: data.description,
             expiresAt:
               data.expiresAt?.toDate(getLocalTimeZone()).toISOString() || null,
+            scope: data.scope === "INGEST" ? "INGEST" : null,
           },
         },
         onCompleted: (response) => {

--- a/app/src/pages/profile/__generated__/ViewerAPIKeysCreateUserAPIKeyMutation.graphql.ts
+++ b/app/src/pages/profile/__generated__/ViewerAPIKeysCreateUserAPIKeyMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a3a67add4969785c6f11680dbba4c644>>
+ * @generated SignedSource<<982a4ec2c0694338f2e7e8352f96ddc2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,10 +10,12 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
+export type ApiKeyScope = "INGEST";
 export type CreateUserApiKeyInput = {
   description?: string | null;
   expiresAt?: string | null;
   name: string;
+  scope?: ApiKeyScope | null;
 };
 export type ViewerAPIKeysCreateUserAPIKeyMutation$variables = {
   input: CreateUserApiKeyInput;

--- a/app/src/pages/project/ProjectAccessPage.tsx
+++ b/app/src/pages/project/ProjectAccessPage.tsx
@@ -1,0 +1,98 @@
+import { useDeferredValue, useState } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+import { Navigate, useParams } from "react-router";
+
+import { useViewerCanManageAccessControl } from "@phoenix/contexts";
+import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
+import {
+  buildSubjectItems,
+  ResourceAccessForm,
+} from "@phoenix/pages/access/ResourceAccessForm";
+
+import type { ProjectAccessPageQuery } from "./__generated__/ProjectAccessPageQuery.graphql";
+
+export function ProjectAccessPage() {
+  const { projectId } = useParams();
+  const canManageAccessControl = useViewerCanManageAccessControl();
+  const { accessControlEnabled } = useFunctionality();
+  if (!accessControlEnabled || !canManageAccessControl) {
+    return <Navigate to={`/projects/${projectId}/spans`} replace />;
+  }
+  return <ProjectAccessPageContent projectId={projectId as string} />;
+}
+
+export function ProjectAccessPageContent({
+  projectId,
+  isModal = false,
+}: {
+  projectId: string;
+  isModal?: boolean;
+}) {
+  const [fetchKey, setFetchKey] = useState(0);
+  const [subjectSearch, setSubjectSearch] = useState("");
+  const deferredSubjectSearch = useDeferredValue(subjectSearch.trim());
+
+  const data = useLazyLoadQuery<ProjectAccessPageQuery>(
+    graphql`
+      query ProjectAccessPageQuery($projectId: ID!, $userFilter: UserFilter) {
+        project: node(id: $projectId) {
+          ... on Project {
+            id
+            accessGrants {
+              subjectKind
+              subjectId
+              subjectName
+              roleId
+              roleName
+            }
+          }
+        }
+        users(first: 25, filter: $userFilter) {
+          edges {
+            user: node {
+              id
+              username
+              email
+            }
+          }
+        }
+        userGroups {
+          id
+          name
+        }
+        permissionSets {
+          id
+          name
+          permissions
+        }
+        resourceTags(objectType: PROJECT, objectId: $projectId) {
+          key
+          value
+        }
+      }
+    `,
+    {
+      projectId,
+      userFilter: deferredSubjectSearch
+        ? { value: deferredSubjectSearch }
+        : null,
+    },
+    { fetchKey, fetchPolicy: "store-and-network" }
+  );
+
+  return (
+    <ResourceAccessForm
+      object={{ projectId }}
+      grants={data.project?.accessGrants ?? []}
+      tags={data.resourceTags}
+      permissionSets={data.permissionSets}
+      subjectItems={buildSubjectItems(
+        data.users.edges.map((edge) => edge.user),
+        data.userGroups
+      )}
+      onSubjectSearchChange={setSubjectSearch}
+      onRefresh={() => setFetchKey((key) => key + 1)}
+      isModal={isModal}
+    />
+  );
+}

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -8,7 +8,13 @@ import {
   useMemo,
 } from "react";
 import { graphql, useLazyLoadQuery, useQueryLoader } from "react-relay";
-import { Outlet, useLocation, useNavigate, useParams } from "react-router";
+import {
+  Navigate,
+  Outlet,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router";
 
 import { LazyTabPanel, Loading, Tab, TabList, Tabs } from "@phoenix/components";
 import {
@@ -16,6 +22,8 @@ import {
   useTimeRange,
 } from "@phoenix/components/datetime";
 import { TopNavActions } from "@phoenix/components/nav";
+import { useViewerCanManageAccessControl } from "@phoenix/contexts";
+import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
 import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 import { StreamStateProvider } from "@phoenix/contexts/StreamStateContext";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
@@ -83,7 +91,14 @@ export function ProjectPage() {
   );
 }
 
-const TABS = ["spans", "traces", "sessions", "config", "metrics"] as const;
+const TABS = [
+  "spans",
+  "traces",
+  "sessions",
+  "config",
+  "metrics",
+  "access",
+] as const;
 
 /**
  * Type guard for the tab path in the URL
@@ -98,6 +113,7 @@ const TAB_INDEX_MAP: Record<(typeof TABS)[number], number> = {
   sessions: 2,
   metrics: 3,
   config: 4,
+  access: 5,
 };
 
 const TAB_PATH_BY_INDEX = Object.fromEntries(
@@ -136,6 +152,9 @@ function ProjectPageContentBody({
   }, [timeRange]);
   const navigate = useNavigate();
   const { rootPath, tab } = useProjectRootPath();
+  const canManageAccessControl = useViewerCanManageAccessControl();
+  const { accessControlEnabled } = useFunctionality();
+  const canShowAccessControl = accessControlEnabled && canManageAccessControl;
   const data = useLazyLoadQuery<ProjectPageQueryType>(
     graphql`
       query ProjectPageQuery($id: ID!, $timeRange: TimeRange!) {
@@ -220,6 +239,10 @@ function ProjectPageContentBody({
     [location.hash, location.search, navigate, rootPath]
   );
 
+  if (tab === "access" && !canShowAccessControl) {
+    return <Navigate to={`${rootPath}/spans`} replace />;
+  }
+
   return (
     <main css={mainCSS}>
       <TopNavActions order={1}>
@@ -247,6 +270,7 @@ function ProjectPageContentBody({
             <Tab id="sessions">Sessions</Tab>
             <Tab id="metrics">Metrics</Tab>
             <Tab id="config">Config</Tab>
+            {canShowAccessControl && <Tab id="access">Access</Tab>}
           </TabList>
           <LazyTabPanel padded={false} id="spans">
             <Outlet />
@@ -261,6 +285,9 @@ function ProjectPageContentBody({
             <Outlet />
           </LazyTabPanel>
           <LazyTabPanel padded={false} id="config">
+            <Outlet />
+          </LazyTabPanel>
+          <LazyTabPanel padded={false} id="access">
             <Outlet />
           </LazyTabPanel>
         </Tabs>

--- a/app/src/pages/project/__generated__/ProjectAccessPageQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectAccessPageQuery.graphql.ts
@@ -1,0 +1,355 @@
+/**
+ * @generated SignedSource<<c3f80567c546bcbe9b5e10c47aca476c>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AccessSubjectKind = "EVERYONE" | "GROUP" | "USER";
+export type ObjectPermission = "EDIT" | "MANAGE_ACCESS" | "VIEW";
+export type UserFilter = {
+  value?: string | null;
+};
+export type ProjectAccessPageQuery$variables = {
+  projectId: string;
+  userFilter?: UserFilter | null;
+};
+export type ProjectAccessPageQuery$data = {
+  readonly permissionSets: ReadonlyArray<{
+    readonly id: string;
+    readonly name: string;
+    readonly permissions: ReadonlyArray<ObjectPermission>;
+  }>;
+  readonly project: {
+    readonly accessGrants?: ReadonlyArray<{
+      readonly roleId: string | null;
+      readonly roleName: string;
+      readonly subjectId: string | null;
+      readonly subjectKind: AccessSubjectKind;
+      readonly subjectName: string;
+    }>;
+    readonly id?: string;
+  };
+  readonly resourceTags: ReadonlyArray<{
+    readonly key: string;
+    readonly value: string;
+  }>;
+  readonly userGroups: ReadonlyArray<{
+    readonly id: string;
+    readonly name: string;
+  }>;
+  readonly users: {
+    readonly edges: ReadonlyArray<{
+      readonly user: {
+        readonly email: string | null;
+        readonly id: string;
+        readonly username: string;
+      };
+    }>;
+  };
+};
+export type ProjectAccessPageQuery = {
+  response: ProjectAccessPageQuery$data;
+  variables: ProjectAccessPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "projectId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "userFilter"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "AccessGrant",
+  "kind": "LinkedField",
+  "name": "accessGrants",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "subjectKind",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "subjectId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "subjectName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "roleId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "roleName",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "filter",
+      "variableName": "userFilter"
+    },
+    {
+      "kind": "Literal",
+      "name": "first",
+      "value": 25
+    }
+  ],
+  "concreteType": "UserConnection",
+  "kind": "LinkedField",
+  "name": "users",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "UserEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": "user",
+          "args": null,
+          "concreteType": "User",
+          "kind": "LinkedField",
+          "name": "node",
+          "plural": false,
+          "selections": [
+            (v2/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "username",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "email",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "UserGroup",
+  "kind": "LinkedField",
+  "name": "userGroups",
+  "plural": true,
+  "selections": [
+    (v2/*: any*/),
+    (v5/*: any*/)
+  ],
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PermissionSet",
+  "kind": "LinkedField",
+  "name": "permissionSets",
+  "plural": true,
+  "selections": [
+    (v2/*: any*/),
+    (v5/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "permissions",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "objectId",
+      "variableName": "projectId"
+    },
+    {
+      "kind": "Literal",
+      "name": "objectType",
+      "value": "PROJECT"
+    }
+  ],
+  "concreteType": "ResourceTag",
+  "kind": "LinkedField",
+  "name": "resourceTags",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "key",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "value",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectAccessPageQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      (v4/*: any*/),
+      (v6/*: any*/),
+      (v7/*: any*/),
+      (v8/*: any*/)
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ProjectAccessPageQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      (v4/*: any*/),
+      (v6/*: any*/),
+      (v7/*: any*/),
+      (v8/*: any*/)
+    ]
+  },
+  "params": {
+    "cacheID": "f189de63fd0ab404d78ceca4deb2e9d4",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectAccessPageQuery",
+    "operationKind": "query",
+    "text": "query ProjectAccessPageQuery(\n  $projectId: ID!\n  $userFilter: UserFilter\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      id\n      accessGrants {\n        subjectKind\n        subjectId\n        subjectName\n        roleId\n        roleName\n      }\n    }\n    id\n  }\n  users(first: 25, filter: $userFilter) {\n    edges {\n      user: node {\n        id\n        username\n        email\n      }\n    }\n  }\n  userGroups {\n    id\n    name\n  }\n  permissionSets {\n    id\n    name\n    permissions\n  }\n  resourceTags(objectType: PROJECT, objectId: $projectId) {\n    key\n    value\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "cf8d18fd67c7073f050b7dc8cbb51127";
+
+export default node;

--- a/app/src/pages/projects/ProjectActionMenu.tsx
+++ b/app/src/pages/projects/ProjectActionMenu.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useCallback, useState } from "react";
+import { startTransition, Suspense, useCallback, useState } from "react";
 import { graphql, useMutation } from "react-relay";
 
 import {
@@ -7,6 +7,7 @@ import {
   Flex,
   Icon,
   Icons,
+  Loading,
   Menu,
   MenuItem,
   MenuTrigger,
@@ -24,7 +25,12 @@ import {
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
-import { useNotifySuccess } from "@phoenix/contexts";
+import {
+  useNotifySuccess,
+  useViewerCanManageAccessControl,
+} from "@phoenix/contexts";
+import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
+import { ProjectAccessPageContent } from "@phoenix/pages/project/ProjectAccessPage";
 
 import type { ProjectActionMenuClearMutation } from "./__generated__/ProjectActionMenuClearMutation.graphql";
 import type { ProjectActionMenuDeleteMutation } from "./__generated__/ProjectActionMenuDeleteMutation.graphql";
@@ -32,6 +38,7 @@ import { RemoveProjectDataForm } from "./RemoveProjectDataForm";
 
 enum ProjectAction {
   COPY_NAME = "copyName",
+  MANAGE_ACCESS = "manageAccess",
   DELETE = "deleteProject",
   CLEAR = "clearProject",
   REMOVE_DATA = "removeProjectData",
@@ -51,6 +58,10 @@ export function ProjectActionMenu({
   onProjectDelete: () => void;
 }) {
   const notifySuccess = useNotifySuccess();
+  const canManageAccessControl = useViewerCanManageAccessControl();
+  const { accessControlEnabled } = useFunctionality();
+  const canShowManageAccess = accessControlEnabled && canManageAccessControl;
+  const [showManageAccessDialog, setShowManageAccessDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showClearDialog, setShowClearDialog] = useState(false);
   const [showRemoveDataDialog, setShowRemoveDataDialog] = useState(false);
@@ -134,6 +145,10 @@ export function ProjectActionMenu({
                 case ProjectAction.DELETE: {
                   return onDelete();
                 }
+                case ProjectAction.MANAGE_ACCESS: {
+                  setShowManageAccessDialog(true);
+                  return;
+                }
                 case ProjectAction.CLEAR: {
                   return onClear();
                 }
@@ -155,6 +170,22 @@ export function ProjectActionMenu({
                 <Text>Copy Name</Text>
               </Flex>
             </MenuItem>
+            {canShowManageAccess ? (
+              <MenuItem
+                id={ProjectAction.MANAGE_ACCESS}
+                textValue="Manage access"
+              >
+                <Flex
+                  direction={"row"}
+                  gap="size-75"
+                  justifyContent={"start"}
+                  alignItems={"center"}
+                >
+                  <Icon svg={<Icons.Shield />} />
+                  <Text>Manage Access</Text>
+                </Flex>
+              </MenuItem>
+            ) : null}
             <MenuItem id={ProjectAction.CLEAR} textValue="Clear All Traces">
               <Flex
                 direction={"row"}
@@ -193,6 +224,26 @@ export function ProjectActionMenu({
           </Menu>
         </Popover>
       </MenuTrigger>
+      <ModalOverlay
+        isOpen={showManageAccessDialog}
+        onOpenChange={setShowManageAccessDialog}
+      >
+        <Modal variant="slideover" size="L">
+          <Dialog>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Manage Access</DialogTitle>
+                <DialogTitleExtra>
+                  <DialogCloseButton />
+                </DialogTitleExtra>
+              </DialogHeader>
+              <Suspense fallback={<Loading />}>
+                <ProjectAccessPageContent projectId={projectId} isModal />
+              </Suspense>
+            </DialogContent>
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
       <ModalOverlay
         isOpen={showDeleteDialog}
         onOpenChange={setShowDeleteDialog}

--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -62,6 +62,7 @@ import {
   usePreferencesContext,
   useViewerCanModify,
 } from "@phoenix/contexts";
+import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
 import { useInterval } from "@phoenix/hooks";
 import type {
   ProjectsPageProjectMetricsQuery,
@@ -187,6 +188,7 @@ export function ProjectsPageContent({
             project: node {
               id
               name
+              accessPosture
               gradientStartColor
               gradientEndColor
               endTime
@@ -503,6 +505,45 @@ function ProjectsGrid({
   );
 }
 
+const POSTURE_META = {
+  ADMINS_ONLY: { label: "Admins only", icon: <Icons.Lock /> },
+  SHARED: { label: "Shared", icon: <Icons.Share /> },
+  ALL_USERS: { label: "All users", icon: <Icons.Globe /> },
+} as const;
+
+/**
+ * A compact, at-a-glance indicator of how a project is shared. Rendered only when access
+ * control is enforced: with enforcement off, every authenticated user can see every project
+ * regardless of grants, so a badge would imply a restriction that is not actually applied.
+ */
+function VisibilityBadge({
+  posture,
+}: {
+  posture: ProjectsPageProjectsFragment$data["projects"]["edges"][number]["project"]["accessPosture"];
+}) {
+  const meta = POSTURE_META[posture as keyof typeof POSTURE_META];
+  if (!meta) return null;
+  return (
+    <Flex
+      direction="row"
+      gap="size-50"
+      alignItems="center"
+      css={css`
+        flex: none;
+        padding: var(--global-dimension-size-25)
+          var(--global-dimension-size-100);
+        border-radius: var(--global-rounding-medium);
+        background-color: var(--global-color-gray-100);
+      `}
+    >
+      <Icon svg={meta.icon} />
+      <Text size="XS" color="text-700">
+        {meta.label}
+      </Text>
+    </Flex>
+  );
+}
+
 type ProjectItemProps = {
   project: ProjectsPageProjectsFragment$data["projects"]["edges"][number]["project"];
   onProjectDelete: () => void;
@@ -522,6 +563,7 @@ function ProjectItem({
   timeRange,
 }: ProjectItemProps) {
   const { gradientStartColor, gradientEndColor, endTime } = project;
+  const { accessControlEnabled } = useFunctionality();
   const lastUpdatedText = useMemo(() => {
     if (endTime) {
       return `Last updated  ${formatDistance(new Date(endTime), new Date(), { addSuffix: true })}`;
@@ -571,15 +613,20 @@ function ProjectItem({
             </Text>
           </Flex>
         </Flex>
-        <CanModify>
-          <ProjectActionMenu
-            projectId={project.id}
-            projectName={project.name}
-            onProjectDelete={onProjectDelete}
-            onProjectClear={onProjectClear}
-            onProjectRemoveData={onProjectRemoveData}
-          />
-        </CanModify>
+        <Flex direction="row" gap="size-100" alignItems="center" flex="none">
+          {accessControlEnabled && (
+            <VisibilityBadge posture={project.accessPosture} />
+          )}
+          <CanModify>
+            <ProjectActionMenu
+              projectId={project.id}
+              projectName={project.name}
+              onProjectDelete={onProjectDelete}
+              onProjectClear={onProjectClear}
+              onProjectRemoveData={onProjectRemoveData}
+            />
+          </CanModify>
+        </Flex>
       </Flex>
       <ProjectMetrics projectId={project.id} timeRange={timeRange} />
     </div>

--- a/app/src/pages/projects/__generated__/ProjectsPageProjectsFragment.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageProjectsFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c70464ee56bf821921d873b5ad33c38e>>
+ * @generated SignedSource<<ad93d5a2418393d62500ff924e8745db>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,11 +9,13 @@
 // @ts-nocheck
 
 import { ReaderFragment } from 'relay-runtime';
+export type ProjectAccessPosture = "ADMINS_ONLY" | "ALL_USERS" | "SHARED";
 import { FragmentRefs } from "relay-runtime";
 export type ProjectsPageProjectsFragment$data = {
   readonly projects: {
     readonly edges: ReadonlyArray<{
       readonly project: {
+        readonly accessPosture: ProjectAccessPosture;
         readonly endTime: string | null;
         readonly gradientEndColor: string;
         readonly gradientStartColor: string;
@@ -137,6 +139,13 @@ return {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
+                  "name": "accessPosture",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
                   "name": "gradientStartColor",
                   "storageKey": null
                 },
@@ -226,6 +235,6 @@ return {
 };
 })();
 
-(node as any).hash = "d4c6c361639eeba67a41568089bf699a";
+(node as any).hash = "a0babffd230994bfcd23bf00859b3883";
 
 export default node;

--- a/app/src/pages/projects/__generated__/ProjectsPageProjectsQuery.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageProjectsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c8b16535855ce9899471aef1ea978b0e>>
+ * @generated SignedSource<<179243d052ce79bf00e7628e6399212a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -145,6 +145,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "accessPosture",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "gradientStartColor",
                     "storageKey": null
                   },
@@ -244,16 +251,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4ce729574f508383c8126b9947ee799c",
+    "cacheID": "1add6ce312771afa09d6c9c7fb54c0cc",
     "id": null,
     "metadata": {},
     "name": "ProjectsPageProjectsQuery",
     "operationKind": "query",
-    "text": "query ProjectsPageProjectsQuery(\n  $after: String = null\n  $filter: ProjectFilter = null\n  $first: Int = 50\n  $sort: ProjectSort = null\n) {\n  ...ProjectsPageProjectsFragment_3JsJJ3\n}\n\nfragment ProjectsPageProjectsFragment_3JsJJ3 on Query {\n  projects(first: $first, after: $after, sort: $sort, filter: $filter) {\n    edges {\n      project: node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n        endTime\n        startTime\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query ProjectsPageProjectsQuery(\n  $after: String = null\n  $filter: ProjectFilter = null\n  $first: Int = 50\n  $sort: ProjectSort = null\n) {\n  ...ProjectsPageProjectsFragment_3JsJJ3\n}\n\nfragment ProjectsPageProjectsFragment_3JsJJ3 on Query {\n  projects(first: $first, after: $after, sort: $sort, filter: $filter) {\n    edges {\n      project: node {\n        id\n        name\n        accessPosture\n        gradientStartColor\n        gradientEndColor\n        endTime\n        startTime\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d4c6c361639eeba67a41568089bf699a";
+(node as any).hash = "a0babffd230994bfcd23bf00859b3883";
 
 export default node;

--- a/app/src/pages/projects/__generated__/ProjectsPageQuery.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<42974c6c52b03b63f4e9593c7a56509c>>
+ * @generated SignedSource<<ca7a3f1b0956ce752417c9872ce3a37a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -140,6 +140,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "accessPosture",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "gradientStartColor",
                     "storageKey": null
                   },
@@ -239,12 +246,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ca0df034be070fca2025c4f8922b9932",
+    "cacheID": "9be8f49e7fe869a4f3838bd7653970b6",
     "id": null,
     "metadata": {},
     "name": "ProjectsPageQuery",
     "operationKind": "query",
-    "text": "query ProjectsPageQuery(\n  $first: Int\n  $sort: ProjectSort\n  $filter: ProjectFilter\n) {\n  ...ProjectsPageProjectsFragment_1bvy9D\n}\n\nfragment ProjectsPageProjectsFragment_1bvy9D on Query {\n  projects(first: $first, sort: $sort, filter: $filter) {\n    edges {\n      project: node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n        endTime\n        startTime\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query ProjectsPageQuery(\n  $first: Int\n  $sort: ProjectSort\n  $filter: ProjectFilter\n) {\n  ...ProjectsPageProjectsFragment_1bvy9D\n}\n\nfragment ProjectsPageProjectsFragment_1bvy9D on Query {\n  projects(first: $first, sort: $sort, filter: $filter) {\n    edges {\n      project: node {\n        id\n        name\n        accessPosture\n        gradientStartColor\n        gradientEndColor\n        endTime\n        startTime\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/prompts/PromptAccessPage.tsx
+++ b/app/src/pages/prompts/PromptAccessPage.tsx
@@ -1,0 +1,79 @@
+import { useDeferredValue, useState } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+
+import {
+  buildSubjectItems,
+  ResourceAccessForm,
+} from "@phoenix/pages/access/ResourceAccessForm";
+
+import type { PromptAccessPageQuery } from "./__generated__/PromptAccessPageQuery.graphql";
+
+export function PromptAccessPageContent({ promptId }: { promptId: string }) {
+  const [fetchKey, setFetchKey] = useState(0);
+  const [subjectSearch, setSubjectSearch] = useState("");
+  const deferredSubjectSearch = useDeferredValue(subjectSearch.trim());
+
+  const data = useLazyLoadQuery<PromptAccessPageQuery>(
+    graphql`
+      query PromptAccessPageQuery($promptId: ID!, $userFilter: UserFilter) {
+        prompt: node(id: $promptId) {
+          ... on Prompt {
+            id
+            accessGrants {
+              subjectKind
+              subjectId
+              subjectName
+              roleId
+              roleName
+            }
+          }
+        }
+        users(first: 25, filter: $userFilter) {
+          edges {
+            user: node {
+              id
+              username
+              email
+            }
+          }
+        }
+        userGroups {
+          id
+          name
+        }
+        permissionSets {
+          id
+          name
+          permissions
+        }
+        resourceTags(objectType: PROMPT, objectId: $promptId) {
+          key
+          value
+        }
+      }
+    `,
+    {
+      promptId,
+      userFilter: deferredSubjectSearch
+        ? { value: deferredSubjectSearch }
+        : null,
+    },
+    { fetchKey, fetchPolicy: "store-and-network" }
+  );
+
+  return (
+    <ResourceAccessForm
+      object={{ promptId }}
+      grants={data.prompt?.accessGrants ?? []}
+      tags={data.resourceTags}
+      permissionSets={data.permissionSets}
+      subjectItems={buildSubjectItems(
+        data.users.edges.map((edge) => edge.user),
+        data.userGroups
+      )}
+      onSubjectSearchChange={setSubjectSearch}
+      onRefresh={() => setFetchKey((key) => key + 1)}
+      isModal
+    />
+  );
+}

--- a/app/src/pages/prompts/PromptActionMenu.tsx
+++ b/app/src/pages/prompts/PromptActionMenu.tsx
@@ -1,9 +1,10 @@
 import { css } from "@emotion/react";
-import { Suspense, useCallback, useState } from "react";
+import { Suspense, useState } from "react";
 import { SubmenuTrigger } from "react-aria-components";
 
 import {
   Button,
+  Dialog,
   DialogTrigger,
   Flex,
   Icon,
@@ -13,16 +14,28 @@ import {
   MenuItem,
   MenuTrigger,
   Modal,
+  ModalOverlay,
   Popover,
   PopoverArrow,
   Text,
 } from "@phoenix/components";
+import {
+  DialogCloseButton,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTitleExtra,
+} from "@phoenix/components/core/dialog";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
+import { useViewerCanManageAccessControl } from "@phoenix/contexts";
+import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
 import { PromptLabelSelectionContent } from "@phoenix/pages/prompt/PromptLabelConfigButton";
 
 import { DeletePromptDialog } from "./DeletePromptDialog";
+import { PromptAccessPageContent } from "./PromptAccessPage";
 
 enum PromptAction {
+  MANAGE_ACCESS = "MANAGE_ACCESS",
   DELETE = "DELETE",
   LABELS = "LABELS",
 }
@@ -34,11 +47,11 @@ export function PromptActionMenu({
   promptId: string;
   onDeleted: () => void;
 }) {
+  const canManageAccessControl = useViewerCanManageAccessControl();
+  const { accessControlEnabled } = useFunctionality();
+  const canShowManageAccess = accessControlEnabled && canManageAccessControl;
+  const [showManageAccessDialog, setShowManageAccessDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-
-  const onDelete = useCallback(() => {
-    setShowDeleteDialog(true);
-  }, []);
 
   return (
     <StopPropagation>
@@ -53,8 +66,11 @@ export function PromptActionMenu({
             aria-label="Prompt action menu"
             onAction={(action) => {
               switch (action) {
+                case PromptAction.MANAGE_ACCESS:
+                  setShowManageAccessDialog(true);
+                  break;
                 case PromptAction.DELETE:
-                  onDelete();
+                  setShowDeleteDialog(true);
                   break;
               }
             }}
@@ -93,6 +109,22 @@ export function PromptActionMenu({
                 </Suspense>
               </Popover>
             </SubmenuTrigger>
+            {canShowManageAccess ? (
+              <MenuItem
+                id={PromptAction.MANAGE_ACCESS}
+                textValue="Manage access"
+              >
+                <Flex
+                  direction={"row"}
+                  gap="size-75"
+                  justifyContent={"start"}
+                  alignItems={"center"}
+                >
+                  <Icon svg={<Icons.Shield />} />
+                  <Text>Manage Access</Text>
+                </Flex>
+              </MenuItem>
+            ) : null}
             <MenuItem id={PromptAction.DELETE}>
               <Flex
                 direction={"row"}
@@ -107,6 +139,26 @@ export function PromptActionMenu({
           </Menu>
         </Popover>
       </MenuTrigger>
+      <ModalOverlay
+        isOpen={showManageAccessDialog}
+        onOpenChange={setShowManageAccessDialog}
+      >
+        <Modal variant="slideover" size="L">
+          <Dialog>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Manage Access</DialogTitle>
+                <DialogTitleExtra>
+                  <DialogCloseButton />
+                </DialogTitleExtra>
+              </DialogHeader>
+              <Suspense fallback={<Loading />}>
+                <PromptAccessPageContent promptId={promptId} />
+              </Suspense>
+            </DialogContent>
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
       <DialogTrigger
         isOpen={showDeleteDialog}
         onOpenChange={setShowDeleteDialog}

--- a/app/src/pages/prompts/__generated__/PromptAccessPageQuery.graphql.ts
+++ b/app/src/pages/prompts/__generated__/PromptAccessPageQuery.graphql.ts
@@ -1,0 +1,355 @@
+/**
+ * @generated SignedSource<<12b681e34998c3af668996f3151b5eef>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AccessSubjectKind = "EVERYONE" | "GROUP" | "USER";
+export type ObjectPermission = "EDIT" | "MANAGE_ACCESS" | "VIEW";
+export type UserFilter = {
+  value?: string | null;
+};
+export type PromptAccessPageQuery$variables = {
+  promptId: string;
+  userFilter?: UserFilter | null;
+};
+export type PromptAccessPageQuery$data = {
+  readonly permissionSets: ReadonlyArray<{
+    readonly id: string;
+    readonly name: string;
+    readonly permissions: ReadonlyArray<ObjectPermission>;
+  }>;
+  readonly prompt: {
+    readonly accessGrants?: ReadonlyArray<{
+      readonly roleId: string | null;
+      readonly roleName: string;
+      readonly subjectId: string | null;
+      readonly subjectKind: AccessSubjectKind;
+      readonly subjectName: string;
+    }>;
+    readonly id?: string;
+  };
+  readonly resourceTags: ReadonlyArray<{
+    readonly key: string;
+    readonly value: string;
+  }>;
+  readonly userGroups: ReadonlyArray<{
+    readonly id: string;
+    readonly name: string;
+  }>;
+  readonly users: {
+    readonly edges: ReadonlyArray<{
+      readonly user: {
+        readonly email: string | null;
+        readonly id: string;
+        readonly username: string;
+      };
+    }>;
+  };
+};
+export type PromptAccessPageQuery = {
+  response: PromptAccessPageQuery$data;
+  variables: PromptAccessPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "promptId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "userFilter"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "promptId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "AccessGrant",
+  "kind": "LinkedField",
+  "name": "accessGrants",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "subjectKind",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "subjectId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "subjectName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "roleId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "roleName",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "filter",
+      "variableName": "userFilter"
+    },
+    {
+      "kind": "Literal",
+      "name": "first",
+      "value": 25
+    }
+  ],
+  "concreteType": "UserConnection",
+  "kind": "LinkedField",
+  "name": "users",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "UserEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": "user",
+          "args": null,
+          "concreteType": "User",
+          "kind": "LinkedField",
+          "name": "node",
+          "plural": false,
+          "selections": [
+            (v2/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "username",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "email",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "UserGroup",
+  "kind": "LinkedField",
+  "name": "userGroups",
+  "plural": true,
+  "selections": [
+    (v2/*: any*/),
+    (v5/*: any*/)
+  ],
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PermissionSet",
+  "kind": "LinkedField",
+  "name": "permissionSets",
+  "plural": true,
+  "selections": [
+    (v2/*: any*/),
+    (v5/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "permissions",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "objectId",
+      "variableName": "promptId"
+    },
+    {
+      "kind": "Literal",
+      "name": "objectType",
+      "value": "PROMPT"
+    }
+  ],
+  "concreteType": "ResourceTag",
+  "kind": "LinkedField",
+  "name": "resourceTags",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "key",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "value",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "PromptAccessPageQuery",
+    "selections": [
+      {
+        "alias": "prompt",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ],
+            "type": "Prompt",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      (v4/*: any*/),
+      (v6/*: any*/),
+      (v7/*: any*/),
+      (v8/*: any*/)
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "PromptAccessPageQuery",
+    "selections": [
+      {
+        "alias": "prompt",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/)
+            ],
+            "type": "Prompt",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      (v4/*: any*/),
+      (v6/*: any*/),
+      (v7/*: any*/),
+      (v8/*: any*/)
+    ]
+  },
+  "params": {
+    "cacheID": "4b24c24c05ef0620a7dd39a6367cb3d4",
+    "id": null,
+    "metadata": {},
+    "name": "PromptAccessPageQuery",
+    "operationKind": "query",
+    "text": "query PromptAccessPageQuery(\n  $promptId: ID!\n  $userFilter: UserFilter\n) {\n  prompt: node(id: $promptId) {\n    __typename\n    ... on Prompt {\n      id\n      accessGrants {\n        subjectKind\n        subjectId\n        subjectName\n        roleId\n        roleName\n      }\n    }\n    id\n  }\n  users(first: 25, filter: $userFilter) {\n    edges {\n      user: node {\n        id\n        username\n        email\n      }\n    }\n  }\n  userGroups {\n    id\n    name\n  }\n  permissionSets {\n    id\n    name\n    permissions\n  }\n  resourceTags(objectType: PROMPT, objectId: $promptId) {\n    key\n    value\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "2e9fb717fb5bbb57254889b06aeba5ec";
+
+export default node;

--- a/app/src/pages/settings/APIKeysCard.tsx
+++ b/app/src/pages/settings/APIKeysCard.tsx
@@ -71,12 +71,14 @@ export function APIKeysCard() {
         $name: String!
         $description: String = null
         $expiresAt: DateTime = null
+        $scope: ApiKeyScope = null
       ) {
         createSystemApiKey(
           input: {
             name: $name
             description: $description
             expiresAt: $expiresAt
+            scope: $scope
           }
         ) {
           jwt
@@ -94,9 +96,11 @@ export function APIKeysCard() {
     (data: APIKeyFormParams) => {
       commit({
         variables: {
-          ...data,
+          name: data.name,
+          description: data.description,
           expiresAt:
             data.expiresAt?.toDate(getLocalTimeZone()).toISOString() || null,
+          scope: data.scope === "INGEST" ? "INGEST" : null,
         },
         onCompleted: (response) => {
           setFetchKey((prev) => prev + 1);

--- a/app/src/pages/settings/SettingsAccessPage.tsx
+++ b/app/src/pages/settings/SettingsAccessPage.tsx
@@ -1,0 +1,15 @@
+import { Flex } from "@phoenix/components";
+
+import { SettingsGroupsPage } from "./SettingsGroupsPage";
+import { SettingsRolesPage } from "./SettingsRolesPage";
+import { SettingsTagGrantsPage } from "./SettingsTagGrantsPage";
+
+export function SettingsAccessPage() {
+  return (
+    <Flex direction="column" gap="size-200" width="100%">
+      <SettingsGroupsPage />
+      <SettingsRolesPage />
+      <SettingsTagGrantsPage />
+    </Flex>
+  );
+}

--- a/app/src/pages/settings/SettingsGroupsPage.tsx
+++ b/app/src/pages/settings/SettingsGroupsPage.tsx
@@ -1,0 +1,489 @@
+import { css } from "@emotion/react";
+import { useCallback, useDeferredValue, useMemo, useState } from "react";
+import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
+
+import {
+  Alert,
+  Button,
+  Card,
+  ComboBox,
+  ComboBoxItem,
+  Dialog,
+  DialogCloseButton,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTitleExtra,
+  DialogTrigger,
+  Flex,
+  Icon,
+  Icons,
+  Input,
+  Loading,
+  Modal,
+  ModalOverlay,
+  Text,
+  TextField,
+  View,
+} from "@phoenix/components";
+import { ConfirmButton } from "@phoenix/components/ConfirmButton";
+import { tableCSS } from "@phoenix/components/table/styles";
+import { useNotifySuccess } from "@phoenix/contexts";
+import { parseGlobalId } from "@phoenix/utils/globalIdUtils";
+
+import type { SettingsGroupsPageAddMemberMutation } from "./__generated__/SettingsGroupsPageAddMemberMutation.graphql";
+import type { SettingsGroupsPageCreateMutation } from "./__generated__/SettingsGroupsPageCreateMutation.graphql";
+import type { SettingsGroupsPageDeleteMutation } from "./__generated__/SettingsGroupsPageDeleteMutation.graphql";
+import type { SettingsGroupsPageQuery } from "./__generated__/SettingsGroupsPageQuery.graphql";
+import type { SettingsGroupsPageRemoveMemberMutation } from "./__generated__/SettingsGroupsPageRemoveMemberMutation.graphql";
+
+const cardToolbarCSS = css`
+  display: flex;
+  justify-content: flex-end;
+  padding: var(--global-dimension-size-200);
+  border-bottom: var(--global-border-size-thin) solid
+    var(--global-border-color-default);
+`;
+
+const groupNameFieldCSS = css`
+  width: 260px;
+`;
+
+export function SettingsGroupsPage() {
+  const [fetchKey, setFetchKey] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [newName, setNewName] = useState("");
+  const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
+  const [memberToAdd, setMemberToAdd] = useState<string | null>(null);
+  const [memberToRemove, setMemberToRemove] = useState<number | null>(null);
+  const [memberSearch, setMemberSearch] = useState("");
+  const deferredMemberSearch = useDeferredValue(memberSearch.trim());
+  const notifySuccess = useNotifySuccess();
+
+  const data = useLazyLoadQuery<SettingsGroupsPageQuery>(
+    graphql`
+      query SettingsGroupsPageQuery($userFilter: UserFilter) {
+        userGroups {
+          groupId
+          name
+          provider
+          isLocal
+          memberUserIds
+        }
+        users(first: 1000) {
+          edges {
+            user: node {
+              id
+              username
+              email
+            }
+          }
+        }
+        memberCandidates: users(first: 25, filter: $userFilter) {
+          edges {
+            user: node {
+              id
+              username
+              email
+            }
+          }
+        }
+      }
+    `,
+    {
+      userFilter: deferredMemberSearch ? { value: deferredMemberSearch } : null,
+    },
+    { fetchKey, fetchPolicy: "store-and-network" }
+  );
+
+  const [commitCreate, isCreating] =
+    useMutation<SettingsGroupsPageCreateMutation>(graphql`
+      mutation SettingsGroupsPageCreateMutation($name: String!) {
+        createUserGroup(name: $name) {
+          __typename
+        }
+      }
+    `);
+  const [commitDelete, isDeleting] =
+    useMutation<SettingsGroupsPageDeleteMutation>(graphql`
+      mutation SettingsGroupsPageDeleteMutation($groupId: Int!) {
+        deleteUserGroup(groupId: $groupId) {
+          __typename
+        }
+      }
+    `);
+  const [commitAdd, isAdding] =
+    useMutation<SettingsGroupsPageAddMemberMutation>(graphql`
+      mutation SettingsGroupsPageAddMemberMutation(
+        $groupId: Int!
+        $userId: Int!
+      ) {
+        addUserGroupMember(groupId: $groupId, userId: $userId) {
+          __typename
+        }
+      }
+    `);
+  const [commitRemove, isRemoving] =
+    useMutation<SettingsGroupsPageRemoveMemberMutation>(graphql`
+      mutation SettingsGroupsPageRemoveMemberMutation(
+        $groupId: Int!
+        $userId: Int!
+      ) {
+        removeUserGroupMember(groupId: $groupId, userId: $userId) {
+          __typename
+        }
+      }
+    `);
+
+  const refresh = useCallback(() => setFetchKey((k) => k + 1), []);
+  const closeGroupDialog = useCallback(() => {
+    setSelectedGroupId(null);
+    setMemberToAdd(null);
+    setMemberToRemove(null);
+    setMemberSearch("");
+  }, []);
+  const isMutating = isCreating || isDeleting || isAdding || isRemoving;
+
+  const groups = data.userGroups;
+  const usersByNumericId = useMemo(() => {
+    const m = new Map<number, string>();
+    for (const { user } of data.users.edges) {
+      const parsed = parseGlobalId(user.id);
+      if (!parsed) continue;
+      m.set(
+        Number(parsed.nodeId),
+        user.email || user.username || `user ${parsed.nodeId}`
+      );
+    }
+    return m;
+  }, [data.users.edges]);
+
+  const selectedGroup = useMemo(
+    () => groups.find((g) => g.groupId === selectedGroupId) ?? null,
+    [groups, selectedGroupId]
+  );
+
+  const addableUsers = useMemo(() => {
+    if (!selectedGroup) return [] as { id: string; label: string }[];
+    const members = new Set(selectedGroup.memberUserIds);
+    const items: { id: string; label: string }[] = [];
+    for (const { user } of data.memberCandidates.edges) {
+      const parsed = parseGlobalId(user.id);
+      if (!parsed) continue;
+      const numId = Number(parsed.nodeId);
+      const label = user.email || user.username || `user ${parsed.nodeId}`;
+      if (!members.has(numId)) items.push({ id: String(numId), label });
+    }
+    return items;
+  }, [data.memberCandidates.edges, selectedGroup]);
+
+  const handleCreate = useCallback(() => {
+    const name = newName.trim();
+    if (!name) return;
+    setError(null);
+    commitCreate({
+      variables: { name },
+      onCompleted: () => {
+        notifySuccess({ title: "Group created", message: `Created ${name}.` });
+        setNewName("");
+        refresh();
+      },
+      onError: (e) => setError(e.message),
+    });
+  }, [commitCreate, newName, notifySuccess, refresh]);
+
+  const handleDelete = useCallback(
+    (groupId: number) => {
+      setError(null);
+      commitDelete({
+        variables: { groupId },
+        onCompleted: () => {
+          notifySuccess({
+            title: "Group deleted",
+            message: "The group and its grants were removed.",
+          });
+          if (selectedGroupId === groupId) closeGroupDialog();
+          refresh();
+        },
+        onError: (e) => setError(e.message),
+      });
+    },
+    [closeGroupDialog, commitDelete, notifySuccess, refresh, selectedGroupId]
+  );
+
+  const handleAddMember = useCallback(() => {
+    if (!selectedGroup || !memberToAdd) return;
+    setError(null);
+    commitAdd({
+      variables: {
+        groupId: selectedGroup.groupId,
+        userId: Number(memberToAdd),
+      },
+      onCompleted: () => {
+        notifySuccess({ title: "Member added", message: "Member added." });
+        setMemberToAdd(null);
+        setMemberSearch("");
+        refresh();
+      },
+      onError: (e) => setError(e.message),
+    });
+  }, [commitAdd, memberToAdd, notifySuccess, refresh, selectedGroup]);
+
+  const handleRemoveMember = useCallback(
+    (userId: number) => {
+      if (!selectedGroup) return;
+      setError(null);
+      commitRemove({
+        variables: { groupId: selectedGroup.groupId, userId },
+        onCompleted: () => {
+          notifySuccess({
+            title: "Member removed",
+            message: "Member removed.",
+          });
+          setMemberToRemove(null);
+          refresh();
+        },
+        onError: (e) => setError(e.message),
+      });
+    },
+    [commitRemove, notifySuccess, refresh, selectedGroup]
+  );
+
+  return (
+    <Flex direction="column" gap="size-200" width="100%">
+      {error && <Alert variant="danger">{error}</Alert>}
+      <Card title="User groups" titleSeparator={false}>
+        <div css={cardToolbarCSS}>
+          <Flex direction="row" gap="size-100" alignItems="end">
+            <TextField
+              value={newName}
+              onChange={setNewName}
+              aria-label="New group name"
+              css={groupNameFieldCSS}
+            >
+              <Input placeholder="New group name" />
+            </TextField>
+            <Button
+              size="S"
+              variant="primary"
+              isDisabled={!newName.trim() || isMutating}
+              leadingVisual={<Icon svg={<Icons.PlusCircle />} />}
+              onPress={handleCreate}
+            >
+              Create
+            </Button>
+          </Flex>
+        </div>
+        <table css={tableCSS}>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Source</th>
+              <th>Members</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {groups.length === 0 ? (
+              <tr>
+                <td colSpan={4}>
+                  <View padding="size-200">
+                    <Text color="text-700">
+                      No groups yet. Create a local group to grant access to a
+                      team at once.
+                    </Text>
+                  </View>
+                </td>
+              </tr>
+            ) : (
+              groups.map((group) => (
+                <tr key={group.groupId}>
+                  <td>{group.name}</td>
+                  <td>{group.isLocal ? "Local" : group.provider}</td>
+                  <td>{group.memberUserIds.length}</td>
+                  <td>
+                    <Flex justifyContent="end" gap="size-100">
+                      <Button
+                        size="S"
+                        onPress={() => {
+                          setSelectedGroupId(group.groupId);
+                          setMemberToAdd(null);
+                          setMemberToRemove(null);
+                          setMemberSearch("");
+                        }}
+                      >
+                        {group.isLocal ? "Manage" : "View"}
+                      </Button>
+                      {group.isLocal && (
+                        <ConfirmButton
+                          buttonText="Delete"
+                          buttonAriaLabel={`Delete group ${group.name}`}
+                          isDisabled={isMutating}
+                          title="Delete group"
+                          message={
+                            <>
+                              Delete the group <strong>{group.name}</strong>?
+                              This removes the group and revokes every access
+                              grant made to it.
+                            </>
+                          }
+                          confirmText="Delete group"
+                          onConfirm={() => handleDelete(group.groupId)}
+                        />
+                      )}
+                    </Flex>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </Card>
+
+      <DialogTrigger
+        isOpen={selectedGroup != null}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            closeGroupDialog();
+          }
+        }}
+      >
+        <ModalOverlay>
+          <Modal size="L">
+            {selectedGroup && (
+              <Dialog>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>
+                      {selectedGroup.isLocal ? "Manage" : "View"}{" "}
+                      {selectedGroup.name}
+                    </DialogTitle>
+                    <DialogTitleExtra>
+                      <DialogCloseButton onPress={closeGroupDialog} />
+                    </DialogTitleExtra>
+                  </DialogHeader>
+                  {selectedGroup.isLocal && (
+                    <div css={cardToolbarCSS}>
+                      <Flex direction="row" gap="size-100" alignItems="end">
+                        <ComboBox
+                          label="Add member"
+                          placeholder="Search people…"
+                          width="320px"
+                          selectedKey={memberToAdd}
+                          onSelectionChange={(key) =>
+                            setMemberToAdd(key == null ? null : String(key))
+                          }
+                          onInputChange={setMemberSearch}
+                          renderEmptyState={() => "No people available"}
+                        >
+                          {addableUsers.map((item) => (
+                            <ComboBoxItem
+                              key={item.id}
+                              id={item.id}
+                              textValue={item.label}
+                            >
+                              {item.label}
+                            </ComboBoxItem>
+                          ))}
+                        </ComboBox>
+                        <Button
+                          size="S"
+                          variant="primary"
+                          isDisabled={!memberToAdd || isMutating}
+                          onPress={handleAddMember}
+                        >
+                          Add
+                        </Button>
+                      </Flex>
+                    </div>
+                  )}
+                  {!selectedGroup.isLocal && (
+                    <View padding="size-200">
+                      <Text color="text-700">
+                        This group is synced from {selectedGroup.provider}. Its
+                        membership is managed by the identity provider and is
+                        read-only here.
+                      </Text>
+                    </View>
+                  )}
+                  <table css={tableCSS}>
+                    <thead>
+                      <tr>
+                        <th>Member</th>
+                        <th />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {selectedGroup.memberUserIds.length === 0 ? (
+                        <tr>
+                          <td colSpan={2}>
+                            <View padding="size-200">
+                              <Text color="text-700">No members.</Text>
+                            </View>
+                          </td>
+                        </tr>
+                      ) : (
+                        selectedGroup.memberUserIds.map((userId) => {
+                          const memberLabel =
+                            usersByNumericId.get(userId) ?? `user ${userId}`;
+                          return (
+                            <tr key={userId}>
+                              <td>{memberLabel}</td>
+                              <td>
+                                <Flex justifyContent="end" gap="size-100">
+                                  {selectedGroup.isLocal &&
+                                    (memberToRemove === userId ? (
+                                      <>
+                                        <Button
+                                          size="S"
+                                          onPress={() =>
+                                            setMemberToRemove(null)
+                                          }
+                                        >
+                                          Cancel
+                                        </Button>
+                                        <Button
+                                          size="S"
+                                          variant="danger"
+                                          isDisabled={isMutating}
+                                          onPress={() =>
+                                            handleRemoveMember(userId)
+                                          }
+                                        >
+                                          Remove member
+                                        </Button>
+                                      </>
+                                    ) : (
+                                      <Button
+                                        size="S"
+                                        variant="danger"
+                                        isDisabled={isMutating}
+                                        leadingVisual={
+                                          <Icon svg={<Icons.Trash />} />
+                                        }
+                                        aria-label={`Remove ${memberLabel} from ${selectedGroup.name}`}
+                                        onPress={() =>
+                                          setMemberToRemove(userId)
+                                        }
+                                      >
+                                        Remove
+                                      </Button>
+                                    ))}
+                                </Flex>
+                              </td>
+                            </tr>
+                          );
+                        })
+                      )}
+                    </tbody>
+                  </table>
+                </DialogContent>
+              </Dialog>
+            )}
+          </Modal>
+        </ModalOverlay>
+      </DialogTrigger>
+      {isMutating && <Loading />}
+    </Flex>
+  );
+}

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -5,7 +5,11 @@ import { Collection } from "react-aria-components";
 import { Navigate, Outlet, useLocation, useNavigate } from "react-router";
 
 import { Loading, Tab, TabList, TabPanel, Tabs } from "@phoenix/components";
-import { useViewerCanManageSandboxes } from "@phoenix/contexts";
+import {
+  useViewerCanManageAccessControl,
+  useViewerCanManageSandboxes,
+} from "@phoenix/contexts";
+import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
 
 const settingsPageCSS = css`
   overflow-y: auto;
@@ -24,6 +28,7 @@ const settingsPageInnerCSS = css`
 
 const TABS: { id: string; label: string }[] = [
   { id: "general", label: "General" },
+  { id: "access", label: "Access" },
   { id: "providers", label: "AI Providers" },
   { id: "sandboxes", label: "Sandboxes" },
   { id: "models", label: "Models" },
@@ -50,6 +55,8 @@ export function SettingsPage() {
   const isAgentAssistantEnabled = !window.Config.agentAssistantDisabled;
   const canManageSecrets = useViewerCanManageSandboxes();
   const canManageSandboxes = useViewerCanManageSandboxes();
+  const canManageAccessControl = useViewerCanManageAccessControl();
+  const { accessControlEnabled } = useFunctionality();
   const tabs = TABS.filter((tab) => {
     if (tab.id === "agents" && !isAgentAssistantEnabled) {
       return false;
@@ -60,10 +67,25 @@ export function SettingsPage() {
     if (tab.id === "sandboxes" && !canManageSandboxes) {
       return false;
     }
+    // Hide access-control configuration unless enforcement is enabled.
+    if (
+      tab.id === "access" &&
+      (!accessControlEnabled || !canManageAccessControl)
+    ) {
+      return false;
+    }
     return true;
   });
   if (!tab) {
     return <Navigate to="/settings/general" replace />;
+  }
+  if (tab === "groups" || tab === "people" || tab === "roles") {
+    return (
+      <Navigate
+        to={accessControlEnabled ? "/settings/access" : "/settings/general"}
+        replace
+      />
+    );
   }
   if (!tabs.some((item) => item.id === tab)) {
     return <Navigate to="/settings/general" replace />;

--- a/app/src/pages/settings/SettingsRolesPage.tsx
+++ b/app/src/pages/settings/SettingsRolesPage.tsx
@@ -1,0 +1,331 @@
+import { css } from "@emotion/react";
+import { useCallback, useState } from "react";
+import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
+
+import {
+  Alert,
+  Button,
+  Card,
+  Flex,
+  Icon,
+  Icons,
+  Input,
+  Label,
+  Text,
+  TextField,
+  View,
+} from "@phoenix/components";
+import { ConfirmButton } from "@phoenix/components/ConfirmButton";
+import { Checkbox } from "@phoenix/components/core/checkbox";
+import { tableCSS } from "@phoenix/components/table/styles";
+import { TableEmpty } from "@phoenix/components/table/TableEmpty";
+import { useNotifySuccess } from "@phoenix/contexts";
+
+import type { SettingsRolesPageCreateMutation } from "./__generated__/SettingsRolesPageCreateMutation.graphql";
+import type { SettingsRolesPageDeleteMutation } from "./__generated__/SettingsRolesPageDeleteMutation.graphql";
+import type { SettingsRolesPagePatchMutation } from "./__generated__/SettingsRolesPagePatchMutation.graphql";
+import type { SettingsRolesPageQuery } from "./__generated__/SettingsRolesPageQuery.graphql";
+
+type ObjectPermission = "VIEW" | "EDIT" | "MANAGE_ACCESS";
+
+const ALL_PERMISSIONS: { value: ObjectPermission; label: string }[] = [
+  { value: "VIEW", label: "View" },
+  { value: "EDIT", label: "Edit" },
+  { value: "MANAGE_ACCESS", label: "Manage access" },
+];
+
+const PERMISSION_LABELS = new Map(
+  ALL_PERMISSIONS.map(({ value, label }) => [value, label])
+);
+
+const roleNameFieldCSS = css`
+  flex: 1;
+`;
+
+function formatPermissions(permissions: readonly string[]) {
+  const held = new Set(permissions);
+  const ordered = ALL_PERMISSIONS.filter(({ value }) => held.has(value)).map(
+    ({ label }) => label
+  );
+  const unknown = permissions.filter(
+    (permission) => !PERMISSION_LABELS.has(permission as ObjectPermission)
+  );
+  return [...ordered, ...unknown].join(", ");
+}
+
+export function SettingsRolesPage() {
+  const [fetchKey, setFetchKey] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [name, setName] = useState("");
+  const [permissions, setPermissions] = useState<Set<ObjectPermission>>(
+    new Set(["VIEW"])
+  );
+  const notifySuccess = useNotifySuccess();
+
+  const data = useLazyLoadQuery<SettingsRolesPageQuery>(
+    graphql`
+      query SettingsRolesPageQuery {
+        permissionSets {
+          id
+          name
+          isBuiltIn
+          permissions
+        }
+      }
+    `,
+    {},
+    { fetchKey, fetchPolicy: "store-and-network" }
+  );
+
+  const [commitCreate, isCreating] =
+    useMutation<SettingsRolesPageCreateMutation>(graphql`
+      mutation SettingsRolesPageCreateMutation(
+        $input: CreatePermissionSetInput!
+      ) {
+        createPermissionSet(input: $input) {
+          __typename
+        }
+      }
+    `);
+
+  const [commitPatch, isPatching] =
+    useMutation<SettingsRolesPagePatchMutation>(graphql`
+      mutation SettingsRolesPagePatchMutation(
+        $input: PatchPermissionSetInput!
+      ) {
+        patchPermissionSet(input: $input) {
+          __typename
+        }
+      }
+    `);
+
+  const [commitDelete, isDeleting] =
+    useMutation<SettingsRolesPageDeleteMutation>(graphql`
+      mutation SettingsRolesPageDeleteMutation(
+        $input: DeletePermissionSetInput!
+      ) {
+        deletePermissionSet(input: $input) {
+          __typename
+        }
+      }
+    `);
+
+  const isMutating = isCreating || isPatching || isDeleting;
+  const refresh = useCallback(() => setFetchKey((k) => k + 1), []);
+
+  const reset = useCallback(() => {
+    setEditingId(null);
+    setName("");
+    setPermissions(new Set(["VIEW"]));
+  }, []);
+
+  const togglePermission = useCallback(
+    (permission: ObjectPermission, selected: boolean) => {
+      setPermissions((prev) => {
+        const next = new Set(prev);
+        if (selected) {
+          next.add(permission);
+        } else {
+          next.delete(permission);
+        }
+        return next;
+      });
+    },
+    []
+  );
+
+  const handleSave = useCallback(() => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Permission set name cannot be empty.");
+      return;
+    }
+    if (permissions.size === 0) {
+      setError("A permission set must have at least one permission.");
+      return;
+    }
+    setError(null);
+    const onCompleted = () => {
+      notifySuccess({
+        title:
+          editingId == null
+            ? "Permission set created"
+            : "Permission set updated",
+        message: `"${trimmed}" saved.`,
+      });
+      reset();
+      refresh();
+    };
+    const onError = (e: Error) => setError(e.message);
+    const perms = Array.from(permissions);
+    if (editingId == null) {
+      commitCreate({
+        variables: { input: { name: trimmed, permissions: perms } },
+        onCompleted,
+        onError,
+      });
+    } else {
+      commitPatch({
+        variables: {
+          input: { id: editingId, name: trimmed, permissions: perms },
+        },
+        onCompleted,
+        onError,
+      });
+    }
+  }, [
+    commitCreate,
+    commitPatch,
+    editingId,
+    name,
+    notifySuccess,
+    permissions,
+    refresh,
+    reset,
+  ]);
+
+  const handleEdit = useCallback(
+    (role: SettingsRolesPageQuery["response"]["permissionSets"][number]) => {
+      setEditingId(role.id);
+      setName(role.name);
+      setPermissions(new Set(role.permissions as ObjectPermission[]));
+      setError(null);
+    },
+    []
+  );
+
+  const handleDelete = useCallback(
+    (id: string, roleName: string) => {
+      setError(null);
+      commitDelete({
+        variables: { input: { id } },
+        onCompleted: () => {
+          notifySuccess({
+            title: "Permission set deleted",
+            message: `"${roleName}" removed. Grants using it fall back to view.`,
+          });
+          if (editingId === id) reset();
+          refresh();
+        },
+        onError: (e) => setError(e.message),
+      });
+    },
+    [commitDelete, editingId, notifySuccess, refresh, reset]
+  );
+
+  return (
+    <Flex direction="column" gap="size-200" width="100%">
+      {error && <Alert variant="danger">{error}</Alert>}
+      <Card
+        title={
+          editingId == null ? "Create permission set" : "Edit permission set"
+        }
+        subTitle="Reusable permission sets for project, dataset, and prompt grants."
+        titleSeparator={false}
+      >
+        <View padding="size-200">
+          <Flex direction="column" gap="size-200">
+            <Flex direction="row" gap="size-100" alignItems="end">
+              <TextField value={name} onChange={setName} css={roleNameFieldCSS}>
+                <Label>Name</Label>
+                <Input placeholder="e.g. Annotator" />
+              </TextField>
+              {editingId != null && (
+                <Button size="S" onPress={reset}>
+                  Cancel
+                </Button>
+              )}
+              <Button
+                size="S"
+                variant="primary"
+                isDisabled={
+                  !name.trim() || permissions.size === 0 || isMutating
+                }
+                leadingVisual={<Icon svg={<Icons.PlusCircle />} />}
+                onPress={handleSave}
+              >
+                {editingId == null ? "Create" : "Save"}
+              </Button>
+            </Flex>
+            <Flex direction="row" gap="size-200">
+              {ALL_PERMISSIONS.map((p) => (
+                <Checkbox
+                  key={p.value}
+                  isSelected={permissions.has(p.value)}
+                  onChange={(selected) => togglePermission(p.value, selected)}
+                >
+                  {p.label}
+                </Checkbox>
+              ))}
+            </Flex>
+          </Flex>
+        </View>
+      </Card>
+      <Card
+        title="Permission sets"
+        subTitle="Built-in permission sets are read-only. Custom permission sets can be edited or deleted."
+        titleSeparator={false}
+      >
+        <table css={tableCSS}>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Permissions</th>
+              <th>Type</th>
+              <th />
+            </tr>
+          </thead>
+          {data.permissionSets.length === 0 ? (
+            <TableEmpty message="No permission sets" />
+          ) : (
+            <tbody>
+              {data.permissionSets.map((role) => (
+                <tr key={role.id}>
+                  <td>{role.name}</td>
+                  <td>{formatPermissions(role.permissions)}</td>
+                  <td>
+                    <Text color={role.isBuiltIn ? "gray-500" : undefined}>
+                      {role.isBuiltIn ? "Built-in" : "Custom"}
+                    </Text>
+                  </td>
+                  <td>
+                    <Flex justifyContent="end" gap="size-100">
+                      {!role.isBuiltIn && (
+                        <>
+                          <Button
+                            size="S"
+                            isDisabled={isMutating}
+                            leadingVisual={<Icon svg={<Icons.Edit2 />} />}
+                            onPress={() => handleEdit(role)}
+                          >
+                            Edit
+                          </Button>
+                          <ConfirmButton
+                            buttonText="Delete"
+                            buttonAriaLabel={`Delete permission set ${role.name}`}
+                            isDisabled={isMutating}
+                            title="Delete permission set"
+                            message={
+                              <>
+                                Delete the permission set{" "}
+                                <strong>{role.name}</strong>? Existing grants
+                                that use it will fall back to view-only access.
+                              </>
+                            }
+                            confirmText="Delete permission set"
+                            onConfirm={() => handleDelete(role.id, role.name)}
+                          />
+                        </>
+                      )}
+                    </Flex>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          )}
+        </table>
+      </Card>
+    </Flex>
+  );
+}

--- a/app/src/pages/settings/SettingsTagGrantsPage.tsx
+++ b/app/src/pages/settings/SettingsTagGrantsPage.tsx
@@ -1,0 +1,429 @@
+import { css } from "@emotion/react";
+import { useDeferredValue, useState } from "react";
+import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
+
+import {
+  Alert,
+  Button,
+  Card,
+  ComboBox,
+  ComboBoxItem,
+  Flex,
+  Icon,
+  Icons,
+  Input,
+  Label,
+  ListBox,
+  Popover,
+  Select,
+  SelectChevronUpDownIcon,
+  SelectItem,
+  SelectValue,
+  Text,
+  TextField,
+  Token,
+  View,
+} from "@phoenix/components";
+import { ConfirmButton } from "@phoenix/components/ConfirmButton";
+import { tableCSS } from "@phoenix/components/table/styles";
+import { TableEmpty } from "@phoenix/components/table/TableEmpty";
+import { useNotifySuccess } from "@phoenix/contexts";
+import {
+  buildSubjectItems,
+  resolveSelectedSubject,
+  subjectInputFromParts,
+} from "@phoenix/pages/access/ResourceAccessForm";
+
+import type { SettingsTagGrantsPageGrantMutation } from "./__generated__/SettingsTagGrantsPageGrantMutation.graphql";
+import type { SettingsTagGrantsPageQuery } from "./__generated__/SettingsTagGrantsPageQuery.graphql";
+import type { SettingsTagGrantsPageRevokeMutation } from "./__generated__/SettingsTagGrantsPageRevokeMutation.graphql";
+
+type ObjectType = "PROJECT" | "DATASET" | "PROMPT";
+
+const OBJECT_TYPES: { value: ObjectType; label: string }[] = [
+  { value: "PROJECT", label: "Projects" },
+  { value: "DATASET", label: "Datasets" },
+  { value: "PROMPT", label: "Prompts" },
+];
+
+const OBJECT_TYPE_NOUN: Record<ObjectType, string> = {
+  PROJECT: "project",
+  DATASET: "dataset",
+  PROMPT: "prompt",
+};
+
+const addGrantRowCSS = css`
+  display: grid;
+  grid-template-columns:
+    minmax(200px, 1.4fr) minmax(120px, 0.8fr) minmax(120px, 1fr)
+    minmax(120px, 1fr) minmax(140px, 1fr) auto;
+  gap: var(--global-dimension-size-200);
+  align-items: end;
+
+  @media (max-width: 900px) {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+`;
+
+const tagTokenCSS = css`
+  font-variant-numeric: tabular-nums;
+  .tag-key {
+    font-weight: 600;
+  }
+  .tag-sep {
+    margin: 0 var(--global-dimension-size-75);
+    opacity: 0.5;
+  }
+`;
+
+/**
+ * Type-scoped access by tag. A tag grant gives a person or group a permission set over every project,
+ * dataset, or prompt that carries a `key=value` tag (set from that object's Access page). Unlike
+ * a per-object grant it is anchored to no single object, so authoring one is an administrator
+ * action. A tag grant confers view or edit only — never manage-access — so a tag's mutable reach
+ * can never be someone's sole path to managing an object.
+ */
+export function SettingsTagGrantsPage() {
+  const [fetchKey, setFetchKey] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedSubject, setSelectedSubject] = useState<string | null>(null);
+  const [objectType, setObjectType] = useState<ObjectType>("PROJECT");
+  const [tagKey, setTagKey] = useState("");
+  const [tagValue, setTagValue] = useState("");
+  const [selectedRoleId, setSelectedRoleId] = useState<string | null>(null);
+  const [subjectSearch, setSubjectSearch] = useState("");
+  const deferredSubjectSearch = useDeferredValue(subjectSearch.trim());
+  const notifySuccess = useNotifySuccess();
+
+  const data = useLazyLoadQuery<SettingsTagGrantsPageQuery>(
+    graphql`
+      query SettingsTagGrantsPageQuery($userFilter: UserFilter) {
+        tagGrants {
+          id
+          subjectKind
+          subjectId
+          subjectName
+          objectType
+          tagKey
+          tagValue
+          roleName
+        }
+        users(first: 25, filter: $userFilter) {
+          edges {
+            user: node {
+              id
+              username
+              email
+            }
+          }
+        }
+        userGroups {
+          id
+          name
+        }
+        permissionSets {
+          id
+          name
+          permissions
+        }
+      }
+    `,
+    {
+      userFilter: deferredSubjectSearch
+        ? { value: deferredSubjectSearch }
+        : null,
+    },
+    { fetchKey, fetchPolicy: "store-and-network" }
+  );
+
+  const [commitGrant, isGranting] =
+    useMutation<SettingsTagGrantsPageGrantMutation>(graphql`
+      mutation SettingsTagGrantsPageGrantMutation(
+        $input: TagAccessGrantInput!
+      ) {
+        grantTagAccess(input: $input) {
+          __typename
+        }
+      }
+    `);
+
+  const [commitRevoke, isRevoking] =
+    useMutation<SettingsTagGrantsPageRevokeMutation>(graphql`
+      mutation SettingsTagGrantsPageRevokeMutation(
+        $input: TagAccessGrantInput!
+      ) {
+        revokeTagAccess(input: $input) {
+          __typename
+        }
+      }
+    `);
+
+  const isMutating = isGranting || isRevoking;
+
+  // A tag grant may confer view or edit only — never manage-access — so the picker hides
+  // manage-conferring permission sets (the server rejects them too).
+  const grantableRoles = data.permissionSets.filter(
+    (role) => !role.permissions.includes("MANAGE_ACCESS")
+  );
+
+  const subjectItems = buildSubjectItems(
+    data.users.edges.map((edge) => edge.user),
+    data.userGroups
+  );
+
+  const refresh = () => setFetchKey((k) => k + 1);
+
+  const grant = () => {
+    if (!selectedSubject) return;
+    const subject = resolveSelectedSubject(selectedSubject);
+    if (subject == null) {
+      setError("Could not resolve the selected subject.");
+      return;
+    }
+    const key = tagKey.trim();
+    const value = tagValue.trim();
+    if (!key || !value) {
+      setError("A tag grant needs both a key and a value.");
+      return;
+    }
+    setError(null);
+    commitGrant({
+      variables: {
+        input: {
+          subject,
+          objectType,
+          tagKey: key,
+          tagValue: value,
+          permissionSetId: selectedRoleId || null,
+        },
+      },
+      onCompleted: () => {
+        notifySuccess({
+          title: "Tag grant created",
+          message: `Granted access to ${OBJECT_TYPE_NOUN[objectType]}s tagged ${key} = ${value}.`,
+        });
+        setSelectedSubject(null);
+        setTagKey("");
+        setTagValue("");
+        setSelectedRoleId(null);
+        refresh();
+      },
+      onError: (e) => setError(e.message),
+    });
+  };
+
+  const revoke = (
+    grantRow: SettingsTagGrantsPageQuery["response"]["tagGrants"][number]
+  ) => {
+    setError(null);
+    commitRevoke({
+      variables: {
+        input: {
+          subject: subjectInputFromParts(
+            grantRow.subjectKind,
+            grantRow.subjectId ?? null
+          ),
+          objectType: grantRow.objectType,
+          tagKey: grantRow.tagKey,
+          tagValue: grantRow.tagValue,
+        },
+      },
+      onCompleted: () => {
+        notifySuccess({
+          title: "Tag grant revoked",
+          message: "The tag grant has been removed.",
+        });
+        refresh();
+      },
+      onError: (e) => setError(e.message),
+    });
+  };
+
+  return (
+    <Flex direction="column" gap="size-200" width="100%">
+      {error && <Alert variant="danger">{error}</Alert>}
+      <Card
+        title="Grant access by tag"
+        subTitle="Give a person or group a permission set over every project, dataset, or prompt carrying a tag. Set tags from each object's Access page."
+        titleSeparator={false}
+      >
+        <View padding="size-200">
+          <div css={addGrantRowCSS}>
+            <ComboBox
+              label="Person or group"
+              placeholder="Search people and groups…"
+              width="100%"
+              selectedKey={selectedSubject}
+              onSelectionChange={(key) =>
+                setSelectedSubject(key == null ? null : String(key))
+              }
+              onInputChange={setSubjectSearch}
+              renderEmptyState={() => "No people or groups found"}
+            >
+              {subjectItems.map((item) => (
+                <ComboBoxItem key={item.id} id={item.id} textValue={item.label}>
+                  {item.label}
+                </ComboBoxItem>
+              ))}
+            </ComboBox>
+            <Select
+              value={objectType}
+              onChange={(key) =>
+                key != null && setObjectType(key as ObjectType)
+              }
+            >
+              <Label>Applies to</Label>
+              <Button>
+                <SelectValue />
+                <SelectChevronUpDownIcon />
+              </Button>
+              <Popover>
+                <ListBox>
+                  {OBJECT_TYPES.map((option) => (
+                    <SelectItem key={option.value} id={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </ListBox>
+              </Popover>
+            </Select>
+            <TextField value={tagKey} onChange={setTagKey}>
+              <Label>Tag key</Label>
+              <Input placeholder="e.g. env" />
+            </TextField>
+            <TextField value={tagValue} onChange={setTagValue}>
+              <Label>Tag value</Label>
+              <Input placeholder="e.g. prod" />
+            </TextField>
+            <Select
+              value={selectedRoleId ?? undefined}
+              onChange={(key) =>
+                setSelectedRoleId(key == null ? null : String(key))
+              }
+              placeholder="Viewer"
+            >
+              <Label>Permission set</Label>
+              <Button>
+                <SelectValue />
+                <SelectChevronUpDownIcon />
+              </Button>
+              <Popover>
+                <ListBox>
+                  {grantableRoles.map((role) => (
+                    <SelectItem key={role.id} id={role.id}>
+                      {role.name}
+                    </SelectItem>
+                  ))}
+                </ListBox>
+              </Popover>
+            </Select>
+            <Button
+              size="S"
+              variant="primary"
+              isDisabled={
+                !selectedSubject ||
+                !tagKey.trim() ||
+                !tagValue.trim() ||
+                isMutating
+              }
+              leadingVisual={<Icon svg={<Icons.PlusCircle />} />}
+              onPress={grant}
+            >
+              Grant
+            </Button>
+          </div>
+        </View>
+      </Card>
+      <Card
+        title="Tag grants"
+        subTitle="Access rules that follow tags. A grant applies to any matching object, including ones tagged later."
+        titleSeparator={false}
+      >
+        <table css={tableCSS}>
+          <thead>
+            <tr>
+              <th>Subject</th>
+              <th>Applies to</th>
+              <th>Tag</th>
+              <th>Permission set</th>
+              <th />
+            </tr>
+          </thead>
+          {data.tagGrants.length === 0 ? (
+            <TableEmpty message="No tag grants yet" />
+          ) : (
+            <tbody>
+              {data.tagGrants.map((grantRow) => (
+                <tr key={grantRow.id}>
+                  <td>
+                    <Flex direction="row" gap="size-100" alignItems="center">
+                      <Icon
+                        svg={
+                          grantRow.subjectKind === "EVERYONE" ? (
+                            <Icons.Globe />
+                          ) : (
+                            <Icons.Person />
+                          )
+                        }
+                      />
+                      {grantRow.subjectName}
+                    </Flex>
+                  </td>
+                  <td>
+                    {OBJECT_TYPE_NOUN[grantRow.objectType as ObjectType]}s
+                  </td>
+                  <td>
+                    <Token
+                      size="M"
+                      color="var(--global-color-blue-700)"
+                      css={tagTokenCSS}
+                    >
+                      <span className="tag-key">{grantRow.tagKey}</span>
+                      <span className="tag-sep">=</span>
+                      {grantRow.tagValue}
+                    </Token>
+                  </td>
+                  <td>{grantRow.roleName ?? "Viewer"}</td>
+                  <td>
+                    <Flex justifyContent="end">
+                      <ConfirmButton
+                        buttonText="Revoke"
+                        buttonAriaLabel={`Revoke tag grant for ${grantRow.subjectName}`}
+                        title="Revoke tag grant"
+                        message={
+                          <>
+                            Revoke <strong>{grantRow.subjectName}</strong>
+                            &apos;s access to{" "}
+                            {
+                              OBJECT_TYPE_NOUN[
+                                grantRow.objectType as ObjectType
+                              ]
+                            }
+                            s tagged{" "}
+                            <strong>
+                              {grantRow.tagKey} = {grantRow.tagValue}
+                            </strong>
+                            ?
+                          </>
+                        }
+                        confirmText="Revoke"
+                        isDisabled={isMutating}
+                        onConfirm={() => revoke(grantRow)}
+                      />
+                    </Flex>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          )}
+        </table>
+        <View paddingX="size-200" paddingBottom="size-200">
+          <Text size="XS" color="text-700">
+            Tag grants confer view or edit only — never manage-access.
+          </Text>
+        </View>
+      </Card>
+    </Flex>
+  );
+}

--- a/app/src/pages/settings/UserAccessDialog.tsx
+++ b/app/src/pages/settings/UserAccessDialog.tsx
@@ -1,0 +1,120 @@
+import { css } from "@emotion/react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+
+import {
+  Dialog,
+  DialogCloseButton,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTitleExtra,
+  Flex,
+  Text,
+  View,
+} from "@phoenix/components";
+
+import type { UserAccessDialogQuery } from "./__generated__/UserAccessDialogQuery.graphql";
+
+const accessListCSS = css`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-size-50);
+`;
+
+const RESOURCE_KINDS = [
+  { kind: "project", label: "Projects" },
+  { kind: "dataset", label: "Datasets" },
+  { kind: "prompt", label: "Prompts" },
+] as const;
+
+export function UserAccessDialog({
+  userId,
+  userLabel,
+  onClose,
+}: {
+  userId: string;
+  userLabel: string;
+  onClose: () => void;
+}) {
+  const data = useLazyLoadQuery<UserAccessDialogQuery>(
+    graphql`
+      query UserAccessDialogQuery($userId: ID!) {
+        node(id: $userId) {
+          ... on User {
+            accessSummary {
+              isAdmin
+              allProjects
+              allDatasets
+              allPrompts
+              objects {
+                kind
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    `,
+    { userId }
+  );
+
+  const summary = data.node?.accessSummary;
+  const allByKind: Record<string, boolean> = {
+    project: summary?.allProjects ?? false,
+    dataset: summary?.allDatasets ?? false,
+    prompt: summary?.allPrompts ?? false,
+  };
+
+  return (
+    <Dialog>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Access for {userLabel}</DialogTitle>
+          <DialogTitleExtra>
+            <DialogCloseButton onPress={onClose} slot="close" />
+          </DialogTitleExtra>
+        </DialogHeader>
+        <View padding="size-200">
+          {!summary ? (
+            <Text color="text-700">No access information available.</Text>
+          ) : (
+            <Flex direction="column" gap="size-200">
+              {summary.isAdmin ? (
+                <Text>
+                  Administrator: can access every project, dataset, and prompt.
+                </Text>
+              ) : null}
+              {RESOURCE_KINDS.map(({ kind, label }) => {
+                const items = summary.objects.filter(
+                  (object) => object.kind === kind
+                );
+                return (
+                  <Flex key={kind} direction="column" gap="size-50">
+                    <Text weight="heavy" size="S">
+                      {label}
+                    </Text>
+                    {allByKind[kind] ? (
+                      <Text color="text-700">All {label.toLowerCase()}</Text>
+                    ) : items.length === 0 ? (
+                      <Text color="text-700">None</Text>
+                    ) : (
+                      <ul css={accessListCSS}>
+                        {items.map((item) => (
+                          <li key={item.id}>{item.name}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </Flex>
+                );
+              })}
+            </Flex>
+          )}
+        </View>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/pages/settings/UserActionMenu.tsx
+++ b/app/src/pages/settings/UserActionMenu.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { Suspense, useMemo, useState } from "react";
 import type { DataID } from "relay-runtime";
 
 import {
@@ -7,6 +7,7 @@ import {
   Flex,
   Icon,
   Icons,
+  Loading,
   Menu,
   MenuItem,
   MenuTrigger,
@@ -15,18 +16,22 @@ import {
   Popover,
 } from "@phoenix/components";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
+import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
 
 import type { AuthMethod } from "./__generated__/UsersTable_users.graphql";
 import { DeleteUserDialog } from "./DeleteUserDialog";
 import { ResetPasswordDialog } from "./ResetPasswordDialog";
+import { UserAccessDialog } from "./UserAccessDialog";
 
 type UserActionMenuProps = {
   userId: string;
+  userLabel: string;
   authMethod: AuthMethod;
   connectionIds: DataID[];
 };
 
 enum UserAction {
+  VIEW_ACCESS = "viewAccess",
   DELETE = "deleteUser",
   RESET_PASSWORD = "resetPassword",
 }
@@ -36,11 +41,27 @@ function isLocalAuth(authMethod: AuthMethod): authMethod is "LOCAL" {
 }
 
 export function UserActionMenu(props: UserActionMenuProps) {
-  const { userId, authMethod, connectionIds } = props;
+  const { userId, userLabel, authMethod, connectionIds } = props;
+  const { accessControlEnabled } = useFunctionality();
+  const [showAccessDialog, setShowAccessDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showResetPasswordDialog, setShowResetPasswordDialog] = useState(false);
 
   const actionMenuItems = useMemo(() => {
+    const viewAccessItemEl = (
+      <MenuItem key={UserAction.VIEW_ACCESS} id={UserAction.VIEW_ACCESS}>
+        <Flex
+          direction={"row"}
+          gap="size-75"
+          justifyContent={"start"}
+          alignItems={"center"}
+        >
+          <Icon svg={<Icons.Eye />} />
+          <>View access</>
+        </Flex>
+      </MenuItem>
+    );
+
     const deleteUserItemEl = (
       <MenuItem key={UserAction.DELETE} id={UserAction.DELETE}>
         <Flex
@@ -69,12 +90,14 @@ export function UserActionMenu(props: UserActionMenuProps) {
       </MenuItem>
     );
 
-    const actionMenuItems = [deleteUserItemEl];
+    const actionMenuItems = accessControlEnabled
+      ? [viewAccessItemEl, deleteUserItemEl]
+      : [deleteUserItemEl];
     if (isLocalAuth(authMethod)) {
       actionMenuItems.push(resetPasswordItemEl);
     }
     return actionMenuItems;
-  }, [authMethod]);
+  }, [accessControlEnabled, authMethod]);
 
   return (
     <StopPropagation>
@@ -88,6 +111,9 @@ export function UserActionMenu(props: UserActionMenuProps) {
             aria-label="User Actions"
             onAction={(action) => {
               switch (action) {
+                case UserAction.VIEW_ACCESS:
+                  setShowAccessDialog(true);
+                  break;
                 case UserAction.DELETE:
                   setShowDeleteDialog(true);
                   break;
@@ -101,6 +127,22 @@ export function UserActionMenu(props: UserActionMenuProps) {
           </Menu>
         </Popover>
       </MenuTrigger>
+      <DialogTrigger
+        isOpen={showAccessDialog}
+        onOpenChange={setShowAccessDialog}
+      >
+        <ModalOverlay>
+          <Modal>
+            <Suspense fallback={<Loading />}>
+              <UserAccessDialog
+                userId={userId}
+                userLabel={userLabel}
+                onClose={() => setShowAccessDialog(false)}
+              />
+            </Suspense>
+          </Modal>
+        </ModalOverlay>
+      </DialogTrigger>
       <DialogTrigger
         isOpen={showDeleteDialog}
         onOpenChange={setShowDeleteDialog}

--- a/app/src/pages/settings/UsersTable.tsx
+++ b/app/src/pages/settings/UsersTable.tsx
@@ -211,6 +211,11 @@ export function UsersTable({ query }: { query: UsersTable_users$key }) {
             <Flex direction="row" justifyContent="end" width="100%">
               <UserActionMenu
                 userId={row.original.id}
+                userLabel={
+                  row.original.email
+                    ? `${row.original.username} (${row.original.email})`
+                    : row.original.username
+                }
                 connectionIds={[
                   ConnectionHandler.getConnectionID(
                     "client:root",

--- a/app/src/pages/settings/__generated__/APIKeysCardCreateSystemAPIKeyMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/APIKeysCardCreateSystemAPIKeyMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3731f63019173746e49573b3da013113>>
+ * @generated SignedSource<<32ba75198d3f443e68d46bbba4eaaebd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,10 +10,12 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
+export type ApiKeyScope = "INGEST";
 export type APIKeysCardCreateSystemAPIKeyMutation$variables = {
   description?: string | null;
   expiresAt?: string | null;
   name: string;
+  scope?: ApiKeyScope | null;
 };
 export type APIKeysCardCreateSystemAPIKeyMutation$data = {
   readonly createSystemApiKey: {
@@ -47,7 +49,12 @@ v2 = {
   "kind": "LocalArgument",
   "name": "name"
 },
-v3 = [
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "scope"
+},
+v4 = [
   {
     "fields": [
       {
@@ -64,27 +71,32 @@ v3 = [
         "kind": "Variable",
         "name": "name",
         "variableName": "name"
+      },
+      {
+        "kind": "Variable",
+        "name": "scope",
+        "variableName": "scope"
       }
     ],
     "kind": "ObjectValue",
     "name": "input"
   }
 ],
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "jwt",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "concreteType": "SystemApiKey",
@@ -92,12 +104,12 @@ v6 = {
   "name": "apiKey",
   "plural": false,
   "selections": [
-    (v5/*: any*/)
+    (v6/*: any*/)
   ],
   "storageKey": null
 },
-v7 = [
-  (v5/*: any*/),
+v8 = [
+  (v6/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -132,7 +144,8 @@ return {
     "argumentDefinitions": [
       (v0/*: any*/),
       (v1/*: any*/),
-      (v2/*: any*/)
+      (v2/*: any*/),
+      (v3/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -140,13 +153,13 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "CreateSystemApiKeyMutationPayload",
         "kind": "LinkedField",
         "name": "createSystemApiKey",
         "plural": false,
         "selections": [
-          (v4/*: any*/),
+          (v5/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -163,7 +176,7 @@ return {
             ],
             "storageKey": null
           },
-          (v6/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
@@ -176,20 +189,21 @@ return {
     "argumentDefinitions": [
       (v2/*: any*/),
       (v0/*: any*/),
-      (v1/*: any*/)
+      (v1/*: any*/),
+      (v3/*: any*/)
     ],
     "kind": "Operation",
     "name": "APIKeysCardCreateSystemAPIKeyMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "CreateSystemApiKeyMutationPayload",
         "kind": "LinkedField",
         "name": "createSystemApiKey",
         "plural": false,
         "selections": [
-          (v4/*: any*/),
+          (v5/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -205,7 +219,7 @@ return {
                 "kind": "LinkedField",
                 "name": "systemApiKeys",
                 "plural": true,
-                "selections": (v7/*: any*/),
+                "selections": (v8/*: any*/),
                 "storageKey": null
               },
               {
@@ -223,33 +237,33 @@ return {
                     "kind": "LinkedField",
                     "name": "apiKeys",
                     "plural": true,
-                    "selections": (v7/*: any*/),
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   },
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v6/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "8c8ce75c9f917911796042954e2dbd3b",
+    "cacheID": "53c33decc48d7d11d0264aceef7aba78",
     "id": null,
     "metadata": {},
     "name": "APIKeysCardCreateSystemAPIKeyMutation",
     "operationKind": "mutation",
-    "text": "mutation APIKeysCardCreateSystemAPIKeyMutation(\n  $name: String!\n  $description: String = null\n  $expiresAt: DateTime = null\n) {\n  createSystemApiKey(input: {name: $name, description: $description, expiresAt: $expiresAt}) {\n    jwt\n    query {\n      ...SystemAPIKeysTableFragment\n    }\n    apiKey {\n      id\n    }\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment SystemAPIKeysTableFragment on Query {\n  systemApiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  viewer {\n    ...APIKeysTableFragment\n    id\n  }\n}\n"
+    "text": "mutation APIKeysCardCreateSystemAPIKeyMutation(\n  $name: String!\n  $description: String = null\n  $expiresAt: DateTime = null\n  $scope: ApiKeyScope = null\n) {\n  createSystemApiKey(input: {name: $name, description: $description, expiresAt: $expiresAt, scope: $scope}) {\n    jwt\n    query {\n      ...SystemAPIKeysTableFragment\n    }\n    apiKey {\n      id\n    }\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment SystemAPIKeysTableFragment on Query {\n  systemApiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  viewer {\n    ...APIKeysTableFragment\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a6f84fa9e14f363d2e7317d3d6507590";
+(node as any).hash = "0da9861c8c75d11f13cf5336a2a91ccb";
 
 export default node;

--- a/app/src/pages/settings/__generated__/SettingsGroupsPageAddMemberMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsGroupsPageAddMemberMutation.graphql.ts
@@ -1,0 +1,100 @@
+/**
+ * @generated SignedSource<<92087d2cf9dc8332e24fe8f1e2e48165>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type SettingsGroupsPageAddMemberMutation$variables = {
+  groupId: number;
+  userId: number;
+};
+export type SettingsGroupsPageAddMemberMutation$data = {
+  readonly addUserGroupMember: {
+    readonly __typename: "UserGroupMutationPayload";
+  };
+};
+export type SettingsGroupsPageAddMemberMutation = {
+  response: SettingsGroupsPageAddMemberMutation$data;
+  variables: SettingsGroupsPageAddMemberMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "groupId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "userId"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "groupId",
+        "variableName": "groupId"
+      },
+      {
+        "kind": "Variable",
+        "name": "userId",
+        "variableName": "userId"
+      }
+    ],
+    "concreteType": "UserGroupMutationPayload",
+    "kind": "LinkedField",
+    "name": "addUserGroupMember",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsGroupsPageAddMemberMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SettingsGroupsPageAddMemberMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "5624fbdd98d252515c1a300b83f1cf16",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsGroupsPageAddMemberMutation",
+    "operationKind": "mutation",
+    "text": "mutation SettingsGroupsPageAddMemberMutation(\n  $groupId: Int!\n  $userId: Int!\n) {\n  addUserGroupMember(groupId: $groupId, userId: $userId) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "a1ce124b245ca4fb8dbab9d836336165";
+
+export default node;

--- a/app/src/pages/settings/__generated__/SettingsGroupsPageCreateMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsGroupsPageCreateMutation.graphql.ts
@@ -1,0 +1,89 @@
+/**
+ * @generated SignedSource<<7ee0a29523bc00c6319869ca6126d9c5>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type SettingsGroupsPageCreateMutation$variables = {
+  name: string;
+};
+export type SettingsGroupsPageCreateMutation$data = {
+  readonly createUserGroup: {
+    readonly __typename: "UserGroupMutationPayload";
+  };
+};
+export type SettingsGroupsPageCreateMutation = {
+  response: SettingsGroupsPageCreateMutation$data;
+  variables: SettingsGroupsPageCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "name"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "name",
+        "variableName": "name"
+      }
+    ],
+    "concreteType": "UserGroupMutationPayload",
+    "kind": "LinkedField",
+    "name": "createUserGroup",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsGroupsPageCreateMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SettingsGroupsPageCreateMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "9d4daa6ba3027190a0d33ce677fbbb23",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsGroupsPageCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation SettingsGroupsPageCreateMutation(\n  $name: String!\n) {\n  createUserGroup(name: $name) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "a10ad21bf9e6912dcbe888ffce4a1c55";
+
+export default node;

--- a/app/src/pages/settings/__generated__/SettingsGroupsPageDeleteMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsGroupsPageDeleteMutation.graphql.ts
@@ -1,0 +1,89 @@
+/**
+ * @generated SignedSource<<c5d29f7d46a6455c2bac13e20f58dceb>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type SettingsGroupsPageDeleteMutation$variables = {
+  groupId: number;
+};
+export type SettingsGroupsPageDeleteMutation$data = {
+  readonly deleteUserGroup: {
+    readonly __typename: "UserGroupMutationPayload";
+  };
+};
+export type SettingsGroupsPageDeleteMutation = {
+  response: SettingsGroupsPageDeleteMutation$data;
+  variables: SettingsGroupsPageDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "groupId"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "groupId",
+        "variableName": "groupId"
+      }
+    ],
+    "concreteType": "UserGroupMutationPayload",
+    "kind": "LinkedField",
+    "name": "deleteUserGroup",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsGroupsPageDeleteMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SettingsGroupsPageDeleteMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "72953b7c38cdfde6080186babfeea4a3",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsGroupsPageDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation SettingsGroupsPageDeleteMutation(\n  $groupId: Int!\n) {\n  deleteUserGroup(groupId: $groupId) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1388fc5620a852db93bee7bde6e92603";
+
+export default node;

--- a/app/src/pages/settings/__generated__/SettingsGroupsPageQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsGroupsPageQuery.graphql.ts
@@ -1,0 +1,245 @@
+/**
+ * @generated SignedSource<<1bbb88a4a5458f01937f44131950ab1e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type UserFilter = {
+  value?: string | null;
+};
+export type SettingsGroupsPageQuery$variables = {
+  userFilter?: UserFilter | null;
+};
+export type SettingsGroupsPageQuery$data = {
+  readonly memberCandidates: {
+    readonly edges: ReadonlyArray<{
+      readonly user: {
+        readonly email: string | null;
+        readonly id: string;
+        readonly username: string;
+      };
+    }>;
+  };
+  readonly userGroups: ReadonlyArray<{
+    readonly groupId: number;
+    readonly isLocal: boolean;
+    readonly memberUserIds: ReadonlyArray<number>;
+    readonly name: string;
+    readonly provider: string;
+  }>;
+  readonly users: {
+    readonly edges: ReadonlyArray<{
+      readonly user: {
+        readonly email: string | null;
+        readonly id: string;
+        readonly username: string;
+      };
+    }>;
+  };
+};
+export type SettingsGroupsPageQuery = {
+  response: SettingsGroupsPageQuery$data;
+  variables: SettingsGroupsPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "userFilter"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "groupId",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "provider",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isLocal",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "memberUserIds",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v7 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "UserEdge",
+    "kind": "LinkedField",
+    "name": "edges",
+    "plural": true,
+    "selections": [
+      {
+        "alias": "user",
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v6/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "username",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "email",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+],
+v8 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "first",
+      "value": 1000
+    }
+  ],
+  "concreteType": "UserConnection",
+  "kind": "LinkedField",
+  "name": "users",
+  "plural": false,
+  "selections": (v7/*: any*/),
+  "storageKey": "users(first:1000)"
+},
+v9 = {
+  "alias": "memberCandidates",
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "filter",
+      "variableName": "userFilter"
+    },
+    {
+      "kind": "Literal",
+      "name": "first",
+      "value": 25
+    }
+  ],
+  "concreteType": "UserConnection",
+  "kind": "LinkedField",
+  "name": "users",
+  "plural": false,
+  "selections": (v7/*: any*/),
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsGroupsPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "UserGroup",
+        "kind": "LinkedField",
+        "name": "userGroups",
+        "plural": true,
+        "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/),
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      },
+      (v8/*: any*/),
+      (v9/*: any*/)
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SettingsGroupsPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "UserGroup",
+        "kind": "LinkedField",
+        "name": "userGroups",
+        "plural": true,
+        "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/),
+          (v5/*: any*/),
+          (v6/*: any*/)
+        ],
+        "storageKey": null
+      },
+      (v8/*: any*/),
+      (v9/*: any*/)
+    ]
+  },
+  "params": {
+    "cacheID": "16a90406863ded270489c75fd877eef2",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsGroupsPageQuery",
+    "operationKind": "query",
+    "text": "query SettingsGroupsPageQuery(\n  $userFilter: UserFilter\n) {\n  userGroups {\n    groupId\n    name\n    provider\n    isLocal\n    memberUserIds\n    id\n  }\n  users(first: 1000) {\n    edges {\n      user: node {\n        id\n        username\n        email\n      }\n    }\n  }\n  memberCandidates: users(first: 25, filter: $userFilter) {\n    edges {\n      user: node {\n        id\n        username\n        email\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "570c4c46d3dd66589ca00026a01a73a4";
+
+export default node;

--- a/app/src/pages/settings/__generated__/SettingsGroupsPageRemoveMemberMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsGroupsPageRemoveMemberMutation.graphql.ts
@@ -1,0 +1,100 @@
+/**
+ * @generated SignedSource<<c94f92fb6b0ade1a0643beba5f4acc87>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type SettingsGroupsPageRemoveMemberMutation$variables = {
+  groupId: number;
+  userId: number;
+};
+export type SettingsGroupsPageRemoveMemberMutation$data = {
+  readonly removeUserGroupMember: {
+    readonly __typename: "UserGroupMutationPayload";
+  };
+};
+export type SettingsGroupsPageRemoveMemberMutation = {
+  response: SettingsGroupsPageRemoveMemberMutation$data;
+  variables: SettingsGroupsPageRemoveMemberMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "groupId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "userId"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "groupId",
+        "variableName": "groupId"
+      },
+      {
+        "kind": "Variable",
+        "name": "userId",
+        "variableName": "userId"
+      }
+    ],
+    "concreteType": "UserGroupMutationPayload",
+    "kind": "LinkedField",
+    "name": "removeUserGroupMember",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsGroupsPageRemoveMemberMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SettingsGroupsPageRemoveMemberMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "2a2246bc2c3664eab84392b1123d9187",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsGroupsPageRemoveMemberMutation",
+    "operationKind": "mutation",
+    "text": "mutation SettingsGroupsPageRemoveMemberMutation(\n  $groupId: Int!\n  $userId: Int!\n) {\n  removeUserGroupMember(groupId: $groupId, userId: $userId) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "19b401f364535e22aa1dc3382aec18e6";
+
+export default node;

--- a/app/src/pages/settings/__generated__/SettingsRolesPageCreateMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsRolesPageCreateMutation.graphql.ts
@@ -1,0 +1,94 @@
+/**
+ * @generated SignedSource<<e92b7dc45f3d9775c0e6dbe1f50476b3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ObjectPermission = "EDIT" | "MANAGE_ACCESS" | "VIEW";
+export type CreatePermissionSetInput = {
+  name: string;
+  permissions: ReadonlyArray<ObjectPermission>;
+};
+export type SettingsRolesPageCreateMutation$variables = {
+  input: CreatePermissionSetInput;
+};
+export type SettingsRolesPageCreateMutation$data = {
+  readonly createPermissionSet: {
+    readonly __typename: "PermissionSetMutationPayload";
+  };
+};
+export type SettingsRolesPageCreateMutation = {
+  response: SettingsRolesPageCreateMutation$data;
+  variables: SettingsRolesPageCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "PermissionSetMutationPayload",
+    "kind": "LinkedField",
+    "name": "createPermissionSet",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsRolesPageCreateMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SettingsRolesPageCreateMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "9b92fe9e6950be00fef37ba58a5845a8",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsRolesPageCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation SettingsRolesPageCreateMutation(\n  $input: CreatePermissionSetInput!\n) {\n  createPermissionSet(input: $input) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "65cd1dd205d0b9f8a93e5699d0ea2822";
+
+export default node;

--- a/app/src/pages/settings/__generated__/SettingsRolesPageDeleteMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsRolesPageDeleteMutation.graphql.ts
@@ -1,0 +1,92 @@
+/**
+ * @generated SignedSource<<cfa9a45d322f27c1f7e76ed64446fc77>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeletePermissionSetInput = {
+  id: string;
+};
+export type SettingsRolesPageDeleteMutation$variables = {
+  input: DeletePermissionSetInput;
+};
+export type SettingsRolesPageDeleteMutation$data = {
+  readonly deletePermissionSet: {
+    readonly __typename: "PermissionSetMutationPayload";
+  };
+};
+export type SettingsRolesPageDeleteMutation = {
+  response: SettingsRolesPageDeleteMutation$data;
+  variables: SettingsRolesPageDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "PermissionSetMutationPayload",
+    "kind": "LinkedField",
+    "name": "deletePermissionSet",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsRolesPageDeleteMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SettingsRolesPageDeleteMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "7b3f5adda58f2ca2e75ff92c221d06ce",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsRolesPageDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation SettingsRolesPageDeleteMutation(\n  $input: DeletePermissionSetInput!\n) {\n  deletePermissionSet(input: $input) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1071f0f07e8e6d54e1af945c2fc4862d";
+
+export default node;

--- a/app/src/pages/settings/__generated__/SettingsRolesPagePatchMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsRolesPagePatchMutation.graphql.ts
@@ -1,0 +1,95 @@
+/**
+ * @generated SignedSource<<aea3cd1df291e83ca3d71be9fba563ab>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ObjectPermission = "EDIT" | "MANAGE_ACCESS" | "VIEW";
+export type PatchPermissionSetInput = {
+  id: string;
+  name?: string | null;
+  permissions?: ReadonlyArray<ObjectPermission> | null;
+};
+export type SettingsRolesPagePatchMutation$variables = {
+  input: PatchPermissionSetInput;
+};
+export type SettingsRolesPagePatchMutation$data = {
+  readonly patchPermissionSet: {
+    readonly __typename: "PermissionSetMutationPayload";
+  };
+};
+export type SettingsRolesPagePatchMutation = {
+  response: SettingsRolesPagePatchMutation$data;
+  variables: SettingsRolesPagePatchMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "PermissionSetMutationPayload",
+    "kind": "LinkedField",
+    "name": "patchPermissionSet",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsRolesPagePatchMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SettingsRolesPagePatchMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "416f6a8276a8383e0314cc056a345a18",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsRolesPagePatchMutation",
+    "operationKind": "mutation",
+    "text": "mutation SettingsRolesPagePatchMutation(\n  $input: PatchPermissionSetInput!\n) {\n  patchPermissionSet(input: $input) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "6a96f3a4ba2bc33b5b69f307968a00db";
+
+export default node;

--- a/app/src/pages/settings/__generated__/SettingsRolesPageQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsRolesPageQuery.graphql.ts
@@ -1,0 +1,99 @@
+/**
+ * @generated SignedSource<<f978e202e5e41f3d96429f2630881a35>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ObjectPermission = "EDIT" | "MANAGE_ACCESS" | "VIEW";
+export type SettingsRolesPageQuery$variables = Record<PropertyKey, never>;
+export type SettingsRolesPageQuery$data = {
+  readonly permissionSets: ReadonlyArray<{
+    readonly id: string;
+    readonly isBuiltIn: boolean;
+    readonly name: string;
+    readonly permissions: ReadonlyArray<ObjectPermission>;
+  }>;
+};
+export type SettingsRolesPageQuery = {
+  response: SettingsRolesPageQuery$data;
+  variables: SettingsRolesPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "PermissionSet",
+    "kind": "LinkedField",
+    "name": "permissionSets",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "name",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isBuiltIn",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "permissions",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsRolesPageQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "SettingsRolesPageQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "102f215deca5edff040d9f9076588e3a",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsRolesPageQuery",
+    "operationKind": "query",
+    "text": "query SettingsRolesPageQuery {\n  permissionSets {\n    id\n    name\n    isBuiltIn\n    permissions\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e045e901fc22065e8f75a31534a5df97";
+
+export default node;

--- a/app/src/pages/settings/__generated__/SettingsTagGrantsPageGrantMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsTagGrantsPageGrantMutation.graphql.ts
@@ -1,0 +1,102 @@
+/**
+ * @generated SignedSource<<e00d0052c3e5a63ccb7fbbc5117b241f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AccessObjectType = "DATASET" | "PROJECT" | "PROMPT";
+export type TagAccessGrantInput = {
+  objectType: AccessObjectType;
+  permissionSetId?: string | null;
+  subject: AccessGrantSubjectInput;
+  tagKey: string;
+  tagValue: string;
+};
+export type AccessGrantSubjectInput = {
+  isEveryone?: boolean | null;
+  userGroupId?: string | null;
+  userId?: string | null;
+};
+export type SettingsTagGrantsPageGrantMutation$variables = {
+  input: TagAccessGrantInput;
+};
+export type SettingsTagGrantsPageGrantMutation$data = {
+  readonly grantTagAccess: {
+    readonly __typename: "AccessGrantMutationPayload";
+  };
+};
+export type SettingsTagGrantsPageGrantMutation = {
+  response: SettingsTagGrantsPageGrantMutation$data;
+  variables: SettingsTagGrantsPageGrantMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "AccessGrantMutationPayload",
+    "kind": "LinkedField",
+    "name": "grantTagAccess",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsTagGrantsPageGrantMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SettingsTagGrantsPageGrantMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "38aff8c72ce6f8c696a343d5a1db1dc4",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsTagGrantsPageGrantMutation",
+    "operationKind": "mutation",
+    "text": "mutation SettingsTagGrantsPageGrantMutation(\n  $input: TagAccessGrantInput!\n) {\n  grantTagAccess(input: $input) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "11541b0d52695d0cc63b4d87d0732b96";
+
+export default node;

--- a/app/src/pages/settings/__generated__/SettingsTagGrantsPageQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsTagGrantsPageQuery.graphql.ts
@@ -1,0 +1,263 @@
+/**
+ * @generated SignedSource<<18036e0ef70e9a2a4581a216ab784f3e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AccessObjectType = "DATASET" | "PROJECT" | "PROMPT";
+export type AccessSubjectKind = "EVERYONE" | "GROUP" | "USER";
+export type ObjectPermission = "EDIT" | "MANAGE_ACCESS" | "VIEW";
+export type UserFilter = {
+  value?: string | null;
+};
+export type SettingsTagGrantsPageQuery$variables = {
+  userFilter?: UserFilter | null;
+};
+export type SettingsTagGrantsPageQuery$data = {
+  readonly permissionSets: ReadonlyArray<{
+    readonly id: string;
+    readonly name: string;
+    readonly permissions: ReadonlyArray<ObjectPermission>;
+  }>;
+  readonly tagGrants: ReadonlyArray<{
+    readonly id: string;
+    readonly objectType: AccessObjectType;
+    readonly roleName: string | null;
+    readonly subjectId: string | null;
+    readonly subjectKind: AccessSubjectKind;
+    readonly subjectName: string;
+    readonly tagKey: string;
+    readonly tagValue: string;
+  }>;
+  readonly userGroups: ReadonlyArray<{
+    readonly id: string;
+    readonly name: string;
+  }>;
+  readonly users: {
+    readonly edges: ReadonlyArray<{
+      readonly user: {
+        readonly email: string | null;
+        readonly id: string;
+        readonly username: string;
+      };
+    }>;
+  };
+};
+export type SettingsTagGrantsPageQuery = {
+  response: SettingsTagGrantsPageQuery$data;
+  variables: SettingsTagGrantsPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "userFilter"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "TagAccessGrant",
+    "kind": "LinkedField",
+    "name": "tagGrants",
+    "plural": true,
+    "selections": [
+      (v1/*: any*/),
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "subjectKind",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "subjectId",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "subjectName",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "objectType",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "tagKey",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "tagValue",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "roleName",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "filter",
+        "variableName": "userFilter"
+      },
+      {
+        "kind": "Literal",
+        "name": "first",
+        "value": 25
+      }
+    ],
+    "concreteType": "UserConnection",
+    "kind": "LinkedField",
+    "name": "users",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "UserEdge",
+        "kind": "LinkedField",
+        "name": "edges",
+        "plural": true,
+        "selections": [
+          {
+            "alias": "user",
+            "args": null,
+            "concreteType": "User",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "username",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "email",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "UserGroup",
+    "kind": "LinkedField",
+    "name": "userGroups",
+    "plural": true,
+    "selections": [
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "PermissionSet",
+    "kind": "LinkedField",
+    "name": "permissionSets",
+    "plural": true,
+    "selections": [
+      (v1/*: any*/),
+      (v2/*: any*/),
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "permissions",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsTagGrantsPageQuery",
+    "selections": (v3/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SettingsTagGrantsPageQuery",
+    "selections": (v3/*: any*/)
+  },
+  "params": {
+    "cacheID": "97e2fa2b09da5eea6971e0214466579b",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsTagGrantsPageQuery",
+    "operationKind": "query",
+    "text": "query SettingsTagGrantsPageQuery(\n  $userFilter: UserFilter\n) {\n  tagGrants {\n    id\n    subjectKind\n    subjectId\n    subjectName\n    objectType\n    tagKey\n    tagValue\n    roleName\n  }\n  users(first: 25, filter: $userFilter) {\n    edges {\n      user: node {\n        id\n        username\n        email\n      }\n    }\n  }\n  userGroups {\n    id\n    name\n  }\n  permissionSets {\n    id\n    name\n    permissions\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "c54e9641835e8ffc9ddf393206380b53";
+
+export default node;

--- a/app/src/pages/settings/__generated__/SettingsTagGrantsPageRevokeMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsTagGrantsPageRevokeMutation.graphql.ts
@@ -1,0 +1,102 @@
+/**
+ * @generated SignedSource<<5b6b04459f7ff587f71e957506586864>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AccessObjectType = "DATASET" | "PROJECT" | "PROMPT";
+export type TagAccessGrantInput = {
+  objectType: AccessObjectType;
+  permissionSetId?: string | null;
+  subject: AccessGrantSubjectInput;
+  tagKey: string;
+  tagValue: string;
+};
+export type AccessGrantSubjectInput = {
+  isEveryone?: boolean | null;
+  userGroupId?: string | null;
+  userId?: string | null;
+};
+export type SettingsTagGrantsPageRevokeMutation$variables = {
+  input: TagAccessGrantInput;
+};
+export type SettingsTagGrantsPageRevokeMutation$data = {
+  readonly revokeTagAccess: {
+    readonly __typename: "AccessGrantMutationPayload";
+  };
+};
+export type SettingsTagGrantsPageRevokeMutation = {
+  response: SettingsTagGrantsPageRevokeMutation$data;
+  variables: SettingsTagGrantsPageRevokeMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "AccessGrantMutationPayload",
+    "kind": "LinkedField",
+    "name": "revokeTagAccess",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsTagGrantsPageRevokeMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SettingsTagGrantsPageRevokeMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "313cc89d3ff6338ef4b703327672f5d6",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsTagGrantsPageRevokeMutation",
+    "operationKind": "mutation",
+    "text": "mutation SettingsTagGrantsPageRevokeMutation(\n  $input: TagAccessGrantInput!\n) {\n  revokeTagAccess(input: $input) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "d909fe35944a79996d6bbedad5c8e4f6";
+
+export default node;

--- a/app/src/pages/settings/__generated__/UserAccessDialogQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/UserAccessDialogQuery.graphql.ts
@@ -1,0 +1,193 @@
+/**
+ * @generated SignedSource<<560bdcb4d60681194b2fe15c76948904>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type UserAccessDialogQuery$variables = {
+  userId: string;
+};
+export type UserAccessDialogQuery$data = {
+  readonly node: {
+    readonly accessSummary?: {
+      readonly allDatasets: boolean;
+      readonly allProjects: boolean;
+      readonly allPrompts: boolean;
+      readonly isAdmin: boolean;
+      readonly objects: ReadonlyArray<{
+        readonly id: string;
+        readonly kind: string;
+        readonly name: string;
+      }>;
+    };
+  };
+};
+export type UserAccessDialogQuery = {
+  response: UserAccessDialogQuery$data;
+  variables: UserAccessDialogQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "userId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "userId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "UserAccessSummary",
+      "kind": "LinkedField",
+      "name": "accessSummary",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isAdmin",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "allProjects",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "allDatasets",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "allPrompts",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AccessibleObjectRef",
+          "kind": "LinkedField",
+          "name": "objects",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "kind",
+              "storageKey": null
+            },
+            (v2/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "name",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "UserAccessDialogQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "UserAccessDialogQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v3/*: any*/),
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "e1bea8c5208150f3449cd479a15578cf",
+    "id": null,
+    "metadata": {},
+    "name": "UserAccessDialogQuery",
+    "operationKind": "query",
+    "text": "query UserAccessDialogQuery(\n  $userId: ID!\n) {\n  node(id: $userId) {\n    __typename\n    ... on User {\n      accessSummary {\n        isAdmin\n        allProjects\n        allDatasets\n        allPrompts\n        objects {\n          kind\n          id\n          name\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "821a3a03f7ebfaa77c4c157707c048ff";
+
+export default node;

--- a/app/src/window.d.ts
+++ b/app/src/window.d.ts
@@ -13,6 +13,7 @@ declare global {
       basename: string;
       platformVersion: string;
       authenticationEnabled: boolean;
+      accessControlEnabled: boolean;
       basicAuthDisabled: boolean;
       oAuth2Idps: OAuth2Idp[];
       ldapEnabled: boolean;

--- a/internal_docs/specs/rbac/access-control-implementation-invariants.md
+++ b/internal_docs/specs/rbac/access-control-implementation-invariants.md
@@ -1,0 +1,920 @@
+# Access-Control Implementation Invariants
+
+This note is the implementation companion to the Phoenix access-control design. The
+[survey](./access-control-survey.md) defines the model and a product-neutral vocabulary; the
+[Phoenix design notes](./phoenix-access-control.md) choose the product semantics and record the
+forks. This document names the edge-case invariants that keep the implementation faithful to
+those choices — the properties a reader should be able to assume, and a reviewer should defend,
+when touching authorization code.
+
+The examples are intentionally concrete. Authorization bugs are easiest to miss when described
+as abstract operators and easiest to remember when walked through as a small story. Each section
+runs the same beats: a **Story** (the concrete failure), the **Principle** it offends (the design
+rule we reason from), the **Invariant** that principle demands, the **Requirement** on the
+implementation, and a **Test / guardrail** — closing with a **Status** tag for where the prototype
+stands. The principle is the general commitment; the invariant is the specific property that
+commitment forces.
+
+## How to read this
+
+**Reference model.** Effective access composes as:
+
+```text
+effective = ( admin-baseline  ∪  reaching-grants  ∪  permission-sets )
+            ∩  global-read-only-role
+            ∩  credential-scope
+```
+
+An additive `∪` core (allow-only, monotonic, fail-closed) bounded by two coarse `∩` caps.
+There is deliberately **no `∖` (deny)** operator and no per-object exception — see
+[design notes](./phoenix-access-control.md) §2.13. Consequences of that choice recur below.
+
+**Vocabulary.**
+
+- **Oracle** — the single seam that answers "may subject S do action A on object O?", in three
+  shapes: a point check (`can_access`), a list predicate (`accessible_scope` /
+  `access_predicate`), and an audit view (`subjects_for`).
+- **Access root** — a top-level grantable object: a project, dataset, or prompt. Derived
+  children (an experiment's or evaluator's trace project) are **not** roots; they inherit
+  access from a parent root (see Part D).
+- **Cap** — a coarse `∩` bound: the global read-only role (`VIEWER`) and the credential scope
+  on an API key. Caps only ever *remove* authority.
+- **Reaching grant** — a grant that names the object by id, by type-wide `all`, or through a
+  parent edge.
+
+**Status tags.** Each invariant is tagged with where the current prototype stands, so target
+state is not confused with shipped behavior:
+
+- **Holds** — the code already maintains this; the invariant is a guard-rail against regression.
+- **Gap** — the code violates or does not yet enforce this; it is an implementation task.
+- **Proposed** — this depends on a mechanism not built yet, or a product decision not made yet.
+
+**Reading guidance.** Two rules cut across everything. *Oracle first:* final effective access
+is the oracle's answer; coarse mutation guards may reject a request for operational reasons but
+must not be the only place a semantic lives. *Coverage counts:* an invariant about the oracle's
+answer is worthless on a surface that never calls the oracle.
+
+---
+
+# Part A — One decision, applied everywhere
+
+## A1. The oracle owns effective access
+
+### Story: Morgan owns it, but still cannot write
+
+Morgan creates a dataset as a `MEMBER`. Later an admin demotes Morgan to `VIEWER`. The dataset
+still records Morgan as creator, so ownership still explains why Morgan can *read* it — but
+`VIEWER` is a global read-only cap, so Morgan may not edit it or grant access to anyone.
+
+Today that "no" comes from a GraphQL mutation gate (`IsNotViewer`), while the oracle, asked in
+isolation, would say Morgan *may* manage the dataset (creator ownership confers manage
+unconditionally). Two layers, two answers. The first script, REST route, or background job that
+consults only the oracle will get the permissive one.
+
+Two identities sit deliberately *above* the additive machinery, and both are centralized in the
+oracle rather than scattered as per-resolver bypasses: an `ADMINISTER` holder (`ADMIN` /
+`SYSTEM`) short-circuits to universal access, and enforcement-disabled makes everything
+accessible. Credential scope is the one cap that still binds even an admin — it attenuates at
+the protocol boundary regardless of role.
+
+**Principle:** access has one source of truth — a subject's effective authority is a single
+function of identity, grants, and caps, not something each surface re-derives.
+
+**Invariant:** final effective access is computed by the oracle, including the global read-only
+cap. Grants and ownership add authority; global role and credential scope cap it; `ADMINISTER`
+and enforcement-disabled are explicit oracle-level rules.
+
+**Requirement:** `can_access` / `accessible_scope` must apply the same cap semantics that write
+mutations rely on, so a downgraded creator is denied writes *by the oracle*, not only by a
+resolver gate. Mutation permission classes may remain as coarse preconditions (read-only mode,
+storage lock, authentication present) but must not be the sole carrier of an access semantic.
+
+**Test / guardrail:** a creator downgraded to `VIEWER` can still read their creator-private
+dataset but cannot edit it or manage its access through *any* surface, and the denial is
+explainable as an oracle cap.
+
+**Status:** Gap — the `VIEWER` write-cap currently lives in the `IsNotViewer` gate, not the
+oracle. See [design notes](./phoenix-access-control.md) §2.13 (read-only cap vs. per-object lift).
+
+## A2. Coverage is part of correctness
+
+### Story: The perfect oracle nobody called
+
+A correct oracle protects nothing on a surface that bypasses it. A list resolver may apply the
+access predicate while a nested field resolver, a `node(id:)` lookup, an export endpoint, or a
+metrics aggregate loads the same object without it. The model is enforced by being *applied*
+everywhere data crosses a boundary, not by existing.
+
+**Principle:** a control is only as strong as the surfaces that invoke it; correctness is a
+property of the whole request surface, not of the decision function in isolation.
+
+**Invariant:** every read and write surface routes the same resource/action pair through the
+same access decision.
+
+**Requirement:** maintain an inventory of access-derived operations — list, point-get, node
+lookup, count, aggregate, export, autocomplete, subscription, mutation, transfer, background
+runner reads — each naming the oracle call or SQL predicate it uses. Missing or malformed object
+identity must fail closed; helper code must not treat "no id" as "no check needed" unless the
+operation is explicitly objectless (see A3's fail-open note).
+
+**Test / guardrail:** a user who cannot read an object through the canonical point check also
+fails through GraphQL `node`, REST, export, aggregate, and derived-child queries. Null, missing,
+and malformed ids deny rather than silently skipping the predicate.
+
+**Status:** Gap — enforcement is opt-in per surface; nested resolvers and objectless helpers are
+the main exposure.
+
+## A3. Denial is indistinguishable from absence
+
+### Story: The 404 that does not leak
+
+A user asks for a dataset they may not see. The system must not answer "403 Forbidden" — that
+confirms the dataset *exists*. It answers as if the object is not there: not-found / null, the
+same response an unknown id would produce. Existence itself is information.
+
+The mirror hazard is a helper that short-circuits the wrong way: a guard shaped
+`if object_id is None: return` grants access on a missing id instead of denying it — an
+allow-by-default branch inside a deny-by-default system.
+
+**Principle:** fail closed, and reveal nothing — the existence of a resource is itself
+privileged information, so the error channel must not leak it.
+
+**Invariant:** unauthorized and non-existent are indistinguishable to the caller. Denial reveals
+nothing an unknown id would not.
+
+**Requirement:** point checks surface denial as not-found / null, never as a distinct
+"forbidden" that leaks existence. Guards fail closed on absent or malformed identity.
+
+**Test / guardrail:** the response for "object you may not see" is byte-for-byte the response for
+"object that does not exist." No helper returns access-granted on a null/missing id.
+
+**Status:** H/G — the two halves of this invariant stand differently. *Not-found masking
+Holds*: the oracle and REST helpers surface unauthorized as not-found. *Fail-closed-on-missing-id
+is a Gap*: at least one experiment helper returns access-granted when the parent dataset id is
+absent, an allow-by-default branch to close.
+
+## A4. Enforcement is a latched deployment decision, and presupposes authentication
+
+### Story: The instance with grants but no subjects
+
+Enforcement is a deployment-level switch (`access_control.enabled`), reconciled once from the
+environment at startup; the running app exposes no runtime enable/disable path. Turning it on is
+a deliberate operator action, not a per-request condition.
+
+Now suppose an operator enables access control but disables authentication. Requests carry no
+durable subject, so the oracle has no identity to evaluate. Grant checks and admin checks cannot
+mean what they meant under auth-on: the instance is open by configuration. That is fine for an
+*intentionally* open deployment — but it is not a restricted deployment running in a degraded,
+partially-enforced mode.
+
+**Principle:** authorization presupposes authentication — you cannot restrict access for a
+subject you cannot identify, so there is no partially-enforced state, only enforcing-with-identity
+or open.
+
+**Invariant:** access control presupposes authentication. Auth-off means there is no subject for
+the model to evaluate; enforcement is a startup-latched, deployment-wide decision, not a runtime
+toggle.
+
+**Requirement:** an access-control-on, auth-off configuration must fail loudly before serving
+traffic rather than silently running open. Helpers may no-op under auth-off only because the
+deployment is explicitly open; they must not present grant state as enforced security.
+
+**Test / guardrail:** startup rejects access-control-on plus auth-off. With auth intentionally
+off, access helpers behave as consistent open-mode helpers.
+
+**Status:** H/P — two claims Hold (the startup-only enforcement latch with no runtime toggle,
+and the auth-presupposition: no subject under auth-off); one is Proposed (a *loud startup
+rejection* of access-control-on + auth-off — no such guard exists today, so that config runs
+silently open).
+
+---
+
+# Part B — Ownership and the subject lifecycle
+
+## B1. Creator ownership is data, not role
+
+### Story: Priya leaves, and her private dataset loses its owner
+
+Priya creates a dataset; its creator-private access is carried by a `user_id` column. Role
+changes never touch that column — which is exactly why a downgraded creator keeps ownership
+(A1). But when Priya is deprovisioned, the user row is deleted and the column becomes null. The
+dataset does not become public and does not remember a ghost owner; it becomes reachable only
+through explicit grants or administrator authority — a fail-closed, but silent, outcome.
+
+**Principle:** ownership and role are independent facts with independent lifecycles; authority
+carried by stored data ages with the data, and identity-lifecycle events are authorization
+events.
+
+**Invariant:** creator ownership is a stored relationship. Role changes do not remove it;
+identity deletion does.
+
+**Requirement:** deprovisioning must surface the creator-private resources that will lose their
+owner, transfer them, or accept the admin-only outcome explicitly. Silent orphaning is a product
+event, not an implementation detail.
+
+**Test / guardrail:** deleting a creator removes creator-derived access without granting it to
+anyone else, and the deprovisioning path records or exposes the affected resources before the
+owner relationship is destroyed.
+
+**Status:** the mechanism (ownership survives demotion, dies with the identity) Holds. Surfacing
+the orphaned-island outcome on deprovision is a Gap.
+
+## B2. Enforcement and audit must share one ownership rule
+
+### Story: One prompt, many authors
+
+Alex creates a prompt; Blake later adds a version. Prompt ownership is derived from version
+authorship, so if *any* version author is an owner, Blake now holds owner-level authority over
+the whole prompt — not just the version Blake wrote. Meanwhile the "who can access this?" audit
+answer reports only the first version's author. Enforcement grants owner rights to several
+people; the audit view names one. The panel under-reports real access.
+
+**Principle:** the system must enforce and explain the same model — an audit view that diverges
+from the enforced rule misinforms rather than informs.
+
+**Invariant:** enforcement (`can_access`, `accessible_scope`) and explanation (`subjects_for`)
+must apply the *same* ownership rule.
+
+**Requirement:** choose one prompt-owner model and apply it everywhere — one owner, or all
+version authors as owners, or authorship granting only author-scoped edit. Until decided, prompt
+ownership is an open product question, not a code detail; the oracle, `subjects_for`, and UI copy
+must agree.
+
+**Test / guardrail:** for a prompt with versions from multiple users, the point check, list
+filter, and audit view identify the same owner-derived subjects.
+
+**Status:** Gap — the audit view and the enforcement paths disagree today; the multi-author
+ownership model is also an open product decision.
+
+## B3. Creatorless objects need last-manager protection
+
+### Story: Dana locks herself out
+
+Dana manages the `Fraud-Signals` project. She did not create it — a tracing pipeline did, and
+projects have no creator owner — so her authority is a single manager grant. Cleaning up stale
+access, she removes that grant by mistake. Next request, the project is gone from her list, and
+she cannot grant it back because granting requires manage access she no longer holds. An admin
+can recover it, but the system should not strand a creatorless object because the last delegated
+manager clicked the wrong row.
+
+**Principle:** no single routine action should make a resource permanently unreachable to every
+non-privileged user; recoverability is a design requirement — the last-admin instinct, one level
+down.
+
+**Invariant:** delegated manage access on a creatorless resource is *destructible* authority.
+Removing the last non-admin manager can reduce the object to admin-only.
+
+**Requirement:** default to a last-manager guard — refuse removal of the final non-admin manager
+of a creatorless object unless another remains. The guard must fire on *every* lever that can
+strip the last manager, not only the obvious grant delete: an in-place downgrade and a
+permission-set edit/delete reach the same state by different doors (below). If the product
+intends to allow an object to become admin-only, that path is explicit, admin-visible, and
+audited as a recovery-state transition, not an ordinary revoke.
+
+*Two per-grant paths remove a manager, and both must be guarded.* Deleting the grant is the
+obvious one; **downgrading it in place** — re-granting the same subject as viewer/editor — strips
+manage just as completely, so the guard fires on that change too (skipping only when the new role
+still confers manage). Guarding revoke but not downgrade would leave the invariant reachable
+through the back door.
+
+*A third lever removes manage without touching any grant row: the permission set itself.* A custom
+set that confers `OBJ_MANAGE_ACCESS` can be **edited** to drop that permission, or **deleted** — on
+delete its grants fall back to the view-only default (`acls.role_id` `ON DELETE SET NULL`). Either
+change strips manage from *every* grant carrying the set at once, so a set that is the sole manager
+path to a creatorless object strands it just as a revoke would, reached through the role instead of
+the grant. The permission-set edit and delete mutations therefore consult a role-scoped guard,
+`would_strand_manager_by_role`, before the change lands: for each object whose only id-scoped
+manager grant runs through this set, it asks whether a durable manager survives the set losing
+manage (a live creator, another id-scoped manager on a *different* set, or a type-wide `all`
+manager) and refuses if none does. It is inert unless the set currently confers manage — a
+view/edit-only set removes no manage authority, so deleting an ordinary role stays cheap and
+unblocked, and the guard never false-positives on it. Built-in sets cannot be edited or deleted, so
+only custom manager sets reach here.
+
+*What counts as remaining coverage is deliberately narrow.* A live creator, another id-scoped
+manager, or a type-wide (`all`) manager count — each is a **durable** manager path that a
+non-admin cannot quietly remove. A **tag** manager grant does *not* count. The reason is that a
+tag grant's reach is object-manager-mutable — a manager can drop the object's tag and sever it —
+so it is not a durable manager path. This is why manage is kept off the tag selector entirely
+(**F4**): a tag grant confers view/edit only, so a manage-conferring tag grant cannot be
+authored, and even a seeded one is not honored for manage. That closes the one-step strand a
+tag-only manager would otherwise have (drop your own tag), at its source. Excluding tag grants
+from the survivor set here is then belt-and-suspenders: the survivor set only ever counts durable
+manage paths.
+
+**Test / guardrail:** a non-admin manager cannot remove the final non-admin manager grant from a
+creatorless object — by revoke *or* by downgrade, through **either** the GraphQL mutations or the
+REST access routes. Nor can an admin strip the last manager by **editing or deleting the
+permission set** that carries it. A live creator, another id-scoped manager, or a type-wide manager
+count as remaining coverage; a tag manager grant does not (and cannot be created).
+
+**Status:** Holds across all three levers. The two per-grant paths — `revoke_access` / `grant_access`
+(GraphQL) and `delete_access_grant` / `create_access_grant` (REST v1) — consult one shared
+predicate, `phoenix.server.access.would_strand_last_manager`, on delete and on in-place downgrade
+(covered by `TestRevokeKeepsAManager`, `TestDowngradePreservesManager`,
+`TestTagManagerNotCountedAsSurvivor`, and `TestRestLastManagerGuard`). The role lever —
+`patch_permission_set` (dropping manage) and `delete_permission_set` — consults the sibling
+predicate `would_strand_manager_by_role`, covered by `TestStrandByPermissionSet` (strands /
+another-id-manager-safe / type-wide-safe / creator-safe / non-manager-role-short-circuits) on both
+engines.
+
+## B4. Subject kinds are fully wired or rejected
+
+### Story: The service account that silently cannot read
+
+An operator wants a CI service account to read one dataset. They see `service_account` in the
+subject vocabulary and script a grant to it. The row stores successfully, but the CI job still
+gets not-found: request-subject resolution never matches `service_account` grants. Fail-closed,
+so it is *safe* — but it looks like a feature that works, and the operator burns hours before
+discovering the subject kind is only half-wired.
+
+**Principle:** the vocabulary a system accepts must equal the vocabulary it honors; a name it
+will store but not enforce is a false promise, so partial support fails loudly, not silently.
+
+**Invariant:** a subject kind is supported only if it is matched by *both* the point check
+(Python) and the SQL list predicate — and, if accepted at write time, resolvable in the audit
+view.
+
+**Requirement:** keep the subject enum, grant-write validation, request-subject resolution, SQL
+predicate generation, and `subjects_for` in lockstep. An unimplemented kind must be rejected at
+grant-write time, loudly, rather than stored inert.
+
+**Test / guardrail:** every accepted subject kind has parity tests across `can_access`,
+`accessible_scope`, `access_predicate`, and `subjects_for`. Unsupported kinds fail before a row
+is written.
+
+**Status:** Partial — the exposed write APIs already fail closed: the GraphQL subject input offers
+only `user`/`group`/`everyone` (no service-account option), and the REST route rejects a
+`service_account` subject at write time (422, "reserved but not yet supported"). The residual gap
+is one level down: `SERVICE_ACCOUNT` still exists in the storage/subject vocabulary and is matched
+by neither access path, so a row inserted out-of-band (seed/migration) would be stored inert. The
+lockstep requirement is met at the API boundary; closing it fully means either wiring the kind end
+to end or removing it from the enum until it is.
+
+## B5. Subject membership has a defined freshness boundary
+
+### Story: Removing Devin from Okta does not empty the cached session
+
+Devin belongs to the `fraud-team` group through an external identity provider. An admin removes
+Devin from that group in the IdP. Locally managed group changes take effect on the next request —
+membership is recomputed live — but external group membership is synced at *login*, so Devin's
+existing session can keep the old group-derived authority until the session refreshes or is
+revoked.
+
+**Principle:** every cached authorization fact needs a stated freshness bound, and the bound
+must be explicit wherever authority is derived across a trust boundary such as an external IdP.
+
+**Invariant:** subject membership has a stated freshness boundary, and it may differ for locally
+managed vs. externally synced subjects.
+
+**Requirement:** the product must state when external group and role changes take effect — next
+authorization decision, next token refresh, next login, or explicit revocation — and
+deprovisioning / incident-response docs must not promise immediate removal of externally-synced
+group access unless the session is also invalidated.
+
+**Test / guardrail:** removing a user from a locally managed group changes effective access on
+the next request; removing them from an externally synced group follows the documented boundary,
+and stale sessions do not outlive it.
+
+**Status:** Gap — external group membership is login-time; the freshness boundary is undocumented
+and unbounded within a session.
+
+---
+
+# Part C — The grant algebra (allow-only, monotonic)
+
+## C1. Grants are additive, not ceilings
+
+### Story: Alice is "set to Viewer" but still manages through her team
+
+Alice has a direct viewer grant on a dataset and also belongs to a group with manager access to
+it. Changing Alice's direct row to viewer does not cap her effective access — the group edge
+still contributes manager authority, and in an allow-only model the union wins. Re-granting the
+*same* edge does overwrite that edge's role (a per-edge downgrade is real), but it is not a
+ceiling over other subject paths. Broad subjects are also live: grant `MEMBER` view on a dataset
+and a later `VIEWER`→`MEMBER` promotion silently picks it up.
+
+This is not a bug. It is the price of monotonic grants (see [design notes](./phoenix-access-control.md)
+§2.13: only subtraction conflicts, and there is no subtraction).
+
+**Principle:** grants are allow-only and monotonic — the model only ever adds authority, and
+absence is the only "no." (The design's core commitment; see §2.13.)
+
+**Invariant:** editing one grant edge changes that edge only. The model expresses no "at most,"
+no per-object exception to an `everyone` grant, and no "Alice at most viewer regardless of
+group." Those are new subtractive operators, not different button labels. Broad subject grants
+evaluate against live membership.
+
+**Requirement:** UI and API language must not imply a per-user downgrade caps effective access,
+and must distinguish "direct grant" from "effective access." Role- and group-subject grants must
+be labeled dynamic, with explanations naming the source (direct vs. role vs. group).
+
+**Test / guardrail:** effective-access explanation for Alice shows both the direct viewer row and
+the group manager row and reports the manager result. Promoting a user into a role that holds a
+grant changes their access on the next decision, with the role named as the source.
+
+**Status:** Holds — the intended allow-only behavior (covered by `TestMonotonicGrants`). The
+residual risk is UI copy that implies a ceiling the model cannot express.
+
+## C2. Object identity is `(type, id)`, never `id` alone
+
+### Story: A wildcard grant leaks through a reused row number
+
+An operator writes a seed grant for "object 5" and reaches for `object_type='*'` for
+convenience, meaning dataset 5. But ids are scoped per table, so project 5 also exists: a
+wildcard type paired with a concrete id aliases every unrelated object that shares the integer.
+
+**Principle:** an object's identity is its full composite key, never a fragment; reasoning about
+an id without its type conflates unrelated objects.
+
+**Invariant:** a concrete object grant names a composite identity `(object_type, object_id)`.
+Wildcard type is meaningful only for type-wide grants.
+
+**Requirement:** `selector='ids'` requires a concrete `object_type`; `object_type='*'` is valid
+only with `selector='all'` and a null `object_id`. Enforce with a database constraint or
+write-time validation, not convention — the mutation API never produces the bad shape, so the
+exposure is hand-seeded and migrated rows.
+
+**Test / guardrail:** writing `object_type='*'` with `selector='ids'` fails; type-wide `*` / `all`
+grants continue to behave as deliberate deployment-wide grants.
+
+**Status:** Holds — a `CHECK (object_type != '*' OR selector_kind = 'all')` on `acls` makes the
+shape unrepresentable (covered by `TestWildcardTypeConstraint`).
+
+## C3. Permission sets preserve visibility
+
+### Story: Quinn can edit a thing they cannot see
+
+Quinn receives a custom permission set with `OBJ_EDIT` but not `OBJ_VIEW`. A point edit check
+passes, but the object never appears in Quinn's lists and a view check fails — the oracle checks
+each permission independently, so nothing forces the intended rule that a stronger object
+capability implies visibility. Built-in sets obey the rule; custom sets can violate it. The
+related trap: emptying a custom set does not revoke — it falls back to view-only.
+
+**Principle:** capabilities are hierarchical — a stronger power implies the weaker ones it builds
+on, so you can never act on what you cannot see.
+
+**Invariant:** every object permission stronger than view is visibility-implying; an emptied set
+has an explicit, documented meaning.
+
+**Requirement:** permission-set creation/update rejects sets where `OBJ_EDIT` /
+`OBJ_MANAGE_ACCESS` appear without `OBJ_VIEW`. An empty set is either invalid or a named viewer
+set — never a silent drift that surprises its author.
+
+**Test / guardrail:** custom sets cannot be saved in edit-without-view form; empty sets either
+fail validation or resolve to the documented default consistently.
+
+**Status:** Gap — the invariant is documented in the permission vocabulary but not enforced at
+write time; custom sets can reach edit-without-view.
+
+## C4. Manage-access is powerful but object-scoped
+
+### Story: A manager can make co-managers
+
+Sam holds manage-access on one dataset. Sam can grant another user manager on that dataset, and —
+if the product allows broad subjects — expose it to a group or `everyone`. Sam cannot use that
+authority to grant on a *different* dataset. Powerful within one object, not a pivot to the rest
+of the system. The blast radius is still real: an `everyone` grant exposes the object to every
+authenticated subject, and the allow-only model has no per-user carve-out below it.
+
+**Principle:** least privilege through delegation — a delegated capability is bounded to its
+object and must never be a pivot to broader authority.
+
+**Invariant:** `OBJ_MANAGE_ACCESS` delegates access administration only on the resolved target
+object.
+
+**Requirement:** grant/revoke mutations resolve the target first, check manage-access on that
+exact object, and write only grants for that exact object. Broad subjects such as `everyone`, if
+allowed, are explicit in UI and audit log.
+
+**Test / guardrail:** a manager of X can grant on X and cannot grant on Y. An `everyone` grant on
+X affects X only, cannot be narrowed for one user without revoking the broad grant, and is
+visible in effective-access explanation.
+
+**Status:** Holds by construction — the manage check re-resolves the target object on every call,
+so there is no cross-object pivot (enforced by the mutation shape, not yet a dedicated test).
+
+## C5. Type-wide grants are administrative policy
+
+### Story: Tess grants all datasets
+
+Tess manages one dataset and can share it. She must not be able to grant "all datasets" to a
+group, because that reaches creator-private datasets owned by other people. A type-wide grant is
+not a bigger object share; it is deployment-level policy, and its authoring authority must
+differ accordingly.
+
+**Principle:** authoring authority must scale with blast radius; a deployment-wide grant is an
+administrative act, different in kind from sharing one object.
+
+**Invariant:** type-wide (`selector='all'`) grants are administrative actions. Object managers
+administer the object they manage, not the whole type.
+
+**Requirement:** `all` grants stay admin-only, visually distinct from per-object grants, and
+audited as broad policy. If a future role may author type-wide grants, name that role
+explicitly rather than inferring it from object-level `OBJ_MANAGE_ACCESS`. UI must state that
+"all datasets" includes other users' creator-private datasets unless a narrower selector exists.
+
+**Test / guardrail:** a non-admin manager of D can grant on D and cannot create an "all datasets"
+grant; admin-created type-wide grants appear separately in access lists and explanations.
+
+**Status:** Holds — but by two different mechanisms, worth stating precisely. The **GraphQL**
+mutation only ever writes id-scoped grants, so it cannot author an `all` grant at all. The **REST**
+`create_access_grant` *can* author a type-wide grant (omit `object_id`), and gates that branch on an
+explicit `require_admin` — so `all` grants remain admin-only there too, but by an authorization
+check, not by the write shape. The invariant (type-wide is administrative) holds on both; the
+earlier "the mutation API only writes id-scoped grants" was true only of GraphQL. Watch item: any
+*future* authoring path must likewise gate `all` to admins rather than infer it from object-level
+`OBJ_MANAGE_ACCESS`.
+
+---
+
+# Part D — Propagation through parents
+
+## D1. Parent-derived access is explicit and bounded
+
+### Story: Carla expects access to cascade forever
+
+Carla can read a dataset. Its experiments write traces to derived plumbing projects, and Carla
+can read those because their access is rooted at the dataset. But that inheritance is one
+explicit edge, not a recursive graph walk: the dataset grant does not make every future child,
+grandchild, or downstream project reachable. The boundedness is a feature — it keeps the query
+shape explainable and prevents accidental access expansion through a deep resource tree.
+Revocation follows the same edge: revoke the dataset access and the derived project access
+disappears with it (nothing is stored to dangle).
+
+**Principle:** access reaches only along explicitly declared edges; it must never emerge as an
+unbounded transitive closure over a resource graph.
+
+**Invariant:** access-by-parent is a named containment rule (dataset → its direct
+experiment/evaluator trace projects), not a transitive closure.
+
+**Requirement:** each inherited edge is explicit in the oracle and in the list predicate. A new
+derived resource states its parent edge, its permission mapping (D2), and its stopping point.
+
+**Test / guardrail:** dataset access reaches the intended trace projects and no deeper or
+unrelated project; list and point check agree; revoking the parent removes the derived access.
+
+**Status:** Holds — one hop, computed live from the parent, never stored (covered by
+`TestAccessByParent` and the list/point parity test).
+
+## D2. Parent-derived access carries an explicit permission mapping
+
+### Story: Edit on the parent edits more than people picture
+
+Access-by-parent is currently computed at the *same* permission level as the parent, by reusing
+the permission argument. So edit authority on a dataset also confers edit on its derived trace
+projects. That may be the right policy — but it must be a deliberate mapping, not an accidental
+consequence of passing one argument through.
+
+**Principle:** every propagation of authority is a deliberate policy choice; a permission mapping
+is decided, never inherited by accident of implementation.
+
+**Invariant:** every access-by-parent edge has an explicit permission mapping.
+
+**Requirement:** for each edge, state whether `view` / `edit` / `manage` propagate unchanged,
+narrow to view, or require their own parent action.
+
+**Test / guardrail:** each permission level on a dataset is tested against its derived resources,
+including at least one negative case.
+
+**Status:** Gap — the same-level propagation is real but implicit; whether it is the intended
+mapping is undecided.
+
+---
+
+# Part E — The credential and ingest boundary
+
+*This family is the most Phoenix-specific and the least built. It follows from Phoenix's dual
+nature — a UI/API plane and a high-volume telemetry-ingest plane — and from the design's SYSTEM
+superuser and auto-created projects (see [design notes](./phoenix-access-control.md) §2). Read
+these as the boundary the design must hold as it grows, not as shipped behavior — with one
+exception: E2's read/ingest separation already holds today by construction (the ingest paths
+simply do not consult the read oracle).*
+
+## E1. Credential scope is a protocol-boundary cap
+
+### Story: The ingest key is allowed through one door only
+
+Nora mints an ingest-scoped API key for a collector. It may send OTLP traces. It must not call
+GraphQL, administer access through REST, or open a websocket. The scope is *attenuation*: it
+narrows the owner's live authority before route code does any resource work — the `∩
+credential-scope` cap of the reference model, and the one cap that binds even an admin. If a
+single protocol boundary forgets the check, the key becomes larger than the scope printed on it.
+
+**Principle:** a credential carries no more authority than the scope it was minted with, and that
+cap must bind at every entry point before any application logic runs.
+
+**Invariant:** API-key scope is enforced at every protocol boundary before application handlers
+run; unknown scope values fail closed.
+
+**Requirement:** HTTP, websocket, and gRPC entry points share one scope vocabulary and one
+fail-closed posture. New ingest routes are added to the allowlist deliberately; new non-ingest
+routes deny scoped ingest keys by default.
+
+**Test / guardrail:** an ingest-scoped key uses every intended ingest endpoint and cannot use
+GraphQL, non-ingest REST, or websockets; an unknown scope value is denied everywhere.
+
+**Status:** Proposed — a `scope` column exists on API keys; uniform enforcement across every
+boundary is target-state.
+
+## E2. Ingest authority is separate from read visibility
+
+### Story: The collector can write a project nobody can read
+
+A collector posts spans for a new project `production`. The project is born from ingest, not a
+user clicking "create," and under the fail-closed model it may be admin-only until a human grants
+read. But ingest must continue — a project read grant is not what authorizes the collector to
+write telemetry. The reverse holds too: an ingest credential may append to a project without
+gaining GraphQL read of the spans it wrote.
+
+**Principle:** producing data and consuming it are distinct capabilities; the authority to write
+telemetry and the authority to read it are separate decisions, and neither implies the other.
+
+**Invariant:** project read visibility and ingest write authority are different decisions.
+Project grants gate read and object administration; ingest writes are governed by credential
+capability, protocol scope, and ingest-route policy.
+
+**Requirement:** read predicates must not be inserted into ingest paths as accidental write
+gates, and read-only/UI credentials must not become ingest-capable just by being able to read a
+project. Any future project-level ingest restriction is named as a new ingest authorization rule,
+not smuggled through read visibility.
+
+**Test / guardrail:** with access control on, an ingest credential writes the intended project
+even when no non-admin has a read grant; a read-only credential cannot write spans through the
+ingest protocol.
+
+**Status:** Holds — evidenced by the current code: the trace/span ingest routers do not invoke
+the read oracle, so the two planes are separate code paths today. Recorded here as a guard so a
+future change does not couple them. Several *requirements* above (denying ingest to read-only
+credentials; naming any future project-level ingest rule) remain Proposed.
+
+## E3. Copies across access roots are authorization events
+
+### Story: Riley copies spans into a dataset
+
+Riley can edit a creator-private dataset but **cannot read** project P. Riley runs "create
+examples from spans," pointing at P's spans. If the copy checks only Riley's write access to the
+*target* dataset, Riley pulls data out of a project they were never allowed to read and launders
+it into a dataset they own — then shares or exports it under the dataset's policy. The source
+graph was not mutated, but the data crossed an access boundary, and that is an authorization
+event. (Even a source Riley *can* read may warrant a distinct export/manage action for
+high-sensitivity copies.)
+
+**Principle:** data carries its source's access policy across boundaries; moving it from one
+access root to another requires authority on both sides, not just the destination.
+
+**Invariant:** copying data from one access root to another requires authority on both sides;
+source read is the minimum, and high-sensitivity copy/export may require a distinct action.
+
+**Requirement:** dataset-from-spans, prompt clone, trace transfer, and any future
+"materialize from selected data" feature state the source *and* target action they require. A
+target write check alone is insufficient when the bytes came from a separately protected root.
+
+**Test / guardrail:** a user who can edit dataset D but cannot read project P cannot create
+examples in D from spans in P; a user with both can, and lineage is recorded if the product uses
+it for audit or downstream grants.
+
+**Status:** Gap/Proposed — cross-root copy paths are not known to check the source root today.
+
+## E4. Hidden plumbing names are not authorization
+
+### Story: The hidden experiment name is not a password
+
+An SDK-run experiment gets a server-minted project name like `Experiment-<hex>` and uses it to
+upload that run's traces. The name is hard to guess, but it is a *routing* identifier, not a
+credential. If possession of the name is enough to write forever, a log line, notebook, or
+forwarded config becomes a reusable write capability for hidden plumbing data.
+
+**Principle:** a routing identifier is not a credential — secrecy of a name is not access
+control; authority must rest on a verifiable, revocable capability bound to the actor.
+
+**Invariant:** server-minted plumbing identifiers do not replace authorization. Possession of a
+hidden name may *route* a write, but the write must still be tied to the actor, credential, or
+parent run.
+
+**Requirement:** experiment/evaluator trace writes are bound to a scoped, revocable authorization
+for the parent run (or an equivalent server-side proof the writer acts for that run). The
+concrete mechanism is a design decision — see [design notes](./phoenix-access-control.md) §2; if
+a hidden name remains usable, treat it as secret-bearing and make its use auditable.
+
+**Test / guardrail:** knowing the hidden project name alone is not sufficient to append traces
+outside the authorized run context; completing or revoking the parent run closes the write path
+unless the product explicitly keeps it open.
+
+**Status:** Proposed — the run-scoped write authorization is not built; this records the invariant,
+not the mechanism.
+
+---
+
+# Part F — Attribute-based (tag) access
+
+*The design notes ([§2.11](./phoenix-access-control.md)) scope out attribute-based access at the
+coarse, project-level grain and name curated-tag ABAC only as the fine-grain hybrid a future
+sub-resource requirement would add. That hybrid has been prototyped as an **additive grant
+selector**: a grant can address `selector_kind='tag'`, reaching every object of its type that
+carries a curated `key=value` tag (stored in `resource_tags`). It changes nothing until an admin
+both tags an object and authors a tag grant. These invariants govern that layer; they do not
+revisit the §2.11 verdict, which stands for coarse-grain access.*
+
+## F1. Tag access resolves identically in the scope and predicate paths
+
+### Story: The tag grant that matched everything
+
+A tag grant is authored for "datasets tagged `env=prod`." The point/scope path (Python, which
+materializes ids) correctly returns just the prod dataset. The list path (a SQL `WHERE` predicate)
+returns *every* dataset — because its tag-existence subquery, nested two levels under the object
+query, re-added the object table to its own `FROM` instead of correlating the outer one, turning a
+filter into a cross join. Two code paths answering the same question diverged, and only one was
+right. A parity test caught it; without one, list views would silently over-grant.
+
+**Principle:** the same access question answered two ways must return the same answer; any selector
+that lives in both the materialized-scope path and the SQL predicate path is only as correct as the
+agreement between them.
+
+**Invariant:** for every selector — `ids`, `all`, and `tag` — `can_access(x)` ⟺ `x ∈ list(predicate)`.
+A tag grant contributes the *enumerated ids* of the objects currently carrying its tag on both
+paths, never a type-wide allow.
+
+**Requirement:** the tag branch is added to both `accessible_scope`/`_granted_scope` and
+`access_predicate`/`_access_predicate_for_user`, hand-kept in lockstep. The SQL tag-existence
+subquery must correlate the outer object column (`correlate_except` on the `resource_tags` alias),
+not re-select the object table. A parity test over tag grants runs on **both** engines. (Longer
+term, factor the "grant confers permission and matches object" test into one shared builder so the
+two paths cannot drift; noted, not done.)
+
+**Test / guardrail:** `TestTagGrants` asserts scope/predicate parity across object types and
+permission levels on SQLite and Postgres, including the containment case (a tag grant on a dataset
+reaching its derived trace projects through D1).
+
+**Status:** Holds — both paths learn the tag selector; the correlation fix is in and parity-tested
+on both engines.
+
+## F2. Tag matching is exact and engine-identical
+
+### Story: `Prod` and `prod` quietly diverge
+
+An admin tags one dataset `env=Prod` and another `env=prod`, then grants on `env=prod`. If matching
+were case-insensitive on one engine and not the other — or via `LIKE`/regex whose semantics differ
+between SQLite and Postgres — the same grant would reach different objects depending on where it ran.
+Access would depend on the database, not the policy.
+
+**Principle:** an access decision must not depend on database-specific string semantics; a
+two-engine product can only rely on comparisons that mean the same thing everywhere.
+
+**Invariant:** tag matching is exact equality on `(key, value)` — no `LIKE`, no regex, no
+case-folding, no collation-dependent comparison.
+
+**Requirement:** both oracle paths compare `key` and `value` with `==` only. If case-insensitive or
+fuzzy matching is ever wanted, normalize values **on write** (one canonical form stored) rather than
+matching loosely at read time. Any such normalization is itself an access-affecting decision and
+stated explicitly.
+
+**Test / guardrail:** a grant on `env=prod` does not reach an object tagged `env=Prod`; the portability
+suite runs tag tests identically on both engines.
+
+**Status:** Holds — exact-match only, exercised on SQLite and Postgres.
+
+## F3. Tag grants are type-scoped, never cross-type
+
+### Story: The "everything tagged prod" grant that has no home
+
+An admin wants "everything tagged `env=prod`, regardless of type." Expressed as `object_type='*'`
+with a tag selector, that grant would pair a wildcard type with a non-`all` selector — the exact
+combination **C2** forbids, because object identity is `(type, id)` and a wildcard type is only
+coherent with the type-wide `all` selector. A cross-type tag grant has no coherent storage under the
+current constraint.
+
+**Principle:** a mechanism must not smuggle in a shape the identity model already ruled out; a tag
+grant is still a grant and obeys the `(type, id)` identity rule.
+
+**Invariant:** a tag grant always carries a concrete `object_type` (`project` / `dataset` / `prompt`)
+with `object_id` NULL. It never uses `object_type='*'`. This keeps the `wildcard_type_requires_all_selector`
+CHECK satisfied for free (the type is not `'*'`), and matching is scoped within one type.
+
+**Requirement:** the tag-grant mutation only ever writes a concrete type. Folding objects across
+types is done by authoring one type-scoped tag grant per type. Bringing cross-type tag grants into
+scope is a deliberate future step that must widen the CHECK to `selector_kind IN ('all', 'tag')`
+(table rebuild on SQLite, `DROP/ADD CONSTRAINT` on Postgres) — not an accident of a `'*'` slipping
+through.
+
+**Test / guardrail:** a tag grant scoped to `dataset` reaches only datasets, never a same-tagged
+project or prompt; the wildcard CHECK still rejects `('*', 'ids'|'tag')`.
+
+**Status:** Holds — the mutation is type-scoped by construction; cross-type is explicitly out of
+scope and the CHECK is unchanged.
+
+## F4. Tags are curated authority, gated like the grants they feed
+
+### Story: The ingest pipeline that tagged its way in
+
+If a tag can be set by anyone — or worse, derived from client telemetry — then whoever writes tags
+writes access, because a tag grant turns `env=prod` into "who can reach prod." An ingest pipeline
+labelling its own spans could then widen access without ever touching a grant. Tags that steer
+access must be as privileged as the grants that read them.
+
+**Principle:** anything that changes who can reach an object is an authorization action and carries
+authorization's authority requirements; a tag is not metadata when a grant reads it as policy.
+
+**Invariant:** setting or removing a tag on an object requires `OBJ_MANAGE_ACCESS` on that object —
+the same authority as granting access to it. Authoring or revoking a *tag grant* is admin-only,
+because its blast radius is a whole type, not one object (the **C5** logic: authoring authority
+scales with blast radius). Tags are server/admin-set, never client telemetry, and are kept distinct
+from prompt version/commit labels — "which version" and "who can see it" are different controls and
+namespaces.
+
+*A tag grant confers view or edit, never manage-access.* Manage is delegation authority, and a
+tag's reach is object-manager-mutable (setting/removing a tag needs only `OBJ_MANAGE_ACCESS`, which
+a manage-conferring tag grant would itself hand out). A tag-only manager could then strand an
+ownerless object in one step by removing its own tag — a direct **B3** violation. So manage is kept
+off the tag selector at two layers: the oracle refuses to honor manage from a tag grant (both
+paths), and `grantTagAccess` rejects a manage-conferring permission set at authoring time rather
+than storing a grant that is silently inert for manage.
+
+**Requirement:** `setResourceTag`/`removeResourceTag` gate on `OBJ_MANAGE_ACCESS` on the target;
+`grantTagAccess`/`revokeTagAccess` gate on administrator. `grantTagAccess` rejects a permission set
+that includes `OBJ_MANAGE_ACCESS`; the oracle's tag branch is omitted from any manage-permission
+resolution. No new permission verb — tagging *is* managing access. The tag namespace is separate
+from any content/label namespace.
+
+**Test / guardrail:** a non-manager cannot set or remove a tag; a non-admin cannot author or revoke
+a tag grant; a manage-conferring tag grant is rejected at authoring and never confers manage in the
+oracle.
+
+**Status:** Holds for the data effects, the no-manage rule, and the gating shape
+(`TestResourceTagMutations`, `TestTagAccessGrantMutations`, and the oracle's
+`test_tag_grant_never_confers_manage`). The admin/manager gates themselves are auth-enabled
+integration territory, as elsewhere in this doc. **Gap:** a first-class *audit surface* that
+enumerates tags and tag grants as access-affecting actions (beyond the stored `created_by` and the
+`subjects_for` credit) is not built.
+
+## F5. Tag rows have no foreign key — swept on delete, inert while dangling
+
+### Story: The reused id that inherited a stranger's tags
+
+A dataset is deleted; its numeric id is later reused by a new dataset. The `resource_tags` reference
+is polymorphic `(object_type, object_id)` — no real FK to datasets, so no `ON DELETE CASCADE` fires
+— and the old tag rows were never swept. The new dataset now carries a stranger's `env=prod` tag, and
+any tag grant on `env=prod` silently reaches it. Absence of a FK made cleanup the application's job,
+and the missed sweep became an access leak.
+
+**Principle:** a polymorphic reference the database cannot cascade puts cascade-correctness on the
+application; the delete path must do explicitly what a FK would have done by construction.
+
+**Invariant:** an object's tags are removed on the same delete path, in the same transaction, as its
+grants (`delete_object_tags` is the sibling of `delete_object_grants`). A tag on a non-existent object
+is inert at read time regardless — the object cannot appear in the base query — but the sweep keeps
+the table and the "tags of X" view honest and closes the id-reuse leak. Tag *grants* need no sweep:
+they carry the `key`/`value` as strings, not a FK to a tag row, so a removed tag simply stops matching.
+
+**Requirement:** every object-delete path that sweeps grants also sweeps tags. Read-time resolution
+never assumes a tag's object exists; it matches only objects the base query already produced (fail
+closed during any dangling window). New access-controlled types repeat both sweeps.
+
+**Test / guardrail:** deleting an object removes its tag rows; a tag grant matching a since-deleted
+object grants nothing; the sweep touches only the deleted object's tags, not a sibling's.
+
+**Status:** Holds — `delete_object_tags` wired into all object-delete paths; inertness and
+sweep-isolation covered by `TestTagGrants`.
+
+---
+
+## Summary
+
+Tags: **[H]** holds today · **[G]** gap to close · **[P]** proposed / undecided.
+
+**A — One decision, applied everywhere**
+- **A1** The oracle owns final effective access, caps included. **[G]**
+- **A2** Coverage is correctness: an oracle not called is no protection. **[G]**
+- **A3** Denial is indistinguishable from absence; guards fail closed on missing ids. **[H/G]**
+- **A4** Enforcement is a startup-latched, deployment-wide decision and presupposes auth. **[H/P]**
+
+**B — Ownership and the subject lifecycle**
+- **B1** Ownership is stored data: survives role change, dies with the identity. **[H/G]**
+- **B2** Enforcement and audit share one ownership rule. **[G]**
+- **B3** Creatorless objects need last-manager protection, across all three levers (revoke, downgrade, permission-set edit/delete). **[H]**
+- **B4** Subject kinds are fully wired in point, list, and audit paths — or rejected. **[H/G]**
+- **B5** Subject membership has a defined freshness boundary. **[G]**
+
+**C — The grant algebra (allow-only)**
+- **C1** Grants are additive; editing one edge is not a ceiling; broad subjects are live. **[H]**
+- **C2** Object identity is `(type, id)`; wildcard type cannot pair with a concrete id. **[H]**
+- **C3** Object permissions imply view; custom sets cannot be edit-without-view. **[G]**
+- **C4** Manage-access is object-scoped; it delegates, it does not pivot. **[H]**
+- **C5** Type-wide grants are administrative policy, not big object shares. **[H]**
+
+**D — Propagation through parents**
+- **D1** Parent-derived access is one explicit, bounded edge — no recursive inheritance. **[H]**
+- **D2** Each parent edge carries an explicit permission mapping. **[G]**
+
+**E — The credential and ingest boundary**
+- **E1** Credential scope is a protocol-boundary cap, enforced before handlers run. **[P]**
+- **E2** Ingest write authority is separate from project read visibility. **[H]**
+- **E3** Copies across access roots require authority on both roots. **[G/P]**
+- **E4** Hidden plumbing names route writes; they do not authorize them. **[P]**
+
+**F — Attribute-based (tag) access** (additive selector; §2.11's fine-grain hybrid)
+- **F1** Tag access resolves identically in the scope and SQL-predicate paths. **[H]**
+- **F2** Tag matching is exact equality — no `LIKE`/regex/case-fold, engine-identical. **[H]**
+- **F3** Tag grants are type-scoped, never cross-type (wildcard CHECK unchanged). **[H]**
+- **F4** Tags are curated authority: set/remove is `OBJ_MANAGE_ACCESS`, tag grants admin-only and never confer manage. **[H/G]**
+- **F5** Tag rows have no FK — swept on delete, inert while dangling. **[H]**

--- a/internal_docs/specs/rbac/access-control-survey.md
+++ b/internal_docs/specs/rbac/access-control-survey.md
@@ -1,0 +1,1197 @@
+# Access Control: A Survey of Approaches
+
+A consolidated reference on per-resource access control: the conceptual model (how
+users, groups, roles, permissions, resources, and tags relate), the two architectural
+families this produces, how comparable products implement them, and the design
+considerations that follow. Intended to give a shared vocabulary and mental model before
+design discussions, so they argue trade-offs rather than talk past each other.
+
+**Scope — read this as framework + datapoints, not exhaustive coverage.** This is a
+**conceptual framework plus four peer profiles in our category** (observability / ML-adjacent
+tooling) — *not* a complete map of the field. It does **not** survey relationship-based access
+(ReBAC / tuple-store systems), external policy engines (OPA / Cedar), or cloud-native RBAC
+(AWS IAM, Kubernetes); those are *related families* — touched on in §4 — deliberately out of
+scope. Treat the vendor profiles as datapoints that illustrate the framework, not industry-wide
+truth.
+
+**Anonymization.** Peer products are referred to as Vendor A–D. The public-facing
+profiles intentionally describe architectural shape rather than product names or exact API
+schema. They are reconstructed from public documentation and observed behavior **as of
+2026-06**; some systems are closed-source, so implementation details are directional —
+**re-verify against current product docs before relying on a profile or citing it externally.**
+
+---
+
+## Key Findings
+
+- **Listing drives the architecture.** Point checks centralize easily; list queries decide
+  whether the model can be enforced before pagination and at scale.
+- **Stored edges are the common baseline in this survey.** All four products store coarse
+  access as membership, scoped-permission, or ACL rows the database can traverse.
+- **Attribute predicates appear only as a narrow refinement.** The predicate-based peer
+  gates on curated server-managed tags below workspace RBAC — not arbitrary resource
+  content or telemetry.
+- **Groups reveal the product shape.** Systems either grant directly to groups as
+  subjects, or use identity-provider groups as inputs to tenant role assignment. That
+  choice tracks whether the product is object-grain or workspace-grain.
+- **Allow-only remains the safer default** — *not* "never deny." Contractor walls,
+  regulatory segregation, and break-glass are legitimate deny use cases; explicit deny
+  still changes query shape, explainability, and audit enough to require deliberate design
+  (§11), not a column added and discovered later.
+
+---
+
+## Table of Contents
+
+**Foundations**
+
+1. [The Question, in Three Shapes](#1-the-question-in-three-shapes)
+2. [A Working Vocabulary](#2-a-working-vocabulary)
+3. [The Conceptual Model: Entities as a
+   Graph](#3-the-conceptual-model-entities-as-a-graph)
+4. [Two Families: Stored Edges vs Computed
+   Edges](#4-two-families-stored-edges-vs-computed-edges)
+5. [The Effective-Access Formula and the Single
+   Oracle](#5-the-effective-access-formula-and-the-single-oracle)
+
+**The Landscape**
+
+6. [Vendor Profiles](#6-vendor-profiles)
+7. [How Groups Relate to Access](#7-how-groups-relate-to-access)
+8. [Roles and Custom Roles](#8-roles-and-custom-roles)
+9. [Tenancy and Isolation](#9-tenancy-and-isolation)
+10. [Identity Provisioning](#10-identity-provisioning)
+
+**Design Considerations**
+
+11. [Expressing Exceptions: How Systems Say
+    "No"](#11-expressing-exceptions-how-systems-say-no)
+12. [Behavior Under Change](#12-behavior-under-change)
+13. [Matching Facts to Carriers](#13-matching-facts-to-carriers)
+14. [Auditing: the Record vs the Decision](#14-auditing-the-record-vs-the-decision)
+15. [Comparison Matrix](#15-comparison-matrix)
+16. [Cross-Cutting Findings](#16-cross-cutting-findings)
+17. [Implications for Design](#17-implications-for-design)
+18. [A Decision Checklist](#18-a-decision-checklist)
+
+---
+
+## 1. The Question, in Three Shapes
+
+All access control exists to answer one question:
+
+> Can **this subject** perform **this action** on **this resource**? → allow / deny
+
+Easy to state, but it arrives in three shapes with very different costs:
+
+1. **The check** — "Can Alice read project X?" → yes/no. Every design answers this
+   cheaply.
+2. **The list** — "Alice asked for all projects; which rows come back?" This is not a
+   yes/no — it is *filtering a table*, and it must happen **inside** the SQL query. (The
+   tempting shortcut — fetch rows, then check each — breaks pagination and fails at
+   scale.)
+3. **The audit** — "Who can see project X?" The shape that is forgotten until the first
+   compliance review or a "Sharing" dialog needs it.
+
+**The list is the question designs are really built around.** When evaluating any
+access-control proposal, ask first: *what does the list query look like?* That one
+question reveals which family (Section 4) you are looking at.
+
+---
+
+## 2. A Working Vocabulary
+
+Built up in four layers; this is the canonical vocabulary used throughout.
+
+**Layer 1 — who is asking.**
+- **Identity** — the durable actor that *has* authority on paper: a user, or a service
+  account.
+- **Group** — a reusable *set of subjects*, so access is not granted one identity at a
+  time. A **junction vertex** like a role (§3, "one primitive — four knobs"); the knob
+  settings differ.
+- **Credential** — the artifact presented to prove it: a browser session, or an API key
+  pasted into a collector config months ago.
+- **Subject** — what the server sees on a request: *an identity, as wielded through a
+  credential.* The same identity through two credentials can be two subjects. This split
+  matters because **credentials travel and outlive moments** in ways identities do not —
+  most real incidents are credential stories. A system that collapses the two (a key
+  simply *is* its owner, with all of the owner's power) inherits a class of problems
+  from that collapse.
+
+**Layer 2 — what they may do.**
+- **Authority** — everything an identity could do: the full set of (action, resource)
+  pairs.
+- **Grant** — a *stored row* that produces authority ("Alice has Editor on X").
+- **Policy** — a *rule* that produces authority ("checkout-eng may read anything tagged
+  `team=checkout`").
+- **Permission** — one element of authority (one action on a set of resources).
+- **Role** — a **named junction vertex** in the access graph (§3): its *incoming*
+  edges say who holds it, its *outgoing* edges say what it grants. Products *usually*
+  package a permission bundle into it — a **product choice, not the essence** (§3, "one
+  primitive — four knobs").
+
+Grants and policies are the two possible *sources* of authority — the distinction that
+produces the two families.
+
+**Layer 3 — doing less than you could.**
+- **Attenuation** — a credential carrying *less* authority than its identity (an admin
+  minting an ingest-only key for a collector). The golden rule: **attenuation only ever
+  narrows** — a credential can never out-rank its identity.
+
+**Layer 4 — where facts live.**
+- **Carrier** — every authorization-relevant fact (a grant, role, scope, tag) physically
+  lives somewhere: a database row, a signed token claim, a resource tag, a request
+  header, a code constant, a cache.
+- **Binding strength** — *who can change or shed this fact, and how fast do changes take
+  effect?* A signed claim cannot be altered by its holder; a tag can be edited by
+  whoever edits the resource; a self-reported header can be omitted; a cache holds a
+  stale copy until it expires. The single most useful discipline: **match a carrier's
+  binding strength to the fact's security weight** (Section 13). *One caveat on the axis:*
+  binding strength ranks **mutability and revocation latency**, not tamper-resistance under
+  breach (§13).
+
+Two pairs that sound alike and are not:
+- **Default-deny vs explicit deny.** Default-deny = "no grant found → no access"; every
+  system has it. Explicit deny = "a rule that blocks even when another rule allows";
+  rare, and expensive (Section 11).
+- **Guardrail vs boundary.** A *boundary* holds against an adversary (the constrained
+  party cannot shed it). A *guardrail* protects a cooperating-but-fallible party and is
+  escapable by construction. Confusing them ships a seatbelt as a cell wall.
+
+---
+
+## 3. The Conceptual Model: Entities as a Graph
+
+The cleanest way to see how the entities relate is as a graph, where access is a
+**reachability** question. This is not a stretched analogy — the largest-scale production
+systems (relationship-based / **ReBAC** stores) **model access as a graph** and answer every
+check as a **bounded walk**. (ReBAC as a family is out of scope here; this doc borrows only
+its mental model — see §4 for when to reconsider.)
+
+> Can subject **S** do action **A** on resource **R**? ⟺ **Is there a path from `S` to
+> `R` over edges that permit `A`?**
+
+Allow = a path exists. Deny = no path (or a blocking edge along the way).
+
+**The vertices** (the nouns):
+
+| Vertex | Examples |
+|---|---|
+| Subject | a user (often via a session), an API-key-wielded identity, a service account — an API key is a vertex only if modeled as its own identity rather than a credential |
+| Group | a team / group of subjects |
+| Role | a named junction vertex, usually carrying a permission bundle for a resource (e.g. `editor`) — the bundle is the common preset, not the essence (see "one primitive, four knobs" below). *Caveat:* a **global** tier (`admin`/`member`/`viewer`) used as a clearance is **evaluation context, not a graph vertex** — see "What is *in* the graph" below. |
+| Permission | `read`, `write`, `delete` (sometimes a vertex, sometimes an edge label) |
+| Resource | org → project → trace → span; also dataset, prompt, experiment |
+| Tag value | `team=checkout`, `env=prod` (only in the attribute world) |
+
+**The edges** (the verbs that connect them):
+
+```
+ user     ──memberOf──▶     group
+ group    ──hasRole───▶     role
+ role     ──grants(read,write)──▶  a resource, a resource type, or a permission
+ resource ──childOf───▶     resource     (containment: span ▸ trace ▸ project ▸ org)
+ resource ──taggedWith──▶   tag value    (only in the attribute world)
+ user     ──ownerOf───▶     resource     (creator gets a grant)
+```
+
+A **policy** is a rule about which edges count. A **check** walks the edges. A **"what
+can Alice see?" list query** walks *all* edges out of `Alice` and collects every
+resource vertex it reaches.
+
+### Why roles and groups exist: edge-count compression
+
+This is the core functional relationship. Without a role, you connect every subject
+directly to every permission they need — a complete bipartite mess of `N × M` edges.
+Insert one **role** vertex in the middle and it collapses to `N + M`:
+
+```
+   WITHOUT roles  (N×M edges)        WITH a role vertex  (N+M edges)
+   u1 ─┬─▶ read                       u1 ─┐                ┌─▶ read
+   u1 ─┼─▶ write                          ├─▶ role:editor ─┼─▶ write
+   u2 ─┼─▶ read                       u2 ─┘                └─▶ delete
+   u2 ─┴─▶ write
+```
+
+**Groups do the same trick on the subject side** (many users → one group → …). So in
+graph terms, role-based access control is just: *insert intermediate vertices to trade
+`N×M` edges for `N+M`.* Every role and every group is a reusable junction.
+
+This also names the relationship precisely:
+
+- A **group** answers *who* (a set of subjects). A **role** answers *what bundle* (a set
+  of permissions). They sit on opposite sides of the graph. *(This is the common **preset**,
+  not a categorical line — more precisely both are the same primitive with different knobs;
+  see "Roles and groups are one primitive" below.)*
+- An **assignment / grant** is the single edge that connects a *subject (or group)* to a
+  *role*, optionally *on a resource*. That edge is the only place the two sides meet.
+- Resolution walks it back out: a user inherits their groups' assignments → each
+  assignment expands to a role → each role expands to permissions → the permission is
+  checked against the resource.
+
+Neither grouping is redundant: groups collapse the *user* axis, roles collapse the
+*permission* axis, and you need both to get one assignment to mean *(all members) × (all
+permissions)*. Tags (below) extend the same idea to a third axis — *which resources* —
+replacing "name the object" with "any object matching a rule."
+
+### The access edge, precisely: who / how / what / which
+
+Zoom in on a single grant. It is one **colored, directed edge**, with exactly four degrees
+of freedom:
+
+```
+        subject  ──[ color ]──▶  object
+        (who)        (how)        (what)
+                      resolved by ──┴── which   (applies to BOTH ends)
+```
+
+- **who** — the subject end: a user, a group, `everyone`.
+- **how** — the edge's *color*: the permission level (`read` ⊆ `write` ⊆ `manage`), a
+  partial order.
+- **what** — the object end: a project, dataset, prompt, or `everything`.
+- **which** — *how each endpoint resolves to concrete vertices*, and it applies to **both**
+  ends: `all`, `none`, an explicit `list[id]`, or a **predicate** (membership; or a
+  tag/attribute match).
+
+The `which` axis is the unifier: a **group** is a `which` on the *subject* end; a **tag rule**
+is a `which` on the *object* end — the same mechanism on opposite ends (Family B below is
+"move the predicate from subject to object"). List queries must evaluate or join the predicate
+against candidates — cheap on **indexed, server-managed attributes**, expensive on computed or
+non-indexable content; object-side predicates are the harder case.
+
+### Roles and groups are one primitive — four knobs, not two categories
+
+The "*group* answers who, *role* answers what" split above is the common **preset**, not a
+categorical difference. Both are **reusable junction vertices**: *a named set that expands
+into edges* (the `N×M → N+M` trick, applied to different ends). The precise model is **one
+primitive** — a named set on an edge — with four independent knobs; "role" and "group" are
+just two corners of that space:
+
+| Knob | "role" preset | "group" preset |
+|---|---|---|
+| Which end it reuses | the `(color × object-type)` bundle | the subject set |
+| Where capability lives | packaged into the definition | supplied by external grant edges |
+| Cardinality per subject | often exactly one, total | zero-or-many, optional |
+| Composition operator | sometimes `∩` (a cap) | `∪` (additive) |
+
+A *custom global role* and *a group holding a wildcard grant* are **the same machinery** with
+different knob settings — no clean yes/no at the model level. **Cardinality**, **where
+capability lives**, and downstream lifecycle/UI differ in practice; only the **operator** knob
+(floor `∪` / cap `∩` / deny `∖`) changes *what is safe*. *Extensionally* both classify users;
+**defining payload is dual** — permissions vs users — same junction, dual element-types.
+Parallel **`member_*` fields** encode that duality. **Read the knobs, not the labels.**
+
+### Composition: ∪, ∩, ∖ — and why a "ceiling" is not a "deny"
+
+A subject belongs to many sets at once (itself, its groups, its role, `everyone`). Their
+bundles compose with exactly three set operators, and *which operator each construct uses* is
+the entire security character of a model:
+
+```
+  access(U)  =  ( ⋃ positive edges from every set containing U )   — grants / groups: additive
+                ∩  ceiling(U)                                       — a cap (e.g. read-only)
+                ∖  denials                                          — an explicit "no"
+```
+
+A concrete instance for each operator. Say Alice has a personal `read` grant on a project and
+is in a team granted `write` on it:
+
+- **`∪` (grant + grant):** `read ∪ write = write`. Two reaching edges combine to the *more*
+  permissive — adding the team grant only ever raised her access.
+- **`∩` (cap):** she uses a read-only API key. `write ∩ read-only = read`. The cap *clips* the
+  result down, but it is a property of the key, known before any project is consulted.
+- **`∖` (deny):** an explicit `deny write on this project` row would override both grants —
+  `write ∖ {write} = read` — but only after scanning that project's edges to discover the deny
+  exists.
+
+`∪` is the only **monotonic** operator (adding an edge never *removes* access). `∩` and `∖`
+both subtract — but they differ in **knowability**, and conflating them is a common error:
+
+- A **ceiling** (`∩`) is a **scalar on the subject vertex** — a clearance (`viewer ≤ read`).
+  It is known from the *subject alone*, O(1), before any object edge is read, and it is
+  **monotone-preserving**: a fixed `min` in the evaluation function, not a member of the edge
+  set, so adding edges to a capped subject still only ever *grows* access (up to the cap). A
+  ceiling is a fact about *who the subject is*.
+- A **deny** (`∖`) is a **negative edge in the graph**, aimed at a specific object. It can
+  only be found by *scanning that object's edges*, it breaks the "find one allow and stop"
+  shortcut, and adding one *reduces* access (non-monotonic). A deny is a fact about *an
+  object*.
+
+The two are extensionally interchangeable for a uniform cap (`A ∩ {≤read}` = `A ∖ {>read}`)
+but operationally opposite. The consequence: **a system can offer a hard read-only role
+without any deny edges** — represent the cap as a subject clearance, not a negative edge — and
+so keep a purely monotonic, allow-only graph. Reach for true deny only when the "no" is
+genuinely *per-object* and cannot be expressed as a subject-level cap (§11).
+
+**Most systems implement a *subset* of `∪ / ∩ / ∖`.** This formula is the general space, not a
+spec. The simplest defensible model is **`∪` + absence + one fiat admin**: positive edges
+only, every "no" is a missing edge (fail-closed), and a single superuser by fiat — no `∩`, no
+`∖`. A cap (`∩`) earns its place mainly for **credential attenuation** (a key that tracks its
+owner's *dynamic* authority minus a fixed narrowing — the one thing absence cannot express
+without copying edges). True deny (`∖`) is for genuinely per-object exceptions (§11). Note a
+cap belongs only on a *single per-subject clearance* (a global role, a credential scope) —
+**never on a group**, or joining a group could *reduce* access (a non-monotonic "restriction
+group"). Which subset a system picks is one of its defining choices.
+
+**Corollary — only subtraction conflicts.** **Additive sources never disagree** — `∪` is
+order-independent and monotone, so any number of grant sources compose without conflict.
+The *only* thing that can disagree with a grant is a **subtractive** operator: a `∩` cap or a
+`∖` deny. **Conflict tracks the number of subtractive operators, not the number of sources.**
+If two authority sources "fight," one is a cap or a deny — find *it*, not the grants. (An
+all-`∪` model is conflict-free by construction; every "which source wins?" question is really
+about a cap or a deny.)
+
+### Absence vs. arriving color
+
+In a fail-closed, allow-only graph a "viewer" is often defined by the **absence** of
+higher-color edges: they hold no `write` edge, so they cannot write. This works — but only
+for edges the subject **emits**. It does **not** govern colors that **arrive** through paths
+via other vertices:
+
+```
+   U ──member──▶ G ──[write]──▶ P     U inherits write on P through G,
+   (emits no write edge)              though U itself emits no write edge.
+```
+
+Absence is local to a subject's own edges; reachability is global. To guarantee "U can
+*never* write, even via a group," you need something *at U* that filters **arriving** colors
+— a clearance clamp on the node (`delivered = min(path color, node cap)`), i.e. the `∩`
+ceiling above, **not** a deny edge. So there are two distinct "viewers":
+
+- **viewer-by-absence** — emergent, monotonic, *liftable* by a group grant; a description of
+  the current edges, not a guarantee.
+- **viewer-by-clamp** — a subject clearance clipping arriving colors; *unliftable*. The price
+  of the guarantee is one scalar — still not a deny.
+
+### Admin: "by fiat" is just topology with two flags
+
+A superuser implemented "by fiat" (`if is_admin: allow`, skipping the walk) is
+**extensionally identical** to a subject holding wildcard, max-color edges to every object.
+Fiat-vs-topology is a representation choice, not a semantic one. The fiat encoding carries
+exactly two properties, both expressible as edge flags:
+
+- **axiomatic** — the edges hold even if the edge store is empty or broken, so the recovery
+  path cannot be bricked by bad data;
+- **deny-immune** — they survive the `∖` term, so a misconfigured deny cannot lock the admin
+  out.
+
+The admin is therefore not "outside the graph" — it is the **maximal vertex inside it**,
+holding guaranteed, irrevocable edges. A fail-closed system needs exactly one such actor, or
+a single bad rule could lock everyone out with no way back in.
+
+### What is *in* the graph, and what is evaluation context around it
+
+The graph answers exactly one question — **reachability**: can a subject reach a resource over
+permitted edges? That makes it the right model for the *relational* concepts and the **wrong**
+model for several others. Drawing the boundary explicitly heads off a recurring error
+(trying to make vertices and edges express things they structurally cannot):
+
+**Inside the graph** — walked at decision time: **subjects** (users, service accounts,
+groups, `everyone`), **resources** and their **containment**, the **permission/color** on each
+edge, and the **grants / assignments / permission sets** that *are* those edges. Roles and
+groups are junction vertices here.
+
+**Evaluation context *around* the graph** — not vertices or edges; they parameterize *how* a
+walk is evaluated, and the graph cannot hold them:
+
+- **Credentials.** A credential is not a subject vertex — it is the artifact that *wields* an
+  identity (§2). The same identity through two credentials is **one vertex but possibly two
+  subjects** (one attenuated). "Who can reach what" is in the graph; "how the request was
+  authenticated, and whether that credential is narrowed" is not.
+- **Carriers / binding strength.** *Where* a fact lives and *who can change it* is invisible in
+  the graph: "Alice is an admin" as a **signed claim** (unforgeable) versus a **self-set
+  header** (a suggestion) is the *same arrow*, opposite security (§13). The drawing can't tell
+  them apart.
+- **Subject-level tiers / caps.** A global role (`ADMIN`/`VIEWER`) is a clearance **stamped on
+  a subject**, applied as a bound — a baseline or a `min` — **not** a junction vertex with
+  outgoing grant edges (§3, "Composition: ∪, ∩, ∖" — cap vs deny).
+
+A test when extending the model: *if a fact says **who-can-reach-what**, it is an edge; if it
+says **how-a-request-is-carried**, **where-a-fact-lives**, or **how-high-a-subject's-ceiling-
+is**, it is context the evaluator applies around the graph — keep it out of the edge set.*
+
+### A structural caution: the resource graph is often not a single tree
+
+Containment (`childOf`) is what lets a grant on a container reach everything beneath it.
+But resource graphs are frequently *not* a single tree rooted at one container. Some
+resource types (e.g. datasets, prompts, experiments) may not nest under projects at all
+— they hang off the organization, or nothing:
+
+```
+            org
+          /  |  \
+   project dataset prompt      ◀── dataset/prompt are NOT under project
+     /  \
+  trace  session
+    |
+  span
+```
+
+The consequence stated as a graph fact: a grant on a project is **not an ancestor** of a
+dataset vertex, so *no path exists* — flat "membership in a project" silently misses
+those resources. Any model built on container membership must answer separately: by what
+edge does a subject reach the resources that live outside the container tree?
+
+### Quick answers to the recurring confusions
+
+A short FAQ — signposts only; full treatment in the sections cited. **Read the knobs, not
+the labels.**
+
+- **Is a role a set of *users* or of *permissions*?** → §3, "one primitive — four knobs."
+- **How is a role different from a group?** → same.
+- **Can a group have permissions attached directly?** → same.
+- **Can a role be a bare subject set with *no* intrinsic permissions?** Yes — when capability
+  is **external** (policy-layer roles). **Watch the layer:** the *same* product may *also*
+  attach RBAC permissions to that role elsewhere.
+- **Is *deny* the same as a *cap*?** → §3, "Composition: ∪, ∩, ∖."
+- **Are credentials part of the access graph?** → §2 (identity/credential split) and §13
+  (carriers).
+- **What is a carrier, and why care?** → §13.
+
+---
+
+## 4. Two Families: Stored Edges vs Computed Edges
+
+Re-stated through the graph, the two families differ in exactly one way: **where the
+edges live.**
+
+*A note on a related third pattern.* **Relationship-based access (ReBAC)** — tuple stores with
+`check`/`expand` APIs — is a recognized family of its own: it stores edges (like Family A) but
+computes transitive reachability through them as a first-class operation, often via a dedicated
+authz service. It is **out of scope** for this survey — none of the profiled peers use it — but
+worth knowing it exists, because a containment-heavy model (§3's "not a tree") is the point where
+teams sometimes reach for it. ReBAC earns a fresh look when the graph becomes the product:
+many object types, upward and downward inheritance, cross-container sharing, "who can see X?"
+expansion, and consistency requirements that are hard to keep correct in hand-written SQL.
+It is not automatically the right answer for a simple enumerable-grant model; it brings a
+service boundary, schema language, caching, and consistency semantics. Treat the A/B split
+below as the axis *within* stored-vs-computed, not the whole taxonomy.
+
+### Family A — Enumerated grant: edges stored on disk
+
+Membership rows, scoped-permission rows, and ACL rows **are edges**. You write them into
+tables. Answering "which projects can Alice see?" is a **traversal**: start at `Alice`,
+follow `memberOf → hasRole → grants → childOf`, and collect the resource vertices
+reached.
+
+```
+  Alice
+    │ memberOf
+    ▼
+ group:checkout-team
+    │ hasRole
+    ▼
+ role:editor ──grants(read,write)──▶ project:checkout
+                                          │ childOf⁻¹  (walk down containment)
+                                          ▼
+                                    traces, spans, sessions
+```
+
+The set of vertices reached **is** the SQL `WHERE id IN (...)`. Traversal over indexed
+foreign keys is what databases are built for — expressed as joins, semi-joins, or recursive
+CTEs when grant sets, inheritance, or pagination demand it; the resolver still handles group
+expansion, subject unions, and attenuation, but the work is *traversal*, not rule-to-SQL
+compilation.
+
+### Family B — Attribute predicate: edges computed at query time
+
+Here there is **no stored edge** from `Alice` to `project-42`. Instead `Alice` carries
+an attribute (or her role carries a rule), `project-42` carries tags, and the edge
+exists **if and only if** a function says so:
+
+```
+  Alice {team: checkout}                 project-42 {team: checkout}
+         \                                   /
+          \──────  no stored edge  ─────────/
+                         ╎
+        edge exists  IFF  predicate(Alice.attrs, project.tags) is true
+                    e.g.  Alice.team == project.team
+                    — evaluated at QUERY TIME, not stored
+```
+
+Why not store these edges too? Because there would be O(subjects × resources) of them
+and the tags change constantly — every new resource and every retag would rewrite a
+swathe of edges. So instead of *walking* stored edges, the system **manufactures them on
+the fly**: it compiles the predicate into a `WHERE` clause that regenerates exactly the
+resource set the rule would connect `Alice` to.
+
+> This is the single hardest part of the whole space, and the graph view says why:
+> Family A *reads* edges; Family B *synthesizes* them per query. The "query-time
+> predicate compiler" exists only because there are no edges to follow — you have to
+> invent them, correctly, in SQL, on the hot path.
+
+| | Where edges live | How a check is answered | Cost |
+|---|---|---|---|
+| **A. Enumerated** | stored rows (membership / scope / ACL) | **traverse** them | cheaper; indexed joins / semi-joins / CTEs |
+| **B. Predicate** | a *function* over tags | **evaluate** → compile to `WHERE` | a rule compiler; hot-path risk |
+
+Both families need a resolver (inheritance, group expansion, subject unions,
+attenuation, pagination); only Family B additionally needs a compiler that translates an
+arbitrary policy rule into SQL.
+
+The boundary between them is sharp: the first time a requirement *cannot* be drawn as "a
+path from subject to resource over stored edges" — e.g. "can edit only annotations they
+authored," "only spans where `cost > $5`" — you have crossed into Family B, and the
+predicate compiler is on the table.
+
+Each family is strong where the other is awkward: "give this person this resource" is
+one row for A, a contortion for B; "everyone who can see `env=prod`" is one policy for
+B, an enumeration chore for A. In the surveyed set, three products are **primarily**
+Family A. The fourth ships **Family A at the workspace layer** (stored role/membership
+edges) and adds a **narrow Family B refinement** on top — because the product has a
+curated tagging model below the workspace, not because it replaced enumerated grants.
+
+**In practice, Family B is far narrower than its theory.** The surveyed predicate peer
+restricts rules to one kind of curated, server-managed resource tag — no resource content or
+telemetry. Predicates like "only spans where `cost > $5`" are unexpressible: the
+security-bearing attribute is **privileged and admin-curated by construction** (§13), never
+client-supplied. Tag-at-creation closes the window where a new resource briefly carries wrong
+tags. The lesson: implementations ship "predicate over one curated attribute, applied at birth,"
+not the open-ended theory — because the alternative makes content part of the security surface.
+
+The split is a lens, not a permanent commitment. A real system can start fully
+enumerated and later add constrained predicate edges for a single narrow surface (say,
+an attribute-scoped rule on one resource type) without converting wholesale. The
+discipline a hybrid demands is that **each listing endpoint knows which family it is
+resolving under** — a query that must satisfy both a stored-edge filter and a computed
+predicate has to compose them deliberately, not assume one family answers everything.
+Treat the taxonomy as a property of each access path, not a label stamped once on the
+whole system.
+
+---
+
+## 5. The Effective-Access Formula and the Single Oracle
+
+The vocabulary composes into one sentence:
+
+```
+effective access  =  authority(identity)  ∩  attenuation(credential)
+```
+
+…evaluated, for every request, by **one** function — the oracle — exposed in the three
+shapes from Section 1:
+
+```
+can(subject, action, resource)            → yes/no          (the check)
+accessible_ids(subject, action, type)     → query filter    (the list)
+subjects_for(resource, action)            → who             (the audit)
+```
+
+Why intersection (∩) is the right glue:
+
+- **It can only narrow.** No attenuation, credential, or header can *add* power beyond
+  the identity's. Escalation bugs become structurally impossible on that side.
+- **The two terms are independent.** How authority is stored (the family choice) and how
+  credentials are capped can be designed and built separately, in either order; they
+  meet only at the ∩.
+
+This formula is written for the common case where a credential *wields* an identity
+(Alice's session, or her API key acting as her). If instead API keys or service accounts
+are modeled as **first-class identities with their own grants**, the left term is
+`authority(credential_identity)` — the key's own authority, not the human's — and
+attenuation drops out (there is no larger identity to attenuate from). That is a
+deliberate modeling fork, the same one item 7 of the checklist raises; the oracle's
+signature is unchanged either way, only the resolution of `authority(...)` differs.
+
+**The oracle is the seam.** As long as *every* check goes through it — no hand-written
+`WHERE id IN (...)` in resolvers, no `if is_admin: skip` shortcuts — the implementation
+behind it can evolve from "roles only" to "memberships" to "ACLs" without touching callers.
+
+The discipline that makes this real: **the oracle is only an oracle if it has no
+peers.** Two ways to name the subject is two authorization systems, and one will be
+wrong; a second code path that reads the raw request identity silently bypasses every
+downgrade the oracle applies.
+
+### A worked example
+
+Trace one request end to end. Alice is a member of the group `checkout`, which holds the
+`Viewer` role on project `P`. She makes the request with an **ingest-only API key** she
+minted for a collector, and asks for the spans in `P`.
+
+1. **Resolve the subject.** The key is a credential wielding Alice's identity, so the
+   subject is *Alice, through the ingest-only key.*
+2. **Compute `authority(identity)`.** Walk Alice's edges: `Alice → memberOf → checkout →
+   hasRole → Viewer → grants(read) → project P → (down containment) → spans`. A read
+   path to P's spans exists, so authority *includes* reading them.
+3. **Compute `attenuation(credential)`.** The key carries a signed scope that permits
+   ingest (write) and nothing else.
+4. **Intersect.** `read(spans of P)` is in authority but **not** in the credential's
+   attenuation → the intersection is empty for this action → **deny.**
+
+The point: Alice's *identity* may read those spans, but the *credential* she used cannot —
+denied by the right-hand term of the formula. Swap the ingest-only key for her browser session
+and the identical request is allowed: two subjects, one identity, different answers.
+
+---
+
+## 6. Vendor Profiles
+
+**Reading any product through the framework.** Before the profiles: this grid classifies *any*
+RBAC/ABAC system. Force each product through the same questions and its "roles vs. groups"
+labels stop mattering — you read the *knobs*, not the nouns:
+
+1. **Subject sets** — users, groups, roles, service accounts?
+2. **Membership source** — local UI, IdP/SCIM, token claim, code?
+3. **Where capability lives** — attached to the set, an external grant, a policy, a code constant?
+4. **Scope** — org, workspace, project, object, tag-predicate?
+5. **Composition** — floor (`∪`), cap (`∩`), or deny (`∖`)?
+6. **Grant form** — stored edges or computed predicates (Family A vs. B, §4)?
+7. **List-query shape** — what does "which objects can X see?" compile to (§1)?
+8. **Carriers & revocation** — where do facts live, how fast do changes take effect (§13, §12)?
+9. **Credentials** — identities, or credentials that *wield* identities with attenuation (§2)?
+10. **Audit answer** — can it say "why can / can't X see Y?" (§14)?
+
+The profiles below answer roughly #1–#5 for each vendor; §11–§14 cover #6–#10.
+
+### Vendor A — Membership
+
+Access comes from a membership row — "this user is in this project with this role." The
+unit of access is the project; what each role *can do* is a **constant in code**, not
+data. Tenancy is a two-level Organization → Project hierarchy. The list query is a
+trivial lookup of the user's membership rows. **Limit:** access stops at the project —
+no scoping below a whole project.
+
+### Vendor B — Scoped Permissions
+
+A permission carries a **scope string** naming what it applies to (a resource container,
+or a single resource). Resources are grouped into containers and a role is granted on a
+container; the list query becomes `WHERE container_id IN (…)`. Finer than Vendor A
+(single container or single resource), but still object-level, not attribute-level; the
+granular tier is typically enterprise/paid.
+
+### Vendor C — Per-Object ACLs (with org container)
+
+A **hybrid of container + per-object grants**, not object-grain isolation alone. The
+top level is an **organization**; ACL rows on the org cascade to every project and object
+within it, **including projects created later**. Below that, for *any* object —
+organization, project, single experiment — you write an ACL row: "(user *or* group) has
+(**permission** *or* **role**) on (object)," with grants **inheriting downward**. Objects
+are addressed through a generic typed-object reference — including first-class types for
+telemetry and interactive resources, not just containers — so one mechanism covers every
+type.
+
+**Subjects are first-class** — a grant's subject may be a user or a group; group members
+may be users **or service accounts** (via group membership, not a separate side-channel).
+The product distinguishes built-in, org-wide permission groups from reusable role bundles
+used in grants. Custom permission groups with project- or object-level scope are
+enterprise-tier; built-in groups cover lower tiers, with finer built-in tiers gated by
+plan.
+
+A container grant can be **type-narrowed** without ABAC: an inherited permission can be
+limited to one descendant kind (for example, org-wide read but only for prompts).
+Creating an object auto-writes a **direct owner grant** for the creator (toggleable).
+Permissions are **additive only** — higher-scope grants cannot be revoked at a lower
+scope. The list query remains grant-rows → ids → `IN (...)` (+ inheritance and group
+union).
+
+### Vendor D — RBAC + Curated-Tag ABAC (hybrid)
+
+The clearest **hybrid** in the survey — not a pure attribute-predicate system. Coarse
+access is **Family A**: organization- and workspace-scoped **roles** carrying a large
+`resource:verb` permission catalog; members hold separate org and workspace role
+assignments. Fine access is **Family B, narrowly**: **access policies** attach to
+workspace roles and condition a specific permission on **curated, server-managed resource
+tags**. The predicate domain is deliberately narrow: no telemetry or resource content.
+Tags are created by workspace admins; applying tags at resource birth is permissioned and
+supported inline on create payloads.
+
+Policies have a documented **effect** (`allow | deny`; deny wins). An allow policy can
+grant even without a matching RBAC permission — so deny/non-monotonic resolution lives in
+the ABAC layer even though RBAC itself is allow-only. High-volume child records inherit
+their **parent project's tags**; conditions support pattern matching and
+missing-attribute defaults. Within a workspace, a tag-defined application grouping
+organizes resources below the container.
+
+**Groups are not grant subjects** — identity-provider groups map to role assignments
+(SCIM on enterprise tiers; lighter SSO group sync as an alternative). **Service accounts**
+are first-class org-scoped machine identities (distinct from user-attenuated personal
+tokens). **Capability URLs** for anonymous read of selected resources form a third access
+path outside RBAC/ABAC, gated by dedicated share permissions. List queries must
+**compose** stored role/membership filters with tag-policy evaluation — not a tag-compiler
+alone.
+
+---
+
+## 7. How Groups Relate to Access
+
+Groups attach to access in **two fundamentally different ways**, and the choice shapes
+everything else.
+
+**Pattern 1 — Group as a grant subject.** The group is a first-class entity you grant a
+permission or role *on a resource* (Vendor C — the primary model there). Membership and
+grants are independent: the grant says *what the team can access*, the membership says
+*who is on the team*, and team churn never touches the grant rows. Naturally supports
+service accounts as group members.
+
+**Pattern 2 — Group as a role-mapping input.** The group is not a standalone subject;
+identity-provider groups map to a **role assignment within a tenant**. The group is a
+transient login-time input; what persists is the resolved assignment — a row, session state,
+or IdP claims re-derived each session — not the membership graph (Vendor D, enterprise SSO).
+SCIM-backed systems may persist membership for deprovisioning. **Data minimization:** the
+descriptive group is not retained as a grant subject, only the outcome it resolves to.
+
+These are not interchangeable. Pattern 1 gives per-object control and lets access follow
+teams without enumeration; Pattern 2 keeps access tied to a tenant boundary and stores
+less identity data. The choice tracks the unit-of-isolation decision in Section 9.
+
+### Service accounts as subjects
+
+A **service account** is a non-human identity — a first-class actor that exists
+independently of any person, holds its own grants, appears in audit logs under its own
+name, and authenticates with its own long-lived credential. It is the alternative to the
+other way of granting a machine access: a **personal API key**, which is a *credential
+wielding a human's identity* (the credential/identity fork of Section 2 and the formula
+in Section 5). When a collector posts with a person's key, the server sees that person;
+when it posts with a service account's key, the server sees the service account.
+
+The case for service accounts is lifecycle and blast radius:
+
+- **They outlive people.** A personal key dies on offboarding; a service account is not tied
+  to a person, so removing a human does not take down a workload.
+- **Least privilege without a human's authority.** An unattenuated personal key carries all
+  of its owner's power; a service account is granted only what the workload needs.
+- **Honest audit and ownership.** Grants and audit entries name the workload, not a person
+  standing in for a cron job.
+- **Clean rotation.** Revoking a service account's credential never entangles a person's
+  interactive sessions.
+
+The cost is the data trade Section 17 weighs: first-class service accounts make the
+subject set a **union** (`user | service_account | group`) from the first schema that
+has subjects, and persist more identity rows.
+
+**Support tracks the group-handling choice.** Where groups are first-class grant
+subjects (Pattern 1), a service account is just another group member or direct grantee —
+it reuses the existing subject machinery with no special case, which is why the
+per-object-ACL peer supports it cleanly. Where access is resolved from identity-provider
+group claims at login (Pattern 2), a non-human has no login and no claims, so it does
+not fit the primary path; those products provision machine access separately — typically
+as a **first-class service account** scoped to the org/workspace (Vendor D). The same
+design choice that decides group handling shapes how clean machine access is, not whether
+it exists at all.
+
+---
+
+## 8. Roles and Custom Roles
+
+| Capability | Observed across peers |
+|---|---|
+| Built-in roles | universal (Owner/Member/Viewer-style) |
+| Roles defined as **data** (not code) | most, except the lightest membership model |
+| **Custom roles** | common, frequently gated to higher/enterprise tiers |
+| Role scope | varies: account/workspace-wide, or per-granted-object |
+
+The key distinction is *scope*. A **global** role governs what kinds of action you can
+take account-wide; an **object** role governs what you can do on a specific resource a
+grant names. ACL-family products tend to support permission sets;
+workspace-membership products tend to use global ones.
+
+One subtlety from the graph view: a role (and a group) is a junction many paths run
+through, which is why **editing or deleting one is high-blast-radius** — redefining
+"Viewer" changes everyone's access at once (§14: the audit unit must be *effective-access
+change*, not *row written*).
+
+---
+
+## 9. Tenancy and Isolation
+
+The single largest architectural fork is **the unit of isolation**. In graph terms,
+multi-tenancy wants the graph to split into **one connected component per tenant, with
+no edge crossing the boundary**:
+
+```
+     ── org A ──                 ── org B ──
+     Alice → projA               Bob → projB
+              │                         │
+            spans                     spans
+
+     isolation proof = "no path crosses the gap"
+```
+
+Three implementations, three graph statements:
+
+- **A tenant-id column** — one graph; every query *filters* edges to the current
+  component. Isolation depends on never forgetting the filter.
+- **Row-level security** — the same single graph, but the database *enforces* the
+  `component = current_tenant` filter automatically; you cannot forget it.
+- **Schema/namespace per tenant** — literally separate graphs; cross-component edges are
+  impossible by construction.
+
+The fork at the product level:
+
+- **Object-grain (grant per resource).** Isolate by authoring grants on individual
+  resources. The pure form has no hard tenant boundary — names can collide across teams.
+  **Vendor C is not the pure form:** it has an **organization container** whose grants
+  cascade org-wide (including future projects), then per-object ACLs below. Container +
+  per-object grants, not tenantless object-grain alone.
+- **Workspace-grain (membership per tenant).** A workspace/org is the boundary; isolate
+  by placing subjects in it with a role (Vendor D's RBAC layer, and most enterprise SSO
+  models). True name isolation and per-team admins, at the cost of a heavier tenancy
+  layer. Vendor D then adds tag-conditioned refinement *within* the workspace — the
+  hybrid of Section 4.
+
+A related invariant worth stating up front: **an unauthorized read should look exactly
+like the resource not existing.** A response that distinguishes "you may not see this"
+from "this does not exist" leaks names and existence across the boundary. This is a
+property of the oracle's consumers, decided early.
+
+A classic tenancy pitfall is **globally-unique identifiers**: if record ids
+(trace/span/session ids) are global, two tenants ingesting the same id force one vertex
+into two components — a cross-tenant merge. The fix is to make identity component-local
+— `(tenant_id, record_id)` as the key — so identical ids from two tenants are simply
+different vertices.
+
+---
+
+## 10. Identity Provisioning
+
+- **SSO (SAML/OIDC)** is universal for authentication and, where supported, for carrying
+  group/attribute claims *at login*. Claim-based mapping is evaluated only when a user
+  authenticates, so membership changes lag until the next login and offboarding does not
+  retire credentials that bypass interactive login (e.g. API keys).
+- **SCIM provisioning** appears among more enterprise-oriented products — a push-based
+  continuous sync of users and groups from the provider that closes the staleness window
+  and, critically, handles **deprovisioning** in near-real time. Where SCIM is absent,
+  group handling is login-time only.
+- **Group-to-role mapping** is **per-identity-provider** and usually locked by email
+  domain; identically-named groups from different providers are treated as distinct.
+
+---
+
+## 11. Expressing Exceptions: How Systems Say "No"
+
+In an allow-only system, adding a rule can only ever *add* access. That property —
+**monotonicity** — buys three things: the oracle can stop at the first matching grant;
+independent sources of authority compose safely (a new source never breaks existing
+access); and every "yes" has a **witness** (a row to point at when asked "why can Alice
+see this?").
+
+When a requirement sounds like "no," walk up this ladder and stop at the first rung that
+works:
+
+1. **Absence** (default-deny) — just don't grant it. Solves most cases. In graph terms
+   this is *no path found* — nothing is stored, it fails closed, and every system
+   already has it.
+2. **Structure** — make the wall an *absence of reach*: put the sensitive thing in a
+   container the broad grant does not extend into. Solves "the org sees everything
+   *except the PII project*" with no deny rule — provided container structure matches
+   security boundaries.
+3. **Attenuation** — cap the *credential*, not the world ("this collector key can only
+   ingest"). Subtraction, but contained to one credential.
+4. **Explicit deny** — a global override rule, a *negative edge*. The residue that
+   genuinely needs it is real but small ("contractors never touch prod, no matter what
+   roles they accumulate").
+
+**Explicit deny is expensive because it destroys all three nice properties:**
+
+- **No short-circuit.** Finding an allow-path is not enough; you must prove the
+  *absence* of any blocking edge, every time.
+- **Composition becomes dangerous.** A check that walks two grant sources but forgets a
+  third *deny* source is no longer a lost-access bug — it is a security hole. (This is
+  the real reason "ship the simple model now, layer attributes later" is only safe while
+  you stay allow-only.)
+- **The veto can sit off the path you walked.** A tag-predicate deny attaches to a
+  resource *by attribute*, not along containment, so "why *can't* Alice see this?" loses
+  its single witness, and "grant = access" breaks — you can see the grant row and she
+  still cannot reach the resource.
+
+There is also a trap specific to predicate deny: the negative edge exists only while the
+tag exists, and the tag is usually editable by the resource's own team:
+
+```
+  before:   Alice ──allow(org-wide)──▶ span {pii}   negative edge active → blocked
+  after the pii tag is removed:
+            Alice ──allow(org-wide)──▶ span {}       negative edge GONE → path live
+            …no grant, role, or policy changed. The data fell open silently.
+```
+
+**Deleting a tag became a grant** — performed by exactly the people the deny was meant
+to constrain. The reformulation that makes most denies disappear: instead of *adding a
+negative edge*, **narrow the positive edge so absence fails closed**:
+
+```
+  deny-form:   allow(org-wide)  +  deny if pii     → tag-delete LEAKS
+  allow-form:  allow iff tag == public             → tag-delete FAILS CLOSED
+```
+
+If explicit deny ever ships, decide its semantics *early* (retrofitting it invalidates
+every consumer that learned "grant = access") and match it on **immutable** properties
+(subject identity, ancestry), never a mutable tag.
+
+---
+
+## 12. Behavior Under Change
+
+A static schema diagram hides most traps; they appear only when something changes. Four
+changes every design should be simulated against:
+
+- **A resource is created.** Broad grants include it automatically (maybe wrongly);
+  enumerated grants exclude it silently (maybe wrongly). Neither is safe — the question
+  is *which mistake happens silently.* "What does a new resource's visibility default
+  to?" is the security posture stated in the future tense, per resource type.
+- **A person leaves.** Does their access actually end (and how fast — the *revocation
+  budget*)? Do their API keys die with them (breaking pipelines) or linger as ghosts?
+  The clean answer is to stop conflating credential with identity — give machine
+  credentials their own identity or attenuation so human offboarding is not entangled
+  with service continuity.
+- **A group or role definition is edited.** Adding someone to a group, or redefining a
+  role, changes access broadly and instantly — a grants-table audit log keyed on row writes
+  shows nothing (§14).
+- **The grants table itself is written.** Granting is an action on a resource too. A
+  viewer who can open a sharing dialog and make themselves an editor was never a viewer.
+  The rule: *you may grant at most what you hold*, checked through the same oracle as
+  everything else.
+
+---
+
+## 13. Matching Facts to Carriers
+
+Every authorization fact lives on a carrier, and a large share of real flaws are a heavy
+fact on a weak carrier. Ordered weakest to strongest for **legitimate mutability and
+revocation latency** — who can change the fact, and how fast changes take effect:
+
+- **Self-reported header** — the holder can shed it by omission. Legitimate only as a
+  *guardrail* for a cooperating party (observability, agent self-labeling), never as a
+  boundary against an adversary.
+- **Tag** — editable by whoever edits the resource; dangerous the moment it *gates access*
+  (§11). Security weight requires a privileged key or an immutable property.
+- **Cache / flattened claim** — holds a stale copy until it expires. Real revocation
+  latency is *the longest cache TTL in the chain*; pick a revocation budget and let it
+  constrain caching, not the reverse.
+- **Signed token claim** — cannot be altered by the holder; narrows-only when used for
+  attenuation. A strong carrier for capability scoping.
+- **Database row** — the source of truth; changes take effect as fast as the caches in
+  front of it allow.
+- **Code constant** — only engineers and code review can change it; deploys are audited.
+  A *strong* carrier, appropriate for facts that change at the pace of releases (what a
+  built-in role can do) and wrong for facts that change at the pace of customers.
+
+This is not a single tamper-resistance ladder under every threat model. A code constant
+resists casual product-admin change but a bad deploy can widen it; a database row changes
+legitimately with ease but is also what a database compromise rewrites. Use this ordering for
+access-model placement, and name a different ordering if the threat is breach resistance.
+
+One carrier becomes an **access path** of its own: the **capability URL** — an unguessable
+share token where *possession of the link is the access.* It sits outside all four families
+(no subject, no grant row, no predicate). At least one surveyed peer offers it, gated by a
+`share` permission. Useful for frictionless external sharing; dangerous because a leaked link
+is a **silent grant** no "who can see X?" review surfaces, persisting until the token is
+rotated. If offered: minting is a privileged action; tokens should be first-class **revocable**
+objects; remember they are a second door the oracle never sees.
+
+---
+
+## 14. Auditing: the Record vs the Decision
+
+Access control decides; auditing *records*. They are adjacent and easy to conflate, but a
+system needs both, and the record has its own design questions the decision model does not
+answer. Three distinct things travel under the word "audit":
+
+1. **The audit query — "who can see X?"** This is the read side (Section 5's
+   `subjects_for`): given a resource, enumerate the subjects who currently reach it. It is
+   a *present-tense* question about the access graph, not a log. It is the shape forgotten
+   until a sharing dialog or a compliance review needs it (Section 1).
+
+2. **The change log — "how did access become what it is?"** A record of grants written,
+   roles edited, group memberships changed. The sharp pitfall (Sections 8 and 12): a log
+   keyed on *grant rows written* misses the highest-blast-radius changes, because
+   redefining a role or editing a group alters everyone's access at once while writing zero
+   grant rows. **The audit unit must be the *effective-access change*, not the row
+   written** — which means the log has to record the resolved consequence ("these subjects
+   gained read on these resources"), not just the literal mutation.
+
+3. **The action log — "who did what?"** A record of the actions subjects took: reads of
+   sensitive resources, writes, deletes, cross-boundary moves, logins, credential minting
+   and use. This is what most people mean by "audit log," and the access-control model
+   barely touches it — yet it is where compliance lives. Note especially **read auditing**
+   ("who *accessed* this private resource"), which is different from the audit query ("who
+   *can*") and is often the actual regulatory requirement.
+
+**The single oracle is the natural emission point.** The same seam that *decides* access
+(§5) should *emit* audit records: every check flows through it, so decision and log entry
+are produced together. Audit bolted on at scattered call sites logs inconsistently for the
+requests that matter. Returning (or emitting) the *reason*, not just the boolean, makes deny
+explainable ("why can't I see this?", §17) and lets the change log state consequences, not
+mutations.
+
+What to record is the conventional tuple — **who** (subject *and* credential, §2), **what**
+action, **on what** resource, **when**, **from where**, and **result** (allow/deny, and on
+deny, why). The log must be **append-only and tamper-evident** (§13 binding strength) with
+**retention** as a policy input — what makes access control *accountable*, not part of the
+decision itself.
+
+---
+
+## 15. Comparison Matrix
+
+| Dimension | Vendor A | Vendor B | Vendor C | Vendor D |
+|---|---|---|---|---|
+| Family | membership | scoped permissions | per-object ACL + org container | **RBAC + curated-tag ABAC (hybrid)** |
+| Edges | stored | stored | stored | **stored (RBAC) + computed (ABAC)** |
+| Sub-object / attribute-level scoping? | no | no | type-narrowed inheritance | **yes (ABAC tags)** |
+| Roles as data | no (code) | yes | yes | yes |
+| Custom roles | no | partial | custom groups (enterprise) | yes (enterprise) |
+| Group as **grant subject** | no | no | **yes** | no |
+| Group as **role-mapping input** | n/a | yes | SSO only; primary = grant subject | **yes (SCIM / SSO sync)** |
+| Service accounts as subjects | limited | limited | **yes (via groups)** | first-class org-scoped |
+| Allow / deny | allow-only | allow-only | allow-only | RBAC allow-only; **ABAC allow + deny** |
+| Isolation unit | project | container | **org → project → object** | **org → workspace** (+ tag groups) |
+| List-query mechanism | membership `IN` | scope `IN` | ACL `IN` (+ inheritance) | **role filter + tag-policy compose** |
+| SCIM provisioning | unknown / not observed | unknown / not observed | SSO (no SCIM observed) | yes (enterprise) |
+
+---
+
+## 16. Cross-Cutting Findings
+
+1. **Enumerated-grant is the common baseline in this surveyed set.** All four store
+   coarse access as rows resolved to `id IN (...)`. One peer adds a **narrow
+   attribute-predicate refinement** on top of stored RBAC — curated tag keys only, not a
+   wholesale Family B conversion — and is the only one composing a query-time tag-policy
+   evaluator alongside stored edges.
+2. **Allow-only is the norm at the coarse layer.** Three of the four are allow-only
+   throughout; the hybrid peer is allow-only in RBAC but supports **explicit deny in
+   ABAC** (deny wins). The enumerated families handle exceptions structurally (don't
+   grant) rather than with deny.
+3. **Groups attach two ways** — as grant subjects, or as role-mapping inputs — and this
+   is the clearest design signal. Subject-based group access pairs with per-object ACL
+   models (Vendor C); role-mapping pairs with workspace-grain isolation (Vendor D).
+   Vendor C also has SSO but its primary model is Pattern 1, not IdP group resolution.
+4. **In this set, three of four model roles as data, with custom roles usually tier-gated.**
+   Of those three, two support fully custom roles and one a partial set — frequently behind
+   an enterprise tier.
+5. **The unit of isolation (object vs workspace) is the dominant fork** and drives group
+   handling, role scope, and name collisions. Even object-grain ACL products may still
+   ship an org container (Vendor C); the fork is whether workspace membership is the
+   *primary* isolation story (Vendor D) or per-object grants with org-wide cascade (Vendor C).
+6. **Provisioning maturity varies.** Login-time SSO mapping is common; continuous SCIM
+   provisioning (and prompt deprovisioning) is an enterprise differentiator (observed on
+   Vendor D; Vendor C documents SSO but not SCIM).
+
+---
+
+## 17. Implications for Design
+
+The landscape suggests a default path and a few decisions to make deliberately rather
+than inherit (detail in §18):
+
+- **One scope assumption to check first: who *creates* the resource.** This survey (and the
+  `ownerOf` edge in §3) assumes the familiar UI-driven story — a user creates a resource and
+  becomes its owner. Products whose resources are **machine-created** (pipeline / ingest-born,
+  no human creator) break that assumption and need a separate **birth-time policy**: default
+  visibility when there is no owner, and a split between **write (ingest) authority** and
+  **read (visibility) authority** that the owner-grant pattern doesn't address. If that's your
+  world, the owner-grant default below may not apply — see the companion Phoenix design notes,
+  which treat machine-created, ownerless resources as the central problem.
+
+- **Let the shape of the requirement pick the family.** Pick enumerated grants unless a real
+  requirement is shaped "everything matching X" — and Family B brings a tag-as-security-surface
+  problem (§18 #1).
+
+- **Allow-only is a safe default.** The *semantics* of deny are not cheap — precedence, audit,
+  list-query shape, authoring UX — and either way, do not write a single `deny` row until those
+  semantics are designed (§18 #10).
+
+- **Decide the unit of isolation consciously** — object-grain vs workspace-grain is the dominant
+  fork (§18 #2).
+
+- **Choose group handling with eyes open** — first-class grant subjects vs role-mapping inputs
+  follows from that fork (§18 #8).
+
+- **Treat provisioning as a maturity axis, not a correctness one** — login-time SSO mapping ships;
+  SCIM is the enterprise upgrade (§18 #12).
+
+---
+
+## 18. A Decision Checklist
+
+A team designing access control can settle the questions below in order; each answer
+constrains the next, and most cannot be changed cheaply once data exists — schema for
+subject unions, default visibility, and revocation posture costs nothing now and a rewrite
+later. The list is deliberately product-agnostic — substitute your own resource and container
+names where appropriate.
+
+1. **Family.** Is access "these subjects, these named resources" (enumerated edges you
+   store and walk) or "everything matching this predicate" (edges you compute from
+   attributes)? Pick the enumerated family unless a real, named requirement is shaped
+   "everything matching X." The choice decides whether you owe a rule compiler.
+
+2. **Unit of isolation.** Is the boundary the individual object, or a container /
+   workspace? This is the dominant fork: it drives group handling, role scope, name
+   collisions, and whether a tenancy layer is required up front.
+
+3. **Resource reachability.** When a subject can reach a container, what can they reach
+   *through* it? Define the containment edges and whether access flows down them, so
+   "access to a project" has one unambiguous meaning for its children.
+
+4. **New-resource default visibility, per type.** When a resource is created (often
+   implicitly, by first use), who can see it — everyone, the creator, or a container's
+   members? Decide this per resource type; the answer is a security posture, not a
+   default you can flip later without surprising users.
+
+5. **Revocation budget.** When a grant is removed, how promptly must access stop —
+   immediately, or by next login/token refresh? This determines whether you can cache
+   resolved access and for how long.
+
+6. **Unauthorized read ≡ not-found.** Does probing a resource you cannot access return
+   "forbidden" or "does not exist"? Returning not-found avoids leaking the existence of
+   private resources, but must be applied uniformly across point lookups and lists.
+
+7. **Subjects.** What kinds of subject can hold a grant — users, service accounts,
+   groups? Put the union type in the first schema that has subjects, even if only users
+   are populated initially. Decide explicitly whether API keys are *credentials* that
+   wield a subject's identity (and attenuate it) or *identities* that hold grants of
+   their own.
+
+8. **Group handling.** Are groups first-class **grant subjects** (a group can be granted
+   a specific resource) or **role-mapping inputs** (a group resolves to a role at
+   login)? The first persists a membership graph and pairs with per-object ACL models
+   (often with an org container above — Section 9); the second stores only the resolved
+   assignment and pairs with workspace-grain isolation. This follows from the
+   unit-of-isolation choice.
+
+9. **Roles.** Are roles code or data? Will you offer custom roles, and at what scope —
+   global, or scoped to a single object? Roles are an edge-count compression over
+   (subject × permission); decide early whether that table is yours to extend or fixed
+   in code.
+
+10. **Deny in scope.** Do you need explicit deny, or does allow-only with specificity
+    precedence suffice? If deny is plausible, reserve the schema field (`effect`) now to
+    avoid a later migration — but do not implement deny *semantics* (precedence, audit,
+    `NOT IN` query shape, authoring UX) until a concrete requirement forces it. If deny
+    is genuinely out of scope, omit the field rather than ship a column that invites
+    callers, tests, and future engineers to assume deny already works.
+
+11. **List-query shape.** Every listing endpoint must filter by the same access rule the
+    point check uses. Confirm the oracle can produce a **relational predicate the
+    database applies before pagination** — indexed joins, semi-joins, or a CTE resolving
+    to `id IN (...)` — rather than a per-row check evaluated in application code after
+    the rows are fetched. Verify this before the object count grows.
+
+12. **Provisioning.** Is login-time SSO mapping enough to ship, or is continuous SCIM
+    provisioning (and the prompt deprovisioning it enables) a named requirement? Treat
+    this as a maturity axis to grow into, not a correctness gate.
+
+13. **Oracle location.** Is the resolver **in-process** (a library call) or **delegated** to an
+    external policy engine / authz service (a network hop, e.g. OPA / Cedar / a ReBAC store)?
+    This decides latency, caching, consistency, and who owns the decision — and it is hard to
+    reverse once call sites assume one or the other.
+
+14. **Rollout / migration.** If you are turning this on for an **existing** deployment, is the
+    cutover a graceful no-op or a **hard open → fail-closed flip** that hides previously-visible
+    data until grants are written? Plan the blast radius (a dry-run "who loses access?" preview)
+    *before* flipping; a fail-closed cutover is a planned outage, not a config toggle.
+
+15. **Surface coverage & oracle bypass.** Does **every** read/write surface — list, point-get,
+    count, aggregate, export, subscription/stream, and *every* API (REST *and* GraphQL) — route
+    the **same predicate through the same oracle**? The same operation on two surfaces must give
+    the same answer, or the stricter one is bypassable by switching surfaces. One forgotten
+    endpoint is a silent leak no model-level test catches.
+
+A single rule resolves all of these consistently only if every check — point lookups and
+list queries alike — routes through one oracle. Two code paths that each answer "can
+this subject do this?" is two authorization systems, and one of them will eventually be
+wrong.
+
+> If you keep one line: **enumerated access is edges you store and walk; predicate
+> access is edges you compute on the fly. Both still need a resolver that turns a
+> request into an `id IN (...)` filter; only the predicate family additionally needs a
+> compiler that turns a policy into that filter.**

--- a/internal_docs/specs/rbac/phoenix-access-control.md
+++ b/internal_docs/specs/rbac/phoenix-access-control.md
@@ -1,0 +1,1701 @@
+# Phoenix Access Control: Design Notes
+
+A Phoenix-specific companion to [access-control-survey.md](./access-control-survey.md).
+The survey is anonymized and product-neutral — a shared vocabulary and mental model. This
+document is the opposite: it records what is *peculiar to Phoenix* and the design
+reasoning that follows.
+
+**Terms imported from the survey** (read it for the full treatment): *subject / identity /
+credential / grant*; the **single oracle** (one function answers every "can X do Y on Z?");
+the **effective-access formula** (`authority(identity) ∩ attenuation(credential)`); the
+**two families** — *Family A* (enumerated grants: rows you store and join) vs *Family B*
+(attribute/predicate rules, "ABAC"); and group **Pattern 1** (a group is a first-class grant
+subject) vs **Pattern 2** (a group maps to a role). "Survey §N" references point at that doc.
+
+**Scope and status.** This is a *design document written against `main`*. The questions
+in §2 are properties of Phoenix's domain and hold regardless of any implementation. Where
+it refers to a concrete mechanism — an `acls` table, a single oracle, an attenuating
+`scope` on API keys, a `subject_kind` discriminator, an access-control feature flag — that
+is **the proposed direction (a prototype), not shipped code on `main`.** Such references
+are named for concreteness and labeled as proposed; they are deliberately kept free of
+file/line citations so the doc does not rot as the prototype moves.
+
+A second distinction matters for the security-driving claims: some are **domain
+assumptions this design relies on** (projects are auto-created on ingestion; a
+deleted-then-re-ingested project gets a new id; SYSTEM is a hidden superuser) — stable
+enough to build on, but **if any of them changes, revisit the affected sections**. Others
+are **current-code observations** that are more likely to change and should be
+**re-verified against the code before implementation** — chiefly that trace transfer
+updates only `project_rowid` and leaves the session behind (§2.9); that `session_id`
+was resolved globally before the composite-unique fix (§3.3); and the §2.8
+system-generated-project facts (the shared `playground` singleton, the hidden
+`Experiment-<hex>` / `dataset-evaluator-<hex>` projects, the `exclude_*` list filters,
+parent-`user_id` ownership, and the client-vs-server experiment execution paths); and the
+§6 global-object facts (the `secrets` store, the evaluator / annotation-config / model /
+label library, retention policies, system settings). These were verified against `main`
+(as of 2026-06), but the doc cites no line numbers, so re-verify against current code
+before building on them. Where this doc draws a security conclusion from either kind, treat
+the conclusion as sound but the code detail as "verify current behavior first."
+
+A third provenance applies narrowly to §2.8's **online-eval** material: it is drawn from a
+**separate, concurrent design effort** (targeting the same release) — neither `main` nor this
+prototype — so its specifics (a production project as the data context, where the judge's own
+trace lands) are *proposed shape*, not observed behavior, and should be reconciled with that
+workstream as it lands.
+
+If you only read one thing: **most RBAC designs assume a person creates a resource and
+becomes its owner. Phoenix's highest-volume resources are created by a telemetry
+pipeline, not a user** — and every tension in §2 is a consequence of that fact.
+
+**Tenancy is in scope as a structural direction, not as a full design.** This doc's spine
+is per-resource access control — *who can see this project*. But per-resource grants can
+hide Team B's `production` from Team A and still cannot give each team its *own*
+`production`, namespace ingest routing, or stop write-time existence leaks ("name already
+exists"). That gap — **tenancy / namespace isolation** — is the structural fix for the
+deepest tensions in this doc, so it is treated as a named direction in **§5** rather than
+deferred. What §5 does *not* attempt is the full tenancy design (org model, provisioning,
+migration mechanics); that remains a follow-on. (One piece that *isn't* tenancy-shaped —
+a blocked producer creating a new visible project under a different name — is covered as
+ingestion-time creation authority in §2.2.)
+
+---
+
+## 1. The strawman (and the analysis behind it)
+
+**Proposed strawman** — here *strawman* means a deliberate, conservative **starting
+proposal** to anchor discussion (not an argument set up to be knocked down). It is
+fail-closed and easy to relax:
+
+- **Flag off → no change** (everything open, exactly as `main` behaves today).
+- **Flag on:**
+  - **Ingest-born projects** (no human creator) default to **admin-only**: visible to
+    administrators and to whoever is explicitly granted, nobody else. Ingestion stays
+    **unimpeded** — any **ingest-capable** credential may create/write any project, and
+    project-level grants do not gate ingest. (API-key *scopes* still apply: this does not turn
+    a read-only or UI credential into an ingest credential — only *project*-level read-gating
+    is lifted, not credential attenuation, §2.5.) Only *read visibility* is gated by grants.
+    (Read-safe, but *operationally* abusable — any ingest-capable credential can spawn
+    unbounded invisible projects; see §2.2.)
+  - **User-created resources** (datasets, prompts) default to **creator-private** (creator +
+    admins).
+  - **Administrators retain visibility to everything; only admins delete projects.**
+  - **Read visibility** is **monotonic allow-only** — grants only ever *add*. There is no
+    everyone-baseline to shadow, so no non-monotonic resolution, no `restricted` marker, no
+    last-grant footgun. The default mechanism is **hand-written group grants** applied *after*
+    birth (admins triage the admin-only project and grant a group); creator-private resources
+    (datasets, prompts) instead **auto-grant their creator at creation**.
+
+  *Scope — "access" here means **read visibility**, and the verbs are governed separately:*
+  reads are gated by grants (above); **ingest writes** are *ungated*; **delete** is
+  admin-only; and **other project-lifecycle actions** (rename, settings, retention,
+  manage-access, and any archive/restore) are separate **manage/admin** actions,
+  admin-by-default until specified. So "can write any project" is *ingest*, not all writes —
+  don't read the monotonic-grant rule as governing every verb.
+
+*Why this is the right strawman:* for a *security* feature, being too restrictive fails more
+safely *for confidentiality* — the cost is access friction (ask an admin), up to a planned
+non-admin cutover at the flip (§2.1, §3.5), but no data escapes — while being too open is a
+leak you can't take back. So fail-closed is the safe anchor, and you iterate *from* it by
+**adding** grants (safe), never by removing exposure (risky).
+It is the simplest model available, positioned so the discussion *relaxes* it, not tightens
+it.
+
+*Two costs, stated up front:* (1) the flag flip is a **hard cutover, not a no-op** —
+enabling it locks non-admins out of ungranted projects until grants are written (flag-*off*
+is unchanged); the §3.9 dry-run and communication manage it. (2) **Admin/creator is in the
+loop for the default case** — fine at low project churn (one group grant at birth), but a
+genuine **support cliff at high project counts**, because "ask an admin" is only benign if
+admins can *identify which team owns which project* and pre-write grants. So a
+**grant-authoring + project-ownership-identification workflow is a launch prerequisite**, not
+an afterthought — and it is the pressure that justifies the churn-driven escalations
+(credential-derived auto-grants, then tenancy, §5). Those escalations are deliberately
+**not** baked into the strawman — they are the evolution paths the discussion should pull
+in, not pre-decided parts of it.
+
+*Considered and rejected for the strawman:* an **everyone-allow baseline + shadowing** (the
+gentler, no-op-on-flip alternative) — rejected as fail-*open* and non-monotonic (it is the
+source of the shadowing / `restricted`-marker / last-grant complexity discussed in §2.1);
+**ABAC / tags** (§2.11 — and worse than hand group-grants); **tenancy** (§5 — churn-driven,
+not day-one).
+
+*How to read the rest:* §2 is the *analysis that produced this strawman* — each section is
+the reasoning behind a choice above, with the rejected everyone-allow model kept for the
+record. §3 is the implementation work the strawman still needs (coverage above all). **§6**
+(global objects) is orthogonal. **§5** (tenancy) is the *structural direction* — out of
+prototype scope, but not irrelevant: it is the structural fix for the birth tensions
+(§2.1/§2.3/§2.4).
+
+The shape of the problem, in one line:
+
+> Phoenix's RBAC problem is not "how do users share objects?" It is **"how does an
+> unattended telemetry pipeline safely create, route, and continue writing resources whose
+> visibility may later narrow?"** Everything else follows from that: fail-closed cutover
+> migration, creation authority, machine credentials, containment integrity, and coverage
+> across derived read surfaces.
+
+A project is auto-created the first time a span carrying its name is ingested. There is
+no interactive, authenticated user clicking "New Project," and the same is true of the
+spans, traces, and sessions underneath it. The surveyed vendors mostly assume UI-driven
+creation, where the creator is a known user who naturally becomes the owner. Phoenix's
+dominant creation path is a collector posting OTLP — no user, often no human-scoped
+credential at all. This is true on `main` today, and the vendors get to lean on "creator
+owns it" where Phoenix cannot, for its most common resource.
+
+The high-level conclusions that follow, each developed in §2–§3:
+
+- **It is an ingestion problem, not a sharing-dialog problem.** Most RBAC products start
+  from "a user creates a resource, then shares it"; Phoenix starts from "a machine creates
+  a resource by writing telemetry." That flips the hard questions away from grant-authoring
+  UI toward creation authority, default visibility, machine credentials, and ingestion
+  failure modes (the *Birth and creation* and *Identity and authority* groups of §2).
+
+- **One rooting principle, not a taxonomy of resource kinds: root each resource's access at
+  its real data context.** For trace-bearing, project-contained data the principle yields two
+  common access roots — the **telemetry world** (machine-created projects, ownerless →
+  admin-only) and the **dataset world** (human-created datasets/prompts → creator-owned).
+  Everything else — experiment traces, evaluator traces, online-eval scores — is a
+  **run-artifact rooted at the data context it evaluates** (a dataset offline, a production
+  project online), not a third kind of project. "Project" is just the span store, reused
+  (§2.8). And the principle, not the pair, decides the cases the two common roots don't
+  cover: playground's data context is the user who ran it (per-user scratch, §2.8), and
+  deployment-global objects that hang off **no** project — secrets, the shared
+  evaluator/model/label library, system config — have no data context to root at, so they get
+  their own treatment in §6.
+
+- **Birth-time policy matters more than after-the-fact sharing.** When resources are
+  created unattended, the decision made *at creation* — visible, invisible, or routed
+  somewhere surprising — is the primary control. Grants written later are remediation, not
+  the main mechanism (§2.1, §2.2).
+
+- **Visibility isolation and namespace isolation are different products — and tenancy is
+  the structural fix.** Per-resource grants can hide Team B's project from Team A, but
+  cannot give both teams a project named `production` or disambiguate ingest routing. That
+  is a *separate layer*, namespace/tenancy — and it is also the structural resolution of the
+  hardest tensions below: a container above `project` is what gives an ownerless,
+  machine-created resource something to inherit. It is the recommended direction (§5), not
+  a footnote — though a two-sided one: it ameliorates the birth pains and exacerbates the
+  operational ones. Crucially, the per-resource RBAC proposed here **ships and stands on its
+  own without tenancy**; tenancy is a later structural change to the preferred *defaults and
+  creation model*, not a prerequisite — this is not "don't build RBAC until tenancy."
+
+- **Fail-closed and monotonic is the default — not an open baseline.** The everyone-allow
+  alternative leans on a baseline + shadowing so the flag flip is a no-op; the
+  strawman rejects it (§2.1) for **admin-only-default**, whose **read visibility** is
+  **monotonic allow-only** — grants only *add*, so the shadowing apparatus, the `restricted`
+  marker, and the
+  last-grant-reopen footgun all disappear. The price is a hard-cutover flip rather than a
+  no-op — the deliberate fail-closed trade (§2.1, §3.5).
+
+- **Machine identity is the center of least privilege.** Human-owned API keys are tolerable
+  as a first step, especially with attenuation, but every serious rollout pressure —
+  continuity across offboarding, honest audit, scoped credentials, stable ownership of
+  ingestion — points toward first-class service accounts (§2.5).
+
+- **The hardest implementation work is coverage, not schema.** The ACL table and oracle are
+  small; the real work is making every list, count, aggregate, export, subscription,
+  dashboard, ingest path, and transfer apply the *same* predicate (§3.7). The write side has
+  the same hazard in sharper form: the *same* operation must resolve to the *same*
+  authorization answer regardless of which API surface it arrives on. Authorization placed as
+  per-route/per-resolver decorators drifts — project mutations diverged, with REST reserving
+  project delete/update for admins (`require_admin`) while the GraphQL resolvers let any
+  non-viewer member run them: one operation, two answers, the stricter one bypassable by
+  switching surfaces. A control you can route around that way is not enforcing what it appears
+  to. Reconciling the two (here, tightening the GraphQL resolvers to admin-when-auth-on to
+  match REST) is a hand-patch; the durable fix is a single shared gate, not a decorator
+  re-applied per surface for each surface's assumed consumer.
+
+- **Attribute-based access (ABAC) isn't needed for project-level access.** Phoenix's
+  project-level access is plain enumeration — these teams see these projects — which ordinary
+  grants handle directly; ABAC's "everything matching a rule" power solves a problem Phoenix
+  doesn't have *there*. The one place a predicate could earn its keep is **sub-resource**
+  scoping (e.g. a server-classified `pii=true` view, "only annotations I authored"), which is
+  out of current scope — so the verdict is scoped, not absolute (§2.11).
+
+### Open decisions
+
+The strawman settles the default-visibility *model* (fail-closed admin-only, monotonic).
+What remains open — to be argued, not assumed:
+
+- **Ratify the hard-cutover flip?** The strawman's flip locks non-admins out of ungranted
+  projects until granted (vs the rejected everyone-allow no-op). This is the headline trade
+  to accept consciously (§2.1, §3.5).
+- **Human-authored project creation** — when a person *explicitly* creates a project (a
+  `POST /projects` call, opening a playground), the ingest-born admin-only default is wrong:
+  it locks the creator out of what they just made (§2.3). The question is the posture for that
+  explicit-create case, of which **playground** is one instance. Three options: (1) **status
+  quo** — project-by-table, ownerless → admin-only (reject: the locked-out-creator footgun);
+  (2) **intent-keyed** — explicit create auto-grants its creator, exactly as a dataset does,
+  shrinking the ownerless case to *auto-vivification-on-ingest alone*; (3) **admin-only
+  endpoint** — gate explicit project-create to admins, so a non-admin's only path to a project
+  is ingest (→ admin-only) and the "created a project I can't see" state cannot arise (minimal
+  surface, no new grant semantics). For playground specifically the lean is (2) — **per-user
+  `kind=PLAYGROUND` projects auto-granted to the creator** (keeps access project-level, no
+  sub-resource exception) over the shared-project + per-run-attribution alternative (§2.8).
+  (Experiment/evaluator **access-by-parent** is *not* open — it is a settled invariant, because
+  admin-only there is a straight bug.)
+- **Service-account timing** — first-class non-human identities vs attenuated user keys
+  (§2.5).
+- **Global read-only cap vs. per-object lift (§2.13)** — does a global `VIEWER` *hard-cap*
+  object write-roles (the current, **emergent** behavior — an object Manager grant to a VIEWER
+  is visibility-only), or do object Editor/Manager grants *lift* the write-cap **for that
+  object**? Lean **A (hard ceiling)** for an auditable read-only guarantee — but ratify it
+  deliberately and document the footgun (object write-roles presuppose MEMBER+); reconsider
+  **B** only if per-project write-delegation to otherwise-read-only users becomes a real need.
+- **Churn-driven escalation timing** — when project churn justifies *credential-derived
+  auto-grants* (a project auto-grants the team owning the key that created it, removing admin
+  from the common case), and then the tenant layer (§5).
+- **Ungated ingest integrity budget** — the strawman deliberately leaves project-level ingest
+  writes open (§2.2). Ratify whether that means *any* ingest-capable credential may append to
+  an existing private project by name, and if so which mitigation bounds the poisoning cost
+  (the §2.2 menu).
+- **Dataset copies from telemetry** — when a user creates a dataset from project spans/traces,
+  is that a permitted copy of data they can read, or must the dataset inherit/check the source
+  project's access (§2.9)? This is the copy-shaped analogue of trace transfer.
+- **Hidden experiment project write authority** — client-initiated experiments write to a
+  server-minted `Experiment-<hex>` target (§2.8). Decide whether the project name is treated as
+  a bearer capability, or whether ingestion into `kind=EXPERIMENT` / `kind=EVALUATOR` projects
+  requires a scoped, revocable authorization tied to the parent run.
+- **Disable surface & break-glass (latch already built)** — the **DB-latched activation model
+  is implemented** (one-way latch in `system_settings`, plus a drift guard and an auth guard
+  that refuse to start on env/latch or auth mismatch; §3.5), so *enable-only* and
+  *drift-immunity* are settled. **Open:** there is **no audited in-app disable and no
+  break-glass surface** — disabling today is a raw out-of-band DB edit before startup. Decide the
+  audited-disable UX and the break-glass escape (§3.5).
+- **Revocation and audit floors** — grant changes should take effect on the next request unless
+  an explicit cache budget says otherwise (§3.13); pre-existing API keys with nullable `scope`
+  need a stated default at cutover (§2.10); and the initial ship needs a decision on the base
+  action log, not only point-in-time effective-access history (§3.11).
+- **Global-object policy** — secret value-vs-metadata, per-type read for the shared library,
+  retention-write authority (§6).
+
+*Settled by the strawman (not among the open items above):* the restricted-state model
+(monotonic ⇒ no marker, no shadowing); per-type default visibility (projects admin-only,
+datasets/prompts creator-private); ingestion-time creation authority (creation exposes
+nothing, so ingestion stays ungated); and **access-by-parent for experiment/evaluator
+projects** — a settled invariant, since making them admin-only hides a non-admin's own
+results (§2.8).
+
+### The verb model — what `can(subject, action, resource)` must express
+
+The strawman pins down `read` and `ingest_write` precisely; the rest of the verb space was
+left as "admin-by-default until specified," which is not enough to implement an oracle from.
+The minimal verb enum and the per-type defaults under the flag:
+
+| Verb | Meaning | Notes |
+|------|---------|-------|
+| `read` | View a resource and its contained data | The monotonic, grant-gated verb (§1). Inherited by containment children (§2.7). |
+| `ingest_write` | Append telemetry to a project | **Not** gated by project grants (§2.2); still bounded by the credential's `scope` (§2.5). Creates the project if absent. |
+| `annotate` | Create/edit user-authored sub-objects (annotations, labels, feedback) on readable data | A reader may create; *edit* is **author-scoped** (you edit your own), the sole sub-object exception (§2.7). Distinct from `read` — and distinct from `ingest_write`. |
+| `manage` | Mutate a resource's own config/lifecycle (rename, settings, retention, transfer-out, manage-access) | Admin-by-default; a project-manage grant may delegate it **to a MEMBER+** — a global `VIEWER` is blocked by the read-only gate regardless of the grant (the §2.13 fork). Transfer-out needs `manage` on the *source* (§2.9). |
+| `grant` | Change who has access to a resource | A security-load-bearing slice of `manage`, named separately so it can be audited/restricted on its own. |
+| `delete` | Destroy a resource | **Admin-only** for projects (§1); creator+admin for datasets/prompts. |
+
+Per-resource-type defaults under the flag (✓ = has it by default; *grant* = only via an explicit grant; *admin* = administrators only):
+
+| Resource | `read` | `ingest_write` | `annotate` | `manage` / `grant` | `delete` |
+|----------|--------|----------------|------------|--------------------|----------|
+| Telemetry project | *grant* + admin | any ingest-scoped credential | reader; author-edit | admin | admin |
+| Dataset / prompt | creator + *grant* + admin | n/a | creator + readers | creator + admin | creator + admin |
+| Experiment / evaluator | **inherits parent dataset** (§2.8) | n/a (runner writes plumbing project) | via parent | via parent | via parent |
+| Annotation (sub-object) | inherits project | n/a | author (+admin) | n/a | author (+admin) |
+| Global objects (§6) | per-type (open) | n/a | n/a | admin (open) | admin |
+
+This resolves the read-only-vs-write ambiguity directly: a **read-only grantee** has `read`
+only — they may `annotate` (their own) but **cannot** `transfer` (that needs `manage` on the
+source) and cannot perform any other `manage`/`delete` action. "Ingest is ungated" never
+implies "non-ingest writes are ungated."
+
+**Precedence — how the layers compose.** A subject's *authority* for `(action, resource)` is
+the **union** of: (1) their **global role**'s baseline permissions (e.g. `ADMINISTER` ⇒ all
+`read`/`delete`), (2) **object grants** naming them (or a group they're in), and (3) any
+**permission set** on that resource (§3.2). Grants and permission sets only ever *add*
+(monotonic). That authority is then bounded by **two coarse caps** (`∩`): the **global
+read-only role** (refuses write-verbs) and the credential's **`scope`** (§2.5, the survey's
+`authority(identity) ∩ attenuation(credential)`). So the full pipeline is: *authority =
+admin-baseline ∪ object grants ∪ permission sets; effective = authority ∩ global-read-only-role
+∩ credential-scope*. `ADMINISTER` *contributes* the admin baseline for `read`/`delete` (still
+subject to the caps — a *scoped* admin key is narrowed); **only the SYSTEM / admin-secret path
+bypasses the caps** (§2.6). (Many cells above —
+global-object verbs, whether `manage` is ever delegated below admin — remain open; the *shape*
+of the oracle is not. And whether the read-only role genuinely *caps* object grants is itself
+the open §2.13 fork.)
+
+### Mental model: the whole thing in one formula
+
+> **`effective(user, action, object) = ( admin-baseline ∪ reaching-grants ∪ permission-sets ) ∩ global-read-only-role ∩ credential-scope`**
+>
+> Authority is **additive** (`∪`): an admin baseline, the grants that reach the user
+> (directly, via a group, or via `everyone`), and any permission sets. It is then bounded
+> by **two coarse caps** (`∩`): the **global read-only role** (refuses write-verbs) and the
+> **credential's `scope`**. There are **no deny rows** — every per-object "no" is the
+> **absence** of a reaching grant — and **no per-object cap**. One exception: the
+> **SYSTEM / admin-secret** credential is *not* narrowed by the caps (§2.6).
+
+That is the whole model. **Read visibility** — what this doc's strawman is about — is the
+additive `∪` core: monotonic, allow-only, fail-closed. The two `∩` caps are **coarse**
+(verb-level and subject/credential-scoped — never per-object, never deny edges). The
+[survey §3](./access-control-survey.md) lays out the *general* `∪ / ∩ / ∖` design space;
+Phoenix uses this small subset of it — notably **no `∖` deny and no per-object `∩`**.
+
+*(One term is not yet settled: the `∩ global-read-only-role` cap reflects **current / Lean-A
+behavior**. Whether the global read-only role genuinely **caps** object grants — or is merely a
+liftable **default** (all-floors) — is the open §2.13 fork. Read the formula as "under Lean A.")*
+
+**Definitions — used exactly, throughout.** (The metaphors that recur — "color", "cap",
+"fiat", "floor" — are bound here; after this they are precise terms, not imagery.)
+
+- **Grant edge** — a stored row asserting `(subject, access level, object)`: "this subject
+  holds *at least* this access level on this object." It is always an *allow*; it is the only
+  stored access primitive.
+- **Access level** ("color") — the permission content carried on a grant edge: the verbs of
+  the §1 verb model (`read`, `annotate`, `manage`, `grant`, `delete`). It is a **partial
+  order, not a scalar**, so access levels compose by **union of permissions**, never a numeric
+  maximum.
+- **Subject** ("who") — a grant edge's left endpoint: a **user**, a **group** (resolved to its
+  current members), or **everyone**. Groups are many-per-user and purely additive.
+- **Object** ("what") — a grant edge's right endpoint: a project, dataset, or prompt; its
+  containment children inherit (§2.7).
+- **Effective access** of a user on an object — the **union** of the access levels of *every
+  grant edge that reaches them* (held directly, via any group, or via *everyone*), **then
+  clipped by the caps** (the formula's `∩` terms). Adding a *grant* never lowers it (the union
+  is monotonic); the *caps* are what bound it. So "effective access" is the **union-under-the-
+  caps**, not the bare union — the bare union is the user's *authority*, before caps.
+- **Global role** — the single, mandatory, per-user tier (`SYSTEM`/`ADMIN`/`MEMBER`/`VIEWER`;
+  one `users.user_role_id` FK column). It is **not** a grant edge. `ADMIN`/`SYSTEM` contribute
+  the **admin baseline** (below); `VIEWER` / read-only is one of the two **caps** (below) — a
+  coarse refusal of write-verbs. `MEMBER` confers **no per-object access beyond its own
+  grants**.
+- **Admin baseline** — `ADMIN`/`SYSTEM` as a global role contribute maximal authority *before*
+  any grant is consulted, so admin works even if the grant tables are empty. It is **still
+  bounded by the credential's `scope`** like everyone else's authority — a *scoped* admin key
+  does less than its owner. This is the §1 precedence paragraph's `ADMINISTER` baseline;
+  "baseline," not "override," precisely because scope still narrows it.
+- **SYSTEM / admin-secret backstop** — the one path the caps do *not* narrow: presenting the
+  static admin secret authenticates as SYSTEM, which credential `scope` cannot attenuate and
+  fail-closed does not apply to (§2.6, §3.6). This is the true unconditional override and the
+  highest-value credential in the system.
+- **Absence (fail-closed)** — the *only* representation of "no" for reads: no reaching grant
+  edge ⇒ denied. There are **no stored deny rows**.
+- **Cap (`∩`)** — a bound applied *after* authority is computed. Phoenix has exactly **two,
+  both coarse**: the **global read-only role** (refuses write-verbs) and the credential's
+  **`scope`** (`authority ∩ scope`, §2.5). Both are verb-level and known from the
+  subject/credential alone — **neither is a per-object clearance, neither is a deny edge.**
+  (`scope` is also called **attenuation**; it earns its place because a key must track its
+  owner's *dynamic* authority minus a fixed narrowing — the one thing absence cannot express
+  without copying edges.)
+- **Permission set** (the `PermissionSet` model) — a reusable named bundle of permissions for
+  one object type, conferred by a grant; purely additive (a **floor**), distinct from the
+  global role.
+
+**Stated precisely:** *a user may perform an action on an object **iff** the action's access
+level is contained in their **authority** — `admin-baseline ∪ reaching grants ∪ permission
+sets` — **and** the action survives both coarse caps: the **global read-only role** (write-
+verbs refused) and the **credential's `scope`**. There are no deny rows and no per-object cap,
+so every other "no" is the **absence** of a reaching grant. The one exception is the
+**SYSTEM / admin-secret** credential, which the caps do not narrow (§2.6).*
+
+**Worked example — follow one read.** Alice is a `MEMBER` with no grants. She opens the
+project list and it is **empty**; Project P returns *not-found* — not because anything forbids
+her, but because no grant edge reaches her (**absence** is the only "no"). An admin then grants
+`read` to the **ML-team** group on P; Alice is a member, so a reaching edge now exists and **P
+appears** (**effective access = the union of reaching edges**, here arriving through her
+group). Delete that grant and P **vanishes again** — still nothing *denies* her; the access
+simply isn't there (**no deny rows**). Throughout, **Dr. Bob** (an `ADMIN`) sees P with no
+grant at all, and would still see it if every grant row were deleted (the **admin baseline** —
+it precedes grants). But Bob is not above the caps: he mints an ingest-only API key, and its
+`scope` **narrows** even his authority, so the key cannot read P's settings though Bob's own
+session can (`authority ∩ scope`). The *only* thing the caps cannot narrow is the
+**SYSTEM / admin-secret** path (§2.6) — not an ordinary admin key. That one paragraph
+exercises every term in the definitions.
+
+**Thought experiment — can joining a group ever take access away?** No. Adding Alice to
+ML-team can only *add* reaching edges, never remove one. If joining a group *did* lower her
+access, that group would be carrying a cap — a "restriction group" — and the model would be
+non-monotonic in membership. Phoenix deliberately has no such thing: caps live only on a
+single per-subject clearance (the global role, a credential's scope), never on a group.
+
+**Thought experiment — is "viewer" a promise Alice will never write?** It depends *which*
+viewer — and conflating the two is the trap. A **global `VIEWER`** (the role) **is** an
+unliftable write guarantee: the `IsNotViewer` / `IsNotReadOnly` gates refuse her writes
+regardless of any grant, so even an object **Manager** grant via a group gives her *visibility
+only*, never write (this is the §2.13 fork — and the reason that "manage may be delegated"
+holds only for MEMBER+). What is *liftable* is the **other** "viewer": a **`MEMBER`** who
+merely *holds no write grant on P* — a group `Editor`/`Manager` grant on P **does** give her
+write, because she clears the global gate. So: **global-role read-only is a hard, unliftable
+cap; per-object "viewer-by-absence" (for a non-VIEWER) is liftable.** What the strawman lacks
+is a *per-object* clamp — read-only on one project for someone who writes elsewhere.
+
+The remaining design choices — beyond what the formula already states, and the ones that most
+often trip people up:
+
+- **Viewer splits in two — don't conflate them.** A **global `VIEWER`** is an *unliftable*
+  write cap: the `IsNotViewer` / `IsNotReadOnly` gates refuse writes regardless of grants, so an
+  object Editor/Manager grant confers *visibility only* (§2.13). Separately, a **non-VIEWER who
+  merely lacks a write grant on P** is read-only on P *by absence* — and that **is** liftable (a
+  group `Editor` grant on P gives them write). What the strawman does **not** have is a
+  *per-object* clamp making an otherwise-writing user read-only on one specific project.
+- **Groups are additive subject sets; a cap must never live on one.** Groups are first-class
+  grant subjects (Pattern 1), many-per-user, composing by `∪` — so adding someone to a group
+  can only ever *grant*, never revoke. Putting a cap (or deny) on a group would make joining a
+  team silently *reduce* access (a non-monotonic "restriction group"); the strawman does not
+  do this. (Object-side tag predicates — the `which`-on-the-object mirror of a group — are
+  rejected at the coarse grain, §2.11.)
+- **Permission sets are *floors*, never caps.** A custom **permission set** is a
+  `(color × object-type)` bundle that only ever *adds* (a `∪` floor), so it is safe under the
+  monotonic model and ships via a separate permission-set table (§3.2). It is **not** a cap: in a
+  no-deny world a **permission set** *cannot* restrict below what other grants give (that would be
+  a deny edge). A **custom *global* role** is the different, higher-scrutiny case — it edits the
+  global tier itself (the admin baseline / caps)
+  and needs the closed-set column migration of §3.2 — strictly higher-scrutiny, and out of
+  strawman scope.
+
+*Naming caution:* "role" is overloaded. The **global role** (one mandatory tier per user —
+`SYSTEM`/`ADMIN`/`MEMBER`/`VIEWER`, a single FK column) and a **permission set** (the
+`PermissionSet` model — a per-resource, many-per-user color bundle conferred by a grant) are
+different things (survey §3), and discussion derails when the two are conflated. Where the
+distinction matters, say *global role* vs. *permission set*.
+
+### FAQ — the recurring confusions
+
+- **Built-in vs. custom role?** A **mutability/provenance** distinction (`is_built_in`),
+  orthogonal to the model: built-in = seeded, immutable, a closed set (semantics can live in a
+  **code constant**); custom = admin-authored, editable, free-form (semantics **must** be DB
+  data). Always ask the **grain** — a custom *global* role (the tier; deferred, §3.2) vs. a
+  custom *permission set* (per-resource; ships).
+- **What is a permission set?** The **object-scoped, additive bundle a grant confers** (view /
+  edit / manage) — the "color" of a grant edge (the `PermissionSet` model). It is **not** a
+  global role and **not** a cap; it only ever *adds* (a floor).
+- **Floor vs. cap?** A **floor** adds — "at least this much" (`∪`); a **cap** bounds — "no more
+  than this much" (`∩`). Object grants / permission sets are floors; the global `VIEWER`
+  read-only role is a cap.
+- **Can a `VIEWER` write if granted Manager on a project?** The **§2.13 fork.** Under current /
+  Lean-A behavior, **no** — global `VIEWER` is a hard cap, so the Manager grant confers
+  visibility only. Under all-floors (Option B), **yes** — the object grant lifts them for that
+  project.
+- **Why not put caps on groups?** Because then **joining a group could *reduce* access** —
+  non-monotonic and surprising ("a team I joined removed my write"). Phoenix keeps groups
+  **additive only**; a cap lives on the single per-subject clearance, never on a group (§2.13).
+- **Why does Phoenix have `role_permissions` if grants exist?** Because the **global role's
+  behavior (the read-only cap, the admin baseline) lives *outside* the additive grant graph** —
+  grants are allow-only floors and cannot express a ceiling, so the global-role layer is
+  persisted separately. It isn't *strictly* required, though: the built-in roles are enforceable
+  from the `BUILTIN_ROLE_PERMISSIONS` **constant**, so the table is **forward-compat for custom
+  global roles + uniform resolution**, not a hard dependency (§3.2).
+
+---
+
+## 2. Design tensions
+
+This section is the **analysis that produced the §1 strawman** — most of these questions the
+strawman *resolves* (each subsection opens with its resolution), and they are kept as the
+reasoning behind a choice, not as live forks. The handful that remain genuinely open are
+collected in §1's *Open decisions*. Read §2 to understand *why* the strawman is what it is —
+including why the everyone-allow model is documented and rejected — rather than as a menu of
+undecided options.
+
+### Birth and creation
+
+*Default visibility, who may create, ownership, and identity churn at the moment a resource appears.*
+
+#### 2.1 Open-by-default vs closed-by-default for machine-created resources
+
+This is the deepest question in the design, and it is easy to answer by accident.
+
+**Strawman resolution (§1): fail-closed, admin-only, monotonic.** New ingest-born projects
+default to admin-only; **read visibility** is **monotonic allow-only** — grants only *add*,
+with no deployment-wide open baseline. Datasets and prompts (user-created) default to creator-private.
+The rest of this section is *why* that choice, told against the alternative it rejects.
+
+**The rejected alternative: everyone-allow + shadowing.** The opposite default — every new
+project visible to everyone until a grant narrows it — is operationally gentler (the flag
+flip is a no-op). It is rejected for two reasons. First, it is **fail-open**: a new project
+is exposed until an admin acts, which a security review rightly challenges. Second, it is
+**non-monotonic**: a narrowing grant does not *add* access, it *shadows* the everyone-baseline
+(the object becomes private to the named subjects), so the model needs an apparatus —
+specificity precedence, a notion of "restricted," and a rule for the **last** grant. That
+last point is a real footgun: if "restricted" is *inferred* from grant presence, deleting the
+last grant **silently reopens the object to everyone** — "remove access" becomes "publish" —
+and closing it requires an explicit `restricted` marker, more machinery still.
+
+**Admin-only-monotonic makes all of that disappear.** Closed-by-default means grants are
+purely additive: no baseline to shadow, no specificity precedence, no `restricted` marker,
+and removing the last grant leaves an object admin-only — never reopened. That simplicity,
+plus fail-closed's benign failure mode (§1), is the case for the strawman; the cost (a
+hard-cutover flip, admins-in-the-loop) is in §1 and §3.5.
+
+**Why the strawman also makes deletion admin-only:** the same logic. Project deletion is
+*destructive*, and ingest-born projects have **no non-admin owner** to entrust it to (§2.3) —
+so there is no natural party below admin to hold delete authority. Admin-only delete is the
+conservative default for a destructive action on an ownerless resource; like the rest of the
+strawman it is meant to be *relaxed* later (e.g. delegating delete via a grant), not the end
+state.
+
+The default is chosen **per type, explicitly** — projects admin-only, datasets/prompts
+creator-private — not inherited from whichever seed ships. One case the per-type call must
+still cover: the **playground** project (§2.8) is a single *shared* project holding every
+user's prompt-playground traces (often sensitive prompts), so its open question is
+*shared-vs-per-user*, not open-vs-private — a posture chosen by construction today, not
+deliberately. (The structural resolution — a default scoped to a *container's* members rather
+than the whole deployment — is what a tenant layer buys; see §5.)
+
+#### 2.2 Ingestion-time authorization: creation and partial batches
+
+**Strawman resolution (§1): ingestion stays unimpeded.** Any **ingest-capable** credential may
+create and write any project — *project-level grants* don't gate ingest, but the credential's
+own *scope* still does (a read-only key cannot ingest; §2.5). This is safe under
+admin-only-default because **creation
+exposes no read access** — a new project is visible only to admins until granted, so there is
+nothing to gate at creation. It also closes the bypass an open-by-default model would have
+had: there, a key *blocked* from project P could emit under a new name, auto-creating an
+*open* P2 and landing its data somewhere visible; admin-only makes that pointless. So the
+whole "who may create / who may write" fork — load-bearing under the rejected open baseline —
+dissolves.
+
+**The cost of ungated writes: unbounded invisible projects and possible poisoning.** The
+creation half is not a *confidentiality* problem (ordinary users can't see admin-only
+projects), but it is an **operational** one: any key can spawn arbitrarily many admin-only
+projects — clutter in the admin's all-projects view, triage load (admins must sort real from
+junk before granting), and a soft resource-DoS. There is also an **integrity** half: if writes
+are truly ungated by project grants, any ingest-capable credential that can name an existing
+private project can append telemetry to it. That can pollute another team's traces,
+dashboards, metrics, and any future evaluator fed by those traces, even though it does not let
+the writer read the result. Treat that as an accepted trade only if the mitigating boundary is
+explicit (credential scope, per-key project allowlists, signed routing context, quotas,
+auditing, or eventually gated writes). The takeaway: ungated writes are *read-safe* but not
+automatically acceptable *product* behavior; "unbounded invisible project creation" and
+"write poisoning of existing projects" are the costs to weigh.
+
+*If write-gating ever returns,* it reopens **partial-batch semantics** (an OTLP batch mixing
+allowed and disallowed projects must choose accept-partial, reject-whole, or per-item-errors)
+— moot while writes are open, and the only durable rule is that whatever drops must be
+**counted and surfaced**, never silently discarded (§3.7).
+
+#### 2.3 Is "ownership" even the right model when there is no creator?
+
+The survey's graph has a `user ──ownerOf──▶ resource` edge: the creator gets a grant. For
+a machine-created project there is no creator to attach it to, so the instinct is to
+*patch* the model — invent a standing owner, or assign a system identity.
+
+The deeper move is to question whether ownership is the right primitive here at all.
+Ownership is fundamentally a *UI-creation* concept ("I made this, I control who else sees
+it"). A project that materializes from a pipeline has no one in that relationship to it.
+An alternative model: machine-created resources are **governed by group and admin grants
+only** — no owner, access is purely "which teams were granted this project," and the admin
+role is the backstop. User-created resources (datasets, prompts) keep ownership because
+there genuinely is an owner.
+
+This matters because "give every project an owner" sounds harmless but quietly commits the
+system to manufacturing a fake owner for the 99% case, and to a UX that implies a person
+controls something no person created. Worth deciding deliberately. (The structural answer —
+the resource inherits a *container's* access instead of needing an owner at all — is the
+tenant layer of §5; "governed, not owned" is exactly what a space-with-members provides.)
+
+Note the no-creator problem is specific to **ingest-born** projects. For experiment and
+dataset-evaluator projects (§2.8) the robust rule is **access-by-parent**: their access
+derives from the parent dataset/experiment, full stop — that holds with auth on or off and
+never depends on a stored owner. The parent *also* records a creator (`user_id` on the
+experiment/evaluator) *when auth is enabled*, but that is the weaker, conditional signal —
+nullable, `ON DELETE SET NULL`, and absent on auth-off deployments — so lean on
+parent-access, not creator-ownership. Among the system-generated kinds, the shared
+**playground** project is auto-*provisioned* but human-*triggered* — which is why its
+posture is open rather than settled-ownerless (its lean is creator-owned; see *Open
+decisions*).
+
+This exposes a sharper line than *project vs dataset*: the ownerless default keys on **how
+a project is born**, not on the `project` table. A project that **auto-vivifies** when the
+first span names it has no author to attach; a project brought into being by a **deliberate
+create** — a `POST /projects` call, opening a playground — has one, exactly as a dataset
+does. The implemented discriminator is the table (it is a project, so it inherits the
+project rule), which silently routes an explicit human create into the ingest-born
+admin-only bucket and locks the creator out of what they just made. If provenance is the
+principle (§1), the discriminator should be **create-intent**: explicit authoring earns a
+creator grant, and only auto-vivification-on-ingest is genuinely ownerless. One caveat keeps
+the line honest — *create-intent*, not "a user is on the request": an authenticated ingest
+write also carries a user (§2.2/§2.5), so keying on user-presence would wrongly mint a
+creator-owned project on the first span. Which posture to adopt for the explicit-create case
+is deferred to *Open decisions*.
+
+#### 2.4 Should a recreated same-name resource inherit prior grants?
+
+A project deleted and re-created under the same name via later ingestion gets a **new id**
+— this is `main`'s behavior today. The safety answer is clear: grants should key on the
+durable id, so old grants are dangling and the new project starts clean — silently
+re-attaching access to logically-new data would be a leak.
+
+But the *product* intent genuinely conflicts with that. A user who deletes and re-creates
+"my-project" through their pipeline reasonably expects "give me my access back," not "a
+stranger's blank project." The tension is real: id-keying is correct for safety,
+name-continuity is what the user expects. There is no free answer — only a choice about
+which surprise is more acceptable, possibly mediated by an explicit "restore grants"
+affordance rather than automatic inheritance. The safe branch (id-keyed, no inheritance)
+is defensible, but it should be a known, stated trade rather than an accident of schema.
+(A tenant layer softens this too: a re-ingested resource re-lands in the same container and
+inherits its **container default** access, so continuity comes from the container even though
+the id still changes; see §5.)
+
+### Identity and authority
+
+*Who acts, and the credentials and identities they wield.*
+
+#### 2.5 Service accounts: credential or identity?
+
+On `main`, a Phoenix API key wields a *user's* identity — every key belongs to a user and
+is deleted with that user, and the "system" key is just a key against a SYSTEM-role user,
+not a first-class non-human identity. There is no service-account identity, so the
+offboarding problem is latent: a pipeline authenticated by a departed employee's key
+breaks when that user is deprovisioned.
+
+Two honest paths (the survey's credential-vs-identity fork):
+
+- **Option A — stay credential-only.** Keep keys tied to users; add an attenuating *scope*
+  so an admin can mint narrow, purpose-built keys (ingest-only, single-project write). No
+  new subject kind, the oracle is unchanged, and it is sufficient for most ingestion. Left
+  unsolved: the key still dies with its owning user. *(The prototype takes this path — the
+  `scope` is the attenuation half of the effective-access formula.)*
+
+- **Option B — first-class service accounts.** Add `service_account` as a subject kind so
+  a non-human identity holds grants directly and can be a group member. It composes with a
+  generic grant table — the grant's subject reference does not care whether it points at a
+  user or a service account, and the oracle's signature is unchanged (only the resolution
+  of `authority(...)` differs). The cost is a service-account table, a credential lifecycle
+  independent of any user, and management UI.
+
+**Recommendation: Option A now, reserve for B.** If the grant model is polymorphic over a
+subject-kind discriminator, reserving room for `service_account` in the schema shape is
+cheap and avoids a later migration — the same "reserve the field, defer the semantics"
+discipline the survey applies to the `effect` column. But "reserve" is not "accept": until
+the lifecycle and authority resolution are designed, the system must **reject**
+`service_account` rows, not silently store them. A half-built subject kind that the
+database tolerates is one that fixtures, GraphQL enums, UI pickers, and call sites will
+start depending on before it works — the same trap as a `deny` `effect` that nothing
+enforces. Build the identity and lifecycle only when a concrete "this pipeline must survive
+offboarding" requirement lands.
+
+#### 2.6 The SYSTEM user is a break-glass backstop, not a workhorse
+
+On `main`, Phoenix seeds a single hidden **SYSTEM** user: a superuser carrying every
+permission (`READ`/`WRITE`/`ADMINISTER`), with no usable password, filtered out of every
+user- and role-listing query, and refused by the user-management mutations. It is the
+identity behind the `PHOENIX_ADMIN_SECRET` (presenting that secret authenticates as the
+SYSTEM user) and the owner of "system" API keys. It exists so the server always has an
+authority of last resort. The recurring design mistake is to reach for it whenever an
+identity is missing — and there are two such temptations, both of which should be
+resisted.
+
+- **Do not make SYSTEM the owner of ownerless resources.** §2.3 notes machine-created
+  projects have no creator. SYSTEM is the tempting backfill, but "owned by SYSTEM" means
+  *owned by an invisible god-user* — it conveys no per-team access and conflates "nobody
+  owns this" with "the superuser owns this." If §2.3 resolves to group/admin governance,
+  SYSTEM must explicitly **not** be written in as owner.
+
+- **Do not make SYSTEM the identity for routine machine traffic.** A collector
+  authenticated as SYSTEM is an unattenuated superuser performing `write`. Ingestion
+  should use *attenuated* credentials (ingest-only scope), and the clean end state is
+  first-class service accounts (§2.5) — a distinct, non-SYSTEM, scoped subject kind.
+  Modeling automation as additional SYSTEM users would multiply superusers, the opposite
+  of least privilege.
+
+Two further consequences worth stating plainly:
+
+- **SYSTEM must be filtered out of the audit answer.** Because ADMINISTER reaches
+  everything, SYSTEM appears in "who can see this resource?" for *every* object. The
+  oracle's `subjects_for` (and every "Sharing" view built on it) must exclude SYSTEM, or
+  the answer to "who has access?" is always "everyone, plus a user you can't see."
+
+- **Privacy claims must include administrators — and every SYSTEM-mediated read path.**
+  With the flag on, SYSTEM's ADMINISTER override sees everything regardless of grants, so
+  "private to team X" is never private *from* SYSTEM or the admin-secret holder. But the
+  admin-secret holder is not the only such reader: **background jobs, exports, support and
+  debug tooling, and scheduled tasks** that read via SYSTEM (or the admin secret) all
+  bypass access control the same way. Each is an *invisible universal reader*. A concrete
+  instance is the **server-side experiment-runner daemon** (§2.8) — *not* client-initiated
+  experiments, which run under the user's own credential: it reads datasets and prompts and
+  writes the experiment project as a background process, so it should act under a scoped
+  identity tied to the experiment's creator, not SYSTEM. If any such path touches user data,
+  it must either run as a scoped identity instead of SYSTEM, or
+  emit an audit record — otherwise "private" is a claim the system cannot honestly make.
+  User-facing language should say "private to team X (and administrators)," not "private."
+  This applies uniformly to *every* SYSTEM-mediated background reader that can touch the data
+  — exports, the retention/cron jobs (§6), and any future background runner — not only the
+  experiment runner: each is an invisible reader the "private" claim must account for, so the
+  honest copy is "private to team X (and administrators and system processes)" wherever an
+  unscoped background job can reach the resource.
+
+The admin secret deserves separate emphasis: it is a **static shared credential that
+bypasses the API-key table and the token store**, so the proposed `scope` attenuation
+cannot narrow it — it is the one credential the effective-access formula's right-hand side
+does not apply to. It appears in no key-listing UI, rotates only by redeploy, and
+attributes every action to "SYSTEM" rather than to the human holding it. It is the
+highest-value credential in the system and lives entirely outside the RBAC model; treat it
+as the thing to guard, log, and rotate first.
+
+### Resource graph
+
+*How access flows through containment — and what breaks when the graph is mutated.*
+
+#### 2.7 Containment children: sessions, traces, spans
+
+Project sessions — and traces and spans — are the awkward case, but the awkwardness is in
+*data modeling*, not access control. A project session is created lazily on first ingest,
+keyed on a client-supplied string (`session.id`, usually `"default"`), with a time window
+that extends as later traces arrive, and an identity meaningful only as
+`(project_id, session_id)`. None of that needs to touch access control, because the right
+model is unambiguous: **these are pure containment children — never grant subjects, with
+access inherited entirely from the containing project.** Every child has a path up to a
+project (`ProjectSession.project_id`; `Trace.project_rowid`; `Span → Trace → project`), and
+the prototype already reflects this — only `project`/`dataset`/`prompt` are grantable
+object types; sessions, traces, and spans are not. Cardinality settles it even if one
+wished otherwise: there are orders of magnitude more spans than projects, so per-object
+ACLs on them are a non-starter. This is §2.3's "governed, not owned" in its clearest form —
+no one would claim to *own* a span.
+
+Three consequences follow:
+
+- **The containment edges are security-load-bearing.** Once a child's access is inherited
+  through `project_id`, the integrity of that edge *is* an access boundary. A bug that lets
+  a span attach to the wrong project's session — exactly the `session_id="default"`
+  collision in §3.3 — stops being a data-quality glitch and becomes a **cross-project
+  leak**: a viewer scoped to project A sees a trace that drifted in from project B. So the
+  session-scoping fix is a precondition for sound inheritance, not an incidental cleanup
+  (§3.3 is annotated accordingly).
+
+- **The risk is surface-area, not mechanism.** Because access lives on the project and
+  nothing is stored on the children, the danger is the *many* read paths — span search,
+  session lists, trace detail, dashboards, metrics, exports — each of which must
+  independently filter by "containing project ∈ my accessible projects." One child-read
+  endpoint that forgets the filter is a silent leak that no project-level test will catch.
+  This is where the single-oracle discipline earns its keep: every child query should
+  express access as the same reusable predicate (a semi-join,
+  `child.project_id IN (accessible_project_ids)`), never a per-row check or a hand-written
+  `WHERE`.
+
+- **What it makes *easy*, don't over-build.** Inheritance means a project flipping to
+  private renders all its children inaccessible immediately — no fan-out write to millions
+  of rows — provided nothing caches child access independently of the project's. And
+  because children are never granted, their constant ingest-churn produces zero orphaned
+  ACL rows (the §2.12 cleanup concern bites only grantable types). The highest-volume
+  objects are the ones access control touches least.
+
+The one genuine exception is **user-authored children**: span/trace/session *annotations*
+have a real creator, unlike a span. They are the sole candidate for a finer rule —
+read-access still inherits from the project, but *edit* might be scoped to the author
+("you can only edit annotations you authored"), which is precisely the survey's sub-object
+/ Family-B example. Keep the machine-created children pure-inherit; treat an authorship
+layer as something added only on top of project inheritance, only for authored sub-objects,
+and not generalized to the hierarchy.
+
+#### 2.8 Rooting access at the data context: the telemetry and dataset worlds
+
+Step back from "kinds of project" to the structure underneath. The rule is one principle,
+not a taxonomy: **a resource's access is rooted at its real data context.** For
+trace-bearing, project-contained data, applying it yields two common access roots
+(deployment-global objects outside any project have no data context to root at — §6):
+
+- **Telemetry world** — application **projects**: machine-created by ingestion, no human
+  creator → **admin-only** (§2.1).
+- **Dataset world** — **datasets** (and prompts): human-created, a real creator →
+  **creator-private**.
+
+Nearly everything else hangs off one of these — and where something doesn't (playground,
+below), the principle, not the pair, decides. The clarifying question is *what produces a trace?*
+A **dataset produces none** — it is data (the access *root*), not an execution. **Experiment
+and evaluator runs** produce traces (the task and judge executions). Those traces sit in
+`projects` rows only because "project" is Phoenix's span container — **storage reuse, not a
+third kind of access subject.**
+
+That is the principle at work: **eval traces (and the scores on them) are
+run-artifacts rooted at the data context they evaluate.** A dataset's access governs its
+*entire* world — the dataset, every experiment and evaluator run on it, and all their traces.
+*One* access decision (the dataset) governs the whole eval workflow.
+
+##### Hidden eval-trace projects
+
+The `Experiment-<hex>` / `dataset-evaluator-<hex>` projects are exactly this plumbing:
+random-named and *hidden* (today via name-pattern + the `exclude_*` joins; cleanly via a
+**server-set `kind` discriminator** that marks "plumbing vs real project," §4). They are not
+standalone projects.
+
+For the hidden kinds, access must derive from the **parent dataset/experiment**, not from an
+independent grant on the project — the same containment rule as above, run *upward*
+(dataset → experiment → experiment-project → spans). Treating them as ordinary top-level
+projects gets it wrong either way: under the strawman's **admin-only** project default, the
+experiment's *own (non-admin) creator* can't see their own results; under the rejected
+everyone-allow model, the inverse bug — anyone who can name the project reads the
+experiment/eval traces. Both are why these need access-by-parent, not the plain project
+default. This also **doubles the coverage obligation**: every project-surfacing read must
+apply *both* the access predicate *and* the hide-internal predicate (the list and count do;
+a path that forgets either leaks a hidden project or an inaccessible one).
+
+**Experiments and experiment jobs.** Experiments (`Experiment.dataset_id`) and their runs
+are likewise children of a dataset, so experiment access derives from the dataset. An
+**experiment job** (`experiment_jobs`, 1:1 with its experiment) is the *execution/lifecycle*
+layer (status, concurrency) — it holds no traces and grants nothing, so it is **not** an
+access resource; but the *actions* on it (start/stop/resume) are authorization-relevant and
+should inherit the dataset/experiment's access. One trap to avoid: an experiment job's
+`claimed_by`/`claimed_at` is a **worker claim** (which background worker is executing, for
+concurrency) — *not* access-control ownership of the kind §2.3 discusses.
+
+This corroborates the **containment principle** at a mature peer (the tag/attribute vendor of
+the survey, §4): in its model **datasets and prompts are standalone grantable resources**
+(each with its own permission set), while
+**experiments are *not* a distinct access-controlled resource** — an experiment is "the
+results of evaluating on a dataset," so its access flows through the dataset, and its runs
+inherit the parent project. That validates the *principle* proposed here — grant on
+datasets/prompts/projects; derive experiments from the dataset, runs from the project. It is
+**not** evidence for the specific hidden-`Experiment-<hex>`-project mechanism: where the
+peer physically stores experiment traces is unresolved (its docs are ambiguous), so the
+containment *principle* is corroborated, the *trace-storage analogue* is not.
+
+##### Execution models: who reads and writes
+
+The two execution models have **different actor models**, and only one involves a background
+reader:
+
+- **Client-initiated (SDK).** The client calls `POST /datasets/{id}/experiments` with the
+  *user's* credential; the server generates the project name and returns it, and the client
+  then runs the task locally and **uploads its traces via its own ingestion** (tagged with
+  that returned name), plus structured runs/evaluations. The user is the actor throughout —
+  **no background reader**, so the §2.6 invisible-reader concern does not apply here. What
+  does apply is §2.2: the client writes spans into a *server-assigned, hidden, parent-owned*
+  project, so the ingestion path must authorize that write — but it is the *controlled* case
+  (authenticated key, server-chosen name), not the anonymous-auto-create one.
+- **Server-side (runner daemon).** The `ExperimentJob` runner executes the task on the
+  server, reading the dataset/prompt and writing the experiment project as a background
+  process — *this* is the §2.6 invisible-reader, and the one that needs a scoped identity.
+
+The server-chosen hidden project name is not itself a durable security boundary. Under
+ungated ingest, `Experiment-<hex>` behaves like a narrow **capability string**: possession of
+the name is enough to write spans to that plumbing project. The property doing the security
+work is unguessability by an adversary, not collision avoidance, so the name should carry the
+survey's capability-URL discipline — minting is
+privileged, the value is secret-bearing, use is auditable, and revocation is possible — or,
+better, replaced by a scoped write authorization for `kind=EXPERIMENT` / `kind=EVALUATOR`
+projects that is tied to the parent run and cannot be reused as a general project-name write.
+
+##### Online evals
+
+**The principle generalizes — and online evals prove it isn't really "the dataset."**
+*(Online evals are a separate concurrent design effort, not current `main`; the shape below is
+drawn from that workstream's design, and the trace-placement is a proposal, not an
+observed behavior.)* An *online* evaluator judges **live production traces**: there is no
+dataset; the data context is a **production project**. So the root is not specifically the
+dataset — it is *the data context being evaluated*: a dataset offline, a production project
+online. The score is an annotation on the production trace (it inherits the production
+project's access); the judge's own trace is cleanest **attached to the trace it judged**
+(inheriting that access) rather than parked in a new project. The online runner is the §2.6 background-reader *at scale* —
+continuous, cross-project production reads — so it must run as a **scoped identity**, not
+SYSTEM. (This is also why a denormalized `project.dataset_id` is the wrong cache: online has a
+*project*, not a dataset, as its root. Root the artifact at the *run*, §4.)
+
+##### Playground
+
+**Playground fits neither common root — its data context is the user who ran it.** Its
+prompts are the most sensitive
+data in the system, so the shared singleton it is today is a latent leak. The lean is
+**per-user `kind=PLAYGROUND` projects, auto-granted to the creator** — which keeps access
+uniformly *project-level* (no sub-resource exception). The alternatives: shared-everyone
+(leaks), admin-only (hides the user's own runs), or one shared project + per-run attribution
+(pays its cost as a mostly-NULL `created_by_user_id` on the hottest table, `traces`, plus a
+bespoke read filter). Still an open decision (§1), but "shared" is rejected as the default.
+Worth flagging that this is a **third root chosen by the principle**, not a variant of either
+common case: playground traces are *machine-ingested* (telemetry-world mechanics) yet
+*creator-private* (dataset-world semantics), and the data-context rule is what resolves the
+clash — the context is the creator. Implementers should treat it as a deliberate hybrid — per-user
+`kind=PLAYGROUND` with a creator grant — rather than silently bucketing it with ordinary
+telemetry projects (which would make it admin-only and hide a user's own runs).
+
+##### User-named experiment projects (#13726)
+
+**#13726 fits the frame, not as a special case.** A real request asks to let an experiment
+write to a *user-named* project (to consolidate eval runs into one browsable place). That is
+the user **promoting eval traces out of plumbing into a real telemetry-world project** —
+visible, persistent, separately grantable, decoupled from the dataset. It falls out of the
+`kind` dispatch (omit a name → plumbing `kind=EXPERIMENT`; provide one → a normal
+`kind=TELEMETRY` project), which is the clean way to ship it rather than the name-pattern
+classification the issue proposes.
+
+A *related* category sits one step further out — objects that belong to **no project at
+all** (secrets, the shared evaluator/annotation-config/model/label library, admin config).
+The containment rules here don't reach them; they get their own treatment in **§6**.
+
+#### 2.9 Moving or copying data across boundaries
+
+There are two cross-boundary shapes, and they need different policy words. A **move** changes
+the containment edge of existing data, so access follows the destination. A **copy** creates a
+new object containing data derived from a source, so source and destination can diverge.
+Phoenix has both shapes: trace transfer is the move case; "create a dataset from spans/traces"
+is the copy case.
+
+The copy case is easy to miss because it does not mutate the source graph. A user with read
+access to project P can select spans/traces and materialize them into a creator-private dataset
+whose grants are independent of P. That may be the intended product contract — read access
+implies the right to copy/export and then share under the dataset's policy — but it is a real
+exfiltration decision, not an implementation detail. If that contract is too broad, dataset
+creation from telemetry must check more than source `read`: it may require `manage` on P (or
+a new, finer verb — an explicit `export` right — added to the §1 verb model), inherit the
+source project's access until deliberately relaxed, record source lineage,
+or restrict downstream grants. Pick one; do not let "copy, not move" bypass the two-container
+thinking below.
+
+Trace transfer is the concrete instance of a general rule worth stating explicitly, because it
+will recur (dataset moves, prompt copies, any future reparent): **any operation that mutates
+a containment edge must check authority on *both* the old and the new container, move the
+entire access-derived subtree atomically, and emit an audit event.** A move is the one
+operation that changes *inherited* access, so it is governed by the source and the
+destination at once — and it is exactly where the convenient "access just follows
+containment" model needs the most care.
+
+Phoenix's instance of this is transferring traces between projects (a
+`transfer_traces_to_project` mutation that re-parents traces by updating
+`Trace.project_rowid` — though verify the current implementation per the status note). It
+is the one supported operation that *deliberately mutates* the security-load-bearing
+containment edge of §2.7, which makes it the single most sensitive write in the child
+hierarchy. Today it is gated only by global role checks (not-read-only, not-viewer); under
+access control that is not enough.
+
+- **A move is a two-sided operation; one check is wrong.** Reads and ordinary writes touch
+  one resource; a move touches a *source* and a *destination* and needs authority on both.
+  A global-role gate would let a user who can see neither project re-home traces between
+  them. The correct check is per-project on both ends — *manage/ADMINISTER on the source*
+  (data is leaving it) **and** *write on the destination* (data is entering it) — and the
+  destination must be a project the caller can actually access, not any id in the system.
+
+- **It is an exfiltration and a concealment vector.** With private projects, transfer can
+  move traces *out* of a private source into an open destination (exposing them to people
+  who could never see the source), or move someone's traces *into* a private destination
+  (hiding them from those meant to see them). The one-sided default-visibility lesson of
+  §2.1 applies: an open or auto-created destination turns a transfer into an exposure.
+  Note the interaction with the verb model (§1): `delete` is admin-only, but `transfer`
+  rides on `manage`. If `manage` is ever delegated below admin, a non-admin could exfiltrate
+  via transfer-out while being unable to delete — so either keep transfer-out admin-only too,
+  or accept that delegating `manage` delegates this exfiltration path consciously.
+
+- **The move must carry the whole subtree — today it does not.** Spans follow correctly
+  (they inherit via `trace_rowid`), but a trace's **session** (`project_session_rowid`)
+  belongs to the *source* project and is left behind. After a transfer the trace points at
+  the destination while its session still lives in the source — the exact cross-project
+  break §3.3 warns about, now manufactured by a supported operation, and a read-leak back
+  into the source (the source's session still lists a trace that has left). A correct move
+  must atomically re-home or detach everything whose access derives from the project — i.e.
+  the containment children of §2.7 — not just the `project_rowid` column.
+
+- **Audit it.** Re-homing data across an access boundary is exactly the survey's audit
+  shape: after the move, the only record that a trace ever lived in the source is gone. Who
+  moved which traces, from where, to where, must be recorded.
+
+### Rollout and operations
+
+*Turning the system on for an existing deployment.*
+
+#### 2.10 Upgrade and rollout for existing deployments
+
+This is where §1's thesis comes due. Every project, dataset, span, and key in an existing
+deployment was created *before* any access model existed — so the upgrade is the moment a
+system full of ownerless, world-visible resources has to acquire boundaries without
+breaking the people and pipelines depending on the old open world. The mechanics are
+easy; the *experience* is where the pain is, and it is worth understanding the failure
+modes concretely rather than trusting the happy path.
+
+**Two rails bound the whole thing — internalize these first.** (1) Default-off is a true
+no-op: the oracle short-circuits to "everything" before any grant lookup, so upgrading and
+doing nothing changes nothing, at no query cost, even with the new tables present. The
+schema change is additive (new tables, a nullable key `scope`) — no rewrite of existing
+rows, so DB size is irrelevant. (2) Reversibility cuts **both** ways, and this is subtle
+under fail-closed. *During rollout* — before anything is restricted — flipping the flag back
+off restores the open world instantly, which permits a cautious enable; built grants/groups
+sit inert while off. *After* a deployment has restricted data, that same reversibility is a
+**liability**: turning the flag off (or losing the env var to config drift / a redeploy)
+**silently re-opens every admin-only project to everyone** — the roles and grants persist
+inert, but the *enforcement* evaporates. So "reversible kill-switch" is a rollout safety
+feature *and* a steady-state exposure risk; the disable path must be hardened (see §3.5).
+
+The nullable key `scope` is part of the cutover contract, not just schema convenience. For
+pre-existing API keys, `NULL` must have an explicit meaning. The least-surprising migration is
+`NULL = unattenuated legacy key` (the key retains whatever authority its owning identity had
+before scopes existed), with newly minted keys carrying an explicit scope. That is a
+compatibility default, not a security property: operators should be able to inventory,
+rotate, and eventually require explicit scopes for old keys. If instead `NULL` means
+"ingest-only" or "no authority," the upgrade breaks existing collectors and must be surfaced
+as a deliberate breaking change.
+
+**"Existing users" is not one population, and the split is the first pain point.** Access
+control grants on *identities*, and an anonymous instance has none:
+
+- **Auth-disabled / open instances** (likely the majority of self-hosted deployments — no
+  login, anyone who reaches the URL sees everything) cannot meaningfully adopt access
+  control at all until they first enable authentication. For them the upgrade is a no-op
+  *and the feature is unavailable*: adopting it is gated on a strictly larger migration
+  (create users, distribute credentials, possibly wire SSO). The trap is assuming "turn on
+  the access-control flag" is the project, when the real cost is the auth migration
+  underneath it.
+- **Auth-enabled instances** can adopt it gradually — but inherit every pain point below.
+
+**No *schema* backfill — but flag-on is a deliberate cutover, not a graceful no-op.** The
+new tables (object grants, groups) start empty, so there is no per-object data migration —
+that part is free. But under the strawman (§1), flag-on does **not** preserve pre-upgrade
+behavior: ingest-born projects become admin-only, so **every non-admin loses visibility to
+ungranted projects at flip time.** That is the intended fail-closed cutover (§3.5), not a
+regression — but it means the safe upgrade move is *flip off → pre-write the grants teams
+need → dry-run → flip on*, **not** *flip on and opt into restriction later*. (The
+everyone-allow model's "graceful, opt-into-restriction one grant at a time" flip is the
+rejected alternative, §2.1.)
+
+Now the pain points, each worth understanding as a concrete failure, not a checklist item:
+
+- **Ingestion does *not* break — a pain the strawman dissolves.** Because the strawman
+  gates only *reads*, never writes (ingestion stays unimpeded, §1/§2.2), existing collectors
+  keep ingesting straight through the flip. The everyone-allow design had a
+  highest-probability incident here — "the moment a project goes private and the ingesting
+  key isn't granted *write*, spans silently drop" — and the strawman removes it by not
+  gating writes at all. (It would return only if a future design chose to gate ingestion
+  writes; until then, this whole failure mode is off the table — a real simplification.)
+
+- **Restriction reads as deletion — and under the strawman it hits *everyone at once*.**
+  Because unauthorized ≡ not-found and there is no deny-explainability yet (§2.1; survey
+  §17), an affected user does not see "you lost access to project X" — the project
+  *vanishes* (a 404, an empty list), and "restricted" and "deleted" are indistinguishable.
+  Under the everyone-allow model this bit *per narrowing grant*; under the strawman the
+  **flip itself** is the mass-restriction event — every non-admin's ungranted projects
+  disappear simultaneously. So the go-live moment is the flip, and the mitigation is
+  front-loaded: pre-write grants, announce, name a contact, and *especially* run the §3.9
+  dry-run first. This severity is the strongest argument for prioritizing explainability and
+  the preview before any non-trivial rollout.
+
+- **The change is invisible before it happens — the missing de-risker.** The flag is
+  reversible, but disruption is better *avoided* than *undone*. The oracle already holds
+  the pieces (`subjects_for`, `accessible_scope`) to answer "given the current grants, who
+  would lose access to what the moment I flip this?" — a dry-run preview. It does not exist
+  today, and its absence means the only way to learn the blast radius of enabling the flag
+  is to enable it. Building this preview is the single highest-leverage investment in the
+  upgrade experience; name it as a gap rather than discovering it during an incident.
+
+- **Empty or half-synced groups lock out the people they were meant to admit.** Existing
+  deployments have no groups. SSO-backed groups populate only on each user's *next login*;
+  local-only deployments must build groups by hand. A narrowing grant aimed at a group that
+  has not finished syncing excludes exactly the members it was supposed to include — the
+  restriction lands before the admit-list does. Verify group membership is real before
+  relying on a group in a grant; do not flip the flag on the assumption that "the SSO
+  groups are there."
+
+The throughline: the binary upgrade is safe (flag-off is a
+no-op, reversible), but **the flip is a deliberate hard cutover** — non-admins lose
+ungranted projects all at once. The strawman *removes* one of the two classic bites
+(ingestion no longer breaks — writes stay open) and *concentrates* the other (restriction-
+as-disappearance now happens to everyone at flip time, not drip-by-drip). That makes the
+§3.9 dry-run preview and explicit communication matter even more — they are the difference
+between a planned cutover and a surprise outage.
+
+### Rejected alternative
+
+*A plausible alternative model that does not fit Phoenix's needs.*
+
+#### 2.11 Attribute-based access (ABAC) isn't justified for project-level access
+
+Could attribute/rule-based access — the survey's Family B (computed edges) — fit Phoenix
+better than enumerated grants? **For the current project-level, enumerable problem, no.**
+Phoenix's access is **enumerable** ("these teams see these projects"), so Family B's
+"everything matching a rule" power solves a problem Phoenix doesn't have here, while adding a
+query-time predicate cost and a curation burden. The enumerated model (Family A) is the fit.
+(This is a scoped verdict, not "ABAC is never useful" — the exception below is real.)
+
+The one genuine exception is **sub-resource scoping** — a rule *below* the project, like a
+`pii=true` or `cost > 5` view — which enumerated project grants structurally cannot express.
+That has real value, but it must come from a **server-derived** predicate (a classifier the
+server runs, never a client-set attribute), and it is a narrow hybrid (survey §4), not a
+general access model.
+
+**ABAC and tenancy aren't either/or — a peer does both, as a hybrid.** Don't read "ABAC
+isn't needed" as "the problem doesn't exist." The shared need is **fine-grained isolation
+within a shared boundary** — by team, or by data sensitivity (an `env=prod` or PII-only
+view). At least one peer in this space layers **two** mechanisms: a **workspace** trust
+boundary (a tenant container, the analog of §5) *and*, *below* it, **curated-tag predicates**
+for sub-container grouping and access. The predicate runs over *admin-set resource tags*,
+**not** client telemetry (its policy engine evaluates only curated tags), which is exactly
+why it is the *defensible* form, not a counterexample to the disqualifier above. That is the
+survey's §4 **hybrid**: enumerated/role-based at the coarse grain, a narrow curated predicate
+at the fine grain. Phoenix's verdict is scoped accordingly: the *project-level, enumerable*
+need is handled by container (§5) + grants alone; the curated-predicate layer is precisely
+what the **sub-resource exception** above would add if a concrete finer requirement
+(`pii=true`, "only annotations I authored") lands. So "ABAC isn't needed *here*" means *not
+at the coarse grain* — a peer with a tenant layer still reached for predicates at the fine
+grain, as a hybrid on top of its container, not as a replacement for one.
+
+(Scope note: this verdict is for the current target — project-level access, with tenancy in
+§5 and sub-resource access not a goal. If that scope widens, the sub-resource exception is
+where attributes re-enter the picture, and this should be re-evaluated.)
+
+(One naming caution for that day: if curated access tags are ever added, keep them distinct
+from **prompt version labels**. Phoenix prompts are versioned, and a peer that ships both
+explicitly separates *commit tags* (which version) from *resource tags* (organization /
+access) — conflating "which version" with "who can see it" is a trap worth avoiding by
+construction.)
+
+(The concrete shape this fine-grain exception takes — a curated-tag layer expressed as an
+*additive grant selector* rather than a separate engine, and the correctness obligations it
+inherits from the polymorphic schema and the dual-path oracle — is worked out as an
+implementation concern in [Part F of the implementation invariants](./access-control-implementation-invariants.md).
+That does not move the verdict above: coarse, project-level access remains enumerated; the tag
+layer is the narrow fine-grain hybrid this exception anticipates, and only becomes load-bearing
+if a concrete sub-resource requirement lands.)
+
+### Schema trade
+
+*An implementation choice, weighed for completeness rather than product pain.*
+
+#### 2.12 One ACL mechanism vs per-type FK safety
+
+Phoenix has many resource types (project, dataset, prompt, experiment, …). A **generic**
+ACL table — addressing objects as `(object_type, object_id)` — covers all of them with one
+mechanism and one list query (`grant rows → ids → IN (...)`), and adding a new resource
+type is free. But a generic shape **cannot carry a real foreign key**, so it loses
+`ON DELETE CASCADE` (grant rows orphan when a resource is deleted and must be cleaned up
+explicitly), and it assumes every grantable resource has a uniform primary-key type —
+Phoenix's integer ids fit, but a future non-integer-keyed type would not.
+
+The generic table is not merely cheaper, it is **load-bearing for grants that span types**.
+A grant can address `object_type='*'` (all types) or a type at large via
+`selector_kind='all'` (`object_id` NULL) — the org-wide and admin-baseline grants. These
+rows have no home in a `dataset_acls`/`prompt_acls` split: a type-wide row belongs to no one
+type's table, and a `*` row belongs to all of them at once. So some grants exist *only*
+because the target address is polymorphic — which turns this from "convenience vs FK safety"
+into "one branch cannot represent part of the model."
+
+**Per-type** ACL tables are the other branch: they keep cascade and FK integrity but
+multiply the schema and turn the oracle's single list query into a union across tables.
+The deeper cost is not query count but **parity**: the oracle resolves access along two
+paths that must agree — a Python one (`accessible_scope`, materializing ids) and a SQL one
+(`access_predicate`, a `WHERE` clause pushed into the query). A single `acls` table lets
+both read the same rows the same way; per-type tables would fork *both* paths per type,
+hand-maintained in lockstep, and every omission is a silent drift between what the two
+paths grant. The generic table forecloses that drift by construction.
+
+Underneath, this is the standard polymorphic-vs-per-type trade. The prototype takes the generic table
+(optionality over FK safety); the cost — explicit orphan cleanup and a uniform-PK
+assumption — is real and should be revisited if either a non-integer-keyed resource or a
+cascade-correctness incident appears.
+
+Because the generic table cannot lean on an FK to fail, the oracle's **read-time** behavior
+toward a dangling ACL (one pointing at a deleted object) must be defined, not left to
+chance: a grant whose object no longer exists must be **inert — ignored, never
+access-granting (fail closed)** — with the rows swept asynchronously. This is not just
+hygiene; it is a security requirement that ties back to §2.4. If integer `object_id` is ever a
+*reusable* key space (sequence reset, import, a future non-monotonic scheme), a stale ACL on
+deleted project 42 must never silently re-grant access to a *new* project 42 — the same
+id-reuse leak as §2.4, in ACL form. Keying inertness on existence (the object must currently
+exist *and* match) rather than on cleanup-having-run closes the *dangling* window even before
+the sweep catches up; the reuse window is closed by cleanup-before-reuse (see the subject-side
+treatment below, which mirrors this exactly).
+
+Read-time inertness is the security floor, but **grant *creation* should also validate** that
+the target object exists and is of the declared `object_type`. Creation-time validation is
+not load-bearing for safety (the read-time check already fails closed), but it prevents
+orphan rows, mistyped grants, and the audit noise of grants that never resolved — catching the
+error where a human can still correct it rather than letting it sit inert and confusing.
+
+**The same hole exists on the *subject* side — and it is the easier one to miss.** A grant's
+`subject_id` is as FK-less as its `object_id`, and for the same reason: the column is
+*polymorphic* (a user, role, group, or "everyone" all share it), so no single foreign key can
+guard it. Deleting a user is a **hard delete** of the row, and nothing cascades that user's
+`subject_kind='user'` grants — so they persist as **dangling rows**. Two distinct
+consequences, worth separating because they have different severities:
+
+- **Guaranteed (every delete): cruft and audit noise.** The dangling grants never get cleaned
+  up, so the "who can access X?" view (`subjects_for`) can list a *ghost* subject that no
+  longer exists, and the `acls` table accumulates rows that resolve to nobody.
+- **Latent (only under id reuse): a re-target leak.** *If* the integer id can ever be
+  reassigned — sequence reset, manual/import id assignment, or any future non-monotonic id
+  scheme — a recycled `subject_id` points the old grant at a **new, unrelated principal**.
+  This is the §2.4 reuse class, now mis-aiming the *subject* rather than the *object*, and it
+  generalizes to recreated **group** and **role** ids. Under plain autoincrement, ids are
+  monotonic and not reused, so this stays latent — but it is exactly the kind of assumption
+  that should be guarded by construction rather than relied on. The danger is never the
+  deleted user keeping access (they can no longer authenticate); it is the recycled id.
+
+The two halves of the fix attack the two consequences:
+
+- **Cleanup on delete (the load-bearing half):** the delete path for a user/group/role must
+  remove that subject's `acls` rows in the same transaction. This clears the cruft *and*
+  closes the reuse window before any id can be reassigned — the write-time symmetry of the
+  creation-time validation above.
+- **Read-time existence guard (the floor):** resolve a user/group/role-subject grant only
+  against a subject that *currently exists*, so a dangling grant lists and grants nothing even
+  before cleanup runs. Note this guard closes the *dangling* window but **not** the reuse case
+  on its own — a reused id refers to a subject that genuinely exists again, so only
+  cleanup-before-reuse (or keying grants on a non-recycled subject identifier) forecloses it.
+
+Worth noting what the schema *does* get right by leaning on real FKs elsewhere, which throws
+the gap into relief: a resource's **creator** `user_id` is a genuine FK with `ON DELETE SET
+NULL`, so deleting a creator leaves a creator-*less* resource that fails closed — it collapses
+to *admins + explicit grants*, never widening (a sole-owner dataset with no other grant simply
+becomes admin-only-orphaned). **Group memberships** `CASCADE`, so a deleted user cleanly stops
+matching group-subject grants. Only the polymorphic `subject_id` — the one column that cannot
+carry an FK — is left to the cleanup-plus-read-time-inertness discipline above. The lesson is
+the same as the object side: *where a foreign key cannot enforce it, the oracle must.*
+
+### Authority composition
+
+*How the global-role layer and the object-grant layer compose — a tension currently resolved by accident.*
+
+#### 2.13 Does a global read-only role cap object write-roles, or do object grants lift it?
+
+**Lean (to ratify, not yet settled): A — the global role is a hard verb ceiling.** A global
+`VIEWER` can never write, even holding an object **Manager** grant via a group; the object
+grant confers *visibility only*. This is the conservative, auditable choice — but right now it
+is **emergent, not chosen**, and that is the reason to surface it.
+
+**Why it's emergent.** Two layers compose here, and neither was designed against the other.
+The new object oracle (grants + permission sets + the `ADMINISTER` override) decides *object*
+access. The **pre-existing** global gate (`IsNotReadOnly` / `IsNotViewer`, on the write
+mutations) decides *whether a write-verb runs at all*. A write action like `grant_access`
+carries **both** — `permission_classes=[IsNotReadOnly, IsNotViewer, …]` **and** an
+`OBJ_MANAGE_ACCESS` object check — and both must pass. So a global `VIEWER` in a group granted
+`OBJ_MANAGE_ACCESS` on P clears the object check but **fails the global gate**: blocked. The
+hard ceiling is what falls out of the gate sitting in front of the oracle — not a decision
+anyone recorded.
+
+**The deeper reason: only caps conflict.** Everything the new RBAC adds is a **floor** — object
+grants, group grants, direct grants, custom permission sets all *grant* capability and compose by
+**union**, which is order-independent and never disagrees with itself (stack `Viewer` + `Editor`
++ `Manager` on one object, through any mix of groups and direct grants, and it resolves to
+`Manager`). So the conflict is **not** caused by having a second way to collect users — groups
+are incidental; a *direct* `Manager` grant to a `VIEWER` triggers it identically. It is caused
+by the one **subtractive** operator in the picture: the global read-only **cap**, the only thing
+that can *disagree* with a floor (survey §3, "only subtraction conflicts"). The new design is
+therefore conflict-free **by construction** — all floors — and the entire tension is the seam
+between it and the **one inherited cap**, which predates RBAC. The cap is also the only place
+"read-only" means *subtraction*: an **object** `Resource Viewer` permission set is a **floor** (grants
+view, blocks nothing), while the **global** `VIEWER` is a **cap** (blocks writes). Same word,
+opposite mechanism — only the cap conflicts.
+
+**The fork.**
+
+- **A — keep the cap (global role is a hard verb ceiling; current behavior).** Object
+  write-roles operate only *within* the user's global role. *Pros:* `VIEWER` is a reliable,
+  one-field-auditable read-only **guarantee**; no gate change; fail-safe. *Cons:* object
+  Editor/Manager grants are **silently partly-inert** for a `VIEWER` (they get the `OBJ_VIEW`
+  part, not edit/manage), and the only way to delegate per-project write is to promote the
+  user's **global** role to `MEMBER` — a coarser, anti-least-privilege escalation to achieve a
+  fine-grained intent.
+- **B — drop the cap (let the all-floors model stand).** Stop enforcing `VIEWER` as a
+  write-*blocking* gate; let it be a low baseline floor (`{READ}`), so write-ability comes purely
+  from object grants. A `VIEWER` granted Editor on P then writes P. *Pros:* the conflict
+  **disappears** — the model is purely monotonic `∪`, object write-roles are meaningful for
+  everyone, no special case to ship. *Cons:* you lose the *unliftable* read-only **guarantee** —
+  "read-only" becomes a liftable *default* (absence), not a promise. This is the accurate framing
+  of "lift the cap": not *teach the gate about object grants*, but *remove the gate*.
+
+**It's a grain mismatch, not a necessary cost.** The conflict comes from read-only living at a
+*coarser grain* (a global verb tier) than the write-roles it must compose with (per-object).
+Align the grains and it dissolves: if read-only is scoped to the **same grain** as the
+write-roles — for instance, separate tiers that govern **disjoint** actions (a coarse-grain
+"viewer" and a fine-grain "admin" that never apply to the same action, so they coexist without
+either overriding the other), or a purely per-object model with no global tier at all — there is
+nothing for a global cap to conflict with. Phoenix's tension is specifically the artifact of a
+*global* read-only tier (inherited from before per-resource RBAC) meeting *per-object*
+write-roles (new); it is a property of **mixing grains**, not an inherent cost of per-resource
+access.
+
+**The collision that makes this load-bearing.** The §1 verb model says `manage` "may be
+delegated by a project-manage grant." Under A that promise holds **only for MEMBER+** — a
+`VIEWER`'s manage grant is inert — so doc and code currently disagree for read-only users. The
+verb-model row is annotated accordingly; this subsection is the decision it points to.
+
+**Recommendation — it reduces to one question: do you need an *unliftable* global read-only
+guarantee?**
+
+- **Yes →** keep **A**, but *as a stated choice*: document that object write-roles presuppose a
+  `MEMBER+` global role, and that granting one to a `VIEWER` confers visibility only (a footgun
+  worth a §3 note once ratified).
+- **No →** take **B** (drop the cap), and the entire §2.13 tension **evaporates** — the all-floors
+  RBAC ships with no special case, read-only scoped to the per-object grain; "read-only" is then
+  an absence-default, liftable by grant.
+
+**Scope boundary (and an existence proof).** This fork *assumes the global role exists* — it
+predates this work and gates actions app-wide; the decision here is its **composition operator**
+(cap vs. floor), **not its existence**. Eliminating the global tier entirely — pure per-object
+grants + admin-by-fiat, read-only as mere absence — is coherent but a wholesale auth redesign,
+out of scope like tenancy (§5). It is not hypothetical: at least one mature peer ships exactly a
+**pure all-floors, no-clearance** model (every role is an additive bundle; `∩`/`∖` simply don't
+exist), so Option B's destination is **known to work in production** — the only thing given up is
+the unliftable read-only guarantee. And the *root* of the fork is worth naming: a ceiling is the
+cost of making a role a **guarantee** ("read-only no matter what grants accumulate") rather than
+a **default** ("read-only until granted more") — worth paying only for *containment* roles, where
+a mis-grant must fail safe.
+
+Either way the choice is **independent of the rest of the RBAC design**: the cap is a separate
+gate layer, so the all-floors oracle ships unchanged and this is decided on its own — *the one
+question above is the whole decision.*
+
+---
+
+## 3. Implementation notes & gotchas
+
+Real, but each has a single settled answer. These are forward-looking guidance for
+whoever builds the feature, not properties of `main`.
+
+- **3.1 Grants must key on id, never name.** The mechanical half of §2.4: because
+  re-ingestion produces a new id for a same-named resource, any grant keyed on the mutable
+  name would mis-target. Reference the durable integer id.
+
+- **3.2 Custom *global* roles collide with an enum-typed column.** On `main`, the
+  `user_roles.name` column is typed as a closed set of built-in names
+  (`SYSTEM/ADMIN/MEMBER/VIEWER`), so a custom name needs a schema migration. The clean way
+  to ship custom **permission sets** without that migration is a **separate permission-set
+  table**; shipping custom *global* roles means first migrating that column off the closed
+  set. (Phoenix's role model already distinguishes built-in from custom via an
+  `is_built_in` flag — the natural seam for this.)
+
+  *Storage is itself a fork, and the `role_permissions` table is forward-compat, not a
+  requirement.* The **VIEWER cap and every built-in role check are enforceable from the
+  `BUILTIN_ROLE_PERMISSIONS` constant** — no table needed for the closed built-in set. The table
+  earns its place only to (a) resolve permissions uniformly with the per-resource side and (b)
+  **store custom global roles**, which are runtime-authored and can't live in a constant — and
+  even then a *column* on `user_roles` (bitmask / array / JSON) would do; the **join table is a
+  normalization choice, not a necessity**. So `role_permissions` is **droppable if custom global
+  roles are ruled out**, and its shape — constant / column / join-table — is the sub-fork.
+
+- **3.3 `session_id` is scoped per project, not globally.** `session.id` is client-supplied
+  and most commonly `"default"`; resolving by `session_id` alone would link one project's
+  traces to another's session. The fix is a composite-unique `(project_id, session_id)`.
+  This looks like a pure ingestion-isolation concern, but under containment-based access
+  (§2.7) it is **security-load-bearing**: because a session's access is inherited through
+  its `project_id`, a cross-project attachment is a cross-project read leak, not just dirty
+  data. The integrity of every containment edge is part of the access boundary.
+
+- **3.4 Don't expose a non-global field named `id` on a GraphQL type.** Relay normalizes
+  its store on `id` as the canonical global Node ID; exposing a plain `Int` field named
+  `id` (e.g. on a permission-set type) crashes the app with a blank page. Name it `role_id`
+  (or similar). Applies to any new access-control type on the Strawberry/Relay stack.
+
+- **3.5 The flag flip is a deliberate hard cutover (under the strawman).** This is the
+  opposite of the everyone-allow alternative, in which the flip is engineered to be a no-op.
+  Under the §1 strawman, enabling the flag **intentionally** makes ingest-born projects
+  admin-only —
+  non-admins lose visibility to ungranted projects at flip time, by design (flag-*off* is
+  unchanged). So the requirement is no longer "changes nothing"; it is "the disruption is
+  *known and managed*": surface the blast radius with the §3.9 dry-run **before** flipping,
+  communicate, and pre-write the grants teams need. The everyone-allow no-op alternative is
+  documented and rejected in §2.1.
+
+  **The dangerous direction is *off*, and an env-var flag gets it wrong.** First, name two
+  things the word "flag" conflates: **config/availability** — the operator's intent (an env
+  var: "may this deployment run access control?") — and the **enforcement activation state** —
+  whether access control is *actually enforcing right now*. The bug is letting the first
+  silently drive the second *off*. Once a deployment has restricted data, disabling
+  enforcement **silently re-opens every admin-only project to everyone** (roles/grants persist
+  inert; enforcement evaporates — §2.10). An ephemeral env var that defaults to "open" is the
+  wrong control surface for the *activation state*: config drift, a redeploy that drops the
+  var, or a careless flip becomes a mass data-exposure. The fix is *not* strict irreversibility
+  (a one-way latch with no escape can brick a deployment whose access control is locking out
+  its own admins), but **"easy on, hard and deliberate off, immune to drift."**
+
+  **Status — the latch and its guards are built; only the disable *surface* is open.** The
+  prototype implements the read-side at startup in `_ensure_access_control_latch` (the
+  facilitator): **(1)** the **activation state lives in the DB** (`system_settings`, key
+  `access_control.enabled`), distinct from the env-var availability; **(2)** it is **latched on
+  and one-way** — the env var can only ever *bootstrap* the latch on, and a boot where the latch
+  is on but the env var is falsey **refuses to start** (the drift guard) rather than silently
+  disabling. A companion **auth guard** refuses to start with access-control-on + auth-off
+  (enforcement with no identities is a silent allow-all). So **drift-immunity and enable-only are
+  done** — and note the runtime check (`enforcement_enabled`) still reads the *env var*, which is
+  safe precisely because boot guarantees env-agrees-with-latch-or-no-start. What is **not** built
+  remains the open decision: **(3)** an explicit, **admin-authenticated, *audited* in-app
+  disable** — today disabling is a *raw, out-of-band edit of the `system_settings` row before
+  startup*: deliberate, but unaudited and undocumented; and **(4)** a documented **break-glass**
+  disable path (loud audit trail) for the genuine locked-out case — **there is no break-glass
+  surface today.** So the open residue is narrow: the *disable UX and its audit trail*, not the
+  latch model itself (§1).
+
+- **3.6 SYSTEM is the one identity exempt from "fail closed," by design.** A normal user
+  resolves to *no* permissions on an invalid claim set (the oracle fails closed); the
+  SYSTEM user is constructed directly with the SYSTEM role and no claim validation, because
+  the gate is the admin-secret comparison upstream. This is correct, but it makes SYSTEM a
+  singleton trust anchor with total blast radius — the design leans on there being exactly
+  one. Anything wanting "another automation identity" must go through service accounts
+  (§2.5), never a second SYSTEM-role user.
+
+- **3.7 Coverage is the hard part — keep an inventory of access-derived operations.** §2.7
+  warns that the risk is surface-area, not mechanism: the ACL model is small, but *every*
+  operation that returns or acts on access-derived data must carry the same predicate, and
+  for Phoenix that set is large and easy to under-count. One missed endpoint is a silent
+  leak no model-level test will catch. Maintain an explicit inventory and confirm each
+  applies the oracle's filter — at least: **list** (paginated reads), **point-get** (by
+  id), **project resolution by name during ingest** (the authorization/creation check of
+  §2.2 — *not* namespace isolation, which is the §5 tenancy concern), **write / bulk write**,
+  **delete**, **count**, **aggregate / metrics / dashboards**, **export / download**,
+  **subscription / streaming**, **autocomplete / typeahead**, and **transfer / move**
+  (§2.9). A *second* predicate compounds this: every project-surfacing read must also apply
+  the **hide-internal** filter (`exclude_experiment_projects`,
+  `exclude_dataset_evaluator_projects`), and the hidden experiment/evaluator projects need
+  **access-by-parent**, not the ordinary baseline (§2.8) — so internal/shared projects must
+  never be swept under the default project rule without an explicit decision. The honest
+  expectation: for Phoenix, getting *coverage* right is harder and more
+  bug-prone than getting the *access model* right, because the model lives in one module
+  while coverage is spread across every read path in the API.
+
+  The hottest version of that predicate needs a concrete query plan before rollout. For
+  child-heavy tables (spans, traces, sessions), `child.project_id IN (accessible_project_ids)`
+  is the conceptual shape, not a license to materialize a huge Python list on every request.
+  The implementation should use the database shape that fits the caller: an admin fast path
+  with no ACL join, a semi-join / `EXISTS` against grants for ordinary users, or a bounded
+  materialized id set only where the cardinality is small and measured. The flag-off no-query-
+  cost claim is also an invariant to test: when enforcement is off, hot span/trace queries
+  should not pay for ACL joins or accessible-id computation at all.
+
+- **3.8 Access control presupposes authentication — enforce that precondition loudly.**
+  The oracle grants on *identities* (§2.10); an anonymous, auth-disabled instance has none,
+  so there is no subject for the oracle to evaluate and access control cannot function
+  there at all. (This is distinct from the `everyone` subject in the model — an
+  auth-off request carries *no* identity to resolve, not "the everyone identity.") The trap
+  is an operator enabling the flag on an auth-off deployment and *believing* it is secured
+  when in fact nothing can be restricted, because there is no one to restrict *against*. The
+  flag must therefore never be silently "on but ineffective." For a
+  *security* flag the right default is to **fail closed on misconfiguration: reject it at
+  startup** (refuse to boot with access-control-on + auth-off), so the operator cannot
+  mistake an open instance for a secured one. Downgrading to "no-op with a loud, repeated
+  warning" should be a deliberate fallback chosen only for a strong backward-compatibility
+  reason, not the baseline behavior. Either way, adopting access control on an open instance
+  is gated on the strictly larger auth migration underneath it.
+
+- **3.9 Build the dry-run preview before the first rollout.** §2.10 names this the
+  highest-leverage rollout investment; it should be an actual deliverable, not a footnote.
+  The capability — "given the current grants, who would lose access to what the moment the
+  flag flips (or this grant lands)?" — is derivable from the existing oracle
+  (`subjects_for` / `accessible_scope`) with no enforcement change, e.g. a
+  `preview_access_changes` query. Under the strawman the flip is a *silent mass restriction*
+  (non-admins' ungranted projects disappear all at once — ingestion itself does not break,
+  §2.2), so surfacing that blast radius *before* the flip is worth more than any amount of
+  after-the-fact auditing.
+
+- **3.10 Support needs an audited explainability path under not-found semantics.**
+  Unauthorized-≡-not-found is correct for end users (§2.10, and the §4 realization row) but
+  creates an operational bind:
+  when a user reports "I can't see project X," support must diagnose it without casually
+  confirming to that user that X exists. This is distinct from raw SYSTEM access — the
+  answer is an **admin-only "why can't this user see X?" path**, built on the same oracle
+  machinery as the §3.9 preview, and itself **audited** under the §2.6 rule that every
+  privileged read leaves a record. Without it, the only ways to debug an access complaint
+  are to leak existence to the user or to hand a human the SYSTEM/admin secret — both bad.
+
+- **3.11 Decide the base audit log before arguing about history.** The survey separates
+  the audit query ("who can see X?"), the change log ("how did access become this?"), and the
+  action log ("who did what?"). The support path in §3.10 and every SYSTEM-mediated read in
+  §2.6 already require at least a base **action log** for privileged reads/writes: who,
+  credential, action, resource, time, result, and reason. That base log must be settled
+  before launch — decided in scope, or its absence explicitly accepted — rather than deferred
+  as a compliance nicety, because unaudited privileged reads are exactly the paths the design
+  otherwise asks users to trust.
+
+  Point-in-time audit is the larger conditional requirement. The survey's change-log unit is
+  *effective-access change*, but support and compliance often ask "who could see X **at time
+  T**?", not just now — and the answer drifts as groups, roles, and grants all change over
+  time. Answering it requires either periodic **effective-access snapshots** or enough
+  **event history** to reconstruct effective access at an arbitrary past instant. This carries
+  real storage/retention cost, so treat it as conditional: decide up front whether
+  point-in-time answers are a requirement, because retrofitting the history after the fact is
+  impossible — the events that were not recorded are gone.
+
+- **3.12 Group provisioning is three sources over one schema — and the `provider`
+  namespace is what makes that safe.** A group becomes useful as a grant subject only once
+  it is *populated*, and there are three ways that happens, addressing three deployment
+  shapes:
+  1. **Login-time IdP sync** (the default; the prototype's `sync_user_groups`) — at each
+     OAuth2/LDAP login a user's memberships are reconciled to the IdP's *current* group
+     claims. Simple, but **reactive**: a removal in the IdP takes effect only on that user's
+     *next login*, so the **revocation budget is effectively unbounded** (a user who never
+     returns keeps their access — the unbounded-revocation hazard of survey §12). Groups also
+     exist only for users who have logged in, so you cannot grant to a team before it onboards.
+  2. **SCIM** (deferred, the enterprise tier — survey §10/§16/§17) — the IdP *pushes*
+     user/group create/update/**delete** out-of-band of login, which is the only thing that
+     makes **deprovisioning prompt** and lets groups exist before first login. SCIM is a
+     provisioning *transport*, not a change to the access model.
+  3. **Local/admin-managed groups** — created and populated by an admin in-product, the
+     **only** option for a deployment with no IdP at all (basic-auth-only); login-time sync
+     and SCIM both require an IdP, so neither helps here. The prototype does **not** yet
+     offer this; today a no-IdP deployment can grant **per-user only**.
+
+  The load-bearing design point: the `user_groups.provider` column **namespaces** each
+  source (`oauth2:<idp>`, `ldap`, `scim`, `local`), and the login reconcile is
+  **provider-scoped** — it only ever deletes memberships *within the provider it is syncing*.
+  So the three sources coexist without clobbering each other, SCIM can be added later as just
+  another provider **with no schema change**, and local groups are immune to being wiped by
+  an IdP login. The one rule that prevents a double source of truth: **if SCIM provisions a
+  directory, disable login-time claim-sync for that same provider** — SCIM owns the
+  directory, login only authenticates. And provisioning *deletes* (a SCIM user/group DELETE,
+  or a local-group delete) must run the same dangling-grant cleanup as §2.12 — deleting the
+  subject's `acls` rows — or a recycled id silently inherits the old grants.
+
+- **3.13 Grant-side revocation should be next-request unless deliberately cached.** §3.12
+  names the unbounded revocation budget for login-time group sync, but grant rows themselves
+  should have a tighter default: deleting a direct grant, removing a user from a local group,
+  or changing a permission set should affect the next authorization check. That follows
+  naturally if `can` / `accessible_ids` read DB state per request and do not cache effective
+  access across requests. If a later optimization introduces request-external caching
+  (flattened accessible-id sets, token-embedded grants, cross-request LRU), the cache TTL
+  becomes part of the security contract and must be bounded by an explicit revocation budget.
+  Until then, document the invariant as **grant revocation is next-request; IdP revocation is
+  only as fast as the provisioning source**.
+
+---
+
+## 4. Proposed realization (prototype)
+
+For reference, how the prototype maps the survey's concepts onto Phoenix. **None of this
+is on `main`** — it is the current direction, subject to change, included to make §2 and
+§3 concrete.
+
+| Survey concept | Proposed Phoenix realization |
+|---|---|
+| Family A (stored edges) | a generic `acls` table; list query is `grant rows → ids → IN (...)` |
+| Single oracle | one access module exposing `can` / `accessible_ids` / `subjects_for` |
+| `authority(identity) ∩ attenuation(credential)` | applies to **read / non-ingest** surfaces: a credential's read access = its identity's grants ∩ an attenuating `scope`. It does **not** gate ingestion writes — under the strawman those are ungated (§2.2); a key's `scope` may still bound its non-write capabilities (read, verb-level), not project write authorization. |
+| Subject union | a `subject_kind` discriminator (`user`/`group`/`everyone`; `service_account` reserved, §2.5). **Note:** `everyone` exists as a subject for *explicit* grants (deliberately sharing an object with all users); it is **not** a seeded deployment-wide open baseline — the strawman has no open seed, so do not reintroduce the rejected everyone-allow model by auto-creating an `everyone` grant. |
+| Group as grant subject (Pattern 1) | user-group + membership tables, grantable on objects |
+| Roles as data | global role + permission tables (built-in only at first); a separate permission-set table for custom permission sets |
+| New-resource default visibility | **Strawman (§1):** fail-closed per type — ingest-born **projects → admin-only**, user-created **datasets/prompts → creator-private**. No seeded everyone-allow grant. (The everyone-allow alternative's all-types-open seed is rejected — §2.1.) |
+| Eval-world plumbing & playground (§2.8) | A server-set, immutable **`kind`** discriminator (`TELEMETRY`/`PLAYGROUND`/`EXPERIMENT`/`EVALUATOR`) marks *plumbing vs real project*, replacing today's name-pattern + `exclude_*` heuristics. **Settled:** experiment/evaluator trace-projects are plumbing — access is **rooted at the run's data context** (the dataset), not an independent grant. **Provisional (online-eval workstream, not `main`):** the *production-project-as-data-context* root and the preference for rooting at the *run* over a denormalized `project.dataset_id` come from the concurrent online-eval design — reconcile before building (§2.8 header note). **Open:** playground — lean per-user `kind=PLAYGROUND` projects + creator grant (§2.8). |
+| Ingestion-time creation authority | **Strawman (§1):** *settled* — any authenticated ingest key may create/write any project; creation exposes no read access (admin-only default), so creation is deliberately ungated. Partial batches are never rejected for authorization while writes are open (§2.2). |
+| Unauthorized read ≡ not-found | point checks return not-found for unreachable objects |
+| Monotonic allow-only (strawman) | every row is `effect = allow`; default is **closed** (admin-only), so grants only *add* — no shadowing, no `restricted` marker; last-grant removal leaves an object admin-only, never reopened. (The non-monotonic everyone-allow alternative and *why* it's rejected: §2.1.) |
+| ADMINISTER override | resolved as a rule inside the oracle, not a call-site shortcut |
+
+---
+
+## 5. Tenancy: the structural direction
+
+Everything above is per-resource access control *within* a flat, global project namespace.
+The recurring subtext — and the clearest finding when Phoenix is compared with mature
+multi-tenant peers — is that the deepest tensions are **symptoms of `project` being a
+top-level resource with nothing above it.** A **tenant layer** (a container such as a
+*space*, itself inside an *org* / *account*, with `project` and the other resources living
+*inside* it) is the structural fix. To be clear up front: this does **not** make tenancy a
+prerequisite for the per-resource RBAC of §1–§4 — that proposal ships on its own. Tenancy
+changes the preferred *defaults and creation model* later; it is an evolution, not a gate.
+This section states the direction and its trade-offs;
+it is **not** the tenancy design — the org model, provisioning (SSO/SCIM), data isolation,
+and migration mechanics are a follow-on.
+
+**Status.** Unlike the rest of this doc, tenancy is **not prototyped** — there is no tenant
+layer on `main` and none in the working-tree prototype. Treat §5 as a recommended
+direction, not a description of something that exists.
+
+**The core mechanism.** A container with members gives a machine-created resource
+*something to inherit*. The pipeline writes *into* a space (selected by the credential,
+routing context, or a future tenant-scoped ingest configuration — undesigned),
+and the space's access governs by default, with resource-specific grants adding access from
+there. That single change is what dissolves the birth-cluster tensions — they exist
+only because, today, a project has no parent.
+
+Tenancy is **two-sided**: it ameliorates the *design* (birth) pains and exacerbates the
+*operational* ones.
+
+### What it ameliorates — the Birth-and-creation cluster
+
+- **§2.1 default visibility** — the default gains a *scope*: "visible to the owning space's
+  members," which is neither global-open nor global-private. The fail-open/fail-closed
+  dilemma dissolves into "inherit the container."
+- **§2.3 ownership without a creator** — *strongest effect.* An auto-created project lands
+  inside a space that already has members and inherits its access; no owner need be
+  manufactured. "Governed, not owned" becomes the literal model.
+- **§2.4 recreated same-name** — a re-ingested resource re-lands in the same container and
+  inherits the same **container default** access, so continuity comes from the container
+  rather than from re-attaching id-keyed grants (direct restrictions still don't carry to
+  the new id).
+- **§2.2 creation authority** — *ameliorated but relocated.* The "create a new world-visible
+  project under a different name" bypass shrinks (creation requires write to a space, and
+  the result inherits space access, not global visibility) — but the fork climbs a level to
+  **"who may create a *space*?"**, which the tenancy design must answer.
+
+### What it exacerbates — the operational cluster
+
+- **§2.9 moving across boundaries** — a *new, harder* class appears: cross-tenant moves
+  (project between spaces, space between orgs). These are the hardest authorization case —
+  two-sided rights across a boundary whose entire purpose is to prevent data crossing it.
+  The likely answer is to **forbid** cross-tenant moves rather than secure them.
+- **§2.10 rollout** — introducing a container layer where there was none is itself a
+  *structural* migration, larger than the access-flag flip: every existing project assigned
+  to a space, every user mapped to space/org memberships, and — the breaking change —
+  **ingest routing must carry container context** (a span no longer names a global project;
+  it resolves to a project *within* a space, which the key determines). Existing collector
+  configs may need updating.
+- **§3.7 coverage** — the bar rises and gains a second dimension: tenant isolation. *Every*
+  query must be tenant-scoped, not just the access-derived read surfaces — a hard boundary
+  whose violation (one tenant seeing another's data) is the worst case. This is a distinct,
+  even less forgiving, coverage obligation layered on top of the per-resource one.
+
+### Net
+
+Tenancy is **the cure for the birth pains and the cause of the operational ones.** It is
+adopted to make unattended, ownerless ingestion tractable — the pipeline writes into a
+container with a pre-existing access model — and paid for in a one-time structural migration
+and a tenant boundary that every read must thereafter respect. It is the right long-term
+move precisely because it converts the hardest *design* questions (§2.1/§2.3/§2.4) into
+inherited behavior; it is deferred to its own pass precisely because the *operational* cost
+(§2.9/§2.10/§3.7) and the surrounding product decisions (deployment model, provisioning) are
+large enough to deserve dedicated treatment rather than being folded in here.
+
+---
+
+## 6. Global objects outside the containment tree
+
+§2 models the world as a **containment tree** — resources under projects (and datasets and
+prompts), governed by grants plus downward inheritance (§2.7), with system-generated
+projects as a wrinkle (§2.8). But Phoenix's schema also has a **global layer**: objects that
+belong to *no* project and are reused across the deployment. The access model is silent on
+them, and they do **not** fit "containment + per-resource grant." They come in three shapes,
+each with different access semantics — and a fourth note on credential carriers.
+
+*(Provenance: the table names below were verified against `main` (as of 2026-06) and carry
+no line citations — re-verify against current code before building, as with the rest of §2.)*
+
+**1. Secrets — the most sensitive object, with unique semantics.** The `secrets` table is a
+deployment-global key→encrypted-value store holding **third-party credentials** (model-provider
+API keys and the like); credential-bearing config blobs such as a custom model provider's
+connection `config` are the same class. The invariant is about the **value**, not the row:
+a secret's **value is never returned, echoed, logged, or exposed through an error** — it is
+write-only from the API's perspective, and admin-gated to set. Its **metadata** (the key /
+name / handle, who set it, when) *may* be listed where the UI needs to show which secrets
+exist — that is a normal admin-gated read, not a value disclosure. This is distinct from
+Phoenix's own auth keys (§2.5, which are *credentials* the system issues); secrets are
+*foreign* credentials the system *stores*. The value is the single most access-sensitive
+datum in the schema and the clearest current gap.
+
+**2. Shared "library" objects — restricted-write, read policy *per type*, not contained.**
+Globally unique, reused across the tree, fitting neither containment nor a per-object grant:
+**evaluators** (the reusable evaluator library, linked to datasets via dataset-evaluators —
+distinct from the hidden evaluator *projects* of §2.8), **annotation configs** (shared
+annotation *schemas* attached to many projects), **global model definitions and pricing**,
+and **dataset/prompt labels** (globally-unique labels applied across many resources). Their
+access question is two-sided and unlike the tree's: **create/edit is admin-or-author**,
+while **read/use is a per-type policy decision, not a blanket rule** — many (labels, pricing,
+built-in evaluators) are reasonably "anyone in the deployment," but some (a custom evaluator
+carrying a proprietary prompt) may warrant tighter read. The point is that these objects need
+*a* read decision made per type, not that they are all open. Neither side is a grant on a
+contained object. (A mature peer makes several of these — evaluators,
+annotation configs, labels/tags — *first-class resource types*, which is evidence they
+deserve explicit treatment rather than silence.)
+
+**3. Admin / global config — privileged writes, one of them destructive.** **Trace
+retention policies** govern data *deletion* (a cron + rule applied across many projects), so
+"who may set retention?" is a privileged action with destructive consequences and deserves
+the same care as a delete grant. **System settings** and **sandbox/execution config** are
+admin-only (the latter possibly credential-bearing, see shape 1).
+
+**4. Credential carriers (not resources, but must-not-leak).** The concrete auth artifacts —
+refresh tokens, access tokens, password-reset tokens — are the physical form of §2's
+identity/credential split. They are not grantable resources and need no grant model, but
+they must never leak; worth one line so they are not mistaken for ordinary rows.
+
+The throughline: the containment tree is most of the model but not all of it. Separate the
+two parts — the **security invariants are settled** (non-negotiable now), only the
+**policy/UI treatment is open**:
+
+- **Settled invariants:** a secret's *value* is never returned, logged, or echoed; auth
+  tokens never leak; trace-retention *writes* are privileged (destructive). These are not up
+  for debate — only their enforcement is implementation work.
+- **Open policy:** the per-type *read* decision for the shared library; secret/token
+  *metadata* listing UX; which roles hold the privileged config writes.
+
+Secrets (shape 1) are the priority among the invariants, because the failure mode — a
+foreign credential **value** leaking through a response, log, or error — is the worst in the
+schema.

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -4,6 +4,278 @@
  */
 
 export interface paths {
+    "/v1/access/grants": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List access grants */
+        get: operations["listAccessGrants"];
+        put?: never;
+        /**
+         * Author an access grant (allow-only, idempotent)
+         * @description Grant a subject access to an object (or, with ``object_id`` omitted, to every
+         *     object of that type). Monotonic and allow-only: grants only ever *add* access.
+         *     Idempotent — re-granting the same subject+object updates only the role. Authoring a grant
+         *     on a specific object needs OBJ_MANAGE_ACCESS on it; a type-wide grant is admin-only.
+         */
+        post: operations["createAccessGrant"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/tag-grants": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List tag grants */
+        get: operations["listTagGrants"];
+        put?: never;
+        /**
+         * Author a tag grant (allow-only, idempotent)
+         * @description Grant a subject access to every object of a type carrying a given key=value tag.
+         *     Type-scoped and additive — admin-only, like other type-wide policy. Idempotent: re-granting
+         *     the same (subject, type, tag) updates only the role. A tag grant may confer view or edit,
+         *     never manage-access: a tag's reach is object-manager-mutable, so a manage-conferring tag
+         *     grant would let a non-admin strand an object; it is rejected here and the oracle refuses to
+         *     honor manage from a tag selector regardless.
+         */
+        post: operations["createTagGrant"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/tag-grants/{grant_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Revoke a tag grant
+         * @description Revoke a tag grant. Admin-only, like authoring one. No last-manager guard applies: a tag
+         *     grant is type-scoped and never confers manage, so it is never an object's last manager.
+         */
+        delete: operations["deleteTagGrant"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/object-roles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the permission sets a grant may confer
+         * @description The permission sets a grant may confer — viewer (visibility), editor (mutate), manager
+         *     (manage access). The oracle enforces each tier at its permission level.
+         */
+        get: operations["listPermissionSets"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/enforcement": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Whether access control is enforcing
+         * @description The DB-latched activation state — the source of truth for whether enforcement is on.
+         *     Read-only: there is intentionally no enable/disable endpoint (enabling is the one-way env
+         *     switch; disabling is a deliberate ops action).
+         */
+        get: operations["getAccessEnforcement"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/groups": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List local (admin-managed) groups */
+        get: operations["listLocalGroups"];
+        put?: never;
+        /** Create a local (admin-managed) group */
+        post: operations["createLocalGroup"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/groups/{group_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a local group (and sweep its grants) */
+        delete: operations["deleteLocalGroup"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/groups/{group_id}/members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Add a user to a local group */
+        post: operations["addLocalGroupMember"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/groups/{group_id}/members/{user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Remove a user from a local group */
+        delete: operations["removeLocalGroupMember"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/grants/{grant_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke an access grant */
+        delete: operations["deleteAccessGrant"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/objects/{object_type}/{object_id}/subjects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Who can access this object ("who can see X?")
+         * @description The audit read: the subjects currently granted access to the object (plus its
+         *     creator). Needs OBJ_MANAGE_ACCESS on the object. Administrators have
+         *     implicit access and are not enumerated.
+         */
+        get: operations["listObjectSubjects"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/objects/{object_type}/{object_id}/tags/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Set (or update) a curated tag on an object
+         * @description Apply or update a curated key=value tag on an object. A tag grant reads the tag as
+         *     policy, so setting one changes who can reach the object — it requires OBJ_MANAGE_ACCESS on
+         *     the target, the same authority as granting access. Idempotent: re-setting a key overwrites
+         *     its value.
+         */
+        put: operations["setResourceTag"];
+        post?: never;
+        /**
+         * Remove a curated tag from an object
+         * @description Remove a curated tag. A tag grant that reached the object via this key simply stops
+         *     matching — no grant is deleted (tag grants carry the strings, not a link to the tag row).
+         *     Requires OBJ_MANAGE_ACCESS on the object.
+         */
+        delete: operations["removeResourceTag"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/access/objects/{object_type}/{object_id}/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List an object's curated tags
+         * @description The curated tags on an object. Tags steer access, so reading them needs
+         *     OBJ_MANAGE_ACCESS on the object — the same gate as the "who can see X?" audit read.
+         */
+        get: operations["listResourceTags"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/annotation_configs": {
         parameters: {
             query?: never;
@@ -2569,6 +2841,17 @@ export interface components {
             /** Approval */
             approval?: components["schemas"]["ToolApprovalRequested"] | components["schemas"]["ToolApprovalResponded"] | null;
         };
+        /** Enforcement */
+        Enforcement: {
+            /** Enabled */
+            enabled: boolean;
+            /** Source */
+            source: string;
+        };
+        /** EnforcementResponseBody */
+        EnforcementResponseBody: {
+            data: components["schemas"]["Enforcement"];
+        };
         /** Experiment */
         Experiment: {
             /**
@@ -2896,6 +3179,49 @@ export interface components {
             /** Data */
             data: components["schemas"]["LocalUser"] | components["schemas"]["OAuth2User"] | components["schemas"]["LDAPUser"] | components["schemas"]["AnonymousUser"];
         };
+        /** Grant */
+        Grant: {
+            /** Id */
+            id: string;
+            subject: components["schemas"]["Subject"];
+            object_type: components["schemas"]["GrantObjectType"];
+            /** Object Id */
+            object_id: string | null;
+            /** Role */
+            role: string | null;
+        };
+        /** GrantCreate */
+        GrantCreate: {
+            subject: components["schemas"]["Subject"];
+            object_type: components["schemas"]["GrantObjectType"];
+            /** Object Id */
+            object_id?: string | null;
+            /** Role */
+            role?: string | null;
+        };
+        /**
+         * GrantObjectType
+         * @description The grantable access roots. Containment children and eval artifacts are
+         *     intentionally absent: their access is inherited from a parent, never granted directly.
+         * @enum {string}
+         */
+        GrantObjectType: "project" | "dataset" | "prompt";
+        /** GrantResponseBody */
+        GrantResponseBody: {
+            data: components["schemas"]["Grant"];
+        };
+        /**
+         * GrantSubjectKind
+         * @description Who a grant targets. ``everyone`` is the only kind with no id — a deliberate
+         *     'make this object visible to all' grant, not a seeded baseline.
+         * @enum {string}
+         */
+        GrantSubjectKind: "user" | "group" | "role" | "service_account" | "everyone";
+        /** GrantsResponseBody */
+        GrantsResponseBody: {
+            /** Data */
+            data: components["schemas"]["Grant"][];
+        };
         /**
          * GraphQLContext
          * @description GraphQL runtime state.
@@ -2908,6 +3234,29 @@ export interface components {
             type: "graphql";
             /** Mutationsenabled */
             mutationsEnabled: boolean;
+        };
+        /** GroupCreate */
+        GroupCreate: {
+            /** Name */
+            name: string;
+        };
+        /** GroupData */
+        GroupData: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Member User Ids */
+            member_user_ids: string[];
+        };
+        /** GroupResponseBody */
+        GroupResponseBody: {
+            data: components["schemas"]["GroupData"];
+        };
+        /** GroupsResponseBody */
+        GroupsResponseBody: {
+            /** Data */
+            data: components["schemas"]["GroupData"][];
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -3134,6 +3483,11 @@ export interface components {
             auth_method: "LOCAL";
             /** Password */
             password?: string;
+        };
+        /** MemberCreate */
+        MemberCreate: {
+            /** User Id */
+            user_id: string;
         };
         /**
          * ModelProvider
@@ -3403,6 +3757,22 @@ export interface components {
              * @description A developer-facing human readable error message.
              */
             message?: string | null;
+        };
+        /** PermissionSetData */
+        PermissionSetData: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Is Built In */
+            is_built_in: boolean;
+            /** Permissions */
+            permissions: string[];
+        };
+        /** PermissionSetsResponseBody */
+        PermissionSetsResponseBody: {
+            /** Data */
+            data: components["schemas"]["PermissionSetData"][];
         };
         /**
          * PlaygroundBuiltinModelContext
@@ -4374,6 +4744,30 @@ export interface components {
                 };
             } | null;
         };
+        /** ResourceTagBody */
+        ResourceTagBody: {
+            /** Value */
+            value: string;
+        };
+        /** ResourceTagData */
+        ResourceTagData: {
+            object_type: components["schemas"]["GrantObjectType"];
+            /** Object Id */
+            object_id: string;
+            /** Key */
+            key: string;
+            /** Value */
+            value: string;
+        };
+        /** ResourceTagResponseBody */
+        ResourceTagResponseBody: {
+            data: components["schemas"]["ResourceTagData"];
+        };
+        /** ResourceTagsResponseBody */
+        ResourceTagsResponseBody: {
+            /** Data */
+            data: components["schemas"]["ResourceTagData"][];
+        };
         /** ResponseBody[UpsertOrDeleteSecretsResult] */
         ResponseBody_UpsertOrDeleteSecretsResult_: {
             data: components["schemas"]["UpsertOrDeleteSecretsResult"];
@@ -4966,6 +5360,50 @@ export interface components {
             type: "subagents";
             /** Enabled */
             enabled: boolean;
+        };
+        /** Subject */
+        Subject: {
+            kind: components["schemas"]["GrantSubjectKind"];
+            /** Id */
+            id?: string | null;
+        };
+        /** SubjectsResponseBody */
+        SubjectsResponseBody: {
+            /** Data */
+            data: components["schemas"]["Subject"][];
+        };
+        /** TagGrant */
+        TagGrant: {
+            /** Id */
+            id: string;
+            subject: components["schemas"]["Subject"];
+            object_type: components["schemas"]["GrantObjectType"];
+            /** Tag Key */
+            tag_key: string;
+            /** Tag Value */
+            tag_value: string;
+            /** Role */
+            role: string | null;
+        };
+        /** TagGrantCreate */
+        TagGrantCreate: {
+            subject: components["schemas"]["Subject"];
+            object_type: components["schemas"]["GrantObjectType"];
+            /** Tag Key */
+            tag_key: string;
+            /** Tag Value */
+            tag_value: string;
+            /** Role */
+            role?: string | null;
+        };
+        /** TagGrantResponseBody */
+        TagGrantResponseBody: {
+            data: components["schemas"]["TagGrant"];
+        };
+        /** TagGrantsResponseBody */
+        TagGrantsResponseBody: {
+            /** Data */
+            data: components["schemas"]["TagGrant"][];
         };
         /** TextContentPart */
         TextContentPart: {
@@ -5726,6 +6164,792 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    listAccessGrants: {
+        parameters: {
+            query?: {
+                object_type?: components["schemas"]["GrantObjectType"] | null;
+                /** @description Filter to one object (requires object_type). */
+                object_id?: string | null;
+                subject_kind?: components["schemas"]["GrantSubjectKind"] | null;
+                /** @description Filter to one subject (requires subject_kind). */
+                subject_id?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GrantsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    createAccessGrant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GrantCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GrantResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listTagGrants: {
+        parameters: {
+            query?: {
+                object_type?: components["schemas"]["GrantObjectType"] | null;
+                subject_kind?: components["schemas"]["GrantSubjectKind"] | null;
+                /** @description Filter to one subject (requires subject_kind). */
+                subject_id?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TagGrantsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    createTagGrant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TagGrantCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TagGrantResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteTagGrant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The tag grant GlobalID */
+                grant_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listPermissionSets: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PermissionSetsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    getAccessEnforcement: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EnforcementResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listLocalGroups: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    createLocalGroup: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteLocalGroup: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The local group GlobalID */
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    addLocalGroupMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The local group GlobalID */
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MemberCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    removeLocalGroupMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The local group GlobalID */
+                group_id: string;
+                /** @description The user GlobalID to remove */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteAccessGrant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The access grant GlobalID */
+                grant_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listObjectSubjects: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                object_type: components["schemas"]["GrantObjectType"];
+                /** @description The object GlobalID */
+                object_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubjectsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    setResourceTag: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                object_type: components["schemas"]["GrantObjectType"];
+                /** @description The object GlobalID */
+                object_id: string;
+                /** @description The tag key */
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ResourceTagBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceTagResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    removeResourceTag: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                object_type: components["schemas"]["GrantObjectType"];
+                /** @description The object GlobalID */
+                object_id: string;
+                /** @description The tag key */
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listResourceTags: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                object_type: components["schemas"]["GrantObjectType"];
+                /** @description The object GlobalID */
+                object_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceTagsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
     list_annotation_configs_v1_annotation_configs_get: {
         parameters: {
             query?: {
@@ -8718,6 +9942,24 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Conflict */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -161,6 +161,15 @@ class DeleteSessionsRequestBody(TypedDict):
     session_identifiers: Sequence[str]
 
 
+class Enforcement(TypedDict):
+    enabled: bool
+    source: str
+
+
+class EnforcementResponseBody(TypedDict):
+    data: Enforcement
+
+
 class Experiment(TypedDict):
     id: str
     dataset_id: str
@@ -224,6 +233,24 @@ class GetExperimentResponseBody(TypedDict):
 class GraphQLContext(TypedDict):
     type: Literal["graphql"]
     mutationsEnabled: bool
+
+
+class GroupCreate(TypedDict):
+    name: str
+
+
+class GroupData(TypedDict):
+    id: str
+    name: str
+    member_user_ids: Sequence[str]
+
+
+class GroupResponseBody(TypedDict):
+    data: GroupData
+
+
+class GroupsResponseBody(TypedDict):
+    data: Sequence[GroupData]
 
 
 class IncompleteExperimentEvaluation(TypedDict):
@@ -325,6 +352,10 @@ class LocalUser(LocalUserData):
     password_needs_reset: bool
 
 
+class MemberCreate(TypedDict):
+    user_id: str
+
+
 class OAuth2UserData(TypedDict):
     email: str
     username: str
@@ -344,6 +375,17 @@ class OAuth2User(OAuth2UserData):
 class OtlpStatus(TypedDict):
     code: NotRequired[int]
     message: NotRequired[str]
+
+
+class PermissionSetData(TypedDict):
+    id: str
+    name: str
+    is_built_in: bool
+    permissions: Sequence[str]
+
+
+class PermissionSetsResponseBody(TypedDict):
+    data: Sequence[PermissionSetData]
 
 
 class PlaygroundBuiltinModelContext(TypedDict):
@@ -649,6 +691,25 @@ class ReasoningUIPart(TypedDict):
     providerMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
 
 
+class ResourceTagBody(TypedDict):
+    value: str
+
+
+class ResourceTagData(TypedDict):
+    object_type: Literal["project", "dataset", "prompt"]
+    object_id: str
+    key: str
+    value: str
+
+
+class ResourceTagResponseBody(TypedDict):
+    data: ResourceTagData
+
+
+class ResourceTagsResponseBody(TypedDict):
+    data: Sequence[ResourceTagData]
+
+
 class SecretKeyValue(TypedDict):
     key: str
     value: Optional[str]
@@ -786,6 +847,40 @@ class StepStartUIPart(TypedDict):
 class SubagentsContext(TypedDict):
     type: Literal["subagents"]
     enabled: bool
+
+
+class Subject(TypedDict):
+    kind: Literal["user", "group", "role", "service_account", "everyone"]
+    id: NotRequired[str]
+
+
+class SubjectsResponseBody(TypedDict):
+    data: Sequence[Subject]
+
+
+class TagGrant(TypedDict):
+    id: str
+    subject: Subject
+    object_type: Literal["project", "dataset", "prompt"]
+    tag_key: str
+    tag_value: str
+    role: Optional[str]
+
+
+class TagGrantCreate(TypedDict):
+    subject: Subject
+    object_type: Literal["project", "dataset", "prompt"]
+    tag_key: str
+    tag_value: str
+    role: NotRequired[str]
+
+
+class TagGrantResponseBody(TypedDict):
+    data: TagGrant
+
+
+class TagGrantsResponseBody(TypedDict):
+    data: Sequence[TagGrant]
 
 
 class TextContentPart(TypedDict):
@@ -1339,6 +1434,29 @@ class GetUsersResponseBody(TypedDict):
 
 class GetViewerResponseBody(TypedDict):
     data: Union[LocalUser, OAuth2User, LDAPUser, AnonymousUser]
+
+
+class Grant(TypedDict):
+    id: str
+    subject: Subject
+    object_type: Literal["project", "dataset", "prompt"]
+    object_id: Optional[str]
+    role: Optional[str]
+
+
+class GrantCreate(TypedDict):
+    subject: Subject
+    object_type: Literal["project", "dataset", "prompt"]
+    object_id: NotRequired[str]
+    role: NotRequired[str]
+
+
+class GrantResponseBody(TypedDict):
+    data: Grant
+
+
+class GrantsResponseBody(TypedDict):
+    data: Sequence[Grant]
 
 
 class HTTPValidationError(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -6,6 +6,1113 @@
     "version": "1.0"
   },
   "paths": {
+    "/v1/access/grants": {
+      "get": {
+        "tags": [
+          "access"
+        ],
+        "summary": "List access grants",
+        "operationId": "listAccessGrants",
+        "parameters": [
+          {
+            "name": "object_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/GrantObjectType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Object Type"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to one object (requires object_type).",
+              "title": "Object Id"
+            },
+            "description": "Filter to one object (requires object_type)."
+          },
+          {
+            "name": "subject_kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/GrantSubjectKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Subject Kind"
+            }
+          },
+          {
+            "name": "subject_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to one subject (requires subject_kind).",
+              "title": "Subject Id"
+            },
+            "description": "Filter to one subject (requires subject_kind)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GrantsResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "access"
+        ],
+        "summary": "Author an access grant (allow-only, idempotent)",
+        "description": "Grant a subject access to an object (or, with ``object_id`` omitted, to every\nobject of that type). Monotonic and allow-only: grants only ever *add* access.\nIdempotent \u2014 re-granting the same subject+object updates only the role. Authoring a grant\non a specific object needs OBJ_MANAGE_ACCESS on it; a type-wide grant is admin-only.",
+        "operationId": "createAccessGrant",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GrantCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GrantResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      }
+    },
+    "/v1/access/tag-grants": {
+      "post": {
+        "tags": [
+          "access"
+        ],
+        "summary": "Author a tag grant (allow-only, idempotent)",
+        "description": "Grant a subject access to every object of a type carrying a given key=value tag.\nType-scoped and additive \u2014 admin-only, like other type-wide policy. Idempotent: re-granting\nthe same (subject, type, tag) updates only the role. A tag grant may confer view or edit,\nnever manage-access: a tag's reach is object-manager-mutable, so a manage-conferring tag\ngrant would let a non-admin strand an object; it is rejected here and the oracle refuses to\nhonor manage from a tag selector regardless.",
+        "operationId": "createTagGrant",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagGrantCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagGrantResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "access"
+        ],
+        "summary": "List tag grants",
+        "operationId": "listTagGrants",
+        "parameters": [
+          {
+            "name": "object_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/GrantObjectType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Object Type"
+            }
+          },
+          {
+            "name": "subject_kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/GrantSubjectKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Subject Kind"
+            }
+          },
+          {
+            "name": "subject_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to one subject (requires subject_kind).",
+              "title": "Subject Id"
+            },
+            "description": "Filter to one subject (requires subject_kind)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagGrantsResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      }
+    },
+    "/v1/access/tag-grants/{grant_id}": {
+      "delete": {
+        "tags": [
+          "access"
+        ],
+        "summary": "Revoke a tag grant",
+        "description": "Revoke a tag grant. Admin-only, like authoring one. No last-manager guard applies: a tag\ngrant is type-scoped and never confers manage, so it is never an object's last manager.",
+        "operationId": "deleteTagGrant",
+        "parameters": [
+          {
+            "name": "grant_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The tag grant GlobalID",
+              "title": "Grant Id"
+            },
+            "description": "The tag grant GlobalID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      }
+    },
+    "/v1/access/object-roles": {
+      "get": {
+        "tags": [
+          "access"
+        ],
+        "summary": "List the permission sets a grant may confer",
+        "description": "The permission sets a grant may confer \u2014 viewer (visibility), editor (mutate), manager\n(manage access). The oracle enforces each tier at its permission level.",
+        "operationId": "listPermissionSets",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionSetsResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/access/enforcement": {
+      "get": {
+        "tags": [
+          "access"
+        ],
+        "summary": "Whether access control is enforcing",
+        "description": "The DB-latched activation state \u2014 the source of truth for whether enforcement is on.\nRead-only: there is intentionally no enable/disable endpoint (enabling is the one-way env\nswitch; disabling is a deliberate ops action).",
+        "operationId": "getAccessEnforcement",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnforcementResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/access/groups": {
+      "get": {
+        "tags": [
+          "access"
+        ],
+        "summary": "List local (admin-managed) groups",
+        "operationId": "listLocalGroups",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupsResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "access"
+        ],
+        "summary": "Create a local (admin-managed) group",
+        "operationId": "createLocalGroup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GroupCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/access/groups/{group_id}": {
+      "delete": {
+        "tags": [
+          "access"
+        ],
+        "summary": "Delete a local group (and sweep its grants)",
+        "operationId": "deleteLocalGroup",
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The local group GlobalID",
+              "title": "Group Id"
+            },
+            "description": "The local group GlobalID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      }
+    },
+    "/v1/access/groups/{group_id}/members": {
+      "post": {
+        "tags": [
+          "access"
+        ],
+        "summary": "Add a user to a local group",
+        "operationId": "addLocalGroupMember",
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The local group GlobalID",
+              "title": "Group Id"
+            },
+            "description": "The local group GlobalID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemberCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      }
+    },
+    "/v1/access/groups/{group_id}/members/{user_id}": {
+      "delete": {
+        "tags": [
+          "access"
+        ],
+        "summary": "Remove a user from a local group",
+        "operationId": "removeLocalGroupMember",
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The local group GlobalID",
+              "title": "Group Id"
+            },
+            "description": "The local group GlobalID"
+          },
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The user GlobalID to remove",
+              "title": "User Id"
+            },
+            "description": "The user GlobalID to remove"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      }
+    },
+    "/v1/access/grants/{grant_id}": {
+      "delete": {
+        "tags": [
+          "access"
+        ],
+        "summary": "Revoke an access grant",
+        "operationId": "deleteAccessGrant",
+        "parameters": [
+          {
+            "name": "grant_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The access grant GlobalID",
+              "title": "Grant Id"
+            },
+            "description": "The access grant GlobalID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      }
+    },
+    "/v1/access/objects/{object_type}/{object_id}/subjects": {
+      "get": {
+        "tags": [
+          "access"
+        ],
+        "summary": "Who can access this object (\"who can see X?\")",
+        "description": "The audit read: the subjects currently granted access to the object (plus its\ncreator). Needs OBJ_MANAGE_ACCESS on the object. Administrators have\nimplicit access and are not enumerated.",
+        "operationId": "listObjectSubjects",
+        "parameters": [
+          {
+            "name": "object_type",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/GrantObjectType"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The object GlobalID",
+              "title": "Object Id"
+            },
+            "description": "The object GlobalID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubjectsResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      }
+    },
+    "/v1/access/objects/{object_type}/{object_id}/tags/{key}": {
+      "put": {
+        "tags": [
+          "access"
+        ],
+        "summary": "Set (or update) a curated tag on an object",
+        "description": "Apply or update a curated key=value tag on an object. A tag grant reads the tag as\npolicy, so setting one changes who can reach the object \u2014 it requires OBJ_MANAGE_ACCESS on\nthe target, the same authority as granting access. Idempotent: re-setting a key overwrites\nits value.",
+        "operationId": "setResourceTag",
+        "parameters": [
+          {
+            "name": "object_type",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/GrantObjectType"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The object GlobalID",
+              "title": "Object Id"
+            },
+            "description": "The object GlobalID"
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The tag key",
+              "title": "Key"
+            },
+            "description": "The tag key"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResourceTagBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceTagResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "access"
+        ],
+        "summary": "Remove a curated tag from an object",
+        "description": "Remove a curated tag. A tag grant that reached the object via this key simply stops\nmatching \u2014 no grant is deleted (tag grants carry the strings, not a link to the tag row).\nRequires OBJ_MANAGE_ACCESS on the object.",
+        "operationId": "removeResourceTag",
+        "parameters": [
+          {
+            "name": "object_type",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/GrantObjectType"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The object GlobalID",
+              "title": "Object Id"
+            },
+            "description": "The object GlobalID"
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The tag key",
+              "title": "Key"
+            },
+            "description": "The tag key"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      }
+    },
+    "/v1/access/objects/{object_type}/{object_id}/tags": {
+      "get": {
+        "tags": [
+          "access"
+        ],
+        "summary": "List an object's curated tags",
+        "description": "The curated tags on an object. Tags steer access, so reading them needs\nOBJ_MANAGE_ACCESS on the object \u2014 the same gate as the \"who can see X?\" audit read.",
+        "operationId": "listResourceTags",
+        "parameters": [
+          {
+            "name": "object_type",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/GrantObjectType"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The object GlobalID",
+              "title": "Object Id"
+            },
+            "description": "The object GlobalID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceTagsResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      }
+    },
     "/v1/annotation_configs": {
       "get": {
         "tags": [
@@ -5365,6 +6472,26 @@
             },
             "description": "Forbidden"
           },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
           "422": {
             "content": {
               "text/plain": {
@@ -10322,6 +11449,36 @@
         "title": "DynamicToolOutputErrorPart",
         "description": "Dynamic tool part in output-error state."
       },
+      "Enforcement": {
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source"
+          }
+        },
+        "type": "object",
+        "required": [
+          "enabled",
+          "source"
+        ],
+        "title": "Enforcement"
+      },
+      "EnforcementResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Enforcement"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "EnforcementResponseBody"
+      },
       "Experiment": {
         "properties": {
           "id": {
@@ -11281,6 +12438,139 @@
         ],
         "title": "GetViewerResponseBody"
       },
+      "Grant": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/Subject"
+          },
+          "object_type": {
+            "$ref": "#/components/schemas/GrantObjectType"
+          },
+          "object_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Object Id"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "subject",
+          "object_type",
+          "object_id",
+          "role"
+        ],
+        "title": "Grant"
+      },
+      "GrantCreate": {
+        "properties": {
+          "subject": {
+            "$ref": "#/components/schemas/Subject"
+          },
+          "object_type": {
+            "$ref": "#/components/schemas/GrantObjectType"
+          },
+          "object_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Object Id"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          }
+        },
+        "type": "object",
+        "required": [
+          "subject",
+          "object_type"
+        ],
+        "title": "GrantCreate"
+      },
+      "GrantObjectType": {
+        "type": "string",
+        "enum": [
+          "project",
+          "dataset",
+          "prompt"
+        ],
+        "title": "GrantObjectType",
+        "description": "The grantable access roots. Containment children and eval artifacts are\nintentionally absent: their access is inherited from a parent, never granted directly."
+      },
+      "GrantResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Grant"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "GrantResponseBody"
+      },
+      "GrantSubjectKind": {
+        "type": "string",
+        "enum": [
+          "user",
+          "group",
+          "role",
+          "service_account",
+          "everyone"
+        ],
+        "title": "GrantSubjectKind",
+        "description": "Who a grant targets. ``everyone`` is the only kind with no id \u2014 a deliberate\n'make this object visible to all' grant, not a seeded baseline."
+      },
+      "GrantsResponseBody": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Grant"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "GrantsResponseBody"
+      },
       "GraphQLContext": {
         "properties": {
           "type": {
@@ -11300,6 +12590,73 @@
         ],
         "title": "GraphQLContext",
         "description": "GraphQL runtime state."
+      },
+      "GroupCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "GroupCreate"
+      },
+      "GroupData": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "member_user_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Member User Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "member_user_ids"
+        ],
+        "title": "GroupData"
+      },
+      "GroupResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/GroupData"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "GroupResponseBody"
+      },
+      "GroupsResponseBody": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/GroupData"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "GroupsResponseBody"
       },
       "HTTPValidationError": {
         "properties": {
@@ -11811,6 +13168,19 @@
           "auth_method"
         ],
         "title": "LocalUserData"
+      },
+      "MemberCreate": {
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "user_id"
+        ],
+        "title": "MemberCreate"
       },
       "ModelProvider": {
         "type": "string",
@@ -12460,6 +13830,53 @@
         "additionalProperties": false,
         "type": "object",
         "title": "OtlpStatus"
+      },
+      "PermissionSetData": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "is_built_in": {
+            "type": "boolean",
+            "title": "Is Built In"
+          },
+          "permissions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Permissions"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "is_built_in",
+          "permissions"
+        ],
+        "title": "PermissionSetData"
+      },
+      "PermissionSetsResponseBody": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PermissionSetData"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "PermissionSetsResponseBody"
       },
       "PlaygroundBuiltinModelContext": {
         "properties": {
@@ -14834,6 +16251,74 @@
         "title": "ReasoningUIPart",
         "description": "A reasoning part of a message."
       },
+      "ResourceTagBody": {
+        "properties": {
+          "value": {
+            "type": "string",
+            "title": "Value"
+          }
+        },
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "title": "ResourceTagBody"
+      },
+      "ResourceTagData": {
+        "properties": {
+          "object_type": {
+            "$ref": "#/components/schemas/GrantObjectType"
+          },
+          "object_id": {
+            "type": "string",
+            "title": "Object Id"
+          },
+          "key": {
+            "type": "string",
+            "title": "Key"
+          },
+          "value": {
+            "type": "string",
+            "title": "Value"
+          }
+        },
+        "type": "object",
+        "required": [
+          "object_type",
+          "object_id",
+          "key",
+          "value"
+        ],
+        "title": "ResourceTagData"
+      },
+      "ResourceTagResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ResourceTagData"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ResourceTagResponseBody"
+      },
+      "ResourceTagsResponseBody": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ResourceTagData"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ResourceTagsResponseBody"
+      },
       "ResponseBody_UpsertOrDeleteSecretsResult_": {
         "properties": {
           "data": {
@@ -15916,6 +17401,153 @@
         ],
         "title": "SubagentsContext",
         "description": "User's per-turn request to expose the subagent-spawning tool."
+      },
+      "Subject": {
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/GrantSubjectKind"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "kind"
+        ],
+        "title": "Subject"
+      },
+      "SubjectsResponseBody": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Subject"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "SubjectsResponseBody"
+      },
+      "TagGrant": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/Subject"
+          },
+          "object_type": {
+            "$ref": "#/components/schemas/GrantObjectType"
+          },
+          "tag_key": {
+            "type": "string",
+            "title": "Tag Key"
+          },
+          "tag_value": {
+            "type": "string",
+            "title": "Tag Value"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "subject",
+          "object_type",
+          "tag_key",
+          "tag_value",
+          "role"
+        ],
+        "title": "TagGrant"
+      },
+      "TagGrantCreate": {
+        "properties": {
+          "subject": {
+            "$ref": "#/components/schemas/Subject"
+          },
+          "object_type": {
+            "$ref": "#/components/schemas/GrantObjectType"
+          },
+          "tag_key": {
+            "type": "string",
+            "title": "Tag Key"
+          },
+          "tag_value": {
+            "type": "string",
+            "title": "Tag Value"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          }
+        },
+        "type": "object",
+        "required": [
+          "subject",
+          "object_type",
+          "tag_key",
+          "tag_value"
+        ],
+        "title": "TagGrantCreate"
+      },
+      "TagGrantResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TagGrant"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "TagGrantResponseBody"
+      },
+      "TagGrantsResponseBody": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TagGrant"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "TagGrantsResponseBody"
       },
       "TextContentPart": {
         "properties": {

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -49,6 +49,72 @@ CREATE TABLE public.languages (
 );
 
 
+-- Table: permission_sets
+-- ----------------------
+CREATE TABLE public.permission_sets (
+    id serial NOT NULL,
+    name VARCHAR NOT NULL,
+    is_built_in BOOLEAN NOT NULL DEFAULT true,
+    CONSTRAINT pk_permission_sets PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX ix_permission_sets_name ON public.permission_sets
+    USING btree (name);
+
+
+-- Table: acls
+-- -----------
+CREATE TABLE public.acls (
+    id serial NOT NULL,
+    subject_kind VARCHAR NOT NULL,
+    subject_id INTEGER,
+    role_id INTEGER,
+    object_type VARCHAR NOT NULL,
+    object_id INTEGER,
+    selector_kind VARCHAR NOT NULL DEFAULT 'ids'::character varying,
+    tag_key VARCHAR,
+    tag_value VARCHAR,
+    effect VARCHAR NOT NULL DEFAULT 'allow'::character varying,
+    CONSTRAINT pk_acls PRIMARY KEY (id),
+    CHECK ((((object_type)::text <> '*'::text) OR ((selector_kind)::text = 'all'::text))),
+    CONSTRAINT fk_acls_role_id_permission_sets FOREIGN KEY
+        (role_id)
+        REFERENCES public.permission_sets (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_acls_object_access_lookup ON public.acls
+    USING btree (effect, object_type, object_id, selector_kind);
+CREATE INDEX ix_acls_object_type_object_id ON public.acls
+    USING btree (object_type, object_id);
+CREATE INDEX ix_acls_subject_access_lookup ON public.acls
+    USING btree (effect, subject_kind, subject_id, object_type, selector_kind, object_id);
+CREATE INDEX ix_acls_subject_kind_subject_id ON public.acls
+    USING btree (subject_kind, subject_id);
+
+
+-- Table: permission_set_items
+-- ---------------------------
+CREATE TABLE public.permission_set_items (
+    id serial NOT NULL,
+    permission_set_id INTEGER NOT NULL,
+    permission VARCHAR NOT NULL,
+    CONSTRAINT pk_permission_set_items PRIMARY KEY (id),
+    CONSTRAINT uq_permission_set_items_permission_set_id_permission
+        UNIQUE (permission_set_id, permission),
+    CONSTRAINT fk_permission_set_items_permission_set_id_permission_sets
+        FOREIGN KEY
+        (permission_set_id)
+        REFERENCES public.permission_sets (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_permission_set_items_permission_permission_set_id ON public.permission_set_items
+    USING btree (permission, permission_set_id);
+CREATE INDEX ix_permission_set_items_permission_set_id ON public.permission_set_items
+    USING btree (permission_set_id);
+
+
 -- Table: project_trace_retention_policies
 -- ---------------------------------------
 CREATE TABLE public.project_trace_retention_policies (
@@ -71,6 +137,7 @@ CREATE TABLE public.projects (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     trace_retention_policy_id INTEGER,
+    kind VARCHAR NOT NULL DEFAULT 'TELEMETRY'::character varying,
     CONSTRAINT pk_projects PRIMARY KEY (id),
     CONSTRAINT uq_projects_name
         UNIQUE (name),
@@ -81,6 +148,8 @@ CREATE TABLE public.projects (
         ON DELETE SET NULL
 );
 
+CREATE INDEX ix_projects_kind ON public.projects
+    USING btree (kind);
 CREATE INDEX ix_projects_trace_retention_policy_id ON public.projects
     USING btree (trace_retention_policy_id);
 
@@ -121,8 +190,8 @@ CREATE TABLE public.project_sessions (
     start_time TIMESTAMP WITH TIME ZONE NOT NULL,
     end_time TIMESTAMP WITH TIME ZONE NOT NULL,
     CONSTRAINT pk_project_sessions PRIMARY KEY (id),
-    CONSTRAINT uq_project_sessions_session_id
-        UNIQUE (session_id),
+    CONSTRAINT uq_project_sessions_project_id_session_id
+        UNIQUE (project_id, session_id),
     CONSTRAINT fk_project_sessions_project_id_projects FOREIGN KEY
         (project_id)
         REFERENCES public.projects (id)
@@ -353,16 +422,49 @@ CREATE INDEX ix_span_cost_details_token_type ON public.span_cost_details
     USING btree (token_type);
 
 
+-- Table: user_groups
+-- ------------------
+CREATE TABLE public.user_groups (
+    id serial NOT NULL,
+    provider VARCHAR NOT NULL,
+    group_key VARCHAR NOT NULL,
+    display_name VARCHAR,
+    CONSTRAINT pk_user_groups PRIMARY KEY (id),
+    CONSTRAINT uq_user_groups_provider_group_key
+        UNIQUE (provider, group_key)
+);
+
+
 -- Table: user_roles
 -- -----------------
 CREATE TABLE public.user_roles (
     id serial NOT NULL,
     name VARCHAR NOT NULL,
+    is_built_in BOOLEAN NOT NULL DEFAULT true,
     CONSTRAINT pk_user_roles PRIMARY KEY (id)
 );
 
 CREATE UNIQUE INDEX ix_user_roles_name ON public.user_roles
     USING btree (name);
+
+
+-- Table: role_permissions
+-- -----------------------
+CREATE TABLE public.role_permissions (
+    id serial NOT NULL,
+    user_role_id INTEGER NOT NULL,
+    permission VARCHAR NOT NULL,
+    CONSTRAINT pk_role_permissions PRIMARY KEY (id),
+    CONSTRAINT uq_role_permissions_user_role_id_permission
+        UNIQUE (user_role_id, permission),
+    CONSTRAINT fk_role_permissions_user_role_id_user_roles FOREIGN KEY
+        (user_role_id)
+        REFERENCES public.user_roles (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_role_permissions_user_role_id ON public.role_permissions
+    USING btree (user_role_id);
 
 
 -- Table: users
@@ -420,6 +522,7 @@ CREATE TABLE public.api_keys (
     description VARCHAR,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     expires_at TIMESTAMP WITH TIME ZONE,
+    scope VARCHAR,
     CONSTRAINT pk_api_keys PRIMARY KEY (id),
     CONSTRAINT fk_api_keys_user_id_users FOREIGN KEY
         (user_id)
@@ -778,11 +881,11 @@ CREATE TABLE public.experiments (
     description VARCHAR,
     repetitions INTEGER NOT NULL,
     metadata JSONB NOT NULL,
-    project_name VARCHAR,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     user_id BIGINT,
     is_ephemeral BOOLEAN NOT NULL DEFAULT false,
+    project_id INTEGER,
     CONSTRAINT pk_experiments PRIMARY KEY (id),
     CONSTRAINT fk_experiments_dataset_id_datasets FOREIGN KEY
         (dataset_id)
@@ -793,6 +896,10 @@ CREATE TABLE public.experiments (
         (dataset_version_id)
         REFERENCES public.dataset_versions (id)
         ON DELETE CASCADE,
+    CONSTRAINT fk_experiments_project_id_projects FOREIGN KEY
+        (project_id)
+        REFERENCES public.projects (id)
+        ON DELETE SET NULL,
     CONSTRAINT fk_experiments_user_id_users FOREIGN KEY
         (user_id)
         REFERENCES public.users (id)
@@ -805,8 +912,8 @@ CREATE INDEX ix_experiments_dataset_version_id ON public.experiments
     USING btree (dataset_version_id);
 CREATE INDEX ix_experiments_ephemeral_updated_at ON public.experiments
     USING btree (updated_at) WHERE (is_ephemeral IS TRUE);
-CREATE INDEX ix_experiments_project_name ON public.experiments
-    USING btree (project_name);
+CREATE INDEX ix_experiments_project_id ON public.experiments
+    USING btree (project_id);
 
 
 -- Table: experiment_jobs
@@ -1382,6 +1489,31 @@ CREATE INDEX ix_access_tokens_user_id ON public.access_tokens
     USING btree (user_id);
 
 
+-- Table: resource_tags
+-- --------------------
+CREATE TABLE public.resource_tags (
+    id serial NOT NULL,
+    object_type VARCHAR NOT NULL,
+    object_id INTEGER NOT NULL,
+    key VARCHAR NOT NULL,
+    value VARCHAR NOT NULL,
+    created_by INTEGER,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    CONSTRAINT pk_resource_tags PRIMARY KEY (id),
+    CONSTRAINT uq_resource_tags_object_type_object_id_key
+        UNIQUE (object_type, object_id, key),
+    CONSTRAINT fk_resource_tags_created_by_users FOREIGN KEY
+        (created_by)
+        REFERENCES public.users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_resource_tags_object_type_key_value ON public.resource_tags
+    USING btree (object_type, key, value);
+CREATE INDEX ix_resource_tags_object_type_object_id ON public.resource_tags
+    USING btree (object_type, object_id);
+
+
 -- Table: sandbox_providers
 -- ------------------------
 CREATE TABLE public.sandbox_providers (
@@ -1616,3 +1748,24 @@ CREATE TABLE public.trace_annotations (
 
 CREATE INDEX ix_trace_annotations_trace_rowid ON public.trace_annotations
     USING btree (trace_rowid);
+
+
+-- Table: user_group_memberships
+-- -----------------------------
+CREATE TABLE public.user_group_memberships (
+    user_group_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    CONSTRAINT pk_user_group_memberships PRIMARY KEY (user_group_id, user_id),
+    CONSTRAINT fk_user_group_memberships_user_group_id_user_groups
+        FOREIGN KEY
+        (user_group_id)
+        REFERENCES public.user_groups (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_user_group_memberships_user_id_users FOREIGN KEY
+        (user_id)
+        REFERENCES public.users (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_user_group_memberships_user_id ON public.user_group_memberships
+    USING btree (user_id);

--- a/scripts/docker/devops/docker-compose.yml
+++ b/scripts/docker/devops/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - PHOENIX_SQL_DATABASE_URL=postgresql://postgres:postgres@db:5433/postgres
       - PHOENIX_ENABLE_PROMETHEUS=true
       - PHOENIX_LOG_LEVEL=DEBUG
+      - PHOENIX_MASK_INTERNAL_SERVER_ERRORS=false
       - PHOENIX_HOST_ROOT_PATH=/phoenix
       - PHOENIX_ROOT_URL=http://localhost:18273/phoenix
       - PYTHONDONTWRITEBYTECODE=1
@@ -61,6 +62,7 @@ services:
       - PHOENIX_SECRET=phoenix-secret-abc-123-for-development-only-not-secure
       - PHOENIX_ADMIN_SECRET=phoenix-admin-secret-abc-123-for-development-only-not-secure
       - PHOENIX_ADMINS=TestUser=testuser@arize.com
+      - PHOENIX_ACCESS_CONTROL_ENABLED=true
       - PHOENIX_OAUTH2_DEV_CLIENT_ID=phoenix-oidc-client-id
       - PHOENIX_OAUTH2_DEV_CLIENT_SECRET=phoenix-oidc-client-secret-abc-123
       - PHOENIX_OAUTH2_DEV_OIDC_CONFIG_URL=http://localhost:18273/oidc/.well-known/openid-configuration
@@ -131,7 +133,8 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     expose:
       - "9000"
     volumes:

--- a/scripts/docker/devops/oidc-server/src/database/client.ts
+++ b/scripts/docker/devops/oidc-server/src/database/client.ts
@@ -15,54 +15,88 @@ export class DatabaseClient {
   private static readonly FAST_POLL_MS = 500; // 500ms when waiting for migrations
   private static readonly NORMAL_POLL_MS = 5000; // 5 seconds once tables are ready
 
-  private client: Client;
+  private client: Client | null = null;
   private connected = false;
   private tablesReady = false;
   private users: User[] = [];
   private pollingInterval: NodeJS.Timeout | null = null;
 
   constructor() {
-    this.client = new Client({
+    this.client = this.createClient();
+    this.users = [DatabaseClient.DEFAULT_USER];
+  }
+
+  private createClient(): Client {
+    return new Client({
       host: process.env.DB_HOST || "db",
       port: parseInt(process.env.DB_PORT || "5432"),
       database: process.env.DB_NAME || "postgres",
       user: process.env.DB_USER || "postgres",
       password: process.env.DB_PASSWORD || "postgres",
     });
-    this.users = [DatabaseClient.DEFAULT_USER];
   }
 
   async connect(): Promise<void> {
     try {
-      await this.client.connect();
-      this.connected = true;
-      const dbConnected = {
-        timestamp: new Date().toISOString(),
-        event: "database_connected",
-        host: process.env.DB_HOST || "db",
-        port: parseInt(process.env.DB_PORT || "5432"),
-        database: process.env.DB_NAME || "postgres",
-      };
-      console.log(JSON.stringify(dbConnected));
-
+      await this.connectClient({ event: "database_connected" });
       await this.fetchUsers();
       this.startPolling();
     } catch (error) {
-      const dbConnectionFailed = {
-        timestamp: new Date().toISOString(),
+      this.logConnectionFailure({
         event: "database_connection_failed",
-        error: error instanceof Error ? error.message : String(error),
-        host: process.env.DB_HOST || "db",
-        port: parseInt(process.env.DB_PORT || "5432"),
-      };
-      console.log(JSON.stringify(dbConnectionFailed));
-
+        error,
+        action: "falling_back_to_default_user",
+      });
+      this.disposeClient();
       this.fallbackToNoUsers();
     }
   }
 
+  private async connectClient({ event }: { event: string }): Promise<void> {
+    if (!this.client) {
+      this.client = this.createClient();
+    }
+
+    await this.client.connect();
+    this.connected = true;
+
+    const dbConnected = {
+      timestamp: new Date().toISOString(),
+      event,
+      host: process.env.DB_HOST || "db",
+      port: parseInt(process.env.DB_PORT || "5432"),
+      database: process.env.DB_NAME || "postgres",
+    };
+    console.log(JSON.stringify(dbConnected));
+  }
+
+  private disposeClient(): void {
+    this.connected = false;
+    this.client = null;
+  }
+
+  private logConnectionFailure({
+    event,
+    error,
+    action,
+  }: {
+    event: string;
+    error: unknown;
+    action: string;
+  }): void {
+    const dbConnectionFailed = {
+      timestamp: new Date().toISOString(),
+      event,
+      error: error instanceof Error ? error.message : String(error),
+      host: process.env.DB_HOST || "db",
+      port: parseInt(process.env.DB_PORT || "5432"),
+      action,
+    };
+    console.log(JSON.stringify(dbConnectionFailed));
+  }
+
   private async fetchUsers(): Promise<void> {
-    if (!this.connected) {
+    if (!this.connected || !this.client) {
       const dbNotConnected = {
         timestamp: new Date().toISOString(),
         event: "database_fetch_skipped",
@@ -197,7 +231,24 @@ export class DatabaseClient {
           action: "keeping_existing_users",
         };
         console.log(JSON.stringify(dbQueryFailed));
+        this.disposeClient();
       }
+    }
+  }
+
+  private async pollUsers(): Promise<void> {
+    try {
+      if (!this.connected) {
+        await this.connectClient({ event: "database_reconnected" });
+      }
+      await this.fetchUsers();
+    } catch (error) {
+      this.logConnectionFailure({
+        event: "database_reconnect_failed",
+        error,
+        action: "retrying_on_next_poll",
+      });
+      this.disposeClient();
     }
   }
 
@@ -207,9 +258,7 @@ export class DatabaseClient {
       ? DatabaseClient.NORMAL_POLL_MS
       : DatabaseClient.FAST_POLL_MS;
 
-    this.pollingInterval = setInterval(async () => {
-      await this.fetchUsers();
-    }, intervalMs);
+    this.pollingInterval = setInterval(() => void this.pollUsers(), intervalMs);
 
     const pollingStarted = {
       timestamp: new Date().toISOString(),
@@ -227,9 +276,7 @@ export class DatabaseClient {
       clearInterval(this.pollingInterval);
     }
 
-    this.pollingInterval = setInterval(async () => {
-      await this.fetchUsers();
-    }, intervalMs);
+    this.pollingInterval = setInterval(() => void this.pollUsers(), intervalMs);
 
     const pollingRestarted = {
       timestamp: new Date().toISOString(),
@@ -253,27 +300,10 @@ export class DatabaseClient {
     };
     console.log(JSON.stringify(fallbackMode));
 
-    setInterval(async () => {
-      if (!this.connected) {
-        try {
-          await this.client.connect();
-          this.connected = true;
-
-          const dbReconnected = {
-            timestamp: new Date().toISOString(),
-            event: "database_reconnected",
-            action: "resuming_user_fetch",
-          };
-          console.log(JSON.stringify(dbReconnected));
-
-          await this.fetchUsers();
-        } catch {
-          // Reconnection will be retried on next poll
-        }
-      } else {
-        await this.fetchUsers();
-      }
-    }, DatabaseClient.FAST_POLL_MS);
+    this.pollingInterval = setInterval(
+      () => void this.pollUsers(),
+      DatabaseClient.FAST_POLL_MS
+    );
   }
 
   private getGroupsForUser(row: { role_name?: string }): string[] {
@@ -312,7 +342,7 @@ export class DatabaseClient {
     if (this.pollingInterval) {
       clearInterval(this.pollingInterval);
     }
-    if (this.connected) {
+    if (this.connected && this.client) {
       await this.client.end();
       this.connected = false;
 

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -354,6 +354,14 @@ ENV_PHOENIX_DISABLE_BASIC_AUTH = "PHOENIX_DISABLE_BASIC_AUTH"
 Forbid login via password and disable the creation of local users, which log in via passwords.
 This can be helpful in setups where authentication is handled entirely through OAUTH2.
 """
+ENV_PHOENIX_ACCESS_CONTROL_ENABLED = "PHOENIX_ACCESS_CONTROL_ENABLED"
+"""
+Enforce per-resource access grants. Off by default: every authenticated user
+sees every resource, exactly as before. Turning it on flips the default to
+deny — only resources reachable through an authored grant (or the seeded
+everyone-allow default) are visible. Schema and grant authoring exist
+regardless; this flag only gates enforcement.
+"""
 ENV_PHOENIX_ALLOWED_PROVIDERS = "PHOENIX_ALLOWED_PROVIDERS"
 """
 Comma-separated list of provider names to show in the UI.
@@ -1160,6 +1168,15 @@ def get_env_enable_auth() -> bool:
     Gets the value of the PHOENIX_ENABLE_AUTH environment variable.
     """
     return _bool_val(ENV_PHOENIX_ENABLE_AUTH, False)
+
+
+def get_env_access_control_enabled() -> bool:
+    """
+    Gets the value of the PHOENIX_ACCESS_CONTROL_ENABLED environment variable.
+    When false (the default), per-resource access control is not enforced and
+    every authenticated user can see every resource.
+    """
+    return _bool_val(ENV_PHOENIX_ACCESS_CONTROL_ENABLED, False)
 
 
 def get_env_disable_basic_auth() -> bool:

--- a/src/phoenix/db/facilitator.py
+++ b/src/phoenix/db/facilitator.py
@@ -9,10 +9,13 @@ from asyncio import gather
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from pathlib import Path
-from typing import NamedTuple, Optional, Union
+from typing import Any, Mapping, NamedTuple, Optional, Sequence, Union
 
 import sqlalchemy as sa
-from sqlalchemy import select
+from sqlalchemy import Executable, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import InstrumentedAttribute, joinedload
 from sqlalchemy.sql.dml import ReturningDelete
 
@@ -26,11 +29,14 @@ from phoenix.auth import (
     compute_password_hash,
 )
 from phoenix.config import (
+    ENV_PHOENIX_ENABLE_AUTH,
     LDAPConfig,
+    get_env_access_control_enabled,
     get_env_admins,
     get_env_default_admin_initial_password,
     get_env_default_retention_policy_days,
     get_env_disable_basic_auth,
+    get_env_enable_auth,
     get_env_oauth2_settings,
 )
 from phoenix.db import models
@@ -47,12 +53,42 @@ from phoenix.db.types.trace_retention import (
     TraceRetentionCronExpression,
     TraceRetentionRule,
 )
+from phoenix.server.access import (
+    ACCESS_CONTROL_ENABLED_KEY,
+    BUILTIN_PERMISSION_SETS,
+    BUILTIN_ROLE_PERMISSIONS,
+)
 from phoenix.server.email.types import WelcomeEmailSender
 from phoenix.server.types import DbSessionFactory
 
 logger = logging.getLogger(__name__)
 
 USER_FEEDBACK_ANNOTATION_NAME = "user_feedback"
+
+
+def _insert_on_conflict_do_nothing(
+    session: AsyncSession,
+    table: type[models.Base],
+    values: Sequence[Mapping[str, Any]],
+    unique_columns: Sequence[str],
+) -> Executable:
+    bind = session.bind
+    if bind is None:
+        raise RuntimeError("Session has no bound engine; cannot determine SQL dialect.")
+    dialect_name = bind.dialect.name
+    if dialect_name == "postgresql":
+        return (
+            pg_insert(table)
+            .values(list(values))
+            .on_conflict_do_nothing(index_elements=list(unique_columns))
+        )
+    if dialect_name == "sqlite":
+        return (
+            sqlite_insert(table)
+            .values(list(values))
+            .on_conflict_do_nothing(index_elements=list(unique_columns))
+        )
+    raise ValueError(f"Unsupported SQL dialect for facilitator sync: {dialect_name}")
 
 
 class Facilitator:
@@ -76,6 +112,9 @@ class Facilitator:
         for fn in (
             _ensure_enums,
             _ensure_user_roles,
+            _ensure_role_permissions,
+            _ensure_permission_sets,
+            _ensure_access_control_latch,
             _get_system_user_id,
             partial(_ensure_admins, email_sender=self._email_sender),
             _ensure_default_project_trace_retention_policy,
@@ -157,6 +196,170 @@ async def _ensure_user_roles(db: DbSessionFactory) -> None:
         await session.flush()
 
 
+async def _ensure_role_permissions(db: DbSessionFactory) -> None:
+    """
+    Ensure every built-in role's permission rows match its bundle in
+    phoenix.server.access. Idempotent: missing rows are inserted and stray rows
+    on built-in roles are removed, so the database is the persisted form of the
+    constant. Runs on every boot, so an upgraded database gains the rows without
+    a data migration and every user keeps exactly the access they had.
+    """
+    async with db() as session:
+        role_ids: dict[str, int] = {
+            name: id_
+            async for name, id_ in await session.stream(
+                sa.select(models.UserRole.name, models.UserRole.id)
+            )
+        }
+        existing: set[tuple[int, str]] = {
+            (role_id, permission)
+            async for role_id, permission in await session.stream(
+                sa.select(
+                    models.RolePermission.user_role_id,
+                    models.RolePermission.permission,
+                )
+            )
+        }
+        to_insert: list[dict[str, Union[int, str]]] = []
+        for role_name, permissions in BUILTIN_ROLE_PERMISSIONS.items():
+            if (role_id := role_ids.get(role_name)) is None:
+                continue
+            desired = {permission.value for permission in permissions}
+            current = {permission for rid, permission in existing if rid == role_id}
+            for permission in desired - current:
+                to_insert.append({"user_role_id": role_id, "permission": permission})
+            if stray := current - desired:
+                await session.execute(
+                    sa.delete(models.RolePermission).where(
+                        models.RolePermission.user_role_id == role_id,
+                        models.RolePermission.permission.in_(stray),
+                    )
+                )
+        if to_insert:
+            await session.execute(
+                _insert_on_conflict_do_nothing(
+                    session,
+                    models.RolePermission,
+                    to_insert,
+                    unique_columns=["user_role_id", "permission"],
+                )
+            )
+
+
+async def _ensure_permission_sets(db: DbSessionFactory) -> None:
+    """
+    Ensure the built-in permission sets (Resource Viewer/Editor/Manager) and their
+    permissions exist and match their bundles. Idempotent and drift-repairing,
+    like the global role seeding. Custom permission sets live alongside and are left
+    untouched.
+    """
+    async with db() as session:
+        await session.execute(
+            _insert_on_conflict_do_nothing(
+                session,
+                models.PermissionSet,
+                [{"name": role_name, "is_built_in": True} for role_name in BUILTIN_PERMISSION_SETS],
+                unique_columns=["name"],
+            )
+        )
+        role_ids: dict[str, int] = {
+            name: id_
+            async for name, id_ in await session.stream(
+                sa.select(models.PermissionSet.name, models.PermissionSet.id)
+            )
+        }
+        existing: set[tuple[int, str]] = {
+            (role_id, permission)
+            async for role_id, permission in await session.stream(
+                sa.select(
+                    models.PermissionSetItem.permission_set_id,
+                    models.PermissionSetItem.permission,
+                )
+            )
+        }
+        to_insert: list[dict[str, Union[int, str]]] = []
+        for role_name, permissions in BUILTIN_PERMISSION_SETS.items():
+            if (role_id := role_ids.get(role_name)) is None:
+                raise RuntimeError(f"Missing built-in permission set: {role_name}")
+            desired = {permission.value for permission in permissions}
+            current = {permission for rid, permission in existing if rid == role_id}
+            for permission in desired - current:
+                to_insert.append({"permission_set_id": role_id, "permission": permission})
+            if stray := current - desired:
+                await session.execute(
+                    sa.delete(models.PermissionSetItem).where(
+                        models.PermissionSetItem.permission_set_id == role_id,
+                        models.PermissionSetItem.permission.in_(stray),
+                    )
+                )
+        if to_insert:
+            await session.execute(
+                _insert_on_conflict_do_nothing(
+                    session,
+                    models.PermissionSetItem,
+                    to_insert,
+                    unique_columns=["permission_set_id", "permission"],
+                )
+            )
+
+
+async def _ensure_access_control_latch(db: DbSessionFactory) -> None:
+    """Bootstrap and guard the access-control activation latch at startup.
+
+    ``PHOENIX_ACCESS_CONTROL_ENABLED`` is a *one-way switch*. When set, it turns
+    the DB-latched ``access_control.enabled`` setting on — but only if the latch
+    has never been set, so it can only ever *enable*, never disable, and once the
+    latch row exists the env var stops bootstrapping. The running app exposes no
+    runtime enable/disable path; changing the latch is an operator action that
+    takes effect on a subsequent startup.
+
+    Drift guard: if the env switch is *falsey* while access control is **on**, the
+    deployment has lost its declared switch (config drift, a dropped var). Rather
+    than run in that inconsistent state, refuse to start and make the operator
+    re-assert the switch. Disabling access control is not an in-process operation;
+    the latch must be changed out of band before startup.
+
+    Authentication guard: access control presupposes authentication. Every access
+    decision is keyed on an authenticated user identity; with auth off there is no
+    such identity, so enforcement degrades to allow-all — a silent no-op that looks
+    like it is enforcing but is not. Refuse to start with access control on and auth
+    off rather than offer that false assurance. Idempotent.
+    """
+    env_enabled = get_env_access_control_enabled()
+    auth_enabled = get_env_enable_auth()
+    async with db() as session:
+        value = await session.scalar(
+            sa.select(models.SystemSetting.value).where(
+                models.SystemSetting.key == ACCESS_CONTROL_ENABLED_KEY
+            )
+        )
+        latched_on = isinstance(value, dict) and bool(value.get("enabled", False))
+        bootstrapping_on = value is None and env_enabled
+        if (latched_on or bootstrapping_on) and not auth_enabled:
+            raise RuntimeError(
+                "Access control is enabled but authentication is not "
+                f"({ENV_PHOENIX_ENABLE_AUTH} is falsey). Access decisions require an "
+                "authenticated user; with authentication off, enforcement silently allows "
+                "everything. Enable authentication, or disable access control."
+            )
+        if env_enabled and value is None:
+            await session.execute(
+                _insert_on_conflict_do_nothing(
+                    session,
+                    models.SystemSetting,
+                    [{"key": ACCESS_CONTROL_ENABLED_KEY, "value": {"enabled": True}}],
+                    unique_columns=["key"],
+                )
+            )
+        elif latched_on and not env_enabled:
+            raise RuntimeError(
+                "PHOENIX_ACCESS_CONTROL_ENABLED is falsey but access control is enabled "
+                "(the access_control.enabled latch is on). Refusing to start in this "
+                "inconsistent state. Set PHOENIX_ACCESS_CONTROL_ENABLED to re-assert the "
+                "switch, or change the latch out of band before startup."
+            )
+
+
 async def _get_system_user_id(db: DbSessionFactory) -> None:
     """
     Set the system user ID in the config. This is used to identify the system user in the database.
@@ -182,25 +385,25 @@ async def _ensure_user_feedback_annotation_config(db: DbSessionFactory) -> None:
     does not overwrite user data if a deployment already has a config with that name.
     """
     async with db() as session:
-        existing_config_id = await session.scalar(
-            sa.select(models.AnnotationConfig.id).where(
-                models.AnnotationConfig.name == USER_FEEDBACK_ANNOTATION_NAME
-            )
-        )
-        if existing_config_id is not None:
-            return
-        session.add(
-            models.AnnotationConfig(
-                name=USER_FEEDBACK_ANNOTATION_NAME,
-                config=CategoricalAnnotationConfig(
-                    type=AnnotationType.CATEGORICAL.value,
-                    description="User feedback labels for traces.",
-                    optimization_direction=OptimizationDirection.MAXIMIZE,
-                    values=[
-                        CategoricalAnnotationValue(label="positive", score=1.0),
-                        CategoricalAnnotationValue(label="negative", score=0.0),
-                    ],
-                ),
+        await session.execute(
+            _insert_on_conflict_do_nothing(
+                session,
+                models.AnnotationConfig,
+                [
+                    {
+                        "name": USER_FEEDBACK_ANNOTATION_NAME,
+                        "config": CategoricalAnnotationConfig(
+                            type=AnnotationType.CATEGORICAL.value,
+                            description="User feedback labels for traces.",
+                            optimization_direction=OptimizationDirection.MAXIMIZE,
+                            values=[
+                                CategoricalAnnotationValue(label="positive", score=1.0),
+                                CategoricalAnnotationValue(label="negative", score=0.0),
+                            ],
+                        ),
+                    }
+                ],
+                unique_columns=["name"],
             )
         )
 
@@ -388,29 +591,24 @@ async def _ensure_default_project_trace_retention_policy(db: DbSessionFactory) -
     """
     assert DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID == 0
     async with db() as session:
-        if await session.scalar(
-            sa.select(
-                sa.exists().where(
-                    models.ProjectTraceRetentionPolicy.id
-                    == DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID
-                )
-            )
-        ):
-            return
         cron_expression = TraceRetentionCronExpression(root="0 0 * * 0")
         rule = TraceRetentionRule(
             root=MaxDaysRule(max_days=get_env_default_retention_policy_days())
         )
         await session.execute(
-            sa.insert(models.ProjectTraceRetentionPolicy),
-            [
-                {
-                    "id": DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID,
-                    "name": "Default",
-                    "cron_expression": cron_expression,
-                    "rule": rule,
-                }
-            ],
+            _insert_on_conflict_do_nothing(
+                session,
+                models.ProjectTraceRetentionPolicy,
+                [
+                    {
+                        "id": DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID,
+                        "name": "Default",
+                        "cron_expression": cron_expression,
+                        "rule": rule,
+                    }
+                ],
+                unique_columns=["id"],
+            )
         )
 
 

--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -27,7 +27,6 @@ from sqlalchemy.orm import QueryableAttribute, aliased
 from sqlalchemy.sql.roles import InElementRole
 from typing_extensions import assert_never
 
-from phoenix.config import PLAYGROUND_PROJECT_NAME
 from phoenix.db import models
 
 
@@ -395,22 +394,15 @@ _AnyTuple = TypeVar("_AnyTuple", bound=tuple[Any, ...])
 def exclude_experiment_projects(
     stmt: Select[_AnyTuple],
 ) -> Select[_AnyTuple]:
-    return stmt.outerjoin(
-        models.Experiment,
-        and_(
-            models.Project.name == models.Experiment.project_name,
-            models.Experiment.project_name != PLAYGROUND_PROJECT_NAME,
-        ),
-    ).where(models.Experiment.project_name.is_(None))
+    # Hide-internal by the server-set kind discriminator rather than a name
+    # pattern + outerjoin. Playground (kind=PLAYGROUND) stays visible, as before.
+    return stmt.where(models.Project.kind != "EXPERIMENT")
 
 
 def exclude_dataset_evaluator_projects(
     stmt: Select[_AnyTuple],
 ) -> Select[_AnyTuple]:
-    return stmt.outerjoin(
-        models.DatasetEvaluators,
-        models.Project.id == models.DatasetEvaluators.project_id,
-    ).where(models.DatasetEvaluators.project_id.is_(None))
+    return stmt.where(models.Project.kind != "EVALUATOR")
 
 
 def date_trunc(

--- a/src/phoenix/db/insertion/span.py
+++ b/src/phoenix/db/insertion/span.py
@@ -74,8 +74,11 @@ async def insert_span(
             select(models.ProjectSession).filter_by(id=trace.project_session_rowid)
         )
     elif session_id:
+        # Resolve the session *within this project*. session_id values collide
+        # across projects (e.g. "default", a conversation id), so a global lookup
+        # would attach this trace to another project's session.
         project_session = await session.scalar(
-            select(models.ProjectSession).filter_by(session_id=session_id)
+            select(models.ProjectSession).filter_by(project_id=project_rowid, session_id=session_id)
         ) or models.ProjectSession(session_id=session_id)
 
     if project_session is not None:

--- a/src/phoenix/db/migrations/versions/f7a3c1e9d2b4_add_access_control.py
+++ b/src/phoenix/db/migrations/versions/f7a3c1e9d2b4_add_access_control.py
@@ -1,0 +1,351 @@
+"""add per-resource access control
+
+Revision ID: f7a3c1e9d2b4
+Revises: d4e5f6a7b8c9
+Create Date: 2026-06-14 00:00:00.000000
+
+The schema for per-resource access control, in one migration:
+
+- scope session uniqueness to (project_id, session_id) instead of session_id
+  alone, so two projects can each have a session with the same id.
+- roles as data: role_permissions + user_roles.is_built_in.
+- subjects: user_groups + user_group_memberships (IdP/LDAP groups).
+- permission sets: permission_sets + permission_set_items.
+- grants: the acls table + a durable scope column on api_keys.
+- a server-set ``kind`` discriminator on projects (TELEMETRY / PLAYGROUND /
+  EXPERIMENT / EVALUATOR), backfilled for existing rows, dispatching per-kind
+  access policy and replacing the name-pattern + exclude_* heuristics.
+- a ``project_id`` FK on experiments, the durable link for access-by-parent,
+  backfilled from the existing ``project_name``.
+
+Schema only — built-in role bundles and the built-in permission sets are seeded
+idempotently at startup by the Facilitator. The model is fail-closed and
+monotonic (admin-only by default; grants only add), so there is no everyone-allow
+default to seed. Enforcement is driven by a DB-latched ``access_control.enabled``
+system setting (the sole source of truth, off by default), which
+PHOENIX_ACCESS_CONTROL_ENABLED can only ever *bootstrap on* (a one-way switch);
+so this migration changes no behavior.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f7a3c1e9d2b4"
+down_revision: Union[str, None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_UQ_COMPOSITE = "uq_project_sessions_project_id_session_id"
+_UQ_SINGLE = "uq_project_sessions_session_id"
+
+# Lets batch_alter_table render a deterministic name for the reflected,
+# originally-unnamed unique constraint so it can be dropped on SQLite.
+_NAMING = {"uq": "uq_%(table_name)s_%(column_0_N_name)s"}
+
+
+def upgrade() -> None:
+    _scope_sessions_to_project()
+
+    # roles as data
+    op.create_table(
+        "role_permissions",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "user_role_id",
+            sa.Integer,
+            sa.ForeignKey("user_roles.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("permission", sa.String, nullable=False),
+        sa.UniqueConstraint(
+            "user_role_id",
+            "permission",
+            name="uq_role_permissions_user_role_id_permission",
+        ),
+    )
+    with op.batch_alter_table("user_roles") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "is_built_in",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.true(),
+            ),
+        )
+
+    # subjects: groups
+    op.create_table(
+        "user_groups",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("provider", sa.String, nullable=False),
+        sa.Column("group_key", sa.String, nullable=False),
+        sa.Column("display_name", sa.String, nullable=True),
+        sa.UniqueConstraint("provider", "group_key", name="uq_user_groups_provider_group_key"),
+    )
+    op.create_table(
+        "user_group_memberships",
+        # The natural key (user_group_id, user_id) is the primary key — a membership is just
+        # the pair, so a surrogate id would only add a second index. user_group_id needs no
+        # separate index (it is the PK's leftmost column); user_id does (it is not a PK prefix).
+        sa.Column(
+            "user_group_id",
+            sa.Integer,
+            sa.ForeignKey("user_groups.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+            index=True,
+        ),
+    )
+
+    # permission sets (what a grant confers on its object)
+    op.create_table(
+        "permission_sets",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String, nullable=False, unique=True, index=True),
+        sa.Column("is_built_in", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.create_table(
+        "permission_set_items",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "permission_set_id",
+            sa.Integer,
+            sa.ForeignKey("permission_sets.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("permission", sa.String, nullable=False),
+        sa.UniqueConstraint(
+            "permission_set_id",
+            "permission",
+            name="uq_permission_set_items_permission_set_id_permission",
+        ),
+    )
+    op.create_index(
+        "ix_permission_set_items_permission_permission_set_id",
+        "permission_set_items",
+        ["permission", "permission_set_id"],
+    )
+
+    # grants
+    op.create_table(
+        "acls",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("subject_kind", sa.String, nullable=False),
+        sa.Column("subject_id", sa.Integer, nullable=True),
+        sa.Column(
+            "role_id",
+            sa.Integer,
+            sa.ForeignKey("permission_sets.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("object_type", sa.String, nullable=False),
+        sa.Column("object_id", sa.Integer, nullable=True),
+        sa.Column("selector_kind", sa.String, nullable=False, server_default="ids"),
+        # Attribute (tag) selector: set only when selector_kind='tag'. A tag grant
+        # reaches every object of its type carrying this exact key=value (see
+        # resource_tags); NULL for id/all grants.
+        sa.Column("tag_key", sa.String, nullable=True),
+        sa.Column("tag_value", sa.String, nullable=True),
+        sa.Column("effect", sa.String, nullable=False, server_default="allow"),
+        # A wildcard object_type ('*' = all types) is only coherent with the type-wide
+        # 'all' selector; an id-scoped '*' grant would alias every row sharing that id
+        # across tables, since object identity is the (type, id) pair, not the id alone.
+        sa.CheckConstraint(
+            "object_type != '*' OR selector_kind = 'all'",
+            # Short name; the shared naming convention renders it to ck_<table>_`<name>`,
+            # so the migrated schema and the metadata-built one agree.
+            name="wildcard_type_requires_all_selector",
+        ),
+    )
+    op.create_index("ix_acls_object_type_object_id", "acls", ["object_type", "object_id"])
+    op.create_index("ix_acls_subject_kind_subject_id", "acls", ["subject_kind", "subject_id"])
+    op.create_index(
+        "ix_acls_subject_access_lookup",
+        "acls",
+        ["effect", "subject_kind", "subject_id", "object_type", "selector_kind", "object_id"],
+    )
+    op.create_index(
+        "ix_acls_object_access_lookup",
+        "acls",
+        ["effect", "object_type", "object_id", "selector_kind"],
+    )
+
+    # curated object attributes — the source of truth a tag grant expands against.
+    # Polymorphic (object_type, object_id) like acls: one table for every resource
+    # type, at the cost of no FK to the target (swept on the delete path instead).
+    op.create_table(
+        "resource_tags",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("object_type", sa.String, nullable=False),
+        sa.Column("object_id", sa.Integer, nullable=False),
+        sa.Column("key", sa.String, nullable=False),
+        sa.Column("value", sa.String, nullable=False),
+        sa.Column(
+            "created_by",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint(
+            "object_type",
+            "object_id",
+            "key",
+            name="uq_resource_tags_object_type_object_id_key",
+        ),
+    )
+    op.create_index(
+        "ix_resource_tags_object_type_object_id",
+        "resource_tags",
+        ["object_type", "object_id"],
+    )
+    op.create_index(
+        "ix_resource_tags_object_type_key_value",
+        "resource_tags",
+        ["object_type", "key", "value"],
+    )
+
+    with op.batch_alter_table("api_keys") as batch_op:
+        batch_op.add_column(sa.Column("scope", sa.String, nullable=True))
+
+    # the project access "kind" discriminator + the experiment->project FK
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.add_column(
+            sa.Column("kind", sa.String, nullable=False, server_default="TELEMETRY")
+        )
+        batch_op.create_index("ix_projects_kind", ["kind"])
+    with op.batch_alter_table("experiments") as batch_op:
+        batch_op.add_column(sa.Column("project_id", sa.Integer, nullable=True))
+        batch_op.create_index("ix_experiments_project_id", ["project_id"])
+        batch_op.create_foreign_key(
+            "fk_experiments_project_id_projects",
+            "projects",
+            ["project_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    # backfill kind for existing rows (precise joins, not name patterns) and the
+    # experiment->project FK from the existing project_name. Order matters:
+    # evaluator/experiment before the playground singleton.
+    op.execute(
+        "UPDATE projects SET kind = 'EVALUATOR' WHERE id IN "
+        "(SELECT project_id FROM dataset_evaluators WHERE project_id IS NOT NULL)"
+    )
+    op.execute(
+        "UPDATE projects SET kind = 'EXPERIMENT' WHERE name IN "
+        "(SELECT project_name FROM experiments WHERE project_name IS NOT NULL) "
+        "AND kind = 'TELEMETRY'"
+    )
+    op.execute("UPDATE projects SET kind = 'PLAYGROUND' WHERE name = 'playground'")
+    op.execute(
+        "UPDATE experiments SET project_id = "
+        "(SELECT projects.id FROM projects WHERE projects.name = experiments.project_name) "
+        "WHERE project_name IS NOT NULL"
+    )
+
+    # Drop the now-redundant experiments.project_name. The experiment->project link lives
+    # solely in project_id; the name is derived from projects.name through it, so the stored
+    # copy can only drift. Done after the backfill above, which read it to populate project_id.
+    with op.batch_alter_table("experiments") as batch_op:
+        batch_op.drop_index("ix_experiments_project_name")
+        batch_op.drop_column("project_name")
+
+
+def downgrade() -> None:
+    # Restore the denormalized experiments.project_name, backfilled from project_id, before
+    # the FK that now sources it is dropped.
+    with op.batch_alter_table("experiments") as batch_op:
+        batch_op.add_column(sa.Column("project_name", sa.String, nullable=True))
+        batch_op.create_index("ix_experiments_project_name", ["project_name"])
+    op.execute(
+        "UPDATE experiments SET project_name = "
+        "(SELECT projects.name FROM projects WHERE projects.id = experiments.project_id) "
+        "WHERE project_id IS NOT NULL"
+    )
+    with op.batch_alter_table("experiments") as batch_op:
+        batch_op.drop_constraint("fk_experiments_project_id_projects", type_="foreignkey")
+        batch_op.drop_index("ix_experiments_project_id")
+        batch_op.drop_column("project_id")
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.drop_index("ix_projects_kind")
+        batch_op.drop_column("kind")
+
+    with op.batch_alter_table("api_keys") as batch_op:
+        batch_op.drop_column("scope")
+    op.drop_index("ix_resource_tags_object_type_key_value", table_name="resource_tags")
+    op.drop_index("ix_resource_tags_object_type_object_id", table_name="resource_tags")
+    op.drop_table("resource_tags")
+
+    op.drop_index("ix_acls_object_access_lookup", table_name="acls")
+    op.drop_index("ix_acls_subject_access_lookup", table_name="acls")
+    op.drop_index("ix_acls_subject_kind_subject_id", table_name="acls")
+    op.drop_index("ix_acls_object_type_object_id", table_name="acls")
+    op.drop_table("acls")
+
+    op.drop_index(
+        "ix_permission_set_items_permission_permission_set_id",
+        table_name="permission_set_items",
+    )
+    op.drop_table("permission_set_items")
+    op.drop_table("permission_sets")
+
+    op.drop_table("user_group_memberships")
+    op.drop_table("user_groups")
+
+    with op.batch_alter_table("user_roles") as batch_op:
+        batch_op.drop_column("is_built_in")
+    op.drop_table("role_permissions")
+
+    _unscope_sessions_from_project()
+
+
+def _scope_sessions_to_project() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        # column-level unique=True was emitted with the dialect-default name;
+        # cover both the Postgres default and the naming-convention spelling.
+        op.execute(
+            "ALTER TABLE project_sessions DROP CONSTRAINT IF EXISTS project_sessions_session_id_key"
+        )
+        op.execute(f"ALTER TABLE project_sessions DROP CONSTRAINT IF EXISTS {_UQ_SINGLE}")
+        op.create_unique_constraint(_UQ_COMPOSITE, "project_sessions", ["project_id", "session_id"])
+    else:
+        # SQLite: batch recreate, reflecting and preserving existing indexes + FK.
+        with op.batch_alter_table("project_sessions", naming_convention=_NAMING) as batch_op:
+            batch_op.drop_constraint(_UQ_SINGLE, type_="unique")
+            batch_op.create_unique_constraint(_UQ_COMPOSITE, ["project_id", "session_id"])
+        _restore_start_time_desc_index()
+
+
+def _unscope_sessions_from_project() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.drop_constraint(_UQ_COMPOSITE, "project_sessions", type_="unique")
+        op.create_unique_constraint(_UQ_SINGLE, "project_sessions", ["session_id"])
+    else:
+        with op.batch_alter_table("project_sessions", naming_convention=_NAMING) as batch_op:
+            batch_op.drop_constraint(_UQ_COMPOSITE, type_="unique")
+            batch_op.create_unique_constraint(_UQ_SINGLE, ["session_id"])
+        _restore_start_time_desc_index()
+
+
+def _restore_start_time_desc_index() -> None:
+    # The SQLite batch recreate reflects the composite index but drops its
+    # DESC ordering (see migration 735d3d93c33e). Restore it so SQLite matches
+    # Postgres and the pre-migration schema.
+    op.execute("DROP INDEX IF EXISTS ix_project_sessions_project_id_start_time")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_project_sessions_project_id_start_time "
+        "ON project_sessions (project_id, start_time DESC)"
+    )

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -43,6 +43,7 @@ from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
     WriteOnlyMapped,
+    column_property,
     mapped_column,
     relationship,
 )
@@ -187,6 +188,7 @@ ExperimentLogLevel: TypeAlias = Literal["ERROR", "WARN", "INFO"]
 SystemSettingKey: TypeAlias = Literal[
     "agent.assistant.trace_recording",
     "agent.assistant.enabled",
+    "access_control.enabled",
 ]
 
 
@@ -692,10 +694,21 @@ class ProjectTraceRetentionPolicy(HasId):
     )
 
 
+# The access "kind" of a project — server-set at creation, immutable, and
+# security-load-bearing: it dispatches per-kind access policy (TELEMETRY is the
+# admin-only telemetry world; EXPERIMENT/EVALUATOR are plumbing whose access
+# derives from the parent dataset; PLAYGROUND is per-user scratch). Replaces the
+# fragile name-pattern + exclude_* heuristics.
+ProjectKind: TypeAlias = Literal["TELEMETRY", "PLAYGROUND", "EXPERIMENT", "EVALUATOR"]
+
+
 class Project(HasId):
     __tablename__ = "projects"
     name: Mapped[str]
     description: Mapped[Optional[str]]
+    kind: Mapped[ProjectKind] = mapped_column(
+        String, nullable=False, server_default="TELEMETRY", index=True
+    )
     gradient_start_color: Mapped[str] = mapped_column(
         String,
         server_default=text("'#5bdbff'"),
@@ -734,7 +747,7 @@ class Project(HasId):
 
 class ProjectSession(HasId):
     __tablename__ = "project_sessions"
-    session_id: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    session_id: Mapped[str] = mapped_column(String, nullable=False)
     project_id: Mapped[int] = mapped_column(
         ForeignKey("projects.id", ondelete="CASCADE"),
         nullable=False,
@@ -746,7 +759,12 @@ class ProjectSession(HasId):
         back_populates="project_session",
         uselist=True,
     )
+    # session_id is unique *within* a project, not globally: two projects may each
+    # have a session named "default". Resolving by session_id alone (the prior
+    # global-unique constraint) linked a second project's traces to the first
+    # project's session and extended its time window — a cross-project write.
     __table_args__ = (
+        UniqueConstraint("project_id", "session_id"),
         Index(
             "ix_project_sessions_project_id_start_time",
             "project_id",
@@ -1550,7 +1568,12 @@ class Experiment(HasId):
         default=False,
         server_default=sa.false(),
     )
-    project_name: Mapped[Optional[str]] = mapped_column(index=True)
+    project_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("projects.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    project_name: Mapped[Optional[str]] = column_property(
+        select(Project.name).where(Project.id == project_id).scalar_subquery(),
+    )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("users.id", ondelete="SET NULL"))
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
@@ -2009,7 +2032,231 @@ class ExperimentJobLog(ExperimentLog):
 class UserRole(HasId):
     __tablename__ = "user_roles"
     name: Mapped[UserRoleName] = mapped_column(unique=True, index=True)
+    # Built-in roles (SYSTEM/ADMIN/MEMBER/VIEWER) are seeded and immutable: their
+    # name and permission bundle may not be edited or deleted. Custom roles, when
+    # they ship, carry is_built_in=False and are freely editable.
+    is_built_in: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=expression.true(),
+    )
     users: Mapped[list["User"]] = relationship("User", back_populates="role")
+    permissions: Mapped[list["RolePermission"]] = relationship(
+        "RolePermission",
+        back_populates="role",
+        cascade="all, delete-orphan",
+    )
+
+
+class RolePermission(HasId):
+    """A single permission granted to a role. A role's authority is the set of
+    its RolePermission rows — the persisted form of the built-in bundles defined
+    in phoenix.server.access, resolved per request from the database."""
+
+    __tablename__ = "role_permissions"
+    user_role_id: Mapped[int] = mapped_column(
+        ForeignKey("user_roles.id", ondelete="CASCADE"),
+        index=True,
+    )
+    permission: Mapped[str] = mapped_column(String, nullable=False)
+    role: Mapped["UserRole"] = relationship("UserRole", back_populates="permissions")
+    __table_args__ = (UniqueConstraint("user_role_id", "permission"),)
+
+
+class UserGroup(HasId):
+    """An external identity group (e.g. an OAuth2/IdP or LDAP group) that access
+    can be granted to directly. Namespaced by provider so the same group name from
+    two providers stays distinct. Materialized at login from IdP claims; before
+    this, groups were parsed to derive a role and then discarded."""
+
+    __tablename__ = "user_groups"
+    provider: Mapped[str] = mapped_column(String, nullable=False)
+    group_key: Mapped[str] = mapped_column(String, nullable=False)
+    display_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    memberships: Mapped[list["UserGroupMembership"]] = relationship(
+        "UserGroupMembership",
+        back_populates="group",
+        cascade="all, delete-orphan",
+    )
+    __table_args__ = (UniqueConstraint("provider", "group_key"),)
+
+
+class UserGroupMembership(Base):
+    """A user's membership in a group. Reconciled at each login from the IdP's
+    current group claims — memberships for that provider not present at login are
+    removed, so offboarding from a group takes effect on the user's next login.
+
+    The natural key (user_group_id, user_id) is the primary key — a membership is the
+    pair, with no attributes of its own, so a surrogate id would only add a second
+    index. user_group_id is the PK's leftmost column, so it needs no separate index;
+    user_id does (it is not a prefix of the PK, yet drives the per-user lookups and the
+    cascade on user delete)."""
+
+    __tablename__ = "user_group_memberships"
+    user_group_id: Mapped[int] = mapped_column(
+        ForeignKey("user_groups.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+        index=True,
+    )
+    group: Mapped["UserGroup"] = relationship("UserGroup", back_populates="memberships")
+
+
+class PermissionSet(HasId):
+    """A named bundle of object-level permissions — what a subject may do on a
+    granted resource (view / edit / manage-access). Built-in presets (Resource
+    Viewer/Editor/Manager) are immutable; custom permission sets are editable rows.
+    Referenced by acls.role_id. Lives in its own table (not user_roles) so custom
+    roles can have free-form names without touching the auth-central roles enum."""
+
+    __tablename__ = "permission_sets"
+    name: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
+    is_built_in: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=expression.true(),
+    )
+    permissions: Mapped[list["PermissionSetItem"]] = relationship(
+        "PermissionSetItem",
+        back_populates="role",
+        cascade="all, delete-orphan",
+    )
+
+
+class PermissionSetItem(HasId):
+    """A single object-level permission held by an permission set."""
+
+    __tablename__ = "permission_set_items"
+    permission_set_id: Mapped[int] = mapped_column(
+        ForeignKey("permission_sets.id", ondelete="CASCADE"),
+        index=True,
+    )
+    permission: Mapped[str] = mapped_column(String, nullable=False)
+    role: Mapped["PermissionSet"] = relationship("PermissionSet", back_populates="permissions")
+    __table_args__ = (
+        UniqueConstraint("permission_set_id", "permission"),
+        Index(
+            "ix_permission_set_items_permission_permission_set_id",
+            "permission",
+            "permission_set_id",
+        ),
+    )
+
+
+class AccessGrant(HasId):
+    """An access grant: "this subject may access these objects." The persisted
+    unit of per-resource access.
+
+    Allow-only — ``effect`` is always ``allow`` — but the column exists so a deny
+    variant can be added without a migration. Selector discipline: an object is
+    named by id (``selector_kind='ids'``, ``object_id`` set), as "all of a type"
+    (``selector_kind='all'``, ``object_id`` NULL), or by a curated attribute
+    (``selector_kind='tag'``, ``tag_key``/``tag_value`` set, ``object_id`` NULL) —
+    which reaches every object of its type carrying that exact ``key=value`` tag
+    (see :class:`ResourceTag`).
+
+    A generic ``(object_type, object_id)`` reference covers projects and the orphan
+    roots (datasets, prompts) alike, and an object_type of ``*`` means all types —
+    used by the seeded everyone-allow default, so that turning enforcement on hides
+    nothing until an object-specific grant is authored.
+
+    An object's identity is the *pair* ``(object_type, object_id)``; an id alone is
+    meaningless, because ids are per-table and collide across types (dataset 5 and
+    project 5 both exist). So a wildcard ``object_type='*'`` is only coherent with the
+    type-wide ``selector_kind='all'``: pairing ``*`` with an id-scoped selector would
+    alias every row that happens to share that id, in every table. The check constraint
+    forbids that combination at the storage layer, where hand-seeded or migrated rows —
+    which never pass through the grant mutation — are still caught.
+    """
+
+    __tablename__ = "acls"
+    subject_kind: Mapped[str] = mapped_column(String, nullable=False)
+    subject_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    # The permission set conferred by this grant — what the subject may do on the
+    # object. NULL falls back to view-only (legacy grants, the everyone-allow
+    # default). ON DELETE SET NULL so removing a role degrades grants to view.
+    role_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("permission_sets.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    object_type: Mapped[str] = mapped_column(String, nullable=False)
+    object_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    selector_kind: Mapped[str] = mapped_column(String, nullable=False, server_default="ids")
+    # Attribute (tag) selector: set only when selector_kind='tag'. The grant reaches
+    # every object of its object_type currently carrying this exact key=value tag.
+    # Stored as strings and matched exactly — not a FK to a ResourceTag row — so a
+    # removed tag simply stops matching (inert, fail-closed) with no dangling grant.
+    tag_key: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    tag_value: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    effect: Mapped[str] = mapped_column(String, nullable=False, server_default="allow")
+    __table_args__ = (
+        CheckConstraint(
+            "object_type != '*' OR selector_kind = 'all'",
+            name="wildcard_type_requires_all_selector",
+        ),
+        Index("ix_acls_object_type_object_id", "object_type", "object_id"),
+        Index("ix_acls_subject_kind_subject_id", "subject_kind", "subject_id"),
+        Index(
+            "ix_acls_subject_access_lookup",
+            "effect",
+            "subject_kind",
+            "subject_id",
+            "object_type",
+            "selector_kind",
+            "object_id",
+        ),
+        Index(
+            "ix_acls_object_access_lookup",
+            "effect",
+            "object_type",
+            "object_id",
+            "selector_kind",
+        ),
+    )
+
+
+class ResourceTag(HasId):
+    """A curated attribute on an access-controlled object — "this object carries
+    ``key=value``". The source of truth for attribute-based (tag) access grants: a
+    grant with ``selector_kind='tag'`` names a ``(key, value)`` pair and reaches
+    every object of its type that currently carries it (see :class:`AccessGrant`).
+
+    Server/admin-set, never client telemetry — applying a tag changes who can reach
+    the object, so it is a privileged action gated on ``OBJ_MANAGE_ACCESS`` like a
+    grant. Kept distinct from prompt version/commit labels: "which version" and "who
+    may see it" are different controls and namespaces.
+
+    The reference is polymorphic ``(object_type, object_id)`` like ``acls`` — one
+    table for every resource type, at the cost of no real FK to the target. So there
+    is no ``ON DELETE CASCADE`` to lean on: a deleted object's tags must be swept on
+    the delete path (a sibling to the grant sweep). ``key``/``value`` are stored as
+    strings and matched exactly; a tag grant carries the strings, not a FK to a row
+    here, so removing a tag just stops matching — no dangling grant to clean up.
+
+    UNIQUE ``(object_type, object_id, key)`` — one value per key per object. The
+    forward index answers "the tags of this object"; the reverse index answers
+    "the objects of this type with this key=value", which is how a tag grant expands
+    to ids."""
+
+    __tablename__ = "resource_tags"
+    object_type: Mapped[str] = mapped_column(String, nullable=False)
+    object_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    key: Mapped[str] = mapped_column(String, nullable=False)
+    value: Mapped[str] = mapped_column(String, nullable=False)
+    # Audit only — who applied the tag. ON DELETE SET NULL so deprovisioning the
+    # author leaves the tag (and the access it confers) intact.
+    created_by: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+    __table_args__ = (
+        UniqueConstraint("object_type", "object_id", "key"),
+        Index("ix_resource_tags_object_type_object_id", "object_type", "object_id"),
+        Index("ix_resource_tags_object_type_key_value", "object_type", "key", "value"),
+    )
 
 
 class User(HasId):
@@ -2277,6 +2524,10 @@ class ApiKey(HasId):
     user: Mapped["User"] = relationship("User", back_populates="api_keys")
     name: Mapped[str]
     description: Mapped[Optional[str]]
+    # The key's attenuating scope, as data. NULL = full authority. The signed JWT
+    # claim remains the enforcement carrier; this column is the durable, listable
+    # source of truth for display.
+    scope: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
     expires_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp, nullable=True, index=True)
     __table_args__ = (dict(sqlite_autoincrement=True),)

--- a/src/phoenix/server/access/__init__.py
+++ b/src/phoenix/server/access/__init__.py
@@ -1,0 +1,84 @@
+"""The access-control seam.
+
+This package is the single place authorization decisions are made. It answers
+both the role-level question — *does this role hold this permission?*
+(:func:`can`) — and the per-resource questions — *which objects may this actor
+access?* (:func:`accessible_scope`) and *who can access this object?*
+(:func:`subjects_for`) — so callers never branch on roles or grants directly.
+
+Built-in roles resolve from :data:`BUILTIN_ROLE_PERMISSIONS`, a constant that is
+both the runtime source of truth and the seed for the ``role_permissions``
+table. A user's effective permissions are resolved from the database per request
+(:func:`permissions_for_user_id`), so a role or membership change takes effect on
+the next request without reissuing the user's token.
+"""
+
+from phoenix.server.access.cleanup import delete_object_grants, delete_object_tags
+from phoenix.server.access.groups import sync_user_groups
+from phoenix.server.access.manager_guard import (
+    would_strand_last_manager,
+    would_strand_manager_by_role,
+)
+from phoenix.server.access.oracle import (
+    OBJECT_TYPE_ALL,
+    OBJECT_TYPE_DATASET,
+    OBJECT_TYPE_PROJECT,
+    OBJECT_TYPE_PROMPT,
+    AccessScope,
+    access_predicate,
+    accessible_scope,
+    can_access,
+    subjects_for,
+)
+from phoenix.server.access.permissions import (
+    BUILTIN_PERMISSION_SETS,
+    BUILTIN_ROLE_PERMISSIONS,
+    DEFAULT_OBJECT_PERMISSIONS,
+    DEFAULT_PERMISSION_SET,
+    OBJECT_PERMISSIONS,
+    Permission,
+    can,
+    permissions_for_role,
+)
+from phoenix.server.access.resolution import (
+    object_permissions_for_grant_role,
+    permissions_for_user_id,
+)
+from phoenix.server.access.subjects import Subject, SubjectKind, subjects_for_user
+
+# The system_settings key for the access-control activation latch — reconciled with the
+# env var once at startup by the facilitator's drift guard; the running app exposes no
+# runtime enable/disable path. Runtime checks read the env directly via
+# get_env_access_control_enabled().
+ACCESS_CONTROL_ENABLED_KEY = "access_control.enabled"
+
+__all__ = [
+    "ACCESS_CONTROL_ENABLED_KEY",
+    "BUILTIN_PERMISSION_SETS",
+    "BUILTIN_ROLE_PERMISSIONS",
+    "DEFAULT_OBJECT_PERMISSIONS",
+    "DEFAULT_PERMISSION_SET",
+    "OBJECT_PERMISSIONS",
+    "OBJECT_TYPE_ALL",
+    "OBJECT_TYPE_DATASET",
+    "OBJECT_TYPE_PROJECT",
+    "OBJECT_TYPE_PROMPT",
+    "AccessScope",
+    "Permission",
+    "Subject",
+    "SubjectKind",
+    "access_predicate",
+    "accessible_scope",
+    "can",
+    "can_access",
+    "delete_object_grants",
+    "delete_object_tags",
+    "object_permissions_for_grant_role",
+    "permissions_for_role",
+    "permissions_for_user_id",
+    "subjects_for",
+    "subjects_for_user",
+    "sync_user_groups",
+    "would_strand_last_manager",
+    "would_strand_manager_by_role",
+]

--- a/src/phoenix/server/access/cleanup.py
+++ b/src/phoenix/server/access/cleanup.py
@@ -1,0 +1,39 @@
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from phoenix.db import models
+
+
+async def delete_object_grants(session: AsyncSession, object_type: str, object_id: int) -> None:
+    """Remove grants that name one concrete object.
+
+    ACL object references are polymorphic (object_type, object_id), so the database
+    cannot enforce an ON DELETE CASCADE to projects/datasets/prompts. Type-wide grants
+    intentionally remain: deleting one project must not remove "all projects" access.
+    """
+    await session.execute(
+        delete(models.AccessGrant).where(
+            models.AccessGrant.object_type == object_type,
+            models.AccessGrant.object_id == object_id,
+            models.AccessGrant.selector_kind == "ids",
+        )
+    )
+
+
+async def delete_object_tags(session: AsyncSession, object_type: str, object_id: int) -> None:
+    """Remove the curated tags of one concrete object.
+
+    Like ACL references, ResourceTag references are polymorphic (object_type,
+    object_id), so no ON DELETE CASCADE fires when the object is deleted — its tags
+    must be swept explicitly, alongside :func:`delete_object_grants`, on the same
+    delete path and in the same transaction. Without this, a later object that reused
+    the freed id would inherit the stale tags (and any tag grant matching them). Tag
+    *grants* need no sweep: they carry the key/value as strings, not a FK to a tag
+    row, so a removed tag simply stops matching.
+    """
+    await session.execute(
+        delete(models.ResourceTag).where(
+            models.ResourceTag.object_type == object_type,
+            models.ResourceTag.object_id == object_id,
+        )
+    )

--- a/src/phoenix/server/access/groups.py
+++ b/src/phoenix/server/access/groups.py
@@ -1,0 +1,86 @@
+"""Group materialization from IdP claims.
+
+IdP/LDAP groups were previously parsed at login only to derive a role, then
+discarded. :func:`sync_user_groups` persists them so access can be granted to a
+group directly.
+
+Refresh cadence: a user's memberships are reconciled at each login against the
+provider's *current* group claims — groups gain a row, and memberships for that
+provider not present in this login are removed. So a user added to or removed
+from a group sees the effect on their next login (membership is not refreshed
+mid-session). This is distinct from role and permission edits, which take effect
+on the next request.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from phoenix.db import models
+
+
+async def sync_user_groups(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    provider: str,
+    group_keys: Iterable[str],
+) -> None:
+    """Reconcile a user's group memberships for one provider to exactly the given
+    set of group keys, creating group rows as needed.
+
+    ``provider`` namespaces the keys (e.g. ``"oauth2:google"``, ``"ldap"``) so the
+    same group name from two providers stays distinct.
+    """
+    desired = {key.strip() for key in group_keys if key and key.strip()}
+
+    group_id_by_key: dict[str, int] = {}
+    if desired:
+        existing = await session.execute(
+            select(models.UserGroup.id, models.UserGroup.group_key).where(
+                models.UserGroup.provider == provider,
+                models.UserGroup.group_key.in_(desired),
+            )
+        )
+        for group_id, key in existing:
+            group_id_by_key[key] = group_id
+        for key in desired - set(group_id_by_key):
+            group = models.UserGroup(provider=provider, group_key=key, display_name=key)
+            session.add(group)
+            await session.flush()
+            group_id_by_key[key] = group.id
+
+    desired_group_ids = set(group_id_by_key.values())
+
+    # The user's current group ids *within this provider* only — memberships from other
+    # providers must not be touched. Each (user, group) pair is unique, so the group id alone
+    # identifies the membership.
+    current_group_ids = set(
+        await session.scalars(
+            select(models.UserGroupMembership.user_group_id)
+            .join(
+                models.UserGroup,
+                models.UserGroup.id == models.UserGroupMembership.user_group_id,
+            )
+            .where(
+                models.UserGroupMembership.user_id == user_id,
+                models.UserGroup.provider == provider,
+            )
+        )
+    )
+
+    for group_id in desired_group_ids - current_group_ids:
+        session.add(models.UserGroupMembership(user_group_id=group_id, user_id=user_id))
+
+    stale_group_ids = current_group_ids - desired_group_ids
+    if stale_group_ids:
+        await session.execute(
+            delete(models.UserGroupMembership).where(
+                models.UserGroupMembership.user_id == user_id,
+                models.UserGroupMembership.user_group_id.in_(stale_group_ids),
+            )
+        )
+    await session.flush()

--- a/src/phoenix/server/access/manager_guard.py
+++ b/src/phoenix/server/access/manager_guard.py
@@ -1,0 +1,194 @@
+"""The last-manager guard, shared by every write path that can remove a manager.
+
+A creatorless object (every project; any dataset/prompt whose creator was
+deprovisioned) whose final manage-conferring grant is removed becomes reachable
+only by administrators — no non-admin could restore access to it. Both the GraphQL
+mutations and the REST access routes can reach that state (by revoke or by an
+in-place downgrade), so the decision lives here as one predicate they both call and
+each turns into its own error type (GraphQL ``Conflict`` / HTTP 409).
+
+See the implementation invariants, B3.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from phoenix.db import models
+from phoenix.server.access.oracle import (
+    OBJECT_TYPE_ALL,
+    OBJECT_TYPE_DATASET,
+    OBJECT_TYPE_PROMPT,
+)
+from phoenix.server.access.permissions import Permission
+
+_SELECTOR_IDS = "ids"
+_SELECTOR_ALL = "all"
+_EFFECT_ALLOW = "allow"
+
+
+async def _object_has_creator(session: AsyncSession, object_type: str, object_id: int) -> bool:
+    """Whether the object has a creator-owner — a permanent, non-revocable manager.
+
+    Datasets and prompts are creator-private (ownership lives on ``datasets.user_id`` and
+    each prompt version's ``user_id``); a project has no creator column. A creator whose
+    account was deprovisioned leaves the column NULL, so ownership can also be absent on a
+    type that normally has it."""
+    if object_type == OBJECT_TYPE_DATASET:
+        creator = await session.scalar(
+            select(models.Dataset.user_id).where(models.Dataset.id == object_id)
+        )
+        return creator is not None
+    if object_type == OBJECT_TYPE_PROMPT:
+        version = await session.scalar(
+            select(models.PromptVersion.id).where(
+                models.PromptVersion.prompt_id == object_id,
+                models.PromptVersion.user_id.isnot(None),
+            )
+        )
+        return version is not None
+    return False  # projects carry no creator column
+
+
+async def would_strand_last_manager(
+    session: AsyncSession,
+    *,
+    object_type: str,
+    object_id: int,
+    subject_kind: str,
+    subject_id: Optional[int],
+    new_role_id: Optional[int] = None,
+) -> bool:
+    """Whether removing or downgrading this subject's id-scoped grant would leave a
+    creatorless object reachable only by administrators.
+
+    Two paths remove a manager and both must consult this: deleting the grant
+    (``new_role_id=None``) and downgrading it in place to a non-manager role
+    (``new_role_id`` = the new role). A change that keeps the grant a manager, or that
+    was never a manager grant, cannot strand anything.
+
+    Coverage that keeps the object safe is deliberately narrow — a live creator, another
+    id-scoped manager, or a type-wide (``all``) manager. A **tag** manager grant does not
+    count: its reach is object-manager-mutable, so relying on it would let the last durable
+    manager be dropped and then the tag removed. (Tag grants cannot confer manage at all —
+    see the oracle — so in practice none exist; this stays defensive regardless.)"""
+    manager_role_ids = set(
+        await session.scalars(
+            select(models.PermissionSetItem.permission_set_id).where(
+                models.PermissionSetItem.permission == Permission.OBJ_MANAGE_ACCESS.value
+            )
+        )
+    )
+    subject_id_clause = (
+        models.AccessGrant.subject_id.is_(None)
+        if subject_id is None
+        else models.AccessGrant.subject_id == subject_id
+    )
+    removed = await session.scalar(
+        select(models.AccessGrant).where(
+            models.AccessGrant.subject_kind == subject_kind,
+            subject_id_clause,
+            models.AccessGrant.object_type == object_type,
+            models.AccessGrant.object_id == object_id,
+            models.AccessGrant.selector_kind == _SELECTOR_IDS,
+            models.AccessGrant.effect == _EFFECT_ALLOW,
+        )
+    )
+    if removed is None or removed.role_id not in manager_role_ids:
+        return False  # not currently a manager grant — nothing to strand
+    if new_role_id is not None and new_role_id in manager_role_ids:
+        return False  # a downgrade that stays a manager keeps the object reachable
+    if await _object_has_creator(session, object_type, object_id):
+        return False
+    # Another durable manage-conferring grant (id-scoped on this object, or type-wide
+    # 'all' on this type) keeps the object reachable. Exclude the row being changed.
+    another_manager = await session.scalar(
+        select(models.AccessGrant.id)
+        .where(
+            models.AccessGrant.effect == _EFFECT_ALLOW,
+            models.AccessGrant.role_id.in_(manager_role_ids),
+            models.AccessGrant.id != removed.id,
+            or_(
+                (models.AccessGrant.selector_kind == _SELECTOR_IDS)
+                & (models.AccessGrant.object_type == object_type)
+                & (models.AccessGrant.object_id == object_id),
+                (models.AccessGrant.selector_kind == _SELECTOR_ALL)
+                & models.AccessGrant.object_type.in_([object_type, OBJECT_TYPE_ALL]),
+            ),
+        )
+        .limit(1)
+    )
+    return another_manager is None
+
+
+async def would_strand_manager_by_role(session: AsyncSession, role_id: int) -> bool:
+    """Whether stripping OBJ_MANAGE_ACCESS from permission set ``role_id`` would leave some
+    creatorless object reachable only by administrators.
+
+    The per-grant guard above covers revoking or downgrading a single grant. A permission
+    set is the other lever on the same invariant: editing a custom set to drop manage, or
+    deleting it (its grants fall back to ``role_id`` NULL, i.e. view-only), silently strips
+    manage authority from *every* grant that carries it at once. If any such grant is the
+    sole durable manager of an ownerless object, the change strands it. Call this before the
+    edit/delete and refuse when it returns True.
+
+    An object stays safe if it has a live creator, or another durable manager grant whose
+    role still confers manage *after* this set stops doing so (another id-scoped manager on
+    the object, or a type-wide ``all`` manager on the type)."""
+    # A set that does not confer manage today loses no manage authority when changed, so it
+    # can strand nothing — short-circuit before scanning grants (also avoids a false positive
+    # on deleting a view/edit-only role whose objects happen to lack another manager).
+    role_confers_manage = await session.scalar(
+        select(models.PermissionSetItem.id).where(
+            models.PermissionSetItem.permission_set_id == role_id,
+            models.PermissionSetItem.permission == Permission.OBJ_MANAGE_ACCESS.value,
+        )
+    )
+    if role_confers_manage is None:
+        return False
+    # The sets that still confer manage once role_id no longer does.
+    surviving_manager_role_ids = set(
+        await session.scalars(
+            select(models.PermissionSetItem.permission_set_id).where(
+                models.PermissionSetItem.permission == Permission.OBJ_MANAGE_ACCESS.value,
+                models.PermissionSetItem.permission_set_id != role_id,
+            )
+        )
+    )
+    # The objects whose only manage path today may be an id-scoped grant on this set.
+    at_risk = (
+        await session.execute(
+            select(models.AccessGrant.object_type, models.AccessGrant.object_id)
+            .where(
+                models.AccessGrant.effect == _EFFECT_ALLOW,
+                models.AccessGrant.selector_kind == _SELECTOR_IDS,
+                models.AccessGrant.role_id == role_id,
+                models.AccessGrant.object_id.isnot(None),
+            )
+            .distinct()
+        )
+    ).all()
+    for object_type, object_id in at_risk:
+        if await _object_has_creator(session, object_type, object_id):
+            continue
+        another_manager = await session.scalar(
+            select(models.AccessGrant.id)
+            .where(
+                models.AccessGrant.effect == _EFFECT_ALLOW,
+                models.AccessGrant.role_id.in_(surviving_manager_role_ids),
+                or_(
+                    (models.AccessGrant.selector_kind == _SELECTOR_IDS)
+                    & (models.AccessGrant.object_type == object_type)
+                    & (models.AccessGrant.object_id == object_id),
+                    (models.AccessGrant.selector_kind == _SELECTOR_ALL)
+                    & models.AccessGrant.object_type.in_([object_type, OBJECT_TYPE_ALL]),
+                ),
+            )
+            .limit(1)
+        )
+        if another_manager is None:
+            return True
+    return False

--- a/src/phoenix/server/access/oracle.py
+++ b/src/phoenix/server/access/oracle.py
@@ -1,0 +1,595 @@
+"""The per-resource access oracle.
+
+One seam answers the three shapes of access question over the ``acls`` grants:
+
+- list  — :func:`accessible_scope` compiles grants to a ``WHERE`` clause;
+- point — :func:`can_access` answers yes/no for one object;
+- audit — :func:`subjects_for` answers "who can see this object?".
+
+The model is **fail-closed and monotonic** (admin-only by default; grants only
+ever *add*). There is no everyone-baseline and no shadowing: an object is
+reachable only if the actor is an administrator, holds a grant that names it (or
+a type-wide ``all`` grant), owns it (datasets/prompts are creator-private), or
+reaches it *through its parent* (an experiment/evaluator trace project derives
+its access from the dataset it runs on — access-by-parent).
+
+Access is **tiered**: each grant carries an permission set (viewer / editor / manager),
+and every question is asked at a permission level — ``OBJ_VIEW`` for reads (the
+default), ``OBJ_EDIT`` for mutations, ``OBJ_MANAGE_ACCESS`` for administering an
+object's access. A grant contributes to a check only if its role includes the
+permission asked for; a grant with no role is visibility-only. Creators and
+administrators hold every permission on what they own/all.
+
+Two rules sit above the grant data, both centralized here rather than scattered
+as bypasses:
+
+- when enforcement is disabled, everything is accessible;
+- an actor holding ADMINISTER has universal access — "admin sees everything" as
+  a rule inside the oracle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, FrozenSet, List, Optional, Set, Tuple, Union
+
+from sqlalchemy import false, literal, or_, select, true, tuple_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from phoenix.db import models
+from phoenix.server.access.permissions import DEFAULT_OBJECT_PERMISSIONS, Permission
+from phoenix.server.access.resolution import permissions_for_user_id
+from phoenix.server.access.subjects import Subject, SubjectKind
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import InstrumentedAttribute
+    from sqlalchemy.sql.elements import ColumnElement
+
+    _IntColumn = Union[ColumnElement[int], InstrumentedAttribute[int]]
+    _OptionalIntColumn = Union[ColumnElement[Optional[int]], InstrumentedAttribute[Optional[int]]]
+
+OBJECT_TYPE_ALL = "*"
+OBJECT_TYPE_PROJECT = "project"
+OBJECT_TYPE_DATASET = "dataset"
+OBJECT_TYPE_PROMPT = "prompt"
+_EFFECT_ALLOW = "allow"
+_SELECTOR_ALL = "all"
+_SELECTOR_IDS = "ids"
+_SELECTOR_TAG = "tag"
+
+# A subject as stored on a grant: (kind, id), with id None for "everyone".
+_SubjectRef = Tuple[str, Optional[int]]
+
+
+@dataclass(frozen=True)
+class AccessScope:
+    """Which objects of one type an actor may access. Monotonic: either
+    everything, a type-wide allow, or an enumerated allow-set — never a baseline
+    with exceptions carved out."""
+
+    everything: bool
+    type_allows: bool
+    allowed_ids: FrozenSet[int]
+
+    def allows(self, object_id: int) -> bool:
+        if self.everything or self.type_allows:
+            return True
+        return object_id in self.allowed_ids
+
+    def apply(self, column: "_IntColumn") -> "ColumnElement[bool]":
+        """A WHERE clause restricting ``column`` (an object-id column) to the
+        allowed set. Fail-closed: an empty allow-set matches nothing."""
+        if self.everything or self.type_allows:
+            return true()
+        if not self.allowed_ids:
+            return false()
+        return column.in_(self.allowed_ids)
+
+
+def _subject_match(subjects: Set[_SubjectRef]) -> "ColumnElement[bool]":
+    clauses = []
+    for kind, subject_id in subjects:
+        clauses.append(
+            (models.AccessGrant.subject_kind == kind)
+            & (
+                models.AccessGrant.subject_id.is_(None)
+                if subject_id is None
+                else (models.AccessGrant.subject_id == subject_id)
+            )
+        )
+    return or_(*clauses) if clauses else false()
+
+
+async def actor_subjects(session: AsyncSession, user_id: int) -> set[_SubjectRef]:
+    """Every grant-subject a live actor matches: themselves, their role, and each
+    group they belong to. Derived from the *current* user, so deleted subjects
+    never appear here (the read-time existence guard is implicit on this side);
+    the dangling-grant risk is on stale ``acls`` rows, swept on subject delete."""
+    subjects: Set[_SubjectRef] = {(SubjectKind.USER.value, user_id)}
+    role_id = await session.scalar(
+        select(models.User.user_role_id).where(models.User.id == user_id)
+    )
+    if role_id is not None:
+        subjects.add((SubjectKind.ROLE.value, role_id))
+    group_ids = await session.scalars(
+        select(models.UserGroupMembership.user_group_id).where(
+            models.UserGroupMembership.user_id == user_id
+        )
+    )
+    for group_id in group_ids:
+        subjects.add((SubjectKind.GROUP.value, group_id))
+    return subjects
+
+
+async def _roles_with_permission(session: AsyncSession, permission: Permission) -> set[int]:
+    """The object-role ids whose permission set includes ``permission``."""
+    return set(
+        await session.scalars(
+            select(models.PermissionSetItem.permission_set_id).where(
+                models.PermissionSetItem.permission == permission.value
+            )
+        )
+    )
+
+
+async def _granted_scope(
+    session: AsyncSession,
+    match: "ColumnElement[bool]",
+    object_type: str,
+    permission: Permission,
+) -> Tuple[bool, Set[int]]:
+    """The (type_allows, enumerated-ids) an actor's grants confer for one type *at the
+    requested permission level*. A grant contributes its object only if the permission set it
+    carries includes ``permission`` — so a viewer-tier grant counts toward a view check but
+    not an edit check. A grant naming no role (``role_id`` NULL) confers the view-only
+    default: a plain grant is visibility, never edit/manage."""
+    grants = (
+        await session.execute(
+            select(
+                models.AccessGrant.selector_kind,
+                models.AccessGrant.object_id,
+                models.AccessGrant.role_id,
+                models.AccessGrant.tag_key,
+                models.AccessGrant.tag_value,
+            ).where(
+                models.AccessGrant.effect == _EFFECT_ALLOW,
+                models.AccessGrant.object_type.in_([object_type, OBJECT_TYPE_ALL]),
+                match,
+            )
+        )
+    ).all()
+    roles_with_permission = await _roles_with_permission(session, permission)
+    null_role_confers = permission in DEFAULT_OBJECT_PERMISSIONS
+
+    def confers(role_id: Optional[int]) -> bool:
+        if role_id is None:
+            return null_role_confers
+        return role_id in roles_with_permission
+
+    type_allows = any(
+        selector == _SELECTOR_ALL and confers(role_id) for selector, _, role_id, _, _ in grants
+    )
+    granted_ids = {
+        object_id
+        for selector, object_id, role_id, _, _ in grants
+        if selector == _SELECTOR_IDS and object_id is not None and confers(role_id)
+    }
+
+    # Tag grants contribute *enumerated ids* — the objects of this type currently
+    # carrying the granted key=value — never a type-wide allow. One query resolves
+    # every conferring pair to ids; a pair that matches no object adds nothing (the
+    # fail-closed, inert case). Matched exactly (==), never LIKE/regex/case-fold,
+    # which diverge across SQLite and Postgres.
+    #
+    # A tag grant never confers manage-access. Manage is delegation authority, and a
+    # tag's reach is object-manager-mutable (a manager can drop the object's tag), so
+    # letting a tag grant be someone's only manage path would let a non-admin strand an
+    # ownerless object in one step (removeResourceTag). Tag grants scope view/edit only;
+    # manage stays on durable id/all grants. Enforced here (both oracle paths) and
+    # rejected at authoring time.
+    tag_pairs = {
+        (tag_key, tag_value)
+        for selector, _, role_id, tag_key, tag_value in grants
+        if selector == _SELECTOR_TAG
+        and tag_key is not None
+        and tag_value is not None
+        and confers(role_id)
+    }
+    if permission == Permission.OBJ_MANAGE_ACCESS:
+        tag_pairs = set()
+    if tag_pairs:
+        tag_ids = await session.scalars(
+            select(models.ResourceTag.object_id).where(
+                models.ResourceTag.object_type == object_type,
+                tuple_(models.ResourceTag.key, models.ResourceTag.value).in_(tag_pairs),
+            )
+        )
+        granted_ids |= set(tag_ids)
+    return type_allows, granted_ids
+
+
+def _subject_match_sql(
+    grant: Any,
+    user_id: int,
+) -> "ColumnElement[bool]":
+    role_id = select(models.User.user_role_id).where(models.User.id == user_id).scalar_subquery()
+    group_ids = select(models.UserGroupMembership.user_group_id).where(
+        models.UserGroupMembership.user_id == user_id
+    )
+    return or_(
+        (grant.subject_kind == SubjectKind.EVERYONE.value) & grant.subject_id.is_(None),
+        (grant.subject_kind == SubjectKind.USER.value) & (grant.subject_id == user_id),
+        (grant.subject_kind == SubjectKind.ROLE.value) & (grant.subject_id == role_id),
+        (grant.subject_kind == SubjectKind.GROUP.value) & grant.subject_id.in_(group_ids),
+    )
+
+
+def _grant_role_confers(
+    role_id: "_OptionalIntColumn",
+    permission: Permission,
+) -> "ColumnElement[bool]":
+    role_has_permission = (
+        select(models.PermissionSetItem.id)
+        .where(
+            models.PermissionSetItem.permission_set_id == role_id,
+            models.PermissionSetItem.permission == permission.value,
+        )
+        .exists()
+    )
+    if permission in DEFAULT_OBJECT_PERMISSIONS:
+        return role_id.is_(None) | role_has_permission
+    return role_has_permission
+
+
+def _access_predicate_for_user(
+    *,
+    user_id: int,
+    object_type: str,
+    id_column: "_IntColumn",
+    permission: Permission,
+) -> "ColumnElement[bool]":
+    grant = aliased(models.AccessGrant)
+    tag = aliased(models.ResourceTag)
+    selectors = [
+        grant.selector_kind == _SELECTOR_ALL,
+        (grant.selector_kind == _SELECTOR_IDS) & (grant.object_id == id_column),
+    ]
+    # A tag grant never confers manage-access (see _granted_scope): scope view/edit
+    # only, so the tag branch is omitted from a manage-permission predicate entirely.
+    if permission != Permission.OBJ_MANAGE_ACCESS:
+        selectors.append(
+            # Tag grant: the object carries the granted key=value tag. The inner
+            # EXISTS is nested two levels under the object query, so id_column's
+            # table must be *correlated* from the outer query, not re-added to this
+            # subquery's FROM — correlate_except(tag) forces that (without it the
+            # subquery cross-joins the object table and matches every row). Kept
+            # identical to the Python path's tag resolution (parity).
+            (grant.selector_kind == _SELECTOR_TAG)
+            & select(tag.id)
+            .where(
+                tag.object_type == object_type,
+                tag.object_id == id_column,
+                tag.key == grant.tag_key,
+                tag.value == grant.tag_value,
+            )
+            .correlate_except(tag)
+            .exists()
+        )
+    predicates: list["ColumnElement[bool]"] = [
+        select(grant.id)
+        .where(
+            grant.effect == _EFFECT_ALLOW,
+            grant.object_type.in_([object_type, OBJECT_TYPE_ALL]),
+            _subject_match_sql(grant, user_id),
+            _grant_role_confers(grant.role_id, permission),
+            or_(*selectors),
+        )
+        .exists()
+    ]
+    if object_type == OBJECT_TYPE_DATASET:
+        predicates.append(
+            id_column.in_(select(models.Dataset.id).where(models.Dataset.user_id == user_id))
+        )
+    elif object_type == OBJECT_TYPE_PROMPT:
+        predicates.append(
+            id_column.in_(
+                select(models.PromptVersion.prompt_id)
+                .where(models.PromptVersion.user_id == user_id)
+                .distinct()
+            )
+        )
+    elif object_type == OBJECT_TYPE_PROJECT:
+        experiment_dataset_access = _access_predicate_for_user(
+            user_id=user_id,
+            object_type=OBJECT_TYPE_DATASET,
+            id_column=models.Experiment.dataset_id,
+            permission=permission,
+        )
+        evaluator_dataset_access = _access_predicate_for_user(
+            user_id=user_id,
+            object_type=OBJECT_TYPE_DATASET,
+            id_column=models.DatasetEvaluators.dataset_id,
+            permission=permission,
+        )
+        # Access-by-parent as a correlated EXISTS keyed on ``id_column`` (the outer
+        # project), not ``id_column IN (SELECT project_id ...)``. The two are logically
+        # identical, but the EXISTS lets a *pinned* check (id_column bound to one id, as
+        # in a point check) push ``project_id = <id>`` into the subquery and ride the
+        # ``experiments.project_id`` / ``dataset_evaluators.project_id`` index — it scans
+        # only that project's rows instead of every experiment. (List queries never reach
+        # this predicate; they materialize the scope and filter with ``id IN (...)``.)
+        predicates.extend(
+            [
+                select(1)
+                .where(
+                    models.Experiment.project_id == id_column,
+                    experiment_dataset_access,
+                )
+                .exists(),
+                select(1)
+                .where(
+                    models.DatasetEvaluators.project_id == id_column,
+                    evaluator_dataset_access,
+                )
+                .exists(),
+            ]
+        )
+    return or_(*predicates)
+
+
+async def access_predicate(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    object_type: str,
+    id_column: "_IntColumn",
+    enabled: bool,
+    permission: Permission = Permission.OBJ_VIEW,
+) -> "ColumnElement[bool]":
+    """A SQL predicate for list/count queries.
+
+    Unlike :func:`accessible_scope`, this keeps explicit grants, creator ownership, and
+    inherited eval-project access as SQL subqueries, so pagination does not require
+    materializing every accessible id in Python first.
+    """
+    if not enabled:
+        return true()
+    if Permission.ADMINISTER in await permissions_for_user_id(session, user_id):
+        return true()
+    return _access_predicate_for_user(
+        user_id=user_id,
+        object_type=object_type,
+        id_column=id_column,
+        permission=permission,
+    )
+
+
+async def _creator_owned_ids(session: AsyncSession, object_type: str, user_id: int) -> set[int]:
+    """Ids of creator-private objects this actor owns. Datasets and prompts are
+    creator-private; a project has no creator column, so the set is empty for projects."""
+    if object_type == OBJECT_TYPE_DATASET:
+        ids = await session.scalars(
+            select(models.Dataset.id).where(models.Dataset.user_id == user_id)
+        )
+        return set(ids)
+    if object_type == OBJECT_TYPE_PROMPT:
+        # Prompts carry no creator column; ownership lives on the versions.
+        ids = await session.scalars(
+            select(models.PromptVersion.prompt_id)
+            .where(models.PromptVersion.user_id == user_id)
+            .distinct()
+        )
+        return set(ids)
+    return set()
+
+
+async def _accessible_eval_project_ids(
+    session: AsyncSession, dataset_scope: AccessScope
+) -> set[int]:
+    """Access-by-parent: the trace-project ids of experiments and evaluators whose
+    parent dataset the actor can access. A kind=EXPERIMENT/EVALUATOR project is
+    plumbing — its access derives from the dataset, never an independent grant."""
+    experiment_ids = select(models.Experiment.project_id).where(
+        models.Experiment.project_id.isnot(None)
+    )
+    evaluator_ids = select(models.DatasetEvaluators.project_id).where(
+        models.DatasetEvaluators.project_id.isnot(None)
+    )
+    if not (dataset_scope.everything or dataset_scope.type_allows):
+        if not dataset_scope.allowed_ids:
+            return set()
+        experiment_ids = experiment_ids.where(
+            models.Experiment.dataset_id.in_(dataset_scope.allowed_ids)
+        )
+        evaluator_ids = evaluator_ids.where(
+            models.DatasetEvaluators.dataset_id.in_(dataset_scope.allowed_ids)
+        )
+    ids: Set[int] = set()
+    ids.update(i for i in await session.scalars(experiment_ids) if i is not None)
+    ids.update(i for i in await session.scalars(evaluator_ids) if i is not None)
+    return ids
+
+
+async def accessible_scope(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    object_type: str,
+    enabled: bool,
+    permission: Permission = Permission.OBJ_VIEW,
+) -> AccessScope:
+    """The objects of ``object_type`` on which the actor holds ``permission`` (default
+    ``OBJ_VIEW``, i.e. visibility). Pass ``OBJ_EDIT`` to compile the set the actor may
+    mutate, ``OBJ_MANAGE_ACCESS`` the set whose access it may administer."""
+    everything = AccessScope(True, True, frozenset())
+    if not enabled:
+        return everything
+    if Permission.ADMINISTER in await permissions_for_user_id(session, user_id):
+        return everything
+
+    subjects = await actor_subjects(session, user_id)
+    match = _subject_match(subjects)
+
+    type_allows, allowed_ids = await _granted_scope(session, match, object_type, permission)
+    if type_allows:
+        return AccessScope(False, True, frozenset())
+
+    # The creator of a creator-private object holds every object permission on it.
+    allowed_ids |= await _creator_owned_ids(session, object_type, user_id)
+
+    # Access-by-parent: an experiment/evaluator trace project inherits the actor's access to
+    # the parent dataset *at the same permission level*.
+    if object_type == OBJECT_TYPE_PROJECT:
+        dataset_scope = await accessible_scope(
+            session,
+            user_id=user_id,
+            object_type=OBJECT_TYPE_DATASET,
+            enabled=True,
+            permission=permission,
+        )
+        allowed_ids |= await _accessible_eval_project_ids(session, dataset_scope)
+
+    return AccessScope(False, False, frozenset(allowed_ids))
+
+
+async def can_access(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    object_type: str,
+    object_id: int,
+    enabled: bool,
+    permission: Permission = Permission.OBJ_VIEW,
+) -> bool:
+    """Whether the actor holds ``permission`` on one object (default ``OBJ_VIEW``).
+    Unauthorized is indistinguishable from not-found to the caller, which must surface it
+    as 404/null.
+
+    A point check evaluates the grant predicate *pinned to this one id* — the same
+    predicate :func:`access_predicate` compiles, but with ``id_column`` bound to
+    ``object_id`` (a literal) so it collapses to a scalar boolean with no table scan.
+    That is far cheaper than materializing the actor's whole accessible set only to ask
+    whether one id is in it; the two agree by construction (parity with
+    :func:`accessible_scope`)."""
+    if not enabled:
+        return True
+    if Permission.ADMINISTER in await permissions_for_user_id(session, user_id):
+        return True
+    predicate = _access_predicate_for_user(
+        user_id=user_id,
+        object_type=object_type,
+        id_column=literal(object_id),
+        permission=permission,
+    )
+    return bool(await session.scalar(select(predicate)))
+
+
+async def _existing_subject_ids(
+    session: AsyncSession, kind: str, subject_ids: Set[int]
+) -> Set[int]:
+    """Which of ``subject_ids`` still exist, for one subject kind — the read-time
+    existence guard that keeps a dangling grant (subject deleted) out of the audit
+    view, batched to a single query per kind instead of one per subject."""
+    if not subject_ids:
+        return set()
+    table: type[Any]
+    if kind == SubjectKind.USER.value:
+        table = models.User
+    elif kind == SubjectKind.GROUP.value:
+        table = models.UserGroup
+    elif kind == SubjectKind.ROLE.value:
+        table = models.UserRole
+    else:
+        return set(subject_ids)  # service accounts and any future kinds: not guarded here
+    return set(await session.scalars(select(table.id).where(table.id.in_(subject_ids))))
+
+
+async def subjects_for(
+    session: AsyncSession,
+    object_type: str,
+    object_id: int,
+) -> List[Subject]:
+    """Who can access an object — for the "who can see this?" audit view. Returns
+    the subjects of the grants that name it plus any type-wide ``all`` grants, any
+    tag grant whose ``key=value`` the object currently carries, and the creator
+    (datasets/prompts). Administrators have implicit access and are not enumerated.
+    Subjects that no longer exist are filtered out (a dangling grant lists nobody)."""
+    tag = aliased(models.ResourceTag)
+    rows = (
+        await session.execute(
+            select(models.AccessGrant.subject_kind, models.AccessGrant.subject_id).where(
+                models.AccessGrant.effect == _EFFECT_ALLOW,
+                or_(
+                    (models.AccessGrant.selector_kind == _SELECTOR_IDS)
+                    & (models.AccessGrant.object_type == object_type)
+                    & (models.AccessGrant.object_id == object_id),
+                    (models.AccessGrant.selector_kind == _SELECTOR_ALL)
+                    & models.AccessGrant.object_type.in_([object_type, OBJECT_TYPE_ALL]),
+                    (models.AccessGrant.selector_kind == _SELECTOR_TAG)
+                    & (models.AccessGrant.object_type == object_type)
+                    & select(tag.id)
+                    .where(
+                        tag.object_type == object_type,
+                        tag.object_id == object_id,
+                        tag.key == models.AccessGrant.tag_key,
+                        tag.value == models.AccessGrant.tag_value,
+                    )
+                    .exists(),
+                ),
+            )
+        )
+    ).all()
+
+    # Dedup to first appearance, preserving order.
+    seen: Set[_SubjectRef] = set()
+    ordered: List[_SubjectRef] = []
+    for kind, subject_id in rows:
+        ref = (kind, subject_id)
+        if ref not in seen:
+            seen.add(ref)
+            ordered.append(ref)
+
+    # Apply the existence guard in one query per kind, not one per subject.
+    ids_by_kind: dict[str, Set[int]] = {}
+    for kind, subject_id in ordered:
+        if subject_id is not None:
+            ids_by_kind.setdefault(kind, set()).add(subject_id)
+    existing_by_kind = {
+        kind: await _existing_subject_ids(session, kind, ids) for kind, ids in ids_by_kind.items()
+    }
+
+    subjects: List[Subject] = []
+    for kind, subject_id in ordered:
+        if subject_id is None:
+            if kind != SubjectKind.EVERYONE.value:
+                continue
+        elif subject_id not in existing_by_kind.get(kind, set()):
+            continue
+        try:
+            subjects.append(Subject(SubjectKind(kind), subject_id if subject_id is not None else 0))
+        except ValueError:
+            continue
+
+    creator_id = await _creator_user_id(session, object_type, object_id)
+    if creator_id is not None and (SubjectKind.USER.value, creator_id) not in seen:
+        subjects.append(Subject(SubjectKind.USER, creator_id))
+    return subjects
+
+
+async def _creator_user_id(
+    session: AsyncSession, object_type: str, object_id: int
+) -> Optional[int]:
+    """The creator of a creator-private object, if any."""
+    if object_type == OBJECT_TYPE_DATASET:
+        return await session.scalar(
+            select(models.Dataset.user_id).where(models.Dataset.id == object_id)
+        )
+    if object_type == OBJECT_TYPE_PROMPT:
+        return await session.scalar(
+            select(models.PromptVersion.user_id)
+            .where(models.PromptVersion.prompt_id == object_id)
+            .order_by(models.PromptVersion.id)
+            .limit(1)
+        )
+    return None

--- a/src/phoenix/server/access/permissions.py
+++ b/src/phoenix/server/access/permissions.py
@@ -1,0 +1,82 @@
+"""Permission vocabulary and built-in role bundles.
+
+Two kinds of role, two kinds of permission:
+
+- **Global roles** (``users.user_role_id``) grant account-wide capabilities. The
+  three coarse permissions — ``READ`` / ``WRITE`` / ``ADMINISTER`` — back the
+  long-standing ``is_viewer`` / ``is_admin`` gates. Global roles are the built-in
+  set (SYSTEM/ADMIN/MEMBER/VIEWER); custom *global* roles require freeing the
+  ``user_roles.name`` enum and are deferred.
+
+- **Permission sets** (``acls.role_id`` → ``permission_sets``) say what a subject may do
+  *on the granted object* — view it, edit it, or manage who else can access it
+  (the ``OBJ_*`` set). These ship with built-in presets and support custom roles,
+  since permission sets live in their own table with free-form names.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import FrozenSet, Mapping
+
+
+class Permission(Enum):
+    # Global capabilities — back is_viewer / is_admin and the base gates.
+    READ = "read"
+    WRITE = "write"
+    ADMINISTER = "administer"
+    # Object capabilities — what a grant's role confers on its object.
+    OBJ_VIEW = "obj_view"
+    OBJ_EDIT = "obj_edit"
+    OBJ_MANAGE_ACCESS = "obj_manage_access"
+
+
+# The source of truth for built-in global roles. Seeded into role_permissions so
+# resolution can read a role from the database.
+BUILTIN_ROLE_PERMISSIONS: Mapping[str, FrozenSet[Permission]] = {
+    "SYSTEM": frozenset({Permission.READ, Permission.WRITE, Permission.ADMINISTER}),
+    "ADMIN": frozenset({Permission.READ, Permission.WRITE, Permission.ADMINISTER}),
+    "MEMBER": frozenset({Permission.READ, Permission.WRITE}),
+    "VIEWER": frozenset({Permission.READ}),
+}
+
+# Built-in permission sets — the presets offered when granting access to a resource.
+# "Resource Viewer" is the back-compatible default: a plain grant = visibility.
+BUILTIN_PERMISSION_SETS: Mapping[str, FrozenSet[Permission]] = {
+    "Resource Viewer": frozenset({Permission.OBJ_VIEW}),
+    "Resource Editor": frozenset({Permission.OBJ_VIEW, Permission.OBJ_EDIT}),
+    "Resource Manager": frozenset(
+        {Permission.OBJ_VIEW, Permission.OBJ_EDIT, Permission.OBJ_MANAGE_ACCESS}
+    ),
+}
+
+# What a grant confers when it names no permission set (legacy grants and the
+# everyone-allow default): visibility only.
+DEFAULT_PERMISSION_SET = "Resource Viewer"
+DEFAULT_OBJECT_PERMISSIONS: FrozenSet[Permission] = frozenset({Permission.OBJ_VIEW})
+
+# Every object permission is a visibility-implying capability — an permission set
+# that lets you edit a project also lets you see it.
+OBJECT_PERMISSIONS: FrozenSet[Permission] = frozenset(
+    {Permission.OBJ_VIEW, Permission.OBJ_EDIT, Permission.OBJ_MANAGE_ACCESS}
+)
+
+
+def permissions_for_role(role_name: str) -> FrozenSet[Permission]:
+    """The permissions held by a built-in role (global or object).
+
+    Unknown roles resolve to the empty set — the oracle fails closed. Custom object
+    roles are resolved from the database (see resolution.py), not this constant.
+    """
+    for name, permissions in BUILTIN_ROLE_PERMISSIONS.items():
+        if name == role_name:
+            return permissions
+    for name, permissions in BUILTIN_PERMISSION_SETS.items():
+        if name == role_name:
+            return permissions
+    return frozenset()
+
+
+def can(role_name: str, permission: Permission) -> bool:
+    """Whether a built-in role holds a permission. The single role-level check."""
+    return permission in permissions_for_role(role_name)

--- a/src/phoenix/server/access/resolution.py
+++ b/src/phoenix/server/access/resolution.py
@@ -1,0 +1,63 @@
+"""Per-request permission resolution from the database.
+
+Permissions are resolved from the database keyed off the actor's *identity*
+rather than the role carried in the token, so the picture is always current:
+
+- editing a role's permissions takes effect on the actor's next request;
+- changing a user's role takes effect immediately, even for an API key minted
+  under the old role (the key carries only identity, not authority);
+- deleting a user resolves to no permissions, so their API keys stop working.
+
+Callers cache the result for the request (see the GraphQL context) so repeated
+checks cost one query.
+"""
+
+from __future__ import annotations
+
+from typing import FrozenSet, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from phoenix.db import models
+from phoenix.server.access.permissions import DEFAULT_OBJECT_PERMISSIONS, Permission
+
+
+def _to_permissions(values: object) -> FrozenSet[Permission]:
+    resolved = set()
+    for value in values:  # type: ignore[attr-defined]
+        try:
+            resolved.add(Permission(value))
+        except ValueError:
+            # A permission string this server does not recognize grants nothing
+            # here — unknown authority fails closed.
+            continue
+    return frozenset(resolved)
+
+
+async def permissions_for_user_id(session: AsyncSession, user_id: int) -> FrozenSet[Permission]:
+    """The permissions a user currently holds, read live from the database via
+    their role's persisted bundle. Empty if the user no longer exists."""
+    values = await session.scalars(
+        select(models.RolePermission.permission)
+        .join(models.UserRole, models.UserRole.id == models.RolePermission.user_role_id)
+        .join(models.User, models.User.user_role_id == models.UserRole.id)
+        .where(models.User.id == user_id)
+    )
+    return _to_permissions(values)
+
+
+async def object_permissions_for_grant_role(
+    session: AsyncSession, role_id: Optional[int]
+) -> FrozenSet[Permission]:
+    """The object-level permissions a grant confers, from its permission set. A grant
+    with no role (legacy grants, the everyone-allow default) confers view only."""
+    if role_id is None:
+        return DEFAULT_OBJECT_PERMISSIONS
+    values = await session.scalars(
+        select(models.PermissionSetItem.permission).where(
+            models.PermissionSetItem.permission_set_id == role_id
+        )
+    )
+    permissions = _to_permissions(values)
+    return permissions or DEFAULT_OBJECT_PERMISSIONS

--- a/src/phoenix/server/access/subjects.py
+++ b/src/phoenix/server/access/subjects.py
@@ -1,0 +1,50 @@
+"""The subject union — *who* access is granted to.
+
+A subject is a user, a group, or a service account (a machine identity). Grants
+reference a subject by ``(kind, id)``; resolving a request's access means
+gathering every subject the actor stands in for — themselves plus their groups —
+and unioning the grants attached to each.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import List
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from phoenix.db import models
+
+
+class SubjectKind(Enum):
+    USER = "user"
+    GROUP = "group"
+    SERVICE_ACCOUNT = "service_account"
+    # Grants may also target a role (everyone holding it) or everyone. These are
+    # what the seeded admin grant and the everyone-allow default are attached to.
+    ROLE = "role"
+    EVERYONE = "everyone"
+
+
+@dataclass(frozen=True)
+class Subject:
+    """A reference to something access can be granted to. ``id`` is the row id in
+    the table named by ``kind`` (users / user_groups)."""
+
+    kind: SubjectKind
+    id: int
+
+
+async def subjects_for_user(session: AsyncSession, user_id: int) -> List[Subject]:
+    """Every subject a user's request stands in for: the user, plus each group
+    they belong to. Access is the union of the grants attached to these."""
+    subjects: List[Subject] = [Subject(SubjectKind.USER, user_id)]
+    group_ids = await session.scalars(
+        select(models.UserGroupMembership.user_group_id).where(
+            models.UserGroupMembership.user_id == user_id
+        )
+    )
+    subjects.extend(Subject(SubjectKind.GROUP, group_id) for group_id in group_ids)
+    return subjects

--- a/src/phoenix/server/api/auth.py
+++ b/src/phoenix/server/api/auth.py
@@ -6,6 +6,7 @@ from strawberry.permission import BasePermission
 from typing_extensions import override
 
 from phoenix.config import get_env_support_email
+from phoenix.server.access import Permission
 from phoenix.server.api.exceptions import InsufficientStorage, Unauthorized
 from phoenix.server.bearer_auth import PhoenixUser
 
@@ -25,10 +26,14 @@ class IsNotReadOnly(Authorization):
 class IsNotViewer(Authorization):
     message = "Viewers cannot perform this action"
 
-    def has_permission(self, source: Any, info: Info, **kwargs: Any) -> bool:
+    async def has_permission(self, source: Any, info: Info, **kwargs: Any) -> bool:
         if not info.context.auth_enabled:
             return True
-        return isinstance((user := info.context.user), PhoenixUser) and not user.is_viewer
+        if not isinstance(info.context.user, PhoenixUser):
+            return False
+        # Resolved live from the database: a user demoted to viewer loses write on
+        # their next request, without re-login.
+        return Permission.WRITE in await info.context.actor_permissions()
 
 
 class IsLocked(BasePermission):
@@ -69,16 +74,20 @@ MSG_ADMIN_ONLY = "Only admin can perform this action"
 class IsAdmin(Authorization):
     message = MSG_ADMIN_ONLY
 
-    def has_permission(self, source: Any, info: Info, **kwargs: Any) -> bool:
+    async def has_permission(self, source: Any, info: Info, **kwargs: Any) -> bool:
         if not info.context.auth_enabled:
             return False
-        return isinstance((user := info.context.user), PhoenixUser) and user.is_admin
+        if not isinstance(info.context.user, PhoenixUser):
+            return False
+        return Permission.ADMINISTER in await info.context.actor_permissions()
 
 
 class IsAdminIfAuthEnabled(Authorization):
     message = MSG_ADMIN_ONLY
 
-    def has_permission(self, source: Any, info: Info, **kwargs: Any) -> bool:
+    async def has_permission(self, source: Any, info: Info, **kwargs: Any) -> bool:
         if not info.context.auth_enabled:
             return True
-        return isinstance((user := info.context.user), PhoenixUser) and user.is_admin
+        if not isinstance(info.context.user, PhoenixUser):
+            return False
+        return Permission.ADMINISTER in await info.context.actor_permissions()

--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -1,22 +1,34 @@
 from __future__ import annotations
 
 from asyncio import get_running_loop
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property, partial
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 
 from pydantic import SecretStr
+from sqlalchemy import true
+from sqlalchemy.orm import InstrumentedAttribute
 from starlette.requests import Request as StarletteRequest
 from starlette.responses import Response as StarletteResponse
 from strawberry.fastapi import BaseContext
 
 from phoenix.auth import compute_password_hash
 from phoenix.db import models
+from phoenix.server.access import (
+    AccessScope,
+    Permission,
+    accessible_scope,
+    can_access,
+    permissions_for_user_id,
+)
 from phoenix.server.api.dataloaders import CacheForDataLoaders, DataLoaders, build_data_loaders
-from phoenix.server.bearer_auth import PhoenixUser
+from phoenix.server.bearer_auth import PhoenixSystemUser, PhoenixUser
 from phoenix.server.types import UserId
 
 if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlalchemy.sql.elements import ColumnElement
+
     from phoenix.server.daemons.experiment_runner import ExperimentRunner
     from phoenix.server.daemons.span_cost_calculator import SpanCostCalculator
     from phoenix.server.daemons.system_settings import SystemSettings
@@ -53,9 +65,16 @@ class Context(BaseContext):
     read_only: bool = False
     locked: bool = False
     auth_enabled: bool = False
+    access_control_enabled: bool = False
     secret: Optional[SecretStr] = None
     token_store: Optional[TokenStore] = None
     email_sender: Optional[EmailSender] = None
+    _permissions_cache: Optional[frozenset[Permission]] = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _access_scope_cache: dict[str, AccessScope] = field(
+        default_factory=dict, init=False, repr=False, compare=False
+    )
 
     def get_secret(self) -> SecretStr:
         """A type-safe way to get the application secret. Throws an error if the secret is not set.
@@ -113,6 +132,80 @@ class Context(BaseContext):
         except Exception:
             return None
 
+    async def actor_permissions(self) -> frozenset[Permission]:
+        """The current actor's permissions, resolved live from the database and
+        cached for this request. Reading from the database (rather than the role
+        carried in the token) is what makes a role-permission edit take effect on
+        the next request, and makes a deleted user's API keys go dead."""
+        if self._permissions_cache is None:
+            self._permissions_cache = await self._resolve_permissions()
+        return self._permissions_cache
+
+    async def _resolve_permissions(self) -> frozenset[Permission]:
+        user = self.user
+        # The admin-secret system actor always holds every permission, independent
+        # of any database row.
+        if isinstance(user, PhoenixSystemUser):
+            return frozenset(Permission)
+        if (user_id := self.user_id) is None:
+            return frozenset()
+        async with self.db() as session:
+            return await permissions_for_user_id(session, user_id)
+
+    async def access_scope(self, session: "AsyncSession", object_type: str) -> AccessScope:
+        """Which objects of ``object_type`` the current actor may access, for use
+        as a list filter (``scope.apply(column)``) or a point check
+        (``scope.allows(id)``). When access control is disabled, the scope is
+        everything — so resolvers can apply it unconditionally with no behavior
+        change. Cached per object type for the request."""
+        if object_type not in self._access_scope_cache:
+            user_id = self.user_id
+            if not self.access_control_enabled or user_id is None:
+                self._access_scope_cache[object_type] = AccessScope(True, True, frozenset())
+            else:
+                self._access_scope_cache[object_type] = await accessible_scope(
+                    session, user_id=user_id, object_type=object_type, enabled=True
+                )
+        return self._access_scope_cache[object_type]
+
+    async def access_filter(
+        self,
+        session: "AsyncSession",
+        object_type: str,
+        id_column: Union["ColumnElement[int]", InstrumentedAttribute[int]],
+    ) -> "ColumnElement[bool]":
+        """A WHERE predicate restricting a *list/count* query to the rows the actor may
+        read. Compiles the accessible scope to ``id_column IN (...)`` from the (per-request
+        cached) materialized set — a single hashed lookup. This deliberately does NOT use a
+        correlated per-row grant subquery: on a full-table list that subquery re-runs for
+        every candidate row and is orders of magnitude slower. Point checks should use
+        :meth:`can_access` (a single-id predicate), not this filter.
+        """
+        user_id = self.user_id
+        if not self.access_control_enabled or user_id is None:
+            return true()
+        return (await self.access_scope(session, object_type)).apply(id_column)
+
+    async def can_access(
+        self,
+        session: "AsyncSession",
+        object_type: str,
+        object_id: int,
+    ) -> bool:
+        """Whether the current actor may view one object — a point check. Evaluates the
+        grant predicate pinned to this id (no table scan, no whole-scope materialization).
+        Everything is accessible when access control is disabled or auth is off."""
+        user_id = self.user_id
+        if not self.access_control_enabled or user_id is None:
+            return True
+        return await can_access(
+            session,
+            user_id=user_id,
+            object_type=object_type,
+            object_id=object_id,
+            enabled=True,
+        )
+
 
 def build_context(
     *,
@@ -129,6 +222,7 @@ def build_context(
     allowed_provider_names: Optional[frozenset[str]] = None,
     read_only: bool = False,
     auth_enabled: bool = False,
+    access_control_enabled: bool = False,
     secret: Optional[SecretStr] = None,
     token_store: Optional[TokenStore] = None,
     email_sender: Optional[EmailSender] = None,
@@ -151,6 +245,7 @@ def build_context(
         allowed_provider_names=allowed_provider_names,
         read_only=read_only,
         auth_enabled=auth_enabled,
+        access_control_enabled=access_control_enabled,
         secret=secret,
         token_store=token_store,
         email_sender=email_sender,

--- a/src/phoenix/server/api/input_types/UserFilter.py
+++ b/src/phoenix/server/api/input_types/UserFilter.py
@@ -1,0 +1,8 @@
+from typing import Optional
+
+import strawberry
+
+
+@strawberry.input(description="A filter for users")
+class UserFilter:
+    value: Optional[str] = None

--- a/src/phoenix/server/api/mutations/__init__.py
+++ b/src/phoenix/server/api/mutations/__init__.py
@@ -1,5 +1,6 @@
 import strawberry
 
+from phoenix.server.api.mutations.access_grant_mutations import AccessGrantMutationMixin
 from phoenix.server.api.mutations.annotation_config_mutations import AnnotationConfigMutationMixin
 from phoenix.server.api.mutations.api_key_mutations import ApiKeyMutationMixin
 from phoenix.server.api.mutations.chat_mutations import (
@@ -17,6 +18,7 @@ from phoenix.server.api.mutations.generative_model_custom_provider_mutations imp
     GenerativeModelCustomProviderMutationMixin,
 )
 from phoenix.server.api.mutations.model_mutations import ModelMutationMixin
+from phoenix.server.api.mutations.permission_set_mutations import PermissionSetMutationMixin
 from phoenix.server.api.mutations.project_annotations_mutations import (
     ProjectAnnotationMutationMixin,
 )
@@ -36,11 +38,13 @@ from phoenix.server.api.mutations.span_annotations_mutations import SpanAnnotati
 from phoenix.server.api.mutations.system_settings_mutations import SystemSettingsMutationMixin
 from phoenix.server.api.mutations.trace_annotations_mutations import TraceAnnotationMutationMixin
 from phoenix.server.api.mutations.trace_mutations import TraceMutationMixin
+from phoenix.server.api.mutations.user_group_mutations import UserGroupMutationMixin
 from phoenix.server.api.mutations.user_mutations import UserMutationMixin
 
 
 @strawberry.type
 class Mutation(
+    AccessGrantMutationMixin,
     AnnotationConfigMutationMixin,
     ApiKeyMutationMixin,
     ChatCompletionMutationMixin,
@@ -52,6 +56,7 @@ class Mutation(
     ExperimentMutationMixin,
     GenerativeModelCustomProviderMutationMixin,
     ModelMutationMixin,
+    PermissionSetMutationMixin,
     ProjectAnnotationMutationMixin,
     ProjectMutationMixin,
     ProjectTraceRetentionPolicyMutationMixin,
@@ -65,6 +70,7 @@ class Mutation(
     ProjectSessionAnnotationMutationMixin,
     TraceAnnotationMutationMixin,
     TraceMutationMixin,
+    UserGroupMutationMixin,
     UserMutationMixin,
 ):
     pass

--- a/src/phoenix/server/api/mutations/access_grant_mutations.py
+++ b/src/phoenix/server/api/mutations/access_grant_mutations.py
@@ -1,0 +1,507 @@
+from typing import Optional, cast
+
+import strawberry
+from sqlalchemy import ColumnElement, delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry import UNSET
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from phoenix.db import models
+from phoenix.server.access import (
+    DEFAULT_PERMISSION_SET,
+    OBJECT_TYPE_DATASET,
+    OBJECT_TYPE_PROJECT,
+    OBJECT_TYPE_PROMPT,
+    Permission,
+    can_access,
+    would_strand_last_manager,
+)
+from phoenix.server.api.auth import IsAdminIfAuthEnabled, IsLocked, IsNotReadOnly, IsNotViewer
+from phoenix.server.api.context import Context
+from phoenix.server.api.exceptions import BadRequest, Conflict, NotFound
+from phoenix.server.api.queries import Query
+from phoenix.server.api.types.AccessObjectType import AccessObjectType
+from phoenix.server.api.types.AccessSubjectKind import AccessSubjectKind
+from phoenix.server.api.types.Dataset import Dataset
+from phoenix.server.api.types.node import from_global_id_with_expected_type
+from phoenix.server.api.types.PermissionSet import PermissionSet
+from phoenix.server.api.types.Project import Project
+from phoenix.server.api.types.Prompt import Prompt
+from phoenix.server.api.types.User import User
+from phoenix.server.api.types.UserGroup import UserGroup
+
+
+@strawberry.input(one_of=True)
+class AccessGrantSubjectInput:
+    user_id: Optional[GlobalID] = UNSET
+    user_group_id: Optional[GlobalID] = UNSET
+    is_everyone: Optional[bool] = UNSET
+
+
+@strawberry.input(one_of=True)
+class AccessGrantObjectInput:
+    project_id: Optional[GlobalID] = UNSET
+    dataset_id: Optional[GlobalID] = UNSET
+    prompt_id: Optional[GlobalID] = UNSET
+
+
+@strawberry.input
+class AccessGrantInput:
+    subject: AccessGrantSubjectInput
+    object: AccessGrantObjectInput
+    permission_set_id: Optional[GlobalID] = UNSET
+
+
+@strawberry.input
+class ResourceTagInput:
+    """Apply/remove a curated ``key=value`` tag on one concrete object. Only ``key``
+    identifies the tag on removal; ``value`` is required to set it."""
+
+    object: AccessGrantObjectInput
+    key: str
+    value: Optional[str] = UNSET
+
+
+@strawberry.input
+class TagAccessGrantInput:
+    """Author/revoke a tag grant: give a subject a permission set over every object
+    of ``object_type`` carrying ``tag_key=tag_value``. Type-scoped, not object-scoped,
+    so it is an administrator action rather than a per-object one."""
+
+    subject: AccessGrantSubjectInput
+    object_type: AccessObjectType
+    tag_key: str
+    tag_value: str
+    permission_set_id: Optional[GlobalID] = UNSET
+
+
+@strawberry.type
+class AccessGrantMutationPayload:
+    query: Query
+
+
+async def _resolve_project_rowid(session: AsyncSession, project_id: GlobalID) -> int:
+    try:
+        rowid = from_global_id_with_expected_type(project_id, Project.__name__)
+    except ValueError:
+        raise NotFound(f"Unknown project: {project_id}") from None
+    exists = await session.scalar(select(models.Project.id).where(models.Project.id == rowid))
+    if exists is None:
+        raise NotFound(f"Unknown project: {project_id}")
+    return rowid
+
+
+async def _resolve_prompt_rowid(session: AsyncSession, prompt_id: GlobalID) -> int:
+    try:
+        rowid = from_global_id_with_expected_type(prompt_id, Prompt.__name__)
+    except ValueError:
+        raise NotFound(f"Unknown prompt: {prompt_id}") from None
+    exists = await session.scalar(select(models.Prompt.id).where(models.Prompt.id == rowid))
+    if exists is None:
+        raise NotFound(f"Unknown prompt: {prompt_id}")
+    return rowid
+
+
+async def _resolve_dataset_rowid(session: AsyncSession, dataset_id: GlobalID) -> int:
+    try:
+        rowid = from_global_id_with_expected_type(dataset_id, Dataset.__name__)
+    except ValueError:
+        raise NotFound(f"Unknown dataset: {dataset_id}") from None
+    exists = await session.scalar(select(models.Dataset.id).where(models.Dataset.id == rowid))
+    if exists is None:
+        raise NotFound(f"Unknown dataset: {dataset_id}")
+    return rowid
+
+
+async def _resolve_object_rowid(
+    session: AsyncSession, object: AccessGrantObjectInput
+) -> tuple[str, int]:
+    if object.dataset_id is None:
+        raise BadRequest("datasetId must not be null")
+    if object.dataset_id is not UNSET:
+        return OBJECT_TYPE_DATASET, await _resolve_dataset_rowid(session, object.dataset_id)
+    if object.project_id is None:
+        raise BadRequest("projectId must not be null")
+    if object.project_id is not UNSET:
+        return OBJECT_TYPE_PROJECT, await _resolve_project_rowid(session, object.project_id)
+    if object.prompt_id is None:
+        raise BadRequest("promptId must not be null")
+    if object.prompt_id is not UNSET:
+        return OBJECT_TYPE_PROMPT, await _resolve_prompt_rowid(session, object.prompt_id)
+    raise BadRequest("An object is required")
+
+
+async def _resolve_permission_set_id(
+    session: AsyncSession, permission_set_id: Optional[GlobalID]
+) -> Optional[int]:
+    """The permission set to attach to a grant — viewer (visibility), editor (mutate), or manager
+    (manage access); the oracle enforces each tier at its permission level. An explicit id is
+    validated; absent, it defaults to the built-in "Resource Viewer"."""
+    if permission_set_id is not None and permission_set_id is not UNSET:
+        try:
+            permission_set_rowid = from_global_id_with_expected_type(
+                permission_set_id, PermissionSet.__name__
+            )
+        except ValueError:
+            raise NotFound(f"Unknown permission set: {permission_set_id}") from None
+        role_id: Optional[int] = await session.scalar(
+            select(models.PermissionSet.id).where(models.PermissionSet.id == permission_set_rowid)
+        )
+        if role_id is None:
+            raise NotFound(f"Unknown permission set: {permission_set_id}")
+        return role_id
+    return cast(
+        Optional[int],
+        await session.scalar(
+            select(models.PermissionSet.id).where(
+                models.PermissionSet.name == DEFAULT_PERMISSION_SET
+            )
+        ),
+    )
+
+
+async def _assert_can_manage_object(
+    info: Info[Context, None], session: AsyncSession, object_type: str, object_rowid: int
+) -> None:
+    """The caller must hold OBJ_MANAGE_ACCESS on the object. Unauthorized is surfaced as
+    not-found (indistinguishable from an object the caller cannot see). A no-op when auth is
+    disabled."""
+    user_id = info.context.user_id
+    if user_id is None:
+        return
+    if not await can_access(
+        session,
+        user_id=user_id,
+        object_type=object_type,
+        object_id=object_rowid,
+        enabled=True,
+        permission=Permission.OBJ_MANAGE_ACCESS,
+    ):
+        raise NotFound("Unknown access object")
+
+
+async def _assert_revoke_keeps_a_manager(
+    session: AsyncSession,
+    object_type: str,
+    object_rowid: int,
+    subject_kind: AccessSubjectKind,
+    subject_rowid: Optional[int],
+    *,
+    new_role_id: Optional[int] = None,
+) -> None:
+    """Refuse to strip the last manager of an object that has no owner.
+
+    Managing access is a delegated capability stored as a grant row, so — unlike creator
+    ownership, which lives on the object itself and cannot be revoked — it can be taken
+    away from its holder. An object with no creator (every project, and any dataset/prompt
+    whose creator was deprovisioned) that loses its final manage-conferring grant becomes
+    reachable only by administrators: no non-admin could ever restore access to it. This
+    refuses that change, the way a system refuses to delete its last administrator; the
+    caller must designate another manager first.
+
+    Two paths remove the last manager and both go through here: deleting the grant
+    (``revoke_access``, ``new_role_id=None``) and *downgrading* it in place to a non-manager
+    role (``grant_access`` re-granting the same subject as viewer/editor). The REST access
+    routes call the same shared predicate directly. Decision logic lives in
+    :func:`phoenix.server.access.would_strand_last_manager`; this only adapts it to the
+    GraphQL ``Conflict``."""
+    if await would_strand_last_manager(
+        session,
+        object_type=object_type,
+        object_id=object_rowid,
+        subject_kind=subject_kind.value,
+        subject_id=subject_rowid,
+        new_role_id=new_role_id,
+    ):
+        raise Conflict(
+            "Cannot remove the last manager of an object that has no owner. "
+            "Grant another manager first."
+        )
+
+
+async def _resolve_subject_rowid(
+    session: AsyncSession, subject: AccessGrantSubjectInput
+) -> tuple[AccessSubjectKind, Optional[int]]:
+    """Validate and resolve the grant subject. EVERYONE carries no id; USER and GROUP must
+    reference an existing row by Relay id."""
+    if subject.user_id is None:
+        raise BadRequest("userId must not be null")
+    if subject.user_id is not UNSET:
+        user_id = subject.user_id
+        try:
+            rowid = from_global_id_with_expected_type(user_id, User.__name__)
+        except ValueError:
+            raise NotFound(f"Unknown user: {user_id}") from None
+        exists = await session.scalar(select(models.User.id).where(models.User.id == rowid))
+        if exists is None:
+            raise NotFound(f"Unknown user: {user_id}")
+        return AccessSubjectKind.USER, rowid
+    if subject.user_group_id is None:
+        raise BadRequest("userGroupId must not be null")
+    if subject.user_group_id is not UNSET:
+        user_group_id = subject.user_group_id
+        try:
+            rowid = from_global_id_with_expected_type(user_group_id, UserGroup.__name__)
+        except ValueError:
+            raise NotFound(f"Unknown group: {user_group_id}") from None
+        exists = await session.scalar(
+            select(models.UserGroup.id).where(models.UserGroup.id == rowid)
+        )
+        if exists is None:
+            raise NotFound(f"Unknown group: {user_group_id}")
+        return AccessSubjectKind.GROUP, rowid
+    if subject.is_everyone is not UNSET:
+        if subject.is_everyone is not True:
+            raise BadRequest("isEveryone must be true when provided")
+        return AccessSubjectKind.EVERYONE, None
+    raise BadRequest("A subject is required")
+
+
+def _subject_id_clause(subject_id: Optional[int]) -> "ColumnElement[bool]":
+    """Match a grant's subject id, treating EVERYONE's null id correctly (``== None`` would
+    never match a NULL column)."""
+    if subject_id is None:
+        return models.AccessGrant.subject_id.is_(None)
+    return models.AccessGrant.subject_id == subject_id
+
+
+async def _role_confers_manage(session: AsyncSession, role_id: int) -> bool:
+    """Whether a permission set includes OBJ_MANAGE_ACCESS."""
+    return (
+        await session.scalar(
+            select(models.PermissionSetItem.id).where(
+                models.PermissionSetItem.permission_set_id == role_id,
+                models.PermissionSetItem.permission == Permission.OBJ_MANAGE_ACCESS.value,
+            )
+        )
+    ) is not None
+
+
+@strawberry.type
+class AccessGrantMutationMixin:
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked])  # type: ignore
+    async def grant_access(
+        self, info: Info[Context, None], input: AccessGrantInput
+    ) -> AccessGrantMutationPayload:
+        """Grant a user or group an permission set on an access-controlled object. The model is
+        allow-only — the grant only *adds* a grantee to an object that is otherwise admin-only.
+        Authoring requires OBJ_MANAGE_ACCESS on the target object. Idempotent:
+        re-granting the same subject updates the role.
+
+        Re-granting is also how a manager is *downgraded*, which can strip the last manager of
+        an ownerless object just as a revoke can — so the same last-manager guard applies to
+        that in-place change, not only to ``revoke_access``."""
+        async with info.context.db() as session:
+            object_type, object_rowid = await _resolve_object_rowid(session, input.object)
+            await _assert_can_manage_object(info, session, object_type, object_rowid)
+            subject_kind, subject_rowid = await _resolve_subject_rowid(session, input.subject)
+            role_id = await _resolve_permission_set_id(session, input.permission_set_id)
+            existing = await session.scalar(
+                select(models.AccessGrant).where(
+                    models.AccessGrant.subject_kind == subject_kind.value,
+                    _subject_id_clause(subject_rowid),
+                    models.AccessGrant.object_type == object_type,
+                    models.AccessGrant.object_id == object_rowid,
+                    models.AccessGrant.selector_kind == "ids",
+                    models.AccessGrant.effect == "allow",
+                )
+            )
+            if existing is None:
+                session.add(
+                    models.AccessGrant(
+                        subject_kind=subject_kind.value,
+                        subject_id=subject_rowid,
+                        role_id=role_id,
+                        object_type=object_type,
+                        object_id=object_rowid,
+                        selector_kind="ids",
+                        effect="allow",
+                    )
+                )
+            else:
+                # A downgrade to a non-manager role is a manage-revoke in disguise; guard it.
+                # No-op unless this grant is the object's last manager (helper decides).
+                await _assert_revoke_keeps_a_manager(
+                    session,
+                    object_type,
+                    object_rowid,
+                    subject_kind,
+                    subject_rowid,
+                    new_role_id=role_id,
+                )
+                existing.role_id = role_id
+        return AccessGrantMutationPayload(query=Query())
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked])  # type: ignore
+    async def revoke_access(
+        self, info: Info[Context, None], input: AccessGrantInput
+    ) -> AccessGrantMutationPayload:
+        """Remove a subject's grant on an access-controlled object. Requires OBJ_MANAGE_ACCESS
+        (or admin privileges)."""
+        async with info.context.db() as session:
+            object_type, object_rowid = await _resolve_object_rowid(session, input.object)
+            await _assert_can_manage_object(info, session, object_type, object_rowid)
+            subject_kind, subject_rowid = await _resolve_subject_rowid(session, input.subject)
+            await _assert_revoke_keeps_a_manager(
+                session, object_type, object_rowid, subject_kind, subject_rowid
+            )
+            await session.execute(
+                delete(models.AccessGrant).where(
+                    models.AccessGrant.subject_kind == subject_kind.value,
+                    _subject_id_clause(subject_rowid),
+                    models.AccessGrant.object_type == object_type,
+                    models.AccessGrant.object_id == object_rowid,
+                    models.AccessGrant.selector_kind == "ids",
+                )
+            )
+        return AccessGrantMutationPayload(query=Query())
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked])  # type: ignore
+    async def set_resource_tag(
+        self, info: Info[Context, None], input: ResourceTagInput
+    ) -> AccessGrantMutationPayload:
+        """Apply (or update) a curated key=value tag on an access-controlled object.
+        A tag changes who can reach the object, so setting one requires OBJ_MANAGE_ACCESS
+        on the target — the same gate as granting access, which is what makes tags
+        server-curated rather than user/telemetry data. Idempotent: re-setting a key
+        overwrites its value."""
+        if input.value is None or input.value is UNSET:
+            raise BadRequest("value must not be null")
+        if not input.key:
+            raise BadRequest("key must not be empty")
+        async with info.context.db() as session:
+            object_type, object_rowid = await _resolve_object_rowid(session, input.object)
+            await _assert_can_manage_object(info, session, object_type, object_rowid)
+            existing = await session.scalar(
+                select(models.ResourceTag).where(
+                    models.ResourceTag.object_type == object_type,
+                    models.ResourceTag.object_id == object_rowid,
+                    models.ResourceTag.key == input.key,
+                )
+            )
+            if existing is None:
+                session.add(
+                    models.ResourceTag(
+                        object_type=object_type,
+                        object_id=object_rowid,
+                        key=input.key,
+                        value=input.value,
+                        created_by=info.context.user_id,
+                    )
+                )
+            else:
+                existing.value = input.value
+        return AccessGrantMutationPayload(query=Query())
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked])  # type: ignore
+    async def remove_resource_tag(
+        self, info: Info[Context, None], input: ResourceTagInput
+    ) -> AccessGrantMutationPayload:
+        """Remove a curated tag from an object. Requires OBJ_MANAGE_ACCESS (or admin).
+        A tag grant that reached the object via this key simply stops matching — no
+        grant is deleted (tag grants carry the strings, not a link to this row)."""
+        if not input.key:
+            raise BadRequest("key must not be empty")
+        async with info.context.db() as session:
+            object_type, object_rowid = await _resolve_object_rowid(session, input.object)
+            await _assert_can_manage_object(info, session, object_type, object_rowid)
+            await session.execute(
+                delete(models.ResourceTag).where(
+                    models.ResourceTag.object_type == object_type,
+                    models.ResourceTag.object_id == object_rowid,
+                    models.ResourceTag.key == input.key,
+                )
+            )
+        return AccessGrantMutationPayload(query=Query())
+
+    @strawberry.mutation(
+        permission_classes=[IsAdminIfAuthEnabled, IsNotReadOnly, IsNotViewer, IsLocked]
+    )  # type: ignore
+    async def grant_tag_access(
+        self, info: Info[Context, None], input: TagAccessGrantInput
+    ) -> AccessGrantMutationPayload:
+        """Grant a subject a permission set over every object of a type carrying a given
+        key=value tag. Type-scoped and additive — it only ever *adds* reach, to whatever
+        objects currently carry the tag (none, harmlessly, if none do). Administrator-only:
+        unlike a per-object grant, it is not anchored to one object the caller could hold
+        OBJ_MANAGE_ACCESS on. Idempotent: re-granting the same (subject, type, tag) updates
+        the permission set.
+
+        A tag grant may confer view or edit, never *manage-access*. Manage is delegation
+        authority; a tag's reach is object-manager-mutable (a manager can drop the object's
+        tag), so a manage-conferring tag grant could be a non-admin's only manage path and
+        let them strand an ownerless object in one step. The oracle already refuses to honor
+        manage from a tag selector; this rejects authoring one, loudly, rather than storing a
+        grant that is silently inert for manage."""
+        if not input.tag_key or not input.tag_value:
+            raise BadRequest("tagKey and tagValue must not be empty")
+        object_type = input.object_type.value
+        async with info.context.db() as session:
+            subject_kind, subject_rowid = await _resolve_subject_rowid(session, input.subject)
+            role_id = await _resolve_permission_set_id(session, input.permission_set_id)
+            if role_id is not None and await _role_confers_manage(session, role_id):
+                raise BadRequest(
+                    "A tag grant cannot confer manage-access. Choose a viewer or editor "
+                    "permission set, or author a per-object grant for manage-access."
+                )
+            existing = await session.scalar(
+                select(models.AccessGrant).where(
+                    models.AccessGrant.subject_kind == subject_kind.value,
+                    _subject_id_clause(subject_rowid),
+                    models.AccessGrant.object_type == object_type,
+                    models.AccessGrant.selector_kind == "tag",
+                    models.AccessGrant.tag_key == input.tag_key,
+                    models.AccessGrant.tag_value == input.tag_value,
+                    models.AccessGrant.effect == "allow",
+                )
+            )
+            if existing is None:
+                session.add(
+                    models.AccessGrant(
+                        subject_kind=subject_kind.value,
+                        subject_id=subject_rowid,
+                        role_id=role_id,
+                        object_type=object_type,
+                        object_id=None,
+                        selector_kind="tag",
+                        tag_key=input.tag_key,
+                        tag_value=input.tag_value,
+                        effect="allow",
+                    )
+                )
+            else:
+                existing.role_id = role_id
+        return AccessGrantMutationPayload(query=Query())
+
+    @strawberry.mutation(
+        permission_classes=[IsAdminIfAuthEnabled, IsNotReadOnly, IsNotViewer, IsLocked]
+    )  # type: ignore
+    async def revoke_tag_access(
+        self, info: Info[Context, None], input: TagAccessGrantInput
+    ) -> AccessGrantMutationPayload:
+        """Remove a subject's tag grant. Administrator-only, like authoring one.
+
+        No last-manager guard applies here, by design. A tag manager grant *can* be the
+        only manager path to an ownerless object, but tag-grant lifecycle is admin-only,
+        and an administrator both always reaches the object and can re-author the grant —
+        so an admin removing it is recoverable, unlike a non-admin manager stripping the
+        last durable id-scoped manager (which ``revoke_access``/``grant_access`` do guard).
+        Correspondingly, the last-manager guard never counts tag grants as a surviving
+        manager (see ``_assert_revoke_keeps_a_manager``)."""
+        if not input.tag_key or not input.tag_value:
+            raise BadRequest("tagKey and tagValue must not be empty")
+        object_type = input.object_type.value
+        async with info.context.db() as session:
+            subject_kind, subject_rowid = await _resolve_subject_rowid(session, input.subject)
+            await session.execute(
+                delete(models.AccessGrant).where(
+                    models.AccessGrant.subject_kind == subject_kind.value,
+                    _subject_id_clause(subject_rowid),
+                    models.AccessGrant.object_type == object_type,
+                    models.AccessGrant.selector_kind == "tag",
+                    models.AccessGrant.tag_key == input.tag_key,
+                    models.AccessGrant.tag_value == input.tag_value,
+                )
+            )
+        return AccessGrantMutationPayload(query=Query())

--- a/src/phoenix/server/api/mutations/api_key_mutations.py
+++ b/src/phoenix/server/api/mutations/api_key_mutations.py
@@ -13,6 +13,7 @@ from phoenix.server.api.auth import IsAdmin, IsLocked, IsNotReadOnly, IsNotViewe
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import Unauthorized
 from phoenix.server.api.queries import Query
+from phoenix.server.api.types.ApiKeyScope import ApiKeyScope
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.SystemApiKey import SystemApiKey
 from phoenix.server.api.types.UserApiKey import UserApiKey
@@ -32,6 +33,7 @@ class CreateApiKeyInput:
     name: str
     description: Optional[str] = UNSET
     expires_at: Optional[datetime] = UNSET
+    scope: Optional[ApiKeyScope] = UNSET
 
 
 @strawberry.type
@@ -46,6 +48,19 @@ class CreateUserApiKeyInput:
     name: str
     description: Optional[str] = UNSET
     expires_at: Optional[datetime] = UNSET
+    scope: Optional[ApiKeyScope] = UNSET
+
+
+def _scoped_description(description: Optional[str], scope: Optional[ApiKeyScope]) -> Optional[str]:
+    """
+    Echo the scope into the key's description at mint time so it is visible
+    in key listings. The scope itself lives in the signed token; the
+    description copy is display-only and never consulted for authorization.
+    """
+    if not scope:
+        return description
+    marker = f"[scope:{scope.value}]"
+    return f"{marker} {description}" if description else marker
 
 
 @strawberry.input
@@ -79,6 +94,7 @@ class ApiKeyMutationMixin:
             if system_user is None:
                 raise ValueError("System user not found")
         issued_at = datetime.now(timezone.utc)
+        description = _scoped_description(input.description or None, input.scope or None)
         claims = ApiKeyClaims(
             subject=UserId(system_user.id),
             issued_at=issued_at,
@@ -86,7 +102,8 @@ class ApiKeyMutationMixin:
             attributes=ApiKeyAttributes(
                 user_role=user_role,
                 name=input.name,
-                description=input.description,
+                description=description,
+                scope=input.scope.value if input.scope else None,
             ),
         )
         token, token_id = await token_store.create_api_key(claims)
@@ -115,6 +132,7 @@ class ApiKeyMutationMixin:
             user_role = "VIEWER"
         else:
             user_role = "MEMBER"
+        description = _scoped_description(input.description or None, input.scope or None)
         claims = ApiKeyClaims(
             subject=user.identity,
             issued_at=issued_at,
@@ -122,7 +140,8 @@ class ApiKeyMutationMixin:
             attributes=ApiKeyAttributes(
                 user_role=user_role,
                 name=input.name,
-                description=input.description,
+                description=description,
+                scope=input.scope.value if input.scope else None,
             ),
         )
         token, token_id = await token_store.create_api_key(claims)

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -196,6 +196,7 @@ def _get_project_for_dataset_evaluator(
         description=(
             f"Traces for dataset evaluator: {dataset_evaluator_name} on dataset: {dataset_name}"
         ),
+        kind="EVALUATOR",
     )
 
 

--- a/src/phoenix/server/api/mutations/experiment_mutations.py
+++ b/src/phoenix/server/api/mutations/experiment_mutations.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 import strawberry
 from sqlalchemy import delete, or_, select, update
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
 from strawberry import UNSET
 from strawberry.dataloader import DataLoader
@@ -14,9 +15,10 @@ from phoenix.config import EXPERIMENT_TOGGLE_COOLDOWN
 from phoenix.db import models
 from phoenix.db.helpers import get_eval_trace_ids_for_experiments, get_project_names_for_experiments
 from phoenix.db.insertion.helpers import insert_on_conflict
+from phoenix.server.access import OBJECT_TYPE_DATASET, Permission, can_access
 from phoenix.server.api.auth import IsLocked, IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
-from phoenix.server.api.exceptions import BadRequest, Conflict, CustomGraphQLError
+from phoenix.server.api.exceptions import BadRequest, Conflict, CustomGraphQLError, NotFound
 from phoenix.server.api.experiment_tags import BASELINE_EXPERIMENT_TAG_NAME
 from phoenix.server.api.input_types.DeleteExperimentsInput import DeleteExperimentsInput
 from phoenix.server.api.input_types.GenerativeCredentialInput import GenerativeCredentialInput
@@ -58,6 +60,71 @@ class PatchExperimentPayload:
     experiment: Experiment
 
 
+async def _assert_can_edit_experiment(
+    info: Info[Context, None],
+    session: AsyncSession,
+    experiment_id: int,
+    experiment_gid: GlobalID,
+) -> None:
+    user_id = info.context.user_id
+    if not info.context.access_control_enabled or user_id is None:
+        return
+    dataset_id = await session.scalar(
+        select(models.Experiment.dataset_id).where(models.Experiment.id == experiment_id)
+    )
+    if dataset_id is None:
+        raise NotFound(f"Experiment {experiment_gid} not found")
+    if not await can_access(
+        session,
+        user_id=user_id,
+        object_type=OBJECT_TYPE_DATASET,
+        object_id=dataset_id,
+        enabled=True,
+        permission=Permission.OBJ_EDIT,
+    ):
+        raise NotFound(f"Experiment {experiment_gid} not found")
+
+
+async def _assert_can_edit_experiments(
+    info: Info[Context, None], session: AsyncSession, experiment_ids: list[int]
+) -> None:
+    user_id = info.context.user_id
+    if not info.context.access_control_enabled or user_id is None:
+        return
+    rows = (
+        await session.execute(
+            select(models.Experiment.id, models.Experiment.dataset_id).where(
+                models.Experiment.id.in_(experiment_ids)
+            )
+        )
+    ).all()
+    dataset_id_by_experiment_id = {experiment_id: dataset_id for experiment_id, dataset_id in rows}
+    unknown_experiment_ids = set(experiment_ids) - set(dataset_id_by_experiment_id)
+    if unknown_experiment_ids:
+        raise NotFound(
+            "Unknown experiment(s): "
+            + str(
+                [
+                    str(GlobalID(Experiment.__name__, str(experiment_id)))
+                    for experiment_id in sorted(unknown_experiment_ids)
+                ]
+            )
+        )
+    for experiment_id in experiment_ids:
+        dataset_id = dataset_id_by_experiment_id[experiment_id]
+        if not await can_access(
+            session,
+            user_id=user_id,
+            object_type=OBJECT_TYPE_DATASET,
+            object_id=dataset_id,
+            enabled=True,
+            permission=Permission.OBJ_EDIT,
+        ):
+            raise NotFound(
+                f"Experiment {GlobalID(Experiment.__name__, str(experiment_id))} not found"
+            )
+
+
 @strawberry.type
 class SetExperimentBaselinePayload:
     experiment: Experiment
@@ -82,6 +149,7 @@ class ExperimentMutationMixin:
         now = datetime.now(timezone.utc)
 
         async with info.context.db() as session:
+            await _assert_can_edit_experiment(info, session, exp_rowid, experiment_id)
             # Single atomic UPDATE: state guard + cooldown in one statement
             stmt = (
                 update(models.ExperimentJob)
@@ -137,6 +205,7 @@ class ExperimentMutationMixin:
         replica_id = info.context.experiment_runner.replica_id
 
         async with info.context.db() as session:
+            await _assert_can_edit_experiment(info, session, exp_rowid, experiment_id)
             # Single atomic UPDATE: state guard + cooldown in one statement
             # NOTE: COMPLETED experiments are resumable — the runner scans for
             # incomplete/errored runs, so resuming retries failures or picks up new examples.
@@ -193,6 +262,7 @@ class ExperimentMutationMixin:
         """
         exp_rowid = from_global_id_with_expected_type(experiment_id, Experiment.__name__)
         async with info.context.db() as session:
+            await _assert_can_edit_experiment(info, session, exp_rowid, experiment_id)
             stmt = (
                 update(models.Experiment)
                 .where(models.Experiment.id == exp_rowid)
@@ -215,6 +285,7 @@ class ExperimentMutationMixin:
         """
         exp_rowid = from_global_id_with_expected_type(experiment_id, Experiment.__name__)
         async with info.context.db() as session:
+            await _assert_can_edit_experiment(info, session, exp_rowid, experiment_id)
             stmt = (
                 update(models.Experiment)
                 .where(models.Experiment.id == exp_rowid)
@@ -252,6 +323,7 @@ class ExperimentMutationMixin:
         if not patch:
             raise BadRequest("No fields to patch.")
         async with info.context.db() as session:
+            await _assert_can_edit_experiment(info, session, experiment_id, input.experiment_id)
             experiment = await session.scalar(
                 update(models.Experiment)
                 .where(models.Experiment.id == experiment_id)
@@ -353,6 +425,8 @@ class ExperimentMutationMixin:
         # deployments, another replica's shielded writes may still race with
         # the DELETE (possible FK errors or orphaned rows), but these are
         # harmless since the experiment is being deleted anyway.
+        async with info.context.db() as session:
+            await _assert_can_edit_experiments(info, session, experiment_ids)
         for exp_id in experiment_ids:
             await info.context.experiment_runner.stop_experiment(exp_id)
         project_names_stmt = get_project_names_for_experiments(*experiment_ids)

--- a/src/phoenix/server/api/mutations/permission_set_mutations.py
+++ b/src/phoenix/server/api/mutations/permission_set_mutations.py
@@ -1,0 +1,175 @@
+from typing import Optional
+
+import strawberry
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+from strawberry import UNSET
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from phoenix.db import models
+from phoenix.server.access import would_strand_manager_by_role
+from phoenix.server.api.auth import IsAdmin, IsLocked, IsNotReadOnly, IsNotViewer
+from phoenix.server.api.context import Context
+from phoenix.server.api.exceptions import BadRequest, Conflict, NotFound
+from phoenix.server.api.queries import Query
+from phoenix.server.api.types.node import from_global_id_with_expected_type
+from phoenix.server.api.types.PermissionSet import (
+    ObjectPermission,
+    PermissionSet,
+    to_gql_permission_set,
+)
+
+
+@strawberry.input
+class CreatePermissionSetInput:
+    name: str
+    permissions: list[ObjectPermission]
+
+
+@strawberry.input
+class PatchPermissionSetInput:
+    id: GlobalID
+    name: Optional[str] = UNSET
+    permissions: Optional[list[ObjectPermission]] = UNSET
+
+
+@strawberry.input
+class DeletePermissionSetInput:
+    id: GlobalID
+
+
+@strawberry.type
+class PermissionSetMutationPayload:
+    permission_set: Optional[PermissionSet]
+    query: Query
+
+
+async def _load(session: AsyncSession, role_id: int) -> models.PermissionSet:
+    # populate_existing refreshes the identity-mapped object so a permissions
+    # collection loaded earlier in the request reflects an intervening edit.
+    role: Optional[models.PermissionSet] = await session.scalar(
+        select(models.PermissionSet)
+        .options(joinedload(models.PermissionSet.permissions))
+        .where(models.PermissionSet.id == role_id)
+        .execution_options(populate_existing=True)
+    )
+    if role is None:
+        raise NotFound(f"Unknown permission set: {role_id}")
+    return role
+
+
+def _permission_set_rowid(role_id: GlobalID) -> int:
+    try:
+        return from_global_id_with_expected_type(role_id, PermissionSet.__name__)
+    except ValueError:
+        raise NotFound(f"Unknown permission set: {role_id}") from None
+
+
+async def _set_permissions(
+    session: AsyncSession, role_id: int, permissions: list[ObjectPermission]
+) -> None:
+    """Replace a role's permissions. Delete-then-add with a flush between, so
+    re-setting a permission a role already has doesn't trip the unique constraint
+    (the ORM would otherwise insert the new row before deleting the old)."""
+    await session.execute(
+        delete(models.PermissionSetItem).where(
+            models.PermissionSetItem.permission_set_id == role_id
+        )
+    )
+    await session.flush()
+    session.add_all(
+        models.PermissionSetItem(permission_set_id=role_id, permission=p.value)
+        for p in dict.fromkeys(permissions)
+    )
+    await session.flush()
+
+
+@strawberry.type
+class PermissionSetMutationMixin:
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdmin, IsLocked])  # type: ignore
+    async def create_permission_set(
+        self, info: Info[Context, None], input: CreatePermissionSetInput
+    ) -> PermissionSetMutationPayload:
+        name = input.name.strip()
+        if not name:
+            raise BadRequest("Role name cannot be empty.")
+        if not input.permissions:
+            raise BadRequest("A role must have at least one permission.")
+        async with info.context.db() as session:
+            if await session.scalar(
+                select(models.PermissionSet.id).where(models.PermissionSet.name == name)
+            ):
+                raise Conflict(f"A role named {name!r} already exists.")
+            role = models.PermissionSet(name=name, is_built_in=False)
+            session.add(role)
+            await session.flush()
+            await _set_permissions(session, role.id, input.permissions)
+            role = await _load(session, role.id)
+            gql = to_gql_permission_set(role)
+        return PermissionSetMutationPayload(permission_set=gql, query=Query())
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdmin, IsLocked])  # type: ignore
+    async def patch_permission_set(
+        self, info: Info[Context, None], input: PatchPermissionSetInput
+    ) -> PermissionSetMutationPayload:
+        async with info.context.db() as session:
+            role = await _load(session, _permission_set_rowid(input.id))
+            if role.is_built_in:
+                raise BadRequest("Built-in roles cannot be edited.")
+            if input.name is not UNSET and input.name is not None:
+                name = input.name.strip()
+                if not name:
+                    raise BadRequest("Role name cannot be empty.")
+                clash = await session.scalar(
+                    select(models.PermissionSet.id).where(
+                        models.PermissionSet.name == name, models.PermissionSet.id != role.id
+                    )
+                )
+                if clash:
+                    raise Conflict(f"A role named {name!r} already exists.")
+                role.name = name
+            if input.permissions is not UNSET and input.permissions is not None:
+                if not input.permissions:
+                    raise BadRequest("A role must have at least one permission.")
+                # Dropping manage-access from this role revokes it from every grant that
+                # carries the role at once — the same last-manager invariant the per-grant
+                # revoke/downgrade guards protect, reached here through the role instead of a
+                # grant. Refuse if it would strand a creatorless object. (The guard is inert
+                # unless the role currently confers manage.)
+                if ObjectPermission.MANAGE_ACCESS not in input.permissions:
+                    if await would_strand_manager_by_role(session, role.id):
+                        raise Conflict(
+                            "Cannot remove manage-access from this role: it is the last "
+                            "manager of an object that has no owner. Grant that object "
+                            "another manager first."
+                        )
+                await _set_permissions(session, role.id, input.permissions)
+            await session.flush()
+            role = await _load(session, role.id)
+            gql = to_gql_permission_set(role)
+        return PermissionSetMutationPayload(permission_set=gql, query=Query())
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdmin, IsLocked])  # type: ignore
+    async def delete_permission_set(
+        self, info: Info[Context, None], input: DeletePermissionSetInput
+    ) -> PermissionSetMutationPayload:
+        async with info.context.db() as session:
+            role = await _load(session, _permission_set_rowid(input.id))
+            if role.is_built_in:
+                raise BadRequest("Built-in roles cannot be deleted.")
+            # Deleting the role drops its grants to the view-only default (acls.role_id ON
+            # DELETE SET NULL), so if it currently confers manage this strips manage from
+            # every grant that carries it — refuse if that would strand a creatorless object.
+            if await would_strand_manager_by_role(session, role.id):
+                raise Conflict(
+                    "Cannot delete this role: it is the last manager of an object that has "
+                    "no owner. Grant that object another manager first."
+                )
+            # Grants referencing this role fall back to view (acls.role_id ON DELETE
+            # SET NULL), so removing a role never orphans or deletes a grant.
+            await session.execute(
+                delete(models.PermissionSet).where(models.PermissionSet.id == role.id)
+            )
+        return PermissionSetMutationPayload(permission_set=None, query=Query())

--- a/src/phoenix/server/api/mutations/project_mutations.py
+++ b/src/phoenix/server/api/mutations/project_mutations.py
@@ -9,7 +9,12 @@ from strawberry.types import Info
 
 from phoenix.config import DEFAULT_PROJECT_NAME
 from phoenix.db import models
-from phoenix.server.api.auth import IsNotReadOnly, IsNotViewer
+from phoenix.server.access import (
+    OBJECT_TYPE_PROJECT,
+    delete_object_grants,
+    delete_object_tags,
+)
+from phoenix.server.api.auth import IsAdminIfAuthEnabled, IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, Conflict
 from phoenix.server.api.input_types.ClearProjectInput import ClearProjectInput
@@ -54,7 +59,7 @@ class ProjectMutationMixin:
         info.context.event_queue.put(ProjectInsertEvent((project.id,)))
         return ProjectMutationPayload(project=to_gql_project(project), query=Query())
 
-    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled])  # type: ignore
     async def delete_project(self, info: Info[Context, None], id: GlobalID) -> Query:
         project_id = from_global_id_with_expected_type(global_id=id, expected_type_name="Project")
         async with info.context.db() as session:
@@ -67,11 +72,13 @@ class ProjectMutationMixin:
                 raise ValueError(f"Unknown project: {id}")
             if project.name == DEFAULT_PROJECT_NAME:
                 raise ValueError(f"Cannot delete the {DEFAULT_PROJECT_NAME} project")
+            await delete_object_grants(session, OBJECT_TYPE_PROJECT, project_id)
+            await delete_object_tags(session, OBJECT_TYPE_PROJECT, project_id)
             await session.delete(project)
         info.context.event_queue.put(ProjectDeleteEvent((project_id,)))
         return Query()
 
-    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled])  # type: ignore
     async def clear_project(self, info: Info[Context, None], input: ClearProjectInput) -> Query:
         project_id = from_global_id_with_expected_type(
             global_id=input.id, expected_type_name="Project"
@@ -97,7 +104,7 @@ class ProjectMutationMixin:
         info.context.event_queue.put(SpanDeleteEvent((project_id,)))
         return Query()
 
-    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled])  # type: ignore
     async def patch_project(
         self,
         info: Info[Context, None],

--- a/src/phoenix/server/api/mutations/prompt_mutations.py
+++ b/src/phoenix/server/api/mutations/prompt_mutations.py
@@ -15,6 +15,11 @@ from phoenix.db import models
 from phoenix.db.types.identifier import Identifier
 from phoenix.db.types.model_provider import is_sdk_compatible_with_model_provider
 from phoenix.db.types.prompts import normalize_invocation_parameters_for_write
+from phoenix.server.access import (
+    OBJECT_TYPE_PROMPT,
+    delete_object_grants,
+    delete_object_tags,
+)
 from phoenix.server.api.auth import IsLocked, IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, Conflict, NotFound
@@ -168,6 +173,8 @@ class PromptMutationMixin:
             if result.rowcount == 0:  # type: ignore[attr-defined]
                 raise NotFound(f"Prompt with ID '{input.prompt_id}' not found")
 
+            await delete_object_grants(session, OBJECT_TYPE_PROMPT, prompt_id)
+            await delete_object_tags(session, OBJECT_TYPE_PROMPT, prompt_id)
             await session.commit()
         return DeletePromptMutationPayload(query=Query())
 

--- a/src/phoenix/server/api/mutations/trace_mutations.py
+++ b/src/phoenix/server/api/mutations/trace_mutations.py
@@ -1,5 +1,5 @@
 import strawberry
-from sqlalchemy import and_, delete, not_, select, update
+from sqlalchemy import and_, delete, not_, select
 from sqlalchemy.orm import load_only
 from sqlalchemy.sql import literal
 from strawberry.relay import GlobalID
@@ -109,10 +109,74 @@ class TraceMutationMixin:
             if len(source_project_ids) > 1:
                 raise BadRequest("Cannot transfer traces from multiple projects")
 
-            await session.execute(
-                update(models.Trace)
-                .where(models.Trace.id.in_(trace_rowids))
-                .values(project_rowid=dest_project_rowid)
-            )
+            # The source sessions the moved traces belong to — remembered so any left without
+            # traces can be swept after the move.
+            source_session_rowids = {
+                trace.project_session_rowid
+                for trace in traces
+                if trace.project_session_rowid is not None
+            }
+            # A session_id is unique only within a project, so a moved trace cannot keep its
+            # link to the source project's session. Resolve each trace's session_id in the
+            # destination: join the destination's session of that id (creating it if absent),
+            # never the source's.
+            session_id_by_rowid: dict[int, str] = {}
+            if source_session_rowids:
+                session_id_by_rowid = {
+                    rowid: session_id
+                    for rowid, session_id in await session.execute(
+                        select(models.ProjectSession.id, models.ProjectSession.session_id).where(
+                            models.ProjectSession.id.in_(source_session_rowids)
+                        )
+                    )
+                }
+            dest_session_by_session_id: dict[str, models.ProjectSession] = {}
+            for trace in traces:
+                trace.project_rowid = dest_project_rowid
+                if trace.project_session_rowid is None:
+                    continue
+                session_id = session_id_by_rowid.get(trace.project_session_rowid)
+                if session_id is None:
+                    trace.project_session_rowid = None
+                    continue
+                dest_session = dest_session_by_session_id.get(session_id)
+                if dest_session is None:
+                    dest_session = await session.scalar(
+                        select(models.ProjectSession).filter_by(
+                            project_id=dest_project_rowid, session_id=session_id
+                        )
+                    )
+                    if dest_session is None:
+                        dest_session = models.ProjectSession(
+                            project_id=dest_project_rowid,
+                            session_id=session_id,
+                            start_time=trace.start_time,
+                            end_time=trace.end_time,
+                        )
+                        session.add(dest_session)
+                        await session.flush()
+                    dest_session_by_session_id[session_id] = dest_session
+                # Widen the destination session's window to cover the moved trace.
+                if trace.start_time < dest_session.start_time:
+                    dest_session.start_time = trace.start_time
+                if dest_session.end_time < trace.end_time:
+                    dest_session.end_time = trace.end_time
+                trace.project_session_rowid = dest_session.id
+            await session.flush()
+
+            # Sweep source sessions left with no traces — including the just-vacated ones, and
+            # before their (project_id, session_id) could be reused.
+            if source_session_rowids:
+                still_referenced = set(
+                    await session.scalars(
+                        select(models.Trace.project_session_rowid)
+                        .where(models.Trace.project_session_rowid.in_(source_session_rowids))
+                        .distinct()
+                    )
+                )
+                if orphaned := source_session_rowids - still_referenced:
+                    await session.execute(
+                        delete(models.ProjectSession).where(models.ProjectSession.id.in_(orphaned))
+                    )
 
         return Query()

--- a/src/phoenix/server/api/mutations/user_group_mutations.py
+++ b/src/phoenix/server/api/mutations/user_group_mutations.py
@@ -1,0 +1,132 @@
+from typing import Optional
+
+import strawberry
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.types import Info
+
+from phoenix.db import models
+from phoenix.server.access import SubjectKind
+from phoenix.server.api.auth import IsAdmin, IsLocked, IsNotReadOnly, IsNotViewer
+from phoenix.server.api.context import Context
+from phoenix.server.api.exceptions import BadRequest, Conflict, NotFound
+from phoenix.server.api.queries import Query
+from phoenix.server.api.types.UserGroup import LOCAL_PROVIDER, UserGroup, to_gql_user_group
+
+
+@strawberry.type
+class UserGroupMutationPayload:
+    query: Query
+    user_group: Optional[UserGroup] = None
+
+
+async def _local_group_or_not_found(session: AsyncSession, group_id: int) -> models.UserGroup:
+    """Fetch an admin-managed group, or 'not found'. IdP-synced groups are invisible
+    here — they are owned by the login-time reconcile, not editable in-product."""
+    group = await session.scalar(
+        select(models.UserGroup).where(
+            models.UserGroup.id == group_id,
+            models.UserGroup.provider == LOCAL_PROVIDER,
+        )
+    )
+    if group is None:
+        raise NotFound(f"Unknown local group: {group_id}")
+    return group
+
+
+async def _member_ids(session: AsyncSession, group_id: int) -> list[int]:
+    return list(
+        await session.scalars(
+            select(models.UserGroupMembership.user_id).where(
+                models.UserGroupMembership.user_group_id == group_id
+            )
+        )
+    )
+
+
+@strawberry.type
+class UserGroupMutationMixin:
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdmin, IsLocked])  # type: ignore
+    async def create_user_group(
+        self, info: Info[Context, None], name: str
+    ) -> UserGroupMutationPayload:
+        """Create an admin-managed (local) group — the no-IdP path so a basic-auth
+        deployment can grant to teams rather than per-user. Coexists with IdP groups
+        via a distinct provider namespace, so the login reconcile never touches it."""
+        clean = name.strip()
+        if not clean:
+            raise BadRequest("Group name must be non-empty")
+        async with info.context.db() as session:
+            existing = await session.scalar(
+                select(models.UserGroup.id).where(
+                    models.UserGroup.provider == LOCAL_PROVIDER,
+                    models.UserGroup.group_key == clean,
+                )
+            )
+            if existing is not None:
+                raise Conflict(f"A local group named {clean!r} already exists")
+            group = models.UserGroup(provider=LOCAL_PROVIDER, group_key=clean, display_name=clean)
+            session.add(group)
+            await session.flush()
+            gql = to_gql_user_group(group, [])
+        return UserGroupMutationPayload(query=Query(), user_group=gql)
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdmin, IsLocked])  # type: ignore
+    async def delete_user_group(
+        self, info: Info[Context, None], group_id: int
+    ) -> UserGroupMutationPayload:
+        """Delete a local group and sweep its grants. The group's acl rows carry no foreign
+        key, so deleting the group does not cascade them — remove them in the same transaction
+        before the id can be reused, otherwise a future group assigned this id would silently
+        inherit the stale grants. Memberships cascade via their foreign key."""
+        async with info.context.db() as session:
+            await _local_group_or_not_found(session, group_id)
+            await session.execute(
+                delete(models.AccessGrant).where(
+                    models.AccessGrant.subject_kind == SubjectKind.GROUP.value,
+                    models.AccessGrant.subject_id == group_id,
+                )
+            )
+            await session.execute(delete(models.UserGroup).where(models.UserGroup.id == group_id))
+        return UserGroupMutationPayload(query=Query())
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdmin, IsLocked])  # type: ignore
+    async def add_user_group_member(
+        self, info: Info[Context, None], group_id: int, user_id: int
+    ) -> UserGroupMutationPayload:
+        """Add a user to a local group. Idempotent. Takes effect immediately — the
+        oracle reads memberships live per request."""
+        async with info.context.db() as session:
+            group = await _local_group_or_not_found(session, group_id)
+            user_exists = await session.scalar(
+                select(models.User.id).where(models.User.id == user_id)
+            )
+            if user_exists is None:
+                raise NotFound(f"Unknown user: {user_id}")
+            existing = await session.scalar(
+                select(models.UserGroupMembership.user_id).where(
+                    models.UserGroupMembership.user_group_id == group_id,
+                    models.UserGroupMembership.user_id == user_id,
+                )
+            )
+            if existing is None:
+                session.add(models.UserGroupMembership(user_group_id=group_id, user_id=user_id))
+                await session.flush()
+            gql = to_gql_user_group(group, await _member_ids(session, group_id))
+        return UserGroupMutationPayload(query=Query(), user_group=gql)
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdmin, IsLocked])  # type: ignore
+    async def remove_user_group_member(
+        self, info: Info[Context, None], group_id: int, user_id: int
+    ) -> UserGroupMutationPayload:
+        """Remove a user from a local group. Takes effect on the member's next request."""
+        async with info.context.db() as session:
+            group = await _local_group_or_not_found(session, group_id)
+            await session.execute(
+                delete(models.UserGroupMembership).where(
+                    models.UserGroupMembership.user_group_id == group_id,
+                    models.UserGroupMembership.user_id == user_id,
+                )
+            )
+            gql = to_gql_user_group(group, await _member_ids(session, group_id))
+        return UserGroupMutationPayload(query=Query(), user_group=gql)

--- a/src/phoenix/server/api/mutations/user_mutations.py
+++ b/src/phoenix/server/api/mutations/user_mutations.py
@@ -355,6 +355,17 @@ class UserMutationMixin:
                     select(models.ApiKey.id).where(models.ApiKey.user_id.in_(user_rowids))
                 )
             ]
+            # Sweep this user's access grants in the same transaction. acls.subject_id
+            # is polymorphic and carries no FK, so nothing cascades; left behind, a
+            # user-subject grant becomes a dangling row that a recycled user id could
+            # silently inherit. Remove it before the id can be reused (the write-time
+            # half of the dangling/reuse fix; read-time inertness is the other half).
+            await session.execute(
+                delete(models.AccessGrant).where(
+                    models.AccessGrant.subject_kind == "user",
+                    models.AccessGrant.subject_id.in_(user_rowids),
+                )
+            )
             deleted_user_ids = await session.scalars(
                 delete(models.User).where(models.User.id.in_(user_rowids)).returning(models.User.id)
             )

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -7,6 +7,7 @@ from typing import cast as type_cast
 
 import strawberry
 from sqlalchemy import ColumnElement, String, and_, case, cast, exists, func, or_, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, load_only, with_polymorphic
 from starlette.authentication import UnauthenticatedUser
 from strawberry import UNSET
@@ -33,7 +34,13 @@ from phoenix.db.helpers import (
 from phoenix.db.models import LatencyMs
 from phoenix.db.types.annotation_configs import OptimizationDirection
 from phoenix.db.types.prompts import PromptMessageRole
-from phoenix.server.api.auth import MSG_ADMIN_ONLY, IsAdmin
+from phoenix.server.access import (
+    OBJECT_TYPE_DATASET,
+    OBJECT_TYPE_PROJECT,
+    OBJECT_TYPE_PROMPT,
+    SubjectKind,
+)
+from phoenix.server.api.auth import MSG_ADMIN_ONLY, IsAdmin, IsAdminIfAuthEnabled
 from phoenix.server.api.context import Context
 from phoenix.server.api.evaluators import (
     apply_input_mapping,
@@ -67,6 +74,8 @@ from phoenix.server.api.input_types.ProjectSort import ProjectColumn, ProjectSor
 from phoenix.server.api.input_types.PromptFilter import PromptFilter
 from phoenix.server.api.input_types.PromptTemplateOptions import PromptTemplateOptions
 from phoenix.server.api.input_types.PromptVersionInput import PromptChatTemplateInput
+from phoenix.server.api.input_types.UserFilter import UserFilter
+from phoenix.server.api.types.AccessObjectType import AccessObjectType
 from phoenix.server.api.types.AgentsConfig import AgentsConfig
 from phoenix.server.api.types.AgentSkill import AgentSkill
 from phoenix.server.api.types.AnnotationConfig import AnnotationConfig, to_gql_annotation_config
@@ -108,6 +117,7 @@ from phoenix.server.api.types.pagination import (
     connection_from_cursors_and_nodes,
     connection_from_list,
 )
+from phoenix.server.api.types.PermissionSet import PermissionSet, to_gql_permission_set
 from phoenix.server.api.types.PlaygroundModel import PlaygroundModel
 from phoenix.server.api.types.Project import Project
 from phoenix.server.api.types.ProjectSession import ProjectSession
@@ -128,6 +138,11 @@ from phoenix.server.api.types.PromptVersionTemplate import (
     ToolResultContentPart,
     ToolResultContentValue,
 )
+from phoenix.server.api.types.ResourceTag import (
+    ResourceTag,
+    TagAccessGrant,
+    to_gql_tag_grant,
+)
 from phoenix.server.api.types.SandboxConfig import (
     SandboxBackendInfo,
     SandboxConfig,
@@ -144,6 +159,7 @@ from phoenix.server.api.types.Trace import Trace
 from phoenix.server.api.types.TraceAnnotation import TraceAnnotation
 from phoenix.server.api.types.User import User
 from phoenix.server.api.types.UserApiKey import UserApiKey
+from phoenix.server.api.types.UserGroup import LOCAL_PROVIDER, UserGroup, to_gql_user_group
 from phoenix.server.api.types.UserRole import UserRole
 from phoenix.server.api.types.ValidationResult import ValidationResult
 from phoenix.server.sandbox.types import SANDBOX_BACKEND_TYPES
@@ -212,6 +228,206 @@ class ExperimentRunMetricComparisons:
     total_cost: ExperimentRunMetricComparison
     prompt_cost: ExperimentRunMetricComparison
     completion_cost: ExperimentRunMetricComparison
+
+
+async def _parent_project_id(
+    session: "AsyncSession", type_name: str, node_id: int
+) -> Optional[int]:
+    """The project a containment child belongs to, walking the containment edges.
+    Annotations are reached through their span/trace; access derives from the project,
+    never an independent grant on the child itself."""
+    if type_name == Trace.__name__:
+        return type_cast(
+            Optional[int],
+            await session.scalar(
+                select(models.Trace.project_rowid).where(models.Trace.id == node_id)
+            ),
+        )
+    if type_name == Span.__name__:
+        return type_cast(
+            Optional[int],
+            await session.scalar(
+                select(models.Trace.project_rowid)
+                .join(models.Span, models.Span.trace_rowid == models.Trace.id)
+                .where(models.Span.id == node_id)
+            ),
+        )
+    if type_name == ProjectSession.__name__:
+        return type_cast(
+            Optional[int],
+            await session.scalar(
+                select(models.ProjectSession.project_id).where(models.ProjectSession.id == node_id)
+            ),
+        )
+    if type_name == SpanAnnotation.__name__:
+        return type_cast(
+            Optional[int],
+            await session.scalar(
+                select(models.Trace.project_rowid)
+                .join(models.Span, models.Span.trace_rowid == models.Trace.id)
+                .join(models.SpanAnnotation, models.SpanAnnotation.span_rowid == models.Span.id)
+                .where(models.SpanAnnotation.id == node_id)
+            ),
+        )
+    if type_name == TraceAnnotation.__name__:
+        return type_cast(
+            Optional[int],
+            await session.scalar(
+                select(models.Trace.project_rowid)
+                .join(models.TraceAnnotation, models.TraceAnnotation.trace_rowid == models.Trace.id)
+                .where(models.TraceAnnotation.id == node_id)
+            ),
+        )
+    return None
+
+
+async def _containment_readable(info: Info[Context, None], type_name: str, node_id: int) -> bool:
+    """Whether a containment child (span/trace/session/annotation) is readable — via
+    its parent project's accessibility. Short-circuits when the actor sees everything."""
+    async with info.context.db.read() as session:
+        scope = await info.context.access_scope(session, OBJECT_TYPE_PROJECT)
+        if scope.everything or scope.type_allows:
+            return True
+        project_id = await _parent_project_id(session, type_name, node_id)
+    return project_id is not None and scope.allows(project_id)
+
+
+async def _gate_containment_node(
+    info: Info[Context, None], type_name: str, node_id: int, gid: strawberry.ID
+) -> None:
+    """Gate a containment-child node fetch by its parent project's accessibility.
+    Unauthorized is indistinguishable from not-found."""
+    if not await _containment_readable(info, type_name, node_id):
+        raise NotFound(f"Unknown node: {gid}")
+
+
+# The eval-world nodes derive access from their data context: dataset-rooted (experiments,
+# runs, jobs, examples) or prompt-rooted (prompt versions). They never carry their own grant.
+_EVAL_NODE_OBJECT_TYPE: dict[str, str] = {
+    "DatasetExample": OBJECT_TYPE_DATASET,
+    "Experiment": OBJECT_TYPE_DATASET,
+    "ExperimentRun": OBJECT_TYPE_DATASET,
+    "ExperimentJob": OBJECT_TYPE_DATASET,
+    "PromptVersion": OBJECT_TYPE_PROMPT,
+}
+
+
+async def _eval_node_parent_id(
+    session: "AsyncSession", type_name: str, node_id: int
+) -> Optional[int]:
+    """The dataset/prompt id an eval-world node derives access from (access-by-parent)."""
+    if type_name == "DatasetExample":
+        return type_cast(
+            Optional[int],
+            await session.scalar(
+                select(models.DatasetExample.dataset_id).where(models.DatasetExample.id == node_id)
+            ),
+        )
+    if type_name == "Experiment":
+        return type_cast(
+            Optional[int],
+            await session.scalar(
+                select(models.Experiment.dataset_id).where(models.Experiment.id == node_id)
+            ),
+        )
+    if type_name == "ExperimentRun":
+        return type_cast(
+            Optional[int],
+            await session.scalar(
+                select(models.Experiment.dataset_id)
+                .join(
+                    models.ExperimentRun, models.ExperimentRun.experiment_id == models.Experiment.id
+                )
+                .where(models.ExperimentRun.id == node_id)
+            ),
+        )
+    if type_name == "ExperimentJob":
+        # experiment_jobs.id is a 1:1 FK to experiments.id.
+        return type_cast(
+            Optional[int],
+            await session.scalar(
+                select(models.Experiment.dataset_id).where(models.Experiment.id == node_id)
+            ),
+        )
+    if type_name == "PromptVersion":
+        return type_cast(
+            Optional[int],
+            await session.scalar(
+                select(models.PromptVersion.prompt_id).where(models.PromptVersion.id == node_id)
+            ),
+        )
+    return None
+
+
+async def _eval_readable(info: Info[Context, None], type_name: str, node_id: int) -> bool:
+    """Whether an eval-world node (experiment/run/job/example/prompt-version) is readable
+    — via its parent dataset's or prompt's accessibility (access-by-parent)."""
+    object_type = _EVAL_NODE_OBJECT_TYPE.get(type_name)
+    if object_type is None:
+        return True
+    async with info.context.db.read() as session:
+        scope = await info.context.access_scope(session, object_type)
+        if scope.everything or scope.type_allows:
+            return True
+        parent_id = await _eval_node_parent_id(session, type_name, node_id)
+    return parent_id is not None and scope.allows(parent_id)
+
+
+async def _gate_eval_node(
+    info: Info[Context, None], type_name: str, node_id: int, gid: strawberry.ID
+) -> None:
+    """Gate an eval-world node fetch by its parent dataset's or prompt's accessibility
+    (access-by-parent). Unauthorized is indistinguishable from not-found."""
+    if not await _eval_readable(info, type_name, node_id):
+        raise NotFound(f"Unknown node: {gid}")
+
+
+# The Relay type name and ORM model backing each grantable object kind, so a tag read can
+# decode the object's GlobalID and confirm it exists.
+_ACCESS_OBJECT_GQL: dict[AccessObjectType, tuple[str, type[models.HasId]]] = {
+    AccessObjectType.PROJECT: ("Project", models.Project),
+    AccessObjectType.DATASET: ("Dataset", models.Dataset),
+    AccessObjectType.PROMPT: ("Prompt", models.Prompt),
+}
+
+
+async def _tag_grant_subject_names(
+    session: AsyncSession, rows: Iterable[models.AccessGrant]
+) -> dict[tuple[str, int], str]:
+    """Display names keyed by (subject_kind, subject_id) for a batch of tag grants, so the list
+    reads as people and groups rather than raw ids. EVERYONE carries no id and is named in the
+    mapper. One query per referenced kind — not per row."""
+    user_ids: set[int] = set()
+    group_ids: set[int] = set()
+    for row in rows:
+        if row.subject_id is None:
+            continue
+        if row.subject_kind == SubjectKind.USER.value:
+            user_ids.add(row.subject_id)
+        elif row.subject_kind == SubjectKind.GROUP.value:
+            group_ids.add(row.subject_id)
+    names: dict[tuple[str, int], str] = {}
+    if user_ids:
+        for uid, username, email in (
+            await session.execute(
+                select(models.User.id, models.User.username, models.User.email).where(
+                    models.User.id.in_(user_ids)
+                )
+            )
+        ).all():
+            names[(SubjectKind.USER.value, uid)] = email or username or f"user:{uid}"
+    if group_ids:
+        for gid, display_name, group_key in (
+            await session.execute(
+                select(
+                    models.UserGroup.id,
+                    models.UserGroup.display_name,
+                    models.UserGroup.group_key,
+                ).where(models.UserGroup.id.in_(group_ids))
+            )
+        ).all():
+            names[(SubjectKind.GROUP.value, gid)] = display_name or group_key or f"group:{gid}"
+    return names
 
 
 @strawberry.type
@@ -372,6 +588,7 @@ class Query:
         last: Optional[int] = UNSET,
         after: Optional[CursorString] = UNSET,
         before: Optional[CursorString] = UNSET,
+        filter: Optional[UserFilter] = UNSET,
     ) -> Connection[User]:
         args = ConnectionArgs(
             first=first,
@@ -386,6 +603,13 @@ class Query:
             .order_by(models.User.email)
             .options(joinedload(models.User.role))
         )
+        if filter is not UNSET and filter and filter.value:
+            value = filter.value.strip()
+            if value:
+                search = f"%{value}%"
+                stmt = stmt.where(
+                    or_(models.User.email.ilike(search), models.User.username.ilike(search))
+                )
         async with info.context.db.read() as session:
             users = await session.stream_scalars(stmt)
             data = [User(id=user.id, db_record=user) async for user in users]
@@ -475,6 +699,11 @@ class Query:
         projects_query = exclude_experiment_projects(projects_query)
         projects_query = exclude_dataset_evaluator_projects(projects_query)
         async with info.context.db.read() as session:
+            # Restrict to the projects this actor may access. A no-op when access
+            # control is disabled.
+            projects_query = projects_query.where(
+                await info.context.access_filter(session, OBJECT_TYPE_PROJECT, models.Project.id)
+            )
             projects = await session.stream_scalars(projects_query)
             data = [Project(id=project.id, db_record=project) async for project in projects]
         return connection_from_list(data=data, args=args)
@@ -482,6 +711,102 @@ class Query:
     @strawberry.field
     def projects_last_updated_at(self, info: Info[Context, None]) -> Optional[datetime]:
         return info.context.last_updated_at.get(models.Project)
+
+    @strawberry.field(permission_classes=[IsAdmin])  # type: ignore[untyped-decorator]
+    async def permission_sets(self, info: Info[Context, None]) -> list[PermissionSet]:
+        """The permission sets available when granting access — built-in presets plus
+        any custom roles. Drives the role picker and the roles admin view."""
+        async with info.context.db.read() as session:
+            roles = (
+                await session.scalars(
+                    select(models.PermissionSet)
+                    .options(joinedload(models.PermissionSet.permissions))
+                    .order_by(models.PermissionSet.is_built_in.desc(), models.PermissionSet.name)
+                )
+            ).unique()
+        return [to_gql_permission_set(role) for role in roles]
+
+    @strawberry.field(permission_classes=[IsAdminIfAuthEnabled])  # type: ignore[untyped-decorator]
+    async def resource_tags(
+        self,
+        info: Info[Context, None],
+        object_type: AccessObjectType,
+        object_id: GlobalID,
+    ) -> list[ResourceTag]:
+        """The curated ``key=value`` tags on one access-controlled object — the read-back for
+        ``setResourceTag`` / ``removeResourceTag``. Admin-gated when auth is enabled (open
+        otherwise, as access control presupposes auth)."""
+        type_name, model = _ACCESS_OBJECT_GQL[object_type]
+        try:
+            rowid = from_global_id_with_expected_type(object_id, type_name)
+        except ValueError:
+            raise NotFound(f"Unknown {type_name}: {object_id}") from None
+        async with info.context.db.read() as session:
+            if await session.scalar(select(model.id).where(model.id == rowid)) is None:
+                raise NotFound(f"Unknown {type_name}: {object_id}")
+            rows = (
+                await session.execute(
+                    select(models.ResourceTag.key, models.ResourceTag.value)
+                    .where(
+                        models.ResourceTag.object_type == object_type.value,
+                        models.ResourceTag.object_id == rowid,
+                    )
+                    .order_by(models.ResourceTag.key)
+                )
+            ).all()
+        return [ResourceTag(key=key, value=value) for key, value in rows]
+
+    @strawberry.field(permission_classes=[IsAdminIfAuthEnabled])  # type: ignore[untyped-decorator]
+    async def tag_grants(
+        self,
+        info: Info[Context, None],
+        object_type: Optional[AccessObjectType] = None,
+    ) -> list[TagAccessGrant]:
+        """The tag grants (optionally scoped to one object type) — the read-back for
+        ``grantTagAccess`` / ``revokeTagAccess``. Type-scoped policy, so admin-gated like
+        authoring one (open when auth is disabled)."""
+        async with info.context.db.read() as session:
+            stmt = select(models.AccessGrant).where(
+                models.AccessGrant.effect == "allow",
+                models.AccessGrant.selector_kind == "tag",
+            )
+            if object_type is not None:
+                stmt = stmt.where(models.AccessGrant.object_type == object_type.value)
+            rows = (await session.scalars(stmt.order_by(models.AccessGrant.id.desc()))).all()
+            role_names: dict[int, str] = {
+                rid: name
+                for rid, name in (
+                    await session.execute(
+                        select(models.PermissionSet.id, models.PermissionSet.name)
+                    )
+                ).all()
+            }
+            subject_names = await _tag_grant_subject_names(session, rows)
+        return [to_gql_tag_grant(row, role_names, subject_names) for row in rows]
+
+    @strawberry.field(permission_classes=[IsAdmin])  # type: ignore[untyped-decorator]
+    async def user_groups(
+        self, info: Info[Context, None], local_only: bool = False
+    ) -> list[UserGroup]:
+        """Groups usable as grant subjects. ``local_only`` filters to admin-managed
+        groups (the manageable set); the full list also includes IdP-synced groups, for
+        the grant picker."""
+        async with info.context.db.read() as session:
+            stmt = select(models.UserGroup).order_by(models.UserGroup.id)
+            if local_only:
+                stmt = stmt.where(models.UserGroup.provider == LOCAL_PROVIDER)
+            groups = (await session.scalars(stmt)).all()
+            result: list[UserGroup] = []
+            for group in groups:
+                member_ids = list(
+                    await session.scalars(
+                        select(models.UserGroupMembership.user_id).where(
+                            models.UserGroupMembership.user_group_id == group.id
+                        )
+                    )
+                )
+                result.append(to_gql_user_group(group, member_ids))
+        return result
 
     @strawberry.field
     async def datasets(
@@ -535,6 +860,11 @@ class Query:
                         .distinct()
                     )
         async with info.context.db.read() as session:
+            # Restrict to the datasets this actor may access (creator-private +
+            # grants). A no-op when access control is disabled.
+            stmt = stmt.where(
+                await info.context.access_filter(session, OBJECT_TYPE_DATASET, models.Dataset.id)
+            )
             datasets = await session.scalars(stmt)
         return connection_from_list(
             data=[Dataset(id=dataset.id, db_record=dataset) for dataset in datasets], args=args
@@ -578,6 +908,11 @@ class Query:
                 raise BadRequest(f"Invalid compare experiment ID: {compare_experiment_id}")
 
         experiment_rowids = [base_experiment_rowid, *compare_experiment_rowids]
+
+        # Every named experiment must be readable via its dataset (access-by-parent).
+        for rowid in experiment_rowids:
+            if not await _eval_readable(info, "Experiment", rowid):
+                raise NotFound("Unknown experiment")
 
         cursor = Cursor.from_string(after) if after else None
         page_size = first or 50
@@ -719,6 +1054,11 @@ class Query:
                 )
             except ValueError:
                 raise BadRequest(f"Invalid compare experiment ID: {compare_experiment_id}")
+
+        # Every named experiment must be readable via its dataset (access-by-parent).
+        for rowid in (base_experiment_rowid, *compare_experiment_rowids):
+            if not await _eval_readable(info, "Experiment", rowid):
+                raise NotFound("Unknown experiment")
 
         base_experiment_runs = (
             select(
@@ -1005,6 +1345,9 @@ class Query:
                 )
             except Exception:
                 raise NotFound(f"Unknown node: {id}")
+            # The run group is readable iff its experiment's dataset is (access-by-parent).
+            if not await _eval_readable(info, "Experiment", experiment_rowid):
+                raise NotFound(f"Unknown node: {id}")
             return ExperimentRepeatedRunGroup(
                 experiment_rowid=experiment_rowid,
                 dataset_example_rowid=dataset_example_rowid,
@@ -1032,32 +1375,88 @@ class Query:
         if type_name == "Dimension" or type_name == "EmbeddingDimension":
             raise NotFound(f"Unknown node type: {type_name}")
         if type_name == Project.__name__:
+            async with info.context.db.read() as session:
+                # Existence and access are distinct: can_access alone answers True for an
+                # administrator or a type-wide grant holder even for an id that names no
+                # project, so a bare authorization check would resolve a nonexistent node to
+                # a stub. Confirm the row exists, then gate on access (short-circuited).
+                exists_row = await session.scalar(
+                    select(models.Project.id).where(models.Project.id == node_id)
+                )
+                readable = exists_row is not None and await info.context.can_access(
+                    session, OBJECT_TYPE_PROJECT, node_id
+                )
+            if not readable:
+                raise NotFound(f"Unknown node: {id}")
             return Project(id=node_id)
         elif type_name == Trace.__name__:
+            await _gate_containment_node(info, type_name, node_id, id)
             return Trace(id=node_id)
         elif type_name == Span.__name__:
+            await _gate_containment_node(info, type_name, node_id, id)
             return Span(id=node_id)
         elif type_name == Dataset.__name__:
+            async with info.context.db.read() as session:
+                scope = await info.context.access_scope(session, OBJECT_TYPE_DATASET)
+            if not scope.allows(node_id):
+                raise NotFound(f"Unknown node: {id}")
             return Dataset(id=node_id)
         elif type_name == DatasetExample.__name__:
+            await _gate_eval_node(info, type_name, node_id, id)
             return DatasetExample(id=node_id)
         elif type_name == DatasetSplit.__name__:
             return DatasetSplit(id=node_id)
         elif type_name == Experiment.__name__:
+            await _gate_eval_node(info, type_name, node_id, id)
             return Experiment(id=node_id)
         elif type_name == ExperimentRun.__name__:
+            await _gate_eval_node(info, type_name, node_id, id)
             return ExperimentRun(id=node_id)
         elif type_name == ExperimentJob.__name__:
+            await _gate_eval_node(info, type_name, node_id, id)
             return ExperimentJob(id=node_id)
         elif type_name == User.__name__:
             if int((user := info.context.user).identity) != node_id and not user.is_admin:
                 raise Unauthorized(MSG_ADMIN_ONLY)
             return User(id=node_id)
+        elif type_name == UserGroup.__name__:
+            if not info.context.user.is_admin:
+                raise Unauthorized(MSG_ADMIN_ONLY)
+            async with info.context.db.read() as session:
+                group = await session.get(models.UserGroup, node_id)
+                if group is None:
+                    raise NotFound(f"Unknown node: {id}")
+                member_ids = list(
+                    await session.scalars(
+                        select(models.UserGroupMembership.user_id).where(
+                            models.UserGroupMembership.user_group_id == group.id
+                        )
+                    )
+                )
+            return to_gql_user_group(group, member_ids)
+        elif type_name == PermissionSet.__name__:
+            if not info.context.user.is_admin:
+                raise Unauthorized(MSG_ADMIN_ONLY)
+            async with info.context.db.read() as session:
+                role = await session.scalar(
+                    select(models.PermissionSet)
+                    .options(joinedload(models.PermissionSet.permissions))
+                    .where(models.PermissionSet.id == node_id)
+                )
+            if role is None:
+                raise NotFound(f"Unknown node: {id}")
+            return to_gql_permission_set(role)
         elif type_name == ProjectSession.__name__:
+            await _gate_containment_node(info, type_name, node_id, id)
             return ProjectSession(id=node_id)
         elif type_name == Prompt.__name__:
+            async with info.context.db.read() as session:
+                scope = await info.context.access_scope(session, OBJECT_TYPE_PROMPT)
+            if not scope.allows(node_id):
+                raise NotFound(f"Unknown node: {id}")
             return Prompt(id=node_id)
         elif type_name == PromptVersion.__name__:
+            await _gate_eval_node(info, type_name, node_id, id)
             async with info.context.db.read() as session:
                 if orm_prompt_version := await session.scalar(
                     select(models.PromptVersion).where(models.PromptVersion.id == node_id)
@@ -1072,8 +1471,10 @@ class Query:
         elif type_name == ProjectTraceRetentionPolicy.__name__:
             return ProjectTraceRetentionPolicy(id=node_id)
         elif type_name == SpanAnnotation.__name__:
+            await _gate_containment_node(info, type_name, node_id, id)
             return SpanAnnotation(id=node_id)
         elif type_name == TraceAnnotation.__name__:
+            await _gate_containment_node(info, type_name, node_id, id)
             return TraceAnnotation(id=node_id)
         elif type_name == GenerativeModel.__name__:
             return GenerativeModel(id=node_id)
@@ -1140,6 +1541,11 @@ class Query:
             )
             stmt = stmt.distinct()
         async with info.context.db.read() as session:
+            # Restrict to the prompts this actor may access (creator-private +
+            # grants). A no-op when access control is disabled.
+            stmt = stmt.where(
+                await info.context.access_filter(session, OBJECT_TYPE_PROMPT, models.Prompt.id)
+            )
             orm_prompts = await session.stream_scalars(stmt)
             data = [
                 Prompt(id=orm_prompt.id, db_record=orm_prompt) async for orm_prompt in orm_prompts
@@ -1571,7 +1977,9 @@ class Query:
         stmt = select(models.Span.id).filter_by(span_id=span_id)
         async with info.context.db.read() as session:
             span_rowid = await session.scalar(stmt)
-        if span_rowid:
+        # Unauthorized is indistinguishable from not-found: a span's access derives from
+        # its project (containment).
+        if span_rowid and await _containment_readable(info, "Span", span_rowid):
             return Span(id=span_rowid)
         return None
 
@@ -1584,7 +1992,7 @@ class Query:
         stmt = select(models.Trace.id).where(models.Trace.trace_id == trace_id)
         async with info.context.db.read() as session:
             trace_rowid = await session.scalar(stmt)
-        if trace_rowid:
+        if trace_rowid and await _containment_readable(info, "Trace", trace_rowid):
             return Trace(id=trace_rowid)
         return None
 
@@ -1597,6 +2005,11 @@ class Query:
         stmt = select(models.Project).where(models.Project.name == name)
         async with info.context.db.read() as session:
             project_row = await session.scalar(stmt)
+            # Unauthorized is indistinguishable from not-found (no name oracle).
+            if project_row is not None:
+                scope = await info.context.access_scope(session, OBJECT_TYPE_PROJECT)
+                if not scope.allows(project_row.id):
+                    return None
         if project_row:
             return Project(id=project_row.id, db_record=project_row)
         return None
@@ -1610,7 +2023,7 @@ class Query:
         stmt = select(models.ProjectSession).where(models.ProjectSession.session_id == session_id)
         async with info.context.db.read() as session:
             session_row = await session.scalar(stmt)
-        if session_row:
+        if session_row and await _containment_readable(info, "ProjectSession", session_row.id):
             return ProjectSession(id=session_row.id, db_record=session_row)
         return None
 
@@ -1630,7 +2043,8 @@ class Query:
         )
         async with info.context.db() as session:
             example = await session.scalar(stmt)
-        if example:
+        # A dataset example's access derives from its dataset (access-by-parent).
+        if example and await _eval_readable(info, "DatasetExample", example.id):
             return DatasetExample(id=example.id, db_record=example)
         return None
 
@@ -1737,17 +2151,26 @@ class Query:
         stmt = exclude_experiment_projects(stmt)
         stmt = exclude_dataset_evaluator_projects(stmt)
         async with info.context.db.read() as session:
+            stmt = stmt.where(
+                await info.context.access_filter(session, OBJECT_TYPE_PROJECT, models.Project.id)
+            )
             return await session.scalar(stmt) or 0
 
     @strawberry.field
     async def dataset_count(self, info: Info[Context, None]) -> int:
         async with info.context.db.read() as session:
-            return await session.scalar(select(func.count(models.Dataset.id))) or 0
+            stmt = select(func.count(models.Dataset.id)).where(
+                await info.context.access_filter(session, OBJECT_TYPE_DATASET, models.Dataset.id)
+            )
+            return await session.scalar(stmt) or 0
 
     @strawberry.field
     async def prompt_count(self, info: Info[Context, None]) -> int:
         async with info.context.db.read() as session:
-            return await session.scalar(select(func.count(models.Prompt.id))) or 0
+            stmt = select(func.count(models.Prompt.id)).where(
+                await info.context.access_filter(session, OBJECT_TYPE_PROMPT, models.Prompt.id)
+            )
+            return await session.scalar(stmt) or 0
 
     @strawberry.field
     async def evaluator_count(self, info: Info[Context, None]) -> int:

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -399,7 +399,7 @@ async def _persist_db_traces(
     project_sessions = [
         db_trace.project_session for db_trace in db_traces if db_trace.project_session is not None
     ]
-    persistent_by_session_id = await _upsert_project_sessions(session, project_sessions)
+    persistent_by_project_session = await _upsert_project_sessions(session, project_sessions)
 
     existing_traces_by_trace_id = {
         trace.trace_id: trace
@@ -425,7 +425,9 @@ async def _persist_db_traces(
         # Only inserted traces should point at the persistent ProjectSession;
         # associating skipped transient traces causes autoflush warnings.
         persistent_project_session = (
-            persistent_by_session_id[db_trace.project_session.session_id]
+            persistent_by_project_session[
+                (db_trace.project_rowid, db_trace.project_session.session_id)
+            ]
             if db_trace.project_session is not None
             else None
         )
@@ -679,25 +681,26 @@ async def _ensure_project_exists(db: DbSessionFactory, project_name: str) -> int
 async def _upsert_project_sessions(
     session: AsyncSession,
     project_sessions: Iterable[models.ProjectSession],
-) -> dict[str, models.ProjectSession]:
+) -> dict[tuple[int, str], models.ProjectSession]:
     """
-    Upsert ProjectSession rows keyed by session_id, returning a
-    {session_id: ProjectSession} map of persistent ORM objects (loaded into the
-    session's identity map). Duplicates in the input are merged by session_id,
-    widening the start/end time range across duplicates.
+    Upsert ProjectSession rows keyed by (project_id, session_id), returning a
+    {(project_id, session_id): ProjectSession} map of persistent ORM objects
+    (loaded into the session's identity map). Duplicates in the input are merged
+    by that composite key, widening the start/end time range across duplicates.
     """
-    project_sessions_by_session_id: dict[str, models.ProjectSession] = {}
+    project_sessions_by_key: dict[tuple[int, str], models.ProjectSession] = {}
     for project_session in project_sessions:
-        existing = project_sessions_by_session_id.get(project_session.session_id)
+        key = (project_session.project_id, project_session.session_id)
+        existing = project_sessions_by_key.get(key)
         if existing is None:
-            project_sessions_by_session_id[project_session.session_id] = project_session
+            project_sessions_by_key[key] = project_session
         else:
             if project_session.start_time < existing.start_time:
                 existing.start_time = project_session.start_time
             if existing.end_time < project_session.end_time:
                 existing.end_time = project_session.end_time
 
-    if not project_sessions_by_session_id:
+    if not project_sessions_by_key:
         return {}
 
     dialect = SupportedSQLDialect(session.bind.dialect.name)
@@ -708,13 +711,13 @@ async def _upsert_project_sessions(
             "start_time": project_session.start_time,
             "end_time": project_session.end_time,
         }
-        for project_session in project_sessions_by_session_id.values()
+        for project_session in project_sessions_by_key.values()
     ]
     upsert: Insert
     if dialect is SupportedSQLDialect.POSTGRESQL:
         pg_insert = insert_postgresql(models.ProjectSession).values(records)
         upsert = pg_insert.on_conflict_do_update(
-            index_elements=["session_id"],
+            index_elements=["project_id", "session_id"],
             set_={
                 "start_time": func.least(
                     models.ProjectSession.start_time, pg_insert.excluded.start_time
@@ -729,7 +732,7 @@ async def _upsert_project_sessions(
         # functions (i.e. with >1 argument) are the equivalent.
         sqlite_insert = insert_sqlite(models.ProjectSession).values(records)
         upsert = sqlite_insert.on_conflict_do_update(
-            index_elements=["session_id"],
+            index_elements=["project_id", "session_id"],
             set_={
                 "start_time": func.min(
                     models.ProjectSession.start_time, sqlite_insert.excluded.start_time
@@ -742,7 +745,7 @@ async def _upsert_project_sessions(
     else:
         assert_never(dialect)
     returned_rows = await session.scalars(upsert.returning(models.ProjectSession))
-    return {row.session_id: row for row in returned_rows}
+    return {(row.project_id, row.session_id): row for row in returned_rows}
 
 
 def _maybe_using_user(

--- a/src/phoenix/server/api/routers/auth.py
+++ b/src/phoenix/server/api/routers/auth.py
@@ -35,6 +35,7 @@ from phoenix.config import (
     get_env_disable_rate_limit,
 )
 from phoenix.db import models
+from phoenix.server.access import sync_user_groups
 from phoenix.server.api.routers.ldap import get_or_create_ldap_user
 from phoenix.server.bearer_auth import PhoenixUser, create_access_and_refresh_tokens
 from phoenix.server.email.types import EmailSender
@@ -365,6 +366,13 @@ async def _ldap_login(request: Request) -> Response:
     # Get or create user in Phoenix database
     async with request.app.state.db() as session:
         user = await get_or_create_ldap_user(session, user_info, authenticator.config)
+        # Materialize the LDAP groups so access can be granted to them.
+        await sync_user_groups(
+            session,
+            user_id=user.id,
+            provider="ldap",
+            group_keys=user_info.groups,
+        )
 
     _record_brute_force_success(lockout_key)
     return await _create_auth_response(request, user)

--- a/src/phoenix/server/api/routers/ldap.py
+++ b/src/phoenix/server/api/routers/ldap.py
@@ -183,6 +183,9 @@ async def get_or_create_ldap_user(
     )
     user.role = role  # Set relationship for eager access after session closes
     session.add(user)
+    # Flush so user.id is populated before callers (e.g. group sync) reference it —
+    # a membership insert with a null user_id would otherwise violate NOT NULL.
+    await session.flush()
     return user
 
 

--- a/src/phoenix/server/api/routers/oauth2.py
+++ b/src/phoenix/server/api/routers/oauth2.py
@@ -45,6 +45,7 @@ from phoenix.config import (
     get_env_disable_rate_limit,
 )
 from phoenix.db import models
+from phoenix.server.access import sync_user_groups
 from phoenix.server.api.auth_messages import AuthErrorCode
 from phoenix.server.bearer_auth import create_access_and_refresh_tokens
 from phoenix.server.oauth2 import DEFAULT_EMAIL_PATH, OAuth2Client, search_claim_path
@@ -260,6 +261,15 @@ async def create_tokens(
                 allow_sign_up=oauth2_client.allow_sign_up,
                 role_name=role_name,
                 role_resync=oauth2_client.role_resync,
+            )
+            # Materialize the IdP groups so access can be granted to them. The
+            # groups were already extracted for access validation above; persist
+            # them now, namespaced by this IdP, in the same transaction.
+            await sync_user_groups(
+                session,
+                user_id=user.id,
+                provider=f"oauth2:{idp_name}",
+                group_keys=oauth2_client.extract_groups(user_info.claims),
             )
     except EmailAlreadyInUse as e:
         logger.error("Email already in use for IDP %s: %s", idp_name, e)

--- a/src/phoenix/server/api/routers/v1/__init__.py
+++ b/src/phoenix/server/api/routers/v1/__init__.py
@@ -7,6 +7,8 @@ from phoenix.server.authorization import (
 )
 from phoenix.server.bearer_auth import is_authenticated
 
+from .access import owner_router as access_owner_router
+from .access import router as access_router
 from .annotation_configs import router as annotation_configs_router
 from .annotations import router as annotations_router
 from .dataset_labels import router as dataset_labels_router
@@ -27,7 +29,11 @@ from .utils import add_errors_to_responses
 REST_API_VERSION = "1.0"
 
 
-def create_v1_router(authentication_enabled: bool) -> APIRouter:
+def create_v1_router(
+    authentication_enabled: bool,
+    *,
+    access_control_enabled: bool = True,
+) -> APIRouter:
     """
     Instantiates the v1 REST API router.
     """
@@ -55,6 +61,9 @@ def create_v1_router(authentication_enabled: bool) -> APIRouter:
             ]
         ),
     )
+    if access_control_enabled:
+        router.include_router(access_router)
+        router.include_router(access_owner_router)
     router.include_router(annotation_configs_router)
     router.include_router(annotations_router)
     router.include_router(dataset_labels_router)

--- a/src/phoenix/server/api/routers/v1/access.py
+++ b/src/phoenix/server/api/routers/v1/access.py
@@ -1,0 +1,1029 @@
+"""The access-control admin API (the REST complement to the GraphQL grant mutations).
+
+A deliberately small surface. The grantable ``object_type`` enum is exactly the three
+access *roots* — project / dataset / prompt. Containment children (spans, traces,
+annotations) and eval artifacts (experiments, runs) are absent *by design*: their access is
+inherited from a parent, so they are never granted directly. The model is **allow-only**:
+there is no ``effect`` field, so the schema cannot express deny. Type-wide authoring is
+**admin-only**; per-object authoring requires ``OBJ_MANAGE_ACCESS`` on that object (open when
+auth is disabled).
+
+**Id convention:** every id on the wire is a Relay **GlobalID string**, matching the rest
+of the v1 API — objects (``Project``/``Dataset``/``Prompt``), users (``User``), and the
+access-control entities (``UserGroup``/``Role``/``ServiceAccount``/``AccessGrant``/
+``PermissionSet``). The latter are not GraphQL nodes, so their GlobalIDs are opaque type-tagged
+tokens that do not resolve through ``node()`` — but a client uses one id format everywhere.
+"""
+
+from enum import Enum
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+from starlette.requests import Request
+from strawberry.relay import GlobalID
+
+from phoenix.config import get_env_access_control_enabled
+from phoenix.db import models
+from phoenix.server.access import (
+    DEFAULT_PERMISSION_SET,
+    OBJECT_TYPE_DATASET,
+    OBJECT_TYPE_PROJECT,
+    OBJECT_TYPE_PROMPT,
+    Permission,
+    SubjectKind,
+    can_access,
+    subjects_for,
+    would_strand_last_manager,
+)
+from phoenix.server.api.types.node import from_global_id_with_expected_type
+from phoenix.server.authorization import require_admin
+
+from .models import V1RoutesBaseModel
+from .utils import ResponseBody, add_errors_to_responses, request_user_id
+
+# Org-wide access administration — authoring type-wide grants, managing groups, reading
+# enforcement. Admin-only (open when auth is disabled).
+router = APIRouter(tags=["access"], dependencies=[Depends(require_admin)])
+
+# Per-object access administration — granting/revoking on, and auditing, a specific object.
+# Not blanket admin: each endpoint authorizes "admin OR a subject holding OBJ_MANAGE_ACCESS"
+# in-body, so a resource manager can share that object without being a global administrator.
+owner_router = APIRouter(tags=["access"])
+
+
+async def _assert_can_manage_object(
+    request: Request,
+    session: AsyncSession,
+    object_type: str,
+    object_id: int,
+    not_found_detail: str,
+) -> None:
+    """Authorize a per-object access-admin action: the caller must hold OBJ_MANAGE_ACCESS on
+    the object. Unauthorized is surfaced as 404, indistinguishable from a missing object. A
+    no-op when auth is disabled (access control presupposes auth)."""
+    user_id = request_user_id(request)
+    if user_id is None:
+        return
+    if not await can_access(
+        session,
+        user_id=user_id,
+        object_type=object_type,
+        object_id=object_id,
+        enabled=True,
+        permission=Permission.OBJ_MANAGE_ACCESS,
+    ):
+        raise HTTPException(404, not_found_detail)
+
+
+_SELECTOR_IDS = "ids"
+_SELECTOR_ALL = "all"
+_SELECTOR_TAG = "tag"
+_EFFECT_ALLOW = "allow"
+# Admin-managed groups live under their own provider so the login-time IdP reconcile
+# (which is provider-scoped) never touches them. This is how a deployment with no identity
+# provider gets groups at all: admins create them in-product instead of syncing from an IdP.
+_LOCAL_PROVIDER = "local"
+
+# GlobalID type tags for the access-control entities.
+_USER = "User"
+_GROUP = "UserGroup"
+_ROLE = "Role"
+_SERVICE_ACCOUNT = "ServiceAccount"
+_GRANT = "AccessGrant"
+_PERMISSION_SET = "PermissionSet"
+
+
+class GrantObjectType(str, Enum):
+    """The grantable access roots. Containment children and eval artifacts are
+    intentionally absent: their access is inherited from a parent, never granted directly."""
+
+    project = OBJECT_TYPE_PROJECT
+    dataset = OBJECT_TYPE_DATASET
+    prompt = OBJECT_TYPE_PROMPT
+
+
+class GrantSubjectKind(str, Enum):
+    """Who a grant targets. ``everyone`` is the only kind with no id — a deliberate
+    'make this object visible to all' grant, not a seeded baseline."""
+
+    user = SubjectKind.USER.value
+    group = SubjectKind.GROUP.value
+    role = SubjectKind.ROLE.value
+    service_account = SubjectKind.SERVICE_ACCOUNT.value
+    everyone = SubjectKind.EVERYONE.value
+
+
+_GLOBAL_ID_TYPE_NAME = {
+    GrantObjectType.project: "Project",
+    GrantObjectType.dataset: "Dataset",
+    GrantObjectType.prompt: "Prompt",
+}
+_OBJECT_MODEL = {
+    GrantObjectType.project: models.Project,
+    GrantObjectType.dataset: models.Dataset,
+    GrantObjectType.prompt: models.Prompt,
+}
+_SUBJECT_TYPE_NAME = {
+    GrantSubjectKind.user: _USER,
+    GrantSubjectKind.group: _GROUP,
+    GrantSubjectKind.role: _ROLE,
+    GrantSubjectKind.service_account: _SERVICE_ACCOUNT,
+}
+# The row a grant subject must reference, by kind. `everyone` has no row; `service_account`
+# is reserved but has no identity lifecycle yet, so it is rejected rather than resolved.
+_SUBJECT_MODEL = {
+    GrantSubjectKind.user: models.User,
+    GrantSubjectKind.group: models.UserGroup,
+    GrantSubjectKind.role: models.UserRole,
+}
+
+
+def _encode(type_name: str, rowid: int) -> str:
+    return str(GlobalID(type_name, str(rowid)))
+
+
+def _decode(type_name: str, gid: str) -> int:
+    try:
+        return from_global_id_with_expected_type(GlobalID.from_id(gid), type_name)
+    except Exception:
+        raise HTTPException(422, f"Invalid {type_name} id: {gid!r}")
+
+
+class Subject(V1RoutesBaseModel):
+    kind: GrantSubjectKind
+    # GlobalID of the user / group / role / service account. Null only for `everyone`.
+    id: Optional[str] = None
+
+
+class GrantCreate(V1RoutesBaseModel):
+    subject: Subject
+    object_type: GrantObjectType
+    # GlobalID of the object. Omit for a deliberate type-wide grant ("all projects").
+    object_id: Optional[str] = None
+    # Permission set conferred — viewer / editor / manager. Omit → the view-only default.
+    role: Optional[str] = None
+
+
+class Grant(V1RoutesBaseModel):
+    id: str  # GlobalID
+    subject: Subject
+    object_type: GrantObjectType
+    object_id: Optional[str]  # GlobalID, or null for a type-wide grant
+    role: Optional[str]
+
+
+class ResourceTagBody(V1RoutesBaseModel):
+    value: str
+
+
+class ResourceTagData(V1RoutesBaseModel):
+    object_type: GrantObjectType
+    object_id: str  # GlobalID
+    key: str
+    value: str
+
+
+class TagGrantCreate(V1RoutesBaseModel):
+    subject: Subject
+    object_type: GrantObjectType
+    tag_key: str
+    tag_value: str
+    # Permission set conferred — viewer or editor only; a tag grant may never confer
+    # manage-access. Omit → the view-only default.
+    role: Optional[str] = None
+
+
+class TagGrant(V1RoutesBaseModel):
+    id: str  # GlobalID
+    subject: Subject
+    object_type: GrantObjectType
+    tag_key: str
+    tag_value: str
+    role: Optional[str]
+
+
+class PermissionSetData(V1RoutesBaseModel):
+    id: str  # GlobalID
+    name: str
+    is_built_in: bool
+    permissions: list[str]
+
+
+class Enforcement(V1RoutesBaseModel):
+    enabled: bool
+    source: str
+
+
+class GroupCreate(V1RoutesBaseModel):
+    name: str
+
+
+class MemberCreate(V1RoutesBaseModel):
+    user_id: str  # GlobalID
+
+
+class GroupData(V1RoutesBaseModel):
+    id: str  # GlobalID
+    name: str
+    member_user_ids: list[str]  # GlobalIDs
+
+
+class GrantResponseBody(ResponseBody[Grant]):
+    pass
+
+
+class GrantsResponseBody(ResponseBody[list[Grant]]):
+    pass
+
+
+class SubjectsResponseBody(ResponseBody[list[Subject]]):
+    pass
+
+
+class ResourceTagResponseBody(ResponseBody[ResourceTagData]):
+    pass
+
+
+class ResourceTagsResponseBody(ResponseBody[list[ResourceTagData]]):
+    pass
+
+
+class TagGrantResponseBody(ResponseBody[TagGrant]):
+    pass
+
+
+class TagGrantsResponseBody(ResponseBody[list[TagGrant]]):
+    pass
+
+
+class PermissionSetsResponseBody(ResponseBody[list[PermissionSetData]]):
+    pass
+
+
+class EnforcementResponseBody(ResponseBody[Enforcement]):
+    pass
+
+
+class GroupResponseBody(ResponseBody[GroupData]):
+    pass
+
+
+class GroupsResponseBody(ResponseBody[list[GroupData]]):
+    pass
+
+
+def _decode_subject_id(kind: GrantSubjectKind, gid: Optional[str]) -> Optional[int]:
+    """The subject's row id, decoding its GlobalID and validating it matches the kind.
+    ``everyone`` carries no id; every other kind requires one."""
+    if kind is GrantSubjectKind.everyone:
+        if gid is not None:
+            raise HTTPException(422, "subject.id must be omitted for kind=everyone")
+        return None
+    if gid is None:
+        raise HTTPException(422, f"subject.id is required for kind={kind.value}")
+    return _decode(_SUBJECT_TYPE_NAME[kind], gid)
+
+
+async def _resolve_subject_rowid(
+    session: AsyncSession, kind: GrantSubjectKind, gid: Optional[str]
+) -> Optional[int]:
+    """Decode *and validate* a grant subject. ``everyone`` carries no id. ``service_account``
+    is reserved but not yet grantable — there is no service-account identity lifecycle, so a
+    grant naming one would point at a subject that can never exist; reject it. Every other kind
+    must reference a row that exists: a grant to a deleted user/group/role is a client error,
+    not a silently-stored dangling subject (the GlobalID shape alone says nothing about
+    existence, which is why decoding is not enough)."""
+    if kind is GrantSubjectKind.service_account:
+        raise HTTPException(422, "service_account subjects are reserved but not yet supported")
+    subject_id = _decode_subject_id(kind, gid)
+    if subject_id is None:  # everyone
+        return None
+    model = _SUBJECT_MODEL[kind]
+    exists = await session.scalar(select(model.id).where(model.id == subject_id))
+    if exists is None:
+        raise HTTPException(404, f"{kind.value} {gid} not found")
+    return subject_id
+
+
+def _encode_subject(kind_str: str, rowid: Optional[int]) -> Subject:
+    kind = GrantSubjectKind(kind_str)
+    if kind is GrantSubjectKind.everyone or rowid is None:
+        return Subject(kind=kind, id=None)
+    return Subject(kind=kind, id=_encode(_SUBJECT_TYPE_NAME[kind], rowid))
+
+
+async def _resolve_object_rowid(
+    session: AsyncSession, object_type: GrantObjectType, object_id: str
+) -> int:
+    """Resolve an object GlobalID to its row id, validating type and existence
+    (404 = absent — admins see all, so there is no unauthorized case here)."""
+    rowid = _decode(_GLOBAL_ID_TYPE_NAME[object_type], object_id)
+    exists = await session.scalar(
+        select(_OBJECT_MODEL[object_type].id).where(_OBJECT_MODEL[object_type].id == rowid)
+    )
+    if exists is None:
+        raise HTTPException(404, f"{object_type.value} {object_id} not found")
+    return rowid
+
+
+async def _resolve_role_id(session: AsyncSession, role: Optional[str]) -> Optional[int]:
+    """The permission set a grant confers — viewer (visibility), editor (mutate), or manager
+    (manage access). The oracle enforces these tiers per permission. Absent ⇒ the view-only
+    default; a *named* role that does not exist is a client error."""
+    name = role or DEFAULT_PERMISSION_SET
+    role_id = await session.scalar(
+        select(models.PermissionSet.id).where(models.PermissionSet.name == name)
+    )
+    if role_id is None and role is not None:
+        raise HTTPException(422, f"Unknown permission set: {role}")
+    return role_id
+
+
+async def _role_names(session: AsyncSession) -> dict[int, str]:
+    rows = await session.execute(select(models.PermissionSet.id, models.PermissionSet.name))
+    return {id_: name for id_, name in rows}
+
+
+async def _role_confers_manage(session: AsyncSession, role_id: int) -> bool:
+    """Whether a permission set includes OBJ_MANAGE_ACCESS."""
+    return (
+        await session.scalar(
+            select(models.PermissionSetItem.id).where(
+                models.PermissionSetItem.permission_set_id == role_id,
+                models.PermissionSetItem.permission == Permission.OBJ_MANAGE_ACCESS.value,
+            )
+        )
+    ) is not None
+
+
+def _object_global_id(object_type: GrantObjectType, rowid: Optional[int]) -> Optional[str]:
+    if rowid is None:
+        return None
+    return _encode(_GLOBAL_ID_TYPE_NAME[object_type], rowid)
+
+
+def _to_grant(row: models.AccessGrant, role_names: dict[int, str]) -> Grant:
+    object_type = GrantObjectType(row.object_type)
+    return Grant(
+        id=_encode(_GRANT, row.id),
+        subject=_encode_subject(row.subject_kind, row.subject_id),
+        object_type=object_type,
+        object_id=_object_global_id(object_type, row.object_id),
+        role=role_names.get(row.role_id) if row.role_id is not None else None,
+    )
+
+
+def _to_tag_grant(row: models.AccessGrant, role_names: dict[int, str]) -> TagGrant:
+    return TagGrant(
+        id=_encode(_GRANT, row.id),
+        subject=_encode_subject(row.subject_kind, row.subject_id),
+        object_type=GrantObjectType(row.object_type),
+        tag_key=row.tag_key or "",
+        tag_value=row.tag_value or "",
+        role=role_names.get(row.role_id) if row.role_id is not None else None,
+    )
+
+
+@owner_router.post(
+    "/access/grants",
+    operation_id="createAccessGrant",
+    summary="Author an access grant (allow-only, idempotent)",
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def create_access_grant(request: Request, body: GrantCreate) -> GrantResponseBody:
+    """Grant a subject access to an object (or, with ``object_id`` omitted, to every
+    object of that type). Monotonic and allow-only: grants only ever *add* access.
+    Idempotent — re-granting the same subject+object updates only the role. Authoring a grant
+    on a specific object needs OBJ_MANAGE_ACCESS on it; a type-wide grant is admin-only."""
+    selector = _SELECTOR_ALL if body.object_id is None else _SELECTOR_IDS
+    async with request.app.state.db() as session:
+        subject_id = await _resolve_subject_rowid(session, body.subject.kind, body.subject.id)
+        if body.object_id is None:
+            # A type-wide ("all of a type") grant names no owned object — admin only.
+            require_admin(request)
+            object_rowid = None
+        else:
+            object_rowid = await _resolve_object_rowid(session, body.object_type, body.object_id)
+            await _assert_can_manage_object(
+                request,
+                session,
+                body.object_type.value,
+                object_rowid,
+                f"{body.object_type.value} {body.object_id} not found",
+            )
+        role_id = await _resolve_role_id(session, body.role)
+        grant = await session.scalar(
+            select(models.AccessGrant).where(
+                models.AccessGrant.subject_kind == body.subject.kind.value,
+                models.AccessGrant.subject_id == subject_id,
+                models.AccessGrant.object_type == body.object_type.value,
+                models.AccessGrant.object_id == object_rowid,
+                models.AccessGrant.selector_kind == selector,
+                models.AccessGrant.effect == _EFFECT_ALLOW,
+            )
+        )
+        if grant is None:
+            grant = models.AccessGrant(
+                subject_kind=body.subject.kind.value,
+                subject_id=subject_id,
+                role_id=role_id,
+                object_type=body.object_type.value,
+                object_id=object_rowid,
+                selector_kind=selector,
+                effect=_EFFECT_ALLOW,
+            )
+            session.add(grant)
+        else:
+            # Re-granting downgrades in place. Downgrading the sole manager of a creatorless
+            # object strands it just as a delete would — guard the change (B3).
+            if object_rowid is not None and await would_strand_last_manager(
+                session,
+                object_type=body.object_type.value,
+                object_id=object_rowid,
+                subject_kind=body.subject.kind.value,
+                subject_id=subject_id,
+                new_role_id=role_id,
+            ):
+                raise HTTPException(
+                    409,
+                    "Cannot remove the last manager of an object that has no owner. "
+                    "Grant another manager first.",
+                )
+            grant.role_id = role_id
+        await session.flush()
+        names = await _role_names(session)
+        data = _to_grant(grant, names)
+    return GrantResponseBody(data=data)
+
+
+@router.get(
+    "/access/grants",
+    operation_id="listAccessGrants",
+    summary="List access grants",
+    responses=add_errors_to_responses([403, 422]),
+)
+async def list_access_grants(
+    request: Request,
+    object_type: Optional[GrantObjectType] = Query(default=None),
+    object_id: Optional[str] = Query(
+        default=None, description="Filter to one object (requires object_type)."
+    ),
+    subject_kind: Optional[GrantSubjectKind] = Query(default=None),
+    subject_id: Optional[str] = Query(
+        default=None, description="Filter to one subject (requires subject_kind)."
+    ),
+) -> GrantsResponseBody:
+    if object_id is not None and object_type is None:
+        raise HTTPException(422, "object_type is required when object_id is given")
+    if subject_id is not None and subject_kind is None:
+        raise HTTPException(422, "subject_kind is required when subject_id is given")
+    grantable = [t.value for t in GrantObjectType]
+    async with request.app.state.db() as session:
+        stmt = select(models.AccessGrant).where(
+            models.AccessGrant.effect == _EFFECT_ALLOW,
+            models.AccessGrant.object_type.in_(grantable),
+            # Ordinary grants only. A tag grant also carries a grantable object_type and a
+            # null object_id, so without this it would serialize as a fake all-of-type grant
+            # with its key=value silently dropped — tag grants belong to /access/tag-grants.
+            models.AccessGrant.selector_kind.in_((_SELECTOR_IDS, _SELECTOR_ALL)),
+        )
+        if object_type is not None:
+            stmt = stmt.where(models.AccessGrant.object_type == object_type.value)
+        if object_id is not None and object_type is not None:
+            rowid = await _resolve_object_rowid(session, object_type, object_id)
+            stmt = stmt.where(models.AccessGrant.object_id == rowid)
+        if subject_kind is not None:
+            stmt = stmt.where(models.AccessGrant.subject_kind == subject_kind.value)
+        if subject_id is not None and subject_kind is not None:
+            stmt = stmt.where(
+                models.AccessGrant.subject_id == _decode_subject_id(subject_kind, subject_id)
+            )
+        rows = (await session.scalars(stmt.order_by(models.AccessGrant.id.desc()))).all()
+        names = await _role_names(session)
+        data = [_to_grant(r, names) for r in rows]
+    return GrantsResponseBody(data=data)
+
+
+@owner_router.delete(
+    "/access/grants/{grant_id}",
+    operation_id="deleteAccessGrant",
+    summary="Revoke an access grant",
+    status_code=204,
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def delete_access_grant(
+    request: Request, grant_id: str = Path(description="The access grant GlobalID")
+) -> None:
+    rowid = _decode(_GRANT, grant_id)
+    async with request.app.state.db() as session:
+        grant = await session.scalar(
+            select(models.AccessGrant).where(models.AccessGrant.id == rowid)
+        )
+        if grant is None:
+            raise HTTPException(404, f"Grant {grant_id} not found")
+        # Revoking on a specific object needs OBJ_MANAGE_ACCESS on it; a
+        # type-wide grant is admin-only.
+        if grant.selector_kind == _SELECTOR_ALL or grant.object_id is None:
+            require_admin(request)
+        else:
+            await _assert_can_manage_object(
+                request, session, grant.object_type, grant.object_id, f"Grant {grant_id} not found"
+            )
+            # Refuse to delete the last manager of a creatorless object (B3).
+            if await would_strand_last_manager(
+                session,
+                object_type=grant.object_type,
+                object_id=grant.object_id,
+                subject_kind=grant.subject_kind,
+                subject_id=grant.subject_id,
+            ):
+                raise HTTPException(
+                    409,
+                    "Cannot remove the last manager of an object that has no owner. "
+                    "Grant another manager first.",
+                )
+        await session.delete(grant)
+
+
+@owner_router.get(
+    "/access/objects/{object_type}/{object_id}/subjects",
+    operation_id="listObjectSubjects",
+    summary='Who can access this object ("who can see X?")',
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def list_object_subjects(
+    request: Request,
+    object_type: GrantObjectType = Path(),
+    object_id: str = Path(description="The object GlobalID"),
+) -> SubjectsResponseBody:
+    """The audit read: the subjects currently granted access to the object (plus its
+    creator). Needs OBJ_MANAGE_ACCESS on the object. Administrators have
+    implicit access and are not enumerated."""
+    async with request.app.state.db() as session:
+        rowid = await _resolve_object_rowid(session, object_type, object_id)
+        await _assert_can_manage_object(
+            request, session, object_type.value, rowid, f"{object_type.value} {object_id} not found"
+        )
+        resolved = await subjects_for(session, object_type.value, rowid)
+    data = [
+        _encode_subject(s.kind.value, None if s.kind is SubjectKind.EVERYONE else s.id)
+        for s in resolved
+    ]
+    return SubjectsResponseBody(data=data)
+
+
+# --- curated resource tags & attribute-based (tag) grants -----------------------------
+#
+# A tag is a curated key=value on an object; a tag grant reaches every object of a type that
+# carries a given key=value. Setting a tag changes who can reach the object, so it needs
+# OBJ_MANAGE_ACCESS on that object (owner_router). Authoring a tag grant is type-scoped policy,
+# so it is admin-only (router). A tag grant may confer view/edit, never manage-access.
+
+
+@owner_router.put(
+    "/access/objects/{object_type}/{object_id}/tags/{key}",
+    operation_id="setResourceTag",
+    summary="Set (or update) a curated tag on an object",
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def set_resource_tag(
+    request: Request,
+    body: ResourceTagBody,
+    object_type: GrantObjectType = Path(),
+    object_id: str = Path(description="The object GlobalID"),
+    key: str = Path(description="The tag key"),
+) -> ResourceTagResponseBody:
+    """Apply or update a curated key=value tag on an object. A tag grant reads the tag as
+    policy, so setting one changes who can reach the object — it requires OBJ_MANAGE_ACCESS on
+    the target, the same authority as granting access. Idempotent: re-setting a key overwrites
+    its value."""
+    if not key:
+        raise HTTPException(422, "tag key must not be empty")
+    async with request.app.state.db() as session:
+        rowid = await _resolve_object_rowid(session, object_type, object_id)
+        await _assert_can_manage_object(
+            request, session, object_type.value, rowid, f"{object_type.value} {object_id} not found"
+        )
+        existing = await session.scalar(
+            select(models.ResourceTag).where(
+                models.ResourceTag.object_type == object_type.value,
+                models.ResourceTag.object_id == rowid,
+                models.ResourceTag.key == key,
+            )
+        )
+        if existing is None:
+            session.add(
+                models.ResourceTag(
+                    object_type=object_type.value,
+                    object_id=rowid,
+                    key=key,
+                    value=body.value,
+                    created_by=request_user_id(request),
+                )
+            )
+        else:
+            existing.value = body.value
+    return ResourceTagResponseBody(
+        data=ResourceTagData(
+            object_type=object_type, object_id=object_id, key=key, value=body.value
+        )
+    )
+
+
+@owner_router.get(
+    "/access/objects/{object_type}/{object_id}/tags",
+    operation_id="listResourceTags",
+    summary="List an object's curated tags",
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def list_resource_tags(
+    request: Request,
+    object_type: GrantObjectType = Path(),
+    object_id: str = Path(description="The object GlobalID"),
+) -> ResourceTagsResponseBody:
+    """The curated tags on an object. Tags steer access, so reading them needs
+    OBJ_MANAGE_ACCESS on the object — the same gate as the "who can see X?" audit read."""
+    async with request.app.state.db() as session:
+        rowid = await _resolve_object_rowid(session, object_type, object_id)
+        await _assert_can_manage_object(
+            request, session, object_type.value, rowid, f"{object_type.value} {object_id} not found"
+        )
+        rows = (
+            await session.execute(
+                select(models.ResourceTag.key, models.ResourceTag.value)
+                .where(
+                    models.ResourceTag.object_type == object_type.value,
+                    models.ResourceTag.object_id == rowid,
+                )
+                .order_by(models.ResourceTag.key)
+            )
+        ).all()
+    data = [
+        ResourceTagData(object_type=object_type, object_id=object_id, key=k, value=v)
+        for k, v in rows
+    ]
+    return ResourceTagsResponseBody(data=data)
+
+
+@owner_router.delete(
+    "/access/objects/{object_type}/{object_id}/tags/{key}",
+    operation_id="removeResourceTag",
+    summary="Remove a curated tag from an object",
+    status_code=204,
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def remove_resource_tag(
+    request: Request,
+    object_type: GrantObjectType = Path(),
+    object_id: str = Path(description="The object GlobalID"),
+    key: str = Path(description="The tag key"),
+) -> None:
+    """Remove a curated tag. A tag grant that reached the object via this key simply stops
+    matching — no grant is deleted (tag grants carry the strings, not a link to the tag row).
+    Requires OBJ_MANAGE_ACCESS on the object."""
+    async with request.app.state.db() as session:
+        rowid = await _resolve_object_rowid(session, object_type, object_id)
+        await _assert_can_manage_object(
+            request, session, object_type.value, rowid, f"{object_type.value} {object_id} not found"
+        )
+        await session.execute(
+            delete(models.ResourceTag).where(
+                models.ResourceTag.object_type == object_type.value,
+                models.ResourceTag.object_id == rowid,
+                models.ResourceTag.key == key,
+            )
+        )
+
+
+@router.post(
+    "/access/tag-grants",
+    operation_id="createTagGrant",
+    summary="Author a tag grant (allow-only, idempotent)",
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def create_tag_grant(request: Request, body: TagGrantCreate) -> TagGrantResponseBody:
+    """Grant a subject access to every object of a type carrying a given key=value tag.
+    Type-scoped and additive — admin-only, like other type-wide policy. Idempotent: re-granting
+    the same (subject, type, tag) updates only the role. A tag grant may confer view or edit,
+    never manage-access: a tag's reach is object-manager-mutable, so a manage-conferring tag
+    grant would let a non-admin strand an object; it is rejected here and the oracle refuses to
+    honor manage from a tag selector regardless."""
+    if not body.tag_key or not body.tag_value:
+        raise HTTPException(422, "tag_key and tag_value must not be empty")
+    async with request.app.state.db() as session:
+        subject_id = await _resolve_subject_rowid(session, body.subject.kind, body.subject.id)
+        role_id = await _resolve_role_id(session, body.role)
+        if role_id is not None and await _role_confers_manage(session, role_id):
+            raise HTTPException(
+                422,
+                "A tag grant cannot confer manage-access. Choose a viewer or editor permission "
+                "set, or author a per-object grant for manage-access.",
+            )
+        grant = await session.scalar(
+            select(models.AccessGrant).where(
+                models.AccessGrant.subject_kind == body.subject.kind.value,
+                models.AccessGrant.subject_id == subject_id,
+                models.AccessGrant.object_type == body.object_type.value,
+                models.AccessGrant.selector_kind == _SELECTOR_TAG,
+                models.AccessGrant.tag_key == body.tag_key,
+                models.AccessGrant.tag_value == body.tag_value,
+                models.AccessGrant.effect == _EFFECT_ALLOW,
+            )
+        )
+        if grant is None:
+            grant = models.AccessGrant(
+                subject_kind=body.subject.kind.value,
+                subject_id=subject_id,
+                role_id=role_id,
+                object_type=body.object_type.value,
+                object_id=None,
+                selector_kind=_SELECTOR_TAG,
+                tag_key=body.tag_key,
+                tag_value=body.tag_value,
+                effect=_EFFECT_ALLOW,
+            )
+            session.add(grant)
+        else:
+            grant.role_id = role_id
+        await session.flush()
+        names = await _role_names(session)
+        data = _to_tag_grant(grant, names)
+    return TagGrantResponseBody(data=data)
+
+
+@router.get(
+    "/access/tag-grants",
+    operation_id="listTagGrants",
+    summary="List tag grants",
+    responses=add_errors_to_responses([403, 422]),
+)
+async def list_tag_grants(
+    request: Request,
+    object_type: Optional[GrantObjectType] = Query(default=None),
+    subject_kind: Optional[GrantSubjectKind] = Query(default=None),
+    subject_id: Optional[str] = Query(
+        default=None, description="Filter to one subject (requires subject_kind)."
+    ),
+) -> TagGrantsResponseBody:
+    if subject_id is not None and subject_kind is None:
+        raise HTTPException(422, "subject_kind is required when subject_id is given")
+    async with request.app.state.db() as session:
+        stmt = select(models.AccessGrant).where(
+            models.AccessGrant.effect == _EFFECT_ALLOW,
+            models.AccessGrant.selector_kind == _SELECTOR_TAG,
+        )
+        if object_type is not None:
+            stmt = stmt.where(models.AccessGrant.object_type == object_type.value)
+        if subject_kind is not None:
+            stmt = stmt.where(models.AccessGrant.subject_kind == subject_kind.value)
+        if subject_id is not None and subject_kind is not None:
+            stmt = stmt.where(
+                models.AccessGrant.subject_id == _decode_subject_id(subject_kind, subject_id)
+            )
+        rows = (await session.scalars(stmt.order_by(models.AccessGrant.id.desc()))).all()
+        names = await _role_names(session)
+        data = [_to_tag_grant(r, names) for r in rows]
+    return TagGrantsResponseBody(data=data)
+
+
+@router.delete(
+    "/access/tag-grants/{grant_id}",
+    operation_id="deleteTagGrant",
+    summary="Revoke a tag grant",
+    status_code=204,
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def delete_tag_grant(
+    request: Request, grant_id: str = Path(description="The tag grant GlobalID")
+) -> None:
+    """Revoke a tag grant. Admin-only, like authoring one. No last-manager guard applies: a tag
+    grant is type-scoped and never confers manage, so it is never an object's last manager."""
+    rowid = _decode(_GRANT, grant_id)
+    async with request.app.state.db() as session:
+        grant = await session.scalar(
+            select(models.AccessGrant).where(
+                models.AccessGrant.id == rowid,
+                models.AccessGrant.selector_kind == _SELECTOR_TAG,
+            )
+        )
+        if grant is None:
+            raise HTTPException(404, f"Tag grant {grant_id} not found")
+        await session.delete(grant)
+
+
+@router.get(
+    "/access/object-roles",
+    operation_id="listPermissionSets",
+    summary="List the permission sets a grant may confer",
+    responses=add_errors_to_responses([403]),
+)
+async def list_permission_sets(request: Request) -> PermissionSetsResponseBody:
+    """The permission sets a grant may confer — viewer (visibility), editor (mutate), manager
+    (manage access). The oracle enforces each tier at its permission level."""
+    async with request.app.state.db() as session:
+        roles = (
+            (
+                await session.scalars(
+                    select(models.PermissionSet)
+                    .options(joinedload(models.PermissionSet.permissions))
+                    .order_by(models.PermissionSet.is_built_in.desc(), models.PermissionSet.name)
+                )
+            )
+            .unique()
+            .all()
+        )
+    data = [
+        PermissionSetData(
+            id=_encode(_PERMISSION_SET, r.id),
+            name=r.name,
+            is_built_in=r.is_built_in,
+            permissions=[p.permission for p in r.permissions],
+        )
+        for r in roles
+    ]
+    return PermissionSetsResponseBody(data=data)
+
+
+@router.get(
+    "/access/enforcement",
+    operation_id="getAccessEnforcement",
+    summary="Whether access control is enforcing",
+    responses=add_errors_to_responses([403]),
+)
+async def get_access_enforcement() -> EnforcementResponseBody:
+    """The DB-latched activation state — the source of truth for whether enforcement is on.
+    Read-only: there is intentionally no enable/disable endpoint (enabling is the one-way env
+    switch; disabling is a deliberate ops action)."""
+    return EnforcementResponseBody(
+        data=Enforcement(enabled=get_env_access_control_enabled(), source="db-latch")
+    )
+
+
+# --- local (admin-managed) groups ---------------------------------------------------
+#
+# A deployment with only basic auth has no identity provider to sync groups from, so without
+# these endpoints it could grant per-user only. They touch *only* `provider="local"` groups;
+# IdP-synced groups (`oauth2:*`, `ldap`) are owned by the login-time reconcile and are not
+# mutable here.
+
+
+async def _local_group_or_404(session: AsyncSession, group_rowid: int) -> models.UserGroup:
+    group = await session.scalar(
+        select(models.UserGroup).where(
+            models.UserGroup.id == group_rowid,
+            models.UserGroup.provider == _LOCAL_PROVIDER,
+        )
+    )
+    if group is None:
+        raise HTTPException(404, f"Local group {_encode(_GROUP, group_rowid)} not found")
+    return group
+
+
+async def _group_data(session: AsyncSession, group: models.UserGroup) -> GroupData:
+    member_ids = list(
+        await session.scalars(
+            select(models.UserGroupMembership.user_id).where(
+                models.UserGroupMembership.user_group_id == group.id
+            )
+        )
+    )
+    return GroupData(
+        id=_encode(_GROUP, group.id),
+        name=group.display_name or group.group_key,
+        member_user_ids=[_encode(_USER, uid) for uid in member_ids],
+    )
+
+
+@router.post(
+    "/access/groups",
+    operation_id="createLocalGroup",
+    summary="Create a local (admin-managed) group",
+    responses=add_errors_to_responses([403, 409, 422]),
+)
+async def create_local_group(request: Request, body: GroupCreate) -> GroupResponseBody:
+    name = body.name.strip()
+    if not name:
+        raise HTTPException(422, "name must be non-empty")
+    async with request.app.state.db() as session:
+        existing = await session.scalar(
+            select(models.UserGroup.id).where(
+                models.UserGroup.provider == _LOCAL_PROVIDER,
+                models.UserGroup.group_key == name,
+            )
+        )
+        if existing is not None:
+            raise HTTPException(409, f"A local group named {name!r} already exists")
+        group = models.UserGroup(provider=_LOCAL_PROVIDER, group_key=name, display_name=name)
+        session.add(group)
+        await session.flush()
+        data = await _group_data(session, group)
+    return GroupResponseBody(data=data)
+
+
+@router.get(
+    "/access/groups",
+    operation_id="listLocalGroups",
+    summary="List local (admin-managed) groups",
+    responses=add_errors_to_responses([403]),
+)
+async def list_local_groups(request: Request) -> GroupsResponseBody:
+    async with request.app.state.db() as session:
+        groups = (
+            await session.scalars(
+                select(models.UserGroup)
+                .where(models.UserGroup.provider == _LOCAL_PROVIDER)
+                .order_by(models.UserGroup.id)
+            )
+        ).all()
+        data = [await _group_data(session, g) for g in groups]
+    return GroupsResponseBody(data=data)
+
+
+@router.delete(
+    "/access/groups/{group_id}",
+    operation_id="deleteLocalGroup",
+    summary="Delete a local group (and sweep its grants)",
+    status_code=204,
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def delete_local_group(
+    request: Request, group_id: str = Path(description="The local group GlobalID")
+) -> None:
+    group_rowid = _decode(_GROUP, group_id)
+    async with request.app.state.db() as session:
+        await _local_group_or_404(session, group_rowid)
+        # A group's acl rows carry no foreign key, so deleting the group does not cascade
+        # them. Remove them in the same transaction, before the id can be reused — otherwise a
+        # future group assigned this id would silently inherit the stale grants.
+        await session.execute(
+            delete(models.AccessGrant).where(
+                models.AccessGrant.subject_kind == SubjectKind.GROUP.value,
+                models.AccessGrant.subject_id == group_rowid,
+            )
+        )
+        # Memberships cascade via their FK; delete the group itself.
+        await session.execute(delete(models.UserGroup).where(models.UserGroup.id == group_rowid))
+
+
+@router.post(
+    "/access/groups/{group_id}/members",
+    operation_id="addLocalGroupMember",
+    summary="Add a user to a local group",
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def add_local_group_member(
+    request: Request,
+    body: MemberCreate,
+    group_id: str = Path(description="The local group GlobalID"),
+) -> GroupResponseBody:
+    group_rowid = _decode(_GROUP, group_id)
+    user_rowid = _decode(_USER, body.user_id)
+    async with request.app.state.db() as session:
+        group = await _local_group_or_404(session, group_rowid)
+        user_exists = await session.scalar(
+            select(models.User.id).where(models.User.id == user_rowid)
+        )
+        if user_exists is None:
+            raise HTTPException(404, f"User {body.user_id} not found")
+        existing = await session.scalar(
+            select(models.UserGroupMembership.user_id).where(
+                models.UserGroupMembership.user_group_id == group_rowid,
+                models.UserGroupMembership.user_id == user_rowid,
+            )
+        )
+        if existing is None:
+            session.add(models.UserGroupMembership(user_group_id=group_rowid, user_id=user_rowid))
+            await session.flush()
+        data = await _group_data(session, group)
+    return GroupResponseBody(data=data)
+
+
+@router.delete(
+    "/access/groups/{group_id}/members/{user_id}",
+    operation_id="removeLocalGroupMember",
+    summary="Remove a user from a local group",
+    status_code=204,
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def remove_local_group_member(
+    request: Request,
+    group_id: str = Path(description="The local group GlobalID"),
+    user_id: str = Path(description="The user GlobalID to remove"),
+) -> None:
+    group_rowid = _decode(_GROUP, group_id)
+    user_rowid = _decode(_USER, user_id)
+    async with request.app.state.db() as session:
+        await _local_group_or_404(session, group_rowid)
+        deleted = await session.scalar(
+            delete(models.UserGroupMembership)
+            .where(
+                models.UserGroupMembership.user_group_id == group_rowid,
+                models.UserGroupMembership.user_id == user_rowid,
+            )
+            .returning(models.UserGroupMembership.user_id)
+        )
+        if deleted is None:
+            raise HTTPException(404, f"User {user_id} is not a member of group {group_id}")

--- a/src/phoenix/server/api/routers/v1/annotations.py
+++ b/src/phoenix/server/api/routers/v1/annotations.py
@@ -7,12 +7,18 @@ from typing import Annotated, Any, Literal, Optional
 from fastapi import APIRouter, HTTPException, Path, Query
 from pydantic import Field
 from sqlalchemy import ColumnElement, delete, exists, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 from strawberry.relay import GlobalID
 
+from phoenix.config import get_env_access_control_enabled
 from phoenix.datetime_utils import normalize_datetime
 from phoenix.db import models
 from phoenix.db.insertion.types import Precursors
+from phoenix.server.access import (
+    OBJECT_TYPE_PROJECT,
+    can_access,
+)
 from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
 from phoenix.server.api.types.ProjectSessionAnnotation import (
     ProjectSessionAnnotation as SessionAnnotationNodeType,
@@ -291,6 +297,7 @@ async def list_span_annotations(
                 status_code=404,
                 detail=f"Project with identifier {project_identifier} not found",
             )
+        await _assert_project_accessible(session, request, project.id, project_identifier)
 
         # Build the base query
         where_conditions = [models.Project.id == project.id]
@@ -471,6 +478,7 @@ async def list_trace_annotations(
                 status_code=404,
                 detail=f"Project with identifier {project_identifier} not found",
             )
+        await _assert_project_accessible(session, request, project.id, project_identifier)
 
         # Build the base query
         where_conditions = [models.Project.id == project.id]
@@ -647,6 +655,7 @@ async def list_session_annotations(
                 status_code=404,
                 detail=f"Project with identifier {project_identifier} not found",
             )
+        await _assert_project_accessible(session, request, project.id, project_identifier)
 
         # Build the base query
         where_conditions = [models.Project.id == project.id]
@@ -737,6 +746,36 @@ async def list_session_annotations(
         ]
 
     return SessionAnnotationsResponseBody(data=data, next_cursor=next_cursor)
+
+
+async def _assert_project_accessible(
+    session: "AsyncSession",
+    request: Request,
+    project_id: int,
+    project_identifier: str,
+) -> None:
+    """Gate a project-scoped read by the caller's access to the project, so the
+    project's containment children (here, annotations) inherit it. Unauthorized
+    is surfaced as 404 — indistinguishable from not-found. A no-op when access
+    control is not enforcing or auth is disabled (access control presupposes
+    auth). Admins pass via the oracle's ADMINISTER rule."""
+    if not get_env_access_control_enabled():
+        return
+    user = request.user if request.app.state.authentication_enabled else None
+    user_id = int(user.identity) if isinstance(user, PhoenixUser) else None
+    if user_id is None:
+        return
+    if not await can_access(
+        session,
+        user_id=user_id,
+        object_type=OBJECT_TYPE_PROJECT,
+        object_id=project_id,
+        enabled=True,
+    ):
+        raise HTTPException(
+            status_code=404,
+            detail=f"Project with identifier {project_identifier} not found",
+        )
 
 
 def _resolve_non_admin_user_id(request: Request) -> Optional[int]:

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -44,6 +44,12 @@ from phoenix.db.insertion.dataset import (
     add_dataset_examples,
 )
 from phoenix.db.types.db_helper_types import UNDEFINED
+from phoenix.server.access import (
+    OBJECT_TYPE_DATASET,
+    Permission,
+    delete_object_grants,
+    delete_object_tags,
+)
 from phoenix.server.api.types.Dataset import Dataset as DatasetNodeType
 from phoenix.server.api.types.DatasetExample import DatasetExample as DatasetExampleNodeType
 from phoenix.server.api.types.DatasetSplit import DatasetSplit as DatasetSplitNodeType
@@ -61,6 +67,9 @@ from .utils import (
     ResponseBody,
     add_errors_to_responses,
     add_text_csv_content_to_responses,
+    assert_can_access,
+    assert_can_read,
+    scope_predicate,
 )
 
 csv.field_size_limit(
@@ -118,6 +127,14 @@ async def list_datasets(
             .add_columns(func.coalesce(func.sum(value), 0).label("example_count"))
             .outerjoin_from(models.Dataset, models.DatasetExample)
             .outerjoin_from(models.DatasetExample, models.DatasetExampleRevision)
+            .where(
+                await scope_predicate(
+                    session,
+                    request,
+                    object_type=OBJECT_TYPE_DATASET,
+                    id_column=models.Dataset.id,
+                )
+            )
             .group_by(models.Dataset.id)
             .order_by(models.Dataset.id.desc())
         )
@@ -195,10 +212,22 @@ async def delete_dataset(
         delete(models.Dataset).where(models.Dataset.id == dataset_id).returning(models.Dataset.id)
     )
     async with request.app.state.db() as session:
+        # Deleting mutates the dataset root, so it needs edit (not just view) access to it.
+        # Unauthorized is surfaced as the same 404 as a missing dataset.
+        await assert_can_access(
+            session,
+            request,
+            object_type=OBJECT_TYPE_DATASET,
+            object_id=dataset_id,
+            permission=Permission.OBJ_EDIT,
+            not_found_detail="Dataset does not exist",
+        )
         project_names = await session.scalars(project_names_stmt)
         eval_trace_ids = await session.scalars(eval_trace_ids_stmt)
-        if (await session.scalar(stmt)) is None:
+        if (deleted_dataset_id := await session.scalar(stmt)) is None:
             raise HTTPException(detail="Dataset does not exist", status_code=404)
+        await delete_object_grants(session, OBJECT_TYPE_DATASET, deleted_dataset_id)
+        await delete_object_tags(session, OBJECT_TYPE_DATASET, deleted_dataset_id)
     tasks = BackgroundTasks()
     tasks.add_task(delete_projects, request.app.state.db, *project_names)
     tasks.add_task(delete_traces, request.app.state.db, *eval_trace_ids)
@@ -232,6 +261,13 @@ async def get_dataset(
     if (type_name := dataset_id.type_name) != DATASET_NODE_NAME:
         raise HTTPException(detail=f"ID {dataset_id} refers to a f{type_name}", status_code=404)
     async with request.app.state.db() as session:
+        await assert_can_read(
+            session,
+            request,
+            object_type=OBJECT_TYPE_DATASET,
+            object_id=int(dataset_id.node_id),
+            not_found_detail=f"Dataset with ID {dataset_id} not found",
+        )
         result = await session.execute(
             select(models.Dataset, models.Dataset.example_count).filter(
                 models.Dataset.id == int(dataset_id.node_id)
@@ -322,6 +358,13 @@ async def list_dataset_versions(
         ).scalar_subquery()
         stmt = stmt.filter(models.DatasetVersion.id <= max_dataset_version_id)
     async with request.app.state.db() as session:
+        await assert_can_read(
+            session,
+            request,
+            object_type=OBJECT_TYPE_DATASET,
+            object_id=dataset_id,
+            not_found_detail=f"Dataset with ID {id} not found",
+        )
         data = [
             DatasetVersion(
                 version_id=str(GlobalID(DATASET_VERSION_NODE_NAME, str(version.id))),
@@ -624,6 +667,20 @@ async def upload_dataset(
             splits_provided=splits_provided,
         ),
     )
+    async with request.app.state.db() as session:
+        dataset_id = await session.scalar(
+            select(models.Dataset.id).where(models.Dataset.name == name)
+        )
+        if dataset_id is not None:
+            if action is DatasetAction.CREATE:
+                raise HTTPException(detail="Dataset name is unavailable", status_code=409)
+            await assert_can_read(
+                session,
+                request,
+                object_type=OBJECT_TYPE_DATASET,
+                object_id=dataset_id,
+                not_found_detail=f'Dataset "{name}" not found or not accessible',
+            )
     if sync:
         try:
             async with request.app.state.db() as session:
@@ -1367,6 +1424,13 @@ async def get_dataset_examples(
                 detail=f"No dataset with id {dataset_gid} can be found.",
                 status_code=404,
             )
+        await assert_can_read(
+            session,
+            request,
+            object_type=OBJECT_TYPE_DATASET,
+            object_id=resolved_dataset_id,
+            not_found_detail=f"No dataset with id {dataset_gid} can be found.",
+        )
 
         # Subquery to find the maximum created_at for each dataset_example_id
         # timestamp tiebreaks are resolved by the largest id
@@ -1509,6 +1573,13 @@ async def get_dataset_csv(
             ) from e
     try:
         async with request.app.state.db() as session:
+            await assert_can_read(
+                session,
+                request,
+                object_type=OBJECT_TYPE_DATASET,
+                object_id=dataset_id,
+                not_found_detail=f"Dataset with ID {id} not found",
+            )
             dataset_name = await _get_dataset_name(session=session, dataset_id=dataset_id)
             revisions = await _get_dataset_example_revisions(
                 session=session, dataset_id=dataset_id, dataset_version_id=dataset_version_id
@@ -1569,6 +1640,13 @@ async def get_dataset_jsonl(
             ) from e
     try:
         async with request.app.state.db() as session:
+            await assert_can_read(
+                session,
+                request,
+                object_type=OBJECT_TYPE_DATASET,
+                object_id=dataset_id,
+                not_found_detail=f"Dataset with ID {id} not found",
+            )
             dataset_name = await _get_dataset_name(session=session, dataset_id=dataset_id)
             revisions = await _get_dataset_example_revisions(
                 session=session, dataset_id=dataset_id, dataset_version_id=dataset_version_id
@@ -1626,6 +1704,13 @@ async def get_dataset_jsonl_openai_ft(
             ) from e
     try:
         async with request.app.state.db() as session:
+            await assert_can_read(
+                session,
+                request,
+                object_type=OBJECT_TYPE_DATASET,
+                object_id=dataset_id,
+                not_found_detail=f"Dataset with ID {id} not found",
+            )
             dataset_name = await _get_dataset_name(session=session, dataset_id=dataset_id)
             revisions = await _get_dataset_example_revisions(
                 session=session, dataset_id=dataset_id, dataset_version_id=dataset_version_id
@@ -1681,6 +1766,13 @@ async def get_dataset_jsonl_openai_evals(
             ) from e
     try:
         async with request.app.state.db() as session:
+            await assert_can_read(
+                session,
+                request,
+                object_type=OBJECT_TYPE_DATASET,
+                object_id=dataset_id,
+                not_found_detail=f"Dataset with ID {id} not found",
+            )
             dataset_name = await _get_dataset_name(session=session, dataset_id=dataset_id)
             revisions = await _get_dataset_example_revisions(
                 session=session, dataset_id=dataset_id, dataset_version_id=dataset_version_id

--- a/src/phoenix/server/api/routers/v1/experiment_runs.py
+++ b/src/phoenix/server/api/routers/v1/experiment_runs.py
@@ -18,7 +18,12 @@ from phoenix.server.authorization import is_not_locked
 from phoenix.server.dml_event import ExperimentRunInsertEvent
 
 from .models import V1RoutesBaseModel
-from .utils import PaginatedResponseBody, ResponseBody, add_errors_to_responses
+from .utils import (
+    PaginatedResponseBody,
+    ResponseBody,
+    add_errors_to_responses,
+    assert_can_read_experiment,
+)
 
 router = APIRouter(tags=["experiments"], include_in_schema=True)
 
@@ -234,6 +239,12 @@ async def list_experiment_runs(
         stmt = stmt.limit(limit + 1)
 
     async with request.app.state.db() as session:
+        await assert_can_read_experiment(
+            session,
+            request,
+            experiment_rowid,
+            not_found_detail=f"Experiment with ID {experiment_gid} does not exist",
+        )
         experiment_runs = (await session.scalars(stmt)).all()
 
     if not experiment_runs:
@@ -361,6 +372,12 @@ async def get_incomplete_evaluations(
                 detail=f"Experiment with ID {experiment_globalid} does not exist",
                 status_code=404,
             )
+        await assert_can_read_experiment(
+            session,
+            request,
+            experiment_rowid,
+            not_found_detail=f"Experiment with ID {experiment_globalid} does not exist",
+        )
 
         # Query for runs with incomplete evaluations in a single query
         # This fetches runs, revisions, and annotations together to minimize round-trips

--- a/src/phoenix/server/api/routers/v1/experiments.py
+++ b/src/phoenix/server/api/routers/v1/experiments.py
@@ -22,6 +22,7 @@ from phoenix.db.helpers import (
 )
 from phoenix.db.insertion.helpers import insert_on_conflict
 from phoenix.db.types.db_helper_types import UNDEFINED
+from phoenix.server.access import OBJECT_TYPE_DATASET, Permission
 from phoenix.server.api.routers.v1.datasets import DatasetExample
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.authorization import is_not_locked
@@ -36,6 +37,10 @@ from .utils import (
     ResponseBody,
     add_errors_to_responses,
     add_text_csv_content_to_responses,
+    assert_can_access,
+    assert_can_access_experiment,
+    assert_can_read,
+    assert_can_read_experiment,
 )
 
 router = APIRouter(tags=["experiments"], include_in_schema=True)
@@ -142,6 +147,8 @@ async def create_experiment(
         )
 
     dataset_version_globalid_str = request_body.version_id
+    dataset_version_globalid: Optional[GlobalID] = None
+    dataset_version_id: Optional[int] = None
     if dataset_version_globalid_str is not None:
         try:
             dataset_version_globalid = GlobalID.from_id(dataset_version_globalid_str)
@@ -169,6 +176,14 @@ async def create_experiment(
                 detail=f"Dataset with ID {dataset_globalid} does not exist",
                 status_code=404,
             )
+        await assert_can_access(
+            session,
+            request,
+            object_type=OBJECT_TYPE_DATASET,
+            object_id=dataset_rowid,
+            permission=Permission.OBJ_EDIT,
+            not_found_detail=f"Dataset with ID {dataset_globalid} does not exist",
+        )
         dataset_name = result.name
         if dataset_version_globalid_str is None:
             dataset_version_result = await session.execute(
@@ -186,7 +201,10 @@ async def create_experiment(
             dataset_version_globalid = GlobalID("DatasetVersion", str(dataset_version_id))
         else:
             dataset_version = await session.execute(
-                select(models.DatasetVersion).where(models.DatasetVersion.id == dataset_version_id)
+                select(models.DatasetVersion).where(
+                    models.DatasetVersion.id == dataset_version_id,
+                    models.DatasetVersion.dataset_id == dataset_rowid,
+                )
             )
             dataset_version = dataset_version.scalar()
             if not dataset_version:
@@ -194,6 +212,10 @@ async def create_experiment(
                     detail=f"DatasetVersion with ID {dataset_version_globalid} does not exist",
                     status_code=404,
                 )
+            dataset_version_id = dataset_version.id
+            dataset_version_globalid = GlobalID("DatasetVersion", str(dataset_version_id))
+        assert dataset_version_id is not None
+        assert dataset_version_globalid is not None
         user_id: Optional[int] = None
         if request.app.state.authentication_enabled and isinstance(request.user, PhoenixUser):
             user_id = int(request.user.identity)
@@ -211,7 +233,6 @@ async def create_experiment(
             description=request_body.description,
             repetitions=request_body.repetitions,
             metadata_=request_body.metadata or {},
-            project_name=project_name,
             user_id=user_id,
         )
 
@@ -236,6 +257,7 @@ async def create_experiment(
                 dict(
                     name=project_name,
                     description=project_description,
+                    kind="EXPERIMENT",
                     created_at=experiment.created_at,
                     updated_at=experiment.updated_at,
                 ),
@@ -245,6 +267,13 @@ async def create_experiment(
             ).returning(models.Project.id)
         )
         assert project_rowid is not None
+        # Durable link for access-by-parent: this kind=EXPERIMENT project inherits
+        # access from the experiment's dataset. Flush + refresh so the instance's
+        # server-side `updated_at` (bumped by this UPDATE's onupdate) is reloaded
+        # while still session-bound — the response reads it after the session closes.
+        experiment.project_id = project_rowid
+        await session.flush()
+        await session.refresh(experiment)
 
         experiment_globalid = GlobalID("Experiment", str(experiment.id))
         if dataset_version_globalid_str is None:
@@ -324,6 +353,13 @@ async def get_experiment(request: Request, experiment_id: str) -> GetExperimentR
                 detail=f"Experiment with ID {experiment_globalid} does not exist",
                 status_code=404,
             )
+        await assert_can_read(
+            session,
+            request,
+            object_type=OBJECT_TYPE_DATASET,
+            object_id=experiment.dataset_id,
+            not_found_detail=f"Experiment with ID {experiment_globalid} does not exist",
+        )
 
         dataset_globalid = GlobalID("Dataset", str(experiment.dataset_id))
         dataset_version_globalid = GlobalID("DatasetVersion", str(experiment.dataset_version_id))
@@ -476,6 +512,13 @@ async def update_experiment(
         )
 
     async with request.app.state.db() as session:
+        await assert_can_access_experiment(
+            session,
+            request,
+            experiment_rowid,
+            permission=Permission.OBJ_EDIT,
+            not_found_detail=f"Experiment with ID {experiment_globalid} does not exist",
+        )
         experiment = await session.scalar(
             update(models.Experiment)
             .where(models.Experiment.id == experiment_rowid)
@@ -487,6 +530,10 @@ async def update_experiment(
                 detail=f"Experiment with ID {experiment_globalid} does not exist",
                 status_code=404,
             )
+        # project_name is derived from project_id (a correlated subquery), so it is not
+        # populated by UPDATE...RETURNING; load it before the session closes and the
+        # instance detaches.
+        await session.refresh(experiment, ["project_name"])
 
         dataset_globalid = GlobalID("Dataset", str(experiment.dataset_id))
         dataset_version_globalid = GlobalID("DatasetVersion", str(experiment.dataset_version_id))
@@ -581,29 +628,45 @@ async def delete_experiment(
             status_code=404,
         )
 
-    # Stop any running experiment and wait for in-flight shielded DB writes
-    # to drain, avoiding FK constraint violations from concurrent writes.
-    # Note: only drains experiments owned by this replica. In multi-replica
-    # deployments, another replica's shielded writes may still race with
-    # the DELETE (possible FK errors or orphaned rows), but these are
-    # harmless since the experiment is being deleted anyway.
-    await request.state.experiment_runner.stop_experiment(experiment_rowid)
-
     stmt = (
         sa.delete(models.Experiment)
         .where(models.Experiment.id == experiment_rowid)
-        .returning(models.Experiment.project_name)
+        .returning(models.Experiment.project_id)
     )
     async with request.app.state.db() as session:
+        await assert_can_access_experiment(
+            session,
+            request,
+            experiment_rowid,
+            permission=Permission.OBJ_EDIT,
+            not_found_detail=f"Experiment with ID {experiment_globalid} does not exist",
+        )
+        # Stop any running experiment and wait for in-flight shielded DB writes
+        # to drain, avoiding FK constraint violations from concurrent writes.
+        # Note: only drains experiments owned by this replica. In multi-replica
+        # deployments, another replica's shielded writes may still race with
+        # the DELETE (possible FK errors or orphaned rows), but these are
+        # harmless since the experiment is being deleted anyway.
+        await request.state.experiment_runner.stop_experiment(experiment_rowid)
         result = (await session.execute(stmt)).first()
         if result is None:
             raise HTTPException(detail="Experiment does not exist", status_code=404)
-        project_name = result.project_name
-        if delete_project and project_name:
-            delete_project_stmt = sa.delete(models.Project).where(
-                models.Project.name == project_name
-            )
-            await session.execute(delete_project_stmt)
+        project_id = result.project_id
+        if project_id is not None:
+            if delete_project:
+                await session.execute(
+                    sa.delete(models.Project).where(models.Project.id == project_id)
+                )
+            else:
+                # The experiment is gone but its trace project is kept — it is no longer an
+                # experiment's hidden store, so surface it as a normal (TELEMETRY) project.
+                # (Before the kind discriminator, deleting the experiment un-hid its project,
+                # because the experiment-project exclusion keyed on a *live* experiment.)
+                await session.execute(
+                    sa.update(models.Project)
+                    .where(models.Project.id == project_id, models.Project.kind == "EXPERIMENT")
+                    .values(kind="TELEMETRY")
+                )
 
 
 class ListExperimentsResponseBody(PaginatedResponseBody[Experiment]):
@@ -691,6 +754,14 @@ async def get_incomplete_runs(
     async with request.app.state.db() as session:
         experiment_result = await session.execute(select(models.Experiment).filter_by(id=id_))
         experiment = experiment_result.scalar()
+        if experiment is not None:
+            await assert_can_read(
+                session,
+                request,
+                object_type=OBJECT_TYPE_DATASET,
+                object_id=experiment.dataset_id,
+                not_found_detail=f"Experiment with ID {experiment_globalid} does not exist",
+            )
         if not experiment:
             raise HTTPException(
                 detail=f"Experiment with ID {experiment_globalid} does not exist",
@@ -802,6 +873,13 @@ async def list_experiments(
             status_code=404,
         )
     async with request.app.state.db() as session:
+        await assert_can_read(
+            session,
+            request,
+            object_type=OBJECT_TYPE_DATASET,
+            object_id=dataset_rowid,
+            not_found_detail=f"Dataset with ID {dataset_gid} does not exist",
+        )
         query = (
             select(models.Experiment)
             .where(models.Experiment.dataset_id == dataset_rowid)
@@ -1016,6 +1094,12 @@ async def get_experiment_json(
         )
 
     async with request.app.state.db() as session:
+        await assert_can_read_experiment(
+            session,
+            request,
+            experiment_rowid,
+            not_found_detail=f"Experiment with ID {experiment_globalid} does not exist",
+        )
         experiment, runs, revisions = await _get_experiment_runs_and_revisions(
             session, experiment_rowid
         )
@@ -1089,6 +1173,12 @@ async def get_experiment_csv(
         )
 
     async with request.app.state.db() as session:
+        await assert_can_read_experiment(
+            session,
+            request,
+            experiment_rowid,
+            not_found_detail=f"Experiment with ID {experiment_globalid} does not exist",
+        )
         experiment, runs, revisions = await _get_experiment_runs_and_revisions(
             session, experiment_rowid
         )

--- a/src/phoenix/server/api/routers/v1/projects.py
+++ b/src/phoenix/server/api/routers/v1/projects.py
@@ -12,12 +12,19 @@ from phoenix.db.helpers import (
     exclude_dataset_evaluator_projects,
     exclude_experiment_projects,
 )
+from phoenix.server.access import (
+    OBJECT_TYPE_PROJECT,
+    delete_object_grants,
+    delete_object_tags,
+)
 from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
 from phoenix.server.api.routers.v1.utils import (
     PaginatedResponseBody,
     ResponseBody,
     add_errors_to_responses,
+    assert_can_read,
     get_project_by_identifier,
+    scope_predicate,
 )
 from phoenix.server.api.types.Project import Project as ProjectNodeType
 from phoenix.server.authorization import is_not_locked, require_admin
@@ -119,6 +126,12 @@ async def get_projects(
     if name_contains:
         stmt = stmt.where(models.CaseInsensitiveContains(models.Project.name, name_contains))
     async with request.app.state.db() as session:
+        # Restrict to the projects this caller may read (no-op when not enforcing).
+        stmt = stmt.where(
+            await scope_predicate(
+                session, request, object_type=OBJECT_TYPE_PROJECT, id_column=models.Project.id
+            )
+        )
         if cursor:
             try:
                 cursor_id = GlobalID.from_id(cursor).node_id
@@ -180,6 +193,13 @@ async def get_project(
     """  # noqa: E501
     async with request.app.state.db() as session:
         project = await get_project_by_identifier(session, project_identifier)
+        await assert_can_read(
+            session,
+            request,
+            object_type=OBJECT_TYPE_PROJECT,
+            object_id=project.id,
+            not_found_detail=f"Project with identifier {project_identifier} not found",
+        )
     data = _to_project_response(project)
     return GetProjectResponseBody(data=data)
 
@@ -319,6 +339,8 @@ async def delete_project(
                 detail="The default project cannot be deleted",
             )
 
+        await delete_object_grants(session, OBJECT_TYPE_PROJECT, project.id)
+        await delete_object_tags(session, OBJECT_TYPE_PROJECT, project.id)
         await session.delete(project)
     return None
 

--- a/src/phoenix/server/api/routers/v1/prompts.py
+++ b/src/phoenix/server/api/routers/v1/prompts.py
@@ -1,15 +1,17 @@
 import logging
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import ValidationError, field_validator, model_validator
 from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import Select
 from starlette.requests import Request
 from strawberry.relay import GlobalID
 from typing_extensions import Self, TypeAlias, assert_never
 
+from phoenix.config import get_env_access_control_enabled
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
@@ -24,11 +26,22 @@ from phoenix.db.types.prompts import (
     PromptTools,
     normalize_invocation_parameters_for_write,
 )
+from phoenix.server.access import (
+    OBJECT_TYPE_PROMPT,
+    Permission,
+    can_access,
+    delete_object_grants,
+    delete_object_tags,
+)
 from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
 from phoenix.server.api.routers.v1.utils import (
     PaginatedResponseBody,
     ResponseBody,
     add_errors_to_responses,
+    assert_can_access,
+    assert_can_read,
+    request_user_id,
+    scope_predicate,
 )
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.Prompt import Prompt as PromptNodeType
@@ -119,6 +132,8 @@ router = APIRouter(tags=["prompts"])
     response_description="A list of prompts with pagination information",
     responses=add_errors_to_responses(
         [
+            404,
+            409,
             422,
         ]
     ),
@@ -154,7 +169,15 @@ async def get_prompts(
             if not prompt_exists:
                 return GetPromptsResponseBody(next_cursor=None, data=[])
 
-        query = select(models.Prompt).order_by(models.Prompt.id.desc())
+        query = (
+            select(models.Prompt)
+            .where(
+                await scope_predicate(
+                    session, request, object_type=OBJECT_TYPE_PROMPT, id_column=models.Prompt.id
+                )
+            )
+            .order_by(models.Prompt.id.desc())
+        )
 
         if cursor:
             try:
@@ -228,6 +251,15 @@ async def list_prompt_versions(
     query = query.order_by(models.PromptVersion.id.desc())
 
     async with request.app.state.db() as session:
+        prompt_rowid = await _resolve_prompt_rowid(session, prompt_identifier)
+        if prompt_rowid is not None:
+            await assert_can_read(
+                session,
+                request,
+                object_type=OBJECT_TYPE_PROMPT,
+                object_id=prompt_rowid,
+                not_found_detail=f"Prompt {prompt_identifier} not found",
+            )
         if cursor:
             try:
                 cursor_id = GlobalID.from_id(cursor).node_id
@@ -305,6 +337,13 @@ async def get_prompt_version_by_prompt_version_id(
         prompt_version = await session.scalar(stmt)
         if prompt_version is None:
             raise HTTPException(404)
+        await assert_can_read(
+            session,
+            request,
+            object_type=OBJECT_TYPE_PROMPT,
+            object_id=prompt_version.prompt_id,
+            not_found_detail="Prompt version not found",
+        )
     data = _prompt_version_from_orm_version(prompt_version)
     return GetPromptResponseBody(data=data)
 
@@ -357,6 +396,15 @@ async def get_prompt_version_by_tag_name(
     )
     stmt = _filter_by_prompt_identifier(stmt.join(models.Prompt), prompt_identifier)
     async with request.app.state.db() as session:
+        prompt_rowid = await _resolve_prompt_rowid(session, prompt_identifier)
+        if prompt_rowid is not None:
+            await assert_can_read(
+                session,
+                request,
+                object_type=OBJECT_TYPE_PROMPT,
+                object_id=prompt_rowid,
+                not_found_detail=f"Prompt {prompt_identifier} not found",
+            )
         prompt_version: models.PromptVersion = await session.scalar(stmt)
         if prompt_version is None:
             raise HTTPException(404)
@@ -405,6 +453,15 @@ async def get_prompt_version_by_latest(
     )
     stmt = _filter_by_prompt_identifier(stmt.join(models.Prompt), prompt_identifier)
     async with request.app.state.db() as session:
+        prompt_rowid = await _resolve_prompt_rowid(session, prompt_identifier)
+        if prompt_rowid is not None:
+            await assert_can_read(
+                session,
+                request,
+                object_type=OBJECT_TYPE_PROMPT,
+                object_id=prompt_rowid,
+                not_found_detail=f"Prompt {prompt_identifier} not found",
+            )
         prompt_version: models.PromptVersion = await session.scalar(stmt)
         if prompt_version is None:
             raise HTTPException(404)
@@ -468,11 +525,34 @@ async def create_prompt(
         assert isinstance(user := request.user, PhoenixUser)
         user_id = int(user.identity)
     async with request.app.state.db() as session:
-        if not (prompt_orm := await session.scalar(select(models.Prompt).filter_by(name=name))):
+        prompt_orm = await session.scalar(select(models.Prompt).filter_by(name=name))
+        if prompt_orm is None:
             prompt_orm = models.Prompt(
                 name=name,
                 description=prompt.description,
                 metadata_=prompt.metadata or {},
+            )
+        else:
+            # Appending a version mutates an existing prompt root, so it needs edit access.
+            # Creating a brand-new prompt needs no gate — the author becomes its owner.
+            if get_env_access_control_enabled():
+                existing_user_id = request_user_id(request)
+                if existing_user_id is not None and not await can_access(
+                    session,
+                    user_id=existing_user_id,
+                    object_type=OBJECT_TYPE_PROMPT,
+                    object_id=prompt_orm.id,
+                    enabled=True,
+                    permission=Permission.OBJ_VIEW,
+                ):
+                    raise HTTPException(detail="Prompt name is unavailable", status_code=409)
+            await assert_can_access(
+                session,
+                request,
+                object_type=OBJECT_TYPE_PROMPT,
+                object_id=prompt_orm.id,
+                permission=Permission.OBJ_EDIT,
+                not_found_detail=f"Prompt {name} not found or not accessible",
             )
         version_orm = models.PromptVersion(
             user_id=user_id,
@@ -585,6 +665,17 @@ async def list_prompt_version_tags(
     stmt = stmt.limit(limit + 1)
 
     async with request.app.state.db() as session:
+        prompt_rowid = await session.scalar(
+            select(models.PromptVersion.prompt_id).where(models.PromptVersion.id == id_)
+        )
+        if prompt_rowid is not None:
+            await assert_can_read(
+                session,
+                request,
+                object_type=OBJECT_TYPE_PROMPT,
+                object_id=prompt_rowid,
+                not_found_detail="Prompt version not found",
+            )
         result = (await session.execute(stmt)).all()
 
     # Check if prompt version exists
@@ -674,6 +765,15 @@ async def create_prompt_version_tag(
         prompt_id = await session.scalar(select(models.PromptVersion.prompt_id).filter_by(id=id_))
         if prompt_id is None:
             raise HTTPException(404)
+        # Tagging mutates the prompt root, so it needs edit access.
+        await assert_can_access(
+            session,
+            request,
+            object_type=OBJECT_TYPE_PROMPT,
+            object_id=prompt_id,
+            permission=Permission.OBJ_EDIT,
+            not_found_detail="Prompt version not found",
+        )
         dialect = SupportedSQLDialect(session.bind.dialect.name)
         values = dict(
             name=request_body.name,
@@ -746,6 +846,15 @@ async def delete_prompt_version_tag(
         prompt_id = await session.scalar(select(models.PromptVersion.prompt_id).filter_by(id=id_))
         if prompt_id is None:
             raise HTTPException(404)
+        # Removing a tag mutates the prompt root, so it needs edit access.
+        await assert_can_access(
+            session,
+            request,
+            object_type=OBJECT_TYPE_PROMPT,
+            object_id=prompt_id,
+            permission=Permission.OBJ_EDIT,
+            not_found_detail="Prompt version not found",
+        )
         tag = await session.scalar(
             select(models.PromptVersionTag).where(
                 models.PromptVersionTag.prompt_id == prompt_id,
@@ -779,11 +888,21 @@ async def delete_prompt(
     else:
         assert_never(identifier)
     async with request.app.state.db() as session:
-        prompt_id = await session.scalar(
-            delete(models.Prompt).where(where_clause).returning(models.Prompt.id)
+        prompt_id = await session.scalar(select(models.Prompt.id).where(where_clause))
+        if prompt_id is None:
+            raise HTTPException(status_code=404, detail="Prompt not found")
+        # Deleting mutates the prompt root, so it needs edit access before removing it.
+        await assert_can_access(
+            session,
+            request,
+            object_type=OBJECT_TYPE_PROMPT,
+            object_id=prompt_id,
+            permission=Permission.OBJ_EDIT,
+            not_found_detail="Prompt not found",
         )
-    if prompt_id is None:
-        raise HTTPException(status_code=404, detail="Prompt not found")
+        await delete_object_grants(session, OBJECT_TYPE_PROMPT, prompt_id)
+        await delete_object_tags(session, OBJECT_TYPE_PROMPT, prompt_id)
+        await session.execute(delete(models.Prompt).where(models.Prompt.id == prompt_id))
 
 
 class _PromptId(int): ...
@@ -820,6 +939,17 @@ def _filter_by_prompt_identifier(
     if isinstance(identifier, Identifier):
         return stmt.where(models.Prompt.name == identifier)
     assert_never(identifier)
+
+
+async def _resolve_prompt_rowid(session: AsyncSession, prompt_identifier: str) -> Optional[int]:
+    """The prompt's row id from a name-or-GlobalID identifier, or None if absent."""
+    identifier = _parse_prompt_identifier(prompt_identifier)
+    if isinstance(identifier, _PromptId):
+        return int(identifier)
+    return cast(
+        Optional[int],
+        await session.scalar(select(models.Prompt.id).where(models.Prompt.name == identifier)),
+    )
 
 
 def _prompt_version_from_orm_version(

--- a/src/phoenix/server/api/routers/v1/sessions.py
+++ b/src/phoenix/server/api/routers/v1/sessions.py
@@ -14,12 +14,14 @@ from strawberry.relay import GlobalID
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect, token_counts_by_session
 from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
+from phoenix.server.access import OBJECT_TYPE_PROJECT
 from phoenix.server.api.helpers.annotations import get_note_identifier
 from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
 from phoenix.server.api.routers.v1.utils import (
     PaginatedResponseBody,
     ResponseBody,
     add_errors_to_responses,
+    assert_can_read,
     get_project_by_identifier,
 )
 from phoenix.server.api.types.node import from_global_id_with_expected_type
@@ -209,6 +211,13 @@ async def get_session(
 ) -> GetSessionResponseBody:
     async with request.app.state.db.read() as db_session:
         project_session = await _get_session_by_identifier(db_session, session_identifier)
+        await assert_can_read(
+            db_session,
+            request,
+            object_type=OBJECT_TYPE_PROJECT,
+            object_id=project_session.project_id,
+            not_found_detail=f"Session with identifier {session_identifier} not found",
+        )
         traces_stmt = (
             select(models.Trace)
             .filter_by(project_session_rowid=project_session.id)
@@ -359,6 +368,13 @@ async def list_project_sessions(
 ) -> GetSessionsResponseBody:
     async with request.app.state.db.read() as db_session:
         project = await get_project_by_identifier(db_session, project_identifier)
+        await assert_can_read(
+            db_session,
+            request,
+            object_type=OBJECT_TYPE_PROJECT,
+            object_id=project.id,
+            not_found_detail=f"Project with identifier {project_identifier} not found",
+        )
 
         if order == "desc":
             order_clause = models.ProjectSession.id.desc()

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -21,6 +21,7 @@ from phoenix.datetime_utils import is_timezone_aware, normalize_datetime
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect, get_ancestor_span_rowids
 from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
+from phoenix.server.access import OBJECT_TYPE_PROJECT
 from phoenix.server.api.helpers.annotations import get_note_identifier
 from phoenix.server.api.routers.utils import df_to_bytes
 from phoenix.server.api.routers.v1.annotations import SpanAnnotationData
@@ -56,6 +57,7 @@ from .utils import (
     RequestBody,
     ResponseBody,
     add_errors_to_responses,
+    assert_can_read,
     get_project_by_identifier,
 )
 
@@ -619,6 +621,17 @@ async def query_spans_handler(
         )
 
     async with request.app.state.db.read() as session:
+        project_id = await session.scalar(
+            select(models.Project.id).where(models.Project.name == project_name)
+        )
+        if project_id is not None:
+            await assert_can_read(
+                session,
+                request,
+                object_type=OBJECT_TYPE_PROJECT,
+                object_id=project_id,
+                not_found_detail=f"Project with name {project_name} not found",
+            )
         results: list[pd.DataFrame] = []
         for query in span_queries:
             df = await session.run_sync(
@@ -761,6 +774,13 @@ async def span_search_otlpv1(
 
     async with request.app.state.db.read() as session:
         project = await get_project_by_identifier(session, project_identifier)
+        await assert_can_read(
+            session,
+            request,
+            object_type=OBJECT_TYPE_PROJECT,
+            object_id=project.id,
+            not_found_detail=f"Project with identifier {project_identifier} not found",
+        )
 
     project_id: int = project.id
     order_by = [models.Span.id.desc()]
@@ -943,6 +963,13 @@ async def span_search(
 ) -> SpansResponseBody:
     async with request.app.state.db.read() as session:
         project = await get_project_by_identifier(session, project_identifier)
+        await assert_can_read(
+            session,
+            request,
+            object_type=OBJECT_TYPE_PROJECT,
+            object_id=project.id,
+            not_found_detail=f"Project with identifier {project_identifier} not found",
+        )
 
     project_id: int = project.id
     order_by = [models.Span.id.desc()]

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -22,6 +22,7 @@ from phoenix.datetime_utils import normalize_datetime
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect, token_counts_by_trace
 from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
+from phoenix.server.access import OBJECT_TYPE_PROJECT
 from phoenix.server.api.helpers.annotations import get_note_identifier
 from phoenix.server.api.routers.v1.annotations import TraceAnnotationData
 from phoenix.server.api.types.node import from_global_id_with_expected_type
@@ -46,6 +47,7 @@ from .utils import (
     RequestBody,
     ResponseBody,
     add_errors_to_responses,
+    assert_can_read,
     get_project_by_identifier,
 )
 
@@ -158,6 +160,13 @@ async def list_project_traces(
 ) -> GetTracesResponseBody:
     async with request.app.state.db.read() as session:
         project = await get_project_by_identifier(session, project_identifier)
+        await assert_can_read(
+            session,
+            request,
+            object_type=OBJECT_TYPE_PROJECT,
+            object_id=project.id,
+            not_found_detail=f"Project with identifier {project_identifier} not found",
+        )
         project_rowid = project.id
 
         # Build query with sort order

--- a/src/phoenix/server/api/routers/v1/utils.py
+++ b/src/phoenix/server/api/routers/v1/utils.py
@@ -2,17 +2,169 @@ from typing import Annotated, Any, Generic, Optional, TypedDict, TypeVar, Union
 
 from fastapi import HTTPException
 from pydantic import Field
-from sqlalchemy import select
+from sqlalchemy import ColumnElement, select, true
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import InstrumentedAttribute
+from starlette.requests import Request
 from strawberry.relay import GlobalID
 from typing_extensions import TypeAlias, assert_never
 
+from phoenix.config import get_env_access_control_enabled
 from phoenix.db import models
+from phoenix.server.access import (
+    OBJECT_TYPE_DATASET,
+    Permission,
+    accessible_scope,
+    can_access,
+)
 from phoenix.server.api.types.Dataset import Dataset as DatasetNodeType
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.Project import Project as ProjectNodeType
+from phoenix.server.bearer_auth import PhoenixUser
 
 from .models import V1RoutesBaseModel
+
+
+def request_user_id(request: Request) -> Optional[int]:
+    """The caller's user id, or None when auth is disabled or the caller is not a
+    PhoenixUser. (Admins are PhoenixUsers too — the oracle's ADMINISTER rule, not
+    a None here, is what grants them universal access.)"""
+    if not request.app.state.authentication_enabled:
+        return None
+    user = request.user
+    return int(user.identity) if isinstance(user, PhoenixUser) else None
+
+
+async def assert_can_access(
+    session: AsyncSession,
+    request: Request,
+    *,
+    object_type: str,
+    object_id: int,
+    permission: Permission,
+    not_found_detail: str,
+) -> None:
+    """Gate an action on ``(object_type, object_id)`` by the caller's ``permission`` on it
+    (``OBJ_VIEW`` for reads, ``OBJ_EDIT`` for mutations). Unauthorized is surfaced as **404**
+    — indistinguishable from not-found. A no-op when access control is not enforcing or auth
+    is disabled (access control presupposes auth). Containment children pass their *parent's*
+    (object_type, object_id); roots pass their own."""
+    if not get_env_access_control_enabled():
+        return
+    user_id = request_user_id(request)
+    if user_id is None:
+        return
+    if not await can_access(
+        session,
+        user_id=user_id,
+        object_type=object_type,
+        object_id=object_id,
+        enabled=True,
+        permission=permission,
+    ):
+        raise HTTPException(status_code=404, detail=not_found_detail)
+
+
+async def assert_can_read(
+    session: AsyncSession,
+    request: Request,
+    *,
+    object_type: str,
+    object_id: int,
+    not_found_detail: str,
+) -> None:
+    """Gate a *read* by the caller's visibility (``OBJ_VIEW``) of ``(object_type,
+    object_id)``. Thin wrapper over :func:`assert_can_access`."""
+    await assert_can_access(
+        session,
+        request,
+        object_type=object_type,
+        object_id=object_id,
+        permission=Permission.OBJ_VIEW,
+        not_found_detail=not_found_detail,
+    )
+
+
+async def scope_predicate(
+    session: AsyncSession,
+    request: Request,
+    *,
+    object_type: str,
+    id_column: "InstrumentedAttribute[int]",
+) -> "ColumnElement[bool]":
+    """A WHERE predicate restricting a *list* query to the rows the caller may
+    read. ``true()`` when access control is not enforcing or auth is disabled, so
+    callers can ``.where(...)`` it unconditionally with no behavior change.
+
+    Compiles the actor's accessible scope to ``id_column IN (...)`` — a single hashed
+    lookup. Not a correlated per-row grant subquery, which on a full-table list re-runs
+    for every candidate row and is orders of magnitude slower."""
+    if not get_env_access_control_enabled():
+        return true()
+    user_id = request_user_id(request)
+    if user_id is None:
+        return true()
+    scope = await accessible_scope(
+        session,
+        user_id=user_id,
+        object_type=object_type,
+        enabled=True,
+    )
+    return scope.apply(id_column)
+
+
+async def assert_can_read_experiment(
+    session: AsyncSession,
+    request: Request,
+    experiment_rowid: int,
+    *,
+    not_found_detail: str,
+) -> None:
+    """Access-by-parent for experiments: an experiment (and its runs, evaluations, and
+    exports) derives its access from the dataset it runs on. Resolves the parent dataset and
+    gates on it. A no-op if the experiment is absent (the endpoint surfaces its own
+    not-found)."""
+    await assert_can_access_experiment(
+        session,
+        request,
+        experiment_rowid,
+        permission=Permission.OBJ_VIEW,
+        not_found_detail=not_found_detail,
+    )
+
+
+async def assert_can_access_experiment(
+    session: AsyncSession,
+    request: Request,
+    experiment_rowid: int,
+    *,
+    permission: Permission,
+    not_found_detail: str,
+) -> None:
+    """Gate an experiment action through the parent dataset's access policy."""
+    dataset_id = await session.scalar(
+        select(models.Experiment.dataset_id).where(models.Experiment.id == experiment_rowid)
+    )
+    if dataset_id is None:
+        return
+    await assert_can_read(
+        session,
+        request,
+        object_type=OBJECT_TYPE_DATASET,
+        object_id=dataset_id,
+        not_found_detail=not_found_detail,
+    )
+    if permission is Permission.OBJ_VIEW:
+        return
+    await assert_can_access(
+        session,
+        request,
+        object_type=OBJECT_TYPE_DATASET,
+        object_id=dataset_id,
+        permission=permission,
+        not_found_detail=not_found_detail,
+    )
+
 
 StatusCode: TypeAlias = int
 DataType = TypeVar("DataType")

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -20,7 +20,7 @@ from sqlalchemy import func as sa_func
 from strawberry.types import Info
 from typing_extensions import TypeAlias
 
-from phoenix.config import PLAYGROUND_PROJECT_NAME
+from phoenix.config import PLAYGROUND_PROJECT_NAME, get_env_access_control_enabled
 from phoenix.db import models
 from phoenix.db.helpers import (
     get_dataset_example_revisions,
@@ -213,19 +213,41 @@ class Subscription:
                 connection=connection,
                 headers=headers,
             )
+            # Playground prompts are the most sensitive data in the system, so
+            # under enforcement the playground is per-user (kind=PLAYGROUND, with a
+            # creator grant) rather than the shared singleton. Flag off → unchanged.
+            playground_user_id = get_user(info)
+            enforcing = get_env_access_control_enabled()
+            playground_name = (
+                f"{PLAYGROUND_PROJECT_NAME}:{playground_user_id}"
+                if enforcing and playground_user_id is not None
+                else PLAYGROUND_PROJECT_NAME
+            )
             if (
                 playground_project_id := await session.scalar(
-                    select(models.Project.id).where(models.Project.name == PLAYGROUND_PROJECT_NAME)
+                    select(models.Project.id).where(models.Project.name == playground_name)
                 )
             ) is None:
                 playground_project_id = await session.scalar(
                     insert(models.Project)
                     .returning(models.Project.id)
                     .values(
-                        name=PLAYGROUND_PROJECT_NAME,
+                        name=playground_name,
                         description="Traces from prompt playground",
+                        kind="PLAYGROUND",
                     )
                 )
+                if enforcing and playground_user_id is not None:
+                    session.add(
+                        models.AccessGrant(
+                            subject_kind="user",
+                            subject_id=playground_user_id,
+                            object_type="project",
+                            object_id=playground_project_id,
+                            selector_kind="ids",
+                            effect="allow",
+                        )
+                    )
 
         not_started: deque[tuple[RepetitionNumber, ChatStream]] = deque(
             (
@@ -363,17 +385,17 @@ class Subscription:
 
             # === Create project (same as chat_completion_over_dataset) ===
             project_name = generate_experiment_project_name()
-            if (
-                await session.scalar(
-                    select(models.Project.id).where(models.Project.name == project_name)
-                )
-            ) is None:
-                await session.scalar(
+            experiment_project_id = await session.scalar(
+                select(models.Project.id).where(models.Project.name == project_name)
+            )
+            if experiment_project_id is None:
+                experiment_project_id = await session.scalar(
                     insert(models.Project)
                     .returning(models.Project.id)
                     .values(
                         name=project_name,
                         description="Traces from prompt playground",
+                        kind="EXPERIMENT",
                     )
                 )
 
@@ -388,7 +410,7 @@ class Subscription:
                 repetitions=input.repetitions,
                 metadata_=input.experiment_metadata or dict(),
                 is_ephemeral=bool(input.create_ephemeral_experiment),
-                project_name=project_name,
+                project_id=experiment_project_id,
                 user_id=user_id,
             )
             if resolved_split_ids:

--- a/src/phoenix/server/api/types/AccessGrant.py
+++ b/src/phoenix/server/api/types/AccessGrant.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+import strawberry
+from strawberry.relay import GlobalID
+
+from phoenix.server.api.types.AccessSubjectKind import AccessSubjectKind
+
+
+@strawberry.type
+class AccessGrant:
+    """One object access grant: a subject and the permission set it confers."""
+
+    subject_kind: AccessSubjectKind
+    subject_id: Optional[GlobalID]
+    subject_name: str
+    role_id: Optional[GlobalID]
+    role_name: str

--- a/src/phoenix/server/api/types/AccessObjectType.py
+++ b/src/phoenix/server/api/types/AccessObjectType.py
@@ -1,0 +1,20 @@
+import enum
+
+import strawberry
+
+from phoenix.server.access import (
+    OBJECT_TYPE_DATASET,
+    OBJECT_TYPE_PROJECT,
+    OBJECT_TYPE_PROMPT,
+)
+
+
+@strawberry.enum
+class AccessObjectType(enum.Enum):
+    """The access-controlled resource types a tag grant can be scoped to. A tag
+    grant names a type (never a concrete object) plus a key=value, and reaches every
+    object of that type currently carrying the tag."""
+
+    PROJECT = OBJECT_TYPE_PROJECT
+    DATASET = OBJECT_TYPE_DATASET
+    PROMPT = OBJECT_TYPE_PROMPT

--- a/src/phoenix/server/api/types/AccessSubjectKind.py
+++ b/src/phoenix/server/api/types/AccessSubjectKind.py
@@ -1,0 +1,15 @@
+import enum
+
+import strawberry
+
+from phoenix.server.access import SubjectKind
+
+
+@strawberry.enum
+class AccessSubjectKind(enum.Enum):
+    """The subject kinds a grant can be authored for through the API. ``EVERYONE``
+    (all authenticated users) carries no subject id; roles are seeded, not authored here."""
+
+    USER = SubjectKind.USER.value
+    GROUP = SubjectKind.GROUP.value
+    EVERYONE = SubjectKind.EVERYONE.value

--- a/src/phoenix/server/api/types/ApiKeyScope.py
+++ b/src/phoenix/server/api/types/ApiKeyScope.py
@@ -1,0 +1,19 @@
+from enum import Enum
+
+import strawberry
+
+from phoenix.server.api_key_scope import API_KEY_SCOPE_INGEST
+
+
+@strawberry.enum
+class ApiKeyScope(Enum):
+    """
+    Attenuation for an API key, signed into the key's JWT at creation.
+
+    A key without a scope has full legacy access (it acts with its owner's
+    role). A scoped key can only do less than its owner, never more. The
+    scope cannot be changed after creation; to narrow or widen a key,
+    create a new one and delete the old.
+    """
+
+    INGEST = API_KEY_SCOPE_INGEST

--- a/src/phoenix/server/api/types/Dataset.py
+++ b/src/phoenix/server/api/types/Dataset.py
@@ -14,11 +14,15 @@ from strawberry.scalars import JSON
 from strawberry.types import Info
 
 from phoenix.db import models
+from phoenix.server.access import DEFAULT_PERMISSION_SET, OBJECT_TYPE_DATASET, SubjectKind
+from phoenix.server.api.auth import IsAdmin
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, NotFound
 from phoenix.server.api.input_types.DatasetEvaluatorFilter import DatasetEvaluatorFilter
 from phoenix.server.api.input_types.DatasetEvaluatorSort import DatasetEvaluatorSort
 from phoenix.server.api.input_types.DatasetVersionSort import DatasetVersionSort
+from phoenix.server.api.types.AccessGrant import AccessGrant
+from phoenix.server.api.types.AccessSubjectKind import AccessSubjectKind
 from phoenix.server.api.types.DatasetExample import DatasetExample
 from phoenix.server.api.types.DatasetExperimentAnnotationSummary import (
     DatasetExperimentAnnotationSummary,
@@ -48,6 +52,100 @@ class Dataset(Node):
     def __post_init__(self) -> None:
         if self.db_record and self.id != self.db_record.id:
             raise ValueError("Dataset ID mismatch")
+
+    @strawberry.field(permission_classes=[IsAdmin])  # type: ignore[untyped-decorator]
+    async def access_grants(
+        self,
+        info: Info[Context, None],
+    ) -> list[AccessGrant]:
+        """The user/group grants on this dataset, with display names."""
+        async with info.context.db.read() as session:
+            rows = (
+                await session.execute(
+                    select(
+                        models.AccessGrant.subject_kind,
+                        models.AccessGrant.subject_id,
+                        models.AccessGrant.role_id,
+                    ).where(
+                        models.AccessGrant.object_type == OBJECT_TYPE_DATASET,
+                        models.AccessGrant.object_id == self.id,
+                        models.AccessGrant.selector_kind == "ids",
+                        models.AccessGrant.effect == "allow",
+                    )
+                )
+            ).all()
+            user_ids = [
+                sid for kind, sid, _ in rows if kind == SubjectKind.USER.value and sid is not None
+            ]
+            group_ids = [
+                sid for kind, sid, _ in rows if kind == SubjectKind.GROUP.value and sid is not None
+            ]
+            user_names: dict[int, str] = {}
+            if user_ids:
+                for uid, username, email in (
+                    await session.execute(
+                        select(models.User.id, models.User.username, models.User.email).where(
+                            models.User.id.in_(user_ids)
+                        )
+                    )
+                ).all():
+                    user_names[uid] = email or username
+            group_names: dict[int, str] = {}
+            if group_ids:
+                for gid, display_name in (
+                    await session.execute(
+                        select(models.UserGroup.id, models.UserGroup.display_name).where(
+                            models.UserGroup.id.in_(group_ids)
+                        )
+                    )
+                ).all():
+                    group_names[gid] = display_name or f"group:{gid}"
+            role_names: dict[int, str] = {
+                rid: name
+                for rid, name in (
+                    await session.execute(
+                        select(models.PermissionSet.id, models.PermissionSet.name)
+                    )
+                ).all()
+            }
+        grants: list[AccessGrant] = []
+        for kind, sid, role_id in rows:
+            role_name = (
+                role_names.get(role_id, DEFAULT_PERMISSION_SET)
+                if role_id
+                else DEFAULT_PERMISSION_SET
+            )
+            if kind == SubjectKind.EVERYONE.value:
+                grants.append(
+                    AccessGrant(
+                        subject_kind=AccessSubjectKind.EVERYONE,
+                        subject_id=None,
+                        subject_name="All users",
+                        role_id=GlobalID("PermissionSet", str(role_id)) if role_id else None,
+                        role_name=role_name,
+                    )
+                )
+            elif kind == SubjectKind.USER.value and sid is not None:
+                grants.append(
+                    AccessGrant(
+                        subject_kind=AccessSubjectKind.USER,
+                        subject_id=GlobalID("User", str(sid)),
+                        subject_name=user_names.get(sid, f"user:{sid}"),
+                        role_id=GlobalID("PermissionSet", str(role_id)) if role_id else None,
+                        role_name=role_name,
+                    )
+                )
+            elif kind == SubjectKind.GROUP.value and sid is not None:
+                grants.append(
+                    AccessGrant(
+                        subject_kind=AccessSubjectKind.GROUP,
+                        subject_id=GlobalID("UserGroup", str(sid)),
+                        subject_name=group_names.get(sid, f"group:{sid}"),
+                        role_id=GlobalID("PermissionSet", str(role_id)) if role_id else None,
+                        role_name=role_name,
+                    )
+                )
+        return grants
 
     @strawberry.field
     async def name(

--- a/src/phoenix/server/api/types/PermissionSet.py
+++ b/src/phoenix/server/api/types/PermissionSet.py
@@ -1,0 +1,42 @@
+import enum
+
+import strawberry
+from strawberry.relay import Node, NodeID
+
+from phoenix.db import models
+from phoenix.server.access import Permission
+
+
+@strawberry.enum
+class ObjectPermission(enum.Enum):
+    """What an permission set lets a subject do on a granted resource."""
+
+    VIEW = Permission.OBJ_VIEW.value
+    EDIT = Permission.OBJ_EDIT.value
+    MANAGE_ACCESS = Permission.OBJ_MANAGE_ACCESS.value
+
+
+@strawberry.type
+class PermissionSet(Node):
+    """A named bundle of object-level permissions, attachable to a grant. Built-in
+    presets are immutable; custom permission sets are editable."""
+
+    id: NodeID[int]
+    name: str
+    is_built_in: bool
+    permissions: list[ObjectPermission]
+
+
+def to_gql_permission_set(role: models.PermissionSet) -> PermissionSet:
+    permissions = []
+    for row in role.permissions:
+        try:
+            permissions.append(ObjectPermission(row.permission))
+        except ValueError:
+            continue
+    return PermissionSet(
+        id=role.id,
+        name=role.name,
+        is_built_in=role.is_built_in,
+        permissions=sorted(permissions, key=lambda p: p.value),
+    )

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -1,3 +1,4 @@
+import enum
 import operator
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, cast
@@ -18,6 +19,12 @@ from typing_extensions import assert_never
 from phoenix.datetime_utils import get_timestamp_range, normalize_datetime, right_open_time_range
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect, date_trunc
+from phoenix.server.access import (
+    DEFAULT_PERMISSION_SET,
+    OBJECT_TYPE_PROJECT,
+    SubjectKind,
+)
+from phoenix.server.api.auth import IsAdmin
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest
 from phoenix.server.api.extensions import RequireForwardPaginationExtension
@@ -28,6 +35,8 @@ from phoenix.server.api.input_types.ProjectSessionSort import (
 from phoenix.server.api.input_types.SpanSort import SpanColumn, SpanSort, SpanSortConfig
 from phoenix.server.api.input_types.TimeBinConfig import TimeBinConfig, TimeBinScale
 from phoenix.server.api.input_types.TimeRange import TimeRange
+from phoenix.server.api.types.AccessGrant import AccessGrant
+from phoenix.server.api.types.AccessSubjectKind import AccessSubjectKind
 from phoenix.server.api.types.AnnotationConfig import AnnotationConfig, to_gql_annotation_config
 from phoenix.server.api.types.AnnotationNameCount import AnnotationNameCount
 from phoenix.server.api.types.AnnotationSummary import AnnotationSummary
@@ -189,6 +198,16 @@ def _apply_project_session_filters(
     )
 
 
+@strawberry.enum
+class ProjectAccessPosture(enum.Enum):
+    """How a project is shared, for an at-a-glance badge. Derived from its grants,
+    independent of whether enforcement is currently on."""
+
+    ADMINS_ONLY = "admins_only"
+    SHARED = "shared"
+    ALL_USERS = "all_users"
+
+
 @strawberry.type
 class Project(Node):
     id: NodeID[int]
@@ -210,6 +229,125 @@ class Project(Node):
                 (self.id, models.Project.name),
             )
         return name
+
+    @strawberry.field(permission_classes=[IsAdmin])  # type: ignore[untyped-decorator]
+    async def access_grants(
+        self,
+        info: Info[Context, None],
+    ) -> list[AccessGrant]:
+        """The user/group grants on this project, with display names — drives the
+        Access tab's "who can see this project" view."""
+        async with info.context.db.read() as session:
+            rows = (
+                await session.execute(
+                    select(
+                        models.AccessGrant.subject_kind,
+                        models.AccessGrant.subject_id,
+                        models.AccessGrant.role_id,
+                    ).where(
+                        models.AccessGrant.object_type == OBJECT_TYPE_PROJECT,
+                        models.AccessGrant.object_id == self.id,
+                        models.AccessGrant.selector_kind == "ids",
+                        models.AccessGrant.effect == "allow",
+                    )
+                )
+            ).all()
+            user_ids = [
+                sid for kind, sid, _ in rows if kind == SubjectKind.USER.value and sid is not None
+            ]
+            group_ids = [
+                sid for kind, sid, _ in rows if kind == SubjectKind.GROUP.value and sid is not None
+            ]
+            user_names: dict[int, str] = {}
+            if user_ids:
+                for uid, username, email in (
+                    await session.execute(
+                        select(models.User.id, models.User.username, models.User.email).where(
+                            models.User.id.in_(user_ids)
+                        )
+                    )
+                ).all():
+                    user_names[uid] = email or username
+            group_names: dict[int, str] = {}
+            if group_ids:
+                for gid, display_name in (
+                    await session.execute(
+                        select(models.UserGroup.id, models.UserGroup.display_name).where(
+                            models.UserGroup.id.in_(group_ids)
+                        )
+                    )
+                ).all():
+                    group_names[gid] = display_name or f"group:{gid}"
+            role_names: dict[int, str] = {
+                rid: name
+                for rid, name in (
+                    await session.execute(
+                        select(models.PermissionSet.id, models.PermissionSet.name)
+                    )
+                ).all()
+            }
+        grants: list[AccessGrant] = []
+        for kind, sid, role_id in rows:
+            # A grant with no role confers view; show the default role's name.
+            role_name = (
+                role_names.get(role_id, DEFAULT_PERMISSION_SET)
+                if role_id
+                else DEFAULT_PERMISSION_SET
+            )
+            if kind == SubjectKind.EVERYONE.value:
+                # The everyone baseline carries no subject id; 0 is a UI sentinel (revoke keys
+                # on the kind, not the id).
+                grants.append(
+                    AccessGrant(
+                        subject_kind=AccessSubjectKind.EVERYONE,
+                        subject_id=None,
+                        subject_name="All users",
+                        role_id=GlobalID("PermissionSet", str(role_id)) if role_id else None,
+                        role_name=role_name,
+                    )
+                )
+            elif kind == SubjectKind.USER.value and sid is not None:
+                grants.append(
+                    AccessGrant(
+                        subject_kind=AccessSubjectKind.USER,
+                        subject_id=GlobalID("User", str(sid)),
+                        subject_name=user_names.get(sid, f"user:{sid}"),
+                        role_id=GlobalID("PermissionSet", str(role_id)) if role_id else None,
+                        role_name=role_name,
+                    )
+                )
+            elif kind == SubjectKind.GROUP.value and sid is not None:
+                grants.append(
+                    AccessGrant(
+                        subject_kind=AccessSubjectKind.GROUP,
+                        subject_id=GlobalID("UserGroup", str(sid)),
+                        subject_name=group_names.get(sid, f"group:{sid}"),
+                        role_id=GlobalID("PermissionSet", str(role_id)) if role_id else None,
+                        role_name=role_name,
+                    )
+                )
+        return grants
+
+    @strawberry.field
+    async def access_posture(self, info: Info[Context, None]) -> ProjectAccessPosture:
+        """How this project is shared, for the projects-list badge: ADMINS_ONLY (no grants),
+        SHARED (granted to specific users/groups), or ALL_USERS (an everyone grant). Derived
+        from grants; orthogonal to whether enforcement is currently on."""
+        async with info.context.db.read() as session:
+            kinds = set(
+                await session.scalars(
+                    select(models.AccessGrant.subject_kind).where(
+                        models.AccessGrant.object_type == OBJECT_TYPE_PROJECT,
+                        models.AccessGrant.object_id == self.id,
+                        models.AccessGrant.effect == "allow",
+                    )
+                )
+            )
+        if SubjectKind.EVERYONE.value in kinds:
+            return ProjectAccessPosture.ALL_USERS
+        if kinds:
+            return ProjectAccessPosture.SHARED
+        return ProjectAccessPosture.ADMINS_ONLY
 
     @strawberry.field
     async def description(

--- a/src/phoenix/server/api/types/Prompt.py
+++ b/src/phoenix/server/api/types/Prompt.py
@@ -11,8 +11,11 @@ from strawberry.types import Info
 
 from phoenix.db import models
 from phoenix.db.types.identifier import Identifier
+from phoenix.server.access import DEFAULT_PERMISSION_SET, OBJECT_TYPE_PROMPT, SubjectKind
+from phoenix.server.api.auth import IsAdmin
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import NotFound
+from phoenix.server.api.types.AccessSubjectKind import AccessSubjectKind
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.pagination import (
     ConnectionArgs,
@@ -20,6 +23,7 @@ from phoenix.server.api.types.pagination import (
     connection_from_list,
 )
 
+from .AccessGrant import AccessGrant
 from .PromptLabel import PromptLabel
 from .PromptVersion import (
     PromptVersion,
@@ -36,6 +40,100 @@ class Prompt(Node):
     def __post_init__(self) -> None:
         if self.db_record and self.id != self.db_record.id:
             raise ValueError("Prompt ID mismatch")
+
+    @strawberry.field(permission_classes=[IsAdmin])  # type: ignore[untyped-decorator]
+    async def access_grants(
+        self,
+        info: Info[Context, None],
+    ) -> list[AccessGrant]:
+        """The user/group grants on this prompt, with display names."""
+        async with info.context.db.read() as session:
+            rows = (
+                await session.execute(
+                    select(
+                        models.AccessGrant.subject_kind,
+                        models.AccessGrant.subject_id,
+                        models.AccessGrant.role_id,
+                    ).where(
+                        models.AccessGrant.object_type == OBJECT_TYPE_PROMPT,
+                        models.AccessGrant.object_id == self.id,
+                        models.AccessGrant.selector_kind == "ids",
+                        models.AccessGrant.effect == "allow",
+                    )
+                )
+            ).all()
+            user_ids = [
+                sid for kind, sid, _ in rows if kind == SubjectKind.USER.value and sid is not None
+            ]
+            group_ids = [
+                sid for kind, sid, _ in rows if kind == SubjectKind.GROUP.value and sid is not None
+            ]
+            user_names: dict[int, str] = {}
+            if user_ids:
+                for uid, username, email in (
+                    await session.execute(
+                        select(models.User.id, models.User.username, models.User.email).where(
+                            models.User.id.in_(user_ids)
+                        )
+                    )
+                ).all():
+                    user_names[uid] = email or username
+            group_names: dict[int, str] = {}
+            if group_ids:
+                for gid, display_name in (
+                    await session.execute(
+                        select(models.UserGroup.id, models.UserGroup.display_name).where(
+                            models.UserGroup.id.in_(group_ids)
+                        )
+                    )
+                ).all():
+                    group_names[gid] = display_name or f"group:{gid}"
+            role_names: dict[int, str] = {
+                rid: name
+                for rid, name in (
+                    await session.execute(
+                        select(models.PermissionSet.id, models.PermissionSet.name)
+                    )
+                ).all()
+            }
+        grants: list[AccessGrant] = []
+        for kind, sid, role_id in rows:
+            role_name = (
+                role_names.get(role_id, DEFAULT_PERMISSION_SET)
+                if role_id
+                else DEFAULT_PERMISSION_SET
+            )
+            if kind == SubjectKind.EVERYONE.value:
+                grants.append(
+                    AccessGrant(
+                        subject_kind=AccessSubjectKind.EVERYONE,
+                        subject_id=None,
+                        subject_name="All users",
+                        role_id=GlobalID("PermissionSet", str(role_id)) if role_id else None,
+                        role_name=role_name,
+                    )
+                )
+            elif kind == SubjectKind.USER.value and sid is not None:
+                grants.append(
+                    AccessGrant(
+                        subject_kind=AccessSubjectKind.USER,
+                        subject_id=GlobalID("User", str(sid)),
+                        subject_name=user_names.get(sid, f"user:{sid}"),
+                        role_id=GlobalID("PermissionSet", str(role_id)) if role_id else None,
+                        role_name=role_name,
+                    )
+                )
+            elif kind == SubjectKind.GROUP.value and sid is not None:
+                grants.append(
+                    AccessGrant(
+                        subject_kind=AccessSubjectKind.GROUP,
+                        subject_id=GlobalID("UserGroup", str(sid)),
+                        subject_name=group_names.get(sid, f"group:{sid}"),
+                        role_id=GlobalID("PermissionSet", str(role_id)) if role_id else None,
+                        role_name=role_name,
+                    )
+                )
+        return grants
 
     @strawberry.field
     async def source_prompt_id(

--- a/src/phoenix/server/api/types/ResourceTag.py
+++ b/src/phoenix/server/api/types/ResourceTag.py
@@ -1,0 +1,67 @@
+from typing import Optional
+
+import strawberry
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.server.access import SubjectKind
+from phoenix.server.api.types.AccessObjectType import AccessObjectType
+from phoenix.server.api.types.AccessSubjectKind import AccessSubjectKind
+
+# The Relay type tag for each grantable object kind, so a stored row id can be re-encoded as the
+# GlobalID a client sent in.
+_SUBJECT_TYPE_NAME = {
+    SubjectKind.USER.value: "User",
+    SubjectKind.GROUP.value: "UserGroup",
+}
+
+
+@strawberry.type
+class ResourceTag:
+    """A curated ``key=value`` tag on an access-controlled object. Tags are policy inputs a
+    tag grant reads, not user data — which is why setting one takes the same authority as
+    granting access. This is the read-back for ``setResourceTag`` / ``removeResourceTag``."""
+
+    key: str
+    value: str
+
+
+@strawberry.type
+class TagAccessGrant:
+    """A tag grant: a subject given a permission set over every object of ``object_type``
+    carrying ``tag_key=tag_value``. The read-back for ``grantTagAccess`` / ``revokeTagAccess``.
+    ``role_name`` is null when the grant confers the view-only default."""
+
+    id: GlobalID
+    subject_kind: AccessSubjectKind
+    subject_id: Optional[GlobalID]
+    subject_name: str
+    object_type: AccessObjectType
+    tag_key: str
+    tag_value: str
+    role_name: Optional[str]
+
+
+def to_gql_tag_grant(
+    row: models.AccessGrant,
+    role_names: dict[int, str],
+    subject_names: dict[tuple[str, int], str],
+) -> TagAccessGrant:
+    # EVERYONE carries no subject id; every other kind re-encodes its row id as a GlobalID.
+    subject_id: Optional[GlobalID] = None
+    subject_name = "All users"
+    if row.subject_id is not None and row.subject_kind in _SUBJECT_TYPE_NAME:
+        subject_id = GlobalID(_SUBJECT_TYPE_NAME[row.subject_kind], str(row.subject_id))
+        subject_name = subject_names.get(
+            (row.subject_kind, row.subject_id), f"{row.subject_kind.lower()}:{row.subject_id}"
+        )
+    return TagAccessGrant(
+        id=GlobalID("AccessGrant", str(row.id)),
+        subject_kind=AccessSubjectKind(row.subject_kind),
+        subject_id=subject_id,
+        subject_name=subject_name,
+        object_type=AccessObjectType(row.object_type),
+        tag_key=row.tag_key or "",
+        tag_value=row.tag_value or "",
+        role_name=role_names.get(row.role_id) if row.role_id is not None else None,
+    )

--- a/src/phoenix/server/api/types/User.py
+++ b/src/phoenix/server/api/types/User.py
@@ -3,17 +3,50 @@ from typing import Optional
 
 import strawberry
 from sqlalchemy import select
-from strawberry.relay import Node, NodeID
+from strawberry.relay import GlobalID, Node, NodeID
 from strawberry.types import Info
 
-from phoenix.config import get_env_admins
+from phoenix.config import get_env_access_control_enabled, get_env_admins
 from phoenix.db import models
+from phoenix.server.access import (
+    OBJECT_TYPE_DATASET,
+    OBJECT_TYPE_PROJECT,
+    OBJECT_TYPE_PROMPT,
+    Permission,
+    accessible_scope,
+    permissions_for_user_id,
+)
+from phoenix.server.api.auth import IsAdmin
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import NotFound
 from phoenix.server.api.types.AuthMethod import AuthMethod
 from phoenix.server.api.types.UserApiKey import UserApiKey
 
 from .UserRole import UserRole, to_gql_user_role
+
+
+@strawberry.type
+class AccessibleObjectRef:
+    """One object a user can access, for the admin "what can this person see" view."""
+
+    kind: str
+    id: GlobalID
+    name: str
+
+
+@strawberry.type
+class UserAccessSummary:
+    """Everything a user can currently view across the access roots (projects, datasets,
+    prompts). A type is reported as "all" when the user can see every object of that type —
+    because they are an administrator, because enforcement is off, or because of a type-wide
+    or everyone grant — in which case its per-object list is omitted."""
+
+    enforced: bool
+    is_admin: bool
+    all_projects: bool
+    all_datasets: bool
+    all_prompts: bool
+    objects: list[AccessibleObjectRef]
 
 
 @strawberry.type
@@ -138,3 +171,52 @@ class User(Node):
         if email in initial_admins or email == "admin@localhost":
             return True
         return False
+
+    @strawberry.field(permission_classes=[IsAdmin])  # type: ignore
+    async def access_summary(self, info: Info[Context, None]) -> UserAccessSummary:
+        """The objects this user can currently view, for the admin People view. Mirrors the
+        oracle's visibility decision per access root; a type marked "all" lists no individual
+        objects (the user can see every object of that type)."""
+        kinds = (
+            ("project", OBJECT_TYPE_PROJECT, models.Project, "Project"),
+            ("dataset", OBJECT_TYPE_DATASET, models.Dataset, "Dataset"),
+            ("prompt", OBJECT_TYPE_PROMPT, models.Prompt, "Prompt"),
+        )
+        all_flags: dict[str, bool] = {}
+        objects: list[AccessibleObjectRef] = []
+        async with info.context.db.read() as session:
+            enforced = get_env_access_control_enabled()
+            is_admin = Permission.ADMINISTER in await permissions_for_user_id(session, self.id)
+            for label, object_type, model, type_name in kinds:
+                scope = await accessible_scope(
+                    session,
+                    user_id=self.id,
+                    object_type=object_type,
+                    enabled=enforced,
+                    permission=Permission.OBJ_VIEW,
+                )
+                is_all = scope.everything or scope.type_allows
+                all_flags[label] = is_all
+                if is_all or not scope.allowed_ids:
+                    continue
+                rows = (
+                    await session.execute(
+                        select(model.id, model.name)
+                        .where(model.id.in_(scope.allowed_ids))
+                        .order_by(model.name)
+                    )
+                ).all()
+                objects.extend(
+                    AccessibleObjectRef(
+                        kind=label, id=GlobalID(type_name, str(oid)), name=str(name)
+                    )
+                    for oid, name in rows
+                )
+        return UserAccessSummary(
+            enforced=enforced,
+            is_admin=is_admin,
+            all_projects=all_flags["project"],
+            all_datasets=all_flags["dataset"],
+            all_prompts=all_flags["prompt"],
+            objects=objects,
+        )

--- a/src/phoenix/server/api/types/UserGroup.py
+++ b/src/phoenix/server/api/types/UserGroup.py
@@ -1,0 +1,33 @@
+import strawberry
+from strawberry.relay import Node, NodeID
+
+from phoenix.db import models
+
+# Admin-managed groups; IdP groups use "ldap" / "oauth2:<idp>" and are read-only here.
+LOCAL_PROVIDER = "local"
+
+
+@strawberry.type
+class UserGroup(Node):
+    """A group of users, usable as a grant subject. **Local** groups are admin-managed
+    in-product (the no-IdP path); IdP groups are materialized from OAuth2/LDAP claims at
+    login and are read-only here."""
+
+    id: NodeID[int]
+    # Keep the row id for existing group-management mutations, which are not Relay-node based.
+    group_id: int
+    name: str
+    provider: str
+    is_local: bool
+    member_user_ids: list[int]
+
+
+def to_gql_user_group(group: models.UserGroup, member_user_ids: list[int]) -> UserGroup:
+    return UserGroup(
+        id=group.id,
+        group_id=group.id,
+        name=group.display_name or group.group_key,
+        provider=group.provider,
+        is_local=group.provider == LOCAL_PROVIDER,
+        member_user_ids=member_user_ids,
+    )

--- a/src/phoenix/server/api_key_scope.py
+++ b/src/phoenix/server/api_key_scope.py
@@ -1,0 +1,140 @@
+"""
+API-key scope attenuation.
+
+A Phoenix API key may carry a ``scope`` claim signed into its JWT at mint
+time. The claim is attenuation: the key's effective power is the
+intersection of its owner's live role and the scope, so a scope can only
+ever narrow access — never widen it. A key without a scope claim behaves
+exactly as before (full legacy access), which is what makes the feature
+safe to deploy: existing keys are unaffected, and the claim is covered by
+the token signature, so a holder cannot strip it.
+
+The scope vocabulary is public API the moment a customer mints a token
+carrying it, so it is deliberately tiny:
+
+- ``ingest`` — the key may only write trace data. Permitted surfaces:
+    * gRPC OTLP trace export (the gRPC server serves only the OTLP
+      ``TraceService``, so a valid scoped key passes as-is)
+    * ``POST /v1/traces`` (HTTP OTLP trace export)
+    * ``POST /v1/projects/{project_identifier}/spans`` (REST span creation)
+  Everything else — all other REST routes, all of GraphQL, websockets —
+  is denied with 403.
+
+A scope value this module does not recognize (e.g. minted by a newer
+Phoenix version) denies everything: fail closed.
+
+Enforcement is a single chokepoint: ``ApiKeyScopeEnforcementMiddleware``
+runs immediately inside the authentication middleware, sees every HTTP
+and websocket request with the authenticated user already resolved, and
+consults :func:`is_allowed_for_scope`. Route handlers never check scopes
+themselves.
+"""
+
+import re
+from typing import Any, Optional
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+API_KEY_SCOPE_INGEST = "ingest"
+
+KNOWN_API_KEY_SCOPES = frozenset({API_KEY_SCOPE_INGEST})
+
+_INGEST_ROUTES: tuple[tuple[str, "re.Pattern[str]"], ...] = (
+    ("POST", re.compile(r"^/v1/traces/?$")),
+    ("POST", re.compile(r"^/v1/projects/[^/]+/spans/?$")),
+)
+
+
+def is_allowed_for_scope(scope_value: str, method: str, path: str) -> bool:
+    """
+    Decide whether a request may proceed under the given API-key scope.
+
+    Unrecognized scope values deny everything (fail closed): a key minted
+    by a newer server with a scope this version doesn't know must not
+    fall back to full access.
+    """
+    if scope_value == API_KEY_SCOPE_INGEST:
+        return any(
+            method == allowed_method and pattern.match(path)
+            for allowed_method, pattern in _INGEST_ROUTES
+        )
+    return False
+
+
+def get_request_api_key_scope(user: Any) -> Optional[str]:
+    """
+    Extract the scope claim from an authenticated request user, or None if
+    the request is not backed by a scoped API key (browser sessions, the
+    admin secret, and unscoped keys all return None).
+    """
+    # Local imports avoid a circular dependency: bearer_auth has no need to
+    # know about scopes, but this module needs its types to recognize them.
+    from phoenix.server.bearer_auth import PhoenixSystemUser, PhoenixUser
+    from phoenix.server.types import ApiKeyClaims
+
+    if not isinstance(user, PhoenixUser) or isinstance(user, PhoenixSystemUser):
+        return None
+    claims = getattr(user, "claims", None)
+    if not isinstance(claims, ApiKeyClaims) or claims.attributes is None:
+        return None
+    return claims.attributes.scope
+
+
+class ApiKeyScopeEnforcementMiddleware:
+    """
+    Pure ASGI middleware enforcing API-key scope attenuation.
+
+    Must be mounted inside (i.e. after) the authentication middleware so
+    that ``scope["user"]`` is populated. Requests not bearing a scoped API
+    key pass through untouched.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+        key_scope = get_request_api_key_scope(scope.get("user"))
+        if key_scope is None:
+            await self.app(scope, receive, send)
+            return
+        path = scope.get("path", "")
+        if scope["type"] == "http" and is_allowed_for_scope(
+            key_scope, scope.get("method", ""), path
+        ):
+            await self.app(scope, receive, send)
+            return
+        await self._deny(scope, send, key_scope)
+
+    @staticmethod
+    async def _deny(scope: Scope, send: Send, key_scope: str) -> None:
+        if scope["type"] == "websocket":
+            await send({"type": "websocket.close", "code": 1008})
+            return
+        body = (
+            f'{{"detail":"API key scope \'{key_scope}\' does not permit this request"}}'
+        ).encode()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 403,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode()),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+
+
+def deny_unknown_grpc_scope(key_scope: Optional[str]) -> bool:
+    """
+    Whether a gRPC request bearing this API-key scope must be rejected.
+
+    The gRPC server serves only the OTLP TraceService (ingest), so the
+    ``ingest`` scope — and the absence of a scope — both pass. Anything
+    else is an unrecognized scope and fails closed.
+    """
+    return key_scope is not None and key_scope != API_KEY_SCOPE_INGEST

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -61,6 +61,7 @@ from phoenix.config import (
     ENV_PHOENIX_CSRF_TRUSTED_ORIGINS,
     SERVER_DIR,
     OAuth2ClientConfig,
+    get_env_access_control_enabled,
     get_env_allow_external_resources,
     get_env_allowed_providers,
     get_env_csrf_trusted_origins,
@@ -97,6 +98,7 @@ from phoenix.server.api.routers import (
 from phoenix.server.api.routers.auth_md import router as auth_md_router
 from phoenix.server.api.routers.v1 import REST_API_VERSION
 from phoenix.server.api.schema import build_graphql_schema
+from phoenix.server.api_key_scope import ApiKeyScopeEnforcementMiddleware
 from phoenix.server.bearer_auth import BearerTokenAuthBackend, PhoenixUser, is_authenticated
 from phoenix.server.daemons.db_disk_usage_monitor import DbDiskUsageMonitor
 from phoenix.server.daemons.experiment_runner import ExperimentRunner
@@ -209,6 +211,8 @@ class AppConfig(NamedTuple):
     auth_error_messages: dict[AuthErrorCode, str]
     """ Mapping of auth error codes to user-friendly messages """
     oauth2_idps: Sequence[OAuth2Idp]
+    access_control_enabled: bool = False
+    """ Whether PHOENIX_ACCESS_CONTROL_ENABLED is set for this server process """
     basic_auth_disabled: bool = False
     ldap_enabled: bool = False
     """ Whether LDAP authentication is configured """
@@ -284,6 +288,7 @@ class Static(StaticFiles):
                     "vite_port": self._app_config.dev_vite_port,
                     "manifest": self._web_manifest,
                     "authentication_enabled": self._app_config.authentication_enabled,
+                    "access_control_enabled": self._app_config.access_control_enabled,
                     "oauth2_idps": self._app_config.oauth2_idps,
                     "basic_auth_disabled": self._app_config.basic_auth_disabled,
                     "ldap_enabled": self._app_config.ldap_enabled,
@@ -710,6 +715,7 @@ def create_graphql_router(
     secret: Optional[SecretStr] = None,
     token_store: Optional[TokenStore] = None,
     email_sender: Optional[EmailSender] = None,
+    access_control_enabled: bool = False,
 ) -> GraphQLRouter[Context, None]:
     """Creates the GraphQL router.
 
@@ -747,6 +753,7 @@ def create_graphql_router(
             allowed_provider_names=allowed_provider_names,
             read_only=read_only,
             auth_enabled=authentication_enabled,
+            access_control_enabled=access_control_enabled,
             secret=secret,
             token_store=token_store,
             email_sender=email_sender,
@@ -862,6 +869,7 @@ def create_app(
     shutdown_callbacks_list: list[_Callback] = list(shutdown_callbacks)
     startup_callbacks_list.append(Facilitator(db=db))
     startup_callbacks_list.append(prefetch_wasm_binary_if_needed)
+    access_control_enabled = get_env_access_control_enabled()
     initial_batch_of_spans: Iterable[tuple[Span, str]] = (
         ()
         if initial_spans is None
@@ -905,6 +913,10 @@ def create_app(
                 backend=BearerTokenAuthBackend(token_store),
             )
         )
+        # Must come after AuthenticationMiddleware so request.user is
+        # populated: this is the single chokepoint that enforces API-key
+        # scope attenuation across every HTTP surface (REST, GraphQL, OTLP).
+        middlewares.append(Middleware(ApiKeyScopeEnforcementMiddleware))
     else:
         token_store = None
     dml_event_handler = DmlEventHandler(
@@ -979,6 +991,7 @@ def create_app(
         sandbox_session_manager=sandbox_session_manager,
         encrypt=encryption_service.encrypt,
         decrypt=encryption_service.decrypt,
+        access_control_enabled=access_control_enabled,
     )
     if enable_prometheus:
         from phoenix.server.prometheus import PrometheusMiddleware
@@ -1028,7 +1041,12 @@ def create_app(
             "defaultModelsExpandDepth": -1,  # hides the schema section in the Swagger UI
         },
     )
-    app.include_router(create_v1_router(authentication_enabled))
+    app.include_router(
+        create_v1_router(
+            authentication_enabled,
+            access_control_enabled=access_control_enabled,
+        )
+    )
     if not get_env_disable_agent_assistant():
         app.include_router(create_agents_router(authentication_enabled))
     app.include_router(router)
@@ -1092,6 +1110,7 @@ def create_app(
                     authentication_enabled=authentication_enabled,
                     web_manifest_path=web_manifest_path,
                     oauth2_idps=oauth2_idps,
+                    access_control_enabled=access_control_enabled,
                     basic_auth_disabled=basic_auth_disabled,
                     ldap_enabled=ldap_config is not None,
                     # Disable manual user creation when LDAP disabled or no email attr
@@ -1152,6 +1171,7 @@ def create_app(
         allowed_provider_names=get_env_allowed_providers(),
         read_only=read_only,
         authentication_enabled=authentication_enabled,
+        access_control_enabled=access_control_enabled,
         secret=secret,
         token_store=token_store,
         email_sender=email_sender,
@@ -1225,6 +1245,7 @@ def _get_build_graphql_context_function(
     secret: Optional[SecretStr],
     token_store: Optional[TokenStore],
     email_sender: Optional[EmailSender],
+    access_control_enabled: bool,
 ) -> Callable[[Optional[PhoenixUser]], Context]:
     """Factory for creating GraphQL context."""
 
@@ -1249,6 +1270,7 @@ def _get_build_graphql_context_function(
             allowed_provider_names=allowed_provider_names,
             read_only=read_only,
             auth_enabled=authentication_enabled,
+            access_control_enabled=access_control_enabled,
             secret=secret,
             token_store=token_store,
             email_sender=email_sender,

--- a/src/phoenix/server/bearer_auth.py
+++ b/src/phoenix/server/bearer_auth.py
@@ -20,6 +20,8 @@ from phoenix.auth import (
 )
 from phoenix.config import get_env_phoenix_admin_secret
 from phoenix.db import models
+from phoenix.server.access import Permission, permissions_for_role
+from phoenix.server.api_key_scope import deny_unknown_grpc_scope
 from phoenix.server.types import (
     AccessToken,
     AccessTokenAttributes,
@@ -72,20 +74,29 @@ class PhoenixUser(BaseUser):
         self._user_id = user_id
         self.claims = claims
         assert claims.attributes
-        self._is_admin = (
-            claims.status is ClaimSetStatus.VALID and claims.attributes.user_role == "ADMIN"
+        # The role is authoritative only for a valid claim set; otherwise the
+        # user resolves to no permissions (the oracle fails closed).
+        self._role_name: Optional[str] = (
+            claims.attributes.user_role if claims.status is ClaimSetStatus.VALID else None
         )
-        self._is_viewer = (
-            claims.status is ClaimSetStatus.VALID and claims.attributes.user_role == "VIEWER"
-        )
+
+    @cached_property
+    def permissions(self) -> frozenset[Permission]:
+        """The user's permissions, resolved from their role through the oracle."""
+        return permissions_for_role(self._role_name) if self._role_name else frozenset()
+
+    def can(self, permission: Permission) -> bool:
+        return permission in self.permissions
 
     @cached_property
     def is_admin(self) -> bool:
-        return self._is_admin
+        # An admin is anyone holding the ADMINISTER permission (SYSTEM, ADMIN).
+        return Permission.ADMINISTER in self.permissions
 
     @cached_property
     def is_viewer(self) -> bool:
-        return self._is_viewer
+        # A viewer is a valid user who cannot write — i.e. read-only.
+        return self._role_name is not None and Permission.WRITE not in self.permissions
 
     @cached_property
     def identity(self) -> UserId:
@@ -99,12 +110,8 @@ class PhoenixUser(BaseUser):
 class PhoenixSystemUser(PhoenixUser):
     def __init__(self, user_id: UserId) -> None:
         self._user_id = user_id
-        self._is_admin = True  # System users have admin privileges
-        self._is_viewer = False  # System users are not viewers
-
-    @property
-    def is_admin(self) -> bool:
-        return True
+        # System users carry the SYSTEM role and therefore every permission.
+        self._role_name = "SYSTEM"
 
 
 class ApiKeyInterceptor(HasTokenStore, AsyncServerInterceptor):
@@ -138,6 +145,15 @@ class ApiKeyInterceptor(HasTokenStore, AsyncServerInterceptor):
                     or claims.status is not ClaimSetStatus.VALID
                 ):
                     break
+                # The gRPC server serves only OTLP trace export, so the
+                # "ingest" scope (and the absence of a scope) passes; any
+                # unrecognized scope fails closed.
+                if (
+                    isinstance(claims, ApiKeyClaims)
+                    and claims.attributes is not None
+                    and deny_unknown_grpc_scope(claims.attributes.scope)
+                ):
+                    await context.abort(grpc.StatusCode.PERMISSION_DENIED)
                 return await method(request_or_iterator, context)
         await context.abort(grpc.StatusCode.UNAUTHENTICATED)
 

--- a/src/phoenix/server/daemons/experiment_runner.py
+++ b/src/phoenix/server/daemons/experiment_runner.py
@@ -1458,18 +1458,12 @@ class RunningExperiment:
                     assert session.bind is not None
                     dialect = SupportedSQLDialect(session.bind.dialect.name)
 
-                    # Get project_id from cache or DB
+                    # The experiment's trace project, by FK (the durable link).
                     if self._project_id is None:
-                        self._project_id = await session.scalar(
-                            select(models.Project.id).where(
-                                models.Project.name == self._experiment.project_name
-                            )
-                        )
+                        self._project_id = self._experiment.project_id
                         if self._project_id is None:
                             logger.error(
-                                f"Project '{self._experiment.project_name}' "
-                                "not found for experiment "
-                                f"{self._experiment.id}"
+                                f"No trace project linked to experiment {self._experiment.id}"
                             )
                             self._task_db_exhausted = True
                             return

--- a/src/phoenix/server/daemons/experiment_sweeper.py
+++ b/src/phoenix/server/daemons/experiment_sweeper.py
@@ -44,25 +44,23 @@ class ExperimentSweeper(DaemonTask):
             sa.delete(models.Experiment)
             .where(models.Experiment.is_ephemeral.is_(True))
             .where(models.Experiment.updated_at < cutoff)
-            .returning(models.Experiment.project_name)
+            .returning(models.Experiment.project_id)
         )
         async with self._db() as session:
-            project_names = (await session.scalars(stmt)).all()
-            num_deleted = len(project_names)
-            non_null_project_names = {
-                project_name for project_name in project_names if project_name
-            }
-            if non_null_project_names:
+            project_ids = (await session.scalars(stmt)).all()
+            num_deleted = len(project_ids)
+            non_null_project_ids = {project_id for project_id in project_ids if project_id}
+            if non_null_project_ids:
                 # Only delete projects that have no remaining experiments (ephemeral or
                 # non-ephemeral) referencing them.
                 no_experiment_refs = ~sa.exists(
                     sa.select(1)
                     .select_from(models.Experiment)
-                    .where(models.Experiment.project_name == models.Project.name)
+                    .where(models.Experiment.project_id == models.Project.id)
                 )
                 await session.execute(
                     sa.delete(models.Project)
-                    .where(models.Project.name.in_(non_null_project_names))
+                    .where(models.Project.id.in_(non_null_project_ids))
                     .where(no_experiment_refs)
                 )
         if num_deleted:

--- a/src/phoenix/server/jwt_store.py
+++ b/src/phoenix/server/jwt_store.py
@@ -86,7 +86,19 @@ class JwtStore:
             return None
         if (token_id := TokenId.parse(jti)) is None:
             return None
-        return await self._get(token_id)
+        claims = await self._get(token_id)
+        # An API key's scope lives only in the signed token payload — the DB
+        # row doesn't store it, so the rebuilt claims can't know it. Merge it
+        # here, at the single entry point every request passes through. The
+        # claim is covered by the signature, so a holder can neither alter
+        # nor strip it.
+        if (
+            isinstance(claims, ApiKeyClaims)
+            and claims.attributes is not None
+            and isinstance(scope := decoded.claims.get("scope"), str)
+        ):
+            claims = replace(claims, attributes=replace(claims.attributes, scope=scope))
+        return claims
 
     @singledispatchmethod
     async def _get(self, _: TokenId) -> Optional[ClaimSet]:
@@ -466,6 +478,20 @@ class _ApiKeyStore(
     _token_id = ApiKeyId
     _token = ApiKey
 
+    def _encode(self, claim: ClaimSet) -> str:
+        payload: dict[str, Any] = dict(jti=claim.token_id)
+        # The scope is attenuation and must be tamper-proof, so it travels in
+        # the signed payload rather than the database (which has no column
+        # for it). JwtStore.read() merges it back into the claims.
+        if (
+            isinstance(claim, ApiKeyClaims)
+            and claim.attributes is not None
+            and claim.attributes.scope
+        ):
+            payload["scope"] = claim.attributes.scope
+        header = {"alg": self._algorithm}
+        return jwt.encode(header, payload, OctKey.import_key(self._secret.get_secret_value()))
+
     def _from_db(
         self,
         record: models.ApiKey,
@@ -481,6 +507,7 @@ class _ApiKeyStore(
                 user_role=user_role,
                 name=record.name,
                 description=record.description,
+                scope=record.scope,
             ),
         )
 
@@ -493,6 +520,7 @@ class _ApiKeyStore(
             user_id=user_id,
             name=claims.attributes.name,
             description=claims.attributes.description or None,
+            scope=claims.attributes.scope,
             created_at=claims.issued_at,
             expires_at=claims.expiration_time or None,
         )

--- a/src/phoenix/server/oauth2.py
+++ b/src/phoenix/server/oauth2.py
@@ -259,6 +259,11 @@ class OAuth2Client(AsyncOAuth2Mixin, AsyncOpenIDMixin, BaseApp):  # type:ignore[
                 "Access denied. Your account does not belong to any authorized groups."
             )
 
+    def extract_groups(self, claims: dict[str, Any]) -> list[str]:
+        """The user's groups from their claims, or [] if groups aren't configured.
+        Used to materialize group memberships at login (see phoenix.server.access)."""
+        return self._extract_groups_from_claims(claims)
+
     def _extract_groups_from_claims(self, claims: dict[str, Any]) -> list[str]:
         """Extract group values from claims using the configured JMESPath expression."""
         if not self._compiled_groups_path:

--- a/src/phoenix/server/settings/registry.py
+++ b/src/phoenix/server/settings/registry.py
@@ -32,9 +32,24 @@ class AgentAssistantEnabledSetting(BaseModel):
     enabled: bool = Field(default=True)
 
 
+class AccessControlEnabledSetting(BaseModel):
+    """The DB-latched activation state for per-resource access control.
+
+    Distinct from ``PHOENIX_ACCESS_CONTROL_ENABLED`` (the env-var availability /
+    kill-switch). Fail-closed: defaults to ``False``, so an absent or unset latch
+    leaves the deployment unenforced. The running app does not expose a runtime
+    enable/disable path; operators change the latch out of band before startup.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, validate_assignment=True)
+
+    enabled: bool = Field(default=False)
+
+
 SETTINGS_REGISTRY: Mapping[SystemSettingKey, type[BaseModel]] = MappingProxyType(
     {
         "agent.assistant.trace_recording": AgentTraceRecordingSetting,
         "agent.assistant.enabled": AgentAssistantEnabledSetting,
+        "access_control.enabled": AccessControlEnabledSetting,
     }
 )

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -134,6 +134,7 @@
               basename: "{{basename}}",
               platformVersion: "{{platform_version}}",
               authenticationEnabled: Boolean("{{authentication_enabled}}" == "True"),
+              accessControlEnabled: Boolean("{{access_control_enabled}}" == "True"),
               oAuth2Idps: {{ oauth2_idps | tojson }},
               basicAuthDisabled: Boolean("{{basic_auth_disabled}}" == "True"),
               ldapEnabled: Boolean("{{ldap_enabled}}" == "True"),

--- a/src/phoenix/server/types.py
+++ b/src/phoenix/server/types.py
@@ -192,6 +192,14 @@ class AccessTokenAttributes(UserTokenAttributes):
 class ApiKeyAttributes(UserTokenAttributes):
     name: str
     description: Optional[str] = None
+    scope: Optional[str] = None
+    """Attenuation carried as a signed claim in the API-key JWT. An absent scope
+    means full legacy access (the key acts with its owner's role). A present
+    scope can only ever narrow what the owner's role allows; it can never widen
+    it. The value is kept as ``str`` rather than a Literal so that a token
+    minted by a newer server with an unrecognized scope is carried through and
+    denied (fail closed) instead of crashing. Known values are enumerated in
+    ``phoenix.server.api_key_scope``."""
 
 
 class _DbId(str, ABC):

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -250,8 +250,9 @@ class _User:
         *,
         name: Optional[_Name] = None,
         expires_at: Optional[datetime] = None,
+        scope: Optional[str] = None,
     ) -> _ApiKey:
-        return _create_api_key(app, self, kind, name=name, expires_at=expires_at)
+        return _create_api_key(app, self, kind, name=name, expires_at=expires_at, scope=scope)
 
     def delete_api_key(self, app: _AppInfo, api_key: _ApiKey, /) -> None:
         return _delete_api_key(app, api_key, self)
@@ -1052,10 +1053,13 @@ def _create_api_key(
     *,
     name: Optional[_Name] = None,
     expires_at: Optional[datetime] = None,
+    scope: Optional[str] = None,
 ) -> _ApiKey:
     if name is None:
         name = datetime.now(timezone.utc).isoformat()
     exp = f' expiresAt:"{expires_at.isoformat()}"' if expires_at else ""
+    # scope is a GraphQL enum (e.g. INGEST), so it is not quoted
+    exp += f" scope:{scope}" if scope else ""
     args, out = (f'name:"{name}"' + exp), "jwt apiKey{id name expiresAt}"
     field = f"create{kind}ApiKey"
     query = "mutation{" + field + "(input:{" + args + "}){" + out + "}}"
@@ -2225,6 +2229,7 @@ _COMMON_RESOURCE_ENDPOINTS = (
     (404, "GET", "v1/projects/fake-id-{}/traces"),
     # Viewer (authenticated user profile)
     (200, "GET", "v1/user"),
+    # Access (per-object audit read; invalid ids → 422)
 )
 
 # Admin-only endpoints (user management, project CRUD)
@@ -2236,6 +2241,7 @@ _ADMIN_ONLY_ENDPOINTS = (
     (422, "PUT", "v1/projects/fake-id-{}"),
     (404, "DELETE", "v1/projects/fake-id-{}"),
     (422, "PUT", "v1/secrets"),
+    # Access (org-wide administration)
 )
 
 # Write operations blocked for viewers (POST/PUT/DELETE)
@@ -2261,6 +2267,7 @@ _VIEWER_BLOCKED_WRITE_OPERATIONS = (
     (422, "POST", "v1/trace_annotations"),
     (422, "POST", "v1/trace_notes"),
     (415, "POST", "v1/traces"),
+    # Access (per-object grant authoring)
     # PUT routes
     (422, "PUT", "v1/annotation_configs/fake-id-{}"),
     (404, "PUT", "v1/projects/{0}/annotation_configs/{0}"),
@@ -2310,14 +2317,22 @@ def _get_api_route_methods_and_paths(
             )
 
 
+def _format_test_endpoint(endpoint: str) -> str:
+    while "fake-id-{}" in endpoint:
+        endpoint = endpoint.replace("fake-id-{}", f"fake-id-{token_hex(4)}", 1)
+    return endpoint
+
+
 def _ensure_endpoint_coverage_is_exhaustive() -> None:
     """Verify that test constants cover all actual v1 API routes.
 
     This runs at module import time as a prerequisite check. If endpoint
     coverage is incomplete, all tests that import this module will fail fast.
     """
-    # Get all actual routes from the v1 router
-    router = create_v1_router(authentication_enabled=False)
+    # Get all actual routes from the v1 router. Match the no-auth app under test: access
+    # control cannot run with auth disabled (the boot guard refuses it), so its routes are
+    # never mounted here and are covered separately by the access-control integration tests.
+    router = create_v1_router(authentication_enabled=False, access_control_enabled=False)
     actual_routes = set(_get_api_route_methods_and_paths(router.routes))
 
     # Get all routes from test constants

--- a/tests/integration/auth/test_access_control.py
+++ b/tests/integration/auth/test_access_control.py
@@ -1,0 +1,588 @@
+"""End-to-end integration tests for the per-resource access-control facility.
+
+Why these live here (and not in unit tests)
+--------------------------------------------
+The oracle, the gate helpers, and the object-role tiers are exhaustively unit-tested
+in isolation. But every unit test runs with **auth disabled**, where every access gate is
+a deliberate no-op (access control presupposes authentication). So the one thing unit
+tests *cannot* exercise is the property that matters most in production: that with auth on
+**and** enforcement on, the gates actually deny. These integration tests run a real server
+with ``PHOENIX_ENABLE_AUTH=true`` and ``PHOENIX_ACCESS_CONTROL_ENABLED=true`` and drive it
+over HTTP as real users, so they verify enforcement, not just logic.
+
+Design: rigorous but parsimonious
+---------------------------------
+One test per *distinct, emergent* invariant — the ones that only appear once auth and
+enforcement are both on. Combinatorial detail (every tier, every subject kind, every object
+type, access-by-parent, containment) is left to the unit suite; here we assert the seams hold
+end to end. The chosen invariants:
+
+1. ``test_admin_only_default_and_grant_visibility`` — the headline. New named projects are
+   admin-only by default (the built-in ``default`` project is the deliberate shared landing
+   area), grant → exactly-that-object visible, revoke → gone, and list-endpoint filtering —
+   in one cohesive flow.
+2. ``test_unauthorized_read_is_not_found`` — unauthorized point reads return **404**
+   (indistinguishable from missing), never 403; you cannot probe for objects you can't see.
+3. ``test_viewer_tier_reads_editor_tier_writes`` — the object-role tiers are *enforced*:
+   a viewer-tier grant permits reads but a mutation 404s; an editor-tier grant permits it.
+4. ``test_creator_sees_own_dataset_without_grant`` — creator-private roots: the creator of a
+   dataset reaches it with no grant; another member cannot.
+5. ``test_manager_can_administer_access_non_manager_cannot`` — decentralized sharing: a
+   holder of ``OBJ_MANAGE_ACCESS`` may grant others on that object; a non-manager non-admin
+   may not.
+6. ``test_local_group_grant_confers_and_revokes_access`` — group-as-subject: a grant to a
+   local (admin-managed) group reaches its members, and removing a member revokes access.
+7. ``test_last_manager_of_an_ownerless_object_cannot_be_stranded`` — an object with no creator
+   cannot lose its final manager (by delete *or* in-place downgrade), so it never becomes
+   reachable only by administrators; naming a second manager first lifts the guard.
+8. ``test_tag_grant_confers_curated_access_and_cannot_delegate_management`` — attribute-based
+   access: an admin-set tag plus a tag grant reach whoever the tag matches; removing the tag
+   severs it; and a tag grant may confer view/edit but never manage-access.
+
+Deliberately deferred to the unit suite or to a follow-up (noted so the omission is a
+choice, not an oversight):
+- the oracle's tier/creator/access-by-parent/containment *logic* (unit-tested);
+- the ingestion-birth invariant (ingest is ungated, ingest-born projects are admin-only) —
+  worth an integration test, but needs an OTLP exporter authenticated with an ingest-scoped
+  API key; add as ``test_ingest_born_project_is_admin_only`` once that exporter helper lands;
+- the boot guard (refuse to start with access control on and auth off) — a process-startup
+  assertion, better as a dedicated server-launch test than mixed in here.
+
+NOTE: these require the integration environment (Postgres or sqlite + a live server
+subprocess) and have not been executed in-repo; run via the integration tox target. The
+access-control DB latch is **global to the database**, so this module gets its **own isolated
+schema** (``_env_database_access_control``) — sharing the package schema would flip
+enforcement for ``test_auth.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator, Mapping
+from secrets import token_hex
+from typing import Any, cast
+
+import httpx
+import pytest
+
+from phoenix.config import (
+    ENV_PHOENIX_ACCESS_CONTROL_ENABLED,
+    ENV_PHOENIX_SQL_DATABASE_SCHEMA,
+)
+from tests.integration._helpers import (
+    _DEFAULT_ADMIN,
+    _MEMBER,
+    _AppInfo,
+    _httpx_client,
+    _Profile,
+    _random_schema,
+    _server,
+    _User,
+)
+
+# --- fixtures: a server with auth AND access control on, on an isolated database ----------
+
+
+@pytest.fixture(scope="package")
+def _env_database_access_control(_sql_database_url: Any) -> Iterator[dict[str, str]]:
+    """A *separate* database/schema from the rest of the auth package.
+
+    The ``access_control.enabled`` latch is a single row keyed to the database. Enabling it
+    here on the shared package schema would turn enforcement on for every other app in the
+    package (``test_auth.py`` et al.) mid-run, so this app gets its own schema.
+    """
+    env = {"PHOENIX_SQL_DATABASE_URL": _sql_database_url.render_as_string(hide_password=False)}
+    if not _sql_database_url.get_backend_name().startswith("postgresql"):
+        # sqlite ``:memory:`` is already per-process isolated.
+        yield env
+        return
+    loop = asyncio.new_event_loop()
+    ctx = _random_schema(_sql_database_url)
+    schema = loop.run_until_complete(ctx.__aenter__())
+    try:
+        yield {**env, ENV_PHOENIX_SQL_DATABASE_SCHEMA: schema}
+    finally:
+        loop.run_until_complete(ctx.__aexit__(None, None, None))
+        loop.close()
+
+
+@pytest.fixture(scope="package")
+def _env_ports_access_control(_ports: Iterator[int]) -> dict[str, str]:
+    return {"PHOENIX_PORT": str(next(_ports)), "PHOENIX_GRPC_PORT": str(next(_ports))}
+
+
+@pytest.fixture(scope="package")
+def _app(
+    _env_auth: Mapping[str, str],
+    _env_smtp: Mapping[str, str],
+    _env_tls: Mapping[str, str],
+    _env_database_access_control: Mapping[str, str],
+    _env_ports_access_control: Mapping[str, str],
+) -> Iterator[_AppInfo]:
+    """A live server with authentication and per-resource access control both enforcing."""
+    env = {
+        **_env_tls,
+        **_env_smtp,
+        **_env_auth,
+        **_env_database_access_control,
+        **_env_ports_access_control,
+        ENV_PHOENIX_ACCESS_CONTROL_ENABLED: "true",
+    }
+    with _server(_AppInfo(env)) as app:
+        yield app
+
+
+# --- small REST helpers (all access-control surfaces are GlobalID-consistent) -------------
+
+
+def _member(app: _AppInfo, _profiles: Iterator[_Profile]) -> _User:
+    return _DEFAULT_ADMIN.create_user(app, _MEMBER, profile=next(_profiles))
+
+
+def _create_project(app: _AppInfo, actor: _User) -> str:
+    """Create a project as ``actor``; return its GlobalID."""
+    resp = _httpx_client(app, actor).post("v1/projects", json={"name": f"p-{token_hex(4)}"})
+    resp.raise_for_status()
+    return cast(str, resp.json()["data"]["id"])
+
+
+def _list_project_ids(app: _AppInfo, actor: _User) -> set[str]:
+    resp = _httpx_client(app, actor).get("v1/projects")
+    resp.raise_for_status()
+    return {p["id"] for p in resp.json()["data"]}
+
+
+def _grant(
+    app: _AppInfo,
+    actor: _User,
+    *,
+    user: _User,
+    object_id: str,
+    object_type: str = "project",
+    role: str | None = None,
+) -> httpx.Response:
+    body: dict[str, Any] = {
+        "subject": {"kind": "user", "id": user.gid},
+        "object_type": object_type,
+        "object_id": object_id,
+    }
+    if role is not None:
+        body["role"] = role
+    return _httpx_client(app, actor).post("v1/access/grants", json=body)
+
+
+def _graphql(app: _AppInfo, actor: _User, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    """Run a GraphQL operation as ``actor`` (the tag mutations are GraphQL-only). Returns the
+    decoded body — GraphQL surfaces authorization/validation failures as an ``errors`` field on
+    an HTTP 200, so callers assert on ``result["errors"]``, not the status code."""
+    resp = _httpx_client(app, actor).post("graphql", json={"query": query, "variables": variables})
+    resp.raise_for_status()
+    return cast(dict[str, Any], resp.json())
+
+
+class TestAccessControlEnforcement:
+    def test_admin_only_default_and_grant_visibility(
+        self, _app: _AppInfo, _profiles: Iterator[_Profile]
+    ) -> None:
+        member = _member(_app, _profiles)
+        proj_a = _create_project(_app, _DEFAULT_ADMIN)
+        proj_b = _create_project(_app, _DEFAULT_ADMIN)
+
+        # New named projects are admin-only by default: the admin sees both; an ungranted
+        # member sees neither. The built-in `default` project is seeded as an explicit
+        # everyone-visible exception.
+        admin_view = _list_project_ids(_app, _DEFAULT_ADMIN)
+        assert {proj_a, proj_b} <= admin_view
+        member_view = _list_project_ids(_app, member)
+        assert proj_a not in member_view and proj_b not in member_view
+
+        # A grant adds exactly its object — monotonic, nothing else leaks.
+        assert _grant(_app, _DEFAULT_ADMIN, user=member, object_id=proj_a).status_code == 200
+        member_view = _list_project_ids(_app, member)
+        assert proj_a in member_view and proj_b not in member_view
+
+        # Revoking removes it again (back to admin-only, not open-to-everyone).
+        grant_id = (
+            _httpx_client(_app, _DEFAULT_ADMIN)
+            .get("v1/access/grants", params={"object_type": "project", "object_id": proj_a})
+            .json()["data"][0]["id"]
+        )
+        assert (
+            _httpx_client(_app, _DEFAULT_ADMIN).delete(f"v1/access/grants/{grant_id}").status_code
+            == 204
+        )
+        assert proj_a not in _list_project_ids(_app, member)
+
+    def test_unauthorized_read_is_not_found(
+        self, _app: _AppInfo, _profiles: Iterator[_Profile]
+    ) -> None:
+        member = _member(_app, _profiles)
+        proj = _create_project(_app, _DEFAULT_ADMIN)
+        # The admin can read it; the ungranted member gets 404 (not 403) — unauthorized is
+        # indistinguishable from not-found, so the object's existence cannot be probed.
+        assert _httpx_client(_app, _DEFAULT_ADMIN).get(f"v1/projects/{proj}").status_code == 200
+        assert _httpx_client(_app, member).get(f"v1/projects/{proj}").status_code == 404
+
+    def test_viewer_tier_reads_editor_tier_writes(
+        self, _app: _AppInfo, _profiles: Iterator[_Profile]
+    ) -> None:
+        member = _member(_app, _profiles)
+        dataset_id = _upload_dataset(_app, _DEFAULT_ADMIN)
+
+        # Viewer tier: may read, but a mutation (delete) is 404 (no edit permission).
+        assert (
+            _grant(
+                _app,
+                _DEFAULT_ADMIN,
+                user=member,
+                object_id=dataset_id,
+                object_type="dataset",
+                role="Resource Viewer",
+            ).status_code
+            == 200
+        )
+        client = _httpx_client(_app, member)
+        assert client.get(f"v1/datasets/{dataset_id}").status_code == 200
+        assert client.delete(f"v1/datasets/{dataset_id}").status_code == 404
+
+        # Upgrade to editor tier (idempotent re-grant): the mutation now succeeds.
+        assert (
+            _grant(
+                _app,
+                _DEFAULT_ADMIN,
+                user=member,
+                object_id=dataset_id,
+                object_type="dataset",
+                role="Resource Editor",
+            ).status_code
+            == 200
+        )
+        assert _httpx_client(_app, member).delete(f"v1/datasets/{dataset_id}").status_code == 204
+
+    def test_creator_sees_own_dataset_without_grant(
+        self, _app: _AppInfo, _profiles: Iterator[_Profile]
+    ) -> None:
+        creator = _member(_app, _profiles)
+        other = _member(_app, _profiles)
+        dataset_id = _upload_dataset(_app, creator)  # creator-private root
+        # The creator reaches it with no grant; an unrelated member cannot.
+        assert _httpx_client(_app, creator).get(f"v1/datasets/{dataset_id}").status_code == 200
+        assert _httpx_client(_app, other).get(f"v1/datasets/{dataset_id}").status_code == 404
+
+    def test_hidden_dataset_name_create_collision_is_conflict(
+        self, _app: _AppInfo, _profiles: Iterator[_Profile]
+    ) -> None:
+        creator = _member(_app, _profiles)
+        other = _member(_app, _profiles)
+        name = f"ds-{token_hex(4)}"
+        _upload_dataset(_app, creator, name=name)
+        client = _httpx_client(_app, other)
+
+        # Creating with a globally occupied name should report name unavailability, not a
+        # hidden-resource 404. The response still does not reveal who owns the dataset.
+        resp = _upload_dataset_response(_app, other, name=name, action="create")
+        assert resp.status_code == 409
+        assert resp.text == "Dataset name is unavailable"
+
+        # Append/update target an existing dataset, so hidden datasets remain hidden as 404.
+        assert _upload_dataset_response(_app, other, name=name, action="append").status_code == 404
+        assert _upload_dataset_response(_app, other, name=name, action="update").status_code == 404
+        list_resp = client.get("v1/datasets", params={"name": name})
+        assert list_resp.status_code == 200
+        assert list_resp.json()["data"] == []
+
+    def test_hidden_prompt_name_create_collision_is_conflict(
+        self, _app: _AppInfo, _profiles: Iterator[_Profile]
+    ) -> None:
+        creator = _member(_app, _profiles)
+        other = _member(_app, _profiles)
+        name = f"prompt-{token_hex(4)}"
+        _create_prompt_response(_app, creator, name=name).raise_for_status()
+
+        resp = _create_prompt_response(_app, other, name=name)
+        assert resp.status_code == 409
+        assert "Prompt name is unavailable" in resp.text
+
+    def test_experiment_writes_require_dataset_editor(
+        self, _app: _AppInfo, _profiles: Iterator[_Profile]
+    ) -> None:
+        creator = _member(_app, _profiles)
+        collaborator = _member(_app, _profiles)
+        dataset_id = _upload_dataset(_app, creator)
+
+        # No dataset access: cannot create an experiment from a hidden dataset.
+        assert _create_experiment_response(_app, collaborator, dataset_id).status_code == 404
+
+        # Viewer access is enough to read the dataset, but not to create or mutate experiments.
+        assert (
+            _grant(
+                _app,
+                _DEFAULT_ADMIN,
+                user=collaborator,
+                object_id=dataset_id,
+                object_type="dataset",
+                role="Resource Viewer",
+            ).status_code
+            == 200
+        )
+        assert _create_experiment_response(_app, collaborator, dataset_id).status_code == 404
+
+        experiment = _create_experiment_response(_app, creator, dataset_id).json()["data"]
+        experiment_id = experiment["id"]
+        client = _httpx_client(_app, collaborator)
+        assert client.get(f"v1/experiments/{experiment_id}").status_code == 200
+        assert (
+            client.patch(f"v1/experiments/{experiment_id}", json={"name": "x"}).status_code == 404
+        )
+        assert client.delete(f"v1/experiments/{experiment_id}").status_code == 404
+
+        gql_resp = client.post(
+            "graphql",
+            json={
+                "query": """
+              mutation($experimentId: ID!) {
+                patchExperiment(input: {experimentId: $experimentId, name: "patched"}) {
+                  experiment { id }
+                }
+              }
+            """,
+                "variables": {"experimentId": experiment_id},
+            },
+        )
+        assert gql_resp.status_code == 200
+        assert gql_resp.json().get("errors")
+
+        # Editor access can create and mutate experiments derived from the dataset.
+        assert (
+            _grant(
+                _app,
+                _DEFAULT_ADMIN,
+                user=collaborator,
+                object_id=dataset_id,
+                object_type="dataset",
+                role="Resource Editor",
+            ).status_code
+            == 200
+        )
+        editor_experiment = _create_experiment_response(_app, collaborator, dataset_id).json()[
+            "data"
+        ]
+        editor_experiment_id = editor_experiment["id"]
+        assert (
+            client.patch(
+                f"v1/experiments/{editor_experiment_id}", json={"name": "patched"}
+            ).status_code
+            == 200
+        )
+        assert client.delete(f"v1/experiments/{editor_experiment_id}").status_code == 204
+
+    def test_manager_can_administer_access_non_manager_cannot(
+        self, _app: _AppInfo, _profiles: Iterator[_Profile]
+    ) -> None:
+        manager = _member(_app, _profiles)
+        grantee = _member(_app, _profiles)
+        outsider = _member(_app, _profiles)
+        proj = _create_project(_app, _DEFAULT_ADMIN)
+
+        # Admin grants manager-tier access (OBJ_MANAGE_ACCESS) on the project.
+        assert (
+            _grant(
+                _app, _DEFAULT_ADMIN, user=manager, object_id=proj, role="Resource Manager"
+            ).status_code
+            == 200
+        )
+
+        # The manager may now grant others on that object, without being a global admin.
+        assert _grant(_app, manager, user=grantee, object_id=proj).status_code == 200
+        assert proj in _list_project_ids(_app, grantee)
+
+        # An outsider (no manage-access) cannot administer the project's access: 404.
+        assert _grant(_app, outsider, user=outsider, object_id=proj).status_code == 404
+
+    def test_local_group_grant_confers_and_revokes_access(
+        self, _app: _AppInfo, _profiles: Iterator[_Profile]
+    ) -> None:
+        member = _member(_app, _profiles)
+        proj = _create_project(_app, _DEFAULT_ADMIN)
+        admin = _httpx_client(_app, _DEFAULT_ADMIN)
+
+        # Admin creates a local group and grants it the project.
+        group_id = admin.post("v1/access/groups", json={"name": f"team-{token_hex(4)}"}).json()[
+            "data"
+        ]["id"]
+        admin.post(
+            "v1/access/grants",
+            json={
+                "subject": {"kind": "group", "id": group_id},
+                "object_type": "project",
+                "object_id": proj,
+            },
+        ).raise_for_status()
+
+        # Not a member yet → no access. Add to group → access. Remove → access revoked.
+        assert proj not in _list_project_ids(_app, member)
+        admin.post(f"v1/access/groups/{group_id}/members", json={"user_id": member.gid})
+        assert proj in _list_project_ids(_app, member)
+        admin.delete(f"v1/access/groups/{group_id}/members/{member.gid}")
+        assert proj not in _list_project_ids(_app, member)
+
+    def test_last_manager_of_an_ownerless_object_cannot_be_stranded(
+        self, _app: _AppInfo, _profiles: Iterator[_Profile]
+    ) -> None:
+        manager = _member(_app, _profiles)
+        other = _member(_app, _profiles)
+        proj = _create_project(_app, _DEFAULT_ADMIN)  # a project has no creator-owner
+        admin = _httpx_client(_app, _DEFAULT_ADMIN)
+
+        # Make `manager` the project's only manager.
+        grant_id = _grant(
+            _app, _DEFAULT_ADMIN, user=manager, object_id=proj, role="Resource Manager"
+        ).json()["data"]["id"]
+
+        # Removing that last manager — by deleting the grant, or by downgrading it in place to a
+        # viewer — is refused. A project with no owner would otherwise be reachable only by
+        # administrators, with no non-admin able to restore access. Even the admin gets 409; the
+        # remedy is to name another manager first, not to force the object admin-only by accident.
+        assert admin.delete(f"v1/access/grants/{grant_id}").status_code == 409
+        assert (
+            _grant(
+                _app, _DEFAULT_ADMIN, user=manager, object_id=proj, role="Resource Viewer"
+            ).status_code
+            == 409
+        )
+
+        # The grant is untouched, so `manager` still manages the project end to end — they can
+        # grant another member on it without being a global admin.
+        assert _grant(_app, manager, user=other, object_id=proj).status_code == 200
+
+        # Once a second manager exists, removing the original no longer strands the object.
+        assert (
+            _grant(
+                _app, _DEFAULT_ADMIN, user=other, object_id=proj, role="Resource Manager"
+            ).status_code
+            == 200
+        )
+        assert admin.delete(f"v1/access/grants/{grant_id}").status_code == 204
+
+    def test_tag_grant_confers_curated_access_and_cannot_delegate_management(
+        self, _app: _AppInfo, _profiles: Iterator[_Profile]
+    ) -> None:
+        member = _member(_app, _profiles)
+        proj = _create_project(_app, _DEFAULT_ADMIN)
+        admin = _httpx_client(_app, _DEFAULT_ADMIN)
+        proj_object = {"projectId": proj}
+        set_tag = "mutation($i: ResourceTagInput!){ setResourceTag(input:$i){ query{__typename} } }"
+        remove_tag = (
+            "mutation($i: ResourceTagInput!){ removeResourceTag(input:$i){ query{__typename} } }"
+        )
+        grant_tag = (
+            "mutation($i: TagAccessGrantInput!){ grantTagAccess(input:$i){ query{__typename} } }"
+        )
+
+        # An admin tags the project, then grants "any project tagged env=prod" to the member.
+        # Access is attribute-based: the member is reached because the object *carries the tag*,
+        # not because it was named. (Permission set omitted → the view-only default.)
+        _graphql(
+            _app,
+            _DEFAULT_ADMIN,
+            set_tag,
+            {"i": {"object": proj_object, "key": "env", "value": "prod"}},
+        )
+        assert proj not in _list_project_ids(_app, member)
+        granted = _graphql(
+            _app,
+            _DEFAULT_ADMIN,
+            grant_tag,
+            {
+                "i": {
+                    "subject": {"userId": member.gid},
+                    "objectType": "PROJECT",
+                    "tagKey": "env",
+                    "tagValue": "prod",
+                }
+            },
+        )
+        assert not granted.get("errors")
+        assert proj in _list_project_ids(_app, member)
+
+        # Removing the tag severs the access — the grant now matches nothing (fail-closed).
+        _graphql(_app, _DEFAULT_ADMIN, remove_tag, {"i": {"object": proj_object, "key": "env"}})
+        assert proj not in _list_project_ids(_app, member)
+
+        # A tag grant may confer view or edit, never manage-access. A tag's reach is mutable (a
+        # manager can drop the object's tag), so a manage-conferring tag grant would let a
+        # non-admin strand an object in one step. Authoring one is rejected outright.
+        manager_role = next(
+            r["id"]
+            for r in admin.get("v1/access/object-roles").json()["data"]
+            if r["name"] == "Resource Manager"
+        )
+        rejected = _graphql(
+            _app,
+            _DEFAULT_ADMIN,
+            grant_tag,
+            {
+                "i": {
+                    "subject": {"userId": member.gid},
+                    "objectType": "PROJECT",
+                    "tagKey": "env",
+                    "tagValue": "prod",
+                    "permissionSetId": manager_role,
+                }
+            },
+        )
+        assert rejected.get("errors")
+
+
+def _upload_dataset_response(
+    app: _AppInfo, actor: _User, *, name: str, action: str = "create"
+) -> httpx.Response:
+    data: dict[str, Any] = {
+        "name": name,
+        "action": action,
+        "input_keys[]": ["q"],
+        "output_keys[]": ["a"],
+    }
+    return _httpx_client(app, actor).post(
+        "v1/datasets/upload",
+        params={"sync": "true"},
+        files={"file": (f"{name}.csv", b"q,a\nhello,world\n", "text/csv")},
+        data=data,
+    )
+
+
+def _upload_dataset(app: _AppInfo, actor: _User, *, name: str | None = None) -> str:
+    """Create a one-row dataset as ``actor`` via the REST upload; return its GlobalID.
+
+    The uploader becomes the dataset's creator (creator-private root).
+    """
+    resp = _upload_dataset_response(app, actor, name=name or f"ds-{token_hex(4)}")
+    resp.raise_for_status()
+    return str(resp.json()["data"]["dataset_id"])
+
+
+def _create_prompt_response(app: _AppInfo, actor: _User, *, name: str) -> httpx.Response:
+    return _httpx_client(app, actor).post(
+        "v1/prompts",
+        json={
+            "prompt": {"name": name},
+            "version": {
+                "model_provider": "OPENAI",
+                "model_name": "gpt-4o-mini",
+                "template": {
+                    "type": "chat",
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+                "template_type": "CHAT",
+                "template_format": "MUSTACHE",
+                "invocation_parameters": {"type": "openai", "openai": {}},
+            },
+        },
+    )
+
+
+def _create_experiment_response(app: _AppInfo, actor: _User, dataset_id: str) -> httpx.Response:
+    return _httpx_client(app, actor).post(
+        f"v1/datasets/{dataset_id}/experiments",
+        json={"version_id": None, "repetitions": 1},
+    )

--- a/tests/integration/auth/test_auth.py
+++ b/tests/integration/auth/test_auth.py
@@ -46,6 +46,7 @@ from .._helpers import (
     _AccessToken,
     _AdminSecret,
     _ApiKey,
+    _ApiKeyKind,
     _AppInfo,
     _create_api_key,
     _create_user,
@@ -54,6 +55,7 @@ from .._helpers import (
     _ExistingSpan,
     _Expectation,
     _extract_html,
+    _format_test_endpoint,
     _GetUser,
     _GqlId,
     _Headers,
@@ -1482,6 +1484,74 @@ class TestSpanExporters:
         assert export(_spans) is expected
 
 
+class TestApiKeyScopes:
+    """
+    An ingest-scoped API key may only write trace data. The scope rides as a
+    signed claim in the key's JWT (there is no scope column), so these tests
+    exercise the full path: GraphQL mint -> signed token -> middleware/gRPC
+    interceptor enforcement -> instant revocation via the jti lookup.
+    """
+
+    def test_ingest_key_can_export_spans_and_dies_on_revocation(
+        self,
+        _span_exporter: _SpanExporterFactory,
+        _spans: Sequence[ReadableSpan],
+        _app: _AppInfo,
+    ) -> None:
+        api_key = _DEFAULT_ADMIN.create_api_key(_app, "System", scope="INGEST")
+        # Must use all lower case for `authorization` because
+        # otherwise it would crash the gRPC receiver.
+        headers = dict(authorization=f"Bearer {api_key}")
+        export = _span_exporter(_app, headers=headers).export
+        for _ in range(2):
+            assert export(_spans) is SpanExportResult.SUCCESS
+        # revocation must take effect immediately, scope claim and all
+        _DEFAULT_ADMIN.delete_api_key(_app, api_key)
+        assert export(_spans) is SpanExportResult.FAILURE
+
+    @pytest.mark.parametrize("kind", ["System", "User"])
+    def test_ingest_key_is_denied_everywhere_else(
+        self,
+        kind: _ApiKeyKind,
+        _get_user: _GetUser,
+        _app: _AppInfo,
+    ) -> None:
+        if kind == "System":
+            api_key = _DEFAULT_ADMIN.create_api_key(_app, "System", scope="INGEST")
+        else:
+            logged_in_user = _get_user(_app, _MEMBER).log_in(_app)
+            api_key = logged_in_user.create_api_key(_app, scope="INGEST")
+        client = _httpx_client(_app, api_key)
+        # REST reads and writes outside the ingest surface are denied
+        assert client.get("v1/projects").status_code == 403
+        assert client.post("v1/datasets/upload").status_code == 403
+        assert client.delete("v1/traces").status_code == 403
+        # GraphQL is denied entirely for scoped keys
+        resp = client.post("graphql", json={"query": "{projects{edges{node{name}}}}"})
+        assert resp.status_code == 403
+
+    def test_unscoped_key_retains_full_legacy_access(
+        self,
+        _app: _AppInfo,
+    ) -> None:
+        api_key = _DEFAULT_ADMIN.create_api_key(_app, "System")
+        client = _httpx_client(_app, api_key)
+        assert client.get("v1/projects").status_code == 200
+        resp = client.post("graphql", json={"query": "{projects{edges{node{name}}}}"})
+        assert resp.status_code == 200
+        assert "errors" not in resp.json()
+
+    def test_scope_is_echoed_into_description(
+        self,
+        _app: _AppInfo,
+    ) -> None:
+        api_key = _DEFAULT_ADMIN.create_api_key(_app, "System", scope="INGEST")
+        query = "query{systemApiKeys{id description}}"
+        resp_dict, _ = _DEFAULT_ADMIN.gql(_app, query)
+        descriptions = {k["id"]: k["description"] for k in resp_dict["data"]["systemApiKeys"]}
+        assert descriptions[api_key.gid] == "[scope:ingest]"
+
+
 class TestPrompts:
     def test_authenticated_users_are_recorded_in_prompts(
         self,
@@ -2145,7 +2215,7 @@ class TestApiAccessViaCookiesOrApiKeys:
                     f"Test misconfiguration: expected_status_code should not be "
                     f"401 or 403 (got {expected_status_code} for {method} {endpoint})"
                 )
-                endpoint = endpoint.format(token_hex(4))
+                endpoint = _format_test_endpoint(endpoint)
                 response = client.request(method, endpoint)
                 assert response.status_code == expected_status_code, (
                     f"Expected {expected_status_code} but got {response.status_code} for {endpoint}"
@@ -2153,7 +2223,7 @@ class TestApiAccessViaCookiesOrApiKeys:
 
             # Test 2: Admin-only endpoints - only admins should have access
             for expected_status_code, method, endpoint in _ADMIN_ONLY_ENDPOINTS:
-                endpoint = endpoint.format(token_hex(4))
+                endpoint = _format_test_endpoint(endpoint)
                 response = client.request(method, endpoint)
                 if is_admin:
                     assert response.status_code == expected_status_code, (
@@ -2168,7 +2238,7 @@ class TestApiAccessViaCookiesOrApiKeys:
 
             # Test 3: Write operations - viewers blocked, admins/members have access
             for expected_status_code, method, endpoint in _VIEWER_BLOCKED_WRITE_OPERATIONS:
-                endpoint = endpoint.format(token_hex(4))
+                endpoint = _format_test_endpoint(endpoint)
                 response = client.request(method, endpoint)
                 if is_viewer:
                     assert response.status_code == 403, (

--- a/tests/integration/project_sessions/test_project_sessions.py
+++ b/tests/integration/project_sessions/test_project_sessions.py
@@ -40,10 +40,12 @@ class TestProjectSessions:
         str_session_id = str(session_id).strip()
         num_traces, num_spans_per_trace = 2, 3
         assert num_traces > 1 and num_spans_per_trace > 2
-        project_names = []
+        # Sessions are scoped per project: the same session_id in two projects yields two
+        # separate sessions. To exercise a session that groups multiple traces, ingest all
+        # traces into one project.
+        project_name = token_hex(8)
         spans: List[Span] = []
         for _ in range(num_traces):
-            project_names.append(token_hex(8))
             with ExitStack() as stack:
                 for i in range(num_spans_per_trace):
                     if i == 0:
@@ -52,7 +54,7 @@ class TestProjectSessions:
                     else:
                         attributes = {SpanAttributes.SESSION_ID: session_id}
                     span = _start_span(
-                        project_name=project_names[-1],
+                        project_name=project_name,
                         exporter=_grpc_span_exporter(_app),
                         attributes=attributes,
                     )
@@ -60,7 +62,6 @@ class TestProjectSessions:
                     stack.enter_context(use_span(span, end_on_exit=True))
                     sleep(0.001)
         assert len(spans) == num_traces * num_spans_per_trace
-        project_name = project_names[0]
 
         def query_fn() -> Optional[dict[str, Any]]:
             res, *_ = _gql(
@@ -72,7 +73,7 @@ class TestProjectSessions:
                 "traces(first: 1000){edges{node{"
                 "spans(first: 1000){edges{node{context{spanId}}}}}}}}}}}}}}",
             )
-            if num_spans_per_trace != sum(
+            if len(spans) != sum(
                 len(project["node"]["spans"]["edges"])
                 for project in res["data"]["projects"]["edges"]
                 if project["node"]["name"] == project_name

--- a/tests/integration/server/test_launch_app.py
+++ b/tests/integration/server/test_launch_app.py
@@ -23,6 +23,7 @@ from .._helpers import (
     _COMMON_RESOURCE_ENDPOINTS,
     _VIEWER_BLOCKED_WRITE_OPERATIONS,
     _AppInfo,
+    _format_test_endpoint,
     _get,
     _get_gql_spans,
     _grpc_span_exporter,
@@ -215,7 +216,7 @@ class TestLaunchApp:
             _ADMIN_ONLY_ENDPOINTS,
             _VIEWER_BLOCKED_WRITE_OPERATIONS,
         ):
-            response = client.request(method, endpoint.format(token_hex(4)))
+            response = client.request(method, _format_test_endpoint(endpoint))
             assert response.status_code == expected_status_code, (
                 f"Expected {expected_status_code} but "
                 f"got {response.status_code} for {method} {endpoint}"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -25,6 +25,7 @@ from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
 from starlette.types import ASGIApp
 
+from phoenix.config import get_env_enable_auth, get_env_phoenix_secret
 from phoenix.db import models
 from phoenix.db.bulk_inserter import BulkInserter
 from phoenix.db.engines import (
@@ -298,12 +299,17 @@ async def project(db: DbSessionFactory) -> None:
 async def app(
     db: DbSessionFactory,
 ) -> AsyncIterator[FastAPI]:
+    # Default off (PHOENIX_ENABLE_AUTH unset → False), so existing tests are unchanged;
+    # tests that need auth (e.g. access control) opt in via the env vars. The signing secret
+    # must be supplied for the auth middleware to be installed.
+    auth_enabled = get_env_enable_auth()
     async with contextlib.AsyncExitStack() as stack:
         await stack.enter_async_context(patch_batched_caller())
         await stack.enter_async_context(patch_grpc_server())
         yield create_app(
             db=db,
-            authentication_enabled=False,
+            authentication_enabled=auth_enabled,
+            secret=get_env_phoenix_secret() if auth_enabled else None,
             serve_ui=False,
             bulk_inserter_factory=TestBulkInserter,
         )

--- a/tests/unit/db/insertion/test_span.py
+++ b/tests/unit/db/insertion/test_span.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timezone
+from secrets import token_hex
+
+from sqlalchemy import select
+
+from phoenix.db import models
+from phoenix.db.insertion.span import insert_span
+from phoenix.server.types import DbSessionFactory
+from phoenix.trace.schemas import (
+    Span,
+    SpanContext,
+    SpanKind,
+    SpanStatusCode,
+)
+
+
+def _make_span(session_id: str) -> Span:
+    now = datetime.now(timezone.utc)
+    return Span(
+        name="root",
+        context=SpanContext(trace_id=token_hex(16), span_id=token_hex(8)),
+        span_kind=SpanKind.CHAIN,
+        parent_id=None,
+        start_time=now,
+        end_time=now,
+        status_code=SpanStatusCode.OK,
+        status_message="",
+        # Attributes are stored un-flattened (nested), so "session.id" lives at
+        # attributes["session"]["id"].
+        attributes={"session": {"id": session_id}},
+        events=[],
+        conversation=None,
+    )
+
+
+class TestSessionIdIsScopedToProject:
+    async def test_same_session_id_in_two_projects_yields_distinct_sessions(
+        self,
+        db: DbSessionFactory,
+    ) -> None:
+        # Two projects each ingest a span carrying session_id "default" — the most
+        # common collision. Before the fix, the second project's trace attached to
+        # the first project's session (a cross-project write).
+        async with db() as session:
+            await insert_span(session, _make_span("default"), project_name="project-a")
+            await insert_span(session, _make_span("default"), project_name="project-b")
+
+        async with db() as session:
+            project_sessions = (
+                await session.scalars(
+                    select(models.ProjectSession).where(
+                        models.ProjectSession.session_id == "default"
+                    )
+                )
+            ).all()
+            projects = {p.id: p.name for p in (await session.scalars(select(models.Project))).all()}
+
+        # One ProjectSession row per project, not a single shared row.
+        assert len(project_sessions) == 2
+        owning_projects = {projects[ps.project_id] for ps in project_sessions}
+        assert owning_projects == {"project-a", "project-b"}
+
+    async def test_same_session_id_same_project_reuses_session(
+        self,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            await insert_span(session, _make_span("default"), project_name="project-a")
+            await insert_span(session, _make_span("default"), project_name="project-a")
+
+        async with db() as session:
+            project_sessions = (
+                await session.scalars(
+                    select(models.ProjectSession).where(
+                        models.ProjectSession.session_id == "default"
+                    )
+                )
+            ).all()
+            traces = (await session.scalars(select(models.Trace))).all()
+
+        # Same project + same session_id reuses the one session; both traces hang off it.
+        assert len(project_sessions) == 1
+        assert {t.project_session_rowid for t in traces} == {project_sessions[0].id}

--- a/tests/unit/db/test_facilitator.py
+++ b/tests/unit/db/test_facilitator.py
@@ -11,15 +11,22 @@ from sqlalchemy.orm import joinedload
 from phoenix.db import models
 from phoenix.db.enums import ENUM_COLUMNS
 from phoenix.db.facilitator import (
+    _ensure_access_control_latch,
     _ensure_admins,
     _ensure_default_project_trace_retention_policy,
     _ensure_enums,
     _ensure_model_costs,
+    _ensure_permission_sets,
+    _ensure_role_permissions,
 )
 from phoenix.db.types.trace_retention import (
     MaxDaysRule,
     TraceRetentionCronExpression,
     TraceRetentionRule,
+)
+from phoenix.server.access import (
+    ACCESS_CONTROL_ENABLED_KEY,
+    BUILTIN_ROLE_PERMISSIONS,
 )
 from phoenix.server.types import DbSessionFactory
 
@@ -780,3 +787,192 @@ class TestEnsureUserFeedbackAnnotationConfig:
 
         assert len(annotation_configs) == 1
         assert isinstance(annotation_configs[0].config, FreeformAnnotationConfig)
+
+
+class TestEnsureRolePermissions:
+    async def _permissions_by_role(self, db: DbSessionFactory) -> dict[str, set[str]]:
+        async with db() as session:
+            rows = await session.execute(
+                select(models.UserRole.name, models.RolePermission.permission).join_from(
+                    models.RolePermission, models.UserRole
+                )
+            )
+        result: dict[str, set[str]] = {}
+        for name, permission in rows:
+            result.setdefault(name, set()).add(permission)
+        return result
+
+    async def test_seeds_builtin_bundles(self, db: DbSessionFactory) -> None:
+        await _ensure_enums(db)
+        await _ensure_role_permissions(db)
+        expected = {
+            role: {permission.value for permission in permissions}
+            for role, permissions in BUILTIN_ROLE_PERMISSIONS.items()
+        }
+        assert await self._permissions_by_role(db) == expected
+
+    async def test_is_idempotent(self, db: DbSessionFactory) -> None:
+        await _ensure_enums(db)
+        await _ensure_role_permissions(db)
+        first = await self._permissions_by_role(db)
+        await _ensure_role_permissions(db)
+        await _ensure_role_permissions(db)
+        async with db() as session:
+            total = await session.scalar(select(sa.func.count()).select_from(models.RolePermission))
+        # No duplicate rows accumulate across reseeds.
+        assert total == sum(len(v) for v in first.values())
+        assert await self._permissions_by_role(db) == first
+
+    async def test_reseed_repairs_drift(self, db: DbSessionFactory) -> None:
+        await _ensure_enums(db)
+        await _ensure_role_permissions(db)
+        async with db() as session:
+            viewer_id = await session.scalar(
+                select(models.UserRole.id).where(models.UserRole.name == "VIEWER")
+            )
+            # A stray permission on a built-in role, and a missing one.
+            session.add(models.RolePermission(user_role_id=viewer_id, permission="administer"))
+            await session.execute(
+                sa.delete(models.RolePermission).where(
+                    models.RolePermission.user_role_id == viewer_id,
+                    models.RolePermission.permission == "read",
+                )
+            )
+        await _ensure_role_permissions(db)
+        # The built-in bundle is restored exactly: the constant is authoritative.
+        assert (await self._permissions_by_role(db))["VIEWER"] == {"read"}
+
+    async def test_builtin_roles_are_marked_immutable(self, db: DbSessionFactory) -> None:
+        await _ensure_enums(db)
+        async with db() as session:
+            built_in = await session.scalars(
+                select(models.UserRole.is_built_in).where(
+                    models.UserRole.name.in_(BUILTIN_ROLE_PERMISSIONS.keys())
+                )
+            )
+        assert all(built_in)
+
+
+class TestEnsurePermissionSets:
+    async def _permissions_by_role(self, db: DbSessionFactory) -> dict[str, set[str]]:
+        async with db() as session:
+            rows = await session.execute(
+                select(models.PermissionSet.name, models.PermissionSetItem.permission).join_from(
+                    models.PermissionSetItem, models.PermissionSet
+                )
+            )
+        result: dict[str, set[str]] = {}
+        for name, permission in rows:
+            result.setdefault(name, set()).add(permission)
+        return result
+
+    async def test_seeds_builtin_permission_sets(self, db: DbSessionFactory) -> None:
+        await _ensure_permission_sets(db)
+        by_role = await self._permissions_by_role(db)
+        assert by_role["Resource Viewer"] == {"obj_view"}
+        assert by_role["Resource Editor"] == {"obj_view", "obj_edit"}
+        assert by_role["Resource Manager"] == {"obj_view", "obj_edit", "obj_manage_access"}
+        async with db() as session:
+            built_in = await session.scalars(select(models.PermissionSet.is_built_in))
+        assert all(built_in)
+
+    async def test_is_idempotent_and_repairs_drift(self, db: DbSessionFactory) -> None:
+        await _ensure_permission_sets(db)
+        async with db() as session:
+            viewer_id = await session.scalar(
+                select(models.PermissionSet.id).where(
+                    models.PermissionSet.name == "Resource Viewer"
+                )
+            )
+            session.add(
+                models.PermissionSetItem(permission_set_id=viewer_id, permission="obj_edit")
+            )
+        await _ensure_permission_sets(db)
+        await _ensure_permission_sets(db)
+        # Stray permission removed, no duplicates.
+        assert (await self._permissions_by_role(db))["Resource Viewer"] == {"obj_view"}
+
+
+class TestEnsureAccessControlLatch:
+    async def _latch(self, db: DbSessionFactory) -> object:
+        async with db() as session:
+            return await session.scalar(
+                sa.select(models.SystemSetting.value).where(
+                    models.SystemSetting.key == ACCESS_CONTROL_ENABLED_KEY
+                )
+            )
+
+    async def _set_latch(self, db: DbSessionFactory, enabled: bool) -> None:
+        async with db() as session:
+            session.add(
+                models.SystemSetting(key=ACCESS_CONTROL_ENABLED_KEY, value={"enabled": enabled})
+            )
+
+    async def test_env_on_bootstraps_latch_when_absent(
+        self, db: DbSessionFactory, monkeypatch: MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PHOENIX_ACCESS_CONTROL_ENABLED", "true")
+        monkeypatch.setenv("PHOENIX_ENABLE_AUTH", "true")  # access control presupposes auth
+        await _ensure_access_control_latch(db)
+        assert await self._latch(db) == {"enabled": True}
+
+    async def test_env_on_is_one_way_and_respects_deliberate_off(
+        self, db: DbSessionFactory, monkeypatch: MonkeyPatch
+    ) -> None:
+        # An operator deliberately disabled the persisted latch; bootstrap must not re-enable.
+        await self._set_latch(db, enabled=False)
+        monkeypatch.setenv("PHOENIX_ACCESS_CONTROL_ENABLED", "true")
+        await _ensure_access_control_latch(db)
+        assert await self._latch(db) == {"enabled": False}
+
+    async def test_env_on_with_latch_on_is_noop(
+        self, db: DbSessionFactory, monkeypatch: MonkeyPatch
+    ) -> None:
+        await self._set_latch(db, enabled=True)
+        monkeypatch.setenv("PHOENIX_ACCESS_CONTROL_ENABLED", "true")
+        monkeypatch.setenv("PHOENIX_ENABLE_AUTH", "true")
+        await _ensure_access_control_latch(db)
+        assert await self._latch(db) == {"enabled": True}
+
+    async def test_env_off_with_no_latch_is_noop(
+        self, db: DbSessionFactory, monkeypatch: MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("PHOENIX_ACCESS_CONTROL_ENABLED", raising=False)
+        await _ensure_access_control_latch(db)
+        assert await self._latch(db) is None
+
+    async def test_env_off_with_latch_off_is_noop(
+        self, db: DbSessionFactory, monkeypatch: MonkeyPatch
+    ) -> None:
+        await self._set_latch(db, enabled=False)
+        monkeypatch.delenv("PHOENIX_ACCESS_CONTROL_ENABLED", raising=False)
+        await _ensure_access_control_latch(db)
+        assert await self._latch(db) == {"enabled": False}
+
+    async def test_env_off_while_enforcing_refuses_to_start(
+        self, db: DbSessionFactory, monkeypatch: MonkeyPatch
+    ) -> None:
+        await self._set_latch(db, enabled=True)
+        monkeypatch.delenv("PHOENIX_ACCESS_CONTROL_ENABLED", raising=False)
+        monkeypatch.setenv("PHOENIX_ENABLE_AUTH", "true")  # isolate drift guard from auth guard
+        with pytest.raises(RuntimeError, match="PHOENIX_ACCESS_CONTROL_ENABLED"):
+            await _ensure_access_control_latch(db)
+
+    async def test_env_on_with_auth_off_refuses_to_start(
+        self, db: DbSessionFactory, monkeypatch: MonkeyPatch
+    ) -> None:
+        # Access control presupposes authentication: enabling it with auth off would degrade
+        # enforcement to a silent allow-all. Refuse to bootstrap the latch in that state.
+        monkeypatch.setenv("PHOENIX_ACCESS_CONTROL_ENABLED", "true")
+        monkeypatch.delenv("PHOENIX_ENABLE_AUTH", raising=False)
+        with pytest.raises(RuntimeError, match="authentication"):
+            await _ensure_access_control_latch(db)
+        assert await self._latch(db) is None
+
+    async def test_latched_on_with_auth_off_refuses_to_start(
+        self, db: DbSessionFactory, monkeypatch: MonkeyPatch
+    ) -> None:
+        await self._set_latch(db, enabled=True)
+        monkeypatch.delenv("PHOENIX_ENABLE_AUTH", raising=False)
+        with pytest.raises(RuntimeError, match="authentication"):
+            await _ensure_access_control_latch(db)

--- a/tests/unit/server/access/test_oracle.py
+++ b/tests/unit/server/access/test_oracle.py
@@ -1,0 +1,1064 @@
+from secrets import token_bytes, token_hex
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from phoenix.db import models
+from phoenix.server.access import (
+    OBJECT_TYPE_DATASET,
+    OBJECT_TYPE_PROJECT,
+    Permission,
+    SubjectKind,
+    access_predicate,
+    accessible_scope,
+    can_access,
+    delete_object_grants,
+    delete_object_tags,
+    subjects_for,
+    would_strand_manager_by_role,
+)
+from phoenix.server.access.subjects import Subject
+from phoenix.server.types import DbSessionFactory
+
+_PROJECT = OBJECT_TYPE_PROJECT
+_DATASET = OBJECT_TYPE_DATASET
+_VIEW = Permission.OBJ_VIEW
+_EDIT = Permission.OBJ_EDIT
+_MANAGE = Permission.OBJ_MANAGE_ACCESS
+
+
+async def _role(session: AsyncSession, name: str, permissions: set[str]) -> int:
+    role = models.UserRole(name=name)
+    session.add(role)
+    await session.flush()
+    for permission in permissions:
+        session.add(models.RolePermission(user_role_id=role.id, permission=permission))
+    await session.flush()
+    return role.id
+
+
+async def _permission_set(session: AsyncSession, name: str, permissions: set[str]) -> int:
+    """An permission set (viewer/editor/owner tier) with its object-level permission set."""
+    role = models.PermissionSet(name=name, is_built_in=False)
+    session.add(role)
+    await session.flush()
+    for permission in permissions:
+        session.add(models.PermissionSetItem(permission_set_id=role.id, permission=permission))
+    await session.flush()
+    return role.id
+
+
+async def _user(session: AsyncSession, role_id: int) -> int:
+    user = models.LocalUser(
+        user_role_id=role_id,
+        username=token_hex(8),
+        email=f"{token_hex(8)}@x.test",
+        reset_password=False,
+        password_salt=token_bytes(32),
+        password_hash=token_bytes(32),
+    )
+    session.add(user)
+    await session.flush()
+    return user.id
+
+
+async def _project(session: AsyncSession, name: str, kind: str = "TELEMETRY") -> int:
+    project = models.Project(name=name, kind=kind)
+    session.add(project)
+    await session.flush()
+    return project.id
+
+
+async def _dataset(session: AsyncSession, name: str, user_id: Optional[int] = None) -> int:
+    dataset = models.Dataset(name=name, metadata_={}, user_id=user_id)
+    session.add(dataset)
+    await session.flush()
+    return dataset.id
+
+
+async def _experiment(session: AsyncSession, *, dataset_id: int, project_id: int) -> int:
+    version = models.DatasetVersion(dataset_id=dataset_id, metadata_={})
+    session.add(version)
+    await session.flush()
+    experiment = models.Experiment(
+        dataset_id=dataset_id,
+        dataset_version_id=version.id,
+        name=token_hex(8),
+        repetitions=1,
+        metadata_={},
+        project_id=project_id,
+    )
+    session.add(experiment)
+    await session.flush()
+    return experiment.id
+
+
+async def _group(session: AsyncSession, user_id: int, key: str) -> int:
+    group = models.UserGroup(provider="test", group_key=key, display_name=key)
+    session.add(group)
+    await session.flush()
+    session.add(models.UserGroupMembership(user_group_id=group.id, user_id=user_id))
+    await session.flush()
+    return group.id
+
+
+async def _grant(
+    session: AsyncSession,
+    *,
+    subject_kind: str,
+    subject_id: Optional[int],
+    object_type: str,
+    object_id: Optional[int],
+    selector_kind: str,
+    role_id: Optional[int] = None,
+    tag_key: Optional[str] = None,
+    tag_value: Optional[str] = None,
+) -> None:
+    session.add(
+        models.AccessGrant(
+            subject_kind=subject_kind,
+            subject_id=subject_id,
+            role_id=role_id,
+            object_type=object_type,
+            object_id=object_id,
+            selector_kind=selector_kind,
+            tag_key=tag_key,
+            tag_value=tag_value,
+            effect="allow",
+        )
+    )
+    await session.flush()
+
+
+async def _tag(
+    session: AsyncSession,
+    *,
+    object_type: str,
+    object_id: int,
+    key: str,
+    value: str,
+) -> None:
+    session.add(
+        models.ResourceTag(object_type=object_type, object_id=object_id, key=key, value=value)
+    )
+    await session.flush()
+
+
+async def _accessible_ids(
+    session: AsyncSession,
+    user_id: int,
+    object_type: str,
+    enabled: bool,
+    permission: Permission = Permission.OBJ_VIEW,
+) -> set[int]:
+    scope = await accessible_scope(
+        session, user_id=user_id, object_type=object_type, enabled=enabled, permission=permission
+    )
+    column = models.Project.id if object_type == _PROJECT else models.Dataset.id
+    table = models.Project if object_type == _PROJECT else models.Dataset
+    ids = await session.scalars(select(table.id).where(scope.apply(column)))
+    return set(ids)
+
+
+async def _predicate_ids(
+    session: AsyncSession,
+    user_id: int,
+    object_type: str,
+    enabled: bool,
+    permission: Permission = Permission.OBJ_VIEW,
+) -> set[int]:
+    column = models.Project.id if object_type == _PROJECT else models.Dataset.id
+    table = models.Project if object_type == _PROJECT else models.Dataset
+    predicate = await access_predicate(
+        session,
+        user_id=user_id,
+        object_type=object_type,
+        id_column=column,
+        enabled=enabled,
+        permission=permission,
+    )
+    ids = await session.scalars(select(table.id).where(predicate))
+    return set(ids)
+
+
+class TestEnforcementDisabled:
+    async def test_flag_off_sees_everything(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            user_id = await _user(session, await _role(session, "MEMBER", {"read"}))
+            p1, p2 = await _project(session, "a"), await _project(session, "b")
+            # A grant naming p1 — ignored entirely while the flag is off.
+            await _grant(
+                session,
+                subject_kind="group",
+                subject_id=999,
+                object_type=_PROJECT,
+                object_id=p1,
+                selector_kind="ids",
+            )
+        async with db() as session:
+            assert await _accessible_ids(session, user_id, _PROJECT, enabled=False) == {p1, p2}
+            assert await can_access(
+                session, user_id=user_id, object_type=_PROJECT, object_id=p1, enabled=False
+            )
+
+
+class TestAdminOnlyDefault:
+    async def test_member_with_no_grants_sees_nothing(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            user_id = await _user(session, await _role(session, "MEMBER", {"read"}))
+            await _project(session, "a")
+            await _project(session, "b")
+        async with db() as session:
+            # Fail-closed: no everyone-baseline, so an ungranted member sees no
+            # ingest-born projects at all.
+            assert await _accessible_ids(session, user_id, _PROJECT, enabled=True) == set()
+
+    async def test_admin_sees_everything(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            admin = await _user(session, await _role(session, "ADMIN", {"read", "administer"}))
+            p1, p2 = await _project(session, "a"), await _project(session, "b")
+        async with db() as session:
+            assert await _accessible_ids(session, admin, _PROJECT, enabled=True) == {p1, p2}
+            assert await can_access(
+                session, user_id=admin, object_type=_PROJECT, object_id=p1, enabled=True
+            )
+
+
+class TestMonotonicGrants:
+    async def test_grant_only_adds_access(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice, bob = await _user(session, member), await _user(session, member)
+            team_a = await _group(session, alice, "team-a")
+            a_proj = await _project(session, "team-a-proj")
+            other = await _project(session, "other")
+            # Grant Team A its project. Nothing else becomes visible to anyone.
+            await _grant(
+                session,
+                subject_kind="group",
+                subject_id=team_a,
+                object_type=_PROJECT,
+                object_id=a_proj,
+                selector_kind="ids",
+            )
+        async with db() as session:
+            # Alice (Team A) sees only the granted project — not `other`.
+            alice_ids = await _accessible_ids(session, alice, _PROJECT, enabled=True)
+            assert alice_ids == {a_proj}
+            assert other not in alice_ids
+            # Bob, in no group, sees nothing.
+            assert await _accessible_ids(session, bob, _PROJECT, enabled=True) == set()
+            # Point lookup: Bob probing Team A's project is denied (caller -> 404).
+            assert not await can_access(
+                session, user_id=bob, object_type=_PROJECT, object_id=a_proj, enabled=True
+            )
+
+    async def test_two_teams_isolated(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice, bob = await _user(session, member), await _user(session, member)
+            team_a = await _group(session, alice, "team-a")
+            team_b = await _group(session, bob, "team-b")
+            a_proj = await _project(session, "a")
+            b_proj = await _project(session, "b")
+            for team, proj in ((team_a, a_proj), (team_b, b_proj)):
+                await _grant(
+                    session,
+                    subject_kind="group",
+                    subject_id=team,
+                    object_type=_PROJECT,
+                    object_id=proj,
+                    selector_kind="ids",
+                )
+        async with db() as session:
+            assert await _accessible_ids(session, alice, _PROJECT, enabled=True) == {a_proj}
+            assert await _accessible_ids(session, bob, _PROJECT, enabled=True) == {b_proj}
+
+    async def test_type_wide_grant_opens_all_of_a_type(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            p1, p2 = await _project(session, "a"), await _project(session, "b")
+            # An explicit type-wide grant (e.g. a support group) — monotonic, adds all.
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_PROJECT,
+                object_id=None,
+                selector_kind="all",
+            )
+        async with db() as session:
+            assert await _accessible_ids(session, alice, _PROJECT, enabled=True) == {p1, p2}
+
+
+class TestCreatorPrivate:
+    async def test_creator_sees_own_dataset_without_a_grant(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice, bob = await _user(session, member), await _user(session, member)
+            mine = await _dataset(session, "mine", user_id=alice)
+            theirs = await _dataset(session, "theirs", user_id=bob)
+        async with db() as session:
+            assert await _accessible_ids(session, alice, _DATASET, enabled=True) == {mine}
+            assert await _accessible_ids(session, bob, _DATASET, enabled=True) == {theirs}
+            assert not await can_access(
+                session, user_id=alice, object_type=_DATASET, object_id=theirs, enabled=True
+            )
+
+
+class TestAccessByParent:
+    async def test_experiment_project_inherits_dataset(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice, bob = await _user(session, member), await _user(session, member)
+            ds = await _dataset(session, "ds", user_id=alice)  # alice owns it
+            exp_proj = await _project(session, f"Experiment-{token_hex(6)}", kind="EXPERIMENT")
+            await _experiment(session, dataset_id=ds, project_id=exp_proj)
+        async with db() as session:
+            # Alice can read the experiment's trace project *because* she can read
+            # the dataset it runs on — access-by-parent, no grant on the project.
+            assert exp_proj in await _accessible_ids(session, alice, _PROJECT, enabled=True)
+            assert await can_access(
+                session, user_id=alice, object_type=_PROJECT, object_id=exp_proj, enabled=True
+            )
+            # Bob, who cannot read the dataset, cannot read its experiment project.
+            assert exp_proj not in await _accessible_ids(session, bob, _PROJECT, enabled=True)
+
+
+class TestAccessPredicate:
+    async def test_sql_predicate_matches_materialized_scope(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice, bob = await _user(session, member), await _user(session, member)
+            team = await _group(session, alice, "team")
+            viewer = await _permission_set(session, "Viewer", {"obj_view"})
+            editor = await _permission_set(session, "Editor", {"obj_view", "obj_edit"})
+            visible = await _project(session, "visible")
+            editable = await _project(session, "editable")
+            hidden = await _project(session, "hidden")
+            owned_dataset = await _dataset(session, "owned", user_id=alice)
+            other_dataset = await _dataset(session, "other", user_id=bob)
+            experiment_project = await _project(session, f"Experiment-{token_hex(6)}")
+            await _experiment(session, dataset_id=owned_dataset, project_id=experiment_project)
+            await _grant(
+                session,
+                subject_kind="group",
+                subject_id=team,
+                object_type=_PROJECT,
+                object_id=visible,
+                selector_kind="ids",
+                role_id=viewer,
+            )
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_PROJECT,
+                object_id=editable,
+                selector_kind="ids",
+                role_id=editor,
+            )
+        async with db() as session:
+            for object_type, permission in (
+                (_PROJECT, _VIEW),
+                (_PROJECT, _EDIT),
+                (_DATASET, _VIEW),
+                (_DATASET, _EDIT),
+            ):
+                assert await _predicate_ids(
+                    session, alice, object_type, enabled=True, permission=permission
+                ) == await _accessible_ids(
+                    session, alice, object_type, enabled=True, permission=permission
+                )
+            assert hidden not in await _predicate_ids(session, alice, _PROJECT, enabled=True)
+            assert other_dataset not in await _predicate_ids(session, alice, _DATASET, enabled=True)
+
+    async def test_project_list_predicate_and_point_scope_match_for_member(
+        self, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            user_id = await _user(session, member)
+            granted = await _project(session, "granted")
+            hidden = await _project(session, "hidden")
+            await _grant(
+                session,
+                subject_kind=SubjectKind.USER.value,
+                subject_id=user_id,
+                object_type=_PROJECT,
+                object_id=granted,
+                selector_kind="ids",
+            )
+
+        async with db() as session:
+            listed_ids = await _predicate_ids(session, user_id, _PROJECT, enabled=True)
+            scoped_ids = await _accessible_ids(session, user_id, _PROJECT, enabled=True)
+
+        assert listed_ids == scoped_ids == {granted}
+        assert hidden not in listed_ids
+
+
+class TestAclCleanup:
+    async def test_delete_object_grants_sweeps_only_concrete_object_grants(
+        self, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            deleted_project = await _project(session, "deleted")
+            kept_project = await _project(session, "kept")
+            await _grant(
+                session,
+                subject_kind=SubjectKind.USER.value,
+                subject_id=alice,
+                object_type=_PROJECT,
+                object_id=deleted_project,
+                selector_kind="ids",
+            )
+            await _grant(
+                session,
+                subject_kind=SubjectKind.USER.value,
+                subject_id=alice,
+                object_type=_PROJECT,
+                object_id=kept_project,
+                selector_kind="ids",
+            )
+            await _grant(
+                session,
+                subject_kind=SubjectKind.USER.value,
+                subject_id=alice,
+                object_type=_PROJECT,
+                object_id=None,
+                selector_kind="all",
+            )
+            await delete_object_grants(session, _PROJECT, deleted_project)
+
+            rows = (
+                await session.execute(
+                    select(models.AccessGrant.selector_kind, models.AccessGrant.object_id).where(
+                        models.AccessGrant.subject_kind == SubjectKind.USER.value,
+                        models.AccessGrant.subject_id == alice,
+                        models.AccessGrant.object_type == _PROJECT,
+                    )
+                )
+            ).all()
+        assert set(rows) == {("ids", kept_project), ("all", None)}
+
+
+class TestPermissionSetTiers:
+    """Grants carry an permission set; the oracle answers per permission. A viewer-tier grant
+    confers view but not edit; an editor-tier grant confers both; a grant with no role is
+    view-only; creators and admins hold every permission."""
+
+    async def test_viewer_grant_sees_but_cannot_edit(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            alice = await _user(session, await _role(session, "MEMBER", {"read"}))
+            team = await _group(session, alice, "team")
+            proj = await _project(session, "p")
+            viewer = await _permission_set(session, "Viewer", {"obj_view"})
+            await _grant(
+                session,
+                subject_kind="group",
+                subject_id=team,
+                object_type=_PROJECT,
+                object_id=proj,
+                selector_kind="ids",
+                role_id=viewer,
+            )
+        async with db() as session:
+            assert proj in await _accessible_ids(session, alice, _PROJECT, True, _VIEW)
+            assert proj not in await _accessible_ids(session, alice, _PROJECT, True, _EDIT)
+            assert await can_access(
+                session,
+                user_id=alice,
+                object_type=_PROJECT,
+                object_id=proj,
+                enabled=True,
+                permission=_VIEW,
+            )
+            assert not await can_access(
+                session,
+                user_id=alice,
+                object_type=_PROJECT,
+                object_id=proj,
+                enabled=True,
+                permission=_EDIT,
+            )
+
+    async def test_editor_grant_can_view_and_edit(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            alice = await _user(session, await _role(session, "MEMBER", {"read"}))
+            team = await _group(session, alice, "team")
+            proj = await _project(session, "p")
+            editor = await _permission_set(session, "Editor", {"obj_view", "obj_edit"})
+            await _grant(
+                session,
+                subject_kind="group",
+                subject_id=team,
+                object_type=_PROJECT,
+                object_id=proj,
+                selector_kind="ids",
+                role_id=editor,
+            )
+        async with db() as session:
+            assert proj in await _accessible_ids(session, alice, _PROJECT, True, _VIEW)
+            assert proj in await _accessible_ids(session, alice, _PROJECT, True, _EDIT)
+
+    async def test_roleless_grant_is_view_only(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            alice = await _user(session, await _role(session, "MEMBER", {"read"}))
+            proj = await _project(session, "p")
+            # role_id=None — a plain/legacy grant.
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_PROJECT,
+                object_id=proj,
+                selector_kind="ids",
+            )
+        async with db() as session:
+            assert await can_access(
+                session,
+                user_id=alice,
+                object_type=_PROJECT,
+                object_id=proj,
+                enabled=True,
+                permission=_VIEW,
+            )
+            assert not await can_access(
+                session,
+                user_id=alice,
+                object_type=_PROJECT,
+                object_id=proj,
+                enabled=True,
+                permission=_EDIT,
+            )
+
+    async def test_type_wide_grant_respects_tier(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            alice = await _user(session, await _role(session, "MEMBER", {"read"}))
+            p1, p2 = await _project(session, "a"), await _project(session, "b")
+            viewer = await _permission_set(session, "Viewer", {"obj_view"})
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_PROJECT,
+                object_id=None,
+                selector_kind="all",
+                role_id=viewer,
+            )
+        async with db() as session:
+            assert await _accessible_ids(session, alice, _PROJECT, True, _VIEW) == {p1, p2}
+            assert await _accessible_ids(session, alice, _PROJECT, True, _EDIT) == set()
+
+    async def test_creator_can_edit_own_dataset(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice, bob = await _user(session, member), await _user(session, member)
+            mine = await _dataset(session, "mine", user_id=alice)
+        async with db() as session:
+            # The creator owns it — every object permission, including edit.
+            assert await can_access(
+                session,
+                user_id=alice,
+                object_type=_DATASET,
+                object_id=mine,
+                enabled=True,
+                permission=_EDIT,
+            )
+            assert not await can_access(
+                session,
+                user_id=bob,
+                object_type=_DATASET,
+                object_id=mine,
+                enabled=True,
+                permission=_EDIT,
+            )
+
+    async def test_admin_can_edit_everything(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            admin = await _user(session, await _role(session, "ADMIN", {"read", "administer"}))
+            proj = await _project(session, "p")
+        async with db() as session:
+            assert await can_access(
+                session,
+                user_id=admin,
+                object_type=_PROJECT,
+                object_id=proj,
+                enabled=True,
+                permission=_EDIT,
+            )
+
+    async def test_manager_tier_confers_manage_access_editor_does_not(
+        self, db: DbSessionFactory
+    ) -> None:
+        # The semantic that backs decentralized grant authoring: a manager holds
+        # OBJ_MANAGE_ACCESS on the object (so may administer its access), an editor does not.
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            manager_user, editor_user = await _user(session, member), await _user(session, member)
+            proj = await _project(session, "p")
+            manager = await _permission_set(
+                session, "Manager", {"obj_view", "obj_edit", "obj_manage_access"}
+            )
+            editor = await _permission_set(session, "Editor", {"obj_view", "obj_edit"})
+            for subject, role in ((manager_user, manager), (editor_user, editor)):
+                await _grant(
+                    session,
+                    subject_kind="user",
+                    subject_id=subject,
+                    object_type=_PROJECT,
+                    object_id=proj,
+                    selector_kind="ids",
+                    role_id=role,
+                )
+        async with db() as session:
+            assert await can_access(
+                session,
+                user_id=manager_user,
+                object_type=_PROJECT,
+                object_id=proj,
+                enabled=True,
+                permission=_MANAGE,
+            )
+            assert not await can_access(
+                session,
+                user_id=editor_user,
+                object_type=_PROJECT,
+                object_id=proj,
+                enabled=True,
+                permission=_MANAGE,
+            )
+
+
+class TestSubjectsFor:
+    async def test_granted_object_lists_its_grantees(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            team_a = await _group(session, alice, "team-a")
+            proj = await _project(session, "p")
+            await _grant(
+                session,
+                subject_kind="group",
+                subject_id=team_a,
+                object_type=_PROJECT,
+                object_id=proj,
+                selector_kind="ids",
+            )
+        async with db() as session:
+            who = await subjects_for(session, _PROJECT, proj)
+        assert Subject(SubjectKind.GROUP, team_a) in who
+
+    async def test_ungranted_project_lists_nobody_explicit(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            proj = await _project(session, "p")
+        async with db() as session:
+            who = await subjects_for(session, _PROJECT, proj)
+        # No everyone-default any more: an ungranted project has no explicit
+        # subjects (admins are implicit, not enumerated).
+        assert who == []
+
+    async def test_dangling_user_grant_is_not_listed(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            proj = await _project(session, "p")
+            # A grant to a user id that does not exist (deleted/recycled).
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=987654,
+                object_type=_PROJECT,
+                object_id=proj,
+                selector_kind="ids",
+            )
+        async with db() as session:
+            who = await subjects_for(session, _PROJECT, proj)
+        # The read-time existence guard keeps the dangling subject out of the view.
+        assert who == []
+
+
+class TestStrandByPermissionSet:
+    """A permission set is the other lever on the last-manager invariant: editing a custom
+    set to drop manage, or deleting it (its grants fall back to view), strips manage from
+    every grant carrying it at once. ``would_strand_manager_by_role`` catches the case where
+    that leaves a creatorless object reachable only by administrators."""
+
+    async def test_sole_manager_via_role_would_strand(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            manager = await _permission_set(session, "mgr", {"obj_view", "obj_manage_access"})
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            proj = await _project(session, "p")  # projects are creatorless
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_PROJECT,
+                object_id=proj,
+                selector_kind="ids",
+                role_id=manager,
+            )
+        async with db() as session:
+            assert await would_strand_manager_by_role(session, manager) is True
+
+    async def test_another_id_manager_via_a_different_role_is_safe(
+        self, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            manager = await _permission_set(session, "mgr", {"obj_view", "obj_manage_access"})
+            other_mgr = await _permission_set(session, "mgr2", {"obj_view", "obj_manage_access"})
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            bob = await _user(session, member)
+            proj = await _project(session, "p")
+            for uid, rid in ((alice, manager), (bob, other_mgr)):
+                await _grant(
+                    session,
+                    subject_kind="user",
+                    subject_id=uid,
+                    object_type=_PROJECT,
+                    object_id=proj,
+                    selector_kind="ids",
+                    role_id=rid,
+                )
+        async with db() as session:
+            # Dropping `manager` still leaves bob as a manager via `other_mgr`.
+            assert await would_strand_manager_by_role(session, manager) is False
+
+    async def test_type_wide_all_manager_is_safe(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            manager = await _permission_set(session, "mgr", {"obj_view", "obj_manage_access"})
+            other_mgr = await _permission_set(session, "mgr2", {"obj_view", "obj_manage_access"})
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            bob = await _user(session, member)
+            proj = await _project(session, "p")
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_PROJECT,
+                object_id=proj,
+                selector_kind="ids",
+                role_id=manager,
+            )
+            # A type-wide manager on the project type keeps every project reachable.
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=bob,
+                object_type=_PROJECT,
+                object_id=None,
+                selector_kind="all",
+                role_id=other_mgr,
+            )
+        async with db() as session:
+            assert await would_strand_manager_by_role(session, manager) is False
+
+    async def test_creator_owned_object_is_safe(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            manager = await _permission_set(session, "mgr", {"obj_view", "obj_manage_access"})
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            owner = await _user(session, member)
+            ds = await _dataset(session, "d", user_id=owner)  # creator is a durable manager
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_DATASET,
+                object_id=ds,
+                selector_kind="ids",
+                role_id=manager,
+            )
+        async with db() as session:
+            assert await would_strand_manager_by_role(session, manager) is False
+
+    async def test_non_manager_role_strands_nothing(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            viewer = await _permission_set(session, "v", {"obj_view"})
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            proj = await _project(session, "p")  # creatorless, no other manager
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_PROJECT,
+                object_id=proj,
+                selector_kind="ids",
+                role_id=viewer,
+            )
+        async with db() as session:
+            # A view-only role confers no manage, so editing/deleting it removes no manage
+            # authority — the guard must short-circuit to False, not false-positive.
+            assert await would_strand_manager_by_role(session, viewer) is False
+
+
+class TestTagGrants:
+    """Attribute-based grants: a tag grant (selector_kind='tag') names a
+    key=value and reaches every object of its type carrying that tag. Additive,
+    exact-match, resolved identically by the Python and SQL paths."""
+
+    async def test_tag_grant_reaches_only_tagged_objects_with_parity(
+        self, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            viewer = await _permission_set(session, "v", {"obj_view"})
+            prod = await _dataset(session, "prod-ds")
+            staging = await _dataset(session, "staging-ds")
+            untagged = await _dataset(session, "untagged-ds")
+            await _tag(session, object_type=_DATASET, object_id=prod, key="env", value="prod")
+            await _tag(session, object_type=_DATASET, object_id=staging, key="env", value="staging")
+            # One tag grant: "datasets tagged env=prod".
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_DATASET,
+                object_id=None,
+                selector_kind="tag",
+                role_id=viewer,
+                tag_key="env",
+                tag_value="prod",
+            )
+        async with db() as session:
+            # Reaches the prod dataset; not staging (wrong value), not untagged.
+            assert await _accessible_ids(session, alice, _DATASET, enabled=True) == {prod}
+            assert staging not in await _accessible_ids(session, alice, _DATASET, enabled=True)
+            assert untagged not in await _accessible_ids(session, alice, _DATASET, enabled=True)
+            # Parity: the SQL predicate and the materialized scope agree exactly.
+            assert await _predicate_ids(
+                session, alice, _DATASET, enabled=True
+            ) == await _accessible_ids(session, alice, _DATASET, enabled=True)
+            assert await can_access(
+                session, user_id=alice, object_type=_DATASET, object_id=prod, enabled=True
+            )
+            assert not await can_access(
+                session, user_id=alice, object_type=_DATASET, object_id=staging, enabled=True
+            )
+
+    async def test_tag_grant_matching_no_object_grants_nothing(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            viewer = await _permission_set(session, "v", {"obj_view"})
+            ds = await _dataset(session, "ds")  # deliberately untagged
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_DATASET,
+                object_id=None,
+                selector_kind="tag",
+                role_id=viewer,
+                tag_key="env",
+                tag_value="prod",
+            )
+        async with db() as session:
+            # Fail-closed: a tag grant whose key=value matches no object grants nothing.
+            assert await _accessible_ids(session, alice, _DATASET, enabled=True) == set()
+            assert ds not in await _predicate_ids(session, alice, _DATASET, enabled=True)
+
+    async def test_removed_tag_is_inert_and_swept(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            viewer = await _permission_set(session, "v", {"obj_view"})
+            ds = await _dataset(session, "ds")
+            await _tag(session, object_type=_DATASET, object_id=ds, key="env", value="prod")
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_DATASET,
+                object_id=None,
+                selector_kind="tag",
+                role_id=viewer,
+                tag_key="env",
+                tag_value="prod",
+            )
+        async with db() as session:
+            assert ds in await _accessible_ids(session, alice, _DATASET, enabled=True)
+        # Sweeping the object's tags (the delete-path sibling) removes the match.
+        async with db() as session:
+            await delete_object_tags(session, _DATASET, ds)
+        async with db() as session:
+            assert ds not in await _accessible_ids(session, alice, _DATASET, enabled=True)
+            assert await _predicate_ids(session, alice, _DATASET, enabled=True) == set()
+            # The grant itself survives — it carries strings, not a link to the tag row.
+            remaining = await session.scalar(
+                select(models.AccessGrant.id).where(models.AccessGrant.selector_kind == "tag")
+            )
+            assert remaining is not None
+
+    async def test_tag_grant_unions_with_direct_grant(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            viewer = await _permission_set(session, "v", {"obj_view"})
+            direct = await _dataset(session, "direct-ds")
+            tagged = await _dataset(session, "tagged-ds")
+            await _tag(session, object_type=_DATASET, object_id=tagged, key="env", value="prod")
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_DATASET,
+                object_id=direct,
+                selector_kind="ids",
+                role_id=viewer,
+            )
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_DATASET,
+                object_id=None,
+                selector_kind="tag",
+                role_id=viewer,
+                tag_key="env",
+                tag_value="prod",
+            )
+        async with db() as session:
+            # Monotonic union: direct-named object and tag-matched object together.
+            assert await _accessible_ids(session, alice, _DATASET, enabled=True) == {direct, tagged}
+            assert await _predicate_ids(session, alice, _DATASET, enabled=True) == {direct, tagged}
+
+    async def test_tag_grant_respects_permission_tier(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            viewer = await _permission_set(session, "v", {"obj_view"})
+            ds = await _dataset(session, "ds")
+            await _tag(session, object_type=_DATASET, object_id=ds, key="env", value="prod")
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_DATASET,
+                object_id=None,
+                selector_kind="tag",
+                role_id=viewer,
+                tag_key="env",
+                tag_value="prod",
+            )
+        async with db() as session:
+            # A viewer-tier tag grant confers visibility, not edit.
+            assert ds in await _accessible_ids(session, alice, _DATASET, True, _VIEW)
+            assert ds not in await _accessible_ids(session, alice, _DATASET, True, _EDIT)
+            assert await _predicate_ids(session, alice, _DATASET, True, _EDIT) == set()
+
+    async def test_tag_grant_never_confers_manage(self, db: DbSessionFactory) -> None:
+        # A tag grant scopes view/edit only. A manager-tier tag grant (which authoring
+        # rejects, but which a seed could still insert) confers view and edit but *not*
+        # manage — otherwise a non-admin could become an object's manager via a tag and
+        # then strand it by dropping the tag. The oracle refuses manage on both paths.
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            manager = await _permission_set(
+                session, "m", {"obj_view", "obj_edit", "obj_manage_access"}
+            )
+            ds = await _dataset(session, "ds")
+            await _tag(session, object_type=_DATASET, object_id=ds, key="env", value="prod")
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_DATASET,
+                object_id=None,
+                selector_kind="tag",
+                role_id=manager,
+                tag_key="env",
+                tag_value="prod",
+            )
+        async with db() as session:
+            # View and edit flow from the tag grant...
+            assert ds in await _accessible_ids(session, alice, _DATASET, True, _VIEW)
+            assert ds in await _accessible_ids(session, alice, _DATASET, True, _EDIT)
+            # ...but manage does not, on either path.
+            assert ds not in await _accessible_ids(session, alice, _DATASET, True, _MANAGE)
+            assert await _predicate_ids(session, alice, _DATASET, True, _MANAGE) == set()
+            assert not await can_access(
+                session,
+                user_id=alice,
+                object_type=_DATASET,
+                object_id=ds,
+                enabled=True,
+                permission=_MANAGE,
+            )
+
+    async def test_tag_grant_on_dataset_reaches_experiment_project(
+        self, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            viewer = await _permission_set(session, "v", {"obj_view"})
+            ds = await _dataset(session, "ds")
+            exp_proj = await _project(session, f"Experiment-{token_hex(6)}", kind="EXPERIMENT")
+            await _experiment(session, dataset_id=ds, project_id=exp_proj)
+            await _tag(session, object_type=_DATASET, object_id=ds, key="env", value="prod")
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_DATASET,
+                object_id=None,
+                selector_kind="tag",
+                role_id=viewer,
+                tag_key="env",
+                tag_value="prod",
+            )
+        async with db() as session:
+            # Containment: the tag grant on the dataset flows to its experiment
+            # trace project through access-by-parent, on both paths.
+            assert exp_proj in await _accessible_ids(session, alice, _PROJECT, enabled=True)
+            assert exp_proj in await _predicate_ids(session, alice, _PROJECT, enabled=True)
+
+    async def test_subjects_for_lists_tag_grantee(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            member = await _role(session, "MEMBER", {"read"})
+            alice = await _user(session, member)
+            viewer = await _permission_set(session, "v", {"obj_view"})
+            ds = await _dataset(session, "ds")
+            await _tag(session, object_type=_DATASET, object_id=ds, key="env", value="prod")
+            await _grant(
+                session,
+                subject_kind="user",
+                subject_id=alice,
+                object_type=_DATASET,
+                object_id=None,
+                selector_kind="tag",
+                role_id=viewer,
+                tag_key="env",
+                tag_value="prod",
+            )
+        async with db() as session:
+            who = await subjects_for(session, _DATASET, ds)
+        assert Subject(SubjectKind.USER, alice) in who
+
+    async def test_delete_object_tags_sweeps_only_that_object(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            keep = await _dataset(session, "keep")
+            drop = await _dataset(session, "drop")
+            await _tag(session, object_type=_DATASET, object_id=keep, key="env", value="prod")
+            await _tag(session, object_type=_DATASET, object_id=drop, key="env", value="prod")
+        async with db() as session:
+            await delete_object_tags(session, _DATASET, drop)
+        async with db() as session:
+            surviving = set(
+                await session.scalars(
+                    select(models.ResourceTag.object_id).where(
+                        models.ResourceTag.object_type == _DATASET
+                    )
+                )
+            )
+        assert surviving == {keep}

--- a/tests/unit/server/access/test_permissions.py
+++ b/tests/unit/server/access/test_permissions.py
@@ -1,0 +1,117 @@
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from phoenix.server.access import (
+    BUILTIN_ROLE_PERMISSIONS,
+    Permission,
+    can,
+    permissions_for_role,
+)
+from phoenix.server.bearer_auth import PhoenixSystemUser, PhoenixUser
+from phoenix.server.types import ApiKeyAttributes, ApiKeyClaims, ApiKeyId, UserId
+
+
+class TestOracle:
+    @pytest.mark.parametrize(
+        "role, permission, expected",
+        [
+            ("SYSTEM", Permission.ADMINISTER, True),
+            ("ADMIN", Permission.ADMINISTER, True),
+            ("ADMIN", Permission.WRITE, True),
+            ("ADMIN", Permission.READ, True),
+            ("MEMBER", Permission.READ, True),
+            ("MEMBER", Permission.WRITE, True),
+            ("MEMBER", Permission.ADMINISTER, False),
+            ("VIEWER", Permission.READ, True),
+            ("VIEWER", Permission.WRITE, False),
+            ("VIEWER", Permission.ADMINISTER, False),
+        ],
+    )
+    def test_can(self, role: str, permission: Permission, expected: bool) -> None:
+        assert can(role, permission) is expected
+
+    def test_unknown_role_holds_nothing(self) -> None:
+        # The oracle fails closed for an unrecognized role.
+        assert permissions_for_role("AUDITOR") == frozenset()
+        assert can("AUDITOR", Permission.READ) is False
+
+    def test_every_role_can_read(self) -> None:
+        for role, permissions in BUILTIN_ROLE_PERMISSIONS.items():
+            assert Permission.READ in permissions, role
+
+    def test_only_viewer_lacks_write(self) -> None:
+        lacks_write = {
+            role
+            for role, perms in BUILTIN_ROLE_PERMISSIONS.items()
+            if Permission.WRITE not in perms
+        }
+        assert lacks_write == {"VIEWER"}
+
+    def test_administer_is_system_and_admin_only(self) -> None:
+        administers = {
+            role
+            for role, perms in BUILTIN_ROLE_PERMISSIONS.items()
+            if Permission.ADMINISTER in perms
+        }
+        assert administers == {"SYSTEM", "ADMIN"}
+
+
+def _api_key_user(role: str, expired: bool = False) -> PhoenixUser:
+    # A claim set is VALID when it has a subject + token_id and is unexpired;
+    # an expiration in the past makes it EXPIRED (status is derived, not set).
+    expiration = (
+        datetime.now(timezone.utc) - timedelta(hours=1)
+        if expired
+        else datetime.now(timezone.utc) + timedelta(hours=1)
+    )
+    claims = ApiKeyClaims(
+        subject=UserId(1),
+        token_id=ApiKeyId(1),
+        expiration_time=expiration,
+        attributes=ApiKeyAttributes(user_role=role, name="k"),  # type: ignore[arg-type]
+    )
+    return PhoenixUser(UserId(1), claims)
+
+
+class TestPhoenixUserResolvesThroughOracle:
+    @pytest.mark.parametrize(
+        "role, is_admin, is_viewer, can_write",
+        [
+            ("ADMIN", True, False, True),
+            ("MEMBER", False, False, True),
+            ("VIEWER", False, True, False),
+        ],
+    )
+    def test_role_properties(
+        self, role: str, is_admin: bool, is_viewer: bool, can_write: bool
+    ) -> None:
+        user = _api_key_user(role)
+        assert user.is_admin is is_admin
+        assert user.is_viewer is is_viewer
+        assert user.can(Permission.WRITE) is can_write
+
+    def test_invalid_claim_holds_no_permissions(self) -> None:
+        # An invalid claim set resolves to no permissions, and — preserving prior
+        # behavior — is treated as neither admin nor viewer.
+        user = _api_key_user("ADMIN", expired=True)
+        assert user.permissions == frozenset()
+        assert user.is_admin is False
+        assert user.is_viewer is False
+
+    def test_system_user_holds_everything(self) -> None:
+        system = PhoenixSystemUser(UserId(1))
+        assert system.is_admin is True
+        assert system.is_viewer is False
+        assert system.can(Permission.ADMINISTER) is True
+        assert system.can(Permission.WRITE) is True
+
+    def test_claim_status_does_not_widen(self) -> None:
+        valid = _api_key_user("VIEWER")
+        # A viewer never gains write, however the claim is read.
+        assert not valid.can(Permission.WRITE)
+        attributes = valid.claims.attributes
+        assert attributes is not None
+        elevated = replace(valid.claims, attributes=replace(attributes, user_role="ADMIN"))
+        assert PhoenixUser(UserId(1), elevated).can(Permission.WRITE)

--- a/tests/unit/server/access/test_subjects_groups_resolution.py
+++ b/tests/unit/server/access/test_subjects_groups_resolution.py
@@ -1,0 +1,208 @@
+from secrets import token_bytes, token_hex
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from phoenix.db import models
+from phoenix.server.access import (
+    Permission,
+    Subject,
+    SubjectKind,
+    permissions_for_user_id,
+    subjects_for_user,
+    sync_user_groups,
+)
+from phoenix.server.types import DbSessionFactory
+
+
+async def _role(session: AsyncSession, name: str, permissions: set[str]) -> int:
+    role = models.UserRole(name=name)
+    session.add(role)
+    await session.flush()
+    for permission in permissions:
+        session.add(models.RolePermission(user_role_id=role.id, permission=permission))
+    await session.flush()
+    return role.id
+
+
+async def _user(session: AsyncSession, role_id: int) -> int:
+    user = models.LocalUser(
+        user_role_id=role_id,
+        username=token_hex(8),
+        email=f"{token_hex(8)}@x.test",
+        reset_password=False,
+        password_salt=token_bytes(32),
+        password_hash=token_bytes(32),
+    )
+    session.add(user)
+    await session.flush()
+    return user.id
+
+
+class TestSyncUserGroups:
+    async def test_creates_groups_and_memberships(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            user_id = await _user(session, await _role(session, "MEMBER", {"read"}))
+            await sync_user_groups(
+                session,
+                user_id=user_id,
+                provider="oauth2:acme",
+                group_keys=["engineering", "all-staff"],
+            )
+        async with db() as session:
+            groups = {
+                g.group_key: g.provider for g in await session.scalars(select(models.UserGroup))
+            }
+            memberships = (await session.scalars(select(models.UserGroupMembership.user_id))).all()
+        assert groups == {"engineering": "oauth2:acme", "all-staff": "oauth2:acme"}
+        assert memberships == [user_id, user_id]
+
+    async def test_reconciles_added_and_removed(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            user_id = await _user(session, await _role(session, "MEMBER", {"read"}))
+            await sync_user_groups(session, user_id=user_id, provider="ldap", group_keys=["a", "b"])
+        async with db() as session:
+            # User left "b", joined "c".
+            await sync_user_groups(session, user_id=user_id, provider="ldap", group_keys=["a", "c"])
+        async with db() as session:
+            keys = {
+                g.group_key
+                for g in await session.scalars(
+                    select(models.UserGroup)
+                    .join(models.UserGroupMembership)
+                    .where(models.UserGroupMembership.user_id == user_id)
+                )
+            }
+        assert keys == {"a", "c"}
+
+    async def test_provider_isolation(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            user_id = await _user(session, await _role(session, "MEMBER", {"read"}))
+            await sync_user_groups(
+                session, user_id=user_id, provider="oauth2:acme", group_keys=["x"]
+            )
+            await sync_user_groups(session, user_id=user_id, provider="ldap", group_keys=["y"])
+        async with db() as session:
+            # Re-syncing one provider must not disturb memberships from another.
+            await sync_user_groups(session, user_id=user_id, provider="oauth2:acme", group_keys=[])
+        async with db() as session:
+            keys = {
+                g.group_key
+                for g in await session.scalars(
+                    select(models.UserGroup)
+                    .join(models.UserGroupMembership)
+                    .where(models.UserGroupMembership.user_id == user_id)
+                )
+            }
+        assert keys == {"y"}
+
+
+class TestSubjectsForUser:
+    async def test_includes_user_and_groups(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            user_id = await _user(session, await _role(session, "MEMBER", {"read"}))
+            await sync_user_groups(
+                session, user_id=user_id, provider="ldap", group_keys=["g1", "g2"]
+            )
+        async with db() as session:
+            subjects = await subjects_for_user(session, user_id)
+        assert Subject(SubjectKind.USER, user_id) in subjects
+        group_subjects = [s for s in subjects if s.kind is SubjectKind.GROUP]
+        assert len(group_subjects) == 2
+
+
+class TestPermissionsForUserId:
+    async def test_resolves_role_bundle(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            role_id = await _role(session, "MEMBER", {"read", "write"})
+            user_id = await _user(session, role_id)
+        async with db() as session:
+            perms = await permissions_for_user_id(session, user_id)
+        assert perms == {Permission.READ, Permission.WRITE}
+
+    async def test_permission_edit_takes_effect(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            role_id = await _role(session, "MEMBER", {"read", "write"})
+            user_id = await _user(session, role_id)
+        async with db() as session:
+            # An admin removes write from the role.
+            await session.execute(
+                delete(models.RolePermission).where(
+                    models.RolePermission.user_role_id == role_id,
+                    models.RolePermission.permission == "write",
+                )
+            )
+        async with db() as session:
+            perms = await permissions_for_user_id(session, user_id)
+        # Resolved live: the edit is visible without reissuing the user's token.
+        assert perms == {Permission.READ}
+
+    async def test_deleted_user_holds_nothing(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            user_id = await _user(session, await _role(session, "MEMBER", {"read"}))
+            await session.execute(delete(models.User).where(models.User.id == user_id))
+        async with db() as session:
+            perms = await permissions_for_user_id(session, user_id)
+        assert perms == frozenset()
+
+    async def test_unknown_permission_string_is_ignored(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            role_id = await _role(session, "MEMBER", {"read"})
+            session.add(models.RolePermission(user_role_id=role_id, permission="teleport"))
+            await session.flush()
+            user_id = await _user(session, role_id)
+        async with db() as session:
+            perms = await permissions_for_user_id(session, user_id)
+        # A permission this server doesn't know grants nothing here (fails closed).
+        assert perms == {Permission.READ}
+
+
+class TestObjectPermissionsForGrantRole:
+    async def _role(self, session: AsyncSession, name: str, perms: set[str]) -> int:
+        role = models.PermissionSet(name=name, is_built_in=False)
+        session.add(role)
+        await session.flush()
+        for perm in perms:
+            session.add(models.PermissionSetItem(permission_set_id=role.id, permission=perm))
+        await session.flush()
+        return role.id
+
+    async def test_none_role_is_view_only(self, db: DbSessionFactory) -> None:
+        from phoenix.server.access import object_permissions_for_grant_role
+
+        async with db() as session:
+            perms = await object_permissions_for_grant_role(session, None)
+        assert perms == {Permission.OBJ_VIEW}
+
+    async def test_resolves_role_permissions(self, db: DbSessionFactory) -> None:
+        from phoenix.server.access import object_permissions_for_grant_role
+
+        async with db() as session:
+            role_id = await self._role(session, "Editor", {"obj_view", "obj_edit"})
+        async with db() as session:
+            perms = await object_permissions_for_grant_role(session, role_id)
+        assert perms == {Permission.OBJ_VIEW, Permission.OBJ_EDIT}
+
+    async def test_replacing_permissions_has_no_unique_conflict(self, db: DbSessionFactory) -> None:
+        # The pattern the patch mutation relies on: delete-then-add lets a role keep
+        # a permission it already had without tripping the unique constraint.
+
+        async with db() as session:
+            role_id = await self._role(session, "R", {"obj_view", "obj_edit"})
+        async with db() as session:
+            await session.execute(
+                delete(models.PermissionSetItem).where(
+                    models.PermissionSetItem.permission_set_id == role_id
+                )
+            )
+            await session.flush()
+            session.add_all(
+                models.PermissionSetItem(permission_set_id=role_id, permission=p)
+                for p in ("obj_view", "obj_manage_access")
+            )
+            await session.flush()
+        async with db() as session:
+            from phoenix.server.access import object_permissions_for_grant_role
+
+            perms = await object_permissions_for_grant_role(session, role_id)
+        assert perms == {Permission.OBJ_VIEW, Permission.OBJ_MANAGE_ACCESS}

--- a/tests/unit/server/api/conftest.py
+++ b/tests/unit/server/api/conftest.py
@@ -468,13 +468,18 @@ async def dataset_with_experiments_without_runs(
     empty_dataset: Any,
 ) -> None:
     async with db() as session:
+        project_default = models.Project(name="default", kind="EXPERIMENT")
+        project_random = models.Project(name="random", kind="EXPERIMENT")
+        session.add_all([project_default, project_random])
+        await session.flush()
+
         experiment_0 = models.Experiment(
             id=0,
             dataset_id=1,
             dataset_version_id=1,
             name="test",
             repetitions=1,
-            project_name="default",
+            project_id=project_default.id,
             metadata_={"info": "a test experiment"},
         )
         session.add(experiment_0)
@@ -486,7 +491,7 @@ async def dataset_with_experiments_without_runs(
             dataset_version_id=2,
             name="second test",
             repetitions=1,
-            project_name="random",
+            project_id=project_random.id,
             metadata_={"info": "a second test experiment"},
         )
         session.add(experiment_1)

--- a/tests/unit/server/api/mutations/test_access_grant_mutations.py
+++ b/tests/unit/server/api/mutations/test_access_grant_mutations.py
@@ -1,0 +1,909 @@
+from secrets import token_bytes, token_hex
+from typing import Any, cast
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.schema import CheckConstraint, Table
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.db.types.identifier import Identifier
+from phoenix.server.access import (
+    OBJECT_TYPE_DATASET,
+    OBJECT_TYPE_PROJECT,
+    OBJECT_TYPE_PROMPT,
+    Permission,
+)
+from phoenix.server.api.exceptions import Conflict, NotFound
+from phoenix.server.api.mutations.access_grant_mutations import (
+    AccessGrantObjectInput,
+    AccessGrantSubjectInput,
+    _assert_revoke_keeps_a_manager,
+    _resolve_object_rowid,
+    _resolve_permission_set_id,
+    _resolve_subject_rowid,
+)
+from phoenix.server.api.types.AccessSubjectKind import AccessSubjectKind
+from phoenix.server.types import DbSessionFactory
+from tests.unit.graphql import AsyncGraphQLClient
+
+_USER = AccessSubjectKind.USER.value
+
+
+async def _permission_set(session: AsyncSession, permission: Permission) -> models.PermissionSet:
+    permission_set = models.PermissionSet(name=f"set-{token_hex(4)}", is_built_in=False)
+    session.add(permission_set)
+    await session.flush()
+    session.add(
+        models.PermissionSetItem(permission_set_id=permission_set.id, permission=permission.value)
+    )
+    await session.flush()
+    return permission_set
+
+
+def _grant(
+    *,
+    subject_id: int,
+    role_id: int,
+    object_type: str,
+    object_id: int,
+    selector_kind: str = "ids",
+) -> models.AccessGrant:
+    return models.AccessGrant(
+        subject_kind=_USER,
+        subject_id=subject_id,
+        role_id=role_id,
+        object_type=object_type,
+        object_id=object_id if selector_kind == "ids" else None,
+        selector_kind=selector_kind,
+        effect="allow",
+    )
+
+
+class TestResolveSubjectRowid:
+    async def test_accepts_existing_user_and_group(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            role = models.UserRole(name=f"r{token_hex(2)}")
+            session.add(role)
+            await session.flush()
+            user = models.LocalUser(
+                user_role_id=role.id,
+                username=token_hex(8),
+                email=f"{token_hex(8)}@x.test",
+                reset_password=False,
+                password_salt=token_bytes(32),
+                password_hash=token_bytes(32),
+            )
+            group = models.UserGroup(
+                provider="test",
+                group_key=f"team-{token_hex(4)}",
+                display_name="Team",
+            )
+            session.add_all([user, group])
+            await session.flush()
+
+            assert await _resolve_subject_rowid(
+                session,
+                AccessGrantSubjectInput(user_id=GlobalID("User", str(user.id))),
+            ) == (AccessSubjectKind.USER, user.id)
+            assert await _resolve_subject_rowid(
+                session,
+                AccessGrantSubjectInput(user_group_id=GlobalID("UserGroup", str(group.id))),
+            ) == (AccessSubjectKind.GROUP, group.id)
+            assert await _resolve_subject_rowid(
+                session,
+                AccessGrantSubjectInput(is_everyone=True),
+            ) == (AccessSubjectKind.EVERYONE, None)
+
+    async def test_rejects_missing_subject(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            with pytest.raises(NotFound, match="Unknown user"):
+                await _resolve_subject_rowid(
+                    session,
+                    AccessGrantSubjectInput(user_id=GlobalID("User", "999999")),
+                )
+            with pytest.raises(NotFound, match="Unknown group"):
+                await _resolve_subject_rowid(
+                    session,
+                    AccessGrantSubjectInput(user_group_id=GlobalID("UserGroup", "999999")),
+                )
+
+
+class TestResolveObjectRowid:
+    async def test_accepts_existing_project_dataset_and_prompt(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            project = models.Project(name=f"project-{token_hex(4)}")
+            dataset = models.Dataset(name=f"dataset-{token_hex(4)}")
+            prompt = models.Prompt(name=Identifier(f"prompt-{token_hex(4)}"))
+            session.add_all([project, dataset, prompt])
+            await session.flush()
+
+            assert await _resolve_object_rowid(
+                session,
+                AccessGrantObjectInput(dataset_id=GlobalID("Dataset", str(dataset.id))),
+            ) == (OBJECT_TYPE_DATASET, dataset.id)
+            assert await _resolve_object_rowid(
+                session,
+                AccessGrantObjectInput(project_id=GlobalID("Project", str(project.id))),
+            ) == (OBJECT_TYPE_PROJECT, project.id)
+            assert await _resolve_object_rowid(
+                session,
+                AccessGrantObjectInput(prompt_id=GlobalID("Prompt", str(prompt.id))),
+            ) == (OBJECT_TYPE_PROMPT, prompt.id)
+
+    async def test_rejects_missing_object(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            with pytest.raises(NotFound, match="Unknown dataset"):
+                await _resolve_object_rowid(
+                    session,
+                    AccessGrantObjectInput(dataset_id=GlobalID("Dataset", "999999")),
+                )
+            with pytest.raises(NotFound, match="Unknown project"):
+                await _resolve_object_rowid(
+                    session,
+                    AccessGrantObjectInput(project_id=GlobalID("Project", "999999")),
+                )
+            with pytest.raises(NotFound, match="Unknown prompt"):
+                await _resolve_object_rowid(
+                    session,
+                    AccessGrantObjectInput(prompt_id=GlobalID("Prompt", "999999")),
+                )
+
+
+class TestResolvePermissionSetId:
+    async def test_accepts_existing_permission_set_global_id(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            role = models.PermissionSet(name=f"Role-{token_hex(4)}", is_built_in=False)
+            session.add(role)
+            await session.flush()
+
+            assert (
+                await _resolve_permission_set_id(
+                    session,
+                    GlobalID("PermissionSet", str(role.id)),
+                )
+                == role.id
+            )
+
+    async def test_rejects_missing_permission_set_global_id(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            with pytest.raises(NotFound, match="Unknown permission set"):
+                await _resolve_permission_set_id(
+                    session,
+                    GlobalID("PermissionSet", "999999"),
+                )
+
+
+class TestWildcardTypeConstraint:
+    """A wildcard object_type ('*') is only coherent with the type-wide 'all' selector.
+    Object identity is the (type, id) pair, so an id-scoped '*' grant would alias every
+    row sharing that id across tables. The mutation API never writes such a row; the DB
+    check constraint is the backstop for hand-seeded / migrated rows."""
+
+    def test_constraint_is_declared_on_the_table(self) -> None:
+        # Enforcement is a platform guarantee once the CHECK is declared; asserting the
+        # declaration (rather than round-tripping a bad INSERT) keeps this deterministic
+        # across the sqlean/aiosqlite driver, whose failed-statement cursor re-raises on
+        # close. The positive round-trips below confirm the condition does not over-reject.
+        table = cast(Table, models.AccessGrant.__table__)
+        constraint = next(
+            (
+                c
+                for c in table.constraints
+                if "wildcard_type_requires_all_selector" in (getattr(c, "name", None) or "")
+            ),
+            None,
+        )
+        assert constraint is not None
+        assert isinstance(constraint, CheckConstraint)
+        condition = str(constraint.sqltext)
+        assert "object_type" in condition and "selector_kind" in condition
+
+    async def test_allows_wildcard_type_with_all_selector(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            session.add(
+                models.AccessGrant(
+                    subject_kind=_USER,
+                    subject_id=1,
+                    object_type="*",
+                    object_id=None,
+                    selector_kind="all",
+                    effect="allow",
+                )
+            )
+            await session.flush()  # does not raise
+
+    async def test_allows_concrete_type_with_ids_selector(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            session.add(
+                models.AccessGrant(
+                    subject_kind=_USER,
+                    subject_id=1,
+                    object_type=OBJECT_TYPE_PROJECT,
+                    object_id=5,
+                    selector_kind="ids",
+                    effect="allow",
+                )
+            )
+            await session.flush()  # does not raise
+
+
+class TestRevokeKeepsAManager:
+    """Revoking the last manager of an object with no owner would strand it (reachable only
+    by admins). The guard refuses that, the way a system refuses to delete its last admin."""
+
+    async def test_blocks_stranding_a_project(self, db: DbSessionFactory) -> None:
+        # A project has no creator; if its sole manager's grant is revoked, no non-admin
+        # could ever restore access — so the revoke is refused.
+        async with db() as session:
+            manager = await _permission_set(session, Permission.OBJ_MANAGE_ACCESS)
+            session.add(
+                _grant(
+                    subject_id=1, role_id=manager.id, object_type=OBJECT_TYPE_PROJECT, object_id=100
+                )
+            )
+            await session.flush()
+            with pytest.raises(Conflict, match="last manager"):
+                await _assert_revoke_keeps_a_manager(
+                    session, OBJECT_TYPE_PROJECT, 100, AccessSubjectKind.USER, 1
+                )
+
+    async def test_allows_when_another_id_manager_remains(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            manager = await _permission_set(session, Permission.OBJ_MANAGE_ACCESS)
+            session.add_all(
+                [
+                    _grant(
+                        subject_id=1,
+                        role_id=manager.id,
+                        object_type=OBJECT_TYPE_PROJECT,
+                        object_id=100,
+                    ),
+                    _grant(
+                        subject_id=2,
+                        role_id=manager.id,
+                        object_type=OBJECT_TYPE_PROJECT,
+                        object_id=100,
+                    ),
+                ]
+            )
+            await session.flush()
+            # A second manager remains, so revoking the first does not strand the object.
+            await _assert_revoke_keeps_a_manager(
+                session, OBJECT_TYPE_PROJECT, 100, AccessSubjectKind.USER, 1
+            )
+
+    async def test_allows_when_type_wide_all_manager_remains(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            manager = await _permission_set(session, Permission.OBJ_MANAGE_ACCESS)
+            session.add_all(
+                [
+                    _grant(
+                        subject_id=1,
+                        role_id=manager.id,
+                        object_type=OBJECT_TYPE_PROJECT,
+                        object_id=100,
+                    ),
+                    _grant(
+                        subject_id=2,
+                        role_id=manager.id,
+                        object_type=OBJECT_TYPE_PROJECT,
+                        object_id=100,
+                        selector_kind="all",
+                    ),
+                ]
+            )
+            await session.flush()
+            # A type-wide "all" manager still reaches the object.
+            await _assert_revoke_keeps_a_manager(
+                session, OBJECT_TYPE_PROJECT, 100, AccessSubjectKind.USER, 1
+            )
+
+    async def test_allows_revoking_a_non_manager_grant(self, db: DbSessionFactory) -> None:
+        # Revoking a viewer grant cannot reduce the manager count, so it is never blocked —
+        # even when it is the object's only grant.
+        async with db() as session:
+            viewer = await _permission_set(session, Permission.OBJ_VIEW)
+            session.add(
+                _grant(
+                    subject_id=1, role_id=viewer.id, object_type=OBJECT_TYPE_PROJECT, object_id=100
+                )
+            )
+            await session.flush()
+            await _assert_revoke_keeps_a_manager(
+                session, OBJECT_TYPE_PROJECT, 100, AccessSubjectKind.USER, 1
+            )
+
+    async def test_allows_when_object_has_a_creator(self, db: DbSessionFactory) -> None:
+        # A dataset with a live creator has a permanent, non-revocable manager, so revoking
+        # its sole manager grant does not strand it.
+        async with db() as session:
+            role = models.UserRole(name=f"r{token_hex(2)}")
+            session.add(role)
+            await session.flush()
+            user = models.LocalUser(
+                user_role_id=role.id,
+                username=token_hex(8),
+                email=f"{token_hex(8)}@x.test",
+                reset_password=False,
+                password_salt=token_bytes(32),
+                password_hash=token_bytes(32),
+            )
+            session.add(user)
+            await session.flush()
+            dataset = models.Dataset(name=f"dataset-{token_hex(4)}", user_id=user.id)
+            session.add(dataset)
+            await session.flush()
+            manager = await _permission_set(session, Permission.OBJ_MANAGE_ACCESS)
+            session.add(
+                _grant(
+                    subject_id=user.id,
+                    role_id=manager.id,
+                    object_type=OBJECT_TYPE_DATASET,
+                    object_id=dataset.id,
+                )
+            )
+            await session.flush()
+            await _assert_revoke_keeps_a_manager(
+                session, OBJECT_TYPE_DATASET, dataset.id, AccessSubjectKind.USER, user.id
+            )
+
+    async def test_blocks_stranding_a_dataset_whose_creator_was_deprovisioned(
+        self, db: DbSessionFactory
+    ) -> None:
+        # A dataset whose creator was deleted has user_id NULL (ON DELETE SET NULL), so it
+        # is ownerless like a project — its last manager must not be revoked.
+        async with db() as session:
+            dataset = models.Dataset(name=f"dataset-{token_hex(4)}", user_id=None)
+            session.add(dataset)
+            await session.flush()
+            manager = await _permission_set(session, Permission.OBJ_MANAGE_ACCESS)
+            session.add(
+                _grant(
+                    subject_id=1,
+                    role_id=manager.id,
+                    object_type=OBJECT_TYPE_DATASET,
+                    object_id=dataset.id,
+                )
+            )
+            await session.flush()
+            with pytest.raises(Conflict, match="last manager"):
+                await _assert_revoke_keeps_a_manager(
+                    session, OBJECT_TYPE_DATASET, dataset.id, AccessSubjectKind.USER, 1
+                )
+
+
+class TestDowngradePreservesManager:
+    """grant_access re-grants a subject in place, so downgrading the sole manager of an
+    ownerless object strips its last manager just as a revoke would — the same guard
+    applies via new_role_id (the role the grant is changing to)."""
+
+    async def test_blocks_downgrading_the_last_manager(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            manager = await _permission_set(session, Permission.OBJ_MANAGE_ACCESS)
+            viewer = await _permission_set(session, Permission.OBJ_VIEW)
+            session.add(
+                _grant(
+                    subject_id=1, role_id=manager.id, object_type=OBJECT_TYPE_PROJECT, object_id=100
+                )
+            )
+            await session.flush()
+            # Downgrading the sole manager to viewer would strand the ownerless project.
+            with pytest.raises(Conflict, match="last manager"):
+                await _assert_revoke_keeps_a_manager(
+                    session,
+                    OBJECT_TYPE_PROJECT,
+                    100,
+                    AccessSubjectKind.USER,
+                    1,
+                    new_role_id=viewer.id,
+                )
+
+    async def test_allows_downgrade_that_stays_a_manager(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            manager = await _permission_set(session, Permission.OBJ_MANAGE_ACCESS)
+            manager_2 = await _permission_set(session, Permission.OBJ_MANAGE_ACCESS)
+            session.add(
+                _grant(
+                    subject_id=1, role_id=manager.id, object_type=OBJECT_TYPE_PROJECT, object_id=100
+                )
+            )
+            await session.flush()
+            # The new role still confers manage, so this is not a downgrade — no strand.
+            await _assert_revoke_keeps_a_manager(
+                session,
+                OBJECT_TYPE_PROJECT,
+                100,
+                AccessSubjectKind.USER,
+                1,
+                new_role_id=manager_2.id,
+            )
+
+    async def test_allows_downgrade_when_another_manager_remains(
+        self, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            manager = await _permission_set(session, Permission.OBJ_MANAGE_ACCESS)
+            viewer = await _permission_set(session, Permission.OBJ_VIEW)
+            session.add_all(
+                [
+                    _grant(
+                        subject_id=1,
+                        role_id=manager.id,
+                        object_type=OBJECT_TYPE_PROJECT,
+                        object_id=100,
+                    ),
+                    _grant(
+                        subject_id=2,
+                        role_id=manager.id,
+                        object_type=OBJECT_TYPE_PROJECT,
+                        object_id=100,
+                    ),
+                ]
+            )
+            await session.flush()
+            # A second id-manager remains, so downgrading the first is allowed.
+            await _assert_revoke_keeps_a_manager(
+                session,
+                OBJECT_TYPE_PROJECT,
+                100,
+                AccessSubjectKind.USER,
+                1,
+                new_role_id=viewer.id,
+            )
+
+
+class TestTagManagerNotCountedAsSurvivor:
+    """A tag manager grant reaches the object, but its reach is object-manager-mutable
+    (any manager can drop the object's tag), so it is deliberately not counted as a
+    surviving manager — the guard stays strictly fail-safe against non-admin stranding."""
+
+    async def test_tag_manager_does_not_rescue_the_last_id_manager(
+        self, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            manager = await _permission_set(session, Permission.OBJ_MANAGE_ACCESS)
+            # Sole id-manager on an ownerless project...
+            session.add(
+                _grant(
+                    subject_id=1, role_id=manager.id, object_type=OBJECT_TYPE_PROJECT, object_id=100
+                )
+            )
+            # ...plus a tag manager grant that also confers manage on projects.
+            session.add(
+                models.AccessGrant(
+                    subject_kind=_USER,
+                    subject_id=2,
+                    role_id=manager.id,
+                    object_type=OBJECT_TYPE_PROJECT,
+                    object_id=None,
+                    selector_kind="tag",
+                    tag_key="env",
+                    tag_value="prod",
+                    effect="allow",
+                )
+            )
+            await session.flush()
+            # The tag grant is not durable, so the revoke is still refused.
+            with pytest.raises(Conflict, match="last manager"):
+                await _assert_revoke_keeps_a_manager(
+                    session, OBJECT_TYPE_PROJECT, 100, AccessSubjectKind.USER, 1
+                )
+
+
+async def _project(session: AsyncSession, name: str) -> int:
+    project = models.Project(name=name, kind="TELEMETRY")
+    session.add(project)
+    await session.flush()
+    return project.id
+
+
+async def _local_user(session: AsyncSession) -> int:
+    role = models.UserRole(name=f"r{token_hex(2)}")
+    session.add(role)
+    await session.flush()
+    user = models.LocalUser(
+        user_role_id=role.id,
+        username=token_hex(8),
+        email=f"{token_hex(8)}@x.test",
+        reset_password=False,
+        password_salt=token_bytes(32),
+        password_hash=token_bytes(32),
+    )
+    session.add(user)
+    await session.flush()
+    return user.id
+
+
+class TestResourceTagMutations:
+    """End-to-end coverage of setResourceTag / removeResourceTag through the schema.
+    Auth is off in unit tests, so the OBJ_MANAGE_ACCESS gate is exercised in the
+    integration suite; these lock the data effects and idempotency."""
+
+    _SET = """
+      mutation($input: ResourceTagInput!) {
+        setResourceTag(input: $input) { query { __typename } }
+      }
+    """
+    _REMOVE = """
+      mutation($input: ResourceTagInput!) {
+        removeResourceTag(input: $input) { query { __typename } }
+      }
+    """
+
+    async def _tags(self, db: DbSessionFactory, project_id: int) -> list[tuple[str, str]]:
+        async with db() as session:
+            rows = await session.execute(
+                select(models.ResourceTag.key, models.ResourceTag.value).where(
+                    models.ResourceTag.object_type == OBJECT_TYPE_PROJECT,
+                    models.ResourceTag.object_id == project_id,
+                )
+            )
+        return [(k, v) for k, v in rows]
+
+    async def test_set_tags_the_object(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            pid = await _project(session, "p")
+        obj = {"projectId": str(GlobalID("Project", str(pid)))}
+        response = await gql_client.execute(
+            query=self._SET, variables={"input": {"object": obj, "key": "env", "value": "prod"}}
+        )
+        assert not response.errors
+        assert await self._tags(db, pid) == [("env", "prod")]
+
+    async def test_set_is_idempotent_and_updates_value(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            pid = await _project(session, "p")
+        obj = {"projectId": str(GlobalID("Project", str(pid)))}
+        for value in ("prod", "staging"):
+            response = await gql_client.execute(
+                query=self._SET, variables={"input": {"object": obj, "key": "env", "value": value}}
+            )
+            assert not response.errors
+        # One row per (object, key) — the second set overwrote the value.
+        assert await self._tags(db, pid) == [("env", "staging")]
+
+    async def test_remove_deletes_the_tag(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            pid = await _project(session, "p")
+        obj = {"projectId": str(GlobalID("Project", str(pid)))}
+        await gql_client.execute(
+            query=self._SET, variables={"input": {"object": obj, "key": "env", "value": "prod"}}
+        )
+        response = await gql_client.execute(
+            query=self._REMOVE, variables={"input": {"object": obj, "key": "env"}}
+        )
+        assert not response.errors
+        assert await self._tags(db, pid) == []
+
+
+class TestTagAccessGrantMutations:
+    """End-to-end coverage of grantTagAccess / revokeTagAccess through the schema."""
+
+    _GRANT = """
+      mutation($input: TagAccessGrantInput!) {
+        grantTagAccess(input: $input) { query { __typename } }
+      }
+    """
+    _REVOKE = """
+      mutation($input: TagAccessGrantInput!) {
+        revokeTagAccess(input: $input) { query { __typename } }
+      }
+    """
+
+    async def _tag_grants(
+        self, db: DbSessionFactory, subject_id: int
+    ) -> list[tuple[str, str, str]]:
+        async with db() as session:
+            rows = await session.execute(
+                select(
+                    models.AccessGrant.object_type,
+                    models.AccessGrant.tag_key,
+                    models.AccessGrant.tag_value,
+                ).where(
+                    models.AccessGrant.subject_kind == _USER,
+                    models.AccessGrant.subject_id == subject_id,
+                    models.AccessGrant.selector_kind == "tag",
+                )
+            )
+        return [(t, k, v) for t, k, v in rows]
+
+    def _input(self, subject_id: int, role_gid: str) -> dict[str, Any]:
+        return {
+            "subject": {"userId": str(GlobalID("User", str(subject_id)))},
+            "objectType": "DATASET",
+            "tagKey": "env",
+            "tagValue": "prod",
+            "permissionSetId": role_gid,
+        }
+
+    async def test_grant_creates_a_type_scoped_tag_grant(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            uid = await _local_user(session)
+            viewer = await _permission_set(session, Permission.OBJ_VIEW)
+        role_gid = str(GlobalID("PermissionSet", str(viewer.id)))
+        response = await gql_client.execute(
+            query=self._GRANT, variables={"input": self._input(uid, role_gid)}
+        )
+        assert not response.errors
+        assert await self._tag_grants(db, uid) == [(OBJECT_TYPE_DATASET, "env", "prod")]
+
+    async def test_grant_is_idempotent(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            uid = await _local_user(session)
+            viewer = await _permission_set(session, Permission.OBJ_VIEW)
+        role_gid = str(GlobalID("PermissionSet", str(viewer.id)))
+        for _ in range(2):
+            response = await gql_client.execute(
+                query=self._GRANT, variables={"input": self._input(uid, role_gid)}
+            )
+            assert not response.errors
+        assert await self._tag_grants(db, uid) == [(OBJECT_TYPE_DATASET, "env", "prod")]
+
+    async def test_revoke_deletes_the_tag_grant(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            uid = await _local_user(session)
+            viewer = await _permission_set(session, Permission.OBJ_VIEW)
+        role_gid = str(GlobalID("PermissionSet", str(viewer.id)))
+        await gql_client.execute(query=self._GRANT, variables={"input": self._input(uid, role_gid)})
+        response = await gql_client.execute(
+            query=self._REVOKE, variables={"input": self._input(uid, role_gid)}
+        )
+        assert not response.errors
+        assert await self._tag_grants(db, uid) == []
+
+    async def test_grant_rejects_a_manage_conferring_permission_set(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        # A tag grant may confer view/edit, never manage — a manage-conferring tag grant
+        # would give a non-admin a one-step strand path (drop the tag). Authoring is refused.
+        async with db() as session:
+            uid = await _local_user(session)
+            manager = await _permission_set(session, Permission.OBJ_MANAGE_ACCESS)
+        role_gid = str(GlobalID("PermissionSet", str(manager.id)))
+        response = await gql_client.execute(
+            query=self._GRANT, variables={"input": self._input(uid, role_gid)}
+        )
+        assert response.errors is not None
+        assert "manage-access" in str(response.errors)
+        # Nothing was written.
+        assert await self._tag_grants(db, uid) == []
+
+
+class TestResourceTagsQuery:
+    """The resourceTags query — the read-back for setResourceTag / removeResourceTag."""
+
+    _QUERY = """
+      query($objectType: AccessObjectType!, $objectId: ID!) {
+        resourceTags(objectType: $objectType, objectId: $objectId) { key value }
+      }
+    """
+
+    async def test_lists_an_objects_tags_sorted_by_key(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            pid = await _project(session, "p")
+            # Insert out of key order to prove the query sorts.
+            session.add_all(
+                [
+                    models.ResourceTag(
+                        object_type=OBJECT_TYPE_PROJECT, object_id=pid, key="tier", value="gold"
+                    ),
+                    models.ResourceTag(
+                        object_type=OBJECT_TYPE_PROJECT, object_id=pid, key="env", value="prod"
+                    ),
+                ]
+            )
+            await session.flush()
+        response = await gql_client.execute(
+            query=self._QUERY,
+            variables={"objectType": "PROJECT", "objectId": str(GlobalID("Project", str(pid)))},
+        )
+        assert not response.errors
+        assert response.data is not None
+        assert response.data["resourceTags"] == [
+            {"key": "env", "value": "prod"},
+            {"key": "tier", "value": "gold"},
+        ]
+
+    async def test_empty_when_object_has_no_tags(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            pid = await _project(session, "p")
+        response = await gql_client.execute(
+            query=self._QUERY,
+            variables={"objectType": "PROJECT", "objectId": str(GlobalID("Project", str(pid)))},
+        )
+        assert not response.errors
+        assert response.data is not None
+        assert response.data["resourceTags"] == []
+
+    async def test_unknown_object_is_rejected(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            pid = await _project(session, "p")
+        response = await gql_client.execute(
+            query=self._QUERY,
+            # A well-formed Project id that names no row.
+            variables={
+                "objectType": "PROJECT",
+                "objectId": str(GlobalID("Project", str(pid + 10_000))),
+            },
+        )
+        assert response.errors is not None
+        assert "Unknown Project" in str(response.errors)
+
+
+class TestTagGrantsQuery:
+    """The tagGrants query — the read-back for grantTagAccess / revokeTagAccess."""
+
+    _QUERY = """
+      query($objectType: AccessObjectType) {
+        tagGrants(objectType: $objectType) {
+          subjectKind subjectId subjectName objectType tagKey tagValue roleName
+        }
+      }
+    """
+
+    async def test_lists_tag_grants_with_subject_and_role(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            uid = await _local_user(session)
+            email = await session.scalar(select(models.User.email).where(models.User.id == uid))
+            viewer = await _permission_set(session, Permission.OBJ_VIEW)
+            session.add(
+                models.AccessGrant(
+                    subject_kind=_USER,
+                    subject_id=uid,
+                    role_id=viewer.id,
+                    object_type=OBJECT_TYPE_DATASET,
+                    object_id=None,
+                    selector_kind="tag",
+                    tag_key="env",
+                    tag_value="prod",
+                    effect="allow",
+                )
+            )
+            await session.flush()
+        response = await gql_client.execute(query=self._QUERY, variables={"objectType": None})
+        assert not response.errors
+        assert response.data is not None
+        # subjectName resolves the subject to a display name (here, the user's email).
+        assert response.data["tagGrants"] == [
+            {
+                "subjectKind": "USER",
+                "subjectId": str(GlobalID("User", str(uid))),
+                "subjectName": email,
+                "objectType": "DATASET",
+                "tagKey": "env",
+                "tagValue": "prod",
+                "roleName": viewer.name,
+            }
+        ]
+
+    async def test_object_type_filter_excludes_other_types(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            uid = await _local_user(session)
+            viewer = await _permission_set(session, Permission.OBJ_VIEW)
+            session.add_all(
+                [
+                    models.AccessGrant(
+                        subject_kind=_USER,
+                        subject_id=uid,
+                        role_id=viewer.id,
+                        object_type=OBJECT_TYPE_DATASET,
+                        object_id=None,
+                        selector_kind="tag",
+                        tag_key="env",
+                        tag_value="prod",
+                        effect="allow",
+                    ),
+                    models.AccessGrant(
+                        subject_kind=_USER,
+                        subject_id=uid,
+                        role_id=viewer.id,
+                        object_type=OBJECT_TYPE_PROJECT,
+                        object_id=None,
+                        selector_kind="tag",
+                        tag_key="env",
+                        tag_value="prod",
+                        effect="allow",
+                    ),
+                ]
+            )
+            await session.flush()
+        response = await gql_client.execute(query=self._QUERY, variables={"objectType": "PROJECT"})
+        assert not response.errors
+        assert response.data is not None
+        assert [g["objectType"] for g in response.data["tagGrants"]] == ["PROJECT"]
+
+    async def test_ordinary_id_grants_are_not_listed(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        # tagGrants must show tag-selector grants only; an ordinary id grant carries no
+        # tag_key/tag_value and belongs to access_grants, not here.
+        async with db() as session:
+            pid = await _project(session, "p")
+            uid = await _local_user(session)
+            viewer = await _permission_set(session, Permission.OBJ_VIEW)
+            session.add(
+                _grant(
+                    subject_id=uid,
+                    role_id=viewer.id,
+                    object_type=OBJECT_TYPE_PROJECT,
+                    object_id=pid,
+                )
+            )
+            await session.flush()
+        response = await gql_client.execute(query=self._QUERY, variables={"objectType": None})
+        assert not response.errors
+        assert response.data is not None
+        assert response.data["tagGrants"] == []
+
+
+class TestGrantAccessDowngradeEndToEnd:
+    """The last-manager guard must fire through the schema, not just at the helper."""
+
+    _GRANT = """
+      mutation($input: AccessGrantInput!) {
+        grantAccess(input: $input) { query { __typename } }
+      }
+    """
+
+    async def test_downgrading_the_last_manager_is_rejected(
+        self, gql_client: AsyncGraphQLClient, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            pid = await _project(session, "p")
+            uid = await _local_user(session)
+            manager = await _permission_set(session, Permission.OBJ_MANAGE_ACCESS)
+            viewer = await _permission_set(session, Permission.OBJ_VIEW)
+            # Seed the subject as the project's sole manager.
+            session.add(
+                _grant(
+                    subject_id=uid,
+                    role_id=manager.id,
+                    object_type=OBJECT_TYPE_PROJECT,
+                    object_id=pid,
+                )
+            )
+            await session.flush()
+        variables = {
+            "input": {
+                "subject": {"userId": str(GlobalID("User", str(uid)))},
+                "object": {"projectId": str(GlobalID("Project", str(pid)))},
+                "permissionSetId": str(GlobalID("PermissionSet", str(viewer.id))),
+            }
+        }
+        response = await gql_client.execute(query=self._GRANT, variables=variables)
+        assert response.errors is not None
+        assert "last manager" in str(response.errors)
+        # The grant was not downgraded — it remains a manager.
+        async with db() as session:
+            role_id = await session.scalar(
+                select(models.AccessGrant.role_id).where(
+                    models.AccessGrant.subject_id == uid,
+                    models.AccessGrant.object_type == OBJECT_TYPE_PROJECT,
+                    models.AccessGrant.object_id == pid,
+                )
+            )
+        assert role_id == manager.id

--- a/tests/unit/server/api/mutations/test_trace_transfer_mutations.py
+++ b/tests/unit/server/api/mutations/test_trace_transfer_mutations.py
@@ -95,6 +95,121 @@ class TestTraceTransferMutationMixin:
             ).all()
             assert len(span_costs) == 2
 
+    async def test_transfer_merges_into_destination_session_of_the_same_id(
+        self,
+        gql_client: AsyncGraphQLClient,
+        trace_transfer_fixture: dict[str, int],
+        db: DbSessionFactory,
+    ) -> None:
+        """When the destination already has a session with the moved trace's session_id, the
+        trace joins *that* session (not the source's, and not a duplicate), widening its
+        window. Sessions are unique per (project, session_id), so a merge is the only option."""
+        dest_project_id = trace_transfer_fixture["dest_project_id"]
+        trace1_id = trace_transfer_fixture["trace1_id"]
+        trace2_id = trace_transfer_fixture["trace2_id"]
+
+        async with db() as session:
+            src_session_rowid = await session.scalar(
+                select(models.Trace.project_session_rowid).where(models.Trace.id == trace1_id)
+            )
+            # The destination already has a session of the same id (a later window).
+            dest_session_rowid = await session.scalar(
+                insert(models.ProjectSession)
+                .values(
+                    session_id="test-session-1",
+                    project_id=dest_project_id,
+                    start_time=datetime.fromisoformat("2021-01-01T00:05:00.000+00:00"),
+                    end_time=datetime.fromisoformat("2021-01-01T00:06:00.000+00:00"),
+                )
+                .returning(models.ProjectSession.id)
+            )
+
+        # Transfer only trace1 (trace2 stays, keeping the source session alive).
+        result = await gql_client.execute(
+            self.TRANSFER_TRACES_MUTATION,
+            variables={
+                "traceIds": [str(GlobalID("Trace", str(trace1_id)))],
+                "projectId": str(GlobalID("Project", str(dest_project_id))),
+            },
+        )
+        assert not result.errors
+
+        async with db() as session:
+            trace1 = await session.get(models.Trace, trace1_id)
+            assert trace1 is not None
+            # Joined the destination's existing session — not the source's, not a new one.
+            assert trace1.project_rowid == dest_project_id
+            assert trace1.project_session_rowid == dest_session_rowid
+            # Still exactly one "test-session-1" in the destination project.
+            dest_sessions = (
+                await session.scalars(
+                    select(models.ProjectSession.id).where(
+                        models.ProjectSession.project_id == dest_project_id,
+                        models.ProjectSession.session_id == "test-session-1",
+                    )
+                )
+            ).all()
+            assert list(dest_sessions) == [dest_session_rowid]
+            # Its window widened to cover the moved trace (trace1 starts at 00:00).
+            dest_session = await session.get(models.ProjectSession, dest_session_rowid)
+            assert dest_session is not None
+            assert dest_session.start_time == datetime.fromisoformat(
+                "2021-01-01T00:00:00.000+00:00"
+            )
+            # The source session survives — trace2 still references it.
+            trace2 = await session.get(models.Trace, trace2_id)
+            assert trace2 is not None
+            assert trace2.project_session_rowid == src_session_rowid
+            assert await session.get(models.ProjectSession, src_session_rowid) is not None
+
+    async def test_transfer_moves_session_and_sweeps_emptied_source(
+        self,
+        gql_client: AsyncGraphQLClient,
+        trace_transfer_fixture: dict[str, int],
+        db: DbSessionFactory,
+    ) -> None:
+        """With no collision, moving every trace of a session re-creates it in the destination
+        and sweeps the now-empty source session."""
+        dest_project_id = trace_transfer_fixture["dest_project_id"]
+        trace1_id = trace_transfer_fixture["trace1_id"]
+        trace2_id = trace_transfer_fixture["trace2_id"]
+
+        async with db() as session:
+            src_session_rowid = await session.scalar(
+                select(models.Trace.project_session_rowid).where(models.Trace.id == trace1_id)
+            )
+
+        result = await gql_client.execute(
+            self.TRANSFER_TRACES_MUTATION,
+            variables={
+                "traceIds": [
+                    str(GlobalID("Trace", str(trace1_id))),
+                    str(GlobalID("Trace", str(trace2_id))),
+                ],
+                "projectId": str(GlobalID("Project", str(dest_project_id))),
+            },
+        )
+        assert not result.errors
+
+        async with db() as session:
+            # Source session swept (no traces remain).
+            assert await session.get(models.ProjectSession, src_session_rowid) is None
+            # Destination has a session of the same id, holding both moved traces.
+            dest_session = await session.scalar(
+                select(models.ProjectSession).where(
+                    models.ProjectSession.project_id == dest_project_id,
+                    models.ProjectSession.session_id == "test-session-1",
+                )
+            )
+            assert dest_session is not None
+            traces = (
+                await session.scalars(
+                    select(models.Trace).where(models.Trace.id.in_([trace1_id, trace2_id]))
+                )
+            ).all()
+            assert all(t.project_rowid == dest_project_id for t in traces)
+            assert all(t.project_session_rowid == dest_session.id for t in traces)
+
     async def test_transfer_traces_fails_with_non_existent_trace_id(
         self,
         gql_client: AsyncGraphQLClient,

--- a/tests/unit/server/api/mutations/test_user_group_mutations.py
+++ b/tests/unit/server/api/mutations/test_user_group_mutations.py
@@ -1,0 +1,56 @@
+"""GraphQL admin-gating for the local-group mutations + query.
+
+The happy-path logic (create / delete-sweep / membership over the `user_groups` and
+`acls` tables) is exercised by the REST suite (`routers/v1/test_access.py`) against the
+identical models — `require_admin` is open when auth is disabled, so those tests can run
+it. The local-group GraphQL mutations use ``IsAdmin``, which is *closed* when auth is
+disabled, so the default client cannot reach the resolver body — what a unit test can assert
+here is that the surface exists with the right shape and is admin-gated.
+"""
+
+from tests.unit.graphql import AsyncGraphQLClient
+
+_CREATE = """
+mutation ($name: String!) {
+  createUserGroup(name: $name) { userGroup { groupId name provider isLocal memberUserIds } }
+}
+"""
+_DELETE = "mutation ($g: Int!) { deleteUserGroup(groupId: $g) { query { __typename } } }"
+_ADD = """
+mutation ($g: Int!, $u: Int!) {
+  addUserGroupMember(groupId: $g, userId: $u) { userGroup { groupId memberUserIds } }
+}
+"""
+_REMOVE = """
+mutation ($g: Int!, $u: Int!) {
+  removeUserGroupMember(groupId: $g, userId: $u) { userGroup { groupId memberUserIds } }
+}
+"""
+_LIST = """
+query ($localOnly: Boolean!) {
+  userGroups(localOnly: $localOnly) { groupId name isLocal memberUserIds }
+}
+"""
+
+
+def _is_admin_error(result: object) -> bool:
+    errors = getattr(result, "errors", None)
+    return bool(errors) and "admin" in str(errors).lower()
+
+
+class TestUserGroupSurfaceIsAdminGated:
+    async def test_mutations_require_admin(self, gql_client: AsyncGraphQLClient) -> None:
+        # Each mutation exists with the right input shape (no validation error) and is
+        # rejected for the non-admin default client (the admin guard, not a 400).
+        for query, variables in (
+            (_CREATE, {"name": "team-x"}),
+            (_DELETE, {"g": 1}),
+            (_ADD, {"g": 1, "u": 1}),
+            (_REMOVE, {"g": 1, "u": 1}),
+        ):
+            result = await gql_client.execute(query, variables)
+            assert _is_admin_error(result), (query, result.errors)
+
+    async def test_query_requires_admin(self, gql_client: AsyncGraphQLClient) -> None:
+        result = await gql_client.execute(_LIST, {"localOnly": True})
+        assert _is_admin_error(result), result.errors

--- a/tests/unit/server/api/routers/v1/test_access.py
+++ b/tests/unit/server/api/routers/v1/test_access.py
@@ -1,0 +1,597 @@
+from secrets import token_bytes, token_hex
+
+import httpx
+import pytest
+from sqlalchemy import insert, select
+from starlette.types import ASGIApp
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+_ADMIN_SECRET = "unit-test-admin-secret-0123456789abcdef0123456789"
+
+
+@pytest.fixture(autouse=True)
+def _enable_access_control(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Access control requires authentication (the boot guard refuses access-on + auth-off),
+    # so these tests run an auth- and access-enabled app; the client below acts as an admin.
+    monkeypatch.setenv("PHOENIX_ENABLE_AUTH", "true")
+    monkeypatch.setenv("PHOENIX_ACCESS_CONTROL_ENABLED", "true")
+    monkeypatch.setenv("PHOENIX_SECRET", "unit-test-phoenix-secret-0123456789abcdef0123456789")
+    monkeypatch.setenv("PHOENIX_ADMIN_SECRET", _ADMIN_SECRET)
+
+
+@pytest.fixture
+def httpx_client(asgi_app: ASGIApp) -> httpx.AsyncClient:
+    # Authenticate as an administrator (SYSTEM) via the admin-secret bearer token.
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=asgi_app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {_ADMIN_SECRET}"},
+    )
+
+
+def _gid(type_name: str, rowid: int) -> str:
+    return str(GlobalID(type_name, str(rowid)))
+
+
+def _rowid(gid: str) -> int:
+    return int(GlobalID.from_id(gid).node_id)
+
+
+async def _project(db: DbSessionFactory, name: str) -> int:
+    async with db() as session:
+        rowid = await session.scalar(
+            insert(models.Project).values(name=name).returning(models.Project.id)
+        )
+    assert rowid is not None
+    return rowid
+
+
+async def _user(db: DbSessionFactory) -> int:
+    async with db() as session:
+        role = models.UserRole(name=f"r{token_hex(2)}")
+        session.add(role)
+        await session.flush()
+        user = models.LocalUser(
+            user_role_id=role.id,
+            username=token_hex(8),
+            email=f"{token_hex(8)}@x.test",
+            reset_password=False,
+            password_salt=token_bytes(32),
+            password_hash=token_bytes(32),
+        )
+        session.add(user)
+        await session.flush()
+        return user.id
+
+
+async def _group(db: DbSessionFactory, key: str) -> int:
+    async with db() as session:
+        gid = await session.scalar(
+            insert(models.UserGroup)
+            .values(provider="test", group_key=key, display_name=key)
+            .returning(models.UserGroup.id)
+        )
+    assert gid is not None
+    return gid
+
+
+class TestAccessGrants:
+    async def test_grant_lifecycle(
+        self, httpx_client: httpx.AsyncClient, db: DbSessionFactory
+    ) -> None:
+        project_id = await _project(db, f"p-{token_hex(4)}")
+        group_id = await _group(db, f"team-{token_hex(4)}")
+        object_gid = _gid("Project", project_id)
+        group_gid = _gid("UserGroup", group_id)
+
+        # Author a grant: the group may read the project. All ids are GlobalIDs.
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={
+                "subject": {"kind": "group", "id": group_gid},
+                "object_type": "project",
+                "object_id": object_gid,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        grant = resp.json()["data"]
+        assert grant["subject"] == {"kind": "group", "id": group_gid}
+        assert grant["object_id"] == object_gid
+        grant_gid = grant["id"]
+        assert _rowid(grant_gid)  # it's a real AccessGrant GlobalID
+
+        # Re-granting is idempotent — same id.
+        resp2 = await httpx_client.post(
+            "v1/access/grants",
+            json={
+                "subject": {"kind": "group", "id": group_gid},
+                "object_type": "project",
+                "object_id": object_gid,
+            },
+        )
+        assert resp2.json()["data"]["id"] == grant_gid
+
+        # List, filtered to the object.
+        resp = await httpx_client.get(
+            "v1/access/grants", params={"object_type": "project", "object_id": object_gid}
+        )
+        assert [g["id"] for g in resp.json()["data"]] == [grant_gid]
+
+        # The audit read: who can see the project?
+        resp = await httpx_client.get(f"v1/access/objects/project/{object_gid}/subjects")
+        assert resp.status_code == 200, resp.text
+        assert {"kind": "group", "id": group_gid} in resp.json()["data"]
+
+        # Revoke, then it's gone.
+        resp = await httpx_client.delete(f"v1/access/grants/{grant_gid}")
+        assert resp.status_code == 204, resp.text
+        resp = await httpx_client.get(
+            "v1/access/grants", params={"object_type": "project", "object_id": object_gid}
+        )
+        assert resp.json()["data"] == []
+        async with db() as session:
+            assert (
+                await session.scalar(
+                    select(models.AccessGrant.id).where(models.AccessGrant.id == _rowid(grant_gid))
+                )
+            ) is None
+
+    async def test_list_grants_excludes_tag_grants(
+        self, httpx_client: httpx.AsyncClient, db: DbSessionFactory
+    ) -> None:
+        # A tag grant carries a grantable object_type and a null object_id, so it would
+        # otherwise surface in the ordinary grant list serialized as a fake all-of-type grant
+        # with its key=value dropped. The ordinary list must show only ids/all grants; tag
+        # grants belong to /access/tag-grants.
+        project_id = await _project(db, f"p-{token_hex(4)}")
+        group_gid = _gid("UserGroup", await _group(db, f"team-{token_hex(4)}"))
+
+        ids_grant = await httpx_client.post(
+            "v1/access/grants",
+            json={
+                "subject": {"kind": "group", "id": group_gid},
+                "object_type": "project",
+                "object_id": _gid("Project", project_id),
+            },
+        )
+        assert ids_grant.status_code == 200, ids_grant.text
+        ids_grant_gid = ids_grant.json()["data"]["id"]
+
+        tag_grant = await httpx_client.post(
+            "v1/access/tag-grants",
+            json={
+                "subject": {"kind": "group", "id": group_gid},
+                "object_type": "project",
+                "tag_key": "env",
+                "tag_value": "prod",
+            },
+        )
+        assert tag_grant.status_code == 200, tag_grant.text
+        tag_grant_gid = tag_grant.json()["data"]["id"]
+
+        # The ordinary list shows the id grant but not the tag grant.
+        listed = await httpx_client.get("v1/access/grants", params={"object_type": "project"})
+        assert listed.status_code == 200, listed.text
+        listed_ids = {g["id"] for g in listed.json()["data"]}
+        assert ids_grant_gid in listed_ids
+        assert tag_grant_gid not in listed_ids
+
+        # The tag grant is visible on its own endpoint, key=value intact.
+        tags = await httpx_client.get("v1/access/tag-grants", params={"object_type": "project"})
+        listed_tag = next(g for g in tags.json()["data"] if g["id"] == tag_grant_gid)
+        assert listed_tag["tag_key"] == "env"
+        assert listed_tag["tag_value"] == "prod"
+
+    async def test_everyone_grant_makes_object_public(
+        self, httpx_client: httpx.AsyncClient, db: DbSessionFactory
+    ) -> None:
+        project_id = await _project(db, f"p-{token_hex(4)}")
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={
+                "subject": {"kind": "everyone"},
+                "object_type": "project",
+                "object_id": _gid("Project", project_id),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["subject"] == {"kind": "everyone", "id": None}
+
+    async def test_validation(self, httpx_client: httpx.AsyncClient, db: DbSessionFactory) -> None:
+        project_id = await _project(db, f"p-{token_hex(4)}")
+        object_gid = _gid("Project", project_id)
+        a_user = _gid("User", 1)
+
+        # everyone must not carry an id.
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={"subject": {"kind": "everyone", "id": a_user}, "object_type": "project"},
+        )
+        assert resp.status_code == 422, resp.text
+
+        # a user subject must carry an id.
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={"subject": {"kind": "user"}, "object_type": "project", "object_id": object_gid},
+        )
+        assert resp.status_code == 422, resp.text
+
+        # a subject id of the wrong type is rejected (a Project GlobalID where a User is expected).
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={
+                "subject": {"kind": "user", "id": object_gid},
+                "object_type": "project",
+                "object_id": object_gid,
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+        # an ungrantable object type is rejected by the enum.
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={"subject": {"kind": "user", "id": a_user}, "object_type": "span"},
+        )
+        assert resp.status_code == 422, resp.text
+
+        # a grant on a nonexistent object is not-found.
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={
+                "subject": {"kind": "user", "id": a_user},
+                "object_type": "project",
+                "object_id": _gid("Project", 999999),
+            },
+        )
+        assert resp.status_code == 404, resp.text
+
+    async def test_rejects_unresolvable_subjects_and_unknown_roles(
+        self, httpx_client: httpx.AsyncClient, db: DbSessionFactory
+    ) -> None:
+        project_id = await _project(db, f"p-{token_hex(4)}")
+        object_gid = _gid("Project", project_id)
+        user_id = await _user(db)
+
+        # A subject whose GlobalID is well-formed but references no row is not-found: the id
+        # shape alone does not prove the user exists.
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={
+                "subject": {"kind": "user", "id": _gid("User", 999999)},
+                "object_type": "project",
+                "object_id": object_gid,
+            },
+        )
+        assert resp.status_code == 404, resp.text
+
+        # service_account subjects are reserved but have no identity lifecycle yet, so a grant
+        # naming one is refused rather than stored against a subject that can never exist.
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={
+                "subject": {"kind": "service_account", "id": _gid("ServiceAccount", 1)},
+                "object_type": "project",
+                "object_id": object_gid,
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+        # A named permission set that does not exist is a client error.
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={
+                "subject": {"kind": "user", "id": _gid("User", user_id)},
+                "object_type": "project",
+                "object_id": object_gid,
+                "role": "No Such Role",
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+        # An existing subject with the view-only default (role omitted) succeeds.
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={
+                "subject": {"kind": "user", "id": _gid("User", user_id)},
+                "object_type": "project",
+                "object_id": object_gid,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+    async def test_permission_sets_and_enforcement(
+        self, httpx_client: httpx.AsyncClient, db: DbSessionFactory
+    ) -> None:
+        async with db() as session:
+            role_id = await session.scalar(
+                insert(models.PermissionSet)
+                .values(name=f"Role-{token_hex(4)}", is_built_in=True)
+                .returning(models.PermissionSet.id)
+            )
+            assert role_id is not None
+            session.add(models.PermissionSetItem(permission_set_id=role_id, permission="obj_view"))
+
+        resp = await httpx_client.get("v1/access/object-roles")
+        assert resp.status_code == 200, resp.text
+        mine = [r for r in resp.json()["data"] if r["id"] == _gid("PermissionSet", role_id)]
+        assert mine and mine[0]["permissions"] == ["obj_view"]
+
+        # These tests run an access-control-enabled app (see the module fixture), so the
+        # DB latch is on and enforcement reports enabled.
+        resp = await httpx_client.get("v1/access/enforcement")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"] == {"enabled": True, "source": "db-latch"}
+
+
+class TestLocalGroups:
+    async def test_group_and_member_lifecycle(
+        self, httpx_client: httpx.AsyncClient, db: DbSessionFactory
+    ) -> None:
+        resp = await httpx_client.post("v1/access/groups", json={"name": f"team-{token_hex(4)}"})
+        assert resp.status_code == 200, resp.text
+        group = resp.json()["data"]
+        assert group["member_user_ids"] == []
+        group_gid = group["id"]
+        assert _rowid(group_gid)  # a real UserGroup GlobalID
+
+        user_gid = _gid("User", await _user(db))
+        resp = await httpx_client.post(
+            f"v1/access/groups/{group_gid}/members", json={"user_id": user_gid}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["member_user_ids"] == [user_gid]
+
+        # Adding the same member again is idempotent.
+        resp = await httpx_client.post(
+            f"v1/access/groups/{group_gid}/members", json={"user_id": user_gid}
+        )
+        assert resp.json()["data"]["member_user_ids"] == [user_gid]
+
+        resp = await httpx_client.get("v1/access/groups")
+        assert group_gid in [g["id"] for g in resp.json()["data"]]
+
+        resp = await httpx_client.delete(f"v1/access/groups/{group_gid}/members/{user_gid}")
+        assert resp.status_code == 204, resp.text
+        resp = await httpx_client.get("v1/access/groups")
+        mine = next(g for g in resp.json()["data"] if g["id"] == group_gid)
+        assert mine["member_user_ids"] == []
+
+    async def test_delete_group_sweeps_its_grants(
+        self, httpx_client: httpx.AsyncClient, db: DbSessionFactory
+    ) -> None:
+        resp = await httpx_client.post("v1/access/groups", json={"name": f"team-{token_hex(4)}"})
+        group_gid = resp.json()["data"]["id"]
+        project_id = await _project(db, f"p-{token_hex(4)}")
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={
+                "subject": {"kind": "group", "id": group_gid},
+                "object_type": "project",
+                "object_id": _gid("Project", project_id),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        grant_gid = resp.json()["data"]["id"]
+        user_gid = _gid("User", await _user(db))
+        await httpx_client.post(f"v1/access/groups/{group_gid}/members", json={"user_id": user_gid})
+
+        resp = await httpx_client.delete(f"v1/access/groups/{group_gid}")
+        assert resp.status_code == 204, resp.text
+
+        group_rowid = _rowid(group_gid)
+        async with db() as session:
+            # The group's grant was swept on delete (no FK on acls.subject_id, so it
+            # cannot cascade) — the grant row is gone ...
+            assert (
+                await session.scalar(
+                    select(models.AccessGrant.id).where(models.AccessGrant.id == _rowid(grant_gid))
+                )
+            ) is None
+            # ... and the group + its memberships are gone.
+            assert (
+                await session.scalar(
+                    select(models.UserGroup.id).where(models.UserGroup.id == group_rowid)
+                )
+            ) is None
+            assert (
+                await session.scalar(
+                    select(models.UserGroupMembership.user_group_id).where(
+                        models.UserGroupMembership.user_group_id == group_rowid
+                    )
+                )
+            ) is None
+
+    async def test_validation_and_idp_groups_untouchable(
+        self, httpx_client: httpx.AsyncClient, db: DbSessionFactory
+    ) -> None:
+        name = f"team-{token_hex(4)}"
+        assert (await httpx_client.post("v1/access/groups", json={"name": name})).status_code == 200
+        # duplicate name → 409
+        dup = await httpx_client.post("v1/access/groups", json={"name": name})
+        assert dup.status_code == 409, dup.text
+        # empty name → 422
+        empty = await httpx_client.post("v1/access/groups", json={"name": "  "})
+        assert empty.status_code == 422, empty.text
+
+        # An IdP-synced (non-local) group is neither listed nor mutable here.
+        idp_gid = _gid("UserGroup", await _group(db, f"k-{token_hex(4)}"))  # provider="test"
+        assert (await httpx_client.delete(f"v1/access/groups/{idp_gid}")).status_code == 404
+        r = await httpx_client.post(
+            f"v1/access/groups/{idp_gid}/members", json={"user_id": _gid("User", 1)}
+        )
+        assert r.status_code == 404, r.text
+        resp = await httpx_client.get("v1/access/groups")
+        assert idp_gid not in [g["id"] for g in resp.json()["data"]]
+
+
+async def _manager_role(db: DbSessionFactory) -> str:
+    """A permission set conferring manage-access; returns its name (the REST role param)."""
+    name = f"Mgr-{token_hex(4)}"
+    async with db() as session:
+        role_id = await session.scalar(
+            insert(models.PermissionSet)
+            .values(name=name, is_built_in=False)
+            .returning(models.PermissionSet.id)
+        )
+        assert role_id is not None
+        session.add(
+            models.PermissionSetItem(permission_set_id=role_id, permission="obj_manage_access")
+        )
+    return name
+
+
+class TestRestLastManagerGuard:
+    """The last-manager guard (B3) must fire on the REST access routes too, not only on
+    the GraphQL mutations — REST can delete a grant and downgrade it in place."""
+
+    async def test_delete_of_the_last_manager_is_rejected(
+        self, httpx_client: httpx.AsyncClient, db: DbSessionFactory
+    ) -> None:
+        project_id = await _project(db, f"p-{token_hex(4)}")
+        user_id = await _user(db)
+        manager = await _manager_role(db)
+        object_gid = _gid("Project", project_id)
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={
+                "subject": {"kind": "user", "id": _gid("User", user_id)},
+                "object_type": "project",
+                "object_id": object_gid,
+                "role": manager,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        grant_gid = resp.json()["data"]["id"]
+        # Deleting the sole manager of a creatorless project would strand it — refused.
+        resp = await httpx_client.delete(f"v1/access/grants/{grant_gid}")
+        assert resp.status_code == 409, resp.text
+        assert "last manager" in resp.text
+        # The grant survives.
+        async with db() as session:
+            assert (
+                await session.scalar(
+                    select(models.AccessGrant.id).where(models.AccessGrant.id == _rowid(grant_gid))
+                )
+                is not None
+            )
+
+    async def test_downgrade_of_the_last_manager_is_rejected(
+        self, httpx_client: httpx.AsyncClient, db: DbSessionFactory
+    ) -> None:
+        project_id = await _project(db, f"p-{token_hex(4)}")
+        user_id = await _user(db)
+        manager = await _manager_role(db)
+        object_gid = _gid("Project", project_id)
+        subject = {"kind": "user", "id": _gid("User", user_id)}
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={
+                "subject": subject,
+                "object_type": "project",
+                "object_id": object_gid,
+                "role": manager,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        # Re-granting the same subject as a viewer (role omitted → default) downgrades in
+        # place, stripping the last manager — refused, just like a delete.
+        resp = await httpx_client.post(
+            "v1/access/grants",
+            json={"subject": subject, "object_type": "project", "object_id": object_gid},
+        )
+        assert resp.status_code == 409, resp.text
+        assert "last manager" in resp.text
+        # The grant is unchanged — still a manager.
+        async with db() as session:
+            role_id = await session.scalar(
+                select(models.AccessGrant.role_id).where(
+                    models.AccessGrant.object_type == "project",
+                    models.AccessGrant.object_id == project_id,
+                    models.AccessGrant.subject_id == user_id,
+                )
+            )
+            manager_role_id = await session.scalar(
+                select(models.PermissionSet.id).where(models.PermissionSet.name == manager)
+            )
+        assert role_id == manager_role_id
+
+
+class TestResourceTags:
+    """The REST surface for curated tags and attribute-based (tag) grants."""
+
+    async def test_tag_crud_on_an_object(
+        self, httpx_client: httpx.AsyncClient, db: DbSessionFactory
+    ) -> None:
+        project_id = await _project(db, f"p-{token_hex(4)}")
+        object_gid = _gid("Project", project_id)
+        base = f"v1/access/objects/project/{object_gid}/tags"
+
+        # Set a tag, then read it back.
+        resp = await httpx_client.put(f"{base}/env", json={"value": "prod"})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"] == {
+            "object_type": "project",
+            "object_id": object_gid,
+            "key": "env",
+            "value": "prod",
+        }
+        resp = await httpx_client.get(base)
+        assert resp.json()["data"] == [
+            {"object_type": "project", "object_id": object_gid, "key": "env", "value": "prod"}
+        ]
+
+        # Re-setting the same key overwrites the value (one row per key).
+        resp = await httpx_client.put(f"{base}/env", json={"value": "staging"})
+        assert resp.status_code == 200, resp.text
+        resp = await httpx_client.get(base)
+        assert [t["value"] for t in resp.json()["data"]] == ["staging"]
+
+        # Remove it.
+        assert (await httpx_client.delete(f"{base}/env")).status_code == 204
+        assert (await httpx_client.get(base)).json()["data"] == []
+
+    async def test_tag_grant_lifecycle_and_manage_is_rejected(
+        self, httpx_client: httpx.AsyncClient, db: DbSessionFactory
+    ) -> None:
+        user_id = await _user(db)
+        subject = {"kind": "user", "id": _gid("User", user_id)}
+        create = {
+            "subject": subject,
+            "object_type": "dataset",
+            "tag_key": "env",
+            "tag_value": "prod",
+        }
+
+        # Author a tag grant (view-only default).
+        resp = await httpx_client.post("v1/access/tag-grants", json=create)
+        assert resp.status_code == 200, resp.text
+        grant = resp.json()["data"]
+        assert grant["object_type"] == "dataset"
+        assert grant["tag_key"] == "env" and grant["tag_value"] == "prod"
+        grant_gid = grant["id"]
+
+        # Re-granting is idempotent (same id) and updates only the role.
+        resp = await httpx_client.post(
+            "v1/access/tag-grants", json={**create, "role": "Resource Editor"}
+        )
+        assert resp.json()["data"]["id"] == grant_gid
+        assert resp.json()["data"]["role"] == "Resource Editor"
+
+        # It lists, filtered by type.
+        resp = await httpx_client.get("v1/access/tag-grants", params={"object_type": "dataset"})
+        assert [g["id"] for g in resp.json()["data"]] == [grant_gid]
+
+        # A manage-conferring permission set is refused — a tag grant never delegates management.
+        resp = await httpx_client.post(
+            "v1/access/tag-grants", json={**create, "role": "Resource Manager"}
+        )
+        assert resp.status_code == 422, resp.text
+        assert "manage-access" in resp.text
+
+        # Revoke, then it's gone.
+        assert (await httpx_client.delete(f"v1/access/tag-grants/{grant_gid}")).status_code == 204
+        resp = await httpx_client.get("v1/access/tag-grants")
+        assert grant_gid not in [g["id"] for g in resp.json()["data"]]

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -661,7 +661,9 @@ async def test_post_dataset_upload_create_conflicts_on_existing_name_while_updat
         json=body,
     )
     assert conflict_response.status_code == 409
-    assert name in conflict_response.text
+    # The create-conflict message is deliberately generic — it does not echo the name back,
+    # so it never reveals whether a name is taken by a dataset the caller cannot see.
+    assert "Dataset name is unavailable" in conflict_response.text
 
     # action=update converges instead of conflicting on the existing name.
     update_body = {**body, "action": "update"}

--- a/tests/unit/server/api/routers/v1/test_experiments.py
+++ b/tests/unit/server/api/routers/v1/test_experiments.py
@@ -261,6 +261,67 @@ async def test_reading_experiments(
     assert all(experiment[key] == value for key, value in expected.items())
 
 
+async def test_delete_experiment_keeps_project_and_resets_its_kind(
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
+    db: DbSessionFactory,
+) -> None:
+    """Deleting an experiment but keeping its project (the default) leaves the project and
+    surfaces it as a normal TELEMETRY project — it is no longer an experiment's hidden store,
+    so it reappears in the (experiment-project-excluding) projects list."""
+    dataset_gid = GlobalID("Dataset", "0")
+    created = (
+        await httpx_client.post(
+            f"v1/datasets/{dataset_gid}/experiments",
+            json={"version_id": None, "repetitions": 1},
+        )
+    ).json()["data"]
+    experiment_gid = created["id"]
+    project_name = created["project_name"]
+    assert project_name
+    async with db() as session:
+        kind = await session.scalar(
+            select(models.Project.kind).where(models.Project.name == project_name)
+        )
+    assert kind == "EXPERIMENT"
+
+    resp = await httpx_client.delete(f"v1/experiments/{experiment_gid}")
+    assert resp.status_code in (200, 204), resp.text
+
+    async with db() as session:
+        kind = await session.scalar(
+            select(models.Project.kind).where(models.Project.name == project_name)
+        )
+    assert kind == "TELEMETRY"  # kept, and no longer hidden as an experiment project
+
+
+async def test_delete_experiment_with_delete_project_flag_removes_project(
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
+    db: DbSessionFactory,
+) -> None:
+    dataset_gid = GlobalID("Dataset", "0")
+    created = (
+        await httpx_client.post(
+            f"v1/datasets/{dataset_gid}/experiments",
+            json={"version_id": None, "repetitions": 1},
+        )
+    ).json()["data"]
+    experiment_gid = created["id"]
+    project_name = created["project_name"]
+
+    resp = await httpx_client.delete(
+        f"v1/experiments/{experiment_gid}", params={"delete_project": "true"}
+    )
+    assert resp.status_code in (200, 204), resp.text
+
+    async with db() as session:
+        exists = await session.scalar(
+            select(models.Project.id).where(models.Project.name == project_name)
+        )
+    assert exists is None  # project deleted
+
+
 async def test_listing_experiments_on_empty_dataset(
     httpx_client: httpx.AsyncClient,
     dataset_with_experiments_without_runs: Any,

--- a/tests/unit/server/api/routers/v1/test_projects.py
+++ b/tests/unit/server/api/routers/v1/test_projects.py
@@ -755,6 +755,7 @@ class TestProjects:
             experiment_project = models.Project(
                 name="experiment-project",
                 description="A project created from an experiment - should be filtered by default",
+                kind="EXPERIMENT",
             )
             session.add(experiment_project)
             await session.flush()
@@ -778,7 +779,7 @@ class TestProjects:
                 name="test-experiment",
                 repetitions=1,
                 metadata_={},
-                project_name="experiment-project",
+                project_id=experiment_project.id,
             )
             session.add(experiment)
             await session.flush()
@@ -787,6 +788,7 @@ class TestProjects:
             playground_project = models.Project(
                 name=PLAYGROUND_PROJECT_NAME,
                 description="Playground project - should always be visible",
+                kind="PLAYGROUND",
             )
             session.add(playground_project)
             await session.flush()
@@ -880,6 +882,7 @@ class TestProjects:
             dataset_evaluator_project = models.Project(
                 name="dataset-evaluator-project",
                 description="A project created from a dataset evaluator - should be filtered by default",
+                kind="EVALUATOR",
             )
             session.add(dataset_evaluator_project)
             await session.flush()

--- a/tests/unit/server/api/test_containment_gating.py
+++ b/tests/unit/server/api/test_containment_gating.py
@@ -1,0 +1,168 @@
+from datetime import datetime
+
+from sqlalchemy import insert
+
+from phoenix.db import models
+from phoenix.server.api.queries import _eval_node_parent_id, _parent_project_id
+from phoenix.server.types import DbSessionFactory
+
+_T = datetime.fromisoformat("2021-01-01T00:00:00.000+00:00")
+
+
+def _require_id(value: int | None, label: str) -> int:
+    assert value is not None, label
+    return value
+
+
+async def test_parent_project_id_walks_containment_edges(db: DbSessionFactory) -> None:
+    """The access gate for containment children (spans, traces, sessions,
+    annotations) resolves each one's owning project, so they inherit its access."""
+    async with db() as session:
+        project_id = await session.scalar(
+            insert(models.Project).values(name="p").returning(models.Project.id)
+        )
+        other_project_id = await session.scalar(
+            insert(models.Project).values(name="other").returning(models.Project.id)
+        )
+        trace_id = await session.scalar(
+            insert(models.Trace)
+            .values(trace_id="t1", project_rowid=project_id, start_time=_T, end_time=_T)
+            .returning(models.Trace.id)
+        )
+        session_id = await session.scalar(
+            insert(models.ProjectSession)
+            .values(session_id="s1", project_id=project_id, start_time=_T, end_time=_T)
+            .returning(models.ProjectSession.id)
+        )
+        span_id = await session.scalar(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_id,
+                span_id="span1",
+                parent_id=None,
+                name="n",
+                span_kind="CHAIN",
+                start_time=_T,
+                end_time=_T,
+                attributes={},
+                events=[],
+                status_code="OK",
+                status_message="",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )
+        span_annotation_id = await session.scalar(
+            insert(models.SpanAnnotation)
+            .values(
+                span_rowid=span_id,
+                name="c",
+                label="x",
+                score=1.0,
+                explanation="",
+                metadata_={},
+                annotator_kind="HUMAN",
+                source="API",
+                identifier="i1",
+            )
+            .returning(models.SpanAnnotation.id)
+        )
+        trace_annotation_id = await session.scalar(
+            insert(models.TraceAnnotation)
+            .values(
+                trace_rowid=trace_id,
+                name="c",
+                label="x",
+                score=1.0,
+                explanation="",
+                metadata_={},
+                annotator_kind="HUMAN",
+                source="API",
+                identifier="i1",
+            )
+            .returning(models.TraceAnnotation.id)
+        )
+        await session.commit()
+
+    project_id = _require_id(project_id, "project_id")
+    trace_id = _require_id(trace_id, "trace_id")
+    session_id = _require_id(session_id, "session_id")
+    span_id = _require_id(span_id, "span_id")
+    span_annotation_id = _require_id(span_annotation_id, "span_annotation_id")
+    trace_annotation_id = _require_id(trace_annotation_id, "trace_annotation_id")
+
+    assert other_project_id != project_id
+    async with db() as session:
+        assert await _parent_project_id(session, "Trace", trace_id) == project_id
+        assert await _parent_project_id(session, "Span", span_id) == project_id
+        assert await _parent_project_id(session, "ProjectSession", session_id) == project_id
+        assert await _parent_project_id(session, "SpanAnnotation", span_annotation_id) == project_id
+        assert (
+            await _parent_project_id(session, "TraceAnnotation", trace_annotation_id) == project_id
+        )
+        # A nonexistent node resolves to None → the caller raises not-found.
+        assert await _parent_project_id(session, "Span", 999999) is None
+        # An unhandled type resolves to None (not a containment child here).
+        assert await _parent_project_id(session, "Dataset", span_id) is None
+
+
+async def test_eval_node_parent_id_roots_at_data_context(db: DbSessionFactory) -> None:
+    """Eval-world nodes derive access from their data context (access-by-parent):
+    experiments, runs, jobs, and examples from the dataset; prompt versions from the
+    prompt."""
+    async with db() as session:
+        dataset_id = await session.scalar(
+            insert(models.Dataset).values(name="ds", metadata_={}).returning(models.Dataset.id)
+        )
+        version_id = await session.scalar(
+            insert(models.DatasetVersion)
+            .values(dataset_id=dataset_id, metadata_={})
+            .returning(models.DatasetVersion.id)
+        )
+        example_id = await session.scalar(
+            insert(models.DatasetExample)
+            .values(dataset_id=dataset_id)
+            .returning(models.DatasetExample.id)
+        )
+        experiment_id = await session.scalar(
+            insert(models.Experiment)
+            .values(
+                dataset_id=dataset_id,
+                dataset_version_id=version_id,
+                name="exp",
+                repetitions=1,
+                metadata_={},
+            )
+            .returning(models.Experiment.id)
+        )
+        run_id = await session.scalar(
+            insert(models.ExperimentRun)
+            .values(
+                experiment_id=experiment_id,
+                dataset_example_id=example_id,
+                output={},
+                repetition_number=1,
+                start_time=_T,
+                end_time=_T,
+                error=None,
+            )
+            .returning(models.ExperimentRun.id)
+        )
+        await session.commit()
+
+    dataset_id = _require_id(dataset_id, "dataset_id")
+    example_id = _require_id(example_id, "example_id")
+    experiment_id = _require_id(experiment_id, "experiment_id")
+    run_id = _require_id(run_id, "run_id")
+
+    async with db() as session:
+        assert await _eval_node_parent_id(session, "DatasetExample", example_id) == dataset_id
+        assert await _eval_node_parent_id(session, "Experiment", experiment_id) == dataset_id
+        assert await _eval_node_parent_id(session, "ExperimentRun", run_id) == dataset_id
+        # ExperimentJob shares experiments.id 1:1, so it resolves like the experiment.
+        assert await _eval_node_parent_id(session, "ExperimentJob", experiment_id) == dataset_id
+        # Nonexistent / unhandled resolve to None → caller raises not-found.
+        assert await _eval_node_parent_id(session, "Experiment", 999999) is None
+        assert await _eval_node_parent_id(session, "DatasetSplit", example_id) is None

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -670,12 +670,13 @@ async def projects_with_and_without_experiments(
                 description="non-experiment-project-description",
             )
         )
-        await session.scalar(
+        experiment_project_id = await session.scalar(
             insert(models.Project)
             .returning(models.Project.id)
             .values(
                 name="experiment-project-name",
                 description="experiment-project-description",
+                kind="EXPERIMENT",
             )
         )
         dataset_id = await session.scalar(
@@ -697,7 +698,7 @@ async def projects_with_and_without_experiments(
                 name="experiment-name",
                 repetitions=1,
                 metadata_={},
-                project_name="experiment-project-name",
+                project_id=experiment_project_id,
             )
         )
 
@@ -718,6 +719,7 @@ async def projects_with_and_without_dataset_evaluators(
         dataset_evaluator_project = models.Project(
             name="dataset-evaluator-project-name",
             description="dataset-evaluator-project-description",
+            kind="EVALUATOR",
         )
         session.add(non_dataset_evaluator_project)
         session.add(dataset_evaluator_project)
@@ -2879,3 +2881,33 @@ async def test_node_with_noninteger_payload_returns_bad_request(
     assert response.data is None
     assert response.errors
     assert f"Invalid node id: {bad_id}" in response.errors[0].message
+
+
+async def test_node_project_requires_existence_not_only_access(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+) -> None:
+    # node() resolving a Project must confirm the row exists, not merely that the caller is
+    # authorized: access control answers "yes" for an administrator or a type-wide grant
+    # holder even for an id that names no project, so a bare authorization check would resolve
+    # a nonexistent node to a stub. (Access control is off in this harness, which is itself a
+    # "sees everything" caller — the existence check is what makes the missing case 404.)
+    async with db() as session:
+        project_id = await session.scalar(
+            insert(models.Project).returning(models.Project.id).values(name="real-project")
+        )
+    assert project_id is not None
+    query = "query ($id: ID!) { node(id: $id) { __typename ... on Project { id } } }"
+
+    ok = await gql_client.execute(
+        query=query, variables={"id": str(GlobalID("Project", str(project_id)))}
+    )
+    assert not ok.errors
+    assert ok.data is not None
+    assert ok.data["node"]["__typename"] == "Project"
+
+    missing_id = str(GlobalID("Project", str(project_id + 10_000)))
+    missing = await gql_client.execute(query=query, variables={"id": missing_id})
+    assert missing.data is None
+    assert missing.errors
+    assert f"Unknown node: {missing_id}" in missing.errors[0].message

--- a/tests/unit/server/daemons/test_experiment_runner.py
+++ b/tests/unit/server/daemons/test_experiment_runner.py
@@ -33,7 +33,7 @@ from phoenix.server.types import DbSessionFactory
 def _make_experiment(experiment_id: int = 1) -> models.Experiment:
     exp = MagicMock(spec=models.Experiment)
     exp.id = experiment_id
-    exp.project_name = "test-project"
+    exp.project_id = 1
     return exp
 
 

--- a/tests/unit/server/daemons/test_experiment_sweeper.py
+++ b/tests/unit/server/daemons/test_experiment_sweeper.py
@@ -71,9 +71,13 @@ class TestExperimentSweeper:
                 is_ephemeral=is_ephemeral,
                 repetitions=1,
                 metadata_={},
-                project_name=project_name,
                 created_at=created_at,
             )
+            if project_name is not None:
+                # Link by FK: the project (created by the test) is resolved by name to its id.
+                experiment_kwargs["project_id"] = await session.scalar(
+                    sa.select(models.Project.id).where(models.Project.name == project_name)
+                )
             if updated_at is not None:
                 experiment_kwargs["updated_at"] = updated_at
             experiment = models.Experiment(**experiment_kwargs)

--- a/tests/unit/server/test_api_key_scope.py
+++ b/tests/unit/server/test_api_key_scope.py
@@ -1,0 +1,239 @@
+from collections.abc import MutableMapping
+from datetime import datetime, timezone
+from typing import Any, Optional
+from unittest import mock
+
+import pytest
+from joserfc import jwt
+from joserfc.jwk import OctKey
+from pydantic import SecretStr
+
+from phoenix.server.api_key_scope import (
+    API_KEY_SCOPE_INGEST,
+    ApiKeyScopeEnforcementMiddleware,
+    deny_unknown_grpc_scope,
+    get_request_api_key_scope,
+    is_allowed_for_scope,
+)
+from phoenix.server.bearer_auth import PhoenixSystemUser, PhoenixUser
+from phoenix.server.jwt_store import JwtStore
+from phoenix.server.types import (
+    AccessTokenAttributes,
+    AccessTokenClaims,
+    AccessTokenId,
+    ApiKeyAttributes,
+    ApiKeyClaims,
+    ApiKeyId,
+    RefreshTokenId,
+    UserId,
+)
+
+
+def _api_key_user(scope: Optional[str]) -> PhoenixUser:
+    user_id = UserId(1)
+    claims = ApiKeyClaims(
+        subject=user_id,
+        token_id=ApiKeyId(1),
+        attributes=ApiKeyAttributes(user_role="MEMBER", name="key", scope=scope),
+    )
+    return PhoenixUser(user_id, claims)
+
+
+def _session_user() -> PhoenixUser:
+    user_id = UserId(1)
+    claims = AccessTokenClaims(
+        subject=user_id,
+        token_id=AccessTokenId(1),
+        attributes=AccessTokenAttributes(user_role="MEMBER", refresh_token_id=RefreshTokenId(1)),
+    )
+    return PhoenixUser(user_id, claims)
+
+
+class TestIsAllowedForScope:
+    @pytest.mark.parametrize(
+        "method,path",
+        [
+            ("POST", "/v1/traces"),
+            ("POST", "/v1/traces/"),
+            ("POST", "/v1/projects/my-project/spans"),
+            ("POST", "/v1/projects/UHJvamVjdDox/spans"),
+        ],
+    )
+    def test_ingest_allows_trace_writes(self, method: str, path: str) -> None:
+        assert is_allowed_for_scope(API_KEY_SCOPE_INGEST, method, path)
+
+    @pytest.mark.parametrize(
+        "method,path",
+        [
+            ("GET", "/v1/traces"),  # reads are not ingest
+            ("DELETE", "/v1/traces"),
+            ("GET", "/v1/projects"),
+            ("GET", "/v1/projects/my-project/spans"),
+            ("POST", "/v1/projects/my-project/spans/otlpv1"),  # span search, not a write
+            ("POST", "/v1/datasets/upload"),
+            ("POST", "/v1/span_annotations"),
+            ("POST", "/graphql"),
+            ("GET", "/graphql"),
+            ("POST", "/v1/projects"),
+            ("GET", "/"),
+        ],
+    )
+    def test_ingest_denies_everything_else(self, method: str, path: str) -> None:
+        assert not is_allowed_for_scope(API_KEY_SCOPE_INGEST, method, path)
+
+    @pytest.mark.parametrize("path", ["/v1/traces", "/graphql", "/v1/projects/p/spans"])
+    def test_unknown_scope_denies_everything(self, path: str) -> None:
+        # A scope minted by a newer server must fail closed, not fall back
+        # to full access.
+        assert not is_allowed_for_scope("future-scope", "POST", path)
+
+
+class TestGetRequestApiKeyScope:
+    def test_scoped_api_key(self) -> None:
+        assert get_request_api_key_scope(_api_key_user("ingest")) == "ingest"
+
+    def test_unscoped_api_key(self) -> None:
+        assert get_request_api_key_scope(_api_key_user(None)) is None
+
+    def test_session_user(self) -> None:
+        assert get_request_api_key_scope(_session_user()) is None
+
+    def test_system_user(self) -> None:
+        assert get_request_api_key_scope(PhoenixSystemUser(UserId(1))) is None
+
+    def test_unauthenticated(self) -> None:
+        assert get_request_api_key_scope(None) is None
+
+
+class TestDenyUnknownGrpcScope:
+    def test_absent_scope_passes(self) -> None:
+        assert not deny_unknown_grpc_scope(None)
+
+    def test_ingest_passes(self) -> None:
+        assert not deny_unknown_grpc_scope(API_KEY_SCOPE_INGEST)
+
+    def test_unknown_scope_denied(self) -> None:
+        assert deny_unknown_grpc_scope("future-scope")
+
+
+class TestApiKeyScopeEnforcementMiddleware:
+    @staticmethod
+    async def _run(
+        scope: dict[str, Any],
+    ) -> tuple[bool, list[dict[str, Any]]]:
+        """Returns (reached_downstream_app, messages_sent)."""
+        reached = False
+        sent: list[dict[str, Any]] = []
+
+        async def app(scope: Any, receive: Any, send: Any) -> None:
+            nonlocal reached
+            reached = True
+
+        async def receive() -> dict[str, Any]:
+            return {"type": "http.request"}
+
+        async def send(message: MutableMapping[str, Any]) -> None:
+            sent.append(dict(message))
+
+        await ApiKeyScopeEnforcementMiddleware(app)(scope, receive, send)
+        return reached, sent
+
+    async def test_unscoped_user_passes_through(self) -> None:
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/v1/projects",
+            "user": _api_key_user(None),
+        }
+        reached, sent = await self._run(scope)
+        assert reached
+        assert not sent
+
+    async def test_session_user_passes_through(self) -> None:
+        scope = {"type": "http", "method": "POST", "path": "/graphql", "user": _session_user()}
+        reached, _ = await self._run(scope)
+        assert reached
+
+    async def test_scoped_key_allowed_on_ingest_route(self) -> None:
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/traces",
+            "user": _api_key_user("ingest"),
+        }
+        reached, _ = await self._run(scope)
+        assert reached
+
+    @pytest.mark.parametrize(
+        "method,path",
+        [
+            ("POST", "/graphql"),
+            ("GET", "/v1/projects"),
+            ("POST", "/v1/datasets/upload"),
+            ("DELETE", "/v1/traces"),
+        ],
+    )
+    async def test_scoped_key_denied_elsewhere(self, method: str, path: str) -> None:
+        scope = {"type": "http", "method": method, "path": path, "user": _api_key_user("ingest")}
+        reached, sent = await self._run(scope)
+        assert not reached
+        assert sent[0]["type"] == "http.response.start"
+        assert sent[0]["status"] == 403
+
+    async def test_scoped_key_denied_on_websocket(self) -> None:
+        scope = {"type": "websocket", "path": "/graphql", "user": _api_key_user("ingest")}
+        reached, sent = await self._run(scope)
+        assert not reached
+        assert sent == [{"type": "websocket.close", "code": 1008}]
+
+    async def test_lifespan_passes_through(self) -> None:
+        reached, _ = await self._run({"type": "lifespan"})
+        assert reached
+
+
+class TestJwtScopeRoundTrip:
+    """The scope must survive mint → token → read, and absence must too."""
+
+    _secret = SecretStr("0123456789abcdef0123456789abcdef")
+
+    def _store(self) -> JwtStore:
+        return JwtStore(mock.Mock(), self._secret)
+
+    def _claims(self, scope: Optional[str]) -> ApiKeyClaims:
+        return ApiKeyClaims(
+            subject=UserId(7),
+            token_id=ApiKeyId(7),
+            issued_at=datetime.now(timezone.utc),
+            attributes=ApiKeyAttributes(user_role="MEMBER", name="k", scope=scope),
+        )
+
+    @pytest.mark.parametrize("scope", ["ingest", None])
+    async def test_round_trip(self, scope: Optional[str]) -> None:
+        store = self._store()
+        api_key_store = store._api_key_store
+        claims = self._claims(scope)
+        token = api_key_store._token(api_key_store._encode(claims))
+
+        # the signed payload carries the scope claim (or omits it)
+        decoded = jwt.decode(str(token), OctKey.import_key(self._secret.get_secret_value()))
+        assert decoded.claims.get("scope") == scope
+        assert decoded.claims["jti"] == "ApiKey:7"
+
+        # read() rebuilds claims from the store (which knows no scope —
+        # there is no DB column) and merges the scope from the token
+        api_key_store._claims[ApiKeyId(7)] = self._claims(None)
+        read_claims = await store.read(token)
+        assert isinstance(read_claims, ApiKeyClaims)
+        assert read_claims.attributes is not None
+        assert read_claims.attributes.scope == scope
+
+    async def test_scope_cannot_be_forged_without_secret(self) -> None:
+        store = self._store()
+        api_key_store = store._api_key_store
+        api_key_store._claims[ApiKeyId(7)] = self._claims(None)
+        forged = jwt.encode(
+            {"alg": "HS256"},
+            {"jti": "ApiKey:7", "scope": None},
+            OctKey.import_key("wrong-secret-wrong-secret-wrong!"),
+        )
+        assert await store.read(api_key_store._token(forged)) is None


### PR DESCRIPTION
Fail-closed, monotonic allow-only access control for **projects, datasets, and prompts**, gated behind `PHOENIX_ACCESS_CONTROL_ENABLED` (DB-latched, with an auth precondition / boot guard). Flag-off is a true no-op.

## Highlights
- Generic `acls` table + a single access oracle (`can` / `accessible_scope` / `subjects_for`)
- Unified `AccessGrantInput` (`@oneOf` subject/object) grant + revoke mutations
- Object roles (view / edit / manage-access) with custom-role CRUD
- Local and IdP-synced user groups as grant subjects
- Admin-only default for ingest-born projects; creator-private datasets/prompts; access-by-parent for experiment/evaluator trace projects
- Frontend: shared `ResourceAccessForm` (modal + tab), consolidated Settings → Access, searchable pickers, confirm dialogs, visibility posture badges
- Regenerated OpenAPI, DDL, and phoenix clients
- Design notes under `internal_docs/specs/rbac/`