### PR TITLE
fix: pin starlette below 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "jsonschema",
   "pystache",
   "PyYAML",
-  "starlette>=0.37.0",
+  "starlette>=0.37.0,<2",
   "uvicorn",
   "psutil",
   "strawberry-graphql==0.316.0",

--- a/uv.lock
+++ b/uv.lock
@@ -745,7 +745,7 @@ requires-dist = [
     { name = "sqlean-py", marker = "sys_platform == 'win32'", specifier = ">=3.45.1,<3.50" },
     { name = "sqlean-py", marker = "python_full_version < '3.14' and sys_platform != 'win32'", specifier = ">=3.45.1" },
     { name = "sqlean-py", marker = "python_full_version >= '3.14' and sys_platform != 'win32'", specifier = ">=3.50" },
-    { name = "starlette", specifier = ">=0.37.0" },
+    { name = "starlette", specifier = ">=0.37.0,<2" },
     { name = "strawberry-graphql", specifier = "==0.316.0" },
     { name = "strawberry-graphql", extras = ["opentelemetry"], marker = "extra == 'container'", specifier = "==0.316.0" },
     { name = "tqdm" },


### PR DESCRIPTION
## Summary
- add an explicit <2 upper bound to the Starlette dependency
- keep uv.lock dependency metadata in sync

## Testing
- uv lock --check