### PR TITLE
feat(pxi): add prompt route contexts

### DIFF
--- a/.github/workflows/openapi-schema.yaml
+++ b/.github/workflows/openapi-schema.yaml
@@ -4,6 +4,7 @@ permissions:
 
 on:
   push:
+    branches: [main]
     paths:
       - "schemas/openapi.json"
   pull_request:

--- a/app/src/agent/context/__tests__/deriveRouteContexts.test.ts
+++ b/app/src/agent/context/__tests__/deriveRouteContexts.test.ts
@@ -89,4 +89,29 @@ describe("deriveRouteContexts", () => {
       { type: "span", projectNodeId: "P1", spanNodeId: "SPAN1" },
     ]);
   });
+
+  it("derives prompt context from a prompt route", () => {
+    const contexts = deriveRouteContexts(
+      [match({ promptId: "PROMPT1" })],
+      new URLSearchParams()
+    );
+
+    expect(contexts).toEqual([{ type: "prompt", promptNodeId: "PROMPT1" }]);
+  });
+
+  it("derives prompt and prompt version contexts from a prompt version route", () => {
+    const contexts = deriveRouteContexts(
+      [match({ promptId: "PROMPT1" }), match({ versionId: "VERSION1" })],
+      new URLSearchParams()
+    );
+
+    expect(contexts).toEqual([
+      { type: "prompt", promptNodeId: "PROMPT1" },
+      {
+        type: "prompt_version",
+        promptNodeId: "PROMPT1",
+        promptVersionNodeId: "VERSION1",
+      },
+    ]);
+  });
 });

