### PR TITLE
fix(retention): remove unbatched RETURNING clause from delete_traces

### DIFF
--- a/src/phoenix/db/types/trace_retention.py
+++ b/src/phoenix/db/types/trace_retention.py
@@ -63,22 +63,17 @@ class MaxDaysRule(_MaxDays, BaseModel):
             return set()
         from phoenix.db.models import Trace
 
-        affected = set(
-            await session.scalars(
-                sa.select(Trace.project_rowid)
-                .where(Trace.project_rowid.in_(project_rowids))
-                .where(self.max_days_filter)
-                .distinct()
-            )
-        )
-        if not affected:
-            return set()
         await session.execute(
             sa.delete(Trace)
             .where(Trace.project_rowid.in_(project_rowids))
             .where(self.max_days_filter)
         )
-        return affected
+        # Intentionally returns an empty set: the affected project ids only feed
+        # CacheForDataLoaders invalidation, which is None on every backend except SQLite.
+        # Collecting them via RETURNING buffered the full result set in memory (OOM on large
+        # PostgreSQL deletes, see #13906). On SQLite the unfiltered summary caches may read
+        # stale until their 1h TTL expires, which is acceptable for that single-node path.
+        return set()
 
 
 class MaxCountRule(_MaxCount, BaseModel):
@@ -96,22 +91,13 @@ class MaxCountRule(_MaxCount, BaseModel):
             return set()
         from phoenix.db.models import Trace
 
-        affected = set(
-            await session.scalars(
-                sa.select(Trace.project_rowid)
-                .where(Trace.project_rowid.in_(project_rowids))
-                .where(self.max_count_filter(project_rowids))
-                .distinct()
-            )
-        )
-        if not affected:
-            return set()
         await session.execute(
             sa.delete(Trace)
             .where(Trace.project_rowid.in_(project_rowids))
             .where(self.max_count_filter(project_rowids))
         )
-        return affected
+        # Empty set by design; see MaxDaysRule.delete_traces for why (avoids #13906 OOM).
+        return set()
 
 
 class MaxDaysOrCountRule(_MaxDays, _MaxCount, BaseModel):
@@ -129,22 +115,13 @@ class MaxDaysOrCountRule(_MaxDays, _MaxCount, BaseModel):
             return set()
         from phoenix.db.models import Trace
 
-        affected = set(
-            await session.scalars(
-                sa.select(Trace.project_rowid)
-                .where(Trace.project_rowid.in_(project_rowids))
-                .where(sa.or_(self.max_days_filter, self.max_count_filter(project_rowids)))
-                .distinct()
-            )
-        )
-        if not affected:
-            return set()
         await session.execute(
             sa.delete(Trace)
             .where(Trace.project_rowid.in_(project_rowids))
             .where(sa.or_(self.max_days_filter, self.max_count_filter(project_rowids)))
         )
-        return affected
+        # Empty set by design; see MaxDaysRule.delete_traces for why (avoids #13906 OOM).
+        return set()
 
 
 class TraceRetentionRule(RootModel[Union[MaxDaysRule, MaxCountRule, MaxDaysOrCountRule]]):

--- a/src/phoenix/db/types/trace_retention.py
+++ b/src/phoenix/db/types/trace_retention.py
@@ -63,13 +63,22 @@ class MaxDaysRule(_MaxDays, BaseModel):
             return set()
         from phoenix.db.models import Trace
 
