### PR TITLE
feat(pxi): add slash command support with /clear and syntax highlighting

### DIFF
--- a/js/.changeset/pxi-slash-commands.md
+++ b/js/.changeset/pxi-slash-commands.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": patch
+---
+
+**PXI:** Add slash command support to the `pxi` terminal client. Type `/clear` to reset the conversation history, `/exit` to quit, or `/help` to list available commands. The input prompt now syntax-highlights command tokens in yellow and shows a live completion list while you type.

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -254,7 +254,10 @@ function InputPrompt({ draft, status }: { draft: string; status: PxiStatus }) {
               <Text color="yellow" bold>
                 {cmd.name}
               </Text>
-              <Text dimColor>{"  "}{cmd.description}</Text>
+              <Text dimColor>
+                {"  "}
+                {cmd.description}
+              </Text>
             </Text>
           ))}
         </Box>
@@ -410,11 +413,19 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
         const helpReply: PxiMessage = {
           id: crypto.randomUUID(),
           role: "assistant",
-          parts: [{ type: "text", text: `Available commands:\n${helpLines}`, state: "done" }],
+          parts: [
+            {
+              type: "text",
+              text: `Available commands:\n${helpLines}`,
+              state: "done",
+            },
+          ],
         };
         setMessages((m) => [...m, helpMessage, helpReply]);
       } else if (result.type === "unknown") {
-        setError(`Unknown command: /${result.name}. Type /help to see available commands.`);
+        setError(
+          `Unknown command: /${result.name}. Type /help to see available commands.`
+        );
       }
       return;
     }

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -2,6 +2,12 @@ import { Box, Text, useApp, useInput } from "ink";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 
 import { createPxiChatClient, createUserMessage } from "./client";
+import {
+  getSlashCommandName,
+  matchingCommands,
+  runSlashCommand,
+  SLASH_COMMANDS,
+} from "./commands";
 import { Markdown } from "./inkMarkdown";
 import { getToolProgressFromPart, type ToolProgress } from "./toolProgress";
 import type { PxiChatClient, PxiMessage, PxiRuntimeOptions } from "./types";
@@ -178,9 +184,52 @@ function Transcript({
   );
 }
 
+/**
+ * Render the draft text with slash-command syntax highlighting.
+ *
+ * When the draft starts with `/`, the command name is colored yellow and the
+ * arguments follow in default color. Everything else renders as plain text.
+ */
+function HighlightedDraft({ draft }: { draft: string }) {
+  if (!draft.startsWith("/")) {
+    return <Text>{draft}</Text>;
+  }
+  const rest = draft.slice(1);
+  const spaceIndex = rest.indexOf(" ");
+  if (spaceIndex === -1) {
+    // Still typing the command name — color the whole token
+    return (
+      <Text>
+        <Text color="yellow">/</Text>
+        <Text color="yellow" bold>
+          {rest}
+        </Text>
+      </Text>
+    );
+  }
+  const cmdName = rest.slice(0, spaceIndex);
+  const args = rest.slice(spaceIndex);
+  return (
+    <Text>
+      <Text color="yellow">/</Text>
+      <Text color="yellow" bold>
+        {cmdName}
+      </Text>
+      <Text>{args}</Text>
+    </Text>
+  );
+}
+
 /** Render the prompt row with helper text below it. */
 function InputPrompt({ draft, status }: { draft: string; status: PxiStatus }) {
   const cursor = status === "streaming" ? "" : "█";
+  const cmdName = getSlashCommandName(draft);
+  // Show matching commands while the user is still typing the command token
+  // (no space yet means they haven't moved on to arguments).
+  const showHints =
+    cmdName !== null && !draft.includes(" ") && draft.length > 1;
+  const hints = showHints ? matchingCommands(cmdName) : [];
+
   return (
     <Box flexDirection="column" marginTop={1} gap={1}>
       <Box
@@ -193,14 +242,28 @@ function InputPrompt({ draft, status }: { draft: string; status: PxiStatus }) {
       >
         <Text>
           <Text color="cyan">{"> "}</Text>
-          {draft}
+          <HighlightedDraft draft={draft} />
           {cursor}
         </Text>
       </Box>
-      <Text dimColor>
-        Enter sends. Shift+Enter inserts a newline. Esc interrupts a reply.
-        Ctrl+D or Ctrl+C exits.
-      </Text>
+      {hints.length > 0 ? (
+        <Box flexDirection="column">
+          {hints.map((cmd) => (
+            <Text key={cmd.name}>
+              <Text color="yellow">{"  /"}</Text>
+              <Text color="yellow" bold>
+                {cmd.name}
+              </Text>
+              <Text dimColor>{"  "}{cmd.description}</Text>
+            </Text>
+          ))}
+        </Box>
+      ) : (
+        <Text dimColor>
+          Enter sends. Shift+Enter inserts a newline. Esc interrupts. Type /help
+          for commands. Ctrl+D or Ctrl+C exits.
+        </Text>
+      )}
     </Box>
   );
 }
@@ -320,11 +383,42 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
     setStatus("idle");
   };
 
