### PR TITLE
feat(pxi): show running token usage on the prompt status line

### DIFF
--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -240,7 +240,7 @@ function InputPrompt({
   const hints = showHints ? matchingCommands(cmdName) : [];
 
   return (
-    <Box flexDirection="column" marginTop={1} gap={1}>
+    <Box flexDirection="column" marginTop={1}>
       <Box
         borderStyle="single"
         borderLeft={false}
@@ -282,7 +282,7 @@ function InputPrompt({
         )}
         {usageLine ? (
           <Box flexShrink={0} marginLeft={2}>
-            <Text dimColor>{usageLine}</Text>
+            <Text color="green">{usageLine}</Text>
           </Box>
         ) : null}
       </Box>

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -9,6 +9,7 @@ import {
   SLASH_COMMANDS,
 } from "./commands";
 import { Markdown } from "./inkMarkdown";
+import { formatTokenUsageLine, getLatestAssistantUsage } from "./tokenUsage";
 import { getToolProgressFromPart, type ToolProgress } from "./toolProgress";
 import type { PxiChatClient, PxiMessage, PxiRuntimeOptions } from "./types";
 
@@ -221,7 +222,15 @@ function HighlightedDraft({ draft }: { draft: string }) {
 }
 
 /** Render the prompt row with helper text below it. */
-function InputPrompt({ draft, status }: { draft: string; status: PxiStatus }) {
+function InputPrompt({
+  draft,
+  status,
+  usageLine,
+}: {
+  draft: string;
+  status: PxiStatus;
+  usageLine: string | null;
+}) {
   const cursor = status === "streaming" ? "" : "█";
   const cmdName = getSlashCommandName(draft);
   // Show matching commands while the user is still typing the command token
@@ -246,27 +255,37 @@ function InputPrompt({ draft, status }: { draft: string; status: PxiStatus }) {
           {cursor}
         </Text>
       </Box>
-      {hints.length > 0 ? (
-        <Box flexDirection="column">
-          {hints.map((cmd) => (
-            <Text key={cmd.name}>
-              <Text color="yellow">{"  /"}</Text>
-              <Text color="yellow" bold>
-                {cmd.name}
+      {/* Footer: helper text / command hints on the left, and the running token
+          usage pinned to the bottom-right so the user can gauge how much of the
+          context window is in play (mirrors the web UI's session usage line). */}
+      <Box flexDirection="row" justifyContent="space-between">
+        {hints.length > 0 ? (
+          <Box flexDirection="column">
+            {hints.map((cmd) => (
+              <Text key={cmd.name}>
+                <Text color="yellow">{"  /"}</Text>
+                <Text color="yellow" bold>
+                  {cmd.name}
+                </Text>
+                <Text dimColor>
+                  {"  "}
+                  {cmd.description}
+                </Text>
               </Text>
-              <Text dimColor>
-                {"  "}
-                {cmd.description}
-              </Text>
-            </Text>
-          ))}
-        </Box>
-      ) : (
-        <Text dimColor>
-          Enter sends. Shift+Enter inserts a newline. Esc interrupts. Type /help
-          for commands. Ctrl+D or Ctrl+C exits.
-        </Text>
-      )}
+            ))}
+          </Box>
+        ) : (
+          <Text dimColor>
+            Enter sends. Shift+Enter inserts a newline. Esc interrupts. Type
+            /help for commands. Ctrl+D or Ctrl+C exits.
+          </Text>
+        )}
+        {usageLine ? (
+          <Box flexShrink={0} marginLeft={2}>
+            <Text dimColor>{usageLine}</Text>
+          </Box>
+        ) : null}
+      </Box>
     </Box>
   );
 }
@@ -521,7 +540,11 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
         </Box>
       ) : null}
       {status === "streaming" ? <ThinkingIndicator /> : null}
-      <InputPrompt draft={draft} status={status} />
+      <InputPrompt
+        draft={draft}
+        status={status}
+        usageLine={formatTokenUsageLine(getLatestAssistantUsage(messages))}
+      />
     </Box>
   );
 }

