### PR TITLE
fix(tutorials): copy recipe list before shuffle so BM25 corpus order is preserved (#13394)

### DIFF
--- a/tutorials/ai_evals_course/ai_evals_hw4_solution.ipynb
+++ b/tutorials/ai_evals_course/ai_evals_hw4_solution.ipynb
@@ -13,7 +13,7 @@
    "id": "990f673b",
    "metadata": {},
    "source": [
-    "# HW4: Recipe RAG — BM25, Synthetic Queries, Phoenix\n",
+    "# HW4: Recipe RAG \u2014 BM25, Synthetic Queries, Phoenix\n",
     "\n",
     "\n",
     "<center>\n",
@@ -28,30 +28,30 @@
     "    </p>\n",
     "</center>\n",
     "\n",
-    "## 🎯 Assignment Overview\n",
-    "In this assignment, you’ll build and evaluate a BM25-based RAG system for recipes, generate synthetic user queries with llm_generate, and trace everything in Phoenix for visibility and analysis.\n",
+    "## \ud83c\udfaf Assignment Overview\n",
+    "In this assignment, you\u2019ll build and evaluate a BM25-based RAG system for recipes, generate synthetic user queries with llm_generate, and trace everything in Phoenix for visibility and analysis.\n",
     "\n",
     "#### Workflow\n",
-    "- 🧰 Setup — Install deps, set env vars, and import libs.\n",
+    "- \ud83e\uddf0 Setup \u2014 Install deps, set env vars, and import libs.\n",
     "\n",
-    "- 📥 Load & structure data — Read RAW_recipes.csv, normalize fields (title, ingredients, steps, raw text).\n",
+    "- \ud83d\udce5 Load & structure data \u2014 Read RAW_recipes.csv, normalize fields (title, ingredients, steps, raw text).\n",
     "\n",
-    "- 🔤 Tokenize & index — Use a number-preserving tokenizer (keeps 375 F, 9x13) and build/load a BM25 index.\n",
+    "- \ud83d\udd24 Tokenize & index \u2014 Use a number-preserving tokenizer (keeps 375 F, 9x13) and build/load a BM25 index.\n",
     "\n",
-    "- 🧪 Generate synthetic queries — Use llm_generate to create realistic, technical cooking questions (+ validation & dedupe).\n",
+    "- \ud83e\uddea Generate synthetic queries \u2014 Use llm_generate to create realistic, technical cooking questions (+ validation & dedupe).\n",
     "\n",
-    "- ☁️ Upload dataset to Phoenix — Map to input (query) and output (salient_fact) and upload as a Phoenix Dataset.\n",
+    "- \u2601\ufe0f Upload dataset to Phoenix \u2014 Map to input (query) and output (salient_fact) and upload as a Phoenix Dataset.\n",
     "\n",
-    "- 🔎 Run retriever with tracing — For each query, call retrieve_bm25() (decorated) to emit rag.query → retrieval.bm25 spans.\n",
+    "- \ud83d\udd0e Run retriever with tracing \u2014 For each query, call retrieve_bm25() (decorated) to emit rag.query \u2192 retrieval.bm25 spans.\n",
     "\n",
-    "- 🧪 Experiments — Run a Phoenix Experiment (Recall@1/3/5, MRR) and compare runs.\n",
+    "- \ud83e\uddea Experiments \u2014 Run a Phoenix Experiment (Recall@1/3/5, MRR) and compare runs.\n",
     "\n",
-    "- 💾 Save results — Persist per-query outputs & summary to JSON for offline review.\n",
+    "- \ud83d\udcbe Save results \u2014 Persist per-query outputs & summary to JSON for offline review.\n",
     "\n",
-    "- 📊 Inspect in Phoenix — View spans, top-k documents, evaluation chips, and experiment summaries.\n",
+    "- \ud83d\udcca Inspect in Phoenix \u2014 View spans, top-k documents, evaluation chips, and experiment summaries.\n",
     "\n",
-    "#### Core Task: “Can the retriever surface the correct recipe?”\n",
-    "You’ll evaluate whether the ground-truth recipe (the one that the synthetic question depends on) appears in the top-k results—especially top-1/3/5."
+    "#### Core Task: \u201cCan the retriever surface the correct recipe?\u201d\n",
+    "You\u2019ll evaluate whether the ground-truth recipe (the one that the synthetic question depends on) appears in the top-k results\u2014especially top-1/3/5."
    ]
   },
   {
@@ -145,22 +145,22 @@
     "_JSON_RE = re.compile(r\"\\{.*\\}\", re.S)\n",
     "_WORD_RE = re.compile(r\"[a-zA-Z]+\")\n",
     "_TECH = re.compile(\n",
-    "    r\"\\b\\d[\\d/\\.\\s]*(?:sec|second|min|minute|hour|hr|°[CF]|deg(?:rees)?\\s*[CF]|tsp|tbsp|cup|cups|g|gram|ml|°)\\b\",\n",
+    "    r\"\\b\\d[\\d/\\.\\s]*(?:sec|second|min|minute|hour|hr|\u00b0[CF]|deg(?:rees)?\\s*[CF]|tsp|tbsp|cup|cups|g|gram|ml|\u00b0)\\b\",\n",
     "    re.I,\n",
     ")\n",
     "_TOKEN_RE = re.compile(\n",
-    "    r\"\\d+\\s*[x×]\\s*\\d+\"\n",
+    "    r\"\\d+\\s*[x\u00d7]\\s*\\d+\"\n",
     "    r\"|(?:\\d+/?\\d+)\"\n",
     "    r\"|(?:\\d+(?:\\.\\d+)?)\"\n",
-    "    r\"|(?:°[fc])\"\n",
+    "    r\"|(?:\u00b0[fc])\"\n",
     "    r\"|[a-z]+\"\n",
     ")\n",
     "\n",
     "\n",
     "def tokenize(text: str) -> list[str]:\n",
     "    s = (text or \"\").lower()\n",
-    "    s = s.replace(\"degrees f\", \"°f\").replace(\"degree f\", \"°f\")\n",
-    "    s = s.replace(\"degrees c\", \"°c\").replace(\"degree c\", \"°c\")\n",
+    "    s = s.replace(\"degrees f\", \"\u00b0f\").replace(\"degree f\", \"\u00b0f\")\n",
+    "    s = s.replace(\"degrees c\", \"\u00b0c\").replace(\"degree c\", \"\u00b0c\")\n",
     "    s = s.replace(\"mins\", \"min\").replace(\"minutes\", \"min\")\n",
     "    s = s.replace(\"hours\", \"hr\").replace(\"hrs\", \"hr\")\n",
     "    return _TOKEN_RE.findall(s)\n",
@@ -258,7 +258,7 @@
    "outputs": [],
    "source": [
     "if \"OPENAI_API_KEY\" not in os.environ:\n",
-    "    os.environ[\"OPENAI_API_KEY\"] = getpass(\"🔑 Enter your OpenAI API key: \")"
+    "    os.environ[\"OPENAI_API_KEY\"] = getpass(\"\ud83d\udd11 Enter your OpenAI API key: \")"
    ]
   },
   {
@@ -297,7 +297,7 @@
     "        )\n",
     "        Path(LOCAL_RAW_CSV).parent.mkdir(parents=True, exist_ok=True)\n",
     "        df.to_csv(LOCAL_RAW_CSV, index=False)\n",
-    "        print(f\"✅ Saved raw CSV to {LOCAL_RAW_CSV}\")\n",
+    "        print(f\"\u2705 Saved raw CSV to {LOCAL_RAW_CSV}\")\n",
     "        return df\n",
     "    except ModuleNotFoundError as e:\n",
     "        raise RuntimeError(\n",
@@ -528,7 +528,7 @@
     "#### BM25 retriever with tracing\n",
     "@retriever(\"retrieval.bm25\") emits a RETRIEVER span and logs each top-k doc (id, score, short content, metadata) for Phoenix.\n",
     "\n",
-    "retrieve_bm25(..., emit_detail_spans=False) runs BM25 and, if enabled, adds tiny child spans (query.normalize → query.tokenize → bm25.score/bm25.rank → results.build).\n",
+    "retrieve_bm25(..., emit_detail_spans=False) runs BM25 and, if enabled, adds tiny child spans (query.normalize \u2192 query.tokenize \u2192 bm25.score/bm25.rank \u2192 results.build).\n",
     "\n",
     "Returns ranked hits with useful metadata (matched terms, doc length, etc.)."
    ]
