### PR TITLE
feat(ui): show usage counts for dataset and prompt labels

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1132,6 +1132,9 @@ type DatasetLabel implements Node {
   name: String!
   description: String
   color: String!
+
+  """The number of datasets that this label is applied to."""
+  usageCount: Int!
 }
 
 """A connection to a list of items."""
@@ -3115,6 +3118,9 @@ type PromptLabel implements Node {
   name: String!
   description: String
   color: String
+
+  """The number of prompts that this label is applied to."""
+  usageCount: Int!
 }
 
 type PromptLabelAssociationMutationPayload {

--- a/app/src/components/dataset/__generated__/useDatasetLabelMutationsAddLabelMutation.graphql.ts
+++ b/app/src/components/dataset/__generated__/useDatasetLabelMutationsAddLabelMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<707594cdfd4d14039665205b1c9f0013>>
+ * @generated SignedSource<<769ee772aee57dab19dcb4c791145912>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,6 +25,7 @@ export type useDatasetLabelMutationsAddLabelMutation$data = {
       readonly color: string;
       readonly id: string;
       readonly name: string;
+      readonly usageCount: number;
     };
     readonly datasets: ReadonlyArray<{
       readonly id: string;
@@ -66,34 +67,42 @@ v3 = {
   "name": "id",
   "storageKey": null
 },
-v4 = [
-  (v3/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "name",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "color",
-    "storageKey": null
-  }
-],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
 v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "color",
+  "storageKey": null
+},
+v6 = {
   "alias": null,
   "args": null,
   "concreteType": "DatasetLabel",
   "kind": "LinkedField",
   "name": "datasetLabel",
   "plural": false,
-  "selections": (v4/*: any*/),
+  "selections": [
+    (v3/*: any*/),
+    (v4/*: any*/),
+    (v5/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "usageCount",
+      "storageKey": null
+    }
+  ],
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "concreteType": "Dataset",
@@ -109,7 +118,11 @@ v6 = {
       "kind": "LinkedField",
       "name": "labels",
       "plural": true,
-      "selections": (v4/*: any*/),
+      "selections": [
+        (v3/*: any*/),
+        (v4/*: any*/),
+        (v5/*: any*/)
+      ],
       "storageKey": null
     }
   ],
@@ -133,8 +146,8 @@ return {
         "name": "createDatasetLabel",
         "plural": false,
         "selections": [
-          (v5/*: any*/),
-          (v6/*: any*/)
+          (v6/*: any*/),
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
@@ -159,7 +172,7 @@ return {
         "name": "createDatasetLabel",
         "plural": false,
         "selections": [
-          (v5/*: any*/),
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -181,23 +194,23 @@ return {
               }
             ]
           },
-          (v6/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "2ef998561a150eeacbaffdebc07bc94a",
+    "cacheID": "812ff73c35044115993d749c5ebef822",
     "id": null,
     "metadata": {},
     "name": "useDatasetLabelMutationsAddLabelMutation",
     "operationKind": "mutation",
-    "text": "mutation useDatasetLabelMutationsAddLabelMutation(\n  $input: CreateDatasetLabelInput!\n) {\n  createDatasetLabel(input: $input) {\n    datasetLabel {\n      id\n      name\n      color\n    }\n    datasets {\n      id\n      labels {\n        id\n        name\n        color\n      }\n    }\n  }\n}\n"
+    "text": "mutation useDatasetLabelMutationsAddLabelMutation(\n  $input: CreateDatasetLabelInput!\n) {\n  createDatasetLabel(input: $input) {\n    datasetLabel {\n      id\n      name\n      color\n      usageCount\n    }\n    datasets {\n      id\n      labels {\n        id\n        name\n        color\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0ea9c100ed6c060e7fc59b9c9f4e9db1";
+(node as any).hash = "edd67fe48c47ce070d116d1de17602ae";
 
 export default node;

--- a/app/src/components/dataset/useDatasetLabelMutations.tsx
+++ b/app/src/components/dataset/useDatasetLabelMutations.tsx
@@ -37,6 +37,7 @@ export const useDatasetLabelMutations = ({
             id
             name
             color
+            usageCount
           }
           datasets {
             id

--- a/app/src/components/prompt/__generated__/usePromptLabelMutationsCreateLabelMutation.graphql.ts
+++ b/app/src/components/prompt/__generated__/usePromptLabelMutationsCreateLabelMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1d9c1c9999de8153d647b57de4eab2b4>>
+ * @generated SignedSource<<aae8d4fa21570fa185c2e3b1c01047f9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -24,6 +24,7 @@ export type usePromptLabelMutationsCreateLabelMutation$data = {
       readonly color: string | null;
       readonly id: string;
       readonly name: string;
+      readonly usageCount: number;
     }>;
   };
 };
@@ -77,6 +78,13 @@ v3 = {
       "args": null,
       "kind": "ScalarField",
       "name": "color",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "usageCount",
       "storageKey": null
     }
   ],
@@ -153,16 +161,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8600130cb9db02bec9b9002a6338b796",
+    "cacheID": "056f27e5e547ee415dcc74ff4e48c487",
     "id": null,
     "metadata": {},
     "name": "usePromptLabelMutationsCreateLabelMutation",
     "operationKind": "mutation",
-    "text": "mutation usePromptLabelMutationsCreateLabelMutation(\n  $label: CreatePromptLabelInput!\n) {\n  createPromptLabel(input: $label) {\n    promptLabels {\n      id\n      name\n      color\n    }\n  }\n}\n"
+    "text": "mutation usePromptLabelMutationsCreateLabelMutation(\n  $label: CreatePromptLabelInput!\n) {\n  createPromptLabel(input: $label) {\n    promptLabels {\n      id\n      name\n      color\n      usageCount\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4a8dfd9b431701c95705b5098fdb8be2";
+(node as any).hash = "6de334eb8b54795e0e70fb3e432b04e4";
 
 export default node;

--- a/app/src/components/prompt/usePromptLabelMutations.tsx
+++ b/app/src/components/prompt/usePromptLabelMutations.tsx
@@ -47,6 +47,7 @@ export const usePromptLabelMutations = () => {
             id
             name
             color
+            usageCount
           }
         }
       }

--- a/app/src/pages/settings/datasets/DatasetLabelsTable.tsx
+++ b/app/src/pages/settings/datasets/DatasetLabelsTable.tsx
@@ -9,6 +9,7 @@ import { graphql, useFragment } from "react-relay";
 
 import { Flex, Token } from "@phoenix/components";
 import { TableEmpty } from "@phoenix/components/table";
+import { IntCell } from "@phoenix/components/table/IntCell";
 import { tableCSS } from "@phoenix/components/table/styles";
 
 import type { DatasetLabelsTableFragment$key } from "./__generated__/DatasetLabelsTableFragment.graphql";
@@ -32,6 +33,7 @@ export function DatasetLabelsTable({
               name
               description
               color
+              usageCount
             }
           }
         }
