### PR TITLE
feat(agents): add PXI graphql eval datasets, evaluators, and harness wiring

### DIFF
--- a/evals/pxi/datasets/graphql_query_shape.yaml
+++ b/evals/pxi/datasets/graphql_query_shape.yaml
@@ -1,0 +1,229 @@
+dataset_name: graphql_query_shape
+description: >-
+  PXI server-side eval that checks the subagent can still land on the correct
+  GraphQL query shape after the pre-seeded /phoenix virtual-filesystem query
+  files were removed from the bash tool. Each example mirrors one of the deleted
+  fileBuilders/graphql query builders: given the matching UI context and an
+  open-ended user question, the agent must load the phoenix-graphql skill and
+  emit a phoenix-gql query whose shape matches the deleted operation. Because
+  the agent writes ad-hoc GraphQL (not a persisted operation), each case asserts
+  the query's distinguishing entrypoint/fields/args via bash_command_substrings_match
+  rather than an operation name. The contrastive pairs (recent-traces vs
+  recent-spans, trace-latency vs trace-details) verify the agent picks the right
+  granularity, not just any query against the right entity.
+evaluators:
+  - correct_tools_called
+  - tool_call_args_match
+  - bash_command_substrings_match
+
+examples:
+
+  # ===== Dataset page (datasetNodeId in context) =====
+
+  - id: dataset-by-id
+    splits: [regression]
+    input:
+      contexts:
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+      messages:
+        - role: user
+          content: "What is this dataset about? IMPORTANT — you MUST delegate this ENTIRE task to a subagent by calling the call_subagent tool."
+    expected:
+      tools:
+        required: [load_skill, bash]
+      tool_call_args:
+        load_skill:
+          skill_name: phoenix-graphql
+      bash_command:
+        - contains: [Dataset, description]
+          not_contains: [experiments]
+    metadata:
+      mirrors_deleted_query: datasetPageContextByIdQuery
+      category: dataset_by_id
+
+  - id: dataset-experiments
+    splits: [regression]
+    input:
+      contexts:
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+      messages:
+        - role: user
+          content: "Summarize the last ten experiments for this dataset. IMPORTANT — you MUST delegate this ENTIRE task to a subagent by calling the call_subagent tool."
+    expected:
+      tools:
+        required: [load_skill, bash]
+      tool_call_args:
+        load_skill:
+          skill_name: phoenix-graphql
+      bash_command:
+        - contains: [experiments]
+    metadata:
+      mirrors_deleted_query: datasetPageContextExperimentsQuery
+      category: dataset_experiments
+
+  # ===== Project page (projectNodeId in context) =====
+
+  - id: project-by-id
+    splits: [regression]
+    input:
+      contexts:
+        - type: project
+          projectNodeId: UHJvamVjdDox
+          spanFilter: ""
+          rootSpansOnly: false
+      messages:
+        - role: user
+          content: "How many traces and spans does this project have? IMPORTANT — you MUST delegate this ENTIRE task to a subagent by calling the call_subagent tool."
+    expected:
+      tools:
+        required: [load_skill, bash]
+      tool_call_args:
+        load_skill:
+          skill_name: phoenix-graphql
+      bash_command:
+        - contains: [traceCount, recordCount]
+    metadata:
+      mirrors_deleted_query: projectPageContextProjectByIdQuery
+      category: project_by_id
+
+  - id: project-recent-traces
+    splits: [regression]
+    input:
+      contexts:
+        - type: project
+          projectNodeId: UHJvamVjdDox
+          spanFilter: ""
+          rootSpansOnly: false
+      messages:
+        - role: user
+          content: "Show me the 5 most recent traces in this project. IMPORTANT — you MUST delegate this ENTIRE task to a subagent by calling the call_subagent tool."
+    expected:
+      tools:
+        required: [load_skill, bash]
+      tool_call_args:
+        load_skill:
+          skill_name: phoenix-graphql
+      bash_command:
+        # "recent traces" collapses to root spans: assert the VALUE
+        # rootSpansOnly: true (substring matcher is whitespace-sensitive, so
+        # cover both spacings as OR variants), not just the key's presence.
+        - contains: ["rootSpansOnly: true", startTime]
+        - contains: ["rootSpansOnly:true", startTime]
+    metadata:
+      mirrors_deleted_query: projectPageContextRecentTracesQuery
+      category: project_recent_traces
+      annotation:
+        notes: >-
+          Contrast with project-recent-spans: "recent traces" must collapse to
+          root spans (rootSpansOnly: true), one row per trace.
+
+  - id: project-recent-spans
+    splits: [regression]
+    input:
+      contexts:
+        - type: project
+          projectNodeId: UHJvamVjdDox
+          spanFilter: ""
+          rootSpansOnly: false
+      messages:
+        - role: user
+          content: "What are the latest spans across this project, of any kind? IMPORTANT — you MUST delegate this ENTIRE task to a subagent by calling the call_subagent tool."
+    expected:
+      tools:
+        required: [load_skill, bash]
+      tool_call_args:
+        load_skill:
+          skill_name: phoenix-graphql
+      bash_command:
+        # "latest spans of any kind" must NOT collapse to root spans. Forbid the
+        # VALUE rootSpansOnly: true (the recent-traces behavior), not the key --
+        # an explicit `rootSpansOnly: false` is correct and must still pass.
+        - contains: [spanKind, startTime]
+          not_contains: ["rootSpansOnly: true", "rootSpansOnly:true"]
+    metadata:
+      mirrors_deleted_query: projectPageContextRecentSpansQuery
+      category: project_recent_spans
+      annotation:
+        notes: >-
+          Contrast with project-recent-traces: "latest spans of any kind" must
+          NOT set rootSpansOnly and should surface spanKind.
+
+  - id: project-recent-sessions
+    splits: [regression]
+    input:
+      contexts:
+        - type: project
+          projectNodeId: UHJvamVjdDox
+          spanFilter: ""
+          rootSpansOnly: false
+      messages:
+        - role: user
+          content: "List the most recent sessions in this project. IMPORTANT — you MUST delegate this ENTIRE task to a subagent by calling the call_subagent tool."
+    expected:
+      tools:
+        required: [load_skill, bash]
+      tool_call_args:
+        load_skill:
+          skill_name: phoenix-graphql
+      bash_command:
+        - contains: [sessions, startTime]
+    metadata:
+      mirrors_deleted_query: projectPageContextRecentSessionsQuery
+      category: project_recent_sessions
+
+  # ===== Trace page (trace context: projectNodeId + otelTraceId) =====
+
+  - id: trace-latency-only
+    splits: [regression]
+    input:
+      contexts:
+        - type: trace
+          projectNodeId: UHJvamVjdDox
+          otelTraceId: 4b730708c417639830d19ff8533a265d
+      messages:
+        - role: user
+          content: "How long did this trace take? IMPORTANT — you MUST delegate this ENTIRE task to a subagent by calling the call_subagent tool."
+    expected:
+      tools:
+        required: [load_skill, bash]
+      tool_call_args:
+        load_skill:
+          skill_name: phoenix-graphql
+      bash_command:
+        - contains: [latencyMs]
+          not_contains: [spans]
+    metadata:
+      mirrors_deleted_query: tracePageContextFromProjectQuery
+      category: trace_latency
+      annotation:
+        notes: >-
+          Strict over-fetch check (contrast with trace-details): a latency
+          question should read only latencyMs, not pull the span tree.
+
+  - id: trace-details
+    splits: [regression]
+    input:
+      contexts:
+        - type: trace
+          projectNodeId: UHJvamVjdDox
+          otelTraceId: 4b730708c417639830d19ff8533a265d
+      messages:
+        - role: user
+          content: "Walk me through the spans in this trace step by step. IMPORTANT — you MUST delegate this ENTIRE task to a subagent by calling the call_subagent tool."
+    expected:
+      tools:
+        required: [load_skill, bash]
+      tool_call_args:
+        load_skill:
+          skill_name: phoenix-graphql
+      bash_command:
+        - contains: [spans, spanKind]
+    metadata:
+      mirrors_deleted_query: tracePageContextDetailsQuery
+      category: trace_details
+      annotation:
+        notes: >-
+          Contrast with trace-latency-only: a step-by-step request must pull the
+          span tree (spans + spanKind).

