### PR TITLE
fix(pxi): render dataset_file with forward slashes on Windows

### DIFF
--- a/evals/pxi/harness/reporting.py
+++ b/evals/pxi/harness/reporting.py
@@ -438,7 +438,9 @@ def build_report(
     return Report(
         dataset_name=dataset.dataset_name,
         dataset_stem=dataset_stem,
-        dataset_file=str(_DATASETS_DIR_RELATIVE / f"{dataset_stem}.yaml"),
+        # ``as_posix`` keeps forward slashes so the repo-relative path renders
+        # and compares identically on Windows (avoids backslash separators).
+        dataset_file=(_DATASETS_DIR_RELATIVE / f"{dataset_stem}.yaml").as_posix(),
         experiment_name=experiment_name,
         experiment_url=_experiment_url(experiment, base_url),
         git_sha=str(metadata.get("git_sha", "unknown")),


### PR DESCRIPTION
## Summary

The scheduled **main Python All Platforms** job failed on `windows-latest` with two failures in `tests/unit/pxi/evals/test_reporting.py`:

```
AssertionError: assert 'evals\pxi\...le_suite.yaml' == 'evals/pxi/da...le_suite.yaml'
```

`build_report` set `dataset_file` via `str(_DATASETS_DIR_RELATIVE / ...)`. `str()` on a `Path` uses the OS-native separator, so Windows produced backslashes (`evals\pxi\datasets\example_suite.yaml`).

`dataset_file` is a display/metadata pointer — it's rendered into the Markdown report header (`- **Dataset file**: \`...\``) and stored in the JSON report — not a path opened on disk. So the canonical repo-relative forward-slash form is correct on every platform (it matches git/GitHub paths and the YAML loader's own globbing). Switching to `Path.as_posix()` makes the rendered path identical regardless of where the report was generated and fixes the cross-platform test mismatch.

## Changes

- `evals/pxi/harness/reporting.py`: use `.as_posix()` instead of `str()` for `dataset_file`.

## Testing

`uv run pytest tests/unit/pxi/evals/test_reporting.py` — 15 passed.