### PR TITLE
fix(pxi): support intuitive prompt editing

### DIFF
--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -60,6 +60,7 @@ const THINKING_FRAMES = [
   "PXI is thinking...",
 ];
 const KEYBOARD_PROTOCOL_RESPONSE_PATTERN = /^\[\?\d+u$/;
+const BRACKETED_PASTE_MARKER_PATTERN = /(?:\x1B)?\[(?:200|201)~/g;
 const INTERRUPTED_MESSAGE_TEXT = "\n\n[Interrupted by user before completion.]";
 
 export type PxiAppProps = {
@@ -283,22 +284,21 @@ function HighlightedDraft({
           const beforeCursor = segment.text.slice(0, cursorOffset);
           const cursorText = segment.text.slice(cursorOffset, cursorOffset + 1);
           const isCursorOnNewline = cursorText === "\n";
-          const afterCursor = segment.text.slice(
-            cursorOffset + (isCursorOnNewline ? 0 : 1)
-          );
+          const afterCursor = segment.text.slice(cursorOffset + 1);
           return [
             <HighlightedDraftSegment
               key={`${segmentIndex}-before`}
               segment={{ ...segment, text: beforeCursor }}
             />,
-            <HighlightedDraftSegment
-              key={`${segmentIndex}-cursor`}
-              segment={{
-                ...segment,
-                text: isCursorOnNewline ? "█" : cursorText,
-              }}
-              isInverse
-            />,
+            isCursorOnNewline ? (
+              <Text key={`${segmentIndex}-cursor`}>{"█\n"}</Text>
+            ) : (
+              <HighlightedDraftSegment
+                key={`${segmentIndex}-cursor`}
+                segment={{ ...segment, text: cursorText }}
+                isInverse
+              />
+            ),
             <HighlightedDraftSegment
               key={`${segmentIndex}-after`}
               segment={{ ...segment, text: afterCursor }}
@@ -392,6 +392,13 @@ function InputPrompt({
 
 function isKeyboardProtocolResponseInput({ input }: { input: string }) {
   return KEYBOARD_PROTOCOL_RESPONSE_PATTERN.test(input);
+}
+
+function getDraftInputText({ input }: { input: string }) {
+  return input
+    .replace(BRACKETED_PASTE_MARKER_PATTERN, "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
 }
 
 function getCompletedInterruptedPart({
@@ -655,7 +662,10 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
       return;
     }
     if (input) {
-      setDraft((value) => insertDraftText({ draft: value, text: input }));
+      const text = getDraftInputText({ input });
+      if (text) {
+        setDraft((value) => insertDraftText({ draft: value, text }));
+      }
     }
   });
 

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -231,18 +231,24 @@ function getHighlightedDraftSegments({
   ];
 }
 
-function HighlightedDraftSegment({ segment }: { segment: DraftSegment }) {
+function HighlightedDraftSegment({
+  segment,
+  isInverse = false,
+}: {
+  segment: DraftSegment;
+  isInverse?: boolean;
+}) {
   if (!segment.text) {
     return null;
   }
   if (segment.isCommandSegment) {
     return (
-      <Text color="yellow" bold={segment.isBold}>
+      <Text color="yellow" bold={segment.isBold} inverse={isInverse}>
         {segment.text}
       </Text>
     );
   }
-  return <Text>{segment.text}</Text>;
+  return <Text inverse={isInverse}>{segment.text}</Text>;
 }
 
 function HighlightedDraft({
@@ -267,22 +273,32 @@ function HighlightedDraft({
         nextSegmentStartIndex = segmentEndIndex;
 
         if (
+          isCursorVisible &&
           !hasRenderedCursor &&
           boundedCursorIndex >= segmentStartIndex &&
-          boundedCursorIndex <= segmentEndIndex
+          boundedCursorIndex < segmentEndIndex
         ) {
           hasRenderedCursor = true;
           const cursorOffset = boundedCursorIndex - segmentStartIndex;
           const beforeCursor = segment.text.slice(0, cursorOffset);
-          const afterCursor = segment.text.slice(cursorOffset);
+          const cursorText = segment.text.slice(cursorOffset, cursorOffset + 1);
+          const isCursorOnNewline = cursorText === "\n";
+          const afterCursor = segment.text.slice(
+            cursorOffset + (isCursorOnNewline ? 0 : 1)
+          );
           return [
             <HighlightedDraftSegment
               key={`${segmentIndex}-before`}
               segment={{ ...segment, text: beforeCursor }}
             />,
-            isCursorVisible ? (
-              <Text key={`${segmentIndex}-cursor`}>█</Text>
-            ) : null,
+            <HighlightedDraftSegment
+              key={`${segmentIndex}-cursor`}
+              segment={{
+                ...segment,
+                text: isCursorOnNewline ? "█" : cursorText,
+              }}
+              isInverse
+            />,
             <HighlightedDraftSegment
               key={`${segmentIndex}-after`}
               segment={{ ...segment, text: afterCursor }}

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -71,7 +71,6 @@ const KITTY_BACKSPACE_INPUT_PATTERN =
   /^\x1B\[(?:8|127)(?:;\d+(?::[12])?(?:;[\d:]+)?)?u$/;
 const KITTY_FORWARD_DELETE_INPUT_PATTERN = /^\x1B\[3;\d+:[12]~$/;
 const KEYBOARD_PROTOCOL_RESPONSE_PATTERN = /^\[\?\d+u$/;
-const BRACKETED_PASTE_MARKER_PATTERN = /(?:\x1B)?\[(?:200|201)~/g;
 const INTERRUPTED_MESSAGE_TEXT = "\n\n[Interrupted by user before completion.]";
 
 export type PxiAppProps = {
@@ -405,6 +404,14 @@ function isKeyboardProtocolResponseInput({ input }: { input: string }) {
   return KEYBOARD_PROTOCOL_RESPONSE_PATTERN.test(input);
 }
 
+function isBracketedPasteMarkerInput({ input }: { input: string }) {
+  return input === `${ESCAPE_INPUT}[200~` || input === `${ESCAPE_INPUT}[201~`;
+}
+
+function isStrippedBracketedPasteMarkerInput({ input }: { input: string }) {
+  return input === "[200~" || input === "[201~";
+}
+
 function isBackspaceInput({ input }: { input: string }) {
   return (
     BACKSPACE_INPUTS.has(input) || KITTY_BACKSPACE_INPUT_PATTERN.test(input)
@@ -419,10 +426,7 @@ function isForwardDeleteInput({ input }: { input: string }) {
 }
 
 function getDraftInputText({ input }: { input: string }) {
-  return input
-    .replace(BRACKETED_PASTE_MARKER_PATTERN, "")
-    .replace(/\r\n/g, "\n")
-    .replace(/\r/g, "\n");
+  return input.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
 function getCompletedInterruptedPart({
@@ -623,6 +627,36 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
       });
   };
 
+  const bracketedPasteMarkerCountRef = useRef(0);
+  const handleRawInput = (input: string) => {
+    if (status === "streaming") {
+      return;
+    }
+    if (isBracketedPasteMarkerInput({ input })) {
+      bracketedPasteMarkerCountRef.current += 1;
+      return;
+    }
+    if (isBackspaceInput({ input })) {
+      setDraft((value) => deleteDraftTextBeforeCursor({ draft: value }));
+      return;
+    }
+    if (isForwardDeleteInput({ input })) {
+      setDraft((value) => deleteDraftTextAtCursor({ draft: value }));
+    }
+  };
+  const rawInputHandlerRef = useRef(handleRawInput);
+  rawInputHandlerRef.current = handleRawInput;
+
+  useEffect(() => {
+    const handleInputEvent = (input: string) => {
+      rawInputHandlerRef.current(input);
+    };
+    inputEventEmitter.on("input", handleInputEvent);
+    return () => {
+      inputEventEmitter.removeListener("input", handleInputEvent);
+    };
+  }, [inputEventEmitter]);
+
   useInput((input, key) => {
     if (key.escape) {
       interruptStream();
@@ -685,6 +719,13 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
     if (key.backspace || key.delete) {
       return;
     }
+    if (
+      isStrippedBracketedPasteMarkerInput({ input }) &&
+      bracketedPasteMarkerCountRef.current > 0
+    ) {
+      bracketedPasteMarkerCountRef.current -= 1;
+      return;
+    }
     if (input) {
       const text = getDraftInputText({ input });
       if (text) {
@@ -692,31 +733,6 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
       }
     }
   });
-
-  const handleDeleteInput = (input: string) => {
-    if (status === "streaming") {
-      return;
-    }
-    if (isBackspaceInput({ input })) {
-      setDraft((value) => deleteDraftTextBeforeCursor({ draft: value }));
-      return;
-    }
-    if (isForwardDeleteInput({ input })) {
-      setDraft((value) => deleteDraftTextAtCursor({ draft: value }));
-    }
-  };
-  const deleteInputHandlerRef = useRef(handleDeleteInput);
-  deleteInputHandlerRef.current = handleDeleteInput;
-
-  useEffect(() => {
-    const handleInputEvent = (input: string) => {
-      deleteInputHandlerRef.current(input);
-    };
-    inputEventEmitter.on("input", handleInputEvent);
-    return () => {
-      inputEventEmitter.removeListener("input", handleInputEvent);
-    };
-  }, [inputEventEmitter]);
 
   return (
     <Box flexDirection="column" paddingX={1}>

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -25,6 +25,15 @@ import type { PxiChatClient, PxiMessage, PxiRuntimeOptions } from "./types";
 /** Whether the app is waiting on input (`idle`) or streaming a reply. */
 type PxiStatus = "idle" | "streaming";
 type PxiMessagePart = PxiMessage["parts"][number];
+type DraftEditorState = {
+  value: string;
+  cursorIndex: number;
+};
+type DraftSegment = {
+  text: string;
+  isCommandSegment: boolean;
+  isBold?: boolean;
+};
 
 const PXI_BANNER = String.raw`
 __/\\\\\\\\\\\\\____/\\\_______/\\\__/\\\\\\\\\\\_
@@ -46,6 +55,10 @@ const THINKING_FRAMES = [
 ];
 const KEYBOARD_PROTOCOL_RESPONSE_PATTERN = /^\[\?\d+u$/;
 const INTERRUPTED_MESSAGE_TEXT = "\n\n[Interrupted by user before completion.]";
+const EMPTY_DRAFT_EDITOR_STATE: DraftEditorState = {
+  value: "",
+  cursorIndex: 0,
+};
 
 export type PxiAppProps = {
   options: PxiRuntimeOptions;
@@ -191,32 +204,98 @@ function Transcript({
  * When the draft starts with `/`, the command name is colored yellow and the
  * arguments follow in default color. Everything else renders as plain text.
  */
-function HighlightedDraft({ draft }: { draft: string }) {
+function getHighlightedDraftSegments({
+  draft,
+}: {
+  draft: string;
+}): DraftSegment[] {
   if (!draft.startsWith("/")) {
-    return <Text>{draft}</Text>;
+    return [{ text: draft, isCommandSegment: false }];
   }
   const rest = draft.slice(1);
   const spaceIndex = rest.indexOf(" ");
   if (spaceIndex === -1) {
-    // Still typing the command name — color the whole token
-    return (
-      <Text>
-        <Text color="yellow">/</Text>
-        <Text color="yellow" bold>
-          {rest}
-        </Text>
-      </Text>
-    );
+    return [
+      { text: "/", isCommandSegment: true, isBold: false },
+      { text: rest, isCommandSegment: true, isBold: true },
+    ];
   }
   const cmdName = rest.slice(0, spaceIndex);
   const args = rest.slice(spaceIndex);
+  return [
+    { text: "/", isCommandSegment: true, isBold: false },
+    { text: cmdName, isCommandSegment: true, isBold: true },
+    { text: args, isCommandSegment: false },
+  ];
+}
+
+function HighlightedDraftSegment({ segment }: { segment: DraftSegment }) {
+  if (!segment.text) {
+    return null;
+  }
+  if (segment.isCommandSegment) {
+    return (
+      <Text color="yellow" bold={segment.isBold}>
+        {segment.text}
+      </Text>
+    );
+  }
+  return <Text>{segment.text}</Text>;
+}
+
+function HighlightedDraft({
+  draft,
+  cursorIndex,
+  isCursorVisible,
+}: {
+  draft: string;
+  cursorIndex: number;
+  isCursorVisible: boolean;
+}) {
+  const segments = getHighlightedDraftSegments({ draft });
+  const boundedCursorIndex = Math.min(Math.max(cursorIndex, 0), draft.length);
+  let nextSegmentStartIndex = 0;
+  let hasRenderedCursor = false;
+
   return (
     <Text>
-      <Text color="yellow">/</Text>
-      <Text color="yellow" bold>
-        {cmdName}
-      </Text>
-      <Text>{args}</Text>
+      {segments.flatMap((segment, segmentIndex) => {
+        const segmentStartIndex = nextSegmentStartIndex;
+        const segmentEndIndex = segmentStartIndex + segment.text.length;
+        nextSegmentStartIndex = segmentEndIndex;
+
+        if (
+          !hasRenderedCursor &&
+          boundedCursorIndex >= segmentStartIndex &&
+          boundedCursorIndex <= segmentEndIndex
+        ) {
+          hasRenderedCursor = true;
+          const cursorOffset = boundedCursorIndex - segmentStartIndex;
+          const beforeCursor = segment.text.slice(0, cursorOffset);
+          const afterCursor = segment.text.slice(cursorOffset);
+          return [
+            <HighlightedDraftSegment
+              key={`${segmentIndex}-before`}
+              segment={{ ...segment, text: beforeCursor }}
+            />,
+            isCursorVisible ? (
+              <Text key={`${segmentIndex}-cursor`}>█</Text>
+            ) : null,
+            <HighlightedDraftSegment
+              key={`${segmentIndex}-after`}
+              segment={{ ...segment, text: afterCursor }}
+            />,
+          ];
+        }
+
+        return [
+          <HighlightedDraftSegment
+            key={`${segmentIndex}-whole`}
+            segment={segment}
+          />,
+        ];
+      })}
+      {!hasRenderedCursor && isCursorVisible ? <Text>█</Text> : null}
     </Text>
   );
 }
@@ -227,16 +306,16 @@ function InputPrompt({
   status,
   usageLine,
 }: {
-  draft: string;
+  draft: DraftEditorState;
   status: PxiStatus;
   usageLine: string | null;
 }) {
-  const cursor = status === "streaming" ? "" : "█";
-  const cmdName = getSlashCommandName(draft);
+  const draftValue = draft.value;
+  const cmdName = getSlashCommandName(draftValue);
   // Show matching commands while the user is still typing the command token
   // (no space yet means they haven't moved on to arguments).
   const showHints =
-    cmdName !== null && !draft.includes(" ") && draft.length > 1;
+    cmdName !== null && !draftValue.includes(" ") && draftValue.length > 1;
   const hints = showHints ? matchingCommands(cmdName) : [];
 
   return (
@@ -251,8 +330,11 @@ function InputPrompt({
       >
         <Text>
           <Text color="cyan">{"> "}</Text>
-          <HighlightedDraft draft={draft} />
-          {cursor}
+          <HighlightedDraft
+            draft={draftValue}
+            cursorIndex={draft.cursorIndex}
+            isCursorVisible={status !== "streaming"}
+          />
         </Text>
       </Box>
       {/* Footer: helper text / command hints on the left, and the running token
@@ -288,6 +370,89 @@ function InputPrompt({
       </Box>
     </Box>
   );
+}
+
+function clampCursorIndex({ draft }: { draft: DraftEditorState }): number {
+  return Math.min(Math.max(draft.cursorIndex, 0), draft.value.length);
+}
+
+function insertDraftText({
+  draft,
+  text,
+}: {
+  draft: DraftEditorState;
+  text: string;
+}): DraftEditorState {
+  const cursorIndex = clampCursorIndex({ draft });
+  return {
+    value:
+      draft.value.slice(0, cursorIndex) + text + draft.value.slice(cursorIndex),
+    cursorIndex: cursorIndex + text.length,
+  };
+}
+
+function moveDraftCursor({
+  draft,
+  offset,
+}: {
+  draft: DraftEditorState;
+  offset: number;
+}): DraftEditorState {
+  return {
+    value: draft.value,
+    cursorIndex: Math.min(
+      Math.max(clampCursorIndex({ draft }) + offset, 0),
+      draft.value.length
+    ),
+  };
+}
+
+function moveDraftCursorToStart({
+  draft,
+}: {
+  draft: DraftEditorState;
+}): DraftEditorState {
+  return { value: draft.value, cursorIndex: 0 };
+}
+
+function moveDraftCursorToEnd({
+  draft,
+}: {
+  draft: DraftEditorState;
+}): DraftEditorState {
+  return { value: draft.value, cursorIndex: draft.value.length };
+}
+
+function deleteDraftTextBeforeCursor({
+  draft,
+}: {
+  draft: DraftEditorState;
+}): DraftEditorState {
+  const cursorIndex = clampCursorIndex({ draft });
+  if (cursorIndex === 0) {
+    return draft;
+  }
+  return {
+    value:
+      draft.value.slice(0, cursorIndex - 1) + draft.value.slice(cursorIndex),
+    cursorIndex: cursorIndex - 1,
+  };
+}
+
+function deleteDraftTextAtCursor({
+  draft,
+}: {
+  draft: DraftEditorState;
+}): DraftEditorState {
+  const cursorIndex = clampCursorIndex({ draft });
+  if (cursorIndex >= draft.value.length) {
+    return draft;
+  }
+  return {
+    value:
+      draft.value.slice(0, cursorIndex) + draft.value.slice(cursorIndex + 1),
+    cursorIndex,
+  };
 }
 
 function isKeyboardProtocolResponseInput({ input }: { input: string }) {
@@ -368,7 +533,9 @@ export function ThinkingIndicator() {
 export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
   const { exit } = useApp();
   const [messages, setMessages] = useState<PxiMessage[]>(initialMessages);
-  const [draft, setDraft] = useState("");
+  const [draft, setDraft] = useState<DraftEditorState>(
+    EMPTY_DRAFT_EDITOR_STATE
+  );
   const [status, setStatus] = useState<PxiStatus>("idle");
   const [error, setError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -408,18 +575,18 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
   const clearMessages = () => {
     setMessages([]);
     setError(null);
-    setDraft("");
+    setDraft(EMPTY_DRAFT_EDITOR_STATE);
   };
 
   const submitDraft = () => {
-    const text = draft.trim();
+    const text = draft.value.trim();
     if (!text || status === "streaming") {
       return;
     }
 
     // Intercept slash commands before sending to the server.
     if (text.startsWith("/")) {
-      setDraft("");
+      setDraft(EMPTY_DRAFT_EDITOR_STATE);
       const result = runSlashCommand(text, {
         clearMessages,
         exit: handleExit,
@@ -454,7 +621,7 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
     streamingAssistantMessageRef.current = null;
-    setDraft("");
+    setDraft(EMPTY_DRAFT_EDITOR_STATE);
     setError(null);
     setStatus("streaming");
     setMessages(nextMessages);
@@ -504,20 +671,48 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
     if (isKeyboardProtocolResponseInput({ input })) {
       return;
     }
+    if (key.ctrl && input === "a") {
+      setDraft((value) => moveDraftCursorToStart({ draft: value }));
+      return;
+    }
+    if (key.ctrl && input === "e") {
+      setDraft((value) => moveDraftCursorToEnd({ draft: value }));
+      return;
+    }
     if (key.return && key.shift) {
-      setDraft((value) => `${value}\n`);
+      setDraft((value) => insertDraftText({ draft: value, text: "\n" }));
       return;
     }
     if (key.return) {
       submitDraft();
       return;
     }
-    if (key.backspace || key.delete) {
-      setDraft((value) => value.slice(0, -1));
+    if (key.leftArrow) {
+      setDraft((value) => moveDraftCursor({ draft: value, offset: -1 }));
+      return;
+    }
+    if (key.rightArrow) {
+      setDraft((value) => moveDraftCursor({ draft: value, offset: 1 }));
+      return;
+    }
+    if (key.home) {
+      setDraft((value) => moveDraftCursorToStart({ draft: value }));
+      return;
+    }
+    if (key.end) {
+      setDraft((value) => moveDraftCursorToEnd({ draft: value }));
+      return;
+    }
+    if (key.backspace) {
+      setDraft((value) => deleteDraftTextBeforeCursor({ draft: value }));
+      return;
+    }
+    if (key.delete) {
+      setDraft((value) => deleteDraftTextAtCursor({ draft: value }));
       return;
     }
     if (input) {
-      setDraft((value) => `${value}${input}`);
+      setDraft((value) => insertDraftText({ draft: value, text: input }));
     }
   });
 

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -8,6 +8,16 @@ import {
   runSlashCommand,
   SLASH_COMMANDS,
 } from "./commands";
+import {
+  deleteDraftTextBeforeCursor,
+  EMPTY_DRAFT_EDITOR_STATE,
+  insertDraftText,
+  moveDraftCursor,
+  moveDraftCursorToEnd,
+  moveDraftCursorToStart,
+  moveDraftCursorVertically,
+  type DraftEditorState,
+} from "./draftEditor";
 import { Markdown } from "./inkMarkdown";
 import { formatTokenUsageLine, getLatestAssistantUsage } from "./tokenUsage";
 import { getToolProgressFromPart, type ToolProgress } from "./toolProgress";
@@ -25,10 +35,6 @@ import type { PxiChatClient, PxiMessage, PxiRuntimeOptions } from "./types";
 /** Whether the app is waiting on input (`idle`) or streaming a reply. */
 type PxiStatus = "idle" | "streaming";
 type PxiMessagePart = PxiMessage["parts"][number];
-type DraftEditorState = {
-  value: string;
-  cursorIndex: number;
-};
 type DraftSegment = {
   text: string;
   isCommandSegment: boolean;
@@ -55,10 +61,6 @@ const THINKING_FRAMES = [
 ];
 const KEYBOARD_PROTOCOL_RESPONSE_PATTERN = /^\[\?\d+u$/;
 const INTERRUPTED_MESSAGE_TEXT = "\n\n[Interrupted by user before completion.]";
-const EMPTY_DRAFT_EDITOR_STATE: DraftEditorState = {
-  value: "",
-  cursorIndex: 0,
-};
 
 export type PxiAppProps = {
   options: PxiRuntimeOptions;
@@ -372,89 +374,6 @@ function InputPrompt({
   );
 }
 
-function clampCursorIndex({ draft }: { draft: DraftEditorState }): number {
-  return Math.min(Math.max(draft.cursorIndex, 0), draft.value.length);
-}
-
-function insertDraftText({
-  draft,
-  text,
-}: {
-  draft: DraftEditorState;
-  text: string;
-}): DraftEditorState {
-  const cursorIndex = clampCursorIndex({ draft });
-  return {
-    value:
-      draft.value.slice(0, cursorIndex) + text + draft.value.slice(cursorIndex),
-    cursorIndex: cursorIndex + text.length,
-  };
-}
-
-function moveDraftCursor({
-  draft,
-  offset,
-}: {
-  draft: DraftEditorState;
-  offset: number;
-}): DraftEditorState {
-  return {
-    value: draft.value,
-    cursorIndex: Math.min(
-      Math.max(clampCursorIndex({ draft }) + offset, 0),
-      draft.value.length
-    ),
-  };
-}
-
-function moveDraftCursorToStart({
-  draft,
-}: {
-  draft: DraftEditorState;
-}): DraftEditorState {
-  return { value: draft.value, cursorIndex: 0 };
-}
-
-function moveDraftCursorToEnd({
-  draft,
-}: {
-  draft: DraftEditorState;
-}): DraftEditorState {
-  return { value: draft.value, cursorIndex: draft.value.length };
-}
-
-function deleteDraftTextBeforeCursor({
-  draft,
-}: {
-  draft: DraftEditorState;
-}): DraftEditorState {
-  const cursorIndex = clampCursorIndex({ draft });
-  if (cursorIndex === 0) {
-    return draft;
-  }
-  return {
-    value:
-      draft.value.slice(0, cursorIndex - 1) + draft.value.slice(cursorIndex),
-    cursorIndex: cursorIndex - 1,
-  };
-}
-
-function deleteDraftTextAtCursor({
-  draft,
-}: {
-  draft: DraftEditorState;
-}): DraftEditorState {
-  const cursorIndex = clampCursorIndex({ draft });
-  if (cursorIndex >= draft.value.length) {
-    return draft;
-  }
-  return {
-    value:
-      draft.value.slice(0, cursorIndex) + draft.value.slice(cursorIndex + 1),
-    cursorIndex,
-  };
-}
-
 function isKeyboardProtocolResponseInput({ input }: { input: string }) {
   return KEYBOARD_PROTOCOL_RESPONSE_PATTERN.test(input);
 }
@@ -695,6 +614,18 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
       setDraft((value) => moveDraftCursor({ draft: value, offset: 1 }));
       return;
     }
+    if (key.upArrow) {
+      setDraft((value) =>
+        moveDraftCursorVertically({ draft: value, direction: -1 })
+      );
+      return;
+    }
+    if (key.downArrow) {
+      setDraft((value) =>
+        moveDraftCursorVertically({ draft: value, direction: 1 })
+      );
+      return;
+    }
     if (key.home) {
       setDraft((value) => moveDraftCursorToStart({ draft: value }));
       return;
@@ -703,12 +634,8 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
       setDraft((value) => moveDraftCursorToEnd({ draft: value }));
       return;
     }
-    if (key.backspace) {
+    if (key.backspace || key.delete) {
       setDraft((value) => deleteDraftTextBeforeCursor({ draft: value }));
-      return;
-    }
-    if (key.delete) {
-      setDraft((value) => deleteDraftTextAtCursor({ draft: value }));
       return;
     }
     if (input) {

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, useApp, useInput } from "ink";
+import { Box, Text, useApp, useInput, useStdin } from "ink";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 
 import { createPxiChatClient, createUserMessage } from "./client";
@@ -9,6 +9,7 @@ import {
   SLASH_COMMANDS,
 } from "./commands";
 import {
+  deleteDraftTextAtCursor,
   deleteDraftTextBeforeCursor,
   EMPTY_DRAFT_EDITOR_STATE,
   insertDraftText,
@@ -59,6 +60,16 @@ const THINKING_FRAMES = [
   "PXI is thinking.. ",
   "PXI is thinking...",
 ];
+const ESCAPE_INPUT = "\x1B";
+const BACKSPACE_INPUTS = new Set(["\b", "\x7F"]);
+const FORWARD_DELETE_INPUTS = new Set([
+  `${ESCAPE_INPUT}[3~`,
+  `${ESCAPE_INPUT}[3$`,
+  `${ESCAPE_INPUT}[3^`,
+]);
+const KITTY_BACKSPACE_INPUT_PATTERN =
+  /^\x1B\[(?:8|127)(?:;\d+(?::[12])?(?:;[\d:]+)?)?u$/;
+const KITTY_FORWARD_DELETE_INPUT_PATTERN = /^\x1B\[3;\d+:[12]~$/;
 const KEYBOARD_PROTOCOL_RESPONSE_PATTERN = /^\[\?\d+u$/;
 const BRACKETED_PASTE_MARKER_PATTERN = /(?:\x1B)?\[(?:200|201)~/g;
 const INTERRUPTED_MESSAGE_TEXT = "\n\n[Interrupted by user before completion.]";
@@ -394,6 +405,19 @@ function isKeyboardProtocolResponseInput({ input }: { input: string }) {
   return KEYBOARD_PROTOCOL_RESPONSE_PATTERN.test(input);
 }
 
+function isBackspaceInput({ input }: { input: string }) {
+  return (
+    BACKSPACE_INPUTS.has(input) || KITTY_BACKSPACE_INPUT_PATTERN.test(input)
+  );
+}
+
+function isForwardDeleteInput({ input }: { input: string }) {
+  return (
+    FORWARD_DELETE_INPUTS.has(input) ||
+    KITTY_FORWARD_DELETE_INPUT_PATTERN.test(input)
+  );
+}
+
 function getDraftInputText({ input }: { input: string }) {
   return input
     .replace(BRACKETED_PASTE_MARKER_PATTERN, "")
@@ -474,6 +498,7 @@ export function ThinkingIndicator() {
  */
 export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
   const { exit } = useApp();
+  const { internal_eventEmitter: inputEventEmitter } = useStdin();
   const [messages, setMessages] = useState<PxiMessage[]>(initialMessages);
   const [draft, setDraft] = useState<DraftEditorState>(
     EMPTY_DRAFT_EDITOR_STATE
@@ -658,7 +683,6 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
       return;
     }
     if (key.backspace || key.delete) {
-      setDraft((value) => deleteDraftTextBeforeCursor({ draft: value }));
       return;
     }
     if (input) {
@@ -668,6 +692,31 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
       }
     }
   });
+
+  const handleDeleteInput = (input: string) => {
+    if (status === "streaming") {
+      return;
+    }
+    if (isBackspaceInput({ input })) {
+      setDraft((value) => deleteDraftTextBeforeCursor({ draft: value }));
+      return;
+    }
+    if (isForwardDeleteInput({ input })) {
+      setDraft((value) => deleteDraftTextAtCursor({ draft: value }));
+    }
+  };
+  const deleteInputHandlerRef = useRef(handleDeleteInput);
+  deleteInputHandlerRef.current = handleDeleteInput;
+
+  useEffect(() => {
+    const handleInputEvent = (input: string) => {
+      deleteInputHandlerRef.current(input);
+    };
+    inputEventEmitter.on("input", handleInputEvent);
+    return () => {
+      inputEventEmitter.removeListener("input", handleInputEvent);
+    };
+  }, [inputEventEmitter]);
 
   return (
     <Box flexDirection="column" paddingX={1}>

--- a/js/packages/phoenix-cli/src/pxi/draftEditor.ts
+++ b/js/packages/phoenix-cli/src/pxi/draftEditor.ts
@@ -1,0 +1,145 @@
+export type DraftEditorState = {
+  value: string;
+  cursorIndex: number;
+  preferredColumn?: number;
+};
+
+export const EMPTY_DRAFT_EDITOR_STATE: DraftEditorState = {
+  value: "",
+  cursorIndex: 0,
+};
+
+function clampCursorIndex({ draft }: { draft: DraftEditorState }): number {
+  return Math.min(Math.max(draft.cursorIndex, 0), draft.value.length);
+}
+
+export function insertDraftText({
+  draft,
+  text,
+}: {
+  draft: DraftEditorState;
+  text: string;
+}): DraftEditorState {
+  const cursorIndex = clampCursorIndex({ draft });
+  return {
+    value:
+      draft.value.slice(0, cursorIndex) + text + draft.value.slice(cursorIndex),
+    cursorIndex: cursorIndex + text.length,
+  };
+}
+
+export function moveDraftCursor({
+  draft,
+  offset,
+}: {
+  draft: DraftEditorState;
+  offset: number;
+}): DraftEditorState {
+  return {
+    value: draft.value,
+    cursorIndex: Math.min(
+      Math.max(clampCursorIndex({ draft }) + offset, 0),
+      draft.value.length
+    ),
+  };
+}
+
+export function moveDraftCursorToStart({
+  draft,
+}: {
+  draft: DraftEditorState;
+}): DraftEditorState {
+  return { value: draft.value, cursorIndex: 0 };
+}
+
+export function moveDraftCursorToEnd({
+  draft,
+}: {
+  draft: DraftEditorState;
+}): DraftEditorState {
+  return { value: draft.value, cursorIndex: draft.value.length };
+}
+
+export function deleteDraftTextBeforeCursor({
+  draft,
+}: {
+  draft: DraftEditorState;
+}): DraftEditorState {
+  const cursorIndex = clampCursorIndex({ draft });
+  if (cursorIndex === 0) {
+    return draft;
+  }
+  return {
+    value:
+      draft.value.slice(0, cursorIndex - 1) + draft.value.slice(cursorIndex),
+    cursorIndex: cursorIndex - 1,
+  };
+}
+
+function getDraftLineInfo({ draft }: { draft: DraftEditorState }): {
+  lineStartIndex: number;
+  lineEndIndex: number;
+  column: number;
+} {
+  const cursorIndex = clampCursorIndex({ draft });
+  const lineStartSearchIndex = Math.max(0, cursorIndex - 1);
+  const lineStartIndex =
+    draft.value.lastIndexOf("\n", lineStartSearchIndex) + 1;
+  const nextNewlineIndex = draft.value.indexOf("\n", cursorIndex);
+  const lineEndIndex =
+    nextNewlineIndex === -1 ? draft.value.length : nextNewlineIndex;
+  return {
+    lineStartIndex,
+    lineEndIndex,
+    column: cursorIndex - lineStartIndex,
+  };
+}
+
+export function moveDraftCursorVertically({
+  draft,
+  direction,
+}: {
+  draft: DraftEditorState;
+  direction: -1 | 1;
+}): DraftEditorState {
+  const currentLine = getDraftLineInfo({ draft });
+  const preferredColumn = draft.preferredColumn ?? currentLine.column;
+
+  if (direction === -1) {
+    if (currentLine.lineStartIndex === 0) {
+      return {
+        value: draft.value,
+        cursorIndex: clampCursorIndex({ draft }),
+        preferredColumn,
+      };
+    }
+    const previousLineEndIndex = currentLine.lineStartIndex - 1;
+    const previousLineStartIndex =
+      draft.value.lastIndexOf("\n", previousLineEndIndex - 1) + 1;
+    const previousLineLength = previousLineEndIndex - previousLineStartIndex;
+    return {
+      value: draft.value,
+      cursorIndex:
+        previousLineStartIndex + Math.min(preferredColumn, previousLineLength),
+      preferredColumn,
+    };
+  }
+
+  if (currentLine.lineEndIndex >= draft.value.length) {
+    return {
+      value: draft.value,
+      cursorIndex: clampCursorIndex({ draft }),
+      preferredColumn,
+    };
+  }
+  const nextLineStartIndex = currentLine.lineEndIndex + 1;
+  const nextNewlineIndex = draft.value.indexOf("\n", nextLineStartIndex);
+  const nextLineEndIndex =
+    nextNewlineIndex === -1 ? draft.value.length : nextNewlineIndex;
+  const nextLineLength = nextLineEndIndex - nextLineStartIndex;
+  return {
+    value: draft.value,
+    cursorIndex: nextLineStartIndex + Math.min(preferredColumn, nextLineLength),
+    preferredColumn,
+  };
+}

--- a/js/packages/phoenix-cli/src/pxi/draftEditor.ts
+++ b/js/packages/phoenix-cli/src/pxi/draftEditor.ts
@@ -98,9 +98,8 @@ function getDraftLineInfo({ draft }: { draft: DraftEditorState }): {
   column: number;
 } {
   const cursorIndex = clampCursorIndex({ draft });
-  const lineStartSearchIndex = Math.max(0, cursorIndex - 1);
   const lineStartIndex =
-    draft.value.lastIndexOf("\n", lineStartSearchIndex) + 1;
+    cursorIndex === 0 ? 0 : draft.value.lastIndexOf("\n", cursorIndex - 1) + 1;
   const nextNewlineIndex = draft.value.indexOf("\n", cursorIndex);
   const lineEndIndex =
     nextNewlineIndex === -1 ? draft.value.length : nextNewlineIndex;

--- a/js/packages/phoenix-cli/src/pxi/draftEditor.ts
+++ b/js/packages/phoenix-cli/src/pxi/draftEditor.ts
@@ -76,6 +76,22 @@ export function deleteDraftTextBeforeCursor({
   };
 }
 
+export function deleteDraftTextAtCursor({
+  draft,
+}: {
+  draft: DraftEditorState;
+}): DraftEditorState {
+  const cursorIndex = clampCursorIndex({ draft });
+  if (cursorIndex >= draft.value.length) {
+    return draft;
+  }
+  return {
+    value:
+      draft.value.slice(0, cursorIndex) + draft.value.slice(cursorIndex + 1),
+    cursorIndex,
+  };
+}
+
 function getDraftLineInfo({ draft }: { draft: DraftEditorState }): {
   lineStartIndex: number;
   lineEndIndex: number;

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -10,6 +10,8 @@ const ESCAPE_CHARACTER = String.fromCharCode(27);
 const ANSI_ESCAPE_PATTERN = new RegExp(`${ESCAPE_CHARACTER}\\[[0-9;]*m`, "g");
 const KITTY_SHIFT_ENTER = `${ESCAPE_CHARACTER}[13;2u`;
 const KITTY_PROTOCOL_RESPONSE = `${ESCAPE_CHARACTER}[?0u`;
+const BRACKETED_PASTE_START = `${ESCAPE_CHARACTER}[200~`;
+const BRACKETED_PASTE_END = `${ESCAPE_CHARACTER}[201~`;
 const UP_ARROW = `${ESCAPE_CHARACTER}[A`;
 const DOWN_ARROW = `${ESCAPE_CHARACTER}[B`;
 const LEFT_ARROW = `${ESCAPE_CHARACTER}[D`;
@@ -366,6 +368,124 @@ describe("PXI app", () => {
     await writeInput({ stdin, input: "\r" });
 
     expect(submittedText).toBe("say hello world");
+    unmount();
+  });
+
+  it("normalizes multiline pasted text before inserting it into the prompt", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+    const prompt = [
+      "Summarize the trace behavior below.",
+      "",
+      "First, identify the main failure mode.",
+      "",
+      "Then list the affected spans:",
+      "",
+      "- root span",
+      "- retrieval span",
+      "- generation span",
+      "",
+      "Now explain why the middle blank line matters:",
+      "",
+      "",
+      "After that, propose a fix.",
+      "",
+      "Finally, give me a concise next step.",
+    ].join("\n");
+
+    await writeInput({ stdin, input: prompt.replace(/\n/g, "\r\n") });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe(prompt);
+    unmount();
+  });
+
+  it("renders multiline pasted text without carriage-return compression", async () => {
+    const client: PxiChatClient = {
+      sendMessage: async () => null,
+    };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({
+      stdin,
+      input: [
+        "Now explain why the middle blank line matters:",
+        "",
+        "",
+        "After that, propose a fix.",
+        "",
+        "Finally, give me a concise next step.",
+      ].join("\r\n"),
+    });
+
+    const frame = stripAnsi(lastFrame() ?? "");
+    expect(frame).not.toContain("\r");
+    expect(frame).toMatch(
+      /Now explain why the middle blank line matters:\n\s*\n\s*\n\s*After that, propose a fix\.\n\s*\n\s*Finally, give me a concise next step\.█/
+    );
+    unmount();
+  });
+
+  it("deletes predictably after multiline pasted text", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+    const prompt = [
+      "Now explain why the middle blank line matters:",
+      "",
+      "",
+      "After that, propose a fix.",
+      "",
+      "Finally, give me a concise next step.",
+    ].join("\n");
+    const deletedText = "\nFinally, give me a concise next step.";
+
+    await writeInput({ stdin, input: prompt.replace(/\n/g, "\r\n") });
+    await writeInputRepeatedly({
+      stdin,
+      input: DELETE_KEY,
+      count: deletedText.length,
+    });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe(prompt.slice(0, -deletedText.length).trim());
+    unmount();
+  });
+
+  it("ignores bracketed paste markers around multiline pasted text", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+    const prompt = "top\n\nbottom";
+
+    await writeInput({
+      stdin,
+      input: `${BRACKETED_PASTE_START}${prompt}${BRACKETED_PASTE_END}`,
+    });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe(prompt);
     unmount();
   });
 

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -140,6 +140,42 @@ describe("PXI app", () => {
     unmount();
   });
 
+  it("renders the cursor over the selected character without shifting draft text", async () => {
+    const client: PxiChatClient = {
+      sendMessage: async () => null,
+    };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "hello" });
+    await writeInputRepeatedly({ stdin, input: LEFT_ARROW, count: 2 });
+
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toContain("█");
+    expect(stripAnsi(frame)).toContain("> hello");
+    unmount();
+  });
+
+  it("renders the cursor on an empty prompt line", async () => {
+    const client: PxiChatClient = {
+      sendMessage: async () => null,
+    };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "top" });
+    await writeInput({ stdin, input: KITTY_SHIFT_ENTER });
+    await writeInput({ stdin, input: KITTY_SHIFT_ENTER });
+    await writeInput({ stdin, input: "bottom" });
+    await writeInput({ stdin, input: UP_ARROW });
+
+    const frame = lastFrame() ?? "";
+    expect(stripAnsi(frame)).toMatch(/> top\n\s*█\n\s*bottom/);
+    unmount();
+  });
+
   it("uses Up arrow to move to the previous prompt line", async () => {
     let submittedText: string | undefined;
     const client = createCapturingClient({

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -10,6 +10,14 @@ const ESCAPE_CHARACTER = String.fromCharCode(27);
 const ANSI_ESCAPE_PATTERN = new RegExp(`${ESCAPE_CHARACTER}\\[[0-9;]*m`, "g");
 const KITTY_SHIFT_ENTER = `${ESCAPE_CHARACTER}[13;2u`;
 const KITTY_PROTOCOL_RESPONSE = `${ESCAPE_CHARACTER}[?0u`;
+const LEFT_ARROW = `${ESCAPE_CHARACTER}[D`;
+const RIGHT_ARROW = `${ESCAPE_CHARACTER}[C`;
+const HOME_KEY = `${ESCAPE_CHARACTER}[H`;
+const END_KEY = `${ESCAPE_CHARACTER}[F`;
+const DELETE_KEY = `${ESCAPE_CHARACTER}[3~`;
+const CTRL_A = "\x01";
+const CTRL_E = "\x05";
+const BACKSPACE = "\b";
 
 function stripAnsi(text: string): string {
   return text.replace(ANSI_ESCAPE_PATTERN, "");
@@ -30,6 +38,47 @@ function createOptions({
   });
 }
 
+function createCapturingClient({
+  onSubmit,
+}: {
+  onSubmit: (text: string | undefined) => void;
+}): PxiChatClient {
+  return {
+    sendMessage: async ({ messages }) => {
+      const userMessage = messages.at(-1);
+      const textPart = userMessage?.parts.find((part) => part.type === "text");
+      onSubmit(textPart?.text);
+      return null;
+    },
+  };
+}
+
+async function writeInput({
+  stdin,
+  input,
+}: {
+  stdin: { write: (input: string) => unknown };
+  input: string;
+}) {
+  await act(async () => {
+    stdin.write(input);
+  });
+}
+
+async function writeInputRepeatedly({
+  stdin,
+  input,
+  count,
+}: {
+  stdin: { write: (input: string) => unknown };
+  input: string;
+  count: number;
+}) {
+  for (let index = 0; index < count; index++) {
+    await writeInput({ stdin, input });
+  }
+}
+
 describe("PXI app", () => {
   it("renders the initial terminal UI", () => {
     const client: PxiChatClient = {
@@ -47,36 +96,130 @@ describe("PXI app", () => {
     unmount();
   });
 
-  it("uses Shift+Enter to insert a newline before submitting", async () => {
+  it("uses Shift+Enter to insert a newline at the cursor before submitting", async () => {
     let submittedText: string | undefined;
-    const client: PxiChatClient = {
-      sendMessage: async ({ messages }) => {
-        const userMessage = messages.at(-1);
-        const textPart = userMessage?.parts.find(
-          (part) => part.type === "text"
-        );
-        submittedText = textPart?.text;
-        return null;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
       },
-    };
+    });
     const { stdin, unmount } = render(
       <PxiApp options={createOptions()} client={client} />
     );
 
-    await act(async () => {
-      stdin.write("first line");
-    });
-    await act(async () => {
-      stdin.write(KITTY_SHIFT_ENTER);
-    });
-    await act(async () => {
-      stdin.write("second line");
-    });
-    await act(async () => {
-      stdin.write("\r");
-    });
+    await writeInput({ stdin, input: "first linesecond line" });
+    await writeInputRepeatedly({ stdin, input: LEFT_ARROW, count: 11 });
+    await writeInput({ stdin, input: KITTY_SHIFT_ENTER });
+    await writeInput({ stdin, input: "\r" });
 
     expect(submittedText).toBe("first line\nsecond line");
+    unmount();
+  });
+
+  it("uses Left and Right arrows to insert typed text at the cursor", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "helo" });
+    await writeInput({ stdin, input: LEFT_ARROW });
+    await writeInput({ stdin, input: "l" });
+    await writeInput({ stdin, input: RIGHT_ARROW });
+    await writeInput({ stdin, input: "!" });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("hello!");
+    unmount();
+  });
+
+  it("uses Backspace before the cursor and Delete at the cursor", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "abXYcd" });
+    await writeInputRepeatedly({ stdin, input: LEFT_ARROW, count: 3 });
+    await writeInput({ stdin, input: BACKSPACE });
+    await writeInput({ stdin, input: DELETE_KEY });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("abcd");
+    unmount();
+  });
+
+  it("uses Home and End to move the cursor", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "middle" });
+    await writeInput({ stdin, input: HOME_KEY });
+    await writeInput({ stdin, input: "start-" });
+    await writeInput({ stdin, input: END_KEY });
+    await writeInput({ stdin, input: "-end" });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("start-middle-end");
+    unmount();
+  });
+
+  it("uses Ctrl+A and Ctrl+E to move the cursor", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "middle" });
+    await writeInput({ stdin, input: CTRL_A });
+    await writeInput({ stdin, input: "start-" });
+    await writeInput({ stdin, input: CTRL_E });
+    await writeInput({ stdin, input: "-end" });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("start-middle-end");
+    unmount();
+  });
+
+  it("inserts pasted text at the cursor", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "hello world" });
+    await writeInput({ stdin, input: HOME_KEY });
+    await writeInput({ stdin, input: "say " });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("say hello world");
     unmount();
   });
 

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -227,6 +227,28 @@ describe("PXI app", () => {
     unmount();
   });
 
+  it("uses Down arrow from a blank first prompt line", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: KITTY_SHIFT_ENTER });
+    await writeInput({ stdin, input: "world" });
+    await writeInput({ stdin, input: CTRL_A });
+    await writeInput({ stdin, input: DOWN_ARROW });
+    await writeInput({ stdin, input: "!" });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("!world");
+    unmount();
+  });
+
   it("preserves the preferred cursor column across vertical cursor movement", async () => {
     let submittedText: string | undefined;
     const client = createCapturingClient({
@@ -558,6 +580,25 @@ describe("PXI app", () => {
     unmount();
   });
 
+  it("preserves literal bracketed paste marker text", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+    const prompt = "literal [200~ marker [201~ text";
+
+    await writeInput({ stdin, input: prompt });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe(prompt);
+    unmount();
+  });
+
   it("ignores terminal keyboard protocol responses", async () => {
     const client: PxiChatClient = {
       sendMessage: async () => null,
@@ -631,6 +672,8 @@ describe("PXI app", () => {
     await writeInput({ stdin, input: "ignored" });
     await writeInput({ stdin, input: MAC_DELETE });
     await writeInput({ stdin, input: DELETE_KEY });
+    await writeInput({ stdin, input: BRACKETED_PASTE_START });
+    await writeInput({ stdin, input: BRACKETED_PASTE_END });
     await writeInput({ stdin, input: "\r" });
 
     expect(submittedTexts).toEqual(["hello"]);
@@ -638,10 +681,10 @@ describe("PXI app", () => {
     await act(async () => {
       resolveResponse?.(null);
     });
-    await writeInput({ stdin, input: "next" });
+    await writeInput({ stdin, input: "next [200~ [201~" });
     await writeInput({ stdin, input: "\r" });
 
-    expect(submittedTexts).toEqual(["hello", "next"]);
+    expect(submittedTexts).toEqual(["hello", "next [200~ [201~"]);
     unmount();
   });
 

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -10,6 +10,8 @@ const ESCAPE_CHARACTER = String.fromCharCode(27);
 const ANSI_ESCAPE_PATTERN = new RegExp(`${ESCAPE_CHARACTER}\\[[0-9;]*m`, "g");
 const KITTY_SHIFT_ENTER = `${ESCAPE_CHARACTER}[13;2u`;
 const KITTY_PROTOCOL_RESPONSE = `${ESCAPE_CHARACTER}[?0u`;
+const UP_ARROW = `${ESCAPE_CHARACTER}[A`;
+const DOWN_ARROW = `${ESCAPE_CHARACTER}[B`;
 const LEFT_ARROW = `${ESCAPE_CHARACTER}[D`;
 const RIGHT_ARROW = `${ESCAPE_CHARACTER}[C`;
 const HOME_KEY = `${ESCAPE_CHARACTER}[H`;
@@ -138,7 +140,77 @@ describe("PXI app", () => {
     unmount();
   });
 
-  it("uses Backspace before the cursor and Delete at the cursor", async () => {
+  it("uses Up arrow to move to the previous prompt line", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "hello" });
+    await writeInput({ stdin, input: KITTY_SHIFT_ENTER });
+    await writeInput({ stdin, input: "world" });
+    await writeInput({ stdin, input: UP_ARROW });
+    await writeInput({ stdin, input: "!" });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("hello!\nworld");
+    unmount();
+  });
+
+  it("uses Down arrow to move to the next prompt line", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "hello" });
+    await writeInput({ stdin, input: KITTY_SHIFT_ENTER });
+    await writeInput({ stdin, input: "world" });
+    await writeInput({ stdin, input: CTRL_A });
+    await writeInput({ stdin, input: DOWN_ARROW });
+    await writeInput({ stdin, input: "!" });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("hello\n!world");
+    unmount();
+  });
+
+  it("preserves the preferred cursor column across vertical cursor movement", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "abcd" });
+    await writeInput({ stdin, input: KITTY_SHIFT_ENTER });
+    await writeInput({ stdin, input: "ef" });
+    await writeInput({ stdin, input: KITTY_SHIFT_ENTER });
+    await writeInput({ stdin, input: "ghij" });
+    await writeInput({ stdin, input: UP_ARROW });
+    await writeInput({ stdin, input: UP_ARROW });
+    await writeInput({ stdin, input: "!" });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("abcd!\nef\nghij");
+    unmount();
+  });
+
+  it("uses Backspace before the cursor", async () => {
     let submittedText: string | undefined;
     const client = createCapturingClient({
       onSubmit: (text) => {
@@ -152,10 +224,48 @@ describe("PXI app", () => {
     await writeInput({ stdin, input: "abXYcd" });
     await writeInputRepeatedly({ stdin, input: LEFT_ARROW, count: 3 });
     await writeInput({ stdin, input: BACKSPACE });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("abYcd");
+    unmount();
+  });
+
+  it("uses Delete before the cursor", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "abXcd" });
+    await writeInputRepeatedly({ stdin, input: LEFT_ARROW, count: 2 });
     await writeInput({ stdin, input: DELETE_KEY });
     await writeInput({ stdin, input: "\r" });
 
     expect(submittedText).toBe("abcd");
+    unmount();
+  });
+
+  it("uses Delete before the cursor at the end of the prompt", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "abc" });
+    await writeInput({ stdin, input: DELETE_KEY });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("ab");
     unmount();
   });
 

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -19,9 +19,13 @@ const RIGHT_ARROW = `${ESCAPE_CHARACTER}[C`;
 const HOME_KEY = `${ESCAPE_CHARACTER}[H`;
 const END_KEY = `${ESCAPE_CHARACTER}[F`;
 const DELETE_KEY = `${ESCAPE_CHARACTER}[3~`;
+const MODIFIED_DELETE_KEY = `${ESCAPE_CHARACTER}[3$`;
+const KITTY_MAC_DELETE = `${ESCAPE_CHARACTER}[127;1:1u`;
+const KITTY_FORWARD_DELETE_KEY = `${ESCAPE_CHARACTER}[3;1:1~`;
 const CTRL_A = "\x01";
 const CTRL_E = "\x05";
 const BACKSPACE = "\b";
+const MAC_DELETE = "\x7F";
 
 function stripAnsi(text: string): string {
   return text.replace(ANSI_ESCAPE_PATTERN, "");
@@ -268,7 +272,10 @@ describe("PXI app", () => {
     unmount();
   });
 
-  it("uses Delete before the cursor", async () => {
+  it.each([
+    ["Mac Delete", MAC_DELETE],
+    ["Kitty-enhanced Mac Delete", KITTY_MAC_DELETE],
+  ])("uses %s before the cursor", async (_name, deleteInput) => {
     let submittedText: string | undefined;
     const client = createCapturingClient({
       onSubmit: (text) => {
@@ -281,6 +288,45 @@ describe("PXI app", () => {
 
     await writeInput({ stdin, input: "abXcd" });
     await writeInputRepeatedly({ stdin, input: LEFT_ARROW, count: 2 });
+    await writeInput({ stdin, input: deleteInput });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("abcd");
+    unmount();
+  });
+
+  it("uses Mac Delete before the cursor at the end of the prompt", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "abc" });
+    await writeInput({ stdin, input: MAC_DELETE });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("ab");
+    unmount();
+  });
+
+  it("uses forward Delete after the cursor", async () => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "abXcd" });
+    await writeInputRepeatedly({ stdin, input: LEFT_ARROW, count: 3 });
     await writeInput({ stdin, input: DELETE_KEY });
     await writeInput({ stdin, input: "\r" });
 
@@ -288,7 +334,30 @@ describe("PXI app", () => {
     unmount();
   });
 
-  it("uses Delete before the cursor at the end of the prompt", async () => {
+  it.each([
+    ["modified terminal forward Delete", MODIFIED_DELETE_KEY],
+    ["Kitty-enhanced forward Delete", KITTY_FORWARD_DELETE_KEY],
+  ])("uses %s after the cursor", async (_name, deleteInput) => {
+    let submittedText: string | undefined;
+    const client = createCapturingClient({
+      onSubmit: (text) => {
+        submittedText = text;
+      },
+    });
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "abXcd" });
+    await writeInputRepeatedly({ stdin, input: LEFT_ARROW, count: 3 });
+    await writeInput({ stdin, input: deleteInput });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedText).toBe("abcd");
+    unmount();
+  });
+
+  it("leaves the prompt unchanged when forward Delete is pressed at the end", async () => {
     let submittedText: string | undefined;
     const client = createCapturingClient({
       onSubmit: (text) => {
@@ -303,7 +372,7 @@ describe("PXI app", () => {
     await writeInput({ stdin, input: DELETE_KEY });
     await writeInput({ stdin, input: "\r" });
 
-    expect(submittedText).toBe("ab");
+    expect(submittedText).toBe("abc");
     unmount();
   });
 
@@ -435,7 +504,7 @@ describe("PXI app", () => {
     unmount();
   });
 
-  it("deletes predictably after multiline pasted text", async () => {
+  it("uses Mac Delete predictably after multiline pasted text", async () => {
     let submittedText: string | undefined;
     const client = createCapturingClient({
       onSubmit: (text) => {
@@ -458,7 +527,7 @@ describe("PXI app", () => {
     await writeInput({ stdin, input: prompt.replace(/\n/g, "\r\n") });
     await writeInputRepeatedly({
       stdin,
-      input: DELETE_KEY,
+      input: MAC_DELETE,
       count: deletedText.length,
     });
     await writeInput({ stdin, input: "\r" });
@@ -532,6 +601,47 @@ describe("PXI app", () => {
     });
 
     expect(abortSignal?.aborted).toBe(true);
+    unmount();
+  });
+
+  it("ignores prompt editing while streaming", async () => {
+    const submittedTexts: string[] = [];
+    let resolveResponse: ((message: PxiMessage | null) => void) | undefined;
+    const client: PxiChatClient = {
+      sendMessage: async ({ messages }) => {
+        const userMessage = messages.at(-1);
+        const textPart = userMessage?.parts.find(
+          (part) => part.type === "text"
+        );
+        submittedTexts.push(textPart?.text ?? "");
+        if (submittedTexts.length === 1) {
+          return new Promise((resolve) => {
+            resolveResponse = resolve;
+          });
+        }
+        return null;
+      },
+    };
+    const { stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "hello" });
+    await writeInput({ stdin, input: "\r" });
+    await writeInput({ stdin, input: "ignored" });
+    await writeInput({ stdin, input: MAC_DELETE });
+    await writeInput({ stdin, input: DELETE_KEY });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedTexts).toEqual(["hello"]);
+
+    await act(async () => {
+      resolveResponse?.(null);
+    });
+    await writeInput({ stdin, input: "next" });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(submittedTexts).toEqual(["hello", "next"]);
     unmount();
   });
 


### PR DESCRIPTION
## Summary

Adds cursor-aware editing to the PXI prompt input so users can edit text in the middle of a draft instead of only appending at the end.

## Changes

- Replaces the single draft string with a small draft editor state that tracks both value and cursor position.
- Adds pure prompt-editing helpers for:
  - inserting typed or pasted text at the cursor
  - moving left/right
  - moving up/down across multiline prompts
  - moving to start/end with Home/End and Ctrl+A/Ctrl+E
  - deleting before the cursor with Backspace or Mac Delete
  - deleting at the cursor with terminal forward Delete
- Renders the visible cursor in-place over the selected character instead of pushing text aside.
- Preserves cursor visibility on empty lines inside multiline prompts.
- Normalizes pasted multiline text so CRLF paste input renders and submits predictably.
- Keeps PXI input disabled while streaming, while preserving Esc interrupt and Ctrl+C/Ctrl+D exit behavior.

## Testing

- `cd js/packages/phoenix-cli && pnpm test -- pxiApp.test.tsx`
- `cd js/packages/phoenix-cli && pnpm typecheck`

Related issue: N/A
