### PR TITLE
fix(evals): trustworthy gating — infra errors warn, regressions confirmed twice

### DIFF
--- a/.github/workflows/pxi-evals.yml
+++ b/.github/workflows/pxi-evals.yml
@@ -170,7 +170,6 @@ jobs:
               --dataset "${dataset}" \
               --splits regression \
               --fail-on-regression \
-              --retry-failed \
               --report-dir "${report_dir}" \
               --experiment-name "${experiment_name}"
             dataset_result=$?

--- a/.github/workflows/pxi-evals.yml
+++ b/.github/workflows/pxi-evals.yml
@@ -71,8 +71,15 @@ jobs:
             fi
           done
           if [[ "${phoenix_ok}" -eq 0 ]]; then
-            echo "::error::Phoenix unavailable at ${phoenix_url} after 3 attempts — aborting all dataset runs. Check PHOENIX_COLLECTOR_ENDPOINT."
-            exit 1
+            echo "::warning title=PXI eval infra issue::Phoenix unavailable at ${phoenix_url} after 3 attempts — skipping PXI eval gate. Check PHOENIX_COLLECTOR_ENDPOINT."
+            {
+              echo "## PXI Regression Evals"
+              echo ""
+              echo "**Result: ⚠️ Infrastructure issue**"
+              echo ""
+              echo "Phoenix unavailable at ${phoenix_url}; no regression signal was produced."
+            } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+            exit 0
           fi
 
           report_dir="${RUNNER_TEMP}/pxi-eval-reports"
@@ -80,6 +87,7 @@ jobs:
 
           failed=0
           failed_datasets=()
+          infra_datasets=()
           short_sha="${GITHUB_SHA::7}"
           branch_slug="${GITHUB_REF_NAME//\//-}"
           step_summary="${GITHUB_STEP_SUMMARY:-/dev/null}"
@@ -157,19 +165,35 @@ jobs:
             echo "::group::PXI eval dataset: ${dataset}"
             echo "Dataset file: ${dataset_file}"
             echo "Running PXI regression eval: ${experiment_name}"
-            if uv run python -m evals.pxi.harness.run_experiment \
+            set +e
+            uv run python -m evals.pxi.harness.run_experiment \
               --dataset "${dataset}" \
               --splits regression \
               --fail-on-regression \
+              --retry-failed \
               --report-dir "${report_dir}" \
-              --experiment-name "${experiment_name}"; then
-              dataset_result=0
-            else
-              dataset_result=1
-            fi
+              --experiment-name "${experiment_name}"
+            dataset_result=$?
+            set -uo pipefail
             echo "::endgroup::"
 
-            if [[ "${dataset_result}" -ne 0 ]]; then
+            if [[ "${dataset_result}" -eq 2 ]]; then
+              infra_datasets+=("${dataset}")
+              report_md="${report_dir}/${dataset}.report.md"
+              if [[ -f "${report_md}" ]]; then
+                echo "⚠️ ${dataset}: infrastructure issue — see the report group below"
+                stop_token="pxi-report-${GITHUB_RUN_ID}-${RANDOM}${RANDOM}"
+                echo "::group::PXI EVAL INFRA REPORT (agent-readable): ${dataset}"
+                echo "::stop-commands::${stop_token}"
+                cat "${report_md}"
+                echo "::${stop_token}::"
+                echo "::endgroup::"
+              else
+                echo "⚠️ ${dataset}: infrastructure issue before a report could be written"
+              fi
+              echo "::warning title=PXI eval infra issue::Dataset '${dataset}' hit an infrastructure issue. This does not fail the PR gate."
+              echo "| \`${dataset}\` | ⚠️ infra |" >> "${step_summary}"
+            elif [[ "${dataset_result}" -ne 0 ]]; then
               failed=1
               failed_datasets+=("${dataset}")
               # Embed the full agent-readable report in the job log under its
@@ -197,13 +221,24 @@ jobs:
               fi
               echo "| \`${dataset}\` | ❌ FAILED |" >> "${step_summary}"
             else
-              echo "✅ ${dataset}: all passed"
-              echo "| \`${dataset}\` | ✅ passed |" >> "${step_summary}"
+              report_json="${report_dir}/${dataset}.report.json"
+              flaky_count=0
+              if [[ -f "${report_json}" ]]; then
+                flaky_count="$(jq -r '.flaky_count // 0' "${report_json}")"
+              fi
+              if [[ "${flaky_count}" -gt 0 ]]; then
+                echo "✅ ${dataset}: passed after ${flaky_count} flaky retry confirmation(s)"
+                echo "| \`${dataset}\` | ✅ passed (${flaky_count} flaky-passed) |" >> "${step_summary}"
+              else
+                echo "✅ ${dataset}: all passed"
+                echo "| \`${dataset}\` | ✅ passed |" >> "${step_summary}"
+              fi
             fi
           done
 
           total="${#dataset_files[@]}"
           n_failed="${#failed_datasets[@]}"
+          n_infra="${#infra_datasets[@]}"
 
           echo ""
           echo "════════════════════════════════════════"
@@ -212,6 +247,10 @@ jobs:
             {
               echo ""
               echo "**Result: ❌ ${n_failed} of ${total} datasets failed**"
+              if [[ "${n_infra}" -ne 0 ]]; then
+                echo ""
+                echo "⚠️ ${n_infra} dataset(s) had infrastructure issues."
+              fi
               echo ""
               echo "Failed: $(IFS=', '; echo "${failed_datasets[*]}")"
               echo ""
@@ -222,6 +261,17 @@ jobs:
                 "for the JSON artifacts."
             } >> "${step_summary}"
             for dataset in "${failed_datasets[@]}"; do
+              append_failure_summary "${dataset}"
+            done
+          elif [[ "${n_infra}" -ne 0 ]]; then
+            echo "RESULT: no confirmed regressions; ${n_infra}/${total} dataset(s) had infra issues — ${infra_datasets[*]}"
+            {
+              echo ""
+              echo "**Result: ⚠️ No confirmed regressions; ${n_infra} of ${total} datasets had infrastructure issues**"
+              echo ""
+              echo "Infra: $(IFS=', '; echo "${infra_datasets[*]}")"
+            } >> "${step_summary}"
+            for dataset in "${infra_datasets[@]}"; do
               append_failure_summary "${dataset}"
             done
           else

