### PR TITLE
feat(experiments): show copyable trace ID in trace details dialog header

### DIFF
--- a/app/src/pages/experiment/TraceDetailsDialog.tsx
+++ b/app/src/pages/experiment/TraceDetailsDialog.tsx
@@ -1,8 +1,11 @@
 import { Suspense } from "react";
 
 import {
+  CopyToClipboardButton,
   Dialog,
   DialogCloseButton,
+  Flex,
+  IDBadge,
   LinkButton,
   Loading,
 } from "@phoenix/components";
@@ -27,7 +30,15 @@ export function TraceDetailsDialog({
     <Dialog>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
+          <Flex direction="row" gap="size-100" alignItems="center" minWidth={0}>
+            <DialogTitle>{title}</DialogTitle>
+            <IDBadge id={traceId} />
+            <CopyToClipboardButton
+              size="S"
+              text={traceId}
+              tooltipText="Copy Trace ID"
+            />
+          </Flex>
           <DialogTitleExtra>
             <LinkButton
               size="S"


### PR DESCRIPTION
## Problem

When opening trace details from experiment views (compare, list, and table pages — e.g. clicking a span in the experiment compare view), the dialog header only showed a plain text title like "Experiment Run Trace". There was no way to see or copy the trace ID, making it hard to use the ID for debugging.

## Change

Added an `IDBadge` and a `CopyToClipboardButton` for the trace ID to the `TraceDetailsDialog` header. Because this dialog is the shared component used across all the experiment trace views, the fix applies everywhere those views open trace details.

The header now shows:
- The existing title
- The trace ID in a monospace ID badge
- A copy button (tooltip: "Copy Trace ID")

This mirrors the existing copy-ID pattern used in the main `SpanDetails` header.

## Testing

- `tsc --noEmit` passes for the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mcg964nRoEz2tijXR4o8Y4)_