--- a/js/packages/phoenix-cli/src/pxi/tokenUsage.ts
+++ b/js/packages/phoenix-cli/src/pxi/tokenUsage.ts
@@ -1,0 +1,83 @@
+import type { AssistantMessageMetadata, PxiMessage } from "./types";
+
+/**
+ * Token-usage helpers for the PXI status line.
+ *
+ * The Phoenix server attaches {@link AssistantMessageMetadata} usage to each
+ * assistant turn. These helpers pull the most recent usage off the transcript
+ * and format it for the bottom-right status line, mirroring how the web UI's
+ * `ChatSessionUsage` surfaces the latest token count plus any cache activity so
+ * the user can gauge how much of the context window is in play.
+ */
+
+/** The usage metadata reported for a single assistant turn. */
+export type PxiUsage = NonNullable<AssistantMessageMetadata["usage"]>;
+
+/**
+ * Return the usage reported by the most recent assistant message that carries
+ * any, scanning newest-first. Returns `null` when no assistant turn reported
+ * usage (tracing/usage reporting can be disabled server-side).
+ */
+export function getLatestAssistantUsage(
+  messages: PxiMessage[]
+): PxiUsage | null {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.role !== "assistant") {
+      continue;
+    }
+    const usage = message.metadata?.usage;
+    if (usage != null) {
+      return usage;
+    }
+  }
+  return null;
+}
+
+/** Format a token count with thousands separators (e.g. `12,345`). */
+export function formatTokenCount(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+/**
+ * Build the cache-activity portion of the status line from a turn's prompt
+ * details, matching the web UI: always show cache reads, and only show cache
+ * writes when non-zero (OpenAI never reports them). Returns `null` when there
+ * is no cache activity to surface.
+ */
+export function formatCacheSummary(
+  promptDetails: PxiUsage["promptDetails"]
+): string | null {
+  if (!promptDetails) {
+    return null;
+  }
+  const cacheRead = promptDetails.cacheRead ?? 0;
+  const cacheWrite = promptDetails.cacheWrite ?? 0;
+  if (cacheRead <= 0 && cacheWrite <= 0) {
+    return null;
+  }
+  const parts = [`cache read ${formatTokenCount(cacheRead)}`];
+  if (cacheWrite > 0) {
+    parts.push(`cache write ${formatTokenCount(cacheWrite)}`);
+  }
+  return parts.join(" / ");
+}
+
+/**
+ * Compose the full bottom-right status line for a turn's usage — the headline
+ * total token count, optionally preceded by a cache-activity summary. Returns
+ * `null` when there is no usage to show, so the caller can omit the line
+ * entirely.
+ */
+export function formatTokenUsageLine(usage: PxiUsage | null): string | null {
+  if (!usage) {
+    return null;
+  }
+  const segments: string[] = [];
+  const cacheSummary = formatCacheSummary(usage.promptDetails);
+  if (cacheSummary) {
+    segments.push(cacheSummary);
+  }
+  segments.push(`${formatTokenCount(usage.tokens.total)} tokens`);
+  return segments.join("  ·  ");
+}

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -396,6 +396,39 @@ describe("PXI app", () => {
     unmount();
   });
 
+  it("shows the latest assistant token usage on the bottom-right status line", () => {
+    const assistantMessage: PxiMessage = {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "Done.", state: "done" }],
+      metadata: {
+        sessionId: "session-1",
+        usage: {
+          tokens: { prompt: 12000, completion: 345, total: 12345 },
+          promptDetails: { cacheRead: 8000, cacheWrite: 200 },
+        },
+      },
+    };
+    const { lastFrame, unmount } = render(
+      <PxiApp options={createOptions()} initialMessages={[assistantMessage]} />
+    );
+
+    const frame = stripAnsi(lastFrame() ?? "");
+    expect(frame).toContain("12,345 tokens");
+    expect(frame).toContain("cache read 8,000 / cache write 200");
+    unmount();
+  });
+
+  it("omits the token usage status line until usage is reported", () => {
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const { lastFrame, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    expect(stripAnsi(lastFrame() ?? "")).not.toContain("tokens");
+    unmount();
+  });
+
   it("renders assistant Phoenix-relative links with the configured endpoint", () => {
     const assistantMessage: PxiMessage = {
       id: "assistant-1",

--- a/js/packages/phoenix-cli/test/pxiTokenUsage.test.ts
+++ b/js/packages/phoenix-cli/test/pxiTokenUsage.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatCacheSummary,
+  formatTokenCount,
+  formatTokenUsageLine,
+  getLatestAssistantUsage,
+} from "../src/pxi/tokenUsage";
+import type { PxiMessage } from "../src/pxi/types";
+
+function assistantMessage(
+  id: string,
+  usage?: PxiMessage["metadata"]
+): PxiMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: [{ type: "text", text: "hi", state: "done" }],
+    ...(usage ? { metadata: usage } : {}),
+  };
+}
+
+describe("getLatestAssistantUsage", () => {
+  it("returns null when no assistant message carries usage", () => {
+    const messages: PxiMessage[] = [
+      { id: "user-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      assistantMessage("assistant-1"),
+    ];
+    expect(getLatestAssistantUsage(messages)).toBeNull();
+  });
+
+  it("returns the usage from the most recent assistant message that has it", () => {
+    const messages: PxiMessage[] = [
+      assistantMessage("assistant-1", {
+        sessionId: "s",
+        usage: { tokens: { prompt: 1, completion: 1, total: 2 } },
+      }),
+      assistantMessage("assistant-2", {
+        sessionId: "s",
+        usage: { tokens: { prompt: 10, completion: 5, total: 15 } },
+      }),
+    ];
+    expect(getLatestAssistantUsage(messages)?.tokens.total).toBe(15);
+  });
+
+  it("skips a trailing assistant message without usage and falls back to an earlier one", () => {
+    const messages: PxiMessage[] = [
+      assistantMessage("assistant-1", {
+        sessionId: "s",
+        usage: { tokens: { prompt: 10, completion: 5, total: 15 } },
+      }),
+      assistantMessage("assistant-2"),
+    ];
+    expect(getLatestAssistantUsage(messages)?.tokens.total).toBe(15);
+  });
+});
+
+describe("formatTokenCount", () => {
+  it("formats with thousands separators", () => {
+    expect(formatTokenCount(1234567)).toBe("1,234,567");
+    expect(formatTokenCount(42)).toBe("42");
+  });
+});
+
+describe("formatCacheSummary", () => {
+  it("returns null when there is no cache activity", () => {
+    expect(formatCacheSummary(null)).toBeNull();
+    expect(formatCacheSummary({ cacheRead: 0, cacheWrite: 0 })).toBeNull();
+  });
+
+  it("shows cache read only when there is no cache write", () => {
+    expect(formatCacheSummary({ cacheRead: 1234, cacheWrite: 0 })).toBe(
+      "cache read 1,234"
+    );
+  });
+
+  it("shows both cache read and write when present", () => {
+    expect(formatCacheSummary({ cacheRead: 1234, cacheWrite: 56 })).toBe(
+      "cache read 1,234 / cache write 56"
+    );
+  });
+});
+
+describe("formatTokenUsageLine", () => {
+  it("returns null when there is no usage", () => {
+    expect(formatTokenUsageLine(null)).toBeNull();
+  });
+
+  it("shows the total token count", () => {
+    expect(
+      formatTokenUsageLine({
+        tokens: { prompt: 100, completion: 23, total: 123 },
+      })
+    ).toBe("123 tokens");
+  });
+
+  it("prefixes the cache summary before the total", () => {
+    expect(
+      formatTokenUsageLine({
+        tokens: { prompt: 1000, completion: 234, total: 1234 },
+        promptDetails: { cacheRead: 800, cacheWrite: 200 },
+      })
+    ).toBe("cache read 800 / cache write 200  ·  1,234 tokens");
+  });
+});


### PR DESCRIPTION
## Summary

The PXI CLI now surfaces the agent's token usage in the **bottom-right of the prompt**, so a user can gauge how much of the context window is in play — mirroring how the web UI's `ChatSessionUsage` line presents it.

- Reads the usage metadata (`tokens` + `promptDetails`) already attached to each assistant turn by the Phoenix server-agent endpoint.
- Pulls the most recent assistant turn that reported usage (newest-first), and renders it right-aligned in the prompt footer opposite the helper text / command hints.
- Shows the **total token count** as the headline, and — when present — a **cache read / write** summary, matching the web UI's behavior (cache write omitted when zero, e.g. for OpenAI).
- The status line is omitted entirely until usage is reported.

## Implementation

- New `src/pxi/tokenUsage.ts` module with pure, testable helpers: `getLatestAssistantUsage`, `formatTokenCount`, `formatCacheSummary`, and `formatTokenUsageLine`.
- `App.tsx` `InputPrompt` footer restructured into a `space-between` row (helper/hints left, usage pinned right via `flexShrink={0}`).

## Testing

- New unit tests in `test/pxiTokenUsage.test.ts` covering usage extraction (newest-first, fallback past turns without usage) and all formatting cases.
- New `App` tests asserting the usage line renders the total + cache summary, and is absent before any usage is reported.
- Full `phoenix-cli` suite passes (438 tests), `tsc --noEmit`, oxlint, and oxfmt all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011wTRChKkc4DbeXfWmr7XSx)_