--- a/app/src/agent/context/agentContextTypes.ts
+++ b/app/src/agent/context/agentContextTypes.ts
@@ -70,6 +70,10 @@ export function agentContextKey(context: AgentContext): string {
       return `trace:${context.projectNodeId}:${context.otelTraceId}`;
     case "session":
       return `session:${context.projectNodeId}:${context.sessionNodeId}`;
+    case "prompt":
+      return `prompt:${context.promptNodeId}`;
+    case "prompt_version":
+      return `prompt_version:${context.promptNodeId}:${context.promptVersionNodeId}`;
     case "span": {
       const project = context.projectNodeId ?? "";
       const span = context.spanNodeId

--- a/app/src/agent/context/deriveRouteContexts.ts
+++ b/app/src/agent/context/deriveRouteContexts.ts
@@ -47,6 +47,8 @@ export function deriveRouteContexts(
   const projectNodeId = params["projectId"];
   const otelTraceId = params["traceId"];
   const sessionNodeId = params["sessionId"];
+  const promptNodeId = params["promptId"];
+  const promptVersionNodeId = params["versionId"];
   const routeSpanNodeId = params["spanId"];
   const selectedSpanNodeId = searchParams.get(SELECTED_SPAN_NODE_ID_PARAM);
   const selectedTraceId = searchParams.get(SELECTED_TRACE_ID_PARAM);
@@ -66,6 +68,18 @@ export function deriveRouteContexts(
 
   if (projectNodeId && sessionNodeId) {
     contexts.push({ type: "session", projectNodeId, sessionNodeId });
+  }
+
+  if (promptNodeId) {
+    contexts.push({ type: "prompt", promptNodeId });
+  }
+
+  if (promptNodeId && promptVersionNodeId) {
+    contexts.push({
+      type: "prompt_version",
+      promptNodeId,
+      promptVersionNodeId,
+    });
   }
 
   if (selectedSpanNodeId) {

--- a/app/src/agent/tools/getRouteInfo/routeParams.ts
+++ b/app/src/agent/tools/getRouteInfo/routeParams.ts
@@ -56,6 +56,11 @@ export function buildParamsFromContexts(
       }
     } else if (context.type === "dataset") {
       params.datasetId = context.datasetNodeId;
+    } else if (context.type === "prompt") {
+      params.promptId = context.promptNodeId;
+    } else if (context.type === "prompt_version") {
+      params.promptId = context.promptNodeId;
+      params.versionId = context.promptVersionNodeId;
     }
   }
   return params;

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1614,7 +1614,7 @@ export interface components {
          * ChatContext
          * @description Discriminated union of every UI-state context the agent understands.
          */
-        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["SessionContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["CodeEvaluatorContext"] | components["schemas"]["LlmEvaluatorContext"] | components["schemas"]["DatasetContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"] | components["schemas"]["SubagentsContext"];
+        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["SessionContext"] | components["schemas"]["PromptContext"] | components["schemas"]["PromptVersionContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["CodeEvaluatorContext"] | components["schemas"]["LlmEvaluatorContext"] | components["schemas"]["DatasetContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"] | components["schemas"]["SubagentsContext"];
         /**
          * ChatRegenerateMessage
          * @description Regenerate message extended with Phoenix-specific fields.
@@ -3506,6 +3506,19 @@ export interface components {
             /** Messages */
             messages: components["schemas"]["PromptMessage"][];
         };
+        /**
+         * PromptContext
+         * @description Prompt the user is currently viewing.
+         */
+        PromptContext: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "prompt";
+            /** Promptnodeid */
+            promptNodeId: string;
+        };
         /** PromptData */
         PromptData: {
             name: components["schemas"]["Identifier"];
@@ -4005,6 +4018,21 @@ export interface components {
             response_format?: components["schemas"]["PromptResponseFormatJSONSchema"] | null;
             /** Id */
             id: string;
+        };
+        /**
+         * PromptVersionContext
+         * @description Prompt version the user is currently viewing.
+         */
+        PromptVersionContext: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "prompt_version";
+            /** Promptnodeid */
+            promptNodeId: string;
+            /** Promptversionnodeid */
+            promptVersionNodeId: string;
         };
         /** PromptVersionData */
         PromptVersionData: {

--- a/app/src/components/agent/AgentContextPills.tsx
+++ b/app/src/components/agent/AgentContextPills.tsx
@@ -43,6 +43,10 @@ function contextLabel(context: AgentContext): string {
       return "Trace";
     case "session":
       return "Session";
+    case "prompt":
+      return "Prompt";
+    case "prompt_version":
+      return "Prompt Version";
     case "span":
       return "Span";
     case "code_evaluator":
@@ -61,6 +65,10 @@ function contextDetail(context: AgentContext): string | undefined {
       return truncateId(context.otelTraceId);
     case "session":
       return truncateId(context.sessionNodeId);
+    case "prompt":
+      return truncateId(context.promptNodeId);
+    case "prompt_version":
+      return truncateId(context.promptVersionNodeId);
     case "span": {
       const spanId = context.spanNodeId ?? context.otelSpanId;
       if (spanId == null) {

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1614,7 +1614,7 @@ export interface components {
          * ChatContext
          * @description Discriminated union of every UI-state context the agent understands.
          */
-        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["SessionContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["CodeEvaluatorContext"] | components["schemas"]["LlmEvaluatorContext"] | components["schemas"]["DatasetContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"] | components["schemas"]["SubagentsContext"];
+        ChatContext: components["schemas"]["AppContext"] | components["schemas"]["ProjectContext"] | components["schemas"]["TraceContext"] | components["schemas"]["SessionContext"] | components["schemas"]["PromptContext"] | components["schemas"]["PromptVersionContext"] | components["schemas"]["AgentSpanContext"] | components["schemas"]["PlaygroundContext"] | components["schemas"]["CodeEvaluatorContext"] | components["schemas"]["LlmEvaluatorContext"] | components["schemas"]["DatasetContext"] | components["schemas"]["GraphQLContext"] | components["schemas"]["WebAccessContext"] | components["schemas"]["SubagentsContext"];
         /**
          * ChatRegenerateMessage
          * @description Regenerate message extended with Phoenix-specific fields.
@@ -3506,6 +3506,19 @@ export interface components {
             /** Messages */
             messages: components["schemas"]["PromptMessage"][];
         };
+        /**
+         * PromptContext
+         * @description Prompt the user is currently viewing.
+         */
+        PromptContext: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "prompt";
+            /** Promptnodeid */
+            promptNodeId: string;
+        };
         /** PromptData */
         PromptData: {
             name: components["schemas"]["Identifier"];
@@ -4005,6 +4018,21 @@ export interface components {
             response_format?: components["schemas"]["PromptResponseFormatJSONSchema"] | null;
             /** Id */
             id: string;
+        };
+        /**
+         * PromptVersionContext
+         * @description Prompt version the user is currently viewing.
+         */
+        PromptVersionContext: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "prompt_version";
+            /** Promptnodeid */
+            promptNodeId: string;
+            /** Promptversionnodeid */
+            promptVersionNodeId: string;
         };
         /** PromptVersionData */
         PromptVersionData: {

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -430,6 +430,11 @@ class PromptCerebrasInvocationParametersContent(TypedDict):
     extra_body: NotRequired[Mapping[str, Any]]
 
 
+class PromptContext(TypedDict):
+    type: Literal["prompt"]
+    promptNodeId: str
+
+
 class PromptDeepSeekInvocationParametersContent(TypedDict):
     temperature: NotRequired[float]
     max_tokens: NotRequired[int]
@@ -579,6 +584,12 @@ class PromptToolFunctionDefinition(TypedDict):
 class PromptToolRaw(TypedDict):
     type: Literal["raw"]
     raw: Mapping[str, Any]
+
+
+class PromptVersionContext(TypedDict):
+    type: Literal["prompt_version"]
+    promptNodeId: str
+    promptVersionNodeId: str
 
 
 class PromptVersionTag(TypedDict):
@@ -1553,6 +1564,8 @@ class ChatRegenerateMessage(TypedDict):
                 ProjectContext,
                 TraceContext,
                 SessionContext,
+                PromptContext,
+                PromptVersionContext,
                 AgentSpanContext,
                 PlaygroundContext,
                 CodeEvaluatorContext,
@@ -1582,6 +1595,8 @@ class ChatSubmitMessage(TypedDict):
                 ProjectContext,
                 TraceContext,
                 SessionContext,
+                PromptContext,
+                PromptVersionContext,
                 AgentSpanContext,
                 PlaygroundContext,
                 CodeEvaluatorContext,

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -7373,6 +7373,12 @@
             "$ref": "#/components/schemas/SessionContext"
           },
           {
+            "$ref": "#/components/schemas/PromptContext"
+          },
+          {
+            "$ref": "#/components/schemas/PromptVersionContext"
+          },
+          {
             "$ref": "#/components/schemas/AgentSpanContext"
           },
           {
@@ -7409,6 +7415,8 @@
             "llm_evaluator": "#/components/schemas/LlmEvaluatorContext",
             "playground": "#/components/schemas/PlaygroundContext",
             "project": "#/components/schemas/ProjectContext",
+            "prompt": "#/components/schemas/PromptContext",
+            "prompt_version": "#/components/schemas/PromptVersionContext",
             "session": "#/components/schemas/SessionContext",
             "span": "#/components/schemas/AgentSpanContext",
             "subagents": "#/components/schemas/SubagentsContext",
@@ -11959,6 +11967,26 @@
         ],
         "title": "PromptChatTemplate"
       },
+      "PromptContext": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "prompt",
+            "title": "Type"
+          },
+          "promptNodeId": {
+            "type": "string",
+            "title": "Promptnodeid"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "promptNodeId"
+        ],
+        "title": "PromptContext",
+        "description": "Prompt the user is currently viewing."
+      },
       "PromptData": {
         "properties": {
           "name": {
@@ -13211,6 +13239,31 @@
           "id"
         ],
         "title": "PromptVersion"
+      },
+      "PromptVersionContext": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "prompt_version",
+            "title": "Type"
+          },
+          "promptNodeId": {
+            "type": "string",
+            "title": "Promptnodeid"
+          },
+          "promptVersionNodeId": {
+            "type": "string",
+            "title": "Promptversionnodeid"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "promptNodeId",
+          "promptVersionNodeId"
+        ],
+        "title": "PromptVersionContext",
+        "description": "Prompt version the user is currently viewing."
       },
       "PromptVersionData": {
         "properties": {

--- a/src/phoenix/server/agents/capabilities/contexts/__init__.py
+++ b/src/phoenix/server/agents/capabilities/contexts/__init__.py
@@ -17,6 +17,10 @@ from phoenix.server.agents.capabilities.contexts.llm_evaluator import (
 )
 from phoenix.server.agents.capabilities.contexts.playground import PlaygroundContextCapability
 from phoenix.server.agents.capabilities.contexts.project import ProjectContextCapability
+from phoenix.server.agents.capabilities.contexts.prompt import (
+    PromptContextCapability,
+    PromptVersionContextCapability,
+)
 from phoenix.server.agents.capabilities.contexts.session import SessionContextCapability
 from phoenix.server.agents.capabilities.contexts.span import SpanContextCapability
 from phoenix.server.agents.capabilities.contexts.trace import TraceContextCapability
@@ -40,6 +44,8 @@ def get_context_capability_function(
         ProjectContextCapability(instructions=prompts.project_context),
         TraceContextCapability(instructions=prompts.trace_context),
         SessionContextCapability(instructions=prompts.session_context),
+        PromptContextCapability(instructions=prompts.prompt_context),
+        PromptVersionContextCapability(instructions=prompts.prompt_version_context),
         SpanContextCapability(instructions=prompts.span_context),
         PlaygroundContextCapability(instructions=prompts.playground_context),
         CodeEvaluatorContextCapability(instructions=prompts.code_evaluator_context),
@@ -62,6 +68,8 @@ __all__ = [
     "GraphQLMutationsCapability",
     "LlmEvaluatorContextCapability",
     "PlaygroundContextCapability",
+    "PromptContextCapability",
+    "PromptVersionContextCapability",
     "ProjectContextCapability",
     "SessionContextCapability",
     "SpanContextCapability",

--- a/src/phoenix/server/agents/capabilities/contexts/prompt.py
+++ b/src/phoenix/server/agents/capabilities/contexts/prompt.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from jinja2 import Template
+from pydantic_ai import RunContext
+from pydantic_ai.tools import SystemPromptFunc
+
+from phoenix.server.agents.capabilities.base import AbstractDynamicCapability
+from phoenix.server.agents.types import AgentDependencies
+
+
+@dataclass
+class PromptContextCapability(AbstractDynamicCapability[AgentDependencies]):
+    instructions: Template
+
+    def get_dynamic_instructions(self) -> SystemPromptFunc[AgentDependencies]:
+        instructions = self.instructions
+
+        def _instructions(ctx: RunContext[AgentDependencies]) -> str | None:
+            prompt = ctx.deps.contexts.prompt
+            if prompt is None:
+                return None
+            return instructions.render(prompt=prompt)
+
+        return _instructions
+
+    def include_for_run(self, ctx: RunContext[AgentDependencies]) -> bool:
+        return ctx.deps.contexts.prompt is not None
+
+
+@dataclass
+class PromptVersionContextCapability(AbstractDynamicCapability[AgentDependencies]):
+    instructions: Template
+
+    def get_dynamic_instructions(self) -> SystemPromptFunc[AgentDependencies]:
+        instructions = self.instructions
+
+        def _instructions(ctx: RunContext[AgentDependencies]) -> str | None:
+            prompt_version = ctx.deps.contexts.prompt_version
+            if prompt_version is None:
+                return None
+            return instructions.render(prompt_version=prompt_version)
+
+        return _instructions
+
+    def include_for_run(self, ctx: RunContext[AgentDependencies]) -> bool:
+        return ctx.deps.contexts.prompt_version is not None

--- a/src/phoenix/server/agents/context.py
+++ b/src/phoenix/server/agents/context.py
@@ -75,6 +75,21 @@ class SessionContext(_ChatContextBase):
     session_node_id: str = Field(alias="sessionNodeId")
 
 
+class PromptContext(_ChatContextBase):
+    """Prompt the user is currently viewing."""
+
+    type: Literal["prompt"]
+    prompt_node_id: str = Field(alias="promptNodeId")
+
+
+class PromptVersionContext(_ChatContextBase):
+    """Prompt version the user is currently viewing."""
+
+    type: Literal["prompt_version"]
+    prompt_node_id: str = Field(alias="promptNodeId")
+    prompt_version_node_id: str = Field(alias="promptVersionNodeId")
+
+
 class AgentSpanContext(_ChatContextBase):
     """Span the user has selected.
 
@@ -248,6 +263,8 @@ class ChatContext(
             | ProjectContext
             | TraceContext
             | SessionContext
+            | PromptContext
+            | PromptVersionContext
             | AgentSpanContext
             | PlaygroundContext
             | CodeEvaluatorContext
@@ -269,6 +286,8 @@ class ResolvedContexts:
     project: ProjectContext | None = None
     trace: TraceContext | None = None
     session: SessionContext | None = None
+    prompt: PromptContext | None = None
+    prompt_version: PromptVersionContext | None = None
     span: AgentSpanContext | None = None
     playground: PlaygroundContext | None = None
     code_evaluator: CodeEvaluatorContext | None = None
@@ -299,6 +318,10 @@ def resolve_contexts(contexts: list[ChatContext]) -> ResolvedContexts:
             resolved.trace = context_value
         elif isinstance(context_value, SessionContext):
             resolved.session = context_value
+        elif isinstance(context_value, PromptContext):
+            resolved.prompt = context_value
+        elif isinstance(context_value, PromptVersionContext):
+            resolved.prompt_version = context_value
         elif isinstance(context_value, AgentSpanContext):
             resolved.span = context_value
         elif isinstance(context_value, GraphQLContext):

--- a/src/phoenix/server/agents/prompts/__init__.py
+++ b/src/phoenix/server/agents/prompts/__init__.py
@@ -167,6 +167,10 @@ _APP_CONTEXT_TEMPLATE = get_template("context/APP_CONTEXT_INSTRUCTIONS.xml.j2")
 _PROJECT_CONTEXT_TEMPLATE = get_template("context/PROJECT_CONTEXT_INSTRUCTIONS.xml.j2")
 _TRACE_CONTEXT_TEMPLATE = get_template("context/TRACE_CONTEXT_INSTRUCTIONS.xml.j2")
 _SESSION_CONTEXT_TEMPLATE = get_template("context/SESSION_CONTEXT_INSTRUCTIONS.xml.j2")
+_PROMPT_CONTEXT_TEMPLATE = get_template("context/PROMPT_CONTEXT_INSTRUCTIONS.xml.j2")
+_PROMPT_VERSION_CONTEXT_TEMPLATE = get_template(
+    "context/PROMPT_VERSION_CONTEXT_INSTRUCTIONS.xml.j2"
+)
 _SPAN_CONTEXT_TEMPLATE = get_template("context/SPAN_CONTEXT_INSTRUCTIONS.xml.j2")
 _PLAYGROUND_CONTEXT_TEMPLATE = get_template("context/PLAYGROUND_CONTEXT_INSTRUCTIONS.xml.j2")
 _CODE_EVALUATOR_CONTEXT_TEMPLATE = get_template(
@@ -267,6 +271,8 @@ class AgentPrompts:
     project_context: Template = _PROJECT_CONTEXT_TEMPLATE
     trace_context: Template = _TRACE_CONTEXT_TEMPLATE
     session_context: Template = _SESSION_CONTEXT_TEMPLATE
+    prompt_context: Template = _PROMPT_CONTEXT_TEMPLATE
+    prompt_version_context: Template = _PROMPT_VERSION_CONTEXT_TEMPLATE
     span_context: Template = _SPAN_CONTEXT_TEMPLATE
     playground_context: Template = _PLAYGROUND_CONTEXT_TEMPLATE
     code_evaluator_context: Template = _CODE_EVALUATOR_CONTEXT_TEMPLATE

--- a/src/phoenix/server/agents/prompts/context/PROMPT_CONTEXT_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/context/PROMPT_CONTEXT_INSTRUCTIONS.xml.j2
@@ -1,0 +1,5 @@
+<phoenix_prompt_context>
+  <description>The saved prompt the user is currently viewing.</description>
+  <prompt_node_id format="phoenix_node_id">{{ prompt.prompt_node_id | sanitize(enclosing_tag="prompt_node_id", max_chars=128) | e }}</prompt_node_id>
+  <guidance>Use this prompt context to answer questions about the saved prompt, its configuration, labels, versions, and prompt history. If a phoenix_prompt_version_context is also present, it is the specific version currently selected.</guidance>
+</phoenix_prompt_context>

--- a/src/phoenix/server/agents/prompts/context/PROMPT_VERSION_CONTEXT_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/context/PROMPT_VERSION_CONTEXT_INSTRUCTIONS.xml.j2
@@ -1,0 +1,6 @@
+<phoenix_prompt_version_context>
+  <description>The saved prompt version the user is currently viewing.</description>
+  <prompt_node_id format="phoenix_node_id">{{ prompt_version.prompt_node_id | sanitize(enclosing_tag="prompt_node_id", max_chars=128) | e }}</prompt_node_id>
+  <prompt_version_node_id format="phoenix_node_id">{{ prompt_version.prompt_version_node_id | sanitize(enclosing_tag="prompt_version_node_id", max_chars=128) | e }}</prompt_version_node_id>
+  <guidance>Use this prompt version context when the user asks about this revision's messages, model configuration, invocation parameters, tools, tags, or how it differs from other prompt versions.</guidance>
+</phoenix_prompt_version_context>

--- a/tests/unit/server/agents/capabilities/contexts/test_capabilities.py
+++ b/tests/unit/server/agents/capabilities/contexts/test_capabilities.py
@@ -15,6 +15,10 @@ from phoenix.server.agents.capabilities.contexts.llm_evaluator import (
 )
 from phoenix.server.agents.capabilities.contexts.playground import PlaygroundContextCapability
 from phoenix.server.agents.capabilities.contexts.project import ProjectContextCapability
+from phoenix.server.agents.capabilities.contexts.prompt import (
+    PromptContextCapability,
+    PromptVersionContextCapability,
+)
 from phoenix.server.agents.capabilities.contexts.session import SessionContextCapability
 from phoenix.server.agents.capabilities.tools.external.patch_experiment import (
     PatchExperimentCapability,
@@ -30,6 +34,8 @@ from phoenix.server.agents.context import (
     PlaygroundExperimentScaffoldContext,
     PlaygroundInstanceContext,
     ProjectContext,
+    PromptContext,
+    PromptVersionContext,
     ResolvedContexts,
     SessionContext,
 )
@@ -174,6 +180,48 @@ class TestSessionContextCapabilityRender:
         assert '<project_node_id format="phoenix_node_id">UHJvamVjdDox</project_node_id>' in content
         assert (
             '<session_node_id format="phoenix_node_id">UHJvamVjdFNlc3Npb246MQ==</session_node_id>'
+        ) in content
+
+
+class TestPromptContextCapabilityRender:
+    def test_renders_prompt_context(self) -> None:
+        capability = PromptContextCapability(instructions=_DEFAULT_PROMPTS.prompt_context)
+        ctx = _get_run_context(
+            ResolvedContexts(
+                prompt=PromptContext(
+                    type="prompt",
+                    prompt_node_id="UHJvbXB0OjE=",
+                ),
+            )
+        )
+
+        content = _render(capability, ctx)
+
+        assert content.startswith("<phoenix_prompt_context>")
+        assert '<prompt_node_id format="phoenix_node_id">UHJvbXB0OjE=</prompt_node_id>' in content
+
+
+class TestPromptVersionContextCapabilityRender:
+    def test_renders_prompt_version_context(self) -> None:
+        capability = PromptVersionContextCapability(
+            instructions=_DEFAULT_PROMPTS.prompt_version_context
+        )
+        ctx = _get_run_context(
+            ResolvedContexts(
+                prompt_version=PromptVersionContext(
+                    type="prompt_version",
+                    prompt_node_id="UHJvbXB0OjE=",
+                    prompt_version_node_id="UHJvbXB0VmVyc2lvbjox",
+                ),
+            )
+        )
+
+        content = _render(capability, ctx)
+
+        assert content.startswith("<phoenix_prompt_version_context>")
+        assert '<prompt_node_id format="phoenix_node_id">UHJvbXB0OjE=</prompt_node_id>' in content
+        assert (
+            '<prompt_version_node_id format="phoenix_node_id">UHJvbXB0VmVyc2lvbjox</prompt_version_node_id>'
         ) in content
 
 


### PR DESCRIPTION
## Summary
- add prompt and prompt-version PXI context schemas and dynamic context instructions
- derive prompt contexts from prompt routes and surface them in context pills/link generation
- regenerate OpenAPI schema and generated clients

## Tests
- pnpm vitest run agent/context/__tests__/deriveRouteContexts.test.ts
- pnpm typecheck
- uv run pytest tests/unit/server/agents/capabilities/contexts/test_capabilities.py