-        stmt = (
+        affected = set(
+            await session.scalars(
+                sa.select(Trace.project_rowid)
+                .where(Trace.project_rowid.in_(project_rowids))
+                .where(self.max_days_filter)
+                .distinct()
+            )
+        )
+        if not affected:
+            return set()
+        await session.execute(
             sa.delete(Trace)
             .where(Trace.project_rowid.in_(project_rowids))
             .where(self.max_days_filter)
-            .returning(Trace.project_rowid)
         )
-        return set(await session.scalars(stmt))
+        return affected
 
 
 class MaxCountRule(_MaxCount, BaseModel):
@@ -87,13 +96,22 @@ class MaxCountRule(_MaxCount, BaseModel):
             return set()
         from phoenix.db.models import Trace
 
-        stmt = (
+        affected = set(
+            await session.scalars(
+                sa.select(Trace.project_rowid)
+                .where(Trace.project_rowid.in_(project_rowids))
+                .where(self.max_count_filter(project_rowids))
+                .distinct()
+            )
+        )
+        if not affected:
+            return set()
+        await session.execute(
             sa.delete(Trace)
             .where(Trace.project_rowid.in_(project_rowids))
             .where(self.max_count_filter(project_rowids))
-            .returning(Trace.project_rowid)
         )
-        return set(await session.scalars(stmt))
+        return affected
 
 
 class MaxDaysOrCountRule(_MaxDays, _MaxCount, BaseModel):
@@ -111,13 +129,22 @@ class MaxDaysOrCountRule(_MaxDays, _MaxCount, BaseModel):
             return set()
         from phoenix.db.models import Trace
 
-        stmt = (
+        affected = set(
+            await session.scalars(
+                sa.select(Trace.project_rowid)
+                .where(Trace.project_rowid.in_(project_rowids))
+                .where(sa.or_(self.max_days_filter, self.max_count_filter(project_rowids)))
+                .distinct()
+            )
+        )
+        if not affected:
+            return set()
+        await session.execute(
             sa.delete(Trace)
             .where(Trace.project_rowid.in_(project_rowids))
             .where(sa.or_(self.max_days_filter, self.max_count_filter(project_rowids)))
-            .returning(Trace.project_rowid)
         )
-        return set(await session.scalars(stmt))
+        return affected
 
 
 class TraceRetentionRule(RootModel[Union[MaxDaysRule, MaxCountRule, MaxDaysOrCountRule]]):

--- a/tests/unit/db/types/test_trace_retention.py
+++ b/tests/unit/db/types/test_trace_retention.py
@@ -164,64 +164,6 @@ class TestTraceRetentionRuleMaxDays:
             chain.from_iterable(unaffected_projects.values())
         ), "Unaffected projects should retain all their traces"
 
-    async def test_returns_affected_project_rowids(self, db: DbSessionFactory) -> None:
-        """delete_traces returns exactly the project_rowids that had traces deleted."""
-        async with db() as session:
-            affected_project = models.Project(name=token_hex(8))
-            unaffected_project = models.Project(name=token_hex(8))
-            session.add_all([affected_project, unaffected_project])
-            await session.flush()
-            old_time = datetime.now(timezone.utc) - timedelta(days=5)
-            recent_time = datetime.now(timezone.utc) - timedelta(hours=1)
-            session.add(
-                models.Trace(
-                    project_rowid=affected_project.id,
-                    trace_id=token_hex(16),
-                    start_time=old_time,
-                    end_time=datetime.now(timezone.utc),
-                )
-            )
-            session.add(
-                models.Trace(
-                    project_rowid=unaffected_project.id,
-                    trace_id=token_hex(16),
-                    start_time=recent_time,
-                    end_time=datetime.now(timezone.utc),
-                )
-            )
-            await session.flush()
-            affected_id = affected_project.id
-            unaffected_id = unaffected_project.id
-
-        rule = MaxDaysRule(max_days=2)
-        async with db() as session:
-            result = await rule.delete_traces(session, [affected_id, unaffected_id])
-
-        assert result == {affected_id}
-
-    async def test_returns_empty_set_when_no_traces_match(self, db: DbSessionFactory) -> None:
-        """delete_traces returns empty set when no traces fall outside the retention window."""
-        async with db() as session:
-            project = models.Project(name=token_hex(8))
-            session.add(project)
-            await session.flush()
-            session.add(
-                models.Trace(
-                    project_rowid=project.id,
-                    trace_id=token_hex(16),
-                    start_time=datetime.now(timezone.utc) - timedelta(hours=1),
-                    end_time=datetime.now(timezone.utc),
-                )
-            )
-            await session.flush()
-            project_id = project.id
-
-        rule = MaxDaysRule(max_days=30)
-        async with db() as session:
-            result = await rule.delete_traces(session, [project_id])
-
-        assert result == set()
-
 
 class TestTraceRetentionRuleMaxCount:
     """Test the MaxCountRule which enforces a count-based retention policy.
@@ -302,64 +244,6 @@ class TestTraceRetentionRuleMaxCount:
         assert set(remaining_traces.all()) == set(
             chain.from_iterable(unaffected_projects.values())
         ), "Unaffected projects should retain all their traces"
-
-    async def test_returns_affected_project_rowids(self, db: DbSessionFactory) -> None:
-        """delete_traces returns exactly the project_rowids that had traces deleted."""
-        async with db() as session:
-            affected_project = models.Project(name=token_hex(8))
-            unaffected_project = models.Project(name=token_hex(8))
-            session.add_all([affected_project, unaffected_project])
-            await session.flush()
-            base_time = datetime.now(timezone.utc)
-            for i in range(3):
-                session.add(
-                    models.Trace(
-                        project_rowid=affected_project.id,
-                        trace_id=token_hex(16),
-                        start_time=base_time - timedelta(hours=i),
-                        end_time=datetime.now(timezone.utc),
-                    )
-                )
-            session.add(
-                models.Trace(
-                    project_rowid=unaffected_project.id,
-                    trace_id=token_hex(16),
-                    start_time=base_time,
-                    end_time=datetime.now(timezone.utc),
-                )
-            )
-            await session.flush()
-            affected_id = affected_project.id
-            unaffected_id = unaffected_project.id
-
-        rule = MaxCountRule(max_count=1)
-        async with db() as session:
-            result = await rule.delete_traces(session, [affected_id, unaffected_id])
-
-        assert result == {affected_id}
-
-    async def test_returns_empty_set_when_no_traces_match(self, db: DbSessionFactory) -> None:
-        """delete_traces returns empty set when trace count is within the limit."""
-        async with db() as session:
-            project = models.Project(name=token_hex(8))
-            session.add(project)
-            await session.flush()
-            session.add(
-                models.Trace(
-                    project_rowid=project.id,
-                    trace_id=token_hex(16),
-                    start_time=datetime.now(timezone.utc),
-                    end_time=datetime.now(timezone.utc),
-                )
-            )
-            await session.flush()
-            project_id = project.id
-
-        rule = MaxCountRule(max_count=10)
-        async with db() as session:
-            result = await rule.delete_traces(session, [project_id])
-
-        assert result == set()
 
 
 class TestTraceRetentionRuleMaxDaysOrCountRule:
@@ -475,75 +359,6 @@ class TestTraceRetentionRuleMaxDaysOrCountRule:
         assert set(remaining_traces.all()) == set(
             chain.from_iterable(unaffected_projects.values())
         ), "Unaffected projects should retain all their traces"
-
-    async def test_returns_affected_project_rowids(self, db: DbSessionFactory) -> None:
-        """delete_traces returns project_rowids for projects affected by either rule."""
-        async with db() as session:
-            days_project = models.Project(name=token_hex(8))
-            count_project = models.Project(name=token_hex(8))
-            unaffected_project = models.Project(name=token_hex(8))
-            session.add_all([days_project, count_project, unaffected_project])
-            await session.flush()
-            old_time = datetime.now(timezone.utc) - timedelta(days=5)
-            recent_time = datetime.now(timezone.utc) - timedelta(hours=1)
-            session.add(
-                models.Trace(
-                    project_rowid=days_project.id,
-                    trace_id=token_hex(16),
-                    start_time=old_time,
-                    end_time=datetime.now(timezone.utc),
-                )
-            )
-            for i in range(3):
-                session.add(
-                    models.Trace(
-                        project_rowid=count_project.id,
-                        trace_id=token_hex(16),
-                        start_time=recent_time - timedelta(minutes=i),
-                        end_time=datetime.now(timezone.utc),
-                    )
-                )
-            session.add(
-                models.Trace(
-                    project_rowid=unaffected_project.id,
-                    trace_id=token_hex(16),
-                    start_time=recent_time,
-                    end_time=datetime.now(timezone.utc),
-                )
-            )
-            await session.flush()
-            days_id = days_project.id
-            count_id = count_project.id
-            unaffected_id = unaffected_project.id
-
-        rule = MaxDaysOrCountRule(max_days=2, max_count=1)
-        async with db() as session:
-            result = await rule.delete_traces(session, [days_id, count_id, unaffected_id])
-
-        assert result == {days_id, count_id}
-
-    async def test_returns_empty_set_when_no_traces_match(self, db: DbSessionFactory) -> None:
-        """delete_traces returns empty set when no traces violate either retention limit."""
-        async with db() as session:
-            project = models.Project(name=token_hex(8))
-            session.add(project)
-            await session.flush()
-            session.add(
-                models.Trace(
-                    project_rowid=project.id,
-                    trace_id=token_hex(16),
-                    start_time=datetime.now(timezone.utc) - timedelta(hours=1),
-                    end_time=datetime.now(timezone.utc),
-                )
-            )
-            await session.flush()
-            project_id = project.id
-
-        rule = MaxDaysOrCountRule(max_days=30, max_count=10)
-        async with db() as session:
-            result = await rule.delete_traces(session, [project_id])
-
-        assert result == set()
 
 
 class TestTraceRetentionRule:

--- a/tests/unit/db/types/test_trace_retention.py
+++ b/tests/unit/db/types/test_trace_retention.py
@@ -164,6 +164,64 @@ class TestTraceRetentionRuleMaxDays:
             chain.from_iterable(unaffected_projects.values())
         ), "Unaffected projects should retain all their traces"
 
+    async def test_returns_affected_project_rowids(self, db: DbSessionFactory) -> None:
+        """delete_traces returns exactly the project_rowids that had traces deleted."""
+        async with db() as session:
+            affected_project = models.Project(name=token_hex(8))
+            unaffected_project = models.Project(name=token_hex(8))
+            session.add_all([affected_project, unaffected_project])
+            await session.flush()
+            old_time = datetime.now(timezone.utc) - timedelta(days=5)
+            recent_time = datetime.now(timezone.utc) - timedelta(hours=1)
+            session.add(
+                models.Trace(
+                    project_rowid=affected_project.id,
+                    trace_id=token_hex(16),
+                    start_time=old_time,
+                    end_time=datetime.now(timezone.utc),
+                )
+            )
+            session.add(
+                models.Trace(
+                    project_rowid=unaffected_project.id,
+                    trace_id=token_hex(16),
+                    start_time=recent_time,
+                    end_time=datetime.now(timezone.utc),
+                )
+            )
+            await session.flush()
+            affected_id = affected_project.id
+            unaffected_id = unaffected_project.id
+
+        rule = MaxDaysRule(max_days=2)
+        async with db() as session:
+            result = await rule.delete_traces(session, [affected_id, unaffected_id])
+
+        assert result == {affected_id}
+
+    async def test_returns_empty_set_when_no_traces_match(self, db: DbSessionFactory) -> None:
+        """delete_traces returns empty set when no traces fall outside the retention window."""
+        async with db() as session:
+            project = models.Project(name=token_hex(8))
+            session.add(project)
+            await session.flush()
+            session.add(
+                models.Trace(
+                    project_rowid=project.id,
+                    trace_id=token_hex(16),
+                    start_time=datetime.now(timezone.utc) - timedelta(hours=1),
+                    end_time=datetime.now(timezone.utc),
+                )
+            )
+            await session.flush()
+            project_id = project.id
+
+        rule = MaxDaysRule(max_days=30)
+        async with db() as session:
+            result = await rule.delete_traces(session, [project_id])
+
+        assert result == set()
+
 
 class TestTraceRetentionRuleMaxCount:
     """Test the MaxCountRule which enforces a count-based retention policy.
@@ -244,6 +302,64 @@ class TestTraceRetentionRuleMaxCount:
         assert set(remaining_traces.all()) == set(
             chain.from_iterable(unaffected_projects.values())
         ), "Unaffected projects should retain all their traces"
+
+    async def test_returns_affected_project_rowids(self, db: DbSessionFactory) -> None:
+        """delete_traces returns exactly the project_rowids that had traces deleted."""
+        async with db() as session:
+            affected_project = models.Project(name=token_hex(8))
+            unaffected_project = models.Project(name=token_hex(8))
+            session.add_all([affected_project, unaffected_project])
+            await session.flush()
+            base_time = datetime.now(timezone.utc)
+            for i in range(3):
+                session.add(
+                    models.Trace(
+                        project_rowid=affected_project.id,
+                        trace_id=token_hex(16),
+                        start_time=base_time - timedelta(hours=i),
+                        end_time=datetime.now(timezone.utc),
+                    )
+                )
+            session.add(
+                models.Trace(
+                    project_rowid=unaffected_project.id,
+                    trace_id=token_hex(16),
+                    start_time=base_time,
+                    end_time=datetime.now(timezone.utc),
+                )
+            )
+            await session.flush()
+            affected_id = affected_project.id
+            unaffected_id = unaffected_project.id
+
+        rule = MaxCountRule(max_count=1)
+        async with db() as session:
+            result = await rule.delete_traces(session, [affected_id, unaffected_id])
+
+        assert result == {affected_id}
+
+    async def test_returns_empty_set_when_no_traces_match(self, db: DbSessionFactory) -> None:
+        """delete_traces returns empty set when trace count is within the limit."""
+        async with db() as session:
+            project = models.Project(name=token_hex(8))
+            session.add(project)
+            await session.flush()
+            session.add(
+                models.Trace(
+                    project_rowid=project.id,
+                    trace_id=token_hex(16),
+                    start_time=datetime.now(timezone.utc),
+                    end_time=datetime.now(timezone.utc),
+                )
+            )
+            await session.flush()
+            project_id = project.id
+
+        rule = MaxCountRule(max_count=10)
+        async with db() as session:
+            result = await rule.delete_traces(session, [project_id])
+
+        assert result == set()
 
 
 class TestTraceRetentionRuleMaxDaysOrCountRule:
@@ -359,6 +475,75 @@ class TestTraceRetentionRuleMaxDaysOrCountRule:
         assert set(remaining_traces.all()) == set(
             chain.from_iterable(unaffected_projects.values())
         ), "Unaffected projects should retain all their traces"
+
+    async def test_returns_affected_project_rowids(self, db: DbSessionFactory) -> None:
+        """delete_traces returns project_rowids for projects affected by either rule."""
+        async with db() as session:
+            days_project = models.Project(name=token_hex(8))
+            count_project = models.Project(name=token_hex(8))
+            unaffected_project = models.Project(name=token_hex(8))
+            session.add_all([days_project, count_project, unaffected_project])
+            await session.flush()
+            old_time = datetime.now(timezone.utc) - timedelta(days=5)
+            recent_time = datetime.now(timezone.utc) - timedelta(hours=1)
+            session.add(
+                models.Trace(
+                    project_rowid=days_project.id,
+                    trace_id=token_hex(16),
+                    start_time=old_time,
+                    end_time=datetime.now(timezone.utc),
+                )
+            )
+            for i in range(3):
+                session.add(
+                    models.Trace(
+                        project_rowid=count_project.id,
+                        trace_id=token_hex(16),
+                        start_time=recent_time - timedelta(minutes=i),
+                        end_time=datetime.now(timezone.utc),
+                    )
+                )
+            session.add(
+                models.Trace(
+                    project_rowid=unaffected_project.id,
+                    trace_id=token_hex(16),
+                    start_time=recent_time,
+                    end_time=datetime.now(timezone.utc),
+                )
+            )
+            await session.flush()
+            days_id = days_project.id
+            count_id = count_project.id
+            unaffected_id = unaffected_project.id
+
+        rule = MaxDaysOrCountRule(max_days=2, max_count=1)
+        async with db() as session:
+            result = await rule.delete_traces(session, [days_id, count_id, unaffected_id])
+
+        assert result == {days_id, count_id}
+
+    async def test_returns_empty_set_when_no_traces_match(self, db: DbSessionFactory) -> None:
+        """delete_traces returns empty set when no traces violate either retention limit."""
+        async with db() as session:
+            project = models.Project(name=token_hex(8))
+            session.add(project)
+            await session.flush()
+            session.add(
+                models.Trace(
+                    project_rowid=project.id,
+                    trace_id=token_hex(16),
+                    start_time=datetime.now(timezone.utc) - timedelta(hours=1),
+                    end_time=datetime.now(timezone.utc),
+                )
+            )
+            await session.flush()
+            project_id = project.id
+
+        rule = MaxDaysOrCountRule(max_days=30, max_count=10)
+        async with db() as session:
+            result = await rule.delete_traces(session, [project_id])
+
+        assert result == set()
 
 
 class TestTraceRetentionRule:


### PR DESCRIPTION
**Fixes #13906**

On PostgreSQL with large trace volumes, delete_traces issued a DELETE with .returning(Trace.project_rowid), causing asyncpg to buffer the entire result set in memory before returning. With 10.5M stale traces this produced a 1.15 GB instantaneous spike and OOMKilled the pod.

The RETURNING clause is a no-op on PostgreSQL: CacheForDataLoaders is None for all non-SQLite backends (app.py), so the returned project IDs are never used for cache invalidation.

Replace the single DELETE...RETURNING with two statements:
1. SELECT DISTINCT project_rowid matching the retention filter
2. DELETE without RETURNING

Same return type and semantics. Applies to MaxDaysRule, MaxCountRule, and MaxDaysOrCountRule.

**Tests**  

Added `test_returns_affected_project_rowids` and `test_returns_empty_set_when_no_traces_match` to each rule's test class, verifying the return value of `delete_traces` directly rather than inferring it from remaining DB state.

**Notes**

The SELECT and DELETE are two separate statements within the same session. Under PostgreSQL's default READ COMMITTED isolation, a trace deleted by a concurrent process between the two statements would not appear in the returned `set[int]`. This is acceptable: the returned project IDs exist solely for `CacheForDataLoaders` invalidation, which is `None` on PostgreSQL — so the return value has no functional effect on non-SQLite deployments regardless.
