### PR TITLE
fix(sessions): filter by end_time instead of start_time for time-range queries

### DIFF
--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -548,16 +548,18 @@ class Project(Node):
                 )
         stmt = select(table).filter_by(project_id=self.id)
         if time_range:
+            # A session spans [start_time, end_time]; it belongs to the window iff the
+            # two intervals overlap, i.e. the session had activity inside the window.
             if time_range.start:
                 stmt = stmt.where(time_range.start <= table.end_time)
             if time_range.end:
                 stmt = stmt.where(table.start_time < time_range.end)
         if filter_io_substring:
+            # The substring may match anywhere in the session, including traces outside
+            # the window — the overlap filter above already scopes sessions by time.
             filtered_session_rowids = get_filtered_session_rowids_subquery(
                 session_filter_condition=filter_io_substring,
                 project_rowids=[self.id],
-                start_time=time_range.start if time_range else None,
-                end_time=time_range.end if time_range else None,
             )
             stmt = stmt.where(table.id.in_(filtered_session_rowids))
         sort_config: Optional[ProjectSessionSortConfig] = None

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -549,7 +549,7 @@ class Project(Node):
         stmt = select(table).filter_by(project_id=self.id)
         if time_range:
             if time_range.start:
-                stmt = stmt.where(time_range.start <= table.start_time)
+                stmt = stmt.where(time_range.start <= table.end_time)
             if time_range.end:
                 stmt = stmt.where(table.start_time < time_range.end)
         if filter_io_substring:

--- a/tests/unit/_helpers.py
+++ b/tests/unit/_helpers.py
@@ -146,13 +146,14 @@ async def _add_project_session(
     project: models.Project,
     session_id: Optional[str] = None,
     start_time: Optional[datetime] = None,
+    end_time: Optional[datetime] = None,
 ) -> models.ProjectSession:
     start_time = start_time or datetime.now(timezone.utc)
     project_session = models.ProjectSession(
         session_id=session_id or token_hex(4),
         project_id=project.id,
         start_time=start_time,
-        end_time=start_time,
+        end_time=end_time or start_time,
     )
     session.add(project_session)
     await session.flush()

