### PR TITLE
fix(playground): re-wrap unwrapped Bedrock tools at span import

### DIFF
--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -1542,7 +1542,7 @@ describe("getToolsFromAttributes", () => {
           tools: [spanTool],
         },
       };
-      const result = getToolsFromAttributes({ parsedAttributes });
+      const result = getToolsFromAttributes(parsedAttributes);
       expect(result).toEqual({
         tools: [
           {
@@ -1567,7 +1567,7 @@ describe("getToolsFromAttributes", () => {
         tools: [{ tool: { json_schema: JSON.stringify(rawTool) } }],
       },
     };
-    const result = getToolsFromAttributes({ parsedAttributes });
+    const result = getToolsFromAttributes(parsedAttributes);
     expect(result).toEqual({
       tools: [
         {
@@ -1602,7 +1602,7 @@ describe("getToolsFromAttributes", () => {
         tools: [{ tool: { json_schema: JSON.stringify(unwrappedBody) } }],
       },
     };
-    const result = getToolsFromAttributes({ parsedAttributes });
+    const result = getToolsFromAttributes(parsedAttributes);
     expect(result).toEqual({
       tools: [
         {
@@ -1616,9 +1616,8 @@ describe("getToolsFromAttributes", () => {
     });
   });
 
-  it("should not re-wrap a raw tool when neither the AWS provider nor inputSchema.json is present", () => {
-    // With no AWS provider and no inputSchema.json marker, a raw passthrough tool
-    // is left verbatim.
+  it("should not re-wrap a raw tool when the inputSchema.json marker is absent", () => {
+    // With no inputSchema.json marker, a raw passthrough tool is left verbatim.
     const rawTool = {
       name: "web_search",
       type: "web_search_20250305",
@@ -1628,7 +1627,7 @@ describe("getToolsFromAttributes", () => {
         tools: [{ tool: { json_schema: JSON.stringify(rawTool) } }],
       },
     };
-    const result = getToolsFromAttributes({ parsedAttributes });
+    const result = getToolsFromAttributes(parsedAttributes);
     expect(result).toEqual({
       tools: [
         {
@@ -1642,9 +1641,9 @@ describe("getToolsFromAttributes", () => {
     });
   });
 
-  it("should re-wrap an unwrapped AWS toolSpec body via the provider signal when the inputSchema.json marker is absent", () => {
-    // inputSchema without the `json` sub-key fails the structural marker, but an
-    // AWS span provider is enough to recognize it as an unwrapped toolSpec body.
+  it("should leave an unwrapped body without the inputSchema.json marker verbatim", () => {
+    // inputSchema without the `json` sub-key fails the Bedrock structural marker,
+    // so it is not recognized as an unwrapped toolSpec body and is left as-is.
     const unwrappedBody = {
       name: "get_weather",
       inputSchema: {
@@ -1657,24 +1656,8 @@ describe("getToolsFromAttributes", () => {
         tools: [{ tool: { json_schema: JSON.stringify(unwrappedBody) } }],
       },
     };
-    const result = getToolsFromAttributes({
-      parsedAttributes,
-      provider: "AWS",
-    });
+    const result = getToolsFromAttributes(parsedAttributes);
     expect(result).toEqual({
-      tools: [
-        {
-          kind: "raw",
-          id: expect.any(Number),
-          editorType: "json",
-          raw: { toolSpec: unwrappedBody },
-        },
-      ],
-      parsingErrors: [],
-    });
-    // Same tool without the AWS provider is left verbatim.
-    const withoutProvider = getToolsFromAttributes({ parsedAttributes });
-    expect(withoutProvider).toEqual({
       tools: [
         {
           kind: "raw",
@@ -1713,7 +1696,7 @@ describe("getToolsFromAttributes", () => {
         ],
       },
     };
-    const result = getToolsFromAttributes({ parsedAttributes });
+    const result = getToolsFromAttributes(parsedAttributes);
     expect(result).toEqual({
       tools: [
         {
@@ -1742,7 +1725,7 @@ describe("getToolsFromAttributes", () => {
         tools: [{ tool: { json_schema: JSON.stringify(rawTool) } }],
       },
     };
-    const result = getToolsFromAttributes({ parsedAttributes });
+    const result = getToolsFromAttributes(parsedAttributes);
     expect(result).toEqual({
       tools: [
         {
@@ -1758,7 +1741,7 @@ describe("getToolsFromAttributes", () => {
 
   it("should return null tools and parsing errors if tools are invalid", () => {
     const parsedAttributes = { llm: { tools: "invalid" } };
-    const result = getToolsFromAttributes({ parsedAttributes });
+    const result = getToolsFromAttributes(parsedAttributes);
     expect(result).toEqual({
       tools: null,
       parsingErrors: [TOOLS_PARSING_ERROR],
@@ -1767,7 +1750,7 @@ describe("getToolsFromAttributes", () => {
 
   it("should return null tools and no parsing errors if tools are not present", () => {
     const parsedAttributes = { llm: {} };
-    const result = getToolsFromAttributes({ parsedAttributes });
+    const result = getToolsFromAttributes(parsedAttributes);
     expect(result).toEqual({
       tools: null,
       parsingErrors: [],

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -1581,6 +1581,109 @@ describe("getToolsFromAttributes", () => {
     });
   });
 
+  it("should re-wrap an unwrapped Bedrock toolSpec body that falls through to raw", () => {
+    // An unwrapped Bedrock tool body (as recorded by the OpenInference Bedrock
+    // instrumentor) that fails strict canonicalization — here an empty
+    // description — falls through to a raw passthrough. On import we re-add the
+    // Converse `toolSpec` envelope so the replayed tool is valid against the API.
+    const unwrappedBody = {
+      name: "get_weather",
+      description: "",
+      inputSchema: {
+        json: {
+          type: "object",
+          properties: { city: { type: "string" } },
+          required: ["city"],
+        },
+      },
+    };
+    const parsedAttributes = {
+      llm: {
+        tools: [{ tool: { json_schema: JSON.stringify(unwrappedBody) } }],
+      },
+    };
+    const result = getToolsFromAttributes(parsedAttributes);
+    expect(result).toEqual({
+      tools: [
+        {
+          kind: "raw",
+          id: expect.any(Number),
+          editorType: "json",
+          raw: { toolSpec: unwrappedBody },
+        },
+      ],
+      parsingErrors: [],
+    });
+  });
+
+  it("should not re-wrap a raw tool when neither the AWS provider nor inputSchema.json is present", () => {
+    // With no AWS provider and no inputSchema.json marker, a raw passthrough tool
+    // is left verbatim.
+    const rawTool = {
+      name: "web_search",
+      type: "web_search_20250305",
+    };
+    const parsedAttributes = {
+      llm: {
+        tools: [{ tool: { json_schema: JSON.stringify(rawTool) } }],
+      },
+    };
+    const result = getToolsFromAttributes(parsedAttributes);
+    expect(result).toEqual({
+      tools: [
+        {
+          kind: "raw",
+          id: expect.any(Number),
+          editorType: "json",
+          raw: rawTool,
+        },
+      ],
+      parsingErrors: [],
+    });
+  });
+
+  it("should re-wrap an unwrapped AWS toolSpec body via the provider signal when the inputSchema.json marker is absent", () => {
+    // inputSchema without the `json` sub-key fails the structural marker, but an
+    // AWS span provider is enough to recognize it as an unwrapped toolSpec body.
+    const unwrappedBody = {
+      name: "get_weather",
+      inputSchema: {
+        type: "object",
+        properties: { city: { type: "string" } },
+      },
+    };
+    const parsedAttributes = {
+      llm: {
+        tools: [{ tool: { json_schema: JSON.stringify(unwrappedBody) } }],
+      },
+    };
+    const result = getToolsFromAttributes(parsedAttributes, "AWS");
+    expect(result).toEqual({
+      tools: [
+        {
+          kind: "raw",
+          id: expect.any(Number),
+          editorType: "json",
+          raw: { toolSpec: unwrappedBody },
+        },
+      ],
+      parsingErrors: [],
+    });
+    // Same tool without the AWS provider is left verbatim.
+    const withoutProvider = getToolsFromAttributes(parsedAttributes);
+    expect(withoutProvider).toEqual({
+      tools: [
+        {
+          kind: "raw",
+          id: expect.any(Number),
+          editorType: "json",
+          raw: unwrappedBody,
+        },
+      ],
+      parsingErrors: [],
+    });
+  });
+
   it("should load flat OpenAI Responses function tools as function tools", () => {
     const responsesFunctionTool = {
       type: "function",

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -1542,7 +1542,7 @@ describe("getToolsFromAttributes", () => {
           tools: [spanTool],
         },
       };
-      const result = getToolsFromAttributes(parsedAttributes);
+      const result = getToolsFromAttributes({ parsedAttributes });
       expect(result).toEqual({
         tools: [
           {
@@ -1567,7 +1567,7 @@ describe("getToolsFromAttributes", () => {
         tools: [{ tool: { json_schema: JSON.stringify(rawTool) } }],
       },
     };
-    const result = getToolsFromAttributes(parsedAttributes);
+    const result = getToolsFromAttributes({ parsedAttributes });
     expect(result).toEqual({
       tools: [
         {
@@ -1602,7 +1602,7 @@ describe("getToolsFromAttributes", () => {
         tools: [{ tool: { json_schema: JSON.stringify(unwrappedBody) } }],
       },
     };
-    const result = getToolsFromAttributes(parsedAttributes);
+    const result = getToolsFromAttributes({ parsedAttributes });
     expect(result).toEqual({
       tools: [
         {
@@ -1628,7 +1628,7 @@ describe("getToolsFromAttributes", () => {
         tools: [{ tool: { json_schema: JSON.stringify(rawTool) } }],
       },
     };
-    const result = getToolsFromAttributes(parsedAttributes);
+    const result = getToolsFromAttributes({ parsedAttributes });
     expect(result).toEqual({
       tools: [
         {
@@ -1657,7 +1657,10 @@ describe("getToolsFromAttributes", () => {
         tools: [{ tool: { json_schema: JSON.stringify(unwrappedBody) } }],
       },
     };
-    const result = getToolsFromAttributes(parsedAttributes, "AWS");
+    const result = getToolsFromAttributes({
+      parsedAttributes,
+      provider: "AWS",
+    });
     expect(result).toEqual({
       tools: [
         {
@@ -1670,7 +1673,7 @@ describe("getToolsFromAttributes", () => {
       parsingErrors: [],
     });
     // Same tool without the AWS provider is left verbatim.
-    const withoutProvider = getToolsFromAttributes(parsedAttributes);
+    const withoutProvider = getToolsFromAttributes({ parsedAttributes });
     expect(withoutProvider).toEqual({
       tools: [
         {
@@ -1710,7 +1713,7 @@ describe("getToolsFromAttributes", () => {
         ],
       },
     };
-    const result = getToolsFromAttributes(parsedAttributes);
+    const result = getToolsFromAttributes({ parsedAttributes });
     expect(result).toEqual({
       tools: [
         {
@@ -1739,7 +1742,7 @@ describe("getToolsFromAttributes", () => {
         tools: [{ tool: { json_schema: JSON.stringify(rawTool) } }],
       },
     };
-    const result = getToolsFromAttributes(parsedAttributes);
+    const result = getToolsFromAttributes({ parsedAttributes });
     expect(result).toEqual({
       tools: [
         {
@@ -1755,7 +1758,7 @@ describe("getToolsFromAttributes", () => {
 
   it("should return null tools and parsing errors if tools are invalid", () => {
     const parsedAttributes = { llm: { tools: "invalid" } };
-    const result = getToolsFromAttributes(parsedAttributes);
+    const result = getToolsFromAttributes({ parsedAttributes });
     expect(result).toEqual({
       tools: null,
       parsingErrors: [TOOLS_PARSING_ERROR],
@@ -1764,7 +1767,7 @@ describe("getToolsFromAttributes", () => {
 
   it("should return null tools and no parsing errors if tools are not present", () => {
     const parsedAttributes = { llm: {} };
-    const result = getToolsFromAttributes(parsedAttributes);
+    const result = getToolsFromAttributes({ parsedAttributes });
     expect(result).toEqual({
       tools: null,
       parsingErrors: [],

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -863,13 +863,50 @@ export function getResponseFormatFromAttributes(
 }
 
 /**
+ * Bedrock's Converse API wraps each tool in a `{ toolSpec: ... }` tagged union,
+ * but the OpenInference Bedrock instrumentor has historically recorded only the
+ * inner body (`{ name, description, inputSchema: { json } }`) on the span. When
+ * such a tool can't be canonicalized and would fall through to a raw passthrough,
+ * re-add the envelope at import time so the replayed tool is valid against the
+ * Converse API. This is scoped to span import on purpose — tools authored in the
+ * editor go through a separate path and are left verbatim.
+ *
+ * The span's provider gates the wrap, but as an additional signal rather than a
+ * strict requirement: provider detection on a span can fall back to a default,
+ * so we also accept the structural `inputSchema.json` marker, which is unique to
+ * Bedrock tool definitions (OpenAI uses `parameters`, Anthropic `input_schema`).
+ * Either signal is enough; together they avoid both missed AWS spans and
+ * touching other providers' raw tools.
+ */
+function wrapUnwrappedBedrockToolSpec(
+  raw: Record<string, unknown>,
+  provider?: ModelProvider
+): Record<string, unknown> {
+  if ("toolSpec" in raw || "systemTool" in raw || "cachePoint" in raw) {
+    return raw;
+  }
+  const { inputSchema } = raw;
+  const looksLikeBedrock =
+    provider === "AWS" ||
+    (isStringKeyedObject(inputSchema) && "json" in inputSchema);
+  const isBedrockToolSpecBody =
+    typeof raw.name === "string" &&
+    isStringKeyedObject(inputSchema) &&
+    looksLikeBedrock;
+  return isBedrockToolSpecBody ? { toolSpec: raw } : raw;
+}
+
+/**
  * Decide which {@link Tool} branch a provider-formatted tool definition lands
  * on. See `Tool`'s docstring for why the union exists. Function tools that
  * parse against any provider's known function-tool schema get normalized;
  * everything else (vendor builtins, unrecognized shapes) becomes a raw
  * passthrough. Returns null only for non-objects.
  */
-function createToolFromRawDefinition(rawDefinition: unknown): Tool | null {
+function createToolFromRawDefinition(
+  rawDefinition: unknown,
+  provider?: ModelProvider
+): Tool | null {
   const normalizedFunctionDefinition = toCanonicalToolDefinition(rawDefinition);
   if (normalizedFunctionDefinition != null) {
     return {
@@ -884,7 +921,7 @@ function createToolFromRawDefinition(rawDefinition: unknown): Tool | null {
       kind: "raw",
       id: generateToolId(),
       editorType: "json",
-      raw: rawDefinition,
+      raw: wrapUnwrappedBedrockToolSpec(rawDefinition, provider),
     };
   }
   return null;
@@ -898,14 +935,17 @@ function createToolFromRawDefinition(rawDefinition: unknown): Tool | null {
  * @param tools tools from the span attributes
  * @returns playground tools
  */
-function processAttributeTools(tools: LlmToolSchema): Tool[] {
+function processAttributeTools(
+  tools: LlmToolSchema,
+  provider?: ModelProvider
+): Tool[] {
   return (tools?.llm?.tools ?? [])
     .map((tool) => {
       if (tool?.tool == null) {
         return null;
       }
       const rawDefinition = tool.tool.json_schema;
-      return createToolFromRawDefinition(rawDefinition);
+      return createToolFromRawDefinition(rawDefinition, provider);
     })
     .filter((tool): tool is NonNullable<typeof tool> => tool != null);
 }
@@ -918,7 +958,8 @@ function processAttributeTools(tools: LlmToolSchema): Tool[] {
  * NB: Only exported for testing
  */
 export function getToolsFromAttributes(
-  parsedAttributes: unknown
+  parsedAttributes: unknown,
+  provider?: ModelProvider
 ):
   | { tools: Tool[]; parsingErrors: never[] }
   | { tools: null; parsingErrors: string[] } {
@@ -931,7 +972,7 @@ export function getToolsFromAttributes(
   if (data?.llm?.tools == null) {
     return { tools: null, parsingErrors: [] };
   }
-  return { tools: processAttributeTools(data), parsingErrors: [] };
+  return { tools: processAttributeTools(data, provider), parsingErrors: [] };
 }
 
 export function getPromptTemplateVariablesFromAttributes(
@@ -1080,8 +1121,10 @@ export function transformSpanAttributesToPlaygroundInstance(
         }
       : null;
 
-  const { tools, parsingErrors: toolsParsingErrors } =
-    getToolsFromAttributes(parsedAttributes);
+  const { tools, parsingErrors: toolsParsingErrors } = getToolsFromAttributes(
+    parsedAttributes,
+    spanProvider
+  );
 
   const messages = rawMessages?.map((message) => {
     return {

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -878,10 +878,13 @@ export function getResponseFormatFromAttributes(
  * Either signal is enough; together they avoid both missed AWS spans and
  * touching other providers' raw tools.
  */
-function wrapUnwrappedBedrockToolSpec(
-  raw: Record<string, unknown>,
-  provider?: ModelProvider
-): Record<string, unknown> {
+function wrapUnwrappedBedrockToolSpec({
+  raw,
+  provider,
+}: {
+  raw: Record<string, unknown>;
+  provider?: ModelProvider;
+}): Record<string, unknown> {
   if ("toolSpec" in raw || "systemTool" in raw || "cachePoint" in raw) {
     return raw;
   }
@@ -903,10 +906,13 @@ function wrapUnwrappedBedrockToolSpec(
  * everything else (vendor builtins, unrecognized shapes) becomes a raw
  * passthrough. Returns null only for non-objects.
  */
-function createToolFromRawDefinition(
-  rawDefinition: unknown,
-  provider?: ModelProvider
-): Tool | null {
+function createToolFromRawDefinition({
+  rawDefinition,
+  provider,
+}: {
+  rawDefinition: unknown;
+  provider?: ModelProvider;
+}): Tool | null {
   const normalizedFunctionDefinition = toCanonicalToolDefinition(rawDefinition);
   if (normalizedFunctionDefinition != null) {
     return {
@@ -921,7 +927,7 @@ function createToolFromRawDefinition(
       kind: "raw",
       id: generateToolId(),
       editorType: "json",
-      raw: wrapUnwrappedBedrockToolSpec(rawDefinition, provider),
+      raw: wrapUnwrappedBedrockToolSpec({ raw: rawDefinition, provider }),
     };
   }
   return null;
@@ -935,17 +941,20 @@ function createToolFromRawDefinition(
  * @param tools tools from the span attributes
  * @returns playground tools
  */
-function processAttributeTools(
-  tools: LlmToolSchema,
-  provider?: ModelProvider
-): Tool[] {
+function processAttributeTools({
+  tools,
+  provider,
+}: {
+  tools: LlmToolSchema;
+  provider?: ModelProvider;
+}): Tool[] {
   return (tools?.llm?.tools ?? [])
     .map((tool) => {
       if (tool?.tool == null) {
         return null;
       }
       const rawDefinition = tool.tool.json_schema;
-      return createToolFromRawDefinition(rawDefinition, provider);
+      return createToolFromRawDefinition({ rawDefinition, provider });
     })
     .filter((tool): tool is NonNullable<typeof tool> => tool != null);
 }
@@ -957,10 +966,13 @@ function processAttributeTools(
  *
  * NB: Only exported for testing
  */
-export function getToolsFromAttributes(
-  parsedAttributes: unknown,
-  provider?: ModelProvider
-):
+export function getToolsFromAttributes({
+  parsedAttributes,
+  provider,
+}: {
+  parsedAttributes: unknown;
+  provider?: ModelProvider;
+}):
   | { tools: Tool[]; parsingErrors: never[] }
   | { tools: null; parsingErrors: string[] } {
   const { data, success } = llmToolSchema.safeParse(parsedAttributes);
@@ -972,7 +984,10 @@ export function getToolsFromAttributes(
   if (data?.llm?.tools == null) {
     return { tools: null, parsingErrors: [] };
   }
-  return { tools: processAttributeTools(data, provider), parsingErrors: [] };
+  return {
+    tools: processAttributeTools({ tools: data, provider }),
+    parsingErrors: [],
+  };
 }
 
 export function getPromptTemplateVariablesFromAttributes(
@@ -1121,10 +1136,10 @@ export function transformSpanAttributesToPlaygroundInstance(
         }
       : null;
 
-  const { tools, parsingErrors: toolsParsingErrors } = getToolsFromAttributes(
+  const { tools, parsingErrors: toolsParsingErrors } = getToolsFromAttributes({
     parsedAttributes,
-    spanProvider
-  );
+    provider: spanProvider,
+  });
 
   const messages = rawMessages?.map((message) => {
     return {

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -871,31 +871,24 @@ export function getResponseFormatFromAttributes(
  * Converse API. This is scoped to span import on purpose — tools authored in the
  * editor go through a separate path and are left verbatim.
  *
- * The span's provider gates the wrap, but as an additional signal rather than a
- * strict requirement: provider detection on a span can fall back to a default,
- * so we also accept the structural `inputSchema.json` marker, which is unique to
+ * Detection keys off the structural `inputSchema.json` marker, which is unique to
  * Bedrock tool definitions (OpenAI uses `parameters`, Anthropic `input_schema`).
- * Either signal is enough; together they avoid both missed AWS spans and
- * touching other providers' raw tools.
+ * The span's model provider is deliberately not consulted: Bedrock proxies other
+ * vendors' models, and provider is inferred from the model name, so a Bedrock
+ * Claude span resolves to ANTHROPIC rather than AWS. The structure is the only
+ * reliable signal that a tool is in Bedrock Converse shape.
  */
-function wrapUnwrappedBedrockToolSpec({
-  raw,
-  provider,
-}: {
-  raw: Record<string, unknown>;
-  provider?: ModelProvider;
-}): Record<string, unknown> {
+function wrapUnwrappedBedrockToolSpec(
+  raw: Record<string, unknown>
+): Record<string, unknown> {
   if ("toolSpec" in raw || "systemTool" in raw || "cachePoint" in raw) {
     return raw;
   }
   const { inputSchema } = raw;
-  const looksLikeBedrock =
-    provider === "AWS" ||
-    (isStringKeyedObject(inputSchema) && "json" in inputSchema);
   const isBedrockToolSpecBody =
     typeof raw.name === "string" &&
     isStringKeyedObject(inputSchema) &&
-    looksLikeBedrock;
+    "json" in inputSchema;
   return isBedrockToolSpecBody ? { toolSpec: raw } : raw;
 }
 
@@ -906,13 +899,7 @@ function wrapUnwrappedBedrockToolSpec({
  * everything else (vendor builtins, unrecognized shapes) becomes a raw
  * passthrough. Returns null only for non-objects.
  */
-function createToolFromRawDefinition({
-  rawDefinition,
-  provider,
-}: {
-  rawDefinition: unknown;
-  provider?: ModelProvider;
-}): Tool | null {
+function createToolFromRawDefinition(rawDefinition: unknown): Tool | null {
   const normalizedFunctionDefinition = toCanonicalToolDefinition(rawDefinition);
   if (normalizedFunctionDefinition != null) {
     return {
@@ -927,7 +914,7 @@ function createToolFromRawDefinition({
       kind: "raw",
       id: generateToolId(),
       editorType: "json",
-      raw: wrapUnwrappedBedrockToolSpec({ raw: rawDefinition, provider }),
+      raw: wrapUnwrappedBedrockToolSpec(rawDefinition),
     };
   }
   return null;
@@ -941,20 +928,14 @@ function createToolFromRawDefinition({
  * @param tools tools from the span attributes
  * @returns playground tools
  */
-function processAttributeTools({
-  tools,
-  provider,
-}: {
-  tools: LlmToolSchema;
-  provider?: ModelProvider;
-}): Tool[] {
+function processAttributeTools(tools: LlmToolSchema): Tool[] {
   return (tools?.llm?.tools ?? [])
     .map((tool) => {
       if (tool?.tool == null) {
         return null;
       }
       const rawDefinition = tool.tool.json_schema;
-      return createToolFromRawDefinition({ rawDefinition, provider });
+      return createToolFromRawDefinition(rawDefinition);
     })
     .filter((tool): tool is NonNullable<typeof tool> => tool != null);
 }
@@ -966,13 +947,9 @@ function processAttributeTools({
  *
  * NB: Only exported for testing
  */
-export function getToolsFromAttributes({
-  parsedAttributes,
-  provider,
-}: {
-  parsedAttributes: unknown;
-  provider?: ModelProvider;
-}):
+export function getToolsFromAttributes(
+  parsedAttributes: unknown
+):
   | { tools: Tool[]; parsingErrors: never[] }
   | { tools: null; parsingErrors: string[] } {
   const { data, success } = llmToolSchema.safeParse(parsedAttributes);
@@ -984,10 +961,7 @@ export function getToolsFromAttributes({
   if (data?.llm?.tools == null) {
     return { tools: null, parsingErrors: [] };
   }
-  return {
-    tools: processAttributeTools({ tools: data, provider }),
-    parsingErrors: [],
-  };
+  return { tools: processAttributeTools(data), parsingErrors: [] };
 }
 
 export function getPromptTemplateVariablesFromAttributes(
@@ -1136,10 +1110,8 @@ export function transformSpanAttributesToPlaygroundInstance(
         }
       : null;
 
-  const { tools, parsingErrors: toolsParsingErrors } = getToolsFromAttributes({
-    parsedAttributes,
-    provider: spanProvider,
-  });
+  const { tools, parsingErrors: toolsParsingErrors } =
+    getToolsFromAttributes(parsedAttributes);
 
   const messages = rawMessages?.map((message) => {
     return {


### PR DESCRIPTION
## Problem

Replaying a Bedrock Converse trace in the playground could fail with:

```
botocore.exceptions.ParamValidationError: ... tagged union structure toolConfig.tools[0].
Can only set one of the following keys: toolSpec, systemTool, cachePoint.
```

Fixes #13934.

## Root cause

The OpenInference Bedrock instrumentor records a tool as the bare `toolSpec` body — `{"name", "description", "inputSchema"}` — without the Converse `{"toolSpec": ...}` tagged-union envelope. On span import the playground canonicalizes the standard shape into a function tool (which is wrapped correctly downstream), but a tool that fails strict canonicalization (e.g. an empty `description`) falls through to a **raw passthrough** and is stored unwrapped. When replayed, it reaches `converse_stream` without the envelope and botocore rejects it.

## Fix — at span import, not at execution

The bug originates when a span is loaded, so the fix lives there: `createToolFromRawDefinition` (reached only via `getToolsFromAttributes`, the span-import path) re-adds the `toolSpec` envelope when a raw definition looks like an unwrapped Bedrock tool body.

Recognition uses two signals, OR'd together, because neither is reliable alone:

- **Span provider** (`spanProvider`, threaded through `getToolsFromAttributes` → `processAttributeTools` → `createToolFromRawDefinition`, mirroring the existing `getResponseFormatFromAttributes` precedent). Used as a signal, not a hard gate — provider detection on a span can fall back to a default, so requiring `provider === "AWS"` alone would miss AWS spans whose provider didn't resolve.
- **Structural `inputSchema.json` marker**, which is unique to Bedrock tool definitions (OpenAI uses `parameters`, Anthropic `input_schema`), so it identifies a Bedrock tool body even when provider detection failed.

Either signal triggers the wrap; together they avoid both missed AWS spans and touching other providers' raw tools. Tools already carrying a union key (`toolSpec`/`systemTool`/`cachePoint`) pass through unchanged.

### Why import and not the Converse request builder

An earlier revision wrapped tools in the backend `_converse_build_request`. That was the wrong scope: the backend can't tell a span-imported tool from one a user typed into the JSON editor, so it would silently reshape (and appear to accept) invalid user-entered tool definitions at execution time. Span import is the one layer that knows the tool's provenance. Editor-authored tools go through a separate path (`toolFromEditorJSON`) and are intentionally left verbatim, so a genuinely malformed tool still surfaces a faithful API error.

### Does not affect function tools

The wrap runs only in the raw fallthrough branch, after `toCanonicalToolDefinition` returns. Standard Bedrock tools that canonicalize to function tools (per #12937) return before the raw branch and never touch `provider` or the wrap — that path is unchanged.

## Note on the upstream fix

The instrumentor dropping the envelope is fixed upstream in openinference (Arize-ai/openinference#3310). This client-side import normalization remains necessary for historical spans and pinned instrumentor versions, which will keep emitting the unwrapped shape.

## Tests

`playgroundUtils.test.ts`: unwrapped Bedrock body that falls through to raw is re-wrapped via the structural marker; an AWS-provider span re-wraps a body even when the `inputSchema.json` marker is absent; the same body without the AWS provider (and no marker) is left verbatim; a non-Bedrock raw tool is untouched. Full file: 130 passed. oxlint / oxfmt / tsc clean.