### PR TITLE
feat(pxi): support provider/model combined string and persist model to settings

### DIFF
--- a/js/packages/phoenix-cli/src/pxi/options.ts
+++ b/js/packages/phoenix-cli/src/pxi/options.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 
 import { resolveConfig } from "../config";
 import { InvalidArgumentError } from "../exitCodes";
+import { loadSettings, saveSettings } from "../settings";
 import type {
   BuiltInProvider,
   ModelSelection,
@@ -55,6 +56,34 @@ function getExpectedProviderMessage(): string {
   return `Expected one of: ${BUILT_IN_PROVIDERS.join(", ")}.`;
 }
 
+/**
+ * Serialize a {@link ModelSelection} to the canonical `"provider/model"` string
+ * used for storage. Built-in providers are lower-cased; custom providers use
+ * their server-side id as the prefix.
+ */
+export function formatModelSelection(selection: ModelSelection): string {
+  if (selection.providerType === "builtin") {
+    return `${selection.provider.toLowerCase()}/${selection.modelName}`;
+  }
+  return `${selection.providerId}/${selection.modelName}`;
+}
+
+/**
+ * Parse a `"provider/model"` string back into the raw option pair consumed by
+ * {@link resolveModelSelection}. Returns `undefined` for `provider` when the
+ * string contains no slash (treated as a bare model name only).
+ */
+export function parseModelString(s: string): {
+  provider: string | undefined;
+  model: string;
+} {
+  const slashIdx = s.indexOf("/");
+  if (slashIdx === -1) {
+    return { provider: undefined, model: s };
+  }
+  return { provider: s.slice(0, slashIdx), model: s.slice(slashIdx + 1) };
+}
+
 function isBuiltInProvider(provider: string): provider is BuiltInProvider {
   return BUILT_IN_PROVIDERS.includes(provider as BuiltInProvider);
 }
@@ -84,6 +113,19 @@ export function resolveModelSelection({
 }): ModelSelection {
   const trimmedModel = model?.trim();
   const trimmedCustomProviderId = customProviderId?.trim();
+
+  // Support "provider/model" combined format in the --model flag value.
+  // When the model string contains a slash and no custom provider is set,
+  // split it and recurse so all the normal validation still applies.
+  if (trimmedModel?.includes("/") && !trimmedCustomProviderId) {
+    const { provider: embeddedProvider, model: embeddedModel } =
+      parseModelString(trimmedModel);
+    return resolveModelSelection({
+      provider: embeddedProvider ?? provider,
+      model: embeddedModel,
+      customProviderId,
+    });
+  }
 
   if (trimmedCustomProviderId) {
     if (!trimmedModel) {
@@ -218,12 +260,41 @@ Examples:
  */
 export async function parsePxiRuntimeOptions({
   argv = process.argv,
+  settingsPath,
 }: {
   argv?: string[];
+  settingsPath?: string;
 } = {}): Promise<PxiRuntimeOptions> {
   const program = createPxiProgram();
   await program.parseAsync(argv);
-  return resolvePxiRuntimeOptions({
-    cliOptions: program.opts<RawPxiOptions>(),
-  });
+  const rawOpts = program.opts<RawPxiOptions>();
+
+  const providerExplicit = program.getOptionValueSource("provider") === "cli";
+  const modelExplicit = program.getOptionValueSource("model") === "cli";
+  const userSetModel = providerExplicit || modelExplicit;
+
+  if (!userSetModel) {
+    // Restore the last-used model from settings when no explicit flags were passed.
+    const settings = loadSettings({ settingsPath });
+    const storedModel = settings.pxi?.model;
+    if (storedModel) {
+      const parsed = parseModelString(storedModel);
+      rawOpts.provider = parsed.provider;
+      rawOpts.model = parsed.model;
+    }
+  }
+
+  const options = resolvePxiRuntimeOptions({ cliOptions: rawOpts });
+
+  if (userSetModel) {
+    // Persist the newly-chosen model so the next `pxi` launch restores it.
+    const settings = loadSettings({ settingsPath });
+    const modelStr = formatModelSelection(options.modelSelection);
+    saveSettings(
+      { ...settings, pxi: { ...settings.pxi, model: modelStr } },
+      { settingsPath }
+    );
+  }
+
+  return options;
 }

--- a/js/packages/phoenix-cli/src/settings.ts
+++ b/js/packages/phoenix-cli/src/settings.ts
@@ -44,6 +44,17 @@ export const ProfileEntrySchema = z.object({
     ),
 });
 
+export const PxiSettingsSchema = z.object({
+  model: z
+    .string()
+    .optional()
+    .describe(
+      "Last-used model in 'provider/model' format (e.g. openai/gpt-5.5 or anthropic/claude-opus-4-8). Restored automatically when starting pxi without explicit --model or --provider flags."
+    ),
+});
+
+export type PxiSettings = z.infer<typeof PxiSettingsSchema>;
+
 export const SettingsFileSchema = z.object({
   $schema: z
     .string()
@@ -61,6 +72,9 @@ export const SettingsFileSchema = z.object({
     .describe(
       "Map of profile name to profile entry. Keys are the profile names referenced by `activeProfile` and the --profile flag."
     ),
+  pxi: PxiSettingsSchema.optional().describe(
+    "Persisted PXI session settings restored on next launch."
+  ),
 });
 
 /**

--- a/js/packages/phoenix-cli/test/pxiOptions.test.ts
+++ b/js/packages/phoenix-cli/test/pxiOptions.test.ts
@@ -1,11 +1,62 @@
-import { describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { ExitCode, getExitCodeForError } from "../src/exitCodes";
 import {
   createPxiProgram,
+  formatModelSelection,
+  parseModelString,
+  parsePxiRuntimeOptions,
   resolveModelSelection,
   resolvePxiRuntimeOptions,
 } from "../src/pxi/options";
+
+describe("parseModelString", () => {
+  it("splits provider/model combined string", () => {
+    expect(parseModelString("openai/gpt-5.5")).toEqual({
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+  });
+
+  it("returns undefined provider for bare model name", () => {
+    expect(parseModelString("gpt-5.5")).toEqual({
+      provider: undefined,
+      model: "gpt-5.5",
+    });
+  });
+
+  it("uses only the first slash as delimiter", () => {
+    expect(parseModelString("openai/gpt/turbo")).toEqual({
+      provider: "openai",
+      model: "gpt/turbo",
+    });
+  });
+});
+
+describe("formatModelSelection", () => {
+  it("formats a builtin selection as lowercase-provider/model", () => {
+    expect(
+      formatModelSelection({
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-5.5",
+      })
+    ).toBe("openai/gpt-5.5");
+  });
+
+  it("formats a custom selection as providerId/model", () => {
+    expect(
+      formatModelSelection({
+        providerType: "custom",
+        providerId: "my-provider",
+        modelName: "my-model",
+      })
+    ).toBe("my-provider/my-model");
+  });
+});
 
 describe("PXI options", () => {
   it("exposes pxi-specific help", () => {
@@ -88,5 +139,108 @@ describe("PXI options", () => {
     });
 
     expect(options.skipModelPreflight).toBe(true);
+  });
+
+  it("accepts provider/model combined string in --model flag", () => {
+    const selection = resolveModelSelection({ model: "openai/gpt-5.5" });
+
+    expect(selection).toEqual({
+      providerType: "builtin",
+      provider: "OPENAI",
+      modelName: "gpt-5.5",
+    });
+  });
+
+  it("provider/model combined string overrides explicit --provider flag", () => {
+    const selection = resolveModelSelection({
+      provider: "ANTHROPIC",
+      model: "openai/gpt-5.5",
+    });
+
+    expect(selection).toEqual({
+      providerType: "builtin",
+      provider: "OPENAI",
+      modelName: "gpt-5.5",
+    });
+  });
+
+  it("ignores provider/model split for --model when --custom-provider-id is set", () => {
+    const selection = resolveModelSelection({
+      customProviderId: "my-provider",
+      model: "some/model",
+    });
+
+    expect(selection).toEqual({
+      providerType: "custom",
+      providerId: "my-provider",
+      modelName: "some/model",
+    });
+  });
+});
+
+describe("parsePxiRuntimeOptions model persistence", () => {
+  let tmpDir: string;
+  let settingsPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "phoenix-pxi-test-"));
+    settingsPath = path.join(tmpDir, "settings.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("saves the model to settings when --model is passed explicitly", async () => {
+    await parsePxiRuntimeOptions({
+      argv: ["node", "pxi", "--model", "openai/gpt-5.5", "--skip-model-preflight"],
+      settingsPath,
+    });
+
+    const saved = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    expect(saved.pxi?.model).toBe("openai/gpt-5.5");
+  });
+
+  it("saves the model to settings when --provider and --model are passed", async () => {
+    await parsePxiRuntimeOptions({
+      argv: ["node", "pxi", "--provider", "OPENAI", "--model", "gpt-5.5", "--skip-model-preflight"],
+      settingsPath,
+    });
+
+    const saved = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    expect(saved.pxi?.model).toBe("openai/gpt-5.5");
+  });
+
+  it("restores model from settings when no flags are passed", async () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        activeProfile: null,
+        profiles: {},
+        pxi: { model: "openai/gpt-5.5" },
+      }),
+      "utf-8"
+    );
+
+    const options = await parsePxiRuntimeOptions({
+      argv: ["node", "pxi", "--skip-model-preflight"],
+      settingsPath,
+    });
+
+    expect(options.modelSelection).toEqual({
+      providerType: "builtin",
+      provider: "OPENAI",
+      modelName: "gpt-5.5",
+    });
+  });
+
+  it("does not save to settings when no model flags are passed", async () => {
+    await parsePxiRuntimeOptions({
+      argv: ["node", "pxi", "--skip-model-preflight"],
+      settingsPath,
+    });
+
+    expect(fs.existsSync(settingsPath)).toBe(false);
   });
 });

--- a/js/packages/phoenix-cli/test/pxiOptions.test.ts
+++ b/js/packages/phoenix-cli/test/pxiOptions.test.ts
@@ -193,7 +193,13 @@ describe("parsePxiRuntimeOptions model persistence", () => {
 
   it("saves the model to settings when --model is passed explicitly", async () => {
     await parsePxiRuntimeOptions({
-      argv: ["node", "pxi", "--model", "openai/gpt-5.5", "--skip-model-preflight"],
+      argv: [
+        "node",
+        "pxi",
+        "--model",
+        "openai/gpt-5.5",
+        "--skip-model-preflight",
+      ],
       settingsPath,
     });
 
@@ -203,7 +209,15 @@ describe("parsePxiRuntimeOptions model persistence", () => {
 
   it("saves the model to settings when --provider and --model are passed", async () => {
     await parsePxiRuntimeOptions({
-      argv: ["node", "pxi", "--provider", "OPENAI", "--model", "gpt-5.5", "--skip-model-preflight"],
+      argv: [
+        "node",
+        "pxi",
+        "--provider",
+        "OPENAI",
+        "--model",
+        "gpt-5.5",
+        "--skip-model-preflight",
+      ],
       settingsPath,
     });
 

--- a/schemas/phoenix-cli-settings.json
+++ b/schemas/phoenix-cli-settings.json
@@ -52,6 +52,17 @@
         "additionalProperties": false
       },
       "description": "Map of profile name to profile entry. Keys are the profile names referenced by `activeProfile` and the --profile flag."
+    },
+    "pxi": {
+      "description": "Persisted PXI session settings restored on next launch.",
+      "type": "object",
+      "properties": {
+        "model": {
+          "description": "Last-used model in 'provider/model' format (e.g. openai/gpt-5.5 or anthropic/claude-opus-4-8). Restored automatically when starting pxi without explicit --model or --provider flags.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "required": ["activeProfile", "profiles"],


### PR DESCRIPTION
## Summary

- Accept `provider/model` combined format in the `--model` flag (e.g. `pxi --model openai/gpt-5.5`), splitting on the first slash to resolve provider and model simultaneously
- Add `formatModelSelection()` to serialize a `ModelSelection` to `"provider/model"` string
- Add `parseModelString()` to parse `"provider/model"` back into provider/model parts
- Add a `pxi.model` field to `SettingsFileSchema` (`~/.px/settings.json`) to persist the last-used model selection
- In `parsePxiRuntimeOptions`: restore persisted model when no `--model`/`--provider` flags are passed, and save to settings when explicit flags are used

## Behavior

**Input format:** The `--model` flag now accepts either a bare model name (`gpt-5.5`) or a combined `provider/model` string (`openai/gpt-5.5`). When a slash is present, the prefix is treated as the provider and validated against the built-in provider list. Explicit `--provider` is overridden by the embedded provider in the combined string.

**Persistence:** When `--model` or `--provider` is explicitly passed on the CLI, the resolved model is saved to `~/.px/settings.json` under `pxi.model`. On the next `pxi` launch without those flags, the saved model is restored automatically.

**Settings file format:**
```json
{
  "activeProfile": null,
  "profiles": {},
  "pxi": {
    "model": "openai/gpt-5.5"
  }
}
```

## Test plan

- [ ] `parseModelString` splits `provider/model` correctly, handles bare model name, uses first slash only
- [ ] `formatModelSelection` lowercases built-in provider names, handles custom providers
- [ ] `resolveModelSelection` accepts `--model openai/gpt-5.5` combined format
- [ ] Combined format overrides explicit `--provider` flag
- [ ] `--custom-provider-id` ignores slash-splitting (model stored verbatim)
- [ ] `parsePxiRuntimeOptions` saves model to settings on explicit `--model` flag
- [ ] `parsePxiRuntimeOptions` saves model to settings on explicit `--provider --model` flags
- [ ] `parsePxiRuntimeOptions` restores model from settings when no flags passed
- [ ] `parsePxiRuntimeOptions` does NOT write settings when no model flags passed

---
_Generated by [Claude Code](https://claude.ai/code/session_011kzT8LWTR3ndVa6uTPbuSi)_