### PR TITLE
fix: persist PXI local traces with DML invalidation

### DIFF
--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -90,8 +90,9 @@ from phoenix.server.api.types.SandboxConfig import (
     get_sandbox_backend_info,
 )
 from phoenix.server.bearer_auth import PhoenixUser, is_authenticated
+from phoenix.server.dml_event import DmlEvent, SpanInsertEvent
 from phoenix.server.sandbox import SecretsContext
-from phoenix.server.types import DbSessionFactory
+from phoenix.server.types import CanPutItem, DbSessionFactory
 from phoenix.tracers import Tracer, detached_otel_context
 
 _PHOENIX_PROVIDER_METADATA_KEY = "phoenix"
@@ -380,7 +381,8 @@ async def _persist_db_traces(
     *,
     session: AsyncSession,
     db_traces: list[models.Trace],
-) -> None:
+) -> tuple[int, ...]:
+    project_ids = tuple(dict.fromkeys(db_trace.project_rowid for db_trace in db_traces))
     project_sessions = [
         db_trace.project_session for db_trace in db_traces if db_trace.project_session is not None
     ]
@@ -394,6 +396,22 @@ async def _persist_db_traces(
         # from the relationship and doesn't try to cascade-insert a duplicate.
         db_trace.project_session = persistent_by_session_id[project_session.session_id]
     session.add_all(db_traces)
+    await session.flush()
+    return project_ids
+
+
+async def _persist_db_traces_and_emit_event(
+    *,
+    db: DbSessionFactory,
+    event_queue: CanPutItem[DmlEvent],
+    db_traces: list[models.Trace],
+) -> None:
+    if not db_traces:
+        return
+    async with db() as session:
+        project_ids = await _persist_db_traces(session=session, db_traces=db_traces)
+    if project_ids:
+        event_queue.put(SpanInsertEvent(project_ids))
 
 
 async def _load_available_sandbox_backend_types(
@@ -795,10 +813,11 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                             request.app.state.db, project_name
                         )
                         db_traces = tracer.get_db_traces(project_id=project_id)
-                        if db_traces:
-                            async with request.app.state.db() as session:
-                                await _persist_db_traces(session=session, db_traces=db_traces)
-                                await session.flush()
+                        await _persist_db_traces_and_emit_event(
+                            db=request.app.state.db,
+                            event_queue=request.state.event_queue,
+                            db_traces=db_traces,
+                        )
                     tracer.tracer_provider.shutdown()
 
         return adapter.streaming_response(_stream_with_session())
@@ -1036,10 +1055,11 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                             request.app.state.db, project_name
                         )
                         db_traces = tracer.get_db_traces(project_id=project_id)
-                        if db_traces:
-                            async with request.app.state.db() as session:
-                                await _persist_db_traces(session=session, db_traces=db_traces)
-                                await session.flush()
+                        await _persist_db_traces_and_emit_event(
+                            db=request.app.state.db,
+                            event_queue=request.state.event_queue,
+                            db_traces=db_traces,
+                        )
                     tracer.tracer_provider.shutdown()
 
         return adapter.streaming_response(_stream_with_session())
@@ -1106,10 +1126,11 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 if ingest_traces:
                     project_id = await _ensure_project_exists(request.app.state.db, project_name)
                     db_traces = tracer.get_db_traces(project_id=project_id)
-                    if db_traces:
-                        async with request.app.state.db() as session:
-                            await _persist_db_traces(session=session, db_traces=db_traces)
-                            await session.flush()
+                    await _persist_db_traces_and_emit_event(
+                        db=request.app.state.db,
+                        event_queue=request.state.event_queue,
+                        db_traces=db_traces,
+                    )
                 tracer.tracer_provider.shutdown()
         return _SummarizeResponse(summary=result.summary.strip())
 

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import nullcontext
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 from jinja2 import Template
 from pydantic_ai.ui.vercel_ai.response_types import BaseChunk, ToolOutputAvailableChunk
+from sqlalchemy import func, select
 
 from phoenix.db import models
 from phoenix.db.types.identifier import Identifier
