### PR TITLE
fix(playground): guard against empty dataset versions array

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -1276,7 +1276,7 @@ export function PlaygroundDatasetExamplesTable({
   // This is subject to a race condition where a new dataset version is created after the playground experiments were run.
   // We ignore this edge case for now.
   const datasetVersionId = useMemo(() => {
-    return dataset.latestVersions?.edges[0].version.id ?? "";
+    return dataset.latestVersions?.edges[0]?.version.id ?? "";
   }, [dataset.latestVersions?.edges]);
 
   const playgroundInstanceOutputColumns = useMemo((): ColumnDef<TableRow>[] => {


### PR DESCRIPTION
## Summary

Fixes #13901

Accessing `edges[0].version.id` crashes with `Cannot read properties of undefined (reading 'version')` when a dataset has no versions, because `edges[0]` is `undefined` for an empty array.

Adding optional chaining (`?.`) makes the access safe — it returns `undefined` and the existing `?? ""` fallback kicks in, so `datasetVersionId` is an empty string instead of throwing.

**One-character change in** `app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx`:
```ts
// Before
return dataset.latestVersions?.edges[0].version.id ?? "";

// After
return dataset.latestVersions?.edges[0]?.version.id ?? "";
```

## Test plan

- [ ] Create a new dataset without uploading any data (no versions)
- [ ] Navigate to the dataset page
- [ ] Click the **Playground** button — page no longer crashes
- [ ] Verify the Playground loads correctly for datasets that do have versions
