### PR TITLE
docs: document PHOENIX_AGENTS_DISABLE_BASH in PXI config reference

### DIFF
--- a/docs/phoenix/pxi.mdx
+++ b/docs/phoenix/pxi.mdx
@@ -303,6 +303,11 @@ present, so it does not offer an action that cannot succeed on your current page
   <Accordion title="Safety limits">
   - **Verify before you act.** PXI can apply filters, edit prompts, and run
     bash. Review proposed changes — especially prompt edits — before accepting.
+  - **Two bash surfaces.** Beyond the browser-side sandbox shown above, the
+    server can attach a subagent that carries a **server-side** bash tool. Set
+    `PHOENIX_AGENTS_DISABLE_BASH=true` to disable that server-side tool (and hide
+    the subagents toggle in **Settings → Assistant**) without disabling PXI
+    entirely; the browser sandbox is unaffected.
   - **Don't point it at sensitive production data without controls.** PXI sees
     whatever the signed-in user can see.
   - **Treat outputs as suggestions.** PXI hallucinates, especially on long
@@ -315,6 +320,7 @@ present, so it does not offer an action that cannot succeed on your current page
   | `PHOENIX_DISABLE_AGENT_ASSISTANT=true` | Disable PXI for the whole deployment (requires restart). |
   | `PHOENIX_ALLOW_EXTERNAL_RESOURCES=false` | Disable external resource access, including the Phoenix docs MCP lookups. |
   | `PHOENIX_AGENTS_DISABLE_WEB_ACCESS=true` | Disable PXI's web search/fetch tools while leaving other external resources available. |
+  | `PHOENIX_AGENTS_DISABLE_BASH=true` | Disable PXI's **server-side** bash tool by preventing subagents from being attached to the assistant. The subagents toggle is also hidden from **Settings → Assistant**. The browser-side bash sandbox is unaffected; to turn PXI off entirely use `PHOENIX_DISABLE_AGENT_ASSISTANT`. |
   | `PHOENIX_AGENTS_COLLECTOR_ENDPOINT` | Remote collector endpoint for assistant trace export. |
   | `PHOENIX_AGENTS_COLLECTOR_API_KEY` | API key for the remote collector, if required. |
   | `PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME` | Project name for locally recorded assistant traces (default `assistant_agent`). |


### PR DESCRIPTION
resolves #13892

## Summary

Closes the high-severity gap from the 2026-06-24 weekly docs gap audit (#13892): the `PHOENIX_AGENTS_DISABLE_BASH` deployment kill-switch was undocumented in the PXI configuration reference, even though its sibling controls (`PHOENIX_DISABLE_AGENT_ASSISTANT`, `PHOENIX_ALLOW_EXTERNAL_RESOURCES`, `PHOENIX_AGENTS_DISABLE_WEB_ACCESS`) all are.

### Changes to `docs/phoenix/pxi.mdx`

- **Configuration reference** — adds a `PHOENIX_AGENTS_DISABLE_BASH=true` row to the env-var table, explaining it disables PXI's server-side bash tool by preventing subagents from being attached to the assistant (and hides the subagents toggle in Settings → Assistant), that the browser-side bash sandbox is unaffected, and that `PHOENIX_DISABLE_AGENT_ASSISTANT` is the way to turn PXI off entirely.
- **Safety limits** — adds a clarifying bullet that PXI has two distinct bash surfaces (the browser-side sandbox shown in the architecture diagram vs. the server-side subagent tool) so readers can tell which one the flag targets.

The flag behavior was verified against `src/phoenix/config.py` (`get_env_phoenix_agents_disable_bash`) and `src/phoenix/server/api/routers/agents.py` (`_subagents_enabled` returns `False` when the env var is set).

### Audit gaps #2 and #3 — already closed

The audit's two low-severity gaps (trace-level annotations and prompt/dataset label management) are already covered by `docs/phoenix/release-notes/06-2026/06-24-2026-annotations-labels-and-pxi-server-tools.mdx`, which shipped after the audit was filed and includes sections for both, plus a release-note entry for the server-side bash tool itself. No further action needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0137QkM3UGNGFcJxWkstM2n5)_