### PR TITLE
feat(prompts/datasets): filter by label, manage labels from the list, prompt model column

### DIFF
--- a/app/src/components/dataset/DatasetLabelConfigButton.tsx
+++ b/app/src/components/dataset/DatasetLabelConfigButton.tsx
@@ -199,6 +199,7 @@ function DatasetLabelList({
               <Button
                 variant="quiet"
                 size="S"
+                aria-label="Back to labels"
                 leadingVisual={<Icon svg={<Icons.ChevronLeftSmall />} />}
                 onPress={() => setMode("apply")}
               />
@@ -209,6 +210,7 @@ function DatasetLabelList({
               <Button
                 variant="quiet"
                 size="S"
+                aria-label="Create new label"
                 leadingVisual={<Icon svg={<Icons.PlusOutline />} />}
                 onPress={() => setMode("create")}
               />

--- a/app/src/components/dataset/DatasetLabelFilterButton.tsx
+++ b/app/src/components/dataset/DatasetLabelFilterButton.tsx
@@ -93,10 +93,10 @@ function DatasetLabelFilterContent({
 
   const handleSelectionChange = (selection: Selection) => {
     if (selection === "all") {
+      onSelectionChange(labels.map((l) => l.id));
       return;
     }
-    const newLabelIds = [...selection] as string[];
-    onSelectionChange(newLabelIds);
+    onSelectionChange([...selection] as string[]);
   };
 
   const handleClear = () => {
@@ -134,7 +134,12 @@ function DatasetLabelFilterContent({
         </Menu>
       </Autocomplete>
       <MenuFooter>
-        <Button variant="quiet" size="S" onPress={handleClear}>
+        <Button
+          variant="quiet"
+          size="S"
+          onPress={handleClear}
+          isDisabled={selectedLabelIds.length === 0}
+        >
           Clear All
         </Button>
       </MenuFooter>

--- a/app/src/components/prompt/NewPromptLabelDialog.tsx
+++ b/app/src/components/prompt/NewPromptLabelDialog.tsx
@@ -1,6 +1,3 @@
-import { useState } from "react";
-import { ConnectionHandler, graphql, useMutation } from "react-relay";
-
 import {
   Alert,
   Dialog,
@@ -11,55 +8,16 @@ import {
 } from "@phoenix/components";
 import type { LabelParams } from "@phoenix/components/label";
 import { NewLabelForm } from "@phoenix/components/label";
-import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
-
-import type { NewPromptLabelDialogMutation } from "./__generated__/NewPromptLabelDialogMutation.graphql";
+import { usePromptLabelMutations } from "@phoenix/components/prompt/usePromptLabelMutations";
 
 type NewPromptLabelDialogProps = {
   onCompleted: () => void;
 };
 export function NewPromptLabelDialog(props: NewPromptLabelDialogProps) {
-  const [error, setError] = useState("");
   const { onCompleted } = props;
-  const [addLabel, isSubmitting] = useMutation<NewPromptLabelDialogMutation>(
-    graphql`
-      mutation NewPromptLabelDialogMutation(
-        $label: CreatePromptLabelInput!
-        $connections: [ID!]!
-      ) {
-        createPromptLabel(input: $label) {
-          promptLabels
-            @prependNode(
-              connections: $connections
-              edgeTypeName: "PromptLabelEdge"
-            ) {
-            id
-            name
-            color
-          }
-        }
-      }
-    `
-  );
+  const { addLabelMutation, isSubmitting, error } = usePromptLabelMutations();
   const onSubmit = (label: LabelParams) => {
-    const connections = [
-      ConnectionHandler.getConnectionID(
-        "client:root",
-        "PromptLabelConfigButtonAllLabels_promptLabels"
-      ),
-      ConnectionHandler.getConnectionID(
-        "client:root",
-        "PromptLabelsTable__promptLabels"
-      ),
-    ];
-    addLabel({
-      variables: { label, connections },
-      onCompleted,
-      onError: (error) => {
-        const formattedError = getErrorMessagesFromRelayMutationError(error);
-        setError(formattedError?.[0] ?? error.message);
-      },
-    });
+    addLabelMutation(label, onCompleted);
   };
   return (
     <Dialog>

--- a/app/src/components/prompt/__generated__/usePromptLabelMutationsCreateLabelMutation.graphql.ts
+++ b/app/src/components/prompt/__generated__/usePromptLabelMutationsCreateLabelMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bad3979f639994874b99bea8748bdea8>>
+ * @generated SignedSource<<1d9c1c9999de8153d647b57de4eab2b4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,11 +14,11 @@ export type CreatePromptLabelInput = {
   description?: string | null;
   name: string;
 };
-export type NewPromptLabelDialogMutation$variables = {
+export type usePromptLabelMutationsCreateLabelMutation$variables = {
   connections: ReadonlyArray<string>;
   label: CreatePromptLabelInput;
 };
-export type NewPromptLabelDialogMutation$data = {
+export type usePromptLabelMutationsCreateLabelMutation$data = {
   readonly createPromptLabel: {
     readonly promptLabels: ReadonlyArray<{
       readonly color: string | null;
@@ -27,9 +27,9 @@ export type NewPromptLabelDialogMutation$data = {
     }>;
   };
 };
-export type NewPromptLabelDialogMutation = {
-  response: NewPromptLabelDialogMutation$data;
-  variables: NewPromptLabelDialogMutation$variables;
+export type usePromptLabelMutationsCreateLabelMutation = {
+  response: usePromptLabelMutationsCreateLabelMutation$data;
+  variables: usePromptLabelMutationsCreateLabelMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -90,7 +90,7 @@ return {
     ],
     "kind": "Fragment",
     "metadata": null,
-    "name": "NewPromptLabelDialogMutation",
+    "name": "usePromptLabelMutationsCreateLabelMutation",
     "selections": [
       {
         "alias": null,
@@ -115,7 +115,7 @@ return {
       (v0/*: any*/)
     ],
     "kind": "Operation",
-    "name": "NewPromptLabelDialogMutation",
+    "name": "usePromptLabelMutationsCreateLabelMutation",
     "selections": [
       {
         "alias": null,
@@ -153,16 +153,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c61bebc2bf20d8cf12760e79bfd8205b",
+    "cacheID": "8600130cb9db02bec9b9002a6338b796",
     "id": null,
     "metadata": {},
-    "name": "NewPromptLabelDialogMutation",
+    "name": "usePromptLabelMutationsCreateLabelMutation",
     "operationKind": "mutation",
-    "text": "mutation NewPromptLabelDialogMutation(\n  $label: CreatePromptLabelInput!\n) {\n  createPromptLabel(input: $label) {\n    promptLabels {\n      id\n      name\n      color\n    }\n  }\n}\n"
+    "text": "mutation usePromptLabelMutationsCreateLabelMutation(\n  $label: CreatePromptLabelInput!\n) {\n  createPromptLabel(input: $label) {\n    promptLabels {\n      id\n      name\n      color\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ddbd14ff91d53dfbceede5ee349cb9ab";
+(node as any).hash = "4a8dfd9b431701c95705b5098fdb8be2";
 
 export default node;

--- a/app/src/components/prompt/usePromptLabelMutations.tsx
+++ b/app/src/components/prompt/usePromptLabelMutations.tsx
@@ -1,0 +1,70 @@
+import { useCallback, useState } from "react";
+import { ConnectionHandler, graphql, useMutation } from "react-relay";
+
+import type { LabelParams } from "@phoenix/components/label";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
+
+import type { usePromptLabelMutationsCreateLabelMutation } from "./__generated__/usePromptLabelMutationsCreateLabelMutation.graphql";
+
+/**
+ * The Relay connections that hold prompt labels. A newly created label is
+ * prepended to each so it appears immediately wherever prompt labels are listed
+ * (the label picker and the settings table).
+ */
+function getPromptLabelConnectionIds(): string[] {
+  return [
+    ConnectionHandler.getConnectionID(
+      "client:root",
+      "PromptLabelConfigButtonAllLabels_promptLabels"
+    ),
+    ConnectionHandler.getConnectionID(
+      "client:root",
+      "PromptLabelsTable__promptLabels"
+    ),
+  ];
+}
+
+/**
+ * Owns the "create prompt label" mutation and its Relay connection wiring,
+ * shared by every prompt-label creation surface. Mirrors
+ * {@link useDatasetLabelMutations}.
+ */
+export const usePromptLabelMutations = () => {
+  const [error, setError] = useState("");
+
+  const [createLabel, isSubmitting] =
+    useMutation<usePromptLabelMutationsCreateLabelMutation>(graphql`
+      mutation usePromptLabelMutationsCreateLabelMutation(
+        $label: CreatePromptLabelInput!
+        $connections: [ID!]!
+      ) {
+        createPromptLabel(input: $label) {
+          promptLabels
+            @prependNode(
+              connections: $connections
+              edgeTypeName: "PromptLabelEdge"
+            ) {
+            id
+            name
+            color
+          }
+        }
+      }
+    `);
+
+  const addLabelMutation = useCallback(
+    (label: LabelParams, onCompleted: () => void) => {
+      createLabel({
+        variables: { label, connections: getPromptLabelConnectionIds() },
+        onCompleted,
+        onError: (error) => {
+          const formattedError = getErrorMessagesFromRelayMutationError(error);
+          setError(formattedError?.[0] ?? error.message);
+        },
+      });
+    },
+    [createLabel]
+  );
+
+  return { addLabelMutation, isSubmitting, error };
+};

--- a/app/src/constants/searchParams.ts
+++ b/app/src/constants/searchParams.ts
@@ -43,6 +43,14 @@ export const TIME_RANGE_START_PARAM = "timeRangeStart";
  */
 export const TIME_RANGE_END_PARAM = "timeRangeEnd";
 
+/**
+ * The search param that holds the label ids used to filter a list of resources
+ * (e.g. prompts or datasets). Stored as a repeated param so multiple labels can
+ * be selected, e.g. `?labelId=a&labelId=b`. Persisting to the URL makes the
+ * label filter shareable and lets it survive reloads.
+ */
+export const LABEL_ID_PARAM = "labelId";
+
 export const CREATE_CODE_EVALUATOR_PARAM = "createCodeEvaluator";
 
 export const CREATE_LLM_EVALUATOR_PARAM = "createLlmEvaluator";

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -12,3 +12,4 @@ export * from "./useCurrentTime";
 export * from "./useUnnestedValue";
 export * from "./usePersistedState";
 export * from "./useOwnedPreloadedQuery";
+export * from "./useLabelFilterSearchParams";

--- a/app/src/hooks/useLabelFilterSearchParams.ts
+++ b/app/src/hooks/useLabelFilterSearchParams.ts
@@ -1,0 +1,45 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router";
+
+import { LABEL_ID_PARAM } from "@phoenix/constants/searchParams";
+
+/**
+ * Backs a label-id filter selection with the URL search params so the filter is
+ * shareable and survives reloads. Label ids are stored as repeated `labelId`
+ * query params (e.g. `?labelId=a&labelId=b`).
+ *
+ * Returns a `[selectedLabelIds, setSelectedLabelIds]` tuple with the same shape
+ * as `useState<string[]>`, so it can be dropped in wherever local label-filter
+ * state was previously held.
+ */
+export function useLabelFilterSearchParams(): [
+  string[],
+  Dispatch<SetStateAction<string[]>>,
+] {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const selectedLabelIds = useMemo(
+    () => searchParams.getAll(LABEL_ID_PARAM),
+    [searchParams]
+  );
+
+  const setSelectedLabelIds = useCallback<Dispatch<SetStateAction<string[]>>>(
+    (action) => {
+      setSearchParams(
+        (prev) => {
+          const current = prev.getAll(LABEL_ID_PARAM);
+          const next = typeof action === "function" ? action(current) : action;
+          const newParams = new URLSearchParams(prev);
+          newParams.delete(LABEL_ID_PARAM);
+          next.forEach((id) => newParams.append(LABEL_ID_PARAM, id));
+          return newParams;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  return [selectedLabelIds, setSelectedLabelIds];
+}

--- a/app/src/pages/datasets/DatasetActionMenu.tsx
+++ b/app/src/pages/datasets/DatasetActionMenu.tsx
@@ -52,6 +52,7 @@ export function DatasetActionMenu(props: DatasetActionMenuProps) {
       <MenuTrigger>
         <Button
           size="S"
+          aria-label="Dataset actions"
           leadingVisual={<Icon svg={<Icons.MoreHorizontalOutline />} />}
         />
         <Popover>

--- a/app/src/pages/datasets/DatasetsPage.tsx
+++ b/app/src/pages/datasets/DatasetsPage.tsx
@@ -4,6 +4,7 @@ import { graphql, useLazyLoadQuery } from "react-relay";
 import { DebouncedSearch, Flex, Loading, View } from "@phoenix/components";
 import { CanModify } from "@phoenix/components/auth";
 import { DatasetLabelFilterButton } from "@phoenix/components/dataset/DatasetLabelFilterButton";
+import { useLabelFilterSearchParams } from "@phoenix/hooks";
 
 import type { DatasetsPageQuery } from "./__generated__/DatasetsPageQuery.graphql";
 import { CreateDatasetButton } from "./CreateDatasetButton";
@@ -36,7 +37,9 @@ export function DatasetsPageContent() {
   }, [setFetchKey]);
 
   const [filter, setFilter] = useState<string>("");
-  const [selectedLabelIds, setSelectedLabelIds] = useState<string[]>([]);
+  // The label filter is persisted to the URL so it can be shared and survive
+  // reloads.
+  const [selectedLabelIds, setSelectedLabelIds] = useLabelFilterSearchParams();
   return (
     <Flex direction="column" height="100%">
       <View
@@ -73,6 +76,7 @@ export function DatasetsPageContent() {
         query={data}
         filter={filter}
         labelFilter={selectedLabelIds}
+        onLabelFilterChange={setSelectedLabelIds}
       />
     </Flex>
   );

--- a/app/src/pages/datasets/DatasetsTable.tsx
+++ b/app/src/pages/datasets/DatasetsTable.tsx
@@ -10,6 +10,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import type { Dispatch, SetStateAction } from "react";
 import {
   startTransition,
   useCallback,
@@ -43,6 +44,7 @@ import {
 import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { useNotifySuccess, useViewerCanModify } from "@phoenix/contexts";
+import { toggleArrayItem } from "@phoenix/utils/arrayUtils";
 import { makeSafeColumnId } from "@phoenix/utils/tableUtils";
 
 import type { DatasetsTable_datasets$key } from "./__generated__/DatasetsTable_datasets.graphql";
@@ -62,6 +64,7 @@ type DatasetsTableProps = {
   query: DatasetsTable_datasets$key;
   filter: string;
   labelFilter?: string[];
+  onLabelFilterChange?: Dispatch<SetStateAction<string[]>>;
 };
 
 function toGqlSort(sort: SortingState[number]): DatasetSort {
@@ -77,8 +80,15 @@ function toGqlSort(sort: SortingState[number]): DatasetSort {
 
 export function DatasetsTable(props: DatasetsTableProps) {
   "use no memo";
-  const { filter, labelFilter } = props;
+  const { filter, labelFilter, onLabelFilterChange } = props;
   const [sorting, setSorting] = useState<SortingState>([]);
+
+  const toggleLabelFilter = useCallback(
+    (labelId: string) => {
+      onLabelFilterChange?.((prev) => toggleArrayItem(prev, labelId));
+    },
+    [onLabelFilterChange]
+  );
   const [columnSizing, setColumnSizing] = useState({});
   //we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -197,11 +207,17 @@ export function DatasetsTable(props: DatasetsTableProps) {
             >
               {row.original.labels.map((label) => (
                 <li key={label.id}>
-                  <Token color={label.color}>
-                    <Truncate maxWidth={200} title={label.name}>
-                      {label.name}
-                    </Truncate>
-                  </Token>
+                  <StopPropagation>
+                    <Token
+                      color={label.color}
+                      onPress={() => toggleLabelFilter(label.id)}
+                      aria-label={`Filter datasets by label ${label.name}`}
+                    >
+                      <Truncate maxWidth={200} title={label.name}>
+                        {label.name}
+                      </Truncate>
+                    </Token>
+                  </StopPropagation>
                 </li>
               ))}
             </ul>
@@ -356,7 +372,14 @@ export function DatasetsTable(props: DatasetsTableProps) {
       });
     }
     return cols;
-  }, [filter, labelFilter, notifySuccess, refetch, canModify]);
+  }, [
+    filter,
+    labelFilter,
+    notifySuccess,
+    refetch,
+    canModify,
+    toggleLabelFilter,
+  ]);
 
   const table = useReactTable({
     columns,

--- a/app/src/pages/prompt/PromptLabelConfigButton.tsx
+++ b/app/src/pages/prompt/PromptLabelConfigButton.tsx
@@ -1,5 +1,4 @@
 import { Suspense, useMemo, useState } from "react";
-import { ModalOverlay } from "react-aria-components";
 import {
   graphql,
   useFragment,
@@ -8,13 +7,13 @@ import {
 } from "react-relay";
 
 import {
+  Alert,
   Autocomplete,
   Button,
   ColorSwatch,
   Dialog,
   DialogTrigger,
   Icon,
-  IconButton,
   Icons,
   Input,
   LinkButton,
@@ -25,7 +24,6 @@ import {
   MenuHeader,
   MenuHeaderTitle,
   MenuItem,
-  Modal,
   Popover,
   PopoverArrow,
   SearchField,
@@ -33,10 +31,12 @@ import {
   useFilter,
 } from "@phoenix/components";
 import { SearchIcon } from "@phoenix/components/core/field";
-import { NewPromptLabelDialog } from "@phoenix/components/prompt/NewPromptLabelDialog";
+import { NewLabelForm } from "@phoenix/components/label";
+import { usePromptLabelMutations } from "@phoenix/components/prompt/usePromptLabelMutations";
 import type { PromptLabelConfigButton_allLabels$key } from "@phoenix/pages/prompt/__generated__/PromptLabelConfigButton_allLabels.graphql";
 import type { PromptLabelConfigButton_promptLabels$key } from "@phoenix/pages/prompt/__generated__/PromptLabelConfigButton_promptLabels.graphql";
 import type { PromptLabelConfigButtonUnsetLabelsMutation } from "@phoenix/pages/prompt/__generated__/PromptLabelConfigButtonUnsetLabelsMutation.graphql";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import type { PromptLabelConfigButtonQuery } from "./__generated__/PromptLabelConfigButtonQuery.graphql";
 import type { PromptLabelConfigButtonSetLabelsMutation } from "./__generated__/PromptLabelConfigButtonSetLabelsMutation.graphql";
@@ -47,58 +47,36 @@ type PromptLabelConfigButtonProps = {
 
 export function PromptLabelConfigButton(props: PromptLabelConfigButtonProps) {
   const { promptId } = props;
-  const [showNewLabelDialog, setShowNewLabelDialog] = useState<boolean>(false);
-  const [isOpen, setIsOpen] = useState(false);
   return (
-    <>
-      <DialogTrigger
-        isOpen={isOpen && !showNewLabelDialog}
-        onOpenChange={(newIsOpen) => setIsOpen(newIsOpen)}
+    <DialogTrigger>
+      <Button
+        variant="quiet"
+        size="S"
+        leadingVisual={<Icon svg={<Icons.SettingsOutline />} />}
+        aria-label="Edit prompt labels"
+      />
+      <Popover
+        placement="bottom start"
+        shouldCloseOnInteractOutside={() => true}
       >
-        <Button
-          variant="quiet"
-          size="S"
-          leadingVisual={<Icon svg={<Icons.SettingsOutline />} />}
-          aria-label="Edit prompt labels"
-        />
-        <Popover>
-          <PopoverArrow />
-          <Dialog>
-            <Suspense fallback={<Loading />}>
-              <PromptLabelSelectionDialogContent
-                promptId={promptId}
-                onNewLabelPress={() => {
-                  setShowNewLabelDialog(true);
-                }}
-              />
-            </Suspense>
-          </Dialog>
-        </Popover>
-      </DialogTrigger>
-      {showNewLabelDialog ? (
-        <ModalOverlay
-          isOpen
-          onOpenChange={(isOpen) => {
-            if (!isOpen) {
-              setShowNewLabelDialog(false);
-            }
-          }}
-        >
-          <Modal size="S">
-            <NewPromptLabelDialog
-              onCompleted={() => setShowNewLabelDialog(false)}
-            />
-          </Modal>
-        </ModalOverlay>
-      ) : null}
-    </>
+        <PopoverArrow />
+        <Dialog>
+          <Suspense fallback={<Loading />}>
+            <PromptLabelSelectionContent promptId={promptId} />
+          </Suspense>
+        </Dialog>
+      </Popover>
+    </DialogTrigger>
   );
 }
 
-function PromptLabelSelectionDialogContent(props: {
-  promptId: string;
-  onNewLabelPress: () => void;
-}) {
+/**
+ * A self-contained label selection control for a prompt, suitable for rendering
+ * inside a popover (e.g. from a table row action menu). It supports applying
+ * existing labels and creating a new label inline, mirroring the datasets list
+ * experience ({@link DatasetLabelSelectionContent}).
+ */
+export function PromptLabelSelectionContent(props: { promptId: string }) {
   const { promptId } = props;
   const query = useLazyLoadQuery<PromptLabelConfigButtonQuery>(
     graphql`
@@ -114,17 +92,18 @@ function PromptLabelSelectionDialogContent(props: {
     { promptId }
   );
 
-  return <PromptLabelList query={query} prompt={query.prompt} {...props} />;
+  return <PromptLabelList query={query} prompt={query.prompt} />;
 }
+
 function PromptLabelList({
   query,
   prompt,
-  onNewLabelPress,
 }: {
   prompt: PromptLabelConfigButton_promptLabels$key;
   query: PromptLabelConfigButton_allLabels$key;
-  onNewLabelPress: () => void;
 }) {
+  const [mode, setMode] = useState<"apply" | "create">("apply");
+  const [error, setError] = useState<string | null>(null);
   const { contains } = useFilter({ sensitivity: "base" });
   const promptData = useFragment<PromptLabelConfigButton_promptLabels$key>(
     graphql`
@@ -156,10 +135,12 @@ function PromptLabelList({
     query
   );
 
-  const selectedLabelIds = promptData?.labels?.map((label) => label.id) || [];
-  const [selected, setSelected] = useState<Selection>(
-    () => new Set(selectedLabelIds)
+  const selectedLabelIds = useMemo(
+    () => promptData?.labels?.map((label) => label.id) ?? [],
+    [promptData?.labels]
   );
+  // Derive selected state directly from Relay data - no need for separate state
+  const selected = useMemo(() => new Set(selectedLabelIds), [selectedLabelIds]);
 
   const labels = useMemo(
     () => labelData.promptLabels.edges.map((edge) => edge.node),
@@ -205,24 +186,27 @@ function PromptLabelList({
       }
     `);
 
+  const onError = (error: Error) => {
+    const formattedError = getErrorMessagesFromRelayMutationError(error);
+    setError(formattedError?.[0] ?? error.message);
+  };
+
   const onSelectionChange = (selection: Selection) => {
     if (selection === "all") {
       return;
     }
     const newLabelIds = [...selection] as string[];
-    const labelIdsToAdd: string[] = newLabelIds.filter(
+    const labelIdsToAdd = newLabelIds.filter(
       (id) => !selectedLabelIds.includes(id)
     );
-    const labelIdsToRemove: string[] = selectedLabelIds.filter(
+    const labelIdsToRemove = selectedLabelIds.filter(
       (id) => !newLabelIds.includes(id)
     );
 
     if (labelIdsToAdd.length) {
       setPromptLabels({
-        variables: {
-          promptId: promptData.id,
-          promptLabelIds: labelIdsToAdd,
-        },
+        variables: { promptId: promptData.id, promptLabelIds: labelIdsToAdd },
+        onError,
       });
     }
     if (labelIdsToRemove.length) {
@@ -231,58 +215,103 @@ function PromptLabelList({
           promptId: promptData.id,
           promptLabelIds: labelIdsToRemove,
         },
+        onError,
       });
     }
-    setSelected(selection);
   };
+
   return (
     <>
-      <Autocomplete filter={contains}>
-        <MenuHeader>
-          <MenuHeaderTitle
-            trailingContent={
-              <IconButton size="S" onPress={onNewLabelPress}>
-                <Icon svg={<Icons.PlusOutline />} />
-              </IconButton>
-            }
-          >
-            Assign labels to this prompt
-          </MenuHeaderTitle>
-          <SearchField aria-label="Search labels" variant="quiet" autoFocus>
-            <SearchIcon />
-            <Input placeholder="Search labels..." />
-          </SearchField>
-        </MenuHeader>
-        <Menu
-          aria-label="labels"
-          items={labels}
-          selectionMode="multiple"
-          selectedKeys={selected}
-          onSelectionChange={onSelectionChange}
-          renderEmptyState={() => <MenuEmpty>No labels found</MenuEmpty>}
+      {error && <Alert variant="danger">{error}</Alert>}
+      <MenuHeader>
+        <MenuHeaderTitle
+          leadingContent={
+            mode === "create" ? (
+              <Button
+                variant="quiet"
+                size="S"
+                aria-label="Back to labels"
+                leadingVisual={<Icon svg={<Icons.ChevronLeftSmall />} />}
+                onPress={() => setMode("apply")}
+              />
+            ) : undefined
+          }
+          trailingContent={
+            mode === "apply" ? (
+              <Button
+                variant="quiet"
+                size="S"
+                aria-label="Create new label"
+                leadingVisual={<Icon svg={<Icons.PlusOutline />} />}
+                onPress={() => setMode("create")}
+              />
+            ) : undefined
+          }
         >
-          {({ id, name, color }) => (
-            <MenuItem
-              id={id}
-              textValue={name}
-              leadingContent={
-                <ColorSwatch
-                  color={color ?? undefined}
-                  size="M"
-                  shape="circle"
-                />
-              }
+          {mode === "create" ? "Create New Label" : "Assign labels"}
+        </MenuHeaderTitle>
+      </MenuHeader>
+      {mode === "apply" && (
+        <>
+          <Autocomplete filter={contains}>
+            <MenuHeader>
+              <SearchField aria-label="Search labels" variant="quiet" autoFocus>
+                <SearchIcon />
+                <Input placeholder="Search labels..." />
+              </SearchField>
+            </MenuHeader>
+            <Menu
+              aria-label="labels"
+              items={labels}
+              selectionMode="multiple"
+              selectedKeys={selected}
+              onSelectionChange={onSelectionChange}
+              renderEmptyState={() => <MenuEmpty>No labels found</MenuEmpty>}
             >
-              {name}
-            </MenuItem>
-          )}
-        </Menu>
-      </Autocomplete>
-      <MenuFooter>
-        <LinkButton variant="quiet" size="S" to="/settings/prompts">
-          Edit Labels
-        </LinkButton>
-      </MenuFooter>
+              {({ id, name, color }) => (
+                <MenuItem
+                  id={id}
+                  textValue={name}
+                  leadingContent={
+                    <ColorSwatch
+                      color={color ?? undefined}
+                      size="M"
+                      shape="circle"
+                    />
+                  }
+                >
+                  {name}
+                </MenuItem>
+              )}
+            </Menu>
+          </Autocomplete>
+          <MenuFooter>
+            <LinkButton variant="quiet" size="S" to="/settings/prompts">
+              Edit Labels
+            </LinkButton>
+          </MenuFooter>
+        </>
+      )}
+      {mode === "create" && (
+        <CreateNewPromptLabel onCompleted={() => setMode("apply")} />
+      )}
+    </>
+  );
+}
+
+function CreateNewPromptLabel({ onCompleted }: { onCompleted: () => void }) {
+  const { addLabelMutation, isSubmitting, error } = usePromptLabelMutations();
+  return (
+    <>
+      {error && (
+        <Alert banner variant="danger">
+          {error}
+        </Alert>
+      )}
+      <NewLabelForm
+        onSubmit={(label) => addLabelMutation(label, onCompleted)}
+        isSubmitting={isSubmitting}
+      />
     </>
   );
 }

--- a/app/src/pages/prompts/PromptActionMenu.tsx
+++ b/app/src/pages/prompts/PromptActionMenu.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useState } from "react";
+import { css } from "@emotion/react";
+import { Suspense, useCallback, useState } from "react";
+import { SubmenuTrigger } from "react-aria-components";
 
 import {
   Button,
@@ -6,18 +8,23 @@ import {
   Flex,
   Icon,
   Icons,
+  Loading,
   Menu,
   MenuItem,
   MenuTrigger,
   Modal,
   Popover,
+  PopoverArrow,
+  Text,
 } from "@phoenix/components";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
+import { PromptLabelSelectionContent } from "@phoenix/pages/prompt/PromptLabelConfigButton";
 
 import { DeletePromptDialog } from "./DeletePromptDialog";
 
 enum PromptAction {
   DELETE = "DELETE",
+  LABELS = "LABELS",
 }
 
 export function PromptActionMenu({
@@ -38,6 +45,7 @@ export function PromptActionMenu({
       <MenuTrigger>
         <Button
           size="S"
+          aria-label="Prompt actions"
           leadingVisual={<Icon svg={<Icons.MoreHorizontalOutline />} />}
         />
         <Popover>
@@ -51,6 +59,40 @@ export function PromptActionMenu({
               }
             }}
           >
+            <SubmenuTrigger>
+              <MenuItem id={PromptAction.LABELS}>
+                <Flex
+                  direction={"row"}
+                  gap="size-75"
+                  justifyContent={"start"}
+                  alignItems={"center"}
+                >
+                  <Icon svg={<Icons.PriceTagsOutline />} />
+                  <Text>Label</Text>
+                </Flex>
+              </MenuItem>
+              <Popover
+                placement="start top"
+                css={css`
+                  min-width: 300px;
+                  width: 300px;
+                `}
+              >
+                <PopoverArrow />
+                <Suspense
+                  fallback={
+                    <Loading
+                      css={css`
+                        min-width: 300px;
+                        min-height: 100px;
+                      `}
+                    />
+                  }
+                >
+                  <PromptLabelSelectionContent promptId={promptId} />
+                </Suspense>
+              </Popover>
+            </SubmenuTrigger>
             <MenuItem id={PromptAction.DELETE}>
               <Flex
                 direction={"row"}
@@ -59,7 +101,7 @@ export function PromptActionMenu({
                 alignItems={"center"}
               >
                 <Icon svg={<Icons.TrashOutline />} />
-                <>Delete</>
+                <Text>Delete</Text>
               </Flex>
             </MenuItem>
           </Menu>

--- a/app/src/pages/prompts/PromptsFilterProvider.tsx
+++ b/app/src/pages/prompts/PromptsFilterProvider.tsx
@@ -1,6 +1,8 @@
 import type { Dispatch, PropsWithChildren, SetStateAction } from "react";
 import { createContext, useContext, useState } from "react";
 
+import { useLabelFilterSearchParams } from "@phoenix/hooks";
+
 export type PromptsFilterContext = {
   filter: string;
   setFilter: Dispatch<SetStateAction<string>>;
@@ -14,9 +16,10 @@ export const promptsFilterContext = createContext<PromptsFilterContext | null>(
 
 export const PromptsFilterProvider = ({ children }: PropsWithChildren) => {
   const [filter, setFilter] = useState("");
-  const [selectedPromptLabelIds, setSelectedPromptLabelIds] = useState<
-    string[]
-  >([]);
+  // The label filter is persisted to the URL so it can be shared and survive
+  // reloads.
+  const [selectedPromptLabelIds, setSelectedPromptLabelIds] =
+    useLabelFilterSearchParams();
   return (
     <promptsFilterContext.Provider
       value={{

--- a/app/src/pages/prompts/PromptsLabelMenu.tsx
+++ b/app/src/pages/prompts/PromptsLabelMenu.tsx
@@ -5,18 +5,21 @@ import { graphql, useLazyLoadQuery } from "react-relay";
 import {
   Autocomplete,
   Button,
+  ColorSwatch,
+  Counter,
   Icon,
   Icons,
   Input,
   Loading,
   Menu,
   MenuEmpty,
+  MenuFooter,
   MenuHeader,
   MenuItem,
   MenuTrigger,
   Popover,
   SearchField,
-  Token,
+  type Selection,
   useFilter,
 } from "@phoenix/components";
 import { SearchIcon } from "@phoenix/components/core/field";
@@ -28,8 +31,9 @@ type PromptsLabelMenuProps = {
 };
 
 /**
- * The PromptsLabelMenu is a menu that allows the user to filter prompts by labels.
- * Currently supports filtering mode only, with room for future "add" mode functionality.
+ * The PromptsLabelMenu is a menu that allows the user to filter prompts by
+ * labels. It is intentionally kept in sync with the datasets label filter
+ * ({@link DatasetLabelFilterButton}) so the two list pages behave identically.
  */
 export const PromptsLabelMenu = ({
   onSelectionChange,
@@ -37,9 +41,17 @@ export const PromptsLabelMenu = ({
 }: PromptsLabelMenuProps) => {
   return (
     <MenuTrigger>
-      <Button leadingVisual={<Icon svg={<Icons.PriceTagsOutline />} />}>
+      <Button
+        variant="default"
+        size="M"
+        leadingVisual={<Icon svg={<Icons.PriceTagsOutline />} />}
+        trailingVisual={
+          selectedLabelIds.length > 0 ? (
+            <Counter>{selectedLabelIds.length}</Counter>
+          ) : undefined
+        }
+      >
         Labels
-        {selectedLabelIds.length > 0 ? ` (${selectedLabelIds.length})` : ""}
       </Button>
       <Popover placement="bottom end">
         <Suspense
@@ -96,33 +108,62 @@ const LabelMenuFilterContent = ({
     return data.promptLabels.edges.map((edge) => edge.label);
   }, [data]);
 
+  const handleSelectionChange = (selection: Selection) => {
+    if (selection === "all") {
+      onSelectionChange(labels.map((l) => l.id));
+      return;
+    }
+    onSelectionChange([...selection] as string[]);
+  };
+
+  const handleClear = () => {
+    onSelectionChange([]);
+  };
+
   return (
-    <Autocomplete filter={contains}>
-      <MenuHeader>
-        <SearchField aria-label="Search" variant="quiet" autoFocus>
-          <SearchIcon />
-          <Input placeholder="Search labels" />
-        </SearchField>
-      </MenuHeader>
-      <Menu
-        items={labels}
-        selectionMode="multiple"
-        renderEmptyState={() => <MenuEmpty>No labels found</MenuEmpty>}
-        selectedKeys={selectedLabelIds}
-        onSelectionChange={(keys) => {
-          if (keys === "all") {
-            onSelectionChange(labels.map((l) => l.id));
-          } else {
-            onSelectionChange(Array.from(keys as Set<string>));
-          }
-        }}
-      >
-        {({ id, name, color }) => (
-          <MenuItem id={id} textValue={name}>
-            <Token color={color ?? undefined}>{name}</Token>
-          </MenuItem>
-        )}
-      </Menu>
-    </Autocomplete>
+    <>
+      <Autocomplete filter={contains}>
+        <MenuHeader>
+          <SearchField aria-label="Search labels" variant="quiet" autoFocus>
+            <SearchIcon />
+            <Input placeholder="Search labels..." />
+          </SearchField>
+        </MenuHeader>
+        <Menu
+          aria-label="labels"
+          items={labels}
+          selectionMode="multiple"
+          renderEmptyState={() => <MenuEmpty>No labels found</MenuEmpty>}
+          selectedKeys={selectedLabelIds}
+          onSelectionChange={handleSelectionChange}
+        >
+          {({ id, name, color }) => (
+            <MenuItem
+              id={id}
+              textValue={name}
+              leadingContent={
+                <ColorSwatch
+                  color={color ?? undefined}
+                  size="M"
+                  shape="circle"
+                />
+              }
+            >
+              {name}
+            </MenuItem>
+          )}
+        </Menu>
+      </Autocomplete>
+      <MenuFooter>
+        <Button
+          variant="quiet"
+          size="S"
+          onPress={handleClear}
+          isDisabled={selectedLabelIds.length === 0}
+        >
+          Clear All
+        </Button>
+      </MenuFooter>
+    </>
   );
 };

--- a/app/src/pages/prompts/PromptsTable.tsx
+++ b/app/src/pages/prompts/PromptsTable.tsx
@@ -32,6 +32,7 @@ import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { useViewerCanModify } from "@phoenix/contexts";
 import { useInterval } from "@phoenix/hooks/useInterval";
 import { usePromptsFilterContext } from "@phoenix/pages/prompts/PromptsFilterProvider";
+import { toggleArrayItem } from "@phoenix/utils/arrayUtils";
 
 import type { PromptsTable_prompts$key } from "./__generated__/PromptsTable_prompts.graphql";
 import type { PromptsTablePromptsQuery } from "./__generated__/PromptsTablePromptsQuery.graphql";
@@ -47,8 +48,16 @@ type PromptsTableProps = {
 
 export function PromptsTable(props: PromptsTableProps) {
   "use no memo";
-  const { filter, selectedPromptLabelIds } = usePromptsFilterContext();
+  const { filter, selectedPromptLabelIds, setSelectedPromptLabelIds } =
+    usePromptsFilterContext();
   const navigate = useNavigate();
+
+  const toggleLabelFilter = useCallback(
+    (labelId: string) => {
+      setSelectedPromptLabelIds((prev) => toggleArrayItem(prev, labelId));
+    },
+    [setSelectedPromptLabelIds]
+  );
   //we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
 
@@ -186,9 +195,15 @@ export function PromptsTable(props: PromptsTableProps) {
               `}
             >
               {row.original.labels.map((label) => (
-                <Token key={label.id} color={label.color ?? undefined}>
-                  {label.name}
-                </Token>
+                <StopPropagation key={label.id}>
+                  <Token
+                    color={label.color ?? undefined}
+                    onPress={() => toggleLabelFilter(label.id)}
+                    aria-label={`Filter prompts by label ${label.name}`}
+                  >
+                    {label.name}
+                  </Token>
+                </StopPropagation>
               ))}
             </ul>
           );
@@ -242,7 +257,7 @@ export function PromptsTable(props: PromptsTableProps) {
       });
     }
     return cols;
-  }, [refetch, queryArgs, canModify]);
+  }, [refetch, queryArgs, canModify, toggleLabelFilter]);
 
   // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable({

--- a/app/src/pages/prompts/PromptsTable.tsx
+++ b/app/src/pages/prompts/PromptsTable.tsx
@@ -23,11 +23,17 @@ import {
   Icons,
   Link,
   LinkButton,
+  Text,
   Token,
 } from "@phoenix/components";
+import { Truncate } from "@phoenix/components/core/utility/Truncate";
+import { GenerativeProviderIcon } from "@phoenix/components/generative/GenerativeProviderIcon";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
 import { CellWithControlsWrap, TextCell } from "@phoenix/components/table";
-import { selectableTableCSS } from "@phoenix/components/table/styles";
+import {
+  getCommonPinningStyles,
+  selectableTableCSS,
+} from "@phoenix/components/table/styles";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { useViewerCanModify } from "@phoenix/contexts";
 import { useInterval } from "@phoenix/hooks/useInterval";
@@ -94,6 +100,8 @@ export function PromptsTable(props: PromptsTableProps) {
                 description
                 version {
                   createdAt
+                  modelName
+                  modelProvider
                 }
                 labels {
                   id
@@ -142,6 +150,8 @@ export function PromptsTable(props: PromptsTableProps) {
       data.prompts.edges.map((edge) => {
         return {
           lastUpdatedAt: edge.prompt.version.createdAt,
+          modelName: edge.prompt.version.modelName,
+          modelProvider: edge.prompt.version.modelProvider,
           ...edge.prompt,
         };
       }),
@@ -185,6 +195,7 @@ export function PromptsTable(props: PromptsTableProps) {
       {
         header: "labels",
         accessorKey: "labels",
+        enableSorting: false,
         cell: ({ row }) => {
           return (
             <ul
@@ -192,18 +203,24 @@ export function PromptsTable(props: PromptsTableProps) {
                 display: flex;
                 flex-direction: row;
                 gap: var(--global-dimension-size-100);
+                min-width: 0;
+                flex-wrap: wrap;
               `}
             >
               {row.original.labels.map((label) => (
-                <StopPropagation key={label.id}>
-                  <Token
-                    color={label.color ?? undefined}
-                    onPress={() => toggleLabelFilter(label.id)}
-                    aria-label={`Filter prompts by label ${label.name}`}
-                  >
-                    {label.name}
-                  </Token>
-                </StopPropagation>
+                <li key={label.id}>
+                  <StopPropagation>
+                    <Token
+                      color={label.color ?? undefined}
+                      onPress={() => toggleLabelFilter(label.id)}
+                      aria-label={`Filter prompts by label ${label.name}`}
+                    >
+                      <Truncate maxWidth={200} title={label.name}>
+                        {label.name}
+                      </Truncate>
+                    </Token>
+                  </StopPropagation>
+                </li>
               ))}
             </ul>
           );
@@ -214,7 +231,24 @@ export function PromptsTable(props: PromptsTableProps) {
         accessorKey: "description",
         cell: TextCell,
       },
-
+      {
+        header: "model",
+        accessorKey: "modelName",
+        cell: ({ row }) => {
+          const { modelName, modelProvider } = row.original;
+          if (!modelName) {
+            return <Text color="text-700">—</Text>;
+          }
+          return (
+            <Flex direction="row" gap="size-100" alignItems="center">
+              <GenerativeProviderIcon provider={modelProvider} height={16} />
+              <Text minWidth={0}>
+                <Truncate>{modelName}</Truncate>
+              </Text>
+            </Flex>
+          );
+        },
+      },
       {
         header: "last updated",
         accessorKey: "lastUpdatedAt",
@@ -225,7 +259,8 @@ export function PromptsTable(props: PromptsTableProps) {
       cols.push({
         id: "actions",
         header: "",
-        size: 5,
+        size: 150,
+        enableSorting: false,
         accessorKey: "id",
         cell: ({ row }) => {
           return (
@@ -263,6 +298,11 @@ export function PromptsTable(props: PromptsTableProps) {
   const table = useReactTable({
     columns,
     data: tableData,
+    state: {
+      columnPinning: {
+        right: ["actions"],
+      },
+    },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });
@@ -283,12 +323,20 @@ export function PromptsTable(props: PromptsTableProps) {
       onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
       ref={tableContainerRef}
     >
-      <table css={selectableTableCSS}>
+      <table css={selectableTableCSS} data-testid="prompts-table">
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
-                <th colSpan={header.colSpan} key={header.id}>
+                <th
+                  colSpan={header.colSpan}
+                  key={header.id}
+                  style={
+                    header.column.getIsPinned()
+                      ? getCommonPinningStyles(header.column)
+                      : undefined
+                  }
+                >
                   {header.isPlaceholder ? null : (
                     <div
                       {...{
@@ -338,6 +386,11 @@ export function PromptsTable(props: PromptsTableProps) {
                   <td
                     key={cell.id}
                     align={cell.column.columnDef.meta?.textAlign}
+                    style={
+                      cell.column.getIsPinned()
+                        ? getCommonPinningStyles(cell.column)
+                        : undefined
+                    }
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </td>

--- a/app/src/pages/prompts/__generated__/DeletePromptDialogMutation.graphql.ts
+++ b/app/src/pages/prompts/__generated__/DeletePromptDialogMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a7476295d22857c2bba427ce5e638e32>>
+ * @generated SignedSource<<aa97cb2ce61df2aef89a2a29183d34e2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -175,6 +175,20 @@ return {
                                 "name": "createdAt",
                                 "storageKey": null
                               },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "modelName",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "modelProvider",
+                                "storageKey": null
+                              },
                               (v3/*: any*/)
                             ],
                             "storageKey": null
@@ -280,12 +294,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f37f369f2b729a5193d63006fe1ac7e2",
+    "cacheID": "f98bcfbed3d7b46df48d0ca35974cd02",
     "id": null,
     "metadata": {},
     "name": "DeletePromptDialogMutation",
     "operationKind": "mutation",
-    "text": "mutation DeletePromptDialogMutation(\n  $promptId: ID!\n) {\n  deletePrompt(input: {promptId: $promptId}) {\n    query {\n      ...PromptsTable_prompts\n    }\n  }\n}\n\nfragment PromptsTable_prompts on Query {\n  prompts(first: 100) {\n    edges {\n      prompt: node {\n        id\n        name\n        description\n        version {\n          createdAt\n          id\n        }\n        labels {\n          id\n          name\n          color\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "mutation DeletePromptDialogMutation(\n  $promptId: ID!\n) {\n  deletePrompt(input: {promptId: $promptId}) {\n    query {\n      ...PromptsTable_prompts\n    }\n  }\n}\n\nfragment PromptsTable_prompts on Query {\n  prompts(first: 100) {\n    edges {\n      prompt: node {\n        id\n        name\n        description\n        version {\n          createdAt\n          modelName\n          modelProvider\n          id\n        }\n        labels {\n          id\n          name\n          color\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/prompts/__generated__/PromptsTablePromptsQuery.graphql.ts
+++ b/app/src/pages/prompts/__generated__/PromptsTablePromptsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b236257d5e752f094aab5cdf6a8090f3>>
+ * @generated SignedSource<<429cf6b2bb3426aa3a1aa067bf610299>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -158,6 +158,20 @@ return {
                         "name": "createdAt",
                         "storageKey": null
                       },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "modelName",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "modelProvider",
+                        "storageKey": null
+                      },
                       (v2/*: any*/)
                     ],
                     "storageKey": null
@@ -257,16 +271,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c742220ba8617113856418d1b6fb0c13",
+    "cacheID": "aae65784dac1dd298f578f01e6adaaff",
     "id": null,
     "metadata": {},
     "name": "PromptsTablePromptsQuery",
     "operationKind": "query",
-    "text": "query PromptsTablePromptsQuery(\n  $after: String = null\n  $filter: PromptFilter = null\n  $first: Int = 100\n  $labelIds: [ID!] = null\n) {\n  ...PromptsTable_prompts_2FeKoo\n}\n\nfragment PromptsTable_prompts_2FeKoo on Query {\n  prompts(first: $first, after: $after, filter: $filter, labelIds: $labelIds) {\n    edges {\n      prompt: node {\n        id\n        name\n        description\n        version {\n          createdAt\n          id\n        }\n        labels {\n          id\n          name\n          color\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query PromptsTablePromptsQuery(\n  $after: String = null\n  $filter: PromptFilter = null\n  $first: Int = 100\n  $labelIds: [ID!] = null\n) {\n  ...PromptsTable_prompts_2FeKoo\n}\n\nfragment PromptsTable_prompts_2FeKoo on Query {\n  prompts(first: $first, after: $after, filter: $filter, labelIds: $labelIds) {\n    edges {\n      prompt: node {\n        id\n        name\n        description\n        version {\n          createdAt\n          modelName\n          modelProvider\n          id\n        }\n        labels {\n          id\n          name\n          color\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "33daede08f0acc18f45f19692993314f";
+(node as any).hash = "d5dd38748ccb61e832bd17f8dab756cd";
 
 export default node;

--- a/app/src/pages/prompts/__generated__/PromptsTable_prompts.graphql.ts
+++ b/app/src/pages/prompts/__generated__/PromptsTable_prompts.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5e93685810b01465b956606350eb59b2>>
+ * @generated SignedSource<<e121895d059280fde009adfe520b5fec>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ReaderFragment } from 'relay-runtime';
+export type ModelProvider = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "CEREBRAS" | "DEEPSEEK" | "FIREWORKS" | "GOOGLE" | "GROQ" | "MOONSHOT" | "OLLAMA" | "OPENAI" | "PERPLEXITY" | "TOGETHER" | "XAI";
 import { FragmentRefs } from "relay-runtime";
 export type PromptsTable_prompts$data = {
   readonly prompts: {
@@ -24,6 +25,8 @@ export type PromptsTable_prompts$data = {
         readonly name: string;
         readonly version: {
           readonly createdAt: string;
+          readonly modelName: string;
+          readonly modelProvider: ModelProvider;
         };
       };
     }>;
@@ -161,6 +164,20 @@ return {
                       "kind": "ScalarField",
                       "name": "createdAt",
                       "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "modelName",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "modelProvider",
+                      "storageKey": null
                     }
                   ],
                   "storageKey": null
@@ -250,6 +267,6 @@ return {
 };
 })();
 
-(node as any).hash = "33daede08f0acc18f45f19692993314f";
+(node as any).hash = "d5dd38748ccb61e832bd17f8dab756cd";
 
 export default node;

--- a/app/src/pages/prompts/__generated__/promptsLoaderQuery.graphql.ts
+++ b/app/src/pages/prompts/__generated__/promptsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e7131b2efd51501919bf157361632f00>>
+ * @generated SignedSource<<a0df19159c1e7aa29e494b267ea4e970>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -111,6 +111,20 @@ return {
                         "name": "createdAt",
                         "storageKey": null
                       },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "modelName",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "modelProvider",
+                        "storageKey": null
+                      },
                       (v1/*: any*/)
                     ],
                     "storageKey": null
@@ -210,12 +224,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3bf444cc04be064fc037755409e3288d",
+    "cacheID": "4373e9645545d729885b58f67a08898c",
     "id": null,
     "metadata": {},
     "name": "promptsLoaderQuery",
     "operationKind": "query",
-    "text": "query promptsLoaderQuery {\n  ...PromptsTable_prompts\n}\n\nfragment PromptsTable_prompts on Query {\n  prompts(first: 100) {\n    edges {\n      prompt: node {\n        id\n        name\n        description\n        version {\n          createdAt\n          id\n        }\n        labels {\n          id\n          name\n          color\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query promptsLoaderQuery {\n  ...PromptsTable_prompts\n}\n\nfragment PromptsTable_prompts on Query {\n  prompts(first: 100) {\n    edges {\n      prompt: node {\n        id\n        name\n        description\n        version {\n          createdAt\n          modelName\n          modelProvider\n          id\n        }\n        labels {\n          id\n          name\n          color\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/utils/arrayUtils.ts
+++ b/app/src/utils/arrayUtils.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns a new array with `item` removed if present, or appended if absent.
+ *
+ * Useful for toggling a value in a multi-select set (e.g. selected filter ids).
+ */
+export function toggleArrayItem<T>(array: readonly T[], item: T): T[] {
+  return array.includes(item)
+    ? array.filter((existing) => existing !== item)
+    : [...array, item];
+}

--- a/app/tests/label-list-management.spec.ts
+++ b/app/tests/label-list-management.spec.ts
@@ -1,0 +1,264 @@
+import { randomUUID } from "crypto";
+import { expect, test, type Page, type Response } from "@playwright/test";
+
+function isGraphQLMutationResponse(response: Response, operationName: string) {
+  if (!response.url().includes("/graphql") || response.status() !== 200) {
+    return false;
+  }
+  const postData = response.request().postData();
+  return postData?.includes(operationName) ?? false;
+}
+
+/**
+ * Create a prompt label via the settings table. Returns once the create
+ * mutation has resolved and the dialog has closed.
+ */
+async function createPromptLabel(page: Page, labelName: string) {
+  await page.goto("/settings/prompts");
+  await page.waitForURL("**/settings/prompts");
+  await page.getByRole("button", { name: "New Label" }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await page.getByLabel("Label Name").fill(labelName);
+  await Promise.all([
+    page.waitForResponse((resp) =>
+      isGraphQLMutationResponse(
+        resp,
+        "usePromptLabelMutationsCreateLabelMutation"
+      )
+    ),
+    page.getByRole("button", { name: "Create Label" }).click(),
+  ]);
+  await expect(page.getByRole("dialog")).not.toBeVisible();
+}
+
+/**
+ * Create a dataset label via the settings table.
+ */
+async function createDatasetLabel(page: Page, labelName: string) {
+  await page.goto("/settings/datasets");
+  await page.waitForURL("**/settings/datasets");
+  await page.getByRole("button", { name: "New Label" }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await page.getByLabel("Label Name").fill(labelName);
+  await Promise.all([
+    page.waitForResponse((resp) =>
+      isGraphQLMutationResponse(
+        resp,
+        "useDatasetLabelMutationsAddLabelMutation"
+      )
+    ),
+    page.getByRole("button", { name: "Create Label" }).click(),
+  ]);
+  await expect(page.getByRole("dialog")).not.toBeVisible();
+}
+
+/**
+ * Create a prompt by saving the default playground configuration.
+ */
+async function createPrompt(page: Page, promptName: string) {
+  await page.goto("/playground");
+  await page.waitForURL("**/playground");
+  await page.getByRole("button", { name: "Save Prompt" }).click();
+  await page.getByPlaceholder("Select or enter new prompt").click();
+  await page.getByPlaceholder("Select or enter new prompt").fill(promptName);
+  await page.getByLabel("Prompt Description").fill("label e2e coverage");
+  await page.getByRole("button", { name: "Create Prompt" }).click();
+  await expect(page).toHaveURL(/promptId=/);
+}
+
+async function createDataset(page: Page, datasetName: string) {
+  await page.goto("/datasets");
+  await page.waitForURL("**/datasets");
+  await page.getByRole("button", { name: "New Dataset" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Create Dataset" })
+  ).toBeVisible();
+  await page.getByRole("tab", { name: "From scratch" }).click();
+  await page.getByLabel("Dataset Name").clear();
+  await page.getByLabel("Dataset Name").fill(datasetName);
+  await page.getByLabel("Description").fill("label e2e coverage");
+  await page.getByRole("button", { name: "Create Dataset" }).click();
+  await expect(page.getByTestId("dialog")).not.toBeVisible();
+}
+
+function promptRow(page: Page, promptName: string) {
+  return page.getByTestId("prompts-table").getByRole("row").filter({
+    hasText: promptName,
+  });
+}
+
+function datasetRow(page: Page, datasetName: string) {
+  return page.getByTestId("datasets-table").getByRole("row").filter({
+    hasText: datasetName,
+  });
+}
+
+test.describe("Prompt label management from the list", () => {
+  test("can add a label to a prompt and filter by it", async ({ page }) => {
+    const id = randomUUID().slice(0, 8);
+    const labelName = `prompt-label-${id}`;
+    const labeledPrompt = `labeled-prompt-${id}`;
+    const otherPrompt = `other-prompt-${id}`;
+
+    await createPromptLabel(page, labelName);
+    await createPrompt(page, labeledPrompt);
+    await createPrompt(page, otherPrompt);
+
+    await page.goto("/prompts");
+    await page.waitForURL("**/prompts");
+
+    const labeledRow = promptRow(page, labeledPrompt);
+    await expect(labeledRow).toBeVisible();
+
+    // Add the label from the row action menu's Label submenu.
+    await labeledRow.getByRole("button", { name: "Prompt actions" }).click();
+    await page.getByRole("menuitem", { name: "Label" }).hover();
+    const labelOption = page.getByRole("menuitemcheckbox", { name: labelName });
+    await labelOption.waitFor({ state: "visible" });
+    await Promise.all([
+      page.waitForResponse((resp) =>
+        isGraphQLMutationResponse(
+          resp,
+          "PromptLabelConfigButtonSetLabelsMutation"
+        )
+      ),
+      labelOption.click(),
+    ]);
+    // The label chip appears in the row live, without a manual refresh.
+    await expect(
+      labeledRow.getByRole("button", { name: labelName, exact: true })
+    ).toBeVisible();
+
+    // Reload the list to reset menu state; the chip persists across navigation.
+    await page.goto("/prompts");
+    await page.waitForURL("**/prompts");
+    await expect(
+      promptRow(page, labeledPrompt).getByRole("button", {
+        name: labelName,
+        exact: true,
+      })
+    ).toBeVisible();
+
+    // Filter by the label using the dedicated toolbar control.
+    await page.getByRole("button", { name: /^Labels/ }).click();
+    const filterOption = page.getByRole("menuitemcheckbox", {
+      name: labelName,
+    });
+    await filterOption.waitFor({ state: "visible" });
+    await filterOption.click();
+    await page.waitForURL(/labelId=/);
+
+    await expect(promptRow(page, labeledPrompt)).toBeVisible();
+    await expect(promptRow(page, otherPrompt)).not.toBeVisible();
+  });
+
+  test("can create a new label inline and apply it from the list", async ({
+    page,
+  }) => {
+    const id = randomUUID().slice(0, 8);
+    const labelName = `inline-label-${id}`;
+    const promptName = `inline-prompt-${id}`;
+
+    await createPrompt(page, promptName);
+
+    await page.goto("/prompts");
+    await page.waitForURL("**/prompts");
+
+    const row = promptRow(page, promptName);
+    await expect(row).toBeVisible();
+
+    // Open the Label submenu and switch into the inline "create" mode.
+    await row.getByRole("button", { name: "Prompt actions" }).click();
+    await page.getByRole("menuitem", { name: "Label" }).hover();
+    await page.getByRole("button", { name: "Create new label" }).click();
+
+    // Fill out the inline create form (no modal) and submit.
+    await page.getByLabel("Label Name").fill(labelName);
+    await Promise.all([
+      page.waitForResponse((resp) =>
+        isGraphQLMutationResponse(
+          resp,
+          "usePromptLabelMutationsCreateLabelMutation"
+        )
+      ),
+      page.getByRole("button", { name: "Create Label" }).click(),
+    ]);
+
+    // Back in apply mode, the new label is selectable and applies to the prompt.
+    const labelOption = page.getByRole("menuitemcheckbox", { name: labelName });
+    await labelOption.waitFor({ state: "visible" });
+    await Promise.all([
+      page.waitForResponse((resp) =>
+        isGraphQLMutationResponse(
+          resp,
+          "PromptLabelConfigButtonSetLabelsMutation"
+        )
+      ),
+      labelOption.click(),
+    ]);
+
+    await expect(
+      row.getByRole("button", { name: labelName, exact: true })
+    ).toBeVisible();
+  });
+});
+
+test.describe("Dataset label management from the list", () => {
+  test("can add a label to a dataset and filter by it", async ({ page }) => {
+    const id = randomUUID().slice(0, 8);
+    const labelName = `dataset-label-${id}`;
+    const labeledDataset = `labeled-dataset-${id}`;
+    const otherDataset = `other-dataset-${id}`;
+
+    await createDatasetLabel(page, labelName);
+    await createDataset(page, labeledDataset);
+    await createDataset(page, otherDataset);
+
+    await page.goto("/datasets");
+    await page.waitForURL("**/datasets");
+
+    const labeledRow = datasetRow(page, labeledDataset);
+    await expect(labeledRow).toBeVisible();
+
+    // Add the label from the row action menu's Label submenu.
+    await labeledRow.getByRole("button", { name: "Dataset actions" }).click();
+    await page.getByRole("menuitem", { name: "Label" }).hover();
+    const labelOption = page.getByRole("menuitemcheckbox", { name: labelName });
+    await labelOption.waitFor({ state: "visible" });
+    await Promise.all([
+      page.waitForResponse((resp) =>
+        isGraphQLMutationResponse(
+          resp,
+          "DatasetLabelConfigButtonSetLabelsMutation"
+        )
+      ),
+      labelOption.click(),
+    ]);
+    // The label chip appears in the row live, without a manual refresh.
+    await expect(
+      labeledRow.getByRole("button", { name: labelName, exact: true })
+    ).toBeVisible();
+
+    // Reload the list to reset menu state; the chip persists across navigation.
+    await page.goto("/datasets");
+    await page.waitForURL("**/datasets");
+    await expect(
+      datasetRow(page, labeledDataset).getByRole("button", {
+        name: labelName,
+        exact: true,
+      })
+    ).toBeVisible();
+
+    // Filter by the label using the dedicated toolbar control.
+    await page.getByRole("button", { name: /^Labels/ }).click();
+    const filterOption = page.getByRole("menuitemcheckbox", {
+      name: labelName,
+    });
+    await filterOption.waitFor({ state: "visible" });
+    await filterOption.click();
+    await page.waitForURL(/labelId=/);
+
+    await expect(datasetRow(page, labeledDataset)).toBeVisible();
+    await expect(datasetRow(page, otherDataset)).not.toBeVisible();
+  });
+});

--- a/app/tests/settings-labels-tables.spec.ts
+++ b/app/tests/settings-labels-tables.spec.ts
@@ -26,7 +26,10 @@ test.describe("Settings Labels Tables", () => {
       .fill("Prompt label for compiler e2e coverage");
     await Promise.all([
       page.waitForResponse((resp) =>
-        isGraphQLMutationResponse(resp, "NewPromptLabelDialogMutation")
+        isGraphQLMutationResponse(
+          resp,
+          "usePromptLabelMutationsCreateLabelMutation"
+        )
       ),
       page.getByRole("button", { name: "Create Label" }).click(),
     ]);


### PR DESCRIPTION
## Summary

The Prompts and Datasets list pages support labels and filtering by label, but you couldn't click a label to set the filter, and the filter wasn't shareable. This PR makes label tokens clickable to toggle them as filters and persists the active label filter to the URL so the filtered view can be shared and survives reloads.

## Changes

- **Click-to-filter**: Label tokens in both the Prompts and Datasets tables are now interactive (`onPress`) — clicking a label toggles it in the active filter. Wrapped in `StopPropagation` so clicking a label filters instead of navigating into the row.
- **URL persistence**: New `useLabelFilterSearchParams` hook backs the label-id selection with the URL search params, stored as repeated `labelId` params (e.g. `?labelId=a&labelId=b`). It returns a `[ids, setIds]` tuple matching `useState`, used by both the Prompts filter context and the Datasets page. Uses `{ replace: true }` so toggling filters doesn't pollute browser history.
  - `LABEL_ID_PARAM` added to `constants/searchParams.ts`.
- The existing "Labels" dropdown menus continue to work and now reflect/update the same URL-backed state.
- **Shared util**: `toggleArrayItem<T>` in `utils/arrayUtils.ts`, used by both tables' click-to-filter handlers.

## Notes

- Only the label filter is persisted to the URL; the text search box remains ephemeral (local state).

## Test plan

- [ ] Click a label chip on the Prompts page → it toggles into the filter and the URL updates with `labelId`.
- [ ] Click a label chip on the Datasets page → same behavior.
- [ ] The "Labels" dropdown count reflects the URL-backed selection.
- [ ] Copy the URL into a new tab → the filtered list is restored.
- [ ] Toggling labels does not add browser history entries (back button leaves the page).
---

## Additional changes (label management, model column, pinned actions)

Building on the click-to-filter work above, this PR also rounds out the label UX on the **Prompts** list to match **Datasets**, and adds a model column.

### Prompts table
- **Model column**: shows the provider icon + model name (`—` when unset, truncated), matching the `DatasetEvaluatorsTable` convention.
- **Manage labels from the list**: the row action menu now has a **Label** submenu that opens the label picker in a popover (mirrors the datasets list).
- **Pinned actions column**: the actions column is pinned to the right (sticky) via the shared `getCommonPinningStyles`, like the datasets table.
- Label chips now wrap/truncate and use semantic `<li>` markup.

### Consistent, accessible label picker
- The prompt label picker now matches the dataset one: inline **apply / create** mode (no modal), shared `NewLabelForm`, and the same header/back/`+` buttons and titles.
- The two **filter** menus (`PromptsLabelMenu` / `DatasetLabelFilterButton`) were aligned: `Counter` for the selected count, `ColorSwatch` items, a "Clear All" footer (disabled when empty), and `aria-label`ed menus.
- Added accessible names to previously icon-only buttons (action-menu triggers, create/back buttons) in both stacks.

### Refactor
- Extracted `usePromptLabelMutations` so the `createPromptLabel` mutation + Relay connection wiring is shared between the inline picker and the settings dialog (mirrors `useDatasetLabelMutations`), removing duplicated connection-key strings.

### Tests
- New Playwright spec `label-list-management.spec.ts`: add a label to a prompt/dataset from the list, create a label inline, and filter by label via the toolbar.