### PR TITLE
feat(agent): submit highlighted command on Enter in skill prompt

### DIFF
--- a/app/src/components/agent/SkillPromptInput.tsx
+++ b/app/src/components/agent/SkillPromptInput.tsx
@@ -9,7 +9,10 @@ import { usePromptInputContext } from "@phoenix/components/ai/prompt-input/Promp
 import { SkillHighlightOverlay } from "./SkillHighlightOverlay";
 import { SlashCommandMenu } from "./SlashCommandMenu";
 import type { AvailableAgentSkill } from "./useAvailableAgentSkills";
-import type { SlashMenuItem } from "./usePromptSkillCommand";
+import type {
+  SkillCompletion,
+  SlashMenuItem,
+} from "./usePromptSkillCommand";
 import { usePromptSkillCommand } from "./usePromptSkillCommand";
 
 const wrapperCSS = css`
@@ -162,23 +165,21 @@ export function SkillPromptInput({
     );
   };
 
-  type CommitResult = { value: string; caret: number };
-
   // Apply a menu selection, then run `afterCommit` once React has flushed the
   // new value. Deferring past the frame lets `afterCommit` observe the
   // completed token (e.g. a submit reads it, not the partial query).
   const commitItem = (
     item: SlashMenuItem,
-    afterCommit: (result: CommitResult) => void
+    afterCommit: (completion: SkillCompletion) => void
   ) => {
-    const result = skillCommand.selectItem(value, item);
-    if (!result) return;
-    setValue(result.value);
-    requestAnimationFrame(() => afterCommit(result));
+    const completion = skillCommand.selectItem(value, item);
+    if (!completion) return;
+    setValue(completion.value);
+    requestAnimationFrame(() => afterCommit(completion));
   };
 
   // Put the caret just after the inserted token so the user can keep typing.
-  const restoreCaret = ({ value, caret }: CommitResult) => {
+  const restoreCaret = ({ value, caret }: SkillCompletion) => {
     const textarea = textareaRef.current;
     if (!textarea) return;
     textarea.focus();

--- a/app/src/components/agent/SkillPromptInput.tsx
+++ b/app/src/components/agent/SkillPromptInput.tsx
@@ -9,6 +9,7 @@ import { usePromptInputContext } from "@phoenix/components/ai/prompt-input/Promp
 import { SkillHighlightOverlay } from "./SkillHighlightOverlay";
 import { SlashCommandMenu } from "./SlashCommandMenu";
 import type { AvailableAgentSkill } from "./useAvailableAgentSkills";
+import type { SlashMenuItem } from "./usePromptSkillCommand";
 import { usePromptSkillCommand } from "./usePromptSkillCommand";
 
 const wrapperCSS = css`
@@ -161,33 +162,34 @@ export function SkillPromptInput({
     );
   };
 
