### PR TITLE
fix: preserve empty JSON object attributes in load_json_strings

### DIFF
--- a/src/phoenix/trace/attributes.py
+++ b/src/phoenix/trace/attributes.py
@@ -202,7 +202,7 @@ def load_json_strings(key_values: Iterable[tuple[str, Any]]) -> Iterator[tuple[s
             except Exception:
                 yield key, value
             else:
-                if dict_value:
+                if dict_value is not None:
                     yield key, dict_value
         else:
             yield key, value

--- a/tests/unit/trace/test_attributes.py
+++ b/tests/unit/trace/test_attributes.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from phoenix.trace.attributes import get_attribute_value, unflatten
+from phoenix.trace.attributes import get_attribute_value, load_json_strings, unflatten
 
 
 @pytest.mark.parametrize(
@@ -807,3 +807,14 @@ def test_unflatten_edge_cases(
     random.shuffle(shuffled)
     shuffled_result = dict(unflatten(shuffled))
     assert shuffled_result == expected
+
+
+def test_load_json_strings_preserves_empty_json_object() -> None:
+    # A JSON-string attribute that parses to an empty container (e.g. a tool call
+    # with no parameters, serialized as "{}") must round-trip instead of being
+    # dropped. _flatten_mapping emits json.dumps({}) == "{}", so load_json_strings
+    # has to load it back rather than discarding it on a falsy check.
+    assert list(load_json_strings([("metadata", "{}")])) == [("metadata", {})]
+    # non-empty JSON and non-JSON attributes are unaffected
+    assert list(load_json_strings([("metadata", '{"a": 1}')])) == [("metadata", {"a": 1})]
+    assert list(load_json_strings([("name", "value")])) == [("name", "value")]


### PR DESCRIPTION
## Summary

JSON-string span attributes that parse to an **empty container** (most commonly a tool call with **no parameters**, or empty `metadata`) are silently dropped on load.

`load_json_strings` (`src/phoenix/trace/attributes.py`) uses a falsy check:

```python
dict_value = json.loads(value)
...
if dict_value:          # "{}" -> {} is falsy -> dropped
    yield key, dict_value
```

This is asymmetric with the flatten side: `_flatten_mapping` emits `json.dumps({})` → `"{}"` without any falsy check, so an empty `metadata` / `tool.parameters` is written out but then **lost** when read back. The attribute disappears from the span.

## Reproduction

```python
from phoenix.trace.attributes import load_json_strings

list(load_json_strings([("metadata", "{}")]))
```

**Expected:** `[("metadata", {})]`
**Actual:** `[]` (the attribute is dropped)

## Fix

Check `if dict_value is not None:` instead, so successfully-parsed empty containers round-trip. One-line change; non-empty and non-JSON attributes are unaffected.

## Tests

Added `test_load_json_strings_preserves_empty_json_object` in `tests/unit/trace/test_attributes.py`.

Verified locally:
- `pytest tests/unit/trace/test_attributes.py` → **101 passed**
- broader run across `tests/unit/trace/` + span/dataset/evaluator helper suites → **666 passed** (no regressions)
- `ruff check` / `ruff format --check` / `mypy` on the changed files → clean
