### PR TITLE
feat(annotations): show trace-level annotations in trace header

### DIFF
--- a/app/src/components/annotation/AnnotationSummaryGroup.tsx
+++ b/app/src/components/annotation/AnnotationSummaryGroup.tsx
@@ -6,6 +6,7 @@ import { Flex } from "@phoenix/components";
 import type { AnnotationSummaryGroup$key } from "@phoenix/components/annotation/__generated__/AnnotationSummaryGroup.graphql";
 import { AnnotationLabel } from "@phoenix/components/annotation/AnnotationLabel";
 import { AnnotationSummaryPopover } from "@phoenix/components/annotation/AnnotationSummaryPopover";
+import { Divider } from "@phoenix/components/core/layout";
 import {
   Summary,
   SummaryValue,
@@ -135,6 +136,27 @@ const annotationLabelCSS = css`
   display: flex;
 `;
 
+/**
+ * Lays out a row of annotation summary stacks as peer columns alongside the
+ * other header metrics (status, cost, latency). An optional leading divider
+ * segments this group from whatever precedes it — the trace metrics, or a
+ * sibling annotation group (e.g. root span vs. trace) — without consuming the
+ * vertical space a stacked section label would. The divider is owned by the
+ * group so an empty group leaves no dangling separator behind.
+ */
+export const AnnotationSummaryGroupStacksRow = ({
+  leadingDivider = false,
+  children,
+}: {
+  leadingDivider?: boolean;
+  children: React.ReactNode;
+}) => (
+  <Flex direction="row" gap="size-400" alignItems="stretch" flex="none">
+    {leadingDivider ? <Divider orientation="vertical" /> : null}
+    {children}
+  </Flex>
+);
+
 export const AnnotationSummaryGroupTokens = ({
   span,
   showFilterActions = false,
@@ -198,39 +220,44 @@ export const AnnotationSummaryGroupTokens = ({
 export const AnnotationSummaryGroupStacks = ({
   span,
   renderEmptyState,
-}: AnnotationSummaryGroupProps) => {
+  leadingDivider = false,
+}: AnnotationSummaryGroupProps & { leadingDivider?: boolean }) => {
   const {
     sortedSummariesByName,
     annotationsByName,
     categoricalAnnotationConfigsByName,
   } = useAnnotationSummaryGroup(span);
 
-  if (sortedSummariesByName.length === 0 && renderEmptyState) {
-    return renderEmptyState();
+  const stacks = sortedSummariesByName
+    .map((summary) => {
+      const latestAnnotation = annotationsByName[summary.name]?.[0];
+      if (!latestAnnotation) {
+        return null;
+      }
+      return (
+        <Summary name={latestAnnotation.name} key={latestAnnotation.id}>
+          <SummaryValue
+            name={latestAnnotation.name}
+            meanScore={summary.meanScore}
+            labelFractions={summary.labelFractions}
+            count={summary.count}
+            scoreCount={summary.scoreCount}
+            labelCount={summary.labelCount}
+            annotationConfig={
+              categoricalAnnotationConfigsByName[latestAnnotation.name]
+            }
+          />
+        </Summary>
+      );
+    })
+    .filter(Boolean);
+
+  if (stacks.length === 0) {
+    return renderEmptyState ? renderEmptyState() : null;
   }
   return (
-    <Flex direction="row" gap="size-400">
-      {sortedSummariesByName.map((summary) => {
-        const latestAnnotation = annotationsByName[summary.name]?.[0];
-        if (!latestAnnotation) {
-          return null;
-        }
-        return (
-          <Summary name={latestAnnotation.name} key={latestAnnotation.id}>
-            <SummaryValue
-              name={latestAnnotation.name}
-              meanScore={summary.meanScore}
-              labelFractions={summary.labelFractions}
-              count={summary.count}
-              scoreCount={summary.scoreCount}
-              labelCount={summary.labelCount}
-              annotationConfig={
-                categoricalAnnotationConfigsByName[latestAnnotation.name]
-              }
-            />
-          </Summary>
-        );
-      })}
-    </Flex>
+    <AnnotationSummaryGroupStacksRow leadingDivider={leadingDivider}>
+      {stacks}
+    </AnnotationSummaryGroupStacksRow>
   );
 };

--- a/app/src/components/annotation/TraceAnnotationSummaryGroup.tsx
+++ b/app/src/components/annotation/TraceAnnotationSummaryGroup.tsx
@@ -5,8 +5,11 @@ import { graphql, useFragment } from "react-relay";
 import { Flex } from "@phoenix/components";
 import type { TraceAnnotationSummaryGroup$key } from "@phoenix/components/annotation/__generated__/TraceAnnotationSummaryGroup.graphql";
 import { AnnotationLabel } from "@phoenix/components/annotation/AnnotationLabel";
+import { AnnotationSummaryGroupStacksRow } from "@phoenix/components/annotation/AnnotationSummaryGroup";
 import { AnnotationSummaryPopover } from "@phoenix/components/annotation/AnnotationSummaryPopover";
 import {
+  Summary,
+  SummaryValue,
   SummaryValueLabelPreview,
   SummaryValuePreview,
 } from "@phoenix/pages/project/AnnotationSummary";
@@ -192,5 +195,50 @@ export const TraceAnnotationSummaryGroupTokens = ({
         );
       })}
     </Flex>
+  );
+};
+
+export const TraceAnnotationSummaryGroupStacks = ({
+  trace,
+  renderEmptyState,
+  leadingDivider = false,
+}: TraceAnnotationSummaryGroupProps & { leadingDivider?: boolean }) => {
+  const {
+    sortedSummariesByName,
+    annotationsByName,
+    categoricalAnnotationConfigsByName,
+  } = useTraceAnnotationSummaryGroup(trace);
+
+  const stacks = sortedSummariesByName
+    .map((summary) => {
+      const latestAnnotation = annotationsByName[summary.name]?.[0];
+      if (!latestAnnotation) {
+        return null;
+      }
+      return (
+        <Summary name={latestAnnotation.name} key={latestAnnotation.id}>
+          <SummaryValue
+            name={latestAnnotation.name}
+            meanScore={summary.meanScore}
+            labelFractions={summary.labelFractions}
+            count={summary.count}
+            scoreCount={summary.scoreCount}
+            labelCount={summary.labelCount}
+            annotationConfig={
+              categoricalAnnotationConfigsByName[latestAnnotation.name]
+            }
+          />
+        </Summary>
+      );
+    })
+    .filter(Boolean);
+
+  if (stacks.length === 0) {
+    return renderEmptyState ? renderEmptyState() : null;
+  }
+  return (
+    <AnnotationSummaryGroupStacksRow leadingDivider={leadingDivider}>
+      {stacks}
+    </AnnotationSummaryGroupStacksRow>
   );
 };

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -40,6 +40,7 @@ import type {
 import { ConnectedTraceTree } from "./ConnectedTraceTree";
 import { SpanDetails } from "./SpanDetails";
 import { TraceHeaderRootSpanAnnotations } from "./TraceHeaderRootSpanAnnotations";
+import { TraceHeaderTraceAnnotations } from "./TraceHeaderTraceAnnotations";
 
 type RootSpan = NonNullable<
   TraceDetailsQuery$data["project"]["trace"]
@@ -66,6 +67,7 @@ export function TraceDetails(props: TraceDetailsProps) {
         project: node(id: $id) {
           ... on Project {
             trace(traceId: $traceId) {
+              id
               projectSessionId
               ...ConnectedTraceTree
               rootSpans: spans(
@@ -133,6 +135,7 @@ export function TraceDetails(props: TraceDetailsProps) {
     >
       <TraceHeader
         projectId={projectId}
+        traceNodeId={data.project.trace.id}
         rootSpan={rootSpan}
         latencyMs={traceLatencyMs}
         costSummary={costSummary}
@@ -184,12 +187,14 @@ export function TraceDetails(props: TraceDetailsProps) {
 
 function TraceHeader({
   rootSpan,
+  traceNodeId,
   latencyMs,
   costSummary,
   sessionId,
   projectId,
 }: {
   rootSpan: RootSpan | null;
+  traceNodeId: string;
   latencyMs: number | null;
   costSummary?: CostSummary | null;
   sessionId?: string | null;
@@ -278,9 +283,19 @@ function TraceHeader({
             <Text size="L">--</Text>
           )}
         </Flex>
-        {rootSpan ? (
-          <TraceHeaderRootSpanAnnotations spanId={rootSpan.id} />
-        ) : null}
+        <Suspense fallback={null}>
+          <Flex
+            direction="row"
+            gap="size-400"
+            alignItems="stretch"
+            alignSelf="stretch"
+          >
+            {rootSpan ? (
+              <TraceHeaderRootSpanAnnotations spanId={rootSpan.id} />
+            ) : null}
+            <TraceHeaderTraceAnnotations traceId={traceNodeId} />
+          </Flex>
+        </Suspense>
         {sessionId && (
           <span
             css={css`

--- a/app/src/pages/trace/TraceHeaderRootSpanAnnotations.tsx
+++ b/app/src/pages/trace/TraceHeaderRootSpanAnnotations.tsx
@@ -30,6 +30,10 @@ export function TraceHeaderRootSpanAnnotations({ spanId }: { spanId: string }) {
     query.span
   );
   return (
-    <AnnotationSummaryGroupStacks span={span} renderEmptyState={() => null} />
+    <AnnotationSummaryGroupStacks
+      span={span}
+      leadingDivider
+      renderEmptyState={() => null}
+    />
   );
 }

--- a/app/src/pages/trace/TraceHeaderTraceAnnotations.tsx
+++ b/app/src/pages/trace/TraceHeaderTraceAnnotations.tsx
@@ -1,0 +1,39 @@
+import { graphql, useFragment, useLazyLoadQuery } from "react-relay";
+
+import { TraceAnnotationSummaryGroupStacks } from "@phoenix/components/annotation/TraceAnnotationSummaryGroup";
+import type { TraceHeaderTraceAnnotationsFragment$key } from "@phoenix/pages/trace/__generated__/TraceHeaderTraceAnnotationsFragment.graphql";
+
+import type { TraceHeaderTraceAnnotationsQuery } from "./__generated__/TraceHeaderTraceAnnotationsQuery.graphql";
+
+export function TraceHeaderTraceAnnotations({ traceId }: { traceId: string }) {
+  const query = useLazyLoadQuery<TraceHeaderTraceAnnotationsQuery>(
+    graphql`
+      query TraceHeaderTraceAnnotationsQuery($traceId: ID!) {
+        trace: node(id: $traceId) {
+          ... on Trace {
+            ...TraceHeaderTraceAnnotationsFragment
+          }
+        }
+      }
+    `,
+    { traceId },
+    {
+      fetchPolicy: "store-and-network",
+    }
+  );
+  const trace = useFragment<TraceHeaderTraceAnnotationsFragment$key>(
+    graphql`
+      fragment TraceHeaderTraceAnnotationsFragment on Trace {
+        ...TraceAnnotationSummaryGroup
+      }
+    `,
+    query.trace
+  );
+  return (
+    <TraceAnnotationSummaryGroupStacks
+      trace={trace}
+      leadingDivider
+      renderEmptyState={() => null}
+    />
+  );
+}

--- a/app/src/pages/trace/__generated__/TraceDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/TraceDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3790ac6ad7ddf8b82357d7bd112c29a3>>
+ * @generated SignedSource<<801aab508e5a2eb5c5f6aabaf66a1f8d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -29,6 +29,7 @@ export type TraceDetailsQuery$data = {
           readonly cost: number | null;
         };
       };
+      readonly id: string;
       readonly latencyMs: number | null;
       readonly projectSessionId: string | null;
       readonly rootSpans: {
@@ -79,21 +80,21 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "projectSessionId",
+  "name": "id",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "statusCode",
+  "name": "projectSessionId",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "statusCode",
   "storageKey": null
 },
 v7 = {
@@ -150,8 +151,8 @@ v9 = {
           "name": "node",
           "plural": false,
           "selections": [
-            (v5/*: any*/),
             (v6/*: any*/),
+            (v4/*: any*/),
             (v7/*: any*/),
             (v8/*: any*/)
           ],
@@ -271,6 +272,7 @@ return {
                 "plural": false,
                 "selections": [
                   (v4/*: any*/),
+                  (v5/*: any*/),
                   {
                     "args": null,
                     "kind": "FragmentSpread",
@@ -323,6 +325,7 @@ return {
                 "plural": false,
                 "selections": [
                   (v4/*: any*/),
+                  (v5/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -354,7 +357,7 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              (v6/*: any*/),
+                              (v4/*: any*/),
                               (v7/*: any*/),
                               (v15/*: any*/),
                               {
@@ -364,7 +367,7 @@ return {
                                 "name": "spanKind",
                                 "storageKey": null
                               },
-                              (v5/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -479,7 +482,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v13/*: any*/),
-                              (v6/*: any*/)
+                              (v4/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -523,7 +526,6 @@ return {
                     "kind": "LinkedHandle",
                     "name": "spans"
                   },
-                  (v6/*: any*/),
                   (v9/*: any*/),
                   (v10/*: any*/),
                   (v12/*: any*/)
@@ -534,23 +536,23 @@ return {
             "type": "Project",
             "abstractKey": null
           },
-          (v6/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "8061bdefc692c0ac4ce8a3f3c62c89aa",
+    "cacheID": "969f8c2ec6fb03a7304e4c64f8154c45",
     "id": null,
     "metadata": {},
     "name": "TraceDetailsQuery",
     "operationKind": "query",
-    "text": "query TraceDetailsQuery(\n  $traceId: ID!\n  $id: ID!\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      trace(traceId: $traceId) {\n        projectSessionId\n        ...ConnectedTraceTree\n        rootSpans: spans(first: 1, rootSpansOnly: true, orphanSpanAsRootSpan: true) {\n          edges {\n            span: node {\n              statusCode\n              id\n              spanId\n              parentId\n            }\n          }\n        }\n        latencyMs\n        costSummary {\n          prompt {\n            cost\n          }\n          completion {\n            cost\n          }\n          total {\n            cost\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ConnectedTraceTree on Trace {\n  numSpans\n  spans(first: 1000) {\n    edges {\n      span: node {\n        id\n        spanId\n        name\n        spanKind\n        statusCode\n        startTime\n        endTime\n        parentId\n        latencyMs\n        tokenCountTotal\n        spanAnnotationSummaries {\n          labels\n          count\n          labelCount\n          labelFractions {\n            fraction\n            label\n          }\n          name\n          scoreCount\n          meanScore\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query TraceDetailsQuery(\n  $traceId: ID!\n  $id: ID!\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      trace(traceId: $traceId) {\n        id\n        projectSessionId\n        ...ConnectedTraceTree\n        rootSpans: spans(first: 1, rootSpansOnly: true, orphanSpanAsRootSpan: true) {\n          edges {\n            span: node {\n              statusCode\n              id\n              spanId\n              parentId\n            }\n          }\n        }\n        latencyMs\n        costSummary {\n          prompt {\n            cost\n          }\n          completion {\n            cost\n          }\n          total {\n            cost\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ConnectedTraceTree on Trace {\n  numSpans\n  spans(first: 1000) {\n    edges {\n      span: node {\n        id\n        spanId\n        name\n        spanKind\n        statusCode\n        startTime\n        endTime\n        parentId\n        latencyMs\n        tokenCountTotal\n        spanAnnotationSummaries {\n          labels\n          count\n          labelCount\n          labelFractions {\n            fraction\n            label\n          }\n          name\n          scoreCount\n          meanScore\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "b7f5952cd2183ab72fa53058e5c3dd98";
+(node as any).hash = "4cad4506dcc01f5aa68c218641476332";
 
 export default node;

--- a/app/src/pages/trace/__generated__/TraceHeaderTraceAnnotationsFragment.graphql.ts
+++ b/app/src/pages/trace/__generated__/TraceHeaderTraceAnnotationsFragment.graphql.ts
@@ -1,0 +1,40 @@
+/**
+ * @generated SignedSource<<cc9faee1b95342adb65d2c5803ea5399>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type TraceHeaderTraceAnnotationsFragment$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"TraceAnnotationSummaryGroup">;
+  readonly " $fragmentType": "TraceHeaderTraceAnnotationsFragment";
+};
+export type TraceHeaderTraceAnnotationsFragment$key = {
+  readonly " $data"?: TraceHeaderTraceAnnotationsFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"TraceHeaderTraceAnnotationsFragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "TraceHeaderTraceAnnotationsFragment",
+  "selections": [
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "TraceAnnotationSummaryGroup"
+    }
+  ],
+  "type": "Trace",
+  "abstractKey": null
+};
+
+(node as any).hash = "21c430071ea0f24dbec39c57f4b73615";
+
+export default node;

--- a/app/src/pages/trace/__generated__/TraceHeaderTraceAnnotationsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/TraceHeaderTraceAnnotationsQuery.graphql.ts
@@ -1,0 +1,362 @@
+/**
+ * @generated SignedSource<<e78462cddafb14a5fa50ca525b8c2f37>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type TraceHeaderTraceAnnotationsQuery$variables = {
+  traceId: string;
+};
+export type TraceHeaderTraceAnnotationsQuery$data = {
+  readonly trace: {
+    readonly " $fragmentSpreads": FragmentRefs<"TraceHeaderTraceAnnotationsFragment">;
+  };
+};
+export type TraceHeaderTraceAnnotationsQuery = {
+  response: TraceHeaderTraceAnnotationsQuery$data;
+  variables: TraceHeaderTraceAnnotationsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "traceId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "traceId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "score",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TraceHeaderTraceAnnotationsQuery",
+    "selections": [
+      {
+        "alias": "trace",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "TraceHeaderTraceAnnotationsFragment"
+              }
+            ],
+            "type": "Trace",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TraceHeaderTraceAnnotationsQuery",
+    "selections": [
+      {
+        "alias": "trace",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Project",
+                "kind": "LinkedField",
+                "name": "project",
+                "plural": false,
+                "selections": [
+                  (v3/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigConnection",
+                    "kind": "LinkedField",
+                    "name": "annotationConfigs",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "AnnotationConfigEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": null,
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v2/*: any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "annotationType",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "AnnotationConfigBase",
+                                "abstractKey": "__isAnnotationConfigBase"
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v3/*: any*/),
+                                  (v4/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "optimizationDirection",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "CategoricalAnnotationValue",
+                                    "kind": "LinkedField",
+                                    "name": "values",
+                                    "plural": true,
+                                    "selections": [
+                                      (v5/*: any*/),
+                                      (v6/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "CategoricalAnnotationConfig",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v3/*: any*/)
+                                ],
+                                "type": "Node",
+                                "abstractKey": "__isNode"
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "TraceAnnotation",
+                "kind": "LinkedField",
+                "name": "traceAnnotations",
+                "plural": true,
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "annotatorKind",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "createdAt",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "user",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "username",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "profilePictureUrl",
+                        "storageKey": null
+                      },
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AnnotationSummary",
+                "kind": "LinkedField",
+                "name": "traceAnnotationSummaries",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "count",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "scoreCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "labelCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "LabelFraction",
+                    "kind": "LinkedField",
+                    "name": "labelFractions",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "fraction",
+                        "storageKey": null
+                      },
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "meanScore",
+                    "storageKey": null
+                  },
+                  (v4/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "Trace",
+            "abstractKey": null
+          },
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "b8c6624fa40d5595699dfe1e3a90cc0c",
+    "id": null,
+    "metadata": {},
+    "name": "TraceHeaderTraceAnnotationsQuery",
+    "operationKind": "query",
+    "text": "query TraceHeaderTraceAnnotationsQuery(\n  $traceId: ID!\n) {\n  trace: node(id: $traceId) {\n    __typename\n    ... on Trace {\n      ...TraceHeaderTraceAnnotationsFragment\n    }\n    id\n  }\n}\n\nfragment TraceAnnotationSummaryGroup on Trace {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  traceAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  traceAnnotationSummaries {\n    count\n    scoreCount\n    labelCount\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment TraceHeaderTraceAnnotationsFragment on Trace {\n  ...TraceAnnotationSummaryGroup\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "8279883d8f80b70390552bb7875495f3";
+
+export default node;


### PR DESCRIPTION
## Summary

Surfaces **trace-level annotation summaries** in the trace details header, alongside the existing root-span annotations. These are sourced from the `Trace.traceAnnotationSummaries` GraphQL field (resolver already on `main`).

## Header design

Annotations now render as **peer columns** aligned with the `Status` / `Total Cost` / `Latency` metrics — each is a name heading + value, the same rhythm as the metric columns. Distinct sources (root span vs. trace) are segmented with subtle full-height **vertical dividers** instead of stacked uppercase section labels.

The earlier label-stacking approach (`ROOT SPAN ANNOTATIONS` / `TRACE ANNOTATIONS` captions above each group) broke baseline alignment with the metric columns and added a whole row of vertical height. The new layout keeps the header to a single compact, aligned row.

```
Status   Total Cost   Latency │ user_feedback │ user_feedback   [View Session]
 OK       <$0.01       1.5s    │   ○ μ0.00     │   ◉ μ1.00
                            metrics │  root span    │   trace
```

## Screenshots

Trace details header — trace-level annotation (`user_feedback μ1.00`) surfaced alongside the root-span annotation (`user_feedback μ0.00`), as peer columns aligned with Status / Total Cost / Latency, segmented by subtle full-height dividers:

![trace header with trace-level annotations](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/13853-trace-header-annotations.png)

## Changes

- `AnnotationSummaryGroup.tsx` — replace `AnnotationSummaryGroupStacksSection` (uppercase stacked label) with `AnnotationSummaryGroupStacksRow`, which optionally renders a *leading* vertical divider owned by the group, so an empty group leaves no dangling separator.
- `TraceAnnotationSummaryGroup.tsx` — same treatment for the trace variant.
- `TraceHeaderTraceAnnotations.tsx` (new) — fetches `traceAnnotationSummaries` and renders the trace annotation group in the header.
- `TraceHeaderRootSpanAnnotations.tsx` / `TraceDetails.tsx` — wire up the divider-based grouping; stretch the annotation row so dividers span the full header height.

## Notes

- Used the **solid** divider variant, not `fading` — the fading gradient fades over `clamp(48px, 15%, 128px)` per end, which on a ~68px header divider would render nearly invisible.
- The root-span vs. trace distinction is preserved via divider grouping rather than text labels, at zero added vertical height.

## Testing

- `tsc --noEmit` passes, `oxlint` + `oxfmt` clean
- Verified visually against a live trace with both a root-span and a trace `user_feedback` annotation — header renders as a single aligned row with both columns separated by the dividers
