### PR TITLE
docs(phoenix-client): correct create_evaluator 2-tuple scorer docs

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/evaluators.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/evaluators.py
@@ -177,8 +177,8 @@ def create_evaluator(
             function into an `EvaluationResult`. This allows configuring the evaluation
             payload by setting a label, score and explanation. By default, numeric outputs will
             be recorded as scores, boolean outputs will be recorded as scores and labels, and
-            string outputs will be recorded as labels. If the output is a 2-tuple, the first item
-            will be recorded as the score and the second item will recorded as the explanation.
+            string outputs will be recorded as labels. A 2-tuple is recorded as (score, label);
+            a 3-tuple is recorded as (score, label, explanation).
 
     Examples:
         Configuring an evaluator that returns a boolean
@@ -210,16 +210,18 @@ def create_evaluator(
                 label = res.choices[0].message.content
                 return label
 
-        Configuring an evaluator that returns a score and explanation
+        Configuring an evaluator that returns a score, label, and explanation
 
         .. code-block:: python
             from textdistance import levenshtein
 
             @create_evaluator(kind="CODE", name="levenshtein-distance")
-            def ld(output: str, expected: str) -> tuple[float, str]:
+            def ld(output: str, expected: str) -> tuple[float, str, str]:
+                distance = levenshtein(output, expected)
                 return (
-                    levenshtein(output, expected),
-                    f"Levenshtein distance between {output} and {expected}"
+                    distance,
+                    "match" if distance == 0 else "mismatch",
+                    f"Levenshtein distance between {output} and {expected}",
                 )
     """
     if scorer is None:


### PR DESCRIPTION
## Summary

Doc-only fix for `create_evaluator`. The default scorer (`_default_eval_scorer`) records:
- a **2-tuple** as `(score, label)`
- a **3-tuple** as `(score, label, explanation)`

…but the docstring said a 2-tuple's second item becomes the **explanation**, and the worked example returned a `(score, explanation)` 2-tuple whose explanation string would actually be stored as a **label** — so a user following the docs got their explanation silently mislabeled.

## Changes
- `Args.scorer`: "2-tuple is `(score, label)`; 3-tuple is `(score, label, explanation)`."
- Replaced the misleading 2-tuple example with a 3-tuple that genuinely yields an explanation.

No behavior change. The `(score, label)` mapping itself was already corrected in #13874 (the 2-tuple revert); this just aligns the documentation, which the reviewer asked to ship separately.

## Verification
- `ruff check` clean
- `pytest tests/client/resources/experiments/test_default_eval_scorer.py` → 9 passed (regression guards pin 2-tuple=`(score, label)`, 3-tuple=`(score, label, explanation)` — the behavior these docs now describe)