### PR TITLE
docs(evals): document LLM-as-a-judge in pytest and Vitest/Jest test integrations

### DIFF
--- a/.agents/skills/phoenix-evals/SKILL.md
+++ b/.agents/skills/phoenix-evals/SKILL.md
@@ -75,3 +75,4 @@ evaluators-{code|llm}-{python|typescript} → integrations-{pytest|vitest-jest} 
 | Code first | Deterministic before LLM |
 | Validate judges | >80% TPR/TNR |
 | Binary > Likert | Pass/fail, not 1-5 |
+| Invariants gate, signals trend | `assert`/`expect` hard invariants (CI red); log LLM-judge quality signals and gate the aggregate (acceptance criteria), not every case |

--- a/.agents/skills/phoenix-evals/references/integrations-pytest.md
+++ b/.agents/skills/phoenix-evals/references/integrations-pytest.md
@@ -67,7 +67,7 @@ Rule of thumb: assert the behavior you'd be embarrassed to ship broken; log ever
 
 ## LLM-as-a-judge inside a test
 
-A judge is just an evaluator passed to `evaluate()` (or hoisted on the marker). The cleanest judge is a `create_classifier` from `arize-phoenix-evals`: it emits a label mapped to a numeric score plus an explanation, recorded as its own annotation under a linked evaluator span. `evaluate(judge, **kwargs)` fills the prompt-template variables from `kwargs` — pass the judge only what it needs to grade. Use a **stronger model to judge a weaker one** (e.g. Sonnet judging Haiku) so verdicts stay stable — a noisy judge makes the suite flaky.
+A judge is just an evaluator passed to `evaluate()` (or hoisted on the marker). The cleanest judge is a `create_classifier` from `arize-phoenix-evals`: it emits a label mapped to a numeric score plus an explanation, recorded as its own annotation under a linked evaluator span. `evaluate(judge, **kwargs)` fills the prompt-template variables from `kwargs` — pass the judge only what it needs to grade. The judge runs on its own model, configured independently of the system under test (see configuring the judge LLM).
 
 ```python
 import time

--- a/.agents/skills/phoenix-evals/references/integrations-pytest.md
+++ b/.agents/skills/phoenix-evals/references/integrations-pytest.md
@@ -67,7 +67,7 @@ Rule of thumb: assert the behavior you'd be embarrassed to ship broken; log ever
 
 ## LLM-as-a-judge inside a test
 
-A judge is just an evaluator passed to `evaluate()` (or hoisted on the marker). The cleanest judge is a `create_classifier` from `arize-phoenix-evals`: it emits a label mapped to a numeric score plus an explanation, recorded as its own annotation under a linked evaluator span. `evaluate(judge, **kwargs)` fills the prompt-template variables from `kwargs`. Use a **stronger model to judge a weaker one** (e.g. Sonnet judging Haiku) so verdicts stay stable — a noisy judge makes the suite flaky.
+A judge is just an evaluator passed to `evaluate()` (or hoisted on the marker). The cleanest judge is a `create_classifier` from `arize-phoenix-evals`: it emits a label mapped to a numeric score plus an explanation, recorded as its own annotation under a linked evaluator span. `evaluate(judge, **kwargs)` fills the prompt-template variables from `kwargs` — pass the judge only what it needs to grade. Use a **stronger model to judge a weaker one** (e.g. Sonnet judging Haiku) so verdicts stay stable — a noisy judge makes the suite flaky.
 
 ```python
 import time
@@ -76,51 +76,40 @@ import pytest
 from phoenix.client.pytest import evaluate, log_evaluation, log_output
 from phoenix.evals import LLM, create_classifier
 
-# The judge sees the same KB excerpt the bot did, so it can tell whether the
-# answer was grounded — and whether declining was correct when the excerpt is empty.
+# Judge reads just the question + response; the evaluate() kwargs fill these vars.
 helpfulness = create_classifier(
     name="helpfulness",
     llm=LLM(provider="anthropic", model="claude-sonnet-4-6"),
     prompt_template=(
-        "Knowledge base:\n{{knowledge_base}}\n\n"
-        "Question: {{question}}\n\nBot response: {{response}}\n\n"
-        'Label "helpful" if the response is accurate and grounded in the excerpt '
-        '(or correctly declines when the excerpt lacks the answer); otherwise "unhelpful".'
+        "Question: {{question}}\n\nResponse: {{response}}\n\n"
+        'Label "helpful" if it accurately answers the question, else "unhelpful".'
     ),
     choices={"helpful": 1.0, "unhelpful": 0.0},
 )
 
 CASES = [
-    ("How do I download invoices?", "billing", False),
-    ("What's the capital of France?", "", True),  # off-topic → must refuse
+    ("How do I get a refund?", False),
+    ("What's the capital of France?", True),  # off-topic → must refuse
 ]
 
 @pytest.mark.phoenix(dataset="support-bot")
-@pytest.mark.parametrize("question,kb_key,expect_refusal", CASES, ids=["invoices", "offtopic"])
-def test_support_response(question, kb_key, expect_refusal):
-    kb_context = KB.get(kb_key, "")
-
+@pytest.mark.parametrize("question,expect_refusal", CASES, ids=["refund", "offtopic"])
+def test_support_response(question, expect_refusal):
     t0 = time.perf_counter()
-    response = answer_question(question, kb_context)
+    response = answer_question(question)
     log_output({"response": response})
 
-    # Structural metric — a CODE signal, tracked not asserted.
-    log_evaluation(name="latency_ms", score=(time.perf_counter() - t0) * 1000)
+    log_evaluation(name="latency_ms", score=(time.perf_counter() - t0) * 1000)  # CODE signal
 
-    # LLM-judge quality signal — recorded under its own evaluator span, NOT asserted.
-    evaluate(
-        helpfulness,
-        knowledge_base=kb_context or "(empty)",
-        question=question,
-        response=response,
-    )
-
-    # Hard invariant — the one eval we refuse to ship broken.
     if expect_refusal:
-        assert "I don't have information on that" in response
+        assert "I don't have information on that" in response  # hard invariant → gates CI
+    else:
+        # Quality signal — judged, NOT asserted. Helpfulness only means something
+        # for answerable questions, so judge here; it trends in Phoenix.
+        evaluate(helpfulness, question=question, response=response)
 ```
 
-Here the refusal is the invariant (asserted → gates CI); helpfulness and latency are signals (logged → trended). To make a judge gate the case anyway, capture its score and assert: `result = evaluate(judge, ...); assert result["score"] == 1.0` — reserve this for invariants a code check can't express.
+Refusal = invariant (asserted → gates CI); helpfulness + latency = signals (logged → trended). Judge only the cases where quality is meaningful. To gate CI on a judge anyway, capture its score and assert: `result = evaluate(judge, ...); assert result["score"] == 1.0` — reserve for invariants a code check can't express. For *groundedness*, add a `{{context}}` var and pass `context=...`, or use the pre-built `FaithfulnessEvaluator`.
 
 ## Environment variables
 

--- a/.agents/skills/phoenix-evals/references/integrations-pytest.md
+++ b/.agents/skills/phoenix-evals/references/integrations-pytest.md
@@ -56,6 +56,72 @@ Dataset-name precedence: `PHOENIX_TEST_DATASET` env > `phoenix_dataset` in `pyte
 
 Hoisted evaluators bind arguments **by parameter name**: `output` (from `log_output`), `input` (parametrized fields), `expected`/`reference`/`metadata` (parametrized fields of that name), `trace_id`. Any `arize-phoenix-evals` evaluator (`FaithfulnessEvaluator`, etc.) or any `run_experiment` function works unchanged. Every score is wrapped in its own evaluator span linked to the trace.
 
