### PR TITLE
feat(pxi): add @arizeai/pxi terminal chatbot package

### DIFF
--- a/js/packages/pxi/README.md
+++ b/js/packages/pxi/README.md
@@ -1,0 +1,60 @@
+# @arizeai/pxi
+
+A terminal chatbot for **PXI (Phoenix Intelligence)** — the Phoenix server agent.
+`pxi` opens an interactive TUI that streams a conversation with the agent over the
+Phoenix REST endpoint `POST /agents/server/sessions/{session_id}/chat`.
+
+Built with [OpenTUI](https://github.com/sst/opentui) (React bindings) and runs on
+[Bun](https://bun.sh). Type safety for the request/response contract comes from
+`@arizeai/phoenix-client` (generated OpenAPI types) and connection/env resolution
+from `@arizeai/phoenix-config`.
+
+## Requirements
+
+- **Bun** (OpenTUI's native renderer uses FFI, which Bun supports out of the box).
+- A running Phoenix server with the agent enabled.
+
+## Usage
+
+```bash
+# From a published install:
+bunx @arizeai/pxi
+
+# From this monorepo (workspace):
+pnpm --filter @arizeai/pxi dev
+# or
+cd js/packages/pxi && bun run src/index.tsx
+```
+
+Type a message and press **Enter** to send. The assistant reply streams in as
+rendered markdown, and server-side tool activity appears as dim status lines.
+Press **Ctrl+C** to exit. Scroll the transcript with the arrow / Page keys.
+
+## Configuration
+
+Connection settings are resolved by `@arizeai/phoenix-config`. CLI flags take
+precedence over environment variables.
+
+| Setting    | Flag           | Env var                  | Default                 |
+| ---------- | -------------- | ------------------------ | ----------------------- |
+| Host       | `--host`       | `PHOENIX_HOST`           | `http://localhost:6006` |
+| API key    | `--api-key`    | `PHOENIX_API_KEY`        | _(none)_                |
+| Headers    | —              | `PHOENIX_CLIENT_HEADERS` | _(none)_                |
+| Provider   | `--provider`   | —                        | `ANTHROPIC`             |
+| Model      | `--model`      | —                        | `claude-opus-4-6`       |
+| Session id | `--session-id` | —                        | random UUID per run     |
+
+An API key is sent as `Authorization: Bearer <key>`.
+
+```bash
+PHOENIX_HOST=https://my-phoenix.example.com \
+PHOENIX_API_KEY=phx-… \
+bunx @arizeai/pxi --provider OPENAI --model gpt-5
+```
+
+## Scripts
+
+- `bun run dev` — run with file watch
+- `bun run start` — run once
+- `pnpm typecheck` — `tsc --noEmit`
+- `pnpm test` — unit tests (vitest)

--- a/js/packages/pxi/package.json
+++ b/js/packages/pxi/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@arizeai/pxi",
+  "version": "0.1.0",
+  "description": "Phoenix Intelligence (PXI) — a terminal chatbot for the Phoenix server agent",
+  "keywords": [
+    "agent",
+    "arize",
+    "cli",
+    "llmops",
+    "phoenix",
+    "pxi",
+    "tui"
+  ],
+  "homepage": "https://github.com/Arize-ai/phoenix/tree/main/js/packages/pxi",
+  "bugs": {
+    "url": "https://github.com/Arize-ai/phoenix/issues"
+  },
+  "license": "Apache-2.0",
+  "author": "oss@arize.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Arize-ai/phoenix.git"
+  },
+  "bin": {
+    "pxi": "src/index.tsx"
+  },
+  "files": [
+    "src",
+    "README.md",
+    "package.json"
+  ],
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --watch src/index.tsx",
+    "start": "bun run src/index.tsx",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@arizeai/phoenix-client": "workspace:*",
+    "@arizeai/phoenix-config": "workspace:*",
+    "@opentui/core": "^0.4.1",
+    "@opentui/react": "^0.4.1",
+    "ai": "^6.0.208",
+    "commander": "^15.0.0",
+    "react": "^19.2.6"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/node": "^25.9.4",
+    "@types/react": "^19.2.6",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  },
+  "engines": {
+    "bun": ">=1.2",
+    "node": ">=20"
+  }
+}

--- a/js/packages/pxi/src/chat/buildRequestBody.test.ts
+++ b/js/packages/pxi/src/chat/buildRequestBody.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRequestBody } from "./buildRequestBody";
+import type { AgentUIMessage, ModelSelection } from "./types";
+
+const model: ModelSelection = {
+  providerType: "builtin",
+  provider: "ANTHROPIC",
+  modelName: "claude-opus-4-6",
+};
+
+const messages: AgentUIMessage[] = [
+  { id: "m1", role: "user", parts: [{ type: "text", text: "hello" }] },
+];
+
+describe("buildRequestBody", () => {
+  it("builds a submit-message with model, history, and app context", () => {
+    const body = buildRequestBody({
+      id: "session-1",
+      messages,
+      trigger: "submit-message",
+      messageId: undefined,
+      model,
+    });
+
+    expect(body.trigger).toBe("submit-message");
+    expect(body.id).toBe("session-1");
+    expect(body.model).toEqual(model);
+    expect(body.messages).toHaveLength(1);
+
+    const appContext = body.contexts?.find((context) => context.type === "app");
+    expect(appContext).toBeDefined();
+    expect(
+      typeof (appContext as { currentDateTime?: unknown }).currentDateTime
+    ).toBe("string");
+    expect(typeof (appContext as { timeZone?: unknown }).timeZone).toBe(
+      "string"
+    );
+  });
+
+  it("carries messageId on a regenerate-message", () => {
+    const body = buildRequestBody({
+      id: "session-1",
+      messages,
+      trigger: "regenerate-message",
+      messageId: "m1",
+      model,
+    });
+
+    expect(body.trigger).toBe("regenerate-message");
+    expect((body as { messageId?: string | null }).messageId).toBe("m1");
+  });
+});

