### PR TITLE
fix(ui): pin agent chat to bottom when reopening the panel

### DIFF
--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -373,12 +373,21 @@ export function ChatView({
       if (!element) {
         return;
       }
-      // Align restored chat history before first paint; useStickToBottom handles later
-      // resize/follow behavior once its observers are attached.
+      // Synchronously pin restored history to the bottom before first paint so
+      // reopening the panel never flashes the transcript scrolled to the top.
       element.scrollTop = element.scrollHeight - element.clientHeight;
     },
     [scrollRef]
   );
+  // The synchronous alignment above writes scrollTop directly, which leaves
+  // useStickToBottom's lock disengaged. Reopening the panel remounts this view,
+  // and once restored content finishes measuring after mount the controller
+  // stops following — stranding the transcript partway down (#13527). Re-assert
+  // the bottom through the controller on mount to engage the lock; "instant"
+  // keeps it flush without an animated catch-up.
+  useLayoutEffect(() => {
+    void scrollToBottom({ animation: "instant" });
+  }, [scrollToBottom]);
   const store = useAgentStore();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // Seed the input from any prompt staged for this session (e.g. forked from a

--- a/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/app/src/components/agent/__tests__/Chat.test.tsx
@@ -7,6 +7,24 @@ import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
 
 import { ChatView } from "../Chat";
 
+const { scrollToBottomMock } = vi.hoisted(() => ({
+  scrollToBottomMock: vi.fn(),
+}));
+
+// Stub the stick-to-bottom controller so we can assert the chat re-anchors to
+// the bottom through it on mount (the lock that keeps reopened panels pinned).
+vi.mock("use-stick-to-bottom", () => {
+  const noopRef = Object.assign(() => undefined, { current: null });
+  return {
+    useStickToBottom: () => ({
+      contentRef: noopRef,
+      scrollRef: noopRef,
+      scrollToBottom: scrollToBottomMock,
+      stopScroll: () => undefined,
+    }),
+  };
+});
+
 vi.mock("@phoenix/agent/quickActions/quickActions", () => ({
   useAgentQuickActions: () => [],
 }));
@@ -99,6 +117,7 @@ describe("ChatView", () => {
 
   beforeEach(() => {
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    scrollToBottomMock.mockClear();
     vi.stubGlobal(
       "matchMedia",
       vi.fn().mockImplementation((query: string) => ({
@@ -146,5 +165,14 @@ describe("ChatView", () => {
 
     expect(textarea).not.toBeNull();
     expect(document.activeElement).not.toBe(textarea);
+  });
+
+  it("re-anchors the transcript to the bottom on mount", () => {
+    // Reopening the panel remounts this view; it must engage the stick-to-bottom
+    // lock instantly so restored history that finishes measuring after mount
+    // stays pinned to the bottom instead of stranding partway down (#13527).
+    renderChatView(root);
+
+    expect(scrollToBottomMock).toHaveBeenCalledWith({ animation: "instant" });
   });
 });


### PR DESCRIPTION
fixes #13527

## Summary

Reopening the agent chat panel reopens the transcript scrolled to the
middle instead of pinned to the bottom (most recent message).

## Root cause

Closing the panel unmounts the chat view (`AgentChatPanel` returns `null`
when `!isOpen`), so reopening it **remounts** `ChatView`. On mount, the
scroll container's ref callback aligned the transcript to the bottom by
writing `scrollTop` directly:

```ts
element.scrollTop = element.scrollHeight - element.clientHeight;
```

That write bypasses `useStickToBottom`, so the controller's
stick-to-bottom *lock* never engages. Restored history finishes measuring
**after** mount (markdown, tool parts, usage footer, etc. grow the
content), and because the lock is disengaged the controller does not
follow that growth — leaving the transcript stranded partway down.

## Fix

Re-assert the bottom through the controller's `scrollToBottom` in a
`useLayoutEffect` on mount so the lock engages and the transcript stays
pinned as content settles. `"instant"` keeps it flush with no animated
catch-up. The synchronous pre-paint alignment in the ref callback is kept
so there is still no flash of history scrolled to the top.

## Testing

- Added a regression test (`Chat.test.tsx`) asserting the view re-anchors
  to the bottom via the controller on mount.
- `pnpm --dir app test` (Chat + scrollAnchor suites pass)
- `pnpm --dir app typecheck`, `pnpm --dir app lint`, `oxfmt`, and
  `pnpm --dir app build` all pass.

### Manual reproduction

1. Open the agent chat panel and send enough messages to overflow the
   transcript (so it scrolls).
2. Close the panel, then reopen it.
3. Before: the transcript is scrolled to the middle. After: it is pinned
   to the bottom on the most recent message.

I can attach a short screen recording of the before/after if helpful.
