### PR TITLE
fix(cli): improve pxi preflight network errors

### DIFF
--- a/js/.changeset/curly-moons-send.md
+++ b/js/.changeset/curly-moons-send.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": patch
+---
+
+fix(cli): improve pxi preflight network errors

--- a/js/packages/phoenix-cli/src/pxi/preflight.ts
+++ b/js/packages/phoenix-cli/src/pxi/preflight.ts
@@ -120,6 +120,47 @@ function getModelLabel({
   return `${modelSelection.provider}/${modelSelection.modelName}`;
 }
 
+function getErrorMessage({ error }: { error: unknown }): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function getErrorCauseMessage({ error }: { error: unknown }): string | null {
+  if (!(error instanceof Error) || !("cause" in error)) {
+    return null;
+  }
+  const cause = error.cause;
+  if (!cause) {
+    return null;
+  }
+  return getErrorMessage({ error: cause });
+}
+
+function formatEndpointPreflightFailure({
+  error,
+  endpoint,
+  requestUrl,
+}: {
+  error: unknown;
+  endpoint: string;
+  requestUrl: string;
+}): string {
+  const causeMessage = getErrorCauseMessage({ error });
+  const causeLine = causeMessage ? `\nCause: ${causeMessage}` : "";
+  return [
+    "Could not reach Phoenix during PXI startup preflight.",
+    "",
+    `Endpoint: ${endpoint}`,
+    `Request: ${requestUrl}`,
+    `Network error: ${getErrorMessage({ error })}${causeLine}`,
+    "",
+    "How to fix:",
+    "  1. Start Phoenix and confirm the server is listening.",
+    "  2. If Phoenix is running at a different URL, pass --endpoint <url> or set PHOENIX_HOST.",
+    "  3. For remote endpoints, check VPN, proxy, firewall, and DNS settings.",
+    "  4. To skip only model validation, pass --skip-model-preflight.",
+  ].join("\n");
+}
+
 /**
  * Compose the "missing credentials" error for a provider, listing the required
  * environment variables (falling back to all known ones if none are flagged
@@ -219,11 +260,23 @@ export async function fetchPxiModelPreflight({
     query: PXI_MODEL_PREFLIGHT_QUERY,
     config,
   });
-  const response = await fetchImpl(request.url, {
-    method: request.method,
-    headers: request.headers,
-    body: request.body,
-  });
+  let response: Response;
+  try {
+    response = await fetchImpl(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body: request.body,
+    });
+  } catch (error) {
+    throw new TypeError(
+      formatEndpointPreflightFailure({
+        error,
+        endpoint: config.endpoint,
+        requestUrl: request.url,
+      }),
+      { cause: error }
+    );
+  }
   if (!response.ok) {
     const detail = await readResponseText({ response });
     const detailText = detail ? `: ${detail}` : "";

--- a/js/packages/phoenix-cli/test/pxiPreflight.test.ts
+++ b/js/packages/phoenix-cli/test/pxiPreflight.test.ts
@@ -260,4 +260,30 @@ describe("PXI model preflight", () => {
       "Could not validate PXI model selection: HTTP 401 Unauthorized"
     );
   });
+
+  it("formats endpoint connection failures as actionable startup errors", async () => {
+    const options = createRuntimeOptions();
+    const fetchImpl: typeof globalThis.fetch = async () => {
+      throw new TypeError("fetch failed", {
+        cause: new Error("connect ECONNREFUSED 127.0.0.1:6006"),
+      });
+    };
+
+    let message = "";
+    try {
+      await runPxiModelPreflight({ options, fetchImpl });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain(
+      "Could not reach Phoenix during PXI startup preflight."
+    );
+    expect(message).toContain("Endpoint: http://localhost:6006");
+    expect(message).toContain("Request: http://localhost:6006/graphql");
+    expect(message).toContain("Network error: fetch failed");
+    expect(message).toContain("Cause: connect ECONNREFUSED 127.0.0.1:6006");
+    expect(message).toContain("pass --endpoint <url> or set PHOENIX_HOST");
+    expect(message).toContain("pass --skip-model-preflight");
+  });
 });


### PR DESCRIPTION
## Summary
- replace raw PXI preflight fetch failures with actionable endpoint diagnostics
- include endpoint, GraphQL request URL, underlying network cause, and remediation steps
- add regression coverage for fetch failed / ECONNREFUSED startup failures

## Testing
- pnpm test test/pxiPreflight.test.ts
- pnpm typecheck