+## Two kinds of checks: invariants vs. signals
+
+The decision that shapes every eval suite is which checks gate CI and which only trend. Get this split right and the rest is plumbing.
+
+- **Hard invariants** — exactly one acceptable behavior, verifiable in code (a required refusal, valid JSON, a tool that must fire). `assert` these. A failure records `pass=False` and turns CI red, like any unit test.
+- **Quality signals** — answers that live on a spectrum with no single correct string (helpfulness, groundedness, tone). Score with an LLM judge and **`log_evaluation`/`evaluate` only** — do *not* `assert` per case. LLM output is non-deterministic, so one weak answer shouldn't break the build; watch the aggregate trend in Phoenix instead. Gate on the trend separately (e.g. a nightly threshold or `run_experiment`), not on every case.
+
+Rule of thumb: assert the behavior you'd be embarrassed to ship broken; log everything else as a signal.
+
+## LLM-as-a-judge inside a test
+
+A judge is just an evaluator passed to `evaluate()` (or hoisted on the marker). The cleanest judge is a `create_classifier` from `arize-phoenix-evals`: it emits a label mapped to a numeric score plus an explanation, recorded as its own annotation under a linked evaluator span. `evaluate(judge, **kwargs)` fills the prompt-template variables from `kwargs`. Use a **stronger model to judge a weaker one** (e.g. Sonnet judging Haiku) so verdicts stay stable — a noisy judge makes the suite flaky.
+
+```python
+import time
+
+import pytest
+from phoenix.client.pytest import evaluate, log_evaluation, log_output
+from phoenix.evals import LLM, create_classifier
+
+# The judge sees the same KB excerpt the bot did, so it can tell whether the
+# answer was grounded — and whether declining was correct when the excerpt is empty.
+helpfulness = create_classifier(
+    name="helpfulness",
+    llm=LLM(provider="anthropic", model="claude-sonnet-4-6"),
+    prompt_template=(
+        "Knowledge base:\n{{knowledge_base}}\n\n"
+        "Question: {{question}}\n\nBot response: {{response}}\n\n"
+        'Label "helpful" if the response is accurate and grounded in the excerpt '
+        '(or correctly declines when the excerpt lacks the answer); otherwise "unhelpful".'
+    ),
+    choices={"helpful": 1.0, "unhelpful": 0.0},
+)
+
+CASES = [
+    ("How do I download invoices?", "billing", False),
+    ("What's the capital of France?", "", True),  # off-topic → must refuse
+]
+
+@pytest.mark.phoenix(dataset="support-bot")
+@pytest.mark.parametrize("question,kb_key,expect_refusal", CASES, ids=["invoices", "offtopic"])
+def test_support_response(question, kb_key, expect_refusal):
+    kb_context = KB.get(kb_key, "")
+
+    t0 = time.perf_counter()
+    response = answer_question(question, kb_context)
+    log_output({"response": response})
+
+    # Structural metric — a CODE signal, tracked not asserted.
+    log_evaluation(name="latency_ms", score=(time.perf_counter() - t0) * 1000)
+
+    # LLM-judge quality signal — recorded under its own evaluator span, NOT asserted.
+    evaluate(
+        helpfulness,
+        knowledge_base=kb_context or "(empty)",
+        question=question,
+        response=response,
+    )
+
+    # Hard invariant — the one eval we refuse to ship broken.
+    if expect_refusal:
+        assert "I don't have information on that" in response
+```
+
+Here the refusal is the invariant (asserted → gates CI); helpfulness and latency are signals (logged → trended). To make a judge gate the case anyway, capture its score and assert: `result = evaluate(judge, ...); assert result["score"] == 1.0` — reserve this for invariants a code check can't express.
+
 ## Environment variables
 
 | Variable | Default | Purpose |

--- a/.agents/skills/phoenix-evals/references/integrations-vitest-jest.md
+++ b/.agents/skills/phoenix-evals/references/integrations-vitest-jest.md
@@ -63,6 +63,67 @@ Use `px.test.each(rows)` for larger datasets. To run against an existing Phoenix
 - `px.evaluate(evaluator, params?)` — runs an `@arizeai/phoenix-evals` evaluator, records an annotation + linked evaluator trace. Omit `params` to auto-supply the test's `input`/`output`/`expected`/`metadata`/`traceId`.
 - `px.traceEvaluator(fn, options?)` — wrap a plain grading fn; runs in its own evaluator span and captures a returned `{ name, score }` as an annotation. Passes through your args (no auto-supply).
 
+## Two kinds of checks: invariants vs. signals
+
+The decision that shapes every eval suite is which checks gate CI and which only trend.
+
+- **Hard invariants** — exactly one acceptable behavior, verifiable in code (a required refusal, valid JSON, a tool that must fire). Use a per-case `expect()`. A failure fails the run and turns CI red.
+- **Quality signals** — answers on a spectrum with no single correct string (helpfulness, groundedness, tone). Score with an LLM judge and record via `evaluate()`/`logAnnotation()` — do *not* `expect()` per case. Gate them at the **suite** level with `acceptanceCriteria` so aggregate quality (e.g. ≥70% helpful) holds the line while a single weak answer doesn't break the build.
+
+This is the natural division of labor in this runner: invariants → per-case `expect()`; signals → `acceptanceCriteria`.
+
+## LLM-as-a-judge inside a suite
+
+The cleanest judge is a `createClassificationEvaluator` from `@arizeai/phoenix-evals`: it emits a label mapped to a numeric score (recorded as an annotation under a linked evaluator span). `inputMapping` projects the run's auto-supplied `{ input, output }` onto the template variables, so `await px.evaluate(judge)` needs no params. Judge with a **stronger model than the system under test** (e.g. Sonnet judging Haiku) to keep verdicts stable.
+
+```ts
+import { anthropic } from "@ai-sdk/anthropic";
+import * as px from "@arizeai/phoenix-client/vitest";
+import { createClassificationEvaluator } from "@arizeai/phoenix-evals";
+import { expect } from "vitest";
+
+const helpfulness = createClassificationEvaluator<{ input: any; output?: { response: string } }>({
+  name: "helpfulness",
+  model: anthropic("claude-sonnet-4-6"),
+  choices: { helpful: 1, unhelpful: 0 },
+  promptTemplate: `Knowledge base:\n{{knowledge_base}}\n\nQuestion: {{question}}\n\nBot response: {{response}}\n\nLabel "helpful" if accurate and grounded in the excerpt (or a correct decline when the excerpt lacks the answer); otherwise "unhelpful".`,
+  inputMapping: {
+    knowledge_base: (r) => KB[r.input.kbKey] || "(empty)",
+    question: "input.question",
+    response: (r) => r.output?.response ?? "",
+  },
+});
+
+px.describe(
+  "support bot",
+  () => {
+    px.test.each(CASES)((row) => row.id, async ({ input }) => {
+      const start = performance.now();
+      const response = await answerQuestion(input.question, KB[input.kbKey] ?? "");
+
+      px.logOutput({ response });
+      px.logAnnotation({ name: "latency_ms", score: performance.now() - start, annotatorKind: "CODE" });
+
+      // LLM-judge quality signal — NOT asserted; gated by acceptanceCriteria below.
+      await px.evaluate(helpfulness);
+
+      // Hard invariant — the one behavior we refuse to ship broken.
+      if (input.expectRefusal) expect(response).toContain("I don't have information on that");
+    });
+  },
+  {
+    acceptanceCriteria: [
+      // signal gate: ≥70% of runs must score helpful
+      { annotationName: "helpfulness", metric: "passRate", passFn: (a) => a.score === 1, minPassRate: 0.7 },
+      // budget gate: mean latency under 5s
+      { annotationName: "latency_ms", metric: "average", threshold: 5000, direction: "minimize" },
+    ],
+  },
+);
+```
+
+The refusal stays a per-case `expect()` (invariant); helpfulness and latency move into `acceptanceCriteria` (signals). `passFn` receives the full annotation, so you can gate on `score`, `label`, or `explanation`.
+
 ## Acceptance criteria
 
 Suite-level gates evaluated **after** all tests (every case runs first, full scorecard prints before failing). Pass as `describe`'s third arg:

