### PR TITLE
feat(agents): add inference eval live runner

### DIFF
--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -13,6 +13,35 @@ live-model PXI server-side evals as Phoenix experiments.
 Fast unit coverage for the harness and evaluators lives under
 `tests/unit/pxi/evals/`.
 
+## In-Process Inference Evals
+
+PXI also has a server-side live runner in
+`src/phoenix/server/agents/inference_evals.py`. It is intentionally PXI-specific:
+when a traced PXI turn finishes, a span processor hands the completed trace to
+an app-level dispatcher, which scores the turn off the request path and writes
+span annotations plus evaluator spans back to the same destinations as the PXI
+traces. Evaluator spans are appended to the evaluated PXI trace under a
+`PXI inference evals` `EVALUATOR` grouping span when local or remote trace export
+is enabled.
+
+The live runner currently emits:
+
+- `tool_count_per_turn` (`CODE`) -- counts child `TOOL` spans under the
+  `PXIAgent.iter` root span.
+
+Configuration:
+
+```bash
+export PHOENIX_PXI_INFERENCE_EVALS_ENABLED=true        # default true only when PHOENIX_AGENTS_COLLECTOR_ENDPOINT is set
+export PHOENIX_PXI_INFERENCE_EVALS_SAMPLE_RATE=1.0     # deterministic by trace_id
+```
+
+Local annotations and evaluator spans are written only when the PXI request
+locally ingests traces. Remote annotations and evaluator spans are mirrored only
+when the PXI request enables remote trace export. The dispatcher is bounded and
+drops work on overload; scorer failures and timeouts are logged and do not
+affect the agent response.
+
 ## Run Locally
 
 The canonical entrypoint is `evals/pxi/harness/run_experiment.py`. Start

--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -13,35 +13,6 @@ live-model PXI server-side evals as Phoenix experiments.
 Fast unit coverage for the harness and evaluators lives under
 `tests/unit/pxi/evals/`.
 
-## In-Process Inference Evals
-
-PXI also has a server-side live runner in
-`src/phoenix/server/agents/inference_evals.py`. It is intentionally PXI-specific:
-when a traced PXI turn finishes, a span processor hands the completed trace to
-an app-level dispatcher, which scores the turn off the request path and writes
-span annotations plus evaluator spans back to the same destinations as the PXI
-traces. Evaluator spans are appended to the evaluated PXI trace under a
-`PXI inference evals` `EVALUATOR` grouping span when local or remote trace export
-is enabled.
-
-The live runner currently emits:
-
-- `tool_count_per_turn` (`CODE`) -- counts child `TOOL` spans under the
-  `PXIAgent.iter` root span.
-
-Configuration:
-
-```bash
-export PHOENIX_PXI_INFERENCE_EVALS_ENABLED=true        # default true only when PHOENIX_AGENTS_COLLECTOR_ENDPOINT is set
-export PHOENIX_PXI_INFERENCE_EVALS_SAMPLE_RATE=1.0     # deterministic by trace_id
-```
-
-Local annotations and evaluator spans are written only when the PXI request
-locally ingests traces. Remote annotations and evaluator spans are mirrored only
-when the PXI request enables remote trace export. The dispatcher is bounded and
-drops work on overload; scorer failures and timeouts are logged and do not
-affect the agent response.
-
 ## Run Locally
 
 The canonical entrypoint is `evals/pxi/harness/run_experiment.py`. Start

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -90,6 +90,14 @@ ENV_PHOENIX_AGENTS_DISABLE_BASH = "PHOENIX_AGENTS_DISABLE_BASH"
 Disables the server-side bash tool by preventing subagents from being attached to
 the assistant. When true, the option to enable subagents is also hidden from the UI settings.
 """
+ENV_PHOENIX_PXI_INFERENCE_EVALS_ENABLED = "PHOENIX_PXI_INFERENCE_EVALS_ENABLED"
+"""
+Whether to run PXI inference evals asynchronously when a traced PXI turn finishes.
+"""
+ENV_PHOENIX_PXI_INFERENCE_EVALS_SAMPLE_RATE = "PHOENIX_PXI_INFERENCE_EVALS_SAMPLE_RATE"
+"""
+Global deterministic trace sampling rate for PXI inference evals.
+"""
 ENV_PHOENIX_DISABLE_AGENT_ASSISTANT = "PHOENIX_DISABLE_AGENT_ASSISTANT"
 """
 Whether to disable the agent assistant feature (the /chat endpoint). Defaults to False,
@@ -1364,6 +1372,23 @@ def get_env_phoenix_agents_web_access_enabled() -> bool:
 
 def get_env_phoenix_agents_disable_bash() -> bool:
     return _bool_val(ENV_PHOENIX_AGENTS_DISABLE_BASH, False)
+
+
+def get_env_pxi_inference_evals_enabled() -> bool:
+    return _bool_val(
+        ENV_PHOENIX_PXI_INFERENCE_EVALS_ENABLED,
+        bool(get_env_phoenix_agents_collector_endpoint()),
+    )
+
+
+def get_env_pxi_inference_evals_sample_rate() -> float:
+    sample_rate = _float_val(ENV_PHOENIX_PXI_INFERENCE_EVALS_SAMPLE_RATE, 1.0)
+    if not 0 <= sample_rate <= 1:
+        raise ValueError(
+            f"{ENV_PHOENIX_PXI_INFERENCE_EVALS_SAMPLE_RATE} must be between 0 and 1. "
+            f"Got: {sample_rate}"
+        )
+    return sample_rate
 
 
 class AuthSettings(NamedTuple):

--- a/src/phoenix/db/insertion/span.py
+++ b/src/phoenix/db/insertion/span.py
@@ -26,13 +26,18 @@ async def insert_span(
     session: AsyncSession,
     span: Span,
     project_name: str,
+    *,
+    create_trace_if_missing: bool = True,
 ) -> Optional[SpanInsertionEvent]:
     dialect = SupportedSQLDialect(session.bind.dialect.name)
 
     trace_id = span.context.trace_id
-    trace: models.Trace = await session.scalar(
+    trace: models.Trace | None = await session.scalar(
         select(models.Trace).filter_by(trace_id=trace_id)
-    ) or models.Trace(trace_id=trace_id)
+    )
+    if trace is None and not create_trace_if_missing:
+        return None
+    trace = trace or models.Trace(trace_id=trace_id)
 
     if trace.id is not None:
         # We use the existing project_rowid on the trace because we allow users to transfer traces

--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -40,6 +40,8 @@ from phoenix.server.agents.web_access import (
     build_web_search_capability,
 )
 