@@ -666,11 +666,11 @@
     "SYSTEM_PROMPT = \"\"\"You are an advanced user of a recipe search engine.\n",
     "Given a recipe, write ONE realistic, conversational cooking question that depends on a precise, technical detail\n",
     "that is clearly contained in THIS recipe. Focus on:\n",
-    "1) Specific methods (e.g., marinate 4 hours, bake at 375°F for 25 minutes)\n",
-    "2) Appliance settings (e.g., air fryer 400°F for 12 minutes, pressure cook 8 minutes)\n",
+    "1) Specific methods (e.g., marinate 4 hours, bake at 375\u00b0F for 25 minutes)\n",
+    "2) Appliance settings (e.g., air fryer 400\u00b0F for 12 minutes, pressure cook 8 minutes)\n",
     "3) Ingredient prep details (e.g., slice onions paper-thin, whip cream to soft peaks)\n",
     "4) Timing specifics (e.g., rest dough 30 minutes, simmer 45 minutes)\n",
-    "5) Temperature precision (e.g., internal 165°F, oil 350°F)\n",
+    "5) Temperature precision (e.g., internal 165\u00b0F, oil 350\u00b0F)\n",
     "\n",
     "Return EXACTLY a single JSON object:\n",
     "{\"query\":\"...?\",\"salient_fact\":\"<exact quote or tight paraphrase>\"}\"\"\"\n",
