### PR TITLE
fix: app frame corner overlfow

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1278,7 +1278,7 @@ const appGlobalStylesCSS = css`
     font-size: var(--global-font-size-s);
   }
   body {
-    background-color: var(--global-color-gray-75);
+    background-color: var(--global-color-gray-100);
 
     margin: 0;
     overflow: hidden;

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -68,6 +68,7 @@ const contentCSS = css`
   flex-direction: column;
   overflow: hidden;
   box-sizing: border-box;
+  background-color: var(--global-color-gray-75);
   border-left: 1px solid var(--global-border-color-default);
   border-top: 1px solid var(--global-border-color-default);
   border-radius: var(--global-rounding-medium) 0 0 0;

--- a/app/src/pages/dashboards/DashboardsPage.tsx
+++ b/app/src/pages/dashboards/DashboardsPage.tsx
@@ -38,7 +38,6 @@ const toolbarCSS = css`
   gap: var(--global-dimension-size-200);
   padding: var(--global-dimension-size-200);
   border-bottom: 1px solid var(--global-border-color-default);
-  background-color: var(--global-color-gray-50);
 `;
 
 const projectMenuCSS = css`


### PR DESCRIPTION
Before: corner overflow on all pages, incorrect background color on dashboards page.
<img width="273" height="190" alt="Screenshot 2026-06-17 at 8 42 07 PM" src="https://github.com/user-attachments/assets/22f68d66-2937-4b32-b481-87f3879d7070" />
<img width="196" height="150" alt="Screenshot 2026-06-17 at 8 42 05 PM" src="https://github.com/user-attachments/assets/7afb7533-e871-45f8-b0d9-d27c247e6ea0" />

After: corrected
<img width="276" height="240" alt="Screenshot 2026-06-17 at 8 42 13 PM" src="https://github.com/user-attachments/assets/405f6e8a-6549-4182-a35d-e067183b45b7" />