--- a/.agents/skills/phoenix-evals/references/integrations-vitest-jest.md
+++ b/.agents/skills/phoenix-evals/references/integrations-vitest-jest.md
@@ -74,7 +74,7 @@ This is the natural division of labor in this runner: invariants → per-case `e
 
 ## LLM-as-a-judge inside a suite
 
-The cleanest judge is a `createClassificationEvaluator` from `@arizeai/phoenix-evals`: it emits a label mapped to a numeric score (recorded as an annotation under a linked evaluator span). `inputMapping` projects the run's auto-supplied `{ input, output }` onto the template variables, so `await px.evaluate(judge)` needs no params. Judge with a **stronger model than the system under test** (e.g. Sonnet judging Haiku) to keep verdicts stable.
+The cleanest judge is a `createClassificationEvaluator` from `@arizeai/phoenix-evals`: it emits a label mapped to a numeric score (recorded as an annotation under a linked evaluator span). Pass the judge only what it needs to grade as the second arg to `px.evaluate()`, matching the template vars — no `inputMapping` needed. (For structured records or pre-built evaluators, `inputMapping` projects fields onto template vars instead.) Judge with a **stronger model than the system under test** (e.g. Sonnet judging Haiku) to keep verdicts stable.
 
 ```ts
 import { anthropic } from "@ai-sdk/anthropic";
@@ -82,16 +82,11 @@ import * as px from "@arizeai/phoenix-client/vitest";
 import { createClassificationEvaluator } from "@arizeai/phoenix-evals";
 import { expect } from "vitest";
 
