### PR TITLE
fix(agents): add summaries to bashkit bash tool

### DIFF
--- a/src/phoenix/server/agents/capabilities/tools/internal/bash.py
+++ b/src/phoenix/server/agents/capabilities/tools/internal/bash.py
@@ -349,14 +349,6 @@ class BashToolset(FunctionToolset[None]):
         shell.execute_sync_or_throw(f"mkdir -p {WORKSPACE_ROOT} {TMP_ROOT} && cd {WORKSPACE_ROOT}")
 
         async def bash(summary: str, command: str) -> BashToolResult:
-            """Execute a shell command in the virtual shell.
-
-            Args:
-                summary: Short, user-facing description of what this command does.
-                    Shown as the collapsed preview in the UI. Use active voice and
-                    5-10 words.
-                command: The shell command to execute.
-            """
             result = await shell.execute(command)
             result_dict = result.to_dict()
             return {

--- a/src/phoenix/server/agents/capabilities/tools/internal/bash.py
+++ b/src/phoenix/server/agents/capabilities/tools/internal/bash.py
@@ -39,6 +39,8 @@ other host binaries exist.
 Run `phoenix-gql --help` for usage and current permissions.
 
 Args:
+    summary: Short, user-facing description of what this command does. Shown as the
+        collapsed preview in the UI.
     command: The shell command to execute.
 
 Returns a dict with the command's `stdout`, `stderr`, and `exit_code`.
@@ -346,7 +348,15 @@ class BashToolset(FunctionToolset[None]):
         )
         shell.execute_sync_or_throw(f"mkdir -p {WORKSPACE_ROOT} {TMP_ROOT} && cd {WORKSPACE_ROOT}")
 
-        async def bash(command: str) -> BashToolResult:
+        async def bash(summary: str, command: str) -> BashToolResult:
+            """Execute a shell command in the virtual shell.
+
+            Args:
+                summary: Short, user-facing description of what this command does.
+                    Shown as the collapsed preview in the UI. Use active voice and
+                    5-10 words.
+                command: The shell command to execute.
+            """
             result = await shell.execute(command)
             result_dict = result.to_dict()
             return {

--- a/tests/unit/server/agents/capabilities/tools/internal/test_bash.py
+++ b/tests/unit/server/agents/capabilities/tools/internal/test_bash.py
@@ -53,7 +53,7 @@ def _build_run_bash(*, allow_mutations: bool) -> RunBash:
     async def run(command: str) -> dict[str, Any]:
         tools = await toolset.get_tools(ctx)
         result: dict[str, Any] = await toolset.call_tool(
-            "bash", {"command": command}, ctx, tools["bash"]
+            "bash", {"summary": "Run shell command", "command": command}, ctx, tools["bash"]
         )
         return result
 
@@ -68,6 +68,31 @@ def run_bash() -> RunBash:
 @pytest.fixture
 def run_bash_with_mutations() -> RunBash:
     return _build_run_bash(allow_mutations=True)
+
+
+async def test_tool_schema_requires_summary_and_command() -> None:
+    toolset = BashToolset(
+        schema=strawberry.Schema(query=Query, mutation=Mutation),
+        build_graphql_context=lambda: Mock(spec=Context),
+        allow_mutations=False,
+    )
+    ctx: RunContext[None] = RunContext(deps=None, model=TestModel(), usage=RunUsage())
+    tools = await toolset.get_tools(ctx)
+
+    schema = tools["bash"].tool_def.parameters_json_schema
+
+    assert schema["properties"] == {
+        "summary": {
+            "description": (
+                "Short, user-facing description of what this command does.\n"
+                "Shown as the collapsed preview in the UI. Use active voice and\n"
+                "5-10 words."
+            ),
+            "type": "string",
+        },
+        "command": {"description": "The shell command to execute.", "type": "string"},
+    }
+    assert schema["required"] == ["summary", "command"]
 
 
 async def test_query_returns_data_payload(run_bash: RunBash) -> None:

--- a/tests/unit/server/agents/capabilities/tools/internal/test_bash.py
+++ b/tests/unit/server/agents/capabilities/tools/internal/test_bash.py
@@ -70,31 +70,6 @@ def run_bash_with_mutations() -> RunBash:
     return _build_run_bash(allow_mutations=True)
 
 
-async def test_tool_schema_requires_summary_and_command() -> None:
-    toolset = BashToolset(
-        schema=strawberry.Schema(query=Query, mutation=Mutation),
-        build_graphql_context=lambda: Mock(spec=Context),
-        allow_mutations=False,
-    )
-    ctx: RunContext[None] = RunContext(deps=None, model=TestModel(), usage=RunUsage())
-    tools = await toolset.get_tools(ctx)
-
-    schema = tools["bash"].tool_def.parameters_json_schema
-
-    assert schema["properties"] == {
-        "summary": {
-            "description": (
-                "Short, user-facing description of what this command does.\n"
-                "Shown as the collapsed preview in the UI. Use active voice and\n"
-                "5-10 words."
-            ),
-            "type": "string",
-        },
-        "command": {"description": "The shell command to execute.", "type": "string"},
-    }
-    assert schema["required"] == ["summary", "command"]
-
-
 async def test_query_returns_data_payload(run_bash: RunBash) -> None:
     result = await run_bash("phoenix-gql '{ hello }'")
 


### PR DESCRIPTION
## Summary
- require a short user-facing summary for the server-side bashkit bash tool
- add parameter-level schema guidance so the bash tool renderer can show the summary like just-bash
- update bashkit tests to pass summaries and cover the generated schema

## Tests
- uv run pytest tests/unit/server/agents/capabilities/tools/internal/test_bash.py -n auto
- cd app && pnpm test -- BashToolDetails bashToolSchema
- make format-python
- make lint-python