### PR TITLE
fix(js): make PHOENIX_TEST_TRACKING=false reliably disable recording

### DIFF
--- a/js/.changeset/phoenix-client-test-tracking-disable.md
+++ b/js/.changeset/phoenix-client-test-tracking-disable.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+Fix `PHOENIX_TEST_TRACKING=false` not reliably disabling recording in vitest/jest eval suites. The flag is now read robustly (tolerating surrounding quotes and whitespace) and latches off for the whole process the first time it is seen disabled, so one suite can no longer re-enable recording for the others by mutating the environment mid-run. The run and annotation upload paths also honor the flag directly as a safeguard.

--- a/js/packages/phoenix-client/src/testing/phoenix-test-tracking.ts
+++ b/js/packages/phoenix-client/src/testing/phoenix-test-tracking.ts
@@ -28,9 +28,47 @@ import {
 import { currentRun, type RunState, type SuiteState } from "./state";
 import type { Annotation, KVMap } from "./types";
 
-function isFalsyFlag(value: string | undefined): boolean {
-  const v = (value ?? "").toLowerCase();
+export function isFalsyFlag(value: string | undefined): boolean {
+  // Tolerate surrounding whitespace and matching quotes that survive some
+  // shells and `.env` loaders (e.g. `PHOENIX_TEST_TRACKING="false"` or a value
+  // with a trailing newline). Without this, such a value reads as truthy and
+  // silently re-enables recording even though the user asked to disable it.
+  const v = (value ?? "")
+    .trim()
+    .replace(/^(['"])(.*)\1$/, "$2")
+    .trim()
+    .toLowerCase();
   return v === "false" || v === "0" || v === "off" || v === "no";
+}
+
+/**
+ * Snapshot of `PHOENIX_TEST_TRACKING` as it was when this module first loaded.
+ *
+ * When the flag is exported on the command line (the documented `eval:offline`
+ * workflow), this captures the user's intent at process start and is immune to
+ * any later in-process mutation of `process.env` by a sibling suite or setup
+ * file. That mutation is what made tracking leak across suites in #13930: one
+ * suite flipped the env var and re-enabled recording for the others.
+ */
+const trackingDisabledAtLoad = isFalsyFlag(process.env.PHOENIX_TEST_TRACKING);
+
+/**
+ * Latches to `true` the first time tracking is observed disabled in this
+ * process. Recording is opt-out and shared process-wide, so a single falsy
+ * reading turns the whole run off and keeps it off — later suites cannot
+ * re-enable recording regardless of declaration or execution order.
+ */
+let trackingLatchedOff = trackingDisabledAtLoad;
+
+/**
+ * Reset the process-level tracking latch. Test-only seam so unit tests can
+ * exercise the enable/disable transitions in isolation; not part of the
+ * public API.
+ *
+ * @internal
+ */
+export function __resetTrackingLatchForTests(): void {
+  trackingLatchedOff = isFalsyFlag(process.env.PHOENIX_TEST_TRACKING);
 }
 
 /**
@@ -38,12 +76,22 @@ function isFalsyFlag(value: string | undefined): boolean {
  *
  * Tracing is enabled by default. It can be disabled globally by setting
  * `PHOENIX_TEST_TRACKING=false`, or per suite via `SuiteConfig.dryRun`.
+ *
+ * The global disable is sticky for the lifetime of the process: once the flag
+ * is seen falsy — at load time or on any later call — tracking stays off for
+ * every suite. This keeps offline mode deterministic regardless of which
+ * suites are included in a run, or the order they execute in.
  */
 export function isTrackingEnabled(suite?: SuiteState): {
   enabled: boolean;
   reason?: string;
 } {
-  if (isFalsyFlag(process.env.PHOENIX_TEST_TRACKING)) {
+  if (
+    trackingLatchedOff ||
+    trackingDisabledAtLoad ||
+    isFalsyFlag(process.env.PHOENIX_TEST_TRACKING)
+  ) {
+    trackingLatchedOff = true;
     return { enabled: false, reason: "PHOENIX_TEST_TRACKING is disabled" };
   }
   if (suite?.config.dryRun) {
@@ -478,6 +526,7 @@ export async function postExperimentRun(
   if (
     run.dryRun ||
     suite.trackingDisabled ||
+    !isTrackingEnabled(suite).enabled ||
     !suite.client ||
     !suite.experimentId
   ) {
@@ -524,7 +573,13 @@ export async function postAnnotation(
   runId: string | undefined,
   annotation: Annotation
 ): Promise<void> {
-  if (suite.trackingDisabled || !suite.client || !runId) return;
+  if (
+    suite.trackingDisabled ||
+    !isTrackingEnabled(suite).enabled ||
+    !suite.client ||
+    !runId
+  )
+    return;
   const start = new Date();
   const end = new Date();
   try {

--- a/js/packages/phoenix-client/src/testing/phoenix-test-tracking.ts
+++ b/js/packages/phoenix-client/src/testing/phoenix-test-tracking.ts
@@ -86,11 +86,7 @@ export function isTrackingEnabled(suite?: SuiteState): {
   enabled: boolean;
   reason?: string;
 } {
-  if (
-    trackingLatchedOff ||
-    trackingDisabledAtLoad ||
-    isFalsyFlag(process.env.PHOENIX_TEST_TRACKING)
-  ) {
+  if (trackingLatchedOff || isFalsyFlag(process.env.PHOENIX_TEST_TRACKING)) {
     trackingLatchedOff = true;
     return { enabled: false, reason: "PHOENIX_TEST_TRACKING is disabled" };
   }

--- a/js/packages/phoenix-client/test/testing/phoenix-test-tracking.test.ts
+++ b/js/packages/phoenix-client/test/testing/phoenix-test-tracking.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Regression tests for the `PHOENIX_TEST_TRACKING` gate (issue #13930).
+ *
+ * The flag is meant to reliably disable all syncing to Phoenix. These tests
+ * pin down the two failure modes that let recording leak through:
+ *   1. the flag value being read as truthy when wrapped in quotes / whitespace, and
+ *   2. one suite re-enabling recording for the others by mutating the env var
+ *      mid-run (recording is process-wide and opt-out, so it must latch off).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __resetTrackingLatchForTests,
+  isFalsyFlag,
+  isTrackingEnabled,
+  postAnnotation,
+  postExperimentRun,
+} from "../../src/testing/phoenix-test-tracking";
+import type { RunState, SuiteState } from "../../src/testing/state";
+
+const ENV_KEY = "PHOENIX_TEST_TRACKING";
+const original = process.env[ENV_KEY];
+
+function setFlag(value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[ENV_KEY];
+  } else {
+    process.env[ENV_KEY] = value;
+  }
+  // Re-sync the process-level latch to the new value so each assertion starts
+  // from a clean slate (the latch is intentionally sticky within a process).
+  __resetTrackingLatchForTests();
+}
+
+afterEach(() => {
+  setFlag(original);
+});
+
+describe("isFalsyFlag", () => {
+  it.each(["false", "0", "off", "no", "FALSE", "Off", "No"])(
+    "treats %j as falsy",
+    (value) => {
+      expect(isFalsyFlag(value)).toBe(true);
+    }
+  );
+
+  it.each(['"false"', "'false'", "  false  ", '"false"\n', " 0 "])(
+    "tolerates surrounding quotes / whitespace: %j",
+    (value) => {
+      expect(isFalsyFlag(value)).toBe(true);
+    }
+  );
+
+  it.each([undefined, "", "true", "1", "on", "yes", "anything"])(
+    "treats %j as truthy",
+    (value) => {
+      expect(isFalsyFlag(value)).toBe(false);
+    }
+  );
+});
+
+describe("isTrackingEnabled", () => {
+  it("is enabled by default when the flag is unset", () => {
+    setFlag(undefined);
+    expect(isTrackingEnabled().enabled).toBe(true);
+  });
+
+  it("is disabled when the flag is falsy", () => {
+    setFlag("false");
+    const result = isTrackingEnabled();
+    expect(result.enabled).toBe(false);
+    expect(result.reason).toBe("PHOENIX_TEST_TRACKING is disabled");
+  });
+
+  it("is disabled for a quoted falsy value", () => {
+    setFlag('"false"');
+    expect(isTrackingEnabled().enabled).toBe(false);
+  });
+
+  it("is disabled per-suite via dryRun while the flag stays truthy", () => {
+    setFlag("true");
+    const suite = { config: { dryRun: true } } as SuiteState;
+    const result = isTrackingEnabled(suite);
+    expect(result.enabled).toBe(false);
+    expect(result.reason).toBe("suite configured dryRun");
+    // A dryRun suite must not latch tracking off for the whole process.
+    expect(isTrackingEnabled().enabled).toBe(true);
+  });
+
+  it("stays disabled once seen falsy, even if the env var is later flipped truthy", () => {
+    // Suite A observes the flag as disabled.
+    setFlag("false");
+    expect(isTrackingEnabled().enabled).toBe(false);
+
+    // A sibling suite (or setup file) mutates the env var mid-run. Recording
+    // is process-wide, so it must not turn back on for later suites.
+    process.env[ENV_KEY] = "true";
+    expect(isTrackingEnabled().enabled).toBe(false);
+
+    // Deleting the var entirely must not re-enable it either.
+    delete process.env[ENV_KEY];
+    expect(isTrackingEnabled().enabled).toBe(false);
+  });
+});
+
+describe("upload guards honor the flag", () => {
+  beforeEach(() => {
+    setFlag("false");
+  });
+
+  function trackingSuite(): {
+    suite: SuiteState;
+    post: ReturnType<typeof vi.fn>;
+  } {
+    // A suite that *looks* fully initialized for recording (client +
+    // experiment id, tracking not flagged off on the suite itself). The only
+    // thing that should keep it from uploading is the disabled env flag.
+    const post = vi.fn().mockResolvedValue({ data: { data: { id: "run-1" } } });
+    const suite = {
+      name: "leaky suite",
+      config: {},
+      registeredExamples: new Map(),
+      exampleIdsByTest: new Map([
+        ["case", { exampleId: "ex-1", nodeId: "node-1" }],
+      ]),
+      trackingDisabled: false,
+      results: [],
+      links: [],
+      experimentId: "exp-1",
+      client: { POST: post } as unknown as SuiteState["client"],
+    } as SuiteState;
+    return { suite, post };
+  }
+
+  function runState(suite: SuiteState): RunState {
+    return {
+      suite,
+      testName: "case",
+      logicalName: "case",
+      repetitionNumber: 1,
+      dryRun: false,
+      params: { input: { q: "hi" } },
+      output: { a: "ok" },
+      outputSet: true,
+      annotations: [],
+      startTime: new Date(),
+      runMetadata: {},
+    };
+  }
+
+  it("postExperimentRun does not POST when tracking is disabled", async () => {
+    const { suite, post } = trackingSuite();
+    const result = await postExperimentRun(suite, runState(suite));
+    expect(result).toBeUndefined();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("postAnnotation does not POST when tracking is disabled", async () => {
+    const { suite, post } = trackingSuite();
+    await postAnnotation(suite, "run-1", { name: "pass", score: 1 });
+    expect(post).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
resolves #13930

## Problem

`PHOENIX_TEST_TRACKING=false` is documented to disable syncing eval runs to Phoenix from the `@arizeai/phoenix-client/vitest` (and jest) testing API, but recording could still leak through — non-deterministically depending on which suites ran together in a process.

Two root causes:

1. **Value read verbatim.** `isFalsyFlag` lowercased the value but compared it exactly, so a flag wrapped in quotes or surrounded by whitespace (`"false"`, `false⏎`, ` false `) — as produced by some shells and `.env` loaders — was read as *truthy* and silently re-enabled recording.
2. **Decision re-read live, with no process-wide latch.** Recording is opt-out and shared process-wide, but the gate re-read `process.env` on every call. A sibling suite or setup file mutating the env var mid-run could flip tracking back on for later suites, so one suite's behavior leaked into the others.

## Fix

- `isFalsyFlag` now trims surrounding whitespace and matching quotes before comparing.
- The disable decision is **captured at module load** and **latches off** the first time the flag is observed falsy, so it stays off for the whole process regardless of suite composition or execution order. Per-suite `dryRun` is unaffected and does not latch the process.
- `postExperimentRun` / `postAnnotation` now consult the flag directly as a defense-in-depth safeguard, so no run or annotation is posted while tracking is disabled even if a suite was initialized while it was enabled.

## Tests

Added `test/testing/phoenix-test-tracking.test.ts` covering:
- value normalization (quotes / whitespace / case)
- the cross-suite latch (stays disabled after the env var is flipped back truthy or deleted)
- per-suite `dryRun` not latching the process
- the run/annotation upload guards refusing to POST when disabled

Full package test suite passes (450 tests), typecheck and lint clean. Added a changeset (`@arizeai/phoenix-client`: patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5PNTRDfchLfq2hSWqbVHk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5PNTRDfchLfq2hSWqbVHk)_