### PR TITLE
feat(agents): stream subagent progress

### DIFF
--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -48,6 +48,7 @@ import {
 import { ADD_SPANS_TO_DATASET_TOOL_NAME } from "@phoenix/agent/tools/spansToDataset";
 import { Icon, Icons } from "@phoenix/components";
 import type { Variant } from "@phoenix/components/core/types";
+import { MarkdownBlock } from "@phoenix/components/markdown";
 
 import {
   AddDatasetExamplesToolDetails,
@@ -135,7 +136,11 @@ import {
   ToolPartStatus,
 } from "./ToolPartPrimitives";
 import type { MessagePart, ToolInvocationPart } from "./toolPartTypes";
-import { formatToolState, isToolUIPart } from "./toolPartTypes";
+import {
+  formatToolState,
+  isToolUIPart,
+  stringifyToolValue,
+} from "./toolPartTypes";
 import { useToolDisclosure } from "./useToolDisclosure";
 import {
   formatWritePromptToolsState,
@@ -202,6 +207,17 @@ export const toolPartCSS = css`
     overflow-x: auto;
     padding-top: var(--global-dimension-size-125);
     padding-bottom: var(--global-dimension-size-75);
+  }
+
+  .tool-part__subagent-message {
+    font-family: var(--ac-global-font-family-sans);
+    font-size: var(--global-font-size-s);
+    line-height: var(--global-line-height-s);
+    padding: 0 var(--global-dimension-size-250) var(--global-dimension-size-125);
+  }
+
+  .tool-part__subagent-message > .tool-part {
+    margin-top: var(--global-dimension-size-100);
   }
 
   .tool-part__line {
@@ -588,6 +604,10 @@ function ToolInvocationPartDetails({
 
   const isQuiet = variant === "quiet";
   const showQuietSummary = isQuiet && !isRenderedOpen;
+  const statusState =
+    part.state === "output-available" && part.preliminary === true
+      ? "input-available"
+      : part.state;
 
   return (
     <details
@@ -641,7 +661,7 @@ function ToolInvocationPartDetails({
           ) : null}
           {showQuietSummary
             ? null
-            : renderToolPartStatus(part.state, stateLabel, statusVariant)}
+            : renderToolPartStatus(statusState, stateLabel, statusVariant)}
         </div>
       </summary>
       <div>{details}</div>
@@ -848,6 +868,111 @@ function GenericToolDetails({ part }: { part: ToolInvocationPart }) {
         </>
       ) : null}
     </div>
+  );
+}
+
+type CallSubagentOutput = {
+  summary: string;
+  messageParts: MessagePart[];
+};
+
+function CallSubagentToolDetails({ part }: { part: ToolInvocationPart }) {
+  const output =
+    part.state === "output-available"
+      ? parseCallSubagentOutput(part.output)
+      : null;
+  if (!output) {
+    return <GenericToolDetails part={part} />;
+  }
+
+  return (
+    <div className="tool-part__body">
+      {output.summary ? (
+        <>
+          <ToolPartLabel>Summary</ToolPartLabel>
+          <ToolPartExpandableSection>
+            <ToolPartCodeBlock>{output.summary}</ToolPartCodeBlock>
+          </ToolPartExpandableSection>
+        </>
+      ) : null}
+      <ToolPartLabel>Subagent</ToolPartLabel>
+      <div className="tool-part__subagent-message">
+        {output.messageParts.map((messagePart, index) => (
+          <CallSubagentMessagePart
+            key={`${messagePart.type}-${index}`}
+            part={messagePart}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CallSubagentMessagePart({ part }: { part: MessagePart }) {
+  if (part.type === "text") {
+    return (
+      <MarkdownBlock mode="markdown" renderMode="streaming" margin="none">
+        {part.text}
+      </MarkdownBlock>
+    );
+  }
+  if (part.type === "reasoning") {
+    return (
+      <ToolPartExpandableSection>
+        <ToolPartCodeBlock>{part.text}</ToolPartCodeBlock>
+      </ToolPartExpandableSection>
+    );
+  }
+  if (part.type === "step-start") {
+    return null;
+  }
+  if (isToolUIPart(part)) {
+    return (
+      <ToolPart part={part} defaultOpen={part.state !== "output-available"} />
+    );
+  }
+  return (
+    <ToolPartExpandableSection>
+      <ToolPartCodeBlock>{stringifyToolValue(part)}</ToolPartCodeBlock>
+    </ToolPartExpandableSection>
+  );
+}
+
+function parseCallSubagentOutput(output: unknown): CallSubagentOutput | null {
+  if (typeof output !== "object" || output === null || Array.isArray(output)) {
+    return null;
+  }
+  const outputRecord = output as Record<string, unknown>;
+  const message = outputRecord.message;
+  if (
+    typeof message !== "object" ||
+    message === null ||
+    Array.isArray(message)
+  ) {
+    return null;
+  }
+  const messageRecord = message as Record<string, unknown>;
+  const parts = messageRecord.parts;
+  if (!isMessagePartArray(parts)) {
+    return null;
+  }
+  const summary = outputRecord.summary;
+  return {
+    summary: typeof summary === "string" ? summary : "",
+    messageParts: parts,
+  };
+}
+
+function isMessagePartArray(value: unknown): value is MessagePart[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (part): part is MessagePart =>
+        typeof part === "object" &&
+        part !== null &&
+        "type" in part &&
+        typeof (part as { type?: unknown }).type === "string"
+    )
   );
 }
 
@@ -1083,10 +1208,13 @@ function getToolPresentation(
     case CALL_SUBAGENT_TOOL_NAME:
       return {
         preview: getCallSubagentName(part),
-        stateLabel: formatToolState(part.state),
+        stateLabel:
+          part.state === "output-available" && part.preliminary === true
+            ? "Running"
+            : formatToolState(part.state),
         statusVariant,
         icon: <Icons.Split />,
-        details: <GenericToolDetails part={part} />,
+        details: <CallSubagentToolDetails part={part} />,
       };
     case SET_SPANS_FILTER_TOOL_NAME:
       return {

--- a/src/phoenix/server/agents/capabilities/tools/internal/call_subagent.py
+++ b/src/phoenix/server/agents/capabilities/tools/internal/call_subagent.py
@@ -5,8 +5,16 @@ from dataclasses import dataclass
 from pydantic_ai import RunContext, Tool
 from pydantic_ai.agent.abstract import AbstractAgent
 from pydantic_ai.toolsets import AgentToolset, FunctionToolset
+from pydantic_ai.ui.vercel_ai import VercelAIEventStream
+from pydantic_ai.ui.vercel_ai.request_types import SubmitMessage
+from pydantic_ai.ui.vercel_ai.response_types import ToolOutputAvailableChunk
 
 from phoenix.server.agents.capabilities.base import AbstractStaticCapability
+from phoenix.server.agents.subagent_progress import (
+    SubagentUIMessageAccumulator,
+    build_subagent_tool_output,
+    get_subagent_progress_emitter,
+)
 from phoenix.server.agents.types import AgentDependencies
 
 CALL_SUBAGENT_TOOL_DESCRIPTION = """\
@@ -30,12 +38,60 @@ class CallSubAgentToolset(FunctionToolset[AgentDependencies]):
         server_agent: AbstractAgent[None, str],
     ) -> None:
         async def call_subagent(ctx: RunContext[AgentDependencies], name: str, task: str) -> str:
-            result = await server_agent.run(
+            emitter = get_subagent_progress_emitter()
+            if emitter is None or ctx.tool_call_id is None:
+                result = await server_agent.run(
+                    task,
+                    deps=None,
+                    usage=ctx.usage,
+                )
+                return result.output
+
+            tool_call_id = ctx.tool_call_id
+            accumulator = SubagentUIMessageAccumulator()
+            final_summary: str | None = None
+
+            async def on_complete(result: object) -> None:
+                nonlocal final_summary
+                final_summary = str(getattr(result, "output", ""))
+
+            event_stream = VercelAIEventStream(
+                SubmitMessage(id=f"subagent-{tool_call_id}", messages=[])
+            )
+            async with server_agent.run_stream_events(
                 task,
                 deps=None,
                 usage=ctx.usage,
+            ) as native_stream:
+                async for chunk in event_stream.transform_stream(
+                    native_stream,
+                    on_complete=on_complete,
+                ):
+                    if not accumulator.ingest(chunk) or not accumulator.has_visible_parts():
+                        continue
+                    await emitter.emit(
+                        ToolOutputAvailableChunk(
+                            tool_call_id=tool_call_id,
+                            output=build_subagent_tool_output(
+                                accumulator=accumulator,
+                                summary=final_summary,
+                            ),
+                            preliminary=True,
+                        )
+                    )
+
+            if final_summary is None:
+                if accumulator.error_text is not None:
+                    raise RuntimeError(accumulator.error_text)
+                final_summary = accumulator.summary_text()
+            emitter.set_final_output(
+                tool_call_id=tool_call_id,
+                output=build_subagent_tool_output(
+                    accumulator=accumulator,
+                    summary=final_summary,
+                ),
             )
-            return result.output
+            return final_summary
 
         super().__init__(
             tools=[Tool(call_subagent, takes_ctx=True, description=CALL_SUBAGENT_TOOL_DESCRIPTION)]

--- a/src/phoenix/server/agents/capabilities/tools/internal/call_subagent.py
+++ b/src/phoenix/server/agents/capabilities/tools/internal/call_subagent.py
@@ -13,7 +13,6 @@ from phoenix.server.agents.capabilities.base import AbstractStaticCapability
 from phoenix.server.agents.subagent_progress import (
     SubagentUIMessageAccumulator,
     build_subagent_tool_output,
-    get_subagent_progress_emitter,
 )
 from phoenix.server.agents.types import AgentDependencies
 
@@ -38,7 +37,7 @@ class CallSubAgentToolset(FunctionToolset[AgentDependencies]):
         server_agent: AbstractAgent[None, str],
     ) -> None:
         async def call_subagent(ctx: RunContext[AgentDependencies], name: str, task: str) -> str:
-            emitter = get_subagent_progress_emitter()
+            emitter = ctx.deps.subagent_progress_emitter
             if emitter is None or ctx.tool_call_id is None:
                 result = await server_agent.run(
                     task,

--- a/src/phoenix/server/agents/subagent_progress.py
+++ b/src/phoenix/server/agents/subagent_progress.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-import contextvars
-from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Iterator
+from typing import Any
 from uuid import uuid4
 
 from pydantic_ai.ui.vercel_ai.response_types import (
@@ -35,9 +33,6 @@ from pydantic_ai.ui.vercel_ai.response_types import (
 )
 from pydantic_core import to_jsonable_python
 
-_SUBAGENT_PROGRESS_EMITTER: contextvars.ContextVar[SubagentProgressEmitter | None] = (
-    contextvars.ContextVar("phoenix_subagent_progress_emitter", default=None)
-)
 _MISSING = object()
 
 
@@ -65,19 +60,6 @@ class SubagentProgressEmitter:
 
     def get_final_output(self, *, tool_call_id: str) -> Any:
         return self._final_outputs_by_tool_call_id.get(tool_call_id, _MISSING)
-
-
-@contextmanager
-def bind_subagent_progress_emitter(emitter: SubagentProgressEmitter) -> Iterator[None]:
-    token = _SUBAGENT_PROGRESS_EMITTER.set(emitter)
-    try:
-        yield
-    finally:
-        _SUBAGENT_PROGRESS_EMITTER.reset(token)
-
-
-def get_subagent_progress_emitter() -> SubagentProgressEmitter | None:
-    return _SUBAGENT_PROGRESS_EMITTER.get()
 
 
 @dataclass

--- a/src/phoenix/server/agents/subagent_progress.py
+++ b/src/phoenix/server/agents/subagent_progress.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import asyncio
+import contextvars
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Iterator
+from uuid import uuid4
+
+from pydantic_ai.ui.vercel_ai.response_types import (
+    BaseChunk,
+    DataChunk,
+    ErrorChunk,
+    FileChunk,
+    FinishChunk,
+    FinishStepChunk,
+    MessageMetadataChunk,
+    ReasoningDeltaChunk,
+    ReasoningEndChunk,
+    ReasoningStartChunk,
+    SourceDocumentChunk,
+    SourceUrlChunk,
+    StartChunk,
+    StartStepChunk,
+    TextDeltaChunk,
+    TextEndChunk,
+    TextStartChunk,
+    ToolInputAvailableChunk,
+    ToolInputDeltaChunk,
+    ToolInputErrorChunk,
+    ToolInputStartChunk,
+    ToolOutputAvailableChunk,
+    ToolOutputDeniedChunk,
+    ToolOutputErrorChunk,
+)
+from pydantic_core import to_jsonable_python
+
+_SUBAGENT_PROGRESS_EMITTER: contextvars.ContextVar[SubagentProgressEmitter | None] = (
+    contextvars.ContextVar("phoenix_subagent_progress_emitter", default=None)
+)
+_MISSING = object()
+
+
+@dataclass
+class SubagentProgressEmitter:
+    """Per-request side channel for Vercel tool-output progress chunks."""
+
+    _queue: asyncio.Queue[BaseChunk] = field(default_factory=asyncio.Queue)
+    _final_outputs_by_tool_call_id: dict[str, Any] = field(default_factory=dict)
+
+    async def emit(self, chunk: BaseChunk) -> None:
+        await self._queue.put(chunk)
+
+    async def get(self) -> BaseChunk:
+        return await self._queue.get()
+
+    def get_nowait(self) -> BaseChunk:
+        return self._queue.get_nowait()
+
+    def empty(self) -> bool:
+        return self._queue.empty()
+
+    def set_final_output(self, *, tool_call_id: str, output: Any) -> None:
+        self._final_outputs_by_tool_call_id[tool_call_id] = output
+
+    def get_final_output(self, *, tool_call_id: str) -> Any:
+        return self._final_outputs_by_tool_call_id.get(tool_call_id, _MISSING)
+
+
+@contextmanager
+def bind_subagent_progress_emitter(emitter: SubagentProgressEmitter) -> Iterator[None]:
+    token = _SUBAGENT_PROGRESS_EMITTER.set(emitter)
+    try:
+        yield
+    finally:
+        _SUBAGENT_PROGRESS_EMITTER.reset(token)
+
+
+def get_subagent_progress_emitter() -> SubagentProgressEmitter | None:
+    return _SUBAGENT_PROGRESS_EMITTER.get()
+
+
+@dataclass
+class SubagentUIMessageAccumulator:
+    """Build an accumulated UIMessage from Vercel stream chunks."""
+
+    message_id: str = field(default_factory=lambda: str(uuid4()))
+    metadata: Any | None = None
+    error_text: str | None = None
+    _parts: list[dict[str, Any]] = field(default_factory=list)
+    _text_part_indexes: dict[str, int] = field(default_factory=dict)
+    _reasoning_part_indexes: dict[str, int] = field(default_factory=dict)
+    _tool_part_indexes: dict[str, int] = field(default_factory=dict)
+
+    def has_visible_parts(self) -> bool:
+        return any(part.get("type") != "step-start" for part in self._parts)
+
+    def summary_text(self) -> str:
+        return "".join(
+            part.get("text", "")
+            for part in self._parts
+            if part.get("type") == "text" and isinstance(part.get("text"), str)
+        )
+
+    def output(self, *, summary: str | None = None) -> dict[str, Any]:
+        message: dict[str, Any] = {
+            "id": self.message_id,
+            "role": "assistant",
+            "parts": to_jsonable_python(self._parts),
+        }
+        if self.metadata is not None:
+            message["metadata"] = to_jsonable_python(self.metadata)
+        return {
+            "summary": summary if summary is not None else self.summary_text(),
+            "message": message,
+        }
+
+    def ingest(self, chunk: BaseChunk) -> bool:  # noqa: C901
+        if isinstance(chunk, StartChunk):
+            if chunk.message_id:
+                self.message_id = chunk.message_id
+            if chunk.message_metadata is not None:
+                self.metadata = chunk.message_metadata
+            return False
+        if isinstance(chunk, StartStepChunk):
+            self._parts.append({"type": "step-start"})
+            return True
+        if isinstance(chunk, FinishStepChunk | FinishChunk):
+            return False
+        if isinstance(chunk, MessageMetadataChunk):
+            self.metadata = chunk.message_metadata
+            return True
+        if isinstance(chunk, TextStartChunk):
+            part = self._append_indexed_part(
+                indexes=self._text_part_indexes,
+                part_id=chunk.id,
+                part={"type": "text", "text": "", "state": "streaming"},
+            )
+            _set_if_not_none(part, "providerMetadata", chunk.provider_metadata)
+            return True
+        if isinstance(chunk, TextDeltaChunk):
+            part = self._ensure_text_part(chunk.id)
+            part["text"] = f"{part.get('text', '')}{chunk.delta}"
+            _set_if_not_none(part, "providerMetadata", chunk.provider_metadata)
+            return True
+        if isinstance(chunk, TextEndChunk):
+            part = self._ensure_text_part(chunk.id)
+            part["state"] = "done"
+            _set_if_not_none(part, "providerMetadata", chunk.provider_metadata)
+            return True
+        if isinstance(chunk, ReasoningStartChunk):
+            part = self._append_indexed_part(
+                indexes=self._reasoning_part_indexes,
+                part_id=chunk.id,
+                part={"type": "reasoning", "text": "", "state": "streaming"},
+            )
+            _set_if_not_none(part, "providerMetadata", chunk.provider_metadata)
+            return True
+        if isinstance(chunk, ReasoningDeltaChunk):
+            part = self._ensure_reasoning_part(chunk.id)
+            part["text"] = f"{part.get('text', '')}{chunk.delta}"
+            _set_if_not_none(part, "providerMetadata", chunk.provider_metadata)
+            return True
+        if isinstance(chunk, ReasoningEndChunk):
+            part = self._ensure_reasoning_part(chunk.id)
+            part["state"] = "done"
+            _set_if_not_none(part, "providerMetadata", chunk.provider_metadata)
+            return True
+        if isinstance(chunk, ToolInputStartChunk):
+            part = self._ensure_tool_part(
+                tool_call_id=chunk.tool_call_id,
+                tool_name=chunk.tool_name,
+                dynamic=chunk.dynamic,
+            )
+            part["state"] = "input-streaming"
+            part["input"] = ""
+            _set_if_not_none(part, "providerExecuted", chunk.provider_executed)
+            _set_if_not_none(part, "callProviderMetadata", chunk.provider_metadata)
+            return True
+        if isinstance(chunk, ToolInputDeltaChunk):
+            part = self._ensure_tool_part(tool_call_id=chunk.tool_call_id)
+            existing_input = part.get("input")
+            part["input"] = (
+                chunk.input_text_delta
+                if existing_input is None
+                else f"{existing_input}{chunk.input_text_delta}"
+            )
+            return True
+        if isinstance(chunk, ToolInputAvailableChunk):
+            part = self._ensure_tool_part(
+                tool_call_id=chunk.tool_call_id,
+                tool_name=chunk.tool_name,
+                dynamic=chunk.dynamic,
+            )
+            part["state"] = "input-available"
+            part["input"] = to_jsonable_python(chunk.input)
+            _set_if_not_none(part, "providerExecuted", chunk.provider_executed)
+            _set_if_not_none(part, "callProviderMetadata", chunk.provider_metadata)
+            return True
+        if isinstance(chunk, ToolInputErrorChunk):
+            part = self._ensure_tool_part(
+                tool_call_id=chunk.tool_call_id,
+                tool_name=chunk.tool_name,
+                dynamic=chunk.dynamic,
+            )
+            part["state"] = "output-error"
+            part["input"] = to_jsonable_python(chunk.input)
+            part["errorText"] = chunk.error_text
+            _set_if_not_none(part, "providerExecuted", chunk.provider_executed)
+            _set_if_not_none(part, "callProviderMetadata", chunk.provider_metadata)
+            return True
+        if isinstance(chunk, ToolOutputAvailableChunk):
+            part = self._ensure_tool_part(
+                tool_call_id=chunk.tool_call_id,
+                dynamic=chunk.dynamic,
+            )
+            part["state"] = "output-available"
+            part["output"] = to_jsonable_python(chunk.output)
+            _set_if_not_none(part, "providerExecuted", chunk.provider_executed)
+            _set_if_not_none(part, "preliminary", chunk.preliminary)
+            return True
+        if isinstance(chunk, ToolOutputErrorChunk):
+            part = self._ensure_tool_part(
+                tool_call_id=chunk.tool_call_id,
+                dynamic=chunk.dynamic,
+            )
+            part["state"] = "output-error"
+            part["errorText"] = chunk.error_text
+            _set_if_not_none(part, "providerExecuted", chunk.provider_executed)
+            return True
+        if isinstance(chunk, ToolOutputDeniedChunk):
+            part = self._ensure_tool_part(tool_call_id=chunk.tool_call_id)
+            part["state"] = "output-denied"
+            return True
+        if isinstance(chunk, SourceUrlChunk):
+            part = {
+                "type": "source-url",
+                "sourceId": chunk.source_id,
+                "url": chunk.url,
+            }
+            _set_if_not_none(part, "title", chunk.title)
+            _set_if_not_none(part, "providerMetadata", chunk.provider_metadata)
+            self._parts.append(part)
+            return True
+        if isinstance(chunk, SourceDocumentChunk):
+            part = {
+                "type": "source-document",
+                "sourceId": chunk.source_id,
+                "mediaType": chunk.media_type,
+                "title": chunk.title,
+            }
+            _set_if_not_none(part, "filename", chunk.filename)
+            _set_if_not_none(part, "providerMetadata", chunk.provider_metadata)
+            self._parts.append(part)
+            return True
+        if isinstance(chunk, FileChunk):
+            self._parts.append({"type": "file", "url": chunk.url, "mediaType": chunk.media_type})
+            return True
+        if isinstance(chunk, DataChunk):
+            part = {"type": chunk.type, "data": to_jsonable_python(chunk.data)}
+            _set_if_not_none(part, "id", chunk.id)
+            _set_if_not_none(part, "transient", chunk.transient)
+            self._parts.append(part)
+            return True
+        if isinstance(chunk, ErrorChunk):
+            self.error_text = chunk.error_text
+            self._parts.append(
+                {
+                    "type": "text",
+                    "text": f"Subagent error: {chunk.error_text}",
+                    "state": "done",
+                }
+            )
+            return True
+        return False
+
+    def _append_indexed_part(
+        self,
+        *,
+        indexes: dict[str, int],
+        part_id: str,
+        part: dict[str, Any],
+    ) -> dict[str, Any]:
+        indexes[part_id] = len(self._parts)
+        self._parts.append(part)
+        return part
+
+    def _ensure_text_part(self, part_id: str) -> dict[str, Any]:
+        index = self._text_part_indexes.get(part_id)
+        if index is not None:
+            return self._parts[index]
+        return self._append_indexed_part(
+            indexes=self._text_part_indexes,
+            part_id=part_id,
+            part={"type": "text", "text": "", "state": "streaming"},
+        )
+
+    def _ensure_reasoning_part(self, part_id: str) -> dict[str, Any]:
+        index = self._reasoning_part_indexes.get(part_id)
+        if index is not None:
+            return self._parts[index]
+        return self._append_indexed_part(
+            indexes=self._reasoning_part_indexes,
+            part_id=part_id,
+            part={"type": "reasoning", "text": "", "state": "streaming"},
+        )
+
+    def _ensure_tool_part(
+        self,
+        *,
+        tool_call_id: str,
+        tool_name: str | None = None,
+        dynamic: bool | None = None,
+    ) -> dict[str, Any]:
+        index = self._tool_part_indexes.get(tool_call_id)
+        if index is not None:
+            existing_part = self._parts[index]
+            if tool_name is not None and existing_part.get("type") == "dynamic-tool":
+                existing_part["toolName"] = tool_name
+            return existing_part
+        new_part: dict[str, Any] = {
+            "type": "dynamic-tool" if dynamic else f"tool-{tool_name or 'unknown'}",
+            "toolCallId": tool_call_id,
+            "state": "input-streaming",
+        }
+        if dynamic and tool_name is not None:
+            new_part["toolName"] = tool_name
+        self._tool_part_indexes[tool_call_id] = len(self._parts)
+        self._parts.append(new_part)
+        return new_part
+
+
+def build_subagent_tool_output(
+    *,
+    accumulator: SubagentUIMessageAccumulator,
+    summary: str | None = None,
+) -> dict[str, Any]:
+    return accumulator.output(summary=summary)
+
+
+def replace_subagent_final_output(
+    *,
+    emitter: SubagentProgressEmitter,
+    chunk: ToolOutputAvailableChunk,
+) -> ToolOutputAvailableChunk:
+    final_output = emitter.get_final_output(tool_call_id=chunk.tool_call_id)
+    if final_output is _MISSING:
+        return chunk
+    return chunk.model_copy(update={"output": final_output, "preliminary": None})
+
+
+def _set_if_not_none(target: dict[str, Any], key: str, value: Any) -> None:
+    if value is not None:
+        target[key] = to_jsonable_python(value)

--- a/src/phoenix/server/agents/types.py
+++ b/src/phoenix/server/agents/types.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Literal, TypeAlias
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
 from pydantic_ai import DeferredToolRequests
 
 from phoenix.server.agents.context import ResolvedContexts
+
+if TYPE_CHECKING:
+    from phoenix.server.agents.subagent_progress import SubagentProgressEmitter
 
 AgentOutput: TypeAlias = str | DeferredToolRequests
 
@@ -44,4 +49,9 @@ class AgentDependencies:
     sandbox_availability: SandboxAvailability = field(default_factory=SandboxAvailability)
     model_provider_availability: ModelProviderAvailability = field(
         default_factory=ModelProviderAvailability
+    )
+    subagent_progress_emitter: SubagentProgressEmitter | None = field(
+        default=None,
+        repr=False,
+        compare=False,
     )

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -67,7 +67,6 @@ from phoenix.server.agents.skill_requests import (
 from phoenix.server.agents.skills import get_skills_for_contexts
 from phoenix.server.agents.subagent_progress import (
     SubagentProgressEmitter,
-    bind_subagent_progress_emitter,
     replace_subagent_final_output,
 )
 from phoenix.server.agents.summarization import summarize_messages
@@ -294,6 +293,64 @@ def _is_async_generator(
     return all(
         hasattr(obj, name) for name in ("__aiter__", "__anext__", "asend", "athrow", "aclose")
     )
+
+
+async def _iter_agent_chunks_with_subagent_progress(
+    *,
+    agent_chunk_queue: asyncio.Queue[BaseChunk | Exception | None],
+    producer_task: asyncio.Task[None],
+    progress_emitter: SubagentProgressEmitter,
+) -> AsyncIterator[BaseChunk]:
+    """Interleave parent-agent chunks with subagent progress chunks."""
+    agent_stream_done = False
+    try:
+        while not agent_stream_done or not progress_emitter.empty():
+            tasks: set[asyncio.Task[Any]] = set()
+            agent_chunk_task: asyncio.Task[BaseChunk | Exception | None] | None = None
+            progress_chunk_task: asyncio.Task[BaseChunk] | None = None
+            if not agent_stream_done:
+                agent_chunk_task = asyncio.create_task(agent_chunk_queue.get())
+                tasks.add(agent_chunk_task)
+            if not agent_stream_done or not progress_emitter.empty():
+                progress_chunk_task = asyncio.create_task(progress_emitter.get())
+                tasks.add(progress_chunk_task)
+
+            done, pending = await asyncio.wait(
+                tasks,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for pending_task in pending:
+                pending_task.cancel()
+            for pending_task in pending:
+                with suppress(asyncio.CancelledError):
+                    await pending_task
+
+            completed_tasks: list[asyncio.Task[Any]] = []
+            if progress_chunk_task is not None and progress_chunk_task in done:
+                completed_tasks.append(progress_chunk_task)
+            if agent_chunk_task is not None and agent_chunk_task in done:
+                completed_tasks.append(agent_chunk_task)
+            for task in completed_tasks:
+                item = task.result()
+                if task is agent_chunk_task:
+                    if item is None:
+                        agent_stream_done = True
+                        continue
+                    if isinstance(item, Exception):
+                        raise item
+                    if isinstance(item, ToolOutputAvailableChunk):
+                        item = replace_subagent_final_output(
+                            emitter=progress_emitter,
+                            chunk=item,
+                        )
+                    yield item
+                elif task is progress_chunk_task:
+                    yield item
+    finally:
+        if not producer_task.done():
+            producer_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await producer_task
 
 
 class _AgentSpanContextRecorder(SpanProcessor):
@@ -672,12 +729,14 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             run_input=body,
             accept=request.headers.get("accept"),
         )
+        progress_emitter = SubagentProgressEmitter()
         deps = AgentDependencies(
             contexts=resolved_contexts,
             edit_permission=body.edit_permission,
             is_viewer=is_viewer,
             sandbox_availability=sandbox_availability,
             model_provider_availability=model_provider_availability,
+            subagent_progress_emitter=progress_emitter,
         )
 
         async def _on_complete(result: AgentRunResult[Any]) -> AsyncIterator[BaseChunk]:
@@ -691,99 +750,55 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         async def _stream_with_session() -> AsyncIterator[BaseChunk]:
             try:
                 with detached_otel_context(), using_session(session_id=session_id):
-                    progress_emitter = SubagentProgressEmitter()
                     raw_queue: asyncio.Queue[BaseChunk | Exception | None] = asyncio.Queue()
-
-                    async def _enqueue_raw_chunk(chunk: BaseChunk) -> None:
-                        if isinstance(chunk, ToolInputAvailableChunk):
-                            chunk.provider_metadata = _get_updated_provider_metadata(
-                                provider_metadata=chunk.provider_metadata or {},
-                                tool_name=chunk.tool_name,
-                            )
-                        await raw_queue.put(chunk)
 
                     async def _produce_raw_chunks() -> None:
                         try:
-                            with bind_subagent_progress_emitter(progress_emitter):
-                                raw_stream = adapter.run_stream(deps=deps, on_complete=_on_complete)
-                                assert _is_async_generator(raw_stream)
-                                # Forced skills are streamed as their own `load_skill` steps so
-                                # the browser transcript matches what the model received. They
-                                # are emitted once, right after the stream's opening `start`
-                                # chunk and before the model's own output.
-                                forced_skills_streamed = not forced_skills
-                                async with aclosing(raw_stream) as stream:
-                                    async for chunk in stream:
-                                        await _enqueue_raw_chunk(chunk)
-                                        if not forced_skills_streamed and isinstance(
-                                            chunk, StartChunk
-                                        ):
-                                            forced_chunks = iter_requested_skill_response_chunks(
-                                                skills=forced_skills,
-                                                load_skill_template=agent_prompts.load_skill,
-                                            )
-                                            for forced_chunk in forced_chunks:
-                                                await _enqueue_raw_chunk(forced_chunk)
-                                            forced_skills_streamed = True
+                            raw_stream = adapter.run_stream(deps=deps, on_complete=_on_complete)
+                            assert _is_async_generator(raw_stream)
+                            # Forced skills are streamed as their own `load_skill` steps so
+                            # the browser transcript matches what the model received. They
+                            # are emitted once, right after the stream's opening `start`
+                            # chunk and before the model's own output.
+                            forced_skills_streamed = not forced_skills
+                            async with aclosing(raw_stream) as stream:
+                                async for chunk in stream:
+                                    if isinstance(chunk, ToolInputAvailableChunk):
+                                        chunk.provider_metadata = _get_updated_provider_metadata(
+                                            provider_metadata=chunk.provider_metadata or {},
+                                            tool_name=chunk.tool_name,
+                                        )
+                                    await raw_queue.put(chunk)
+                                    if not forced_skills_streamed and isinstance(
+                                        chunk, StartChunk
+                                    ):
+                                        forced_chunks = iter_requested_skill_response_chunks(
+                                            skills=forced_skills,
+                                            load_skill_template=agent_prompts.load_skill,
+                                        )
+                                        for forced_chunk in forced_chunks:
+                                            if isinstance(forced_chunk, ToolInputAvailableChunk):
+                                                forced_chunk.provider_metadata = (
+                                                    _get_updated_provider_metadata(
+                                                        provider_metadata=forced_chunk.provider_metadata
+                                                        or {},
+                                                        tool_name=forced_chunk.tool_name,
+                                                    )
+                                                )
+                                            await raw_queue.put(forced_chunk)
+                                        forced_skills_streamed = True
                         except Exception as exc:
                             await raw_queue.put(exc)
                         finally:
                             await raw_queue.put(None)
 
                     producer = asyncio.create_task(_produce_raw_chunks())
-                    raw_done = False
-                    try:
-                        while not raw_done or not progress_emitter.empty():
-                            tasks: set[asyncio.Task[BaseChunk | Exception | None]] = set()
-                            raw_task: asyncio.Task[BaseChunk | Exception | None] | None = None
-                            progress_task: asyncio.Task[BaseChunk | Exception | None] | None = None
-                            if not raw_done:
-                                raw_task = asyncio.create_task(raw_queue.get())
-                                tasks.add(raw_task)
-                            if not raw_done or not progress_emitter.empty():
-                                progress_task = asyncio.create_task(progress_emitter.get())
-                                tasks.add(progress_task)
-
-                            done, pending = await asyncio.wait(
-                                tasks,
-                                return_when=asyncio.FIRST_COMPLETED,
-                            )
-                            for pending_task in pending:
-                                pending_task.cancel()
-                            for pending_task in pending:
-                                with suppress(asyncio.CancelledError):
-                                    await pending_task
-
-                            completed_tasks: list[asyncio.Task[BaseChunk | Exception | None]] = []
-                            if progress_task is not None and progress_task in done:
-                                completed_tasks.append(progress_task)
-                            if raw_task is not None and raw_task in done:
-                                completed_tasks.append(raw_task)
-                            for task in completed_tasks:
-                                item = task.result()
-                                if task is raw_task:
-                                    if item is None:
-                                        raw_done = True
-                                        continue
-                                    if isinstance(item, Exception):
-                                        raise item
-                                    if isinstance(item, ToolOutputAvailableChunk):
-                                        item = replace_subagent_final_output(
-                                            emitter=progress_emitter,
-                                            chunk=item,
-                                        )
-                                    yield item
-                                elif task is progress_task:
-                                    if item is None:
-                                        continue
-                                    if isinstance(item, Exception):
-                                        raise item
-                                    yield item
-                    finally:
-                        if not producer.done():
-                            producer.cancel()
-                            with suppress(asyncio.CancelledError):
-                                await producer
+                    async for chunk in _iter_agent_chunks_with_subagent_progress(
+                        agent_chunk_queue=raw_queue,
+                        producer_task=producer,
+                        progress_emitter=progress_emitter,
+                    ):
+                        yield chunk
             finally:
                 if tracer is not None:
                     tracer.tracer_provider.force_flush()

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1,6 +1,7 @@
+import asyncio
 import logging
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterable
-from contextlib import aclosing
+from contextlib import aclosing, suppress
 from copy import deepcopy
 from typing import Annotated, Any, Literal, TypeVar
 
@@ -26,6 +27,7 @@ from pydantic_ai.ui.vercel_ai.response_types import (
     ProviderMetadata,
     StartChunk,
     ToolInputAvailableChunk,
+    ToolOutputAvailableChunk,
 )
 from sqlalchemy import Insert, exists, func, select
 from sqlalchemy.dialects.postgresql import insert as insert_postgresql
@@ -63,6 +65,11 @@ from phoenix.server.agents.skill_requests import (
     resolve_requested_skills,
 )
 from phoenix.server.agents.skills import get_skills_for_contexts
+from phoenix.server.agents.subagent_progress import (
+    SubagentProgressEmitter,
+    bind_subagent_progress_emitter,
+    replace_subagent_final_output,
+)
 from phoenix.server.agents.summarization import summarize_messages
 from phoenix.server.agents.types import (
     AgentDependencies,
@@ -684,36 +691,99 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         async def _stream_with_session() -> AsyncIterator[BaseChunk]:
             try:
                 with detached_otel_context(), using_session(session_id=session_id):
-                    raw_stream = adapter.run_stream(deps=deps, on_complete=_on_complete)
-                    assert _is_async_generator(raw_stream)
-                    # Forced skills are streamed as their own `load_skill` steps so
-                    # the browser transcript matches what the model received. They
-                    # are emitted once, right after the stream's opening `start`
-                    # chunk and before the model's own output.
-                    forced_skills_streamed = not forced_skills
-                    async with aclosing(raw_stream) as stream:
-                        async for chunk in stream:
-                            if isinstance(chunk, ToolInputAvailableChunk):
-                                chunk.provider_metadata = _get_updated_provider_metadata(
-                                    provider_metadata=chunk.provider_metadata or {},
-                                    tool_name=chunk.tool_name,
-                                )
-                            yield chunk
-                            if not forced_skills_streamed and isinstance(chunk, StartChunk):
-                                for forced_chunk in iter_requested_skill_response_chunks(
-                                    skills=forced_skills,
-                                    load_skill_template=agent_prompts.load_skill,
-                                ):
-                                    if isinstance(forced_chunk, ToolInputAvailableChunk):
-                                        forced_chunk.provider_metadata = (
-                                            _get_updated_provider_metadata(
-                                                provider_metadata=forced_chunk.provider_metadata
-                                                or {},
-                                                tool_name=forced_chunk.tool_name,
+                    progress_emitter = SubagentProgressEmitter()
+                    raw_queue: asyncio.Queue[BaseChunk | Exception | None] = asyncio.Queue()
+
+                    async def _enqueue_raw_chunk(chunk: BaseChunk) -> None:
+                        if isinstance(chunk, ToolInputAvailableChunk):
+                            chunk.provider_metadata = _get_updated_provider_metadata(
+                                provider_metadata=chunk.provider_metadata or {},
+                                tool_name=chunk.tool_name,
+                            )
+                        await raw_queue.put(chunk)
+
+                    async def _produce_raw_chunks() -> None:
+                        try:
+                            with bind_subagent_progress_emitter(progress_emitter):
+                                raw_stream = adapter.run_stream(deps=deps, on_complete=_on_complete)
+                                assert _is_async_generator(raw_stream)
+                                # Forced skills are streamed as their own `load_skill` steps so
+                                # the browser transcript matches what the model received. They
+                                # are emitted once, right after the stream's opening `start`
+                                # chunk and before the model's own output.
+                                forced_skills_streamed = not forced_skills
+                                async with aclosing(raw_stream) as stream:
+                                    async for chunk in stream:
+                                        await _enqueue_raw_chunk(chunk)
+                                        if not forced_skills_streamed and isinstance(
+                                            chunk, StartChunk
+                                        ):
+                                            forced_chunks = iter_requested_skill_response_chunks(
+                                                skills=forced_skills,
+                                                load_skill_template=agent_prompts.load_skill,
                                             )
+                                            for forced_chunk in forced_chunks:
+                                                await _enqueue_raw_chunk(forced_chunk)
+                                            forced_skills_streamed = True
+                        except Exception as exc:
+                            await raw_queue.put(exc)
+                        finally:
+                            await raw_queue.put(None)
+
+                    producer = asyncio.create_task(_produce_raw_chunks())
+                    raw_done = False
+                    try:
+                        while not raw_done or not progress_emitter.empty():
+                            tasks: set[asyncio.Task[BaseChunk | Exception | None]] = set()
+                            raw_task: asyncio.Task[BaseChunk | Exception | None] | None = None
+                            progress_task: asyncio.Task[BaseChunk | Exception | None] | None = None
+                            if not raw_done:
+                                raw_task = asyncio.create_task(raw_queue.get())
+                                tasks.add(raw_task)
+                            if not raw_done or not progress_emitter.empty():
+                                progress_task = asyncio.create_task(progress_emitter.get())
+                                tasks.add(progress_task)
+
+                            done, pending = await asyncio.wait(
+                                tasks,
+                                return_when=asyncio.FIRST_COMPLETED,
+                            )
+                            for pending_task in pending:
+                                pending_task.cancel()
+                            for pending_task in pending:
+                                with suppress(asyncio.CancelledError):
+                                    await pending_task
+
+                            completed_tasks: list[asyncio.Task[BaseChunk | Exception | None]] = []
+                            if progress_task is not None and progress_task in done:
+                                completed_tasks.append(progress_task)
+                            if raw_task is not None and raw_task in done:
+                                completed_tasks.append(raw_task)
+                            for task in completed_tasks:
+                                item = task.result()
+                                if task is raw_task:
+                                    if item is None:
+                                        raw_done = True
+                                        continue
+                                    if isinstance(item, Exception):
+                                        raise item
+                                    if isinstance(item, ToolOutputAvailableChunk):
+                                        item = replace_subagent_final_output(
+                                            emitter=progress_emitter,
+                                            chunk=item,
                                         )
-                                    yield forced_chunk
-                                forced_skills_streamed = True
+                                    yield item
+                                elif task is progress_task:
+                                    if item is None:
+                                        continue
+                                    if isinstance(item, Exception):
+                                        raise item
+                                    yield item
+                    finally:
+                        if not producer.done():
+                            producer.cancel()
+                            with suppress(asyncio.CancelledError):
+                                await producer
             finally:
                 if tracer is not None:
                     tracer.tracer_provider.force_flush()

--- a/tests/unit/server/agents/test_subagent_progress.py
+++ b/tests/unit/server/agents/test_subagent_progress.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pydantic_ai.ui.vercel_ai.response_types import (
+    TextDeltaChunk,
+    TextEndChunk,
+    TextStartChunk,
+    ToolInputAvailableChunk,
+    ToolInputStartChunk,
+    ToolOutputAvailableChunk,
+)
+
+from phoenix.server.agents.subagent_progress import (
+    SubagentProgressEmitter,
+    SubagentUIMessageAccumulator,
+    build_subagent_tool_output,
+    replace_subagent_final_output,
+)
+
+
+def test_accumulates_subagent_text_and_tool_parts() -> None:
+    accumulator = SubagentUIMessageAccumulator(message_id="subagent-message")
+
+    assert accumulator.ingest(TextStartChunk(id="text-1"))
+    assert accumulator.ingest(TextDeltaChunk(id="text-1", delta="hello"))
+    assert accumulator.ingest(TextDeltaChunk(id="text-1", delta=" world"))
+    assert accumulator.ingest(TextEndChunk(id="text-1"))
+    assert accumulator.ingest(
+        ToolInputStartChunk(
+            tool_call_id="tool-1",
+            tool_name="bash",
+        )
+    )
+    assert accumulator.ingest(
+        ToolInputAvailableChunk(
+            tool_call_id="tool-1",
+            tool_name="bash",
+            input={"cmd": "pwd"},
+        )
+    )
+    assert accumulator.ingest(
+        ToolOutputAvailableChunk(
+            tool_call_id="tool-1",
+            output={"stdout": "/tmp"},
+            preliminary=True,
+        )
+    )
+
+    output = build_subagent_tool_output(accumulator=accumulator, summary="done")
+
+    assert output == {
+        "summary": "done",
+        "message": {
+            "id": "subagent-message",
+            "role": "assistant",
+            "parts": [
+                {"type": "text", "text": "hello world", "state": "done"},
+                {
+                    "type": "tool-bash",
+                    "toolCallId": "tool-1",
+                    "state": "output-available",
+                    "input": {"cmd": "pwd"},
+                    "output": {"stdout": "/tmp"},
+                    "preliminary": True,
+                },
+            ],
+        },
+    }
+
+
+def test_replace_subagent_final_output_uses_cached_ui_output() -> None:
+    emitter = SubagentProgressEmitter()
+    final_output = {"summary": "done", "message": {"id": "m", "role": "assistant", "parts": []}}
+    emitter.set_final_output(tool_call_id="tool-1", output=final_output)
+
+    replaced = replace_subagent_final_output(
+        emitter=emitter,
+        chunk=ToolOutputAvailableChunk(
+            tool_call_id="tool-1",
+            output="done",
+            preliminary=True,
+        ),
+    )
+
+    assert replaced.output == final_output
+    assert replaced.preliminary is None
+
+
+def test_replace_subagent_final_output_leaves_other_tools_unchanged() -> None:
+    emitter = SubagentProgressEmitter()
+    chunk = ToolOutputAvailableChunk(tool_call_id="tool-1", output="done")
+
+    assert replace_subagent_final_output(emitter=emitter, chunk=chunk) is chunk


### PR DESCRIPTION
## Summary
- stream nested subagent progress as preliminary Vercel tool outputs
- preserve the final nested subagent transcript in the call_subagent tool output
- render nested subagent text and tool parts in the agent UI

## Tests
- uv run pytest tests/unit/server/agents/test_subagent_progress.py tests/unit/server/api/routers/test_agents.py
- make lint-python
- make typecheck-python
- make lint-frontend
- make typecheck-frontend
- git diff --check