### PR TITLE
fix(ui): add Copy Trace ID button to span details view

### DIFF
--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -4,6 +4,7 @@ import {
 } from "@arizeai/openinference-semantic-conventions";
 import { css } from "@emotion/react";
 import { isNumber, isString, throttle } from "lodash";
+import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PreloadedQuery } from "react-relay";
 import { graphql, usePaginationFragment, usePreloadedQuery } from "react-relay";
@@ -17,11 +18,11 @@ import type { To } from "react-router";
 import { useLocation, useSearchParams } from "react-router";
 
 import {
+  CopyToClipboardButton,
   Flex,
   ExpandableContent,
   Icon,
   Icons,
-  IDBadge,
   LinkButton,
   ListBox,
   ListBoxItem,
@@ -34,7 +35,6 @@ import {
 } from "@phoenix/components";
 import { AnnotationSummaryGroupTokens } from "@phoenix/components/annotation/AnnotationSummaryGroup";
 import { TraceAnnotationSummaryGroupTokens } from "@phoenix/components/annotation/TraceAnnotationSummaryGroup";
-import { CopyToClipboardButton } from "@phoenix/components/core/copy";
 import { DynamicContent } from "@phoenix/components/DynamicContent";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
 import { EditSpanAnnotationsDialog } from "@phoenix/components/trace/EditSpanAnnotationsDialog";
@@ -132,12 +132,17 @@ const SESSION_TURN_MESSAGE_MAX_HEIGHT = 280;
 type RootSpanMessageRole = "INPUT" | "OUTPUT";
 
 type RootSpanMessageProps = {
+  /**
+   * Optional content rendered opposite the message label in the header,
+   * typically a small action like the trace link.
+   */
+  extra?: ReactNode;
   label?: string;
   role: RootSpanMessageRole;
   value: unknown;
 };
 
-function RootSpanMessage({ label, role, value }: RootSpanMessageProps) {
+function RootSpanMessage({ extra, label, role, value }: RootSpanMessageProps) {
   const isInput = role === "INPUT";
   const styles = useChatMessageStyles(isInput ? "user" : "assistant");
   const defaultLabel = isInput ? "INPUT" : "OUTPUT";
@@ -158,6 +163,7 @@ function RootSpanMessage({ label, role, value }: RootSpanMessageProps) {
         width="100%"
       >
         <Text color="text-700">{label ?? defaultLabel}</Text>
+        {extra}
       </Flex>
       <View
         borderRadius={"medium"}
@@ -211,6 +217,37 @@ function RootSpanEndTime({ rootSpan }: RootSpanProps) {
     <Text color="text-700" size="XS">
       {fullTimeFormatter(endDate)}
     </Text>
+  );
+}
+
+function RootSpanTraceLink({
+  traceId,
+  rootSpan,
+}: RootSpanProps & { traceId: string }) {
+  const location = useLocation();
+
+  return (
+    <Flex direction="row" alignItems="center" gap="size-50">
+      <CopyToClipboardButton
+        text={traceId}
+        variant="quiet"
+        tooltipText="Copy trace ID"
+        aria-label="Copy trace ID"
+      />
+      <LinkButton
+        size="S"
+        variant="quiet"
+        leadingVisual={<Icon svg={<Icons.Trace />} />}
+        to={getSessionTraceUrl({
+          pathname: location.pathname,
+          search: location.search,
+          traceId,
+          spanNodeId: rootSpan.id,
+        })}
+      >
+        Trace
+      </LinkButton>
+    </Flex>
   );
 }
 
@@ -289,74 +326,15 @@ function RootSpanOutputMetadata({ rootSpan }: RootSpanProps) {
   );
 }
 
-const sessionTurnDividerCSS = css`
-  .session-turn-divider__rule {
-    flex: 1;
-    height: 0;
-    border-top: 1px solid var(--global-color-gray-300);
-  }
-`;
-
-/**
- * A divider that labels a turn ("Turn 01") and exposes the turn-level actions:
- * copy the trace ID and view the trace. The whole turn is one trace, so these
- * controls belong here rather than inside the OUTPUT bubble.
- */
-function SessionTurnDivider({
-  index,
-  traceId,
-  rootSpan,
-}: RootSpanProps & { traceId: string; index: number }) {
-  const location = useLocation();
-  const paddedIndex = String(index + 1).padStart(2, "0");
-  return (
-    <Flex
-      direction="row"
-      alignItems="center"
-      gap="size-100"
-      css={sessionTurnDividerCSS}
-    >
-      <Text fontFamily="mono" color="text-500">
-        Turn {paddedIndex}
-      </Text>
-      <div className="session-turn-divider__rule" />
-      <LinkButton
-        size="S"
-        variant="quiet"
-        aria-label="View trace"
-        leadingVisual={<Icon svg={<Icons.Trace />} />}
-        to={getSessionTraceUrl({
-          pathname: location.pathname,
-          search: location.search,
-          traceId,
-          spanNodeId: rootSpan.id,
-        })}
-      >
-        Trace
-      </LinkButton>
-      <IDBadge id={traceId} />
-      <CopyToClipboardButton
-        text={traceId}
-        size="S"
-        variant="quiet"
-        tooltipText="Copy trace ID"
-        aria-label="Copy trace ID"
-      />
-    </Flex>
-  );
-}
-
 function SessionTurnDetail({
-  index,
   traceId,
   rootSpan,
-}: RootSpanProps & { traceId: string; index: number }) {
+}: RootSpanProps & { traceId: string }) {
   const user = getUserFromRootSpanAttributes(rootSpan.attributes);
   const inputLabel = user != null ? `USER: ${user}` : "INPUT";
 
   return (
     <Flex direction="column" gap="size-200">
-      <SessionTurnDivider index={index} traceId={traceId} rootSpan={rootSpan} />
       <Flex
         direction="column"
         gap="size-100"
@@ -378,7 +356,11 @@ function SessionTurnDetail({
         alignItems="end"
         css={messageWrapCSS}
       >
-        <RootSpanMessage role="OUTPUT" value={rootSpan.output?.value} />
+        <RootSpanMessage
+          extra={<RootSpanTraceLink traceId={traceId} rootSpan={rootSpan} />}
+          role="OUTPUT"
+          value={rootSpan.output?.value}
+        />
         <RootSpanOutputMetadata rootSpan={rootSpan} />
       </Flex>
     </Flex>
@@ -547,17 +529,8 @@ function SessionTurnList({
 }
 
 const turnDetailRowCSS = css`
-  &[data-selected],
-  &[data-after-selected] {
-    .session-turn-divider__rule {
-      visibility: hidden;
-    }
-  }
-
   &[data-selected] {
     background-color: var(--global-list-detail-selected-background-color);
-    border-bottom: var(--global-border-size-thin) solid
-      var(--global-border-color-default);
   }
 `;
 
@@ -715,13 +688,6 @@ export function SessionDetailsTraceList({
     }
   }, [selectedTraceId, sessionRootSpans]);
 
-  const selectedIndex =
-    selectedTraceId == null
-      ? -1
-      : sessionRootSpans.findIndex(
-          ({ traceId }) => traceId === selectedTraceId
-        );
-
   const turnListPanel = (
     <div
       css={css`
@@ -770,43 +736,30 @@ export function SessionDetailsTraceList({
             debouncedFetchMoreOnBottomReached(e.target as HTMLDivElement)
           }
         >
-          {sessionRootSpans.map(({ traceId, rootSpan }, index) => {
-            const isSelected = index === selectedIndex;
-            // Hide this row's top divider when the row directly above it is
-            // the selected one, since the selected row draws its own
-            // border-bottom and a divider here would double up.
-            const isAfterSelected =
-              selectedIndex >= 0 && index === selectedIndex + 1;
-            return (
-              <div
-                key={rootSpan.spanId}
-                css={turnDetailRowCSS}
-                data-selected={isSelected || undefined}
-                data-after-selected={isAfterSelected || undefined}
-                ref={(el) => {
-                  if (el) {
-                    rowRefs.current.set(traceId, el);
-                  } else {
-                    rowRefs.current.delete(traceId);
-                  }
-                }}
+          {sessionRootSpans.map(({ traceId, rootSpan }) => (
+            <div
+              key={rootSpan.spanId}
+              css={turnDetailRowCSS}
+              data-selected={traceId === selectedTraceId || undefined}
+              ref={(el) => {
+                if (el) {
+                  rowRefs.current.set(traceId, el);
+                } else {
+                  rowRefs.current.delete(traceId);
+                }
+              }}
+            >
+              <View
+                borderBottomColor="default"
+                borderBottomWidth="thin"
+                padding="size-200"
               >
-                <View
-                  paddingTop="size-100"
-                  paddingBottom="size-200"
-                  paddingX="size-200"
-                >
-                  <View width="100%" maxWidth="size-8500" marginX="auto">
-                    <SessionTurnDetail
-                      index={index}
-                      traceId={traceId}
-                      rootSpan={rootSpan}
-                    />
-                  </View>
+                <View width="100%" maxWidth="size-8500" marginX="auto">
+                  <SessionTurnDetail traceId={traceId} rootSpan={rootSpan} />
                 </View>
-              </div>
-            );
-          })}
+              </View>
+            </div>
+          ))}
           {isLoadingNext && (
             <View
               borderBottomColor="default"

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -4,7 +4,6 @@ import {
 } from "@arizeai/openinference-semantic-conventions";
 import { css } from "@emotion/react";
 import { isNumber, isString, throttle } from "lodash";
-import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PreloadedQuery } from "react-relay";
 import { graphql, usePaginationFragment, usePreloadedQuery } from "react-relay";
@@ -18,11 +17,11 @@ import type { To } from "react-router";
 import { useLocation, useSearchParams } from "react-router";
 
 import {
-  CopyToClipboardButton,
   Flex,
   ExpandableContent,
   Icon,
   Icons,
+  IDBadge,
   LinkButton,
   ListBox,
   ListBoxItem,
@@ -35,6 +34,7 @@ import {
 } from "@phoenix/components";
 import { AnnotationSummaryGroupTokens } from "@phoenix/components/annotation/AnnotationSummaryGroup";
 import { TraceAnnotationSummaryGroupTokens } from "@phoenix/components/annotation/TraceAnnotationSummaryGroup";
+import { CopyToClipboardButton } from "@phoenix/components/core/copy";
 import { DynamicContent } from "@phoenix/components/DynamicContent";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
 import { EditSpanAnnotationsDialog } from "@phoenix/components/trace/EditSpanAnnotationsDialog";
@@ -132,17 +132,12 @@ const SESSION_TURN_MESSAGE_MAX_HEIGHT = 280;
 type RootSpanMessageRole = "INPUT" | "OUTPUT";
 
 type RootSpanMessageProps = {
-  /**
-   * Optional content rendered opposite the message label in the header,
-   * typically a small action like the trace link.
-   */
-  extra?: ReactNode;
   label?: string;
   role: RootSpanMessageRole;
   value: unknown;
 };
 
-function RootSpanMessage({ extra, label, role, value }: RootSpanMessageProps) {
+function RootSpanMessage({ label, role, value }: RootSpanMessageProps) {
   const isInput = role === "INPUT";
   const styles = useChatMessageStyles(isInput ? "user" : "assistant");
   const defaultLabel = isInput ? "INPUT" : "OUTPUT";
@@ -163,7 +158,6 @@ function RootSpanMessage({ extra, label, role, value }: RootSpanMessageProps) {
         width="100%"
       >
         <Text color="text-700">{label ?? defaultLabel}</Text>
-        {extra}
       </Flex>
       <View
         borderRadius={"medium"}
@@ -217,37 +211,6 @@ function RootSpanEndTime({ rootSpan }: RootSpanProps) {
     <Text color="text-700" size="XS">
       {fullTimeFormatter(endDate)}
     </Text>
-  );
-}
-
-function RootSpanTraceLink({
-  traceId,
-  rootSpan,
-}: RootSpanProps & { traceId: string }) {
-  const location = useLocation();
-
-  return (
-    <Flex direction="row" alignItems="center" gap="size-50">
-      <CopyToClipboardButton
-        text={traceId}
-        variant="quiet"
-        tooltipText="Copy trace ID"
-        aria-label="Copy trace ID"
-      />
-      <LinkButton
-        size="S"
-        variant="quiet"
-        leadingVisual={<Icon svg={<Icons.Trace />} />}
-        to={getSessionTraceUrl({
-          pathname: location.pathname,
-          search: location.search,
-          traceId,
-          spanNodeId: rootSpan.id,
-        })}
-      >
-        Trace
-      </LinkButton>
-    </Flex>
   );
 }
 
@@ -326,15 +289,74 @@ function RootSpanOutputMetadata({ rootSpan }: RootSpanProps) {
   );
 }
 
-function SessionTurnDetail({
+const sessionTurnDividerCSS = css`
+  .session-turn-divider__rule {
+    flex: 1;
+    height: 0;
+    border-top: 1px solid var(--global-color-gray-300);
+  }
+`;
+
+/**
+ * A divider that labels a turn ("Turn 01") and exposes the turn-level actions:
+ * copy the trace ID and view the trace. The whole turn is one trace, so these
+ * controls belong here rather than inside the OUTPUT bubble.
+ */
+function SessionTurnDivider({
+  index,
   traceId,
   rootSpan,
-}: RootSpanProps & { traceId: string }) {
+}: RootSpanProps & { traceId: string; index: number }) {
+  const location = useLocation();
+  const paddedIndex = String(index + 1).padStart(2, "0");
+  return (
+    <Flex
+      direction="row"
+      alignItems="center"
+      gap="size-100"
+      css={sessionTurnDividerCSS}
+    >
+      <Text fontFamily="mono" color="text-500">
+        Turn {paddedIndex}
+      </Text>
+      <div className="session-turn-divider__rule" />
+      <LinkButton
+        size="S"
+        variant="quiet"
+        aria-label="View trace"
+        leadingVisual={<Icon svg={<Icons.Trace />} />}
+        to={getSessionTraceUrl({
+          pathname: location.pathname,
+          search: location.search,
+          traceId,
+          spanNodeId: rootSpan.id,
+        })}
+      >
+        Trace
+      </LinkButton>
+      <IDBadge id={traceId} />
+      <CopyToClipboardButton
+        text={traceId}
+        size="S"
+        variant="quiet"
+        tooltipText="Copy trace ID"
+        aria-label="Copy trace ID"
+      />
+    </Flex>
+  );
+}
+
+function SessionTurnDetail({
+  index,
+  traceId,
+  rootSpan,
+}: RootSpanProps & { traceId: string; index: number }) {
   const user = getUserFromRootSpanAttributes(rootSpan.attributes);
   const inputLabel = user != null ? `USER: ${user}` : "INPUT";
 
   return (
     <Flex direction="column" gap="size-200">
+      <SessionTurnDivider index={index} traceId={traceId} rootSpan={rootSpan} />
       <Flex
         direction="column"
         gap="size-100"
@@ -356,11 +378,7 @@ function SessionTurnDetail({
         alignItems="end"
         css={messageWrapCSS}
       >
-        <RootSpanMessage
-          extra={<RootSpanTraceLink traceId={traceId} rootSpan={rootSpan} />}
-          role="OUTPUT"
-          value={rootSpan.output?.value}
-        />
+        <RootSpanMessage role="OUTPUT" value={rootSpan.output?.value} />
         <RootSpanOutputMetadata rootSpan={rootSpan} />
       </Flex>
     </Flex>
@@ -529,8 +547,17 @@ function SessionTurnList({
 }
 
 const turnDetailRowCSS = css`
+  &[data-selected],
+  &[data-after-selected] {
+    .session-turn-divider__rule {
+      visibility: hidden;
+    }
+  }
+
   &[data-selected] {
     background-color: var(--global-list-detail-selected-background-color);
+    border-bottom: var(--global-border-size-thin) solid
+      var(--global-border-color-default);
   }
 `;
 
@@ -688,6 +715,13 @@ export function SessionDetailsTraceList({
     }
   }, [selectedTraceId, sessionRootSpans]);
 
+  const selectedIndex =
+    selectedTraceId == null
+      ? -1
+      : sessionRootSpans.findIndex(
+          ({ traceId }) => traceId === selectedTraceId
+        );
+
   const turnListPanel = (
     <div
       css={css`
@@ -736,30 +770,43 @@ export function SessionDetailsTraceList({
             debouncedFetchMoreOnBottomReached(e.target as HTMLDivElement)
           }
         >
-          {sessionRootSpans.map(({ traceId, rootSpan }) => (
-            <div
-              key={rootSpan.spanId}
-              css={turnDetailRowCSS}
-              data-selected={traceId === selectedTraceId || undefined}
-              ref={(el) => {
-                if (el) {
-                  rowRefs.current.set(traceId, el);
-                } else {
-                  rowRefs.current.delete(traceId);
-                }
-              }}
-            >
-              <View
-                borderBottomColor="default"
-                borderBottomWidth="thin"
-                padding="size-200"
+          {sessionRootSpans.map(({ traceId, rootSpan }, index) => {
+            const isSelected = index === selectedIndex;
+            // Hide this row's top divider when the row directly above it is
+            // the selected one, since the selected row draws its own
+            // border-bottom and a divider here would double up.
+            const isAfterSelected =
+              selectedIndex >= 0 && index === selectedIndex + 1;
+            return (
+              <div
+                key={rootSpan.spanId}
+                css={turnDetailRowCSS}
+                data-selected={isSelected || undefined}
+                data-after-selected={isAfterSelected || undefined}
+                ref={(el) => {
+                  if (el) {
+                    rowRefs.current.set(traceId, el);
+                  } else {
+                    rowRefs.current.delete(traceId);
+                  }
+                }}
               >
-                <View width="100%" maxWidth="size-8500" marginX="auto">
-                  <SessionTurnDetail traceId={traceId} rootSpan={rootSpan} />
+                <View
+                  paddingTop="size-100"
+                  paddingBottom="size-200"
+                  paddingX="size-200"
+                >
+                  <View width="100%" maxWidth="size-8500" marginX="auto">
+                    <SessionTurnDetail
+                      index={index}
+                      traceId={traceId}
+                      rootSpan={rootSpan}
+                    />
+                  </View>
                 </View>
-              </View>
-            </div>
-          ))}
+              </div>
+            );
+          })}
           {isLoadingNext && (
             <View
               borderBottomColor="default"

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -341,6 +341,11 @@ export function SpanDetails({
                 </ToggleButton>
                 <CopyToClipboardButton
                   size="S"
+                  text={span.trace.traceId}
+                  tooltipText="Copy Trace ID"
+                />
+                <CopyToClipboardButton
+                  size="S"
                   text={span.spanId}
                   tooltipText="Copy Span ID"
                 />


### PR DESCRIPTION
## Problem

When navigating to the trace view from a session (e.g. by clicking the Trace link in the session turns view), the root span is always auto-selected. The span details panel only offered a **Copy Span ID** button — there was no way to copy the trace ID directly from that view.

This was the second issue raised in #13709 by @mikeldking:
> "when we move to the trace view, you no longer can copy the trace ID as the trace always selects the root span"

## Fix

Adds a **Copy Trace ID** button next to the existing Copy Span ID button in `SpanDetails`, so users can copy the trace ID regardless of which span is selected.

## Note

The first issue from #13709 (trace link placement at turn level) was already addressed by #14117.