--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -5283,3 +5283,191 @@ async def test_trace_with_unmatched_global_node_id_returns_null(
     assert not response.errors
     assert response.data is not None
     assert response.data["node"]["trace"] is None
+
+
+@dataclass
+class _TimeRangeSessionsData:
+    project: models.Project
+    sessions_by_name: dict[str, models.ProjectSession]
+
+
+class TestProjectSessionsTimeRange:
+    """The sessions connection uses interval-overlap semantics for timeRange:
+    a session is included iff [start_time, end_time] intersects [start, end)."""
+
+    _QUERY = """
+        query ($projectId: ID!, $timeRange: TimeRange, $filterIoSubstring: String) {
+          node(id: $projectId) {
+            ... on Project {
+              sessions(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring) {
+                edges { node { id } }
+              }
+            }
+          }
+        }
+    """
+
+    _BASE_TIME = datetime.fromisoformat("2024-01-01T00:00:00+00:00")
+    _WINDOW_START = _BASE_TIME + timedelta(minutes=10)
+    _WINDOW_END = _BASE_TIME + timedelta(minutes=20)
+
+    @classmethod
+    def _minutes(cls, minute: int) -> datetime:
+        return cls._BASE_TIME + timedelta(minutes=minute)
+
+    @pytest.fixture
+    async def _sessions_data(
+        self,
+        db: DbSessionFactory,
+    ) -> _TimeRangeSessionsData:
+        minutes = self._minutes
+        intervals = {
+            # started before the window, last activity inside it (the long-running case)
+            "long_running": (0, 15),
+            # entirely before the window
+            "before_window": (0, 5),
+            # last activity exactly at the window start (closed lower bound)
+            "ends_at_window_start": (0, 10),
+            # entirely inside the window
+            "inside_window": (12, 13),
+            # spans the entire window
+            "spans_window": (5, 25),
+            # starts exactly at the window end (right-exclusive upper bound)
+            "starts_at_window_end": (20, 30),
+        }
+        sessions_by_name = {}
+        async with db() as session:
+            project = await _add_project(session)
+            for name, (start_minute, end_minute) in intervals.items():
+                project_session = await _add_project_session(
+                    session,
+                    project,
+                    start_time=minutes(start_minute),
+                    end_time=minutes(end_minute),
+                )
+                sessions_by_name[name] = project_session
+                trace = await _add_trace(
+                    session,
+                    project,
+                    project_session,
+                    start_time=minutes(start_minute),
+                    end_time=minutes(start_minute) + timedelta(seconds=30),
+                )
+                await _add_span(
+                    session,
+                    trace,
+                    start_time=minutes(start_minute),
+                    end_time=minutes(start_minute) + timedelta(seconds=30),
+                    attributes={"input": {"value": f"input for {name}"}},
+                )
+        return _TimeRangeSessionsData(project=project, sessions_by_name=sessions_by_name)
+
+    async def _get_session_ids(
+        self,
+        gql_client: AsyncGraphQLClient,
+        data: _TimeRangeSessionsData,
+        time_range: Optional[dict[str, str]],
+        filter_io_substring: Optional[str] = None,
+    ) -> set[str]:
+        response = await gql_client.execute(
+            query=self._QUERY,
+            variables={
+                "projectId": str(GlobalID(Project.__name__, str(data.project.id))),
+                "timeRange": time_range,
+                "filterIoSubstring": filter_io_substring,
+            },
+        )
+        assert not response.errors
+        assert response.data is not None
+        edges = response.data["node"]["sessions"]["edges"]
+        return {edge["node"]["id"] for edge in edges}
+
+    def _expected_ids(self, data: _TimeRangeSessionsData, *names: str) -> set[str]:
+        return {_gid(data.sessions_by_name[name]) for name in names}
+
+    async def test_includes_sessions_overlapping_the_window(
+        self,
+        _sessions_data: _TimeRangeSessionsData,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        time_range = {
+            "start": self._WINDOW_START.isoformat(),
+            "end": self._WINDOW_END.isoformat(),
+        }
+        actual = await self._get_session_ids(gql_client, _sessions_data, time_range)
+        assert actual == self._expected_ids(
+            _sessions_data,
+            "long_running",
+            "ends_at_window_start",
+            "inside_window",
+            "spans_window",
+        )
+
+    async def test_open_ended_lower_bound_filters_by_last_activity(
+        self,
+        _sessions_data: _TimeRangeSessionsData,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        time_range = {"start": self._WINDOW_START.isoformat()}
+        actual = await self._get_session_ids(gql_client, _sessions_data, time_range)
+        assert actual == self._expected_ids(
+            _sessions_data,
+            "long_running",
+            "ends_at_window_start",
+            "inside_window",
+            "spans_window",
+            "starts_at_window_end",
+        )
+
+    async def test_open_ended_upper_bound_filters_by_start_time(
+        self,
+        _sessions_data: _TimeRangeSessionsData,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        time_range = {"end": self._WINDOW_END.isoformat()}
+        actual = await self._get_session_ids(gql_client, _sessions_data, time_range)
+        assert actual == self._expected_ids(
+            _sessions_data,
+            "long_running",
+            "before_window",
+            "ends_at_window_start",
+            "inside_window",
+            "spans_window",
+        )
+
+    async def test_substring_filter_matches_traces_outside_the_window(
+        self,
+        _sessions_data: _TimeRangeSessionsData,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        # The long-running session's only trace starts before the window; the session
+        # must still be returned because it overlaps the window and its content matches.
+        time_range = {
+            "start": self._WINDOW_START.isoformat(),
+            "end": self._WINDOW_END.isoformat(),
+        }
+        actual = await self._get_session_ids(
+            gql_client,
+            _sessions_data,
+            time_range,
+            filter_io_substring="input for long_running",
+        )
+        assert actual == self._expected_ids(_sessions_data, "long_running")
+
+    async def test_substring_filter_does_not_widen_the_window(
+        self,
+        _sessions_data: _TimeRangeSessionsData,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        # A session outside the window stays excluded even if its content matches.
+        time_range = {
+            "start": self._WINDOW_START.isoformat(),
+            "end": self._WINDOW_END.isoformat(),
+        }
+        actual = await self._get_session_ids(
+            gql_client,
+            _sessions_data,
+            time_range,
+            filter_io_substring="input for before_window",
+        )
+        assert actual == set()


### PR DESCRIPTION
## Summary

Fixes #13886

Long-running sessions with recent activity but an old `start_time` were excluded from time-range filters (e.g. "Last 15 min") on the Sessions page.

**Semantics.** A session spans the interval `[start_time, end_time]` (where `end_time` is the last interaction and advances as new traces arrive). The time filter now uses **interval overlap**: a session is included iff it had activity inside the queried window:

```
session.end_time >= range.start  AND  session.start_time < range.end
```

- A session started 30 min ago with activity 5 min ago now appears under "Last 15 min".
- Historical windows still work: the upper bound remains on `start_time`, so sessions that hadn't started yet are excluded.
- `ProjectSession.end_time` is non-nullable and already indexed (`ix_project_sessions_end_time`), so no NULL handling or migration is needed.

**Substring-filter consistency.** The `filterIoSubstring` path previously required the *matching trace* to start inside the window, which would re-introduce the bug for filtered views (a session visible in the unfiltered list would vanish when a substring matched only its older traces). The subquery is no longer time-bounded from this call site: the time window selects sessions (by overlap), the substring selects sessions (by content, anywhere in the session). Trade-off: the substring scan is no longer time-pruned, but it remains project-scoped and only runs when a substring is typed. Other callers of `get_filtered_session_rowids_subquery` (trace/span-level metric dataloaders) are unchanged — trace-level time bounds are correct there.

**Deliberately unchanged:** `sessionAnnotationScoreTimeSeries` still filters/buckets sessions by `start_time` — bucketed time series need a single point per session, consistent with every other Phoenix time series.

## Changes

- `src/phoenix/server/api/types/Project.py` — overlap semantics for the `sessions` connection time filter (lower bound on `end_time` per the original commit) + drop time bounds from the substring subquery call.
- `tests/unit/_helpers.py` — `_add_project_session` accepts an optional `end_time`.
- `tests/unit/server/api/types/test_Project.py` — new `TestProjectSessionsTimeRange` regression suite: long-running session inclusion, sessions entirely before/after the window, boundary conditions (closed lower bound, right-exclusive upper bound), open-ended ranges, and substring + time-range combinations.

## Test plan

- [x] `uv run pytest tests/unit/server/api/types/test_Project.py -k TestProjectSessionsTimeRange` — passes on SQLite and PostgreSQL (`--db postgresql`)
- [x] Verified the new tests fail against the previous `start_time`-based logic (3 behavior tests fail, 2 invariant tests pass)
- [x] `ruff` and `mypy` clean on changed files