### PR TITLE
feat(annotations): show trace annotation summaries in project stats panel

### DIFF
--- a/app/src/pages/project/AnnotationSummary.tsx
+++ b/app/src/pages/project/AnnotationSummary.tsx
@@ -97,7 +97,6 @@ function AnnotationSummaryValue(props: {
   project: AnnotationSummaryValueFragment$key;
 }) {
   const { project, annotationName, filterCondition } = props;
-  const { fetchKey } = useStreamState();
   const [data, refetch] = useRefetchableFragment<
     AnnotationSummaryQuery,
     AnnotationSummaryValueFragment$key
@@ -149,29 +148,71 @@ function AnnotationSummaryValue(props: {
     project
   );
 
-  const refetchAnnotationSummary = useEffectEvent(() => {
+  useRefetchOnStreamAdvance(() => {
     startTransition(() => {
       refetch({ filterCondition }, { fetchPolicy: "store-and-network" });
     });
   });
 
-  // Refetch the annotation summary when streaming data advances.
-  useEffect(() => {
-    refetchAnnotationSummary();
-  }, [fetchKey]);
+  return (
+    <AnnotationSummaryValueView
+      name={annotationName}
+      summary={data?.spanAnnotationSummary}
+      annotationConfigs={data?.annotationConfigs}
+    />
+  );
+}
 
+/**
+ * Refetch an annotation summary whenever streaming data advances. Shared by the
+ * span- and trace-level summary components so the stream-refetch wiring lives in
+ * one place.
+ */
+export function useRefetchOnStreamAdvance(refetch: () => void) {
+  const { fetchKey } = useStreamState();
+  const onStreamAdvance = useEffectEvent(refetch);
+  useEffect(() => {
+    onStreamAdvance();
+  }, [fetchKey]);
+}
+
+type AnnotationSummaryData = {
+  meanScore?: number | null;
+  count?: number | null;
+  scoreCount?: number | null;
+  labelCount?: number | null;
+  labelFractions?: readonly { label: string; fraction: number }[];
+};
+
+/**
+ * Renders a {@link SummaryValue} from a project annotation summary, resolving the
+ * matching annotation config by name. Shared by the span- and trace-level
+ * summary components, which differ only in which GraphQL summary field they read.
+ */
+export function AnnotationSummaryValueView({
+  name,
+  summary,
+  annotationConfigs,
+}: {
+  name: string;
+  summary?: AnnotationSummaryData | null;
+  annotationConfigs?: {
+    readonly edges: readonly {
+      readonly node: { readonly name?: string | null };
+    }[];
+  } | null;
+}) {
   return (
     <SummaryValue
-      name={annotationName}
-      meanScore={data?.spanAnnotationSummary?.meanScore}
-      labelFractions={data?.spanAnnotationSummary?.labelFractions}
-      count={data?.spanAnnotationSummary?.count}
-      scoreCount={data?.spanAnnotationSummary?.scoreCount}
-      labelCount={data?.spanAnnotationSummary?.labelCount}
+      name={name}
+      meanScore={summary?.meanScore}
+      labelFractions={summary?.labelFractions}
+      count={summary?.count}
+      scoreCount={summary?.scoreCount}
+      labelCount={summary?.labelCount}
       annotationConfig={
-        data?.annotationConfigs?.edges.find(
-          (edge) => edge.node.name === annotationName
-        )?.node as AnnotationConfig | undefined
+        annotationConfigs?.edges.find((edge) => edge.node.name === name)
+          ?.node as AnnotationConfig | undefined
       }
     />
   );

--- a/app/src/pages/project/SpansTableAside.tsx
+++ b/app/src/pages/project/SpansTableAside.tsx
@@ -249,7 +249,7 @@ export function SpansTableAside(props: { filterCondition?: string | null }) {
               </StatsSection>
             ) : null}
             {documentEvaluationNames.length > 0 ? (
-              <StatsSection title="Document Evaluations">
+              <StatsSection title="Document Annotations">
                 {documentEvaluationNames.map((name) => (
                   <DocumentEvaluationSummary
                     key={`document-${name}`}

--- a/app/src/pages/project/SpansTableAside.tsx
+++ b/app/src/pages/project/SpansTableAside.tsx
@@ -1,3 +1,5 @@
+import { css } from "@emotion/react";
+import type { ReactNode } from "react";
 import { Focusable } from "react-aria";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { Group } from "react-resizable-panels";
@@ -27,6 +29,44 @@ import { costFormatter, intFormatter } from "@phoenix/utils/numberFormatUtils";
 import type { SpansTableAsideQuery } from "./__generated__/SpansTableAsideQuery.graphql";
 import { AnnotationSummary } from "./AnnotationSummary";
 import { DocumentEvaluationSummary } from "./DocumentEvaluationSummary";
+import { TraceAnnotationSummary } from "./TraceAnnotationSummary";
+
+const sectionHeadingCSS = css`
+  font-size: var(--global-font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--global-text-color-700);
+  margin: 0 0 var(--global-dimension-size-100) 0;
+  padding-bottom: var(--global-dimension-size-50);
+  border-bottom: 1px solid var(--global-border-color-default);
+`;
+
+/**
+ * A titled group of stats. The heading doubles as a divider — an underlined,
+ * uppercase label — so each level of feedback (span, document, trace) reads as
+ * its own clearly delineated section rather than one undifferentiated list.
+ */
+function StatsSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      css={css`
+        width: 100%;
+      `}
+    >
+      <h3 css={sectionHeadingCSS}>{title}</h3>
+      <Flex direction="column" gap="size-200" alignItems="start">
+        {children}
+      </Flex>
+    </section>
+  );
+}
 
 export function SpansTableAside(props: { filterCondition?: string | null }) {
   const filterCondition = props.filterCondition || null;
@@ -73,6 +113,7 @@ export function SpansTableAside(props: { filterCondition?: string | null }) {
               filterCondition: $filterCondition
             )
             spanAnnotationNames
+            traceAnnotationsNames
             documentEvaluationNames
           }
         }
@@ -94,6 +135,8 @@ export function SpansTableAside(props: { filterCondition?: string | null }) {
   const latencyMsP99 = project?.latencyMsP99;
   const spanAnnotationNames =
     project?.spanAnnotationNames?.filter((name) => name !== "note") ?? [];
+  const traceAnnotationNames =
+    project?.traceAnnotationsNames?.filter((name) => name !== "note") ?? [];
   const documentEvaluationNames = project?.documentEvaluationNames ?? [];
   const colors = useCategoryChartColors();
 
@@ -125,88 +168,111 @@ export function SpansTableAside(props: { filterCondition?: string | null }) {
       </TitledPanel>
       <TitledPanel resizable title="Stats" panelProps={{ minSize: "10%" }}>
         <View padding="size-200" overflow="auto" height="100%">
-          <Flex
-            direction="column"
-            gap="size-200"
-            minWidth="size-3400"
-            alignItems="start"
-          >
-            <Flex direction="column" flex="none">
-              <Text elementType="h3" size="S" color="text-700">
-                Total Traces
-              </Text>
-              <Text size="L" fontFamily="mono">
-                {intFormatter(project?.timeRangeTraceCount)}
-              </Text>
+          <Flex direction="column" gap="size-300" minWidth="size-3400">
+            <Flex direction="column" gap="size-200" alignItems="start">
+              <Flex direction="column" flex="none">
+                <Text elementType="h3" size="S" color="text-700">
+                  Total Traces
+                </Text>
+                <Text size="L" fontFamily="mono">
+                  {intFormatter(project?.timeRangeTraceCount)}
+                </Text>
+              </Flex>
+              <Flex direction="column" flex="none">
+                <Text elementType="h3" size="S" color="text-700">
+                  Total Cost
+                </Text>
+                <TooltipTrigger delay={0}>
+                  <Focusable>
+                    <Text size="L" role="button" fontFamily="mono">
+                      {costFormatter(project?.costSummary?.total?.cost ?? 0)}
+                    </Text>
+                  </Focusable>
+                  <RichTooltip placement="bottom">
+                    <TooltipArrow />
+                    <View width="size-3600">
+                      <RichTokenBreakdown
+                        valueLabel="cost"
+                        totalValue={project?.costSummary?.total?.cost ?? 0}
+                        formatter={costFormatter}
+                        segments={[
+                          {
+                            name: "Prompt",
+                            value: project?.costSummary?.prompt?.cost ?? 0,
+                            color: colors.category1,
+                          },
+                          {
+                            name: "Completion",
+                            value: project?.costSummary?.completion?.cost ?? 0,
+                            color: colors.category2,
+                          },
+                        ]}
+                      />
+                    </View>
+                  </RichTooltip>
+                </TooltipTrigger>
+              </Flex>
+              <Flex direction="column" flex="none">
+                <Text elementType="h3" size="S" color="text-700">
+                  Latency P50
+                </Text>
+                {latencyMsP50 != null ? (
+                  <LatencyText latencyMs={latencyMsP50} size="L" />
+                ) : (
+                  <Text size="L">--</Text>
+                )}
+              </Flex>
+              <Flex direction="column" flex="none">
+                <Text elementType="h3" size="S" color="text-700">
+                  Latency P99
+                </Text>
+                {latencyMsP99 != null ? (
+                  <LatencyText latencyMs={latencyMsP99} size="L" />
+                ) : (
+                  <Text size="L">--</Text>
+                )}
+              </Flex>
             </Flex>
-            <Flex direction="column" flex="none">
-              <Text elementType="h3" size="S" color="text-700">
-                Total Cost
-              </Text>
-              <TooltipTrigger delay={0}>
-                <Focusable>
-                  <Text size="L" role="button" fontFamily="mono">
-                    {costFormatter(project?.costSummary?.total?.cost ?? 0)}
-                  </Text>
-                </Focusable>
-                <RichTooltip placement="bottom">
-                  <TooltipArrow />
-                  <View width="size-3600">
-                    <RichTokenBreakdown
-                      valueLabel="cost"
-                      totalValue={project?.costSummary?.total?.cost ?? 0}
-                      formatter={costFormatter}
-                      segments={[
-                        {
-                          name: "Prompt",
-                          value: project?.costSummary?.prompt?.cost ?? 0,
-                          color: colors.category1,
-                        },
-                        {
-                          name: "Completion",
-                          value: project?.costSummary?.completion?.cost ?? 0,
-                          color: colors.category2,
-                        },
-                      ]}
+            {spanAnnotationNames.length > 0 ? (
+              <StatsSection title="Span Annotations">
+                {spanAnnotationNames.map((name) => (
+                  <ErrorBoundary
+                    key={name}
+                    fallback={TextErrorBoundaryFallback}
+                  >
+                    <AnnotationSummary
+                      annotationName={name}
+                      filterCondition={filterCondition}
                     />
-                  </View>
-                </RichTooltip>
-              </TooltipTrigger>
-            </Flex>
-            <Flex direction="column" flex="none">
-              <Text elementType="h3" size="S" color="text-700">
-                Latency P50
-              </Text>
-              {latencyMsP50 != null ? (
-                <LatencyText latencyMs={latencyMsP50} size="L" />
-              ) : (
-                <Text size="L">--</Text>
-              )}
-            </Flex>
-            <Flex direction="column" flex="none">
-              <Text elementType="h3" size="S" color="text-700">
-                Latency P99
-              </Text>
-              {latencyMsP99 != null ? (
-                <LatencyText latencyMs={latencyMsP99} size="L" />
-              ) : (
-                <Text size="L">--</Text>
-              )}
-            </Flex>
-            {spanAnnotationNames.map((name) => (
-              <ErrorBoundary key={name} fallback={TextErrorBoundaryFallback}>
-                <AnnotationSummary
-                  annotationName={name}
-                  filterCondition={filterCondition}
-                />
-              </ErrorBoundary>
-            ))}
-            {documentEvaluationNames.map((name) => (
-              <DocumentEvaluationSummary
-                key={`document-${name}`}
-                evaluationName={name}
-              />
-            ))}
+                  </ErrorBoundary>
+                ))}
+              </StatsSection>
+            ) : null}
+            {documentEvaluationNames.length > 0 ? (
+              <StatsSection title="Document Evaluations">
+                {documentEvaluationNames.map((name) => (
+                  <DocumentEvaluationSummary
+                    key={`document-${name}`}
+                    evaluationName={name}
+                  />
+                ))}
+              </StatsSection>
+            ) : null}
+            {traceAnnotationNames.length > 0 ? (
+              <StatsSection title="Trace Annotations">
+                {traceAnnotationNames.map((name) => (
+                  <ErrorBoundary
+                    key={`trace-${name}`}
+                    fallback={TextErrorBoundaryFallback}
+                  >
+                    <TraceAnnotationSummary
+                      annotationName={name}
+                      filterCondition={filterCondition}
+                    />
+                  </ErrorBoundary>
+                ))}
+              </StatsSection>
+            ) : null}
           </Flex>
         </View>
       </TitledPanel>

--- a/app/src/pages/project/TraceAnnotationSummary.tsx
+++ b/app/src/pages/project/TraceAnnotationSummary.tsx
@@ -1,14 +1,16 @@
-import { startTransition, useEffect, useEffectEvent } from "react";
+import { startTransition } from "react";
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from "react-relay";
 import { useParams } from "react-router";
 
-import type { AnnotationConfig } from "@phoenix/components/annotation";
 import { useTimeRange } from "@phoenix/components/datetime";
-import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 
 import type { TraceAnnotationSummaryQuery } from "./__generated__/TraceAnnotationSummaryQuery.graphql";
 import type { TraceAnnotationSummaryValueFragment$key } from "./__generated__/TraceAnnotationSummaryValueFragment.graphql";
-import { Summary, SummaryValue } from "./AnnotationSummary";
+import {
+  AnnotationSummaryValueView,
+  Summary,
+  useRefetchOnStreamAdvance,
+} from "./AnnotationSummary";
 
 type TraceAnnotationSummaryProps = {
   annotationName: string;
@@ -75,7 +77,6 @@ function TraceAnnotationSummaryValue(props: {
   project: TraceAnnotationSummaryValueFragment$key;
 }) {
   const { project, annotationName, filterCondition } = props;
-  const { fetchKey } = useStreamState();
   const [data, refetch] = useRefetchableFragment<
     TraceAnnotationSummaryQuery,
     TraceAnnotationSummaryValueFragment$key
@@ -127,30 +128,17 @@ function TraceAnnotationSummaryValue(props: {
     project
   );
 
-  const refetchAnnotationSummary = useEffectEvent(() => {
+  useRefetchOnStreamAdvance(() => {
     startTransition(() => {
       refetch({ filterCondition }, { fetchPolicy: "store-and-network" });
     });
   });
 
-  // Refetch the annotation summary when streaming data advances.
-  useEffect(() => {
-    refetchAnnotationSummary();
-  }, [fetchKey]);
-
   return (
-    <SummaryValue
+    <AnnotationSummaryValueView
       name={annotationName}
-      meanScore={data?.traceAnnotationSummary?.meanScore}
-      labelFractions={data?.traceAnnotationSummary?.labelFractions}
-      count={data?.traceAnnotationSummary?.count}
-      scoreCount={data?.traceAnnotationSummary?.scoreCount}
-      labelCount={data?.traceAnnotationSummary?.labelCount}
-      annotationConfig={
-        data?.annotationConfigs?.edges.find(
-          (edge) => edge.node.name === annotationName
-        )?.node as AnnotationConfig | undefined
-      }
+      summary={data?.traceAnnotationSummary}
+      annotationConfigs={data?.annotationConfigs}
     />
   );
 }

--- a/app/src/pages/project/TraceAnnotationSummary.tsx
+++ b/app/src/pages/project/TraceAnnotationSummary.tsx
@@ -1,0 +1,156 @@
+import { startTransition, useEffect, useEffectEvent } from "react";
+import { graphql, useLazyLoadQuery, useRefetchableFragment } from "react-relay";
+import { useParams } from "react-router";
+
+import type { AnnotationConfig } from "@phoenix/components/annotation";
+import { useTimeRange } from "@phoenix/components/datetime";
+import { useStreamState } from "@phoenix/contexts/StreamStateContext";
+
+import type { TraceAnnotationSummaryQuery } from "./__generated__/TraceAnnotationSummaryQuery.graphql";
+import type { TraceAnnotationSummaryValueFragment$key } from "./__generated__/TraceAnnotationSummaryValueFragment.graphql";
+import { Summary, SummaryValue } from "./AnnotationSummary";
+
+type TraceAnnotationSummaryProps = {
+  annotationName: string;
+  /**
+   * Optional span filter condition. When set, the trace annotation summary is
+   * restricted to traces whose spans match the condition.
+   */
+  filterCondition?: string | null;
+};
+
+/**
+ * Project-level summary for a single trace annotation. Mirrors
+ * {@link AnnotationSummary} (which summarizes span annotations) so trace-level
+ * feedback can sit alongside span and document feedback in the stats panel.
+ */
+export function TraceAnnotationSummary({
+  annotationName,
+  filterCondition,
+}: TraceAnnotationSummaryProps) {
+  const { projectId } = useParams();
+  const { timeRange } = useTimeRange();
+  const data = useLazyLoadQuery<TraceAnnotationSummaryQuery>(
+    graphql`
+      query TraceAnnotationSummaryQuery(
+        $id: ID!
+        $annotationName: String!
+        $timeRange: TimeRange!
+        $filterCondition: String
+      ) {
+        project: node(id: $id) {
+          ...TraceAnnotationSummaryValueFragment
+            @arguments(
+              annotationName: $annotationName
+              timeRange: $timeRange
+              filterCondition: $filterCondition
+            )
+        }
+      }
+    `,
+    {
+      annotationName,
+      id: projectId as string,
+      timeRange: {
+        start: timeRange?.start?.toISOString(),
+        end: timeRange?.end?.toISOString(),
+      },
+      filterCondition: filterCondition || null,
+    }
+  );
+  return (
+    <Summary name={annotationName}>
+      <TraceAnnotationSummaryValue
+        annotationName={annotationName}
+        filterCondition={filterCondition || null}
+        project={data.project}
+      />
+    </Summary>
+  );
+}
+
+function TraceAnnotationSummaryValue(props: {
+  annotationName: string;
+  filterCondition: string | null;
+  project: TraceAnnotationSummaryValueFragment$key;
+}) {
+  const { project, annotationName, filterCondition } = props;
+  const { fetchKey } = useStreamState();
+  const [data, refetch] = useRefetchableFragment<
+    TraceAnnotationSummaryQuery,
+    TraceAnnotationSummaryValueFragment$key
+  >(
+    graphql`
+      fragment TraceAnnotationSummaryValueFragment on Project
+      @refetchable(queryName: "TraceAnnotationSummaryValueQuery")
+      @argumentDefinitions(
+        annotationName: { type: "String!" }
+        timeRange: { type: "TimeRange!" }
+        filterCondition: { type: "String", defaultValue: null }
+      ) {
+        annotationConfigs {
+          edges {
+            node {
+              ... on AnnotationConfigBase {
+                annotationType
+              }
+              ... on CategoricalAnnotationConfig {
+                annotationType
+                id
+                optimizationDirection
+                name
+                values {
+                  label
+                  score
+                }
+              }
+            }
+          }
+        }
+        traceAnnotationSummary(
+          annotationName: $annotationName
+          timeRange: $timeRange
+          filterCondition: $filterCondition
+        ) {
+          name
+          count
+          scoreCount
+          labelCount
+          labelFractions {
+            label
+            fraction
+          }
+          meanScore
+        }
+      }
+    `,
+    project
+  );
+
+  const refetchAnnotationSummary = useEffectEvent(() => {
+    startTransition(() => {
+      refetch({ filterCondition }, { fetchPolicy: "store-and-network" });
+    });
+  });
+
+  // Refetch the annotation summary when streaming data advances.
+  useEffect(() => {
+    refetchAnnotationSummary();
+  }, [fetchKey]);
+
+  return (
+    <SummaryValue
+      name={annotationName}
+      meanScore={data?.traceAnnotationSummary?.meanScore}
+      labelFractions={data?.traceAnnotationSummary?.labelFractions}
+      count={data?.traceAnnotationSummary?.count}
+      scoreCount={data?.traceAnnotationSummary?.scoreCount}
+      labelCount={data?.traceAnnotationSummary?.labelCount}
+      annotationConfig={
+        data?.annotationConfigs?.edges.find(
+          (edge) => edge.node.name === annotationName
+        )?.node as AnnotationConfig | undefined
+      }
+    />
+  );
+}

--- a/app/src/pages/project/__generated__/SpansTableAsideQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SpansTableAsideQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b9cc8f93b0ed35556d5239d6addf2706>>
+ * @generated SignedSource<<b5bcf675ad9a49e416333b31dbc83b93>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -38,6 +38,7 @@ export type SpansTableAsideQuery$data = {
     readonly name?: string;
     readonly spanAnnotationNames?: ReadonlyArray<string>;
     readonly timeRangeTraceCount?: number;
+    readonly traceAnnotationsNames?: ReadonlyArray<string>;
   };
 };
 export type SpansTableAsideQuery = {
@@ -197,6 +198,13 @@ v8 = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
+      "name": "traceAnnotationsNames",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
       "name": "documentEvaluationNames",
       "storageKey": null
     }
@@ -270,16 +278,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e6417cbdc9860374a93196aaa89bf7fd",
+    "cacheID": "a1e027b33affffecaa47b7824525b199",
     "id": null,
     "metadata": {},
     "name": "SpansTableAsideQuery",
     "operationKind": "query",
-    "text": "query SpansTableAsideQuery(\n  $id: ID!\n  $timeRange: TimeRange!\n  $filterCondition: String\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      name\n      description\n      timeRangeTraceCount: traceCount(timeRange: $timeRange, filterCondition: $filterCondition)\n      costSummary(timeRange: $timeRange, filterCondition: $filterCondition) {\n        total {\n          cost\n        }\n        prompt {\n          cost\n        }\n        completion {\n          cost\n        }\n      }\n      latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange, filterCondition: $filterCondition)\n      latencyMsP99: latencyMsQuantile(probability: 0.99, timeRange: $timeRange, filterCondition: $filterCondition)\n      spanAnnotationNames\n      documentEvaluationNames\n    }\n    id\n  }\n}\n"
+    "text": "query SpansTableAsideQuery(\n  $id: ID!\n  $timeRange: TimeRange!\n  $filterCondition: String\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      name\n      description\n      timeRangeTraceCount: traceCount(timeRange: $timeRange, filterCondition: $filterCondition)\n      costSummary(timeRange: $timeRange, filterCondition: $filterCondition) {\n        total {\n          cost\n        }\n        prompt {\n          cost\n        }\n        completion {\n          cost\n        }\n      }\n      latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange, filterCondition: $filterCondition)\n      latencyMsP99: latencyMsQuantile(probability: 0.99, timeRange: $timeRange, filterCondition: $filterCondition)\n      spanAnnotationNames\n      traceAnnotationsNames\n      documentEvaluationNames\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "50ef5520bd2830aadbd6bbb40300258b";
+(node as any).hash = "9f9849c08befb130c27f4a869a27686b";
 
 export default node;

--- a/app/src/pages/project/__generated__/TraceAnnotationSummaryQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/TraceAnnotationSummaryQuery.graphql.ts
@@ -1,0 +1,336 @@
+/**
+ * @generated SignedSource<<cacf14ff34a1adc78e07ba907d4e0897>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type TimeRange = {
+  end?: string | null;
+  start?: string | null;
+};
+export type TraceAnnotationSummaryQuery$variables = {
+  annotationName: string;
+  filterCondition?: string | null;
+  id: string;
+  timeRange: TimeRange;
+};
+export type TraceAnnotationSummaryQuery$data = {
+  readonly project: {
+    readonly " $fragmentSpreads": FragmentRefs<"TraceAnnotationSummaryValueFragment">;
+  };
+};
+export type TraceAnnotationSummaryQuery = {
+  response: TraceAnnotationSummaryQuery$data;
+  variables: TraceAnnotationSummaryQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "annotationName"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filterCondition"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "id"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "timeRange"
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v5 = [
+  {
+    "kind": "Variable",
+    "name": "annotationName",
+    "variableName": "annotationName"
+  },
+  {
+    "kind": "Variable",
+    "name": "filterCondition",
+    "variableName": "filterCondition"
+  },
+  {
+    "kind": "Variable",
+    "name": "timeRange",
+    "variableName": "timeRange"
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "annotationType",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TraceAnnotationSummaryQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v5/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "TraceAnnotationSummaryValueFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v2/*: any*/),
+      (v0/*: any*/),
+      (v3/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "TraceAnnotationSummaryQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v6/*: any*/),
+          (v7/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v6/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*: any*/)
+                            ],
+                            "type": "AnnotationConfigBase",
+                            "abstractKey": "__isAnnotationConfigBase"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*: any*/),
+                              (v7/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "optimizationDirection",
+                                "storageKey": null
+                              },
+                              (v9/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": [
+                                  (v10/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "score",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v7/*: any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v5/*: any*/),
+                "concreteType": "AnnotationSummary",
+                "kind": "LinkedField",
+                "name": "traceAnnotationSummary",
+                "plural": false,
+                "selections": [
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "count",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "scoreCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "labelCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "LabelFraction",
+                    "kind": "LinkedField",
+                    "name": "labelFractions",
+                    "plural": true,
+                    "selections": [
+                      (v10/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "fraction",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "meanScore",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "7923bbc73f4ef31e5c3d2ea50dde65dc",
+    "id": null,
+    "metadata": {},
+    "name": "TraceAnnotationSummaryQuery",
+    "operationKind": "query",
+    "text": "query TraceAnnotationSummaryQuery(\n  $id: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $filterCondition: String\n) {\n  project: node(id: $id) {\n    __typename\n    ...TraceAnnotationSummaryValueFragment_3esv1j\n    id\n  }\n}\n\nfragment TraceAnnotationSummaryValueFragment_3esv1j on Project {\n  annotationConfigs {\n    edges {\n      node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          annotationType\n          id\n          optimizationDirection\n          name\n          values {\n            label\n            score\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  traceAnnotationSummary(annotationName: $annotationName, timeRange: $timeRange, filterCondition: $filterCondition) {\n    name\n    count\n    scoreCount\n    labelCount\n    labelFractions {\n      label\n      fraction\n    }\n    meanScore\n  }\n  id\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "f430c8424696b86f88184928da0b3fca";
+
+export default node;

--- a/app/src/pages/project/__generated__/TraceAnnotationSummaryValueFragment.graphql.ts
+++ b/app/src/pages/project/__generated__/TraceAnnotationSummaryValueFragment.graphql.ts
@@ -1,0 +1,275 @@
+/**
+ * @generated SignedSource<<40c4f752cbb07f0da34e7a92d06516d2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type AnnotationType = "CATEGORICAL" | "CONTINUOUS" | "FREEFORM";
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
+import { FragmentRefs } from "relay-runtime";
+export type TraceAnnotationSummaryValueFragment$data = {
+  readonly annotationConfigs: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly annotationType?: AnnotationType;
+        readonly id?: string;
+        readonly name?: string;
+        readonly optimizationDirection?: OptimizationDirection;
+        readonly values?: ReadonlyArray<{
+          readonly label: string;
+          readonly score: number | null;
+        }>;
+      };
+    }>;
+  };
+  readonly id: string;
+  readonly traceAnnotationSummary: {
+    readonly count: number;
+    readonly labelCount: number;
+    readonly labelFractions: ReadonlyArray<{
+      readonly fraction: number;
+      readonly label: string;
+    }>;
+    readonly meanScore: number | null;
+    readonly name: string;
+    readonly scoreCount: number;
+  } | null;
+  readonly " $fragmentType": "TraceAnnotationSummaryValueFragment";
+};
+export type TraceAnnotationSummaryValueFragment$key = {
+  readonly " $data"?: TraceAnnotationSummaryValueFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"TraceAnnotationSummaryValueFragment">;
+};
+
+import TraceAnnotationSummaryValueQuery_graphql from './TraceAnnotationSummaryValueQuery.graphql';
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "annotationType",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "annotationName"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "filterCondition"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "timeRange"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": TraceAnnotationSummaryValueQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "TraceAnnotationSummaryValueFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AnnotationConfigConnection",
+      "kind": "LinkedField",
+      "name": "annotationConfigs",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AnnotationConfigEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": null,
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v0/*: any*/)
+                  ],
+                  "type": "AnnotationConfigBase",
+                  "abstractKey": "__isAnnotationConfigBase"
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v0/*: any*/),
+                    (v1/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "optimizationDirection",
+                      "storageKey": null
+                    },
+                    (v2/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "CategoricalAnnotationValue",
+                      "kind": "LinkedField",
+                      "name": "values",
+                      "plural": true,
+                      "selections": [
+                        (v3/*: any*/),
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "score",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "CategoricalAnnotationConfig",
+                  "abstractKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "annotationName",
+          "variableName": "annotationName"
+        },
+        {
+          "kind": "Variable",
+          "name": "filterCondition",
+          "variableName": "filterCondition"
+        },
+        {
+          "kind": "Variable",
+          "name": "timeRange",
+          "variableName": "timeRange"
+        }
+      ],
+      "concreteType": "AnnotationSummary",
+      "kind": "LinkedField",
+      "name": "traceAnnotationSummary",
+      "plural": false,
+      "selections": [
+        (v2/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "scoreCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "labelCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "LabelFraction",
+          "kind": "LinkedField",
+          "name": "labelFractions",
+          "plural": true,
+          "selections": [
+            (v3/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "fraction",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "meanScore",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    (v1/*: any*/)
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "0f0c91e7567019d3d67518f0495bf25e";
+
+export default node;

--- a/app/src/pages/project/__generated__/TraceAnnotationSummaryValueQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/TraceAnnotationSummaryValueQuery.graphql.ts
@@ -1,0 +1,336 @@
+/**
+ * @generated SignedSource<<dabf0127742e2475c6f4fbef73e576e2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type TimeRange = {
+  end?: string | null;
+  start?: string | null;
+};
+export type TraceAnnotationSummaryValueQuery$variables = {
+  annotationName: string;
+  filterCondition?: string | null;
+  id: string;
+  timeRange: TimeRange;
+};
+export type TraceAnnotationSummaryValueQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"TraceAnnotationSummaryValueFragment">;
+  };
+};
+export type TraceAnnotationSummaryValueQuery = {
+  response: TraceAnnotationSummaryValueQuery$data;
+  variables: TraceAnnotationSummaryValueQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "annotationName"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filterCondition"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "id"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "timeRange"
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v5 = [
+  {
+    "kind": "Variable",
+    "name": "annotationName",
+    "variableName": "annotationName"
+  },
+  {
+    "kind": "Variable",
+    "name": "filterCondition",
+    "variableName": "filterCondition"
+  },
+  {
+    "kind": "Variable",
+    "name": "timeRange",
+    "variableName": "timeRange"
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "annotationType",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TraceAnnotationSummaryValueQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v5/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "TraceAnnotationSummaryValueFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v3/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "TraceAnnotationSummaryValueQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v6/*: any*/),
+          (v7/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v6/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*: any*/)
+                            ],
+                            "type": "AnnotationConfigBase",
+                            "abstractKey": "__isAnnotationConfigBase"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*: any*/),
+                              (v7/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "optimizationDirection",
+                                "storageKey": null
+                              },
+                              (v9/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": [
+                                  (v10/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "score",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v7/*: any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v5/*: any*/),
+                "concreteType": "AnnotationSummary",
+                "kind": "LinkedField",
+                "name": "traceAnnotationSummary",
+                "plural": false,
+                "selections": [
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "count",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "scoreCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "labelCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "LabelFraction",
+                    "kind": "LinkedField",
+                    "name": "labelFractions",
+                    "plural": true,
+                    "selections": [
+                      (v10/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "fraction",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "meanScore",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "21072d6aacf8787f542bfaa3fad1a474",
+    "id": null,
+    "metadata": {},
+    "name": "TraceAnnotationSummaryValueQuery",
+    "operationKind": "query",
+    "text": "query TraceAnnotationSummaryValueQuery(\n  $annotationName: String!\n  $filterCondition: String = null\n  $timeRange: TimeRange!\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...TraceAnnotationSummaryValueFragment_3esv1j\n    id\n  }\n}\n\nfragment TraceAnnotationSummaryValueFragment_3esv1j on Project {\n  annotationConfigs {\n    edges {\n      node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          annotationType\n          id\n          optimizationDirection\n          name\n          values {\n            label\n            score\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  traceAnnotationSummary(annotationName: $annotationName, timeRange: $timeRange, filterCondition: $filterCondition) {\n    name\n    count\n    scoreCount\n    labelCount\n    labelFractions {\n      label\n      fraction\n    }\n    meanScore\n  }\n  id\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "0f0c91e7567019d3d67518f0495bf25e";
+
+export default node;


### PR DESCRIPTION
## Summary

The project spans **Stats** panel previously showed only span annotation summaries and document annotations. This adds **trace-level annotation summaries** so all levels of feedback show up in one place.

The stats are now grouped into clearly-headed sections, each with a subtle underlined heading:

- **Overview** — total traces, cost, latency P50/P99 (unchanged, now ungrouped at top)
- **Span Annotations**
- **Document Annotations**
- **Trace Annotations** *(new)*

Sections only render when they have content.

## Implementation

- New `TraceAnnotationSummary` component (project-level) mirrors the existing span-level `AnnotationSummary`, querying `Project.traceAnnotationSummary(annotationName, timeRange, filterCondition)`.
- The two summaries now share everything except their Relay fragment, which can't be parameterized by field name. The common pieces live in `AnnotationSummary.tsx`:
  - `useRefetchOnStreamAdvance` — the stream-refetch wiring (`fetchKey` effect + `startTransition`).
  - `AnnotationSummaryValueView` — the `SummaryValue` mapping and annotation-config lookup.
  - `Summary` / `SummaryValue` presentation (already shared).
  Each `*SummaryValue` component is now just its fragment plus a call into the shared view, so a future session-level summary is a thin file rather than a third full copy.
- `SpansTableAside` fetches `traceAnnotationsNames` and renders a `StatsSection` per feedback level.
- No backend changes — `Project.traceAnnotationSummary` already existed.

## Testing

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- Verified in-browser on the project spans page