@@ -57,6 +59,14 @@ export function DatasetLabelsTable({
       {
         header: "description",
         accessorKey: "description",
+      },
+      {
+        header: "usage count",
+        accessorKey: "usageCount",
+        meta: {
+          textAlign: "right",
+        },
+        cell: IntCell,
       },
       {
         header: "",

--- a/app/src/pages/settings/datasets/DatasetLabelsTable.tsx
+++ b/app/src/pages/settings/datasets/DatasetLabelsTable.tsx
@@ -63,9 +63,6 @@ export function DatasetLabelsTable({
       {
         header: "usage count",
         accessorKey: "usageCount",
-        meta: {
-          textAlign: "right",
-        },
         cell: IntCell,
       },
       {

--- a/app/src/pages/settings/datasets/__generated__/DatasetLabelsTableFragment.graphql.ts
+++ b/app/src/pages/settings/datasets/__generated__/DatasetLabelsTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9d6564468f6e301bfc3869ec1a338f33>>
+ * @generated SignedSource<<bc0038ed43ff83947a00a28becb9ee25>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,6 +18,7 @@ export type DatasetLabelsTableFragment$data = {
         readonly description: string | null;
         readonly id: string;
         readonly name: string;
+        readonly usageCount: number;
       };
     }>;
   };
@@ -107,6 +108,13 @@ const node: ReaderFragment = {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
+                  "name": "usageCount",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
                   "name": "__typename",
                   "storageKey": null
                 }
@@ -156,6 +164,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "e22f9050d93574e15367cc63e355f3ce";
+(node as any).hash = "7b71c80184a20b85f4b3ab75b87ee583";
 
 export default node;

--- a/app/src/pages/settings/datasets/__generated__/SettingsDatasetsPageQuery.graphql.ts
+++ b/app/src/pages/settings/datasets/__generated__/SettingsDatasetsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9495fa6128f97a99735e3e5d3c3ddca1>>
+ * @generated SignedSource<<420a821c78cf02f1330ca2d315491506>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -105,6 +105,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "usageCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "__typename",
                     "storageKey": null
                   }
@@ -161,12 +168,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d644286d0a3b1a6e827bb334d3435e5f",
+    "cacheID": "2863524d62e5da3226a7403f2e731209",
     "id": null,
     "metadata": {},
     "name": "SettingsDatasetsPageQuery",
     "operationKind": "query",
-    "text": "query SettingsDatasetsPageQuery {\n  ...DatasetLabelsSettingsCardFragment\n}\n\nfragment DatasetLabelsSettingsCardFragment on Query {\n  ...DatasetLabelsTableFragment\n}\n\nfragment DatasetLabelsTableFragment on Query {\n  datasetLabels(first: 100) {\n    edges {\n      node {\n        id\n        name\n        description\n        color\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query SettingsDatasetsPageQuery {\n  ...DatasetLabelsSettingsCardFragment\n}\n\nfragment DatasetLabelsSettingsCardFragment on Query {\n  ...DatasetLabelsTableFragment\n}\n\nfragment DatasetLabelsTableFragment on Query {\n  datasetLabels(first: 100) {\n    edges {\n      node {\n        id\n        name\n        description\n        color\n        usageCount\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/prompts/PromptLabelsTable.tsx
+++ b/app/src/pages/settings/prompts/PromptLabelsTable.tsx
@@ -9,6 +9,7 @@ import { graphql, useFragment } from "react-relay";
 
 import { Flex, Token } from "@phoenix/components";
 import { TableEmpty } from "@phoenix/components/table";
+import { IntCell } from "@phoenix/components/table/IntCell";
 import { tableCSS } from "@phoenix/components/table/styles";
 import { DeletePromptLabelButton } from "@phoenix/pages/settings/prompts/DeletePromptLabelButton";
 
@@ -32,6 +33,7 @@ export function PromptLabelsTable({
               name
               description
               color
+              usageCount
             }
           }
         }
@@ -61,6 +63,14 @@ export function PromptLabelsTable({
       {
         header: "description",
         accessorKey: "description",
+      },
+      {
+        header: "usage count",
+        accessorKey: "usageCount",
+        meta: {
+          textAlign: "right",
+        },
+        cell: IntCell,
       },
       {
         header: "",

--- a/app/src/pages/settings/prompts/PromptLabelsTable.tsx
+++ b/app/src/pages/settings/prompts/PromptLabelsTable.tsx
@@ -43,7 +43,7 @@ export function PromptLabelsTable({
   );
   const tableData = useMemo(
     () => data.promptLabels.edges.map((edge) => edge.node),
-    [data]
+    [data.promptLabels.edges]
   );
 
   // eslint-disable-next-line react-hooks-js/incompatible-library
@@ -67,9 +67,6 @@ export function PromptLabelsTable({
       {
         header: "usage count",
         accessorKey: "usageCount",
-        meta: {
-          textAlign: "right",
-        },
         cell: IntCell,
       },
       {

--- a/app/src/pages/settings/prompts/__generated__/PromptLabelsTableFragment.graphql.ts
+++ b/app/src/pages/settings/prompts/__generated__/PromptLabelsTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<017995d817e4e166f6b16ac88e75dabf>>
+ * @generated SignedSource<<97d2eae8b88c7e270cebf110a7aaea84>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,6 +18,7 @@ export type PromptLabelsTableFragment$data = {
         readonly description: string | null;
         readonly id: string;
         readonly name: string;
+        readonly usageCount: number;
       };
     }>;
   };
@@ -107,6 +108,13 @@ const node: ReaderFragment = {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
+                  "name": "usageCount",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
                   "name": "__typename",
                   "storageKey": null
                 }
@@ -156,6 +164,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "aa6aef745b6890f9e8a48c72d2309626";
+(node as any).hash = "0d56a7fa3df2612dce4bcafd786cafd6";
 
 export default node;

--- a/app/src/pages/settings/prompts/__generated__/settingsPromptsPageLoaderQuery.graphql.ts
+++ b/app/src/pages/settings/prompts/__generated__/settingsPromptsPageLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fd2aed5f8e6f1bad30fecd4970641be4>>
+ * @generated SignedSource<<78adad7f1ece80c1d46b638f29a27298>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -105,6 +105,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "usageCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "__typename",
                     "storageKey": null
                   }
@@ -161,12 +168,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6535608721c8bfc6cd7b5cd97463a7e0",
+    "cacheID": "e450d1e4086deef5d9ee322e015d4fa3",
     "id": null,
     "metadata": {},
     "name": "settingsPromptsPageLoaderQuery",
     "operationKind": "query",
-    "text": "query settingsPromptsPageLoaderQuery {\n  ...PromptLabelsSettingsCardFragment\n}\n\nfragment PromptLabelsSettingsCardFragment on Query {\n  ...PromptLabelsTableFragment\n}\n\nfragment PromptLabelsTableFragment on Query {\n  promptLabels(first: 100) {\n    edges {\n      node {\n        id\n        name\n        description\n        color\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query settingsPromptsPageLoaderQuery {\n  ...PromptLabelsSettingsCardFragment\n}\n\nfragment PromptLabelsSettingsCardFragment on Query {\n  ...PromptLabelsTableFragment\n}\n\nfragment PromptLabelsTableFragment on Query {\n  promptLabels(first: 100) {\n    edges {\n      node {\n        id\n        name\n        description\n        color\n        usageCount\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -27,6 +27,7 @@ from .dataset_example_splits import DatasetExampleSplitsDataLoader
 from .dataset_examples_and_versions_by_experiment_run import (
     DatasetExamplesAndVersionsByExperimentRunDataLoader,
 )
+from .dataset_label_usage_counts import DatasetLabelUsageCountsDataLoader
 from .dataset_labels import DatasetLabelsDataLoader
 from .datasets_by_evaluator import DatasetsByEvaluatorDataLoader
 from .document_evaluation_summaries import (
@@ -62,6 +63,7 @@ from .num_spans_per_trace import NumSpansPerTraceDataLoader
 from .project_by_name import ProjectByNameDataLoader
 from .project_has_traces import ProjectHasTracesDataLoader
 from .project_ids_by_trace_retention_policy_id import ProjectIdsByTraceRetentionPolicyIdDataLoader
+from .prompt_label_usage_counts import PromptLabelUsageCountsDataLoader
 from .prompt_version_sequence_number import PromptVersionSequenceNumberDataLoader
 from .prompt_versions import PromptVersionDataLoader
 from .record_counts import RecordCountCache, RecordCountDataLoader
@@ -162,6 +164,7 @@ class DataLoaders:
     dataset_example_spans: DatasetExampleSpansDataLoader
     dataset_labels: DatasetLabelsDataLoader
     dataset_label_fields: TableFieldsDataLoader
+    dataset_label_usage_counts: DatasetLabelUsageCountsDataLoader
     dataset_dataset_splits: DatasetDatasetSplitsDataLoader
     dataset_examples_and_versions_by_experiment_run: (
         DatasetExamplesAndVersionsByExperimentRunDataLoader
@@ -208,6 +211,7 @@ class DataLoaders:
     projects_by_trace_retention_policy_id: ProjectIdsByTraceRetentionPolicyIdDataLoader
     prompt_fields: TableFieldsDataLoader
     prompt_label_fields: TableFieldsDataLoader
+    prompt_label_usage_counts: PromptLabelUsageCountsDataLoader
     prompt_versions: PromptVersionDataLoader
     prompt_version_sequence_number: PromptVersionSequenceNumberDataLoader
     prompt_version_tag_fields: TableFieldsDataLoader
@@ -304,6 +308,7 @@ def build_data_loaders(
         dataset_version_fields=TableFieldsDataLoader(db, models.DatasetVersion),
         dataset_labels=DatasetLabelsDataLoader(db),
         dataset_label_fields=TableFieldsDataLoader(db, models.DatasetLabel),
+        dataset_label_usage_counts=DatasetLabelUsageCountsDataLoader(db),
         document_evaluation_summaries=DocumentEvaluationSummaryDataLoader(
             db,
             cache_map=(
@@ -362,6 +367,7 @@ def build_data_loaders(
         projects_by_trace_retention_policy_id=ProjectIdsByTraceRetentionPolicyIdDataLoader(db),
         prompt_fields=TableFieldsDataLoader(db, models.Prompt),
         prompt_label_fields=TableFieldsDataLoader(db, models.PromptLabel),
+        prompt_label_usage_counts=PromptLabelUsageCountsDataLoader(db),
         prompt_versions=PromptVersionDataLoader(db),
         prompt_version_sequence_number=PromptVersionSequenceNumberDataLoader(db),
         prompt_version_tag_fields=TableFieldsDataLoader(db, models.PromptVersionTag),

--- a/src/phoenix/server/api/dataloaders/dataset_label_usage_counts.py
+++ b/src/phoenix/server/api/dataloaders/dataset_label_usage_counts.py
@@ -1,0 +1,36 @@
+from sqlalchemy import func, select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+DatasetLabelID: TypeAlias = int
+UsageCount: TypeAlias = int
+Key: TypeAlias = DatasetLabelID
+Result: TypeAlias = UsageCount
+
+
+class DatasetLabelUsageCountsDataLoader(DataLoader[Key, Result]):
+    """Batches per-label counts of how many datasets reference each dataset label."""
+
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: list[Key]) -> list[Result]:
+        dataset_label_ids = keys
+        query = (
+            select(
+                models.DatasetsDatasetLabel.dataset_label_id,
+                func.count(models.DatasetsDatasetLabel.dataset_id),
+            )
+            .where(models.DatasetsDatasetLabel.dataset_label_id.in_(set(dataset_label_ids)))
+            .group_by(models.DatasetsDatasetLabel.dataset_label_id)
+        )
+        async with self._db.read() as session:
+            counts = {
+                dataset_label_id: usage_count
+                async for dataset_label_id, usage_count in await session.stream(query)
+            }
+        return [counts.get(dataset_label_id, 0) for dataset_label_id in keys]

--- a/src/phoenix/server/api/dataloaders/prompt_label_usage_counts.py
+++ b/src/phoenix/server/api/dataloaders/prompt_label_usage_counts.py
@@ -1,0 +1,36 @@
+from sqlalchemy import func, select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+PromptLabelID: TypeAlias = int
+UsageCount: TypeAlias = int
+Key: TypeAlias = PromptLabelID
+Result: TypeAlias = UsageCount
+
+
+class PromptLabelUsageCountsDataLoader(DataLoader[Key, Result]):
+    """Batches per-label counts of how many prompts reference each prompt label."""
+
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: list[Key]) -> list[Result]:
+        prompt_label_ids = keys
+        query = (
+            select(
+                models.PromptPromptLabel.prompt_label_id,
+                func.count(models.PromptPromptLabel.prompt_id),
+            )
+            .where(models.PromptPromptLabel.prompt_label_id.in_(set(prompt_label_ids)))
+            .group_by(models.PromptPromptLabel.prompt_label_id)
+        )
+        async with self._db.read() as session:
+            counts = {
+                prompt_label_id: usage_count
+                async for prompt_label_id, usage_count in await session.stream(query)
+            }
+        return [counts.get(prompt_label_id, 0) for prompt_label_id in keys]

--- a/src/phoenix/server/api/types/DatasetLabel.py
+++ b/src/phoenix/server/api/types/DatasetLabel.py
@@ -55,3 +55,12 @@ class DatasetLabel(Node):
                 (self.id, models.DatasetLabel.color),
             )
         return val
+
+    @strawberry.field(
+        description="The number of datasets that this label is applied to.",
+    )  # type: ignore
+    async def usage_count(
+        self,
+        info: Info[Context, None],
+    ) -> int:
+        return await info.context.data_loaders.dataset_label_usage_counts.load(self.id)

--- a/src/phoenix/server/api/types/PromptLabel.py
+++ b/src/phoenix/server/api/types/PromptLabel.py
@@ -55,3 +55,12 @@ class PromptLabel(Node):
                 (self.id, models.PromptLabel.color),
             )
         return val
+
+    @strawberry.field(
+        description="The number of prompts that this label is applied to.",
+    )  # type: ignore
+    async def usage_count(
+        self,
+        info: Info[Context, None],
+    ) -> int:
+        return await info.context.data_loaders.prompt_label_usage_counts.load(self.id)

--- a/tests/unit/server/api/types/test_DatasetLabel.py
+++ b/tests/unit/server/api/types/test_DatasetLabel.py
@@ -1,0 +1,66 @@
+import pytest
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+from tests.unit.graphql import AsyncGraphQLClient
+
+
+@pytest.fixture
+async def dataset_labels_with_usages(db: DbSessionFactory) -> None:
+    """Three labels: "used-twice" on two datasets, "used-once" on one, "unused" on none."""
+    async with db() as session:
+        used_twice = models.DatasetLabel(name="used-twice", color="#ff0000")
+        used_once = models.DatasetLabel(name="used-once", color="#00ff00")
+        unused = models.DatasetLabel(name="unused", color="#0000ff")
+        session.add_all([used_twice, used_once, unused])
+        await session.flush()
+
+        datasets = [
+            models.Dataset(name=f"dataset-{i}", description=None, metadata_={}) for i in range(2)
+        ]
+        session.add_all(datasets)
+        await session.flush()
+
+        session.add_all(
+            [
+                models.DatasetsDatasetLabel(
+                    dataset_id=datasets[0].id, dataset_label_id=used_twice.id
+                ),
+                models.DatasetsDatasetLabel(
+                    dataset_id=datasets[1].id, dataset_label_id=used_twice.id
+                ),
+                models.DatasetsDatasetLabel(
+                    dataset_id=datasets[0].id, dataset_label_id=used_once.id
+                ),
+            ]
+        )
+
+
+async def test_usage_count_resolver_returns_correct_counts(
+    gql_client: AsyncGraphQLClient,
+    dataset_labels_with_usages: None,
+) -> None:
+    query = """
+      query {
+        datasetLabels {
+          edges {
+            node {
+              name
+              usageCount
+            }
+          }
+        }
+      }
+    """
+    response = await gql_client.execute(query=query)
+    assert not response.errors
+    assert response.data
+    usage_counts = {
+        edge["node"]["name"]: edge["node"]["usageCount"]
+        for edge in response.data["datasetLabels"]["edges"]
+    }
+    assert usage_counts == {
+        "used-twice": 2,
+        "used-once": 1,
+        "unused": 0,
+    }

--- a/tests/unit/server/api/types/test_PromptLabel.py
+++ b/tests/unit/server/api/types/test_PromptLabel.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from phoenix.db import models
+from phoenix.db.types.identifier import Identifier
+from phoenix.server.types import DbSessionFactory
+from tests.unit.graphql import AsyncGraphQLClient
+
+
+@pytest.fixture
+async def prompt_labels_with_usages(db: DbSessionFactory) -> None:
+    """Three labels: "used-twice" on two prompts, "used-once" on one, "unused" on none."""
+    async with db() as session:
+        used_twice = models.PromptLabel(name="used-twice", color="#FF0000")
+        used_once = models.PromptLabel(name="used-once", color="#00FF00")
+        unused = models.PromptLabel(name="unused", color="#0000FF")
+        session.add_all([used_twice, used_once, unused])
+        await session.flush()
+
+        prompts = [
+            models.Prompt(
+                name=Identifier(root=f"prompt-{i}"),
+                description=None,
+                metadata_={},
+                created_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+                updated_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            )
+            for i in range(2)
+        ]
+        session.add_all(prompts)
+        await session.flush()
+
+        session.add_all(
+            [
+                models.PromptPromptLabel(prompt_id=prompts[0].id, prompt_label_id=used_twice.id),
+                models.PromptPromptLabel(prompt_id=prompts[1].id, prompt_label_id=used_twice.id),
+                models.PromptPromptLabel(prompt_id=prompts[0].id, prompt_label_id=used_once.id),
+            ]
+        )
+
+
+async def test_usage_count_resolver_returns_correct_counts(
+    gql_client: AsyncGraphQLClient,
+    prompt_labels_with_usages: None,
+) -> None:
+    query = """
+      query {
+        promptLabels {
+          edges {
+            node {
+              name
+              usageCount
+            }
+          }
+        }
+      }
+    """
+    response = await gql_client.execute(query=query)
+    assert not response.errors
+    assert response.data
+    usage_counts = {
+        edge["node"]["name"]: edge["node"]["usageCount"]
+        for edge in response.data["promptLabels"]["edges"]
+    }
+    assert usage_counts == {
+        "used-twice": 2,
+        "used-once": 1,
+        "unused": 0,
+    }


### PR DESCRIPTION
## Summary

Adds a **usage count** column to the dataset labels and prompt labels tables in settings, indicating how many datasets/prompts reference each label — similar to how GitHub displays label usage counts. This makes it easy to see which labels are in use and which are unused.
