### PR TITLE
docs: Add Phoenix release notes — 2026-06-24

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1250,6 +1250,7 @@
               {
                 "group": "06.2026",
                 "pages": [
+                  "docs/phoenix/release-notes/06-2026/06-24-2026-annotations-labels-and-pxi-server-tools",
                   "docs/phoenix/release-notes/06-2026/06-16-2026-time-range-metrics-and-sharing",
                   "docs/phoenix/release-notes/06-2026/06-11-2026-time-range-and-pxi-slash-commands",
                   "docs/phoenix/release-notes/06-2026/06-10-2026-pxi-agent-update",

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -13,6 +13,17 @@ GitHub
 **We want to hear from you!** The DevRel team wants to hear from the Phoenix community. If you're building with Phoenix and want to tell us what's working, what's painful, or what you wish existed, [grab 25 minutes with us](https://cal.com/team/arize-devrel/user-interview).
 </Info>
 
+<ReleaseUpdate label="06.24.2026" href="/docs/phoenix/release-notes/06-2026/06-24-2026-annotations-labels-and-pxi-server-tools" title="Annotations, Labels, and PXI Server Tools">
+**Available in arize-phoenix 17.9.0+ through 17.11.0+**
+
+A batch of annotation, label, auth, and PXI improvements rolled out across 17.9–17.11.
+
+- **Trace-level annotations** — trace annotation summaries appear in the trace header and project stats panel alongside span annotations
+- **Label management from lists** — filter by label, manage labels inline, and see usage counts on the Prompts and Datasets pages, plus a prompt model column
+- **OAuth2 role overrides** — set `ROLE_RESYNC=false` per IDP to keep manually assigned roles from being overwritten on login
+- **PXI server bash tool** — subagents gain a sandboxed `bash` with `phoenix-gql`, gated network access, and a `PHOENIX_AGENTS_DISABLE_BASH` kill switch
+</ReleaseUpdate>
+
 <ReleaseUpdate label="06.16.2026" href="/docs/phoenix/release-notes/06-2026/06-16-2026-time-range-metrics-and-sharing" title="Time Range, Metrics, and Sharing Upgrades">
 **Available in arize-phoenix 17.5.0+ through 17.7.0+**
 

--- a/docs/phoenix/release-notes/06-2026/06-24-2026-annotations-labels-and-pxi-server-tools.mdx
+++ b/docs/phoenix/release-notes/06-2026/06-24-2026-annotations-labels-and-pxi-server-tools.mdx
@@ -1,0 +1,87 @@
+---
+title: "06.24.2026: Annotations, Labels, and PXI Server Tools"
+description: "Trace-level annotations surfaced across the trace header and project stats, label management from the prompts and datasets lists, OAuth2 role-override preservation, and a server-side bash tool for PXI subagents."
+---
+
+# Trace-Level Annotations Across the UI
+
+June 22, 2026
+
+**Available in arize-phoenix 17.10.0+ (trace header) and 17.11.0+ (project stats panel)**
+
+Trace-level annotations now appear next to span annotations everywhere you review feedback, so
+scores attached to a whole trace are as visible as scores on individual spans.
+
+- **Trace header** — the trace details header shows trace annotation summaries as peer columns
+  beside Status, Total Cost, and Latency, with root span and trace annotations segmented by a
+  subtle divider so each source reads clearly in a single compact row
+- **Project stats panel** — the spans Stats aside groups feedback into clearly headed sections —
+  Span Annotations, Document Evaluations, and Trace Annotations — so every level of feedback reads
+  as its own section
+- **Live updates** — trace annotation summaries refetch as streaming data advances, keeping scores
+  current while you watch a project
+
+# Manage Prompt and Dataset Labels from the List Pages
+
+June 19, 2026
+
+**Available in arize-phoenix 17.9.0+**
+
+Label management moves onto the Prompts and Datasets list pages, so you can filter and organize
+without leaving the table.
+
+- **Click to filter** — click any label token on the Prompts or Datasets list to toggle it as a
+  filter; the active filter is persisted to the URL, so a filtered view is shareable and survives
+  reloads
+- **Manage labels inline** — add labels from a row's action menu and create new ones inline, with
+  no modal, on both the prompts and datasets lists
+- **Usage counts** — the label tables in settings show how many prompts or datasets reference each
+  label, making it easy to spot which labels are in use and which are unused
+- **Prompt model column** — the prompts table adds a model column showing each prompt's provider
+  icon and model name
+
+# Preserve Manual Role Overrides for OAuth2 Logins
+
+June 19, 2026
+
+**Available in arize-phoenix 17.9.0+**
+
+When you map roles from an OAuth2 identity provider with `ROLE_ATTRIBUTE_PATH`, an existing user's
+role was previously re-synced from the IDP on every login — silently overwriting any role you set
+by hand in the Phoenix admin UI. A new per-IDP flag lets those manual overrides stick.
+
+- **Opt out of re-sync** — set `PHOENIX_OAUTH2_<IDP_NAME>_ROLE_RESYNC=false` to stop overwriting an
+  existing user's role from IDP claims on login
+- **New users unaffected** — newly provisioned users still receive their mapped role, so role
+  mapping stays active while manual overrides survive re-login
+- **Defaults preserved** — the flag defaults to `true`, so existing deployments keep their current
+  behavior unless you turn re-sync off
+
+<CardGroup cols={2}>
+  <Card title="Authentication" icon="key" href="/docs/phoenix/self-hosting/features/authentication">
+    Configure OAuth2 identity providers and role mapping for self-hosted Phoenix.
+  </Card>
+</CardGroup>
+
+# Server-Side Bash Tool for PXI Subagents
+
+June 19, 2026
+
+**Available in arize-phoenix 17.9.0+ (PXI beta)**
+
+PXI subagents now run a sandboxed `bash` tool with a built-in `phoenix-gql` command, letting them
+query your Phoenix data through the GraphQL API the same way the main agent does — and respecting
+the same mutation gate, so subagents stay queries-only by default.
+
+- **Network gated by web access** — outbound network built-ins (`curl`, `wget`, `http`) stay
+  offline unless web access is enabled; with it off, every outbound request is positively denied
+  with the SSRF guard on
+- **Deployment kill switch** — set `PHOENIX_AGENTS_DISABLE_BASH=true` to disable the server-side
+  bash tool entirely, which also hides the subagents toggle from the agent settings UI; the
+  in-browser bash tool is unaffected
+
+<CardGroup cols={2}>
+  <Card title="PXI Agent" icon="robot" href="/docs/phoenix/pxi">
+    Learn how to enable and use PXI in your Phoenix deployment.
+  </Card>
+</CardGroup>

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,7 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/06-2026/06-24-2026-annotations-labels-and-pxi-server-tools" arrow="true" title="06.24.2026" icon="calendar" description="Trace-level annotations in the trace header and project stats; label management and usage counts on the Prompts and Datasets lists; OAuth2 role-override preservation; a server-side bash tool for PXI subagents (17.9–17.11)"/>
     <Card href="/docs/phoenix/release-notes/06-2026/06-16-2026-time-range-metrics-and-sharing" arrow="true" title="06.16.2026" icon="calendar" description="Calendar time range picker with pan, zoom, and live streaming controls; shareable trace URLs; trace, session, and token detail metrics; opt-in PXI subagents (17.5–17.7)"/>
     <Card href="/docs/phoenix/release-notes/06-2026/06-11-2026-time-range-and-pxi-slash-commands" arrow="true" title="06.11.2026" icon="calendar" description="Searchable time range selector with free-form durations (25m, 2h, 3d); PXI slash commands and dataset evaluator editing"/>
     <Card href="/docs/phoenix/release-notes/06-2026/06-10-2026-pxi-agent-update" arrow="true" title="06.10.2026" icon="calendar" description="PXI skills menu, parallel subagents, playground orchestration, evaluator authoring, and dataset management; Claude Fable 5 in the playground"/>


### PR DESCRIPTION
## Summary

Adds release notes covering Phoenix server releases **17.8.0 – 17.11.0** (June 17–24, 2026),
the window after the last documented release (06.16.2026, which covered 17.5.0–17.7.0).

The user-facing changes are consolidated into a single multi-topic page,
`06-24-2026-annotations-labels-and-pxi-server-tools.mdx`, dated by the latest release (17.11.0):

- **Trace-level annotations across the UI** (17.10.0 trace header, 17.11.0 project stats panel) —
  trace annotation summaries now appear alongside span annotations in the trace details header and
  in the project spans Stats aside.
- **Label management from the Prompts and Datasets lists** (17.9.0) — click-to-filter by label with
  URL persistence, inline label management from row action menus, usage counts in the settings
  label tables, and a new prompt model column.
- **Preserve manual OAuth2 role overrides** (17.9.0) — the per-IDP
  `PHOENIX_OAUTH2_<IDP_NAME>_ROLE_RESYNC=false` flag stops Phoenix from overwriting manually
  assigned roles on login.
- **Server-side bash tool for PXI subagents** (17.9.0, beta) — subagents gain a sandboxed `bash`
  with a built-in `phoenix-gql` command (queries-only by default), web-access-gated network
  built-ins, and a `PHOENIX_AGENTS_DISABLE_BASH` deployment kill switch.

## Touchpoints updated

- New file: `docs/phoenix/release-notes/06-2026/06-24-2026-annotations-labels-and-pxi-server-tools.mdx`
- `docs/phoenix/release-notes.mdx` — new `<ReleaseUpdate label="06.24.2026">` block at the top
- `docs/phoenix/release-notes/2026.mdx` — new `<Card>` at the top of the year overview
- `docs.json` — new page path added to the `06.2026` navigation group

## Excluded as non-user-facing

Dependency bumps (`pydantic-ai-slim` cap, weekly deps), CI/build changes, dev-only changes (Swagger
agent endpoints under `--dev`), icon/refactor work, internal PXI eval-harness reports, repo skill
updates, FastAPI 0.137 route-coverage fixes, and tutorial/docs commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
