### PR TITLE
feat(agents): Improve PXI chat error recovery

### DIFF
--- a/app/src/components/agent/AgentChatPanel.tsx
+++ b/app/src/components/agent/AgentChatPanel.tsx
@@ -220,6 +220,7 @@ function AgentChatController({
     pendingElicitation,
     handleElicitationSubmit,
     handleElicitationCancel,
+    retryMessage,
     rewindToMessage,
     forkFromMessage,
   } = useAgentChat({
@@ -250,6 +251,7 @@ function AgentChatController({
       {/* Catch runaway suspense triggers that aren't handled locally */}
       <Suspense fallback={<Loading />}>
         <ChatView
+          key={activeSessionId ?? "no-session"}
           sessionId={activeSessionId}
           messages={messages}
           sendMessage={sendMessage}
@@ -259,6 +261,7 @@ function AgentChatController({
           pendingElicitation={pendingElicitation}
           handleElicitationSubmit={handleElicitationSubmit}
           handleElicitationCancel={handleElicitationCancel}
+          retryMessage={retryMessage}
           rewindToMessage={rewindToMessage}
           forkFromMessage={forkFromMessage}
           modelMenuValue={menuValue}

--- a/app/src/components/agent/AssistantMessageActions.tsx
+++ b/app/src/components/agent/AssistantMessageActions.tsx
@@ -159,7 +159,7 @@ async function deleteAnnotations(args: {
  * - Trace: opens the associated trace in a new tab. Requires `traceId`.
  *
  * `children` are rendered after the built-in actions in the same toolbar row
- * (e.g. rewind/fork controls), and force the toolbar to render even when the
+ * (e.g. rewind/branch controls), and force the toolbar to render even when the
  * message itself supports no built-in actions.
  *
  * The component silently renders nothing if the message has no text, no

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -41,6 +41,7 @@ import {
   useAgentModelCredentialStatus,
 } from "./AgentModelCredentialForm";
 import { ChatEmptyState, type EmptyStateQuickAction } from "./ChatEmptyState";
+import { ChatErrorMessage } from "./ChatErrorMessage";
 import { ChatLantern } from "./ChatLantern";
 import {
   AssistantMessage,
@@ -52,6 +53,7 @@ import {
   ElicitationDraftProvider,
   type PendingElicitationDraft,
 } from "./ElicitationDraftContext";
+import { InterruptedChatMessage } from "./InterruptedChatMessage";
 import {
   MessageRewindConfirmation,
   type MessageRewindMode,
@@ -250,13 +252,24 @@ const chatCSS = css`
   .chat__edit-permissions {
     flex: none;
   }
-
-  .chat__error {
-    align-self: flex-start;
-    color: var(--global-color-danger);
-    font-size: var(--global-font-size-s);
-  }
 `;
+
+function getLatestMessageId({
+  messages,
+  role,
+}: {
+  messages: AgentUIMessage[];
+  role: AgentUIMessage["role"];
+}): string | undefined {
+  return messages.findLast((message) => message.role === role)?.id;
+}
+
+function getMessageText(message: AgentUIMessage): string {
+  return message.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+}
 
 /** Connects the presentational chat view to the agent chat controller hook. */
 export function Chat({
@@ -285,12 +298,14 @@ export function Chat({
     pendingElicitation,
     handleElicitationSubmit,
     handleElicitationCancel,
+    retryMessage,
     rewindToMessage,
     forkFromMessage,
   } = useAgentChat({ sessionId, chatApiUrl, modelSelection });
 
   return (
     <ChatView
+      key={sessionId ?? "no-session"}
       sessionId={sessionId}
       messages={messages}
       sendMessage={sendMessage}
@@ -300,6 +315,7 @@ export function Chat({
       pendingElicitation={pendingElicitation}
       handleElicitationSubmit={handleElicitationSubmit}
       handleElicitationCancel={handleElicitationCancel}
+      retryMessage={retryMessage}
       rewindToMessage={rewindToMessage}
       forkFromMessage={forkFromMessage}
       modelMenuValue={modelMenuValue}
@@ -326,6 +342,7 @@ export function ChatView({
   pendingElicitation,
   handleElicitationSubmit,
   handleElicitationCancel,
+  retryMessage,
   rewindToMessage,
   forkFromMessage,
   modelMenuValue,
@@ -347,12 +364,14 @@ export function ChatView({
   pendingElicitation: PendingElicitation | null;
   handleElicitationSubmit: (output: ElicitToolOutput) => void;
   handleElicitationCancel: () => void;
+  /** Retries an assistant response; absent on read-only surfaces. */
+  retryMessage?: (messageId?: string) => void;
   /**
    * Truncates the active session at a message; returns user text to restore.
-   * Absent on read-only surfaces, which hides the rewind/fork controls.
+   * Absent on read-only surfaces, which hides the rewind/branch controls.
    */
   rewindToMessage?: (messageId: string) => string | null;
-  /** Branches a new session from a message; absent hides the fork control. */
+  /** Branches a new session from a message; absent hides the branch control. */
   forkFromMessage?: (messageId: string) => string | null;
   modelMenuValue: ModelMenuValue;
   onModelChange: (model: ModelMenuValue) => void;
@@ -398,6 +417,9 @@ export function ChatView({
   );
   const setPermissions = useAgentContext((state) => state.setPermissions);
   const createSession = useAgentContext((state) => state.createSession);
+  const canForkSessions = useAgentContext(
+    (state) => state.capabilities["session.storeSessions"]
+  );
 
   const setSessionDraftInput = (input: string | null) => {
     if (!sessionId) {
@@ -437,6 +459,9 @@ export function ChatView({
     status,
     messages,
   });
+  const latestMessage = messages.at(-1);
+  const shouldShowInterruptedMessage =
+    status === "ready" && !error && latestMessage?.role === "user";
   const resolvedElicitationDraft =
     pendingElicitation &&
     elicitationDraft?.toolCallId !== pendingElicitation.toolCallId
@@ -476,7 +501,7 @@ export function ChatView({
     textareaRef.current?.focus();
   };
 
-  // Pending rewind/fork confirmation, shown inline in place of the prompt
+  // Pending rewind/branch confirmation, shown inline in place of the prompt
   // input. Panel-local because the confirmation is an inline surface, not a
   // modal — a modal would flip the global open-modal observer and re-parent
   // this panel between its docked/floating layouts, tearing the surface down.
@@ -486,14 +511,16 @@ export function ChatView({
     role: MessageRewindRole;
   } | null>(null);
 
-  // Rewind/fork mutate or branch finalized history, so they are only offered
+  // Rewind/branch changes finalized history, so these actions are only offered
   // once the chat has settled — never mid-request.
+  const hasChatSettled = status === "ready" || status === "error";
+
   const onRewindRequest = useMemo<MessageRewindRequest | undefined>(() => {
-    if (status !== "ready" || !rewindToMessage) {
+    if (!hasChatSettled || !rewindToMessage) {
       return undefined;
     }
     return (request) => setRewindRequest(request);
-  }, [status, rewindToMessage]);
+  }, [hasChatSettled, rewindToMessage]);
 
   const handleConfirmRewind = () => {
     if (!rewindRequest) {
@@ -512,6 +539,19 @@ export function ChatView({
         textareaRef.current?.focus();
       }
     }
+  };
+
+  const handleRetryInterruptedMessage = () => {
+    if (latestMessage?.role !== "user") {
+      return;
+    }
+    const messageText = getMessageText(latestMessage).trim();
+    if (!messageText) {
+      return;
+    }
+    rewindToMessage?.(latestMessage.id);
+    void scrollToBottom();
+    sendMessage({ text: messageText });
   };
 
   useLayoutEffect(() => {
@@ -583,11 +623,11 @@ export function ChatView({
                   // Only the last assistant message can still be streaming — hide
                   // its actions until the chat reports it is settled.
                   const isLast = index === messages.length - 1;
-                  const showActions = !isLast || status === "ready";
+                  const showActions = !isLast || hasChatSettled;
                   // Pin the most recent assistant turn's toolbar so its actions
                   // stay visible; other turns reveal their toolbars on hover to
                   // cut down on stacked-toolbar clutter.
-                  const pinToolbar = isLast && status === "ready";
+                  const pinToolbar = isLast && hasChatSettled;
                   // Rewinding to the last assistant turn is a no-op: nothing
                   // follows it to truncate and, once settled, it has no pending
                   // tool calls to clear. Hide the rewind control there.
@@ -603,7 +643,30 @@ export function ChatView({
                   );
                 })}
                 {showThinkingIndicator && <Loading />}
-                {error && <ErrorMessage error={error} />}
+                {shouldShowInterruptedMessage ? (
+                  <InterruptedChatMessage
+                    latestUserMessageId={latestMessage.id}
+                    canFork={canForkSessions}
+                    onRetry={handleRetryInterruptedMessage}
+                    onRewind={onRewindRequest}
+                  />
+                ) : null}
+                {error && (
+                  <ChatErrorMessage
+                    error={error}
+                    latestAssistantMessageId={getLatestMessageId({
+                      messages,
+                      role: "assistant",
+                    })}
+                    latestUserMessageId={getLatestMessageId({
+                      messages,
+                      role: "user",
+                    })}
+                    canFork={canForkSessions}
+                    onRetry={retryMessage}
+                    onRewind={onRewindRequest}
+                  />
+                )}
               </div>
             </div>
           </div>
@@ -726,9 +789,4 @@ function Loading() {
       </Shimmer>
     </div>
   );
-}
-
-/** Inline request error banner for the active chat turn. */
-function ErrorMessage({ error }: { error: Error }) {
-  return <p className="chat__error">{error.message}</p>;
 }

--- a/app/src/components/agent/ChatErrorMessage.tsx
+++ b/app/src/components/agent/ChatErrorMessage.tsx
@@ -1,0 +1,126 @@
+import { css } from "@emotion/react";
+
+import { Button } from "@phoenix/components/core/button";
+
+import type { MessageRewindRequest } from "./ChatMessage";
+
+const chatErrorMessageCSS = css`
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-size-100);
+  color: var(--global-text-color-900);
+  font-size: var(--global-font-size-s);
+  line-height: var(--global-line-height-s);
+  border-left: var(--global-border-size-thick) solid var(--global-color-danger);
+  padding-left: var(--global-dimension-size-150);
+  max-width: 100%;
+
+  .chat-error-message__title {
+    color: var(--global-color-danger);
+    font-weight: var(--global-font-weight-semibold);
+  }
+
+  .chat-error-message__copy {
+    margin: 0;
+  }
+
+  .chat-error-message__actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--global-dimension-size-100);
+  }
+
+  .chat-error-message__details {
+    color: var(--global-text-color-700);
+  }
+
+  .chat-error-message__details summary {
+    cursor: pointer;
+  }
+
+  .chat-error-message__technical-message {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    margin: var(--global-dimension-size-100) 0 0;
+    color: var(--global-color-danger);
+  }
+`;
+
+/** Inline request error banner for the active chat turn. */
+export function ChatErrorMessage({
+  error,
+  latestAssistantMessageId,
+  latestUserMessageId,
+  canFork,
+  onRetry,
+  onRewind,
+}: {
+  error: Error;
+  latestAssistantMessageId?: string;
+  latestUserMessageId?: string;
+  canFork: boolean;
+  onRetry?: (messageId?: string) => void;
+  onRewind?: MessageRewindRequest;
+}) {
+  const canRetry = onRetry != null;
+  const canUndoOrFork = latestUserMessageId != null && onRewind != null;
+
+  return (
+    <div css={chatErrorMessageCSS} role="alert">
+      <div className="chat-error-message__title">
+        The assistant response failed.
+      </div>
+      <p className="chat-error-message__copy">
+        You can retry the response, undo this turn, or branch before the error.
+      </p>
+      {canRetry || canUndoOrFork ? (
+        <div className="chat-error-message__actions">
+          {canRetry ? (
+            <Button
+              size="S"
+              variant="primary"
+              onPress={() => onRetry(latestAssistantMessageId)}
+            >
+              Retry
+            </Button>
+          ) : null}
+          {canUndoOrFork ? (
+            <Button
+              size="S"
+              onPress={() =>
+                onRewind({
+                  mode: "rewind",
+                  messageId: latestUserMessageId,
+                  role: "user",
+                })
+              }
+            >
+              Undo failed turn
+            </Button>
+          ) : null}
+          {canUndoOrFork && canFork ? (
+            <Button
+              size="S"
+              variant="quiet"
+              onPress={() =>
+                onRewind({
+                  mode: "fork",
+                  messageId: latestUserMessageId,
+                  role: "user",
+                })
+              }
+            >
+              Branch before error
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+      <details className="chat-error-message__details">
+        <summary>Show technical details</summary>
+        <p className="chat-error-message__technical-message">{error.message}</p>
+      </details>
+    </div>
+  );
+}

--- a/app/src/components/agent/ChatMessage.tsx
+++ b/app/src/components/agent/ChatMessage.tsx
@@ -22,7 +22,7 @@ import { partitionMessageParts } from "./partitionMessageParts";
 import { ToolPart } from "./ToolPart";
 
 /**
- * Reports a rewind/fork request from a message's controls up to the chat view,
+ * Reports a rewind/branch request from a message's controls up to the chat view,
  * which owns the single confirmation dialog. Optional so messages can render
  * without the controls (e.g. while streaming) by omitting the prop entirely.
  */
@@ -45,7 +45,7 @@ const assistantMessageCSS = css`
 /**
  * Renders a user message bubble (right-aligned, primary colour) with a toolbar
  * for copying the message and, when `onRewindRequest` is provided, rewinding or
- * forking the conversation from it.
+ * branching the conversation from it.
  */
 export function UserMessage({
   message,
@@ -96,7 +96,7 @@ export function UserMessage({
  *
  * `allowRewind` gates the rewind control. Callers set it to `false` for the
  * last assistant turn, where rewinding to that response is a no-op (see
- * {@link MessageRewindActions}); fork stays available there.
+ * {@link MessageRewindActions}); branch stays available there.
  */
 export function AssistantMessage({
   message,

--- a/app/src/components/agent/InterruptedChatMessage.tsx
+++ b/app/src/components/agent/InterruptedChatMessage.tsx
@@ -1,0 +1,93 @@
+import { css } from "@emotion/react";
+
+import { Button } from "@phoenix/components/core/button";
+
+import type { MessageRewindRequest } from "./ChatMessage";
+
+const interruptedChatMessageCSS = css`
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-size-100);
+  color: var(--global-text-color-900);
+  font-size: var(--global-font-size-s);
+  line-height: var(--global-line-height-s);
+  border-left: var(--global-border-size-thick) solid
+    var(--global-color-warning-500);
+  padding-left: var(--global-dimension-size-150);
+  max-width: 100%;
+
+  .interrupted-chat-message__title {
+    color: var(--global-color-warning-700);
+    font-weight: var(--global-font-weight-semibold);
+  }
+
+  .interrupted-chat-message__copy {
+    margin: 0;
+  }
+
+  .interrupted-chat-message__actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--global-dimension-size-100);
+  }
+`;
+
+/** Recovery affordance for durable transcripts that end on an unanswered user turn. */
+export function InterruptedChatMessage({
+  latestUserMessageId,
+  canFork,
+  onRetry,
+  onRewind,
+}: {
+  latestUserMessageId: string;
+  canFork: boolean;
+  onRetry: () => void;
+  onRewind?: MessageRewindRequest;
+}) {
+  return (
+    <div css={interruptedChatMessageCSS} role="status">
+      <div className="interrupted-chat-message__title">
+        PXI did not respond.
+      </div>
+      <p className="interrupted-chat-message__copy">
+        This message was interrupted before PXI could respond.
+      </p>
+      {onRewind ? (
+        <div className="interrupted-chat-message__actions">
+          <Button size="S" variant="primary" onPress={onRetry}>
+            Retry
+          </Button>
+          <Button
+            size="S"
+            onPress={() =>
+              onRewind({
+                mode: "rewind",
+                messageId: latestUserMessageId,
+                role: "user",
+              })
+            }
+          >
+            Edit message
+          </Button>
+          {canFork ? (
+            <Button
+              size="S"
+              variant="quiet"
+              onPress={() =>
+                onRewind({
+                  mode: "fork",
+                  messageId: latestUserMessageId,
+                  role: "user",
+                })
+              }
+            >
+              Branch before message
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/src/components/agent/MessageRewindActions.tsx
+++ b/app/src/components/agent/MessageRewindActions.tsx
@@ -17,7 +17,7 @@ import type {
 } from "./MessageRewindDialog";
 
 /**
- * Rewind (and, when session storage is enabled, fork) controls rendered under a
+ * Rewind (and, when session storage is enabled, branch) controls rendered under a
  * user or assistant message. These are uncommon, mostly-destructive actions, so
  * they are tucked behind a single "more actions" overflow button rather than
  * sitting inline next to the everyday copy/feedback controls.
@@ -33,7 +33,7 @@ import type {
  * `showRewind` gates the rewind item. Callers set it to `false` for the last
  * assistant turn, where rewinding to that response is a no-op — there is nothing
  * after it to truncate and the chat has settled, so no pending tool calls remain
- * to clear. Fork stays available there because it branches a separate session.
+ * to clear. Branch stays available there because it creates a separate session.
  * When neither item would render, the whole control is omitted.
  */
 export function MessageRewindActions({
@@ -94,7 +94,7 @@ export function MessageRewindActions({
               id="fork"
               leadingContent={<Icon svg={<Icons.GitBranch />} />}
             >
-              Fork from this message
+              Branch from this message
             </MenuItem>
           ) : null}
           {canCopyTraceId ? (

--- a/app/src/components/agent/MessageRewindDialog.tsx
+++ b/app/src/components/agent/MessageRewindDialog.tsx
@@ -29,12 +29,12 @@ function getConfirmationCopy({
 }): ConfirmationCopy {
   if (mode === "fork") {
     return {
-      title: "Fork conversation",
+      title: "Branch conversation",
       description:
         role === "user"
-          ? "Create a new chat from this point. This message is removed from the new chat and placed back in the input so you can edit and re-send it. The current chat is left unchanged."
-          : "Create a new chat that ends at this response. The current chat is left unchanged.",
-      confirmLabel: "Fork conversation",
+          ? "Create a new chat branch from this point. This message is removed from the new branch and placed back in the input so you can edit and re-send it. The current chat is left unchanged."
+          : "Create a new chat branch that ends at this response. The current chat is left unchanged.",
+      confirmLabel: "Branch conversation",
     };
   }
   return {
@@ -69,7 +69,7 @@ const confirmationActionsCSS = css`
 
 /**
  * Inline confirmation shown in place of the prompt input before rewinding or
- * forking a conversation at a chosen message.
+ * branching a conversation at a chosen message.
  *
  * This is intentionally an inline panel rather than a React Aria modal. Opening
  * a modal flips the app's global open-modal observer, which re-parents the

--- a/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/app/src/components/agent/__tests__/Chat.test.tsx
@@ -2,6 +2,7 @@ import { act, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import { AgentProvider } from "@phoenix/contexts/AgentContext";
 import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
 
@@ -48,21 +49,56 @@ vi.mock("../ChatLantern", () => ({
   ChatLantern: () => null,
 }));
 
+vi.mock("../useAvailableAgentSkills", () => ({
+  useAvailableAgentSkills: () => [],
+}));
+
 vi.mock("../ChatMessage", () => ({
   AssistantMessage: () => null,
   UserMessage: () => null,
 }));
 
+const messages = [
+  {
+    id: "user-message",
+    role: "user",
+    parts: [{ type: "text", text: "What happened?" }],
+  },
+  {
+    id: "assistant-message",
+    role: "assistant",
+    parts: [{ type: "text", text: "I started checking." }],
+  },
+] as AgentUIMessage[];
+
+const unansweredUserMessages = [messages[0]!] as AgentUIMessage[];
+
 function renderChatView(
   root: Root,
   {
+    sessionId = "session-1",
     autoFocusInput = false,
-    chatKey = "chat",
+    chatKey,
+    chatMessages = [],
+    error,
+    status = "ready",
+    initialDraftInputBySessionId,
     sendMessage = vi.fn<ChatViewSendMessage>(),
+    retryMessage,
+    rewindToMessage,
+    forkFromMessage,
   }: {
+    sessionId?: string;
     autoFocusInput?: boolean;
     chatKey?: string;
+    chatMessages?: AgentUIMessage[];
+    error?: Error;
+    status?: "ready" | "error";
+    initialDraftInputBySessionId?: Record<string, string>;
     sendMessage?: ChatViewSendMessage;
+    retryMessage?: (messageId?: string) => void;
+    rewindToMessage?: (messageId: string) => string | null;
+    forkFromMessage?: (messageId: string) => string | null;
   } = {}
 ) {
   act(() => {
@@ -86,18 +122,31 @@ function renderChatView(
               allowRemoteExport: false,
             },
           }}
+          capabilities={{
+            "bash.retainInactiveSessions": false,
+            "graphql.mutations": false,
+            "session.storeSessions": true,
+            "subagents.enabled": false,
+            "web.access": false,
+          }}
+          {...(initialDraftInputBySessionId
+            ? { draftInputBySessionId: initialDraftInputBySessionId }
+            : {})}
         >
           <ChatView
-            key={chatKey}
-            sessionId="session-1"
-            messages={[]}
+            key={chatKey ?? sessionId ?? "no-session"}
+            sessionId={sessionId}
+            messages={chatMessages}
             sendMessage={sendMessage}
             stop={async () => undefined}
-            status="ready"
-            error={undefined}
+            status={status}
+            error={error}
             pendingElicitation={null}
             handleElicitationSubmit={vi.fn()}
             handleElicitationCancel={vi.fn()}
+            retryMessage={retryMessage}
+            rewindToMessage={rewindToMessage}
+            forkFromMessage={forkFromMessage}
             modelMenuValue={{ provider: "ANTHROPIC", modelName: "claude" }}
             onModelChange={vi.fn()}
             autoFocusInput={autoFocusInput}
@@ -209,6 +258,20 @@ describe("ChatView", () => {
     expect(remountedTextarea?.value).toBe("preserve this draft");
   });
 
+  it("restores draft input when switching to a keyed session", () => {
+    renderChatView(root, {
+      sessionId: "session-1",
+      initialDraftInputBySessionId: { "fork-session": "edit me" },
+    });
+    renderChatView(root, { sessionId: "fork-session" });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Message input"]'
+    );
+
+    expect(textarea?.value).toBe("edit me");
+  });
+
   it("clears the prompt draft after submit", () => {
     const sendMessage = vi.fn<ChatViewSendMessage>();
     renderChatView(root, { sendMessage });
@@ -226,5 +289,191 @@ describe("ChatView", () => {
       undefined
     );
     expect(textarea?.value).toBe("");
+  });
+
+  it("shows retry and technical details for failed turns", () => {
+    const retryMessage = vi.fn();
+    renderChatView(root, {
+      chatMessages: messages,
+      error: new Error("provider unavailable"),
+      status: "error",
+      retryMessage,
+      rewindToMessage: vi.fn(),
+      forkFromMessage: vi.fn(),
+    });
+
+    const retryButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Retry"
+    );
+    expect(retryButton).not.toBeUndefined();
+
+    act(() => {
+      retryButton?.click();
+    });
+
+    expect(retryMessage).toHaveBeenCalledWith("assistant-message");
+    expect(container.textContent).toContain("Show technical details");
+    expect(container.textContent).toContain("provider unavailable");
+  });
+
+  it("shows interrupted recovery when history ends on a user message", () => {
+    renderChatView(root, {
+      chatMessages: unansweredUserMessages,
+      status: "ready",
+      rewindToMessage: vi.fn(),
+      forkFromMessage: vi.fn(),
+    });
+
+    expect(container.textContent).toContain("PXI did not respond.");
+    expect(container.textContent).toContain(
+      "This message was interrupted before PXI could respond."
+    );
+    expect(container.textContent).toContain("Retry");
+    expect(container.textContent).toContain("Edit message");
+    expect(container.textContent).toContain("Branch before message");
+  });
+
+  it("retries an interrupted user message without duplicating it", () => {
+    const sendMessage = vi.fn();
+    const rewindToMessage = vi.fn(() => "What happened?");
+    renderChatView(root, {
+      chatMessages: unansweredUserMessages,
+      status: "ready",
+      sendMessage,
+      rewindToMessage,
+      forkFromMessage: vi.fn(),
+    });
+
+    const retryButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Retry"
+    );
+    expect(retryButton).not.toBeUndefined();
+
+    act(() => {
+      retryButton?.click();
+    });
+
+    expect(rewindToMessage).toHaveBeenCalledWith("user-message");
+    expect(sendMessage).toHaveBeenCalledWith({ text: "What happened?" });
+  });
+
+  it("confirms editing an interrupted user message", () => {
+    const rewindToMessage = vi.fn(() => "What happened?");
+    renderChatView(root, {
+      chatMessages: unansweredUserMessages,
+      status: "ready",
+      rewindToMessage,
+      forkFromMessage: vi.fn(),
+    });
+
+    const editButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Edit message"
+    );
+    expect(editButton).not.toBeUndefined();
+
+    act(() => {
+      editButton?.click();
+    });
+
+    const confirmButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Rewind conversation"
+    );
+    act(() => {
+      confirmButton?.click();
+    });
+
+    expect(rewindToMessage).toHaveBeenCalledWith("user-message");
+  });
+
+  it("confirms branching before an interrupted user message", () => {
+    const forkFromMessage = vi.fn(() => "branch-session");
+    renderChatView(root, {
+      chatMessages: unansweredUserMessages,
+      status: "ready",
+      rewindToMessage: vi.fn(),
+      forkFromMessage,
+    });
+
+    const branchButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Branch before message"
+    );
+    expect(branchButton).not.toBeUndefined();
+
+    act(() => {
+      branchButton?.click();
+    });
+
+    const confirmButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Branch conversation"
+    );
+    act(() => {
+      confirmButton?.click();
+    });
+
+    expect(forkFromMessage).toHaveBeenCalledWith("user-message");
+  });
+
+  it("confirms undoing a failed turn from the latest user message", () => {
+    const rewindToMessage = vi.fn(() => "What happened?");
+    renderChatView(root, {
+      chatMessages: messages,
+      error: new Error("provider unavailable"),
+      status: "error",
+      retryMessage: vi.fn(),
+      rewindToMessage,
+      forkFromMessage: vi.fn(),
+    });
+
+    const undoButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Undo failed turn"
+    );
+    expect(undoButton).not.toBeUndefined();
+
+    act(() => {
+      undoButton?.click();
+    });
+
+    expect(container.textContent).toContain("Rewind conversation");
+
+    const confirmButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Rewind conversation"
+    );
+    act(() => {
+      confirmButton?.click();
+    });
+
+    expect(rewindToMessage).toHaveBeenCalledWith("user-message");
+  });
+
+  it("confirms branching before a failed turn from the latest user message", () => {
+    const forkFromMessage = vi.fn(() => "forked-session");
+    renderChatView(root, {
+      chatMessages: messages,
+      error: new Error("provider unavailable"),
+      status: "error",
+      retryMessage: vi.fn(),
+      rewindToMessage: vi.fn(),
+      forkFromMessage,
+    });
+
+    const forkButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Branch before error"
+    );
+    expect(forkButton).not.toBeUndefined();
+
+    act(() => {
+      forkButton?.click();
+    });
+
+    expect(container.textContent).toContain("Branch conversation");
+
+    const confirmButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Branch conversation"
+    );
+    act(() => {
+      confirmButton?.click();
+    });
+
+    expect(forkFromMessage).toHaveBeenCalledWith("user-message");
   });
 });

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -175,11 +175,13 @@ export function useAgentChat({
   const {
     messages,
     sendMessage,
+    regenerate,
     status,
     error,
     addToolOutput,
     stop,
     setMessages,
+    clearError,
   } = chat;
 
   // Anthropic doesn't accept unresolved tool calls, so we resolve them by
@@ -303,7 +305,7 @@ export function useAgentChat({
   };
 
   // Releases approval/elicitation state owned by tool calls dropped by a rewind
-  // or fork, so stale Accept/Reject affordances don't dangle against tool calls
+  // or branch, so stale Accept/Reject affordances don't dangle against tool calls
   // the transcript no longer contains.
   const clearDroppedToolState = useCallback(
     ({
@@ -365,13 +367,21 @@ export function useAgentChat({
         next: result.messages,
       });
       setMessages(result.messages);
+      clearError();
       store.getState().setSessionMessages(sessionId, result.messages);
       return result.restoredInput;
     },
-    [chatInstance, clearDroppedToolState, sessionId, setMessages, store]
+    [
+      chatInstance,
+      clearDroppedToolState,
+      clearError,
+      sessionId,
+      setMessages,
+      store,
+    ]
   );
 
-  // Forks the active session into a new session truncated to the chosen
+  // Branches the active session into a new session truncated to the chosen
   // message, leaving the current session untouched. Returns the new session id.
   const forkFromMessage = useCallback(
     (messageId: string): string | null => {
@@ -385,13 +395,24 @@ export function useAgentChat({
       if (!result) {
         return null;
       }
+      clearError();
       return store.getState().forkSession({
         sourceSessionId: sessionId,
         messages: result.messages,
         restoredInput: result.restoredInput,
       });
     },
-    [chatInstance, sessionId, store]
+    [chatInstance, clearError, sessionId, store]
+  );
+
+  const retryMessage = useCallback(
+    (messageId?: string) => {
+      if (!sessionId || !chatInstance || isRequestActive(chatInstance.status)) {
+        return;
+      }
+      void regenerate(messageId ? { messageId } : undefined);
+    },
+    [chatInstance, regenerate, sessionId]
   );
 
   return {
@@ -403,6 +424,7 @@ export function useAgentChat({
     pendingElicitation,
     handleElicitationSubmit,
     handleElicitationCancel,
+    retryMessage,
     rewindToMessage,
     forkFromMessage,
   } as {
@@ -417,6 +439,7 @@ export function useAgentChat({
     pendingElicitation: PendingElicitation | null;
     handleElicitationSubmit: (output: ElicitToolOutput) => void;
     handleElicitationCancel: () => void;
+    retryMessage: (messageId?: string) => void;
     rewindToMessage: (messageId: string) => string | null;
     forkFromMessage: (messageId: string) => string | null;
   };

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -287,7 +287,7 @@ describe("agentStore", () => {
       expect(store.getState().draftInputBySessionId[forkId!]).toBe("edit me");
     });
 
-    it("prefixes the source summary with (fork)", () => {
+    it("prefixes the source summary with (branch)", () => {
       const store = createAgentStore();
       const sourceId = store.getState().createSession();
       store.getState().updateSessionSummary(sourceId, "Debugging traces");
@@ -298,7 +298,7 @@ describe("agentStore", () => {
       });
 
       expect(store.getState().sessionMap[forkId!].shortSummary).toBe(
-        "(fork) Debugging traces"
+        "(branch) Debugging traces"
       );
     });
 
@@ -331,15 +331,15 @@ describe("agentStore", () => {
         messages: [],
       });
       expect(store.getState().sessionMap[refork!].shortSummary).toBe(
-        "(fork) How do I trace OpenAI?"
+        "(branch) How do I trace OpenAI?"
       );
       expect(forkId).not.toBeNull();
     });
 
-    it("does not stack the (fork) prefix when forking a fork", () => {
+    it("does not stack the (branch) prefix when branching from a branch", () => {
       const store = createAgentStore();
       const sourceId = store.getState().createSession();
-      store.getState().updateSessionSummary(sourceId, "(fork) Original");
+      store.getState().updateSessionSummary(sourceId, "(branch) Original");
 
       const forkId = store.getState().forkSession({
         sourceSessionId: sourceId,
@@ -347,7 +347,7 @@ describe("agentStore", () => {
       });
 
       expect(store.getState().sessionMap[forkId!].shortSummary).toBe(
-        "(fork) Original"
+        "(branch) Original"
       );
     });
 

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -167,16 +167,16 @@ const DEFAULT_AGENT_PERMISSIONS: AgentPermissions = {
 
 const MAX_STORED_AGENT_SESSIONS = 3;
 
-/** Prefix applied to a forked session's summary to denote its origin. */
-const FORK_SUMMARY_PREFIX = "(fork) ";
+/** Prefix applied to a branched session's summary to denote its origin. */
+const FORK_SUMMARY_PREFIX = "(branch) ";
 
 /** Max length for a derived (non-LLM) fork summary before truncation. */
 const FORK_SUMMARY_MAX_LENGTH = 50;
 
 /**
- * Builds the summary for a session forked from `source`. Reuses the source's
+ * Builds the summary for a session branched from `source`. Reuses the source's
  * LLM-generated summary when available, otherwise derives a short label from
- * its first user message, then prefixes it with `(fork)`. Seeding a non-empty
+ * its first user message, then prefixes it with `(branch)`. Seeding a non-empty
  * summary here also prevents the async summarizer from overwriting it.
  */
 function buildForkSummary(source: AgentSession): string {
@@ -196,7 +196,7 @@ function buildForkSummary(source: AgentSession): string {
         : text
       : "";
   }
-  // Avoid stacking "(fork) (fork) ..." when forking a fork.
+  // Avoid stacking "(branch) (branch) ..." when branching from a branch.
   if (base.startsWith(FORK_SUMMARY_PREFIX)) {
     return base;
   }


### PR DESCRIPTION


https://github.com/user-attachments/assets/f45937d7-6a11-4109-9830-99870b10ecd0

<img width="530" height="733" alt="Screenshot 2026-06-18 at 10 05 08 AM" src="https://github.com/user-attachments/assets/d0f74bcf-b195-4808-94b2-48660ce1a36b" />


## Summary
- add retry, undo, branch, and technical-detail affordances for failed PXI responses
- show interrupted-turn recovery when chat history ends on an unanswered user message
- rename user-facing fork language to branch and update branched session titles

## Tests
- pnpm test src/components/agent/__tests__/Chat.test.tsx
- pnpm test src/store/__tests__/agentStore.test.ts src/components/agent/__tests__/Chat.test.tsx
- pnpm typecheck
- pnpm exec oxlint ...