### PR TITLE
fix: hide empty subagent message parts

### DIFF
--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -910,6 +910,9 @@ function CallSubagentToolDetails({ part }: { part: ToolInvocationPart }) {
 
 function CallSubagentMessagePart({ part }: { part: MessagePart }) {
   if (part.type === "text") {
+    if (part.text.trim().length === 0) {
+      return null;
+    }
     return (
       <MarkdownBlock mode="markdown" renderMode="streaming" margin="none">
         {part.text}
@@ -917,6 +920,9 @@ function CallSubagentMessagePart({ part }: { part: MessagePart }) {
     );
   }
   if (part.type === "reasoning") {
+    if (part.text.trim().length === 0) {
+      return null;
+    }
     return (
       <ToolPartExpandableSection>
         <ToolPartCodeBlock>{part.text}</ToolPartCodeBlock>
@@ -931,9 +937,13 @@ function CallSubagentMessagePart({ part }: { part: MessagePart }) {
       <ToolPart part={part} defaultOpen={part.state !== "output-available"} />
     );
   }
+  const value = stringifyToolValue(part);
+  if (value.trim().length === 0) {
+    return null;
+  }
   return (
     <ToolPartExpandableSection>
-      <ToolPartCodeBlock>{stringifyToolValue(part)}</ToolPartCodeBlock>
+      <ToolPartCodeBlock>{value}</ToolPartCodeBlock>
     </ToolPartExpandableSection>
   );
 }

--- a/app/src/components/agent/__tests__/ToolPartDisclosure.test.tsx
+++ b/app/src/components/agent/__tests__/ToolPartDisclosure.test.tsx
@@ -18,6 +18,12 @@ vi.mock("@phoenix/components/code/JSONEditor", () => ({
   JSONEditor: () => null,
 }));
 
+vi.mock("@phoenix/components/markdown", () => ({
+  MarkdownBlock: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
 import { getToolPartPreview, ToolPart } from "../ToolPart";
 import type { ToolInvocationPart } from "../toolPartTypes";
 
@@ -208,5 +214,51 @@ describe("tool disclosure controls", () => {
     expect(
       container.querySelector("details.tool-part")?.hasAttribute("open")
     ).toBe(true);
+  });
+
+  it("does not render empty subagent message parts under nested tools", () => {
+    renderToolPart(
+      createToolPart({
+        type: "tool-call_subagent",
+        toolCallId: "tool-call-subagent",
+        input: { name: "Phoenix data", task: "Summarize latency" },
+        output: {
+          summary: "Done",
+          message: {
+            id: "subagent-message",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-bash",
+                toolCallId: "tool-call-bash",
+                state: "output-available",
+                input: { command: "echo hi" },
+                output: "hi",
+              },
+              {
+                type: "reasoning",
+                text: "",
+                state: "done",
+              },
+              {
+                type: "text",
+                text: "   ",
+                state: "done",
+              },
+              {
+                type: "text",
+                text: "Visible answer",
+                state: "done",
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    click(container.querySelector("summary"));
+
+    expect(container.textContent).toContain("Visible answer");
+    expect(container.textContent).not.toContain("(empty)");
   });
 });


### PR DESCRIPTION
## Summary
- Skip empty text and reasoning parts when rendering call_subagent output
- Avoid rendering the shared `(empty)` code-block placeholder beneath nested subagent tools
- Add a regression test for empty subagent message parts after a nested tool

## Tests
- make test-frontend
- make typecheck-frontend
- make lint-frontend
- git diff --check