@@ -684,11 +684,11 @@
    "metadata": {},
    "source": [
     "#### Parse & normalize LLM output\n",
-    "_norm_q(q) — lowercase, strip punctuation, collapse spaces → dedupe-friendly key.\n",
+    "_norm_q(q) \u2014 lowercase, strip punctuation, collapse spaces \u2192 dedupe-friendly key.\n",
     "\n",
-    "_parse_json(text) — parse JSON; if there’s extra text, grab the first {...} block and load it.\n",
+    "_parse_json(text) \u2014 parse JSON; if there\u2019s extra text, grab the first {...} block and load it.\n",
     "\n",
-    "_parse_and_validate(text) — require query + salient_fact, append “?” if missing, enforce a minimum length, and ensure the fact contains a concrete technical detail (time/temp/ratio/etc.). Returns the cleaned pair or None."
+    "_parse_and_validate(text) \u2014 require query + salient_fact, append \u201c?\u201d if missing, enforce a minimum length, and ensure the fact contains a concrete technical detail (time/temp/ratio/etc.). Returns the cleaned pair or None."
    ]
   },
   {
@@ -806,6 +806,7 @@
     "    max_workers: int = MAX_WORKERS,\n",
     "):\n",
     "    Path(out_path).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    recipes = list(recipes)  # don't mutate the shared corpus that BM25 was indexed on\n",
     "    random.shuffle(recipes)\n",
     "\n",
     "    model = OpenAIModel(\n",
@@ -869,7 +870,7 @@
     "\n",
     "    with open(out_path, \"w\", encoding=\"utf-8\") as fp:\n",
     "        json.dump(list(unique.values()), fp, indent=2, ensure_ascii=False)\n",
-    "    print(f\"✅ Saved {len(unique)} queries → {out_path}\")\n",
+    "    print(f\"\u2705 Saved {len(unique)} queries \u2192 {out_path}\")\n",
     "    return out_path"
    ]
   },
@@ -946,7 +947,7 @@
     "        output_keys=[\"output\"],\n",
     "        metadata_keys=meta_cols if meta_cols else [],\n",
     "    )\n",
