### PR TITLE
docs: add Go OpenInference integrations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ Normalize and convert data across other instrumentation libraries by adding span
 | | SpringAI | `openinference-instrumentation-springAI` | [![Maven Central](https://img.shields.io/maven-central/v/com.arize/openinference-instrumentation-springAI.svg)](https://central.sonatype.com/artifact/com.arize/openinference-instrumentation-springAI) |
 | <img src="https://avatars.githubusercontent.com/u/151681568" height="16"> | [Arconia](https://docs.arconia.io/arconia/latest/observability/semantic-conventions/openinference/) for Spring AI | `io.arconia:arconia-openinference-semantic-conventions` | [![Maven Central](https://img.shields.io/maven-central/v/io.arconia/arconia-openinference-ai-semantic-conventions.svg)](https://central.sonatype.com/artifact/io.arconia/arconia-openinference-ai-semantic-conventions) |
 
+### Go Integrations
+
+| | Integration | Package | Version |
+|:---:|---|---|---|
+| <picture><source media="(prefers-color-scheme: dark)" srcset="https://unpkg.com/@lobehub/icons-static-png@latest/dark/openai.png"><img height="14" src="https://unpkg.com/@lobehub/icons-static-png@latest/light/openai.png"></picture> | [OpenAI](https://github.com/Arize-ai/openinference/tree/main/go/openinference-instrumentation-openai-go) | `github.com/Arize-ai/openinference/go/openinference-instrumentation-openai-go` | [![Go Reference](https://pkg.go.dev/badge/github.com/Arize-ai/openinference/go/openinference-instrumentation-openai-go.svg)](https://pkg.go.dev/github.com/Arize-ai/openinference/go/openinference-instrumentation-openai-go) |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="https://unpkg.com/@lobehub/icons-static-png@latest/dark/anthropic.png"><img height="14" src="https://unpkg.com/@lobehub/icons-static-png@latest/light/anthropic.png"></picture> | [Anthropic](https://github.com/Arize-ai/openinference/tree/main/go/openinference-instrumentation-anthropic-sdk-go) | `github.com/Arize-ai/openinference/go/openinference-instrumentation-anthropic-sdk-go` | [![Go Reference](https://pkg.go.dev/badge/github.com/Arize-ai/openinference/go/openinference-instrumentation-anthropic-sdk-go.svg)](https://pkg.go.dev/github.com/Arize-ai/openinference/go/openinference-instrumentation-anthropic-sdk-go) |
+
 ### Platforms
 
 | | Platform | Description | Docs |


### PR DESCRIPTION
## Summary

- Adds a new **Go Integrations** section to the Tracing Integrations table in the top-level README
- Lists the two Go packages from the [OpenInference](https://github.com/Arize-ai/openinference) project:
  - `github.com/Arize-ai/openinference/go/openinference-instrumentation-openai-go` — OpenAI Go SDK instrumentation
  - `github.com/Arize-ai/openinference/go/openinference-instrumentation-anthropic-sdk-go` — Anthropic SDK Go instrumentation
- Follows the same table format used for the existing Java Integrations section, with pkg.go.dev reference badges

## Test plan

- [ ] Verify the Go Reference badges resolve correctly on pkg.go.dev
- [ ] Confirm the GitHub tree links point to the correct directories in the openinference repo
- [ ] Review the rendered markdown table in the PR preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSXLZ66UKXU9Hu6DUv6ZKi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSXLZ66UKXU9Hu6DUv6ZKi)_