-  const commitSelection = (
-    index: number,
-    { submitIfCommand = false }: { submitIfCommand?: boolean } = {}
+  type CommitResult = { value: string; caret: number };
+
+  // Apply a menu selection, then run `afterCommit` once React has flushed the
+  // new value. Deferring past the frame lets `afterCommit` observe the
+  // completed token (e.g. a submit reads it, not the partial query).
+  const commitItem = (
+    item: SlashMenuItem,
+    afterCommit: (result: CommitResult) => void
   ) => {
-    const item = skillCommand.filteredItems[index];
-    if (!item) return;
     const result = skillCommand.selectItem(value, item);
     if (!result) return;
     setValue(result.value);
-    // Commands are UI actions with no follow-on text, so Enter completes and
-    // invokes them in one keystroke; skills always complete-only since the user
-    // typically keeps typing.
-    const submitAfter = submitIfCommand && item.kind === "command";
-    // Wait for React to apply the new value (so the submit reads the completed
-    // token, not the partial query) before restoring the caret or submitting.
-    requestAnimationFrame(() => {
-      if (submitAfter) {
-        onSubmit();
-        return;
-      }
-      const textarea = textareaRef.current;
-      if (textarea) {
-        textarea.focus();
-        textarea.setSelectionRange(result.caret, result.caret);
-        skillCommand.syncFromInput(result.value, result.caret);
-      }
-    });
+    requestAnimationFrame(() => afterCommit(result));
+  };
+
+  // Put the caret just after the inserted token so the user can keep typing.
+  const restoreCaret = ({ value, caret }: CommitResult) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.focus();
+    textarea.setSelectionRange(caret, caret);
+    skillCommand.syncFromInput(value, caret);
+  };
+
+  // Complete the highlighted token in place — the menu's default click action.
+  const commitSelection = (index: number) => {
+    const item = skillCommand.filteredItems[index];
+    if (item) commitItem(item, restoreCaret);
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -211,13 +213,19 @@ export function SkillPromptInput({
           );
           return;
         case "Enter":
-        case "Tab":
+        case "Tab": {
           event.preventDefault();
-          // Enter can invoke a highlighted command outright; Tab only completes.
-          commitSelection(skillCommand.activeIndex, {
-            submitIfCommand: event.key === "Enter",
-          });
+          const item = skillCommand.filteredItems[skillCommand.activeIndex];
+          if (!item) return;
+          // Enter invokes a highlighted command outright (commands carry no
+          // follow-on text); Tab and skills just complete the token in place.
+          if (event.key === "Enter" && item.kind === "command") {
+            commitItem(item, () => onSubmit());
+          } else {
+            commitItem(item, restoreCaret);
+          }
           return;
+        }
         case "Escape":
           event.preventDefault();
           skillCommand.dismiss();

--- a/app/src/components/agent/SkillPromptInput.tsx
+++ b/app/src/components/agent/SkillPromptInput.tsx
@@ -161,14 +161,26 @@ export function SkillPromptInput({
     );
   };
 
-  const commitSelection = (index: number) => {
+  const commitSelection = (
+    index: number,
+    { submitIfCommand = false }: { submitIfCommand?: boolean } = {}
+  ) => {
     const item = skillCommand.filteredItems[index];
     if (!item) return;
     const result = skillCommand.selectItem(value, item);
     if (!result) return;
     setValue(result.value);
-    // Restore the caret after React applies the new value.
+    // Commands are UI actions with no follow-on text, so Enter completes and
+    // invokes them in one keystroke; skills always complete-only since the user
+    // typically keeps typing.
+    const submitAfter = submitIfCommand && item.kind === "command";
+    // Wait for React to apply the new value (so the submit reads the completed
+    // token, not the partial query) before restoring the caret or submitting.
     requestAnimationFrame(() => {
+      if (submitAfter) {
+        onSubmit();
+        return;
+      }
       const textarea = textareaRef.current;
       if (textarea) {
         textarea.focus();
@@ -201,7 +213,10 @@ export function SkillPromptInput({
         case "Enter":
         case "Tab":
           event.preventDefault();
-          commitSelection(skillCommand.activeIndex);
+          // Enter can invoke a highlighted command outright; Tab only completes.
+          commitSelection(skillCommand.activeIndex, {
+            submitIfCommand: event.key === "Enter",
+          });
           return;
         case "Escape":
           event.preventDefault();

--- a/app/src/components/agent/SkillPromptInput.tsx
+++ b/app/src/components/agent/SkillPromptInput.tsx
@@ -9,10 +9,7 @@ import { usePromptInputContext } from "@phoenix/components/ai/prompt-input/Promp
 import { SkillHighlightOverlay } from "./SkillHighlightOverlay";
 import { SlashCommandMenu } from "./SlashCommandMenu";
 import type { AvailableAgentSkill } from "./useAvailableAgentSkills";
-import type {
-  SkillCompletion,
-  SlashMenuItem,
-} from "./usePromptSkillCommand";
+import type { SkillCompletion, SlashMenuItem } from "./usePromptSkillCommand";
 import { usePromptSkillCommand } from "./usePromptSkillCommand";
 
 const wrapperCSS = css`

--- a/app/src/components/agent/usePromptSkillCommand.ts
+++ b/app/src/components/agent/usePromptSkillCommand.ts
@@ -182,6 +182,14 @@ export function getSelectedTokenNames(
   return selected;
 }
 
+/** The text produced by completing a slash token in the prompt. */
+export type SkillCompletion = {
+  /** Textarea value with the active `/query` replaced by `/name `. */
+  value: string;
+  /** Caret offset to restore, just past the inserted token. */
+  caret: number;
+};
+
 export type PromptSkillCommandState = {
   /** Whether the slash menu should be shown. */
   isOpen: boolean;
@@ -204,13 +212,10 @@ export type PromptSkillCommandState = {
   dismiss: () => void;
   /**
    * Apply a menu selection to `value`, replacing the active `/query` with
-   * `/name ` and returning the new value plus the caret position to restore.
-   * Returns null when there is no active query to replace.
+   * `/name ` and returning the completed text. Returns null when there is no
+   * active query to replace.
    */
-  selectItem: (
-    value: string,
-    item: SlashMenuItem
-  ) => { value: string; caret: number } | null;
+  selectItem: (value: string, item: SlashMenuItem) => SkillCompletion | null;
 };
 
 /**


### PR DESCRIPTION
## Summary

In the agent skill prompt input, pressing **Enter** on a highlighted slash-command in the menu now completes *and* invokes it in a single keystroke. Commands are UI actions with no follow-on text, so requiring a second Enter was redundant. **Tab** still completes-only, and skills always complete-only (the user typically keeps typing after a skill token).

## Changes

- `commitSelection` accepts a `submitIfCommand` option; when the committed item is a command and the option is set, it calls `onSubmit()` after React applies the completed token (deferred via `requestAnimationFrame` so the submit reads the full token, not the partial query).
- The `Enter`/`Tab` key handler passes `submitIfCommand: event.key === "Enter"`, keeping the command-vs-skill decision next to where the item is already resolved (no duplicate `filteredItems` lookup).

## Test plan

- Type `/` to open the menu, highlight a command, press Enter → completes and submits.
- Highlight a command, press Tab → completes only, no submit.
- Highlight a skill, press Enter or Tab → completes only, caret restored, keep typing.