-    "    print(f\"✅ Uploaded dataset '{getattr(ds, 'name', ds)}' with {len(upload_df)} rows\")\n",
+    "    print(f\"\u2705 Uploaded dataset '{getattr(ds, 'name', ds)}' with {len(upload_df)} rows\")\n",
     "    return ds"
    ]
   },
@@ -1158,7 +1159,7 @@
    "id": "951c4635",
    "metadata": {},
    "source": [
-    "## 🕰️ Evaluation Time"
+    "## \ud83d\udd70\ufe0f Evaluation Time"
    ]
   },
   {
@@ -1167,11 +1168,11 @@
    "metadata": {},
    "source": [
     "#### IR metric evaluators\n",
-    "_recall_at_k_generic(k, ...): Checks if the ground-truth recipe ID appears in the model’s top_ids. Returns 1.0 if it’s within the top-k, else 0.0.\n",
+    "_recall_at_k_generic(k, ...): Checks if the ground-truth recipe ID appears in the model\u2019s top_ids. Returns 1.0 if it\u2019s within the top-k, else 0.0.\n",
     "\n",
     "RecallAt1 / RecallAt3 / RecallAt5: Thin wrappers around the generic function for k = 1, 3, 5.\n",
     "\n",
-    "MRR: Mean Reciprocal Rank for a single example. If the ground-truth ID is at rank r in top_ids, returns 1/r; returns 0.0 if it’s not found."
+    "MRR: Mean Reciprocal Rank for a single example. If the ground-truth ID is at rank r in top_ids, returns 1/r; returns 0.0 if it\u2019s not found."
    ]
   },
   {
@@ -1270,7 +1271,7 @@
     "\n",
     "    evaluators = [RecallAt1, RecallAt3, RecallAt5, MRR]\n",
     "    experiment = run_experiment(dataset=ds, task=task, evaluators=evaluators)\n",
-    "    print(\"✅ Experiment finished.\")\n",
+    "    print(\"\u2705 Experiment finished.\")\n",
     "\n",
     "    n = len(collector) or 1\n",
     "    sum_r1 = sum(r[\"recall@1\"] for r in collector)\n",
@@ -1294,7 +1295,7 @@
     "    payload = {\"summary\": summary, \"results\": collector}\n",
     "    Path(out_path).parent.mkdir(parents=True, exist_ok=True)\n",
     "    Path(out_path).write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding=\"utf-8\")\n",
-    "    print(f\"💾 Saved detailed results → {out_path}\")\n",
+    "    print(f\"\ud83d\udcbe Saved detailed results \u2192 {out_path}\")\n",
     "\n",
     "    return experiment, out_path"
    ]


### PR DESCRIPTION
## What changed

In `tutorials/ai_evals_course/ai_evals_hw4_solution.ipynb`, `generate_synthetic_queries()` called `random.shuffle(recipes)` on the list passed in. That list is `top_recipes`, which is the **same object** as `corpus` (`corpus = top_recipes`). The BM25 index is built against `corpus` in its original order; the in-place shuffle then permutes that same list, so afterward `bm25.get_scores()` returns scores indexed in the original order while `retrieve_bm25` reads `corpus[idx]` from the shuffled list. Returned document ids no longer match their scores, so `recall@1/3/5` and `MRR` collapse to floor values — the symptom reported in #13394.

Fix: copy the list before shuffling so the shared corpus the index was built on is never reordered.

```python
recipes = list(recipes)  # don't mutate the shared corpus that BM25 was indexed on
random.shuffle(recipes)
```

## Why

This is a corpus/index ordering bug, not a Phoenix version mismatch — a version skew would raise errors rather than silently degrade metrics.

**Note for maintainers:** `build_or_load_bm25` caches the index keyed only on `corpus_size`, so a stale index can also be reloaded after a corpus change; a follow-up could key the cache on corpus content/order, but this PR is intentionally scoped to the metric-killing shuffle only.

Fixes #13394.