--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -36,8 +36,11 @@ uv run python -m evals.pxi.harness.run_experiment --dataset set_spans_filter --s
 ```
 
 `--fail-on-regression` exits nonzero only when an evaluator fails on a
-`regression` example. The runner prints a stdout summary and the Phoenix
-experiment URL.
+`regression` example. Add `--retry-failed` to retry only failed regression
+examples once before deciding the gate; with retry enabled, red means a
+regression example failed twice in a row. Task/runtime errors exit with code
+2 as infrastructure, not regression evidence. The runner prints a stdout
+summary and the Phoenix experiment URL.
 
 ## Failure Reports
 
@@ -342,11 +345,14 @@ the Actions tab.
 
 The workflow invokes the runner for every YAML file in
 `evals/pxi/datasets/*.yaml` with `--splits regression`,
-`--fail-on-regression`, and `--report-dir`. The runner skips datasets when
-the requested split has no regression examples. Each dataset run is printed
-as its own log group with the dataset file and CI experiment name. The
-workflow keeps going after individual dataset failures, and the final status
-is red if any dataset fails.
+`--fail-on-regression`, `--retry-failed`, and `--report-dir`. The runner skips
+datasets when the requested split has no regression examples. Each dataset
+run is printed as its own log group with the dataset file and CI experiment
+name. The workflow keeps going after individual dataset failures. The final
+status is red only when a regression example fails on both the first attempt
+and its targeted retry. Infrastructure issues, including Phoenix
+unavailability and task/runtime errors that prevent assessment, are surfaced
+as warning rows and do not fail the PR gate.
 
 ### Reading a CI failure
 

--- a/evals/pxi/harness/gating.py
+++ b/evals/pxi/harness/gating.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal, Mapping, Sequence
 
-from evals.pxi.harness.datasets import EvalDataset
 from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
+
+from evals.pxi.harness.datasets import EvalDataset
 
 PASSING_SCORE = 1.0
 RETRY_FAILED_CAP = 15
@@ -188,6 +189,10 @@ def decide_gate(
             retry_skipped_reason=f"retry skipped because {len(failed_once_ids)} failures exceed cap {retry_cap}",
         )
 
+    assert retry_attempts is not None, (
+        "retry_attempts must be provided when retry_enabled=True and failures are under cap; "
+        "use retry_ids_for() to get the IDs to retry, then call decide_gate() once with results"
+    )
     confirmed_regression_ids: set[str] = set()
     infra_ids: set[str] = set()
     flaky_ids: set[str] = set()

--- a/evals/pxi/harness/gating.py
+++ b/evals/pxi/harness/gating.py
@@ -11,9 +11,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal, Mapping, Sequence
 
-from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
-
 from evals.pxi.harness.datasets import EvalDataset
+from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
 
 PASSING_SCORE = 1.0
 RETRY_FAILED_CAP = 15
@@ -189,16 +188,6 @@ def decide_gate(
             retry_skipped_reason=f"retry skipped because {len(failed_once_ids)} failures exceed cap {retry_cap}",
         )
 
-    if retry_attempts is None:
-        return GateDecision(
-            status="failed",
-            failed_once_ids=failed_once_ids,
-            retry_ids=failed_once_ids,
-            confirmed_regression_ids=(),
-            infra_ids=(),
-            flaky_ids=(),
-        )
-
     confirmed_regression_ids: set[str] = set()
     infra_ids: set[str] = set()
     flaky_ids: set[str] = set()
@@ -225,3 +214,19 @@ def decide_gate(
         infra_ids=tuple(sorted(infra_ids)),
         flaky_ids=tuple(sorted(flaky_ids)),
     )
+
+
+def retry_ids_for(
+    first_attempts: Mapping[str, AttemptOutcome],
+    *,
+    retry_cap: int = RETRY_FAILED_CAP,
+) -> tuple[str, ...]:
+    """Return the IDs of failed first-attempt examples to retry.
+
+    Returns an empty tuple when no examples failed or when the failure count
+    exceeds *retry_cap* (too many to be a useful confirmation pass — the caller
+    should still invoke :func:`decide_gate` so the cap-exceeded reason is
+    captured in the :class:`GateDecision`).
+    """
+    failed = tuple(sorted(id_ for id_, o in first_attempts.items() if o.failed))
+    return () if not failed or len(failed) > retry_cap else failed

--- a/evals/pxi/harness/gating.py
+++ b/evals/pxi/harness/gating.py
@@ -1,0 +1,227 @@
+"""Gating decisions for the PXI eval harness.
+
+The CI contract is intentionally narrower than the report contract: a red
+check means a regression example produced an assessable evaluator failure twice.
+Task/runtime errors are infrastructure unless a clean evaluator failure is
+reproduced on both attempts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Sequence
+
+from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
+
+from evals.pxi.harness.datasets import EvalDataset
+
+PASSING_SCORE = 1.0
+RETRY_FAILED_CAP = 15
+
+TaskErrorKind = Literal["none", "infra"]
+GateStatus = Literal["passed", "failed", "infra"]
+
+
+def task_run_error(task_run: Mapping[str, Any]) -> str | None:
+    output = task_run.get("output")
+    output_error = output.get("error") if isinstance(output, dict) else None
+    error = task_run.get("error") or output_error
+    return str(error) if error else None
+
+
+def classify_task_error(task_run: Mapping[str, Any]) -> TaskErrorKind:
+    """Classify task errors for gating.
+
+    Unknown task errors still mean the example was not assessable. Treat them
+    as infra, not regression evidence.
+    """
+    return "infra" if task_run_error(task_run) else "none"
+
+
+def score(evaluation_run: ExperimentEvaluationRun) -> float | None:
+    result = evaluation_run.result
+    if not isinstance(result, dict):
+        return None
+    value = result.get("score")
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def is_failed_evaluation(evaluation_run: ExperimentEvaluationRun) -> bool:
+    run_score = score(evaluation_run)
+    return evaluation_run.error is not None or run_score is None or run_score < PASSING_SCORE
+
+
+def example_splits_by_id(dataset: EvalDataset) -> dict[str, set[str]]:
+    return {
+        str(example["id"]): {str(split) for split in example["splits"]}
+        for example in dataset.examples
+    }
+
+
+def stable_example_id(task_run: Mapping[str, Any]) -> str:
+    output = task_run.get("output")
+    if isinstance(output, dict) and isinstance(output.get("stable_example_id"), str):
+        return str(output["stable_example_id"])
+    return str(task_run.get("dataset_example_id", ""))
+
+
+@dataclass(frozen=True)
+class AttemptOutcome:
+    example_id: str
+    attempt: int
+    task_error: str | None
+    failed_evaluators: tuple[str, ...]
+    experiment_id: str | None
+
+    @property
+    def failed(self) -> bool:
+        return self.task_error is not None or bool(self.failed_evaluators)
+
+    @property
+    def assessable_regression_failure(self) -> bool:
+        return self.task_error is None and bool(self.failed_evaluators)
+
+    @property
+    def infra_failure(self) -> bool:
+        return self.task_error is not None
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    status: GateStatus
+    failed_once_ids: tuple[str, ...]
+    retry_ids: tuple[str, ...]
+    confirmed_regression_ids: tuple[str, ...]
+    infra_ids: tuple[str, ...]
+    flaky_ids: tuple[str, ...]
+    retry_skipped_reason: str | None = None
+
+    @property
+    def has_confirmed_regressions(self) -> bool:
+        return bool(self.confirmed_regression_ids)
+
+    @property
+    def has_infra_failures(self) -> bool:
+        return bool(self.infra_ids)
+
+
+def attempt_outcomes(
+    dataset: EvalDataset,
+    experiment: RanExperiment,
+    *,
+    attempt: int,
+    gate_splits: Sequence[str] = ("regression",),
+) -> dict[str, AttemptOutcome]:
+    gated_splits = set(gate_splits)
+    splits_by_id = example_splits_by_id(dataset)
+    task_runs_by_id = {
+        str(task_run["id"]): task_run
+        for task_run in experiment.get("task_runs", [])
+        if "id" in task_run
+    }
+    failed_evaluators_by_run_id: dict[str, list[str]] = {}
+    for evaluation_run in experiment.get("evaluation_runs") or []:
+        if not is_failed_evaluation(evaluation_run):
+            continue
+        failed_evaluators_by_run_id.setdefault(str(evaluation_run.experiment_run_id), []).append(
+            str(evaluation_run.name or "unknown")
+        )
+
+    outcomes: dict[str, AttemptOutcome] = {}
+    for task_run in task_runs_by_id.values():
+        example_id = stable_example_id(task_run)
+        if not (splits_by_id.get(example_id, set()) & gated_splits):
+            continue
+        outcomes[example_id] = AttemptOutcome(
+            example_id=example_id,
+            attempt=attempt,
+            task_error=task_run_error(task_run),
+            failed_evaluators=tuple(failed_evaluators_by_run_id.get(str(task_run["id"]), ())),
+            experiment_id=str(experiment.get("experiment_id") or "") or None,
+        )
+    return outcomes
+
+
+def decide_gate(
+    first_attempts: Mapping[str, AttemptOutcome],
+    *,
+    retry_attempts: Mapping[str, AttemptOutcome] | None = None,
+    retry_enabled: bool,
+    retry_cap: int = RETRY_FAILED_CAP,
+) -> GateDecision:
+    failed_once_ids = tuple(
+        sorted(id_ for id_, outcome in first_attempts.items() if outcome.failed)
+    )
+    if not failed_once_ids:
+        return GateDecision(
+            status="passed",
+            failed_once_ids=(),
+            retry_ids=(),
+            confirmed_regression_ids=(),
+            infra_ids=(),
+            flaky_ids=(),
+        )
+
+    first_infra_ids = {id_ for id_, outcome in first_attempts.items() if outcome.infra_failure}
+    first_regression_ids = {
+        id_ for id_, outcome in first_attempts.items() if outcome.assessable_regression_failure
+    }
+    if not retry_enabled:
+        return GateDecision(
+            status="infra" if first_infra_ids and not first_regression_ids else "failed",
+            failed_once_ids=failed_once_ids,
+            retry_ids=(),
+            confirmed_regression_ids=tuple(sorted(first_regression_ids)),
+            infra_ids=tuple(sorted(first_infra_ids)),
+            flaky_ids=(),
+            retry_skipped_reason="retry disabled",
+        )
+
+    if len(failed_once_ids) > retry_cap:
+        status: GateStatus = "failed" if first_regression_ids else "infra"
+        return GateDecision(
+            status=status,
+            failed_once_ids=failed_once_ids,
+            retry_ids=(),
+            confirmed_regression_ids=tuple(sorted(first_regression_ids)),
+            infra_ids=tuple(sorted(first_infra_ids)),
+            flaky_ids=(),
+            retry_skipped_reason=f"retry skipped because {len(failed_once_ids)} failures exceed cap {retry_cap}",
+        )
+
+    if retry_attempts is None:
+        return GateDecision(
+            status="failed",
+            failed_once_ids=failed_once_ids,
+            retry_ids=failed_once_ids,
+            confirmed_regression_ids=(),
+            infra_ids=(),
+            flaky_ids=(),
+        )
+
+    confirmed_regression_ids: set[str] = set()
+    infra_ids: set[str] = set()
+    flaky_ids: set[str] = set()
+    for example_id in failed_once_ids:
+        first = first_attempts[example_id]
+        retry = retry_attempts.get(example_id)
+        if retry is None:
+            infra_ids.add(example_id)
+            continue
+        if not retry.failed:
+            flaky_ids.add(example_id)
+            continue
+        if first.assessable_regression_failure and retry.assessable_regression_failure:
+            confirmed_regression_ids.add(example_id)
+            continue
+        infra_ids.add(example_id)
+
+    status = "failed" if confirmed_regression_ids else "infra" if infra_ids else "passed"
+    return GateDecision(
+        status=status,
+        failed_once_ids=failed_once_ids,
+        retry_ids=failed_once_ids,
+        confirmed_regression_ids=tuple(sorted(confirmed_regression_ids)),
+        infra_ids=tuple(sorted(infra_ids)),
+        flaky_ids=tuple(sorted(flaky_ids)),
+    )

--- a/evals/pxi/harness/reporting.py
+++ b/evals/pxi/harness/reporting.py
@@ -20,6 +20,7 @@ from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, 
 
 from evals.pxi.harness.datasets import DATASETS_DIR, EvalDataset
 from evals.pxi.harness.gating import (
+    PASSING_SCORE,
     GateDecision,
     attempt_outcomes,
     example_splits_by_id,
@@ -29,7 +30,6 @@ from evals.pxi.harness.gating import (
     task_run_error,
 )
 
-PASSING_SCORE = 1.0
 MAX_TABLE_CELL_WIDTH = 80
 
 # Repo-relative datasets dir for report links and repro commands, derived

--- a/evals/pxi/harness/reporting.py
+++ b/evals/pxi/harness/reporting.py
@@ -13,12 +13,21 @@ import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any, Sequence
 from urllib.parse import urljoin
 
 from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
 
 from evals.pxi.harness.datasets import DATASETS_DIR, EvalDataset
+from evals.pxi.harness.gating import (
+    GateDecision,
+    attempt_outcomes,
+    example_splits_by_id,
+    is_failed_evaluation,
+    score,
+    stable_example_id,
+    task_run_error,
+)
 
 PASSING_SCORE = 1.0
 MAX_TABLE_CELL_WIDTH = 80
@@ -71,10 +80,10 @@ def _result_field(evaluation_run: ExperimentEvaluationRun, key: str) -> str:
 def _task_error_rows(experiment: RanExperiment) -> list[tuple[str, str]]:
     rows: list[tuple[str, str]] = []
     for task_run in experiment.get("task_runs", []):
-        error = _task_run_error(task_run)
+        error = task_run_error(task_run)
         if not error:
             continue
-        rows.append((_truncate_cell(_stable_example_id(task_run)), _truncate_cell(error)))
+        rows.append((_truncate_cell(stable_example_id(task_run)), _truncate_cell(error)))
     return rows
 
 
@@ -98,17 +107,17 @@ def _failed_evaluation_rows(
     }
     rows: list[tuple[str, str, str, str, str]] = []
     for evaluation_run in evaluation_runs:
-        if not _is_failed_evaluation(evaluation_run):
+        if not is_failed_evaluation(evaluation_run):
             continue
         task_run = task_runs_by_id.get(str(evaluation_run.experiment_run_id))
         example_id = (
-            _stable_example_id(task_run) if task_run else str(evaluation_run.experiment_run_id)
+            stable_example_id(task_run) if task_run else str(evaluation_run.experiment_run_id)
         )
         rows.append(
             (
                 _truncate_cell(example_id),
                 _truncate_cell(evaluation_run.name or "unknown"),
-                _score_display(evaluation_run.error, _score(evaluation_run)),
+                _score_display(evaluation_run.error, score(evaluation_run)),
                 _result_field(evaluation_run, "label"),
                 _truncate_cell(
                     evaluation_run.error or _result_field(evaluation_run, "explanation")
@@ -116,26 +125,6 @@ def _failed_evaluation_rows(
             )
         )
     return rows
-
-
-def _score(evaluation_run: ExperimentEvaluationRun) -> float | None:
-    result = evaluation_run.result
-    if not isinstance(result, dict):
-        return None
-    value = result.get("score")
-    return float(value) if isinstance(value, (int, float)) else None
-
-
-def _example_splits_by_id(dataset: EvalDataset) -> dict[str, set[str]]:
-    return {
-        str(example["id"]): {str(split) for split in example["splits"]}
-        for example in dataset.examples
-    }
-
-
-def _is_failed_evaluation(evaluation_run: ExperimentEvaluationRun) -> bool:
-    score = _score(evaluation_run)
-    return evaluation_run.error is not None or score is None or score < PASSING_SCORE
 
 
 def _evaluator_summary_rows(
@@ -149,14 +138,14 @@ def _evaluator_summary_rows(
             {"total": 0, "passing": 0, "failing": 0, "missing_score": 0, "errors": 0},
         )
         summary["total"] += 1
-        score = _score(evaluation_run)
+        run_score = score(evaluation_run)
         if evaluation_run.error is not None:
             summary["errors"] += 1
             summary["failing"] += 1
-        elif score is None:
+        elif run_score is None:
             summary["missing_score"] += 1
             summary["failing"] += 1
-        elif score >= PASSING_SCORE:
+        elif run_score >= PASSING_SCORE:
             summary["passing"] += 1
         else:
             summary["failing"] += 1
@@ -168,19 +157,21 @@ def _has_regression_evaluator_failure(
     experiment: RanExperiment,
     evaluation_runs: Sequence[ExperimentEvaluationRun],
 ) -> bool:
-    splits_by_id = _example_splits_by_id(dataset)
+    splits_by_id = example_splits_by_id(dataset)
     task_runs_by_id = {
         str(task_run["id"]): task_run
         for task_run in experiment.get("task_runs", [])
         if "id" in task_run
     }
     for evaluation_run in evaluation_runs:
-        if not _is_failed_evaluation(evaluation_run):
+        if not is_failed_evaluation(evaluation_run):
             continue
         task_run = task_runs_by_id.get(str(evaluation_run.experiment_run_id))
         if task_run is None:
             continue
-        example_id = _stable_example_id(task_run)
+        if task_run_error(task_run) is not None:
+            continue
+        example_id = stable_example_id(task_run)
         if "regression" in splits_by_id.get(example_id, set()):
             return True
     return False
@@ -264,6 +255,8 @@ class ExampleFailure:
     actual_output: Any
     task_error: str | None
     evaluations: list[EvaluationRecord]
+    attempts: list[dict[str, Any]] = field(default_factory=list)
+    flaky: bool = False
 
 
 @dataclass(frozen=True)
@@ -285,8 +278,12 @@ class Report:
     generated_at: str
     examples_run: int
     examples_passed: int
+    confirmed_regression_count: int
+    infra_failure_count: int
+    flaky_count: int
     evaluator_summary: list[dict[str, Any]]
     failures: list[ExampleFailure]
+    attempts: list[dict[str, Any]]
     repro_command: str
     schema_version: int = REPORT_SCHEMA_VERSION
     notes: list[str] = field(default_factory=list)
@@ -310,20 +307,6 @@ def _trace_url(trace_id: str | None, base_url: str) -> str | None:
     if not trace_id:
         return None
     return urljoin(base_url.rstrip("/") + "/", f"redirects/traces/{trace_id}")
-
-
-def _task_run_error(task_run: Mapping[str, Any]) -> str | None:
-    output = task_run.get("output")
-    output_error = output.get("error") if isinstance(output, dict) else None
-    error = task_run.get("error") or output_error
-    return str(error) if error else None
-
-
-def _stable_example_id(task_run: Mapping[str, Any]) -> str:
-    output = task_run.get("output")
-    if isinstance(output, dict) and isinstance(output.get("stable_example_id"), str):
-        return str(output["stable_example_id"])
-    return str(task_run.get("dataset_example_id", ""))
 
 
 # The serialized pydantic_ai messages repeat the full static system prompt
@@ -365,12 +348,37 @@ def _evaluation_record(evaluation_run: ExperimentEvaluationRun) -> EvaluationRec
     explanation = result.get("explanation")
     return EvaluationRecord(
         name=str(evaluation_run.name or "unknown"),
-        score=_score(evaluation_run),
+        score=score(evaluation_run),
         label=str(label) if label is not None else None,
         explanation=str(explanation) if explanation is not None else None,
         error=evaluation_run.error,
-        passed=not _is_failed_evaluation(evaluation_run),
+        passed=not is_failed_evaluation(evaluation_run),
     )
+
+
+def _attempt_dicts(
+    dataset: EvalDataset,
+    experiment: RanExperiment,
+    *,
+    attempt: int,
+    base_url: str,
+    include_ids: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    outcomes = attempt_outcomes(dataset, experiment, attempt=attempt)
+    experiment_url = _experiment_url(experiment, base_url)
+    return [
+        {
+            "example_id": outcome.example_id,
+            "attempt": outcome.attempt,
+            "experiment_id": outcome.experiment_id,
+            "experiment_url": experiment_url,
+            "task_error": outcome.task_error,
+            "failed_evaluators": list(outcome.failed_evaluators),
+            "failed": outcome.failed,
+        }
+        for outcome in outcomes.values()
+        if outcome.failed or (include_ids is not None and outcome.example_id in include_ids)
+    ]
 
 
 def build_report(
@@ -382,6 +390,8 @@ def build_report(
     experiment_name: str | None = None,
     generated_at: str | None = None,
     dataset_arg: str | None = None,
+    retry_experiment: RanExperiment | None = None,
+    gate_decision: GateDecision | None = None,
 ) -> Report:
     """Build a failure report from a completed experiment.
 
@@ -397,18 +407,54 @@ def build_report(
             evaluation_run
         )
 
+    attempt_records: list[dict[str, Any]] = []
+    if gate_decision is not None or retry_experiment is not None:
+        include_ids = set(gate_decision.failed_once_ids) if gate_decision is not None else None
+        attempt_records.extend(
+            _attempt_dicts(
+                dataset,
+                experiment,
+                attempt=1,
+                base_url=base_url,
+                include_ids=include_ids,
+            )
+        )
+    if retry_experiment is not None:
+        include_ids = set(gate_decision.retry_ids) if gate_decision is not None else None
+        attempt_records.extend(
+            _attempt_dicts(
+                dataset,
+                retry_experiment,
+                attempt=2,
+                base_url=base_url,
+                include_ids=include_ids,
+            )
+        )
+    attempts_by_example: dict[str, list[dict[str, Any]]] = {}
+    for attempt in attempt_records:
+        attempts_by_example.setdefault(str(attempt["example_id"]), []).append(attempt)
+    report_example_ids = set(attempts_by_example)
+    if gate_decision is not None:
+        report_example_ids.update(gate_decision.confirmed_regression_ids)
+        report_example_ids.update(gate_decision.infra_ids)
+        report_example_ids.update(gate_decision.flaky_ids)
+
     failures: list[ExampleFailure] = []
     instructions_stripped = False
     task_runs = list(experiment.get("task_runs") or [])
     for task_run in task_runs:
-        task_error = _task_run_error(task_run)
+        task_error = task_run_error(task_run)
         evaluations = [
             _evaluation_record(run)
             for run in evaluations_by_run_id.get(str(task_run.get("id", "")), [])
         ]
-        if task_error is None and all(record.passed for record in evaluations):
+        example_id = stable_example_id(task_run)
+        if (
+            task_error is None
+            and all(record.passed for record in evaluations)
+            and example_id not in report_example_ids
+        ):
             continue
-        example_id = _stable_example_id(task_run)
         example = examples_by_id.get(example_id, {})
         trace_id = task_run.get("trace_id")
         actual_output, stripped = _strip_static_instructions(task_run.get("output"))
@@ -424,6 +470,8 @@ def build_report(
                 actual_output=actual_output,
                 task_error=task_error,
                 evaluations=evaluations,
+                attempts=attempts_by_example.get(example_id, []),
+                flaky=(gate_decision is not None and example_id in gate_decision.flaky_ids),
             )
         )
 
@@ -451,8 +499,14 @@ def build_report(
         generated_at=generated_at or datetime.now(timezone.utc).isoformat(),
         examples_run=len(task_runs),
         examples_passed=len(task_runs) - len(failures),
+        confirmed_regression_count=(
+            len(gate_decision.confirmed_regression_ids) if gate_decision is not None else 0
+        ),
+        infra_failure_count=len(gate_decision.infra_ids) if gate_decision is not None else 0,
+        flaky_count=len(gate_decision.flaky_ids) if gate_decision is not None else 0,
         evaluator_summary=evaluator_summary,
         failures=failures,
+        attempts=attempt_records,
         repro_command=(
             "uv run python -m evals.pxi.harness.run_experiment "
             f"--dataset {dataset_stem} --splits {' '.join(str(s) for s in splits)}"
@@ -584,6 +638,8 @@ def _md_header(report: Report) -> list[str]:
         f"- **Generated**: {report.generated_at}",
         f"- **Examples**: {report.examples_run} run, "
         f"{report.examples_passed} passed, {failed} failed",
+        f"- **Gate**: {report.confirmed_regression_count} confirmed regression, "
+        f"{report.infra_failure_count} infra, {report.flaky_count} flaky-passed",
         "",
     ]
     digest = _digest_rows(report)
@@ -610,11 +666,35 @@ def _md_escape_cell(text: str) -> str:
 
 def _md_failure_section(failure: ExampleFailure) -> list[str]:
     lines = [f"### Example: `{failure.example_id}`", ""]
+    if failure.flaky:
+        lines.append("- **Flaky**: failed first attempt, passed retry")
     if failure.splits:
         lines.append(f"- **Splits**: {', '.join(failure.splits)}")
     if failure.trace_url:
         lines.append(f"- **Trace**: {failure.trace_url}")
     lines.append("")
+    if failure.attempts:
+        lines.extend(["**Attempts:**", ""])
+        lines.extend(
+            [
+                "| Attempt | Result | Experiment | Details |",
+                "| --- | --- | --- | --- |",
+            ]
+        )
+        for attempt in sorted(failure.attempts, key=lambda item: int(item["attempt"])):
+            details: list[str] = []
+            if attempt.get("task_error"):
+                details.append(_first_line(str(attempt["task_error"])))
+            failed_evaluators = attempt.get("failed_evaluators") or []
+            if failed_evaluators:
+                details.append("failed evaluators: " + ", ".join(map(str, failed_evaluators)))
+            result = "failed" if attempt.get("failed") else "passed"
+            experiment = attempt.get("experiment_url") or attempt.get("experiment_id") or ""
+            lines.append(
+                f"| {attempt['attempt']} | {result} | {_md_escape_cell(str(experiment))} "
+                f"| {_md_escape_cell('; '.join(details))} |"
+            )
+        lines.append("")
     if failure.task_error is not None:
         lines.extend(["**Task error:**", "", _fenced_block(failure.task_error, "text"), ""])
     failed_evaluations = [record for record in failure.evaluations if not record.passed]

--- a/evals/pxi/harness/run_experiment.py
+++ b/evals/pxi/harness/run_experiment.py
@@ -20,6 +20,7 @@ if __package__ in {None, ""}:
 from urllib.parse import urljoin
 
 from phoenix.client import AsyncClient
+from phoenix.client.resources.datasets import Dataset as PhoenixDataset
 from phoenix.client.resources.experiments.types import RanExperiment
 from phoenix.client.utils.config import get_base_url, get_env_phoenix_api_key
 
@@ -35,6 +36,12 @@ from evals.pxi.harness.agent_task import (
 from evals.pxi.harness.datasets import (
     EvalDataset,
     load_dataset,
+)
+from evals.pxi.harness.gating import (
+    RETRY_FAILED_CAP,
+    attempt_outcomes,
+    decide_gate,
+    task_run_error,
 )
 from evals.pxi.harness.reporting import (
     _print_score_summary,
@@ -60,6 +67,8 @@ class ExperimentConfig:
     evaluator_override: tuple[str, ...] | None
     report_dir: Path | None = None
     print_report: bool = False
+    retry_failed: bool = False
+    retry_failed_cap: int = RETRY_FAILED_CAP
 
 
 def _resolve_evaluators(dataset: EvalDataset, override: tuple[str, ...] | None) -> list[Any]:
@@ -190,10 +199,15 @@ def _check_evaluations_ran(experiment: RanExperiment) -> None:
     example would count as vacuously passed -- a false green this guard turns
     into an infrastructure error instead.
     """
-    if experiment.get("task_runs") and not experiment.get("evaluation_runs"):
+    task_runs = list(experiment.get("task_runs") or [])
+    if (
+        task_runs
+        and not experiment.get("evaluation_runs")
+        and any(task_run_error(task_run) is None for task_run in task_runs)
+    ):
         raise RuntimeError(
             "experiment ran "
-            f"{len(experiment['task_runs'])} task(s) but zero evaluations executed; "
+            f"{len(task_runs)} task(s) but zero evaluations executed; "
             "evaluator/example pairing is broken (refusing to report a vacuous pass)"
         )
 
@@ -231,13 +245,8 @@ async def _run_async(config: ExperimentConfig) -> int:
         f"Evaluators: {', '.join(name for name in (config.evaluator_override or dataset.evaluators))}"
     )
     client = AsyncClient(base_url=config.base_url, api_key=config.bearer_token)
-    # Build the docs MCP toolset once and enter its async context manager for
-    # the duration of the run, mirroring the production server's FastAPI
-    # lifespan wiring.
-    docs_mcp_server = build_shared_docs_mcp_server()
     async with AsyncExitStack() as stack:
-        if docs_mcp_server is not None:
-            await stack.enter_async_context(docs_mcp_server)
+        docs_mcp_server = await _enter_docs_mcp_server_with_retry(stack)
         try:
             phoenix_dataset = await client.datasets.create_dataset(
                 name=dataset.dataset_name,
@@ -290,34 +299,48 @@ async def _run_async(config: ExperimentConfig) -> int:
                 "assistant_model": os.getenv(ENV_ASSISTANT_MODEL, DEFAULT_ASSISTANT_MODEL),
                 "started_at": datetime.now(timezone.utc).isoformat(),
             }
-            print(f"Running experiment: {name}")
-            experiment = await client.experiments.run_experiment(
-                dataset=experiment_dataset,
-                task=make_task(docs_mcp_server=docs_mcp_server),
-                experiment_name=name,
-                experiment_description=dataset.description,
-                experiment_metadata=metadata,
-                print_summary=True,
-                concurrency=3,
-                timeout=180,
-                retries=0,
+            description = dataset.description or ""
+            experiment = await _run_and_evaluate_experiment(
+                client,
+                experiment_dataset=experiment_dataset,
+                docs_mcp_server=docs_mcp_server,
+                evaluators=evaluators,
+                name=name,
+                description=description,
+                metadata=metadata,
             )
-            experiment = await client.experiments.evaluate_experiment(
-                experiment=experiment,
-                evaluators=cast(Any, evaluators),
-                print_summary=True,
-                concurrency=3,
-                timeout=180,
-                retries=0,
+            first_attempts = attempt_outcomes(dataset, experiment, attempt=1)
+            gate_decision = decide_gate(
+                first_attempts,
+                retry_enabled=config.retry_failed,
+                retry_cap=config.retry_failed_cap,
             )
-            _check_evaluations_ran(experiment)
-            # Replace Phoenix's relay dataset example ID with the stable YAML
-            # example ID for summary/report rendering. This MUST happen after
-            # ``evaluate_experiment``: the client pairs evaluators with
-            # examples via the example node GlobalID, so rewriting first makes
-            # every lookup miss and silently skips all evaluations (the
-            # false-green failure mode this ordering previously caused).
-            _rewrite_stable_example_ids(experiment, experiment_dataset)
+            retry_experiment: RanExperiment | None = None
+            if gate_decision.retry_ids:
+                retry_name = f"{name}-retry"
+                retry_dataset = _filter_dataset_examples(
+                    experiment_dataset,
+                    gate_decision.retry_ids,
+                )
+                print(
+                    f"Retrying failed PXI eval examples once: {', '.join(gate_decision.retry_ids)}"
+                )
+                retry_experiment = await _run_and_evaluate_experiment(
+                    client,
+                    experiment_dataset=retry_dataset,
+                    docs_mcp_server=docs_mcp_server,
+                    evaluators=evaluators,
+                    name=retry_name,
+                    description=f"{description}\n\nRetry of failed examples from {name}".strip(),
+                    metadata={**metadata, "retry_of_experiment": name},
+                )
+                retry_attempts = attempt_outcomes(dataset, retry_experiment, attempt=2)
+                gate_decision = decide_gate(
+                    first_attempts,
+                    retry_attempts=retry_attempts,
+                    retry_enabled=config.retry_failed,
+                    retry_cap=config.retry_failed_cap,
+                )
         finally:
             # ``AsyncClient`` does not yet expose a public ``aclose``; reach for
             # the underlying httpx client and tolerate it disappearing in a
@@ -333,6 +356,12 @@ async def _run_async(config: ExperimentConfig) -> int:
                         file=sys.stderr,
                     )
     has_regressions = _print_score_summary(dataset, experiment, base_url=config.base_url)
+    if gate_decision.flaky_ids:
+        print(f"::notice::PXI eval flaky-passed examples: {', '.join(gate_decision.flaky_ids)}")
+    if gate_decision.retry_skipped_reason:
+        print(f"warning: {gate_decision.retry_skipped_reason}", file=sys.stderr)
+    if gate_decision.infra_ids:
+        print(f"PXI eval infra examples: {', '.join(gate_decision.infra_ids)}", file=sys.stderr)
     if config.report_dir is not None or config.print_report:
         report = build_report(
             dataset,
@@ -341,6 +370,8 @@ async def _run_async(config: ExperimentConfig) -> int:
             splits=requested,
             experiment_name=name,
             dataset_arg=config.dataset,
+            retry_experiment=retry_experiment,
+            gate_decision=gate_decision,
         )
         md_path = None
         if config.report_dir is not None:
@@ -351,7 +382,86 @@ async def _run_async(config: ExperimentConfig) -> int:
         if config.print_report and report.failures:
             # Reuse the already-rendered file instead of rendering twice.
             print(md_path.read_text() if md_path is not None else report_to_markdown(report))
-    return 1 if has_regressions and config.fail_on_regression else 0
+    if gate_decision.status == "infra":
+        return 2
+    if config.fail_on_regression and gate_decision.has_confirmed_regressions:
+        return 1
+    if config.fail_on_regression and not config.retry_failed and has_regressions:
+        return 1
+    return 0
+
+
+async def _enter_docs_mcp_server_with_retry(stack: AsyncExitStack) -> Any:
+    for attempt in range(1, 3):
+        docs_mcp_server = build_shared_docs_mcp_server()
+        if docs_mcp_server is None:
+            return None
+        try:
+            return await stack.enter_async_context(docs_mcp_server)
+        except Exception as exc:
+            if attempt == 2:
+                raise RuntimeError("docs MCP server failed to start after 2 attempts") from exc
+            print(
+                f"Docs MCP server failed to start (attempt {attempt}/2), retrying in 3s: {exc}",
+                file=sys.stderr,
+            )
+            await asyncio.sleep(3)
+    return None
+
+
+async def _run_and_evaluate_experiment(
+    client: AsyncClient,
+    *,
+    experiment_dataset: Any,
+    docs_mcp_server: Any,
+    evaluators: list[Any],
+    name: str,
+    description: str,
+    metadata: dict[str, Any],
+) -> RanExperiment:
+    print(f"Running experiment: {name}")
+    experiment = await client.experiments.run_experiment(
+        dataset=experiment_dataset,
+        task=make_task(docs_mcp_server=docs_mcp_server),
+        experiment_name=name,
+        experiment_description=description,
+        experiment_metadata=metadata,
+        print_summary=True,
+        concurrency=3,
+        timeout=180,
+        retries=0,
+    )
+    experiment = await client.experiments.evaluate_experiment(
+        experiment=experiment,
+        evaluators=cast(Any, evaluators),
+        print_summary=True,
+        concurrency=3,
+        timeout=180,
+        retries=0,
+    )
+    _check_evaluations_ran(experiment)
+    # Replace Phoenix's relay dataset example ID with the stable YAML
+    # example ID for summary/report rendering. This MUST happen after
+    # ``evaluate_experiment``: the client pairs evaluators with examples via
+    # the example node GlobalID, so rewriting first makes every lookup miss.
+    _rewrite_stable_example_ids(experiment, experiment_dataset)
+    return experiment
+
+
+def _filter_dataset_examples(experiment_dataset: Any, example_ids: Sequence[str]) -> Any:
+    selected_ids = {str(example_id) for example_id in example_ids}
+    if not selected_ids:
+        raise ValueError("cannot retry an empty example set")
+    if not hasattr(experiment_dataset, "to_dict"):
+        raise TypeError("experiment dataset does not support to_dict()")
+    data = experiment_dataset.to_dict()
+    examples = [
+        example for example in data.get("examples", []) if str(example.get("id")) in selected_ids
+    ]
+    if not examples:
+        raise ValueError(f"retry examples not found in dataset: {', '.join(sorted(selected_ids))}")
+    data["examples"] = examples
+    return PhoenixDataset.from_dict(data)
 
 
 def run(config: ExperimentConfig) -> int:
@@ -406,6 +516,17 @@ def build_parser() -> argparse.ArgumentParser:
             "CI embeds the written report file instead."
         ),
     )
+    retry_group = parser.add_mutually_exclusive_group()
+    retry_group.add_argument(
+        "--retry-failed",
+        action="store_true",
+        help="Retry failed regression examples once before deciding the gate.",
+    )
+    retry_group.add_argument(
+        "--no-retry-failed",
+        action="store_true",
+        help="Disable failed-example retry for fast local iteration.",
+    )
     # The dataset YAML's ``evaluators:`` field is the source of truth for
     # what gets scored in normal use. This flag is a transient per-run
     # override -- useful for iterating on a single evaluator (halves eval
@@ -442,6 +563,7 @@ def main(argv: list[str] | None = None) -> int:
         evaluator_override=tuple(args.evaluators) if args.evaluators else None,
         report_dir=args.report_dir,
         print_report=args.print_report,
+        retry_failed=args.retry_failed and not args.no_retry_failed,
     )
     try:
         return run(config)

--- a/evals/pxi/harness/run_experiment.py
+++ b/evals/pxi/harness/run_experiment.py
@@ -19,6 +19,11 @@ if __package__ in {None, ""}:
 
 from urllib.parse import urljoin
 
+from phoenix.client import AsyncClient
+from phoenix.client.resources.datasets import Dataset as PhoenixDataset
+from phoenix.client.resources.experiments.types import RanExperiment
+from phoenix.client.utils.config import get_base_url, get_env_phoenix_api_key
+
 from evals.pxi.evaluators import EVALUATORS_BY_NAME
 from evals.pxi.harness.agent_task import (
     DEFAULT_ASSISTANT_MODEL,
@@ -46,10 +51,6 @@ from evals.pxi.harness.reporting import (
     report_to_markdown,
     write_reports,
 )
-from phoenix.client import AsyncClient
-from phoenix.client.resources.datasets import Dataset as PhoenixDataset
-from phoenix.client.resources.experiments.types import RanExperiment
-from phoenix.client.utils.config import get_base_url, get_env_phoenix_api_key
 
 DEFAULT_BASE_URL = "http://localhost:6006"
 

--- a/evals/pxi/harness/run_experiment.py
+++ b/evals/pxi/harness/run_experiment.py
@@ -19,11 +19,6 @@ if __package__ in {None, ""}:
 
 from urllib.parse import urljoin
 
-from phoenix.client import AsyncClient
-from phoenix.client.resources.datasets import Dataset as PhoenixDataset
-from phoenix.client.resources.experiments.types import RanExperiment
-from phoenix.client.utils.config import get_base_url, get_env_phoenix_api_key
-
 from evals.pxi.evaluators import EVALUATORS_BY_NAME
 from evals.pxi.harness.agent_task import (
     DEFAULT_ASSISTANT_MODEL,
@@ -39,8 +34,10 @@ from evals.pxi.harness.datasets import (
 )
 from evals.pxi.harness.gating import (
     RETRY_FAILED_CAP,
+    AttemptOutcome,
     attempt_outcomes,
     decide_gate,
+    retry_ids_for,
     task_run_error,
 )
 from evals.pxi.harness.reporting import (
@@ -49,6 +46,10 @@ from evals.pxi.harness.reporting import (
     report_to_markdown,
     write_reports,
 )
+from phoenix.client import AsyncClient
+from phoenix.client.resources.datasets import Dataset as PhoenixDataset
+from phoenix.client.resources.experiments.types import RanExperiment
+from phoenix.client.utils.config import get_base_url, get_env_phoenix_api_key
 
 DEFAULT_BASE_URL = "http://localhost:6006"
 
@@ -67,7 +68,7 @@ class ExperimentConfig:
     evaluator_override: tuple[str, ...] | None
     report_dir: Path | None = None
     print_report: bool = False
-    retry_failed: bool = False
+    retry_failed: bool = True
     retry_failed_cap: int = RETRY_FAILED_CAP
 
 
@@ -310,21 +311,17 @@ async def _run_async(config: ExperimentConfig) -> int:
                 metadata=metadata,
             )
             first_attempts = attempt_outcomes(dataset, experiment, attempt=1)
-            gate_decision = decide_gate(
-                first_attempts,
-                retry_enabled=config.retry_failed,
-                retry_cap=config.retry_failed_cap,
+            ids_to_retry = (
+                retry_ids_for(first_attempts, retry_cap=config.retry_failed_cap)
+                if config.retry_failed
+                else ()
             )
             retry_experiment: RanExperiment | None = None
-            if gate_decision.retry_ids:
+            retry_attempts: dict[str, AttemptOutcome] = {}
+            if ids_to_retry:
                 retry_name = f"{name}-retry"
-                retry_dataset = _filter_dataset_examples(
-                    experiment_dataset,
-                    gate_decision.retry_ids,
-                )
-                print(
-                    f"Retrying failed PXI eval examples once: {', '.join(gate_decision.retry_ids)}"
-                )
+                retry_dataset = _filter_dataset_examples(experiment_dataset, ids_to_retry)
+                print(f"Retrying failed PXI eval examples once: {', '.join(ids_to_retry)}")
                 retry_experiment = await _run_and_evaluate_experiment(
                     client,
                     experiment_dataset=retry_dataset,
@@ -335,12 +332,12 @@ async def _run_async(config: ExperimentConfig) -> int:
                     metadata={**metadata, "retry_of_experiment": name},
                 )
                 retry_attempts = attempt_outcomes(dataset, retry_experiment, attempt=2)
-                gate_decision = decide_gate(
-                    first_attempts,
-                    retry_attempts=retry_attempts,
-                    retry_enabled=config.retry_failed,
-                    retry_cap=config.retry_failed_cap,
-                )
+            gate_decision = decide_gate(
+                first_attempts,
+                retry_attempts=retry_attempts,
+                retry_enabled=config.retry_failed,
+                retry_cap=config.retry_failed_cap,
+            )
         finally:
             # ``AsyncClient`` does not yet expose a public ``aclose``; reach for
             # the underlying httpx client and tolerate it disappearing in a
@@ -406,7 +403,6 @@ async def _enter_docs_mcp_server_with_retry(stack: AsyncExitStack) -> Any:
                 file=sys.stderr,
             )
             await asyncio.sleep(3)
-    return None
 
 
 async def _run_and_evaluate_experiment(
@@ -516,16 +512,10 @@ def build_parser() -> argparse.ArgumentParser:
             "CI embeds the written report file instead."
         ),
     )
-    retry_group = parser.add_mutually_exclusive_group()
-    retry_group.add_argument(
-        "--retry-failed",
-        action="store_true",
-        help="Retry failed regression examples once before deciding the gate.",
-    )
-    retry_group.add_argument(
+    parser.add_argument(
         "--no-retry-failed",
         action="store_true",
-        help="Disable failed-example retry for fast local iteration.",
+        help="Disable failed-example retry (default: retry is on). Useful for fast local iteration.",
     )
     # The dataset YAML's ``evaluators:`` field is the source of truth for
     # what gets scored in normal use. This flag is a transient per-run
@@ -563,7 +553,7 @@ def main(argv: list[str] | None = None) -> int:
         evaluator_override=tuple(args.evaluators) if args.evaluators else None,
         report_dir=args.report_dir,
         print_report=args.print_report,
-        retry_failed=args.retry_failed and not args.no_retry_failed,
+        retry_failed=not args.no_retry_failed,
     )
     try:
         return run(config)

--- a/tests/unit/pxi/evals/test_gating.py
+++ b/tests/unit/pxi/evals/test_gating.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, cast
 
 from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
 
@@ -75,7 +75,7 @@ def _evaluation(run_id: str, *, score: float | None = 1.0) -> ExperimentEvaluati
         end_time=NOW,
         name="correct_tools_called",
         annotator_kind="CODE",
-        result=result,
+        result=cast(Any, result),
     )
 
 
@@ -85,15 +85,18 @@ def _experiment(
     *,
     experiment_id: str = "experiment-1",
 ) -> RanExperiment:
-    return {
-        "experiment_id": experiment_id,
-        "dataset_id": "dataset-1",
-        "dataset_version_id": "dataset-version-1",
-        "task_runs": task_runs,
-        "evaluation_runs": evaluation_runs,
-        "experiment_metadata": {},
-        "project_name": None,
-    }
+    return cast(
+        RanExperiment,
+        {
+            "experiment_id": experiment_id,
+            "dataset_id": "dataset-1",
+            "dataset_version_id": "dataset-version-1",
+            "task_runs": task_runs,
+            "evaluation_runs": evaluation_runs,
+            "experiment_metadata": {},
+            "project_name": None,
+        },
+    )
 
 
 def test_classify_task_error_treats_unknown_errors_as_infra() -> None:

--- a/tests/unit/pxi/evals/test_gating.py
+++ b/tests/unit/pxi/evals/test_gating.py
@@ -1,0 +1,242 @@
+"""Unit tests for PXI eval gating decisions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
+
+from evals.pxi.harness.datasets import EvalDataset
+from evals.pxi.harness.gating import (
+    attempt_outcomes,
+    classify_task_error,
+    decide_gate,
+)
+
+NOW = datetime.now(timezone.utc)
+
+
+def _dataset() -> EvalDataset:
+    return EvalDataset.model_validate(
+        {
+            "dataset_name": "example_suite",
+            "evaluators": ["correct_tools_called"],
+            "examples": [
+                {
+                    "id": "regression-example",
+                    "splits": ["regression"],
+                    "input": {"query": "x"},
+                    "expected": {"tools": {"required": []}},
+                },
+                {
+                    "id": "another-regression-example",
+                    "splits": ["regression"],
+                    "input": {"query": "z"},
+                    "expected": {"tools": {"required": []}},
+                },
+                {
+                    "id": "dev-example",
+                    "splits": ["dev"],
+                    "input": {"query": "y"},
+                    "expected": {"tools": {"required": []}},
+                },
+            ],
+        }
+    )
+
+
+def _task_run(
+    run_id: str,
+    example_id: str,
+    *,
+    error: str | None = None,
+    output: Any | None = None,
+) -> dict[str, Any]:
+    task_run = {
+        "id": run_id,
+        "dataset_example_id": example_id,
+        "output": output if output is not None else {},
+        "repetition_number": 1,
+        "start_time": NOW.isoformat(),
+        "end_time": NOW.isoformat(),
+        "experiment_id": "experiment-1",
+    }
+    if error is not None:
+        task_run["error"] = error
+    return task_run
+
+
+def _evaluation(run_id: str, *, score: float | None = 1.0) -> ExperimentEvaluationRun:
+    result = {} if score is None else {"score": score}
+    return ExperimentEvaluationRun(
+        experiment_run_id=run_id,
+        start_time=NOW,
+        end_time=NOW,
+        name="correct_tools_called",
+        annotator_kind="CODE",
+        result=result,
+    )
+
+
+def _experiment(
+    task_runs: list[dict[str, Any]],
+    evaluation_runs: list[ExperimentEvaluationRun],
+    *,
+    experiment_id: str = "experiment-1",
+) -> RanExperiment:
+    return {
+        "experiment_id": experiment_id,
+        "dataset_id": "dataset-1",
+        "dataset_version_id": "dataset-version-1",
+        "task_runs": task_runs,
+        "evaluation_runs": evaluation_runs,
+        "experiment_metadata": {},
+        "project_name": None,
+    }
+
+
+def test_classify_task_error_treats_unknown_errors_as_infra() -> None:
+    assert classify_task_error(_task_run("run-1", "regression-example")) == "none"
+    assert (
+        classify_task_error(
+            _task_run("run-1", "regression-example", error="RuntimeError: something odd")
+        )
+        == "infra"
+    )
+
+
+def test_gate_passes_when_no_regression_examples_fail() -> None:
+    experiment = _experiment(
+        [
+            _task_run("run-1", "regression-example"),
+            _task_run("run-2", "dev-example"),
+        ],
+        [
+            _evaluation("run-1", score=1.0),
+            _evaluation("run-2", score=0.0),
+        ],
+    )
+
+    decision = decide_gate(
+        attempt_outcomes(_dataset(), experiment, attempt=1),
+        retry_enabled=True,
+    )
+
+    assert decision.status == "passed"
+    assert decision.failed_once_ids == ()
+
+
+def test_gate_confirms_regression_only_after_retry_failure() -> None:
+    dataset = _dataset()
+    first = _experiment(
+        [_task_run("run-1", "regression-example")],
+        [_evaluation("run-1", score=0.0)],
+        experiment_id="experiment-1",
+    )
+    retry = _experiment(
+        [_task_run("retry-run-1", "regression-example")],
+        [_evaluation("retry-run-1", score=0.0)],
+        experiment_id="experiment-2",
+    )
+
+    decision = decide_gate(
+        attempt_outcomes(dataset, first, attempt=1),
+        retry_attempts=attempt_outcomes(dataset, retry, attempt=2),
+        retry_enabled=True,
+    )
+
+    assert decision.status == "failed"
+    assert decision.confirmed_regression_ids == ("regression-example",)
+    assert decision.infra_ids == ()
+
+
+def test_gate_records_flaky_pass_when_retry_passes() -> None:
+    dataset = _dataset()
+    first = _experiment(
+        [_task_run("run-1", "regression-example")],
+        [_evaluation("run-1", score=0.0)],
+    )
+    retry = _experiment(
+        [_task_run("retry-run-1", "regression-example")],
+        [_evaluation("retry-run-1", score=1.0)],
+        experiment_id="experiment-2",
+    )
+
+    decision = decide_gate(
+        attempt_outcomes(dataset, first, attempt=1),
+        retry_attempts=attempt_outcomes(dataset, retry, attempt=2),
+        retry_enabled=True,
+    )
+
+    assert decision.status == "passed"
+    assert decision.flaky_ids == ("regression-example",)
+
+
+def test_gate_treats_persistent_task_error_as_infra() -> None:
+    dataset = _dataset()
+    first = _experiment(
+        [_task_run("run-1", "regression-example", error="HTTP 520 from model provider")],
+        [],
+    )
+    retry = _experiment(
+        [_task_run("retry-run-1", "regression-example", error="TimeoutError: task timed out")],
+        [],
+        experiment_id="experiment-2",
+    )
+
+    decision = decide_gate(
+        attempt_outcomes(dataset, first, attempt=1),
+        retry_attempts=attempt_outcomes(dataset, retry, attempt=2),
+        retry_enabled=True,
+    )
+
+    assert decision.status == "infra"
+    assert decision.infra_ids == ("regression-example",)
+    assert decision.confirmed_regression_ids == ()
+
+
+def test_gate_treats_eval_failure_then_task_error_as_infra() -> None:
+    dataset = _dataset()
+    first = _experiment(
+        [_task_run("run-1", "regression-example")],
+        [_evaluation("run-1", score=0.0)],
+    )
+    retry = _experiment(
+        [_task_run("retry-run-1", "regression-example", error="HTTP 429")],
+        [],
+        experiment_id="experiment-2",
+    )
+
+    decision = decide_gate(
+        attempt_outcomes(dataset, first, attempt=1),
+        retry_attempts=attempt_outcomes(dataset, retry, attempt=2),
+        retry_enabled=True,
+    )
+
+    assert decision.status == "infra"
+    assert decision.infra_ids == ("regression-example",)
+
+
+def test_gate_skips_retry_when_over_cap() -> None:
+    dataset = _dataset()
+    first = _experiment(
+        [
+            _task_run("run-1", "regression-example"),
+            _task_run("run-2", "another-regression-example"),
+        ],
+        [
+            _evaluation("run-1", score=0.0),
+            _evaluation("run-2", score=0.0),
+        ],
+    )
+
+    decision = decide_gate(
+        attempt_outcomes(dataset, first, attempt=1),
+        retry_enabled=True,
+        retry_cap=1,
+    )
+
+    assert decision.status == "failed"
+    assert decision.retry_ids == ()
+    assert decision.retry_skipped_reason == "retry skipped because 2 failures exceed cap 1"

--- a/tests/unit/pxi/evals/test_reporting.py
+++ b/tests/unit/pxi/evals/test_reporting.py
@@ -22,6 +22,7 @@ from phoenix.client.resources.experiments.types import (
 )
 
 from evals.pxi.harness.datasets import EvalDataset
+from evals.pxi.harness.gating import GateDecision
 from evals.pxi.harness.reporting import (
     build_report,
     report_to_json,
@@ -318,6 +319,10 @@ def test_json_round_trips_with_schema_fields() -> None:
     payload = json.loads(report_to_json(_report()))
 
     assert payload["schema_version"] == 1
+    assert payload["confirmed_regression_count"] == 0
+    assert payload["infra_failure_count"] == 0
+    assert payload["flaky_count"] == 0
+    assert payload["attempts"] == []
     assert payload["dataset_name"] == "example_suite"
     assert payload["examples_run"] == 4
     assert payload["examples_passed"] == 1
@@ -331,6 +336,40 @@ def test_json_round_trips_with_schema_fields() -> None:
         "expected set_spans_filter, agent called set_time_range"
     )
     assert payload["evaluator_summary"][0]["name"] == "correct_tools_called"
+
+
+def test_report_includes_retry_attempts_and_flaky_examples() -> None:
+    dataset = _dataset()
+    experiment = _experiment()
+    retry_experiment = _experiment()
+    retry_experiment["experiment_id"] = "RXhwZXJpbWVudDoy"
+    retry_experiment["task_runs"] = [_task_run("retry-run-fail", "failing-example")]
+    retry_experiment["evaluation_runs"] = [_evaluation("retry-run-fail", score=1.0)]
+    report = build_report(
+        dataset,
+        experiment,
+        retry_experiment=retry_experiment,
+        gate_decision=GateDecision(
+            status="passed",
+            failed_once_ids=("failing-example",),
+            retry_ids=("failing-example",),
+            confirmed_regression_ids=(),
+            infra_ids=(),
+            flaky_ids=("failing-example",),
+        ),
+        base_url=BASE_URL,
+        splits=["regression"],
+    )
+
+    assert report.flaky_count == 1
+    failure = next(
+        failure for failure in report.failures if failure.example_id == "failing-example"
+    )
+    assert failure.flaky is True
+    assert [attempt["attempt"] for attempt in failure.attempts] == [1, 2]
+    markdown = report_to_markdown(report)
+    assert "**Gate**: 0 confirmed regression, 0 infra, 1 flaky-passed" in markdown
+    assert "- **Flaky**: failed first attempt, passed retry" in markdown
 
 
 def test_markdown_has_sentinels_digest_payloads_and_repro_footer() -> None:

--- a/tests/unit/pxi/evals/test_run_experiment.py
+++ b/tests/unit/pxi/evals/test_run_experiment.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import pytest
+from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
 
 from evals.pxi.harness.datasets import EvalDataset
 from evals.pxi.harness.reporting import (
@@ -28,7 +29,6 @@ from evals.pxi.harness.run_experiment import (
     _rewrite_stable_example_ids,
     main,
 )
-from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
 
 
 def _dataset() -> EvalDataset:

--- a/tests/unit/pxi/evals/test_run_experiment.py
+++ b/tests/unit/pxi/evals/test_run_experiment.py
@@ -23,6 +23,7 @@ from evals.pxi.harness.reporting import (
 from evals.pxi.harness.run_experiment import (
     ExperimentConfig,
     _check_evaluations_ran,
+    _filter_dataset_examples,
     _get_split_filtered_dataset,
     _phoenix_examples,
     _rewrite_stable_example_ids,
@@ -224,6 +225,20 @@ def test_main_defaults_report_flags_off(monkeypatch: pytest.MonkeyPatch) -> None
     assert main(["--dataset", "set_spans_filter"]) == 0
     assert captured[0].report_dir is None
     assert captured[0].print_report is False
+    assert captured[0].retry_failed is False
+
+
+def test_main_forwards_retry_failed_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[ExperimentConfig] = []
+
+    def fake_run(config: ExperimentConfig) -> int:
+        captured.append(config)
+        return 0
+
+    monkeypatch.setattr("evals.pxi.harness.run_experiment.run", fake_run)
+
+    assert main(["--dataset", "set_spans_filter", "--retry-failed"]) == 0
+    assert captured[0].retry_failed is True
 
 
 def test_main_forwards_explicit_splits(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -338,9 +353,41 @@ def test_check_evaluations_ran_accepts_empty_experiment_and_real_evaluations() -
     _check_evaluations_ran(evaluated)
 
 
+def test_check_evaluations_ran_accepts_task_error_only_experiment() -> None:
+    now = datetime.now(timezone.utc)
+    experiment = _ran_experiment()
+    experiment["task_runs"] = [
+        {
+            "id": "run-1",
+            "dataset_example_id": "regression-example",
+            "output": {},
+            "repetition_number": 1,
+            "start_time": now.isoformat(),
+            "end_time": now.isoformat(),
+            "experiment_id": "experiment-1",
+            "error": "TimeoutError: task timed out",
+        }
+    ]
+
+    _check_evaluations_ran(experiment)
+
+
 class _FakeDatasetWithExamples:
     def __init__(self, examples: list[dict[str, object]]) -> None:
         self.examples = examples
+
+
+class _FakePhoenixDataset:
+    def __init__(self, examples: list[dict[str, object]]) -> None:
+        self._examples = examples
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": "dataset-1",
+            "name": "Example Dataset",
+            "version_id": "dataset-version-1",
+            "examples": self._examples,
+        }
 
 
 def test_rewrite_stable_example_ids_maps_global_ids_even_without_output() -> None:
@@ -391,6 +438,21 @@ def test_rewrite_stable_example_ids_maps_global_ids_even_without_output() -> Non
     assert experiment["task_runs"][1]["dataset_example_id"] == "dev-example"
     # Unmapped ids without output fall through unchanged rather than crashing.
     assert experiment["task_runs"][2]["dataset_example_id"] == "unmapped-global-id"
+
+
+def test_filter_dataset_examples_preserves_dataset_version_and_selects_ids() -> None:
+    dataset = _FakePhoenixDataset(
+        [
+            {"id": "regression-example", "input": {}, "output": {}, "metadata": {}},
+            {"id": "dev-example", "input": {}, "output": {}, "metadata": {}},
+        ]
+    )
+
+    filtered = _filter_dataset_examples(dataset, ("regression-example",))
+
+    assert filtered.id == "dataset-1"
+    assert filtered.version_id == "dataset-version-1"
+    assert [example["id"] for example in filtered.examples] == ["regression-example"]
 
 
 def test_fail_on_regression_detects_only_regression_failures() -> None:

--- a/tests/unit/pxi/evals/test_run_experiment.py
+++ b/tests/unit/pxi/evals/test_run_experiment.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import pytest
-from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
 
 from evals.pxi.harness.datasets import EvalDataset
 from evals.pxi.harness.reporting import (
@@ -29,6 +28,7 @@ from evals.pxi.harness.run_experiment import (
     _rewrite_stable_example_ids,
     main,
 )
+from phoenix.client.resources.experiments.types import ExperimentEvaluationRun, RanExperiment
 
 
 def _dataset() -> EvalDataset:
@@ -225,10 +225,10 @@ def test_main_defaults_report_flags_off(monkeypatch: pytest.MonkeyPatch) -> None
     assert main(["--dataset", "set_spans_filter"]) == 0
     assert captured[0].report_dir is None
     assert captured[0].print_report is False
-    assert captured[0].retry_failed is False
+    assert captured[0].retry_failed is True
 
 
-def test_main_forwards_retry_failed_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_main_no_retry_failed_flag_disables_retry(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: list[ExperimentConfig] = []
 
     def fake_run(config: ExperimentConfig) -> int:
@@ -237,8 +237,8 @@ def test_main_forwards_retry_failed_flag(monkeypatch: pytest.MonkeyPatch) -> Non
 
     monkeypatch.setattr("evals.pxi.harness.run_experiment.run", fake_run)
 
-    assert main(["--dataset", "set_spans_filter", "--retry-failed"]) == 0
-    assert captured[0].retry_failed is True
+    assert main(["--dataset", "set_spans_filter", "--no-retry-failed"]) == 0
+    assert captured[0].retry_failed is False
 
 
 def test_main_forwards_explicit_splits(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Classifies task/runtime errors as infrastructure issues (exit 2, warning-not-failure) so transient MCP crashes and HTTP 520s never red the PR gate
- Adds a confirm-twice retry pass: first-attempt failures are retried once; only examples that fail both times count as confirmed regressions
- Adds `retry_ids_for()` helper so `decide_gate()` is called once with actual results (cleaner call site, no planning-phase double-call)
- Infra failures and flaky-passes are surfaced in the step summary and agent-readable reports without blocking the gate

## Test plan

- [ ] `uv run pytest tests/unit/pxi/evals/` — 185 tests pass
- [ ] Trigger CI on a PR and confirm a transient infra error produces a yellow warning, not a red check
- [ ] Confirm a genuine regression (e.g. break an evaluator expectation) still fails the gate after both attempts
