### PR TITLE
docs(eval): add integrations section with pytest and vitest/jest guides

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1267,6 +1267,7 @@
               {
                 "group": "06.2026",
                 "pages": [
+                  "docs/phoenix/release-notes/06-2026/06-26-2026-eval-ci-pytest-vitest-jest",
                   "docs/phoenix/release-notes/06-2026/06-24-2026-annotations-labels-and-pxi-server-tools",
                   "docs/phoenix/release-notes/06-2026/06-16-2026-time-range-metrics-and-sharing",
                   "docs/phoenix/release-notes/06-2026/06-11-2026-time-range-and-pxi-slash-commands",

--- a/docs.json
+++ b/docs.json
@@ -277,6 +277,13 @@
                     ]
                   }
                 ]
+              },
+              {
+                "group": "Integrations",
+                "pages": [
+                  "docs/phoenix/evaluation/integrations/pytest",
+                  "docs/phoenix/evaluation/integrations/vitest-jest"
+                ]
               }
             ]
           },

--- a/docs/phoenix/evaluation/integrations/pytest.mdx
+++ b/docs/phoenix/evaluation/integrations/pytest.mdx
@@ -7,6 +7,16 @@ The Phoenix pytest plugin bridges the gap between your test suite and your evalu
 
 When a test passes, Phoenix records `pass=True`. When it fails, `pass=False`. Because the plugin hooks into pytest's own exit code, your existing CI gate works without any extra configuration: a regression in LLM quality fails the job the same way a broken import would.
 
+## When to use the pytest plugin
+
+Phoenix also offers [`run_experiment`](/phoenix/datasets-and-experiments/how-to-experiments/run-experiments) for evaluating a whole dataset with a single task and a shared set of evaluators. Reach for the pytest plugin instead when:
+
+- **Each case needs different logic.** `run_experiment` runs one task and the same evaluators across every example. When subsets of your system need different inputs, setup, or metrics, separate test functions are easier to express than one branching task.
+- **You want to assert hard expectations.** Tests turn an eval into a binary gate: a failed `assert` fails the pytest item, fails the run, and fails CI — exactly like any other broken test.
+- **You already use pytest.** Add Phoenix tracking to an existing suite without changing how you run it, and keep `pytest` features like fixtures, `parametrize`, `-k` filtering, `pytest-xdist`, and `pytest-asyncio`.
+
+For large, homogeneous datasets where every example is scored the same way, prefer `run_experiment` — it parallelizes the work and keeps each experiment and its dataset easy to manage.
+
 ## How it works
 
 Each marked test suite maps to a **Phoenix dataset**. Each parametrized test case maps to a **dataset example**. Each run of the suite creates a new **experiment** on that dataset. The assertion outcome — did the test pass or fail? — becomes a `pass` annotation on the experiment run. Any additional scores you log become their own named annotations.
@@ -23,16 +33,20 @@ This means the same suite that gates your pull requests also builds a versioned 
 
 ## Installation
 
+<Info>
+Requires **`arize-phoenix-client>=2.10.0`** — the version that introduced the `@pytest.mark.phoenix` plugin.
+</Info>
+
 The plugin ships with `arize-phoenix-client`. Install it with the `pytest` extra:
 
 ```bash
-pip install "arize-phoenix-client[pytest]" pytest
+pip install "arize-phoenix-client[pytest]>=2.10.0" pytest
 ```
 
 If your evaluators use `arize-phoenix-evals`, add that extra too:
 
 ```bash
-pip install "arize-phoenix-client[pytest,evals]" pytest
+pip install "arize-phoenix-client[pytest,evals]>=2.10.0" pytest
 ```
 
 pytest discovers the plugin automatically through its entry point — no `conftest.py` setup required.
@@ -146,6 +160,10 @@ def test_answers(question, expected):
 
 A failed assertion after `evaluate()` records `pass=False` and fails the pytest item — making the evaluator score a CI gate.
 
+<Note>
+Every score from `log_evaluation()`, `evaluate()`, and hoisted marker evaluators is wrapped in its own **evaluator span**, so an LLM-as-judge call is traced separately from the test's task and the annotation links straight to the trace that produced it. You don't need a separate "trace feedback" context — the separation is automatic. Click any annotation in the Phoenix UI to open its evaluator trace.
+</Note>
+
 ## Using pre-built Phoenix evaluators
 
 Evaluators from `arize-phoenix-evals` work directly with `evaluate()` and as hoisted evaluators on the marker:
@@ -183,6 +201,10 @@ Hoisted evaluators are invoked using the same adapter as `run_experiment`, so an
 | `expected` / `reference` | Parametrized field of the same name, if present |
 | `metadata` | Parametrized field of the same name, if present |
 | `trace_id` | The test run's trace id |
+
+<Tip>
+Any evaluator from [`arize-phoenix-evals`](/phoenix/evaluation/pre-built-metrics) works here — `HallucinationEvaluator`, `RelevanceEvaluator`, QA correctness, toxicity, and more — as does any plain function you'd pass to `run_experiment`. Write a custom evaluator once and use it from both.
+</Tip>
 
 ## Repetitions
 
