### PR TITLE
feat(ui): add annotation summary to project settings

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -248,6 +248,11 @@ type AnnotationSummary {
   labelCount: Int!
 }
 
+enum AnnotationTimeRangeField {
+  ANNOTATION_CREATED_AT
+  SOURCE_START_TIME
+}
+
 enum AnnotationType {
   CATEGORICAL
   CONTINUOUS
@@ -1361,6 +1366,26 @@ type DeleteModelMutationPayload {
   query: Query!
 }
 
+type DeleteProjectAnnotationsByNamePayload {
+  deletedAnnotationCount: Int!
+  query: Query!
+}
+
+input DeleteProjectAnnotationsInput {
+  projectId: ID!
+  annotationName: String!
+
+  """
+  If provided, only annotations whose timestamp falls within this range are deleted. The end of the range is right-exclusive.
+  """
+  timeRange: TimeRange
+
+  """
+  Which timestamp the time range is applied against. Defaults to the annotation's own creation time.
+  """
+  timeRangeField: AnnotationTimeRangeField! = ANNOTATION_CREATED_AT
+}
+
 input DeleteProjectTraceRetentionPolicyInput {
   id: ID!
 }
@@ -2407,6 +2432,21 @@ type Mutation {
   createModel(input: CreateModelMutationInput!): CreateModelMutationPayload!
   updateModel(input: UpdateModelMutationInput!): UpdateModelMutationPayload!
   deleteModel(input: DeleteModelMutationInput!): DeleteModelMutationPayload!
+
+  """
+  Delete every span annotation with the given name in a project, optionally restricted to a time range. Admin only when auth is enabled.
+  """
+  deleteProjectSpanAnnotations(input: DeleteProjectAnnotationsInput!): DeleteProjectAnnotationsByNamePayload!
+
+  """
+  Delete every trace annotation with the given name in a project, optionally restricted to a time range. Admin only when auth is enabled.
+  """
+  deleteProjectTraceAnnotations(input: DeleteProjectAnnotationsInput!): DeleteProjectAnnotationsByNamePayload!
+
+  """
+  Delete every session annotation with the given name in a project, optionally restricted to a time range. Admin only when auth is enabled.
+  """
+  deleteProjectSessionAnnotations(input: DeleteProjectAnnotationsInput!): DeleteProjectAnnotationsByNamePayload!
   createProject(input: CreateProjectInput!): ProjectMutationPayload!
   deleteProject(id: ID!): Query!
   clearProject(input: ClearProjectInput!): Query!

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -213,6 +213,11 @@ input AnnotationFilterCondition {
   userIds: [ID]
 }
 
+type AnnotationNameCount {
+  name: String!
+  count: Int!
+}
+
 type AnnotationScoreTimeSeries {
   data: [AnnotationScoreTimeSeriesDataPoint!]!
   names: [String!]!
@@ -2703,6 +2708,21 @@ type Project implements Node {
   Names of all available annotations for sessions. (The list contains no duplicates.)
   """
   sessionAnnotationNames: [String!]!
+
+  """
+  Span annotation names along with the number of span annotations that have been added for each name in this project.
+  """
+  spanAnnotationNameCounts: [AnnotationNameCount!]!
+
+  """
+  Trace annotation names along with the number of trace annotations that have been added for each name in this project.
+  """
+  traceAnnotationNameCounts: [AnnotationNameCount!]!
+
+  """
+  Session annotation names along with the number of session annotations that have been added for each name in this project.
+  """
+  sessionAnnotationNameCounts: [AnnotationNameCount!]!
 
   """Names of available document evaluations."""
   documentEvaluationNames(spanId: ID): [String!]!

--- a/app/src/contexts/NotificationContext/NotificationContext.tsx
+++ b/app/src/contexts/NotificationContext/NotificationContext.tsx
@@ -108,3 +108,26 @@ export const useNotifySuccess = () => {
     []
   );
 };
+
+/**
+ * Trigger a notification with the error variant.
+ *
+ * @param params Notification parameters.
+ * @returns A callback that triggers a notification. The callback returns a key that can be later used to programmatically dismiss the notification.
+ * @example
+ * const notifyError = useNotifyError();
+ * notifyError({ title: "Error", message: "Something went wrong." });
+ */
+export const useNotifyError = () => {
+  return useCallback(
+    ({ expireMs = DEFAULT_EXPIRY, ...params }: NotificationHookParams) =>
+      toastQueue.add(
+        {
+          ...params,
+          variant: "error",
+        },
+        expireMs === null ? undefined : { timeout: expireMs }
+      ),
+    []
+  );
+};

--- a/app/src/contexts/NotificationContext/NotificationContext.tsx
+++ b/app/src/contexts/NotificationContext/NotificationContext.tsx
@@ -108,26 +108,3 @@ export const useNotifySuccess = () => {
     []
   );
 };
-
-/**
- * Trigger a notification with the error variant.
- *
- * @param params Notification parameters.
- * @returns A callback that triggers a notification. The callback returns a key that can be later used to programmatically dismiss the notification.
- * @example
- * const notifyError = useNotifyError();
- * notifyError({ title: "Error", message: "Something went wrong." });
- */
-export const useNotifyError = () => {
-  return useCallback(
-    ({ expireMs = DEFAULT_EXPIRY, ...params }: NotificationHookParams) =>
-      toastQueue.add(
-        {
-          ...params,
-          variant: "error",
-        },
-        expireMs === null ? undefined : { timeout: expireMs }
-      ),
-    []
-  );
-};

--- a/app/src/contexts/ViewerContext.tsx
+++ b/app/src/contexts/ViewerContext.tsx
@@ -71,6 +71,18 @@ export function useViewerCanManageSecrets() {
   return true;
 }
 
+/**
+ * Returns true if the viewer can bulk-delete a project's annotations
+ * Note: when the app is not configured with auth, we assume the user is an admin
+ */
+export function useViewerCanDeleteProjectAnnotations() {
+  const { viewer } = useViewer();
+  if (viewer && viewer?.role?.name !== "ADMIN") {
+    return false;
+  }
+  return true;
+}
+
 export function ViewerProvider({
   query,
   children,

--- a/app/src/contexts/ViewerContext.tsx
+++ b/app/src/contexts/ViewerContext.tsx
@@ -77,7 +77,7 @@ export function useViewerCanManageSecrets() {
  */
 export function useViewerCanDeleteProjectAnnotations() {
   const { viewer } = useViewer();
-  if (viewer && viewer?.role?.name !== "ADMIN") {
+  if (viewer && viewer.role?.name !== "ADMIN") {
     return false;
   }
   return true;

--- a/app/src/pages/project/ProjectAnnotationConfigCard.tsx
+++ b/app/src/pages/project/ProjectAnnotationConfigCard.tsx
@@ -48,7 +48,7 @@ export const ProjectAnnotationConfigCard = (
   props: ProjectAnnotationConfigCardProps
 ) => {
   return (
-    <Card title="Project Annotations">
+    <Card title="Annotation Configs">
       <Alert variant="info" banner>
         Annotation Configs are configured globally and can be associated with
         multiple projects. Select the annotation configs you want to use for

--- a/app/src/pages/project/ProjectAnnotationConfigCard.tsx
+++ b/app/src/pages/project/ProjectAnnotationConfigCard.tsx
@@ -23,6 +23,7 @@ import {
   Alert,
   Card,
   ContentSkeleton,
+  ContextualHelp,
   Empty,
   Flex,
   Link,
@@ -48,12 +49,16 @@ export const ProjectAnnotationConfigCard = (
   props: ProjectAnnotationConfigCardProps
 ) => {
   return (
-    <Card title="Annotation Configs">
-      <Alert variant="info" banner>
-        Annotation Configs are configured globally and can be associated with
-        multiple projects. Select the annotation configs you want to use for
-        this project.
-      </Alert>
+    <Card
+      title="Annotation Configs"
+      titleExtra={
+        <ContextualHelp variant="info">
+          Annotation Configs are configured globally and can be associated with
+          multiple projects. Select the annotation configs you want to use for
+          this project.
+        </ContextualHelp>
+      }
+    >
       <Suspense fallback={<ContentSkeleton />}>
         <ProjectAnnotationConfigCardContent projectId={props.projectId} />
       </Suspense>

--- a/app/src/pages/project/ProjectAnnotationCountsCards.tsx
+++ b/app/src/pages/project/ProjectAnnotationCountsCards.tsx
@@ -10,12 +10,16 @@ import {
   Button,
   Card,
   ContentSkeleton,
+  Counter,
   DateField,
   DateInput,
   DateSegment,
   Dialog,
   DialogTrigger,
-  Empty,
+  Disclosure,
+  DisclosureGroup,
+  DisclosurePanel,
+  DisclosureTrigger,
   FieldError,
   Flex,
   Icon,
@@ -61,9 +65,12 @@ interface AnnotationNameCount {
   readonly count: number;
 }
 
+const sumCounts = (annotations: readonly AnnotationNameCount[]) =>
+  annotations.reduce((total, annotation) => total + annotation.count, 0);
+
 /**
- * Performs the bulk delete for a single annotation level (span, trace, or
- * session). The level-specific Relay mutation is bound by the parent.
+ * Performs the bulk delete for a single annotation target type (span, trace,
+ * or session). The target-type-specific Relay mutation is bound by the parent.
  */
 type DeleteAnnotationsFn = (args: {
   annotationName: string;
@@ -73,30 +80,31 @@ type DeleteAnnotationsFn = (args: {
   onError: (message: string) => void;
 }) => void;
 
-const LEVELS = [
+// The annotation target type is what an annotation is attached to: a span,
+// trace, or session.
+const TARGET_TYPES = [
   {
     title: "Span Annotations",
     // The noun used when describing the source's activity time in the UI.
     sourceNoun: "span",
-    emptyMessage: "No span annotations have been added to this project.",
   },
   {
     title: "Trace Annotations",
     sourceNoun: "trace",
-    emptyMessage: "No trace annotations have been added to this project.",
   },
   {
     title: "Session Annotations",
     sourceNoun: "session",
-    emptyMessage: "No session annotations have been added to this project.",
   },
 ] as const;
 
 /**
- * A set of cards summarizing which annotations have been added to a project at
- * the span, trace, and session levels, along with the number of annotations
- * recorded for each annotation name. Admins can bulk-delete all annotations of a
- * given name, optionally restricted to a time range.
+ * A single card summarizing which annotations have been added to a project,
+ * with a collapsible section per target type (span, trace, and session) listing
+ * the number of annotations recorded for each annotation name. Sections are
+ * collapsed by default to keep the configuration page dense. Admins can
+ * bulk-delete all annotations of a given name, optionally restricted to a time
+ * range.
  */
 export const ProjectAnnotationCountsCards = (
   props: ProjectAnnotationCountsCardsProps
@@ -110,13 +118,9 @@ export const ProjectAnnotationCountsCards = (
 
 const ProjectAnnotationCountsCardsFallback = () => {
   return (
-    <>
-      {LEVELS.map((level) => (
-        <Card key={level.title} title={level.title}>
-          <ContentSkeleton />
-        </Card>
-      ))}
-    </>
+    <Card title="Annotations">
+      <ContentSkeleton />
+    </Card>
   );
 };
 
@@ -218,7 +222,7 @@ const ProjectAnnotationCountsCardsContent = (
       }
     `);
 
-  // The level-specific mutations share an identical variables shape; only the
+  // The target-type-specific mutations share an identical variables shape; only the
   // bound commit fn and the response field they read the count from differ.
   const toVariables = (args: Parameters<DeleteAnnotationsFn>[0]) => ({
     projectId,
@@ -260,42 +264,57 @@ const ProjectAnnotationCountsCardsContent = (
       onError: (error) => args.onError(error.message),
     });
 
-  const levels = [
+  const [spanTargetType, traceTargetType, sessionTargetType] = TARGET_TYPES;
+  const targetTypes = [
     {
-      ...LEVELS[0],
+      ...spanTargetType,
       annotations: data.project.spanAnnotationNameCounts ?? [],
       onDelete: deleteSpan,
       isDeleting: isDeletingSpan,
     },
     {
-      ...LEVELS[1],
+      ...traceTargetType,
       annotations: data.project.traceAnnotationNameCounts ?? [],
       onDelete: deleteTrace,
       isDeleting: isDeletingTrace,
     },
     {
-      ...LEVELS[2],
+      ...sessionTargetType,
       annotations: data.project.sessionAnnotationNameCounts ?? [],
       onDelete: deleteSession,
       isDeleting: isDeletingSession,
     },
   ];
 
+  const grandTotal = targetTypes.reduce(
+    (total, targetType) => total + sumCounts(targetType.annotations),
+    0
+  );
+
   return (
-    <>
-      {levels.map((level) => (
-        <AnnotationCountsCard
-          key={level.title}
-          title={level.title}
-          sourceNoun={level.sourceNoun}
-          emptyMessage={level.emptyMessage}
-          annotations={level.annotations}
-          canDelete={canDelete}
-          isDeleting={level.isDeleting}
-          onDelete={level.onDelete}
-        />
-      ))}
-    </>
+    <Card
+      title="Annotations"
+      extra={
+        <Text css={totalCountCSS} size="S">
+          {grandTotal.toLocaleString()} total
+        </Text>
+      }
+    >
+      <DisclosureGroup>
+        {targetTypes.map((targetType) => (
+          <AnnotationCountsSection
+            key={targetType.title}
+            id={targetType.title}
+            title={targetType.title}
+            sourceNoun={targetType.sourceNoun}
+            annotations={targetType.annotations}
+            canDelete={canDelete}
+            isDeleting={targetType.isDeleting}
+            onDelete={targetType.onDelete}
+          />
+        ))}
+      </DisclosureGroup>
+    </Card>
   );
 };
 
@@ -313,21 +332,21 @@ const actionCellCSS = css`
   width: 48px;
 `;
 
-interface AnnotationCountsCardProps {
+interface AnnotationCountsSectionProps {
+  id: string;
   title: string;
   sourceNoun: string;
-  emptyMessage: string;
   annotations: readonly AnnotationNameCount[];
   canDelete: boolean;
   isDeleting: boolean;
   onDelete: DeleteAnnotationsFn;
 }
 
-const AnnotationCountsCard = (props: AnnotationCountsCardProps) => {
+const AnnotationCountsSection = (props: AnnotationCountsSectionProps) => {
   const {
+    id,
     title,
     sourceNoun,
-    emptyMessage,
     annotations,
     canDelete,
     isDeleting,
@@ -338,25 +357,25 @@ const AnnotationCountsCard = (props: AnnotationCountsCardProps) => {
   const sortedAnnotations = [...annotations].sort(
     (a, b) => b.count - a.count || a.name.localeCompare(b.name)
   );
-  const totalCount = annotations.reduce(
-    (total, annotation) => total + annotation.count,
-    0
-  );
+  const totalCount = sumCounts(annotations);
+  const isEmpty = sortedAnnotations.length === 0;
 
   return (
-    <Card
-      title={title}
-      extra={
+    // Collapse every section by default, and disable the ones with no
+    // annotations so the trigger reads as "nothing to expand".
+    <Disclosure id={id} defaultExpanded={false} isDisabled={isEmpty}>
+      <DisclosureTrigger arrowPosition="start" justifyContent="space-between">
+        <Flex direction="row" gap="size-100" alignItems="center">
+          <Text>{title}</Text>
+          <Counter variant={isEmpty ? "quiet" : "default"}>
+            {sortedAnnotations.length}
+          </Counter>
+        </Flex>
         <Text css={totalCountCSS} size="S">
           {totalCount.toLocaleString()} total
         </Text>
-      }
-    >
-      {sortedAnnotations.length === 0 ? (
-        <View paddingY="size-400">
-          <Empty message={emptyMessage} />
-        </View>
-      ) : (
+      </DisclosureTrigger>
+      <DisclosurePanel>
         <div
           css={css`
             overflow-x: auto;
@@ -404,8 +423,8 @@ const AnnotationCountsCard = (props: AnnotationCountsCardProps) => {
             </tbody>
           </table>
         </div>
-      )}
-    </Card>
+      </DisclosurePanel>
+    </Disclosure>
   );
 };
 

--- a/app/src/pages/project/ProjectAnnotationCountsCards.tsx
+++ b/app/src/pages/project/ProjectAnnotationCountsCards.tsx
@@ -1,21 +1,25 @@
 import { css } from "@emotion/react";
 import { getLocalTimeZone } from "@internationalized/date";
 import { Suspense, useState } from "react";
-import type { DateValue } from "react-aria-components";
-import { DateInput, DateSegment, Label } from "react-aria-components";
+import { Form } from "react-aria-components";
 import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
 
+import type { DateValue } from "@phoenix/components";
 import {
   Button,
   Card,
   ContentSkeleton,
   DateField,
+  DateInput,
+  DateSegment,
   Dialog,
   DialogTrigger,
   Empty,
+  FieldError,
   Flex,
   Icon,
   Icons,
+  Label,
   Modal,
   ModalOverlay,
   Radio,
@@ -26,9 +30,11 @@ import {
 } from "@phoenix/components";
 import { AnnotationLabel } from "@phoenix/components/annotation";
 import {
+  DialogCloseButton,
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
 import { tableCSS } from "@phoenix/components/table/styles";
 import { useNotifyError, useNotifySuccess, useViewer } from "@phoenix/contexts";
@@ -423,7 +429,7 @@ const DeleteAnnotationsButton = (props: DeleteAnnotationsButtonProps) => {
         leadingVisual={<Icon svg={<Icons.TrashOutline />} />}
       />
       <ModalOverlay>
-        <Modal size="M">
+        <Modal size="S">
           <Dialog>
             {({ close }) => (
               <DeleteAnnotationsDialog
@@ -441,18 +447,9 @@ const DeleteAnnotationsButton = (props: DeleteAnnotationsButtonProps) => {
   );
 };
 
-const dialogBodyCSS = css`
-  display: flex;
-  flex-direction: column;
-  gap: var(--ac-global-dimension-size-200);
-`;
-
-const dateFieldsCSS = css`
-  display: flex;
-  flex-direction: column;
-  gap: var(--ac-global-dimension-size-100);
+const dateFieldCSS = css`
   .react-aria-DateInput {
-    min-width: 220px;
+    width: 100%;
   }
 `;
 
@@ -474,17 +471,17 @@ const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
   const [endDate, setEndDate] = useState<DateValue | null>(null);
   const [timeRangeField, setTimeRangeField] =
     useState<AnnotationTimeRangeField>("ANNOTATION_CREATED_AT");
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [endError, setEndError] = useState<string | null>(null);
 
   const handleDelete = () => {
-    setErrorMessage(null);
+    setEndError(null);
     const timeZone = getLocalTimeZone();
     let timeRange: { start: string | null; end: string | null } | null = null;
     if (limitToTimeRange && (startDate || endDate)) {
       const start = startDate ? startDate.toDate(timeZone) : null;
       const end = endDate ? endDate.toDate(timeZone) : null;
-      if (start && end && start >= end) {
-        setErrorMessage("The end of the time range must be after the start.");
+      if (start && end && end <= start) {
+        setEndError("End must be after the start.");
         return;
       }
       timeRange = {
@@ -495,7 +492,9 @@ const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
     onDelete({
       annotationName,
       timeRange,
-      timeRangeField,
+      timeRangeField: limitToTimeRange
+        ? timeRangeField
+        : "ANNOTATION_CREATED_AT",
       onCompleted: (deletedCount) => {
         notifySuccess({
           title: "Annotations deleted",
@@ -517,91 +516,113 @@ const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
   return (
     <DialogContent>
       <DialogHeader>
-        <DialogTitle>
-          Delete &ldquo;{annotationName}&rdquo; annotations
-        </DialogTitle>
+        <DialogTitle>Delete {annotationName} annotations</DialogTitle>
+        <DialogTitleExtra>
+          <DialogCloseButton slot="close" />
+        </DialogTitleExtra>
       </DialogHeader>
-      <View padding="size-200">
-        <div css={dialogBodyCSS}>
-          <Text color="danger">
-            {limitToTimeRange
-              ? `This will permanently delete the "${annotationName}" annotations within the selected time range. This cannot be undone.`
-              : `This will permanently delete all "${annotationName}" annotations in this project. This cannot be undone.`}
-          </Text>
-          <Switch
-            isSelected={limitToTimeRange}
-            onChange={setLimitToTimeRange}
-            labelPlacement="end"
-          >
-            Only delete annotations within a time range
-          </Switch>
-          {limitToTimeRange ? (
-            <div css={dateFieldsCSS}>
-              <DateField
-                value={startDate}
-                onChange={setStartDate}
-                granularity="second"
-                hideTimeZone
-              >
-                <Label>Start (inclusive)</Label>
-                <DateInput>
-                  {(segment) => <DateSegment segment={segment} />}
-                </DateInput>
-              </DateField>
-              <DateField
-                value={endDate}
-                onChange={setEndDate}
-                granularity="second"
-                hideTimeZone
-              >
-                <Label>End (exclusive)</Label>
-                <DateInput>
-                  {(segment) => <DateSegment segment={segment} />}
-                </DateInput>
-              </DateField>
-              <RadioGroup
-                direction="column"
-                value={timeRangeField}
-                onChange={(value) =>
-                  setTimeRangeField(value as AnnotationTimeRangeField)
-                }
-                aria-label="Filter the time range by"
-              >
-                <Radio value="ANNOTATION_CREATED_AT">
-                  When the annotation was created
-                </Radio>
-                <Radio value="SOURCE_START_TIME">
-                  When the {sourceNoun} started
-                </Radio>
-              </RadioGroup>
-              <Text size="XS" color="text-700">
-                Leave either field empty for an open-ended range.
-              </Text>
-            </div>
-          ) : null}
-          {errorMessage ? <Text color="danger">{errorMessage}</Text> : null}
-        </div>
-      </View>
-      <View
-        paddingEnd="size-200"
-        paddingTop="size-100"
-        paddingBottom="size-100"
-        borderTopColor="default"
-        borderTopWidth="thin"
+      <Form
+        onSubmit={(event) => {
+          event.preventDefault();
+          handleDelete();
+        }}
       >
-        <Flex direction="row" justifyContent="end" gap="size-200">
-          <Button onPress={close} isDisabled={isDeleting}>
-            Cancel
-          </Button>
-          <Button
-            variant="danger"
-            isDisabled={isDeleting}
-            onPress={handleDelete}
-          >
-            {isDeleting ? "Deleting…" : "Delete annotations"}
-          </Button>
-        </Flex>
-      </View>
+        <View padding="size-200">
+          <Flex direction="column" gap="size-200">
+            <Text>
+              {limitToTimeRange
+                ? `This permanently deletes the "${annotationName}" annotations in the selected time range. This cannot be undone.`
+                : `This permanently deletes all "${annotationName}" annotations in this project. This cannot be undone.`}
+            </Text>
+            <Switch
+              isSelected={limitToTimeRange}
+              onChange={setLimitToTimeRange}
+              labelPlacement="end"
+            >
+              Only delete within a time range
+            </Switch>
+            {limitToTimeRange ? (
+              <Flex direction="column" gap="size-200">
+                <DateField
+                  value={startDate}
+                  onChange={setStartDate}
+                  granularity="minute"
+                  hideTimeZone
+                  css={dateFieldCSS}
+                >
+                  <Label>Start</Label>
+                  <DateInput>
+                    {(segment) => <DateSegment segment={segment} />}
+                  </DateInput>
+                  <Text slot="description">
+                    Inclusive. Leave empty for no lower bound.
+                  </Text>
+                </DateField>
+                <DateField
+                  value={endDate}
+                  onChange={(value) => {
+                    setEndDate(value);
+                    setEndError(null);
+                  }}
+                  isInvalid={endError != null}
+                  granularity="minute"
+                  hideTimeZone
+                  css={dateFieldCSS}
+                >
+                  <Label>End</Label>
+                  <DateInput>
+                    {(segment) => <DateSegment segment={segment} />}
+                  </DateInput>
+                  {endError ? (
+                    <FieldError>{endError}</FieldError>
+                  ) : (
+                    <Text slot="description">
+                      Exclusive. Leave empty for no upper bound.
+                    </Text>
+                  )}
+                </DateField>
+                <RadioGroup
+                  value={timeRangeField}
+                  onChange={(value) =>
+                    setTimeRangeField(value as AnnotationTimeRangeField)
+                  }
+                  direction="column"
+                >
+                  <Label>Filter on</Label>
+                  <Radio value="ANNOTATION_CREATED_AT">
+                    When the annotation was created
+                  </Radio>
+                  <Radio value="SOURCE_START_TIME">
+                    When the {sourceNoun} started
+                  </Radio>
+                </RadioGroup>
+              </Flex>
+            ) : null}
+          </Flex>
+        </View>
+        <View
+          paddingStart="size-200"
+          paddingEnd="size-200"
+          paddingTop="size-100"
+          paddingBottom="size-100"
+          borderColor="default"
+          borderTopWidth="thin"
+        >
+          <Flex direction="row" gap="size-100" justifyContent="end">
+            <Button size="S" onPress={close} isDisabled={isDeleting}>
+              Cancel
+            </Button>
+            <Button
+              size="S"
+              variant="danger"
+              type="submit"
+              isDisabled={isDeleting}
+            >
+              {isDeleting ? "Deleting…" : "Delete annotations"}
+            </Button>
+          </Flex>
+        </View>
+      </Form>
     </DialogContent>
   );
 };

--- a/app/src/pages/project/ProjectAnnotationCountsCards.tsx
+++ b/app/src/pages/project/ProjectAnnotationCountsCards.tsx
@@ -1,0 +1,185 @@
+import { css } from "@emotion/react";
+import { Suspense } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+
+import { Card, ContentSkeleton, Empty, Text, View } from "@phoenix/components";
+import { AnnotationLabel } from "@phoenix/components/annotation";
+import { tableCSS } from "@phoenix/components/table/styles";
+
+import type { ProjectAnnotationCountsCardsQuery } from "./__generated__/ProjectAnnotationCountsCardsQuery.graphql";
+
+interface ProjectAnnotationCountsCardsProps {
+  projectId: string;
+}
+
+interface AnnotationNameCount {
+  readonly name: string;
+  readonly count: number;
+}
+
+const LEVELS = [
+  {
+    title: "Span Annotations",
+    emptyMessage: "No span annotations have been added to this project.",
+  },
+  {
+    title: "Trace Annotations",
+    emptyMessage: "No trace annotations have been added to this project.",
+  },
+  {
+    title: "Session Annotations",
+    emptyMessage: "No session annotations have been added to this project.",
+  },
+] as const;
+
+/**
+ * A set of cards summarizing which annotations have been added to a project at
+ * the span, trace, and session levels, along with the number of annotations
+ * recorded for each annotation name.
+ */
+export const ProjectAnnotationCountsCards = (
+  props: ProjectAnnotationCountsCardsProps
+) => {
+  return (
+    <Suspense fallback={<ProjectAnnotationCountsCardsFallback />}>
+      <ProjectAnnotationCountsCardsContent projectId={props.projectId} />
+    </Suspense>
+  );
+};
+
+const ProjectAnnotationCountsCardsFallback = () => {
+  return (
+    <>
+      {LEVELS.map((level) => (
+        <Card key={level.title} title={level.title}>
+          <ContentSkeleton />
+        </Card>
+      ))}
+    </>
+  );
+};
+
+const ProjectAnnotationCountsCardsContent = (
+  props: ProjectAnnotationCountsCardsProps
+) => {
+  const data = useLazyLoadQuery<ProjectAnnotationCountsCardsQuery>(
+    graphql`
+      query ProjectAnnotationCountsCardsQuery($projectId: ID!) {
+        project: node(id: $projectId) {
+          ... on Project {
+            spanAnnotationNameCounts {
+              name
+              count
+            }
+            traceAnnotationNameCounts {
+              name
+              count
+            }
+            sessionAnnotationNameCounts {
+              name
+              count
+            }
+          }
+        }
+      }
+    `,
+    { projectId: props.projectId }
+  );
+
+  const annotationsByLevel = [
+    data.project.spanAnnotationNameCounts ?? [],
+    data.project.traceAnnotationNameCounts ?? [],
+    data.project.sessionAnnotationNameCounts ?? [],
+  ];
+
+  return (
+    <>
+      {LEVELS.map((level, index) => (
+        <AnnotationCountsCard
+          key={level.title}
+          title={level.title}
+          emptyMessage={level.emptyMessage}
+          annotations={annotationsByLevel[index]}
+        />
+      ))}
+    </>
+  );
+};
+
+const totalCountCSS = css`
+  color: var(--ac-global-text-color-700);
+`;
+
+const countCellCSS = css`
+  text-align: right;
+  width: 100px;
+`;
+
+interface AnnotationCountsCardProps {
+  title: string;
+  emptyMessage: string;
+  annotations: readonly AnnotationNameCount[];
+}
+
+const AnnotationCountsCard = (props: AnnotationCountsCardProps) => {
+  const { title, emptyMessage, annotations } = props;
+  // Sort by count descending, then name ascending, to surface the most
+  // heavily annotated names first.
+  const sortedAnnotations = [...annotations].sort(
+    (a, b) => b.count - a.count || a.name.localeCompare(b.name)
+  );
+  const totalCount = annotations.reduce(
+    (total, annotation) => total + annotation.count,
+    0
+  );
+
+  return (
+    <Card
+      title={title}
+      extra={
+        <Text css={totalCountCSS} size="S">
+          {totalCount.toLocaleString()} total
+        </Text>
+      }
+    >
+      {sortedAnnotations.length === 0 ? (
+        <View paddingY="size-400">
+          <Empty message={emptyMessage} />
+        </View>
+      ) : (
+        <div
+          css={css`
+            overflow: auto;
+          `}
+        >
+          <table css={tableCSS}>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th css={countCellCSS}>Count</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedAnnotations.map((annotation) => (
+                <tr key={annotation.name}>
+                  <td>
+                    <AnnotationLabel
+                      annotation={{ name: annotation.name }}
+                      annotationDisplayPreference="none"
+                      css={css`
+                        width: fit-content;
+                      `}
+                    />
+                  </td>
+                  <td css={countCellCSS}>
+                    <Text>{annotation.count.toLocaleString()}</Text>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Card>
+  );
+};

--- a/app/src/pages/project/ProjectAnnotationCountsCards.tsx
+++ b/app/src/pages/project/ProjectAnnotationCountsCards.tsx
@@ -37,9 +37,16 @@ import {
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
 import { tableCSS } from "@phoenix/components/table/styles";
-import { useNotifyError, useNotifySuccess, useViewer } from "@phoenix/contexts";
+import {
+  useNotifyError,
+  useNotifySuccess,
+  useViewerCanDeleteProjectAnnotations,
+} from "@phoenix/contexts";
 
-import type { ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation } from "./__generated__/ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation.graphql";
+import type {
+  AnnotationTimeRangeField,
+  ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation,
+} from "./__generated__/ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation.graphql";
 import type { ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation } from "./__generated__/ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation.graphql";
 import type { ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation } from "./__generated__/ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation.graphql";
 import type { ProjectAnnotationCountsCardsQuery } from "./__generated__/ProjectAnnotationCountsCardsQuery.graphql";
@@ -52,8 +59,6 @@ interface AnnotationNameCount {
   readonly name: string;
   readonly count: number;
 }
-
-type AnnotationTimeRangeField = "ANNOTATION_CREATED_AT" | "SOURCE_START_TIME";
 
 /**
  * Performs the bulk delete for a single annotation level (span, trace, or
@@ -118,10 +123,9 @@ const ProjectAnnotationCountsCardsContent = (
   props: ProjectAnnotationCountsCardsProps
 ) => {
   const { projectId } = props;
-  const { viewer } = useViewer();
-  // Mirror the backend's IsAdminIfAuthEnabled gate: when auth is disabled (no
-  // viewer) anyone can delete; otherwise only admins can.
-  const canDelete = !viewer || viewer.role.name === "ADMIN";
+  // Mirrors the backend's IsAdminIfAuthEnabled gate: admins, or anyone when auth
+  // is disabled.
+  const canDelete = useViewerCanDeleteProjectAnnotations();
 
   const data = useLazyLoadQuery<ProjectAnnotationCountsCardsQuery>(
     graphql`
@@ -213,17 +217,21 @@ const ProjectAnnotationCountsCardsContent = (
       }
     `);
 
+  // The level-specific mutations share an identical variables shape; only the
+  // bound commit fn and the response field they read the count from differ.
+  const toVariables = (args: Parameters<DeleteAnnotationsFn>[0]) => ({
+    projectId,
+    input: {
+      projectId,
+      annotationName: args.annotationName,
+      timeRange: args.timeRange ?? undefined,
+      timeRangeField: args.timeRangeField,
+    },
+  });
+
   const deleteSpan: DeleteAnnotationsFn = (args) =>
     commitDeleteSpan({
-      variables: {
-        projectId,
-        input: {
-          projectId,
-          annotationName: args.annotationName,
-          timeRange: args.timeRange ?? undefined,
-          timeRangeField: args.timeRangeField,
-        },
-      },
+      variables: toVariables(args),
       onCompleted: (response) =>
         args.onCompleted(
           response.deleteProjectSpanAnnotations.deletedAnnotationCount
@@ -233,15 +241,7 @@ const ProjectAnnotationCountsCardsContent = (
 
   const deleteTrace: DeleteAnnotationsFn = (args) =>
     commitDeleteTrace({
-      variables: {
-        projectId,
-        input: {
-          projectId,
-          annotationName: args.annotationName,
-          timeRange: args.timeRange ?? undefined,
-          timeRangeField: args.timeRangeField,
-        },
-      },
+      variables: toVariables(args),
       onCompleted: (response) =>
         args.onCompleted(
           response.deleteProjectTraceAnnotations.deletedAnnotationCount
@@ -251,15 +251,7 @@ const ProjectAnnotationCountsCardsContent = (
 
   const deleteSession: DeleteAnnotationsFn = (args) =>
     commitDeleteSession({
-      variables: {
-        projectId,
-        input: {
-          projectId,
-          annotationName: args.annotationName,
-          timeRange: args.timeRange ?? undefined,
-          timeRangeField: args.timeRangeField,
-        },
-      },
+      variables: toVariables(args),
       onCompleted: (response) =>
         args.onCompleted(
           response.deleteProjectSessionAnnotations.deletedAnnotationCount

--- a/app/src/pages/project/ProjectAnnotationCountsCards.tsx
+++ b/app/src/pages/project/ProjectAnnotationCountsCards.tsx
@@ -1,11 +1,41 @@
 import { css } from "@emotion/react";
-import { Suspense } from "react";
-import { graphql, useLazyLoadQuery } from "react-relay";
+import { getLocalTimeZone } from "@internationalized/date";
+import { Suspense, useState } from "react";
+import type { DateValue } from "react-aria-components";
+import { DateInput, DateSegment, Label } from "react-aria-components";
+import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
 
-import { Card, ContentSkeleton, Empty, Text, View } from "@phoenix/components";
+import {
+  Button,
+  Card,
+  ContentSkeleton,
+  DateField,
+  Dialog,
+  DialogTrigger,
+  Empty,
+  Flex,
+  Icon,
+  Icons,
+  Modal,
+  ModalOverlay,
+  Radio,
+  RadioGroup,
+  Switch,
+  Text,
+  View,
+} from "@phoenix/components";
 import { AnnotationLabel } from "@phoenix/components/annotation";
+import {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@phoenix/components/core/dialog";
 import { tableCSS } from "@phoenix/components/table/styles";
+import { useNotifyError, useNotifySuccess, useViewer } from "@phoenix/contexts";
 
+import type { ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation } from "./__generated__/ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation.graphql";
+import type { ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation } from "./__generated__/ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation.graphql";
+import type { ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation } from "./__generated__/ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation.graphql";
 import type { ProjectAnnotationCountsCardsQuery } from "./__generated__/ProjectAnnotationCountsCardsQuery.graphql";
 
 interface ProjectAnnotationCountsCardsProps {
@@ -17,17 +47,35 @@ interface AnnotationNameCount {
   readonly count: number;
 }
 
+type AnnotationTimeRangeField = "ANNOTATION_CREATED_AT" | "SOURCE_START_TIME";
+
+/**
+ * Performs the bulk delete for a single annotation level (span, trace, or
+ * session). The level-specific Relay mutation is bound by the parent.
+ */
+type DeleteAnnotationsFn = (args: {
+  annotationName: string;
+  timeRange: { start: string | null; end: string | null } | null;
+  timeRangeField: AnnotationTimeRangeField;
+  onCompleted: (deletedCount: number) => void;
+  onError: (message: string) => void;
+}) => void;
+
 const LEVELS = [
   {
     title: "Span Annotations",
+    // The noun used when describing the source's activity time in the UI.
+    sourceNoun: "span",
     emptyMessage: "No span annotations have been added to this project.",
   },
   {
     title: "Trace Annotations",
+    sourceNoun: "trace",
     emptyMessage: "No trace annotations have been added to this project.",
   },
   {
     title: "Session Annotations",
+    sourceNoun: "session",
     emptyMessage: "No session annotations have been added to this project.",
   },
 ] as const;
@@ -35,7 +83,8 @@ const LEVELS = [
 /**
  * A set of cards summarizing which annotations have been added to a project at
  * the span, trace, and session levels, along with the number of annotations
- * recorded for each annotation name.
+ * recorded for each annotation name. Admins can bulk-delete all annotations of a
+ * given name, optionally restricted to a time range.
  */
 export const ProjectAnnotationCountsCards = (
   props: ProjectAnnotationCountsCardsProps
@@ -62,6 +111,12 @@ const ProjectAnnotationCountsCardsFallback = () => {
 const ProjectAnnotationCountsCardsContent = (
   props: ProjectAnnotationCountsCardsProps
 ) => {
+  const { projectId } = props;
+  const { viewer } = useViewer();
+  // Mirror the backend's IsAdminIfAuthEnabled gate: when auth is disabled (no
+  // viewer) anyone can delete; otherwise only admins can.
+  const canDelete = !viewer || viewer.role.name === "ADMIN";
+
   const data = useLazyLoadQuery<ProjectAnnotationCountsCardsQuery>(
     graphql`
       query ProjectAnnotationCountsCardsQuery($projectId: ID!) {
@@ -83,23 +138,162 @@ const ProjectAnnotationCountsCardsContent = (
         }
       }
     `,
-    { projectId: props.projectId }
+    { projectId }
   );
 
-  const annotationsByLevel = [
-    data.project.spanAnnotationNameCounts ?? [],
-    data.project.traceAnnotationNameCounts ?? [],
-    data.project.sessionAnnotationNameCounts ?? [],
+  const [commitDeleteSpan, isDeletingSpan] =
+    useMutation<ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation>(graphql`
+      mutation ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation(
+        $projectId: ID!
+        $input: DeleteProjectAnnotationsInput!
+      ) {
+        deleteProjectSpanAnnotations(input: $input) {
+          deletedAnnotationCount
+          query {
+            node(id: $projectId) {
+              ... on Project {
+                spanAnnotationNameCounts {
+                  name
+                  count
+                }
+              }
+            }
+          }
+        }
+      }
+    `);
+
+  const [commitDeleteTrace, isDeletingTrace] =
+    useMutation<ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation>(graphql`
+      mutation ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation(
+        $projectId: ID!
+        $input: DeleteProjectAnnotationsInput!
+      ) {
+        deleteProjectTraceAnnotations(input: $input) {
+          deletedAnnotationCount
+          query {
+            node(id: $projectId) {
+              ... on Project {
+                traceAnnotationNameCounts {
+                  name
+                  count
+                }
+              }
+            }
+          }
+        }
+      }
+    `);
+
+  const [commitDeleteSession, isDeletingSession] =
+    useMutation<ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation>(graphql`
+      mutation ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation(
+        $projectId: ID!
+        $input: DeleteProjectAnnotationsInput!
+      ) {
+        deleteProjectSessionAnnotations(input: $input) {
+          deletedAnnotationCount
+          query {
+            node(id: $projectId) {
+              ... on Project {
+                sessionAnnotationNameCounts {
+                  name
+                  count
+                }
+              }
+            }
+          }
+        }
+      }
+    `);
+
+  const deleteSpan: DeleteAnnotationsFn = (args) =>
+    commitDeleteSpan({
+      variables: {
+        projectId,
+        input: {
+          projectId,
+          annotationName: args.annotationName,
+          timeRange: args.timeRange ?? undefined,
+          timeRangeField: args.timeRangeField,
+        },
+      },
+      onCompleted: (response) =>
+        args.onCompleted(
+          response.deleteProjectSpanAnnotations.deletedAnnotationCount
+        ),
+      onError: (error) => args.onError(error.message),
+    });
+
+  const deleteTrace: DeleteAnnotationsFn = (args) =>
+    commitDeleteTrace({
+      variables: {
+        projectId,
+        input: {
+          projectId,
+          annotationName: args.annotationName,
+          timeRange: args.timeRange ?? undefined,
+          timeRangeField: args.timeRangeField,
+        },
+      },
+      onCompleted: (response) =>
+        args.onCompleted(
+          response.deleteProjectTraceAnnotations.deletedAnnotationCount
+        ),
+      onError: (error) => args.onError(error.message),
+    });
+
+  const deleteSession: DeleteAnnotationsFn = (args) =>
+    commitDeleteSession({
+      variables: {
+        projectId,
+        input: {
+          projectId,
+          annotationName: args.annotationName,
+          timeRange: args.timeRange ?? undefined,
+          timeRangeField: args.timeRangeField,
+        },
+      },
+      onCompleted: (response) =>
+        args.onCompleted(
+          response.deleteProjectSessionAnnotations.deletedAnnotationCount
+        ),
+      onError: (error) => args.onError(error.message),
+    });
+
+  const levels = [
+    {
+      ...LEVELS[0],
+      annotations: data.project.spanAnnotationNameCounts ?? [],
+      onDelete: deleteSpan,
+      isDeleting: isDeletingSpan,
+    },
+    {
+      ...LEVELS[1],
+      annotations: data.project.traceAnnotationNameCounts ?? [],
+      onDelete: deleteTrace,
+      isDeleting: isDeletingTrace,
+    },
+    {
+      ...LEVELS[2],
+      annotations: data.project.sessionAnnotationNameCounts ?? [],
+      onDelete: deleteSession,
+      isDeleting: isDeletingSession,
+    },
   ];
 
   return (
     <>
-      {LEVELS.map((level, index) => (
+      {levels.map((level) => (
         <AnnotationCountsCard
           key={level.title}
           title={level.title}
+          sourceNoun={level.sourceNoun}
           emptyMessage={level.emptyMessage}
-          annotations={annotationsByLevel[index]}
+          annotations={level.annotations}
+          canDelete={canDelete}
+          isDeleting={level.isDeleting}
+          onDelete={level.onDelete}
         />
       ))}
     </>
@@ -115,14 +309,31 @@ const countCellCSS = css`
   width: 100px;
 `;
 
+const actionCellCSS = css`
+  text-align: right;
+  width: 48px;
+`;
+
 interface AnnotationCountsCardProps {
   title: string;
+  sourceNoun: string;
   emptyMessage: string;
   annotations: readonly AnnotationNameCount[];
+  canDelete: boolean;
+  isDeleting: boolean;
+  onDelete: DeleteAnnotationsFn;
 }
 
 const AnnotationCountsCard = (props: AnnotationCountsCardProps) => {
-  const { title, emptyMessage, annotations } = props;
+  const {
+    title,
+    sourceNoun,
+    emptyMessage,
+    annotations,
+    canDelete,
+    isDeleting,
+    onDelete,
+  } = props;
   // Sort by count descending, then name ascending, to surface the most
   // heavily annotated names first.
   const sortedAnnotations = [...annotations].sort(
@@ -157,6 +368,7 @@ const AnnotationCountsCard = (props: AnnotationCountsCardProps) => {
               <tr>
                 <th>Name</th>
                 <th css={countCellCSS}>Count</th>
+                {canDelete ? <th css={actionCellCSS} /> : null}
               </tr>
             </thead>
             <tbody>
@@ -174,6 +386,16 @@ const AnnotationCountsCard = (props: AnnotationCountsCardProps) => {
                   <td css={countCellCSS}>
                     <Text>{annotation.count.toLocaleString()}</Text>
                   </td>
+                  {canDelete ? (
+                    <td css={actionCellCSS}>
+                      <DeleteAnnotationsButton
+                        annotationName={annotation.name}
+                        sourceNoun={sourceNoun}
+                        isDeleting={isDeleting}
+                        onDelete={onDelete}
+                      />
+                    </td>
+                  ) : null}
                 </tr>
               ))}
             </tbody>
@@ -181,5 +403,205 @@ const AnnotationCountsCard = (props: AnnotationCountsCardProps) => {
         </div>
       )}
     </Card>
+  );
+};
+
+interface DeleteAnnotationsButtonProps {
+  annotationName: string;
+  sourceNoun: string;
+  isDeleting: boolean;
+  onDelete: DeleteAnnotationsFn;
+}
+
+const DeleteAnnotationsButton = (props: DeleteAnnotationsButtonProps) => {
+  return (
+    <DialogTrigger>
+      <Button
+        size="S"
+        variant="quiet"
+        aria-label={`Delete all "${props.annotationName}" annotations`}
+        leadingVisual={<Icon svg={<Icons.TrashOutline />} />}
+      />
+      <ModalOverlay>
+        <Modal size="M">
+          <Dialog>
+            {({ close }) => (
+              <DeleteAnnotationsDialog
+                annotationName={props.annotationName}
+                sourceNoun={props.sourceNoun}
+                isDeleting={props.isDeleting}
+                onDelete={props.onDelete}
+                close={close}
+              />
+            )}
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
+  );
+};
+
+const dialogBodyCSS = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--ac-global-dimension-size-200);
+`;
+
+const dateFieldsCSS = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--ac-global-dimension-size-100);
+  .react-aria-DateInput {
+    min-width: 220px;
+  }
+`;
+
+interface DeleteAnnotationsDialogProps {
+  annotationName: string;
+  sourceNoun: string;
+  isDeleting: boolean;
+  onDelete: DeleteAnnotationsFn;
+  close: () => void;
+}
+
+const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
+  const { annotationName, sourceNoun, isDeleting, onDelete, close } = props;
+  const notifySuccess = useNotifySuccess();
+  const notifyError = useNotifyError();
+
+  const [limitToTimeRange, setLimitToTimeRange] = useState(false);
+  const [startDate, setStartDate] = useState<DateValue | null>(null);
+  const [endDate, setEndDate] = useState<DateValue | null>(null);
+  const [timeRangeField, setTimeRangeField] =
+    useState<AnnotationTimeRangeField>("ANNOTATION_CREATED_AT");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleDelete = () => {
+    setErrorMessage(null);
+    const timeZone = getLocalTimeZone();
+    let timeRange: { start: string | null; end: string | null } | null = null;
+    if (limitToTimeRange && (startDate || endDate)) {
+      const start = startDate ? startDate.toDate(timeZone) : null;
+      const end = endDate ? endDate.toDate(timeZone) : null;
+      if (start && end && start >= end) {
+        setErrorMessage("The end of the time range must be after the start.");
+        return;
+      }
+      timeRange = {
+        start: start ? start.toISOString() : null,
+        end: end ? end.toISOString() : null,
+      };
+    }
+    onDelete({
+      annotationName,
+      timeRange,
+      timeRangeField,
+      onCompleted: (deletedCount) => {
+        notifySuccess({
+          title: "Annotations deleted",
+          message: `Deleted ${deletedCount.toLocaleString()} "${annotationName}" annotation${
+            deletedCount === 1 ? "" : "s"
+          }.`,
+        });
+        close();
+      },
+      onError: (message) => {
+        notifyError({
+          title: "Failed to delete annotations",
+          message,
+        });
+      },
+    });
+  };
+
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>
+          Delete &ldquo;{annotationName}&rdquo; annotations
+        </DialogTitle>
+      </DialogHeader>
+      <View padding="size-200">
+        <div css={dialogBodyCSS}>
+          <Text color="danger">
+            {limitToTimeRange
+              ? `This will permanently delete the "${annotationName}" annotations within the selected time range. This cannot be undone.`
+              : `This will permanently delete all "${annotationName}" annotations in this project. This cannot be undone.`}
+          </Text>
+          <Switch
+            isSelected={limitToTimeRange}
+            onChange={setLimitToTimeRange}
+            labelPlacement="end"
+          >
+            Only delete annotations within a time range
+          </Switch>
+          {limitToTimeRange ? (
+            <div css={dateFieldsCSS}>
+              <DateField
+                value={startDate}
+                onChange={setStartDate}
+                granularity="second"
+                hideTimeZone
+              >
+                <Label>Start (inclusive)</Label>
+                <DateInput>
+                  {(segment) => <DateSegment segment={segment} />}
+                </DateInput>
+              </DateField>
+              <DateField
+                value={endDate}
+                onChange={setEndDate}
+                granularity="second"
+                hideTimeZone
+              >
+                <Label>End (exclusive)</Label>
+                <DateInput>
+                  {(segment) => <DateSegment segment={segment} />}
+                </DateInput>
+              </DateField>
+              <RadioGroup
+                direction="column"
+                value={timeRangeField}
+                onChange={(value) =>
+                  setTimeRangeField(value as AnnotationTimeRangeField)
+                }
+                aria-label="Filter the time range by"
+              >
+                <Radio value="ANNOTATION_CREATED_AT">
+                  When the annotation was created
+                </Radio>
+                <Radio value="SOURCE_START_TIME">
+                  When the {sourceNoun} started
+                </Radio>
+              </RadioGroup>
+              <Text size="XS" color="text-700">
+                Leave either field empty for an open-ended range.
+              </Text>
+            </div>
+          ) : null}
+          {errorMessage ? <Text color="danger">{errorMessage}</Text> : null}
+        </div>
+      </View>
+      <View
+        paddingEnd="size-200"
+        paddingTop="size-100"
+        paddingBottom="size-100"
+        borderTopColor="default"
+        borderTopWidth="thin"
+      >
+        <Flex direction="row" justifyContent="end" gap="size-200">
+          <Button onPress={close} isDisabled={isDeleting}>
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            isDisabled={isDeleting}
+            onPress={handleDelete}
+          >
+            {isDeleting ? "Deleting…" : "Delete annotations"}
+          </Button>
+        </Flex>
+      </View>
+    </DialogContent>
   );
 };

--- a/app/src/pages/project/ProjectAnnotationCountsCards.tsx
+++ b/app/src/pages/project/ProjectAnnotationCountsCards.tsx
@@ -6,6 +6,7 @@ import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
 
 import type { DateValue } from "@phoenix/components";
 import {
+  Alert,
   Button,
   Card,
   ContentSkeleton,
@@ -32,13 +33,13 @@ import { AnnotationLabel } from "@phoenix/components/annotation";
 import {
   DialogCloseButton,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
 import { tableCSS } from "@phoenix/components/table/styles";
 import {
-  useNotifyError,
   useNotifySuccess,
   useViewerCanDeleteProjectAnnotations,
 } from "@phoenix/contexts";
@@ -358,15 +359,19 @@ const AnnotationCountsCard = (props: AnnotationCountsCardProps) => {
       ) : (
         <div
           css={css`
-            overflow: auto;
+            overflow-x: auto;
           `}
         >
-          <table css={tableCSS}>
+          <table css={tableCSS} aria-label={`${title} by name`}>
             <thead>
               <tr>
-                <th>Name</th>
-                <th css={countCellCSS}>Count</th>
-                {canDelete ? <th css={actionCellCSS} /> : null}
+                <th scope="col">Name</th>
+                <th scope="col" css={countCellCSS}>
+                  Count
+                </th>
+                {canDelete ? (
+                  <th scope="col" css={actionCellCSS} aria-label="Actions" />
+                ) : null}
               </tr>
             </thead>
             <tbody>
@@ -417,8 +422,9 @@ const DeleteAnnotationsButton = (props: DeleteAnnotationsButtonProps) => {
       <Button
         size="S"
         variant="quiet"
-        aria-label={`Delete all "${props.annotationName}" annotations`}
-        leadingVisual={<Icon svg={<Icons.TrashOutline />} />}
+        aria-label={`Delete all ${props.sourceNoun} annotations named "${props.annotationName}"`}
+        isDisabled={props.isDeleting}
+        leadingVisual={<Icon svg={<Icons.Trash />} />}
       />
       <ModalOverlay>
         <Modal size="S">
@@ -456,7 +462,6 @@ interface DeleteAnnotationsDialogProps {
 const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
   const { annotationName, sourceNoun, isDeleting, onDelete, close } = props;
   const notifySuccess = useNotifySuccess();
-  const notifyError = useNotifyError();
 
   const [limitToTimeRange, setLimitToTimeRange] = useState(false);
   // Pre-fill a concrete, valid range (the last 7 days) so the date segments are
@@ -470,12 +475,20 @@ const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
   const [timeRangeField, setTimeRangeField] =
     useState<AnnotationTimeRangeField>("ANNOTATION_CREATED_AT");
   const [endError, setEndError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const handleDelete = () => {
     setEndError(null);
+    setDeleteError(null);
     const timeZone = getLocalTimeZone();
     let timeRange: { start: string | null; end: string | null } | null = null;
-    if (limitToTimeRange && (startDate || endDate)) {
+    if (limitToTimeRange) {
+      if (!startDate && !endDate) {
+        setDeleteError(
+          "Select a start date, an end date, or turn off the time range limit."
+        );
+        return;
+      }
       const start = startDate ? startDate.toDate(timeZone) : null;
       const end = endDate ? endDate.toDate(timeZone) : null;
       if (start && end && end <= start) {
@@ -503,10 +516,7 @@ const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
         close();
       },
       onError: (message) => {
-        notifyError({
-          title: "Failed to delete annotations",
-          message,
-        });
+        setDeleteError(message);
       },
     });
   };
@@ -519,6 +529,13 @@ const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
           <DialogCloseButton slot="close" />
         </DialogTitleExtra>
       </DialogHeader>
+      {deleteError ? (
+        <View paddingX="size-200" paddingTop="size-100">
+          <Alert variant="danger" banner>
+            {deleteError}
+          </Alert>
+        </View>
+      ) : null}
       <Form
         onSubmit={(event) => {
           event.preventDefault();
@@ -534,7 +551,11 @@ const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
             </Text>
             <Switch
               isSelected={limitToTimeRange}
-              onChange={setLimitToTimeRange}
+              onChange={(isSelected) => {
+                setLimitToTimeRange(isSelected);
+                setDeleteError(null);
+                setEndError(null);
+              }}
               labelPlacement="end"
             >
               Only delete within a time range
@@ -543,7 +564,11 @@ const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
               <Flex direction="column" gap="size-200">
                 <DateField
                   value={startDate}
-                  onChange={setStartDate}
+                  onChange={(value) => {
+                    setStartDate(value);
+                    setDeleteError(null);
+                    setEndError(null);
+                  }}
                   granularity="minute"
                   hideTimeZone
                   css={dateFieldCSS}
@@ -560,6 +585,7 @@ const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
                   value={endDate}
                   onChange={(value) => {
                     setEndDate(value);
+                    setDeleteError(null);
                     setEndError(null);
                   }}
                   isInvalid={endError != null}
@@ -581,9 +607,10 @@ const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
                 </DateField>
                 <RadioGroup
                   value={timeRangeField}
-                  onChange={(value) =>
-                    setTimeRangeField(value as AnnotationTimeRangeField)
-                  }
+                  onChange={(value) => {
+                    setTimeRangeField(value as AnnotationTimeRangeField);
+                    setDeleteError(null);
+                  }}
                   direction="column"
                 >
                   <Label>Filter on</Label>
@@ -598,28 +625,24 @@ const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
             ) : null}
           </Flex>
         </View>
-        <View
-          paddingStart="size-200"
-          paddingEnd="size-200"
-          paddingTop="size-100"
-          paddingBottom="size-100"
-          borderColor="default"
-          borderTopWidth="thin"
-        >
-          <Flex direction="row" gap="size-100" justifyContent="end">
-            <Button size="S" onPress={close} isDisabled={isDeleting}>
-              Cancel
-            </Button>
-            <Button
-              size="S"
-              variant="danger"
-              type="submit"
-              isDisabled={isDeleting}
-            >
-              {isDeleting ? "Deleting…" : "Delete annotations"}
-            </Button>
-          </Flex>
-        </View>
+        <DialogFooter>
+          <Button
+            size="S"
+            onPress={close}
+            isDisabled={isDeleting}
+            type="button"
+          >
+            Cancel
+          </Button>
+          <Button
+            size="S"
+            variant="danger"
+            type="submit"
+            isDisabled={isDeleting}
+          >
+            {isDeleting ? "Deleting..." : "Delete annotations"}
+          </Button>
+        </DialogFooter>
       </Form>
     </DialogContent>
   );

--- a/app/src/pages/project/ProjectAnnotationCountsCards.tsx
+++ b/app/src/pages/project/ProjectAnnotationCountsCards.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { getLocalTimeZone } from "@internationalized/date";
+import { getLocalTimeZone, now } from "@internationalized/date";
 import { Suspense, useState } from "react";
 import { Form } from "react-aria-components";
 import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
@@ -467,8 +467,14 @@ const DeleteAnnotationsDialog = (props: DeleteAnnotationsDialogProps) => {
   const notifyError = useNotifyError();
 
   const [limitToTimeRange, setLimitToTimeRange] = useState(false);
-  const [startDate, setStartDate] = useState<DateValue | null>(null);
-  const [endDate, setEndDate] = useState<DateValue | null>(null);
+  // Pre-fill a concrete, valid range (the last 7 days) so the date segments are
+  // easy to adjust rather than starting from empty placeholders.
+  const [startDate, setStartDate] = useState<DateValue | null>(() =>
+    now(getLocalTimeZone()).subtract({ days: 7 })
+  );
+  const [endDate, setEndDate] = useState<DateValue | null>(() =>
+    now(getLocalTimeZone())
+  );
   const [timeRangeField, setTimeRangeField] =
     useState<AnnotationTimeRangeField>("ANNOTATION_CREATED_AT");
   const [endError, setEndError] = useState<string | null>(null);

--- a/app/src/pages/project/ProjectConfigPage.tsx
+++ b/app/src/pages/project/ProjectConfigPage.tsx
@@ -35,6 +35,8 @@ import { GRADIENT_PRESETS, ProjectForm } from "../projects/ProjectForm";
 import type { ProjectConfigPage_projectConfigCard$key } from "./__generated__/ProjectConfigPage_projectConfigCard.graphql";
 import type { ProjectConfigPagePatchProjectMutation } from "./__generated__/ProjectConfigPagePatchProjectMutation.graphql";
 import type { ProjectPageQueriesProjectConfigQuery as ProjectPageProjectConfigQueryType } from "./__generated__/ProjectPageQueriesProjectConfigQuery.graphql";
+import type { ProjectRetentionPolicyCard_policy$key } from "./__generated__/ProjectRetentionPolicyCard_policy.graphql";
+import type { ProjectRetentionPolicyCard_query$key } from "./__generated__/ProjectRetentionPolicyCard_query.graphql";
 import { isProjectTab } from "./constants";
 import { ProjectAnnotationConfigCard } from "./ProjectAnnotationConfigCard";
 import { ProjectAnnotationCountsCards } from "./ProjectAnnotationCountsCards";
@@ -42,7 +44,7 @@ import {
   ProjectPageQueriesProjectConfigQuery,
   useProjectPageQueryReferenceContext,
 } from "./ProjectPageQueries";
-import { ProjectRetentionPolicyCard } from "./ProjectRetentionPolicyCard";
+import { ProjectRetentionPolicySection } from "./ProjectRetentionPolicyCard";
 
 const projectConfigPageCSS = css`
   overflow-y: auto;
@@ -90,10 +92,13 @@ const ProjectConfigContent = ({
   const data = usePreloadedQuery(ProjectPageQueriesProjectConfigQuery, project);
   return (
     <Flex direction="column" gap="size-200">
-      <ProjectConfigCard project={data.project} />
+      <ProjectConfigCard
+        project={data.project}
+        retentionPolicy={data.project}
+        query={data}
+      />
       <ProjectAnnotationConfigCard projectId={data.project.id} />
       <ProjectAnnotationCountsCards projectId={data.project.id} />
-      <ProjectRetentionPolicyCard project={data.project} query={data} />
     </Flex>
   );
 };
@@ -126,8 +131,12 @@ const ReadOnlyNameField = ({ name }: { name: string }) => (
 
 const ProjectConfigCard = ({
   project,
+  retentionPolicy,
+  query,
 }: {
   project: ProjectConfigPage_projectConfigCard$key;
+  retentionPolicy: ProjectRetentionPolicyCard_policy$key;
+  query: ProjectRetentionPolicyCard_query$key;
 }) => {
   const [data] = useRefetchableFragment(
     graphql`
@@ -225,6 +234,10 @@ const ProjectConfigCard = ({
             ),
           }}
         />
+        <ProjectRetentionPolicySection
+          project={retentionPolicy}
+          query={query}
+        />
       </Card>
     );
   }
@@ -305,6 +318,7 @@ const ProjectConfigCard = ({
           </div>
         </Flex>
       </View>
+      <ProjectRetentionPolicySection project={retentionPolicy} query={query} />
     </Card>
   );
 };

--- a/app/src/pages/project/ProjectConfigPage.tsx
+++ b/app/src/pages/project/ProjectConfigPage.tsx
@@ -37,6 +37,7 @@ import type { ProjectConfigPagePatchProjectMutation } from "./__generated__/Proj
 import type { ProjectPageQueriesProjectConfigQuery as ProjectPageProjectConfigQueryType } from "./__generated__/ProjectPageQueriesProjectConfigQuery.graphql";
 import { isProjectTab } from "./constants";
 import { ProjectAnnotationConfigCard } from "./ProjectAnnotationConfigCard";
+import { ProjectAnnotationCountsCards } from "./ProjectAnnotationCountsCards";
 import {
   ProjectPageQueriesProjectConfigQuery,
   useProjectPageQueryReferenceContext,
@@ -91,6 +92,7 @@ const ProjectConfigContent = ({
     <Flex direction="column" gap="size-200">
       <ProjectConfigCard project={data.project} />
       <ProjectAnnotationConfigCard projectId={data.project.id} />
+      <ProjectAnnotationCountsCards projectId={data.project.id} />
       <ProjectRetentionPolicyCard project={data.project} query={data} />
     </Flex>
   );

--- a/app/src/pages/project/ProjectConfigPage.tsx
+++ b/app/src/pages/project/ProjectConfigPage.tsx
@@ -204,120 +204,116 @@ const ProjectConfigCard = ({
     [commit, data.id, notifySuccess]
   );
 
-  if (isEditing) {
-    return (
-      <Card title="Project Settings">
-        {error && (
-          <View padding="size-200" paddingBottom="size-0">
-            <Alert variant="danger" banner>
-              {error}
-            </Alert>
-          </View>
-        )}
-        <View padding="size-200">
-          <ReadOnlyNameField name={data.name} />
-        </View>
-        <ProjectForm
-          onSubmit={handleSubmit}
-          isSubmitting={isCommitting}
-          submitButtonText={isCommitting ? "Saving..." : "Save"}
-          hideNameField
-          onCancel={() => {
-            setIsEditing(false);
-            setError(null);
-          }}
-          defaultValues={{
-            description: data.description ?? "",
-            gradientPreset: findGradientPreset(
-              data.gradientStartColor,
-              data.gradientEndColor
-            ),
-          }}
-        />
-        <ProjectRetentionPolicySection
-          project={retentionPolicy}
-          query={query}
-        />
-      </Card>
-    );
-  }
-
   return (
     <Card
       title="Project Settings"
       extra={
-        <Button
-          variant="default"
-          size="S"
-          leadingVisual={<Icon svg={<Icons.Edit />} />}
-          onPress={() => setIsEditing(true)}
-        >
-          Edit
-        </Button>
+        isEditing ? undefined : (
+          <Button
+            variant="default"
+            size="S"
+            leadingVisual={<Icon svg={<Icons.Edit />} />}
+            onPress={() => setIsEditing(true)}
+          >
+            Edit
+          </Button>
+        )
       }
     >
-      <View padding="size-200">
-        <Flex direction="row" gap="size-200">
-          <div
-            css={[
-              gradientPreviewCSS,
-              {
-                background: `linear-gradient(136.27deg, ${data.gradientStartColor} 14.03%, ${data.gradientEndColor} 84.38%)`,
-              },
-            ]}
+      {isEditing ? (
+        <>
+          {error && (
+            <View padding="size-200" paddingBottom="size-0">
+              <Alert variant="danger" banner>
+                {error}
+              </Alert>
+            </View>
+          )}
+          <View padding="size-200">
+            <ReadOnlyNameField name={data.name} />
+          </View>
+          <ProjectForm
+            onSubmit={handleSubmit}
+            isSubmitting={isCommitting}
+            submitButtonText={isCommitting ? "Saving..." : "Save"}
+            hideNameField
+            onCancel={() => {
+              setIsEditing(false);
+              setError(null);
+            }}
+            defaultValues={{
+              description: data.description ?? "",
+              gradientPreset: findGradientPreset(
+                data.gradientStartColor,
+                data.gradientEndColor
+              ),
+            }}
           />
-          <div
-            css={css`
-              width: 100%;
-              .dropdown,
-              .dropdown__button {
+        </>
+      ) : (
+        <View padding="size-200">
+          <Flex direction="row" gap="size-200">
+            <div
+              css={[
+                gradientPreviewCSS,
+                {
+                  background: `linear-gradient(136.27deg, ${data.gradientStartColor} 14.03%, ${data.gradientEndColor} 84.38%)`,
+                },
+              ]}
+            />
+            <div
+              css={css`
                 width: 100%;
-              }
-            `}
-          >
-            <Flex direction="column" gap="size-100" width="100%">
-              <ReadOnlyNameField name={data.name} />
-              {data.description && (
-                <TextField value={data.description} isReadOnly>
-                  <Label>Description</Label>
-                  <Input />
-                </TextField>
-              )}
-              <Select
-                value={defaultTab}
-                onChange={(key) => {
-                  if (typeof key === "string" && isProjectTab(key)) {
-                    setDefaultTab(key);
-                  }
-                }}
-                placeholder="Select a default tab"
-              >
-                <Label>Default Project Tab</Label>
-                <Button>
-                  <SelectValue />
-                  <SelectChevronUpDownIcon />
-                </Button>
-                <Popover>
-                  <ListBox>
-                    <SelectItem key="spans" id="spans">
-                      Spans
-                    </SelectItem>
-                    <SelectItem key="traces" id="traces">
-                      Traces
-                    </SelectItem>
-                    <SelectItem key="sessions" id="sessions">
-                      Sessions
-                    </SelectItem>
-                    <SelectItem key="metrics" id="metrics">
-                      Metrics
-                    </SelectItem>
-                  </ListBox>
-                </Popover>
-              </Select>
-            </Flex>
-          </div>
-        </Flex>
-      </View>
+                .dropdown,
+                .dropdown__button {
+                  width: 100%;
+                }
+              `}
+            >
+              <Flex direction="column" gap="size-100" width="100%">
+                <ReadOnlyNameField name={data.name} />
+                {data.description && (
+                  <TextField value={data.description} isReadOnly>
+                    <Label>Description</Label>
+                    <Input />
+                  </TextField>
+                )}
+                <Select
+                  value={defaultTab}
+                  onChange={(key) => {
+                    if (typeof key === "string" && isProjectTab(key)) {
+                      setDefaultTab(key);
+                    }
+                  }}
+                  placeholder="Select a default tab"
+                >
+                  <Label>Default Project Tab</Label>
+                  <Button>
+                    <SelectValue />
+                    <SelectChevronUpDownIcon />
+                  </Button>
+                  <Popover>
+                    <ListBox>
+                      <SelectItem key="spans" id="spans">
+                        Spans
+                      </SelectItem>
+                      <SelectItem key="traces" id="traces">
+                        Traces
+                      </SelectItem>
+                      <SelectItem key="sessions" id="sessions">
+                        Sessions
+                      </SelectItem>
+                      <SelectItem key="metrics" id="metrics">
+                        Metrics
+                      </SelectItem>
+                    </ListBox>
+                  </Popover>
+                </Select>
+              </Flex>
+            </div>
+          </Flex>
+        </View>
+      )}
       <ProjectRetentionPolicySection project={retentionPolicy} query={query} />
     </Card>
   );

--- a/app/src/pages/project/ProjectRetentionPolicyCard.tsx
+++ b/app/src/pages/project/ProjectRetentionPolicyCard.tsx
@@ -1,7 +1,14 @@
 import { useMemo, useState } from "react";
 import { graphql, useFragment, useMutation } from "react-relay";
 
-import { Alert, Card, Flex, Link, Text, View } from "@phoenix/components";
+import {
+  Alert,
+  Flex,
+  Link,
+  SectionHeading,
+  Text,
+  View,
+} from "@phoenix/components";
 import { ProjectTraceRetentionPolicySelect } from "@phoenix/components/retention/ProjectTraceRetentionPolicySelect";
 import {
   useNotifySuccess,
@@ -16,7 +23,12 @@ import type { ProjectRetentionPolicyCard_policy$key } from "./__generated__/Proj
 import type { ProjectRetentionPolicyCard_query$key } from "./__generated__/ProjectRetentionPolicyCard_query.graphql";
 import type { ProjectRetentionPolicyCardSetProjectRetentionPolicyMutation } from "./__generated__/ProjectRetentionPolicyCardSetProjectRetentionPolicyMutation.graphql";
 
-export const ProjectRetentionPolicyCard = ({
+/**
+ * The data retention section of the project settings card. Renders the trace
+ * retention policy selector along with a human-readable summary of what the
+ * policy deletes and on what schedule.
+ */
+export const ProjectRetentionPolicySection = ({
   project,
   query,
 }: {
@@ -110,7 +122,8 @@ export const ProjectRetentionPolicyCard = ({
   };
 
   return (
-    <Card title="Data Retention">
+    <>
+      <SectionHeading>Data Retention</SectionHeading>
       {error && <Alert variant="danger">{error}</Alert>}
       <View paddingX="size-200" paddingY="size-100">
         <Flex direction="row" gap="size-400" alignItems="center">
@@ -147,6 +160,6 @@ export const ProjectRetentionPolicyCard = ({
           <Link to="/settings/data">Configure Retention Policies</Link>
         </Flex>
       </View>
-    </Card>
+    </>
   );
 };

--- a/app/src/pages/project/__generated__/ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation.graphql.ts
@@ -1,0 +1,231 @@
+/**
+ * @generated SignedSource<<eada4924395042f561daf1e87715cdce>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AnnotationTimeRangeField = "ANNOTATION_CREATED_AT" | "SOURCE_START_TIME";
+export type DeleteProjectAnnotationsInput = {
+  annotationName: string;
+  projectId: string;
+  timeRange?: TimeRange | null;
+  timeRangeField?: AnnotationTimeRangeField;
+};
+export type TimeRange = {
+  end?: string | null;
+  start?: string | null;
+};
+export type ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation$variables = {
+  input: DeleteProjectAnnotationsInput;
+  projectId: string;
+};
+export type ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation$data = {
+  readonly deleteProjectSessionAnnotations: {
+    readonly deletedAnnotationCount: number;
+    readonly query: {
+      readonly node: {
+        readonly sessionAnnotationNameCounts?: ReadonlyArray<{
+          readonly count: number;
+          readonly name: string;
+        }>;
+      };
+    };
+  };
+};
+export type ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation = {
+  response: ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation$data;
+  variables: ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "projectId"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedAnnotationCount",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v5 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AnnotationNameCount",
+      "kind": "LinkedField",
+      "name": "sessionAnnotationNameCounts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteProjectAnnotationsByNamePayload",
+        "kind": "LinkedField",
+        "name": "deleteProjectSessionAnnotations",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Query",
+            "kind": "LinkedField",
+            "name": "query",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v5/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteProjectAnnotationsByNamePayload",
+        "kind": "LinkedField",
+        "name": "deleteProjectSessionAnnotations",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Query",
+            "kind": "LinkedField",
+            "name": "query",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  (v5/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "863af3fac614415e167fb20e7357a218",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation",
+    "operationKind": "mutation",
+    "text": "mutation ProjectAnnotationCountsCardsDeleteSessionAnnotationsMutation(\n  $projectId: ID!\n  $input: DeleteProjectAnnotationsInput!\n) {\n  deleteProjectSessionAnnotations(input: $input) {\n    deletedAnnotationCount\n    query {\n      node(id: $projectId) {\n        __typename\n        ... on Project {\n          sessionAnnotationNameCounts {\n            name\n            count\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "00e0503793845c41ae79e2a8a1667f0b";
+
+export default node;

--- a/app/src/pages/project/__generated__/ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation.graphql.ts
@@ -1,0 +1,231 @@
+/**
+ * @generated SignedSource<<425df303d64726d79428e466a9306960>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AnnotationTimeRangeField = "ANNOTATION_CREATED_AT" | "SOURCE_START_TIME";
+export type DeleteProjectAnnotationsInput = {
+  annotationName: string;
+  projectId: string;
+  timeRange?: TimeRange | null;
+  timeRangeField?: AnnotationTimeRangeField;
+};
+export type TimeRange = {
+  end?: string | null;
+  start?: string | null;
+};
+export type ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation$variables = {
+  input: DeleteProjectAnnotationsInput;
+  projectId: string;
+};
+export type ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation$data = {
+  readonly deleteProjectSpanAnnotations: {
+    readonly deletedAnnotationCount: number;
+    readonly query: {
+      readonly node: {
+        readonly spanAnnotationNameCounts?: ReadonlyArray<{
+          readonly count: number;
+          readonly name: string;
+        }>;
+      };
+    };
+  };
+};
+export type ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation = {
+  response: ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation$data;
+  variables: ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "projectId"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedAnnotationCount",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v5 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AnnotationNameCount",
+      "kind": "LinkedField",
+      "name": "spanAnnotationNameCounts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteProjectAnnotationsByNamePayload",
+        "kind": "LinkedField",
+        "name": "deleteProjectSpanAnnotations",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Query",
+            "kind": "LinkedField",
+            "name": "query",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v5/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteProjectAnnotationsByNamePayload",
+        "kind": "LinkedField",
+        "name": "deleteProjectSpanAnnotations",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Query",
+            "kind": "LinkedField",
+            "name": "query",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  (v5/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "bed431a1f79658440ba9f39699be0bfc",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation",
+    "operationKind": "mutation",
+    "text": "mutation ProjectAnnotationCountsCardsDeleteSpanAnnotationsMutation(\n  $projectId: ID!\n  $input: DeleteProjectAnnotationsInput!\n) {\n  deleteProjectSpanAnnotations(input: $input) {\n    deletedAnnotationCount\n    query {\n      node(id: $projectId) {\n        __typename\n        ... on Project {\n          spanAnnotationNameCounts {\n            name\n            count\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "7cd9c4dd5b59090cd32eebc658baf636";
+
+export default node;

--- a/app/src/pages/project/__generated__/ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation.graphql.ts
@@ -1,0 +1,231 @@
+/**
+ * @generated SignedSource<<7e112a998dc7fe6713413b81dbb855fd>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AnnotationTimeRangeField = "ANNOTATION_CREATED_AT" | "SOURCE_START_TIME";
+export type DeleteProjectAnnotationsInput = {
+  annotationName: string;
+  projectId: string;
+  timeRange?: TimeRange | null;
+  timeRangeField?: AnnotationTimeRangeField;
+};
+export type TimeRange = {
+  end?: string | null;
+  start?: string | null;
+};
+export type ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation$variables = {
+  input: DeleteProjectAnnotationsInput;
+  projectId: string;
+};
+export type ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation$data = {
+  readonly deleteProjectTraceAnnotations: {
+    readonly deletedAnnotationCount: number;
+    readonly query: {
+      readonly node: {
+        readonly traceAnnotationNameCounts?: ReadonlyArray<{
+          readonly count: number;
+          readonly name: string;
+        }>;
+      };
+    };
+  };
+};
+export type ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation = {
+  response: ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation$data;
+  variables: ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "projectId"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedAnnotationCount",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v5 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AnnotationNameCount",
+      "kind": "LinkedField",
+      "name": "traceAnnotationNameCounts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteProjectAnnotationsByNamePayload",
+        "kind": "LinkedField",
+        "name": "deleteProjectTraceAnnotations",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Query",
+            "kind": "LinkedField",
+            "name": "query",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v5/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteProjectAnnotationsByNamePayload",
+        "kind": "LinkedField",
+        "name": "deleteProjectTraceAnnotations",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Query",
+            "kind": "LinkedField",
+            "name": "query",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  (v5/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "4e9c9bda076a765f663e8bc7aadd2aa6",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation",
+    "operationKind": "mutation",
+    "text": "mutation ProjectAnnotationCountsCardsDeleteTraceAnnotationsMutation(\n  $projectId: ID!\n  $input: DeleteProjectAnnotationsInput!\n) {\n  deleteProjectTraceAnnotations(input: $input) {\n    deletedAnnotationCount\n    query {\n      node(id: $projectId) {\n        __typename\n        ... on Project {\n          traceAnnotationNameCounts {\n            name\n            count\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "40c81a52b1117a8f8fdac6516ab0c35c";
+
+export default node;

--- a/app/src/pages/project/__generated__/ProjectAnnotationCountsCardsQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectAnnotationCountsCardsQuery.graphql.ts
@@ -1,0 +1,174 @@
+/**
+ * @generated SignedSource<<e985b9faffa353f97f0077cd3d9a622f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ProjectAnnotationCountsCardsQuery$variables = {
+  projectId: string;
+};
+export type ProjectAnnotationCountsCardsQuery$data = {
+  readonly project: {
+    readonly sessionAnnotationNameCounts?: ReadonlyArray<{
+      readonly count: number;
+      readonly name: string;
+    }>;
+    readonly spanAnnotationNameCounts?: ReadonlyArray<{
+      readonly count: number;
+      readonly name: string;
+    }>;
+    readonly traceAnnotationNameCounts?: ReadonlyArray<{
+      readonly count: number;
+      readonly name: string;
+    }>;
+  };
+};
+export type ProjectAnnotationCountsCardsQuery = {
+  response: ProjectAnnotationCountsCardsQuery$data;
+  variables: ProjectAnnotationCountsCardsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "projectId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "name",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "count",
+    "storageKey": null
+  }
+],
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AnnotationNameCount",
+      "kind": "LinkedField",
+      "name": "spanAnnotationNameCounts",
+      "plural": true,
+      "selections": (v2/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AnnotationNameCount",
+      "kind": "LinkedField",
+      "name": "traceAnnotationNameCounts",
+      "plural": true,
+      "selections": (v2/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AnnotationNameCount",
+      "kind": "LinkedField",
+      "name": "sessionAnnotationNameCounts",
+      "plural": true,
+      "selections": (v2/*: any*/),
+      "storageKey": null
+    }
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectAnnotationCountsCardsQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ProjectAnnotationCountsCardsQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "3a70bed7f41655566844d28d6f34b95f",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectAnnotationCountsCardsQuery",
+    "operationKind": "query",
+    "text": "query ProjectAnnotationCountsCardsQuery(\n  $projectId: ID!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanAnnotationNameCounts {\n        name\n        count\n      }\n      traceAnnotationNameCounts {\n        name\n        count\n      }\n      sessionAnnotationNameCounts {\n        name\n        count\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "9fa3baf2b92b1df542a34d067ca19878";
+
+export default node;

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -92,11 +92,9 @@ _original_span_init: Optional[Callable[..., None]] = None
 
 def _patched_span_init(self: ReadableSpan, *args: Any, **kwargs: Any) -> None:
     """Patched version of ReadableSpan.__init__ that applies resource modifications."""
-    # Call the original __init__ method
     if _original_span_init is not None:
         _original_span_init(self, *args, **kwargs)
 
-    # Apply span modifications if an active modifier exists
     if isinstance(span_modifier := _ACTIVE_MODIFIER.get(None), SpanModifier):
         span_modifier.modify_resource(self)
 
@@ -109,7 +107,7 @@ def _monkey_patch_span_init() -> Iterator[None]:
     with _SPAN_INIT_MONKEY_PATCH_LOCK:
         _span_init_monkey_patch_count += 1
         if _span_init_monkey_patch_count == 1:
-            # First caller - apply the patch
+            # first caller installs the patch
             _original_span_init = ReadableSpan.__init__
             setattr(ReadableSpan, "__init__", _patched_span_init)
 
@@ -119,7 +117,7 @@ def _monkey_patch_span_init() -> Iterator[None]:
         with _SPAN_INIT_MONKEY_PATCH_LOCK:
             _span_init_monkey_patch_count -= 1
             if _span_init_monkey_patch_count == 0:
-                # Last caller - restore the original
+                # last caller restores the original
                 if _original_span_init is not None:
                     setattr(ReadableSpan, "__init__", _original_span_init)
                     _original_span_init = None
@@ -393,7 +391,6 @@ def _build_tasks_for_named_evaluators(
 
         incomplete_names = set(incomplete["evaluation_names"])
 
-        # Match evaluator keys with incomplete evaluation names
         for evaluator_name in incomplete_names & evaluators_by_name.keys():
             evaluator = evaluators_by_name[evaluator_name]
             evaluation_tasks.append((example, run, evaluator))
@@ -441,7 +438,6 @@ def _build_incomplete_evaluation_tasks(
     Returns:
         List of tuples: (example, run, evaluator)
     """
-    # Standard case: match evaluator keys with evaluation names
     return _build_tasks_for_named_evaluators(incomplete_evals, evaluators_by_name)
 
 
@@ -599,7 +595,6 @@ class Experiments:
             )
             print(f"Created experiment with ID: {experiment['id']}")
 
-            # Later, run the experiment
             client.experiments.resume_experiment(
                 experiment_id=experiment["id"],
                 task=my_task,
@@ -801,7 +796,6 @@ class Experiments:
 
         task_result_cache: dict[tuple[str, int], Any] = {}
 
-        # Setup rate limiting
         errors: tuple[type[BaseException], ...]
         if not isinstance(rate_limit_errors, Sequence):
             errors = (rate_limit_errors,) if rate_limit_errors is not None else ()
@@ -838,11 +832,10 @@ class Experiments:
         task_runs, _execution_details = executor.run(test_cases)
         print("✅ Task runs completed.")
 
-        # Get the final state of runs from the database if not dry run
+        # re-fetch from the server so task_runs reflects the authoritative, persisted state
         if not dry_run:
             task_runs = self._get_all_experiment_runs(experiment_id=experiment["id"])
 
-            # Check if we got all expected runs
             expected_runs = len(examples_to_process) * repetitions
             actual_runs = len(task_runs)
             if actual_runs < expected_runs:
@@ -851,7 +844,6 @@ class Experiments:
                     "completed successfully."
                 )
 
-        # Create RanExperiment object
         task_runs_list = [r for r in task_runs if r is not None]
         evaluation_runs_list: list[ExperimentEvaluationRun] = []
 
@@ -939,14 +931,13 @@ class Experiments:
                 body = cast(v1.ListExperimentRunsResponseBody, response.json())
                 all_runs.extend(body["data"])
 
-                # Check if there are more pages
                 cursor = body.get("next_cursor")
                 if not cursor:
                     break
 
             except HTTPStatusError as e:
                 if e.response.status_code == 404:
-                    # Experiment doesn't exist - treat as empty result
+                    # experiment doesn't exist; treat as an empty result
                     break
                 else:
                     raise
@@ -984,7 +975,6 @@ class Experiments:
                 print_summary=True,
             )
         """
-        # Get experiment metadata using existing endpoint
         try:
             experiment_response = self._client.get(f"v1/experiments/{experiment_id}")
             experiment_response.raise_for_status()
@@ -1033,7 +1023,6 @@ class Experiments:
             if not json_record:
                 continue
 
-            # Create evaluation runs from annotations if present
             for annotation in json_record.get("annotations", []):  # pyright: ignore [reportUnknownMemberType, reportUnknownVariableType]
                 eval_result = None
                 if (
@@ -1050,10 +1039,9 @@ class Experiments:
                         },
                     )
 
-                # Only create evaluation runs for annotations that have evaluation data
                 if eval_result is not None:
                     eval_run = ExperimentEvaluationRun(
-                        id=f"ExperimentEvaluation:{len(evaluation_runs) + 1}",  # Generate temp ID
+                        id=f"ExperimentEvaluation:{len(evaluation_runs) + 1}",  # temporary id
                         experiment_run_id=run_data["id"],  # pyright: ignore [reportUnknownArgumentType]
                         start_time=datetime.fromisoformat(annotation["start_time"]),  # pyright: ignore [reportUnknownArgumentType]
                         end_time=datetime.fromisoformat(annotation["end_time"]),  # pyright: ignore [reportUnknownArgumentType]
@@ -1142,17 +1130,14 @@ class Experiments:
         task_signature = inspect.signature(task)
         _validate_task_signature(task_signature)
 
-        # Get the experiment metadata
         experiment = self.get(experiment_id=experiment_id)
 
-        # Setup for task execution
         tracer, resource = _get_tracer(
             experiment["project_name"], str(self._client.base_url), dict(self._client.headers)
         )
         root_span_name = f"Task: {get_func_name(task)}"
         task_result_cache: dict[tuple[str, int], Any] = {}
 
-        # Setup rate limiting
         errors: tuple[type[BaseException], ...]
         if not isinstance(rate_limit_errors, Sequence):
             errors = (rate_limit_errors,) if rate_limit_errors is not None else ()
@@ -1178,7 +1163,7 @@ class Experiments:
             lambda fn, limiter: limiter.limit(fn), rate_limiters, sync_run_task
         )
 
-        # Check experiment status using counts from the experiment response
+        # use the run counts from the experiment record rather than fetching every run
         print("🔍 Checking for incomplete runs...")
         total_expected = experiment["example_count"] * experiment["repetitions"]
         incomplete_count = total_expected - experiment["successful_run_count"]
@@ -1206,7 +1191,6 @@ class Experiments:
         total_completed = 0
 
         while True:
-            # Fetch next batch of incomplete runs
             params: dict[str, Any] = {"limit": page_size}
             if cursor:
                 params["cursor"] = cursor
@@ -1224,7 +1208,6 @@ class Experiments:
                 if not batch_incomplete:
                     break
 
-                # Build test cases from this batch
                 batch_test_cases: list[TestCase] = []
                 for incomplete in batch_incomplete:
                     example_data = incomplete["dataset_example"]
@@ -1235,7 +1218,6 @@ class Experiments:
 
                 print(f"Processing batch of {len(batch_test_cases)} incomplete runs...")
 
-                # Execute tasks for this batch
                 executor = SyncExecutor(
                     generation_fn=rate_limited_sync_run_task,
                     tqdm_bar_format=get_tqdm_progress_bar_formatter("resuming tasks"),
@@ -1286,9 +1268,8 @@ class Experiments:
                 "were completed successfully."
             )
 
-        # Run evaluators if provided
         if evaluators:
-            print()  # Add spacing before evaluation output
+            print()  # blank line before evaluation output
             self.resume_evaluation(
                 experiment_id=experiment_id,
                 evaluators=evaluators,
@@ -1298,7 +1279,6 @@ class Experiments:
                 retries=retries,
             )
 
-        # Print summary if requested
         if print_summary:
             print("\n" + "=" * 70)
             print("📊 Experiment Resume Summary")
@@ -1374,17 +1354,14 @@ class Experiments:
         if not evaluators_by_name:
             raise ValueError("Must specify at least one evaluator")
 
-        # Get the experiment metadata
         experiment = self.get(experiment_id=experiment_id)
 
-        # Setup for evaluator execution
         eval_tracer, eval_resource = _get_tracer(
             experiment["project_name"], str(self._client.base_url), dict(self._client.headers)
         )
 
         print("🔍 Checking for incomplete evaluations...")
 
-        # Build evaluation names list for query - derive from evaluator keys
         evaluation_names_list = list(evaluators_by_name.keys())
 
         # Process incomplete evaluations in streaming batches
@@ -1394,7 +1371,6 @@ class Experiments:
         total_completed = 0
 
         while True:
-            # Fetch next batch of incomplete evaluations
             params: dict[str, Any] = {"limit": page_size, "evaluation_name": evaluation_names_list}
             if cursor:
                 params["cursor"] = cursor
@@ -1418,7 +1394,6 @@ class Experiments:
                 if total_processed == 0:
                     print("🧠 Resuming evaluations...")
 
-                # Build evaluation tasks from incomplete evaluations
                 evaluation_tasks = _build_incomplete_evaluation_tasks(
                     batch_incomplete,
                     evaluators_by_name,
@@ -1435,7 +1410,6 @@ class Experiments:
 
                 print(f"Processing batch of {len(evaluation_tasks)} evaluation tasks...")
 
-                # Execute evaluations using refactored method
                 batch_eval_runs = self._run_evaluations(
                     evaluation_tasks,
                     eval_tracer,
@@ -1448,7 +1422,6 @@ class Experiments:
 
                 total_completed += len([r for r in batch_eval_runs if r.error is None])
 
-                # Check for next page
                 cursor = body.get("next_cursor")
                 if not cursor:
                     break
@@ -1486,7 +1459,6 @@ class Experiments:
                 "were completed successfully."
             )
 
-        # Print summary if requested
         if print_summary:
             print("\n" + "=" * 70)
             print("📊 Evaluation Resume Summary")
@@ -1618,7 +1590,6 @@ class Experiments:
         if dry_run:
             print("🌵️ This is a dry-run evaluation.")
 
-        # Build evaluation tasks
         examples_by_id = {_example_global_id(ex): ex for ex in dataset.examples}
         evaluation_tasks = _build_evaluation_tasks(
             task_runs,
@@ -1626,7 +1597,6 @@ class Experiments:
             examples_by_id,
         )
 
-        # Run evaluations
         eval_runs = self._run_evaluations(
             evaluation_tasks,
             eval_tracer,
@@ -1700,11 +1670,9 @@ class Experiments:
         example, repetition_number = test_case.example, test_case.repetition_number
         cache_key = (example["id"], repetition_number)
 
-        # Check if we have a cached result
         if cache_key in task_result_cache:
             cached_value = cast(ExperimentRun, task_result_cache[cache_key])
-            # we only get to this point if the previous post to the sever was cancelled, so we
-            # re-try the post
+            # we only reach here when a previous post to the server was cancelled, so retry it
             if not dry_run:
                 try:
                     resp = self._client.post(
@@ -1771,7 +1739,6 @@ class Experiments:
             span.set_attribute(OPENINFERENCE_SPAN_KIND, CHAIN)
             span.set_status(status)
 
-        # Handle potential None values in span timing
         if span.start_time is not None:
             start_time = _decode_unix_nano(span.start_time)
         if span.end_time is not None:
@@ -1790,13 +1757,12 @@ class Experiments:
             "experiment_id": experiment["id"],
         }
 
-        # Add optional fields if they exist
         if trace_id:
             exp_run["trace_id"] = trace_id
         if error:
             exp_run["error"] = repr(error)
 
-        # here we cache the result because the post to the server may be cancelled
+        # cache the result first, since the post to the server may be cancelled
         task_result_cache[cache_key] = exp_run
 
         if not dry_run:
@@ -1816,11 +1782,9 @@ class Experiments:
                     task_result_cache.pop(cache_key, None)
                     raise
 
-        # Re-raise exception if task failed
         if error is not None:
-            # we can delete the task result from the cache because the result has been
-            # successfully submitted to the server, however we will leave the error check in place
-            # just in case our assumption is wrong
+            # safe to drop from the cache now that the result is persisted on the server; the
+            # error check is left in place in case that assumption is ever wrong
             task_result_cache.pop(cache_key, None)
             raise error
 
@@ -1851,7 +1815,6 @@ class Experiments:
             List of evaluation run results
         """
 
-        # Setup rate limiting
         errors: tuple[type[BaseException], ...]
         if not isinstance(rate_limit_errors, Sequence):
             errors = (rate_limit_errors,) if rate_limit_errors is not None else ()
@@ -1877,7 +1840,6 @@ class Experiments:
             lambda fn, limiter: limiter.limit(fn), rate_limiters, sync_evaluate_run
         )
 
-        # Use sync executor for sync operation
         executor = SyncExecutor(
             generation_fn=rate_limited_sync_evaluate_run,
             max_retries=retries,
@@ -1966,7 +1928,6 @@ class Experiments:
             span.set_attribute(OPENINFERENCE_SPAN_KIND, EVALUATOR)
             span.set_status(status)
 
-        # Handle potential None values in span timing
         if span.start_time is not None:
             start_time = _decode_unix_nano(span.start_time)
         if span.end_time is not None:
@@ -2477,7 +2438,6 @@ class AsyncExperiments:
             )
             print(f"Created experiment with ID: {experiment['id']}")
 
-            # Later, run the experiment
             await async_client.experiments.resume_experiment(
                 experiment_id=experiment["id"],
                 task=my_task,
@@ -2680,7 +2640,6 @@ class AsyncExperiments:
 
         task_result_cache: dict[tuple[str, int], Any] = {}
 
-        # Setup rate limiting
         errors: tuple[type[BaseException], ...]
         if not isinstance(rate_limit_errors, Sequence):
             errors = (rate_limit_errors,) if rate_limit_errors is not None else ()
@@ -2719,11 +2678,10 @@ class AsyncExperiments:
         task_runs, _execution_details = await executor.execute(test_cases)
         print("✅ Task runs completed.")
 
-        # Get the final state of runs from the database if not dry run
+        # re-fetch from the server so task_runs reflects the authoritative, persisted state
         if not dry_run:
             task_runs = await self._get_all_experiment_runs(experiment_id=experiment["id"])
 
-            # Check if we got all expected runs
             expected_runs = len(examples_to_process) * repetitions
             actual_runs = len(task_runs)
             if actual_runs < expected_runs:
@@ -2732,7 +2690,6 @@ class AsyncExperiments:
                     "completed successfully."
                 )
 
-        # Create RanExperiment object
         task_runs_list = [r for r in task_runs if r is not None]
         evaluation_runs_list: list[ExperimentEvaluationRun] = []
 
@@ -2820,14 +2777,13 @@ class AsyncExperiments:
                 body = cast(v1.ListExperimentRunsResponseBody, response.json())
                 all_runs.extend(body["data"])
 
-                # Check if there are more pages
                 cursor = body.get("next_cursor")
                 if not cursor:
                     break
 
             except HTTPStatusError as e:
                 if e.response.status_code == 404:
-                    # Experiment doesn't exist - treat as empty result for robustness
+                    # experiment doesn't exist; treat as an empty result
                     break
                 else:
                     raise
@@ -2865,7 +2821,6 @@ class AsyncExperiments:
                 print_summary=True,
             )
         """
-        # Get experiment metadata using existing endpoint
         try:
             experiment_response = await self._client.get(f"v1/experiments/{experiment_id}")
             experiment_response.raise_for_status()
@@ -2914,7 +2869,6 @@ class AsyncExperiments:
             if not json_record:
                 continue
 
-            # Create evaluation runs from annotations if present
             for annotation in json_record.get("annotations", []):  # pyright: ignore [reportUnknownMemberType, reportUnknownVariableType]
                 eval_result = None
                 if (
@@ -2933,7 +2887,7 @@ class AsyncExperiments:
 
                 if eval_result is not None:
                     eval_run = ExperimentEvaluationRun(
-                        id=f"ExperimentEvaluation:{len(evaluation_runs) + 1}",  # Generate temp ID
+                        id=f"ExperimentEvaluation:{len(evaluation_runs) + 1}",  # temporary id
                         experiment_run_id=run_data["id"],  # pyright: ignore [reportUnknownArgumentType]
                         start_time=datetime.fromisoformat(annotation["start_time"]),  # pyright: ignore [reportUnknownArgumentType]
                         end_time=datetime.fromisoformat(annotation["end_time"]),  # pyright: ignore [reportUnknownArgumentType]
@@ -3024,17 +2978,14 @@ class AsyncExperiments:
         task_signature = inspect.signature(task)
         _validate_task_signature(task_signature)
 
-        # Get the experiment metadata
         experiment = await self.get(experiment_id=experiment_id)
 
-        # Setup for task execution
         tracer, resource = _get_tracer(
             experiment["project_name"], str(self._client.base_url), dict(self._client.headers)
         )
         root_span_name = f"Task: {get_func_name(task)}"
         task_result_cache: dict[tuple[str, int], Any] = {}
 
-        # Setup rate limiting
         errors: tuple[type[BaseException], ...]
         if not isinstance(rate_limit_errors, Sequence):
             errors = (rate_limit_errors,) if rate_limit_errors is not None else ()
@@ -3060,7 +3011,7 @@ class AsyncExperiments:
             lambda fn, limiter: limiter.alimit(fn), rate_limiters, async_run_task
         )
 
-        # Check experiment status using counts from the experiment response
+        # use the run counts from the experiment record rather than fetching every run
         print("🔍 Checking for incomplete runs...")
         total_expected = experiment["example_count"] * experiment["repetitions"]
         incomplete_count = total_expected - experiment["successful_run_count"]
@@ -3088,7 +3039,6 @@ class AsyncExperiments:
         total_completed = 0
 
         while True:
-            # Fetch next batch of incomplete runs
             params: dict[str, Any] = {"limit": page_size}
             if cursor:
                 params["cursor"] = cursor
@@ -3106,7 +3056,6 @@ class AsyncExperiments:
                 if not batch_incomplete:
                     break
 
-                # Build test cases from this batch
                 batch_test_cases: list[TestCase] = []
                 for incomplete in batch_incomplete:
                     example_data = incomplete["dataset_example"]
@@ -3117,7 +3066,6 @@ class AsyncExperiments:
 
                 print(f"Processing batch of {len(batch_test_cases)} incomplete runs...")
 
-                # Execute tasks for this batch
                 executor = AsyncExecutor(
                     generation_fn=rate_limited_async_run_task,
                     concurrency=concurrency,
@@ -3170,9 +3118,8 @@ class AsyncExperiments:
                 "were completed successfully."
             )
 
-        # Run evaluators if provided
         if evaluators:
-            print()  # Add spacing before evaluation output
+            print()  # blank line before evaluation output
             await self.resume_evaluation(
                 experiment_id=experiment_id,
                 evaluators=evaluators,
@@ -3183,7 +3130,6 @@ class AsyncExperiments:
                 retries=retries,
             )
 
-        # Print summary if requested
         if print_summary:
             print("\n" + "=" * 70)
             print("📊 Experiment Resume Summary")
@@ -3261,17 +3207,14 @@ class AsyncExperiments:
         if not evaluators_by_name:
             raise ValueError("Must specify at least one evaluator")
 
-        # Get the experiment metadata
         experiment = await self.get(experiment_id=experiment_id)
 
-        # Setup for evaluator execution
         eval_tracer, eval_resource = _get_tracer(
             experiment["project_name"], str(self._client.base_url), dict(self._client.headers)
         )
 
         print("🔍 Checking for incomplete evaluations...")
 
-        # Build evaluation names list for query - derive from evaluator keys
         evaluation_names_list = list(evaluators_by_name.keys())
 
         # Process incomplete evaluations in streaming batches
@@ -3281,7 +3224,6 @@ class AsyncExperiments:
         total_completed = 0
 
         while True:
-            # Fetch next batch of incomplete evaluations
             params: dict[str, Any] = {"limit": page_size, "evaluation_name": evaluation_names_list}
             if cursor:
                 params["cursor"] = cursor
@@ -3305,7 +3247,6 @@ class AsyncExperiments:
                 if total_processed == 0:
                     print("🧠 Resuming evaluations...")
 
-                # Build evaluation tasks from incomplete evaluations
                 evaluation_tasks = _build_incomplete_evaluation_tasks(
                     batch_incomplete,
                     evaluators_by_name,
@@ -3322,7 +3263,6 @@ class AsyncExperiments:
 
                 print(f"Processing batch of {len(evaluation_tasks)} evaluation tasks...")
 
-                # Execute evaluations using refactored method
                 batch_eval_runs = await self._run_evaluations(
                     evaluation_tasks,
                     eval_tracer,
@@ -3336,7 +3276,6 @@ class AsyncExperiments:
 
                 total_completed += len([r for r in batch_eval_runs if r.error is None])
 
-                # Check for next page
                 cursor = body.get("next_cursor")
                 if not cursor:
                     break
@@ -3374,7 +3313,6 @@ class AsyncExperiments:
                 "were completed successfully."
             )
 
-        # Print summary if requested
         if print_summary:
             print("\n" + "=" * 70)
             print("📊 Evaluation Resume Summary")
@@ -3508,7 +3446,6 @@ class AsyncExperiments:
         if dry_run:
             print("🌵️ This is a dry-run evaluation.")
 
-        # Build evaluation tasks
         examples_by_id = {_example_global_id(ex): ex for ex in dataset.examples}
         evaluation_tasks = _build_evaluation_tasks(
             task_runs,
@@ -3516,7 +3453,6 @@ class AsyncExperiments:
             examples_by_id,
         )
 
-        # Run evaluations
         eval_runs = await self._run_evaluations(
             evaluation_tasks,
             eval_tracer,
@@ -3591,11 +3527,9 @@ class AsyncExperiments:
         example, repetition_number = test_case.example, test_case.repetition_number
         cache_key = (example["id"], repetition_number)
 
-        # Check if we have a cached result
         if cache_key in task_result_cache:
             cached_value = cast(ExperimentRun, task_result_cache[cache_key])
-            # we only get to this point if the previous post to the sever was cancelled, so we
-            # re-try the post
+            # we only reach here when a previous post to the server was cancelled, so retry it
             if not dry_run:
                 try:
                     resp = await self._client.post(
@@ -3659,7 +3593,6 @@ class AsyncExperiments:
             span.set_attribute(OPENINFERENCE_SPAN_KIND, CHAIN)
             span.set_status(status)
 
-        # Handle potential None values in span timing
         if span.start_time is not None:
             start_time = _decode_unix_nano(span.start_time)
         if span.end_time is not None:
@@ -3678,13 +3611,12 @@ class AsyncExperiments:
             "experiment_id": experiment["id"],
         }
 
-        # Add optional fields if they exist
         if trace_id:
             exp_run["trace_id"] = trace_id
         if error:
             exp_run["error"] = repr(error)
 
-        # here we cache the result because the post to the server may be cancelled
+        # cache the result first, since the post to the server may be cancelled
         task_result_cache[cache_key] = exp_run
 
         if not dry_run:
@@ -3704,11 +3636,9 @@ class AsyncExperiments:
                     task_result_cache.pop(cache_key, None)
                     raise
 
-        # Re-raise exception if task failed
         if error is not None:
-            # we can delete the task result from the cache because the result has been
-            # successfully submitted to the server, however we will leave the error check in place
-            # just in case our assumption is wrong
+            # safe to drop from the cache now that the result is persisted on the server; the
+            # error check is left in place in case that assumption is ever wrong
             task_result_cache.pop(cache_key, None)
             raise error
 
@@ -3742,7 +3672,6 @@ class AsyncExperiments:
             List of evaluation run results
         """
 
