### PR TITLE
fix(agents): Prevent pxi logo from shrinking

### DIFF
--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -138,6 +138,7 @@ export function AgentChatHeader({
           fill="var(--global-text-color-900)"
           css={css`
             transform: scale(0.7);
+            flex-shrink: 0;
           `}
         />
         <Text weight="heavy" css={sessionHeadingCSS} title={sessionDisplayName}>


### PR DESCRIPTION
## Before

<img width="274" height="109" alt="Screenshot 2026-06-24 at 3 11 04 PM" src="https://github.com/user-attachments/assets/6c25b072-0bf1-4c65-b8ef-aaddd7c5d608" />

## After

<img width="184" height="100" alt="Screenshot 2026-06-24 at 3 11 16 PM" src="https://github.com/user-attachments/assets/f222403b-1330-4836-bf68-32f91bed8407" />
