### PR TITLE
fix(ui): annotation display and summary preview nits

### DIFF
--- a/app/src/components/annotation/AnnotationNameAndValue.tsx
+++ b/app/src/components/annotation/AnnotationNameAndValue.tsx
@@ -23,6 +23,17 @@ const textCSS = (maxWidth: CSSProperties["maxWidth"]) => css`
   }
 `;
 
+/**
+ * Derives the displayable score and label text for an annotation. Returns
+ * `null` for a part that isn't present so callers can decide how to combine or
+ * render them.
+ */
+const getAnnotationValueParts = (annotation: Annotation) => ({
+  scoreText:
+    typeof annotation.score === "number" ? formatFloat(annotation.score) : null,
+  labelText: annotation.label || null,
+});
+
 const getAnnotationDisplayValue = ({
   annotation,
   displayPreference,
@@ -49,11 +60,7 @@ const getAnnotationDisplayValue = ({
       // When both a label and a score are present, the combined value is
       // rendered as distinct pieces by the component. This branch only handles
       // the case where a single value is available.
-      const scoreText =
-        typeof annotation.score === "number"
-          ? formatFloat(annotation.score)
-          : null;
-      const labelText = annotation.label || null;
+      const { scoreText, labelText } = getAnnotationValueParts(annotation);
       return scoreText || labelText || "n/a";
     }
     case "none":
@@ -93,9 +100,7 @@ export function AnnotationNameAndValue({
     annotation,
     displayPreference,
   });
-  const scoreText =
-    typeof annotation.score === "number" ? formatFloat(annotation.score) : null;
-  const labelText = annotation.label || null;
+  const { scoreText, labelText } = getAnnotationValueParts(annotation);
   // When both a label and a score are shown, render them as distinct pieces:
   // the label in the default font and the score in mono, separated by clear
   // spacing — instead of wrapping the score in parentheses.

--- a/app/src/components/annotation/AnnotationNameAndValue.tsx
+++ b/app/src/components/annotation/AnnotationNameAndValue.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import { Fragment } from "react";
 import type { CSSProperties } from "react";
 
 import { Flex, Text } from "@phoenix/components";
@@ -23,48 +24,69 @@ const textCSS = (maxWidth: CSSProperties["maxWidth"]) => css`
   }
 `;
 
-/**
- * Derives the displayable score and label text for an annotation. Returns
- * `null` for a part that isn't present so callers can decide how to combine or
- * render them.
- */
-const getAnnotationValueParts = (annotation: Annotation) => ({
-  scoreText:
-    typeof annotation.score === "number" ? formatFloat(annotation.score) : null,
-  labelText: annotation.label || null,
-});
+const valuePartsCSS = css`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--global-dimension-size-100);
+`;
 
-const getAnnotationDisplayValue = ({
-  annotation,
-  displayPreference,
-}: {
-  annotation: Annotation;
-  displayPreference: AnnotationDisplayPreference;
-}) => {
+// A thin separator between value pieces (e.g. a label and its score). Tinted
+// with the current text color so it inherits the optimization-direction color.
+const valueDividerCSS = css`
+  width: 1px;
+  height: 0.7em;
+  background-color: currentColor;
+  opacity: 0.2;
+`;
+
+/**
+ * A single renderable piece of an annotation value. Scores render in a
+ * monospace font; labels render in the default font.
+ */
+type AnnotationValuePart = {
+  text: string;
+  fontFamily: "mono" | "default";
+};
+
+/**
+ * Resolves an annotation into the ordered value pieces to render for the given
+ * display preference. Returns an empty array when nothing should be shown (the
+ * "none" preference) and a single "n/a" piece when a value is expected but
+ * absent. The component renders every preference through these parts, so a
+ * score always shows in mono and a label in the default font.
+ */
+const getAnnotationValueParts = (
+  annotation: Annotation,
+  displayPreference: AnnotationDisplayPreference
+): AnnotationValuePart[] => {
+  const scorePart: AnnotationValuePart | null =
+    typeof annotation.score === "number"
+      ? { text: formatFloat(annotation.score), fontFamily: "mono" }
+      : null;
+  const labelPart: AnnotationValuePart | null = annotation.label
+    ? { text: annotation.label, fontFamily: "default" }
+    : null;
+
+  const withFallback = (
+    parts: (AnnotationValuePart | null)[]
+  ): AnnotationValuePart[] => {
+    const present = parts.filter((part): part is AnnotationValuePart => {
+      return part != null;
+    });
+    return present.length > 0
+      ? present
+      : [{ text: "n/a", fontFamily: "default" }];
+  };
+
   switch (displayPreference) {
-    case "label":
-      return (
-        annotation.label ||
-        (typeof annotation.score == "number" &&
-          formatFloat(annotation.score)) ||
-        "n/a"
-      );
-    case "score":
-      return (
-        (typeof annotation.score == "number" &&
-          formatFloat(annotation.score)) ||
-        annotation.label ||
-        "n/a"
-      );
-    case "score-and-label": {
-      // When both a label and a score are present, the combined value is
-      // rendered as distinct pieces by the component. This branch only handles
-      // the case where a single value is available.
-      const { scoreText, labelText } = getAnnotationValueParts(annotation);
-      return scoreText || labelText || "n/a";
-    }
     case "none":
-      return "";
+      return [];
+    case "label":
+      return withFallback([labelPart ?? scorePart]);
+    case "score":
+      return withFallback([scorePart ?? labelPart]);
+    case "score-and-label":
+      return withFallback([labelPart, scorePart]);
     default:
       assertUnreachable(displayPreference);
   }
@@ -96,18 +118,7 @@ export function AnnotationNameAndValue({
   positiveOptimization,
   showColorSwatch = true,
 }: AnnotationNameAndValueProps) {
-  const labelValue = getAnnotationDisplayValue({
-    annotation,
-    displayPreference,
-  });
-  const { scoreText, labelText } = getAnnotationValueParts(annotation);
-  // When both a label and a score are shown, render them as distinct pieces:
-  // the label in the default font and the score in mono, separated by clear
-  // spacing — instead of wrapping the score in parentheses.
-  const showsLabelAndScore =
-    displayPreference === "score-and-label" &&
-    scoreText != null &&
-    labelText != null;
+  const valueParts = getAnnotationValueParts(annotation, displayPreference);
 
   return (
     <Flex
@@ -126,7 +137,7 @@ export function AnnotationNameAndValue({
           {annotation.name}
         </Text>
       </div>
-      {labelValue && (
+      {valueParts.length > 0 && (
         <div
           css={css(
             textCSS(maxWidth),
@@ -135,37 +146,21 @@ export function AnnotationNameAndValue({
             `
           )}
         >
-          <AnnotationScoreText
-            positiveOptimization={positiveOptimization}
-            fontFamily={showsLabelAndScore ? "default" : "mono"}
-          >
-            {showsLabelAndScore ? (
-              <span
-                css={css`
-                  display: inline-flex;
-                  align-items: center;
-                  gap: var(--global-dimension-size-100);
-                `}
-              >
-                <Text color="inherit" size={size}>
-                  {labelText}
-                </Text>
-                <span
-                  aria-hidden
-                  css={css`
-                    width: 1px;
-                    height: 0.7em;
-                    background-color: currentColor;
-                    opacity: 0.2;
-                  `}
-                />
-                <Text fontFamily="mono" color="inherit" size={size}>
-                  {scoreText}
-                </Text>
-              </span>
-            ) : (
-              labelValue
-            )}
+          <AnnotationScoreText positiveOptimization={positiveOptimization}>
+            <span css={valuePartsCSS}>
+              {valueParts.map((part, index) => (
+                <Fragment key={index}>
+                  {index > 0 && <span aria-hidden css={valueDividerCSS} />}
+                  <Text
+                    fontFamily={part.fontFamily}
+                    color="inherit"
+                    size={size}
+                  >
+                    {part.text}
+                  </Text>
+                </Fragment>
+              ))}
+            </span>
           </AnnotationScoreText>
         </div>
       )}

--- a/app/src/components/annotation/AnnotationNameAndValue.tsx
+++ b/app/src/components/annotation/AnnotationNameAndValue.tsx
@@ -46,14 +46,14 @@ const getAnnotationDisplayValue = ({
         "n/a"
       );
     case "score-and-label": {
+      // When both a label and a score are present, the combined value is
+      // rendered as distinct pieces by the component. This branch only handles
+      // the case where a single value is available.
       const scoreText =
         typeof annotation.score === "number"
           ? formatFloat(annotation.score)
           : null;
       const labelText = annotation.label || null;
-      if (scoreText && labelText) {
-        return `${labelText} (${scoreText})`;
-      }
       return scoreText || labelText || "n/a";
     }
     case "none":
@@ -93,6 +93,16 @@ export function AnnotationNameAndValue({
     annotation,
     displayPreference,
   });
+  const scoreText =
+    typeof annotation.score === "number" ? formatFloat(annotation.score) : null;
+  const labelText = annotation.label || null;
+  // When both a label and a score are shown, render them as distinct pieces:
+  // the label in the default font and the score in mono, separated by clear
+  // spacing — instead of wrapping the score in parentheses.
+  const showsLabelAndScore =
+    displayPreference === "score-and-label" &&
+    scoreText != null &&
+    labelText != null;
 
   return (
     <Flex
@@ -122,9 +132,35 @@ export function AnnotationNameAndValue({
         >
           <AnnotationScoreText
             positiveOptimization={positiveOptimization}
-            fontFamily="mono"
+            fontFamily={showsLabelAndScore ? "default" : "mono"}
           >
-            {labelValue}
+            {showsLabelAndScore ? (
+              <span
+                css={css`
+                  display: inline-flex;
+                  align-items: center;
+                  gap: var(--global-dimension-size-100);
+                `}
+              >
+                <Text color="inherit" size={size}>
+                  {labelText}
+                </Text>
+                <span
+                  aria-hidden
+                  css={css`
+                    width: 1px;
+                    height: 0.7em;
+                    background-color: currentColor;
+                    opacity: 0.2;
+                  `}
+                />
+                <Text fontFamily="mono" color="inherit" size={size}>
+                  {scoreText}
+                </Text>
+              </span>
+            ) : (
+              labelValue
+            )}
           </AnnotationScoreText>
         </div>
       )}

--- a/app/src/components/annotation/AnnotationNameAndValue.tsx
+++ b/app/src/components/annotation/AnnotationNameAndValue.tsx
@@ -70,9 +70,9 @@ const getAnnotationValueParts = (
   const withFallback = (
     parts: (AnnotationValuePart | null)[]
   ): AnnotationValuePart[] => {
-    const present = parts.filter((part): part is AnnotationValuePart => {
-      return part != null;
-    });
+    const present = parts.filter(
+      (part): part is AnnotationValuePart => part != null
+    );
     return present.length > 0
       ? present
       : [{ text: "n/a", fontFamily: "default" }];

--- a/app/src/pages/project/AnnotationSummary.tsx
+++ b/app/src/pages/project/AnnotationSummary.tsx
@@ -384,12 +384,7 @@ export function SummaryValuePreview({
   const chartDimensions = SizesMap[size].chart;
   const pieDimensions = SizesMap[size].pie;
   return (
-    <Flex
-      direction="row"
-      alignItems="center"
-      justifyContent="space-between"
-      gap="size-100"
-    >
+    <Flex direction="row" alignItems="center" gap="size-100">
       {hasLabelFractions ? (
         <PieChart {...chartDimensions}>
           <Pie

--- a/app/src/pages/project/AnnotationSummary.tsx
+++ b/app/src/pages/project/AnnotationSummary.tsx
@@ -12,7 +12,6 @@ import {
   Flex,
   RichTooltip,
   Text,
-  Token,
   TooltipTrigger,
   TriggerWrap,
   View,
@@ -27,6 +26,7 @@ import {
 import type {
   ComponentSize,
   SizingProps,
+  TextSize,
 } from "@phoenix/components/core/types";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { useTimeRange } from "@phoenix/components/datetime";
@@ -417,42 +417,66 @@ export function SummaryValuePreview({
           </Pie>
         </PieChart>
       ) : null}
-      <MeanScore
-        fallback={meanScoreFallback}
-        value={meanScore}
-        size={size === "S" ? size : "L"}
-      />
+      {hasMeanScore ? (
+        <MeanScore
+          fallback={meanScoreFallback}
+          value={meanScore}
+          size={size === "S" ? size : "L"}
+        />
+      ) : (
+        // When there is no mean score, a "--" mean score next to the pie chart
+        // is hard to parse. Show the most common labels instead, matching the
+        // text size of the mean score it replaces.
+        <SummaryValueLabelPreview
+          labelFractions={labelFractions ?? []}
+          size={size === "S" ? "S" : "L"}
+        />
+      )}
     </Flex>
   );
 }
 
+const MAX_VISIBLE_LABELS = 2;
+
 export function SummaryValueLabelPreview({
   labelFractions,
+  size = "M",
 }: {
   labelFractions: readonly { label: string; fraction: number }[];
+  /**
+   * The text size for the labels. Defaults to "M" for use in compact contexts
+   * such as table cells.
+   */
+  size?: TextSize;
 }) {
-  const largestFraction = labelFractions.reduce((max, current) => {
-    return Math.max(max, current.fraction);
-  }, 0);
-  const largestFractionLabel = labelFractions.find(
-    (fraction) => fraction.fraction === largestFraction
-  )?.label;
-  const totalCount = labelFractions.length - 1;
-  const hasMoreThanOneLabel = totalCount > 0;
-  if (!largestFractionLabel) {
+  if (labelFractions.length === 0) {
     return null;
   }
+  const sortedLabels = [...labelFractions].sort(
+    (a, b) => b.fraction - a.fraction
+  );
+  const visibleLabels = sortedLabels.slice(0, MAX_VISIBLE_LABELS);
+  const remainingCount = sortedLabels.length - visibleLabels.length;
   return (
     <Flex
       direction="row"
-      alignItems="center"
-      gap="size-50"
-      maxWidth={hasMoreThanOneLabel ? "80%" : "99%"}
+      alignItems="baseline"
+      gap="size-100"
+      minWidth={0}
+      maxWidth="100%"
     >
-      <Token style={{ maxWidth: "100%" }}>
-        <Truncate maxWidth="100%">{largestFractionLabel}</Truncate>
-      </Token>
-      {hasMoreThanOneLabel && <Token>+ {totalCount}</Token>}
+      <Truncate maxWidth="100%">
+        <Text size={size}>
+          {visibleLabels.map((entry) => entry.label).join(", ")}
+        </Text>
+      </Truncate>
+      {remainingCount > 0 && (
+        <Text
+          color="text-700"
+          size="S"
+          flex="none"
+        >{`+ ${remainingCount} more`}</Text>
+      )}
     </Flex>
   );
 }
@@ -477,13 +501,18 @@ export function SummaryValueBreakdown({
   const colors = useAnnotationSummaryChartColors(annotationName);
   const hasMeanScore = typeof meanScore === "number" && !isNaN(meanScore);
   const hasLabelFractions = labelFractions && labelFractions.length > 0;
+  // Only surface coverage when some — but not all — values are present. A count
+  // of 0 means the annotation simply isn't scored/labeled, so "0 of N" would be
+  // misleading rather than informative.
   const isScorePartial =
     typeof scoreCount === "number" &&
     typeof count === "number" &&
+    scoreCount > 0 &&
     scoreCount < count;
   const isLabelPartial =
     typeof labelCount === "number" &&
     typeof count === "number" &&
+    labelCount > 0 &&
     labelCount < count;
   const hasCoverage = isScorePartial || isLabelPartial;
   return (

--- a/app/src/pages/project/SpanFilterConditionField.tsx
+++ b/app/src/pages/project/SpanFilterConditionField.tsx
@@ -77,7 +77,6 @@ const fieldCSS = css`
   box-sizing: border-box;
   .search-icon {
     margin-left: var(--global-dimension-static-size-100);
-    margin-top: var(--global-dimension-static-size-100);
   }
 `;
 
@@ -324,7 +323,7 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
       css={fieldCSS}
       ref={filterConditionFieldRef}
     >
-      <Flex direction="row">
+      <Flex direction="row" alignItems="center">
         <Icon svg={<Icons.Search />} className="search-icon" />
         <CodeMirror
           css={codeMirrorCSS}


### PR DESCRIPTION
## Summary

A handful of UI nits across annotation display and the project annotation summary, plus a follow-on refactor that consolidates the annotation value-rendering logic the nits touched.

### UI nits

- **Annotation name & value** — when both a label and a score are present, render them as distinct pieces (label in the default font, score in mono, separated by a thin divider) instead of `label (score)`.
- **Summary value preview** — when there is no mean score, show the most common labels next to the pie chart instead of a hard-to-parse `--`.
- **Consistent alignment** — left-align annotation summary values so each value sits directly after the equal-width pie chart with a consistent gap, instead of being pushed to the right edge (where differing value widths made `μ 0.80`, `invalid`, etc. start at inconsistent x positions).
- **Label preview** — show up to two top labels as comma-separated text with a `+ N more` overflow indicator (replaces the single-token + count layout).
- **Coverage** — only surface annotation coverage (`X of N`) when *some but not all* values are present; a count of `0` is omitted since "0 of N" is misleading rather than informative.
- **Span filter field** — vertically center the search icon and CodeMirror input.

### Refactor

- **Dedup score/label derivation** — collapse the duplicated score/label extraction into a single shared derivation.
- **Unified value rendering** — render annotation values through a single "value parts" abstraction so chips and summary previews share one code path.
- **Simplified predicate** — collapse the value-part filter predicate to a plain expression.

## Test plan

- [ ] Annotation chips with both label and score render the score in mono with a divider, no parentheses.
- [ ] Annotations with only labels (no mean score) show top labels next to the pie chart.
- [ ] In the Stats panel, all annotation values line up at the same x position regardless of value width.
- [ ] Label preview truncates to two labels and shows `+ N more`.
- [ ] Partially-scored annotations show coverage; fully-unscored ones do not.
- [ ] Search icon is vertically centered in the span filter field.