-        # Setup rate limiting
         errors: tuple[type[BaseException], ...]
         if not isinstance(rate_limit_errors, Sequence):
             errors = (rate_limit_errors,) if rate_limit_errors is not None else ()
@@ -3858,7 +3787,6 @@ class AsyncExperiments:
             span.set_attribute(OPENINFERENCE_SPAN_KIND, EVALUATOR)
             span.set_status(status)
 
-        # Handle potential None values in span timing
         if span.start_time is not None:
             start_time = _decode_unix_nano(span.start_time)
         if span.end_time is not None:

--- a/src/phoenix/server/api/input_types/DeleteProjectAnnotationsInput.py
+++ b/src/phoenix/server/api/input_types/DeleteProjectAnnotationsInput.py
@@ -21,9 +21,9 @@ class AnnotationTimeRangeField(Enum):
 
 @strawberry.input
 class DeleteProjectAnnotationsInput:
-    """Input for bulk-deleting every annotation with a given name at a single
-    level (span, trace, or session) within a project, optionally restricted to a
-    time range."""
+    """Input for bulk-deleting every annotation with a given name for a single
+    target type (span, trace, or session) within a project, optionally restricted
+    to a time range."""
 
     project_id: GlobalID
     annotation_name: str

--- a/src/phoenix/server/api/input_types/DeleteProjectAnnotationsInput.py
+++ b/src/phoenix/server/api/input_types/DeleteProjectAnnotationsInput.py
@@ -1,0 +1,43 @@
+from enum import Enum
+from typing import Optional
+
+import strawberry
+from strawberry import UNSET
+from strawberry.relay import GlobalID
+
+from phoenix.server.api.input_types.TimeRange import TimeRange
+
+
+@strawberry.enum
+class AnnotationTimeRangeField(Enum):
+    """The timestamp that an annotation ``timeRange`` filter is applied against
+    when bulk-deleting annotations by name within a project."""
+
+    # The annotation's own creation time.
+    ANNOTATION_CREATED_AT = "annotation_created_at"
+    # The start time of the span, trace, or session the annotation is attached to.
+    SOURCE_START_TIME = "source_start_time"
+
+
+@strawberry.input
+class DeleteProjectAnnotationsInput:
+    """Input for bulk-deleting every annotation with a given name at a single
+    level (span, trace, or session) within a project, optionally restricted to a
+    time range."""
+
+    project_id: GlobalID
+    annotation_name: str
+    time_range: Optional[TimeRange] = strawberry.field(
+        default=UNSET,
+        description=(
+            "If provided, only annotations whose timestamp falls within this range are "
+            "deleted. The end of the range is right-exclusive."
+        ),
+    )
+    time_range_field: AnnotationTimeRangeField = strawberry.field(
+        default=AnnotationTimeRangeField.ANNOTATION_CREATED_AT,
+        description=(
+            "Which timestamp the time range is applied against. Defaults to the "
+            "annotation's own creation time."
+        ),
+    )