-const helpfulness = createClassificationEvaluator<{ input: any; output?: { response: string } }>({
+const helpfulness = createClassificationEvaluator({
   name: "helpfulness",
   model: anthropic("claude-sonnet-4-6"),
   choices: { helpful: 1, unhelpful: 0 },
-  promptTemplate: `Knowledge base:\n{{knowledge_base}}\n\nQuestion: {{question}}\n\nBot response: {{response}}\n\nLabel "helpful" if accurate and grounded in the excerpt (or a correct decline when the excerpt lacks the answer); otherwise "unhelpful".`,
-  inputMapping: {
-    knowledge_base: (r) => KB[r.input.kbKey] || "(empty)",
-    question: "input.question",
-    response: (r) => r.output?.response ?? "",
-  },
+  promptTemplate: `Question: {{question}}\n\nResponse: {{response}}\n\nLabel "helpful" if it accurately answers the question, else "unhelpful".`,
 });
 
 px.describe(
@@ -99,21 +94,22 @@ px.describe(
   () => {
     px.test.each(CASES)((row) => row.id, async ({ input }) => {
       const start = performance.now();
-      const response = await answerQuestion(input.question, KB[input.kbKey] ?? "");
+      const response = await answerQuestion(input.question);
 
       px.logOutput({ response });
       px.logAnnotation({ name: "latency_ms", score: performance.now() - start, annotatorKind: "CODE" });
 
-      // LLM-judge quality signal — NOT asserted; gated by acceptanceCriteria below.
-      await px.evaluate(helpfulness);
-
-      // Hard invariant — the one behavior we refuse to ship broken.
-      if (input.expectRefusal) expect(response).toContain("I don't have information on that");
+      if (input.expectRefusal) {
+        expect(response).toContain("I don't have information on that");  // hard invariant
+      } else {
+        // Quality signal — NOT asserted; gated by acceptanceCriteria below.
+        await px.evaluate(helpfulness, { question: input.question, response });
+      }
     });
   },
   {
     acceptanceCriteria: [
-      // signal gate: ≥70% of runs must score helpful
+      // signal gate: ≥70% of judged answers must score helpful
       { annotationName: "helpfulness", metric: "passRate", passFn: (a) => a.score === 1, minPassRate: 0.7 },
       // budget gate: mean latency under 5s
       { annotationName: "latency_ms", metric: "average", threshold: 5000, direction: "minimize" },
@@ -122,7 +118,7 @@ px.describe(
 );
 ```
 
-The refusal stays a per-case `expect()` (invariant); helpfulness and latency move into `acceptanceCriteria` (signals). `passFn` receives the full annotation, so you can gate on `score`, `label`, or `explanation`.
+The refusal stays a per-case `expect()` (invariant); helpfulness and latency move into `acceptanceCriteria` (signals). `passFn` receives the full annotation, so you can gate on `score`, `label`, or `explanation`. For *groundedness*, add a `{{context}}` var and pass it too, or use `createFaithfulnessEvaluator`.
 
 ## Acceptance criteria
 

--- a/.agents/skills/phoenix-evals/references/integrations-vitest-jest.md
+++ b/.agents/skills/phoenix-evals/references/integrations-vitest-jest.md
@@ -74,7 +74,7 @@ This is the natural division of labor in this runner: invariants → per-case `e
 
 ## LLM-as-a-judge inside a suite
 
-The cleanest judge is a `createClassificationEvaluator` from `@arizeai/phoenix-evals`: it emits a label mapped to a numeric score (recorded as an annotation under a linked evaluator span). Pass the judge only what it needs to grade as the second arg to `px.evaluate()`, matching the template vars — no `inputMapping` needed. (For structured records or pre-built evaluators, `inputMapping` projects fields onto template vars instead.) Judge with a **stronger model than the system under test** (e.g. Sonnet judging Haiku) to keep verdicts stable.
+The cleanest judge is a `createClassificationEvaluator` from `@arizeai/phoenix-evals`: it emits a label mapped to a numeric score (recorded as an annotation under a linked evaluator span). Pass the judge only what it needs to grade as the second arg to `px.evaluate()`, matching the template vars — no `inputMapping` needed. (For structured records or pre-built evaluators, `inputMapping` projects fields onto template vars instead.) The judge runs on its own model, configured independently of the system under test (see configuring the judge LLM).
 
 ```ts
 import { anthropic } from "@ai-sdk/anthropic";

--- a/docs/phoenix/evaluation/integrations/pytest.mdx
+++ b/docs/phoenix/evaluation/integrations/pytest.mdx
@@ -230,9 +230,9 @@ Any evaluator from [`arize-phoenix-evals`](/docs/phoenix/evaluation/pre-built-me
 
 ## LLM-as-a-judge: scoring quality signals
 
-When a check is a [quality signal](#two-kinds-of-checks-invariants-vs-signals) — accuracy, groundedness, tone — there's no single correct string to assert against. Hand the judging to another model with [`create_classifier`](/docs/phoenix/evaluation/how-to-evals/custom-llm-evaluators), which emits a label mapped to a numeric score plus an explanation. Pass it to `evaluate()` and the verdict is recorded as its own annotation under a linked evaluator span — **without** asserting on it, so a single weak answer trends in Phoenix instead of breaking the build.
+When a check is a [quality signal](#two-kinds-of-checks-invariants-vs-signals) — accuracy, helpfulness, tone — there's no single correct string to assert against. Hand the judging to another model with [`create_classifier`](/docs/phoenix/evaluation/how-to-evals/custom-llm-evaluators), which emits a label mapped to a numeric score plus an explanation. Pass it to `evaluate()` and the verdict is recorded as its own annotation under a linked evaluator span — **without** asserting on it, so a single weak answer trends in Phoenix instead of breaking the build. The judge reads only what it needs to grade — here the question and the bot's response — so the `kwargs` you pass to `evaluate()` are exactly the template variables.
 
-Consider a grounded support bot. It has two jobs that map cleanly onto the two kinds of checks. When a question is covered by a knowledge-base excerpt, it should answer accurately from that excerpt — a *quality signal*, since the bot can phrase a correct answer a dozen ways. When nothing covers the question, it should decline with a fixed line — a *hard invariant*, since exactly one output is acceptable. So we judge helpfulness as a trend and hard-assert only the refusal.
+Consider a support bot with two jobs that map cleanly onto the two kinds of checks. For a question it can answer, the reply should be helpful — a *quality signal*, since a good answer can be phrased a dozen ways. For an off-topic question, it should decline with a fixed line — a *hard invariant*, since exactly one output is acceptable. So we judge helpfulness on the answerable cases and hard-assert the refusal:
 
 ```python
 import time
@@ -241,78 +241,49 @@ import pytest
 from phoenix.client.pytest import evaluate, log_evaluation, log_output
 from phoenix.evals import LLM, create_classifier
 
-# Knowledge-base excerpts; "offtopic" is empty, so the bot must decline.
-KB = {
-    "billing": "Refunds are available within 14 days of a charge. ...",
-    "offtopic": "",
-}
-
-JUDGE_PROMPT = """\
-You are a strict reviewer for a support bot. You see the knowledge-base excerpt
-the bot worked from, the user question, and the bot's response.
-
-Knowledge base:
-{{knowledge_base}}
-
-Question: {{question}}
-
-Bot response: {{response}}
-
-Label the response "helpful" if it is accurate and grounded in the excerpt (or
-correctly declines when the excerpt does not contain the answer). Label it
-"unhelpful" if it is wrong, unsupported, vague, or ignores the question.\
-"""
-
 # A stronger model than the bot (Sonnet judging Haiku) keeps verdicts stable —
-# a noisy judge makes the whole suite flaky. The kwargs to evaluate() below fill
-# these template variables. The judge sees the same excerpt the bot did, so it
-# can tell whether an answer was grounded, and whether declining was the right call.
+# a noisy judge makes the whole suite flaky. The judge reads just the question
+# and response; the kwargs to evaluate() below fill these template variables.
 helpfulness = create_classifier(
     name="helpfulness",
     llm=LLM(provider="anthropic", model="claude-sonnet-4-6"),
-    prompt_template=JUDGE_PROMPT,
+    prompt_template=(
+        "Question: {{question}}\n\nResponse: {{response}}\n\n"
+        'Label the response "helpful" if it accurately and directly answers the '
+        'question, or "unhelpful" if it is wrong, vague, or off-topic.'
+    ),
     choices={"helpful": 1.0, "unhelpful": 0.0},
 )
 
 CASES = [
-    ("How do I get a refund?", "billing", False),
-    ("What's the capital of France?", "offtopic", True),
+    ("How do I get a refund?", False),
+    ("What's the capital of France?", True),  # off-topic → must refuse
 ]
 
 @pytest.mark.phoenix(dataset="support-bot")
-@pytest.mark.parametrize(
-    "question,kb_key,expect_refusal", CASES, ids=["refund", "offtopic"]
-)
-def test_support_response(question, kb_key, expect_refusal):
-    kb_context = KB[kb_key]
-
+@pytest.mark.parametrize("question,expect_refusal", CASES, ids=["refund", "offtopic"])
+def test_support_response(question, expect_refusal):
     t0 = time.perf_counter()
-    response = answer_question(question, kb_context)
-    latency_ms = (time.perf_counter() - t0) * 1000
-
+    response = answer_question(question)
     log_output({"response": response})
 
     # Structural metric, logged as a CODE annotation — a signal, not a gate.
-    log_evaluation(name="latency_ms", score=latency_ms)
+    log_evaluation(name="latency_ms", score=(time.perf_counter() - t0) * 1000)
 
-    # LLM judge, recorded under its own evaluator span and surfaced as "helpfulness".
-    # Note: NOT asserted — on-topic quality rides on the aggregate trend in Phoenix.
-    evaluate(
-        helpfulness,
-        knowledge_base=kb_context or "(empty)",
-        question=question,
-        response=response,
-    )
-
-    # Hard assertion only for the structural refusal check — the one eval we
-    # don't want to ship broken.
     if expect_refusal:
-        assert "I don't have information on that" in response, (
-            f"Expected refusal for off-topic question, got:\n{response}"
-        )
+        # Hard invariant — the one behavior we refuse to ship broken.
+        assert "I don't have information on that" in response
+    else:
+        # Quality signal — judged, NOT asserted. Helpfulness only means something
+        # for answerable questions, so the judge runs here and trends in Phoenix.
+        evaluate(helpfulness, question=question, response=response)
 ```
 
-This is the whole pattern: log the judge's score so it accumulates as a trend, and reserve `assert` for the invariant. To gate CI on a judge anyway — when an invariant genuinely needs an LLM to verify it — capture the result and assert on it: `result = evaluate(judge, ...); assert result["score"] == 1.0`. Use that sparingly, since it makes a non-deterministic score a hard gate.
+This is the whole pattern: judge the cases where quality is meaningful and let the score accumulate as a trend, while `assert` pins the invariant. To gate CI on a judge anyway — when an invariant genuinely needs an LLM to verify it — capture the result and assert on it: `result = evaluate(judge, ...); assert result["score"] == 1.0`. Use that sparingly, since it makes a non-deterministic score a hard gate.
+
+<Tip>
+To grade whether an answer is *grounded* in retrieved context (rather than just on-topic), give the judge that context too — add a `{{context}}` variable to the template and pass `context=...` to `evaluate()`, or reach for the pre-built [`FaithfulnessEvaluator`](/docs/phoenix/evaluation/pre-built-metrics). See [RAG evaluation](/docs/phoenix/evaluation/how-to-evals/custom-llm-evaluators) for the full pattern.
+</Tip>
 
 <Tip>
 Pick the judge model deliberately. Judging a weaker model with a stronger one (here, Sonnet grading Haiku) keeps verdicts stable across runs; a judge that's no better than the system under test adds noise rather than signal. See [configuring the judge LLM](/docs/phoenix/evaluation/how-to-evals/configuring-the-llm).

--- a/docs/phoenix/evaluation/integrations/pytest.mdx
+++ b/docs/phoenix/evaluation/integrations/pytest.mdx
@@ -31,6 +31,27 @@ log_evaluation()   →  named annotation
 
 This means the same suite that gates your pull requests also builds a versioned history of results you can compare in Phoenix over time.
 
+## Two kinds of checks: invariants vs. signals
+
+Before reaching for a single helper, decide what each check *is*. Evals differ from ordinary tests because an LLM is in the loop: outputs are non-deterministic, some can't be graded by code at all, and pass/fail is often too blunt — quality lives on a spectrum. That pushes every check into one of two buckets, and you treat them differently.
+
+- **Hard invariants.** There is exactly one acceptable behavior, and ordinary code can verify it — a required refusal, valid JSON, a tool that must be called. These belong in `assert`. A failed assertion records `pass=False` and turns CI red, exactly like any unit test. If the invariant breaks, the build breaks.
+- **Quality signals.** There's no single correct string, only better and worse answers — helpfulness, groundedness, tone. You *score* these (often with an LLM judge) instead of asserting on them, then watch the trend in Phoenix. A single weak result shouldn't fail the build, because some variance is the nature of the model. Log them with `log_evaluation()` / `evaluate()` and let them accumulate as annotations; gate on the aggregate trend separately rather than on every case.
+
+Deciding which checks are invariants and which are signals is the real first move — everything after it is plumbing. A good rule of thumb: `assert` the smallest behavior you'd be embarrassed to ship broken, and score the fuzzier stuff as a signal.
+
+```python
+@pytest.mark.phoenix(dataset="my-first-eval")
+def test_first_eval():
+    output = run_system(scenario)        # scenario through the system under test
+    log_output({"response": output})
+
+    score = judge(output)                # quality signal → record and trend
+    log_evaluation(name="quality", score=score)
+
+    assert invariant_holds(output)       # hard invariant → gate CI
+```
+
 ## Installation
 
 <Info>
@@ -205,6 +226,96 @@ Hoisted evaluators are invoked using the same adapter as `run_experiment`, so an
 
 <Tip>
 Any evaluator from [`arize-phoenix-evals`](/docs/phoenix/evaluation/pre-built-metrics) works here — `FaithfulnessEvaluator`, `DocumentRelevanceEvaluator`, QA correctness, toxicity, and more — as does any plain function you'd pass to `run_experiment`. Write a custom evaluator once and use it from both.
+</Tip>
+
+## LLM-as-a-judge: scoring quality signals
+
+When a check is a [quality signal](#two-kinds-of-checks-invariants-vs-signals) — accuracy, groundedness, tone — there's no single correct string to assert against. Hand the judging to another model with [`create_classifier`](/docs/phoenix/evaluation/how-to-evals/custom-llm-evaluators), which emits a label mapped to a numeric score plus an explanation. Pass it to `evaluate()` and the verdict is recorded as its own annotation under a linked evaluator span — **without** asserting on it, so a single weak answer trends in Phoenix instead of breaking the build.
+
+Consider a grounded support bot. It has two jobs that map cleanly onto the two kinds of checks. When a question is covered by a knowledge-base excerpt, it should answer accurately from that excerpt — a *quality signal*, since the bot can phrase a correct answer a dozen ways. When nothing covers the question, it should decline with a fixed line — a *hard invariant*, since exactly one output is acceptable. So we judge helpfulness as a trend and hard-assert only the refusal.
+
+```python
+import time
+
+import pytest
+from phoenix.client.pytest import evaluate, log_evaluation, log_output
+from phoenix.evals import LLM, create_classifier
+
+# Knowledge-base excerpts; "offtopic" is empty, so the bot must decline.
+KB = {
+    "billing": "Refunds are available within 14 days of a charge. ...",
+    "offtopic": "",
+}
+
+JUDGE_PROMPT = """\
+You are a strict reviewer for a support bot. You see the knowledge-base excerpt
+the bot worked from, the user question, and the bot's response.
+
+Knowledge base:
+{{knowledge_base}}
+
+Question: {{question}}
+
+Bot response: {{response}}
+
+Label the response "helpful" if it is accurate and grounded in the excerpt (or
+correctly declines when the excerpt does not contain the answer). Label it
+"unhelpful" if it is wrong, unsupported, vague, or ignores the question.\
+"""
+
+# A stronger model than the bot (Sonnet judging Haiku) keeps verdicts stable —
+# a noisy judge makes the whole suite flaky. The kwargs to evaluate() below fill
+# these template variables. The judge sees the same excerpt the bot did, so it
+# can tell whether an answer was grounded, and whether declining was the right call.
+helpfulness = create_classifier(
+    name="helpfulness",
+    llm=LLM(provider="anthropic", model="claude-sonnet-4-6"),
+    prompt_template=JUDGE_PROMPT,
+    choices={"helpful": 1.0, "unhelpful": 0.0},
+)
+
+CASES = [
+    ("How do I get a refund?", "billing", False),
+    ("What's the capital of France?", "offtopic", True),
+]
+
+@pytest.mark.phoenix(dataset="support-bot")
+@pytest.mark.parametrize(
+    "question,kb_key,expect_refusal", CASES, ids=["refund", "offtopic"]
+)
+def test_support_response(question, kb_key, expect_refusal):
+    kb_context = KB[kb_key]
+
+    t0 = time.perf_counter()
+    response = answer_question(question, kb_context)
+    latency_ms = (time.perf_counter() - t0) * 1000
+
+    log_output({"response": response})
+
+    # Structural metric, logged as a CODE annotation — a signal, not a gate.
+    log_evaluation(name="latency_ms", score=latency_ms)
+
+    # LLM judge, recorded under its own evaluator span and surfaced as "helpfulness".
+    # Note: NOT asserted — on-topic quality rides on the aggregate trend in Phoenix.
+    evaluate(
+        helpfulness,
+        knowledge_base=kb_context or "(empty)",
+        question=question,
+        response=response,
+    )
+
+    # Hard assertion only for the structural refusal check — the one eval we
+    # don't want to ship broken.
+    if expect_refusal:
+        assert "I don't have information on that" in response, (
+            f"Expected refusal for off-topic question, got:\n{response}"
+        )
+```
+
+This is the whole pattern: log the judge's score so it accumulates as a trend, and reserve `assert` for the invariant. To gate CI on a judge anyway — when an invariant genuinely needs an LLM to verify it — capture the result and assert on it: `result = evaluate(judge, ...); assert result["score"] == 1.0`. Use that sparingly, since it makes a non-deterministic score a hard gate.
+
+<Tip>
+Pick the judge model deliberately. Judging a weaker model with a stronger one (here, Sonnet grading Haiku) keeps verdicts stable across runs; a judge that's no better than the system under test adds noise rather than signal. See [configuring the judge LLM](/docs/phoenix/evaluation/how-to-evals/configuring-the-llm).
 </Tip>
 
 ## Repetitions

--- a/docs/phoenix/evaluation/integrations/pytest.mdx
+++ b/docs/phoenix/evaluation/integrations/pytest.mdx
@@ -241,9 +241,9 @@ import pytest
 from phoenix.client.pytest import evaluate, log_evaluation, log_output
 from phoenix.evals import LLM, create_classifier
 
-# A stronger model than the bot (Sonnet judging Haiku) keeps verdicts stable —
-# a noisy judge makes the whole suite flaky. The judge reads just the question
-# and response; the kwargs to evaluate() below fill these template variables.
+# The judge runs on its own model, configured independently of the bot under
+# test. It reads just the question and response; the kwargs to evaluate() below
+# fill these template variables.
 helpfulness = create_classifier(
     name="helpfulness",
     llm=LLM(provider="anthropic", model="claude-sonnet-4-6"),
@@ -286,7 +286,7 @@ To grade whether an answer is *grounded* in retrieved context (rather than just 
 </Tip>
 
 <Tip>
-Pick the judge model deliberately. Judging a weaker model with a stronger one (here, Sonnet grading Haiku) keeps verdicts stable across runs; a judge that's no better than the system under test adds noise rather than signal. See [configuring the judge LLM](/docs/phoenix/evaluation/how-to-evals/configuring-the-llm).
+The judge runs on its own model, configured independently of the system under test. See [configuring the judge LLM](/docs/phoenix/evaluation/how-to-evals/configuring-the-llm) for how to choose and tune it.
 </Tip>
 
 ## Repetitions

--- a/docs/phoenix/evaluation/integrations/vitest-jest.mdx
+++ b/docs/phoenix/evaluation/integrations/vitest-jest.mdx
@@ -32,6 +32,15 @@ acceptanceCriteria →  CI gate on aggregate scores
 
 Suite-level `acceptanceCriteria` can fail CI when aggregate metrics drop below a threshold — for example, when average correctness falls below `0.8` or more than 10% of runs produce invalid SQL.
 
+## Two kinds of checks: invariants vs. signals
+
+Before reaching for a helper, decide what each check *is*. Evals differ from ordinary tests because an LLM is in the loop: outputs are non-deterministic, some can't be graded by code at all, and pass/fail is often too blunt — quality lives on a spectrum. That pushes every check into one of two buckets, and this runner gives each its own home.
+
+- **Hard invariants.** There is exactly one acceptable behavior, and ordinary code can verify it — a required refusal, valid JSON, a tool that must be called. These belong in a per-case `expect()`. A failed assertion fails the test, fails the run, and turns CI red.
+- **Quality signals.** There's no single correct string, only better and worse answers — helpfulness, groundedness, tone. You *score* these (often with an LLM judge) and record them with `logAnnotation()` / `evaluate()`, then gate them at the **suite** level with [`acceptanceCriteria`](#acceptance-criteria--ci-gates-on-aggregate-scores). A single weak result shouldn't fail the build, so the gate runs on the aggregate (e.g. ≥70% helpful), not on every case.
+
+The split is the real first move: per-case `expect()` for invariants, `acceptanceCriteria` for signals. `assert` the smallest behavior you'd be embarrassed to ship broken, and let everything fuzzier ride along as a tracked signal.
+
 ## Installation
 
 <Info>
@@ -366,6 +375,102 @@ The annotation name defaults to the function's name, falling back to `"evaluator
 <Note>
 `evaluate()`, `traceEvaluator()`, and any annotation logged through them are recorded under a dedicated evaluator span, so the judge's LLM calls never clutter the task trace and each annotation links straight to the trace that produced it. Click an annotation in the Phoenix UI to open its evaluator trace.
 </Note>
+
+## LLM-as-a-judge: scoring quality signals
+
+When a check is a [quality signal](#two-kinds-of-checks-invariants-vs-signals) — accuracy, groundedness, tone — there's no single correct string to assert against. Hand the judging to another model with [`createClassificationEvaluator`](/docs/phoenix/evaluation/how-to-evals/custom-llm-evaluators), which emits a label mapped to a numeric score plus an explanation. Its `inputMapping` projects the run's auto-supplied `{ input, output }` onto the prompt-template variables, so `await px.evaluate(judge)` needs no params. The verdict is recorded as an annotation under a linked evaluator span — **without** an `expect()`, so it trends in Phoenix and a single weak answer doesn't break the build.
+
+Consider a grounded support bot. It has two jobs that map cleanly onto the two kinds of checks. When a question is covered by a knowledge-base excerpt, it should answer accurately from that excerpt — a *quality signal*, since a correct answer can be phrased many ways. When nothing covers the question, it should decline with a fixed line — a *hard invariant*, since exactly one output is acceptable. So we judge helpfulness as a trend (gated by `acceptanceCriteria`) and hard-assert only the refusal.
+
+```ts
+// support-bot.eval.ts
+import { anthropic } from "@ai-sdk/anthropic";
+import * as px from "@arizeai/phoenix-client/vitest";
+import { createClassificationEvaluator } from "@arizeai/phoenix-evals";
+import { expect } from "vitest";
+
+// Knowledge-base excerpts; "offtopic" is empty, so the bot must decline.
+const KB: Record<string, string> = {
+  billing: "Refunds are available within 14 days of a charge. ...",
+  offtopic: "",
+};
+
+type BotInput = { question: string; kbKey: string; expectRefusal: boolean };
+type JudgeRecord = { input: BotInput; output?: { response: string } };
+
+// A stronger model than the bot (Sonnet judging Haiku) keeps verdicts stable.
+// The judge sees the same excerpt the bot did, so it can tell whether the answer
+// was grounded — and whether declining was the right call when the excerpt is empty.
+const helpfulness = createClassificationEvaluator<JudgeRecord>({
+  name: "helpfulness",
+  model: anthropic("claude-sonnet-4-6"),
+  choices: { helpful: 1, unhelpful: 0 },
+  promptTemplate: `You are a strict reviewer for a support bot.
+
+Knowledge base:
+{{knowledge_base}}
+
+Question: {{question}}
+
+Bot response: {{response}}
+
+Label "helpful" if the response is accurate and grounded in the excerpt (or
+correctly declines when the excerpt does not contain the answer). Label
+"unhelpful" if it is wrong, unsupported, vague, or ignores the question.`,
+  // Project the run's { input, output } onto the template variables.
+  inputMapping: {
+    knowledge_base: (record) => KB[record.input.kbKey] || "(empty)",
+    question: "input.question",
+    response: (record) => record.output?.response ?? "",
+  },
+});
+
+const CASES = [
+  { id: "refund", input: { question: "How do I get a refund?", kbKey: "billing", expectRefusal: false } },
+  { id: "offtopic", input: { question: "What's the capital of France?", kbKey: "offtopic", expectRefusal: true } },
+];
+
+px.describe(
+  "support bot",
+  () => {
+    px.test.each(CASES)(
+      (row) => row.id ?? "case",
+      async ({ input }) => {
+        const start = performance.now();
+        const response = await answerQuestion(input.question, KB[input.kbKey] ?? "");
+
+        px.logOutput({ response });
+
+        // Structural metric — a CODE signal, tracked not asserted.
+        px.logAnnotation({ name: "latency_ms", score: performance.now() - start, annotatorKind: "CODE" });
+
+        // LLM judge, recorded under its own evaluator span. NOT asserted —
+        // on-topic quality is gated by acceptanceCriteria, below.
+        await px.evaluate(helpfulness);
+
+        // Hard assertion only for the structural refusal check.
+        if (input.expectRefusal) {
+          expect(response).toContain("I don't have information on that");
+        }
+      },
+    );
+  },
+  {
+    acceptanceCriteria: [
+      // signal gate: at least 70% of runs must score helpful
+      { annotationName: "helpfulness", metric: "passRate", passFn: (a) => a.score === 1, minPassRate: 0.7 },
+      // budget gate: mean response time under 5 seconds
+      { annotationName: "latency_ms", metric: "average", threshold: 5000, direction: "minimize" },
+    ],
+  },
+);
+```
+
+This is the whole pattern: the refusal stays a per-case `expect()` (invariant), while helpfulness and latency become `acceptanceCriteria` (signals). The suite still fails CI if quality drops across the board — just not on a single unlucky generation.
+
+<Tip>
+Pick the judge model deliberately. Judging a weaker model with a stronger one (here, Sonnet grading Haiku) keeps verdicts stable across runs; a judge that's no better than the system under test adds noise rather than signal. See [configuring the judge LLM](/docs/phoenix/evaluation/how-to-evals/configuring-the-llm).
+</Tip>
 
 ## Acceptance criteria — CI gates on aggregate scores
 

--- a/docs/phoenix/evaluation/integrations/vitest-jest.mdx
+++ b/docs/phoenix/evaluation/integrations/vitest-jest.mdx
@@ -389,8 +389,8 @@ import * as px from "@arizeai/phoenix-client/vitest";
 import { createClassificationEvaluator } from "@arizeai/phoenix-evals";
 import { expect } from "vitest";
 
-// A stronger model than the bot (Sonnet judging Haiku) keeps verdicts stable.
-// The judge reads just the question and response; the params passed to
+// The judge runs on its own model, configured independently of the bot under
+// test. It reads just the question and response; the params passed to
 // px.evaluate() below fill these template variables — no inputMapping needed.
 const helpfulness = createClassificationEvaluator({
   name: "helpfulness",
@@ -447,7 +447,7 @@ px.describe(
 This is the whole pattern: the refusal stays a per-case `expect()` (invariant), while helpfulness and latency become `acceptanceCriteria` (signals). The suite still fails CI if quality drops across the board — just not on a single unlucky generation.
 
 <Tip>
-To grade whether an answer is *grounded* in retrieved context (rather than just on-topic), give the judge that context too — add a `{{context}}` variable to the template and pass `context` alongside `question` and `response`, or reach for a pre-built evaluator like `createFaithfulnessEvaluator` (which can supply its own `inputMapping`). Judge with a model stronger than the system under test (here, Sonnet grading Haiku) to keep verdicts stable; see [configuring the judge LLM](/docs/phoenix/evaluation/how-to-evals/configuring-the-llm).
+To grade whether an answer is *grounded* in retrieved context (rather than just on-topic), give the judge that context too — add a `{{context}}` variable to the template and pass `context` alongside `question` and `response`, or reach for a pre-built evaluator like `createFaithfulnessEvaluator` (which can supply its own `inputMapping`). The judge runs on its own model, configured independently of the system under test; see [configuring the judge LLM](/docs/phoenix/evaluation/how-to-evals/configuring-the-llm) for how to choose and tune it.
 </Tip>
 
 ## Acceptance criteria — CI gates on aggregate scores

--- a/docs/phoenix/evaluation/integrations/vitest-jest.mdx
+++ b/docs/phoenix/evaluation/integrations/vitest-jest.mdx
@@ -446,10 +446,6 @@ px.describe(
 
 This is the whole pattern: the refusal stays a per-case `expect()` (invariant), while helpfulness and latency become `acceptanceCriteria` (signals). The suite still fails CI if quality drops across the board — just not on a single unlucky generation.
 
-<Tip>
-To grade whether an answer is *grounded* in retrieved context (rather than just on-topic), give the judge that context too — add a `{{context}}` variable to the template and pass `context` alongside `question` and `response`, or reach for a pre-built evaluator like `createFaithfulnessEvaluator` (which can supply its own `inputMapping`). The judge runs on its own model, configured independently of the system under test; see [configuring the judge LLM](/docs/phoenix/evaluation/how-to-evals/configuring-the-llm) for how to choose and tune it.
-</Tip>
-
 ## Acceptance criteria — CI gates on aggregate scores
 
 Acceptance criteria let you fail CI when a quality metric drops across the full suite. They run _after_ all tests, so every case still executes and the reporter prints the full scorecard before failing — you see every regression in one run, not just the first.

--- a/docs/phoenix/evaluation/integrations/vitest-jest.mdx
+++ b/docs/phoenix/evaluation/integrations/vitest-jest.mdx
@@ -378,9 +378,9 @@ The annotation name defaults to the function's name, falling back to `"evaluator
 
 ## LLM-as-a-judge: scoring quality signals
 
-When a check is a [quality signal](#two-kinds-of-checks-invariants-vs-signals) — accuracy, groundedness, tone — there's no single correct string to assert against. Hand the judging to another model with [`createClassificationEvaluator`](/docs/phoenix/evaluation/how-to-evals/custom-llm-evaluators), which emits a label mapped to a numeric score plus an explanation. Its `inputMapping` projects the run's auto-supplied `{ input, output }` onto the prompt-template variables, so `await px.evaluate(judge)` needs no params. The verdict is recorded as an annotation under a linked evaluator span — **without** an `expect()`, so it trends in Phoenix and a single weak answer doesn't break the build.
+When a check is a [quality signal](#two-kinds-of-checks-invariants-vs-signals) — accuracy, helpfulness, tone — there's no single correct string to assert against. Hand the judging to another model with [`createClassificationEvaluator`](/docs/phoenix/evaluation/how-to-evals/custom-llm-evaluators), which emits a label mapped to a numeric score plus an explanation. The verdict is recorded as an annotation under a linked evaluator span — **without** an `expect()` — so it trends in Phoenix and a single weak answer doesn't break the build. Pass the judge only what it needs to grade (here the question and response) as the second argument to `px.evaluate()`, matching the template variables — no `inputMapping` required.
 
-Consider a grounded support bot. It has two jobs that map cleanly onto the two kinds of checks. When a question is covered by a knowledge-base excerpt, it should answer accurately from that excerpt — a *quality signal*, since a correct answer can be phrased many ways. When nothing covers the question, it should decline with a fixed line — a *hard invariant*, since exactly one output is acceptable. So we judge helpfulness as a trend (gated by `acceptanceCriteria`) and hard-assert only the refusal.
+Consider a support bot with two jobs that map cleanly onto the two kinds of checks. For a question it can answer, the reply should be helpful — a *quality signal*, since a good answer can be phrased many ways. For an off-topic question, it should decline with a fixed line — a *hard invariant*, since exactly one output is acceptable. So we judge helpfulness on the answerable cases (gated by `acceptanceCriteria`) and hard-assert the refusal:
 
 ```ts
 // support-bot.eval.ts
@@ -389,45 +389,24 @@ import * as px from "@arizeai/phoenix-client/vitest";
 import { createClassificationEvaluator } from "@arizeai/phoenix-evals";
 import { expect } from "vitest";
 
-// Knowledge-base excerpts; "offtopic" is empty, so the bot must decline.
-const KB: Record<string, string> = {
-  billing: "Refunds are available within 14 days of a charge. ...",
-  offtopic: "",
-};
-
-type BotInput = { question: string; kbKey: string; expectRefusal: boolean };
-type JudgeRecord = { input: BotInput; output?: { response: string } };
-
 // A stronger model than the bot (Sonnet judging Haiku) keeps verdicts stable.
-// The judge sees the same excerpt the bot did, so it can tell whether the answer
-// was grounded — and whether declining was the right call when the excerpt is empty.
-const helpfulness = createClassificationEvaluator<JudgeRecord>({
+// The judge reads just the question and response; the params passed to
+// px.evaluate() below fill these template variables — no inputMapping needed.
+const helpfulness = createClassificationEvaluator({
   name: "helpfulness",
   model: anthropic("claude-sonnet-4-6"),
   choices: { helpful: 1, unhelpful: 0 },
-  promptTemplate: `You are a strict reviewer for a support bot.
+  promptTemplate: `Question: {{question}}
 
-Knowledge base:
-{{knowledge_base}}
+Response: {{response}}
 
-Question: {{question}}
-
-Bot response: {{response}}
-
-Label "helpful" if the response is accurate and grounded in the excerpt (or
-correctly declines when the excerpt does not contain the answer). Label
-"unhelpful" if it is wrong, unsupported, vague, or ignores the question.`,
-  // Project the run's { input, output } onto the template variables.
-  inputMapping: {
-    knowledge_base: (record) => KB[record.input.kbKey] || "(empty)",
-    question: "input.question",
-    response: (record) => record.output?.response ?? "",
-  },
+Label "helpful" if the response accurately and directly answers the question, or
+"unhelpful" if it is wrong, vague, or off-topic.`,
 });
 
 const CASES = [
-  { id: "refund", input: { question: "How do I get a refund?", kbKey: "billing", expectRefusal: false } },
-  { id: "offtopic", input: { question: "What's the capital of France?", kbKey: "offtopic", expectRefusal: true } },
+  { id: "refund", input: { question: "How do I get a refund?", expectRefusal: false } },
+  { id: "offtopic", input: { question: "What's the capital of France?", expectRefusal: true } },
 ];
 
 px.describe(
@@ -437,27 +416,26 @@ px.describe(
       (row) => row.id ?? "case",
       async ({ input }) => {
         const start = performance.now();
-        const response = await answerQuestion(input.question, KB[input.kbKey] ?? "");
+        const response = await answerQuestion(input.question);
 
         px.logOutput({ response });
-
         // Structural metric — a CODE signal, tracked not asserted.
         px.logAnnotation({ name: "latency_ms", score: performance.now() - start, annotatorKind: "CODE" });
 
-        // LLM judge, recorded under its own evaluator span. NOT asserted —
-        // on-topic quality is gated by acceptanceCriteria, below.
-        await px.evaluate(helpfulness);
-
-        // Hard assertion only for the structural refusal check.
         if (input.expectRefusal) {
+          // Hard invariant — the one behavior we refuse to ship broken.
           expect(response).toContain("I don't have information on that");
+        } else {
+          // Quality signal — judged, NOT asserted. Gated at the suite level by
+          // acceptanceCriteria below, so a single weak answer won't fail CI.
+          await px.evaluate(helpfulness, { question: input.question, response });
         }
       },
     );
   },
   {
     acceptanceCriteria: [
-      // signal gate: at least 70% of runs must score helpful
+      // signal gate: at least 70% of judged answers must score helpful
       { annotationName: "helpfulness", metric: "passRate", passFn: (a) => a.score === 1, minPassRate: 0.7 },
       // budget gate: mean response time under 5 seconds
       { annotationName: "latency_ms", metric: "average", threshold: 5000, direction: "minimize" },
@@ -469,7 +447,7 @@ px.describe(
 This is the whole pattern: the refusal stays a per-case `expect()` (invariant), while helpfulness and latency become `acceptanceCriteria` (signals). The suite still fails CI if quality drops across the board — just not on a single unlucky generation.
 
 <Tip>
-Pick the judge model deliberately. Judging a weaker model with a stronger one (here, Sonnet grading Haiku) keeps verdicts stable across runs; a judge that's no better than the system under test adds noise rather than signal. See [configuring the judge LLM](/docs/phoenix/evaluation/how-to-evals/configuring-the-llm).
+To grade whether an answer is *grounded* in retrieved context (rather than just on-topic), give the judge that context too — add a `{{context}}` variable to the template and pass `context` alongside `question` and `response`, or reach for a pre-built evaluator like `createFaithfulnessEvaluator` (which can supply its own `inputMapping`). Judge with a model stronger than the system under test (here, Sonnet grading Haiku) to keep verdicts stable; see [configuring the judge LLM](/docs/phoenix/evaluation/how-to-evals/configuring-the-llm).
 </Tip>
 
 ## Acceptance criteria — CI gates on aggregate scores


### PR DESCRIPTION
## Summary

The eval skill and integration docs were enhanced for CI workflows but never incorporated **LLM-as-a-judge**. They covered the CI mechanics (assertions, acceptance criteria, hoisted evaluators) but didn't show how to use an LLM judge *inside* a test runner, nor articulate the core distinction the testing-evals approach rests on: which checks are **hard invariants** that gate CI red, and which are **quality signals** that ride along as trends.

This PR closes that gap across both the agent skill and the public docs.

## Changes

**Skill (`.agents/skills/phoenix-evals/`)**
- `references/integrations-pytest.md` — added "Two kinds of checks: invariants vs. signals" and an LLM-as-a-judge example using `create_classifier` + `evaluate()`.
- `references/integrations-vitest-jest.md` — same framing plus a `createClassificationEvaluator` example with `inputMapping`, wiring the judge signal into suite-level `acceptanceCriteria`.
- `SKILL.md` — added an "Invariants gate, signals trend" key principle.

**Docs (`docs/phoenix/evaluation/integrations/`)**
- `pytest.mdx` — new conceptual section on invariants vs. signals, plus a grounded support-bot LLM-as-judge example (`create_classifier`, stronger model judging a weaker bot, helpfulness logged as a trend while the refusal is hard-asserted).
- `vitest-jest.mdx` — matching section and a `createClassificationEvaluator` support-bot example whose helpfulness/latency signals are gated by `acceptanceCriteria` while the refusal stays a per-case `expect()`.

## Notes
- Verified `inputMapping` (string-path and function forms) and `createClassificationEvaluator` against the shipped `@arizeai/phoenix-evals` source.
- Doc cross-links point to existing pages (`custom-llm-evaluators`, `configuring-the-llm`).
- Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012ugoQHLcrUShYn81TfP9Je)_