### PR TITLE
refactor(js): rename PHOENIX_TEST_TRACING env var to PHOENIX_TEST_TRACKING

### DIFF
--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/ci-evals-vitest.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/ci-evals-vitest.mdx
@@ -90,7 +90,7 @@ px.describe("my suite", () => { ... }, {
 | `client` | `PhoenixClient` | Pre-configured `@arizeai/phoenix-client` instance. |
 | `repetitions` | `number` | Run each test in the suite this many times (default `1`; `PHOENIX_TEST_REPETITIONS` overrides the default). Per-test `repetitions` wins. |
 | `acceptanceCriteria` | `AcceptanceCriterion[]` | Aggregate annotation thresholds that fail the suite after all tests run. |
-| `dryRun` | `boolean` | Run the whole suite locally — no dataset, experiment, runs, or annotations are created in Phoenix. Same effect as `PHOENIX_TEST_TRACING=false`, scoped to this suite. |
+| `dryRun` | `boolean` | Run the whole suite locally — no dataset, experiment, runs, or annotations are created in Phoenix. Same effect as `PHOENIX_TEST_TRACKING=false`, scoped to this suite. |
 
 ### `test(name, params, fn, timeout?)`
 

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/ci-evals.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/ci-evals.mdx
@@ -97,7 +97,7 @@ standard Phoenix env vars.
 | `PHOENIX_HOST` | Phoenix base URL |
 | `PHOENIX_API_KEY` | Bearer token for Phoenix |
 | `PHOENIX_CLIENT_HEADERS` | Optional JSON headers forwarded to the Phoenix client and tracer |
-| `PHOENIX_TEST_TRACING=false` | Disable sync to Phoenix for the current run (tracing is on by default) |
+| `PHOENIX_TEST_TRACKING=false` | Disable sync to Phoenix for the current run (tracing is on by default) |
 | `PHOENIX_TEST_REPETITIONS` | Default number of times to run each test |
 | `PHOENIX_TEST_REPORTER=verbose` | Show every test row plus per-test `output:` detail (default is the compact view) |
 | `PHOENIX_TEST_REPORTER_MAX_ROWS` | Max test rows shown per suite in compact mode (default `10`; failures are never hidden) |
@@ -123,7 +123,7 @@ Dry-run executes test bodies (and tracing, when a tracer is attached) but
 creates no dataset, experiment, run, or annotations in Phoenix. The
 reporter still prints a local summary.
 
-- **Whole process** — `PHOENIX_TEST_TRACING=false`.
+- **Whole process** — `PHOENIX_TEST_TRACKING=false`.
 - **One suite** — `describe(name, fn, { dryRun: true })`.
 - **One test** — `test(name, { input, dryRun: true }, fn)`; that case runs
   as an ordinary local test, with no dataset example and nothing uploaded,

--- a/js/.changeset/rename-phoenix-test-tracking-env.md
+++ b/js/.changeset/rename-phoenix-test-tracking-env.md
@@ -1,0 +1,7 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+Rename the CI eval testing env var `PHOENIX_TEST_TRACING` to `PHOENIX_TEST_TRACKING` so it matches the internal "tracking" terminology (`isTrackingEnabled`, `SuiteState.trackingDisabled`). The behavior is unchanged: set `PHOENIX_TEST_TRACKING=false` to run a suite locally without syncing datasets, experiments, runs, or annotations to Phoenix.
+
+**Beta breaking change:** if you adopted the beta testing API in 6.11.0 and set `PHOENIX_TEST_TRACING=false`, update it to `PHOENIX_TEST_TRACKING=false`. The old name is no longer read.

--- a/js/packages/phoenix-client/examples/README.md
+++ b/js/packages/phoenix-client/examples/README.md
@@ -48,11 +48,11 @@ Then run the whole suite locally without syncing anything to Phoenix:
 
 ```sh
 cd js/packages/phoenix-client
-PHOENIX_TEST_TRACING=false pnpm exec vitest run \
+PHOENIX_TEST_TRACKING=false pnpm exec vitest run \
   --config examples/vitest/phoenix.vitest.config.ts
 ```
 
-To track results to a Phoenix server, drop `PHOENIX_TEST_TRACING=false` and set
+To track results to a Phoenix server, drop `PHOENIX_TEST_TRACKING=false` and set
 `PHOENIX_HOST` / `PHOENIX_API_KEY`. Run a single file by appending its path
 (e.g. `examples/vitest/01-basics.eval.ts`). Run from the package root so
 `pnpm exec` can resolve the workspace package and dependencies.

--- a/js/packages/phoenix-client/examples/vitest/01-basics.eval.ts
+++ b/js/packages/phoenix-client/examples/vitest/01-basics.eval.ts
@@ -3,7 +3,7 @@
  *
  * Run the whole example suite offline (nothing is synced to Phoenix):
  *   cd js/packages/phoenix-client
- *   PHOENIX_TEST_TRACING=false pnpm exec vitest run \
+ *   PHOENIX_TEST_TRACKING=false pnpm exec vitest run \
  *     --config examples/vitest/phoenix.vitest.config.ts
  */
 import * as px from "@arizeai/phoenix-client/vitest";

--- a/js/packages/phoenix-client/examples/vitest/sql.eval.ts
+++ b/js/packages/phoenix-client/examples/vitest/sql.eval.ts
@@ -4,7 +4,7 @@
  *
  * Run with:
  *   cd js/packages/phoenix-client
- *   OPENAI_API_KEY= PHOENIX_TEST_TRACING=false pnpm exec vitest run \
+ *   OPENAI_API_KEY= PHOENIX_TEST_TRACKING=false pnpm exec vitest run \
  *     --config examples/vitest/phoenix.vitest.config.ts examples/vitest/sql.eval.ts
  *
  * Expected env vars (when tracking to a Phoenix server):
@@ -13,7 +13,7 @@
  *   OPENAI_API_KEY=...
  *
  * Without those, the suite still runs locally using a deterministic stand-in;
- * sync to Phoenix is skipped when `PHOENIX_TEST_TRACING=false`.
+ * sync to Phoenix is skipped when `PHOENIX_TEST_TRACKING=false`.
  *
  * NOTE: this file demonstrates the API only — the imports below are not
  * dependencies of `@arizeai/phoenix-client` itself. Install whichever LLM

--- a/js/packages/phoenix-client/src/testing/phoenix-test-tracking.ts
+++ b/js/packages/phoenix-client/src/testing/phoenix-test-tracking.ts
@@ -37,14 +37,14 @@ function isFalsyFlag(value: string | undefined): boolean {
  * Decide whether tests should sync to Phoenix.
  *
  * Tracing is enabled by default. It can be disabled globally by setting
- * `PHOENIX_TEST_TRACING=false`, or per suite via `SuiteConfig.dryRun`.
+ * `PHOENIX_TEST_TRACKING=false`, or per suite via `SuiteConfig.dryRun`.
  */
 export function isTrackingEnabled(suite?: SuiteState): {
   enabled: boolean;
   reason?: string;
 } {
-  if (isFalsyFlag(process.env.PHOENIX_TEST_TRACING)) {
-    return { enabled: false, reason: "PHOENIX_TEST_TRACING is disabled" };
+  if (isFalsyFlag(process.env.PHOENIX_TEST_TRACKING)) {
+    return { enabled: false, reason: "PHOENIX_TEST_TRACKING is disabled" };
   }
   if (suite?.config.dryRun) {
     return { enabled: false, reason: "suite configured dryRun" };
@@ -177,7 +177,7 @@ function buildLinks(
  * Initialize the suite: upload the dataset, create the experiment, and
  * register the OpenInference tracer.
  *
- * If tracing is disabled (no Phoenix env vars, or PHOENIX_TEST_TRACING=false),
+ * If tracing is disabled (no Phoenix env vars, or PHOENIX_TEST_TRACKING=false),
  * this populates a no-op tracer and exits without making any network calls.
  */
 export async function initializeSuite(suite: SuiteState): Promise<void> {

--- a/js/packages/phoenix-client/src/testing/runner.ts
+++ b/js/packages/phoenix-client/src/testing/runner.ts
@@ -148,7 +148,7 @@ export function declareTest<Input extends KVMap, Expected extends KVMap>(
 
   // A per-test `dryRun` opts the case out of Phoenix entirely: no dataset
   // example, no experiment run, no annotations — it runs as an ordinary
-  // local test. Suite-level dryRun (or PHOENIX_TEST_TRACING=false) is
+  // local test. Suite-level dryRun (or PHOENIX_TEST_TRACKING=false) is
   // handled in `initializeSuite`, which never uploads anything anyway.
   const isDryRun = !!params.dryRun;
 

--- a/js/packages/phoenix-client/src/testing/types.ts
+++ b/js/packages/phoenix-client/src/testing/types.ts
@@ -241,7 +241,7 @@ export interface SuiteConfig {
   /**
    * When `true`, the whole suite runs as ordinary local tests — no dataset
    * is uploaded and no experiment, runs, or annotations are created in
-   * Phoenix. Equivalent to `PHOENIX_TEST_TRACING=false` scoped to this
+   * Phoenix. Equivalent to `PHOENIX_TEST_TRACKING=false` scoped to this
    * suite. The reporter still prints a local summary.
    */
   dryRun?: boolean;

--- a/js/packages/phoenix-client/test/testing/report-artifacts.test.ts
+++ b/js/packages/phoenix-client/test/testing/report-artifacts.test.ts
@@ -42,7 +42,7 @@ describe("report artifacts", () => {
       {
         name: "artifact suite",
         trackingDisabled: true,
-        trackingDisabledReason: "PHOENIX_TEST_TRACING is disabled",
+        trackingDisabledReason: "PHOENIX_TEST_TRACKING is disabled",
         results: [
           {
             suiteName: "artifact suite",
@@ -94,7 +94,7 @@ function createSuiteState(): SuiteState {
     registeredExamples: new Map(),
     exampleIdsByTest: new Map(),
     trackingDisabled: true,
-    trackingDisabledReason: "PHOENIX_TEST_TRACING is disabled",
+    trackingDisabledReason: "PHOENIX_TEST_TRACKING is disabled",
     results: [
       {
         suiteName: "artifact suite",

--- a/js/packages/phoenix-client/test/testing/reporter-format.test.ts
+++ b/js/packages/phoenix-client/test/testing/reporter-format.test.ts
@@ -204,7 +204,7 @@ describe("overview", () => {
         suite([result("a", "passed", 1)], {
           name: "alpha",
           trackingDisabled: true,
-          trackingDisabledReason: "PHOENIX_TEST_TRACING is disabled",
+          trackingDisabledReason: "PHOENIX_TEST_TRACKING is disabled",
         }),
         suite([result("b", "passed", 1)], {
           name: "beta",
@@ -214,7 +214,7 @@ describe("overview", () => {
       COMPACT
     );
     expect(out).toContain("tracking disabled (local only)");
-    expect(out).not.toContain("PHOENIX_TEST_TRACING");
+    expect(out).not.toContain("PHOENIX_TEST_TRACKING");
   });
 
   it("emits no ANSI when color is off and aligns columns", () => {

--- a/js/packages/phoenix-client/test/testing/runner.test.ts
+++ b/js/packages/phoenix-client/test/testing/runner.test.ts
@@ -1,7 +1,7 @@
 /**
  * End-to-end test of the runner driving Vitest's own describe/test.
  *
- * `PHOENIX_TEST_TRACING=false` is set globally so no network calls are made
+ * `PHOENIX_TEST_TRACKING=false` is set globally so no network calls are made
  * to a Phoenix server. We assert that the public API records the run's
  * output, annotations, and evaluator results into the suite registry.
  */
@@ -17,7 +17,7 @@ import {
   test as pxTest,
 } from "../../src/vitest";
 
-const originalTracking = process.env.PHOENIX_TEST_TRACING;
+const originalTracking = process.env.PHOENIX_TEST_TRACKING;
 
 // Capture console.warn so we can assert on the "evaluate before logOutput"
 // warning emitted from a wrapped test body during the run phase.
@@ -30,15 +30,15 @@ console.warn = (...args: unknown[]) => {
 /* eslint-enable no-console */
 
 beforeAll(() => {
-  process.env.PHOENIX_TEST_TRACING = "false";
+  process.env.PHOENIX_TEST_TRACKING = "false";
 });
 afterAll(() => {
   // eslint-disable-next-line no-console
   console.warn = originalWarn;
   if (originalTracking === undefined) {
-    delete process.env.PHOENIX_TEST_TRACING;
+    delete process.env.PHOENIX_TEST_TRACKING;
   } else {
-    process.env.PHOENIX_TEST_TRACING = originalTracking;
+    process.env.PHOENIX_TEST_TRACKING = originalTracking;
   }
 });
 


### PR DESCRIPTION
## Summary

Renames the CI eval testing env var `PHOENIX_TEST_TRACING` → `PHOENIX_TEST_TRACKING` so the public env var matches the internal "tracking" terminology already used throughout the module (`isTrackingEnabled`, `SuiteState.trackingDisabled`, `phoenix-test-tracking.ts`). Behavior is unchanged — set `PHOENIX_TEST_TRACKING=false` to run a suite locally without syncing datasets, experiments, runs, or annotations to Phoenix.

Mechanical rename across source, tests, examples, and docs (11 files). Verified no remaining references to the old name in the repo.

## Beta breaking change

The old name shipped in `@arizeai/phoenix-client@6.11.0` as part of the **beta** CI eval testing API (explicitly marked "may change in a future release"). Anyone who set `PHOENIX_TEST_TRACING=false` must update to `PHOENIX_TEST_TRACKING=false`; the old name is no longer read. Documented in the changeset.

## Test plan

- [x] `grep` confirms zero remaining `PHOENIX_TEST_TRACING` references
- [x] Changeset added (`patch`)