--- a/src/phoenix/server/api/mutations/__init__.py
+++ b/src/phoenix/server/api/mutations/__init__.py
@@ -17,6 +17,9 @@ from phoenix.server.api.mutations.generative_model_custom_provider_mutations imp
     GenerativeModelCustomProviderMutationMixin,
 )
 from phoenix.server.api.mutations.model_mutations import ModelMutationMixin
+from phoenix.server.api.mutations.project_annotations_mutations import (
+    ProjectAnnotationMutationMixin,
+)
 from phoenix.server.api.mutations.project_mutations import ProjectMutationMixin
 from phoenix.server.api.mutations.project_session_annotations_mutations import (
     ProjectSessionAnnotationMutationMixin,
@@ -49,6 +52,7 @@ class Mutation(
     ExperimentMutationMixin,
     GenerativeModelCustomProviderMutationMixin,
     ModelMutationMixin,
+    ProjectAnnotationMutationMixin,
     ProjectMutationMixin,
     ProjectTraceRetentionPolicyMutationMixin,
     PromptMutationMixin,

--- a/src/phoenix/server/api/mutations/project_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/project_annotations_mutations.py
@@ -1,0 +1,203 @@
+from datetime import datetime
+from typing import Any
+
+import strawberry
+from sqlalchemy import Select, delete, select
+from sqlalchemy.orm import InstrumentedAttribute
+from strawberry import Info
+
+from phoenix.db import models
+from phoenix.server.api.auth import IsAdminIfAuthEnabled, IsNotReadOnly, IsNotViewer
+from phoenix.server.api.context import Context
+from phoenix.server.api.exceptions import BadRequest
+from phoenix.server.api.input_types.DeleteProjectAnnotationsInput import (
+    AnnotationTimeRangeField,
+    DeleteProjectAnnotationsInput,
+)
+from phoenix.server.api.queries import Query
+from phoenix.server.api.types.node import from_global_id_with_expected_type
+from phoenix.server.dml_event import (
+    ProjectSessionAnnotationDeleteEvent,
+    SpanAnnotationDeleteEvent,
+    TraceAnnotationDeleteEvent,
+)
+
+
+@strawberry.type
+class DeleteProjectAnnotationsByNamePayload:
+    """The result of bulk-deleting annotations by name within a project."""
+
+    deleted_annotation_count: int
+    query: Query
+
+
+def _apply_time_range(
+    stmt: Select[Any],
+    input: DeleteProjectAnnotationsInput,
+    *,
+    created_at_column: InstrumentedAttribute[datetime],
+    source_start_time_column: InstrumentedAttribute[datetime],
+) -> Select[Any]:
+    """Restrict ``stmt`` to the annotations falling within ``input.time_range``.
+
+    The range is applied against either the annotation's own ``created_at`` or the
+    start time of the span/trace/session it is attached to, depending on
+    ``input.time_range_field``. The end of the range is right-exclusive.
+    """
+    time_range = input.time_range
+    if not time_range:
+        return stmt
+    if not time_range.is_valid():
+        raise BadRequest("Invalid time range: start must be before end.")
+    column = (
+        created_at_column
+        if input.time_range_field is AnnotationTimeRangeField.ANNOTATION_CREATED_AT
+        else source_start_time_column
+    )
+    if time_range.start is not None:
+        stmt = stmt.where(column >= time_range.start)
+    if time_range.end is not None:
+        stmt = stmt.where(column < time_range.end)
+    return stmt
+
+
+@strawberry.type
+class ProjectAnnotationMutationMixin:
+    @strawberry.mutation(  # type: ignore
+        permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled],
+        description=(
+            "Delete every span annotation with the given name in a project, optionally "
+            "restricted to a time range. Admin only when auth is enabled."
+        ),
+    )
+    async def delete_project_span_annotations(
+        self, info: Info[Context, None], input: DeleteProjectAnnotationsInput
+    ) -> DeleteProjectAnnotationsByNamePayload:
+        if not input.annotation_name:
+            raise BadRequest("An annotation name is required.")
+        try:
+            project_rowid = from_global_id_with_expected_type(input.project_id, "Project")
+        except ValueError:
+            raise BadRequest(f"Invalid project ID: {input.project_id}")
+
+        stmt = (
+            select(models.SpanAnnotation.id)
+            .join(models.Span, models.SpanAnnotation.span_rowid == models.Span.id)
+            .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+            .where(models.Trace.project_rowid == project_rowid)
+            .where(models.SpanAnnotation.name == input.annotation_name)
+        )
+        stmt = _apply_time_range(
+            stmt,
+            input,
+            created_at_column=models.SpanAnnotation.created_at,
+            source_start_time_column=models.Span.start_time,
+        )
+
+        async with info.context.db() as session:
+            annotation_ids = list(await session.scalars(stmt))
+            if annotation_ids:
+                await session.execute(
+                    delete(models.SpanAnnotation).where(
+                        models.SpanAnnotation.id.in_(annotation_ids)
+                    )
+                )
+
+        if annotation_ids:
+            info.context.event_queue.put(SpanAnnotationDeleteEvent(tuple(annotation_ids)))
+        return DeleteProjectAnnotationsByNamePayload(
+            deleted_annotation_count=len(annotation_ids), query=Query()
+        )
+
+    @strawberry.mutation(  # type: ignore
+        permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled],
+        description=(
+            "Delete every trace annotation with the given name in a project, optionally "
+            "restricted to a time range. Admin only when auth is enabled."
+        ),
+    )
+    async def delete_project_trace_annotations(
+        self, info: Info[Context, None], input: DeleteProjectAnnotationsInput
+    ) -> DeleteProjectAnnotationsByNamePayload:
+        if not input.annotation_name:
+            raise BadRequest("An annotation name is required.")
+        try:
+            project_rowid = from_global_id_with_expected_type(input.project_id, "Project")
+        except ValueError:
+            raise BadRequest(f"Invalid project ID: {input.project_id}")
+
+        stmt = (
+            select(models.TraceAnnotation.id)
+            .join(models.Trace, models.TraceAnnotation.trace_rowid == models.Trace.id)
+            .where(models.Trace.project_rowid == project_rowid)
+            .where(models.TraceAnnotation.name == input.annotation_name)
+        )
+        stmt = _apply_time_range(
+            stmt,
+            input,
+            created_at_column=models.TraceAnnotation.created_at,
+            source_start_time_column=models.Trace.start_time,
+        )
+
+        async with info.context.db() as session:
+            annotation_ids = list(await session.scalars(stmt))
+            if annotation_ids:
+                await session.execute(
+                    delete(models.TraceAnnotation).where(
+                        models.TraceAnnotation.id.in_(annotation_ids)
+                    )
+                )
+
+        if annotation_ids:
+            info.context.event_queue.put(TraceAnnotationDeleteEvent(tuple(annotation_ids)))
+        return DeleteProjectAnnotationsByNamePayload(
+            deleted_annotation_count=len(annotation_ids), query=Query()
+        )
+
+    @strawberry.mutation(  # type: ignore
+        permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled],
+        description=(
+            "Delete every session annotation with the given name in a project, optionally "
+            "restricted to a time range. Admin only when auth is enabled."
+        ),
+    )
+    async def delete_project_session_annotations(
+        self, info: Info[Context, None], input: DeleteProjectAnnotationsInput
+    ) -> DeleteProjectAnnotationsByNamePayload:
+        if not input.annotation_name:
+            raise BadRequest("An annotation name is required.")
+        try:
+            project_rowid = from_global_id_with_expected_type(input.project_id, "Project")
+        except ValueError:
+            raise BadRequest(f"Invalid project ID: {input.project_id}")
+
+        stmt = (
+            select(models.ProjectSessionAnnotation.id)
+            .join(
+                models.ProjectSession,
+                models.ProjectSessionAnnotation.project_session_id == models.ProjectSession.id,
+            )
+            .where(models.ProjectSession.project_id == project_rowid)
+            .where(models.ProjectSessionAnnotation.name == input.annotation_name)
+        )
+        stmt = _apply_time_range(
+            stmt,
+            input,
+            created_at_column=models.ProjectSessionAnnotation.created_at,
+            source_start_time_column=models.ProjectSession.start_time,
+        )
+
+        async with info.context.db() as session:
+            annotation_ids = list(await session.scalars(stmt))
+            if annotation_ids:
+                await session.execute(
+                    delete(models.ProjectSessionAnnotation).where(
+                        models.ProjectSessionAnnotation.id.in_(annotation_ids)
+                    )
+                )
+
+        if annotation_ids:
+            info.context.event_queue.put(ProjectSessionAnnotationDeleteEvent(tuple(annotation_ids)))
+        return DeleteProjectAnnotationsByNamePayload(
+            deleted_annotation_count=len(annotation_ids), query=Query()
+        )