+PXI_AGENT_NAME = "PXIAgent"
+
 
 def get_skills_capability_function(
     *,
@@ -138,7 +140,7 @@ def build_agent(
 
     agent: Agent[AgentDependencies, AgentOutput] = Agent(
         model,
-        name="PXIAgent",
+        name=PXI_AGENT_NAME,
         deps_type=AgentDependencies,
         output_type=[str, DeferredToolRequests],
         instructions=resolved_prompts.base.render(),

--- a/src/phoenix/server/agents/inference_evals.py
+++ b/src/phoenix/server/agents/inference_evals.py
@@ -411,7 +411,12 @@ async def _score_trace(
         context=_target_parent_context(trace=trace, parent_span_id=trace.root.span_id),
     ) as span:
         _set_inference_eval_span_attributes(span, trace)
-        annotations.extend(_run_eval("tool_count_per_turn", trace, tracer=tracer))
+        try:
+            annotations.extend(_score_tool_count_per_turn(trace, tracer=tracer))
+        except Exception:
+            logger.exception(
+                "PXI inference eval tool_count_per_turn failed for trace %s", trace.trace_id
+            )
         span.set_attribute(
             SpanAttributes.OUTPUT_VALUE,
             json.dumps(
@@ -427,19 +432,6 @@ async def _score_trace(
             ),
         )
     return annotations
-
-
-def _run_eval(
-    name: str,
-    trace: FinishedTrace,
-    *,
-    tracer: Any,
-) -> list[InferenceEvalAnnotation]:
-    try:
-        return _score_tool_count_per_turn(trace, tracer=tracer)
-    except Exception:
-        logger.exception("PXI inference eval %s failed for trace %s", name, trace.trace_id)
-    return []
 
 
 def _score_tool_count_per_turn(
@@ -566,18 +558,19 @@ def _snapshot_span(span: SDKSpan | ReadableSpan) -> FinishedSpan:
     parent_id = format_span_id(parent.span_id) if parent is not None else None
     if parent_id == "0000000000000000":
         parent_id = None
+    span_kind = (span.attributes or {}).get(SpanAttributes.OPENINFERENCE_SPAN_KIND)
     return FinishedSpan(
         span_id=format_span_id(context.span_id),
         trace_id=format_trace_id(context.trace_id),
         parent_id=parent_id,
         name=span.name,
-        span_kind=_string_attr((span.attributes or {}).get(SpanAttributes.OPENINFERENCE_SPAN_KIND)),
+        span_kind=span_kind if isinstance(span_kind, str) else None,
         attributes=dict(span.attributes or {}),
     )
 
 
 def _is_root_span(span: FinishedSpan) -> bool:
-    return span.parent_id is None or span.parent_id == "0000000000000000"
+    return span.parent_id is None
 
 
 def _is_turn_start(trace: FinishedTrace) -> bool:
@@ -601,10 +594,6 @@ def _sample(trace_id: str, sample_rate: float) -> bool:
     digest = hashlib.sha256(trace_id.encode("utf-8")).digest()
     value = int.from_bytes(digest[:8], "big") / 2**64
     return value < sample_rate
-
-
-def _string_attr(value: Any) -> str | None:
-    return value if isinstance(value, str) else None
 
 
 async def _ensure_project_exists(db: DbSessionFactory, project_name: str) -> int:

--- a/src/phoenix/server/agents/inference_evals.py
+++ b/src/phoenix/server/agents/inference_evals.py
@@ -1,0 +1,656 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import time
+from collections import OrderedDict
+from collections.abc import Awaitable, Callable, Sequence
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal, cast
+
+import httpx
+from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.sdk.trace import Span as SDKSpan
+from opentelemetry.trace import (
+    NonRecordingSpan,
+    Span,
+    SpanContext,
+    TraceFlags,
+    TraceState,
+    format_span_id,
+    format_trace_id,
+    set_span_in_context,
+)
+from sqlalchemy import select
+
+from phoenix.client import AsyncClient
+from phoenix.client.resources.spans import SpanAnnotationData, SpanAnnotationResult
+from phoenix.config import (
+    get_env_phoenix_agents_assistant_project_name,
+    get_env_phoenix_agents_collector_api_key,
+    get_env_phoenix_agents_collector_endpoint,
+    get_env_pxi_inference_evals_sample_rate,
+)
+from phoenix.db import models
+from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
+from phoenix.db.insertion.span import insert_span
+from phoenix.db.insertion.types import Precursors
+from phoenix.server.daemons.span_cost_calculator import SpanCostCalculator
+from phoenix.server.telemetry import normalize_http_collector_endpoint
+from phoenix.server.types import DbSessionFactory
+from phoenix.trace.schemas import (
+    Span as TraceSpan,
+)
+from phoenix.trace.schemas import (
+    SpanContext as TraceSpanContext,
+)
+from phoenix.trace.schemas import (
+    SpanEvent,
+    SpanKind,
+    SpanStatusCode,
+)
+from phoenix.tracers import Tracer, detached_otel_context
+
+logger = logging.getLogger(__name__)
+
+_QUEUE_MAX_SIZE = 200
+_WORKER_COUNT = 2
+_EVAL_TIMEOUT_SECONDS = 20
+_REMOTE_RETRY_DELAYS_SECONDS = (2.0, 4.0, 8.0, 16.0, 32.0)
+_LOCAL_TRACE_APPEND_RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2, 0.5, 1.0)
+_TRACE_BUFFER_TTL_SECONDS = 300
+_TRACE_BUFFER_MAX_SIZE = 500
+_PXI_ROOT_SPAN_NAME = "PXIAgent.iter"
+_ANNOTATION_IDENTIFIER = "pxi-inference-evals"
+_INFERENCE_EVAL_TRIGGER = "inference"
+
+
+@dataclass(frozen=True)
+class FinishedSpan:
+    span_id: str
+    trace_id: str
+    parent_id: str | None
+    name: str
+    span_kind: str | None
+    attributes: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class FinishedTrace:
+    trace_id: str
+    root: FinishedSpan
+    spans: tuple[FinishedSpan, ...]
+    session_id: str | None
+    project_name: str
+    enable_local_ingest: bool
+    enable_remote_export: bool
+
+
+@dataclass(frozen=True)
+class InferenceEvalAnnotation:
+    span_id: str
+    name: str
+    annotator_kind: Literal["LLM", "CODE"]
+    label: str | None = None
+    score: float | None = None
+    explanation: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    identifier: str = _ANNOTATION_IDENTIFIER
+
+    def as_span_annotation_data(self) -> SpanAnnotationData:
+        result: dict[str, Any] = {}
+        if self.label is not None:
+            result["label"] = self.label
+        if self.score is not None:
+            result["score"] = self.score
+        if self.explanation is not None:
+            result["explanation"] = self.explanation
+        payload: dict[str, Any] = {
+            "span_id": self.span_id,
+            "name": self.name,
+            "annotator_kind": self.annotator_kind,
+            "metadata": self.metadata,
+            "identifier": self.identifier,
+        }
+        if result:
+            payload["result"] = cast(SpanAnnotationResult, result)
+        return cast(SpanAnnotationData, payload)
+
+    def as_precursor(self) -> Precursors.SpanAnnotation:
+        return Precursors.SpanAnnotation(
+            updated_at=datetime.now(timezone.utc),
+            span_id=self.span_id,
+            obj=models.SpanAnnotation(
+                name=self.name,
+                annotator_kind=self.annotator_kind,
+                score=self.score,
+                label=self.label,
+                explanation=self.explanation,
+                metadata_=self.metadata,
+                identifier=self.identifier,
+                source="API",
+            ),
+        )
+
+
+@dataclass
+class _TraceBuffer:
+    created_at: float
+    spans: dict[str, FinishedSpan] = field(default_factory=dict)
+    root: FinishedSpan | None = None
+
+
+class EvalTriggerSpanProcessor(SpanProcessor):
+    """Buffers PXI spans and enqueues a finished trace when an AGENT root span ends."""
+
+    def __init__(
+        self,
+        *,
+        dispatcher: InferenceEvalDispatcher,
+        project_name: str,
+        enable_local_ingest: bool,
+        enable_remote_export: bool,
+        ttl_seconds: float = _TRACE_BUFFER_TTL_SECONDS,
+        max_traces: int = _TRACE_BUFFER_MAX_SIZE,
+    ) -> None:
+        self._dispatcher = dispatcher
+        self._project_name = project_name
+        self._enable_local_ingest = enable_local_ingest
+        self._enable_remote_export = enable_remote_export
+        self._ttl_seconds = ttl_seconds
+        self._max_traces = max_traces
+        self._buffers: OrderedDict[str, _TraceBuffer] = OrderedDict()
+
+    def on_start(self, span: SDKSpan, parent_context: Context | None = None) -> None:
+        self._remember(_snapshot_span(span))
+
+    def on_end(self, span: ReadableSpan) -> None:
+        finished_span = _snapshot_span(span)
+        buffer = self._remember(finished_span)
+        if (
+            _is_root_span(finished_span)
+            and finished_span.name == _PXI_ROOT_SPAN_NAME
+            and finished_span.span_kind == OpenInferenceSpanKindValues.AGENT.value
+        ):
+            buffer.root = finished_span
+            trace = FinishedTrace(
+                trace_id=finished_span.trace_id,
+                root=finished_span,
+                spans=tuple(buffer.spans.values()),
+                session_id=_string_attr(finished_span.attributes.get(SpanAttributes.SESSION_ID)),
+                project_name=self._project_name,
+                enable_local_ingest=self._enable_local_ingest,
+                enable_remote_export=self._enable_remote_export,
+            )
+            self._buffers.pop(finished_span.trace_id, None)
+            self._dispatcher.enqueue_threadsafe(trace)
+
+    def shutdown(self) -> None:
+        self._buffers.clear()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
+
+    def _remember(self, span: FinishedSpan) -> _TraceBuffer:
+        self._evict_old()
+        buffer = self._buffers.get(span.trace_id)
+        if buffer is None:
+            buffer = _TraceBuffer(created_at=time.monotonic())
+            self._buffers[span.trace_id] = buffer
+        self._buffers.move_to_end(span.trace_id)
+        buffer.spans[span.span_id] = span
+        if span.parent_id is None:
+            buffer.root = span
+        while len(self._buffers) > self._max_traces:
+            trace_id, _ = self._buffers.popitem(last=False)
+            logger.warning(
+                "Evicted PXI inference eval trace buffer %s after max-size overflow", trace_id
+            )
+        return buffer
+
+    def _evict_old(self) -> None:
+        now = time.monotonic()
+        expired = [
+            trace_id
+            for trace_id, buffer in self._buffers.items()
+            if now - buffer.created_at > self._ttl_seconds
+        ]
+        for trace_id in expired:
+            self._buffers.pop(trace_id, None)
+            logger.warning("Evicted stale PXI inference eval trace buffer %s", trace_id)
+
+
+class InferenceEvalDispatcher(AbstractAsyncContextManager["InferenceEvalDispatcher"]):
+    """Runs PXI inference evals off the request path and writes span annotations."""
+
+    def __init__(
+        self,
+        *,
+        db: DbSessionFactory,
+        enqueue_annotations: Callable[..., Awaitable[None]],
+        span_cost_calculator: SpanCostCalculator,
+        queue_max_size: int = _QUEUE_MAX_SIZE,
+        worker_count: int = _WORKER_COUNT,
+    ) -> None:
+        self._db = db
+        self._enqueue_annotations = enqueue_annotations
+        self._span_cost_calculator = span_cost_calculator
+        self._queue: asyncio.Queue[FinishedTrace | None] = asyncio.Queue(maxsize=queue_max_size)
+        self._worker_count = worker_count
+        self._workers: list[asyncio.Task[None]] = []
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._dropped_count = 0
+        self._accepting = False
+        self._remote_client: AsyncClient | None = None
+        self._global_sample_rate = get_env_pxi_inference_evals_sample_rate()
+
+    @property
+    def dropped_count(self) -> int:
+        return self._dropped_count
+
+    async def __aenter__(self) -> "InferenceEvalDispatcher":
+        self._loop = asyncio.get_running_loop()
+        self._accepting = True
+        if endpoint := get_env_phoenix_agents_collector_endpoint():
+            base_url = normalize_http_collector_endpoint(endpoint)
+            self._remote_client = AsyncClient(
+                base_url=base_url,
+                api_key=get_env_phoenix_agents_collector_api_key(),
+            )
+        self._workers = [
+            asyncio.create_task(self._worker(), name=f"pxi-inference-eval-worker-{i}")
+            for i in range(self._worker_count)
+        ]
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        self._accepting = False
+        for _ in self._workers:
+            await self._queue.put(None)
+        await asyncio.gather(*self._workers, return_exceptions=True)
+        if self._remote_client is not None:
+            await self._remote_client._client.aclose()
+
+    def enqueue_threadsafe(self, trace: FinishedTrace) -> None:
+        loop = self._loop
+        if loop is None or not self._accepting:
+            return
+        loop.call_soon_threadsafe(self._enqueue_nowait, trace)
+
+    def _enqueue_nowait(self, trace: FinishedTrace) -> None:
+        if not self._accepting:
+            return
+        try:
+            self._queue.put_nowait(trace)
+        except asyncio.QueueFull:
+            self._dropped_count += 1
+            logger.warning(
+                "Dropped PXI inference eval trace %s because the queue is full", trace.trace_id
+            )
+
+    async def _worker(self) -> None:
+        while True:
+            trace = await self._queue.get()
+            try:
+                if trace is None:
+                    return
+                await self._process_trace(trace)
+            except Exception:
+                logger.exception("PXI inference eval worker failed while processing a trace")
+            finally:
+                self._queue.task_done()
+
+    async def _process_trace(self, trace: FinishedTrace) -> None:
+        if not _sample(trace.trace_id, self._global_sample_rate):
+            return
+        annotations: list[InferenceEvalAnnotation] = []
+        eval_tracer = Tracer(
+            span_cost_calculator=self._span_cost_calculator,
+            enable_remote_export=trace.enable_remote_export,
+            project_name=trace.project_name,
+        )
+        try:
+            with detached_otel_context():
+                annotations.extend(await _score_trace(trace, eval_tracer=eval_tracer))
+        finally:
+            eval_tracer.tracer_provider.force_flush()
+            if trace.enable_local_ingest:
+                await self._persist_eval_traces(
+                    eval_tracer=eval_tracer,
+                    project_name=trace.project_name,
+                    target_trace_id=trace.trace_id,
+                )
+            eval_tracer.tracer_provider.shutdown()
+
+        if annotations:
+            await self._write_annotations(trace=trace, annotations=annotations)
+
+    async def _persist_eval_traces(
+        self,
+        *,
+        eval_tracer: Tracer,
+        project_name: str,
+        target_trace_id: str,
+    ) -> None:
+        project_id = await _ensure_project_exists(self._db, project_name)
+        db_traces = eval_tracer.get_db_traces(project_id=project_id)
+        if not db_traces:
+            return
+        for delay in (0.0, *_LOCAL_TRACE_APPEND_RETRY_DELAYS_SECONDS):
+            if delay:
+                await asyncio.sleep(delay)
+            if await _append_eval_spans_to_existing_trace(
+                db=self._db,
+                db_traces=db_traces,
+                project_name=project_name,
+            ):
+                return
+        logger.warning(
+            "Skipped local PXI inference eval spans for trace %s because the target trace "
+            "was not persisted before append retries were exhausted",
+            target_trace_id,
+        )
+
+    async def _write_annotations(
+        self,
+        *,
+        trace: FinishedTrace,
+        annotations: Sequence[InferenceEvalAnnotation],
+    ) -> None:
+        annotation_data = [annotation.as_span_annotation_data() for annotation in annotations]
+        if trace.enable_local_ingest:
+            await self._enqueue_annotations(
+                *(annotation.as_precursor() for annotation in annotations)
+            )
+        if trace.enable_remote_export and self._remote_client is not None:
+            await self._write_remote_annotations(annotation_data)
+
+    async def _write_remote_annotations(self, annotations: Sequence[SpanAnnotationData]) -> None:
+        for attempt, delay in enumerate((0.0, *_REMOTE_RETRY_DELAYS_SECONDS)):
+            if delay:
+                await asyncio.sleep(delay)
+            remote_client = self._remote_client
+            if remote_client is None:
+                return
+            try:
+                await remote_client.spans.log_span_annotations(
+                    span_annotations=annotations,
+                    sync=True,
+                )
+                return
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                if status_code != 404 and status_code < 500:
+                    logger.warning("PXI inference eval remote annotation write failed: %s", exc)
+                    return
+                if attempt == len(_REMOTE_RETRY_DELAYS_SECONDS):
+                    logger.warning(
+                        "PXI inference eval remote annotation write exhausted retries: %s", exc
+                    )
+            except httpx.HTTPError as exc:
+                if attempt == len(_REMOTE_RETRY_DELAYS_SECONDS):
+                    logger.warning(
+                        "PXI inference eval remote annotation write exhausted retries: %s", exc
+                    )
+
+
+async def _score_trace(
+    trace: FinishedTrace, *, eval_tracer: Tracer
+) -> list[InferenceEvalAnnotation]:
+    if not _is_turn_start(trace):
+        return []
+    tracer = eval_tracer.tracer_provider.get_tracer(__name__)
+    annotations: list[InferenceEvalAnnotation] = []
+    with tracer.start_as_current_span(
+        "PXI inference evals",
+        context=_target_parent_context(trace=trace, parent_span_id=trace.root.span_id),
+    ) as span:
+        _set_inference_eval_span_attributes(span, trace)
+        tasks: list[tuple[str, Awaitable[list[InferenceEvalAnnotation]]]] = [
+            ("tool_count_per_turn", _score_tool_count_per_turn_async(trace, tracer=tracer)),
+        ]
+        results = await asyncio.gather(
+            *(_run_eval_task(name, awaitable, trace=trace) for name, awaitable in tasks)
+        )
+        for result in results:
+            annotations.extend(result)
+        span.set_attribute(
+            SpanAttributes.OUTPUT_VALUE,
+            json.dumps(
+                [
+                    {
+                        "name": annotation.name,
+                        "label": annotation.label,
+                        "score": annotation.score,
+                    }
+                    for annotation in annotations
+                ],
+                ensure_ascii=False,
+            ),
+        )
+    return annotations
+
+
+async def _run_eval_task(
+    name: str,
+    awaitable: Awaitable[list[InferenceEvalAnnotation]],
+    *,
+    trace: FinishedTrace,
+) -> list[InferenceEvalAnnotation]:
+    try:
+        return await asyncio.wait_for(awaitable, timeout=_EVAL_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError:
+        logger.warning("PXI inference eval %s timed out for trace %s", name, trace.trace_id)
+    except Exception:
+        logger.exception("PXI inference eval %s failed for trace %s", name, trace.trace_id)
+    return []
+
+
+async def _score_tool_count_per_turn_async(
+    trace: FinishedTrace,
+    *,
+    tracer: Any,
+) -> list[InferenceEvalAnnotation]:
+    return _score_tool_count_per_turn(trace, tracer=tracer)
+
+
+def _score_tool_count_per_turn(
+    trace: FinishedTrace,
+    *,
+    tracer: Any | None = None,
+) -> list[InferenceEvalAnnotation]:
+    count = sum(
+        1 for span in trace.spans if span.span_kind == OpenInferenceSpanKindValues.TOOL.value
+    )
+    annotations = [
+        InferenceEvalAnnotation(
+            span_id=trace.root.span_id,
+            name="tool_count_per_turn",
+            annotator_kind="CODE",
+            score=float(count),
+            explanation=f"Counted {count} TOOL spans under the PXI turn root.",
+            metadata={"trace_id": trace.trace_id},
+        )
+    ]
+    if tracer is None:
+        return annotations
+    input_payload = {"trace_id": trace.trace_id, "root_span_id": trace.root.span_id}
+    with tracer.start_as_current_span("tool_count_per_turn.evaluate") as span:
+        _set_inference_eval_span_attributes(span, trace, input_payload=input_payload)
+        span.set_attribute(
+            SpanAttributes.OUTPUT_VALUE,
+            json.dumps({"score": count}, ensure_ascii=False),
+        )
+    return annotations
+
+
+def _set_inference_eval_span_attributes(
+    span: Span,
+    trace: FinishedTrace,
+    *,
+    input_payload: dict[str, Any] | None = None,
+) -> None:
+    span.set_attribute(
+        SpanAttributes.OPENINFERENCE_SPAN_KIND,
+        OpenInferenceSpanKindValues.EVALUATOR.value,
+    )
+    span.set_attribute("pxi.evaluated.trace_id", trace.trace_id)
+    span.set_attribute("pxi.evaluated.span_id", trace.root.span_id)
+    span.set_attribute("pxi.inference_eval.trigger", _INFERENCE_EVAL_TRIGGER)
+    if input_payload is not None:
+        span.set_attribute(
+            SpanAttributes.INPUT_VALUE,
+            json.dumps(input_payload, ensure_ascii=False),
+        )
+
+
+def _target_parent_context(*, trace: FinishedTrace, parent_span_id: str) -> Context:
+    parent_context = SpanContext(
+        trace_id=int(trace.trace_id, 16),
+        span_id=int(parent_span_id, 16),
+        is_remote=True,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        trace_state=TraceState(),
+    )
+    return set_span_in_context(NonRecordingSpan(parent_context), Context())
+
+
+async def _append_eval_spans_to_existing_trace(
+    *,
+    db: DbSessionFactory,
+    db_traces: Sequence[models.Trace],
+    project_name: str,
+) -> bool:
+    trace_ids = {trace.trace_id for trace in db_traces}
+    async with db() as session:
+        existing_trace_ids = set(
+            await session.scalars(
+                select(models.Trace.trace_id).where(models.Trace.trace_id.in_(trace_ids))
+            )
+        )
+        if trace_ids - existing_trace_ids:
+            return False
+        for db_trace in db_traces:
+            for db_span in db_trace.spans:
+                await insert_span(
+                    session,
+                    _trace_span_from_db_span(trace_id=db_trace.trace_id, db_span=db_span),
+                    project_name,
+                    create_trace_if_missing=False,
+                )
+        await session.flush()
+    return True
+
+
+def _trace_span_from_db_span(*, trace_id: str, db_span: models.Span) -> TraceSpan:
+    return TraceSpan(
+        name=db_span.name,
+        context=TraceSpanContext(trace_id=trace_id, span_id=db_span.span_id),
+        span_kind=SpanKind(db_span.span_kind),
+        parent_id=db_span.parent_id,
+        start_time=db_span.start_time,
+        end_time=db_span.end_time,
+        status_code=SpanStatusCode(db_span.status_code),
+        status_message=db_span.status_message,
+        attributes=db_span.attributes,
+        events=[_trace_span_event(event) for event in db_span.events],
+        conversation=None,
+    )
+
+
+def _trace_span_event(event: dict[str, Any]) -> SpanEvent:
+    timestamp = event.get("timestamp")
+    if isinstance(timestamp, str):
+        timestamp = datetime.fromisoformat(timestamp)
+    if not isinstance(timestamp, datetime):
+        timestamp = datetime.now(timezone.utc)
+    return SpanEvent(
+        name=str(event.get("name", "")),
+        timestamp=timestamp,
+        attributes={key: value for key, value in event.items() if key not in {"name", "timestamp"}},
+    )
+
+
+def _snapshot_span(span: SDKSpan | ReadableSpan) -> FinishedSpan:
+    context = span.get_span_context()
+    assert context is not None
+    parent = getattr(span, "parent", None)
+    parent_id = format_span_id(parent.span_id) if parent is not None else None
+    if parent_id == "0000000000000000":
+        parent_id = None
+    return FinishedSpan(
+        span_id=format_span_id(context.span_id),
+        trace_id=format_trace_id(context.trace_id),
+        parent_id=parent_id,
+        name=span.name,
+        span_kind=_string_attr((span.attributes or {}).get(SpanAttributes.OPENINFERENCE_SPAN_KIND)),
+        attributes=dict(span.attributes or {}),
+    )
+
+
+def _is_root_span(span: FinishedSpan) -> bool:
+    return span.parent_id is None or span.parent_id == "0000000000000000"
+
+
+def _is_turn_start(trace: FinishedTrace) -> bool:
+    input_value = trace.root.attributes.get(SpanAttributes.INPUT_VALUE)
+    if not isinstance(input_value, str) or not input_value.strip():
+        return False
+    try:
+        parsed = json.loads(input_value)
+    except json.JSONDecodeError:
+        return True
+    if isinstance(parsed, dict) and "parts" in parsed:
+        return False
+    return True
+
+
+def _sample(trace_id: str, sample_rate: float) -> bool:
+    if sample_rate >= 1:
+        return True
+    if sample_rate <= 0:
+        return False
+    digest = hashlib.sha256(trace_id.encode("utf-8")).digest()
+    value = int.from_bytes(digest[:8], "big") / 2**64
+    return value < sample_rate
+
+
+def _string_attr(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+async def _ensure_project_exists(db: DbSessionFactory, project_name: str) -> int:
+    async with db() as session:
+        await session.execute(
+            insert_on_conflict(
+                {"name": project_name},
+                table=models.Project,
+                dialect=db.dialect,
+                unique_by=("name",),
+                on_conflict=OnConflict.DO_NOTHING,
+            )
+        )
+        project_id = await session.scalar(select(models.Project.id).filter_by(name=project_name))
+        assert project_id is not None
+        return project_id
+
+
+def build_inference_eval_processor(
+    *,
+    dispatcher: InferenceEvalDispatcher,
+    enable_local_ingest: bool,
+    enable_remote_export: bool,
+    project_name: str | None = None,
+) -> EvalTriggerSpanProcessor:
+    return EvalTriggerSpanProcessor(
+        dispatcher=dispatcher,
+        project_name=project_name or get_env_phoenix_agents_assistant_project_name(),
+        enable_local_ingest=enable_local_ingest,
+        enable_remote_export=enable_remote_export,
+    )

--- a/src/phoenix/server/agents/inference_evals.py
+++ b/src/phoenix/server/agents/inference_evals.py
@@ -7,7 +7,6 @@ import logging
 import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Sequence
-from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Literal, cast
@@ -41,6 +40,7 @@ from phoenix.db import models
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.db.insertion.span import insert_span
 from phoenix.db.insertion.types import Precursors
+from phoenix.server.agents.agent_factory import PXI_AGENT_NAME
 from phoenix.server.daemons.span_cost_calculator import SpanCostCalculator
 from phoenix.server.telemetry import normalize_http_collector_endpoint
 from phoenix.server.types import DbSessionFactory
@@ -61,12 +61,11 @@ logger = logging.getLogger(__name__)
 
 _QUEUE_MAX_SIZE = 200
 _WORKER_COUNT = 2
-_EVAL_TIMEOUT_SECONDS = 20
 _REMOTE_RETRY_DELAYS_SECONDS = (2.0, 4.0, 8.0, 16.0, 32.0)
 _LOCAL_TRACE_APPEND_RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2, 0.5, 1.0)
 _TRACE_BUFFER_TTL_SECONDS = 300
 _TRACE_BUFFER_MAX_SIZE = 500
-_PXI_ROOT_SPAN_NAME = "PXIAgent.iter"
+_PXI_ROOT_SPAN_NAME = f"{PXI_AGENT_NAME}.iter"
 _ANNOTATION_IDENTIFIER = "pxi-inference-evals"
 _INFERENCE_EVAL_TRIGGER = "inference"
 
@@ -86,7 +85,6 @@ class FinishedTrace:
     trace_id: str
     root: FinishedSpan
     spans: tuple[FinishedSpan, ...]
-    session_id: str | None
     project_name: str
     enable_local_ingest: bool
     enable_remote_export: bool
@@ -143,7 +141,6 @@ class InferenceEvalAnnotation:
 class _TraceBuffer:
     created_at: float
     spans: dict[str, FinishedSpan] = field(default_factory=dict)
-    root: FinishedSpan | None = None
 
 
 class EvalTriggerSpanProcessor(SpanProcessor):
@@ -178,12 +175,10 @@ class EvalTriggerSpanProcessor(SpanProcessor):
             and finished_span.name == _PXI_ROOT_SPAN_NAME
             and finished_span.span_kind == OpenInferenceSpanKindValues.AGENT.value
         ):
-            buffer.root = finished_span
             trace = FinishedTrace(
                 trace_id=finished_span.trace_id,
                 root=finished_span,
                 spans=tuple(buffer.spans.values()),
-                session_id=_string_attr(finished_span.attributes.get(SpanAttributes.SESSION_ID)),
                 project_name=self._project_name,
                 enable_local_ingest=self._enable_local_ingest,
                 enable_remote_export=self._enable_remote_export,
@@ -205,8 +200,6 @@ class EvalTriggerSpanProcessor(SpanProcessor):
             self._buffers[span.trace_id] = buffer
         self._buffers.move_to_end(span.trace_id)
         buffer.spans[span.span_id] = span
-        if span.parent_id is None:
-            buffer.root = span
         while len(self._buffers) > self._max_traces:
             trace_id, _ = self._buffers.popitem(last=False)
             logger.warning(
@@ -226,7 +219,7 @@ class EvalTriggerSpanProcessor(SpanProcessor):
             logger.warning("Evicted stale PXI inference eval trace buffer %s", trace_id)
 
 
-class InferenceEvalDispatcher(AbstractAsyncContextManager["InferenceEvalDispatcher"]):
+class InferenceEvalDispatcher:
     """Runs PXI inference evals off the request path and writes span annotations."""
 
     def __init__(
@@ -319,14 +312,20 @@ class InferenceEvalDispatcher(AbstractAsyncContextManager["InferenceEvalDispatch
             with detached_otel_context():
                 annotations.extend(await _score_trace(trace, eval_tracer=eval_tracer))
         finally:
-            eval_tracer.tracer_provider.force_flush()
-            if trace.enable_local_ingest:
-                await self._persist_eval_traces(
-                    eval_tracer=eval_tracer,
-                    project_name=trace.project_name,
-                    target_trace_id=trace.trace_id,
+            try:
+                eval_tracer.tracer_provider.force_flush()
+                if trace.enable_local_ingest:
+                    await self._persist_eval_traces(
+                        eval_tracer=eval_tracer,
+                        project_name=trace.project_name,
+                        target_trace_id=trace.trace_id,
+                    )
+            except Exception:
+                logger.exception(
+                    "PXI inference eval span persistence failed for trace %s", trace.trace_id
                 )
-            eval_tracer.tracer_provider.shutdown()
+            finally:
+                eval_tracer.tracer_provider.shutdown()
 
         if annotations:
             await self._write_annotations(trace=trace, annotations=annotations)
@@ -412,14 +411,7 @@ async def _score_trace(
         context=_target_parent_context(trace=trace, parent_span_id=trace.root.span_id),
     ) as span:
         _set_inference_eval_span_attributes(span, trace)
-        tasks: list[tuple[str, Awaitable[list[InferenceEvalAnnotation]]]] = [
-            ("tool_count_per_turn", _score_tool_count_per_turn_async(trace, tracer=tracer)),
-        ]
-        results = await asyncio.gather(
-            *(_run_eval_task(name, awaitable, trace=trace) for name, awaitable in tasks)
-        )
-        for result in results:
-            annotations.extend(result)
+        annotations.extend(_run_eval("tool_count_per_turn", trace, tracer=tracer))
         span.set_attribute(
             SpanAttributes.OUTPUT_VALUE,
             json.dumps(
@@ -437,27 +429,17 @@ async def _score_trace(
     return annotations
 
 
-async def _run_eval_task(
+def _run_eval(
     name: str,
-    awaitable: Awaitable[list[InferenceEvalAnnotation]],
-    *,
-    trace: FinishedTrace,
-) -> list[InferenceEvalAnnotation]:
-    try:
-        return await asyncio.wait_for(awaitable, timeout=_EVAL_TIMEOUT_SECONDS)
-    except asyncio.TimeoutError:
-        logger.warning("PXI inference eval %s timed out for trace %s", name, trace.trace_id)
-    except Exception:
-        logger.exception("PXI inference eval %s failed for trace %s", name, trace.trace_id)
-    return []
-
-
-async def _score_tool_count_per_turn_async(
     trace: FinishedTrace,
     *,
     tracer: Any,
 ) -> list[InferenceEvalAnnotation]:
-    return _score_tool_count_per_turn(trace, tracer=tracer)
+    try:
+        return _score_tool_count_per_turn(trace, tracer=tracer)
+    except Exception:
+        logger.exception("PXI inference eval %s failed for trace %s", name, trace.trace_id)
+    return []
 
 
 def _score_tool_count_per_turn(

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -49,6 +49,7 @@ from phoenix.config import (
     get_env_phoenix_agents_assistant_project_name,
     get_env_phoenix_agents_disable_bash,
     get_env_phoenix_agents_web_access_enabled,
+    get_env_pxi_inference_evals_enabled,
 )
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
@@ -62,6 +63,10 @@ from phoenix.server.agents.context import (
     resolve_contexts,
 )
 from phoenix.server.agents.exceptions import AgentError, SummarizationError
+from phoenix.server.agents.inference_evals import (
+    InferenceEvalDispatcher,
+    build_inference_eval_processor,
+)
 from phoenix.server.agents.model_factory import build_model
 from phoenix.server.agents.model_selection import AgentModelSelection
 from phoenix.server.agents.prompts import AgentPrompts, ServerAgentPrompts
@@ -333,6 +338,31 @@ class _AgentSpanContextRecorder(SpanProcessor):
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         return True
+
+
+def _add_pxi_inference_eval_processor(
+    *,
+    request: Request,
+    tracer: Tracer | None,
+    project_name: str,
+    ingest_traces: bool,
+    export_remote_traces: bool,
+) -> None:
+    if tracer is None or not get_env_pxi_inference_evals_enabled():
+        return
+    dispatcher = getattr(request.state, "pxi_inference_eval_dispatcher", None)
+    if dispatcher is None:
+        dispatcher = getattr(request.app.state, "pxi_inference_eval_dispatcher", None)
+    if not isinstance(dispatcher, InferenceEvalDispatcher):
+        return
+    tracer.tracer_provider.add_span_processor(
+        build_inference_eval_processor(
+            dispatcher=dispatcher,
+            enable_local_ingest=ingest_traces,
+            enable_remote_export=export_remote_traces,
+            project_name=project_name,
+        )
+    )
 
 
 def _build_message_metadata_chunk(
@@ -852,6 +882,13 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         if tracer is not None:
             agent_span_recorder = _AgentSpanContextRecorder()
             tracer.tracer_provider.add_span_processor(agent_span_recorder)
+            _add_pxi_inference_eval_processor(
+                request=request,
+                tracer=tracer,
+                project_name=project_name,
+                ingest_traces=ingest_traces,
+                export_remote_traces=export_remote_traces,
+            )
 
         resolved_contexts = resolve_contexts(body.contexts)
         user = request.user if "user" in request.scope else None

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -75,6 +75,7 @@ from phoenix.config import (
     get_env_max_spans_queue_size,
     get_env_phoenix_agents_disable_bash,
     get_env_port,
+    get_env_pxi_inference_evals_enabled,
     get_env_support_email,
     server_instrumentation_is_enabled,
     verify_server_environment_variables,
@@ -85,6 +86,7 @@ from phoenix.db.facilitator import Facilitator
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.types import AnnotationPrecursor
 from phoenix.server.agents.capabilities import MintlifyDocsMCPServer
+from phoenix.server.agents.inference_evals import InferenceEvalDispatcher
 from phoenix.server.api.auth_messages import AUTH_ERROR_MESSAGES, AuthErrorCode
 from phoenix.server.api.context import Context, build_context
 from phoenix.server.api.dataloaders import CacheForDataLoaders
@@ -630,6 +632,15 @@ def _lifespan(
             await stack.enter_async_context(generative_model_store)
             await stack.enter_async_context(system_settings)
             await stack.enter_async_context(db_disk_usage_monitor)
+            pxi_inference_eval_dispatcher: InferenceEvalDispatcher | None = None
+            if get_env_pxi_inference_evals_enabled():
+                pxi_inference_eval_dispatcher = await stack.enter_async_context(
+                    InferenceEvalDispatcher(
+                        db=db,
+                        enqueue_annotations=enqueue_annotations,
+                        span_cost_calculator=span_cost_calculator,
+                    )
+                )
             # ``sandbox_session_manager`` must enter before ``experiment_runner``
             # so ``AsyncExitStack`` tears them down in reverse and the runner
             # (which consumes the manager) stops first. If the runner outlived
@@ -667,6 +678,7 @@ def _lifespan(
                 "enqueue_span": enqueue_span,
                 "enqueue_operation": enqueue_operation,
                 "experiment_runner": experiment_runner,
+                "pxi_inference_eval_dispatcher": pxi_inference_eval_dispatcher,
             }
         for callback in shutdown_callbacks:
             if isinstance((res := callback()), Awaitable):

--- a/tests/unit/server/agents/test_inference_evals.py
+++ b/tests/unit/server/agents/test_inference_evals.py
@@ -11,6 +11,7 @@ from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttribu
 from sqlalchemy import select
 
 from phoenix.db import models
+from phoenix.server.agents.agent_factory import PXI_AGENT_NAME
 from phoenix.server.agents.inference_evals import (
     EvalTriggerSpanProcessor,
     FinishedSpan,
@@ -26,6 +27,8 @@ from phoenix.server.api.routers import agents as agents_router
 from phoenix.server.api.routers.agents import _add_pxi_inference_eval_processor
 from phoenix.server.types import DbSessionFactory
 from phoenix.tracers import Tracer
+
+_PXI_ROOT_SPAN_NAME = f"{PXI_AGENT_NAME}.iter"
 
 
 class _Dispatcher:
@@ -122,7 +125,7 @@ def test_eval_trigger_span_processor_assembles_trace_on_agent_root_end() -> None
         trace_id=1,
         span_id=1,
         parent_id=None,
-        name="PXIAgent.iter",
+        name=_PXI_ROOT_SPAN_NAME,
         attributes={
             SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.AGENT.value,
             SpanAttributes.SESSION_ID: "session-1",
@@ -136,11 +139,10 @@ def test_eval_trigger_span_processor_assembles_trace_on_agent_root_end() -> None
 
     assert len(dispatcher.traces) == 1
     trace = dispatcher.traces[0]
-    assert trace.root.name == "PXIAgent.iter"
-    assert trace.session_id == "session-1"
+    assert trace.root.name == _PXI_ROOT_SPAN_NAME
     assert trace.enable_local_ingest is True
     assert trace.enable_remote_export is True
-    assert {span.name for span in trace.spans} == {"tool", "PXIAgent.iter"}
+    assert {span.name for span in trace.spans} == {"tool", _PXI_ROOT_SPAN_NAME}
 
 
 def test_eval_trigger_span_processor_treats_zero_parent_id_as_root() -> None:
@@ -155,7 +157,7 @@ def test_eval_trigger_span_processor_treats_zero_parent_id_as_root() -> None:
         trace_id=1,
         span_id=1,
         parent_id=0,
-        name="PXIAgent.iter",
+        name=_PXI_ROOT_SPAN_NAME,
         attributes={
             SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.AGENT.value,
         },
@@ -209,7 +211,7 @@ def test_tool_count_per_turn_counts_tool_spans() -> None:
             span_id="root",
             trace_id="trace",
             parent_id=None,
-            name="PXIAgent.iter",
+            name=_PXI_ROOT_SPAN_NAME,
             span_kind=OpenInferenceSpanKindValues.AGENT.value,
             attributes={},
         ),
@@ -218,7 +220,6 @@ def test_tool_count_per_turn_counts_tool_spans() -> None:
             _finished_span("tool-2", OpenInferenceSpanKindValues.TOOL.value),
             _finished_span("llm", OpenInferenceSpanKindValues.LLM.value),
         ),
-        session_id="session",
         project_name="assistant_agent",
         enable_local_ingest=True,
         enable_remote_export=False,
@@ -337,7 +338,7 @@ async def test_append_eval_spans_requires_existing_trace(db: DbSessionFactory) -
         }
 
     assert set(span_rows) == {
-        "PXIAgent.iter",
+        _PXI_ROOT_SPAN_NAME,
         "PXI inference evals",
         "tool_count_per_turn.evaluate",
     }
@@ -365,7 +366,7 @@ def _trace_with_root_input(input_value: str) -> FinishedTrace:
         span_id="0000000000000001",
         trace_id="00000000000000000000000000000001",
         parent_id=None,
-        name="PXIAgent.iter",
+        name=_PXI_ROOT_SPAN_NAME,
         span_kind=OpenInferenceSpanKindValues.AGENT.value,
         attributes={SpanAttributes.INPUT_VALUE: input_value},
     )
@@ -373,7 +374,6 @@ def _trace_with_root_input(input_value: str) -> FinishedTrace:
         trace_id="00000000000000000000000000000001",
         root=root,
         spans=(root,),
-        session_id="session",
         project_name="assistant_agent",
         enable_local_ingest=True,
         enable_remote_export=False,

--- a/tests/unit/server/agents/test_inference_evals.py
+++ b/tests/unit/server/agents/test_inference_evals.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
+from sqlalchemy import select
+
+from phoenix.db import models
+from phoenix.server.agents.inference_evals import (
+    EvalTriggerSpanProcessor,
+    FinishedSpan,
+    FinishedTrace,
+    InferenceEvalDispatcher,
+    _append_eval_spans_to_existing_trace,
+    _is_turn_start,
+    _sample,
+    _score_tool_count_per_turn,
+    _score_trace,
+)
+from phoenix.server.api.routers import agents as agents_router
+from phoenix.server.api.routers.agents import _add_pxi_inference_eval_processor
+from phoenix.server.types import DbSessionFactory
+from phoenix.tracers import Tracer
+
+
+class _Dispatcher:
+    def __init__(self) -> None:
+        self.traces: list[FinishedTrace] = []
+
+    def enqueue_threadsafe(self, trace: FinishedTrace) -> None:
+        self.traces.append(trace)
+
+
+@dataclass(frozen=True)
+class _SpanContext:
+    trace_id: int
+    span_id: int
+
+
+@dataclass(frozen=True)
+class _Parent:
+    span_id: int
+
+
+class _Span:
+    def __init__(
+        self,
+        *,
+        trace_id: int,
+        span_id: int,
+        parent_id: int | None,
+        name: str,
+        attributes: dict[str, Any],
+    ) -> None:
+        self._context = _SpanContext(trace_id=trace_id, span_id=span_id)
+        self.parent = _Parent(parent_id) if parent_id is not None else None
+        self.name = name
+        self.attributes = attributes
+
+    def get_span_context(self) -> _SpanContext:
+        return self._context
+
+
+class _TracerProvider:
+    def __init__(self) -> None:
+        self.processors: list[EvalTriggerSpanProcessor] = []
+
+    def add_span_processor(self, processor: EvalTriggerSpanProcessor) -> None:
+        self.processors.append(processor)
+
+
+class _Tracer:
+    def __init__(self) -> None:
+        self.tracer_provider = _TracerProvider()
+
+
+def test_add_pxi_inference_eval_processor_reads_lifespan_request_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(agents_router, "get_env_pxi_inference_evals_enabled", lambda: True)
+    dispatcher = InferenceEvalDispatcher.__new__(InferenceEvalDispatcher)
+    tracer = _Tracer()
+    request = SimpleNamespace(
+        state=SimpleNamespace(pxi_inference_eval_dispatcher=dispatcher),
+        app=SimpleNamespace(state=SimpleNamespace()),
+    )
+
+    _add_pxi_inference_eval_processor(
+        request=request,  # type: ignore[arg-type]
+        tracer=tracer,  # type: ignore[arg-type]
+        project_name="assistant_agent",
+        ingest_traces=True,
+        export_remote_traces=False,
+    )
+
+    assert len(tracer.tracer_provider.processors) == 1
+    processor = tracer.tracer_provider.processors[0]
+    assert processor._dispatcher is dispatcher
+
+
+def test_eval_trigger_span_processor_assembles_trace_on_agent_root_end() -> None:
+    dispatcher = _Dispatcher()
+    processor = EvalTriggerSpanProcessor(
+        dispatcher=dispatcher,  # type: ignore[arg-type]
+        project_name="assistant_agent",
+        enable_local_ingest=True,
+        enable_remote_export=True,
+    )
+    child = _Span(
+        trace_id=1,
+        span_id=2,
+        parent_id=1,
+        name="tool",
+        attributes={SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.TOOL.value},
+    )
+    root = _Span(
+        trace_id=1,
+        span_id=1,
+        parent_id=None,
+        name="PXIAgent.iter",
+        attributes={
+            SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.AGENT.value,
+            SpanAttributes.SESSION_ID: "session-1",
+        },
+    )
+
+    processor.on_start(child)  # type: ignore[arg-type]
+    processor.on_end(child)  # type: ignore[arg-type]
+    processor.on_start(root)  # type: ignore[arg-type]
+    processor.on_end(root)  # type: ignore[arg-type]
+
+    assert len(dispatcher.traces) == 1
+    trace = dispatcher.traces[0]
+    assert trace.root.name == "PXIAgent.iter"
+    assert trace.session_id == "session-1"
+    assert trace.enable_local_ingest is True
+    assert trace.enable_remote_export is True
+    assert {span.name for span in trace.spans} == {"tool", "PXIAgent.iter"}
+
+
+def test_eval_trigger_span_processor_treats_zero_parent_id_as_root() -> None:
+    dispatcher = _Dispatcher()
+    processor = EvalTriggerSpanProcessor(
+        dispatcher=dispatcher,  # type: ignore[arg-type]
+        project_name="assistant_agent",
+        enable_local_ingest=True,
+        enable_remote_export=False,
+    )
+    root = _Span(
+        trace_id=1,
+        span_id=1,
+        parent_id=0,
+        name="PXIAgent.iter",
+        attributes={
+            SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.AGENT.value,
+        },
+    )
+
+    processor.on_end(root)  # type: ignore[arg-type]
+
+    assert len(dispatcher.traces) == 1
+    assert dispatcher.traces[0].root.parent_id is None
+
+
+def test_eval_trigger_span_processor_ignores_non_pxi_agent_root() -> None:
+    dispatcher = _Dispatcher()
+    processor = EvalTriggerSpanProcessor(
+        dispatcher=dispatcher,  # type: ignore[arg-type]
+        project_name="assistant_agent",
+        enable_local_ingest=True,
+        enable_remote_export=False,
+    )
+    root = _Span(
+        trace_id=1,
+        span_id=1,
+        parent_id=None,
+        name="ServerAgent.iter",
+        attributes={
+            SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.AGENT.value,
+        },
+    )
+
+    processor.on_end(root)  # type: ignore[arg-type]
+
+    assert dispatcher.traces == []
+
+
+def test_turn_start_rejects_tool_continuation_payload() -> None:
+    trace = _trace_with_root_input(json.dumps({"parts": [{"tool_name": "search"}]}))
+
+    assert not _is_turn_start(trace)
+
+
+def test_turn_start_accepts_plain_text_input() -> None:
+    trace = _trace_with_root_input("show me traces from yesterday")
+
+    assert _is_turn_start(trace)
+
+
+def test_tool_count_per_turn_counts_tool_spans() -> None:
+    trace = FinishedTrace(
+        trace_id="trace",
+        root=FinishedSpan(
+            span_id="root",
+            trace_id="trace",
+            parent_id=None,
+            name="PXIAgent.iter",
+            span_kind=OpenInferenceSpanKindValues.AGENT.value,
+            attributes={},
+        ),
+        spans=(
+            _finished_span("tool-1", OpenInferenceSpanKindValues.TOOL.value),
+            _finished_span("tool-2", OpenInferenceSpanKindValues.TOOL.value),
+            _finished_span("llm", OpenInferenceSpanKindValues.LLM.value),
+        ),
+        session_id="session",
+        project_name="assistant_agent",
+        enable_local_ingest=True,
+        enable_remote_export=False,
+    )
+
+    annotation = _score_tool_count_per_turn(trace)[0]
+
+    assert annotation.name == "tool_count_per_turn"
+    assert annotation.score == 2.0
+    assert annotation.annotator_kind == "CODE"
+
+
+async def test_score_trace_weaves_eval_spans_under_pxi_root() -> None:
+    trace = _trace_with_root_input("hello")
+    eval_tracer = Tracer(
+        span_cost_calculator=None,  # type: ignore[arg-type]
+        enable_remote_export=False,
+        project_name="assistant_agent",
+    )
+
+    annotations = await _score_trace(trace, eval_tracer=eval_tracer)
+    eval_tracer.tracer_provider.force_flush()
+    db_traces = eval_tracer.get_db_traces(project_id=1)
+    eval_tracer.tracer_provider.shutdown()
+
+    assert {annotation.name for annotation in annotations} == {
+        "tool_count_per_turn",
+    }
+    assert len(db_traces) == 1
+    db_trace = db_traces[0]
+    assert db_trace.trace_id == trace.trace_id
+    spans_by_name = {span.name: span for span in db_trace.spans}
+    group_span = spans_by_name["PXI inference evals"]
+    assert group_span.parent_id == trace.root.span_id
+    assert spans_by_name["tool_count_per_turn.evaluate"].parent_id == group_span.span_id
+    assert group_span.attributes["pxi"]["inference_eval"]["trigger"] == "inference"
+    assert group_span.attributes["pxi"]["evaluated"]["span_id"] == trace.root.span_id
+
+
+async def test_score_trace_skips_tool_continuation_roots() -> None:
+    trace = _trace_with_root_input(json.dumps({"parts": [{"tool_name": "search"}]}))
+    eval_tracer = Tracer(
+        span_cost_calculator=None,  # type: ignore[arg-type]
+        enable_remote_export=False,
+        project_name="assistant_agent",
+    )
+
+    annotations = await _score_trace(trace, eval_tracer=eval_tracer)
+    eval_tracer.tracer_provider.force_flush()
+    db_traces = eval_tracer.get_db_traces(project_id=1)
+    eval_tracer.tracer_provider.shutdown()
+
+    assert annotations == []
+    assert db_traces == []
+
+
+async def test_append_eval_spans_requires_existing_trace(db: DbSessionFactory) -> None:
+    trace = _trace_with_root_input("hello")
+    eval_tracer = Tracer(
+        span_cost_calculator=None,  # type: ignore[arg-type]
+        enable_remote_export=False,
+        project_name="assistant_agent",
+    )
+    await _score_trace(trace, eval_tracer=eval_tracer)
+    eval_tracer.tracer_provider.force_flush()
+    db_traces = eval_tracer.get_db_traces(project_id=1)
+    eval_tracer.tracer_provider.shutdown()
+
+    assert not await _append_eval_spans_to_existing_trace(
+        db=db,
+        db_traces=db_traces,
+        project_name="assistant_agent",
+    )
+
+    now = datetime.now(timezone.utc)
+    async with db() as session:
+        project = models.Project(name="assistant_agent")
+        session.add(project)
+        await session.flush()
+        db_trace = models.Trace(
+            project_rowid=project.id,
+            trace_id=trace.trace_id,
+            start_time=now,
+            end_time=now,
+        )
+        session.add(db_trace)
+        await session.flush()
+        session.add(
+            models.Span(
+                trace_rowid=db_trace.id,
+                span_id=trace.root.span_id,
+                parent_id=None,
+                name=trace.root.name,
+                span_kind=OpenInferenceSpanKindValues.AGENT.value,
+                start_time=now,
+                end_time=now,
+                attributes={},
+                events=[],
+                status_code="OK",
+                status_message="",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+        )
+        await session.flush()
+
+    assert await _append_eval_spans_to_existing_trace(
+        db=db,
+        db_traces=db_traces,
+        project_name="assistant_agent",
+    )
+    async with db() as session:
+        span_rows = {
+            span.name: span async for span in await session.stream_scalars(select(models.Span))
+        }
+
+    assert set(span_rows) == {
+        "PXIAgent.iter",
+        "PXI inference evals",
+        "tool_count_per_turn.evaluate",
+    }
+    assert span_rows["PXI inference evals"].parent_id == trace.root.span_id
+
+
+def test_sample_is_deterministic() -> None:
+    assert _sample("abc", 0.5) == _sample("abc", 0.5)
+    assert _sample("abc", 1.0)
+    assert not _sample("abc", 0.0)
+
+
+def test_dispatcher_exposes_drop_count() -> None:
+    dispatcher = InferenceEvalDispatcher(
+        db=None,  # type: ignore[arg-type]
+        enqueue_annotations=None,  # type: ignore[arg-type]
+        span_cost_calculator=None,  # type: ignore[arg-type]
+    )
+
+    assert dispatcher.dropped_count == 0
+
+
+def _trace_with_root_input(input_value: str) -> FinishedTrace:
+    root = FinishedSpan(
+        span_id="0000000000000001",
+        trace_id="00000000000000000000000000000001",
+        parent_id=None,
+        name="PXIAgent.iter",
+        span_kind=OpenInferenceSpanKindValues.AGENT.value,
+        attributes={SpanAttributes.INPUT_VALUE: input_value},
+    )
+    return FinishedTrace(
+        trace_id="00000000000000000000000000000001",
+        root=root,
+        spans=(root,),
+        session_id="session",
+        project_name="assistant_agent",
+        enable_local_ingest=True,
+        enable_remote_export=False,
+    )
+
+
+def _finished_span(span_id: str, span_kind: str) -> FinishedSpan:
+    return FinishedSpan(
+        span_id=span_id,
+        trace_id="trace",
+        parent_id="root",
+        name=span_id,
+        span_kind=span_kind,
+        attributes={},
+    )


### PR DESCRIPTION
## Summary

- Adds a PXI-specific server-side live inference eval runner.
- When a traced PXI turn finishes, a span processor hands the completed trace to an app-level dispatcher.
- The dispatcher scores the turn off the request path and writes span annotations plus evaluator spans back to the same local/remote trace destinations.
- The live runner currently emits `tool_count_per_turn` (`CODE`) and is controlled by `PHOENIX_PXI_INFERENCE_EVALS_ENABLED` and `PHOENIX_PXI_INFERENCE_EVALS_SAMPLE_RATE`.

## Notes

Evaluator spans are appended to the evaluated PXI trace under a `PXI inference evals` `EVALUATOR` grouping span when local or remote trace export is enabled.

The dispatcher is bounded and drops work on overload. Scorer failures and local/remote write failures are logged and do not affect the agent response.

## Verification

- `uv run pytest tests/unit/server/agents/test_inference_evals.py`
- `uv run ruff check src/phoenix/server/agents/agent_factory.py src/phoenix/server/agents/inference_evals.py tests/unit/server/agents/test_inference_evals.py`
