### PR TITLE
fix(pxi): Preserve PXI draft input across panel remounts

### DIFF
--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -381,14 +381,10 @@ export function ChatView({
   );
   const store = useAgentStore();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  // Seed the input from any prompt staged for this session (e.g. forked from a
-  // user message). The controller remounts this view per session, so the lazy
-  // initializer runs once per session and the store entry is consumed exactly
-  // once. Reading it here (rather than in an effect) avoids a cascading render.
-  const [inputValue, setInputValue] = useState(
-    () =>
-      (sessionId ? store.getState().consumePendingInput(sessionId) : null) ?? ""
+  const draftInput = useAgentContext((state) =>
+    sessionId ? (state.draftInputBySessionId[sessionId] ?? "") : ""
   );
+  const setDraftInput = useAgentContext((state) => state.setDraftInput);
   const [elicitationDraft, setElicitationDraft] =
     useState<PendingElicitationDraft | null>(null);
   const hasAcknowledgedConsent = useAgentContext((state) =>
@@ -402,6 +398,13 @@ export function ChatView({
   );
   const setPermissions = useAgentContext((state) => state.setPermissions);
   const createSession = useAgentContext((state) => state.createSession);
+
+  const setSessionDraftInput = (input: string | null) => {
+    if (!sessionId) {
+      return;
+    }
+    setDraftInput(sessionId, input);
+  };
 
   // Send any message staged for this session (e.g. carried past `/clear` from
   // the previous session) as soon as the view mounts. Consuming is atomic, so
@@ -469,7 +472,7 @@ export function ChatView({
   const quickActions = emptyStateQuickActions ?? contextualQuickActions;
 
   const handleQuickAction = (prompt: string) => {
-    setInputValue(prompt);
+    setSessionDraftInput(prompt);
     textareaRef.current?.focus();
   };
 
@@ -505,7 +508,7 @@ export function ChatView({
     } else {
       const restoredInput = rewindToMessage?.(messageId);
       if (restoredInput != null) {
-        setInputValue(restoredInput);
+        setSessionDraftInput(restoredInput);
         textareaRef.current?.focus();
       }
     }
@@ -645,8 +648,8 @@ export function ChatView({
           ) : (
             <AgentChatInput
               status={status}
-              value={inputValue}
-              onValueChange={setInputValue}
+              value={draftInput}
+              onValueChange={setSessionDraftInput}
               onSubmit={({ text, requestedSkills, commandNames }) => {
                 if (commandNames.length > 0) {
                   runPromptCommands(

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -502,8 +502,8 @@ export function ChatView({
     const { mode, messageId } = rewindRequest;
     setRewindRequest(null);
     if (mode === "fork") {
-      // Forking switches the active session, which remounts this view; the new
-      // session restores any staged input via the lazy initializer above.
+      // Forking switches the active session, which remounts this view; the
+      // forked session receives restored text through draftInputBySessionId.
       forkFromMessage?.(messageId);
     } else {
       const restoredInput = rewindToMessage?.(messageId);
@@ -523,7 +523,14 @@ export function ChatView({
     ) {
       return;
     }
-    textareaRef.current?.focus();
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    textarea.focus();
+    const cursorPosition = textarea.value.length;
+    textarea.setSelectionRange(cursorPosition, cursorPosition);
   }, [
     autoFocusInput,
     hasAcknowledgedConsent,

--- a/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/app/src/components/agent/__tests__/Chat.test.tsx
@@ -7,6 +7,8 @@ import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
 
 import { ChatView } from "../Chat";
 
+type ChatViewSendMessage = Parameters<typeof ChatView>[0]["sendMessage"];
+
 vi.mock("@phoenix/agent/quickActions/quickActions", () => ({
   useAgentQuickActions: () => [],
 }));
@@ -51,7 +53,18 @@ vi.mock("../ChatMessage", () => ({
   UserMessage: () => null,
 }));
 
-function renderChatView(root: Root, { autoFocusInput = false } = {}) {
+function renderChatView(
+  root: Root,
+  {
+    autoFocusInput = false,
+    chatKey = "chat",
+    sendMessage = vi.fn<ChatViewSendMessage>(),
+  }: {
+    autoFocusInput?: boolean;
+    chatKey?: string;
+    sendMessage?: ChatViewSendMessage;
+  } = {}
+) {
   act(() => {
     root.render(
       <ThemeProvider themeMode="light" disableBodyTheme>
@@ -75,9 +88,10 @@ function renderChatView(root: Root, { autoFocusInput = false } = {}) {
           }}
         >
           <ChatView
+            key={chatKey}
             sessionId="session-1"
             messages={[]}
-            sendMessage={vi.fn()}
+            sendMessage={sendMessage}
             stop={async () => undefined}
             status="ready"
             error={undefined}
@@ -90,6 +104,33 @@ function renderChatView(root: Root, { autoFocusInput = false } = {}) {
           />
         </AgentProvider>
       </ThemeProvider>
+    );
+  });
+}
+
+function setTextareaValue(textarea: HTMLTextAreaElement, value: string): void {
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value"
+  )?.set;
+  act(() => {
+    if (valueSetter) {
+      valueSetter.call(textarea, value);
+    } else {
+      textarea.value = value;
+    }
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function pressEnter(textarea: HTMLTextAreaElement): void {
+  act(() => {
+    textarea.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key: "Enter",
+      })
     );
   });
 }
@@ -147,5 +188,43 @@ describe("ChatView", () => {
 
     expect(textarea).not.toBeNull();
     expect(document.activeElement).not.toBe(textarea);
+  });
+
+  it("preserves the prompt draft when the chat view remounts", () => {
+    renderChatView(root, { chatKey: "initial" });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Message input"]'
+    );
+    expect(textarea).not.toBeNull();
+
+    setTextareaValue(textarea!, "preserve this draft");
+
+    renderChatView(root, { chatKey: "remounted" });
+
+    const remountedTextarea = container.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Message input"]'
+    );
+    expect(remountedTextarea).not.toBeNull();
+    expect(remountedTextarea?.value).toBe("preserve this draft");
+  });
+
+  it("clears the prompt draft after submit", () => {
+    const sendMessage = vi.fn<ChatViewSendMessage>();
+    renderChatView(root, { sendMessage });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Message input"]'
+    );
+    expect(textarea).not.toBeNull();
+
+    setTextareaValue(textarea!, "send this draft");
+    pressEnter(textarea!);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      { text: "send this draft" },
+      undefined
+    );
+    expect(textarea?.value).toBe("");
   });
 });

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -274,7 +274,7 @@ describe("agentStore", () => {
       expect(forked.context).toEqual(["span:123"]);
     });
 
-    it("stages restored input for the forked session", () => {
+    it("stages restored input as the forked session draft", () => {
       const store = createAgentStore();
       const sourceId = store.getState().createSession();
 
@@ -284,9 +284,7 @@ describe("agentStore", () => {
         restoredInput: "edit me",
       });
 
-      expect(store.getState().consumePendingInput(forkId!)).toBe("edit me");
-      // Consuming clears the staged input.
-      expect(store.getState().consumePendingInput(forkId!)).toBeNull();
+      expect(store.getState().draftInputBySessionId[forkId!]).toBe("edit me");
     });
 
     it("prefixes the source summary with (fork)", () => {
@@ -367,19 +365,85 @@ describe("agentStore", () => {
     });
   });
 
-  describe("pending input", () => {
-    it("sets and consumes pending input once", () => {
+  describe("draft input", () => {
+    it("sets and clears draft input", () => {
       const store = createAgentStore();
-      store.getState().setPendingInput("session-1", "hello");
-      expect(store.getState().consumePendingInput("session-1")).toBe("hello");
-      expect(store.getState().consumePendingInput("session-1")).toBeNull();
+      store.getState().setDraftInput("session-1", "hello");
+      expect(store.getState().draftInputBySessionId["session-1"]).toBe("hello");
+
+      store.getState().setDraftInput("session-1", "");
+      expect(store.getState().draftInputBySessionId["session-1"]).toBe(
+        undefined
+      );
     });
 
-    it("clears pending input when set to null", () => {
+    it("clears draft input when set to null", () => {
       const store = createAgentStore();
-      store.getState().setPendingInput("session-1", "hello");
-      store.getState().setPendingInput("session-1", null);
-      expect(store.getState().consumePendingInput("session-1")).toBeNull();
+      store.getState().setDraftInput("session-1", "hello");
+      store.getState().setDraftInput("session-1", null);
+      expect(store.getState().draftInputBySessionId["session-1"]).toBe(
+        undefined
+      );
+    });
+
+    it("drops a session draft when that session is deleted", () => {
+      const store = createAgentStore();
+      const sessionId = store.getState().createSession();
+      store.getState().setDraftInput(sessionId, "hello");
+
+      store.getState().deleteSession(sessionId);
+
+      expect(store.getState().draftInputBySessionId[sessionId]).toBeUndefined();
+    });
+
+    it("clears all drafts when all sessions are cleared", () => {
+      const store = createAgentStore();
+      const sessionId = store.getState().createSession();
+      store.getState().setDraftInput(sessionId, "hello");
+
+      store.getState().clearAllSessions();
+
+      expect(store.getState().draftInputBySessionId).toEqual({});
+    });
+
+    it("prunes drafts owned by sessions dropped on retention", () => {
+      const store = createAgentStore();
+      const firstSessionId = store.getState().createSession();
+      store.getState().setDraftInput(firstSessionId, "old draft");
+
+      const secondSessionId = store.getState().createSession();
+      store.getState().setDraftInput(secondSessionId, "new draft");
+
+      expect(
+        store.getState().draftInputBySessionId[firstSessionId]
+      ).toBeUndefined();
+      expect(store.getState().draftInputBySessionId[secondSessionId]).toBe(
+        "new draft"
+      );
+    });
+
+    it("prunes inactive drafts when recent session storage is disabled", () => {
+      const store = createAgentStore();
+      store.getState().setCapability({
+        key: "session.storeSessions",
+        enabled: true,
+      });
+      const firstSessionId = store.getState().createSession();
+      store.getState().setDraftInput(firstSessionId, "old draft");
+      const secondSessionId = store.getState().createSession();
+      store.getState().setDraftInput(secondSessionId, "new draft");
+
+      store.getState().setCapability({
+        key: "session.storeSessions",
+        enabled: false,
+      });
+
+      expect(
+        store.getState().draftInputBySessionId[firstSessionId]
+      ).toBeUndefined();
+      expect(store.getState().draftInputBySessionId[secondSessionId]).toBe(
+        "new draft"
+      );
     });
   });
 

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -336,22 +336,20 @@ export interface AgentState extends AgentProps {
   setSessionChatStatus: (sessionId: string, status: ChatStatus) => void;
 
   /**
-   * Prompt-input text staged for a session that has not yet (re)mounted its
-   * chat view. Used when forking from a user message: the new session opens
-   * with the rewound user message restored into the input so it can be edited
-   * and re-sent. Ephemeral and consumed once by the view on mount.
+   * Current unsent prompt-input draft keyed by session ID. Ephemeral and kept
+   * out of local-storage persistence, but survives remounts while the app is
+   * alive so moving the panel between docked and floating layouts does not
+   * clear the composer.
    */
-  pendingInputBySessionId: Record<string, string>;
-  setPendingInput: (sessionId: string, input: string | null) => void;
-  consumePendingInput: (sessionId: string) => string | null;
+  draftInputBySessionId: Record<string, string>;
+  setDraftInput: (sessionId: string, input: string | null) => void;
 
   /**
    * A message staged to be sent as soon as a session's chat view mounts. Used
    * by local prompt commands (e.g. `/clear fix this`): the command creates a
    * fresh session, and the rest of the submitted message is carried over and
-   * sent there. Unlike {@link pendingInputBySessionId} — which only seeds the
-   * textarea — a consumed pending message is sent immediately. Ephemeral and
-   * consumed once by the view on mount.
+   * sent there. A consumed pending message is sent immediately rather than
+   * placed in the textarea. Ephemeral and consumed once by the view on mount.
    */
   pendingMessageBySessionId: Record<string, PendingAgentMessage>;
   setPendingMessage: (
@@ -594,7 +592,7 @@ function buildSessionRetentionPatch({
   | "sessionMap"
   | "pendingElicitationBySessionId"
   | "chatStatusBySessionId"
-  | "pendingInputBySessionId"
+  | "draftInputBySessionId"
   | "pendingMessageBySessionId"
   | "pendingPatchExperimentsByToolCallId"
 > {
@@ -614,8 +612,8 @@ function buildSessionRetentionPatch({
       record: state.chatStatusBySessionId,
       retainedSessionIds: retainedSessionIdSet,
     }),
-    pendingInputBySessionId: pruneSessionScopedRecord({
-      record: state.pendingInputBySessionId,
+    draftInputBySessionId: pruneSessionScopedRecord({
+      record: state.draftInputBySessionId,
       retainedSessionIds: retainedSessionIdSet,
     }),
     pendingMessageBySessionId: pruneSessionScopedRecord({
@@ -770,20 +768,19 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
           const nextSessionIds = [...state.sessions, sessionId].slice(
             -MAX_STORED_AGENT_SESSIONS
           );
-          const pendingInputBySessionId = { ...state.pendingInputBySessionId };
-          if (restoredInput) {
-            pendingInputBySessionId[sessionId] = restoredInput;
-          }
+          const draftInputBySessionId = restoredInput
+            ? { ...state.draftInputBySessionId, [sessionId]: restoredInput }
+            : state.draftInputBySessionId;
           return {
             ...buildSessionRetentionPatch({
               state: {
                 ...state,
                 sessionMap: { ...state.sessionMap, [sessionId]: session },
+                draftInputBySessionId,
               },
               retainedSessionIds: nextSessionIds,
               activeSessionId: sessionId,
             }),
-            pendingInputBySessionId,
           };
         },
         false,
@@ -804,10 +801,8 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
           delete newPendingElicitationBySessionId[sessionId];
           const newChatStatusBySessionId = { ...state.chatStatusBySessionId };
           delete newChatStatusBySessionId[sessionId];
-          const newPendingInputBySessionId = {
-            ...state.pendingInputBySessionId,
-          };
-          delete newPendingInputBySessionId[sessionId];
+          const newDraftInputBySessionId = { ...state.draftInputBySessionId };
+          delete newDraftInputBySessionId[sessionId];
           const newPendingMessageBySessionId = {
             ...state.pendingMessageBySessionId,
           };
@@ -828,7 +823,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
             activeSessionId: newActiveSessionId,
             pendingElicitationBySessionId: newPendingElicitationBySessionId,
             chatStatusBySessionId: newChatStatusBySessionId,
-            pendingInputBySessionId: newPendingInputBySessionId,
+            draftInputBySessionId: newDraftInputBySessionId,
             pendingMessageBySessionId: newPendingMessageBySessionId,
             pendingPatchExperimentsByToolCallId:
               newPendingPatchExperimentsByToolCallId,
@@ -984,7 +979,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
           sessionMap: {},
           pendingElicitationBySessionId: {},
           chatStatusBySessionId: {},
-          pendingInputBySessionId: {},
+          draftInputBySessionId: {},
           pendingMessageBySessionId: {},
           pendingPatchExperimentsByToolCallId: {},
         },
@@ -1033,39 +1028,21 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
       );
     },
 
-    pendingInputBySessionId: {},
-    setPendingInput: (sessionId, input) => {
+    draftInputBySessionId: {},
+    setDraftInput: (sessionId, input) => {
       set(
         (state) => {
-          const next = { ...state.pendingInputBySessionId };
+          const next = { ...state.draftInputBySessionId };
           if (input) {
             next[sessionId] = input;
           } else {
             delete next[sessionId];
           }
-          return { pendingInputBySessionId: next };
+          return { draftInputBySessionId: next };
         },
         false,
-        { type: "setPendingInput" }
+        { type: "setDraftInput" }
       );
-    },
-    consumePendingInput: (sessionId) => {
-      const input = get().pendingInputBySessionId[sessionId] ?? null;
-      if (input != null) {
-        set(
-          (state) => {
-            if (!(sessionId in state.pendingInputBySessionId)) {
-              return state;
-            }
-            const next = { ...state.pendingInputBySessionId };
-            delete next[sessionId];
-            return { pendingInputBySessionId: next };
-          },
-          false,
-          { type: "consumePendingInput" }
-        );
-      }
-      return input;
     },
 
     pendingMessageBySessionId: {},


### PR DESCRIPTION
## Summary
- move PXI prompt draft state into the agent store so it survives docked/floating panel remounts
- remove the old one-shot pending input state and use draft input for restored rewind/fork text
- place the cursor at the end when an existing draft is restored into the focused composer

## Testing
- make test-frontend
- make typecheck-frontend
- make lint-frontend