@@ -230,6 +252,40 @@ The plugin supports `pytest -n auto`. The controller creates the dataset and exp
 pip install pytest-xdist
 pytest -n auto tests/evals/
 ```
+
+## Works with the rest of pytest
+
+The marker is designed to stay out of your way — the tools you already use keep working:
+
+- **Async tests.** `async def` tests run unchanged under `pytest-asyncio` (or `anyio`). Inline `evaluate()` works inside an async test, including with async evaluators — the result is recorded the same way as a sync one.
+- **Fixtures and `parametrize`.** Use them as normal. Each `parametrize` case becomes its own dataset example; give cases stable `ids` so reruns map back to the same example.
+- **Focusing and skipping.** Filter with `-k`, select markers with `-m`, or skip a case with `@pytest.mark.skip` / `pytest.skip()`. Skipped cases are simply not recorded; a filtered run only *appends* to the dataset (see [How the dataset stays in sync](#how-the-dataset-stays-in-sync)).
+- **Watch mode.** `pytest-watch` (`ptw`) re-runs on save. Pair it with `PHOENIX_TEST_TRACKING=0` while iterating so you don't create an experiment on every keystroke.
+
+```python
+import pytest
+from phoenix.client.pytest import evaluate, log_output
+
+@pytest.mark.phoenix(dataset="qa-suite")
+@pytest.mark.parametrize("question,expected", [("Capital of France?", "Paris")])
+async def test_async_answers(question, expected):
+    answer = await my_async_app(question)   # async task
+    log_output(answer)
+    result = evaluate(my_async_evaluator, output=answer, expected=expected)  # async evaluator
+    assert result["score"] == 1.0
+```
+
+### Configuring the dataset name in `pytest.ini`
+
+To pin a dataset name for a whole project without editing tests or exporting an env var, set the `phoenix_dataset` ini option:
+
+```ini
+# pytest.ini
+[pytest]
+phoenix_dataset = sql-app-evals
+```
+
+`PHOENIX_TEST_DATASET` still takes precedence over the ini option, which in turn takes precedence over the marker's `dataset=` (see [Dataset naming](#dataset-naming)).
 
 ## How the dataset stays in sync
 

--- a/docs/phoenix/evaluation/integrations/pytest.mdx
+++ b/docs/phoenix/evaluation/integrations/pytest.mdx
@@ -367,17 +367,17 @@ def token_f1(output, expected, **_):
 CASES = [
     {
         "input": "Show all users",
-        "expected_sql": "SELECT * FROM users;",
+        "expected": {"sql": "SELECT * FROM users;"},
         "id": "select-all",
     },
     {
         "input": "Count active subscriptions",
-        "expected_sql": "SELECT COUNT(*) FROM subscriptions WHERE status = 'active';",
+        "expected": {"sql": "SELECT COUNT(*) FROM subscriptions WHERE status = 'active';"},
         "id": "count-active",
     },
     {
         "input": "Top 5 customers by revenue",
-        "expected_sql": "SELECT customer_id, SUM(amount) AS revenue FROM orders GROUP BY customer_id ORDER BY revenue DESC LIMIT 5;",
+        "expected": {"sql": "SELECT customer_id, SUM(amount) AS revenue FROM orders GROUP BY customer_id ORDER BY revenue DESC LIMIT 5;"},
         "id": "top-customers",
     },
 ]
@@ -388,11 +388,11 @@ CASES = [
     evaluators=[valid_sql, token_f1],
 )
 @pytest.mark.parametrize(
-    "input,expected_sql",
-    [(c["input"], c["expected_sql"]) for c in CASES],
+    "input,expected",
+    [(c["input"], c["expected"]) for c in CASES],
     ids=[c["id"] for c in CASES],
 )
-def test_text_to_sql(input, expected_sql):
+def test_text_to_sql(input, expected):
     sql = my_sql_generator(input)
     log_output({"sql": sql})
     assert sql.strip().endswith(";"), "SQL must end with a semicolon"

--- a/docs/phoenix/evaluation/integrations/pytest.mdx
+++ b/docs/phoenix/evaluation/integrations/pytest.mdx
@@ -1,0 +1,354 @@
+---
+title: "pytest"
+description: "Write LLM evaluations as ordinary pytest tests that run in CI and record results to Phoenix."
+---
+
+The Phoenix pytest plugin bridges the gap between your test suite and your evaluation pipeline. You write evaluations as normal `pytest` tests — parametrized, marked, and run just like any other test — and Phoenix records each case as an experiment run so you can track quality over time.
+
+When a test passes, Phoenix records `pass=True`. When it fails, `pass=False`. Because the plugin hooks into pytest's own exit code, your existing CI gate works without any extra configuration: a regression in LLM quality fails the job the same way a broken import would.
+
+## How it works
+
+Each marked test suite maps to a **Phoenix dataset**. Each parametrized test case maps to a **dataset example**. Each run of the suite creates a new **experiment** on that dataset. The assertion outcome — did the test pass or fail? — becomes a `pass` annotation on the experiment run. Any additional scores you log become their own named annotations.
+
+```
+pytest test file   →  Phoenix dataset
+parametrize case   →  dataset example
+test run           →  experiment run
+assert outcome     →  "pass" annotation
+log_evaluation()   →  named annotation
+```
+
+This means the same suite that gates your pull requests also builds a versioned history of results you can compare in Phoenix over time.
+
+## Installation
+
+The plugin ships with `arize-phoenix-client`. Install it with the `pytest` extra:
+
+```bash
+pip install "arize-phoenix-client[pytest]" pytest
+```
+
+If your evaluators use `arize-phoenix-evals`, add that extra too:
+
+```bash
+pip install "arize-phoenix-client[pytest,evals]" pytest
+```
+
+pytest discovers the plugin automatically through its entry point — no `conftest.py` setup required.
+
+## Your first eval suite
+
+Here is a minimal example that evaluates a question-answering function:
+
+```python
+import pytest
+from phoenix.client.pytest import log_output, log_evaluation
+
+@pytest.mark.phoenix(dataset="qa-suite")
+@pytest.mark.parametrize(
+    "question,expected",
+    [
+        ("What is the capital of France?", "Paris"),
+        ("What is 12 multiplied by 8?", "96"),
+        ("Who wrote Hamlet?", "Shakespeare"),
+    ],
+    ids=["geography", "arithmetic", "literature"],
+)
+def test_answers(question, expected):
+    result = my_app(question)
+    log_output(result)
+    assert result == expected
+```
+
+Run it with your Phoenix connection set:
+
+```bash
+export PHOENIX_COLLECTOR_ENDPOINT=https://your-phoenix-host
+export PHOENIX_API_KEY=your-api-key        # if required
+pytest tests/evals/test_qa.py
+```
+
+The `ids` you supply to `parametrize` are important: they give each case a **stable identity**. Re-running the suite maps each case back to the same dataset example, so runs accumulate as experiments over a fixed set of examples rather than creating duplicates.
+
+## The `@pytest.mark.phoenix` marker
+
+The marker is what tells the plugin which tests to record. Tests without it run normally and are invisible to Phoenix.
+
+```python
+@pytest.mark.phoenix(
+    dataset="my-eval-suite",
+    evaluators=[correctness_evaluator],
+    repetitions=3,
+)
+def test_my_feature(input, expected): ...
+```
+
+| Argument | Description |
+|---|---|
+| `dataset` | Name of the Phoenix dataset and experiment. Defaults to the test file's relative path when omitted. |
+| `evaluators` | List of evaluators that run automatically against every case. |
+| `repetitions` | Run each case this many times to measure non-determinism. |
+
+### Dataset naming
+
+When you omit `dataset=`, the plugin uses the test file's path relative to your project root — for example `tests/evals/test_sql` — so tests in different files become separate datasets and two files that share a basename never collide.
+
+The full precedence order for dataset names is:
+
+1. `PHOENIX_TEST_DATASET` environment variable (highest — overrides everything)
+2. `phoenix_dataset` in `pytest.ini`
+3. The marker's `dataset=` keyword argument
+4. The file path (default)
+
+## Logging outputs and evaluations
+
+### `log_output(value)`
+
+Records the system-under-test's output for the current run. Pass anything JSON-serializable — a string, dict, or list. Because pytest warns when a test returns a non-`None` value, you pass the output to this helper rather than returning it.
+
+```python
+def test_summarize(document, expected_summary):
+    summary = summarizer(document)
+    log_output({"summary": summary})
+    assert len(summary) < len(document)
+```
+
+### `log_evaluation(name, score, label?, explanation?)`
+
+Records a named score on the current run. Use this to attach any metric you compute inline:
+
+```python
+def test_answers(question, expected):
+    result = my_app(question)
+    log_output(result)
+
+    exact = float(result.strip().lower() == expected.strip().lower())
+    log_evaluation(name="exact_match", score=exact, label="correct" if exact else "wrong")
+
+    assert result == expected
+```
+
+### `evaluate(evaluator, **kwargs)`
+
+Runs an evaluator callable and records its result as an annotation. The function returns the evaluator's result, so you can assert on it to gate the individual test:
+
+```python
+def correctness(output, expected, **_):
+    return {"name": "correctness", "score": float(output == expected)}
+
+def test_answers(question, expected):
+    answer = my_app(question)
+    log_output(answer)
+    result = evaluate(correctness, output=answer, expected=expected)
+    assert result["score"] == 1.0
+```
+
+A failed assertion after `evaluate()` records `pass=False` and fails the pytest item — making the evaluator score a CI gate.
+
+## Using pre-built Phoenix evaluators
+
+Evaluators from `arize-phoenix-evals` work directly with `evaluate()` and as hoisted evaluators on the marker:
+
+```python
+import pytest
+from phoenix.client.pytest import evaluate, log_output
+from phoenix.evals import HallucinationEvaluator, OpenAIModel
+
+hallucination = HallucinationEvaluator(model=OpenAIModel(model="gpt-4o"))
+
+@pytest.mark.phoenix(
+    dataset="rag-quality",
+    evaluators=[hallucination],
+)
+@pytest.mark.parametrize(
+    "context,question,answer",
+    [
+        ("The Eiffel Tower is in Paris.", "Where is the Eiffel Tower?", "It is in Paris."),
+        ("The Amazon is the longest river.", "What is the longest river?", "The Nile."),
+    ],
+    ids=["correct", "hallucination"],
+)
+def test_rag_answers(context, question, answer):
+    log_output({"answer": answer, "context": context})
+    # The hallucination evaluator runs automatically after every case
+```
+
+Hoisted evaluators are invoked using the same adapter as `run_experiment`, so an evaluator you wrote for one works identically under the other. Arguments are bound **by parameter name**:
+
+| Evaluator parameter | Source |
+|---|---|
+| `output` | What you passed to `log_output` |
+| `input` | The test's parametrized fields as a mapping |
+| `expected` / `reference` | Parametrized field of the same name, if present |
+| `metadata` | Parametrized field of the same name, if present |
+| `trace_id` | The test run's trace id |
+
+## Repetitions
+
+Run each case more than once to measure non-determinism in LLM outputs. Each repetition is a separate pytest item — visible to `-k`, `pytest-xdist`, and your IDE — and a separate experiment run in Phoenix. The Phoenix compare view lines them up for you.
+
+```python
+@pytest.mark.phoenix(dataset="creative-writing", repetitions=5)
+@pytest.mark.parametrize("prompt", ["Write a haiku about autumn."])
+def test_haiku_quality(prompt):
+    poem = my_llm(prompt)
+    log_output(poem)
+    score = evaluate_poem_quality(poem)
+    log_evaluation(name="quality", score=score)
+    assert score >= 0.6
+```
+
+Resolution order for `repetitions`: per-test marker argument → `PHOENIX_TEST_REPETITIONS` env var → `1`.
+
+## Environment variables
+
+The plugin is configured entirely through environment variables, so the same suite can behave differently in local development and in CI without code changes.
+
+| Variable | Default | Description |
+|---|---|---|
+| `PHOENIX_TEST_TRACKING` | `true` | Master switch. Set to `0` or `false` to run offline — tests execute but nothing is sent to Phoenix. |
+| `PHOENIX_TEST_REPETITIONS` | `1` | Default repetitions per marked test. |
+| `PHOENIX_TEST_DATASET` | _(file path)_ | Override the dataset name for all collected tests. |
+| `PHOENIX_COLLECTOR_ENDPOINT` | — | Your Phoenix server URL. |
+| `PHOENIX_API_KEY` | — | Bearer token for Phoenix. |
+| `PHOENIX_CLIENT_HEADERS` | — | Optional JSON headers forwarded to the Phoenix client. |
+
+To iterate locally without recording anything:
+
+```bash
+PHOENIX_TEST_TRACKING=0 pytest tests/evals/
+```
+
+Repetitions still expand when tracking is off — useful for surfacing flaky failures locally.
+
+## Running in parallel with pytest-xdist
+
+The plugin supports `pytest -n auto`. The controller creates the dataset and experiment once and distributes their IDs to workers, which record runs concurrently. Exactly one experiment is created regardless of worker count.
+
+```bash
+pip install pytest-xdist
+pytest -n auto tests/evals/
+```
+
+## How the dataset stays in sync
+
+On a **full run** (no path filter), the plugin _updates_ the dataset to match exactly the collected cases, pruning examples for tests that no longer exist.
+
+On a **partial run** (with `-k`, `-m`, a file, or a `::node` filter), the plugin only _appends_, leaving unselected examples in place. This prevents `pytest tests/evals/test_sql.py` from deleting the rest of your dataset.
+
+<Warning>
+Two full runs writing the **same dataset name at the same time** — for example, parallel CI jobs that don't set `PHOENIX_TEST_DATASET` — can prune each other's examples. For genuinely concurrent jobs, give each its own name:
+
+```bash
+PHOENIX_TEST_DATASET=evals-${GIT_BRANCH} pytest tests/evals/
+```
+</Warning>
+
+## Gating CI with GitHub Actions
+
+No additional configuration is needed to use pytest as a CI gate: the pytest exit code is `1` when any test fails, and `0` when all pass. A regression in LLM quality fails the job exactly like a broken import.
+
+```yaml
+name: eval-ci
+
+on:
+  pull_request:
+
+jobs:
+  evals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install "arize-phoenix-client[pytest,evals]" pytest
+      - name: Run eval suite
+        env:
+          PHOENIX_COLLECTOR_ENDPOINT: ${{ secrets.PHOENIX_COLLECTOR_ENDPOINT }}
+          PHOENIX_API_KEY: ${{ secrets.PHOENIX_API_KEY }}
+        run: pytest tests/evals/
+```
+
+<Tip>
+Uploads to Phoenix are best-effort and never fail a test. A network problem is reported as a warning rather than failing the build, so a transient Phoenix outage won't block your deploys.
+</Tip>
+
+## Complete example
+
+A full text-to-SQL eval suite with inline evaluation, hoisted evaluators, and a CI-ready structure:
+
+```python
+import pytest
+from phoenix.client.pytest import evaluate, log_evaluation, log_output
+
+# --- evaluators ---
+
+def valid_sql(output, **_):
+    import sqlparse
+    try:
+        sqlparse.parse(output["sql"])
+        return {"name": "valid_sql", "score": 1.0, "label": "valid"}
+    except Exception:
+        return {"name": "valid_sql", "score": 0.0, "label": "invalid"}
+
+
+def token_f1(output, expected, **_):
+    pred_tokens = set(output["sql"].lower().split())
+    ref_tokens = set((expected or {}).get("sql", "").lower().split())
+    if not ref_tokens:
+        return {"name": "token_f1", "score": 0.0}
+    precision = len(pred_tokens & ref_tokens) / len(pred_tokens) if pred_tokens else 0
+    recall = len(pred_tokens & ref_tokens) / len(ref_tokens)
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0
+    return {"name": "token_f1", "score": f1}
+
+
+# --- test suite ---
+
+CASES = [
+    {
+        "input": "Show all users",
+        "expected_sql": "SELECT * FROM users;",
+        "id": "select-all",
+    },
+    {
+        "input": "Count active subscriptions",
+        "expected_sql": "SELECT COUNT(*) FROM subscriptions WHERE status = 'active';",
+        "id": "count-active",
+    },
+    {
+        "input": "Top 5 customers by revenue",
+        "expected_sql": "SELECT customer_id, SUM(amount) AS revenue FROM orders GROUP BY customer_id ORDER BY revenue DESC LIMIT 5;",
+        "id": "top-customers",
+    },
+]
+
+
+@pytest.mark.phoenix(
+    dataset="text-to-sql",
+    evaluators=[valid_sql, token_f1],
+)
+@pytest.mark.parametrize(
+    "input,expected_sql",
+    [(c["input"], c["expected_sql"]) for c in CASES],
+    ids=[c["id"] for c in CASES],
+)
+def test_text_to_sql(input, expected_sql):
+    sql = my_sql_generator(input)
+    log_output({"sql": sql})
+    assert sql.strip().endswith(";"), "SQL must end with a semicolon"
+```
+
+Run it locally to verify everything before pushing:
+
+```bash
+PHOENIX_TEST_TRACKING=0 pytest tests/evals/test_sql.py -v
+```
+
+Then in CI, enable Phoenix and let the scores accumulate:
+
+```bash
+pytest tests/evals/test_sql.py
+```

--- a/docs/phoenix/evaluation/integrations/pytest.mdx
+++ b/docs/phoenix/evaluation/integrations/pytest.mdx
@@ -5,7 +5,7 @@ description: "Write LLM evaluations as ordinary pytest tests that run in CI and 
 
 The Phoenix pytest plugin bridges the gap between your test suite and your evaluation pipeline. You write evaluations as normal `pytest` tests — parametrized, marked, and run just like any other test — and Phoenix records each case as an experiment run so you can track quality over time.
 
-When a test passes, Phoenix records `pass=True`. When it fails, `pass=False`. Because the plugin hooks into pytest's own exit code, your existing CI gate works without any extra configuration: a regression in LLM quality fails the job the same way a broken import would.
+When a test passes, Phoenix records `pass=True`. When it fails, `pass=False`. Because the plugin hooks into pytest's own exit code, your existing CI gate works without any extra configuration.
 
 ## When to use the pytest plugin
 
@@ -171,25 +171,26 @@ Evaluators from `arize-phoenix-evals` work directly with `evaluate()` and as hoi
 ```python
 import pytest
 from phoenix.client.pytest import evaluate, log_output
