### PR TITLE
docs(phoenix-otel): document new span-kind wrappers and verify re-export

### DIFF
--- a/docs/phoenix/sdk-api-reference/typescript/arizeai-openinference-core.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/arizeai-openinference-core.mdx
@@ -90,6 +90,42 @@ const weatherTool = async (city: string) => {
 const tracedWeatherTool = traceTool(weatherTool, { name: "weather-api" });
 ```
 
+### Additional Span-Kind Wrappers
+
+The remaining OpenInference span kinds each have a matching wrapper. Like `traceChain`/`traceAgent`/`traceTool`, each is a shorthand for `withSpan(fn, { ...options, kind })` and accepts the same options minus `kind`. These wrappers are marked `@experimental` and may change in a future release.
+
+| Wrapper | Span kind | Use it for |
+| ------- | --------- | ---------- |
+| `traceLLM` | `LLM` | Language-model invocations — chat/text completions and other inference calls |
+| `traceRetriever` | `RETRIEVER` | Fetching documents from a knowledge base, vector store, or search index (RAG) |
+| `traceReranker` | `RERANKER` | Reordering or scoring candidate documents by relevance |
+| `traceEmbedding` | `EMBEDDING` | Converting text or data into vector representations |
+| `traceGuardrail` | `GUARDRAIL` | Safety, validation, or policy checks (moderation, PII, compliance) |
+| `traceEvaluator` | `EVALUATOR` | Scoring output quality — relevance, correctness, or LLM-as-a-judge |
+| `tracePrompt` | `PROMPT` | Constructing, rendering, or templating a prompt before a model call |
+
+```typescript
+import {
+  traceEmbedding,
+  traceEvaluator,
+  traceGuardrail,
+  traceLLM,
+  tracePrompt,
+  traceReranker,
+  traceRetriever,
+} from "@arizeai/openinference-core";
+
+const retrieveDocuments = traceRetriever(
+  async (query: string) => vectorStore.similaritySearch(query, 5),
+  { name: "vector-search" }
+);
+
+const evaluateAnswer = traceEvaluator(
+  async (question: string, answer: string) => judge.score({ question, answer }),
+  { name: "answer-evaluation" }
+);
+```
+
 ---
 
 ## Decorators

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/overview.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/overview.mdx
@@ -27,7 +27,7 @@ npm install \
 `@arizeai/phoenix-otel` combines Phoenix registration with OpenInference authoring APIs:
 
 - Phoenix registration: `register()`, `attachGlobalTracerProvider()`, `detachGlobalTracerProvider()`, `createNoOpProvider()`
-- OpenInference wrappers: `withSpan()`, `traceChain()`, `traceAgent()`, `traceTool()`
+- OpenInference wrappers: `withSpan()`, `traceChain()`, `traceAgent()`, `traceTool()`, `traceLLM()`, `traceRetriever()`, `traceReranker()`, `traceEmbedding()`, `traceGuardrail()`, `traceEvaluator()`, `tracePrompt()`
 - decorators and context propagation: `observe()`, `setSession()`, `setUser()`, `setMetadata()`, `setTags()`, `setPromptTemplate()`, `setAttributes()`
 - attribute builders: `getLLMAttributes()`, `getRetrieverAttributes()`, `getEmbeddingAttributes()`, `getToolAttributes()`, `getMetadataAttributes()`, `getInputAttributes()`, `getOutputAttributes()`, `defaultProcessInput()`, `defaultProcessOutput()`
 - redaction and safety helpers: `OITracer`, `withSafety`, `safelyJSONStringify`, `safelyJSONParse`
@@ -233,7 +233,7 @@ await provider.shutdown();
 | Category | Exports |
 |----------|---------|
 | **Registration** | `register()`, `attachGlobalTracerProvider()`, `detachGlobalTracerProvider()`, `createNoOpProvider()` |
-| **Tracing helpers** | `withSpan()`, `traceChain()`, `traceAgent()`, `traceTool()`, `observe()` |
+| **Tracing helpers** | `withSpan()`, `traceChain()`, `traceAgent()`, `traceTool()`, `traceLLM()`, `traceRetriever()`, `traceReranker()`, `traceEmbedding()`, `traceGuardrail()`, `traceEvaluator()`, `tracePrompt()`, `observe()` |
 | **Context attributes** | `setSession()`, `setUser()`, `setMetadata()`, `setTags()`, `setPromptTemplate()`, `setAttributes()`, `getAttributesFromContext()` |
 | **Attribute builders** | `getLLMAttributes()`, `getToolAttributes()`, `getRetrieverAttributes()`, `getEmbeddingAttributes()`, `getMetadataAttributes()` |
 | **Redaction and safety** | `OITracer`, `withSafety()`, `safelyJSONStringify()`, `safelyJSONParse()` |
@@ -243,7 +243,7 @@ await provider.shutdown();
 
 ## Where To Start
 
-- [Tracing helpers](./tracing-helpers) for wrapping functions with `withSpan`, `traceChain`, `traceAgent`, `traceTool`, and `observe`
+- [Tracing helpers](./tracing-helpers) for wrapping functions with `withSpan`, the span-kind wrappers (`traceChain`, `traceAgent`, `traceTool`, `traceLLM`, `traceRetriever`, `traceReranker`, `traceEmbedding`, `traceGuardrail`, `traceEvaluator`, `tracePrompt`), and `observe`
 - [Context attributes](./context-attributes) for propagating sessions, users, metadata, tags, prompt templates, and manual context propagation
 - [Manual spans](./manual-spans) for raw OpenTelemetry spans, attribute builders, `OITracer`, and utility helpers
 

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/tracing-helpers.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/tracing-helpers.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Tracing Helpers"
-description: "Wrap functions and methods with OpenInference spans using withSpan, traceChain, traceAgent, traceTool, and observe"
+description: "Wrap functions and methods with OpenInference spans using withSpan, the span-kind wrappers (traceChain, traceAgent, traceTool, traceLLM, traceRetriever, traceReranker, traceEmbedding, traceGuardrail, traceEvaluator, tracePrompt), and observe"
 ---
 
 `@arizeai/phoenix-otel` re-exports the OpenInference tracing helpers from `@arizeai/openinference-core`, so you can configure Phoenix export and author traced functions from one package path.
@@ -35,7 +35,7 @@ await handleQuery("What's the weather?");
   <ul>
     <li><code>src/index.ts</code> re-exports the helper surface from <code>@arizeai/openinference-core</code></li>
     <li><code>node_modules/@arizeai/openinference-core/src/helpers/withSpan.ts</code> implements wrapper behavior</li>
-    <li><code>node_modules/@arizeai/openinference-core/src/helpers/wrappers.ts</code> defines <code>traceChain</code>, <code>traceAgent</code>, and <code>traceTool</code></li>
+    <li><code>node_modules/@arizeai/openinference-core/src/helpers/wrappers.ts</code> defines the span-kind wrappers <code>traceChain</code>, <code>traceAgent</code>, <code>traceTool</code>, <code>traceLLM</code>, <code>traceRetriever</code>, <code>traceReranker</code>, <code>traceEmbedding</code>, <code>traceGuardrail</code>, <code>traceEvaluator</code>, and <code>tracePrompt</code></li>
     <li><code>node_modules/@arizeai/openinference-core/src/helpers/decorators.ts</code> defines <code>observe</code></li>
   </ul>
 </section>
@@ -135,6 +135,79 @@ const searchDocs = traceTool(
 );
 ```
 
+### Additional Span-Kind Wrappers
+
+Alongside `traceChain`, `traceAgent`, and `traceTool`, the following wrappers cover the remaining OpenInference span kinds. Each is a shorthand for `withSpan(fn, { ...options, kind })` with the listed span kind pre-configured, accepts the same `SpanTraceOptions` (minus `kind`), and resolves the default tracer at invocation time.
+
+<Note>These wrappers are marked `@experimental` in `@arizeai/openinference-core` and may change in a future release.</Note>
+
+| Wrapper | Span kind | Use it for |
+|---------|-----------|------------|
+| `traceLLM(fn, options?)` | `LLM` | Invocations of a large language model — chat or text completions and other foundation-model inference calls. |
+| `traceRetriever(fn, options?)` | `RETRIEVER` | Fetching documents or context from a knowledge base, vector store, or search index (RAG). |
+| `traceReranker(fn, options?)` | `RERANKER` | Reordering or scoring candidate documents by relevance before passing them to a model. |
+| `traceEmbedding(fn, options?)` | `EMBEDDING` | Converting text or other data into vector representations for semantic search and retrieval. |
+| `traceGuardrail(fn, options?)` | `GUARDRAIL` | Safety, validation, or policy checks such as content moderation, PII detection, or compliance enforcement. |
+| `traceEvaluator(fn, options?)` | `EVALUATOR` | Assessing or scoring output quality — relevance scoring, correctness checks, or LLM-as-a-judge evaluations. |
+| `tracePrompt(fn, options?)` | `PROMPT` | Constructing, rendering, or templating a prompt before it is sent to a model. |
+
+```ts
+import {
+  traceEmbedding,
+  traceEvaluator,
+  traceGuardrail,
+  traceLLM,
+  tracePrompt,
+  traceReranker,
+  traceRetriever,
+} from "@arizeai/phoenix-otel";
+
+// traceRetriever — fetch context from a vector store
+const retrieveDocuments = traceRetriever(
+  async (query: string) => vectorStore.similaritySearch(query, 5),
+  { name: "vector-search" }
+);
+
+// traceReranker — reorder candidates by relevance
+const rerankDocuments = traceReranker(
+  async (query: string, documents: Document[]) =>
+    reranker.rerank(query, documents),
+  { name: "rerank" }
+);
+
+// traceEmbedding — turn text into vectors
+const embedText = traceEmbedding(
+  async (text: string) =>
+    client.embeddings.create({ model: "text-embedding-3-small", input: text }),
+  { name: "embed-text" }
+);
+
+// tracePrompt — render a prompt template
+const renderPrompt = tracePrompt(
+  (variables: Record<string, string>) => promptTemplate.format(variables),
+  { name: "render-prompt" }
+);
+
+// traceLLM — call a language model
+const chatCompletion = traceLLM(
+  async (messages: Message[]) =>
+    client.chat.completions.create({ model: "gpt-4", messages }),
+  { name: "chat-completion" }
+);
+
+// traceGuardrail — moderate or validate content
+const moderateContent = traceGuardrail(
+  async (text: string) => moderationClient.check(text),
+  { name: "content-moderation" }
+);
+
+// traceEvaluator — score an answer (e.g. LLM-as-a-judge)
+const evaluateAnswer = traceEvaluator(
+  async (question: string, answer: string) => judge.score({ question, answer }),
+  { name: "answer-evaluation" }
+);
+```
+
 ### `observe(options?)`
 
 Decorator factory for class methods. Use TypeScript 5+ standard decorators.
@@ -186,7 +259,7 @@ const retriever = withSpan(
 );
 ```
 
-The same customization pattern works with `traceChain`, `traceAgent`, and `traceTool`, since they all delegate to `withSpan`.
+The same customization pattern works with every span-kind wrapper (`traceChain`, `traceAgent`, `traceTool`, `traceLLM`, `traceRetriever`, `traceReranker`, `traceEmbedding`, `traceGuardrail`, `traceEvaluator`, and `tracePrompt`), since they all delegate to `withSpan`.
 
 ## Combining Helpers With Context Attributes
 

--- a/js/packages/phoenix-otel/README.md
+++ b/js/packages/phoenix-otel/README.md
@@ -30,7 +30,7 @@ A lightweight wrapper around OpenTelemetry for Node.js applications that simplif
 - **Simple Setup** - One-line configuration with sensible defaults
 - **Environment Variables** - Automatic configuration from environment variables
 - **Batch Processing** - Built-in batch span processing for production use
-- **OpenInference Helpers Included** - Re-exports `withSpan`, `traceChain`, `traceAgent`, `traceTool`, `observe`, context setters, attribute builders, `OITracer`, and utility helpers
+- **OpenInference Helpers Included** - Re-exports `withSpan`, the span-kind wrappers (`traceChain`, `traceAgent`, `traceTool`, `traceLLM`, `traceRetriever`, `traceReranker`, `traceEmbedding`, `traceGuardrail`, `traceEvaluator`, `tracePrompt`), `observe`, context setters, attribute builders, `OITracer`, and utility helpers
 - **Provider-Swap Safe Wrappers** - The re-exported OpenInference helpers resolve the default tracer when the wrapped function executes, so module-scoped wrappers continue following global provider changes
 - **Agent-Friendly Local Docs** - Ships curated docs and source in `node_modules/@arizeai/phoenix-otel/`
 
@@ -165,7 +165,7 @@ const response = await openai.chat.completions.create({
 
 ### Tracing Helpers
 
-The package includes `withSpan`, `traceChain`, `traceAgent`, and `traceTool` for wrapping functions with OpenInference spans. Each helper automatically records inputs, outputs, errors, and span kind.
+The package includes `withSpan` plus span-kind shorthands — `traceChain`, `traceAgent`, and `traceTool` — for wrapping functions with OpenInference spans. Each helper automatically records inputs, outputs, errors, and span kind.
 
 ```typescript
 import {
@@ -211,6 +211,42 @@ const retrieveDocs = withSpan(
 ```
 
 These helpers resolve the default tracer when the wrapped function runs, so traced functions defined at module scope keep following global provider changes.
+
+#### Additional Span-Kind Wrappers
+
+The full set of OpenInference span kinds is covered by matching wrappers, each a shorthand for `withSpan(fn, { ...options, kind })`. They accept the same options as `traceChain`/`traceAgent`/`traceTool` (everything except `kind`, which is pre-set). These wrappers are marked `@experimental` in `@arizeai/openinference-core`.
+
+| Wrapper          | Span kind   | Use it for                                                                    |
+| ---------------- | ----------- | ----------------------------------------------------------------------------- |
+| `traceLLM`       | `LLM`       | Language-model invocations — chat/text completions and other inference calls  |
+| `traceRetriever` | `RETRIEVER` | Fetching documents from a knowledge base, vector store, or search index (RAG) |
+| `traceReranker`  | `RERANKER`  | Reordering or scoring candidate documents by relevance                        |
+| `traceEmbedding` | `EMBEDDING` | Converting text or data into vector representations                           |
+| `traceGuardrail` | `GUARDRAIL` | Safety, validation, or policy checks (moderation, PII, compliance)            |
+| `traceEvaluator` | `EVALUATOR` | Scoring output quality — relevance, correctness, or LLM-as-a-judge            |
+| `tracePrompt`    | `PROMPT`    | Constructing, rendering, or templating a prompt before a model call           |
+
+```typescript
+import {
+  traceEmbedding,
+  traceEvaluator,
+  traceGuardrail,
+  traceLLM,
+  tracePrompt,
+  traceReranker,
+  traceRetriever,
+} from "@arizeai/phoenix-otel";
+
+const retrieveDocuments = traceRetriever(
+  async (query: string) => vectorStore.similaritySearch(query, 5),
+  { name: "vector-search" }
+);
+
+const evaluateAnswer = traceEvaluator(
+  async (question: string, answer: string) => judge.score({ question, answer }),
+  { name: "answer-evaluation" }
+);
+```
 
 ### Custom Input And Output Processing
 
@@ -522,6 +558,13 @@ import {
   observe,
   traceAgent,
   traceChain,
+  traceEmbedding,
+  traceEvaluator,
+  traceGuardrail,
+  traceLLM,
+  tracePrompt,
+  traceReranker,
+  traceRetriever,
   traceTool,
   withSpan,
 } from "@arizeai/phoenix-otel";

--- a/js/packages/phoenix-otel/examples/tracing_wrappers_example.ts
+++ b/js/packages/phoenix-otel/examples/tracing_wrappers_example.ts
@@ -9,13 +9,12 @@
 // traceChain orchestrating the steps.
 
 /* eslint-disable no-console */
-import { context } from "@opentelemetry/api";
-
 import {
   type Document,
   type Embedding,
   type Message,
   type TokenCount,
+  context,
   getEmbeddingAttributes,
   getLLMAttributes,
   getRetrieverAttributes,

--- a/js/packages/phoenix-otel/examples/tracing_wrappers_example.ts
+++ b/js/packages/phoenix-otel/examples/tracing_wrappers_example.ts
@@ -1,0 +1,214 @@
+// Demonstrates the OpenInference span-kind wrappers that @arizeai/phoenix-otel
+// re-exports from @arizeai/openinference-core. Each wrapper preserves the exact
+// type signature of the function it wraps, so the traced pipeline below stays
+// fully type-checked end to end.
+//
+// This example wires the seven span-kind wrappers added in openinference-core
+// 2.4.0 — traceEmbedding, traceRetriever, traceReranker, traceGuardrail,
+// tracePrompt, traceLLM, and traceEvaluator — into a small RAG pipeline, with
+// traceChain orchestrating the steps.
+
+/* eslint-disable no-console */
+import { context } from "@opentelemetry/api";
+
+import {
+  type Document,
+  type Embedding,
+  type Message,
+  type TokenCount,
+  getEmbeddingAttributes,
+  getLLMAttributes,
+  getRetrieverAttributes,
+  register,
+  setSession,
+  traceChain,
+  traceEmbedding,
+  traceEvaluator,
+  traceGuardrail,
+  traceLLM,
+  tracePrompt,
+  traceReranker,
+  traceRetriever,
+} from "../src";
+
+interface RagResult {
+  answer: string;
+  documents: Document[];
+  evaluation: { label: "correct" | "incorrect"; score: number };
+}
+
+async function main() {
+  const provider = register({
+    projectName: "tracing-wrappers-example",
+    batch: false,
+  });
+
+  // traceEmbedding (EMBEDDING) — turn the query text into a vector. processOutput
+  // records the model name and vector via the typed getEmbeddingAttributes builder.
+  const embedQuery = traceEmbedding(
+    async (query: string): Promise<Embedding> => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return { text: query, vector: [0.12, 0.04, 0.91] };
+    },
+    {
+      name: "embed-query",
+      processOutput: (embedding) =>
+        getEmbeddingAttributes({
+          modelName: "text-embedding-3-small",
+          embeddings: [embedding],
+        }),
+    }
+  );
+
+  // traceRetriever (RETRIEVER) — fetch candidate documents for the query vector.
+  const retrieveDocuments = traceRetriever(
+    async (_vector: number[]): Promise<Document[]> => {
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      return [
+        {
+          id: "doc-1",
+          content: "Phoenix is an open-source LLM observability platform.",
+          score: 0.42,
+        },
+        {
+          id: "doc-2",
+          content: "Phoenix traces, evaluates, and monitors LLM applications.",
+          score: 0.39,
+        },
+        {
+          id: "doc-3",
+          content: "An unrelated note about gardening.",
+          score: 0.05,
+        },
+      ];
+    },
+    {
+      name: "retrieve-documents",
+      processOutput: (documents) => getRetrieverAttributes({ documents }),
+    }
+  );
+
+  // traceReranker (RERANKER) — reorder retrieved documents by relevance and keep
+  // the top results.
+  const rerankDocuments = traceReranker(
+    async (_query: string, documents: Document[]): Promise<Document[]> => {
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      return [...documents]
+        .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+        .slice(0, 2);
+    },
+    { name: "rerank-documents" }
+  );
+
+  // traceGuardrail (GUARDRAIL) — screen the user input before it reaches the model.
+  const moderateInput = traceGuardrail(
+    async (text: string): Promise<{ flagged: boolean; reason?: string }> => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return /(password|ssn|api[_-]?key)/i.test(text)
+        ? { flagged: true, reason: "possible sensitive data" }
+        : { flagged: false };
+    },
+    { name: "moderate-input" }
+  );
+
+  // tracePrompt (PROMPT) — assemble the chat messages from the query and context.
+  // A synchronous function is wrapped just as easily as an async one.
+  const buildPrompt = tracePrompt(
+    (query: string, documents: Document[]): Message[] => {
+      const contextText = documents.map((doc) => doc.content ?? "").join("\n");
+      return [
+        { role: "system", content: "Answer using only the provided context." },
+        {
+          role: "user",
+          content: `Context:\n${contextText}\n\nQuestion: ${query}`,
+        },
+      ];
+    },
+    { name: "build-prompt" }
+  );
+
+  // traceLLM (LLM) — call the model. processInput and processOutput use the typed
+  // getLLMAttributes builder to capture messages and token usage.
+  const generateAnswer = traceLLM(
+    async (
+      messages: Message[]
+    ): Promise<{ message: Message; tokenCount: TokenCount }> => {
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      void messages;
+      return {
+        message: {
+          role: "assistant",
+          content:
+            "Phoenix is an open-source platform for tracing and evaluating LLM applications.",
+        },
+        tokenCount: { prompt: 64, completion: 22, total: 86 },
+      };
+    },
+    {
+      name: "generate-answer",
+      processInput: (messages) =>
+        getLLMAttributes({
+          provider: "openai",
+          modelName: "gpt-4o-mini",
+          inputMessages: messages,
+        }),
+      processOutput: (result) =>
+        getLLMAttributes({
+          provider: "openai",
+          modelName: "gpt-4o-mini",
+          outputMessages: [result.message],
+          tokenCount: result.tokenCount,
+        }),
+    }
+  );
+
+  // traceEvaluator (EVALUATOR) — score the answer, e.g. an LLM-as-a-judge check.
+  const evaluateAnswer = traceEvaluator(
+    async (
+      _question: string,
+      answer: string
+    ): Promise<{ label: "correct" | "incorrect"; score: number }> => {
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      const score = answer.toLowerCase().includes("phoenix") ? 1 : 0;
+      return { label: score === 1 ? "correct" : "incorrect", score };
+    },
+    { name: "evaluate-answer" }
+  );
+
+  // traceChain (CHAIN) — orchestrate the steps. The return type flows through the
+  // wrapper unchanged, so `askPhoenix` is typed as `(question: string) => Promise<RagResult>`.
+  const askPhoenix = traceChain(
+    async (question: string): Promise<RagResult> => {
+      const guard = await moderateInput(question);
+      if (guard.flagged) {
+        throw new Error(`Input rejected: ${guard.reason ?? "guardrail"}`);
+      }
+
+      const { vector = [] } = await embedQuery(question);
+      const candidates = await retrieveDocuments(vector);
+      const documents = await rerankDocuments(question, candidates);
+      const messages = buildPrompt(question, documents);
+      const { message } = await generateAnswer(messages);
+      const answer = message.content ?? "";
+      const evaluation = await evaluateAnswer(question, answer);
+
+      return { answer, documents, evaluation };
+    },
+    { name: "ask-phoenix" }
+  );
+
+  // Propagate a session id so every span in the pipeline is grouped together.
+  const result = await context.with(
+    setSession(context.active(), { sessionId: "session-rag-001" }),
+    () => askPhoenix("What is Phoenix?")
+  );
+
+  console.log(`answer: ${result.answer}`);
+  console.log(
+    `evaluation: ${result.evaluation.label} (${result.evaluation.score})`
+  );
+
+  await provider.shutdown();
+}
+
+main().catch(console.error);

--- a/js/packages/phoenix-otel/examples/tsconfig.examples.json
+++ b/js/packages/phoenix-otel/examples/tsconfig.examples.json
@@ -1,7 +1,10 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "composite": false,
+    "incremental": false
   },
+  "include": ["*.ts"],
   "exclude": ["instrumentation_example.ts"]
 }

--- a/js/packages/phoenix-otel/package.json
+++ b/js/packages/phoenix-otel/package.json
@@ -50,7 +50,7 @@
     "prepack": "node ../../scripts/sync-package-docs.mjs phoenix-otel",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc --noEmit -p examples/tsconfig.examples.json"
   },
   "dependencies": {
     "@arizeai/openinference-core": "^2.4.0",

--- a/js/packages/phoenix-otel/test/openinference.test.ts
+++ b/js/packages/phoenix-otel/test/openinference.test.ts
@@ -7,6 +7,15 @@ import {
   observe,
   register,
   trace,
+  traceAgent,
+  traceChain,
+  traceEmbedding,
+  traceEvaluator,
+  traceGuardrail,
+  traceLLM,
+  tracePrompt,
+  traceReranker,
+  traceRetriever,
   traceTool,
   withSpan,
 } from "../src";
@@ -47,6 +56,27 @@ async function runInsideParentSpan<T>(name: string, fn: () => Promise<T>) {
 }
 
 describe("openinference re-exports", () => {
+  test("re-exports the full set of span-kind wrappers from @arizeai/openinference-core", () => {
+    const wrappers = {
+      withSpan,
+      traceChain,
+      traceAgent,
+      traceTool,
+      traceLLM,
+      traceRetriever,
+      traceReranker,
+      traceEmbedding,
+      traceGuardrail,
+      traceEvaluator,
+      tracePrompt,
+      observe,
+    };
+
+    for (const [name, wrapper] of Object.entries(wrappers)) {
+      expect(wrapper, `${name} should be re-exported`).toBeTypeOf("function");
+    }
+  });
+
   test("withSpan resolves the current global tracer when invoked", async () => {
     const { processor, getStartCount } = createCountingSpanProcessor();
     const provider = register({


### PR DESCRIPTION
## Summary

The recent weekly dependency upgrade (#13933) bumped `@arizeai/openinference-core` from `^2.2.0` to `^2.4.0` in `@arizeai/phoenix-otel`. That release added **seven new span-kind wrappers** alongside the existing `traceChain` / `traceAgent` / `traceTool`:

- `traceLLM` (`LLM`)
- `traceRetriever` (`RETRIEVER`)
- `traceReranker` (`RERANKER`)
- `traceEmbedding` (`EMBEDDING`)
- `traceGuardrail` (`GUARDRAIL`)
- `traceEvaluator` (`EVALUATOR`)
- `tracePrompt` (`PROMPT`)

`@arizeai/phoenix-otel` re-exports the full `@arizeai/openinference-core` helper surface via `export * from "@arizeai/openinference-core"`, so the new wrappers are **already re-exported** from the package — this PR verifies that with a test and brings the docs up to date so all ten wrappers are documented.

## Changes

- **Verify re-export**: added a test in `openinference.test.ts` asserting every span-kind wrapper (plus `withSpan`/`observe`) is exported from `@arizeai/phoenix-otel`.
- **Embedded package docs** (`docs/.../packages/phoenix-otel/`): documented the seven new wrappers in `tracing-helpers.mdx` (new "Additional Span-Kind Wrappers" section with a kind/use-case table and examples) and updated the surface lists in `overview.mdx`.
- **openinference-core reference page**: added the same wrapper coverage to `arizeai-openinference-core.mdx`.
- **README**: updated the feature list, the Tracing Helpers section, and the agent-skill import examples to include the new wrappers.

## Verification

- `pnpm run typecheck` — passes
- `pnpm test` — 18 tests pass (incl. the new re-export test)
- `prettier --check` — clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwkTdjeHNmrrHf5fr5MivB)_