### PR TITLE
[codex] Handle empty JSONL trace inputs

### DIFF
--- a/src/phoenix/trace/utils.py
+++ b/src/phoenix/trace/utils.py
@@ -30,8 +30,13 @@ def json_lines_to_df(lines: list[str]) -> pd.DataFrame:
     data = []
 
     for line in lines:
+        if not line.strip():
+            continue
         # Load the JSON object from the line
         data.append(json.loads(line))
+
+    if not data:
+        return pd.DataFrame()
 
     # Normalize data to a flat structure
     df = pd.concat([pd.json_normalize(item, max_level=1) for item in data], ignore_index=True)

--- a/tests/unit/trace/test_utils.py
+++ b/tests/unit/trace/test_utils.py
@@ -1,0 +1,31 @@
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from phoenix.trace.utils import json_lines_to_df
+
+
+def test_json_lines_to_df_returns_empty_dataframe_for_empty_input() -> None:
+    assert_frame_equal(json_lines_to_df([]), pd.DataFrame())
+
+
+def test_json_lines_to_df_ignores_blank_lines() -> None:
+    assert_frame_equal(json_lines_to_df(["\n", "  \n"]), pd.DataFrame())
+
+
+def test_json_lines_to_df_normalizes_json_lines() -> None:
+    lines = [
+        '{"name": "span-1", "context": {"trace_id": "trace-1", "span_id": "span-1"}}',
+        "\n",
+        '{"name": "span-2", "context": {"trace_id": "trace-2", "span_id": "span-2"}}',
+    ]
+
+    assert_frame_equal(
+        json_lines_to_df(lines),
+        pd.DataFrame(
+            {
+                "name": ["span-1", "span-2"],
+                "context.trace_id": ["trace-1", "trace-2"],
+                "context.span_id": ["span-1", "span-2"],
+            }
+        ),
+    )


### PR DESCRIPTION
## Summary

- skip blank JSONL lines in `json_lines_to_df`
- return an empty DataFrame when no JSON objects are provided
- add focused unit coverage for empty input, blank lines, and normal JSONL normalization

Fixes #13774.

## Root cause

`json_lines_to_df` passed every line directly to `json.loads` and then called `pd.concat` over the normalized list. Empty input reached `pd.concat([])`, which raised pandas' raw `ValueError: No objects to concatenate`; blank lines reached `json.loads` and raised a raw `JSONDecodeError`.

## Validation

- `git diff --check`
- isolated local check of `src/phoenix/trace/utils.py` with pandas: verified `[]`, blank-only lines, and mixed valid/blank JSONL input

I also attempted `python -m pytest -q tests/unit/trace/test_utils.py` locally. The editable pip environment resolved `pydantic-ai-slim` to `2.0.0`, while the current Phoenix source imports `MCPServerStreamableHTTP` from the pre-2.0 API, so collection failed before this test module ran. I left the test as a normal project import so CI's locked environment can exercise it directly.
