### PR TITLE
fix(server): cap pydantic-ai-slim below 2.0 to unbreak PyPI installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
   "arize-phoenix-otel>=0.16.1",
   "fastapi>=0.137.0",  # 0.137 keeps included routers as a lazy _IncludedRouter tree; older versions raise AssertionError on 204 routes, see https://github.com/Arize-ai/phoenix/issues/12384
   "pydantic>=2.1.0", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
-  "pydantic-ai-slim[anthropic,bedrock,google,mcp,openai,ui]>=1.95.0",
+  "pydantic-ai-slim[anthropic,bedrock,google,mcp,openai,ui]>=1.95.0,<2",
   "bashkit>=0.10.0",
   "authlib>=1.7.0",
   "joserfc",

--- a/uv.lock
+++ b/uv.lock
@@ -734,7 +734,7 @@ requires-dist = [
     { name = "py-grpc-prometheus", marker = "extra == 'container'" },
     { name = "pyarrow" },
     { name = "pydantic", specifier = ">=2.1.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "google", "mcp", "openai", "ui"], specifier = ">=1.95.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "google", "mcp", "openai", "ui"], specifier = ">=1.95.0,<2" },
     { name = "pystache" },
     { name = "python-dateutil" },
     { name = "python-multipart" },


### PR DESCRIPTION
## Problem

The [PyPI Smoke Test](https://github.com/Arize-ai/phoenix/actions/workflows/pypi-smoke-test.yml) has been failing on every run since **2026-06-23 16:34 UTC** (across all three install modes: `pip install`, `uv pip install`, `uv tool run`).

Root cause: **`pydantic-ai-slim` 2.0.0 was released 2026-06-23 15:48 UTC** — a major version that **removed `MCPServerStreamableHTTP`** and reorganized the MCP module into a toolset architecture (`MCPToolset`, `FastMCPClient`, …). Phoenix imports the removed symbol at module-import time:

```
File ".../phoenix/server/app.py", line 40, in <module>
    from pydantic_ai.mcp import MCPServerStreamableHTTP
ImportError: cannot import name 'MCPServerStreamableHTTP' from 'pydantic_ai.mcp'
```

Our own CI stays green because `uv.lock` pins `1.107.0`, but the production constraint `>=1.95.0` had **no upper bound**, so a plain `pip install arize-phoenix` resolves to 2.0.0 and the server fails to boot. The smoke test caught a real break that public installs hit right now.

## Fix

Cap to `>=1.95.0,<2` to keep public installs on the working 1.x line. Resolved version is unchanged (`1.107.0`), so the lock diff is just the specifier.

The full migration to pydantic-ai 2.0 (which also reorganized `capabilities`, `native_tools`, `toolsets`, etc. that Phoenix uses) is **tracked separately** as a larger effort.