### PR TITLE
docs(evals): fix macro F1 in precision/recall worked example

### DIFF
--- a/docs/phoenix/evaluation/pre-built-metrics/precision-recall-fscore.mdx
+++ b/docs/phoenix/evaluation/pre-built-metrics/precision-recall-fscore.mdx
@@ -100,7 +100,7 @@ For multi-class classification.
         print(f"{score.name}: {score.score:.3f}")
     # precision: 0.889
     # recall: 0.833
-    # f1: 0.833
+    # f1: 0.822
     ```
   </Tab>
 


### PR DESCRIPTION
## Summary

The macro-averaging worked example in the precision/recall/F-score metric doc prints `# f1: 0.833`, but for the inputs shown the macro F1 is `0.822`. This updates that one comment so the example matches the metric's actual output.

Fixes #13812 (gap #1 — stale worked example).

## What changed

* `docs/phoenix/evaluation/pre-built-metrics/precision-recall-fscore.mdx` — macro example comment `# f1: 0.833` → `# f1: 0.822`.

## Why

After #13740 made macro/weighted F-beta compute per class then average (sklearn semantics), the macro F1 for the documented inputs is the mean of the per-class F1s:

```
expected = ["cat", "dog", "cat", "bird", "dog"]
output   = ["cat", "cat", "cat", "bird", "dog"]

cat : precision 0.667, recall 1.000, F1 0.800
dog : precision 1.000, recall 0.500, F1 0.667
bird: precision 1.000, recall 1.000, F1 1.000

macro F1 = mean(0.800, 0.667, 1.000) = 0.822
```

The shown `precision: 0.889` and `recall: 0.833` are already correct (mean of the per-class precisions/recalls); only `f1` was stale. The binary example below (`f1: 0.667`) is unaffected — that path didn't change.

## How I tested

Recomputed the per-class and macro values by hand (above); they match the corrected number. Docs-only change to a comment inside a code sample — no code or build behavior affected.

## Backward compatibility

Docs-only; no API or behavior change.