--- a/js/packages/pxi/src/chat/buildRequestBody.ts
+++ b/js/packages/pxi/src/chat/buildRequestBody.ts
@@ -1,0 +1,76 @@
+import type {
+  AgentUIMessage,
+  ChatContext,
+  ChatRegenerateMessage,
+  ChatRequestBody,
+  ChatSubmitMessage,
+  ModelSelection,
+} from "./types";
+
+export type BuildRequestBodyOptions = {
+  /** Chat/session identifier for this conversation. */
+  id: string;
+  /** Full UI message history to send with the request. */
+  messages: AgentUIMessage[];
+  /** Why the transport is sending this request. */
+  trigger: "submit-message" | "regenerate-message";
+  /** Message id to regenerate (regenerate flows only). */
+  messageId: string | undefined;
+  /** Provider + model selection for this turn. */
+  model: ModelSelection;
+};
+
+/**
+ * Request-only browser-clock context so the agent can resolve relative time
+ * phrases ("yesterday", "last hour"). Mirrors `buildCurrentAppContext` in the
+ * Phoenix web app — generated fresh per turn rather than stored.
+ */
+function buildAppContext(): ChatContext {
+  const now = new Date();
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return { type: "app", currentDateTime: now.toISOString(), timeZone };
+}
+
+/**
+ * Build the typed `ChatRequest` body for the server-agent chat endpoint.
+ *
+ * The CLI runs without the web app's capability store, so capability-derived
+ * contexts are omitted and the server's defaults apply. Tool definitions are
+ * intentionally not sent: the server agent is the model-facing authority and
+ * runs its own tools server-side.
+ */
+export function buildRequestBody({
+  id,
+  messages,
+  trigger,
+  messageId,
+  model,
+}: BuildRequestBodyOptions): ChatRequestBody {
+  // The AI SDK UIMessage and the server's AssistantMetadataUIMessage share the
+  // same wire shape; the server validates the richer structure at runtime.
+  const wireMessages = messages as unknown as ChatSubmitMessage["messages"];
+  const shared = {
+    id,
+    messages: wireMessages,
+    model,
+    contexts: [buildAppContext()],
+    ingestTraces: false,
+    exportRemoteTraces: false,
+    attachUserId: false,
+    editPermission: "manual" as const,
+    requestedSkills: [],
+  };
+
+  if (trigger === "regenerate-message") {
+    return {
+      ...shared,
+      trigger: "regenerate-message",
+      messageId: messageId ?? null,
+    } satisfies ChatRegenerateMessage;
+  }
+
+  return {
+    ...shared,
+    trigger: "submit-message",
+  } satisfies ChatSubmitMessage;
+}

--- a/js/packages/pxi/src/chat/transport.ts
+++ b/js/packages/pxi/src/chat/transport.ts
@@ -1,0 +1,33 @@
+import { DefaultChatTransport } from "ai";
+
+import { buildRequestBody } from "./buildRequestBody";
+import type { AgentUIMessage, ModelSelection } from "./types";
+
+export type CreateTransportOptions = {
+  /** Fully-resolved server-agent chat URL. */
+  chatUrl: string;
+  /** Headers applied to every request (auth + custom client headers). */
+  headers: Record<string, string>;
+  /** Provider + model selection for every turn in this session. */
+  model: ModelSelection;
+};
+
+/**
+ * Create the AI SDK transport that talks to the Phoenix server-agent chat
+ * endpoint. This mirrors how the Phoenix web app wires `DefaultChatTransport`
+ * (see `useAgentChat.ts`): the transport handles SSE framing while
+ * `prepareSendMessagesRequest` injects the typed PXI request body.
+ */
+export function createServerAgentTransport({
+  chatUrl,
+  headers,
+  model,
+}: CreateTransportOptions): DefaultChatTransport<AgentUIMessage> {
+  return new DefaultChatTransport<AgentUIMessage>({
+    api: chatUrl,
+    headers,
+    prepareSendMessagesRequest: ({ id, messages, trigger, messageId }) => ({
+      body: buildRequestBody({ id, messages, trigger, messageId, model }),
+    }),
+  });
+}

--- a/js/packages/pxi/src/chat/types.ts
+++ b/js/packages/pxi/src/chat/types.ts
@@ -1,0 +1,28 @@
+import type { componentsV1 } from "@arizeai/phoenix-client";
+import type { UIMessage } from "ai";
+
+/**
+ * UI message exchanged with the Phoenix server agent. The server speaks the
+ * Vercel AI SDK UI-message format, so the AI SDK {@link UIMessage} is the
+ * wire-compatible shape for both the request history and the streamed reply.
+ */
+export type AgentUIMessage = UIMessage;
+
+/** Discriminated union of chat request payloads accepted by the endpoint. */
+export type ChatRequestBody = componentsV1["schemas"]["ChatRequest"];
+
+/** The `submit-message` branch of {@link ChatRequestBody}. */
+export type ChatSubmitMessage = componentsV1["schemas"]["ChatSubmitMessage"];
+
+/** The `regenerate-message` branch of {@link ChatRequestBody}. */
+export type ChatRegenerateMessage =
+  componentsV1["schemas"]["ChatRegenerateMessage"];
+
+/** Provider + model selection for a turn (built-in or custom provider). */
+export type ModelSelection = ChatSubmitMessage["model"];
+
+/** Built-in model provider enum (e.g. "ANTHROPIC", "OPENAI"). */
+export type ModelProvider = componentsV1["schemas"]["ModelProvider"];
+
+/** Typed UI-state context the server agent understands. */
+export type ChatContext = componentsV1["schemas"]["ChatContext"];

