### PR TITLE
feat(playground): add Claude Sonnet 5

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1388,6 +1388,7 @@ class TogetherStreamingClient(OpenAIBaseStreamingClient):
         "anthropic.claude-fable-5",
         "anthropic.claude-opus-4-8",
         "anthropic.claude-opus-4-7",
+        "anthropic.claude-sonnet-5",
         "anthropic.claude-opus-4-6-v1",
         "anthropic.claude-sonnet-4-6",
         "anthropic.claude-opus-4-5-20251101-v1:0",
@@ -2201,6 +2202,7 @@ def _anthropic_beta_headers_for_tools(
         "claude-fable-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
+        "claude-sonnet-5",
     ],
 )
 class AnthropicStreamingClient(PlaygroundStreamingClient["AsyncAnthropic"]):


### PR DESCRIPTION
## Summary

Adds Claude Sonnet 5 (`claude-sonnet-5`) to the playground client registry so it appears in the playground model dropdown.

- **Direct Anthropic provider** (`AnthropicStreamingClient`) — added `claude-sonnet-5`.
- **AWS Bedrock provider** — added `anthropic.claude-sonnet-5`.

## Placement rationale

Sonnet 5 is registered in the standard `AnthropicStreamingClient` list alongside the other adaptive-thinking models (`fable-5`, `opus-4-8`, `opus-4-7`) rather than `ANTHROPIC_REASONING_MODELS`. The reasoning client is just a `pass` subclass — the split is generational, and Sonnet 5 uses adaptive thinking (its `budget_tokens` parameter is removed at the API level), so it belongs with its generation peers. The generic `_anthropic_message_params` already handles its thinking config, so no other code changes are needed.

The playground model dropdown is populated from this registry via GraphQL, so the new model surfaces automatically.

## Test plan

- [ ] Sonnet 5 appears in the playground model dropdown under the Anthropic provider
- [ ] Sonnet 5 appears under the AWS Bedrock provider
- [ ] A playground run against `claude-sonnet-5` streams a response