### PR TITLE
fix: simplify pxi instrumentation output value

### DIFF
--- a/src/phoenix/server/agents/pydantic_ai/openinference_agent_wrapper.py
+++ b/src/phoenix/server/agents/pydantic_ai/openinference_agent_wrapper.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Iterator, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from inspect import Signature, signature
-from typing import Any, Callable, Literal, TypeAlias
+from typing import Any, Callable, Literal, TypeAlias, overload
 
 import pydantic
 from openinference.instrumentation import (
@@ -287,19 +287,37 @@ def _get_message_io_attributes(
     message: ModelMessage,
     role: Literal["input", "output"],
 ) -> dict[str, AttributeValue]:
-    parts = _get_parts_with_non_empty_content(message)
-    text = _get_single_text_content(parts)
-    if text is not None:
-        value: str = text
-        mime_type = OpenInferenceMimeTypeValues.TEXT
-    else:
-        value = _dump_parts_json(message=message, parts=parts)
-        mime_type = OpenInferenceMimeTypeValues.JSON
+    value, mime_type = _get_message_io_value(message)
     if role == "input":
         return get_input_attributes(value, mime_type=mime_type)
     elif role == "output":
         return get_output_attributes(value, mime_type=mime_type)
     assert_never(role)
+
+
+def _get_message_io_value(message: ModelMessage) -> tuple[str, OpenInferenceMimeTypeValues]:
+    """Return the display value and MIME type for a turn-level message."""
+    if isinstance(message, ModelRequest):
+        request_parts = _get_parts_with_non_empty_content(message)
+        text = _get_single_text_content(request_parts)
+        if text is not None:
+            return text, OpenInferenceMimeTypeValues.TEXT
+        return _dump_model_request_parts_json(request_parts), OpenInferenceMimeTypeValues.JSON
+    if isinstance(message, ModelResponse):
+        response_parts = _get_parts_with_non_empty_content(message)
+        text = _get_single_text_content(response_parts)
+        if text is not None:
+            return text, OpenInferenceMimeTypeValues.TEXT
+        return _dump_model_response_parts_json(response_parts), OpenInferenceMimeTypeValues.JSON
+    assert_never(message)
+
+
+@overload
+def _get_parts_with_non_empty_content(message: ModelRequest) -> list[ModelRequestPart]: ...
+
+
+@overload
+def _get_parts_with_non_empty_content(message: ModelResponse) -> list[ModelResponsePart]: ...
 
 
 def _get_parts_with_non_empty_content(
@@ -376,19 +394,16 @@ def _get_text_content_from_user_content_item(item: UserContent) -> str | None:
     assert_never(item)
 
 
-def _dump_parts_json(
-    *,
-    message: ModelMessage,
-    parts: list[ModelRequestPart] | list[ModelResponsePart],
-) -> str:
-    """Serialize parts as a top-level JSON array with null-valued fields omitted."""
-    if isinstance(message, ModelRequest):
-        payload = _MODEL_REQUEST_PARTS_ADAPTER.dump_python(parts, mode="json")
-        return safe_json_dumps(_drop_none_fields(payload))
-    if isinstance(message, ModelResponse):
-        payload = _MODEL_RESPONSE_PARTS_ADAPTER.dump_python(parts, mode="json")
-        return safe_json_dumps(_drop_none_fields(payload))
-    assert_never(message)
+def _dump_model_request_parts_json(parts: list[ModelRequestPart]) -> str:
+    """Serialize request parts as a top-level JSON array without null-valued fields."""
+    payload = _MODEL_REQUEST_PARTS_ADAPTER.dump_python(parts, mode="json")
+    return safe_json_dumps(_drop_none_fields(payload))
+
+
+def _dump_model_response_parts_json(parts: list[ModelResponsePart]) -> str:
+    """Serialize response parts as a top-level JSON array without null-valued fields."""
+    payload = _MODEL_RESPONSE_PARTS_ADAPTER.dump_python(parts, mode="json")
+    return safe_json_dumps(_drop_none_fields(payload))
 
 
 def _drop_none_fields(value: Any) -> Any:

--- a/src/phoenix/server/agents/pydantic_ai/openinference_agent_wrapper.py
+++ b/src/phoenix/server/agents/pydantic_ai/openinference_agent_wrapper.py
@@ -59,8 +59,12 @@ from phoenix.server.agents.capabilities.tools.external import get_external_tool_
 
 ToolCallId: TypeAlias = str
 
-_MODEL_MESSAGE_ADAPTER: pydantic.TypeAdapter[ModelMessage] = pydantic.TypeAdapter(
-    ModelMessage,
+_MODEL_REQUEST_PARTS_ADAPTER: pydantic.TypeAdapter[list[ModelRequestPart]] = pydantic.TypeAdapter(
+    list[ModelRequestPart],
+    config=pydantic.ConfigDict(ser_json_bytes="base64"),
+)
+_MODEL_RESPONSE_PARTS_ADAPTER: pydantic.TypeAdapter[list[ModelResponsePart]] = pydantic.TypeAdapter(
+    list[ModelResponsePart],
     config=pydantic.ConfigDict(ser_json_bytes="base64"),
 )
 
@@ -283,12 +287,13 @@ def _get_message_io_attributes(
     message: ModelMessage,
     role: Literal["input", "output"],
 ) -> dict[str, AttributeValue]:
-    text = _get_text_content_from_model_message(message)
+    parts = _get_parts_with_non_empty_content(message)
+    text = _get_single_text_content(parts)
     if text is not None:
         value: str = text
         mime_type = OpenInferenceMimeTypeValues.TEXT
     else:
-        value = _MODEL_MESSAGE_ADAPTER.dump_json(message).decode("utf-8")
+        value = _dump_parts_json(message=message, parts=parts)
         mime_type = OpenInferenceMimeTypeValues.JSON
     if role == "input":
         return get_input_attributes(value, mime_type=mime_type)
@@ -297,23 +302,43 @@ def _get_message_io_attributes(
     assert_never(role)
 
 
-def _get_text_content_from_model_message(message: ModelMessage) -> str | None:
-    """Concatenated text if the message has only text-bearing parts; else ``None``."""
+def _get_parts_with_non_empty_content(
+    message: ModelMessage,
+) -> list[ModelRequestPart] | list[ModelResponsePart]:
+    """Return message parts worth displaying in turn-level input/output."""
     if isinstance(message, ModelRequest):
-        return _get_text_content_from_model_request(message)
+        return list(message.parts)
     if isinstance(message, ModelResponse):
-        return _get_text_content_from_model_response(message)
+        return [
+            part
+            for part in message.parts
+            if not (isinstance(part, ThinkingPart) and not part.has_content())
+        ]
     assert_never(message)
 
 
-def _get_text_content_from_model_request(message: ModelRequest) -> str | None:
-    texts: list[str] = []
-    for part in message.parts:
-        text = _get_text_content_from_model_request_part(part)
-        if text is None:
-            return None
-        texts.append(text)
-    return "\n".join(texts)
+def _get_single_text_content(parts: Sequence[ModelRequestPart | ModelResponsePart]) -> str | None:
+    """Return plain text only when exactly one text-bearing part remains."""
+    if len(parts) != 1:
+        return None
+    (part,) = parts
+    if isinstance(part, TextPart):
+        return part.content
+    if isinstance(part, (SystemPromptPart, UserPromptPart, ToolReturnPart, RetryPromptPart)):
+        return _get_text_content_from_model_request_part(part)
+    if isinstance(
+        part,
+        (
+            ToolCallPart,
+            NativeToolCallPart,
+            NativeToolReturnPart,
+            ThinkingPart,
+            CompactionPart,
+            FilePart,
+        ),
+    ):
+        return None
+    assert_never(part)
 
 
 def _get_text_content_from_model_request_part(part: ModelRequestPart) -> str | None:
@@ -351,29 +376,25 @@ def _get_text_content_from_user_content_item(item: UserContent) -> str | None:
     assert_never(item)
 
 
-def _get_text_content_from_model_response(message: ModelResponse) -> str | None:
-    texts: list[str] = []
-    for part in message.parts:
-        text = _get_text_content_from_model_response_part(part)
-        if text is None:
-            return None
-        texts.append(text)
-    return "\n".join(texts) if texts else None
+def _dump_parts_json(
+    *,
+    message: ModelMessage,
+    parts: list[ModelRequestPart] | list[ModelResponsePart],
+) -> str:
+    """Serialize parts as a top-level JSON array with null-valued fields omitted."""
+    if isinstance(message, ModelRequest):
+        payload = _MODEL_REQUEST_PARTS_ADAPTER.dump_python(parts, mode="json")
+        return safe_json_dumps(_drop_none_fields(payload))
+    if isinstance(message, ModelResponse):
+        payload = _MODEL_RESPONSE_PARTS_ADAPTER.dump_python(parts, mode="json")
+        return safe_json_dumps(_drop_none_fields(payload))
+    assert_never(message)
 
 
-def _get_text_content_from_model_response_part(part: ModelResponsePart) -> str | None:
-    if isinstance(part, TextPart):
-        return part.content
-    if isinstance(
-        part,
-        (
-            ToolCallPart,
-            NativeToolCallPart,
-            NativeToolReturnPart,
-            ThinkingPart,
-            CompactionPart,
-            FilePart,
-        ),
-    ):
-        return None
-    assert_never(part)
+def _drop_none_fields(value: Any) -> Any:
+    """Recursively remove mapping entries whose value is ``None``."""
+    if isinstance(value, dict):
+        return {key: _drop_none_fields(item) for key, item in value.items() if item is not None}
+    if isinstance(value, list):
+        return [_drop_none_fields(item) for item in value]
+    return value

--- a/tests/unit/server/agents/pydantic_ai/test_openinference_agent_wrapper.py
+++ b/tests/unit/server/agents/pydantic_ai/test_openinference_agent_wrapper.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
@@ -27,6 +28,7 @@ from pydantic_ai.messages import (
     NativeToolCallPart,
     NativeToolReturnPart,
     TextPart,
+    ThinkingPart,
     ToolCallPart,
     ToolReturnPart,
     UserPromptPart,
@@ -149,6 +151,7 @@ def native_tool_agent(tracer: Tracer) -> OpenInferenceAgentWrapper:
                         tool_call_id="native-call-1",
                         provider_name="openai",
                         provider_details={"status": "completed"},
+                        timestamp=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
                     ),
                     TextPart(content="I found Phoenix tracing documentation."),
                 ]
@@ -215,6 +218,30 @@ def _get_tool_spans(spans: tuple[ReadableSpan, ...]) -> list[ReadableSpan]:
     return [s for s in spans if (s.attributes or {}).get(OPENINFERENCE_SPAN_KIND) == TOOL]
 
 
+@pytest.fixture
+def make_agent_with_response_parts(
+    tracer: Tracer,
+) -> Callable[[list[Any]], OpenInferenceAgentWrapper]:
+    def _make_agent_with_response_parts(parts: list[Any]) -> OpenInferenceAgentWrapper:
+        class _StaticResponseModel(WrapperModel):
+            async def request(
+                self,
+                messages: list[ModelMessage],
+                model_settings: ModelSettings | None,
+                model_request_parameters: ModelRequestParameters,
+            ) -> ModelResponse:
+                return ModelResponse(parts=parts)
+
+        inner: Agent[None, str] = Agent(
+            OpenInferenceModelWrapper(_StaticResponseModel(TestModel()), tracer=tracer),
+            name="StaticResponseAgent",
+            deps_type=type(None),
+        )
+        return OpenInferenceAgentWrapper(inner, tracer=tracer)
+
+    return _make_agent_with_response_parts
+
+
 async def test_iter_emits_agent_span_for_text_response(
     wrapped_agent: OpenInferenceAgentWrapper,
     in_memory_span_exporter: InMemorySpanExporter,
@@ -259,6 +286,51 @@ async def test_iter_emits_agent_span_for_text_response(
     llm_span = llm_spans[0]
     assert llm_span.parent is not None
     assert llm_span.parent.span_id == agent_span.context.span_id
+
+
+async def test_agent_span_filters_empty_thinking_for_single_text_output(
+    make_agent_with_response_parts: Callable[[list[Any]], OpenInferenceAgentWrapper],
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    wrapped_agent = make_agent_with_response_parts(
+        [ThinkingPart(content=""), TextPart(content="Visible answer.")]
+    )
+
+    result = await wrapped_agent.run("question")
+
+    assert result.output == "Visible answer."
+    spans = in_memory_span_exporter.get_finished_spans()
+    agent_span = _get_agent_span(spans)
+    attributes = dict(agent_span.attributes or {})
+    assert attributes.pop(OUTPUT_VALUE) == "Visible answer."
+    assert attributes.pop(OUTPUT_MIME_TYPE) == TEXT
+
+
+async def test_agent_span_serializes_multiple_text_blocks_as_json_array(
+    make_agent_with_response_parts: Callable[[list[Any]], OpenInferenceAgentWrapper],
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    wrapped_agent = make_agent_with_response_parts(
+        [
+            ThinkingPart(content=""),
+            TextPart(content="First block."),
+            TextPart(content="Second block."),
+        ]
+    )
+
+    await wrapped_agent.run("question")
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    agent_span = _get_agent_span(spans)
+    attributes = dict(agent_span.attributes or {})
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    parsed_output = json.loads(output_value)
+    assert parsed_output == [
+        {"content": "First block.", "part_kind": "text"},
+        {"content": "Second block.", "part_kind": "text"},
+    ]
+    assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
 
 async def test_run_emits_agent_span_for_text_response(
@@ -659,6 +731,36 @@ async def test_emits_tool_span_for_provider_native_tool(
     assert tool_span.parent.span_id == agent_span.context.span_id
     assert tool_span.context.trace_id == agent_span.context.trace_id
     assert tool_span.status.status_code == StatusCode.OK
+
+    agent_attributes = dict(agent_span.attributes or {})
+    output_value = agent_attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    parsed_output = json.loads(output_value)
+    assert parsed_output == [
+        {
+            "args": {"query": "phoenix tracing"},
+            "part_kind": "builtin-tool-call",
+            "provider_details": {"type": "web_search_call"},
+            "provider_name": "openai",
+            "tool_call_id": "native-call-1",
+            "tool_name": "web_search",
+        },
+        {
+            "content": {"results": [{"title": "Phoenix"}]},
+            "outcome": "success",
+            "part_kind": "builtin-tool-return",
+            "provider_details": {"status": "completed"},
+            "provider_name": "openai",
+            "timestamp": "2026-01-02T03:04:05Z",
+            "tool_call_id": "native-call-1",
+            "tool_name": "web_search",
+        },
+        {
+            "content": "I found Phoenix tracing documentation.",
+            "part_kind": "text",
+        },
+    ]
+    assert agent_attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
     attributes = dict(tool_span.attributes or {})
     assert attributes.pop(OPENINFERENCE_SPAN_KIND) == TOOL


### PR DESCRIPTION
## Summary
- serialize multi-part Pydantic AI turn input/output as top-level JSON arrays without null fields
- emit single text-only turn values as plain text and filter empty thinking parts from responses
- add coverage for text-only, multi-block, and native tool response output serialization

## Tests
- .venv/bin/pytest tests/unit/server/agents/pydantic_ai/test_openinference_agent_wrapper.py -q