+  const clearMessages = () => {
+    setMessages([]);
+    setError(null);
+    setDraft("");
+  };
+
   const submitDraft = () => {
     const text = draft.trim();
     if (!text || status === "streaming") {
       return;
     }
+
+    // Intercept slash commands before sending to the server.
+    if (text.startsWith("/")) {
+      setDraft("");
+      const result = runSlashCommand(text, {
+        clearMessages,
+        exit: handleExit,
+      });
+      if (result.type === "help") {
+        const helpLines = SLASH_COMMANDS.map(
+          (c) => `  \`/${c.name}\` — ${c.description}`
+        ).join("\n");
+        const helpMessage = createUserMessage({ text });
+        const helpReply: PxiMessage = {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          parts: [{ type: "text", text: `Available commands:\n${helpLines}`, state: "done" }],
+        };
+        setMessages((m) => [...m, helpMessage, helpReply]);
+      } else if (result.type === "unknown") {
+        setError(`Unknown command: /${result.name}. Type /help to see available commands.`);
+      }
+      return;
+    }
+
     const userMessage = createUserMessage({ text });
     const nextMessages = [...messages, userMessage];
     const abortController = new AbortController();

--- a/js/packages/phoenix-cli/src/pxi/commands.ts
+++ b/js/packages/phoenix-cli/src/pxi/commands.ts
@@ -1,0 +1,91 @@
+/**
+ * Client-side slash commands for the PXI chat UI.
+ *
+ * Commands are intercepted before the input reaches the server, so they run
+ * instantly and never consume a network round-trip.
+ */
+
+export type CommandContext = {
+  clearMessages: () => void;
+  exit: () => void;
+};
+
+export type PxiCommand = {
+  /** The name after the leading slash, e.g. "clear" for `/clear`. */
+  name: string;
+  description: string;
+  handler: (args: string, ctx: CommandContext) => void;
+};
+
+export const SLASH_COMMANDS: PxiCommand[] = [
+  {
+    name: "clear",
+    description: "Clear the conversation history",
+    handler: (_args, ctx) => ctx.clearMessages(),
+  },
+  {
+    name: "exit",
+    description: "Exit PXI",
+    handler: (_args, ctx) => ctx.exit(),
+  },
+  {
+    name: "help",
+    description: "Show available slash commands",
+    handler: (_args, _ctx) => {
+      // handled specially in the UI to print the command list
+    },
+  },
+];
+
+const COMMAND_MAP = new Map(SLASH_COMMANDS.map((c) => [c.name, c]));
+
+export type SlashCommandResult =
+  | { type: "unknown"; name: string }
+  | { type: "handled" }
+  | { type: "help" };
+
+/**
+ * Parse and dispatch a slash command string. Returns a result describing what
+ * happened so the caller can react (e.g. display an error for unknown commands).
+ *
+ * @param input - The full draft string, expected to start with `/`.
+ */
+export function runSlashCommand(
+  input: string,
+  ctx: CommandContext
+): SlashCommandResult {
+  const withoutSlash = input.slice(1).trimStart();
+  const spaceIndex = withoutSlash.indexOf(" ");
+  const name =
+    spaceIndex === -1
+      ? withoutSlash
+      : withoutSlash.slice(0, spaceIndex).toLowerCase();
+  const args =
+    spaceIndex === -1 ? "" : withoutSlash.slice(spaceIndex + 1).trim();
+
+  if (name === "help") {
+    return { type: "help" };
+  }
+
+  const command = COMMAND_MAP.get(name);
+  if (!command) {
+    return { type: "unknown", name };
+  }
+
+  command.handler(args, ctx);
+  return { type: "handled" };
+}
+
+/** Return the command name being typed, or null if the input isn't a slash command. */
+export function getSlashCommandName(draft: string): string | null {
+  if (!draft.startsWith("/")) return null;
+  const rest = draft.slice(1);
+  const spaceIndex = rest.indexOf(" ");
+  return spaceIndex === -1 ? rest : rest.slice(0, spaceIndex);
+}
+
+/** Return commands whose names start with the given prefix (case-insensitive). */
+export function matchingCommands(prefix: string): PxiCommand[] {
+  const lower = prefix.toLowerCase();
+  return SLASH_COMMANDS.filter((c) => c.name.startsWith(lower));
+}

--- a/js/packages/phoenix-cli/src/pxi/commands.ts
+++ b/js/packages/phoenix-cli/src/pxi/commands.ts
@@ -56,10 +56,9 @@ export function runSlashCommand(
 ): SlashCommandResult {
   const withoutSlash = input.slice(1).trimStart();
   const spaceIndex = withoutSlash.indexOf(" ");
-  const name =
-    spaceIndex === -1
-      ? withoutSlash
-      : withoutSlash.slice(0, spaceIndex).toLowerCase();
+  const name = (
+    spaceIndex === -1 ? withoutSlash : withoutSlash.slice(0, spaceIndex)
+  ).toLowerCase();
   const args =
     spaceIndex === -1 ? "" : withoutSlash.slice(spaceIndex + 1).trim();
 

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -291,6 +291,111 @@ describe("PXI app", () => {
     unmount();
   });
 
+  it("shows command completions while typing a slash command name", async () => {
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await act(async () => {
+      stdin.write("/cl");
+    });
+
+    const frame = stripAnsi(lastFrame() ?? "");
+    expect(frame).toContain("/clear");
+    expect(frame).toContain("Clear the conversation history");
+    unmount();
+  });
+
+  it("hides completions once the user types a space after the command name", async () => {
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await act(async () => {
+      stdin.write("/clear ");
+    });
+
+    const frame = stripAnsi(lastFrame() ?? "");
+    expect(frame).toContain("Enter sends.");
+    unmount();
+  });
+
+  it("/clear resets the conversation history", async () => {
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const initialMessages: PxiMessage[] = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "hi there", state: "done" }],
+      },
+    ];
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp
+        options={createOptions()}
+        client={client}
+        initialMessages={initialMessages}
+      />
+    );
+
+    expect(lastFrame()).toContain("hi there");
+
+    await act(async () => {
+      stdin.write("/clear");
+    });
+    await act(async () => {
+      stdin.write("\r");
+    });
+
+    expect(stripAnsi(lastFrame() ?? "")).toContain("Phoenix Intelligence.");
+    expect(lastFrame()).not.toContain("hi there");
+    unmount();
+  });
+
+  it("/help prints the command list in the transcript", async () => {
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await act(async () => {
+      stdin.write("/help");
+    });
+    await act(async () => {
+      stdin.write("\r");
+    });
+
+    const frame = stripAnsi(lastFrame() ?? "");
+    expect(frame).toContain("/clear");
+    expect(frame).toContain("/help");
+    expect(frame).toContain("/exit");
+    unmount();
+  });
+
+  it("shows an error for unknown slash commands", async () => {
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await act(async () => {
+      stdin.write("/notacommand");
+    });
+    await act(async () => {
+      stdin.write("\r");
+    });
+
+    const frame = stripAnsi(lastFrame() ?? "");
+    expect(frame).toContain("Unknown command: /notacommand");
+    unmount();
+  });
+
   it("renders assistant Phoenix-relative links with the configured endpoint", () => {
     const assistantMessage: PxiMessage = {
       id: "assistant-1",

--- a/js/packages/phoenix-cli/test/pxiCommands.test.ts
+++ b/js/packages/phoenix-cli/test/pxiCommands.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  getSlashCommandName,
+  matchingCommands,
+  runSlashCommand,
+  SLASH_COMMANDS,
+} from "../src/pxi/commands";
+
+describe("SLASH_COMMANDS", () => {
+  it("includes clear, exit, and help", () => {
+    const names = SLASH_COMMANDS.map((c) => c.name);
+    expect(names).toContain("clear");
+    expect(names).toContain("exit");
+    expect(names).toContain("help");
+  });
+});
+
+describe("runSlashCommand", () => {
+  it("calls clearMessages for /clear", () => {
+    const clearMessages = vi.fn();
+    const result = runSlashCommand("/clear", { clearMessages, exit: vi.fn() });
+    expect(clearMessages).toHaveBeenCalledOnce();
+    expect(result).toEqual({ type: "handled" });
+  });
+
+  it("calls exit for /exit", () => {
+    const exit = vi.fn();
+    const result = runSlashCommand("/exit", { clearMessages: vi.fn(), exit });
+    expect(exit).toHaveBeenCalledOnce();
+    expect(result).toEqual({ type: "handled" });
+  });
+
+  it("returns help result for /help", () => {
+    const result = runSlashCommand("/help", {
+      clearMessages: vi.fn(),
+      exit: vi.fn(),
+    });
+    expect(result).toEqual({ type: "help" });
+  });
+
+  it("returns unknown result for unrecognized commands", () => {
+    const result = runSlashCommand("/foobar", {
+      clearMessages: vi.fn(),
+      exit: vi.fn(),
+    });
+    expect(result).toEqual({ type: "unknown", name: "foobar" });
+  });
+
+  it("is case-insensitive for command names", () => {
+    const clearMessages = vi.fn();
+    runSlashCommand("/CLEAR", { clearMessages, exit: vi.fn() });
+    expect(clearMessages).toHaveBeenCalledOnce();
+  });
+
+  it("ignores arguments after the command name", () => {
+    const clearMessages = vi.fn();
+    runSlashCommand("/clear extra args", { clearMessages, exit: vi.fn() });
+    expect(clearMessages).toHaveBeenCalledOnce();
+  });
+});
+
+describe("getSlashCommandName", () => {
+  it("returns null for non-slash input", () => {
+    expect(getSlashCommandName("hello")).toBeNull();
+    expect(getSlashCommandName("")).toBeNull();
+  });
+
+  it("returns the command name being typed", () => {
+    expect(getSlashCommandName("/cle")).toBe("cle");
+    expect(getSlashCommandName("/clear")).toBe("clear");
+  });
+
+  it("returns only the command token when arguments follow", () => {
+    expect(getSlashCommandName("/clear something")).toBe("clear");
+  });
+
+  it("returns empty string for a bare slash", () => {
+    expect(getSlashCommandName("/")).toBe("");
+  });
+});
+
+describe("matchingCommands", () => {
+  it("returns all commands for empty prefix", () => {
+    expect(matchingCommands("")).toHaveLength(SLASH_COMMANDS.length);
+  });
+
+  it("filters by prefix", () => {
+    const results = matchingCommands("cl");
+    expect(results.map((c) => c.name)).toContain("clear");
+    expect(results.map((c) => c.name)).not.toContain("help");
+  });
+
+  it("is case-insensitive", () => {
+    const results = matchingCommands("CL");
+    expect(results.map((c) => c.name)).toContain("clear");
+  });
+
+  it("returns empty array when nothing matches", () => {
+    expect(matchingCommands("zzz")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Adds client-side slash command support to the PXI interactive chat UI.

## Changes

**`src/pxi/commands.ts`** (new file)
- Defines a `SLASH_COMMANDS` registry with `name`, `description`, and `handler`
- `runSlashCommand()` parses and dispatches a `/command [args]` string, returning a typed result (`handled | help | unknown`) so the caller can react
- `getSlashCommandName()` extracts the command token from a draft string (used for live highlighting)
- `matchingCommands(prefix)` returns commands whose names start with the current prefix (used for the completion list)

**`src/pxi/App.tsx`**
- `HighlightedDraft` component: renders the input with the `/command` token in bold yellow and arguments in default color
- `InputPrompt` now shows a live completion list (yellow, with descriptions) while the user is still typing the command name; falls back to the normal help text once they've moved past the command token
- `clearMessages()` handler resets messages, error, and draft
- `submitDraft()` intercepts input starting with `/` before it reaches the server — `/clear` resets history, `/exit` quits, `/help` appends an inline command list to the transcript, and unknown commands show an error without sending anything

**Commands shipped:**

| Command | Effect |
|---------|--------|
| `/clear` | Clears the conversation history |
| `/exit` | Exits PXI (alias for Ctrl+D) |
| `/help` | Prints available commands inline in the transcript |

---
_Generated by [Claude Code](https://claude.ai/code/session_01S78TJvt2eeRaK6rSygfCya)_