--- a/js/packages/pxi/src/cli.ts
+++ b/js/packages/pxi/src/cli.ts
@@ -1,0 +1,69 @@
+import { Command } from "commander";
+
+import type { ModelProvider } from "./chat/types";
+
+/** PXI CLI version. Kept in sync with package.json `version`. */
+const VERSION = "0.1.0";
+
+/** Default built-in provider/model, mirroring the Phoenix web app default. */
+const DEFAULT_PROVIDER: ModelProvider = "ANTHROPIC";
+const DEFAULT_MODEL = "claude-opus-4-6";
+
+export type CliOptions = {
+  /** Phoenix server base URL override (falls back to PHOENIX_HOST). */
+  host?: string;
+  /** Phoenix API key override (falls back to PHOENIX_API_KEY). */
+  apiKey?: string;
+  /** Built-in model provider. */
+  provider: ModelProvider;
+  /** Model name for the selected provider. */
+  model: string;
+  /** Session id; a fresh UUID per run unless resuming an existing session. */
+  sessionId: string;
+};
+
+/**
+ * Parse PXI command-line flags. Accepts the argv slice *after* the node/bun
+ * executable and script path (i.e. `process.argv.slice(2)`).
+ */
+export function parseCliOptions(argv: string[]): CliOptions {
+  const program = new Command();
+  program
+    .name("pxi")
+    .description("Phoenix Intelligence (PXI) — a terminal chatbot")
+    .option("--host <url>", "Phoenix server base URL (env: PHOENIX_HOST)")
+    .option("--api-key <key>", "Phoenix API key (env: PHOENIX_API_KEY)")
+    .option(
+      "--provider <provider>",
+      "Built-in model provider (e.g. ANTHROPIC, OPENAI)",
+      DEFAULT_PROVIDER
+    )
+    .option(
+      "--model <name>",
+      "Model name for the selected provider",
+      DEFAULT_MODEL
+    )
+    .option(
+      "--session-id <id>",
+      "Resume an existing session id instead of starting a new one"
+    )
+    .helpOption("-h, --help", "Show help")
+    .version(VERSION, "-v, --version", "Show the PXI version");
+
+  program.parse(argv, { from: "user" });
+  const opts = program.opts<{
+    host?: string;
+    apiKey?: string;
+    provider: string;
+    model: string;
+    sessionId?: string;
+  }>();
+
+  return {
+    host: opts.host,
+    apiKey: opts.apiKey,
+    provider: opts.provider as ModelProvider,
+    model: opts.model,
+    sessionId: opts.sessionId ?? crypto.randomUUID(),
+  };
+}