-from phoenix.evals import HallucinationEvaluator, OpenAIModel
+from phoenix.evals import LLM
+from phoenix.evals.metrics import FaithfulnessEvaluator
 
-hallucination = HallucinationEvaluator(model=OpenAIModel(model="gpt-4o"))
+faithfulness = FaithfulnessEvaluator(llm=LLM(provider="openai", model="gpt-4o"))
 
 @pytest.mark.phoenix(
     dataset="rag-quality",
-    evaluators=[hallucination],
+    evaluators=[faithfulness],
 )
 @pytest.mark.parametrize(
-    "context,question,answer",
+    "input,context,answer",
     [
-        ("The Eiffel Tower is in Paris.", "Where is the Eiffel Tower?", "It is in Paris."),
-        ("The Amazon is the longest river.", "What is the longest river?", "The Nile."),
+        ("Where is the Eiffel Tower?", "The Eiffel Tower is in Paris.", "It is in Paris."),
+        ("What is the longest river?", "The Amazon is the longest river.", "The Nile."),
     ],
-    ids=["correct", "hallucination"],
+    ids=["faithful", "unfaithful"],
 )
-def test_rag_answers(context, question, answer):
-    log_output({"answer": answer, "context": context})
-    # The hallucination evaluator runs automatically after every case
+def test_rag_answers(input, context, answer):
+    log_output(answer)
+    # The faithfulness evaluator runs automatically after every case
 ```
 
 Hoisted evaluators are invoked using the same adapter as `run_experiment`, so an evaluator you wrote for one works identically under the other. Arguments are bound **by parameter name**:
@@ -203,7 +204,7 @@ Hoisted evaluators are invoked using the same adapter as `run_experiment`, so an
 | `trace_id` | The test run's trace id |
 
 <Tip>
-Any evaluator from [`arize-phoenix-evals`](/phoenix/evaluation/pre-built-metrics) works here — `HallucinationEvaluator`, `RelevanceEvaluator`, QA correctness, toxicity, and more — as does any plain function you'd pass to `run_experiment`. Write a custom evaluator once and use it from both.
+Any evaluator from [`arize-phoenix-evals`](/phoenix/evaluation/pre-built-metrics) works here — `FaithfulnessEvaluator`, `DocumentRelevanceEvaluator`, QA correctness, toxicity, and more — as does any plain function you'd pass to `run_experiment`. Write a custom evaluator once and use it from both.
 </Tip>
 
 ## Repetitions

--- a/docs/phoenix/evaluation/integrations/pytest.mdx
+++ b/docs/phoenix/evaluation/integrations/pytest.mdx
@@ -9,7 +9,7 @@ When a test passes, Phoenix records `pass=True`. When it fails, `pass=False`. Be
 
 ## When to use the pytest plugin
 
-Phoenix also offers [`run_experiment`](/phoenix/datasets-and-experiments/how-to-experiments/run-experiments) for evaluating a whole dataset with a single task and a shared set of evaluators. Reach for the pytest plugin instead when:
+Phoenix also offers [`run_experiment`](/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments) for evaluating a whole dataset with a single task and a shared set of evaluators. Reach for the pytest plugin instead when:
 
 - **Each case needs different logic.** `run_experiment` runs one task and the same evaluators across every example. When subsets of your system need different inputs, setup, or metrics, separate test functions are easier to express than one branching task.
 - **You want to assert hard expectations.** Tests turn an eval into a binary gate: a failed `assert` fails the pytest item, fails the run, and fails CI — exactly like any other broken test.
@@ -204,7 +204,7 @@ Hoisted evaluators are invoked using the same adapter as `run_experiment`, so an
 | `trace_id` | The test run's trace id |
 
 <Tip>
-Any evaluator from [`arize-phoenix-evals`](/phoenix/evaluation/pre-built-metrics) works here — `FaithfulnessEvaluator`, `DocumentRelevanceEvaluator`, QA correctness, toxicity, and more — as does any plain function you'd pass to `run_experiment`. Write a custom evaluator once and use it from both.
+Any evaluator from [`arize-phoenix-evals`](/docs/phoenix/evaluation/pre-built-metrics) works here — `FaithfulnessEvaluator`, `DocumentRelevanceEvaluator`, QA correctness, toxicity, and more — as does any plain function you'd pass to `run_experiment`. Write a custom evaluator once and use it from both.
 </Tip>
 
 ## Repetitions

--- a/docs/phoenix/evaluation/integrations/vitest-jest.mdx
+++ b/docs/phoenix/evaluation/integrations/vitest-jest.mdx
@@ -1,0 +1,544 @@
+---
+title: "Vitest / Jest"
+description: "Write LLM evaluations as Vitest or Jest tests that record results to Phoenix and gate CI."
+---
+
+`@arizeai/phoenix-client/vitest` and `@arizeai/phoenix-client/jest` let you write evaluations as ordinary test suites — using the `describe` / `test` API you already know — while automatically recording every run to Phoenix as a versioned experiment. LLM calls instrumented with OpenInference appear as child spans of each test's task span, giving you full trace visibility alongside your eval results.
+
+Each `describe()` block becomes a **Phoenix dataset** and a new **experiment**. Each `test()` becomes a **dataset example** plus a recorded **experiment run**. The assertion outcome is captured as a `pass` boolean annotation. Anything you log via `logOutput()`, `logAnnotation()`, or `evaluate()` lands on the run and shows up in the Phoenix UI.
+
+## How it works
+
+```
+describe()         →  Phoenix dataset + experiment
+test()             →  dataset example + experiment run
+assert outcome     →  "pass" annotation
+logOutput()        →  ExperimentRun.output
+logAnnotation()    →  named annotation on the run
+evaluate()         →  annotation + linked evaluator trace
+acceptanceCriteria →  CI gate on aggregate scores
+```
+
+Suite-level `acceptanceCriteria` can fail CI when aggregate metrics drop below a threshold — for example, when average correctness falls below `0.8` or more than 10% of runs produce invalid SQL.
+
+## Installation
+
+<CodeGroup>
+```bash npm
+npm install -D @arizeai/phoenix-client @arizeai/phoenix-evals dotenv
+```
+
+```bash pnpm
+pnpm add -D @arizeai/phoenix-client @arizeai/phoenix-evals dotenv
+```
+</CodeGroup>
+
+The Vitest entrypoint is bundled in `@arizeai/phoenix-client`. No separate package is needed.
+
+## Vitest setup
+
+Create a dedicated config file so eval suites don't get swept into your normal unit-test run:
+
+```ts
+// phoenix.vitest.config.ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.eval.?(c|m)[jt]s"],
+    reporters: ["default", "@arizeai/phoenix-client/vitest/reporter"],
+    setupFiles: ["dotenv/config"],
+    testTimeout: 30_000,
+  },
+});
+```
+
+- **`include`** keeps eval suites in `*.eval.ts` files separate from unit tests.
+- **`reporters`** keeps Vitest's default output and adds the Phoenix summary block.
+- **`setupFiles`** loads `PHOENIX_HOST`, `PHOENIX_API_KEY`, and other env vars from `.env`.
+- **`testTimeout`** is bumped because LLM calls can be slow.
+
+<Note>
+The `jsdom` test environment is not supported. Either omit `environment` or set it to `"node"`.
+</Note>
+
+Add a script to `package.json`:
+
+```json
+{
+  "scripts": {
+    "eval": "vitest run --config phoenix.vitest.config.ts"
+  }
+}
+```
+
+`vitest run` (not watch mode) is intentional — evaluations run once per CI job.
+
+## Jest setup
+
+Create a separate config file for eval suites:
+
+```js
+// phoenix.jest.config.cjs
+module.exports = {
+  testMatch: ["**/*.eval.?(c|m)[jt]s"],
+  reporters: ["default", "@arizeai/phoenix-client/jest/reporter"],
+  setupFiles: ["dotenv/config"],
+  testTimeout: 30_000,
+};
+```
+
+<Note>
+The `jsdom` test environment is not supported. Either omit `testEnvironment` or set it to `"node"`. For TypeScript or ESM projects, use `ts-jest` or `@swc/jest` per Jest's docs.
+</Note>
+
+Add a script to `package.json`:
+
+```json
+{
+  "scripts": {
+    "eval": "jest --config phoenix.jest.config.cjs"
+  }
+}
+```
+
+## Your first eval suite
+
+<CodeGroup>
+```ts Vitest
+// answer-quality.eval.ts
+import * as px from "@arizeai/phoenix-client/vitest";
+import { expect } from "vitest";
+
+px.describe("answer quality", () => {
+  px.test(
+    "capital city lookup",
+    {
+      input: { question: "What is the capital of France?" },
+      expected: { answer: "Paris" },
+    },
+    async ({ input, expected }) => {
+      const result = await myApp(input.question);
+      px.logOutput({ answer: result });
+      expect(result).toContain(expected?.answer ?? "");
+    },
+  );
+
+  px.test(
+    "arithmetic",
+    {
+      input: { question: "What is 12 × 8?" },
+      expected: { answer: "96" },
+    },
+    async ({ input, expected }) => {
+      const result = await myApp(input.question);
+      px.logOutput({ answer: result });
+      expect(result).toContain(expected?.answer ?? "");
+    },
+  );
+});
+```
+
+```ts Jest
+// answer-quality.eval.ts
+import * as px from "@arizeai/phoenix-client/jest";
+
+px.describe("answer quality", () => {
+  px.test(
+    "capital city lookup",
+    {
+      input: { question: "What is the capital of France?" },
+      expected: { answer: "Paris" },
+    },
+    async ({ input, expected }) => {
+      const result = await myApp(input.question);
+      px.logOutput({ answer: result });
+      expect(result).toContain(expected?.answer ?? "");
+    },
+  );
+});
+```
+</CodeGroup>
+
+Run it:
+
+```bash
+# Vitest
+npm run eval
+
+# Jest
+npm run eval
+```
+
+On first run, Phoenix creates the dataset and experiment. Subsequent runs add new experiments to the same dataset so you can compare quality over time.
+
+## Testing many examples with `test.each`
+
+For larger datasets, `test.each` keeps the suite concise:
+
+```ts
+import * as px from "@arizeai/phoenix-client/vitest";
+import { expect } from "vitest";
+
+const DATASET = [
+  { input: { query: "Get all users" }, expected: { sql: "SELECT * FROM users;" } },
+  { input: { query: "Count active subscribers" }, expected: { sql: "SELECT COUNT(*) FROM subscriptions WHERE status = 'active';" } },
+  { input: { query: "Top 5 customers by revenue" }, expected: { sql: "SELECT customer_id, SUM(amount) revenue FROM orders GROUP BY customer_id ORDER BY revenue DESC LIMIT 5;" } },
+];
+
+px.describe("text-to-sql", () => {
+  px.test.each(DATASET)("generates valid SQL %i", async ({ input, expected }) => {
+    const sql = await myApp(input.query);
+    px.logOutput({ sql });
+    expect(sql.trim()).toMatch(/;$/);
+  });
+});
+```
+
+The name template supports `%i` (index), `%s` (stringified), and `%j` (JSON). Without a placeholder the row index is appended automatically.
+
+## Logging outputs and annotations
+
+### `logOutput(value)`
+
+Records the system-under-test's output for the run. Everything you pass here shows up as `ExperimentRun.output` in Phoenix.
+
+```ts
+const result = await myApp(input.query);
+px.logOutput({ sql: result, latencyMs: Date.now() - start });
+```
+
+### `logAnnotation(annotation)`
+
+Records a named score, label, or explanation on the run. Use this for metrics you compute inline.
+
+```ts
+px.logAnnotation({
+  name: "valid_sql",
+  score: isValidSQL(result) ? 1 : 0,
+  label: isValidSQL(result) ? "valid" : "invalid",
+  annotatorKind: "CODE",
+});
+```
+
+The full `Annotation` shape:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `string` | Evaluation name. Required. |
+| `score` | `number \| boolean \| null` | Numeric or boolean score. Booleans are stored as 0 / 1. |
+| `label` | `string \| null` | Categorical label. |
+| `explanation` | `string \| null` | Free-form explanation, shown in the Phoenix UI. |
+| `metadata` | `Record<string, unknown>` | Custom metadata. |
+| `annotatorKind` | `"LLM" \| "CODE" \| "HUMAN"` | Source of the annotation. Defaults to `"CODE"`. |
+
+### `evaluate(evaluator, params?)`
+
+Runs an evaluator object and records its result as an annotation linked to an evaluator trace. This is the recommended approach when you want full trace visibility into the evaluator's LLM calls.
+
+```ts
+import * as px from "@arizeai/phoenix-client/vitest";
+import { createEvaluator } from "@arizeai/phoenix-evals";
+
+const correctness = createEvaluator(
+  async ({ output, expected }: { output: { answer: string }; expected: { answer: string } }) => {
+    const grade = await llmAsJudge(output.answer, expected.answer);
+    return {
+      score: grade.score,
+      label: grade.passed ? "correct" : "incorrect",
+      explanation: grade.rationale,
+    };
+  },
+  { name: "correctness", kind: "LLM" },
+);
+
+px.describe("qa eval", () => {
+  px.test(
+    "paris capital",
+    {
+      input: { question: "Capital of France?" },
+      expected: { answer: "Paris" },
+    },
+    async ({ input, expected }) => {
+      const answer = await myApp(input.question);
+      px.logOutput({ answer });
+      await px.evaluate(correctness, {
+        output: { answer },
+        expected: expected ?? { answer: "" },
+      });
+    },
+  );
+});
+```
+
+If `params` is omitted, Phoenix supplies the current test's `input`, recorded `output`, `expected`, `metadata`, and task `traceId` automatically.
+
+## Acceptance criteria — CI gates on aggregate scores
+
+Acceptance criteria let you fail CI when a quality metric drops across the full suite. They run _after_ all tests, so every case still executes and the reporter prints the full scorecard before failing — you see every regression in one run, not just the first.
+
+```ts
+px.describe("text-to-sql scorecard", () => {
+  // each test logs token_f1 (0–1), valid_sql (boolean), and latency_ms
+}, {
+  acceptanceCriteria: [
+    // overall quality: mean token_f1 must be ≥ 0.8
+    { annotationName: "token_f1", metric: "average", threshold: 0.8 },
+
+    // consistency: at least 90% of runs must score ≥ 0.7
+    {
+      annotationName: "token_f1",
+      metric: "passRate",
+      passFn: (a) => typeof a.score === "number" && a.score >= 0.7,
+      minPassRate: 0.9,
+    },
+
+    // hard floor: every run must produce valid SQL
+    {
+      annotationName: "valid_sql",
+      metric: "passRate",
+      passFn: (a) => a.score === true,
+      minPassRate: 1,
+    },
+
+    // budget: lower is better — mean latency must stay ≤ 800 ms
+    {
+      annotationName: "latency_ms",
+      metric: "average",
+      threshold: 800,
+      direction: "minimize",
+    },
+  ],
+});
+```
+
+### Criterion fields
+
+| Field | Description |
+|---|---|
+| `annotationName` | Annotation to aggregate. If a run logs the same annotation more than once, the last one counts. |
+| `metric` | `"average"` checks the mean of all numeric/boolean scores against `threshold`; `"passRate"` counts runs whose `passFn` returns `true` and requires that fraction to reach `minPassRate`. |
+| `threshold` | **`average` only.** The bar the mean must clear. |
+| `direction` | **`average` only.** `"maximize"` (default — higher is better, clears when `>=`) or `"minimize"` (lower is better, clears when `<=`). Use `"minimize"` for latency, cost, and error rates. |
+| `passFn` | **`passRate` only.** `(annotation) => boolean` predicate deciding whether a single run passes. |
+| `minPassRate` | **`passRate` only.** Minimum fraction of runs (`0`–`1`) that must pass (`1` = all). |
+
+<Tip>
+`passFn` receives the full annotation object — `score`, `label`, `explanation`, `metadata` — so you can gate on any combination. For example, `a.label === "correct" && a.score >= 0.8` or `a.score >= 0.5 && a.score <= 0.9`.
+</Tip>
+
+## Repetitions
+
+Run a test (or a whole suite) multiple times to measure non-determinism. Each repetition is a separate experiment run against the same dataset example, and the Phoenix compare view lines them up side by side.
+
+```ts
+px.describe("creative writing", () => {
+  px.test(
+    "haiku generation",
+    { input: { topic: "autumn" }, repetitions: 5 },
+    async ({ input }) => {
+      const poem = await myLLM(`Write a haiku about ${input.topic}.`);
+      px.logOutput({ poem });
+      px.logAnnotation({ name: "has_5_7_5", score: checkHaiku(poem) });
+    },
+  );
+});
+```
+
+Resolution order: per-test `repetitions` → suite `repetitions` → `PHOENIX_TEST_REPETITIONS` env var → `1`.
+
+## Dry-run mode
+
+Execute test bodies locally without creating anything in Phoenix — useful for iterating on prompts and evaluators:
+
+```bash
+# Whole run
+PHOENIX_TEST_TRACKING=false npm run eval
+
+# One suite in code
+px.describe("my suite", () => { ... }, { dryRun: true });
+
+# One test in code
+px.test("draft case", { input: { q: "..." }, dryRun: true }, async ({ input }) => { ... });
+```
+
+The reporter still prints a local summary even in dry-run mode.
+
+## Environment variables
+
+| Variable | Description |
+|---|---|
+| `PHOENIX_HOST` | Phoenix base URL |
+| `PHOENIX_API_KEY` | Bearer token for Phoenix |
+| `PHOENIX_CLIENT_HEADERS` | Optional JSON headers forwarded to the Phoenix client and tracer |
+| `PHOENIX_TEST_TRACKING` | Set to `false` to disable sync to Phoenix for the current run |
+| `PHOENIX_TEST_REPETITIONS` | Default number of times to run each test |
+| `PHOENIX_TEST_REPORTER` | Set to `verbose` to show every test row plus per-test output detail |
+| `PHOENIX_TEST_REPORTER_MAX_ROWS` | Max test rows shown per suite in compact mode (default `10`; failures are never hidden) |
+| `PHOENIX_TEST_COLOR` | Force ANSI color on/off (auto: on for a TTY, off in CI / `NO_COLOR`) |
+
+## Gating CI with GitHub Actions
+
+<CodeGroup>
+```yaml Vitest
+name: eval-ci
+
+on:
+  pull_request:
+
+jobs:
+  evals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci
+      - name: Run eval suite
+        env:
+          PHOENIX_HOST: ${{ secrets.PHOENIX_HOST }}
+          PHOENIX_API_KEY: ${{ secrets.PHOENIX_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: npm run eval
+```
+
+```yaml Jest
+name: eval-ci
+
+on:
+  pull_request:
+
+jobs:
+  evals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci
+      - name: Run eval suite
+        env:
+          PHOENIX_HOST: ${{ secrets.PHOENIX_HOST }}
+          PHOENIX_API_KEY: ${{ secrets.PHOENIX_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: npm run eval
+```
+</CodeGroup>
+
+The test runner's exit code is your CI gate. A failed assertion — or a failed acceptance criterion — exits with a non-zero code and fails the job.
+
+## Complete example
+
+A full text-to-SQL eval suite with inline evaluators, hoisted annotations, and acceptance criteria:
+
+```ts
+// sql-quality.eval.ts
+import * as px from "@arizeai/phoenix-client/vitest";
+import { createEvaluator } from "@arizeai/phoenix-evals";
+import { expect } from "vitest";
+
+// LLM-as-judge evaluator
+const sqlCorrectness = createEvaluator(
+  async ({
+    output,
+    expected,
+  }: {
+    output: { sql: string };
+    expected: { sql: string };
+  }) => {
+    const grade = await llmAsJudge(output.sql, expected.sql);
+    return {
+      score: grade.score,
+      label: grade.passed ? "correct" : "incorrect",
+      explanation: grade.rationale,
+    };
+  },
+  { name: "sql_correctness", kind: "LLM" },
+);
+
+const CASES = [
+  {
+    input: { query: "Get all users" },
+    expected: { sql: "SELECT * FROM users;" },
+  },
+  {
+    input: { query: "Count active subscribers" },
+    expected: { sql: "SELECT COUNT(*) FROM subscriptions WHERE status = 'active';" },
+  },
+  {
+    input: { query: "Top 5 customers by revenue" },
+    expected: {
+      sql: "SELECT customer_id, SUM(amount) AS revenue FROM orders GROUP BY customer_id ORDER BY revenue DESC LIMIT 5;",
+    },
+  },
+];
+
+px.describe(
+  "text-to-sql",
+  () => {
+    px.test.each(CASES)("generates SQL %i", async ({ input, expected }) => {
+      const start = performance.now();
+      const sql = await myApp(input.query);
+      const latency = performance.now() - start;
+
+      px.logOutput({ sql });
+      px.logAnnotation({
+        name: "latency_ms",
+        score: latency,
+        annotatorKind: "CODE",
+      });
+      px.logAnnotation({
+        name: "ends_with_semicolon",
+        score: sql.trim().endsWith(";"),
+        annotatorKind: "CODE",
+      });
+      await px.evaluate(sqlCorrectness, {
+        output: { sql },
+        expected: expected ?? { sql: "" },
+      });
+
+      expect(sql.trim()).toMatch(/;$/);
+    });
+  },
+  {
+    acceptanceCriteria: [
+      { annotationName: "sql_correctness", metric: "average", threshold: 0.8 },
+      {
+        annotationName: "ends_with_semicolon",
+        metric: "passRate",
+        passFn: (a) => a.score === true,
+        minPassRate: 1,
+      },
+      {
+        annotationName: "latency_ms",
+        metric: "average",
+        threshold: 2000,
+        direction: "minimize",
+      },
+    ],
+  },
+);
+```
+
+Run it locally without recording:
+
+```bash
+PHOENIX_TEST_TRACKING=false npm run eval
+```
+
+Then in CI, enable Phoenix and watch scores accumulate across experiments:
+
+```bash
+npm run eval
+```
+
+## Module map
+
+| Import | Purpose |
+|---|---|
+| `@arizeai/phoenix-client/vitest` | Vitest entrypoint — `describe`, `test`, `it`, `logOutput`, `logAnnotation`, `evaluate` |
+| `@arizeai/phoenix-client/vitest/reporter` | Vitest reporter — Phoenix-flavored summary at end of run |
+| `@arizeai/phoenix-client/jest` | Same API surface, wired to Jest globals |
+| `@arizeai/phoenix-client/jest/reporter` | Jest reporter |

--- a/docs/phoenix/evaluation/integrations/vitest-jest.mdx
+++ b/docs/phoenix/evaluation/integrations/vitest-jest.mdx
@@ -5,7 +5,17 @@ description: "Write LLM evaluations as Vitest or Jest tests that record results 
 
 `@arizeai/phoenix-client/vitest` and `@arizeai/phoenix-client/jest` let you write evaluations as ordinary test suites — using the `describe` / `test` API you already know — while automatically recording every run to Phoenix as a versioned experiment. LLM calls instrumented with OpenInference appear as child spans of each test's task span, giving you full trace visibility alongside your eval results.
 
-Each `describe()` block becomes a **Phoenix dataset** and a new **experiment**. Each `test()` becomes a **dataset example** plus a recorded **experiment run**. The assertion outcome is captured as a `pass` boolean annotation. Anything you log via `logOutput()`, `logAnnotation()`, or `evaluate()` lands on the run and shows up in the Phoenix UI.
+Each `describe()` block becomes a **Phoenix dataset** and a new **experiment**. Each `test()` becomes a **dataset example** plus a recorded **experiment run**. The assertion outcome is captured as a `pass` boolean annotation. Anything you log via `logOutput()`, `logAnnotation()`, `evaluate()`, or `traceEvaluator()` lands on the run and shows up in the Phoenix UI.
+
+## When to use Vitest / Jest
+
+Phoenix also offers [`runExperiment`](/phoenix/sdk-api-reference/typescript/packages/phoenix-client/experiments) for evaluating a whole dataset with one task and a shared set of evaluators. Reach for the test-runner integration instead when:
+
+- **Each case needs different logic.** `runExperiment` runs one task and the same evaluators across every example. When subsets of your system need different inputs, setup, or metrics, separate `test()` cases are easier to express than one branching task.
+- **You want to assert hard expectations.** A failed `expect()` fails the test, fails the run, and fails CI — and [acceptance criteria](#acceptance-criteria--ci-gates-on-aggregate-scores) let you gate the whole suite on aggregate scores.
+- **You already use Vitest or Jest.** Add Phoenix tracking to a suite you already run, keeping `test.each`, `.only` / `.skip`, mocks, and watch mode.
+
+For large, homogeneous datasets where every example is scored the same way, prefer `runExperiment` — it parallelizes the work and keeps each experiment and its dataset easy to manage.
 
 ## How it works
 
@@ -16,6 +26,7 @@ assert outcome     →  "pass" annotation
 logOutput()        →  ExperimentRun.output
 logAnnotation()    →  named annotation on the run
 evaluate()         →  annotation + linked evaluator trace
+traceEvaluator()   →  annotation + linked evaluator trace (wraps a plain fn)
 acceptanceCriteria →  CI gate on aggregate scores
 ```
 
@@ -23,17 +34,21 @@ Suite-level `acceptanceCriteria` can fail CI when aggregate metrics drop below a
 
 ## Installation
 
+<Info>
+Requires **`@arizeai/phoenix-client>=6.11.1`**. The testing API is in **beta** and may change in a future release.
+</Info>
+
 <CodeGroup>
 ```bash npm
-npm install -D @arizeai/phoenix-client @arizeai/phoenix-evals dotenv
+npm install -D @arizeai/phoenix-client@^6.11.1 @arizeai/phoenix-evals dotenv
 ```
 
 ```bash pnpm
-pnpm add -D @arizeai/phoenix-client @arizeai/phoenix-evals dotenv
+pnpm add -D @arizeai/phoenix-client@^6.11.1 @arizeai/phoenix-evals dotenv
 ```
 </CodeGroup>
 
-The Vitest entrypoint is bundled in `@arizeai/phoenix-client`. No separate package is needed.
+The Vitest and Jest entrypoints are bundled in `@arizeai/phoenix-client`. No separate package is needed.
 
 ## Vitest setup
 
@@ -172,6 +187,18 @@ npm run eval
 
 On first run, Phoenix creates the dataset and experiment. Subsequent runs add new experiments to the same dataset so you can compare quality over time.
 
+<Note>
+The reference output can be given under any one of three interchangeable keys — `expected`, `reference`, or `output` (at most one). All three become the dataset example's reference output and arrive as `expected` in the test body, so you can match whichever vocabulary your team or migration source uses:
+
+```ts
+px.test("via reference", { input: { ... }, reference: { sql: "..." } }, async ({ expected }) => {
+  // `reference` arrives here as `expected`
+});
+```
+
+`it` is the canonical alias for `test`; the two are identical.
+</Note>
+
 ## Testing many examples with `test.each`
 
 For larger datasets, `test.each` keeps the suite concise:
@@ -196,6 +223,44 @@ px.describe("text-to-sql", () => {
 ```
 
 The name template supports `%i` (index), `%s` (stringified), and `%j` (JSON). Without a placeholder the row index is appended automatically.
+
+## Running against an existing Phoenix dataset
+
+Instead of defining examples inline, you can pull them from a dataset that already lives in Phoenix — curated in the UI, captured from production traces, or built by a previous run — and fan out over them with `test.each`. Because `test.each` accepts any array, this works with **both Vitest and Jest**.
+
+Fetch the examples at module load with `getDatasetExamples`, map each to a row (`expected` carries the example's reference output), and pass the rows to `test.each`. Preserving each example's `id` upserts runs back onto the same examples so experiments line up across runs.
+
+```ts
+import * as px from "@arizeai/phoenix-client/vitest";
+import { getDatasetExamples } from "@arizeai/phoenix-client/datasets";
+import { expect } from "vitest";
+
+// Top-level await loads the dataset before the suite is declared.
+const { examples } = await getDatasetExamples({ dataset: { datasetName: "text-to-sql" } });
+
+const ROWS = examples.map((e) => ({
+  id: e.id, // keep the example id so runs upsert onto the same example
+  input: e.input,
+  expected: e.output,
+  metadata: e.metadata,
+}));
+
+px.describe("text-to-sql", () => {
+  px.test.each(ROWS)("generates valid SQL %i", async ({ input, expected }) => {
+    const sql = await myApp(input.query as string);
+    px.logOutput({ sql });
+    expect(sql.trim()).toMatch(/;$/);
+  });
+});
+```
+
+<Tip>
+Pass `splits: ["regression"]` (or a `versionId`) to `getDatasetExamples` to evaluate only a slice or a pinned version of the dataset.
+</Tip>
+
+<Note>
+The example loads the dataset with top-level `await`, which requires ESM — native in Vitest, and in Jest when configured for ESM. On CommonJS Jest, fetch the examples in an async bootstrap and reference them once resolved instead.
+</Note>
 
 ## Logging outputs and annotations
 
@@ -273,6 +338,35 @@ px.describe("qa eval", () => {
 
 If `params` is omitted, Phoenix supplies the current test's `input`, recorded `output`, `expected`, `metadata`, and task `traceId` automatically.
 
+### `traceEvaluator(fn, options?)`
+
+When you'd rather grade with a plain inline function than build an `Evaluator` object, wrap it with `traceEvaluator`. The wrapped function runs inside its own **evaluator span** — so an LLM-as-judge call is traced separately from the test's task — and if it returns an `{ name, score }`-shaped value, that result is captured as an annotation automatically.
+
+```ts
+const checkRelevance = px.traceEvaluator(
+  async ({ output }: { output: { answer: string } }) => {
+    const verdict = await llmAsJudge(output.answer);
+    return { name: "relevance", score: verdict.score, label: verdict.label };
+  },
+);
+
+px.test(
+  "stays on topic",
+  { input: { question: "Capital of France?" } },
+  async ({ input }) => {
+    const answer = await myApp(input.question);
+    px.logOutput({ answer });
+    await checkRelevance({ output: { answer } }); // "relevance" annotation + evaluator trace
+  },
+);
+```
+
+The annotation name defaults to the function's name, falling back to `"evaluator"`; override it with `{ name }`. Unlike `evaluate()`, `traceEvaluator()` passes through whatever arguments you give it rather than auto-supplying the test's `input` / `output` / `expected`.
+
+<Note>
+`evaluate()`, `traceEvaluator()`, and any annotation logged through them are recorded under a dedicated evaluator span, so the judge's LLM calls never clutter the task trace and each annotation links straight to the trace that produced it. Click an annotation in the Phoenix UI to open its evaluator trace.
+</Note>
+
 ## Acceptance criteria — CI gates on aggregate scores
 
 Acceptance criteria let you fail CI when a quality metric drops across the full suite. They run _after_ all tests, so every case still executes and the reporter prints the full scorecard before failing — you see every regression in one run, not just the first.
@@ -347,6 +441,23 @@ px.describe("creative writing", () => {
 
 Resolution order: per-test `repetitions` → suite `repetitions` → `PHOENIX_TEST_REPETITIONS` env var → `1`.
 
+## Focusing and skipping tests
+
+`px.test` and `px.describe` carry the same `.only` and `.skip` modifiers as your runner, so you can iterate on one case without running the whole suite:
+
+```ts
+px.describe("text-to-sql", () => {
+  px.test.only("the case I'm debugging", { input: { ... } }, async ({ input }) => { ... });
+  px.test.skip("not ready yet", { input: { ... } }, async ({ input }) => { ... });
+});
+
+// Focus or skip an entire suite:
+px.describe.only("just this suite", () => { ... });
+px.describe.skip("park this suite", () => { ... });
+```
+
+Focused (`.only`) tests run while their siblings in the same file are skipped — focus is file-scoped, so suites in other files still run. Skipped tests are never recorded: no dataset example and no experiment run are created for them. To track a case locally without recording it, use [dry-run mode](#dry-run-mode) instead of `.skip`.
+
 ## Dry-run mode
 
 Execute test bodies locally without creating anything in Phoenix — useful for iterating on prompts and evaluators:
@@ -363,6 +474,56 @@ px.test("draft case", { input: { q: "..." }, dryRun: true }, async ({ input }) =
 ```
 
 The reporter still prints a local summary even in dry-run mode.
+
+## Suite and test configuration
+
+Pass a config object as the third argument to `describe()` to control how the whole suite syncs to Phoenix:
+
+```ts
+px.describe("text-to-sql", () => { ... }, {
+  datasetName: "sql-evals-prod",        // override the dataset / experiment name
+  description: "Nightly SQL quality run",
+  metadata: { model: "gpt-4o", promptVersion: "v3" }, // recorded on every run
+  client: createClient({ options: { baseUrl: "https://my-phoenix" } }), // custom client
+  repetitions: 3,
+  dryRun: false,
+  acceptanceCriteria: [ ... ],
+});
+```
+
+| Field | Description |
+|---|---|
+| `datasetName` | Override the dataset / experiment name (defaults to the `describe` title). |
+| `description` | Description stored on the dataset and experiment. |
+| `metadata` | Metadata applied to every run in the experiment — filter experiments by it in the Phoenix UI. |
+| `client` | A custom client (from `createClient` in `@arizeai/phoenix-client`) used to sync this suite — set its base URL, headers, and auth. |
+| `repetitions` | Default repetitions for every test in the suite. |
+| `dryRun` | Run the whole suite locally without uploading anything. |
+| `acceptanceCriteria` | Aggregate score gates evaluated after all tests — see [Acceptance criteria](#acceptance-criteria--ci-gates-on-aggregate-scores). |
+
+Individual cases (and `test.each` rows) take their own fields alongside `input` and the reference output:
+
+| Field | Description |
+|---|---|
+| `id` | Stable example id. Reuse it across runs to upsert onto the same dataset example rather than creating a new one. |
+| `metadata` | Metadata stored on the example and its run. |
+| `splits` | Slice label(s) for the example (e.g. `["regression", "edge-case"]`), used to filter the dataset and experiment in the UI. |
+| `repetitions` | Per-test repetition count; overrides the suite value. |
+| `dryRun` | Run just this case locally without recording it. |
+| `config` | `{ tags?: string[]; metadata?: KVMap }` recorded on the experiment run — tag runs for filtering in the Phoenix UI. |
+
+```ts
+px.test(
+  "edge case: empty result set",
+  {
+    input: { query: "users created tomorrow" },
+    expected: { sql: "SELECT * FROM users WHERE created_at > NOW();" },
+    splits: ["regression", "edge-case"],
+    config: { tags: ["sql", "temporal"], metadata: { ticket: "ENG-1234" } },
+  },
+  async ({ input, expected }) => { ... },
+);
+```
 
 ## Environment variables
 
@@ -538,7 +699,8 @@ npm run eval
 
 | Import | Purpose |
 |---|---|
-| `@arizeai/phoenix-client/vitest` | Vitest entrypoint — `describe`, `test`, `it`, `logOutput`, `logAnnotation`, `evaluate` |
+| `@arizeai/phoenix-client/vitest` | Vitest entrypoint — `describe`, `test`, `it`, `logOutput`, `logAnnotation`, `evaluate`, `traceEvaluator` |
 | `@arizeai/phoenix-client/vitest/reporter` | Vitest reporter — Phoenix-flavored summary at end of run |
 | `@arizeai/phoenix-client/jest` | Same API surface, wired to Jest globals |
 | `@arizeai/phoenix-client/jest/reporter` | Jest reporter |
+| `@arizeai/phoenix-client/datasets` | Dataset helpers — e.g. `getDatasetExamples` for [running against an existing dataset](#running-against-an-existing-phoenix-dataset) |

--- a/docs/phoenix/evaluation/integrations/vitest-jest.mdx
+++ b/docs/phoenix/evaluation/integrations/vitest-jest.mdx
@@ -9,7 +9,7 @@ Each `describe()` block becomes a **Phoenix dataset** and a new **experiment**. 
 
 ## When to use Vitest / Jest
 
-Phoenix also offers [`runExperiment`](/phoenix/sdk-api-reference/typescript/packages/phoenix-client/experiments) for evaluating a whole dataset with one task and a shared set of evaluators. Reach for the test-runner integration instead when:
+Phoenix also offers [`runExperiment`](/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/experiments) for evaluating a whole dataset with one task and a shared set of evaluators. Reach for the test-runner integration instead when:
 
 - **Each case needs different logic.** `runExperiment` runs one task and the same evaluators across every example. When subsets of your system need different inputs, setup, or metrics, separate `test()` cases are easier to express than one branching task.
 - **You want to assert hard expectations.** A failed `expect()` fails the test, fails the run, and fails CI — and [acceptance criteria](#acceptance-criteria--ci-gates-on-aggregate-scores) let you gate the whole suite on aggregate scores.

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -13,6 +13,18 @@ GitHub
 **We want to hear from you!** The DevRel team wants to hear from the Phoenix community. If you're building with Phoenix and want to tell us what's working, what's painful, or what you wish existed, [grab 25 minutes with us](https://cal.com/team/arize-devrel/user-interview).
 </Info>
 
+<ReleaseUpdate label="06.26.2026" href="/docs/phoenix/release-notes/06-2026/06-26-2026-eval-ci-pytest-vitest-jest" title="Evals as Tests — pytest and Vitest/Jest Integrations">
+**Available in arize-phoenix-client 2.10.0+ (Python) and @arizeai/phoenix-client 6.11.1+ (TypeScript, beta)**
+
+Write LLM evaluations as ordinary pytest, Vitest, or Jest tests — each suite becomes a Phoenix dataset and each run a versioned experiment.
+
+- **Familiar DX** — mark tests with `@pytest.mark.phoenix` or import `describe`/`test` from `@arizeai/phoenix-client/vitest`; keep fixtures, parametrization, watch mode, and `.only`/`.skip`
+- **Debug in Phoenix** — every case is traced; LLM-as-judge calls record under their own evaluator span
+- **Metrics beyond pass/fail** — log scores, labels, and explanations and track them across experiments
+- **CI gates** — per-case asserts plus suite-level acceptance criteria on aggregate scores
+- **Reuse evaluators** — pre-built `arize-phoenix-evals` evaluators plug straight into a test case
+</ReleaseUpdate>
+
 <ReleaseUpdate label="06.24.2026" href="/docs/phoenix/release-notes/06-2026/06-24-2026-annotations-labels-and-pxi-server-tools" title="Annotations, Labels, and PXI Server Tools">
 **Available in arize-phoenix 17.9.0+ through 17.11.0+**
 

--- a/docs/phoenix/release-notes/06-2026/06-26-2026-eval-ci-pytest-vitest-jest.mdx
+++ b/docs/phoenix/release-notes/06-2026/06-26-2026-eval-ci-pytest-vitest-jest.mdx
@@ -1,0 +1,128 @@
+---
+title: "06.26.2026: Evals as Tests — pytest and Vitest/Jest Integrations"
+description: "Write LLM evaluations as ordinary pytest, Vitest, or Jest tests that record every run to Phoenix and gate CI."
+---
+
+Evaluations are how you keep an LLM application reliable as it changes. If you come from software engineering, you already have a tool for that job: tests. Phoenix now lets you write evals as ordinary **pytest**, **Vitest**, or **Jest** tests — the same `describe`/`test`/`assert` workflow you already use — while every run is recorded to Phoenix as a versioned experiment you can debug, compare, and share.
+
+**Available in arize-phoenix-client 2.10.0+ (Python pytest plugin) and @arizeai/phoenix-client 6.11.1+ (TypeScript Vitest/Jest, beta)**
+
+## Why run evals as tests
+
+If your team already lives in pytest or Vitest/Jest, these integrations give you that exact developer experience — fixtures, parametrization, watch mode, `.only`/`.skip`, mocks — backed by Phoenix's observability and collaboration. The mapping is direct: each suite becomes a **dataset**, each case becomes a **dataset example**, and each run of the suite becomes an **experiment**.
+
+- **Debug failures in Phoenix.** LLM apps are nondeterministic, which makes failures hard to chase down from a terminal alone. Every test case is traced — inputs, outputs, and the full span tree — so a failing assertion links straight to the trace that produced it. Evaluator (LLM-as-judge) calls are captured under their own evaluator span, so judge logic never clutters the task trace.
+- **Track metrics beyond pass/fail.** Tests usually only tell you green or red. LLM quality is rarely that binary. Log any score, label, or explanation per case with `log_evaluation` / `logAnnotation`, and Phoenix tracks it across experiments so you can watch quality trend over time instead of just blocking on a hard threshold.
+- **Gate CI on aggregate quality.** Beyond per-case asserts, define **acceptance criteria** that fail the suite when an aggregate metric slips — mean correctness below `0.8`, fewer than 90% of runs passing, or mean latency above a budget. They run after every case, so one CI run surfaces every regression, not just the first.
+- **Share results with your team.** Building with LLMs is a team sport — subject-matter experts weigh in on prompts and rubrics. Experiments live in Phoenix, so anyone can open a run, inspect a trace, and compare against history without rerunning anything locally.
+- **Reuse pre-built evaluators.** Hallucination, relevance, QA correctness, toxicity, and more from `arize-phoenix-evals` (and `@arizeai/phoenix-evals`) plug directly into a test case — the same evaluator you'd pass to `run_experiment` works unchanged here.
+
+## Get started with pytest
+
+Mark a test with `@pytest.mark.phoenix` and log inputs, outputs, and scores with the helpers from `phoenix.client.pytest`. Here a text-to-SQL app is checked for both an inline LLM-as-judge score and a hard assertion.
+
+```bash
+pip install "arize-phoenix-client[pytest,evals]" pytest
+```
+
+```python
+import pytest
+from phoenix.client.pytest import evaluate, log_evaluation, log_output
+
+def llm_judge(output, expected, **_):
+    # Your LLM-as-judge call; returns 1.0 when semantically equivalent.
+    return {"name": "correctness", "score": grade(output, expected)}
+
+@pytest.mark.phoenix(dataset="text-to-sql")
+@pytest.mark.parametrize(
+    "user_query,expected_sql",
+    [
+        ("Get all users from the customers table", "SELECT * FROM customers;"),
+        ("what's up", "Sorry, that is not a valid query."),
+    ],
+    ids=["select-all", "offtopic"],
+)
+def test_generate_sql(user_query, expected_sql):
+    sql = generate_sql(user_query)
+    log_output({"sql": sql})
+
+    # Inline score, traced as its own evaluator span and tracked over time.
+    result = evaluate(llm_judge, output=sql, expected=expected_sql)
+    log_evaluation(name="ends_with_semicolon", score=float(sql.strip().endswith(";")))
+
+    assert result["score"] == 1.0
+```
+
+Run it like any other test suite:
+
+```bash
+PHOENIX_COLLECTOR_ENDPOINT=https://your-phoenix-host pytest tests/evals/
+```
+
+This runs as a normal pytest invocation while logging every case, trace, and score to Phoenix. The plugin works with `pytest-asyncio`, `pytest-xdist` (`-n auto` still creates exactly one experiment), fixtures, and `parametrize`. Set `PHOENIX_TEST_TRACKING=0` to iterate locally without recording.
+
+## Get started with Vitest / Jest
+
+Import `describe`/`test` from the `@arizeai/phoenix-client/vitest` (or `/jest`) entrypoint and add the Phoenix reporter. Suite-level acceptance criteria turn aggregate quality into a CI gate.
+
+```bash
+npm install -D @arizeai/phoenix-client @arizeai/phoenix-evals
+```
+
+```ts
+import * as px from "@arizeai/phoenix-client/vitest";
+import { createEvaluator } from "@arizeai/phoenix-evals";
+import { expect } from "vitest";
+
+const correctness = createEvaluator(
+  async ({ output, expected }: { output: { sql: string }; expected: { sql: string } }) => {
+    const grade = await llmAsJudge(output.sql, expected.sql);
+    return { score: grade.score, label: grade.passed ? "correct" : "incorrect" };
+  },
+  { name: "correctness", kind: "LLM" },
+);
+
+px.describe(
+  "generate sql demo",
+  () => {
+    px.test(
+      "offtopic input",
+      {
+        input: { userQuery: "what's up" },
+        expected: { sql: "Sorry, that is not a valid query." },
+      },
+      async ({ input, expected }) => {
+        const sql = await generateSql(input.userQuery);
+        px.logOutput({ sql });
+        // Automatically logs "correctness" as an annotation with its own evaluator trace.
+        await px.evaluate(correctness, { output: { sql }, expected });
+        expect(sql.trim()).toMatch(/;$/);
+      },
+    );
+  },
+  { acceptanceCriteria: [{ annotationName: "correctness", metric: "average", threshold: 0.8 }] },
+);
+```
+
+The Phoenix reporter prints a scoreboard and results table locally, and the runner's exit code is your CI gate — a failed assertion or a missed acceptance criterion fails the job. The TypeScript testing API is in **beta**; we'd love your feedback.
+
+## Testing frameworks vs. `run_experiment`
+
+Phoenix already offers `run_experiment` (and `runExperiment` in TypeScript): define a dataset up front, then run one task and a shared set of evaluators across every example. That's the right tool for large, homogeneous datasets — black-box testing where every case is scored the same way, parallelized automatically.
+
+The test-runner integrations shine where that uniform shape gets in the way:
+
+- **Per-case evaluation logic.** When you're testing an agent with several tools, how you grade a search call and a code-execution call can be completely different. Separate test cases with their own evaluators are far more natural than one branching global evaluator.
+- **Real-time local feedback.** Watch mode, `.only`, and mocks give you a tight iteration loop while you're developing — fix issues as you spot them, before anything syncs.
+- **Native CI integration.** Pass/fail criteria, assertion errors, and exit codes are what test runners already do. Dropping evals into an existing CI pipeline catches regressions with no new machinery.
+
+You don't have to choose globally — use `run_experiment` for broad dataset sweeps and tests for targeted, heterogeneous checks, all recording to the same Phoenix experiments.
+
+<CardGroup cols={2}>
+  <Card title="Evals with pytest" icon="python" href="/docs/phoenix/evaluation/integrations/pytest">
+    Full how-to: markers, logging, repetitions, xdist, and CI setup.
+  </Card>
+  <Card title="Evals with Vitest / Jest" icon="js" href="/docs/phoenix/evaluation/integrations/vitest-jest">
+    Full how-to: setup, evaluators, acceptance criteria, and CI setup.
+  </Card>
+</CardGroup>

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,7 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/06-2026/06-26-2026-eval-ci-pytest-vitest-jest" arrow="true" title="06.26.2026" icon="calendar" description="Write LLM evals as pytest, Vitest, or Jest tests that record every run to Phoenix as a versioned experiment — familiar DX, full traces, metrics beyond pass/fail, and acceptance-criteria CI gates (arize-phoenix-client 2.10.0; @arizeai/phoenix-client 6.11.1 beta)"/>
     <Card href="/docs/phoenix/release-notes/06-2026/06-24-2026-annotations-labels-and-pxi-server-tools" arrow="true" title="06.24.2026" icon="calendar" description="Trace-level annotations in the trace header and project stats; label management and usage counts on the Prompts and Datasets lists; OAuth2 role-override preservation; a server-side bash tool for PXI subagents (17.9–17.11)"/>
     <Card href="/docs/phoenix/release-notes/06-2026/06-16-2026-time-range-metrics-and-sharing" arrow="true" title="06.16.2026" icon="calendar" description="Calendar time range picker with pan, zoom, and live streaming controls; shareable trace URLs; trace, session, and token detail metrics; opt-in PXI subagents (17.5–17.7)"/>
     <Card href="/docs/phoenix/release-notes/06-2026/06-11-2026-time-range-and-pxi-slash-commands" arrow="true" title="06.11.2026" icon="calendar" description="Searchable time range selector with free-form durations (25m, 2h, 3d); PXI slash commands and dataset evaluator editing"/>


### PR DESCRIPTION
## Summary

- Adds a new **Evaluation → Integrations** section to the docs navigation
- New page: **pytest** — comprehensive guide covering installation, `@pytest.mark.phoenix`, `log_output`/`log_evaluation`/`evaluate`, pre-built Phoenix evaluators, repetitions, env vars, pytest-xdist, dataset sync behavior, and GitHub Actions CI setup; includes a complete text-to-SQL example
- New page: **Vitest / Jest** — comprehensive guide covering setup for both test runners, `describe`/`test`/`test.each`, `logOutput`/`logAnnotation`/`evaluate` with `createEvaluator`, acceptance criteria (average + passRate + direction), repetitions, dry-run mode, env vars, and GitHub Actions CI setup; includes a complete text-to-SQL example with LLM-as-judge

## Test plan

- [ ] Verify `docs.json` navigation renders the new Integrations group under Evaluation
- [ ] Check that `docs/phoenix/evaluation/integrations/pytest.mdx` renders correctly in Mintlify
- [ ] Check that `docs/phoenix/evaluation/integrations/vitest-jest.mdx` renders correctly in Mintlify
- [ ] Verify all code examples are syntactically correct
- [ ] Verify internal links (cross-references to existing pages) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kxSpEDnR6J1tNTjgYzTbF

---
_Generated by [Claude Code](https://claude.ai/code/session_015kxSpEDnR6J1tNTjgYzTbF)_