### PR TITLE
[codex] Preserve HTTP collector path prefixes

### DIFF
--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -731,7 +731,8 @@ def _construct_http_endpoint(parsed_endpoint: ParseResult) -> ParseResult:
     traces_suffix = "/v1/traces"
     if parsed_endpoint.path.endswith(traces_suffix):
         return parsed_endpoint
-    return parsed_endpoint._replace(path=traces_suffix)
+    path_prefix = parsed_endpoint.path.rstrip("/")
+    return parsed_endpoint._replace(path=f"{path_prefix}{traces_suffix}")
 
 
 def _construct_phoenix_cloud_endpoint(parsed_endpoint: ParseResult) -> ParseResult:

--- a/packages/phoenix-otel/tests/test_otel.py
+++ b/packages/phoenix-otel/tests/test_otel.py
@@ -528,6 +528,18 @@ class TestEndpointNormalization:
                 assert parsed.scheme == "http"
                 assert parsed.netloc == "localhost:4317"
 
+    def test_normalized_endpoint_preserves_env_http_path_prefix(self) -> None:
+        from phoenix.otel.otel import _normalized_endpoint
+
+        with patch(
+            "phoenix.otel.otel.get_env_collector_endpoint",
+            return_value="http://example.com/phoenix",
+        ):
+            parsed, endpoint = _normalized_endpoint(None, use_http=True)
+
+        assert parsed.path == "/phoenix/v1/traces"
+        assert endpoint == "http://example.com/phoenix/v1/traces"
+
 
 class TestPhoenixCloudEndpoint:
     def test_space_path_basic(self) -> None:

--- a/packages/phoenix-otel/tests/test_settings.py
+++ b/packages/phoenix-otel/tests/test_settings.py
@@ -33,6 +33,8 @@ def test_get_env_collector_endpoint(env: dict[str, str], expected: Optional[str]
     "endpoint, expected",
     [
         ("http://localhost:6006", "http://localhost:6006/v1/traces"),
+        ("http://localhost:6006/prefix", "http://localhost:6006/prefix/v1/traces"),
+        ("http://localhost:6006/prefix/", "http://localhost:6006/prefix/v1/traces"),
         ("http://localhost:6006/v1/traces", "http://localhost:6006/v1/traces"),
         ("http://localhost:6006/prefix/v1/traces", "http://localhost:6006/prefix/v1/traces"),
     ],


### PR DESCRIPTION
## Summary

- preserve existing path prefixes when constructing HTTP OTLP trace endpoints
- cover both `/prefix` and `/prefix/` inputs in `_construct_http_endpoint`
- add a regression test for env-derived `PHOENIX_COLLECTOR_ENDPOINT` with `use_http=True`

Fixes #13776.

## Root cause

`_construct_http_endpoint()` returned `parsed_endpoint._replace(path="/v1/traces")` whenever the input path did not already end with `/v1/traces`. That appended the HTTP trace suffix for bare host endpoints, but it also replaced reverse-proxy prefixes such as `/phoenix`, producing `http://example.com/v1/traces` instead of `http://example.com/phoenix/v1/traces`.

## Validation

- Reproduced current behavior locally: `http://localhost:6006/prefix` normalized to `http://localhost:6006/v1/traces`
- `.otel-venv/bin/python -m pytest -q packages/phoenix-otel/tests/test_settings.py packages/phoenix-otel/tests/test_otel.py::TestEndpointNormalization`
  - `17 passed, 2 warnings in 0.16s`
- `git diff --check`