--- a/js/packages/pxi/src/components/App.tsx
+++ b/js/packages/pxi/src/components/App.tsx
@@ -1,0 +1,73 @@
+import { TextAttributes } from "@opentui/core";
+import { useState } from "react";
+
+import { createServerAgentTransport } from "../chat/transport";
+import type { ModelSelection } from "../chat/types";
+import { useServerAgentChat } from "../hooks/useServerAgentChat";
+import { InputBar } from "./InputBar";
+import { StatusLine } from "./StatusLine";
+import { Transcript } from "./Transcript";
+
+export type AppProps = {
+  /** Fully-resolved server-agent chat URL. */
+  chatUrl: string;
+  /** Headers applied to every request. */
+  headers: Record<string, string>;
+  /** Base URL shown in the header. */
+  host: string;
+  /** Session id for this run. */
+  sessionId: string;
+  /** Provider + model selection sent with every turn. */
+  model: ModelSelection;
+  /** Human-readable provider/model label for the header. */
+  modelLabel: string;
+};
+
+/** Root PXI terminal chat surface: header, transcript, status, and input. */
+export function App({
+  chatUrl,
+  headers,
+  host,
+  sessionId,
+  model,
+  modelLabel,
+}: AppProps) {
+  // Lazy init keeps a single transport instance for the session's lifetime.
+  const [transport] = useState(() =>
+    createServerAgentTransport({ chatUrl, headers, model })
+  );
+  const { messages, status, error, send } = useServerAgentChat({
+    transport,
+    sessionId,
+  });
+  const [draft, setDraft] = useState("");
+
+  function handleSubmit(value: string) {
+    send(value);
+    setDraft("");
+  }
+
+  return (
+    <box flexDirection="column" flexGrow={1} padding={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <ascii-font font="tiny" text="PXI" />
+        <box flexDirection="column" alignItems="flex-end">
+          <text fg="#565F89" attributes={TextAttributes.DIM}>
+            {host}
+          </text>
+          <text fg="#565F89" attributes={TextAttributes.DIM}>
+            {modelLabel}
+          </text>
+        </box>
+      </box>
+      <Transcript messages={messages} status={status} />
+      <StatusLine status={status} error={error} sessionId={sessionId} />
+      <InputBar
+        value={draft}
+        onInput={setDraft}
+        onSubmit={handleSubmit}
+        disabled={status === "streaming"}
+      />
+    </box>
+  );
+}

--- a/js/packages/pxi/src/components/InputBar.tsx
+++ b/js/packages/pxi/src/components/InputBar.tsx
@@ -1,0 +1,39 @@
+export type InputBarProps = {
+  value: string;
+  onInput: (value: string) => void;
+  onSubmit: (value: string) => void;
+  /** When true, a turn is in flight; submits are ignored upstream. */
+  disabled: boolean;
+};
+
+/** Bottom input field. Enter submits; the field stays focused for the session. */
+export function InputBar({
+  value,
+  onInput,
+  onSubmit,
+  disabled,
+}: InputBarProps) {
+  return (
+    <box
+      border
+      borderStyle="rounded"
+      borderColor="#414868"
+      title="Message"
+      height={3}
+      marginTop={1}
+      paddingLeft={1}
+      paddingRight={1}
+    >
+      <input
+        value={value}
+        placeholder={
+          disabled ? "Waiting for PXI…" : "Type a message, press Enter to send"
+        }
+        onInput={onInput}
+        onSubmit={() => onSubmit(value)}
+        focused
+        cursorColor="#7AA2F7"
+      />
+    </box>
+  );
+}

--- a/js/packages/pxi/src/components/Message.tsx
+++ b/js/packages/pxi/src/components/Message.tsx
@@ -1,0 +1,68 @@
+import { TextAttributes } from "@opentui/core";
+import { getToolName, isToolUIPart } from "ai";
+
+import type { AgentUIMessage } from "../chat/types";
+import { markdownSyntaxStyle } from "./markdownStyle";
+
+export type MessageProps = {
+  message: AgentUIMessage;
+  /** Whether this message is the in-flight assistant reply. */
+  streaming: boolean;
+};
+
+/**
+ * Render a single chat message. User turns are plain prefixed text; assistant
+ * turns render their text as markdown and surface any server-side tool activity
+ * as dim status lines.
+ */
+export function Message({ message, streaming }: MessageProps) {
+  const text = message.parts.reduce(
+    (acc, part) => (part.type === "text" ? acc + part.text : acc),
+    ""
+  );
+
+  if (message.role === "user") {
+    return (
+      <box flexDirection="row" marginTop={1}>
+        <text fg="#7AA2F7" attributes={TextAttributes.BOLD}>
+          {"› "}
+        </text>
+        <text fg="#C0CAF5">{text}</text>
+      </box>
+    );
+  }
+
+  const toolLines = message.parts
+    .filter(isToolUIPart)
+    .map((part) => `⚙ ${getToolName(part)} · ${part.state}`);
+
+  return (
+    <box flexDirection="column" marginTop={1} width="100%">
+      <text fg="#9ECE6A" attributes={TextAttributes.BOLD}>
+        PXI
+      </text>
+      {toolLines.map((line, index) => (
+        <text
+          key={`tool-${index}`}
+          fg="#7A88CF"
+          attributes={TextAttributes.DIM}
+        >
+          {line}
+        </text>
+      ))}
+      {text.length > 0 ? (
+        <box width="100%">
+          <markdown
+            content={text}
+            syntaxStyle={markdownSyntaxStyle}
+            streaming={streaming}
+          />
+        </box>
+      ) : streaming && toolLines.length === 0 ? (
+        <text fg="#565F89" attributes={TextAttributes.DIM}>
+          …
+        </text>
+      ) : null}
+    </box>
+  );
+}

--- a/js/packages/pxi/src/components/StatusLine.tsx
+++ b/js/packages/pxi/src/components/StatusLine.tsx
@@ -1,0 +1,28 @@
+import { TextAttributes } from "@opentui/core";
+
+import type { ChatStatus } from "../hooks/useServerAgentChat";
+
+export type StatusLineProps = {
+  status: ChatStatus;
+  error: string | null;
+  sessionId: string;
+};
+
+/** Single-line footer reflecting connection/streaming state. */
+export function StatusLine({ status, error, sessionId }: StatusLineProps) {
+  if (status === "streaming") {
+    return (
+      <text fg="#E0AF68" attributes={TextAttributes.DIM}>
+        ● PXI is thinking…
+      </text>
+    );
+  }
+  if (status === "error") {
+    return <text fg="#F7768E">✖ {error ?? "Request failed"}</text>;
+  }
+  return (
+    <text fg="#565F89" attributes={TextAttributes.DIM}>
+      Ctrl+C to exit · session {sessionId.slice(0, 8)}
+    </text>
+  );
+}

--- a/js/packages/pxi/src/components/Transcript.tsx
+++ b/js/packages/pxi/src/components/Transcript.tsx
@@ -1,0 +1,39 @@
+import { TextAttributes } from "@opentui/core";
+
+import type { AgentUIMessage } from "../chat/types";
+import type { ChatStatus } from "../hooks/useServerAgentChat";
+import { Message } from "./Message";
+
+export type TranscriptProps = {
+  messages: AgentUIMessage[];
+  status: ChatStatus;
+};
+
+/**
+ * Scrollable conversation transcript. Sticks to the bottom so new content stays
+ * in view while streaming, but lets the user scroll up to read history.
+ */
+export function Transcript({ messages, status }: TranscriptProps) {
+  const lastIndex = messages.length - 1;
+  return (
+    <scrollbox flexGrow={1} stickyScroll stickyStart="bottom" paddingRight={1}>
+      {messages.length === 0 ? (
+        <text fg="#565F89" attributes={TextAttributes.DIM}>
+          Ask PXI anything about your Phoenix data…
+        </text>
+      ) : (
+        messages.map((message, index) => (
+          <Message
+            key={message.id}
+            message={message}
+            streaming={
+              status === "streaming" &&
+              index === lastIndex &&
+              message.role === "assistant"
+            }
+          />
+        ))
+      )}
+    </scrollbox>
+  );
+}

--- a/js/packages/pxi/src/components/markdownStyle.ts
+++ b/js/packages/pxi/src/components/markdownStyle.ts
@@ -1,0 +1,20 @@
+import { RGBA, SyntaxStyle } from "@opentui/core";
+
+/**
+ * Shared syntax style for rendering assistant markdown (headings, lists, inline
+ * code, fenced code blocks). Tuned for a dark terminal background.
+ */
+export const markdownSyntaxStyle = SyntaxStyle.fromStyles({
+  "markup.heading": { fg: RGBA.fromHex("#58A6FF"), bold: true },
+  "markup.heading.1": { fg: RGBA.fromHex("#58A6FF"), bold: true },
+  "markup.heading.2": { fg: RGBA.fromHex("#79C0FF"), bold: true },
+  "markup.list": { fg: RGBA.fromHex("#FF7B72") },
+  "markup.raw": { fg: RGBA.fromHex("#A5D6FF") },
+  "markup.bold": { fg: RGBA.fromHex("#E6EDF3"), bold: true },
+  "markup.italic": { fg: RGBA.fromHex("#E6EDF3"), italic: true },
+  "markup.link": { fg: RGBA.fromHex("#58A6FF"), underline: true },
+  keyword: { fg: RGBA.fromHex("#FF7B72") },
+  string: { fg: RGBA.fromHex("#A5D6FF") },
+  comment: { fg: RGBA.fromHex("#8B949E"), italic: true },
+  default: { fg: RGBA.fromHex("#E6EDF3") },
+});

--- a/js/packages/pxi/src/config.ts
+++ b/js/packages/pxi/src/config.ts
@@ -1,0 +1,50 @@
+import {
+  DEFAULT_PHOENIX_BASE_URL,
+  getEnvironmentConfig,
+} from "@arizeai/phoenix-config";
+
+export type ResolvedConfig = {
+  /** Base URL of the Phoenix server, without a trailing slash. */
+  baseUrl: string;
+  /** Headers to send with every request (auth + any custom client headers). */
+  headers: Record<string, string>;
+};
+
+/**
+ * Resolve the Phoenix connection settings, using `@arizeai/phoenix-config` for
+ * environment resolution so the CLI honours the same env vars as the rest of
+ * the Phoenix tooling. Explicit CLI options take precedence over the
+ * environment, which takes precedence over the built-in default host.
+ */
+export function resolveConfig(options: {
+  host?: string;
+  apiKey?: string;
+}): ResolvedConfig {
+  const env = getEnvironmentConfig();
+  const baseUrl = (
+    options.host ??
+    env.PHOENIX_HOST ??
+    DEFAULT_PHOENIX_BASE_URL
+  ).replace(/\/+$/, "");
+  const apiKey = options.apiKey ?? env.PHOENIX_API_KEY;
+  const headers: Record<string, string> = {
+    ...(env.PHOENIX_CLIENT_HEADERS ?? {}),
+  };
+  if (apiKey) {
+    headers["Authorization"] = `Bearer ${apiKey}`;
+  }
+  return { baseUrl, headers };
+}
+
+/**
+ * Build the URL for the direct server-agent chat endpoint:
+ * `POST /agents/server/sessions/{session_id}/chat`. `server` is a literal path
+ * segment (see `run_server_agent` in the Phoenix server); only the session id
+ * is interpolated.
+ */
+export function buildServerAgentChatUrl(
+  baseUrl: string,
+  sessionId: string
+): string {
+  return `${baseUrl.replace(/\/+$/, "")}/agents/server/sessions/${encodeURIComponent(sessionId)}/chat`;
+}

--- a/js/packages/pxi/src/hooks/useServerAgentChat.ts
+++ b/js/packages/pxi/src/hooks/useServerAgentChat.ts
@@ -1,0 +1,80 @@
+import { readUIMessageStream, type DefaultChatTransport } from "ai";
+import { useState } from "react";
+
+import type { AgentUIMessage } from "../chat/types";
+
+export type ChatStatus = "ready" | "streaming" | "error";
+
+export type UseServerAgentChat = {
+  /** Full conversation history, including the in-flight assistant reply. */
+  messages: AgentUIMessage[];
+  status: ChatStatus;
+  /** Human-readable error from the most recent failed turn, if any. */
+  error: string | null;
+  /** Submit a user message and stream the assistant reply. No-op while busy. */
+  send: (text: string) => void;
+};
+
+/**
+ * Headless chat state backed by the AI SDK transport. We deliberately avoid the
+ * `Chat` class / `@ai-sdk/react` (which assume a DOM host) and fold the UI
+ * message stream into React state ourselves, which keeps this portable to the
+ * OpenTUI renderer.
+ *
+ * `send` is intentionally recreated each render (no `useCallback`) so its
+ * closure always captures the current `messages`/`status` — the stream loop
+ * then advances state via functional updates.
+ */
+export function useServerAgentChat({
+  transport,
+  sessionId,
+}: {
+  transport: DefaultChatTransport<AgentUIMessage>;
+  sessionId: string;
+}): UseServerAgentChat {
+  const [messages, setMessages] = useState<AgentUIMessage[]>([]);
+  const [status, setStatus] = useState<ChatStatus>("ready");
+  const [error, setError] = useState<string | null>(null);
+
+  function send(text: string) {
+    const trimmed = text.trim();
+    if (!trimmed || status === "streaming") {
+      return;
+    }
+
+    const userMessage: AgentUIMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      parts: [{ type: "text", text: trimmed }],
+    };
+    const history = [...messages, userMessage];
+    setMessages(history);
+    setStatus("streaming");
+    setError(null);
+
+    void (async () => {
+      try {
+        const stream = await transport.sendMessages({
+          chatId: sessionId,
+          messages: history,
+          trigger: "submit-message",
+          messageId: undefined,
+          abortSignal: undefined,
+        });
+        // Each yielded value is the assistant message reconstructed so far, so
+        // replacing the trailing entry streams the reply token-by-token.
+        for await (const assistantMessage of readUIMessageStream<AgentUIMessage>(
+          { stream }
+        )) {
+          setMessages([...history, assistantMessage]);
+        }
+        setStatus("ready");
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        setStatus("error");
+      }
+    })();
+  }
+
+  return { messages, status, error, send };
+}