@@ -20,10 +22,113 @@ from phoenix.server.api.routers.agents import (
     _load_phoenix_user_email,
     _load_sandbox_availability,
     _maybe_using_user,
+    _persist_db_traces_and_emit_event,
     _SubagentMessageChunksClosed,
 )
 from phoenix.server.bearer_auth import PhoenixUser
+from phoenix.server.dml_event import DmlEvent, SpanInsertEvent
 from phoenix.server.types import DbSessionFactory, UserId
+
+
+class _EventQueue:
+    def __init__(self) -> None:
+        self.events: list[DmlEvent] = []
+
+    def put(self, item: DmlEvent) -> None:
+        self.events.append(item)
+
+
+class TestPersistDbTracesAndEmitEvent:
+    @staticmethod
+    def _trace(
+        *,
+        project_id: int,
+        session_id: str,
+        trace_id: str,
+        span_id: str,
+        start_time: datetime,
+    ) -> models.Trace:
+        end_time = start_time + timedelta(seconds=1)
+        trace = models.Trace(
+            project_rowid=project_id,
+            trace_id=trace_id,
+            start_time=start_time,
+            end_time=end_time,
+            project_session=models.ProjectSession(
+                project_id=project_id,
+                session_id=session_id,
+                start_time=start_time,
+                end_time=end_time,
+            ),
+        )
+        trace.spans = [
+            models.Span(
+                name="agent",
+                span_id=span_id,
+                parent_id=None,
+                span_kind="AGENT",
+                start_time=start_time,
+                end_time=end_time,
+                attributes={},
+                events=[],
+                status_code="OK",
+                status_message="",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+                llm_token_count_prompt=None,
+                llm_token_count_completion=None,
+            )
+        ]
+        return trace
+
+    async def test_persists_local_traces_and_emits_span_insert_event(
+        self,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project = models.Project(name="pxi-dev-test")
+            session.add(project)
+            await session.flush()
+            project_id = project.id
+
+        start_time = datetime(2026, 6, 29, 15, 0, tzinfo=timezone.utc)
+        db_traces = [
+            self._trace(
+                project_id=project_id,
+                session_id="session-1",
+                trace_id="trace-1",
+                span_id="span-1",
+                start_time=start_time,
+            ),
+            self._trace(
+                project_id=project_id,
+                session_id="session-1",
+                trace_id="trace-2",
+                span_id="span-2",
+                start_time=start_time + timedelta(seconds=2),
+            ),
+        ]
+        event_queue = _EventQueue()
+
+        await _persist_db_traces_and_emit_event(
+            db=db,
+            event_queue=event_queue,
+            db_traces=db_traces,
+        )
+
+        assert event_queue.events == [SpanInsertEvent((project_id,))]
+        async with db.read() as session:
+            trace_count = await session.scalar(
+                select(func.count(models.Trace.id)).where(models.Trace.project_rowid == project_id)
+            )
+            assert trace_count == 2
+            project_session = await session.scalar(
+                select(models.ProjectSession).where(models.ProjectSession.session_id == "session-1")
+            )
+            assert project_session is not None
+            assert project_session.start_time == start_time
+            assert project_session.end_time == start_time + timedelta(seconds=3)
 
 
 class TestLoadSandboxAvailability:


### PR DESCRIPTION
## Summary

- persist PXI local traces through a shared helper that emits `SpanInsertEvent` after the DB write commits
- route UI PXI, CLI/server PXI, and summary trace persistence through the same DML event path
- add a regression test covering local trace persistence, session upsert behavior, and span-insert event emission

## Testing

- `uv run pytest tests/unit/server/api/routers/test_agents.py -q`
- `uv run pytest tests/unit/server/api/routers/v1/test_sessions.py -q`
- `uv run ruff check src/phoenix/server/api/routers/agents.py tests/unit/server/api/routers/test_agents.py`
- `git diff --check -- src/phoenix/server/api/routers/agents.py tests/unit/server/api/routers/test_agents.py`