### PR TITLE
fix(cli): suppress stray kitty-keyboard query echo on pxi startup

### DIFF
--- a/js/packages/phoenix-cli/src/pxi/index.tsx
+++ b/js/packages/phoenix-cli/src/pxi/index.tsx
@@ -25,6 +25,15 @@ export async function main({
 } = {}): Promise<void> {
   const options = await parsePxiRuntimeOptions({ argv });
   await runPxiModelPreflight({ options });
+  // Ink's kitty-keyboard "auto" detection writes a `CSI ? u` capability query to
+  // stdout from its constructor, before it switches the terminal into raw mode.
+  // On a TTY still in canonical mode the terminal echoes its reply (`ESC[?0u`)
+  // back to the screen, leaving a stray `^[[?0u` line above the banner. Putting
+  // stdin into raw mode here disables that echo so Ink consumes the reply
+  // silently; Ink keeps raw mode on for the rest of the session.
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true);
+  }
   const instance = render(<PxiApp options={options} />, {
     exitOnCtrlC: false,
     kittyKeyboard: {


### PR DESCRIPTION
## Summary

Starting `pxi` printed a stray `^[[?0u` line above the banner:

```
➜  ~ pxi
^[[?0u
 __/\\\\\\\\\\\\\____/\\\_______/\\\__/\\\\\\\\\\\_
 ...
```

**Root cause:** Ink's `kittyKeyboard: { mode: "auto" }` detection writes a `CSI ? u` capability query to stdout *from its constructor — before* it switches the terminal into raw mode. While the TTY is still in canonical mode (echo on), the terminal echoes its reply (`ESC[?0u`) straight back to the screen, leaving the stray `^[[?0u` line.

The existing `useInput` filter (`isKeyboardProtocolResponseInput`) only handles the reply when it arrives as input *after* the app mounts; it can't stop the startup echo, which is emitted by the terminal's line discipline outside Ink's managed render region (hence it appears above the padded banner).

**Fix:** Put stdin into raw mode (disabling echo) before calling `render()`, so the terminal's reply is consumed silently by Ink's detection instead of being echoed. Ink keeps raw mode on for the rest of the session, and kitty-protocol features (e.g. Shift+Enter) continue to work.

## Changes

- `js/packages/phoenix-cli/src/pxi/index.tsx`: call `process.stdin.setRawMode(true)` (guarded by `process.stdin.isTTY`) immediately before mounting the Ink app.

## Testing

- `pnpm --filter "@arizeai/phoenix-cli..." run build` — passes (includes `tsc`).
- `pnpm test test/pxiApp.test.tsx` — 16/16 pass, including the existing "ignores terminal keyboard protocol responses" case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019RNT3ppxJ1aaDUjFr3h4mk)_