--- a/js/packages/pxi/src/index.tsx
+++ b/js/packages/pxi/src/index.tsx
@@ -1,0 +1,30 @@
+#!/usr/bin/env bun
+import { createCliRenderer } from "@opentui/core";
+import { createRoot } from "@opentui/react";
+
+import { parseCliOptions } from "./cli";
+import { App } from "./components/App";
+import { buildServerAgentChatUrl, resolveConfig } from "./config";
+
+const cli = parseCliOptions(process.argv.slice(2));
+const { baseUrl, headers } = resolveConfig({
+  host: cli.host,
+  apiKey: cli.apiKey,
+});
+const chatUrl = buildServerAgentChatUrl(baseUrl, cli.sessionId);
+
+const renderer = await createCliRenderer({ exitOnCtrlC: true });
+createRoot(renderer).render(
+  <App
+    chatUrl={chatUrl}
+    headers={headers}
+    host={baseUrl}
+    sessionId={cli.sessionId}
+    model={{
+      providerType: "builtin",
+      provider: cli.provider,
+      modelName: cli.model,
+    }}
+    modelLabel={`${cli.provider} · ${cli.model}`}
+  />
+);

--- a/js/packages/pxi/tsconfig.json
+++ b/js/packages/pxi/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "jsxImportSource": "@opentui/react",
+    "allowJs": true,
+
+    // Bundler mode (bun-native; this package is not part of the tsc project graph)
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    "types": ["bun", "react"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -199,7 +199,7 @@ importers:
         version: 17.4.2
       langchain:
         specifier: 1.4.4
-        version: 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.3))
+        version: 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(react@19.2.7)(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -636,6 +636,46 @@ importers:
       '@types/node':
         specifier: ^25.9.4
         version: 25.9.4
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/pxi:
+    dependencies:
+      '@arizeai/phoenix-client':
+        specifier: workspace:*
+        version: link:../phoenix-client
+      '@arizeai/phoenix-config':
+        specifier: workspace:*
+        version: link:../phoenix-config
+      '@opentui/core':
+        specifier: ^0.4.1
+        version: 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
+      '@opentui/react':
+        specifier: ^0.4.1
+        version: 0.4.1(react-devtools-core@7.0.1)(react@19.2.7)(typescript@6.0.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
+      ai:
+        specifier: ^6.0.208
+        version: 6.0.208(zod@4.4.3)
+      commander:
+        specifier: ^15.0.0
+        version: 15.0.0
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+    devDependencies:
+      '@types/bun':
+        specifier: latest
+        version: 1.3.14
+      '@types/node':
+        specifier: ^25.9.4
+        version: 25.9.4
+      '@types/react':
+        specifier: ^19.2.6
+        version: 19.2.17
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
@@ -1793,6 +1833,60 @@ packages:
     resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
 
+  '@opentui/core-darwin-arm64@0.4.1':
+    resolution: {integrity: sha512-ocs73hj9n0zLArOTpUWIXCWU6ERThG+3wQzO78EvfaR4hb5FRrDHGKWTzXpr6ukSKsUtKdztK5XYTPsJ5e3vww==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opentui/core-darwin-x64@0.4.1':
+    resolution: {integrity: sha512-YogRtDBfxGeOkcSHDMsGkKFBIt3cWPMPGNu2AmEN6a5KKjDYwAZCudwbDJaUbZDCJjfAUHz9iXjhJVXJBXs9vQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opentui/core-linux-arm64-musl@0.4.1':
+    resolution: {integrity: sha512-Eps9qB+vQ/Lel4ZYqMH87Um9oiU17Vu4oWzvRi40Yf+69vA1a3R4D7KUCeY3OxKWnRnwAHkMU9TxNnjKngPH/w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@opentui/core-linux-arm64@0.4.1':
+    resolution: {integrity: sha512-sBZTS1eEGeVSQ8fAmDALKQcT7FckrhK64oHfEO7W0lJ+lXapfJuOKtTM33na54V56GAM9guk4RD4cbPeTXEh4g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opentui/core-linux-x64-musl@0.4.1':
+    resolution: {integrity: sha512-UYcp8XGX4DZXN+VYUVuCrJkbFMJ0L+VUVu0t5KqqaeJ74fI4NZ+DmwNqPPg1+C+EIzoW4QChlEUdhlZRdiEQiA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@opentui/core-linux-x64@0.4.1':
+    resolution: {integrity: sha512-9/xjYGzX5RdUl0qmGQY0OCayjJ4VffDhsBmApQdseUkMT6LGL3RumI4zPK3Y9vo1fuy6ffLnriLFOktOgutXDg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opentui/core-win32-arm64@0.4.1':
+    resolution: {integrity: sha512-hkIbpUJcKd4iLetTygPlFS45teOBTto49aXuxNeafYQUNd3ehiSwJENNBlAGULLfq+KP3dMJoWUiOcbuPVOQRA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@opentui/core-win32-x64@0.4.1':
+    resolution: {integrity: sha512-s1kGBcloy4ksl3wFCMqqOUFtXWlTTpzxe6pkLFhFhzgqKsMXHE9pwebiS3pzJkkFUxah5MYG+kbcn2Dw2Gdncg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@opentui/core@0.4.1':
+    resolution: {integrity: sha512-ejlunoFCGLcghYGdfamI/DlWHsgCTLbuoL2JeOmFuLsN+DM5phje3CQbGR4tpl24cadCgHJQFomjoQ9Htvin+Q==}
+    peerDependencies:
+      web-tree-sitter: 0.25.10
+
+  '@opentui/react@0.4.1':
+    resolution: {integrity: sha512-hYNS8yhwVA+aGru74rtaxI81TM+rEIhMVOdooQOZRHcyVlml3inmKcI5n0Kroy4Vj4M0rCiVAPhovvqf+xfxGA==}
+    peerDependencies:
+      react: '>=19.2.0'
+      react-devtools-core: ^7.0.1
+      ws: ^8.18.0
+
   '@optimize-lodash/rollup-plugin@5.1.0':
     resolution: {integrity: sha512-dBQYGH8+n4Z/877e61PJteVZEc+U1wfRF6IhKqW0cABRIsqMxpWynyov6M6Sd4IUjru0dnh0EG55X86JO6WakQ==}
     engines: {node: '>= 18'}
@@ -2458,6 +2552,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -2509,6 +2606,9 @@ packages:
 
   '@types/node@25.9.4':
     resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -2839,6 +2939,14 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  bun-ffi-structs@0.2.3:
+    resolution: {integrity: sha512-pgJiXP+hEgFo9qG51J6ItfY4ocs3vniwNzJ9WhoakB3QB2GdzQxX2EXssentPYlB2hOfJrTjO6iIQkWYzUodpg==}
+    peerDependencies:
+      typescript: ^5
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
+
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
     engines: {node: '>= 0.8'}
@@ -3083,6 +3191,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
@@ -3165,6 +3276,10 @@ packages:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -3197,6 +3312,9 @@ packages:
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
     engines: {node: '>=12'}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3456,6 +3574,10 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -4143,6 +4265,11 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked@17.0.1:
+    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   mastra@1.15.0:
     resolution: {integrity: sha512-CUwjCOyXXqL7UI2LfPHERSXlxmHv594+plyHgwmsdJ+loczNEm1iGF+84P9Wo0BbKcJ4Mlfv9zahUNgc37yjSg==}
     engines: {node: '>=22.13.0'}
@@ -4797,8 +4924,21 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-devtools-core@7.0.1:
+    resolution: {integrity: sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==}
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -4933,6 +5073,9 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
@@ -5093,6 +5236,10 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
@@ -5102,6 +5249,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
 
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
@@ -5463,6 +5614,14 @@ packages:
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
+  web-tree-sitter@0.25.10:
+    resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
+    peerDependencies:
+      '@types/emscripten': ^1.40.0
+    peerDependenciesMeta:
+      '@types/emscripten':
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -5491,6 +5650,18 @@ packages:
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  ws@7.5.11:
+    resolution: {integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -6528,19 +6699,21 @@ snapshots:
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
 
-  '@langchain/langgraph-sdk@1.9.23(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))':
+  '@langchain/langgraph-sdk@1.9.23(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react@19.2.7)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/protocol': 0.0.16
       '@types/json-schema': 7.0.15
       p-queue: 9.3.0
       p-retry: 7.1.1
+    optionalDependencies:
+      react: 19.2.7
 
-  '@langchain/langgraph@1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
+  '@langchain/langgraph@1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react@19.2.7)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/langgraph-checkpoint': 1.1.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
-      '@langchain/langgraph-sdk': 1.9.23(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
+      '@langchain/langgraph-sdk': 1.9.23(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react@19.2.7)
       '@langchain/protocol': 0.0.16
       '@standard-schema/spec': 1.1.0
       zod: 4.4.3
@@ -7100,6 +7273,61 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
 
+  '@opentui/core-darwin-arm64@0.4.1':
+    optional: true
+
+  '@opentui/core-darwin-x64@0.4.1':
+    optional: true
+
+  '@opentui/core-linux-arm64-musl@0.4.1':
+    optional: true
+
+  '@opentui/core-linux-arm64@0.4.1':
+    optional: true
+
+  '@opentui/core-linux-x64-musl@0.4.1':
+    optional: true
+
+  '@opentui/core-linux-x64@0.4.1':
+    optional: true
+
+  '@opentui/core-win32-arm64@0.4.1':
+    optional: true
+
+  '@opentui/core-win32-x64@0.4.1':
+    optional: true
+
+  '@opentui/core@0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)':
+    dependencies:
+      bun-ffi-structs: 0.2.3(typescript@6.0.3)
+      diff: 9.0.0
+      marked: 17.0.1
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+      web-tree-sitter: 0.25.10
+    optionalDependencies:
+      '@opentui/core-darwin-arm64': 0.4.1
+      '@opentui/core-darwin-x64': 0.4.1
+      '@opentui/core-linux-arm64': 0.4.1
+      '@opentui/core-linux-arm64-musl': 0.4.1
+      '@opentui/core-linux-x64': 0.4.1
+      '@opentui/core-linux-x64-musl': 0.4.1
+      '@opentui/core-win32-arm64': 0.4.1
+      '@opentui/core-win32-x64': 0.4.1
+    transitivePeerDependencies:
+      - typescript
+
+  '@opentui/react@0.4.1(react-devtools-core@7.0.1)(react@19.2.7)(typescript@6.0.3)(web-tree-sitter@0.25.10)(ws@8.21.0)':
+    dependencies:
+      '@opentui/core': 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
+      react: 19.2.7
+      react-devtools-core: 7.0.1
+      react-reconciler: 0.33.0(react@19.2.7)
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - typescript
+      - web-tree-sitter
+
   '@optimize-lodash/rollup-plugin@5.1.0(rollup@4.62.1)':
     dependencies:
       '@optimize-lodash/transform': 3.0.6
@@ -7539,6 +7767,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -7591,6 +7823,10 @@ snapshots:
   '@types/node@25.9.4':
     dependencies:
       undici-types: 7.24.6
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/resolve@1.20.2': {}
 
@@ -7961,6 +8197,14 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bun-ffi-structs@0.2.3(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 25.9.4
+
   bytes@3.0.0: {}
 
   bytes@3.1.2: {}
@@ -8189,6 +8433,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  csstype@3.2.3: {}
+
   dateformat@4.6.3: {}
 
   debug@2.6.9:
@@ -8235,6 +8481,8 @@ snapshots:
 
   diff@8.0.4: {}
 
+  diff@9.0.0: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -8258,6 +8506,8 @@ snapshots:
   electron-to-chromium@1.5.376: {}
 
   emittery@0.13.1: {}
+
+  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -8556,6 +8806,8 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -9214,10 +9466,10 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  langchain@1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.3)):
+  langchain@1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(react@19.2.7)(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.3)):
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
-      '@langchain/langgraph': 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
+      '@langchain/langgraph': 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react@19.2.7)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@langchain/langgraph-checkpoint': 1.1.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
       langsmith: 0.7.10(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       zod: 4.4.3
@@ -9377,6 +9629,8 @@ snapshots:
       uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
+
+  marked@17.0.1: {}
 
   mastra@1.15.0(@hono/node-server@2.0.1(hono@4.12.18))(@mastra/core@1.45.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@6.0.208(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(typescript@6.0.3)(zod@4.4.3):
     dependencies:
@@ -10241,7 +10495,22 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-devtools-core@7.0.1:
+    dependencies:
+      shell-quote: 1.8.4
+      ws: 7.5.11
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   react-is@18.3.1: {}
+
+  react-reconciler@0.33.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react@19.2.7: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -10449,6 +10718,8 @@ snapshots:
 
   sax@1.6.0: {}
 
+  scheduler@0.27.0: {}
+
   section-matter@1.0.0:
     dependencies:
       extend-shallow: 2.0.1
@@ -10640,6 +10911,12 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -10651,6 +10928,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-ansi@7.2.0:
     dependencies:
@@ -10949,6 +11230,8 @@ snapshots:
     dependencies:
       makeerror: 1.0.12
 
+  web-tree-sitter@0.25.10: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -10980,6 +11263,8 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+
+  ws@7.5.11: {}
 
   ws@8.21.0: {}
 


### PR DESCRIPTION
## Summary

Adds **`@arizeai/pxi`** (Phoenix Intelligence) — a terminal chatbot for the Phoenix server agent. It opens an interactive TUI that streams a conversation with the agent over the Phoenix REST endpoint `POST /agents/server/sessions/{session_id}/chat`.

- Built with [OpenTUI](https://github.com/sst/opentui) (React bindings), runs on [Bun](https://bun.sh) (native renderer uses FFI).
- Request/response typing from `@arizeai/phoenix-client` (generated OpenAPI types).
- Connection/env resolution from `@arizeai/phoenix-config`; CLI flags take precedence over env vars.

## Usage

```bash
bunx @arizeai/pxi
# or in this monorepo:
pnpm --filter @arizeai/pxi dev
```

## Configuration

| Setting    | Flag           | Env var                  | Default                 |
| ---------- | -------------- | ------------------------ | ----------------------- |
| Host       | `--host`       | `PHOENIX_HOST`           | `http://localhost:6006` |
| API key    | `--api-key`    | `PHOENIX_API_KEY`        | _(none)_                |
| Provider   | `--provider`   | —                        | `ANTHROPIC`             |
| Model      | `--model`      | —                        | `claude-opus-4-6`       |
| Session id | `--session-id` | —                        | random UUID per run     |

## Test plan

- [ ] `pnpm --filter @arizeai/pxi typecheck`
- [ ] `pnpm --filter @arizeai/pxi test`
- [ ] Manual: run against a local Phoenix server with the agent enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)