### PR TITLE
docs: Audit and update llms.txt

### DIFF
--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -689,7 +689,8 @@
 - [Optimizing Prompts for LLM Classification - Prompt Learning](https://arize.com/docs/phoenix/cookbook/prompt-engineering/prompt-learning-optimizing-prompts-for-classification): Using Prompt Learning to boost accuracy on a classification dataset
 - [Prompt Optimization Techniques](https://arize.com/docs/phoenix/cookbook/prompt-engineering/prompt-optimization): This tutorial will use Phoenix to compare the performance of different prompt optimization techniques
 - [ReAct Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/react-prompting): **ReAct (Reasoning + Acting)** is a prompting technique that enables LLMs to think step-by-step before taking
-- [Agentic RAG Tracing](https://arize.com/docs/phoenix/cookbook/tracing/agentic-rag-tracing): >-
+- [Agentic RAG Tracing](https://arize.com/docs/phoenix/cookbook/tracing/agentic-rag-tracing): Build and trace an agentic RAG system using LlamaIndex's ReAct agent with vector and SQL query tools
+- [OpenInference Best Practices](https://arize.com/docs/phoenix/cookbook/tracing/openinference-best-practices): Enrich auto-instrumented traces with LLM, tool, agent, chain, and session attributes using OpenInference span kinds
 - [More Cookbooks](https://arize.com/docs/phoenix/cookbook/tracing/cookbooks): Trace through the execution of your LLM application to understand its internal structure and to troubleshoot
 - [Generating Synthetic Datasets for LLM Evaluators & Agents](https://arize.com/docs/phoenix/cookbook/tracing/generating-synthetic-datasets-for-llm-evaluators-and-agents): Learn different strategies for dataset generation and show how they can be used to run experiments and test
 - [Product Recommendation Agent: Google Agent Engine & LangGraph](https://arize.com/docs/phoenix/cookbook/tracing/product-recommendation-agent-google-agent-engine-and-langgraph): This notebook is adapted from Google's \"Building and Deploying a LangGraph Application with Agent Engine in
@@ -711,16 +712,7 @@
 
 ### 2026
 
-- [01.05.2026 Appended Messages for Playground Experiments](https://arize.com/docs/phoenix/release-notes/01-2026/01-05-2026-appended-messages-for-playground-experiments): Add suffix messages to Playground experiment runs for A/B testing prompt endings
 - [01.17.2026 Phoenix CLI: Terminal Access for AI Coding Assistants](https://arize.com/docs/phoenix/release-notes/01-2026/01-17-2026-phoenix-cli-ai-agent-debugging): Install px CLI to query traces, spans, and experiments from the terminal
-- [01.21.2026 CLI Datasets, Experiments & Annotations](https://arize.com/docs/phoenix/release-notes/01-2026/01-21-2026-cli-datasets-experiments-annotations): Manage datasets, run experiments, and write annotations from the command line with px
-- [01.21.2026 Create Datasets from Traces with Span Associations](https://arize.com/docs/phoenix/release-notes/01-2026/01-21-2026-create-datasets-from-traces): Build datasets from existing spans using arize-phoenix-client with span-to-example associations
-- [01.22.2026 CLI Prompt Commands](https://arize.com/docs/phoenix/release-notes/01-2026/01-22-2026-cli-prompt-commands): List, pull, and pipe Phoenix prompts to AI assistants from the terminal with px prompts
-- [02.01.2026 Tool Selection and Tool Invocation Evaluators](https://arize.com/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators): New pre-built evals for scoring tool selection and argument quality in Python and TypeScript
-- [02.10.2026 Claude Opus 4.6 Model Support](https://arize.com/docs/phoenix/release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support): Use claude-opus-4-6 in the Playground with extended thinking and accurate cost tracking
-- [02.11.2026 Custom Providers for Playground and Prompts](https://arize.com/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers): Store OpenAI, Azure, Anthropic, Bedrock, and Google credentials server-side and reuse across Playground
-- [02.12.2026 OpenAI Responses API Type Support](https://arize.com/docs/phoenix/release-notes/02-2026/02-12-2026-openai-responses-api-support): Switch between Chat Completions and Responses API per model in Playground and custom providers
-- [02.12.2026 Dataset Evaluators](https://arize.com/docs/phoenix/release-notes/02-2026/02-12-2026-dataset-evaluators): Attach evaluators to datasets so they auto-run server-side on every Playground experiment
 - [Phoenix 13.0](https://arize.com/docs/phoenix/release-notes/02-2026/02-14-2026-phoenix-13-0): Dataset Evaluators, custom model providers, OpenAI Responses API support, and major Playground and experiment
 - [02.27.2026 Sessions API and CLI Support](https://arize.com/docs/phoenix/release-notes/02-2026/02-27-2026-cli-sessions-and-rest-api): Query sessions via REST API and CLI with filtering, sorting, and pagination support
 - [03.05.2026 SDK Session Retrieval](https://arize.com/docs/phoenix/release-notes/03-2026/03-05-2026-sdk-session-retrieval): Get and list sessions programmatically from Python and TypeScript
@@ -760,6 +752,7 @@
 - [06.02.2026 Introducing PXI](https://arize.com/docs/phoenix/release-notes/06-2026/06-02-2026-pxi-agent): Phoenix Intelligence, the built-in AI engineering agent, debuts in beta in arize-phoenix 17.0.0+
 - [06.10.2026 PXI Agent Update](https://arize.com/docs/phoenix/release-notes/06-2026/06-10-2026-pxi-agent-update): PXI gains a skills menu, parallel subagents, playground orchestration, evaluator authoring, and dataset management
 - [06.11.2026 Time Range Selector and PXI Slash Commands](https://arize.com/docs/phoenix/release-notes/06-2026/06-11-2026-time-range-and-pxi-slash-commands): Search presets and type free-form durations in the time range selector; PXI adds local slash commands
+- [06.16.2026 Time Range, Metrics, and Sharing Upgrades](https://arize.com/docs/phoenix/release-notes/06-2026/06-16-2026-time-range-metrics-and-sharing): Pick ranges from a pan/zoom calendar, share trace URLs, and view annotation metrics in arize-phoenix 17.5.0+
 
 ### 2025
 


### PR DESCRIPTION
## Summary

Audited `docs/phoenix/llms.txt` against the docs tree (intersection of `docs.json` navigation and on-disk `.mdx` files). Added newly-published pages, removed orphaned entries that 404 in production, and tidied one broken description.

Coverage of nav-published pages is now **622/629 (98.9%)**, well above the AFDocs 90% target. The 7 uncovered pages are all intentional exclusions (agent-assisted-setup, end-to-end-features notebook, Phoenix Demo, and four redirect-only `resources/*` stubs).

## Changes

### Added (2)
- **OpenInference Best Practices** (`cookbook/tracing/openinference-best-practices`) — substantial prose cookbook teaching how to enrich auto-instrumented traces with span-kind attributes.
- **06.16.2026 Time Range, Metrics, and Sharing Upgrades** (`release-notes/06-2026/06-16-2026-time-range-metrics-and-sharing`) — newly published release note.

### Removed (9 orphans)
These release-note `.mdx` files exist on disk but are **not referenced in `docs.json` navigation**, so Mintlify does not route them and they 404 in production. Linking dead URLs misleads agents, so they were removed:
- `01-2026/01-05-2026-appended-messages-for-playground-experiments`
- `01-2026/01-21-2026-cli-datasets-experiments-annotations`
- `01-2026/01-21-2026-create-datasets-from-traces`
- `01-2026/01-22-2026-cli-prompt-commands`
- `02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators`
- `02-2026/02-10-2026-claude-opus-4-6-model-support`
- `02-2026/02-11-2026-custom-providers`
- `02-2026/02-12-2026-openai-responses-api-support`
- `02-2026/02-12-2026-dataset-evaluators`

> Note: these pages are absent from the `01.2026` and `02.2026` nav groups in `docs.json`. If they were meant to be published, the fix belongs in `docs.json` navigation — at which point they can be re-added here.

### Fixed (1)
- **Agentic RAG Tracing** description was a stray YAML artifact (`>-`); replaced with an action-oriented description.

## Verification
- Re-ran the coverage diff: MISSING contains only intentional exclusions; STALE contains only three regex false-positives (filenames with `.`/`+`: `claude-sonnet-4.5`, `openai-5-1-+-gemini-3`, `…arize-phoenix-vs.-langsmith`), all confirmed present in nav and `llms.txt`.
- No duplicate titles were introduced (pre-existing cross-section duplicates left untouched).
- The CLI parser test (`pnpm test --grep docs`) could not be executed in this sandbox (JS runtime gated); changes are additive markdown links matching the existing format.