--- a/src/phoenix/server/api/mutations/project_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/project_annotations_mutations.py
@@ -9,7 +9,7 @@ from strawberry import Info
 from phoenix.db import models
 from phoenix.server.api.auth import IsAdminIfAuthEnabled, IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
-from phoenix.server.api.exceptions import BadRequest
+from phoenix.server.api.exceptions import BadRequest, NotFound
 from phoenix.server.api.input_types.DeleteProjectAnnotationsInput import (
     AnnotationTimeRangeField,
     DeleteProjectAnnotationsInput,
@@ -94,6 +94,11 @@ async def _delete_project_annotations_by_name(
     )
     stmt = delete(model).where(model.id.in_(id_select)).returning(model.id)
     async with info.context.db() as session:
+        project_exists = await session.scalar(
+            select(models.Project.id).where(models.Project.id == project_rowid)
+        )
+        if project_exists is None:
+            raise NotFound(f"Could not find project with ID: {input.project_id}")
         deleted_ids = tuple(await session.scalars(stmt))
 
     if deleted_ids:

--- a/src/phoenix/server/api/mutations/project_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/project_annotations_mutations.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable
 
@@ -62,22 +63,36 @@ def _apply_time_range(
     return stmt
 
 
+@dataclass(frozen=True)
+class _AnnotationTargetType:
+    """The per-target-type wiring for bulk-deleting annotations by name.
+
+    The target type is what the annotation is attached to: a span, trace, or
+    session. ``model`` is the annotation ORM class and ``build_id_select`` returns
+    the select of its ids scoped to a project and annotation name.
+    ``source_start_time`` is the start time of the span/trace/session the
+    annotation hangs off of, and ``event_cls`` is the DML event to emit for the
+    deleted ids. Keeping these together guarantees the model and its query always
+    belong to the same target type.
+    """
+
+    model: Any
+    build_id_select: Callable[[int, str], Select[Any]]
+    source_start_time: InstrumentedAttribute[datetime]
+    event_cls: Callable[[tuple[int, ...]], DmlEvent]
+
+
 async def _delete_project_annotations_by_name(
     info: Info[Context, None],
     input: DeleteProjectAnnotationsInput,
     *,
-    model: Any,
-    build_id_select: Callable[[int], Select[Any]],
-    source_start_time_column: InstrumentedAttribute[datetime],
-    event_cls: Callable[[tuple[int, ...]], DmlEvent],
+    target_type: _AnnotationTargetType,
 ) -> DeleteProjectAnnotationsByNamePayload:
-    """Bulk-delete every annotation matching ``input`` for a single level.
+    """Bulk-delete every annotation matching ``input`` for a single target type.
 
-    ``model`` is the annotation ORM class and ``build_id_select`` returns its
-    level-specific ``select`` of annotation ids scoped to the given project. The
-    shared logic validates the input, applies the optional time range, deletes the
-    matching rows in a single round trip, and emits the level-specific DML event
-    for the deleted ids.
+    Validates the input, applies the optional time range, deletes the matching
+    rows in a single round trip, and emits the target type's DML event for the
+    deleted ids.
     """
     if not input.annotation_name:
         raise BadRequest("An annotation name is required.")
@@ -87,12 +102,16 @@ async def _delete_project_annotations_by_name(
         raise BadRequest(f"Invalid project ID: {input.project_id}")
 
     id_select = _apply_time_range(
-        build_id_select(project_rowid),
+        target_type.build_id_select(project_rowid, input.annotation_name),
         input,
-        created_at_column=model.created_at,
-        source_start_time_column=source_start_time_column,
+        created_at_column=target_type.model.created_at,
+        source_start_time_column=target_type.source_start_time,
     )
-    stmt = delete(model).where(model.id.in_(id_select)).returning(model.id)
+    stmt = (
+        delete(target_type.model)
+        .where(target_type.model.id.in_(id_select))
+        .returning(target_type.model.id)
+    )
     async with info.context.db() as session:
         project_exists = await session.scalar(
             select(models.Project.id).where(models.Project.id == project_rowid)
@@ -102,10 +121,51 @@ async def _delete_project_annotations_by_name(
         deleted_ids = tuple(await session.scalars(stmt))
 
     if deleted_ids:
-        info.context.event_queue.put(event_cls(deleted_ids))
+        info.context.event_queue.put(target_type.event_cls(deleted_ids))
     return DeleteProjectAnnotationsByNamePayload(
         deleted_annotation_count=len(deleted_ids), query=Query()
     )
+
+
+_SPAN_TARGET_TYPE = _AnnotationTargetType(
+    model=models.SpanAnnotation,
+    build_id_select=lambda project_rowid, annotation_name: (
+        select(models.SpanAnnotation.id)
+        .join(models.Span, models.SpanAnnotation.span_rowid == models.Span.id)
+        .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+        .where(models.Trace.project_rowid == project_rowid)
+        .where(models.SpanAnnotation.name == annotation_name)
+    ),
+    source_start_time=models.Span.start_time,
+    event_cls=SpanAnnotationDeleteEvent,
+)
+
+_TRACE_TARGET_TYPE = _AnnotationTargetType(
+    model=models.TraceAnnotation,
+    build_id_select=lambda project_rowid, annotation_name: (
+        select(models.TraceAnnotation.id)
+        .join(models.Trace, models.TraceAnnotation.trace_rowid == models.Trace.id)
+        .where(models.Trace.project_rowid == project_rowid)
+        .where(models.TraceAnnotation.name == annotation_name)
+    ),
+    source_start_time=models.Trace.start_time,
+    event_cls=TraceAnnotationDeleteEvent,
+)
+
+_SESSION_TARGET_TYPE = _AnnotationTargetType(
+    model=models.ProjectSessionAnnotation,
+    build_id_select=lambda project_rowid, annotation_name: (
+        select(models.ProjectSessionAnnotation.id)
+        .join(
+            models.ProjectSession,
+            models.ProjectSessionAnnotation.project_session_id == models.ProjectSession.id,
+        )
+        .where(models.ProjectSession.project_id == project_rowid)
+        .where(models.ProjectSessionAnnotation.name == annotation_name)
+    ),
+    source_start_time=models.ProjectSession.start_time,
+    event_cls=ProjectSessionAnnotationDeleteEvent,
+)
 
 
 @strawberry.type
@@ -120,20 +180,7 @@ class ProjectAnnotationMutationMixin:
     async def delete_project_span_annotations(
         self, info: Info[Context, None], input: DeleteProjectAnnotationsInput
     ) -> DeleteProjectAnnotationsByNamePayload:
-        return await _delete_project_annotations_by_name(
-            info,
-            input,
-            model=models.SpanAnnotation,
-            build_id_select=lambda project_rowid: (
-                select(models.SpanAnnotation.id)
-                .join(models.Span, models.SpanAnnotation.span_rowid == models.Span.id)
-                .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
-                .where(models.Trace.project_rowid == project_rowid)
-                .where(models.SpanAnnotation.name == input.annotation_name)
-            ),
-            source_start_time_column=models.Span.start_time,
-            event_cls=SpanAnnotationDeleteEvent,
-        )
+        return await _delete_project_annotations_by_name(info, input, target_type=_SPAN_TARGET_TYPE)
 
     @strawberry.mutation(  # type: ignore
         permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled],
@@ -146,17 +193,7 @@ class ProjectAnnotationMutationMixin:
         self, info: Info[Context, None], input: DeleteProjectAnnotationsInput
     ) -> DeleteProjectAnnotationsByNamePayload:
         return await _delete_project_annotations_by_name(
-            info,
-            input,
-            model=models.TraceAnnotation,
-            build_id_select=lambda project_rowid: (
-                select(models.TraceAnnotation.id)
-                .join(models.Trace, models.TraceAnnotation.trace_rowid == models.Trace.id)
-                .where(models.Trace.project_rowid == project_rowid)
-                .where(models.TraceAnnotation.name == input.annotation_name)
-            ),
-            source_start_time_column=models.Trace.start_time,
-            event_cls=TraceAnnotationDeleteEvent,
+            info, input, target_type=_TRACE_TARGET_TYPE
         )
 
     @strawberry.mutation(  # type: ignore
@@ -170,18 +207,5 @@ class ProjectAnnotationMutationMixin:
         self, info: Info[Context, None], input: DeleteProjectAnnotationsInput
     ) -> DeleteProjectAnnotationsByNamePayload:
         return await _delete_project_annotations_by_name(
-            info,
-            input,
-            model=models.ProjectSessionAnnotation,
-            build_id_select=lambda project_rowid: (
-                select(models.ProjectSessionAnnotation.id)
-                .join(
-                    models.ProjectSession,
-                    models.ProjectSessionAnnotation.project_session_id == models.ProjectSession.id,
-                )
-                .where(models.ProjectSession.project_id == project_rowid)
-                .where(models.ProjectSessionAnnotation.name == input.annotation_name)
-            ),
-            source_start_time_column=models.ProjectSession.start_time,
-            event_cls=ProjectSessionAnnotationDeleteEvent,
+            info, input, target_type=_SESSION_TARGET_TYPE
         )

--- a/src/phoenix/server/api/mutations/project_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/project_annotations_mutations.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any
+from typing import Any, Callable
 
 import strawberry
 from sqlalchemy import Select, delete, select
@@ -17,6 +17,7 @@ from phoenix.server.api.input_types.DeleteProjectAnnotationsInput import (
 from phoenix.server.api.queries import Query
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.dml_event import (
+    DmlEvent,
     ProjectSessionAnnotationDeleteEvent,
     SpanAnnotationDeleteEvent,
     TraceAnnotationDeleteEvent,
@@ -61,6 +62,47 @@ def _apply_time_range(
     return stmt
 
 
+async def _delete_project_annotations_by_name(
+    info: Info[Context, None],
+    input: DeleteProjectAnnotationsInput,
+    *,
+    model: Any,
+    build_id_select: Callable[[int], Select[Any]],
+    source_start_time_column: InstrumentedAttribute[datetime],
+    event_cls: Callable[[tuple[int, ...]], DmlEvent],
+) -> DeleteProjectAnnotationsByNamePayload:
+    """Bulk-delete every annotation matching ``input`` for a single level.
+
+    ``model`` is the annotation ORM class and ``build_id_select`` returns its
+    level-specific ``select`` of annotation ids scoped to the given project. The
+    shared logic validates the input, applies the optional time range, deletes the
+    matching rows in a single round trip, and emits the level-specific DML event
+    for the deleted ids.
+    """
+    if not input.annotation_name:
+        raise BadRequest("An annotation name is required.")
+    try:
+        project_rowid = from_global_id_with_expected_type(input.project_id, "Project")
+    except ValueError:
+        raise BadRequest(f"Invalid project ID: {input.project_id}")
+
+    id_select = _apply_time_range(
+        build_id_select(project_rowid),
+        input,
+        created_at_column=model.created_at,
+        source_start_time_column=source_start_time_column,
+    )
+    stmt = delete(model).where(model.id.in_(id_select)).returning(model.id)
+    async with info.context.db() as session:
+        deleted_ids = tuple(await session.scalars(stmt))
+
+    if deleted_ids:
+        info.context.event_queue.put(event_cls(deleted_ids))
+    return DeleteProjectAnnotationsByNamePayload(
+        deleted_annotation_count=len(deleted_ids), query=Query()
+    )
+
+
 @strawberry.type
 class ProjectAnnotationMutationMixin:
     @strawberry.mutation(  # type: ignore
@@ -73,40 +115,19 @@ class ProjectAnnotationMutationMixin:
     async def delete_project_span_annotations(
         self, info: Info[Context, None], input: DeleteProjectAnnotationsInput
     ) -> DeleteProjectAnnotationsByNamePayload:
-        if not input.annotation_name:
-            raise BadRequest("An annotation name is required.")
-        try:
-            project_rowid = from_global_id_with_expected_type(input.project_id, "Project")
-        except ValueError:
-            raise BadRequest(f"Invalid project ID: {input.project_id}")
-
-        stmt = (
-            select(models.SpanAnnotation.id)
-            .join(models.Span, models.SpanAnnotation.span_rowid == models.Span.id)
-            .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
-            .where(models.Trace.project_rowid == project_rowid)
-            .where(models.SpanAnnotation.name == input.annotation_name)
-        )
-        stmt = _apply_time_range(
-            stmt,
+        return await _delete_project_annotations_by_name(
+            info,
             input,
-            created_at_column=models.SpanAnnotation.created_at,
+            model=models.SpanAnnotation,
+            build_id_select=lambda project_rowid: (
+                select(models.SpanAnnotation.id)
+                .join(models.Span, models.SpanAnnotation.span_rowid == models.Span.id)
+                .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+                .where(models.Trace.project_rowid == project_rowid)
+                .where(models.SpanAnnotation.name == input.annotation_name)
+            ),
             source_start_time_column=models.Span.start_time,
-        )
-
-        async with info.context.db() as session:
-            annotation_ids = list(await session.scalars(stmt))
-            if annotation_ids:
-                await session.execute(
-                    delete(models.SpanAnnotation).where(
-                        models.SpanAnnotation.id.in_(annotation_ids)
-                    )
-                )
-
-        if annotation_ids:
-            info.context.event_queue.put(SpanAnnotationDeleteEvent(tuple(annotation_ids)))
-        return DeleteProjectAnnotationsByNamePayload(
-            deleted_annotation_count=len(annotation_ids), query=Query()
+            event_cls=SpanAnnotationDeleteEvent,
         )
 
     @strawberry.mutation(  # type: ignore
@@ -119,39 +140,18 @@ class ProjectAnnotationMutationMixin:
     async def delete_project_trace_annotations(
         self, info: Info[Context, None], input: DeleteProjectAnnotationsInput
     ) -> DeleteProjectAnnotationsByNamePayload:
-        if not input.annotation_name:
-            raise BadRequest("An annotation name is required.")
-        try:
-            project_rowid = from_global_id_with_expected_type(input.project_id, "Project")
-        except ValueError:
-            raise BadRequest(f"Invalid project ID: {input.project_id}")
-
-        stmt = (
-            select(models.TraceAnnotation.id)
-            .join(models.Trace, models.TraceAnnotation.trace_rowid == models.Trace.id)
-            .where(models.Trace.project_rowid == project_rowid)
-            .where(models.TraceAnnotation.name == input.annotation_name)
-        )
-        stmt = _apply_time_range(
-            stmt,
+        return await _delete_project_annotations_by_name(
+            info,
             input,
-            created_at_column=models.TraceAnnotation.created_at,
+            model=models.TraceAnnotation,
+            build_id_select=lambda project_rowid: (
+                select(models.TraceAnnotation.id)
+                .join(models.Trace, models.TraceAnnotation.trace_rowid == models.Trace.id)
+                .where(models.Trace.project_rowid == project_rowid)
+                .where(models.TraceAnnotation.name == input.annotation_name)
+            ),
             source_start_time_column=models.Trace.start_time,
-        )
-
-        async with info.context.db() as session:
-            annotation_ids = list(await session.scalars(stmt))
-            if annotation_ids:
-                await session.execute(
-                    delete(models.TraceAnnotation).where(
-                        models.TraceAnnotation.id.in_(annotation_ids)
-                    )
-                )
-
-        if annotation_ids:
-            info.context.event_queue.put(TraceAnnotationDeleteEvent(tuple(annotation_ids)))
-        return DeleteProjectAnnotationsByNamePayload(
-            deleted_annotation_count=len(annotation_ids), query=Query()
+            event_cls=TraceAnnotationDeleteEvent,
         )
 
     @strawberry.mutation(  # type: ignore
@@ -164,40 +164,19 @@ class ProjectAnnotationMutationMixin:
     async def delete_project_session_annotations(
         self, info: Info[Context, None], input: DeleteProjectAnnotationsInput
     ) -> DeleteProjectAnnotationsByNamePayload:
-        if not input.annotation_name:
-            raise BadRequest("An annotation name is required.")
-        try:
-            project_rowid = from_global_id_with_expected_type(input.project_id, "Project")
-        except ValueError:
-            raise BadRequest(f"Invalid project ID: {input.project_id}")
-
-        stmt = (
-            select(models.ProjectSessionAnnotation.id)
-            .join(
-                models.ProjectSession,
-                models.ProjectSessionAnnotation.project_session_id == models.ProjectSession.id,
-            )
-            .where(models.ProjectSession.project_id == project_rowid)
-            .where(models.ProjectSessionAnnotation.name == input.annotation_name)
-        )
-        stmt = _apply_time_range(
-            stmt,
+        return await _delete_project_annotations_by_name(
+            info,
             input,
-            created_at_column=models.ProjectSessionAnnotation.created_at,
-            source_start_time_column=models.ProjectSession.start_time,
-        )
-
-        async with info.context.db() as session:
-            annotation_ids = list(await session.scalars(stmt))
-            if annotation_ids:
-                await session.execute(
-                    delete(models.ProjectSessionAnnotation).where(
-                        models.ProjectSessionAnnotation.id.in_(annotation_ids)
-                    )
+            model=models.ProjectSessionAnnotation,
+            build_id_select=lambda project_rowid: (
+                select(models.ProjectSessionAnnotation.id)
+                .join(
+                    models.ProjectSession,
+                    models.ProjectSessionAnnotation.project_session_id == models.ProjectSession.id,
                 )
-
-        if annotation_ids:
-            info.context.event_queue.put(ProjectSessionAnnotationDeleteEvent(tuple(annotation_ids)))
-        return DeleteProjectAnnotationsByNamePayload(
-            deleted_annotation_count=len(annotation_ids), query=Query()
+                .where(models.ProjectSession.project_id == project_rowid)
+                .where(models.ProjectSessionAnnotation.name == input.annotation_name)
+            ),
+            source_start_time_column=models.ProjectSession.start_time,
+            event_cls=ProjectSessionAnnotationDeleteEvent,
         )

--- a/src/phoenix/server/api/types/AnnotationNameCount.py
+++ b/src/phoenix/server/api/types/AnnotationNameCount.py
@@ -3,8 +3,8 @@ import strawberry
 
 @strawberry.type
 class AnnotationNameCount:
-    """The number of annotations that share a given name at a particular level
-    (span, trace, or session) within a project."""
+    """The number of annotations that share a given name for a particular target
+    type (span, trace, or session) within a project."""
 
     name: str
     count: int

--- a/src/phoenix/server/api/types/AnnotationNameCount.py
+++ b/src/phoenix/server/api/types/AnnotationNameCount.py
@@ -1,0 +1,10 @@
+import strawberry
+
+
+@strawberry.type
+class AnnotationNameCount:
+    """The number of annotations that share a given name at a particular level
+    (span, trace, or session) within a project."""
+
+    name: str
+    count: int

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -132,6 +132,15 @@ def _sort_token_count_details(details: list["TraceTokenCountDetailsTimeSeriesEnt
     )
 
 
+async def _annotation_name_counts(
+    info: Info[Context, None], stmt: Select[Any]
+) -> list[AnnotationNameCount]:
+    """Run a ``(name, count)`` aggregation query and map it to ``AnnotationNameCount``."""
+    async with info.context.db.read() as session:
+        result = (await session.execute(stmt)).all()
+    return [AnnotationNameCount(name=name, count=count) for name, count in result]
+
+
 @strawberry.type
 class Project(Node):
     id: NodeID[int]
@@ -681,9 +690,7 @@ class Project(Node):
             .group_by(models.SpanAnnotation.name)
             .order_by(models.SpanAnnotation.name)
         )
-        async with info.context.db.read() as session:
-            result = (await session.execute(stmt)).all()
-        return [AnnotationNameCount(name=name, count=count) for name, count in result]
+        return await _annotation_name_counts(info, stmt)
 
     @strawberry.field(
         description="Trace annotation names along with the number of trace annotations "
@@ -700,9 +707,7 @@ class Project(Node):
             .group_by(models.TraceAnnotation.name)
             .order_by(models.TraceAnnotation.name)
         )
-        async with info.context.db.read() as session:
-            result = (await session.execute(stmt)).all()
-        return [AnnotationNameCount(name=name, count=count) for name, count in result]
+        return await _annotation_name_counts(info, stmt)
 
     @strawberry.field(
         description="Session annotation names along with the number of session annotations "
@@ -725,9 +730,7 @@ class Project(Node):
             .group_by(models.ProjectSessionAnnotation.name)
             .order_by(models.ProjectSessionAnnotation.name)
         )
-        async with info.context.db.read() as session:
-            result = (await session.execute(stmt)).all()
-        return [AnnotationNameCount(name=name, count=count) for name, count in result]
+        return await _annotation_name_counts(info, stmt)
 
     @strawberry.field(
         description="Names of available document evaluations.",

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -29,6 +29,7 @@ from phoenix.server.api.input_types.SpanSort import SpanColumn, SpanSort, SpanSo
 from phoenix.server.api.input_types.TimeBinConfig import TimeBinConfig, TimeBinScale
 from phoenix.server.api.input_types.TimeRange import TimeRange
 from phoenix.server.api.types.AnnotationConfig import AnnotationConfig, to_gql_annotation_config
+from phoenix.server.api.types.AnnotationNameCount import AnnotationNameCount
 from phoenix.server.api.types.AnnotationSummary import AnnotationSummary
 from phoenix.server.api.types.CostBreakdown import CostBreakdown
 from phoenix.server.api.types.DocumentEvaluationSummary import DocumentEvaluationSummary
@@ -663,6 +664,70 @@ class Project(Node):
         )
         async with info.context.db.read() as session:
             return list(await session.scalars(stmt))
+
+    @strawberry.field(
+        description="Span annotation names along with the number of span annotations "
+        "that have been added for each name in this project."
+    )  # type: ignore
+    async def span_annotation_name_counts(
+        self,
+        info: Info[Context, None],
+    ) -> list[AnnotationNameCount]:
+        stmt = (
+            select(models.SpanAnnotation.name, func.count(models.SpanAnnotation.id))
+            .join(models.Span, models.SpanAnnotation.span_rowid == models.Span.id)
+            .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+            .where(models.Trace.project_rowid == self.id)
+            .group_by(models.SpanAnnotation.name)
+            .order_by(models.SpanAnnotation.name)
+        )
+        async with info.context.db.read() as session:
+            result = (await session.execute(stmt)).all()
+        return [AnnotationNameCount(name=name, count=count) for name, count in result]
+
+    @strawberry.field(
+        description="Trace annotation names along with the number of trace annotations "
+        "that have been added for each name in this project."
+    )  # type: ignore
+    async def trace_annotation_name_counts(
+        self,
+        info: Info[Context, None],
+    ) -> list[AnnotationNameCount]:
+        stmt = (
+            select(models.TraceAnnotation.name, func.count(models.TraceAnnotation.id))
+            .join(models.Trace, models.TraceAnnotation.trace_rowid == models.Trace.id)
+            .where(models.Trace.project_rowid == self.id)
+            .group_by(models.TraceAnnotation.name)
+            .order_by(models.TraceAnnotation.name)
+        )
+        async with info.context.db.read() as session:
+            result = (await session.execute(stmt)).all()
+        return [AnnotationNameCount(name=name, count=count) for name, count in result]
+
+    @strawberry.field(
+        description="Session annotation names along with the number of session annotations "
+        "that have been added for each name in this project."
+    )  # type: ignore
+    async def session_annotation_name_counts(
+        self,
+        info: Info[Context, None],
+    ) -> list[AnnotationNameCount]:
+        stmt = (
+            select(
+                models.ProjectSessionAnnotation.name,
+                func.count(models.ProjectSessionAnnotation.id),
+            )
+            .join(
+                models.ProjectSession,
+                models.ProjectSessionAnnotation.project_session_id == models.ProjectSession.id,
+            )
+            .where(models.ProjectSession.project_id == self.id)
+            .group_by(models.ProjectSessionAnnotation.name)
+            .order_by(models.ProjectSessionAnnotation.name)
+        )
+        async with info.context.db.read() as session:
+            result = (await session.execute(stmt)).all()
+        return [AnnotationNameCount(name=name, count=count) for name, count in result]
 
     @strawberry.field(
         description="Names of available document evaluations.",

--- a/tests/unit/server/api/mutations/test_project_annotation_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_annotation_mutations.py
@@ -1,0 +1,277 @@
+from datetime import datetime, timezone
+from secrets import token_hex
+
+import pytest
+from sqlalchemy import func, select
+from strawberry.relay.types import GlobalID
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+from tests.unit.graphql import AsyncGraphQLClient
+
+OLD = datetime(2020, 1, 1, tzinfo=timezone.utc)
+MID = datetime(2020, 6, 1, tzinfo=timezone.utc)
+NEW = datetime(2020, 12, 1, tzinfo=timezone.utc)
+
+PROJECT_ID = str(GlobalID("Project", "1"))
+
+DELETE_SPAN = """
+mutation ($input: DeleteProjectAnnotationsInput!) {
+  deleteProjectSpanAnnotations(input: $input) {
+    deletedAnnotationCount
+  }
+}
+"""
+
+DELETE_TRACE = """
+mutation ($input: DeleteProjectAnnotationsInput!) {
+  deleteProjectTraceAnnotations(input: $input) {
+    deletedAnnotationCount
+  }
+}
+"""
+
+DELETE_SESSION = """
+mutation ($input: DeleteProjectAnnotationsInput!) {
+  deleteProjectSessionAnnotations(input: $input) {
+    deletedAnnotationCount
+  }
+}
+"""
+
+
+@pytest.fixture(autouse=True)
+async def annotation_data(db: DbSessionFactory) -> None:
+    """A project with span/trace/session annotations at two distinct timestamps.
+
+    For span annotations, the annotation ``created_at`` is deliberately set to the
+    opposite of the source span ``start_time`` so the two time-range fields select
+    different rows:
+
+    - span_old: source start_time=OLD, annotation created_at=NEW
+    - span_new: source start_time=NEW, annotation created_at=OLD
+    """
+    async with db() as session:
+        project = models.Project(name="default")
+        session.add(project)
+        await session.flush()
+
+        trace_old = models.Trace(
+            project_rowid=project.id,
+            trace_id="trace-old",
+            start_time=OLD,
+            end_time=OLD,
+        )
+        trace_new = models.Trace(
+            project_rowid=project.id,
+            trace_id="trace-new",
+            start_time=NEW,
+            end_time=NEW,
+        )
+        session.add_all([trace_old, trace_new])
+        await session.flush()
+
+        def _span(trace_rowid: int, span_id: str, start_time: datetime) -> models.Span:
+            return models.Span(
+                trace_rowid=trace_rowid,
+                span_id=span_id,
+                name=span_id,
+                span_kind="internal",
+                start_time=start_time,
+                end_time=start_time,
+                attributes={},
+                events=[],
+                status_code="OK",
+                status_message="",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+
+        span_old = _span(trace_old.id, "span-old", OLD)
+        span_new = _span(trace_new.id, "span-new", NEW)
+        session.add_all([span_old, span_new])
+
+        session_old = models.ProjectSession(
+            project_id=project.id, session_id="sess-old", start_time=OLD, end_time=OLD
+        )
+        session_new = models.ProjectSession(
+            project_id=project.id, session_id="sess-new", start_time=NEW, end_time=NEW
+        )
+        session.add_all([session_old, session_new])
+        await session.flush()
+
+        def _span_anno(span_rowid: int, name: str, created_at: datetime) -> models.SpanAnnotation:
+            return models.SpanAnnotation(
+                span_rowid=span_rowid,
+                name=name,
+                annotator_kind="HUMAN",
+                source="APP",
+                metadata_={},
+                identifier=token_hex(4),
+                created_at=created_at,
+            )
+
+        # span "quality": created_at opposite of source start_time; plus a "relevance"
+        session.add_all(
+            [
+                _span_anno(span_old.id, "quality", NEW),
+                _span_anno(span_new.id, "quality", OLD),
+                _span_anno(span_old.id, "relevance", NEW),
+            ]
+        )
+
+        for trace_rowid, created_at in ((trace_old.id, OLD), (trace_new.id, NEW)):
+            session.add(
+                models.TraceAnnotation(
+                    trace_rowid=trace_rowid,
+                    name="quality",
+                    annotator_kind="HUMAN",
+                    source="APP",
+                    metadata_={},
+                    identifier=token_hex(4),
+                    created_at=created_at,
+                )
+            )
+
+        for sess_rowid, created_at in ((session_old.id, OLD), (session_new.id, NEW)):
+            session.add(
+                models.ProjectSessionAnnotation(
+                    project_session_id=sess_rowid,
+                    name="quality",
+                    annotator_kind="HUMAN",
+                    source="APP",
+                    metadata_={},
+                    identifier=token_hex(4),
+                    created_at=created_at,
+                )
+            )
+
+        await session.commit()
+
+
+async def _span_count(db: DbSessionFactory, name: str) -> int:
+    async with db() as session:
+        return await session.scalar(  # type: ignore[return-value]
+            select(func.count())
+            .select_from(models.SpanAnnotation)
+            .where(models.SpanAnnotation.name == name)
+        )
+
+
+class TestProjectAnnotationMutations:
+    async def test_delete_all_span_annotations_by_name(
+        self, db: DbSessionFactory, gql_client: AsyncGraphQLClient
+    ) -> None:
+        result = await gql_client.execute(
+            DELETE_SPAN,
+            {"input": {"projectId": PROJECT_ID, "annotationName": "quality"}},
+        )
+        assert not result.errors
+        assert result.data is not None
+        assert result.data["deleteProjectSpanAnnotations"]["deletedAnnotationCount"] == 2
+        # The matching annotations are gone; other names are untouched.
+        assert await _span_count(db, "quality") == 0
+        assert await _span_count(db, "relevance") == 1
+
+    async def test_delete_span_annotations_filters_by_created_at(
+        self, db: DbSessionFactory, gql_client: AsyncGraphQLClient
+    ) -> None:
+        # Range [MID, inf) over created_at selects span_old's annotation (created NEW).
+        result = await gql_client.execute(
+            DELETE_SPAN,
+            {
+                "input": {
+                    "projectId": PROJECT_ID,
+                    "annotationName": "quality",
+                    "timeRange": {"start": MID.isoformat()},
+                    "timeRangeField": "ANNOTATION_CREATED_AT",
+                }
+            },
+        )
+        assert not result.errors
+        assert result.data is not None
+        assert result.data["deleteProjectSpanAnnotations"]["deletedAnnotationCount"] == 1
+        # Only one "quality" remains (the one created OLD on span_new).
+        assert await _span_count(db, "quality") == 1
+
+    async def test_delete_span_annotations_filters_by_source_start_time(
+        self, db: DbSessionFactory, gql_client: AsyncGraphQLClient
+    ) -> None:
+        # Range [MID, inf) over source start_time selects span_new's annotation.
+        result = await gql_client.execute(
+            DELETE_SPAN,
+            {
+                "input": {
+                    "projectId": PROJECT_ID,
+                    "annotationName": "quality",
+                    "timeRange": {"start": MID.isoformat()},
+                    "timeRangeField": "SOURCE_START_TIME",
+                }
+            },
+        )
+        assert not result.errors
+        assert result.data is not None
+        assert result.data["deleteProjectSpanAnnotations"]["deletedAnnotationCount"] == 1
+        assert await _span_count(db, "quality") == 1
+
+    async def test_delete_trace_annotations_by_name(self, gql_client: AsyncGraphQLClient) -> None:
+        result = await gql_client.execute(
+            DELETE_TRACE,
+            {"input": {"projectId": PROJECT_ID, "annotationName": "quality"}},
+        )
+        assert not result.errors
+        assert result.data is not None
+        assert result.data["deleteProjectTraceAnnotations"]["deletedAnnotationCount"] == 2
+
+    async def test_delete_session_annotations_by_name(self, gql_client: AsyncGraphQLClient) -> None:
+        result = await gql_client.execute(
+            DELETE_SESSION,
+            {"input": {"projectId": PROJECT_ID, "annotationName": "quality"}},
+        )
+        assert not result.errors
+        assert result.data is not None
+        assert result.data["deleteProjectSessionAnnotations"]["deletedAnnotationCount"] == 2
+
+    async def test_delete_with_no_matches_returns_zero(
+        self, gql_client: AsyncGraphQLClient
+    ) -> None:
+        result = await gql_client.execute(
+            DELETE_SPAN,
+            {"input": {"projectId": PROJECT_ID, "annotationName": "does-not-exist"}},
+        )
+        assert not result.errors
+        assert result.data is not None
+        assert result.data["deleteProjectSpanAnnotations"]["deletedAnnotationCount"] == 0
+
+    async def test_delete_with_invalid_time_range_errors(
+        self, gql_client: AsyncGraphQLClient
+    ) -> None:
+        result = await gql_client.execute(
+            DELETE_SPAN,
+            {
+                "input": {
+                    "projectId": PROJECT_ID,
+                    "annotationName": "quality",
+                    "timeRange": {"start": NEW.isoformat(), "end": OLD.isoformat()},
+                }
+            },
+        )
+        assert result.errors
+        assert "Invalid time range" in result.errors[0].message
+
+    async def test_delete_with_invalid_project_id_errors(
+        self, gql_client: AsyncGraphQLClient
+    ) -> None:
+        # A well-formed global ID of the wrong node type is rejected by the resolver.
+        result = await gql_client.execute(
+            DELETE_SPAN,
+            {
+                "input": {
+                    "projectId": str(GlobalID("Span", "1")),
+                    "annotationName": "quality",
+                }
+            },
+        )
+        assert result.errors
+        assert "Invalid project ID" in result.errors[0].message

--- a/tests/unit/server/api/mutations/test_project_annotation_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_annotation_mutations.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from secrets import token_hex
 
@@ -12,8 +13,6 @@ from tests.unit.graphql import AsyncGraphQLClient
 OLD = datetime(2020, 1, 1, tzinfo=timezone.utc)
 MID = datetime(2020, 6, 1, tzinfo=timezone.utc)
 NEW = datetime(2020, 12, 1, tzinfo=timezone.utc)
-
-PROJECT_ID = str(GlobalID("Project", "1"))
 
 DELETE_SPAN = """
 mutation ($input: DeleteProjectAnnotationsInput!) {
@@ -40,8 +39,15 @@ mutation ($input: DeleteProjectAnnotationsInput!) {
 """
 
 
+@dataclass(frozen=True)
+class AnnotationData:
+    project_rowid: int
+    project_id: str
+    other_project_rowid: int
+
+
 @pytest.fixture(autouse=True)
-async def annotation_data(db: DbSessionFactory) -> None:
+async def annotation_data(db: DbSessionFactory) -> AnnotationData:
     """A project with span/trace/session annotations at two distinct timestamps.
 
     For span annotations, the annotation ``created_at`` is deliberately set to the
@@ -53,7 +59,8 @@ async def annotation_data(db: DbSessionFactory) -> None:
     """
     async with db() as session:
         project = models.Project(name="default")
-        session.add(project)
+        other_project = models.Project(name="other")
+        session.add_all([project, other_project])
         await session.flush()
 
         trace_old = models.Trace(
@@ -68,7 +75,13 @@ async def annotation_data(db: DbSessionFactory) -> None:
             start_time=NEW,
             end_time=NEW,
         )
-        session.add_all([trace_old, trace_new])
+        other_trace = models.Trace(
+            project_rowid=other_project.id,
+            trace_id="trace-other",
+            start_time=NEW,
+            end_time=NEW,
+        )
+        session.add_all([trace_old, trace_new, other_trace])
         await session.flush()
 
         def _span(trace_rowid: int, span_id: str, start_time: datetime) -> models.Span:
@@ -90,7 +103,8 @@ async def annotation_data(db: DbSessionFactory) -> None:
 
         span_old = _span(trace_old.id, "span-old", OLD)
         span_new = _span(trace_new.id, "span-new", NEW)
-        session.add_all([span_old, span_new])
+        other_span = _span(other_trace.id, "span-other", NEW)
+        session.add_all([span_old, span_new, other_span])
 
         session_old = models.ProjectSession(
             project_id=project.id, session_id="sess-old", start_time=OLD, end_time=OLD
@@ -98,7 +112,13 @@ async def annotation_data(db: DbSessionFactory) -> None:
         session_new = models.ProjectSession(
             project_id=project.id, session_id="sess-new", start_time=NEW, end_time=NEW
         )
-        session.add_all([session_old, session_new])
+        other_session = models.ProjectSession(
+            project_id=other_project.id,
+            session_id="sess-other",
+            start_time=NEW,
+            end_time=NEW,
+        )
+        session.add_all([session_old, session_new, other_session])
         await session.flush()
 
         def _span_anno(span_rowid: int, name: str, created_at: datetime) -> models.SpanAnnotation:
@@ -118,10 +138,15 @@ async def annotation_data(db: DbSessionFactory) -> None:
                 _span_anno(span_old.id, "quality", NEW),
                 _span_anno(span_new.id, "quality", OLD),
                 _span_anno(span_old.id, "relevance", NEW),
+                _span_anno(other_span.id, "quality", NEW),
             ]
         )
 
-        for trace_rowid, created_at in ((trace_old.id, OLD), (trace_new.id, NEW)):
+        for trace_rowid, created_at in (
+            (trace_old.id, OLD),
+            (trace_new.id, NEW),
+            (other_trace.id, NEW),
+        ):
             session.add(
                 models.TraceAnnotation(
                     trace_rowid=trace_rowid,
@@ -134,7 +159,11 @@ async def annotation_data(db: DbSessionFactory) -> None:
                 )
             )
 
-        for sess_rowid, created_at in ((session_old.id, OLD), (session_new.id, NEW)):
+        for sess_rowid, created_at in (
+            (session_old.id, OLD),
+            (session_new.id, NEW),
+            (other_session.id, NEW),
+        ):
             session.add(
                 models.ProjectSessionAnnotation(
                     project_session_id=sess_rowid,
@@ -148,41 +177,81 @@ async def annotation_data(db: DbSessionFactory) -> None:
             )
 
         await session.commit()
+        return AnnotationData(
+            project_rowid=project.id,
+            project_id=str(GlobalID("Project", str(project.id))),
+            other_project_rowid=other_project.id,
+        )
 
 
-async def _span_count(db: DbSessionFactory, name: str) -> int:
+async def _span_count(db: DbSessionFactory, project_rowid: int, name: str) -> int:
     async with db() as session:
         return await session.scalar(  # type: ignore[return-value]
             select(func.count())
             .select_from(models.SpanAnnotation)
+            .join(models.Span, models.SpanAnnotation.span_rowid == models.Span.id)
+            .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+            .where(models.Trace.project_rowid == project_rowid)
             .where(models.SpanAnnotation.name == name)
+        )
+
+
+async def _trace_count(db: DbSessionFactory, project_rowid: int, name: str) -> int:
+    async with db() as session:
+        return await session.scalar(  # type: ignore[return-value]
+            select(func.count())
+            .select_from(models.TraceAnnotation)
+            .join(models.Trace, models.TraceAnnotation.trace_rowid == models.Trace.id)
+            .where(models.Trace.project_rowid == project_rowid)
+            .where(models.TraceAnnotation.name == name)
+        )
+
+
+async def _session_count(db: DbSessionFactory, project_rowid: int, name: str) -> int:
+    async with db() as session:
+        return await session.scalar(  # type: ignore[return-value]
+            select(func.count())
+            .select_from(models.ProjectSessionAnnotation)
+            .join(
+                models.ProjectSession,
+                models.ProjectSessionAnnotation.project_session_id == models.ProjectSession.id,
+            )
+            .where(models.ProjectSession.project_id == project_rowid)
+            .where(models.ProjectSessionAnnotation.name == name)
         )
 
 
 class TestProjectAnnotationMutations:
     async def test_delete_all_span_annotations_by_name(
-        self, db: DbSessionFactory, gql_client: AsyncGraphQLClient
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+        annotation_data: AnnotationData,
     ) -> None:
         result = await gql_client.execute(
             DELETE_SPAN,
-            {"input": {"projectId": PROJECT_ID, "annotationName": "quality"}},
+            {"input": {"projectId": annotation_data.project_id, "annotationName": "quality"}},
         )
         assert not result.errors
         assert result.data is not None
         assert result.data["deleteProjectSpanAnnotations"]["deletedAnnotationCount"] == 2
         # The matching annotations are gone; other names are untouched.
-        assert await _span_count(db, "quality") == 0
-        assert await _span_count(db, "relevance") == 1
+        assert await _span_count(db, annotation_data.project_rowid, "quality") == 0
+        assert await _span_count(db, annotation_data.project_rowid, "relevance") == 1
+        assert await _span_count(db, annotation_data.other_project_rowid, "quality") == 1
 
     async def test_delete_span_annotations_filters_by_created_at(
-        self, db: DbSessionFactory, gql_client: AsyncGraphQLClient
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+        annotation_data: AnnotationData,
     ) -> None:
         # Range [MID, inf) over created_at selects span_old's annotation (created NEW).
         result = await gql_client.execute(
             DELETE_SPAN,
             {
                 "input": {
-                    "projectId": PROJECT_ID,
+                    "projectId": annotation_data.project_id,
                     "annotationName": "quality",
                     "timeRange": {"start": MID.isoformat()},
                     "timeRangeField": "ANNOTATION_CREATED_AT",
@@ -193,17 +262,21 @@ class TestProjectAnnotationMutations:
         assert result.data is not None
         assert result.data["deleteProjectSpanAnnotations"]["deletedAnnotationCount"] == 1
         # Only one "quality" remains (the one created OLD on span_new).
-        assert await _span_count(db, "quality") == 1
+        assert await _span_count(db, annotation_data.project_rowid, "quality") == 1
+        assert await _span_count(db, annotation_data.other_project_rowid, "quality") == 1
 
     async def test_delete_span_annotations_filters_by_source_start_time(
-        self, db: DbSessionFactory, gql_client: AsyncGraphQLClient
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+        annotation_data: AnnotationData,
     ) -> None:
         # Range [MID, inf) over source start_time selects span_new's annotation.
         result = await gql_client.execute(
             DELETE_SPAN,
             {
                 "input": {
-                    "projectId": PROJECT_ID,
+                    "projectId": annotation_data.project_id,
                     "annotationName": "quality",
                     "timeRange": {"start": MID.isoformat()},
                     "timeRangeField": "SOURCE_START_TIME",
@@ -213,45 +286,65 @@ class TestProjectAnnotationMutations:
         assert not result.errors
         assert result.data is not None
         assert result.data["deleteProjectSpanAnnotations"]["deletedAnnotationCount"] == 1
-        assert await _span_count(db, "quality") == 1
+        assert await _span_count(db, annotation_data.project_rowid, "quality") == 1
+        assert await _span_count(db, annotation_data.other_project_rowid, "quality") == 1
 
-    async def test_delete_trace_annotations_by_name(self, gql_client: AsyncGraphQLClient) -> None:
+    async def test_delete_trace_annotations_by_name(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+        annotation_data: AnnotationData,
+    ) -> None:
         result = await gql_client.execute(
             DELETE_TRACE,
-            {"input": {"projectId": PROJECT_ID, "annotationName": "quality"}},
+            {"input": {"projectId": annotation_data.project_id, "annotationName": "quality"}},
         )
         assert not result.errors
         assert result.data is not None
         assert result.data["deleteProjectTraceAnnotations"]["deletedAnnotationCount"] == 2
+        assert await _trace_count(db, annotation_data.project_rowid, "quality") == 0
+        assert await _trace_count(db, annotation_data.other_project_rowid, "quality") == 1
 
-    async def test_delete_session_annotations_by_name(self, gql_client: AsyncGraphQLClient) -> None:
+    async def test_delete_session_annotations_by_name(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+        annotation_data: AnnotationData,
+    ) -> None:
         result = await gql_client.execute(
             DELETE_SESSION,
-            {"input": {"projectId": PROJECT_ID, "annotationName": "quality"}},
+            {"input": {"projectId": annotation_data.project_id, "annotationName": "quality"}},
         )
         assert not result.errors
         assert result.data is not None
         assert result.data["deleteProjectSessionAnnotations"]["deletedAnnotationCount"] == 2
+        assert await _session_count(db, annotation_data.project_rowid, "quality") == 0
+        assert await _session_count(db, annotation_data.other_project_rowid, "quality") == 1
 
     async def test_delete_with_no_matches_returns_zero(
-        self, gql_client: AsyncGraphQLClient
+        self, gql_client: AsyncGraphQLClient, annotation_data: AnnotationData
     ) -> None:
         result = await gql_client.execute(
             DELETE_SPAN,
-            {"input": {"projectId": PROJECT_ID, "annotationName": "does-not-exist"}},
+            {
+                "input": {
+                    "projectId": annotation_data.project_id,
+                    "annotationName": "does-not-exist",
+                }
+            },
         )
         assert not result.errors
         assert result.data is not None
         assert result.data["deleteProjectSpanAnnotations"]["deletedAnnotationCount"] == 0
 
     async def test_delete_with_invalid_time_range_errors(
-        self, gql_client: AsyncGraphQLClient
+        self, gql_client: AsyncGraphQLClient, annotation_data: AnnotationData
     ) -> None:
         result = await gql_client.execute(
             DELETE_SPAN,
             {
                 "input": {
-                    "projectId": PROJECT_ID,
+                    "projectId": annotation_data.project_id,
                     "annotationName": "quality",
                     "timeRange": {"start": NEW.isoformat(), "end": OLD.isoformat()},
                 }
@@ -259,6 +352,24 @@ class TestProjectAnnotationMutations:
         )
         assert result.errors
         assert "Invalid time range" in result.errors[0].message
+
+    async def test_delete_with_unknown_project_id_errors(
+        self, gql_client: AsyncGraphQLClient, annotation_data: AnnotationData
+    ) -> None:
+        unknown_project_id = str(
+            GlobalID("Project", str(annotation_data.other_project_rowid + 1000))
+        )
+        result = await gql_client.execute(
+            DELETE_SPAN,
+            {
+                "input": {
+                    "projectId": unknown_project_id,
+                    "annotationName": "quality",
+                }
+            },
+        )
+        assert result.errors
+        assert "Could not find project" in result.errors[0].message
 
     async def test_delete_with_invalid_project_id_errors(
         self, gql_client: AsyncGraphQLClient

--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -1849,6 +1849,88 @@ class TestProject:
     ) -> Any:
         return await _node(field, Project.__name__, project.id, httpx_client)
 
+    async def test_annotation_name_counts(
+        self,
+        db: DbSessionFactory,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        """Span/trace/session annotation name counts reflect the number of annotations per name."""
+        async with db() as session:
+            project = await _add_project(session, name="annotation-name-counts-test")
+            project_session = await _add_project_session(session, project)
+            trace = await _add_trace(session, project, project_session)
+            span = await _add_span(session, trace)
+
+            # 2 span annotations named "correctness", 1 named "relevance"
+            for name in ("correctness", "correctness", "relevance"):
+                session.add(
+                    models.SpanAnnotation(
+                        span_rowid=span.id,
+                        name=name,
+                        annotator_kind="HUMAN",
+                        source="APP",
+                        metadata_={},
+                        identifier=token_hex(4),
+                    )
+                )
+            # 3 trace annotations named "quality"
+            for _ in range(3):
+                session.add(
+                    models.TraceAnnotation(
+                        trace_rowid=trace.id,
+                        name="quality",
+                        annotator_kind="HUMAN",
+                        source="APP",
+                        metadata_={},
+                        identifier=token_hex(4),
+                    )
+                )
+            # 1 session annotation named "helpfulness"
+            session.add(
+                models.ProjectSessionAnnotation(
+                    project_session_id=project_session.id,
+                    name="helpfulness",
+                    annotator_kind="HUMAN",
+                    source="APP",
+                    metadata_={},
+                    identifier=token_hex(4),
+                )
+            )
+
+        span_counts = await self._node(
+            "spanAnnotationNameCounts{name count}", project, httpx_client
+        )
+        assert span_counts == [
+            {"name": "correctness", "count": 2},
+            {"name": "relevance", "count": 1},
+        ]
+
+        trace_counts = await self._node(
+            "traceAnnotationNameCounts{name count}", project, httpx_client
+        )
+        assert trace_counts == [{"name": "quality", "count": 3}]
+
+        session_counts = await self._node(
+            "sessionAnnotationNameCounts{name count}", project, httpx_client
+        )
+        assert session_counts == [{"name": "helpfulness", "count": 1}]
+
+    async def test_annotation_name_counts_empty(
+        self,
+        db: DbSessionFactory,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        """Projects without annotations return empty lists for each level."""
+        async with db() as session:
+            project = await _add_project(session, name="annotation-name-counts-empty")
+        assert await self._node("spanAnnotationNameCounts{name count}", project, httpx_client) == []
+        assert (
+            await self._node("traceAnnotationNameCounts{name count}", project, httpx_client) == []
+        )
+        assert (
+            await self._node("sessionAnnotationNameCounts{name count}", project, httpx_client) == []
+        )
+
     @pytest.fixture
     async def _data(
         self,


### PR DESCRIPTION
## Why

You can annotate spans, traces, and sessions to gather analytics, but there was no way to see — or clean up — which annotations a project actually has. This PR adds that view to the project **Config** page, and lets admins **bulk-delete** annotations by name.

The summary is **one "Annotations" card** with a **collapsible section per target type** (span / trace / session), collapsed by default. Rationale: a project can accumulate many annotation names across three target types; three always-open cards pushed the rest of the Config page far down the screen. A single card with collapsed sections keeps the page dense — you see the totals at a glance and expand only the target type you care about.

## Screenshots

**Collapsed by default — dense, totals at a glance**

![annotations card collapsed](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/13850-annotations-collapsed.png)

**Expand a section to see per-name counts and the delete action**

![annotations card expanded](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/13850-annotations-expanded.png)

**Bulk-delete confirmation (with optional time range)**

![delete dialog](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/13850-delete-dialog-v2.png)

## Tests
- `TestProject::test_annotation_name_counts` / `test_annotation_name_counts_empty` cover counts across all three target types.
- `TestProjectAnnotationMutations` covers delete-all, time-range filtering on both `created_at` and source `start_time`, trace/session deletes, no-match, invalid time range, and invalid project id.

## Verification
- `make graphql` clean/idempotent; Python `ruff` / `mypy` / unit tests pass; frontend `tsc --noEmit` / `oxlint` / `oxfmt` pass.