--- a/evals/pxi/datasets/graphql_skill_first_actions.yaml
+++ b/evals/pxi/datasets/graphql_skill_first_actions.yaml
@@ -1,0 +1,74 @@
+dataset_name: graphql_skill_first_actions
+description: >-
+  PXI server-side eval for the phoenix-graphql skill's first-actions footprint.
+  Given a project context and an open-ended data question ("tell me about the
+  traces in this project"), the agent should (1) load the phoenix-graphql skill
+  before composing any GraphQL, (2) read the relevant skill resource
+  (read_skill_resource) to pull the schema facts it needs, then (3) run
+  `phoenix-gql --help` to discover flags and runtime permissions before issuing
+  a real query. The ordered_tool_calls_match evaluator pins both the position
+  and the arguments of those first three actions; the granular evaluators
+  (correct_tools_called, tool_call_args_match, bash_command_substrings_match)
+  are along for diagnostic signal so a partial failure says which sub-step
+  broke.
+evaluators:
+  - ordered_tool_calls_match
+  - correct_tools_called
+  - tool_call_args_match
+  - bash_command_substrings_match
+
+examples:
+
+  - id: tell-me-about-traces
+    splits: [regression]
+    input:
+      contexts:
+        - type: project
+          projectNodeId: UHJvamVjdDox
+          spanFilter: ""
+          rootSpansOnly: false
+      messages:
+        - role: user
+          content: Tell me about the traces in this project.
+    expected:
+      # Primary assertion: (1) load the graphql skill, (2) read a skill
+      # resource, (3) run `phoenix-gql --help`. Prefix match — later query
+      # actions are fine. read_skill_resource's resource_name is left
+      # unconstrained: project-spans-traces is the natural pick for a trace
+      # question, but the assertion is only that a resource read happens here.
+      ordered_tool_calls:
+        - name: load_skill
+          args:
+            skill_name: phoenix-graphql
+        - name: read_skill_resource
+          args:
+            skill_name: phoenix-graphql
+        - name: bash
+          args:
+            command:
+              contains_all: ["phoenix-gql --help"]
+      # Diagnostic redundancy (order-insensitive) so a failure localizes.
+      tools:
+        required: [load_skill, read_skill_resource, bash]
+      tool_call_args:
+        load_skill:
+          skill_name: phoenix-graphql
+        read_skill_resource:
+          skill_name: phoenix-graphql
+      bash_command:
+        - contains: [phoenix-gql --help]
+    metadata:
+      category: graphql_first_actions
+      difficulty: moderate
+      polarity: positive
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Footprint, not trigger. An open-ended "tell me about the traces" data
+          question over a project context should make the agent load the
+          phoenix-graphql skill first (it owns schema entrypoints and the
+          efficiency rule against blind introspection), then run
+          `phoenix-gql --help` to learn flags/permissions before its first real
+          query. Lead-annotated; the ordered_tool_calls expectation encodes the
+          exact two-step opening the skill prescribes.

--- a/evals/pxi/evaluators/__init__.py
+++ b/evals/pxi/evaluators/__init__.py
@@ -8,6 +8,7 @@ from evals.pxi.evaluators.tools import (
     bash_command_substrings_match,
     correct_tools_called,
     forbidden_tool_call_args_match,
+    ordered_tool_calls_match,
     tool_call_args_match,
     tool_call_count_within_limit,
 )
@@ -24,6 +25,7 @@ EVALUATORS_BY_NAME: dict[str, Any] = {
     "correct_tools_called": correct_tools_called,
     "forbidden_tool_call_args_match": forbidden_tool_call_args_match,
     "in_app_links_valid": in_app_links_valid,
+    "ordered_tool_calls_match": ordered_tool_calls_match,
     "tool_call_args_match": tool_call_args_match,
     "tool_call_count_within_limit": tool_call_count_within_limit,
 }
@@ -35,6 +37,7 @@ __all__ = [
     "correct_tools_called",
     "forbidden_tool_call_args_match",
     "in_app_links_valid",
+    "ordered_tool_calls_match",
     "tool_call_args_match",
     "tool_call_count_within_limit",
 ]

--- a/evals/pxi/evaluators/tools.py
+++ b/evals/pxi/evaluators/tools.py
@@ -568,6 +568,103 @@ def evaluate_forbidden_tool_call_args(output: Any, expected: Any) -> dict[str, A
     return _success()
 
 
+def _expected_ordered_tool_calls(expected: Any) -> Any:
+    return _as_dict(expected).get("ordered_tool_calls")
+
+
+def evaluate_ordered_tool_calls(output: Any, expected: Any) -> dict[str, Any]:
+    """Assert the agent's first N actions match an ordered sequence of steps.
+
+    Reads ``expected.ordered_tool_calls`` -- a list of steps, each
+    ``{name: <tool>, args?: {key: value, ...}}``. The check is a **prefix
+    match** against the observed tool-call sequence: observed call ``i`` must
+    be a call to ``steps[i].name`` whose args satisfy ``steps[i].args`` under
+    the same subset + matcher-vocabulary semantics as
+    :func:`evaluate_tool_call_args`. Calls *after* the listed steps are
+    ignored, so this scores "what did the agent do first" without forbidding
+    follow-up actions.
+
+    This is distinct from ``expected.tools.exact_match`` (which constrains the
+    *whole* observed sequence by tool name only, no args and no extras) and
+    from ``tool_call_args_match`` (which is order-insensitive and any-of across
+    calls). Use this when both the *position* and the *arguments* of the first
+    few actions are the behavior under test -- e.g. "the agent must load the
+    phoenix-graphql skill first, then run ``phoenix-gql --help`` before
+    composing a query".
+
+    Passes vacuously when the section is absent, so the evaluator can be
+    enabled for a whole dataset while only scoring examples that opt in.
+    """
+    steps = _expected_ordered_tool_calls(expected)
+    if steps is None:
+        return _success()
+    if not isinstance(steps, list) or not steps:
+        return _failure("expected.ordered_tool_calls must be a non-empty list of step objects")
+
+    observed = tool_calls_from_output(output)
+    observed_names = [_tool_name(call) for call in observed]
+
+    for index, step in enumerate(steps):
+        if not isinstance(step, dict):
+            return _failure(
+                f"expected.ordered_tool_calls[{index}] must be an object",
+                metadata={"step": step},
+            )
+        name = step.get("name")
+        if not isinstance(name, str) or not name:
+            return _failure(
+                f"expected.ordered_tool_calls[{index}].name must be a non-empty string",
+                metadata={"step": step},
+            )
+        args_expectation = step.get("args", {})
+        if not isinstance(args_expectation, dict):
+            return _failure(
+                f"expected.ordered_tool_calls[{index}].args must be an object",
+                metadata={"step": step},
+            )
+        matcher_errors = _matcher_validation_failures([args_expectation])
+        if matcher_errors:
+            return _failure(
+                f"expected.ordered_tool_calls[{index}] arg matcher is malformed",
+                metadata={"matcher_errors": matcher_errors},
+            )
+
+        if index >= len(observed):
+            return _failure(
+                f"Expected at least {len(steps)} tool calls, observed {len(observed)}",
+                metadata={"expected_step": index, "observed_tools": observed_names},
+            )
+        call = observed[index]
+        if _tool_name(call) != name:
+            return _failure(
+                f"Action {index}: expected tool {name!r}, observed {_tool_name(call)!r}",
+                metadata={"observed_tools": observed_names},
+            )
+        call_args = _tool_args(call)
+        if not all(_pair_passes(call_args, key, value) for key, value in args_expectation.items()):
+            return _failure(
+                f"Action {index} ({name}): arguments did not match expected values",
+                metadata={
+                    "expected_args": dict(args_expectation),
+                    "observed_args": dict(call_args),
+                },
+            )
+
+    return _success()
+
+
+@create_evaluator(name="ordered_tool_calls_match", kind="code")
+def ordered_tool_calls_match(output: Any, expected: Any) -> dict[str, Any]:
+    """Evaluator entrypoint: assert the first N actions match an ordered sequence.
+
+    Reads ``expected.ordered_tool_calls`` as a list of
+    ``{name: <tool>, args?: {...}}`` steps and prefix-matches them against the
+    observed tool-call order, with per-step args using the shared matcher
+    vocabulary. See :func:`evaluate_ordered_tool_calls` for full semantics.
+    """
+    return evaluate_ordered_tool_calls(output, expected)
+
+
 @create_evaluator(name="forbidden_tool_call_args_match", kind="code")
 def forbidden_tool_call_args_match(output: Any, expected: Any) -> dict[str, Any]:
     """Evaluator entrypoint: assert a specific tool+args combination was NOT called.

--- a/evals/pxi/harness/agent_task.py
+++ b/evals/pxi/harness/agent_task.py
@@ -3,9 +3,23 @@ from __future__ import annotations
 import json
 import os
 import sys
+import threading
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any, Literal, cast
+from unittest.mock import Mock
+from urllib.parse import urljoin
 
+from openinference.instrumentation import OITracer, TraceConfig
+from openinference.semconv.resource import ResourceAttributes
+from opentelemetry import trace as otel_trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import TracerProvider as AbstractTracerProvider
+from phoenix.client.utils.config import get_base_url, get_env_phoenix_api_key
+from pydantic_ai import Agent
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.mcp import MCPServerStreamableHTTP
 from pydantic_ai.messages import (
@@ -37,7 +51,10 @@ from phoenix.server.agents.model_factory import (
 from phoenix.server.agents.model_factory import (
     azure_endpoint_to_base_url,
 )
+from phoenix.server.agents.pydantic_ai import OpenInferenceModelWrapper
+from phoenix.server.agents.server_agents import build_server_agent
 from phoenix.server.agents.types import AgentDependencies, AgentOutput
+from phoenix.server.api.context import Context
 
 DEFAULT_ASSISTANT_PROVIDER = "OPENAI"
 DEFAULT_ASSISTANT_MODEL = "gpt-5.4"
@@ -46,6 +63,182 @@ ENV_ASSISTANT_PROVIDER = "PHOENIX_AGENTS_ASSISTANT_PROVIDER"
 ENV_ASSISTANT_MODEL = "PHOENIX_AGENTS_ASSISTANT_MODEL"
 ENV_ASSISTANT_OPENAI_API_TYPE = "PHOENIX_AGENTS_ASSISTANT_OPENAI_API_TYPE"
 _MAX_ERROR_MESSAGE_LEN = 200
+
+# One real OTel TracerProvider per Phoenix project, reused across every task in
+# a run. The provider exports the agent's OpenInference spans (LLM calls, tool
+# calls, skill loads) to Phoenix so each experiment run links to a full agent
+# trace -- without this, ``build_agent`` falls back to a NoOp provider and the
+# task span has no children. Keyed by project name because the experiment's
+# project is only known at task time (read off the active task span).
+_TRACER_PROVIDERS: dict[str, TracerProvider] = {}
+_TRACER_PROVIDERS_LOCK = threading.Lock()
+
+
+def _active_span_project_name() -> str | None:
+    """Return the project name on the currently-active span's resource, if any.
+
+    The experiment runner starts each task inside a span whose resource carries
+    ``openinference.project.name`` set to the experiment's project. Reading it
+    back here lets the agent's spans export to the *same* project so they nest
+    under the task span in one trace, instead of fragmenting into a separate
+    project.
+    """
+    span = otel_trace.get_current_span()
+    resource = getattr(span, "resource", None)
+    if resource is None:
+        return None
+    name = resource.attributes.get(ResourceAttributes.PROJECT_NAME)
+    return str(name) if name else None
+
+
+def _experiment_tracer_provider() -> AbstractTracerProvider | None:
+    """Build (or reuse) a Phoenix-exporting TracerProvider for the active task.
+
+    Returns ``None`` when there is no active experiment task span (e.g. a direct
+    ``run_pxi_example`` call), so the agent stays on its NoOp default and no
+    spans are emitted -- preserving the previous behavior outside experiments.
+    """
+    project_name = _active_span_project_name()
+    if not project_name:
+        return None
+    with _TRACER_PROVIDERS_LOCK:
+        provider = _TRACER_PROVIDERS.get(project_name)
+        if provider is None:
+            resource = Resource({ResourceAttributes.PROJECT_NAME: project_name})
+            provider = TracerProvider(resource=resource)
+            api_key = get_env_phoenix_api_key()
+            headers = {"authorization": f"Bearer {api_key}"} if api_key else {}
+            endpoint = urljoin(str(get_base_url()), "v1/traces")
+            # SimpleSpanProcessor exports synchronously on span end, so spans are
+            # flushed by the time ``agent.run`` returns -- no batching to lose.
+            provider.add_span_processor(
+                SimpleSpanProcessor(OTLPSpanExporter(endpoint=endpoint, headers=headers))
+            )
+            _TRACER_PROVIDERS[project_name] = provider
+        return provider
+
+
+def shutdown_experiment_tracer_providers() -> None:
+    """Flush and shut down every per-project provider built during the run.
+
+    Call once after the experiment completes. Best-effort: a provider that fails
+    to shut down does not abort the others.
+    """
+    with _TRACER_PROVIDERS_LOCK:
+        providers = list(_TRACER_PROVIDERS.values())
+        _TRACER_PROVIDERS.clear()
+    for provider in providers:
+        try:
+            provider.shutdown()
+        except Exception as exc:  # pragma: no cover - best-effort cleanup
+            print(f"warning: tracer provider shutdown failed: {exc}", file=sys.stderr)
+
+
+# --- Subagent wiring (call_subagent tool) --------------------------------
+
+# Cap on the subagent's model requests per delegated task. The harness mocks the
+# GraphQL context, so data queries return errors and an uncapped subagent keeps
+# probing (introspection, guessing node IDs) instead of stopping once it has
+# emitted the target query. A legitimate path -- load_skill, read_skill_resource,
+# phoenix-gql --help, the real query, answer -- is ~5 requests; this leaves room
+# for a couple of retries before we cut it off.
+_SUBAGENT_MAX_MODEL_REQUESTS = 8
+
+_GRAPHQL_SCHEMA: Any = None
+
+
+def _eval_graphql_schema() -> Any:
+    """Build and cache the real Phoenix GraphQL schema for subagent runs.
+
+    The subagent's ``phoenix-gql`` validates and introspects against this schema
+    so it sees Phoenix's real fields and arguments. Execution uses a mock GraphQL
+    context (the harness has no DB), so data resolvers error -- harmless here
+    because the eval scores the *emitted* query shape, not the returned rows.
+    Introspection (``__type``/``__schema``) and validation are schema-level and
+    work regardless of the context.
+    """
+    global _GRAPHQL_SCHEMA
+    if _GRAPHQL_SCHEMA is None:
+        from phoenix.server.api.schema import build_graphql_schema
+
+        _GRAPHQL_SCHEMA = build_graphql_schema()
+    return _GRAPHQL_SCHEMA
+
+
+class _RecordingServerAgent:
+    """Wrap the subagent so each delegated run's messages are captured.
+
+    ``call_subagent`` returns only the subagent's final text, so the subagent's
+    tool calls (``load_skill``, ``bash``/``phoenix-gql``) never reach the main
+    agent's message history that the evaluators read. This wrapper appends every
+    subagent run's serialized new messages to ``sink`` so the harness can merge
+    them into the task output, making the subagent's queries visible to the tool
+    and bash-command evaluators. Only ``run`` is exercised by
+    ``CallSubAgentToolset``; every other attribute delegates to the wrapped agent.
+    """
+
+    def __init__(self, inner: Any, sink: list[dict[str, Any]]) -> None:
+        self._inner = inner
+        self._sink = sink
+
+    async def run(self, *args: Any, **kwargs: Any) -> Any:
+        """Drive the subagent via ``iter`` so we can cap model requests.
+
+        ``call_subagent`` only reads ``.output`` off the return value, so we
+        return a lightweight shim. We use ``iter`` (instrumented by the agent
+        wrapper, so spans are preserved) and break after
+        ``_SUBAGENT_MAX_MODEL_REQUESTS`` model-request nodes to stop runaway
+        probing. New messages are captured whether or not the run finished, so
+        the evaluators still see every query the subagent emitted before the cap.
+        """
+        output: Any = None
+        model_requests = 0
+        async with self._inner.iter(*args, **kwargs) as run:
+            async for node in run:
+                if Agent.is_model_request_node(node):
+                    model_requests += 1
+                    if model_requests > _SUBAGENT_MAX_MODEL_REQUESTS:
+                        break
+            if run.result is not None:
+                output = run.result.output
+            try:
+                self._sink.extend(json.loads(run.new_messages_json()))
+            except Exception:  # pragma: no cover - capture must never break the run
+                pass
+        if output is None:
+            output = (
+                "Subagent stopped after reaching the step limit of "
+                f"{_SUBAGENT_MAX_MODEL_REQUESTS} model requests without a final answer. "
+                "Summarize from the data already gathered."
+            )
+        return SimpleNamespace(output=output)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+def _build_eval_subagent(
+    *,
+    model: PydanticAIModel,
+    docs_mcp_server: MCPServerStreamableHTTP | None,
+    tracer_provider: AbstractTracerProvider | None,
+    sink: list[dict[str, Any]],
+) -> _RecordingServerAgent:
+    """Build the GraphQL server subagent for an eval run, recording its messages.
+
+    Mirrors the production wiring in the agents router: the real GraphQL schema,
+    the same (already OpenInference-wrapped) model, the shared docs toolset, and
+    the experiment tracer provider so the subagent's spans nest in the same
+    trace. The GraphQL context is mocked because the harness has no DB.
+    """
+    server_agent = build_server_agent(
+        model=model,
+        schema=_eval_graphql_schema(),
+        build_graphql_context=lambda: Mock(spec=Context),
+        docs_mcp_server=docs_mcp_server,
+        tracer_provider=tracer_provider,
+    )
+    return _RecordingServerAgent(server_agent, sink)
 
 
 def _warn_placeholder_api_key(provider: str, base_url: str) -> None:
@@ -172,11 +365,6 @@ def _build_contexts(input: dict[str, Any]) -> ResolvedContexts:
     if not isinstance(raw_contexts, list):
         raise ValueError("PXI eval input.contexts must be a list when provided")
     return resolve_contexts([ChatContext.model_validate(context) for context in raw_contexts])
-
-
-def _build_dependencies(input: dict[str, Any]) -> AgentDependencies:
-    contexts = _build_contexts(input)
-    return AgentDependencies(contexts=contexts)
 
 
 def _build_run_inputs(
@@ -436,6 +624,7 @@ def _example_input(example: dict[str, Any]) -> dict[str, Any]:
 
 def make_task(
     docs_mcp_server: MCPServerStreamableHTTP | None = None,
+    include_subagent: bool = False,
 ) -> Any:
     """Build a Phoenix experiment task callable bound to a shared toolset.
 
@@ -445,6 +634,9 @@ def make_task(
     to YAML example IDs. The single shared ``docs_mcp_server`` is reused
     across every concurrent task to satisfy anyio's single-owner cancel
     scope rule.
+
+    ``include_subagent`` mounts the ``call_subagent`` tool (backed by the
+    GraphQL server subagent) on the main agent for every example.
     """
 
     async def task(example: dict[str, Any]) -> dict[str, Any]:
@@ -453,6 +645,7 @@ def make_task(
             input_value,
             stable_example_id=example.get("id"),
             docs_mcp_server=docs_mcp_server,
+            include_subagent=include_subagent,
         )
 
     return task
@@ -474,6 +667,7 @@ async def run_pxi_example(
     *,
     stable_example_id: str | None = None,
     docs_mcp_server: MCPServerStreamableHTTP | None = None,
+    include_subagent: bool = False,
 ) -> dict[str, Any]:
     """Run a single PXI agent turn imperatively.
 
@@ -499,13 +693,49 @@ async def run_pxi_example(
     try:
         user_prompt, message_history = _build_run_inputs(input)
         model = await _build_model()
-        agent = build_agent(model=model, docs_mcp_server=docs_mcp_server)
+        # Mirror production: ``build_model`` returns an OpenInference-wrapped
+        # model so LLM calls are traced. The harness builds a raw model, so wrap
+        # it here with the same tracer when an experiment provider is active --
+        # otherwise the trace would show tool spans but no LLM spans.
+        tracer_provider = _experiment_tracer_provider()
+        if tracer_provider is not None:
+            model = OpenInferenceModelWrapper(
+                model,
+                tracer=OITracer(
+                    tracer_provider.get_tracer("phoenix.server.agents"),
+                    config=TraceConfig(),
+                ),
+            )
+        contexts = _build_contexts(input)
+        # With ``include_subagent`` (the ``--include-subagent`` flag), give the
+        # main agent the ``call_subagent`` tool backed by the GraphQL server
+        # subagent (bash + phoenix-gql). Its messages are captured into
+        # ``subagent_messages`` and merged into the task output below, so
+        # evaluators that read tool/bash calls see the queries the subagent
+        # actually emitted.
+        subagent_messages: list[dict[str, Any]] = []
+        server_agent = None
+        if include_subagent:
+            server_agent = _build_eval_subagent(
+                model=model,
+                docs_mcp_server=docs_mcp_server,
+                tracer_provider=tracer_provider,
+                sink=subagent_messages,
+            )
+        agent = build_agent(
+            model=model,
+            docs_mcp_server=docs_mcp_server,
+            tracer_provider=tracer_provider,
+            server_agent=server_agent,
+        )
         result = await agent.run(
             user_prompt,
-            deps=_build_dependencies(input),
+            deps=AgentDependencies(contexts=contexts),
             message_history=message_history,
         )
         output = agent_task_output(result)
+        if subagent_messages:
+            output.setdefault("messages", []).extend(subagent_messages)
     except Exception as exc:
         message = str(exc)
         if len(message) > _MAX_ERROR_MESSAGE_LEN:

--- a/evals/pxi/harness/run_experiment.py
+++ b/evals/pxi/harness/run_experiment.py
@@ -29,6 +29,7 @@ from evals.pxi.harness.agent_task import (
     ENV_ASSISTANT_PROVIDER,
     build_shared_docs_mcp_server,
     make_task,
+    shutdown_experiment_tracer_providers,
 )
 from evals.pxi.harness.datasets import (
     EvalDataset,
@@ -52,6 +53,7 @@ class ExperimentConfig:
     fail_on_regression: bool
     splits: tuple[str, ...]
     evaluator_override: tuple[str, ...] | None
+    include_subagent: bool
 
 
 def _resolve_evaluators(dataset: EvalDataset, override: tuple[str, ...] | None) -> list[Any]:
@@ -413,12 +415,17 @@ async def _run_async(config: ExperimentConfig) -> int:
                 "started_at": datetime.now(timezone.utc).isoformat(),
             }
             print(f"Running experiment: {name}")
-            # Run task first, then evaluate explicitly after replacing Phoenix's
-            # relay dataset example ID with the stable YAML example ID expected
-            # by the client-side evaluator lookup.
+            # Run the task, then evaluate. The evaluation step MUST run before
+            # the stable-id remap below: ``evaluate_experiment`` binds each run
+            # to its example via the relay dataset-example GlobalID
+            # (``dataset_example_id``), so overwriting that id first makes every
+            # run unmatchable and silently produces zero evaluations.
             experiment = await client.experiments.run_experiment(
                 dataset=experiment_dataset,
-                task=make_task(docs_mcp_server=docs_mcp_server),
+                task=make_task(
+                    docs_mcp_server=docs_mcp_server,
+                    include_subagent=config.include_subagent,
+                ),
                 experiment_name=name,
                 experiment_description=dataset.description,
                 experiment_metadata=metadata,
@@ -427,10 +434,6 @@ async def _run_async(config: ExperimentConfig) -> int:
                 timeout=180,
                 retries=0,
             )
-            for task_run in experiment["task_runs"]:
-                output = task_run.get("output")
-                if isinstance(output, dict) and isinstance(output.get("stable_example_id"), str):
-                    task_run["dataset_example_id"] = output["stable_example_id"]
             experiment = await client.experiments.evaluate_experiment(
                 experiment=experiment,
                 evaluators=cast(Any, evaluators),
@@ -439,7 +442,18 @@ async def _run_async(config: ExperimentConfig) -> int:
                 timeout=180,
                 retries=0,
             )
+            # Now that evaluation has bound runs to examples by GlobalID, replace
+            # the relay id with the stable YAML example id so the runner's own
+            # reporting (failure table, regression gate keyed on YAML splits) can
+            # map rows back to dataset examples.
+            for task_run in experiment["task_runs"]:
+                output = task_run.get("output")
+                if isinstance(output, dict) and isinstance(output.get("stable_example_id"), str):
+                    task_run["dataset_example_id"] = output["stable_example_id"]
         finally:
+            # Flush and close the per-project agent tracer providers so the
+            # task spans are fully exported before the process exits.
+            shutdown_experiment_tracer_providers()
             # ``AsyncClient`` does not yet expose a public ``aclose``; reach for
             # the underlying httpx client and tolerate it disappearing in a
             # future refactor so cleanup never shadows a real failure.
@@ -509,6 +523,15 @@ def build_parser() -> argparse.ArgumentParser:
             f"for permanent changes. Valid names: {', '.join(sorted(EVALUATORS_BY_NAME))}."
         ),
     )
+    parser.add_argument(
+        "--include-subagent",
+        action="store_true",
+        help=(
+            "Mount the call_subagent tool (backed by the GraphQL server "
+            "subagent with bash + phoenix-gql) on the main agent for every "
+            "example. Off by default."
+        ),
+    )
     return parser
 
 
@@ -525,6 +548,7 @@ def main(argv: list[str] | None = None) -> int:
         fail_on_regression=args.fail_on_regression,
         splits=tuple(args.splits),
         evaluator_override=tuple(args.evaluators) if args.evaluators else None,
+        include_subagent=args.include_subagent,
     )
     try:
         return run(config)

--- a/tests/unit/pxi/evals/test_agent_task_inputs.py
+++ b/tests/unit/pxi/evals/test_agent_task_inputs.py
@@ -139,20 +139,26 @@ class TestBuildRunInputs:
 
 class TestMaterializeMessages:
     def test_builds_primed_bash_tool_call_and_return(self) -> None:
+        command = (
+            "phoenix-gql '{ projects(first: 1) { edges { node { spans(first: 1, "
+            "sort: {col: startTime, dir: desc}) { edges { node { startTime } } } } } } }' "
+            "--data-only"
+        )
         history = _materialize_messages(
             [
                 {"role": "user", "content": "When were the latest traces?"},
                 {
                     "role": "assistant",
-                    "tool_calls": [
-                        {"id": "t1", "name": "bash", "args": {"command": "ls /phoenix"}}
-                    ],
+                    "tool_calls": [{"id": "t1", "name": "bash", "args": {"command": command}}],
                 },
                 {
                     "role": "tool",
                     "tool_call_id": "t1",
                     "name": "bash",
-                    "content": "agent-start.md\npage-context.json\n",
+                    "content": (
+                        '{"projects": {"edges": [{"node": {"spans": {"edges": '
+                        '[{"node": {"startTime": "2026-06-18T17:42:10+00:00"}}]}}}]}}\n'
+                    ),
                 },
             ]
         )
@@ -165,7 +171,7 @@ class TestMaterializeMessages:
         assert isinstance(call_part, ToolCallPart)
         assert call_part.tool_name == "bash"
         assert call_part.tool_call_id == "t1"
-        assert call_part.args == {"command": "ls /phoenix"}
+        assert call_part.args == {"command": command}
         assert isinstance(tool_turn, ModelRequest)
         return_part = tool_turn.parts[0]
         assert isinstance(return_part, ToolReturnPart)

--- a/tests/unit/pxi/evals/test_evaluators.py
+++ b/tests/unit/pxi/evals/test_evaluators.py
@@ -14,6 +14,7 @@ import pytest
 from evals.pxi.evaluators.links import evaluate_in_app_links
 from evals.pxi.evaluators.text import evaluate_assistant_text_substrings
 from evals.pxi.evaluators.tools import (
+    evaluate_ordered_tool_calls,
     evaluate_tool_call_args,
     evaluate_tools_called,
 )
@@ -611,5 +612,148 @@ class TestAssistantTextSubstringsMatch:
         result = evaluate_assistant_text_substrings(
             output=_text_output("some text"),
             expected=_text_expected(expectation),
+        )
+        assert result["label"] == "fail"
+
+
+def _ordered_output(*calls: tuple[str, dict[str, Any]]) -> dict[str, Any]:
+    """Build a serialized-messages output with tool calls in the given order."""
+    return {
+        "messages": [
+            {
+                "kind": "response",
+                "parts": [
+                    {"part_kind": "tool-call", "tool_name": name, "args": args}
+                    for name, args in calls
+                ],
+            }
+        ]
+    }
+
+
+class TestOrderedToolCallsMatch:
+    def _graphql_first_actions(self) -> dict[str, Any]:
+        # The phoenix-graphql first-actions footprint: load the skill, read a
+        # skill resource, then run `phoenix-gql --help` before any real query.
+        return {
+            "ordered_tool_calls": [
+                {"name": "load_skill", "args": {"skill_name": "phoenix-graphql"}},
+                {"name": "read_skill_resource", "args": {"skill_name": "phoenix-graphql"}},
+                {"name": "bash", "args": {"command": {"contains_all": ["phoenix-gql --help"]}}},
+            ]
+        }
+
+    def _good_sequence(self) -> tuple[tuple[str, dict[str, Any]], ...]:
+        return (
+            ("load_skill", {"skill_name": "phoenix-graphql"}),
+            ("read_skill_resource", {"skill_name": "phoenix-graphql"}),
+            ("bash", {"command": "phoenix-gql --help"}),
+        )
+
+    def test_passes_when_first_actions_match_in_order(self) -> None:
+        result = evaluate_ordered_tool_calls(
+            output=_ordered_output(*self._good_sequence()),
+            expected=self._graphql_first_actions(),
+        )
+        assert result["score"] == 1.0
+        assert result["label"] == "pass"
+
+    def test_allows_trailing_actions_after_the_prefix(self) -> None:
+        result = evaluate_ordered_tool_calls(
+            output=_ordered_output(
+                *self._good_sequence(),
+                ("bash", {"command": "phoenix-gql --query '{ ... }'"}),
+            ),
+            expected=self._graphql_first_actions(),
+        )
+        assert result["label"] == "pass"
+
+    def test_absent_expectation_passes_vacuously(self) -> None:
+        result = evaluate_ordered_tool_calls(
+            output=_ordered_output(("bash", {"command": "echo hi"})),
+            expected={},
+        )
+        assert result["label"] == "pass"
+
+    def test_fails_when_first_action_is_bash_not_load_skill(self) -> None:
+        result = evaluate_ordered_tool_calls(
+            output=_ordered_output(
+                ("bash", {"command": "phoenix-gql --help"}),
+                ("load_skill", {"skill_name": "phoenix-graphql"}),
+                ("read_skill_resource", {"skill_name": "phoenix-graphql"}),
+            ),
+            expected=self._graphql_first_actions(),
+        )
+        assert result["label"] == "fail"
+        assert "Action 0" in result["explanation"]
+
+    def test_fails_when_skill_name_is_wrong(self) -> None:
+        result = evaluate_ordered_tool_calls(
+            output=_ordered_output(
+                ("load_skill", {"skill_name": "debug-trace"}),
+                ("read_skill_resource", {"skill_name": "debug-trace"}),
+                ("bash", {"command": "phoenix-gql --help"}),
+            ),
+            expected=self._graphql_first_actions(),
+        )
+        assert result["label"] == "fail"
+
+    def test_fails_when_resource_read_is_skipped(self) -> None:
+        # load_skill straight to bash, no read_skill_resource second: the
+        # action that should be a resource read is bash, so step 1 mismatches.
+        result = evaluate_ordered_tool_calls(
+            output=_ordered_output(
+                ("load_skill", {"skill_name": "phoenix-graphql"}),
+                ("bash", {"command": "phoenix-gql --help"}),
+            ),
+            expected=self._graphql_first_actions(),
+        )
+        assert result["label"] == "fail"
+        assert "Action 1" in result["explanation"]
+
+    def test_fails_when_help_substring_missing(self) -> None:
+        result = evaluate_ordered_tool_calls(
+            output=_ordered_output(
+                ("load_skill", {"skill_name": "phoenix-graphql"}),
+                ("read_skill_resource", {"skill_name": "phoenix-graphql"}),
+                ("bash", {"command": "phoenix-gql --query '{ projects { ... } }'"}),
+            ),
+            expected=self._graphql_first_actions(),
+        )
+        assert result["label"] == "fail"
+        assert "Action 2" in result["explanation"]
+
+    def test_fails_when_fewer_calls_than_steps(self) -> None:
+        result = evaluate_ordered_tool_calls(
+            output=_ordered_output(
+                ("load_skill", {"skill_name": "phoenix-graphql"}),
+                ("read_skill_resource", {"skill_name": "phoenix-graphql"}),
+            ),
+            expected=self._graphql_first_actions(),
+        )
+        assert result["label"] == "fail"
+
+    def test_fails_when_no_tool_calls_at_all(self) -> None:
+        result = evaluate_ordered_tool_calls(
+            output={"messages": []},
+            expected=self._graphql_first_actions(),
+        )
+        assert result["label"] == "fail"
+
+    @pytest.mark.parametrize(
+        "steps",
+        [
+            "not-a-list",
+            [],
+            ["not-a-dict"],
+            [{"name": ""}],
+            [{"name": "bash", "args": "not-a-dict"}],
+            [{"name": "bash", "args": {"command": {"contains_all": "not-a-list"}}}],
+        ],
+    )
+    def test_malformed_expectation_fails(self, steps: Any) -> None:
+        result = evaluate_ordered_tool_calls(
+            output=_ordered_output(("bash", {"command": "phoenix-gql --help"})),
+            expected={"ordered_tool_calls": steps},
         )
         assert result["label"] == "fail"


### PR DESCRIPTION
## Summary

Splits the PXI GraphQL evaluation work out of #-server-agent-bash branch into its own PR targeting `main`. Contains only the eval harness, datasets, evaluators, and their unit tests — no server or frontend changes.

- `evals/pxi/datasets/graphql_query_shape.yaml` — GraphQL query-shape eval dataset
- `evals/pxi/datasets/graphql_skill_first_actions.yaml` — graphql-skill first-actions eval dataset
- `evals/pxi/evaluators/tools.py` (+ `__init__.py`) — PXI tool-call evaluators
- `evals/pxi/harness/agent_task.py` — `call_subagent` subagent wiring and experiment tracing
- `evals/pxi/harness/run_experiment.py` — `--include-subagent` flag to mount the subagent in the eval harness
- `tests/unit/pxi/evals/test_agent_task_inputs.py`, `tests/unit/pxi/evals/test_evaluators.py`

## Notes

- Stands alone against `main`: `uv run pytest tests/unit/pxi/evals` → 169 passed.
- The datasets and harness wiring were authored to exercise the server-side bash-tool refactor that lives in the companion server PR; running the *experiments* end-to-end exercises that behavior, but the unit tests and imports are self-contained here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)