### PR TITLE
fix(ui): show three significant digits in GitHub star count

### DIFF
--- a/app/src/components/nav/GitHubStarCount.tsx
+++ b/app/src/components/nav/GitHubStarCount.tsx
@@ -10,7 +10,7 @@ export function GitHubStarCount() {
     fetch("https://api.github.com/repos/Arize-ai/phoenix")
       .then((response) => response.json())
       .then((data) => {
-        setStarCountText(format(".2s")(data.stargazers_count));
+        setStarCountText(format(".3s")(data.stargazers_count));
       });
   }, []);
 


### PR DESCRIPTION
## Summary

The nav GitHub star count rounded to two significant digits, collapsing the count to values like `6.0k`. This switches the d3-format specifier from `.2s` to `.3s` so it keeps an extra significant digit (e.g. `6.21k`).

## Changes
- `app/src/components/nav/GitHubStarCount.tsx`: `format(".2s")` → `format(".3s")`

## Test plan
- [ ] Load the app and confirm the nav star count renders with three significant digits.