### PR TITLE
docs(js): add changeset for beta CI eval testing API

### DIFF
--- a/js/.changeset/phoenix-client-ci-eval-testing.md
+++ b/js/.changeset/phoenix-client-ci-eval-testing.md
@@ -1,0 +1,7 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+**Beta:** Add a vitest/jest-based CI eval testing API to `@arizeai/phoenix-client`. New `./vitest`, `./vitest/reporter`, `./jest`, and `./jest/reporter` entrypoints expose a Phoenix reporter (scoreboard + results table), acceptance-criteria support with an optimization `direction` ("maximize"/"minimize"), and tracing that records runs back to Phoenix. `jest` and `vitest` are added as optional peer dependencies.
+
+This API is in beta and may change in a future release.


### PR DESCRIPTION
## Summary

Adds a changeset for the vitest/jest-based CI eval testing API that shipped in #13877 (`@arizeai/phoenix-client`). This produces the package changelog / release note entry, which was missing.

The change is announced as **beta** with an explicit note that the API may change in a future release. Bumped as a `minor`.

### Changeset contents
- `./vitest`, `./vitest/reporter`, `./jest`, `./jest/reporter` entrypoints with a Phoenix reporter (scoreboard + results table)
- acceptance-criteria support with optimization `direction` (`maximize`/`minimize`)
- tracing that records runs back to Phoenix
- `jest` and `vitest` added as optional peer dependencies

## Test plan
- N/A — changeset-only (Markdown). Will be consumed by the release-version workflow.