### PR TITLE
feat(cli): add annotation-config get, create, and update

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -275,7 +275,14 @@ px prompt get <name> --format text --no-progress   # plain text, ideal for pipin
 ```bash
 px annotation-config list                                           # list all configs (table view)
 px annotation-config list --format raw --no-progress | jq '.[].name' # config names as JSON
+
+# update by name or ID — only the fields you pass change; type is immutable
+px annotation-config update quality --name accuracy --optimization-direction MAXIMIZE
+px annotation-config update quality --values '[{"label":"good","score":1},{"label":"bad","score":0}]'
+px annotation-config update cfg-123 --description "Updated" --format raw --no-progress | jq -r '.id'
 ```
+
+`update` fetches the existing config, merges your flags, and writes the full body back via `PUT /v1/annotation_configs/{id}`. At least one field flag is required. Type-specific flags: `--values` (CATEGORICAL), `--lower-bound`/`--upper-bound` (CONTINUOUS/FREEFORM), `--threshold` (FREEFORM). Output is the updated config object (single object in `raw`/`json`, not an array).
 
 ## GraphQL
 

--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -272,17 +272,25 @@ px prompt get <name> --format text --no-progress   # plain text, ideal for pipin
 
 ## Annotation Configs
 
+Full CRUD: `list`, `get`, `create`, `update`, `delete`. Types are `CATEGORICAL` (labels + optional scores), `CONTINUOUS` (numeric range), `FREEFORM` (free text).
+
 ```bash
 px annotation-config list                                           # list all configs (table view)
 px annotation-config list --format raw --no-progress | jq '.[].name' # config names as JSON
+px annotation-config get quality --format raw --no-progress          # fetch one by name or ID
+
+# create — categorical, continuous, or freeform
+px annotation-config create --type CATEGORICAL --name quality --value good=1 --value bad=0
+px annotation-config create --type CONTINUOUS --name score --lower-bound 0 --upper-bound 1
+px annotation-config create --type FREEFORM --name notes --description 'Reviewer notes'
 
 # update by name or ID — only the fields you pass change; type is immutable
 px annotation-config update quality --name accuracy --optimization-direction MAXIMIZE
-px annotation-config update quality --values '[{"label":"good","score":1},{"label":"bad","score":0}]'
+px annotation-config update quality --value good=1 --value bad=0
 px annotation-config update cfg-123 --description "Updated" --format raw --no-progress | jq -r '.id'
 ```
 
-`update` fetches the existing config, merges your flags, and writes the full body back via `PUT /v1/annotation_configs/{id}`. At least one field flag is required. Type-specific flags: `--values` (CATEGORICAL), `--lower-bound`/`--upper-bound` (CONTINUOUS/FREEFORM), `--threshold` (FREEFORM). Output is the updated config object (single object in `raw`/`json`, not an array).
+Categorical values are specified the same way in `create` and `update`: repeatable `--value label[=score]` (score optional), or a single `--values '<json>'` payload — mutually exclusive. `update` fetches the existing config, merges your flags, and writes the full body back via `PUT /v1/annotation_configs/{id}`; it requires at least one field flag. Other type-specific flags: `--lower-bound`/`--upper-bound` (CONTINUOUS/FREEFORM), `--threshold` (FREEFORM). `get`/`create`/`update` output the config object (single object in `raw`/`json`, not an array).
 
 ## GraphQL
 

--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -275,22 +275,25 @@ px prompt get <name> --format text --no-progress   # plain text, ideal for pipin
 Full CRUD: `list`, `get`, `create`, `update`, `delete`. Types are `CATEGORICAL` (labels + optional scores), `CONTINUOUS` (numeric range), `FREEFORM` (free text).
 
 ```bash
-px annotation-config list                                           # list all configs (table view)
-px annotation-config list --format raw --no-progress | jq '.[].name' # config names as JSON
-px annotation-config get quality --format raw --no-progress          # fetch one by name or ID
+px annotation-config list                                                # all configs (table view)
+px annotation-config list --format raw --no-progress | jq -r '.[].name' # config names as JSON
+px annotation-config get response-quality --format raw --no-progress     # one config by name or ID
 
-# create — categorical, continuous, or freeform
-px annotation-config create --type CATEGORICAL --name quality --value good=1 --value bad=0
-px annotation-config create --type CONTINUOUS --name score --lower-bound 0 --upper-bound 1
-px annotation-config create --type FREEFORM --name notes --description 'Reviewer notes'
+# create — categorical (scored labels), continuous (numeric range), or freeform (free text)
+px annotation-config create --type CATEGORICAL --name response-quality --value good=1 --value bad=0
+px annotation-config create --type CONTINUOUS --name confidence --lower-bound 0 --upper-bound 1
+px annotation-config create --type FREEFORM --name reviewer-notes --description 'Free-form reviewer feedback'
 
 # update by name or ID — only the fields you pass change; type is immutable
-px annotation-config update quality --name accuracy --optimization-direction MAXIMIZE
-px annotation-config update quality --value good=1 --value bad=0
-px annotation-config update cfg-123 --description "Updated" --format raw --no-progress | jq -r '.id'
+px annotation-config update response-quality --name answer-quality --optimization-direction MAXIMIZE
+px annotation-config update response-quality --value good=1 --value acceptable=0.5 --value bad=0
+px annotation-config update response-quality --description "Updated" --format raw --no-progress | jq -r '.id'
+
+# delete by ID — requires PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES=true; --yes skips the prompt
+px annotation-config delete QW5ub3RhdGlvbkNvbmZpZzoxMjM= --yes
 ```
 
-Categorical values are specified the same way in `create` and `update`: repeatable `--value label[=score]` (score optional), or a single `--values '<json>'` payload — mutually exclusive. `update` fetches the existing config, merges your flags, and writes the full body back via `PUT /v1/annotation_configs/{id}`; it requires at least one field flag. Other type-specific flags: `--lower-bound`/`--upper-bound` (CONTINUOUS/FREEFORM), `--threshold` (FREEFORM). `get`/`create`/`update` output the config object (single object in `raw`/`json`, not an array).
+Categorical values are specified the same way in `create` and `update`: repeatable `--value label[=score]` (score optional), or a single `--values '<json>'` payload — mutually exclusive. `update` fetches the existing config, merges your flags, and writes the full body back via `PUT /v1/annotation_configs/{id}`; it requires at least one field flag. Other type-specific flags: `--lower-bound`/`--upper-bound` (CONTINUOUS/FREEFORM), `--threshold` (FREEFORM). Invalid input (bad flags, type mismatches, malformed values) exits `3` (`INVALID_ARGUMENT`) with a `{error, code, hint?}` JSON envelope on stderr in `raw`/`json` mode. `get`/`create`/`update` output the config object (single object in `raw`/`json`, not an array).
 
 ## GraphQL
 

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -491,6 +491,37 @@ px annotation-config list --format raw --no-progress | jq '.[].name'
 
 ---
 
+### `px annotation-config update <config-identifier>`
+
+Update an annotation configuration by name or ID. Only the fields you pass are changed — the command fetches the existing config, merges your flags, and writes the result back via `PUT /v1/annotation_configs/{id}`. The config `type` is immutable; to change it, delete and recreate the config. The updated config is written to stdout in the selected `--format`.
+
+```bash
+# Human: rename and change optimization direction
+px annotation-config update quality --name accuracy --optimization-direction MAXIMIZE
+
+# Update the label set of a categorical config
+px annotation-config update quality --values '[{"label":"good","score":1},{"label":"bad","score":0}]'
+
+# Agent: capture the updated ID
+px annotation-config update cfg-123 --description "Updated" --format raw --no-progress | jq -r '.id'
+```
+
+| Option                              | Description                                                | Default  |
+| ----------------------------------- | ---------------------------------------------------------- | -------- |
+| `--name <name>`                     | New name                                                   | —        |
+| `--description <description>`       | New description                                            | —        |
+| `--optimization-direction <dir>`    | `MINIMIZE`, `MAXIMIZE`, or `NONE`                          | —        |
+| `--values <json>`                   | Categorical label objects as JSON (CATEGORICAL configs)    | —        |
+| `--lower-bound <number>`            | Lower bound (CONTINUOUS/FREEFORM configs)                  | —        |
+| `--upper-bound <number>`            | Upper bound (CONTINUOUS/FREEFORM configs)                  | —        |
+| `--threshold <number>`              | Threshold (FREEFORM configs)                               | —        |
+| `--format <format>`                 | `pretty`, `json`, or `raw`                                 | `pretty` |
+| `--no-progress`                     | Suppress progress output                                   | —        |
+
+At least one field flag is required; an invocation with none exits with `INVALID_ARGUMENT`. Flags that don't apply to the config's type (e.g. `--values` on a continuous config) are rejected.
+
+---
+
 ### `px auth status`
 
 Show current Phoenix authentication status, including the configured endpoint, whether you are authenticated or anonymous, and an obscured API key.

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -476,6 +476,24 @@ px session-annotations delete --identifier "$PHOENIX_CODING_IDENTIFIER" --all -y
 
 ---
 
+Annotation configs come in three types — `CATEGORICAL` (a fixed set of labels, each with an optional numeric score), `CONTINUOUS` (a numeric range), and `FREEFORM` (free text). The `create`, `get`, `update`, and `delete` commands round out full CRUD alongside `list`.
+
+#### Specifying categorical values
+
+`create` and `update` accept categorical labels the same way, so you only learn it once. Prefer the repeatable, shell-friendly flag; the JSON form is a bulk/agent alternative.
+
+```bash
+# Repeatable flag: label with an optional score (label=score, or just label)
+--value good=1 --value bad=0 --value needs-review
+
+# JSON payload (handy for agents or large label sets)
+--values '[{"label":"good","score":1},{"label":"bad","score":0}]'
+```
+
+The two forms are mutually exclusive — pass one or the other, not both.
+
+---
+
 ### `px annotation-config list`
 
 List annotation configurations defined in your Phoenix instance.
@@ -491,34 +509,88 @@ px annotation-config list --format raw --no-progress | jq '.[].name'
 
 ---
 
+### `px annotation-config get <config-identifier>`
+
+Fetch a single annotation configuration by name or ID. The config is written to stdout in the selected `--format` (a single object for `raw`/`json`).
+
+```bash
+px annotation-config get quality
+px annotation-config get cfg-123 --format raw --no-progress | jq -r '.id'
+```
+
+| Option              | Description                | Default  |
+| ------------------- | -------------------------- | -------- |
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+| `--no-progress`     | Suppress progress output   | —        |
+
+---
+
+### `px annotation-config create`
+
+Create a new annotation configuration via `POST /v1/annotation_configs`. The created config is written to stdout in the selected `--format`.
+
+```bash
+# Categorical config with labelled values
+px annotation-config create --type CATEGORICAL --name quality --value good=1 --value bad=0
+
+# Continuous config with a numeric range
+px annotation-config create --type CONTINUOUS --name score --lower-bound 0 --upper-bound 1
+
+# Freeform (free-text) config
+px annotation-config create --type FREEFORM --name notes --description 'Reviewer notes'
+
+# Agent: capture the new ID
+px annotation-config create --type CATEGORICAL --name quality --values '[{"label":"good","score":1}]' \
+  --format raw --no-progress | jq -r '.id'
+```
+
+| Option                           | Description                                           | Default  |
+| -------------------------------- | ----------------------------------------------------- | -------- |
+| `--type <type>`                  | `CATEGORICAL`, `CONTINUOUS`, or `FREEFORM` (required) | —        |
+| `--name <name>`                  | Annotation config name (required)                     | —        |
+| `--description <description>`    | Description                                           | —        |
+| `--optimization-direction <dir>` | `MINIMIZE`, `MAXIMIZE`, or `NONE`                     | `NONE`   |
+| `--value <label[=score]>`        | Categorical label (repeatable; CATEGORICAL configs)   | —        |
+| `--values <json>`                | Categorical values as JSON (CATEGORICAL configs)      | —        |
+| `--lower-bound <number>`         | Lower bound (CONTINUOUS/FREEFORM configs)             | —        |
+| `--upper-bound <number>`         | Upper bound (CONTINUOUS/FREEFORM configs)             | —        |
+| `--threshold <number>`           | Threshold (FREEFORM configs)                          | —        |
+| `--format <format>`              | `pretty`, `json`, or `raw`                            | `pretty` |
+| `--no-progress`                  | Suppress progress output                              | —        |
+
+`--type` and `--name` are required; a `CATEGORICAL` config also requires at least one value. Flags that don't apply to the chosen type are rejected.
+
+---
+
 ### `px annotation-config update <config-identifier>`
 
 Update an annotation configuration by name or ID. Only the fields you pass are changed — the command fetches the existing config, merges your flags, and writes the result back via `PUT /v1/annotation_configs/{id}`. The config `type` is immutable; to change it, delete and recreate the config. The updated config is written to stdout in the selected `--format`.
 
 ```bash
-# Human: rename and change optimization direction
+# Rename and change optimization direction
 px annotation-config update quality --name accuracy --optimization-direction MAXIMIZE
 
-# Update the label set of a categorical config
-px annotation-config update quality --values '[{"label":"good","score":1},{"label":"bad","score":0}]'
+# Replace the label set of a categorical config
+px annotation-config update quality --value good=1 --value bad=0
 
 # Agent: capture the updated ID
 px annotation-config update cfg-123 --description "Updated" --format raw --no-progress | jq -r '.id'
 ```
 
-| Option                           | Description                                             | Default  |
-| -------------------------------- | ------------------------------------------------------- | -------- |
-| `--name <name>`                  | New name                                                | —        |
-| `--description <description>`    | New description                                         | —        |
-| `--optimization-direction <dir>` | `MINIMIZE`, `MAXIMIZE`, or `NONE`                       | —        |
-| `--values <json>`                | Categorical label objects as JSON (CATEGORICAL configs) | —        |
-| `--lower-bound <number>`         | Lower bound (CONTINUOUS/FREEFORM configs)               | —        |
-| `--upper-bound <number>`         | Upper bound (CONTINUOUS/FREEFORM configs)               | —        |
-| `--threshold <number>`           | Threshold (FREEFORM configs)                            | —        |
-| `--format <format>`              | `pretty`, `json`, or `raw`                              | `pretty` |
-| `--no-progress`                  | Suppress progress output                                | —        |
+| Option                           | Description                                         | Default  |
+| -------------------------------- | --------------------------------------------------- | -------- |
+| `--name <name>`                  | New name                                            | —        |
+| `--description <description>`    | New description                                     | —        |
+| `--optimization-direction <dir>` | `MINIMIZE`, `MAXIMIZE`, or `NONE`                   | —        |
+| `--value <label[=score]>`        | Categorical label (repeatable; CATEGORICAL configs) | —        |
+| `--values <json>`                | Categorical values as JSON (CATEGORICAL configs)    | —        |
+| `--lower-bound <number>`         | Lower bound (CONTINUOUS/FREEFORM configs)           | —        |
+| `--upper-bound <number>`         | Upper bound (CONTINUOUS/FREEFORM configs)           | —        |
+| `--threshold <number>`           | Threshold (FREEFORM configs)                        | —        |
+| `--format <format>`              | `pretty`, `json`, or `raw`                          | `pretty` |
+| `--no-progress`                  | Suppress progress output                            | —        |
 
-At least one field flag is required; an invocation with none exits with `INVALID_ARGUMENT`. Flags that don't apply to the config's type (e.g. `--values` on a continuous config) are rejected.
+At least one field flag is required; an invocation with none exits with `INVALID_ARGUMENT`. Flags that don't apply to the config's type (e.g. `--value` on a continuous config) are rejected.
 
 ---
 

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -506,17 +506,17 @@ px annotation-config update quality --values '[{"label":"good","score":1},{"labe
 px annotation-config update cfg-123 --description "Updated" --format raw --no-progress | jq -r '.id'
 ```
 
-| Option                              | Description                                                | Default  |
-| ----------------------------------- | ---------------------------------------------------------- | -------- |
-| `--name <name>`                     | New name                                                   | —        |
-| `--description <description>`       | New description                                            | —        |
-| `--optimization-direction <dir>`    | `MINIMIZE`, `MAXIMIZE`, or `NONE`                          | —        |
-| `--values <json>`                   | Categorical label objects as JSON (CATEGORICAL configs)    | —        |
-| `--lower-bound <number>`            | Lower bound (CONTINUOUS/FREEFORM configs)                  | —        |
-| `--upper-bound <number>`            | Upper bound (CONTINUOUS/FREEFORM configs)                  | —        |
-| `--threshold <number>`              | Threshold (FREEFORM configs)                               | —        |
-| `--format <format>`                 | `pretty`, `json`, or `raw`                                 | `pretty` |
-| `--no-progress`                     | Suppress progress output                                   | —        |
+| Option                           | Description                                             | Default  |
+| -------------------------------- | ------------------------------------------------------- | -------- |
+| `--name <name>`                  | New name                                                | —        |
+| `--description <description>`    | New description                                         | —        |
+| `--optimization-direction <dir>` | `MINIMIZE`, `MAXIMIZE`, or `NONE`                       | —        |
+| `--values <json>`                | Categorical label objects as JSON (CATEGORICAL configs) | —        |
+| `--lower-bound <number>`         | Lower bound (CONTINUOUS/FREEFORM configs)               | —        |
+| `--upper-bound <number>`         | Upper bound (CONTINUOUS/FREEFORM configs)               | —        |
+| `--threshold <number>`           | Threshold (FREEFORM configs)                            | —        |
+| `--format <format>`              | `pretty`, `json`, or `raw`                              | `pretty` |
+| `--no-progress`                  | Suppress progress output                                | —        |
 
 At least one field flag is required; an invocation with none exits with `INVALID_ARGUMENT`. Flags that don't apply to the config's type (e.g. `--values` on a continuous config) are rejected.
 

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -558,7 +558,7 @@ px annotation-config create --type CATEGORICAL --name quality --values '[{"label
 | `--format <format>`              | `pretty`, `json`, or `raw`                            | `pretty` |
 | `--no-progress`                  | Suppress progress output                              | —        |
 
-`--type` and `--name` are required; a `CATEGORICAL` config also requires at least one value. Flags that don't apply to the chosen type are rejected.
+`--type` and `--name` are required; a `CATEGORICAL` config also requires at least one value. `--type` and `--optimization-direction` are case-insensitive. Invalid input — including flags that don't apply to the chosen type — exits with `INVALID_ARGUMENT`.
 
 ---
 
@@ -590,7 +590,7 @@ px annotation-config update cfg-123 --description "Updated" --format raw --no-pr
 | `--format <format>`              | `pretty`, `json`, or `raw`                          | `pretty` |
 | `--no-progress`                  | Suppress progress output                            | —        |
 
-At least one field flag is required; an invocation with none exits with `INVALID_ARGUMENT`. Flags that don't apply to the config's type (e.g. `--value` on a continuous config) are rejected.
+At least one field flag is required. Invalid input — including flags that don't apply to the config's type (e.g. `--value` on a continuous config) — exits with `INVALID_ARGUMENT`.
 
 ---
 

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -499,7 +499,14 @@ The two forms are mutually exclusive — pass one or the other, not both.
 List annotation configurations defined in your Phoenix instance.
 
 ```bash
-px annotation-config list --format raw --no-progress | jq '.[].name'
+# Show all annotation configs as a table
+px annotation-config list
+
+# Extract config names as JSON (agent-friendly)
+px annotation-config list --format raw --no-progress | jq -r '.[].name'
+
+# Fetch at most 10 configs
+px annotation-config list --limit 10
 ```
 
 | Option              | Description                | Default  |
@@ -514,8 +521,14 @@ px annotation-config list --format raw --no-progress | jq '.[].name'
 Fetch a single annotation configuration by name or ID. The config is written to stdout in the selected `--format` (a single object for `raw`/`json`).
 
 ```bash
-px annotation-config get quality
-px annotation-config get cfg-123 --format raw --no-progress | jq -r '.id'
+# Look up a config by name
+px annotation-config get response-quality
+
+# Resolve a config name to its ID (agent-friendly)
+px annotation-config get response-quality --format raw --no-progress | jq -r '.id'
+
+# Inspect the labels of a categorical config
+px annotation-config get response-quality --format raw --no-progress | jq '.values'
 ```
 
 | Option              | Description                | Default  |
@@ -530,17 +543,23 @@ px annotation-config get cfg-123 --format raw --no-progress | jq -r '.id'
 Create a new annotation configuration via `POST /v1/annotation_configs`. The created config is written to stdout in the selected `--format`.
 
 ```bash
-# Categorical config with labelled values
-px annotation-config create --type CATEGORICAL --name quality --value good=1 --value bad=0
+# Pass/fail quality rating with scored labels (higher is better)
+px annotation-config create --type CATEGORICAL --name response-quality \
+  --value good=1 --value bad=0 --optimization-direction MAXIMIZE
 
-# Continuous config with a numeric range
-px annotation-config create --type CONTINUOUS --name score --lower-bound 0 --upper-bound 1
+# Sentiment labels without scores
+px annotation-config create --type CATEGORICAL --name sentiment \
+  --value positive --value neutral --value negative
 
-# Freeform (free-text) config
-px annotation-config create --type FREEFORM --name notes --description 'Reviewer notes'
+# Confidence score between 0 and 1
+px annotation-config create --type CONTINUOUS --name confidence --lower-bound 0 --upper-bound 1
 
-# Agent: capture the new ID
-px annotation-config create --type CATEGORICAL --name quality --values '[{"label":"good","score":1}]' \
+# Free-text feedback from human reviewers
+px annotation-config create --type FREEFORM --name reviewer-notes --description 'Free-form reviewer feedback'
+
+# Create from a JSON payload and capture the new config ID (agent-friendly)
+px annotation-config create --type CATEGORICAL --name response-quality \
+  --values '[{"label":"good","score":1},{"label":"bad","score":0}]' \
   --format raw --no-progress | jq -r '.id'
 ```
 
@@ -567,14 +586,20 @@ px annotation-config create --type CATEGORICAL --name quality --values '[{"label
 Update an annotation configuration by name or ID. Only the fields you pass are changed — the command fetches the existing config, merges your flags, and writes the result back via `PUT /v1/annotation_configs/{id}`. The config `type` is immutable; to change it, delete and recreate the config. The updated config is written to stdout in the selected `--format`.
 
 ```bash
-# Rename and change optimization direction
-px annotation-config update quality --name accuracy --optimization-direction MAXIMIZE
+# Change only the description; every other field is preserved
+px annotation-config update response-quality --description 'Pass/fail rating from human review'
+
+# Rename a config and set its optimization direction
+px annotation-config update response-quality --name answer-quality --optimization-direction MAXIMIZE
 
 # Replace the label set of a categorical config
-px annotation-config update quality --value good=1 --value bad=0
+px annotation-config update response-quality --value good=1 --value acceptable=0.5 --value bad=0
 
-# Agent: capture the updated ID
-px annotation-config update cfg-123 --description "Updated" --format raw --no-progress | jq -r '.id'
+# Widen the range of a continuous config
+px annotation-config update confidence --lower-bound -1 --upper-bound 1
+
+# Update and capture the config ID (agent-friendly)
+px annotation-config update response-quality --description 'Updated' --format raw --no-progress | jq -r '.id'
 ```
 
 | Option                           | Description                                         | Default  |
@@ -591,6 +616,28 @@ px annotation-config update cfg-123 --description "Updated" --format raw --no-pr
 | `--no-progress`                  | Suppress progress output                            | —        |
 
 At least one field flag is required. Invalid input — including flags that don't apply to the config's type (e.g. `--value` on a continuous config) — exits with `INVALID_ARGUMENT`.
+
+---
+
+### `px annotation-config delete <config-id>`
+
+Delete an annotation configuration by ID. Like all delete commands, this is disabled unless `PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES=true` is set, and prompts for confirmation unless `--yes` is passed.
+
+```bash
+# Delete with an interactive confirmation prompt
+px annotation-config delete QW5ub3RhdGlvbkNvbmZpZzoxMjM=
+
+# Skip the confirmation prompt (for scripts and agents)
+px annotation-config delete QW5ub3RhdGlvbkNvbmZpZzoxMjM= --yes
+
+# Resolve a name to its ID, then delete it
+px annotation-config get response-quality --format raw --no-progress | jq -r '.id' | xargs px annotation-config delete --yes
+```
+
+| Option          | Description              | Default |
+| --------------- | ------------------------ | ------- |
+| `-y, --yes`     | Skip confirmation prompt | —       |
+| `--no-progress` | Suppress progress output | —       |
 
 ---
 

--- a/js/packages/phoenix-cli/src/commands/annotationConfig.ts
+++ b/js/packages/phoenix-cli/src/commands/annotationConfig.ts
@@ -12,6 +12,11 @@ import { ExitCode, getExitCodeForError } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import { writeStructuredError } from "../structuredError";
 import {
+  collectValueFlag,
+  hasCategoricalValueInput,
+  resolveCategoricalValues,
+} from "./annotationConfigValues";
+import {
   formatAnnotationConfigOutput,
   formatAnnotationConfigsOutput,
   type OutputFormat,
@@ -22,18 +27,23 @@ type AnnotationConfig =
   | componentsV1["schemas"]["ContinuousAnnotationConfig"]
   | componentsV1["schemas"]["FreeformAnnotationConfig"];
 
-type CategoricalAnnotationValue =
-  componentsV1["schemas"]["CategoricalAnnotationValue"];
-
 type CreateAnnotationConfigData =
   componentsV1["schemas"]["CreateAnnotationConfigData"];
 
 type OptimizationDirection = componentsV1["schemas"]["OptimizationDirection"];
 
+type AnnotationConfigType = "CATEGORICAL" | "CONTINUOUS" | "FREEFORM";
+
 const OPTIMIZATION_DIRECTIONS: readonly OptimizationDirection[] = [
   "MINIMIZE",
   "MAXIMIZE",
   "NONE",
+];
+
+const ANNOTATION_CONFIG_TYPES: readonly AnnotationConfigType[] = [
+  "CATEGORICAL",
+  "CONTINUOUS",
+  "FREEFORM",
 ];
 
 interface AnnotationConfigListOptions {
@@ -44,11 +54,34 @@ interface AnnotationConfigListOptions {
   limit?: number;
 }
 
+interface AnnotationConfigGetOptions {
+  endpoint?: string;
+  apiKey?: string;
+  format?: OutputFormat;
+  progress?: boolean;
+}
+
 interface AnnotationConfigDeleteOptions {
   endpoint?: string;
   apiKey?: string;
   yes?: boolean;
   progress?: boolean;
+}
+
+interface AnnotationConfigCreateOptions {
+  endpoint?: string;
+  apiKey?: string;
+  format?: OutputFormat;
+  progress?: boolean;
+  type?: string;
+  name?: string;
+  description?: string;
+  optimizationDirection?: string;
+  lowerBound?: number;
+  upperBound?: number;
+  threshold?: number;
+  value?: string[];
+  values?: string;
 }
 
 interface AnnotationConfigUpdateOptions {
@@ -62,48 +95,87 @@ interface AnnotationConfigUpdateOptions {
   lowerBound?: number;
   upperBound?: number;
   threshold?: number;
+  value?: string[];
   values?: string;
 }
 
 /**
- * Parse the `--values` JSON payload into categorical annotation values.
+ * Build the full config body for `POST /v1/annotation_configs` from create
+ * flags. Type-specific flags are validated against the requested `--type` so a
+ * mismatch (e.g. `--threshold` on a categorical config) fails loudly.
  *
- * Accepts a JSON array of objects shaped like `{ "label": string, "score"?:
- * number }`. Throws a descriptive error on malformed input so the caller can
- * surface an actionable message.
+ * `optimization_direction` is required by the API for categorical and
+ * continuous configs; when omitted it defaults to `NONE`. Freeform configs
+ * leave it null unless explicitly set.
  */
-function parseCategoricalValues(raw: string): CategoricalAnnotationValue[] {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new Error(
-      "--values must be a valid JSON array, e.g. " +
-        '\'[{"label":"good","score":1},{"label":"bad","score":0}]\''
-    );
-  }
-  if (!Array.isArray(parsed) || parsed.length === 0) {
-    throw new Error("--values must be a non-empty JSON array of label objects");
-  }
-  return parsed.map((entry) => {
-    if (
-      typeof entry !== "object" ||
-      entry === null ||
-      typeof (entry as { label?: unknown }).label !== "string"
-    ) {
+function buildCreateConfigData(
+  options: AnnotationConfigCreateOptions,
+  type: AnnotationConfigType
+): CreateAnnotationConfigData {
+  const name = options.name as string;
+  const description = options.description;
+  const optimizationDirection =
+    (options.optimizationDirection as OptimizationDirection | undefined) ??
+    "NONE";
+
+  if (type === "CATEGORICAL") {
+    if (options.lowerBound !== undefined || options.upperBound !== undefined) {
       throw new Error(
-        'Each --values entry must be an object with a string "label" field'
+        "--lower-bound and --upper-bound are not valid for CATEGORICAL configs"
       );
     }
-    const { label, score } = entry as { label: string; score?: unknown };
-    if (score !== undefined && score !== null && typeof score !== "number") {
-      throw new Error('--values "score" must be a number when provided');
+    if (options.threshold !== undefined) {
+      throw new Error("--threshold is not valid for CATEGORICAL configs");
+    }
+    const values = resolveCategoricalValues(options);
+    if (!values) {
+      throw new Error(
+        "CATEGORICAL configs require at least one --value (or --values JSON)"
+      );
     }
     return {
-      label,
-      ...(score !== undefined && score !== null ? { score } : {}),
+      type: "CATEGORICAL",
+      name,
+      description,
+      optimization_direction: optimizationDirection,
+      values,
     };
-  });
+  }
+
+  if (type === "CONTINUOUS") {
+    if (hasCategoricalValueInput(options)) {
+      throw new Error(
+        "--value/--values are only valid for CATEGORICAL configs"
+      );
+    }
+    if (options.threshold !== undefined) {
+      throw new Error("--threshold is not valid for CONTINUOUS configs");
+    }
+    return {
+      type: "CONTINUOUS",
+      name,
+      description,
+      optimization_direction: optimizationDirection,
+      lower_bound: options.lowerBound ?? null,
+      upper_bound: options.upperBound ?? null,
+    };
+  }
+
+  // FREEFORM
+  if (hasCategoricalValueInput(options)) {
+    throw new Error("--value/--values are only valid for CATEGORICAL configs");
+  }
+  return {
+    type: "FREEFORM",
+    name,
+    description,
+    optimization_direction: options.optimizationDirection
+      ? optimizationDirection
+      : null,
+    threshold: options.threshold ?? null,
+    lower_bound: options.lowerBound ?? null,
+    upper_bound: options.upperBound ?? null,
+  };
 }
 
 /**
@@ -114,7 +186,7 @@ function parseCategoricalValues(raw: string): CategoricalAnnotationValue[] {
  * immutable — to change it, delete and recreate the config.
  *
  * Type-specific flags are validated against the existing config's type so a
- * mismatch (e.g. `--values` on a continuous config) fails loudly instead of
+ * mismatch (e.g. `--value` on a continuous config) fails loudly instead of
  * being silently ignored.
  */
 function buildUpdatedConfigData(
@@ -139,22 +211,22 @@ function buildUpdatedConfigData(
     if (options.threshold !== undefined) {
       throw new Error("--threshold is not valid for CATEGORICAL configs");
     }
+    const resolvedValues = resolveCategoricalValues(options);
     return {
       type: "CATEGORICAL",
       name,
       description,
       optimization_direction:
         optimizationDirection ?? existing.optimization_direction,
-      values:
-        options.values !== undefined
-          ? parseCategoricalValues(options.values)
-          : existing.values,
+      values: resolvedValues ?? existing.values,
     };
   }
 
   if (existing.type === "CONTINUOUS") {
-    if (options.values !== undefined) {
-      throw new Error("--values is only valid for CATEGORICAL configs");
+    if (hasCategoricalValueInput(options)) {
+      throw new Error(
+        "--value/--values are only valid for CATEGORICAL configs"
+      );
     }
     if (options.threshold !== undefined) {
       throw new Error("--threshold is not valid for CONTINUOUS configs");
@@ -177,8 +249,8 @@ function buildUpdatedConfigData(
   }
 
   // FREEFORM
-  if (options.values !== undefined) {
-    throw new Error("--values is only valid for CATEGORICAL configs");
+  if (hasCategoricalValueInput(options)) {
+    throw new Error("--value/--values are only valid for CATEGORICAL configs");
   }
   return {
     type: "FREEFORM",
@@ -287,6 +359,175 @@ async function annotationConfigListHandler(
 }
 
 /**
+ * Handler for `annotation-config get`
+ */
+async function annotationConfigGetHandler(
+  configIdentifier: string,
+  options: AnnotationConfigGetOptions
+): Promise<void> {
+  try {
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    const validation = validateConfig({ config, projectRequired: false });
+    if (!validation.valid) {
+      writeError({
+        message: getConfigErrorMessage({ errors: validation.errors }),
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+
+    const client = createPhoenixClient({ config });
+
+    writeProgress({
+      message: `Fetching annotation config ${configIdentifier}...`,
+      noProgress: !options.progress,
+    });
+
+    const response = await client.GET(
+      "/v1/annotation_configs/{config_identifier}",
+      {
+        params: {
+          path: {
+            config_identifier: configIdentifier,
+          },
+        },
+      }
+    );
+
+    // The client throws on non-2xx responses (e.g. a 404 for an unknown
+    // identifier), so this guard only trips on an unexpected empty body.
+    if (response.error || !response.data) {
+      throw new Error(
+        `Annotation config '${configIdentifier}' not found${response.error ? `: ${response.error}` : ""}`
+      );
+    }
+
+    writeOutput({
+      message: formatAnnotationConfigOutput({
+        config: response.data.data,
+        format: options.format,
+      }),
+    });
+  } catch (error) {
+    writeError({
+      message: `Error fetching annotation config: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(getExitCodeForError(error));
+  }
+}
+
+/**
+ * Handler for `annotation-config create`
+ */
+async function annotationConfigCreateHandler(
+  options: AnnotationConfigCreateOptions
+): Promise<void> {
+  // Argument-shape validation runs before the try block so its `process.exit`
+  // isn't caught and re-mapped by the catch-all error handler below.
+  if (!options.type) {
+    writeStructuredError({
+      format: options.format,
+      message: "Missing required flag --type",
+      code: "INVALID_ARGUMENT",
+      hint: "px annotation-config create --type CATEGORICAL --name <name> --value good=1",
+    });
+    process.exit(ExitCode.INVALID_ARGUMENT);
+  }
+  const type = options.type.toUpperCase() as AnnotationConfigType;
+  if (!ANNOTATION_CONFIG_TYPES.includes(type)) {
+    writeStructuredError({
+      format: options.format,
+      message: `Invalid --type '${options.type}'. Must be one of: ${ANNOTATION_CONFIG_TYPES.join(", ")}`,
+      code: "INVALID_ARGUMENT",
+    });
+    process.exit(ExitCode.INVALID_ARGUMENT);
+  }
+  if (!options.name) {
+    writeStructuredError({
+      format: options.format,
+      message: "Missing required flag --name",
+      code: "INVALID_ARGUMENT",
+      hint: `px annotation-config create --type ${type} --name <name>`,
+    });
+    process.exit(ExitCode.INVALID_ARGUMENT);
+  }
+  if (
+    options.optimizationDirection !== undefined &&
+    !OPTIMIZATION_DIRECTIONS.includes(
+      options.optimizationDirection as OptimizationDirection
+    )
+  ) {
+    writeStructuredError({
+      format: options.format,
+      message: `Invalid --optimization-direction '${options.optimizationDirection}'. Must be one of: ${OPTIMIZATION_DIRECTIONS.join(", ")}`,
+      code: "INVALID_ARGUMENT",
+    });
+    process.exit(ExitCode.INVALID_ARGUMENT);
+  }
+  if (type === "CATEGORICAL" && !hasCategoricalValueInput(options)) {
+    writeStructuredError({
+      format: options.format,
+      message:
+        "CATEGORICAL configs require at least one --value (or --values JSON)",
+      code: "INVALID_ARGUMENT",
+      hint: `px annotation-config create --type CATEGORICAL --name ${options.name} --value good=1 --value bad=0`,
+    });
+    process.exit(ExitCode.INVALID_ARGUMENT);
+  }
+
+  try {
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    const validation = validateConfig({ config, projectRequired: false });
+    if (!validation.valid) {
+      writeError({
+        message: getConfigErrorMessage({ errors: validation.errors }),
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+
+    const client = createPhoenixClient({ config });
+
+    const body = buildCreateConfigData(options, type);
+
+    writeProgress({
+      message: `Creating annotation config ${options.name}...`,
+      noProgress: !options.progress,
+    });
+
+    const response = await client.POST("/v1/annotation_configs", {
+      body,
+    });
+
+    if (response.error || !response.data) {
+      throw new Error(`Failed to create annotation config: ${response.error}`);
+    }
+
+    writeOutput({
+      message: formatAnnotationConfigOutput({
+        config: response.data.data,
+        format: options.format,
+      }),
+    });
+  } catch (error) {
+    writeError({
+      message: `Error creating annotation config: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(getExitCodeForError(error));
+  }
+}
+
+/**
  * Handler for `annotation-config delete`
  */
 async function annotationConfigDeleteHandler(
@@ -349,8 +590,8 @@ async function annotationConfigUpdateHandler(
   configIdentifier: string,
   options: AnnotationConfigUpdateOptions
 ): Promise<void> {
-  // Input validation runs before the try block so its `process.exit` isn't
-  // caught and re-mapped by the catch-all error handler below.
+  // Argument-shape validation runs before the try block so its `process.exit`
+  // isn't caught and re-mapped by the catch-all error handler below.
 
   // Require at least one field to update so an accidental no-op invocation
   // fails fast with the correct usage instead of silently re-writing the
@@ -362,7 +603,7 @@ async function annotationConfigUpdateHandler(
     options.lowerBound !== undefined ||
     options.upperBound !== undefined ||
     options.threshold !== undefined ||
-    options.values !== undefined;
+    hasCategoricalValueInput(options);
   if (!hasUpdate) {
     writeStructuredError({
       format: options.format,
@@ -468,14 +709,43 @@ async function annotationConfigUpdateHandler(
 }
 
 /**
+ * Attach the shared categorical value-input options to a command. Both
+ * `create` and `update` accept values the same way: a repeatable, shell-
+ * friendly `--value label[=score]` flag, or a single `--values` JSON payload
+ * for bulk/agent use.
+ */
+function addCategoricalValueOptions(command: Command): Command {
+  return command
+    .option(
+      "--value <label[=score]>",
+      "Categorical label with optional score, e.g. good=1 (repeatable; CATEGORICAL configs)",
+      collectValueFlag,
+      []
+    )
+    .option(
+      "--values <json>",
+      'Categorical values as JSON — bulk/agent alternative to --value, e.g. \'[{"label":"good","score":1}]\''
+    );
+}
+
+/**
  * Create the `annotation-config` command with subcommands
  */
 export function createAnnotationConfigCommand(): Command {
   const command = new Command("annotation-config");
   command.description("Manage Phoenix annotation configurations");
 
-  const listCommand = new Command("list");
-  listCommand
+  command.addCommand(createAnnotationConfigListCommand());
+  command.addCommand(createAnnotationConfigGetCommand());
+  command.addCommand(createAnnotationConfigCreateCommand());
+  command.addCommand(createAnnotationConfigUpdateCommand());
+  command.addCommand(createAnnotationConfigDeleteCommand());
+
+  return command;
+}
+
+export function createAnnotationConfigListCommand(): Command {
+  return new Command("list")
     .description("List all annotation configurations")
     .option("--endpoint <url>", "Phoenix API endpoint")
     .option("--api-key <key>", "Phoenix API key for authentication")
@@ -491,16 +761,78 @@ export function createAnnotationConfigCommand(): Command {
       parseInt
     )
     .action(annotationConfigListHandler);
+}
 
-  command.addCommand(listCommand);
-  command.addCommand(createAnnotationConfigUpdateCommand());
-  command.addCommand(createAnnotationConfigDeleteCommand());
+export function createAnnotationConfigGetCommand(): Command {
+  return new Command("get")
+    .description("Fetch an annotation configuration by name or ID")
+    .argument("<config-identifier>", "Annotation config name or ID")
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .addHelpText(
+      "after",
+      "\nExamples:\n" +
+        "  px annotation-config get quality\n" +
+        "  px annotation-config get cfg-123 --format raw --no-progress | jq -r '.id'\n"
+    )
+    .action(annotationConfigGetHandler);
+}
 
-  return command;
+export function createAnnotationConfigCreateCommand(): Command {
+  const command = new Command("create")
+    .description("Create a new annotation configuration")
+    .option(
+      "--type <type>",
+      "Config type: CATEGORICAL, CONTINUOUS, or FREEFORM"
+    )
+    .option("--name <name>", "Annotation config name")
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option("--description <description>", "Annotation config description")
+    .option(
+      "--optimization-direction <direction>",
+      "Optimization direction: MINIMIZE, MAXIMIZE, or NONE (default: NONE)"
+    )
+    .option(
+      "--lower-bound <number>",
+      "Lower bound (CONTINUOUS/FREEFORM configs)",
+      parseFloat
+    )
+    .option(
+      "--upper-bound <number>",
+      "Upper bound (CONTINUOUS/FREEFORM configs)",
+      parseFloat
+    )
+    .option("--threshold <number>", "Threshold (FREEFORM configs)", parseFloat);
+
+  addCategoricalValueOptions(command);
+
+  return command
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .addHelpText(
+      "after",
+      "\nExamples:\n" +
+        "  px annotation-config create --type CATEGORICAL --name quality --value good=1 --value bad=0\n" +
+        "  px annotation-config create --type CONTINUOUS --name score --lower-bound 0 --upper-bound 1\n" +
+        "  px annotation-config create --type FREEFORM --name notes --description 'Reviewer notes'\n" +
+        '  px annotation-config create --type CATEGORICAL --name quality --values \'[{"label":"good","score":1}]\' --format raw\n'
+    )
+    .action(annotationConfigCreateHandler);
 }
 
 export function createAnnotationConfigUpdateCommand(): Command {
-  return new Command("update")
+  const command = new Command("update")
     .description("Update an annotation configuration")
     .argument("<config-identifier>", "Annotation config name or ID")
     .option("--endpoint <url>", "Phoenix API endpoint")
@@ -521,11 +853,11 @@ export function createAnnotationConfigUpdateCommand(): Command {
       "Upper bound (CONTINUOUS/FREEFORM configs)",
       parseFloat
     )
-    .option("--threshold <number>", "Threshold (FREEFORM configs)", parseFloat)
-    .option(
-      "--values <json>",
-      'Categorical values as JSON, e.g. \'[{"label":"good","score":1}]\''
-    )
+    .option("--threshold <number>", "Threshold (FREEFORM configs)", parseFloat);
+
+  addCategoricalValueOptions(command);
+
+  return command
     .option(
       "--format <format>",
       "Output format: pretty, json, or raw",
@@ -535,9 +867,9 @@ export function createAnnotationConfigUpdateCommand(): Command {
     .addHelpText(
       "after",
       "\nExamples:\n" +
-        "  px annotation-config update my-config --description 'Updated description'\n" +
-        "  px annotation-config update my-config --name renamed --optimization-direction MAXIMIZE\n" +
-        '  px annotation-config update my-config --values \'[{"label":"good","score":1},{"label":"bad","score":0}]\'\n' +
+        "  px annotation-config update quality --description 'Updated description'\n" +
+        "  px annotation-config update quality --name accuracy --optimization-direction MAXIMIZE\n" +
+        "  px annotation-config update quality --value good=1 --value bad=0\n" +
         "  px annotation-config update cfg-123 --name renamed --format raw --no-progress | jq -r '.id'\n"
     )
     .action(annotationConfigUpdateHandler);

--- a/js/packages/phoenix-cli/src/commands/annotationConfig.ts
+++ b/js/packages/phoenix-cli/src/commands/annotationConfig.ts
@@ -10,7 +10,9 @@ import {
 import { assertDeletesEnabled, confirmOrExit } from "../confirm";
 import { ExitCode, getExitCodeForError } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
+import { writeStructuredError } from "../structuredError";
 import {
+  formatAnnotationConfigOutput,
   formatAnnotationConfigsOutput,
   type OutputFormat,
 } from "./formatAnnotationConfigs";
@@ -19,6 +21,20 @@ type AnnotationConfig =
   | componentsV1["schemas"]["CategoricalAnnotationConfig"]
   | componentsV1["schemas"]["ContinuousAnnotationConfig"]
   | componentsV1["schemas"]["FreeformAnnotationConfig"];
+
+type CategoricalAnnotationValue =
+  componentsV1["schemas"]["CategoricalAnnotationValue"];
+
+type CreateAnnotationConfigData =
+  componentsV1["schemas"]["CreateAnnotationConfigData"];
+
+type OptimizationDirection = componentsV1["schemas"]["OptimizationDirection"];
+
+const OPTIMIZATION_DIRECTIONS: readonly OptimizationDirection[] = [
+  "MINIMIZE",
+  "MAXIMIZE",
+  "NONE",
+];
 
 interface AnnotationConfigListOptions {
   endpoint?: string;
@@ -33,6 +49,153 @@ interface AnnotationConfigDeleteOptions {
   apiKey?: string;
   yes?: boolean;
   progress?: boolean;
+}
+
+interface AnnotationConfigUpdateOptions {
+  endpoint?: string;
+  apiKey?: string;
+  format?: OutputFormat;
+  progress?: boolean;
+  name?: string;
+  description?: string;
+  optimizationDirection?: string;
+  lowerBound?: number;
+  upperBound?: number;
+  threshold?: number;
+  values?: string;
+}
+
+/**
+ * Parse the `--values` JSON payload into categorical annotation values.
+ *
+ * Accepts a JSON array of objects shaped like `{ "label": string, "score"?:
+ * number }`. Throws a descriptive error on malformed input so the caller can
+ * surface an actionable message.
+ */
+function parseCategoricalValues(raw: string): CategoricalAnnotationValue[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(
+      "--values must be a valid JSON array, e.g. " +
+        '\'[{"label":"good","score":1},{"label":"bad","score":0}]\''
+    );
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error("--values must be a non-empty JSON array of label objects");
+  }
+  return parsed.map((entry) => {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      typeof (entry as { label?: unknown }).label !== "string"
+    ) {
+      throw new Error(
+        'Each --values entry must be an object with a string "label" field'
+      );
+    }
+    const { label, score } = entry as { label: string; score?: unknown };
+    if (score !== undefined && score !== null && typeof score !== "number") {
+      throw new Error('--values "score" must be a number when provided');
+    }
+    return {
+      label,
+      ...(score !== undefined && score !== null ? { score } : {}),
+    };
+  });
+}
+
+/**
+ * Merge the provided update options onto an existing annotation config to
+ * produce the full replacement body required by `PUT
+ * /v1/annotation_configs/{id}`. Only fields the caller supplied are changed;
+ * everything else is carried over from `existing`. The config `type` is
+ * immutable — to change it, delete and recreate the config.
+ *
+ * Type-specific flags are validated against the existing config's type so a
+ * mismatch (e.g. `--values` on a continuous config) fails loudly instead of
+ * being silently ignored.
+ */
+function buildUpdatedConfigData(
+  existing: AnnotationConfig,
+  options: AnnotationConfigUpdateOptions
+): CreateAnnotationConfigData {
+  const name = options.name ?? existing.name;
+  const description =
+    options.description !== undefined
+      ? options.description
+      : existing.description;
+  const optimizationDirection =
+    (options.optimizationDirection as OptimizationDirection | undefined) ??
+    existing.optimization_direction;
+
+  if (existing.type === "CATEGORICAL") {
+    if (options.lowerBound !== undefined || options.upperBound !== undefined) {
+      throw new Error(
+        "--lower-bound and --upper-bound are not valid for CATEGORICAL configs"
+      );
+    }
+    if (options.threshold !== undefined) {
+      throw new Error("--threshold is not valid for CATEGORICAL configs");
+    }
+    return {
+      type: "CATEGORICAL",
+      name,
+      description,
+      optimization_direction:
+        optimizationDirection ?? existing.optimization_direction,
+      values:
+        options.values !== undefined
+          ? parseCategoricalValues(options.values)
+          : existing.values,
+    };
+  }
+
+  if (existing.type === "CONTINUOUS") {
+    if (options.values !== undefined) {
+      throw new Error("--values is only valid for CATEGORICAL configs");
+    }
+    if (options.threshold !== undefined) {
+      throw new Error("--threshold is not valid for CONTINUOUS configs");
+    }
+    return {
+      type: "CONTINUOUS",
+      name,
+      description,
+      optimization_direction:
+        optimizationDirection ?? existing.optimization_direction,
+      lower_bound:
+        options.lowerBound !== undefined
+          ? options.lowerBound
+          : existing.lower_bound,
+      upper_bound:
+        options.upperBound !== undefined
+          ? options.upperBound
+          : existing.upper_bound,
+    };
+  }
+
+  // FREEFORM
+  if (options.values !== undefined) {
+    throw new Error("--values is only valid for CATEGORICAL configs");
+  }
+  return {
+    type: "FREEFORM",
+    name,
+    description,
+    optimization_direction: optimizationDirection,
+    threshold:
+      options.threshold !== undefined ? options.threshold : existing.threshold,
+    lower_bound:
+      options.lowerBound !== undefined
+        ? options.lowerBound
+        : existing.lower_bound,
+    upper_bound:
+      options.upperBound !== undefined
+        ? options.upperBound
+        : existing.upper_bound,
+  };
 }
 
 /**
@@ -180,6 +343,131 @@ async function annotationConfigDeleteHandler(
 }
 
 /**
+ * Handler for `annotation-config update`
+ */
+async function annotationConfigUpdateHandler(
+  configIdentifier: string,
+  options: AnnotationConfigUpdateOptions
+): Promise<void> {
+  // Input validation runs before the try block so its `process.exit` isn't
+  // caught and re-mapped by the catch-all error handler below.
+
+  // Require at least one field to update so an accidental no-op invocation
+  // fails fast with the correct usage instead of silently re-writing the
+  // config unchanged.
+  const hasUpdate =
+    options.name !== undefined ||
+    options.description !== undefined ||
+    options.optimizationDirection !== undefined ||
+    options.lowerBound !== undefined ||
+    options.upperBound !== undefined ||
+    options.threshold !== undefined ||
+    options.values !== undefined;
+  if (!hasUpdate) {
+    writeStructuredError({
+      format: options.format,
+      message: "No fields to update were provided",
+      code: "INVALID_ARGUMENT",
+      hint: "px annotation-config update <config-id> --name <name>",
+    });
+    process.exit(ExitCode.INVALID_ARGUMENT);
+  }
+
+  if (
+    options.optimizationDirection !== undefined &&
+    !OPTIMIZATION_DIRECTIONS.includes(
+      options.optimizationDirection as OptimizationDirection
+    )
+  ) {
+    writeStructuredError({
+      format: options.format,
+      message: `Invalid --optimization-direction '${options.optimizationDirection}'. Must be one of: ${OPTIMIZATION_DIRECTIONS.join(", ")}`,
+      code: "INVALID_ARGUMENT",
+    });
+    process.exit(ExitCode.INVALID_ARGUMENT);
+  }
+
+  try {
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    const validation = validateConfig({ config, projectRequired: false });
+    if (!validation.valid) {
+      writeError({
+        message: getConfigErrorMessage({ errors: validation.errors }),
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+
+    const client = createPhoenixClient({ config });
+
+    writeProgress({
+      message: `Fetching annotation config ${configIdentifier}...`,
+      noProgress: !options.progress,
+    });
+
+    const getResponse = await client.GET(
+      "/v1/annotation_configs/{config_identifier}",
+      {
+        params: {
+          path: {
+            config_identifier: configIdentifier,
+          },
+        },
+      }
+    );
+
+    if (getResponse.error || !getResponse.data) {
+      throw new Error(
+        `Failed to fetch annotation config: ${getResponse.error}`
+      );
+    }
+
+    const existing = getResponse.data.data;
+    const updatedData = buildUpdatedConfigData(existing, options);
+
+    writeProgress({
+      message: `Updating annotation config ${existing.id}...`,
+      noProgress: !options.progress,
+    });
+
+    const updateResponse = await client.PUT(
+      "/v1/annotation_configs/{config_id}",
+      {
+        params: {
+          path: {
+            config_id: existing.id,
+          },
+        },
+        body: updatedData,
+      }
+    );
+
+    if (updateResponse.error || !updateResponse.data) {
+      throw new Error(
+        `Failed to update annotation config: ${updateResponse.error}`
+      );
+    }
+
+    writeOutput({
+      message: formatAnnotationConfigOutput({
+        config: updateResponse.data.data,
+        format: options.format,
+      }),
+    });
+  } catch (error) {
+    writeError({
+      message: `Error updating annotation config: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(getExitCodeForError(error));
+  }
+}
+
+/**
  * Create the `annotation-config` command with subcommands
  */
 export function createAnnotationConfigCommand(): Command {
@@ -205,9 +493,54 @@ export function createAnnotationConfigCommand(): Command {
     .action(annotationConfigListHandler);
 
   command.addCommand(listCommand);
+  command.addCommand(createAnnotationConfigUpdateCommand());
   command.addCommand(createAnnotationConfigDeleteCommand());
 
   return command;
+}
+
+export function createAnnotationConfigUpdateCommand(): Command {
+  return new Command("update")
+    .description("Update an annotation configuration")
+    .argument("<config-identifier>", "Annotation config name or ID")
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option("--name <name>", "New name for the annotation config")
+    .option("--description <description>", "New description")
+    .option(
+      "--optimization-direction <direction>",
+      "Optimization direction: MINIMIZE, MAXIMIZE, or NONE"
+    )
+    .option(
+      "--lower-bound <number>",
+      "Lower bound (CONTINUOUS/FREEFORM configs)",
+      parseFloat
+    )
+    .option(
+      "--upper-bound <number>",
+      "Upper bound (CONTINUOUS/FREEFORM configs)",
+      parseFloat
+    )
+    .option("--threshold <number>", "Threshold (FREEFORM configs)", parseFloat)
+    .option(
+      "--values <json>",
+      'Categorical values as JSON, e.g. \'[{"label":"good","score":1}]\''
+    )
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .addHelpText(
+      "after",
+      "\nExamples:\n" +
+        "  px annotation-config update my-config --description 'Updated description'\n" +
+        "  px annotation-config update my-config --name renamed --optimization-direction MAXIMIZE\n" +
+        '  px annotation-config update my-config --values \'[{"label":"good","score":1},{"label":"bad","score":0}]\'\n' +
+        "  px annotation-config update cfg-123 --name renamed --format raw --no-progress | jq -r '.id'\n"
+    )
+    .action(annotationConfigUpdateHandler);
 }
 
 export function createAnnotationConfigDeleteCommand(): Command {

--- a/js/packages/phoenix-cli/src/commands/annotationConfig.ts
+++ b/js/packages/phoenix-cli/src/commands/annotationConfig.ts
@@ -8,11 +8,15 @@ import {
   validateConfig,
 } from "../config";
 import { assertDeletesEnabled, confirmOrExit } from "../confirm";
-import { ExitCode, getExitCodeForError } from "../exitCodes";
+import {
+  ExitCode,
+  getExitCodeForError,
+  InvalidArgumentError,
+} from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
+import { collectString, parseNumberOption } from "../optionParsers";
 import { writeStructuredError } from "../structuredError";
 import {
-  collectValueFlag,
   hasCategoricalValueInput,
   resolveCategoricalValues,
 } from "./annotationConfigValues";
@@ -100,9 +104,55 @@ interface AnnotationConfigUpdateOptions {
 }
 
 /**
+ * Flags whose validity depends on the annotation config type — shared shape
+ * between the create and update option interfaces.
+ */
+interface TypeScopedFlagOptions {
+  lowerBound?: number;
+  upperBound?: number;
+  threshold?: number;
+  value?: string[];
+  values?: string;
+}
+
+/**
+ * Reject flags that don't apply to the config's type, so a mismatch (e.g.
+ * `--threshold` on a categorical config) fails loudly instead of being
+ * silently ignored. Shared by both create and update so the rules can't
+ * drift between the two.
+ */
+function assertFlagsValidForConfigType(
+  options: TypeScopedFlagOptions,
+  type: AnnotationConfigType
+): void {
+  if (type === "CATEGORICAL") {
+    if (options.lowerBound !== undefined || options.upperBound !== undefined) {
+      throw new InvalidArgumentError(
+        "--lower-bound and --upper-bound are not valid for CATEGORICAL configs"
+      );
+    }
+    if (options.threshold !== undefined) {
+      throw new InvalidArgumentError(
+        "--threshold is not valid for CATEGORICAL configs"
+      );
+    }
+    return;
+  }
+  if (hasCategoricalValueInput(options)) {
+    throw new InvalidArgumentError(
+      "--value/--values are only valid for CATEGORICAL configs"
+    );
+  }
+  if (type === "CONTINUOUS" && options.threshold !== undefined) {
+    throw new InvalidArgumentError(
+      "--threshold is not valid for CONTINUOUS configs"
+    );
+  }
+}
+
+/**
  * Build the full config body for `POST /v1/annotation_configs` from create
- * flags. Type-specific flags are validated against the requested `--type` so a
- * mismatch (e.g. `--threshold` on a categorical config) fails loudly.
+ * flags.
  *
  * `optimization_direction` is required by the API for categorical and
  * continuous configs; when omitted it defaults to `NONE`. Freeform configs
@@ -112,6 +162,8 @@ function buildCreateConfigData(
   options: AnnotationConfigCreateOptions,
   type: AnnotationConfigType
 ): CreateAnnotationConfigData {
+  assertFlagsValidForConfigType(options, type);
+
   const name = options.name as string;
   const description = options.description;
   const optimizationDirection =
@@ -119,17 +171,9 @@ function buildCreateConfigData(
     "NONE";
 
   if (type === "CATEGORICAL") {
-    if (options.lowerBound !== undefined || options.upperBound !== undefined) {
-      throw new Error(
-        "--lower-bound and --upper-bound are not valid for CATEGORICAL configs"
-      );
-    }
-    if (options.threshold !== undefined) {
-      throw new Error("--threshold is not valid for CATEGORICAL configs");
-    }
     const values = resolveCategoricalValues(options);
     if (!values) {
-      throw new Error(
+      throw new InvalidArgumentError(
         "CATEGORICAL configs require at least one --value (or --values JSON)"
       );
     }
@@ -143,14 +187,6 @@ function buildCreateConfigData(
   }
 
   if (type === "CONTINUOUS") {
-    if (hasCategoricalValueInput(options)) {
-      throw new Error(
-        "--value/--values are only valid for CATEGORICAL configs"
-      );
-    }
-    if (options.threshold !== undefined) {
-      throw new Error("--threshold is not valid for CONTINUOUS configs");
-    }
     return {
       type: "CONTINUOUS",
       name,
@@ -161,10 +197,6 @@ function buildCreateConfigData(
     };
   }
 
-  // FREEFORM
-  if (hasCategoricalValueInput(options)) {
-    throw new Error("--value/--values are only valid for CATEGORICAL configs");
-  }
   return {
     type: "FREEFORM",
     name,
@@ -184,15 +216,13 @@ function buildCreateConfigData(
  * /v1/annotation_configs/{id}`. Only fields the caller supplied are changed;
  * everything else is carried over from `existing`. The config `type` is
  * immutable — to change it, delete and recreate the config.
- *
- * Type-specific flags are validated against the existing config's type so a
- * mismatch (e.g. `--value` on a continuous config) fails loudly instead of
- * being silently ignored.
  */
 function buildUpdatedConfigData(
   existing: AnnotationConfig,
   options: AnnotationConfigUpdateOptions
 ): CreateAnnotationConfigData {
+  assertFlagsValidForConfigType(options, existing.type);
+
   const name = options.name ?? existing.name;
   const description =
     options.description !== undefined
@@ -203,14 +233,6 @@ function buildUpdatedConfigData(
     existing.optimization_direction;
 
   if (existing.type === "CATEGORICAL") {
-    if (options.lowerBound !== undefined || options.upperBound !== undefined) {
-      throw new Error(
-        "--lower-bound and --upper-bound are not valid for CATEGORICAL configs"
-      );
-    }
-    if (options.threshold !== undefined) {
-      throw new Error("--threshold is not valid for CATEGORICAL configs");
-    }
     const resolvedValues = resolveCategoricalValues(options);
     return {
       type: "CATEGORICAL",
@@ -223,14 +245,6 @@ function buildUpdatedConfigData(
   }
 
   if (existing.type === "CONTINUOUS") {
-    if (hasCategoricalValueInput(options)) {
-      throw new Error(
-        "--value/--values are only valid for CATEGORICAL configs"
-      );
-    }
-    if (options.threshold !== undefined) {
-      throw new Error("--threshold is not valid for CONTINUOUS configs");
-    }
     return {
       type: "CONTINUOUS",
       name,
@@ -248,10 +262,6 @@ function buildUpdatedConfigData(
     };
   }
 
-  // FREEFORM
-  if (hasCategoricalValueInput(options)) {
-    throw new Error("--value/--values are only valid for CATEGORICAL configs");
-  }
   return {
     type: "FREEFORM",
     name,
@@ -268,6 +278,54 @@ function buildUpdatedConfigData(
         ? options.upperBound
         : existing.upper_bound,
   };
+}
+
+/**
+ * Validate the numeric and enum flags shared by `create` and `update`,
+ * exiting with `INVALID_ARGUMENT` on the first invalid one. Runs before the
+ * handler's `try` block so the exit code isn't re-mapped by the catch-all.
+ *
+ * Normalizes `optimizationDirection` to uppercase in place so it is
+ * case-insensitive, matching how `--type` is treated.
+ */
+function exitOnInvalidSharedWriteFlags(options: {
+  format?: OutputFormat;
+  optimizationDirection?: string;
+  lowerBound?: number;
+  upperBound?: number;
+  threshold?: number;
+}): void {
+  const numericFlags = [
+    ["--lower-bound", options.lowerBound],
+    ["--upper-bound", options.upperBound],
+    ["--threshold", options.threshold],
+  ] as const;
+  for (const [flag, value] of numericFlags) {
+    if (value !== undefined && !Number.isFinite(value)) {
+      writeStructuredError({
+        format: options.format,
+        message: `${flag} must be a finite number`,
+        code: "INVALID_ARGUMENT",
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+  }
+  if (options.optimizationDirection !== undefined) {
+    const rawDirection = options.optimizationDirection;
+    options.optimizationDirection = rawDirection.toUpperCase();
+    if (
+      !OPTIMIZATION_DIRECTIONS.includes(
+        options.optimizationDirection as OptimizationDirection
+      )
+    ) {
+      writeStructuredError({
+        format: options.format,
+        message: `Invalid --optimization-direction '${rawDirection}'. Must be one of: ${OPTIMIZATION_DIRECTIONS.join(", ")}`,
+        code: "INVALID_ARGUMENT",
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+  }
 }
 
 /**
@@ -456,19 +514,7 @@ async function annotationConfigCreateHandler(
     });
     process.exit(ExitCode.INVALID_ARGUMENT);
   }
-  if (
-    options.optimizationDirection !== undefined &&
-    !OPTIMIZATION_DIRECTIONS.includes(
-      options.optimizationDirection as OptimizationDirection
-    )
-  ) {
-    writeStructuredError({
-      format: options.format,
-      message: `Invalid --optimization-direction '${options.optimizationDirection}'. Must be one of: ${OPTIMIZATION_DIRECTIONS.join(", ")}`,
-      code: "INVALID_ARGUMENT",
-    });
-    process.exit(ExitCode.INVALID_ARGUMENT);
-  }
+  exitOnInvalidSharedWriteFlags(options);
   if (type === "CATEGORICAL" && !hasCategoricalValueInput(options)) {
     writeStructuredError({
       format: options.format,
@@ -614,19 +660,7 @@ async function annotationConfigUpdateHandler(
     process.exit(ExitCode.INVALID_ARGUMENT);
   }
 
-  if (
-    options.optimizationDirection !== undefined &&
-    !OPTIMIZATION_DIRECTIONS.includes(
-      options.optimizationDirection as OptimizationDirection
-    )
-  ) {
-    writeStructuredError({
-      format: options.format,
-      message: `Invalid --optimization-direction '${options.optimizationDirection}'. Must be one of: ${OPTIMIZATION_DIRECTIONS.join(", ")}`,
-      code: "INVALID_ARGUMENT",
-    });
-    process.exit(ExitCode.INVALID_ARGUMENT);
-  }
+  exitOnInvalidSharedWriteFlags(options);
 
   try {
     const config = resolveConfig({
@@ -719,7 +753,7 @@ function addCategoricalValueOptions(command: Command): Command {
     .option(
       "--value <label[=score]>",
       "Categorical label with optional score, e.g. good=1 (repeatable; CATEGORICAL configs)",
-      collectValueFlag,
+      collectString,
       []
     )
     .option(
@@ -759,6 +793,12 @@ export function createAnnotationConfigListCommand(): Command {
       "--limit <number>",
       "Maximum number of annotation configs to fetch",
       parseInt
+    )
+    .addHelpText(
+      "after",
+      "\nExamples:\n" +
+        "  px annotation-config list\n" +
+        "  px annotation-config list --format raw --no-progress | jq '.[].name'\n"
     )
     .action(annotationConfigListHandler);
 }
@@ -802,14 +842,18 @@ export function createAnnotationConfigCreateCommand(): Command {
     .option(
       "--lower-bound <number>",
       "Lower bound (CONTINUOUS/FREEFORM configs)",
-      parseFloat
+      parseNumberOption
     )
     .option(
       "--upper-bound <number>",
       "Upper bound (CONTINUOUS/FREEFORM configs)",
-      parseFloat
+      parseNumberOption
     )
-    .option("--threshold <number>", "Threshold (FREEFORM configs)", parseFloat);
+    .option(
+      "--threshold <number>",
+      "Threshold (FREEFORM configs)",
+      parseNumberOption
+    );
 
   addCategoricalValueOptions(command);
 
@@ -846,14 +890,18 @@ export function createAnnotationConfigUpdateCommand(): Command {
     .option(
       "--lower-bound <number>",
       "Lower bound (CONTINUOUS/FREEFORM configs)",
-      parseFloat
+      parseNumberOption
     )
     .option(
       "--upper-bound <number>",
       "Upper bound (CONTINUOUS/FREEFORM configs)",
-      parseFloat
+      parseNumberOption
     )
-    .option("--threshold <number>", "Threshold (FREEFORM configs)", parseFloat);
+    .option(
+      "--threshold <number>",
+      "Threshold (FREEFORM configs)",
+      parseNumberOption
+    );
 
   addCategoricalValueOptions(command);
 
@@ -883,5 +931,11 @@ export function createAnnotationConfigDeleteCommand(): Command {
     .option("--api-key <key>", "Phoenix API key for authentication")
     .option("-y, --yes", "Skip confirmation prompt")
     .option("--no-progress", "Disable progress indicators")
+    .addHelpText(
+      "after",
+      "\nExamples:\n" +
+        "  px annotation-config delete cfg-123\n" +
+        "  px annotation-config delete cfg-123 --yes\n"
+    )
     .action(annotationConfigDeleteHandler);
 }

--- a/js/packages/phoenix-cli/src/commands/annotationConfig.ts
+++ b/js/packages/phoenix-cli/src/commands/annotationConfig.ts
@@ -797,8 +797,12 @@ export function createAnnotationConfigListCommand(): Command {
     .addHelpText(
       "after",
       "\nExamples:\n" +
-        "  px annotation-config list\n" +
-        "  px annotation-config list --format raw --no-progress | jq '.[].name'\n"
+        "  # Show all annotation configs as a table\n" +
+        "  px annotation-config list\n\n" +
+        "  # Extract config names as JSON (agent-friendly)\n" +
+        "  px annotation-config list --format raw --no-progress | jq -r '.[].name'\n\n" +
+        "  # Fetch at most 10 configs\n" +
+        "  px annotation-config list --limit 10\n"
     )
     .action(annotationConfigListHandler);
 }
@@ -818,8 +822,12 @@ export function createAnnotationConfigGetCommand(): Command {
     .addHelpText(
       "after",
       "\nExamples:\n" +
-        "  px annotation-config get quality\n" +
-        "  px annotation-config get cfg-123 --format raw --no-progress | jq -r '.id'\n"
+        "  # Look up a config by name\n" +
+        "  px annotation-config get response-quality\n\n" +
+        "  # Resolve a config name to its ID (agent-friendly)\n" +
+        "  px annotation-config get response-quality --format raw --no-progress | jq -r '.id'\n\n" +
+        "  # Inspect the labels of a categorical config\n" +
+        "  px annotation-config get response-quality --format raw --no-progress | jq '.values'\n"
     )
     .action(annotationConfigGetHandler);
 }
@@ -867,10 +875,16 @@ export function createAnnotationConfigCreateCommand(): Command {
     .addHelpText(
       "after",
       "\nExamples:\n" +
-        "  px annotation-config create --type CATEGORICAL --name quality --value good=1 --value bad=0\n" +
-        "  px annotation-config create --type CONTINUOUS --name score --lower-bound 0 --upper-bound 1\n" +
-        "  px annotation-config create --type FREEFORM --name notes --description 'Reviewer notes'\n" +
-        '  px annotation-config create --type CATEGORICAL --name quality --values \'[{"label":"good","score":1}]\' --format raw\n'
+        "  # Pass/fail quality rating with scored labels (higher is better)\n" +
+        "  px annotation-config create --type CATEGORICAL --name response-quality --value good=1 --value bad=0 --optimization-direction MAXIMIZE\n\n" +
+        "  # Sentiment labels without scores\n" +
+        "  px annotation-config create --type CATEGORICAL --name sentiment --value positive --value neutral --value negative\n\n" +
+        "  # Confidence score between 0 and 1\n" +
+        "  px annotation-config create --type CONTINUOUS --name confidence --lower-bound 0 --upper-bound 1 --optimization-direction MAXIMIZE\n\n" +
+        "  # Free-text feedback from human reviewers\n" +
+        "  px annotation-config create --type FREEFORM --name reviewer-notes --description 'Free-form reviewer feedback'\n\n" +
+        "  # Create from a JSON payload and capture the new config ID (agent-friendly)\n" +
+        '  px annotation-config create --type CATEGORICAL --name response-quality --values \'[{"label":"good","score":1},{"label":"bad","score":0}]\' --format raw --no-progress | jq -r \'.id\'\n'
     )
     .action(annotationConfigCreateHandler);
 }
@@ -915,10 +929,16 @@ export function createAnnotationConfigUpdateCommand(): Command {
     .addHelpText(
       "after",
       "\nExamples:\n" +
-        "  px annotation-config update quality --description 'Updated description'\n" +
-        "  px annotation-config update quality --name accuracy --optimization-direction MAXIMIZE\n" +
-        "  px annotation-config update quality --value good=1 --value bad=0\n" +
-        "  px annotation-config update cfg-123 --name renamed --format raw --no-progress | jq -r '.id'\n"
+        "  # Change only the description; every other field is preserved\n" +
+        "  px annotation-config update response-quality --description 'Pass/fail rating from human review'\n\n" +
+        "  # Rename a config and set its optimization direction\n" +
+        "  px annotation-config update response-quality --name answer-quality --optimization-direction MAXIMIZE\n\n" +
+        "  # Replace the label set of a categorical config\n" +
+        "  px annotation-config update response-quality --value good=1 --value acceptable=0.5 --value bad=0\n\n" +
+        "  # Widen the range of a continuous config\n" +
+        "  px annotation-config update confidence --lower-bound -1 --upper-bound 1\n\n" +
+        "  # Update and capture the config ID (agent-friendly)\n" +
+        "  px annotation-config update response-quality --description 'Updated' --format raw --no-progress | jq -r '.id'\n"
     )
     .action(annotationConfigUpdateHandler);
 }
@@ -926,16 +946,24 @@ export function createAnnotationConfigUpdateCommand(): Command {
 export function createAnnotationConfigDeleteCommand(): Command {
   return new Command("delete")
     .description("Delete an annotation configuration")
-    .argument("<config-id>", "Annotation config ID")
+    .argument(
+      "<config-id>",
+      "Annotation config ID (resolve a name with: px annotation-config get <name>)"
+    )
     .option("--endpoint <url>", "Phoenix API endpoint")
     .option("--api-key <key>", "Phoenix API key for authentication")
     .option("-y, --yes", "Skip confirmation prompt")
     .option("--no-progress", "Disable progress indicators")
     .addHelpText(
       "after",
-      "\nExamples:\n" +
-        "  px annotation-config delete cfg-123\n" +
-        "  px annotation-config delete cfg-123 --yes\n"
+      "\nDeletes are disabled unless PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES=true is set.\n" +
+        "\nExamples:\n" +
+        "  # Delete with an interactive confirmation prompt\n" +
+        "  px annotation-config delete QW5ub3RhdGlvbkNvbmZpZzoxMjM=\n\n" +
+        "  # Skip the confirmation prompt (for scripts and agents)\n" +
+        "  px annotation-config delete QW5ub3RhdGlvbkNvbmZpZzoxMjM= --yes\n\n" +
+        "  # Resolve a name to its ID, then delete it\n" +
+        "  px annotation-config get response-quality --format raw --no-progress | jq -r '.id' | xargs px annotation-config delete --yes\n"
     )
     .action(annotationConfigDeleteHandler);
 }

--- a/js/packages/phoenix-cli/src/commands/annotationConfigValues.ts
+++ b/js/packages/phoenix-cli/src/commands/annotationConfigValues.ts
@@ -1,5 +1,7 @@
 import type { componentsV1 } from "@arizeai/phoenix-client";
 
+import { InvalidArgumentError } from "../exitCodes";
+
 type CategoricalAnnotationValue =
   componentsV1["schemas"]["CategoricalAnnotationValue"];
 
@@ -9,20 +11,15 @@ type CategoricalAnnotationValue =
  * `value` is the repeatable, shell-friendly form (`--value good=1`); `values`
  * is the JSON escape hatch (`--values '[{"label":"good","score":1}]'`) for
  * bulk or agent-driven use. The two are mutually exclusive.
+ *
+ * All parse failures throw `InvalidArgumentError` so handlers exit with
+ * `ExitCode.INVALID_ARGUMENT` rather than the generic failure code.
  */
 export interface CategoricalValueOptions {
   /** Collected occurrences of the repeatable `--value label[=score]` flag. */
   value?: string[];
   /** The `--values <json>` payload. */
   values?: string;
-}
-
-/**
- * Commander collector for the repeatable `--value` flag. Appends each
- * occurrence to a fresh array so the shared option default is never mutated.
- */
-export function collectValueFlag(entry: string, previous: string[]): string[] {
-  return [...previous, entry];
 }
 
 /**
@@ -36,23 +33,25 @@ function parseValueFlag(entry: string): CategoricalAnnotationValue {
   const separatorIndex = entry.indexOf("=");
   if (separatorIndex === -1) {
     if (entry.length === 0) {
-      throw new Error("--value requires a non-empty label");
+      throw new InvalidArgumentError("--value requires a non-empty label");
     }
     return { label: entry };
   }
   const label = entry.slice(0, separatorIndex);
   const scoreText = entry.slice(separatorIndex + 1);
   if (label.length === 0) {
-    throw new Error(`--value '${entry}' is missing a label before '='`);
+    throw new InvalidArgumentError(
+      `--value '${entry}' is missing a label before '='`
+    );
   }
   if (scoreText.trim().length === 0) {
-    throw new Error(
+    throw new InvalidArgumentError(
       `--value '${entry}' has an empty score; use 'label' for no score or 'label=<number>'`
     );
   }
   const score = Number(scoreText);
   if (!Number.isFinite(score)) {
-    throw new Error(
+    throw new InvalidArgumentError(
       `--value '${entry}' has a non-numeric score; expected 'label=<number>'`
     );
   }
@@ -70,13 +69,15 @@ function parseValuesJson(raw: string): CategoricalAnnotationValue[] {
   try {
     parsed = JSON.parse(raw);
   } catch {
-    throw new Error(
+    throw new InvalidArgumentError(
       "--values must be a valid JSON array, e.g. " +
         '\'[{"label":"good","score":1},{"label":"bad","score":0}]\''
     );
   }
   if (!Array.isArray(parsed) || parsed.length === 0) {
-    throw new Error("--values must be a non-empty JSON array of label objects");
+    throw new InvalidArgumentError(
+      "--values must be a non-empty JSON array of label objects"
+    );
   }
   return parsed.map((entry) => {
     if (
@@ -85,13 +86,15 @@ function parseValuesJson(raw: string): CategoricalAnnotationValue[] {
       typeof (entry as { label?: unknown }).label !== "string" ||
       (entry as { label: string }).label.length === 0
     ) {
-      throw new Error(
+      throw new InvalidArgumentError(
         'Each --values entry must be an object with a non-empty string "label"'
       );
     }
     const { label, score } = entry as { label: string; score?: unknown };
     if (score !== undefined && score !== null && typeof score !== "number") {
-      throw new Error('--values "score" must be a number when provided');
+      throw new InvalidArgumentError(
+        '--values "score" must be a number when provided'
+      );
     }
     return {
       label,
@@ -115,7 +118,7 @@ export function resolveCategoricalValues(
   const hasFlags = options.value !== undefined && options.value.length > 0;
   const hasJson = options.values !== undefined;
   if (hasFlags && hasJson) {
-    throw new Error(
+    throw new InvalidArgumentError(
       "Specify categorical values with either repeatable --value flags or a single --values JSON payload, not both"
     );
   }

--- a/js/packages/phoenix-cli/src/commands/annotationConfigValues.ts
+++ b/js/packages/phoenix-cli/src/commands/annotationConfigValues.ts
@@ -1,0 +1,142 @@
+import type { componentsV1 } from "@arizeai/phoenix-client";
+
+type CategoricalAnnotationValue =
+  componentsV1["schemas"]["CategoricalAnnotationValue"];
+
+/**
+ * Options carrying the two supported ways to specify categorical values.
+ *
+ * `value` is the repeatable, shell-friendly form (`--value good=1`); `values`
+ * is the JSON escape hatch (`--values '[{"label":"good","score":1}]'`) for
+ * bulk or agent-driven use. The two are mutually exclusive.
+ */
+export interface CategoricalValueOptions {
+  /** Collected occurrences of the repeatable `--value label[=score]` flag. */
+  value?: string[];
+  /** The `--values <json>` payload. */
+  values?: string;
+}
+
+/**
+ * Commander collector for the repeatable `--value` flag. Appends each
+ * occurrence to a fresh array so the shared option default is never mutated.
+ */
+export function collectValueFlag(entry: string, previous: string[]): string[] {
+  return [...previous, entry];
+}
+
+/**
+ * Parse a single `--value label[=score]` token.
+ *
+ * The label is everything before the first `=`; the optional score is
+ * everything after it. Splitting on the first `=` keeps labels that contain
+ * later `=` characters intact. A label with no `=` has no score.
+ */
+function parseValueFlag(entry: string): CategoricalAnnotationValue {
+  const separatorIndex = entry.indexOf("=");
+  if (separatorIndex === -1) {
+    if (entry.length === 0) {
+      throw new Error("--value requires a non-empty label");
+    }
+    return { label: entry };
+  }
+  const label = entry.slice(0, separatorIndex);
+  const scoreText = entry.slice(separatorIndex + 1);
+  if (label.length === 0) {
+    throw new Error(`--value '${entry}' is missing a label before '='`);
+  }
+  if (scoreText.trim().length === 0) {
+    throw new Error(
+      `--value '${entry}' has an empty score; use 'label' for no score or 'label=<number>'`
+    );
+  }
+  const score = Number(scoreText);
+  if (!Number.isFinite(score)) {
+    throw new Error(
+      `--value '${entry}' has a non-numeric score; expected 'label=<number>'`
+    );
+  }
+  return { label, score };
+}
+
+/**
+ * Parse the `--values` JSON payload into categorical annotation values.
+ *
+ * Accepts a JSON array of objects shaped like `{ "label": string, "score"?:
+ * number }`. Throws a descriptive error on malformed input.
+ */
+function parseValuesJson(raw: string): CategoricalAnnotationValue[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(
+      "--values must be a valid JSON array, e.g. " +
+        '\'[{"label":"good","score":1},{"label":"bad","score":0}]\''
+    );
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error("--values must be a non-empty JSON array of label objects");
+  }
+  return parsed.map((entry) => {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      typeof (entry as { label?: unknown }).label !== "string" ||
+      (entry as { label: string }).label.length === 0
+    ) {
+      throw new Error(
+        'Each --values entry must be an object with a non-empty string "label"'
+      );
+    }
+    const { label, score } = entry as { label: string; score?: unknown };
+    if (score !== undefined && score !== null && typeof score !== "number") {
+      throw new Error('--values "score" must be a number when provided');
+    }
+    return {
+      label,
+      ...(score !== undefined && score !== null ? { score } : {}),
+    };
+  });
+}
+
+/**
+ * Resolve categorical values from whichever input form the caller supplied.
+ *
+ * - Returns `undefined` when neither `--value` nor `--values` was provided, so
+ *   callers can distinguish "leave unchanged" (update) from "explicitly set".
+ * - Rejects supplying both forms at once — they'd have ambiguous precedence.
+ * - Always returns a non-empty list when it returns one; both parsers reject
+ *   empty input.
+ */
+export function resolveCategoricalValues(
+  options: CategoricalValueOptions
+): CategoricalAnnotationValue[] | undefined {
+  const hasFlags = options.value !== undefined && options.value.length > 0;
+  const hasJson = options.values !== undefined;
+  if (hasFlags && hasJson) {
+    throw new Error(
+      "Specify categorical values with either repeatable --value flags or a single --values JSON payload, not both"
+    );
+  }
+  if (hasFlags) {
+    return options.value!.map(parseValueFlag);
+  }
+  if (hasJson) {
+    return parseValuesJson(options.values!);
+  }
+  return undefined;
+}
+
+/**
+ * Whether the caller supplied any categorical value input at all (either
+ * form). Used to reject `--value`/`--values` on non-categorical configs.
+ */
+export function hasCategoricalValueInput(
+  options: CategoricalValueOptions
+): boolean {
+  return (
+    (options.value !== undefined && options.value.length > 0) ||
+    options.values !== undefined
+  );
+}

--- a/js/packages/phoenix-cli/src/commands/dataset.ts
+++ b/js/packages/phoenix-cli/src/commands/dataset.ts
@@ -11,6 +11,7 @@ import {
 import { assertDeletesEnabled, confirmOrExit } from "../confirm";
 import { ExitCode, getExitCodeForError } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
+import { collectString } from "../optionParsers";
 import {
   type DatasetExamplesData,
   formatDatasetExamplesOutput,
@@ -347,13 +348,6 @@ async function datasetDeleteHandler(
 }
 
 /**
- * Collect multiple --split options into an array
- */
-function collectSplits(value: string, previous: string[]): string[] {
-  return previous.concat([value]);
-}
-
-/**
  * Create the `dataset get` command
  */
 export function createDatasetGetCommand(): Command {
@@ -372,7 +366,7 @@ export function createDatasetGetCommand(): Command {
     .option(
       "--split <name>",
       "Filter by split name (can be used multiple times)",
-      collectSplits,
+      collectString,
       []
     )
     .option("--version <id>", "Fetch from a specific dataset version")

--- a/js/packages/phoenix-cli/src/commands/docs.ts
+++ b/js/packages/phoenix-cli/src/commands/docs.ts
@@ -4,6 +4,7 @@ import { Command } from "commander";
 
 import { ExitCode, getExitCodeForError } from "../exitCodes";
 import { writeError, writeOutput } from "../io";
+import { collectString } from "../optionParsers";
 
 const LLMS_TXT_URL = "https://arize.com/docs/phoenix/llms.txt";
 const PHOENIX_DOCS_PREFIX = "https://arize.com/docs/phoenix/";
@@ -415,7 +416,7 @@ function addDocsOptions(command: Command): Command {
     .option(
       "--workflow <name>",
       `Filter by workflow category (repeatable) [possible values: ${VALID_WORKFLOWS.join(", ")}, all] [default: ${DEFAULT_WORKFLOWS.join(", ")}]`,
-      (value: string, previous: string[]) => previous.concat([value]),
+      collectString,
       [] as string[]
     )
     .option(

--- a/js/packages/phoenix-cli/src/commands/formatAnnotationConfigs.ts
+++ b/js/packages/phoenix-cli/src/commands/formatAnnotationConfigs.ts
@@ -34,6 +34,36 @@ export function formatAnnotationConfigsOutput({
   return formatAnnotationConfigsPretty(configs);
 }
 
+export interface FormatAnnotationConfigOutputOptions {
+  /**
+   * Annotation config to format.
+   */
+  config: AnnotationConfig;
+  /**
+   * Output format. Defaults to `"pretty"`.
+   */
+  format?: OutputFormat;
+}
+
+/**
+ * Format a single annotation config. `raw`/`json` emit the config object
+ * directly (not wrapped in an array) so agents can extract fields such as
+ * `.id` without indexing. `pretty` renders the shared single-row table.
+ */
+export function formatAnnotationConfigOutput({
+  config,
+  format,
+}: FormatAnnotationConfigOutputOptions): string {
+  const selected = format || "pretty";
+  if (selected === "raw") {
+    return JSON.stringify(config);
+  }
+  if (selected === "json") {
+    return JSON.stringify(config, null, 2);
+  }
+  return formatAnnotationConfigsPretty([config]);
+}
+
 function formatAnnotationConfigsPretty(configs: AnnotationConfig[]): string {
   if (configs.length === 0) {
     return "No annotation configs found";

--- a/js/packages/phoenix-cli/src/commands/profile.ts
+++ b/js/packages/phoenix-cli/src/commands/profile.ts
@@ -6,6 +6,7 @@ import { Command } from "commander";
 
 import { ExitCode } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
+import { collectString } from "../optionParsers";
 import {
   type ProfileEntry,
   type SettingsFile,
@@ -55,10 +56,6 @@ function isValidUrl(value: string): boolean {
   } catch {
     return false;
   }
-}
-
-function collectStrings(value: string, previous: string[]): string[] {
-  return previous.concat([value]);
 }
 
 /**
@@ -252,7 +249,7 @@ function createProfileCreateCommand(): Command {
     .option(
       "--header <key=value>",
       "Custom HTTP header (repeatable)",
-      collectStrings,
+      collectString,
       []
     )
     .option(

--- a/js/packages/phoenix-cli/src/optionParsers.ts
+++ b/js/packages/phoenix-cli/src/optionParsers.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared Commander option-argument parsers.
+ */
+
+/**
+ * Commander collector for repeatable string flags. Appends each occurrence to
+ * a fresh array so the option's default array is never mutated.
+ */
+export function collectString(value: string, previous: string[]): string[] {
+  return previous.concat([value]);
+}
+
+/**
+ * Parse a numeric option argument strictly. Unlike `parseFloat`, trailing
+ * garbage (`"1abc"`) and empty strings do not truncate to a number — they
+ * yield `NaN`. Callers must reject non-finite results (`Number.isFinite`)
+ * before use so a typo errors instead of silently becoming `null` on the
+ * wire.
+ */
+export function parseNumberOption(value: string): number {
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? NaN : Number(trimmed);
+}

--- a/js/packages/phoenix-cli/test/annotationConfigConventions.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigConventions.test.ts
@@ -1,0 +1,211 @@
+import * as fs from "fs";
+import { fileURLToPath } from "url";
+import type { Command } from "commander";
+import { describe, expect, it } from "vitest";
+
+import { createAnnotationConfigCommand } from "../src/commands/annotationConfig";
+
+/**
+ * Convention tests for the `annotation-config` command tree, per the CLI
+ * design spec (phoenix-cli-development skill): noun-verb structure, dual
+ * audience (humans and coding agents), `--help` examples, and consistent
+ * option surfaces. These exist to catch drift — a renamed flag, a dropped
+ * example, or docs that reference options that no longer exist.
+ */
+
+const EXPECTED_SUBCOMMANDS = ["list", "get", "create", "update", "delete"];
+
+/** Subcommands that write data to stdout and must support output formats. */
+const DATA_SUBCOMMANDS = ["list", "get", "create", "update"];
+
+function getSubcommands(): Map<string, Command> {
+  return new Map(
+    createAnnotationConfigCommand().commands.map((command) => [
+      command.name(),
+      command,
+    ])
+  );
+}
+
+/** Render a command's full help output, including addHelpText additions. */
+function renderHelp(command: Command): string {
+  let output = "";
+  command.configureOutput({
+    writeOut: (text: string) => {
+      output += text;
+    },
+    writeErr: (text: string) => {
+      output += text;
+    },
+  });
+  command.outputHelp();
+  return output;
+}
+
+interface ExampleInvocation {
+  subcommand: string;
+  flags: string[];
+}
+
+/**
+ * Extract every `px annotation-config <subcommand> ...` invocation from a
+ * block of text (help output or docs) along with the flags it uses, so
+ * examples can be validated against the real option surface. Handles shell
+ * line continuations and pipelines (each pipe segment is inspected
+ * independently, so `... | xargs px annotation-config delete --yes` is
+ * validated against `delete`).
+ */
+function extractExampleInvocations(text: string): ExampleInvocation[] {
+  const joined = text.replace(/\\\n\s*/g, " ");
+  const invocations: ExampleInvocation[] = [];
+  for (const line of joined.split("\n")) {
+    for (const segment of line.split("|")) {
+      const match = segment.match(/px annotation-config ([a-z-]+)(.*)/);
+      if (!match) {
+        continue;
+      }
+      const flags = [...match[2].matchAll(/(?:^|\s)(--?[a-z][a-z-]*)/g)].map(
+        (flagMatch) => flagMatch[1]
+      );
+      invocations.push({ subcommand: match[1], flags });
+    }
+  }
+  return invocations;
+}
+
+/**
+ * Assert every extracted invocation targets a real subcommand and only uses
+ * flags that subcommand actually defines.
+ */
+function assertInvocationsValid(
+  invocations: ExampleInvocation[],
+  source: string
+): void {
+  const subcommands = getSubcommands();
+  expect(
+    invocations.length,
+    `${source}: expected at least one example invocation`
+  ).toBeGreaterThan(0);
+  for (const { subcommand, flags } of invocations) {
+    const command = subcommands.get(subcommand);
+    expect(
+      command,
+      `${source}: example references unknown subcommand '${subcommand}'`
+    ).toBeDefined();
+    const knownFlags = new Set(
+      command!.options.flatMap((option) =>
+        [option.long, option.short].filter(Boolean)
+      )
+    );
+    for (const flag of flags) {
+      expect(
+        knownFlags.has(flag),
+        `${source}: example uses flag '${flag}' which does not exist on 'annotation-config ${subcommand}'`
+      ).toBe(true);
+    }
+  }
+}
+
+describe("annotation-config CLI conventions", () => {
+  it("exposes the full CRUD surface", () => {
+    const names = [...getSubcommands().keys()].sort();
+    expect(names).toEqual([...EXPECTED_SUBCOMMANDS].sort());
+  });
+
+  it("every subcommand has a description and a commented Examples block", () => {
+    for (const [name, command] of getSubcommands()) {
+      expect(
+        command.description(),
+        `'${name}' is missing a description`
+      ).toBeTruthy();
+
+      const help = renderHelp(command);
+      expect(help, `'${name}' --help is missing an Examples block`).toContain(
+        "Examples:"
+      );
+      expect(
+        help,
+        `'${name}' --help examples are missing '#' description comments`
+      ).toMatch(/^ {2}# /m);
+      expect(
+        help,
+        `'${name}' --help examples must show a full 'px annotation-config ${name}' invocation`
+      ).toContain(`px annotation-config ${name}`);
+    }
+  });
+
+  it("help examples only use flags that exist on the command they invoke", () => {
+    for (const [name, command] of getSubcommands()) {
+      assertInvocationsValid(
+        extractExampleInvocations(renderHelp(command)),
+        `--help for '${name}'`
+      );
+    }
+  });
+
+  it("README examples stay in sync with the option surface", () => {
+    const readmePath = fileURLToPath(new URL("../README.md", import.meta.url));
+    const readme = fs.readFileSync(readmePath, "utf8");
+    assertInvocationsValid(extractExampleInvocations(readme), "README.md");
+  });
+
+  it("phoenix-cli skill examples stay in sync with the option surface", () => {
+    const skillPath = fileURLToPath(
+      new URL(
+        "../../../../.agents/skills/phoenix-cli/SKILL.md",
+        import.meta.url
+      )
+    );
+    const skill = fs.readFileSync(skillPath, "utf8");
+    assertInvocationsValid(extractExampleInvocations(skill), "SKILL.md");
+  });
+
+  it("every subcommand accepts --endpoint and --api-key", () => {
+    for (const [name, command] of getSubcommands()) {
+      const longFlags = command.options.map((option) => option.long);
+      expect(longFlags, `'${name}' is missing --endpoint`).toContain(
+        "--endpoint"
+      );
+      expect(longFlags, `'${name}' is missing --api-key`).toContain(
+        "--api-key"
+      );
+    }
+  });
+
+  it("data-returning subcommands support --format (default pretty) and --no-progress", () => {
+    const subcommands = getSubcommands();
+    for (const name of DATA_SUBCOMMANDS) {
+      const command = subcommands.get(name)!;
+      const formatOption = command.options.find(
+        (option) => option.long === "--format"
+      );
+      expect(formatOption, `'${name}' is missing --format`).toBeDefined();
+      expect(
+        formatOption!.defaultValue,
+        `'${name}' --format must default to pretty`
+      ).toBe("pretty");
+      expect(
+        command.options.map((option) => option.long),
+        `'${name}' is missing --no-progress`
+      ).toContain("--no-progress");
+    }
+  });
+
+  it("create and update share the categorical value input surface", () => {
+    const subcommands = getSubcommands();
+    for (const name of ["create", "update"]) {
+      const longFlags = subcommands.get(name)!.options.map((o) => o.long);
+      expect(longFlags, `'${name}' is missing --value`).toContain("--value");
+      expect(longFlags, `'${name}' is missing --values`).toContain("--values");
+    }
+  });
+
+  it("delete supports -y/--yes for non-interactive use", () => {
+    const deleteCommand = getSubcommands().get("delete")!;
+    const yesOption = deleteCommand.options.find(
+      (option) => option.long === "--yes"
+    );
+    expect(yesOption).toBeDefined();
+    expect(yesOption!.short).toBe("-y");
+  });
+});

--- a/js/packages/phoenix-cli/test/annotationConfigGetCreate.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigGetCreate.test.ts
@@ -292,7 +292,7 @@ describe("annotation-config create", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("exits FAILURE when a value flag is used on a non-categorical type", async () => {
+  it("exits INVALID_ARGUMENT when a value flag is used on a non-categorical type", async () => {
     const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
     vi.stubGlobal("fetch", fetchMock);
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -316,8 +316,71 @@ describe("annotation-config create", () => {
         ],
         { from: "user" }
       )
-    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
-    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("exits INVALID_ARGUMENT before any network call when a numeric flag is not a number", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createAnnotationConfigCommand().parseAsync(
+        [
+          "create",
+          "--type",
+          "CONTINUOUS",
+          "--name",
+          "score",
+          "--lower-bound",
+          "abc",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    // A typo'd bound must never be sent to the API as null.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts a lowercase --optimization-direction and sends it uppercased", async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { data: CATEGORICAL } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createAnnotationConfigCommand().parseAsync(
+      [
+        "create",
+        "--type",
+        "categorical",
+        "--name",
+        "quality",
+        "--value",
+        "good=1",
+        "--optimization-direction",
+        "maximize",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    const body = (await getFetchBody(
+      fetchMock.mock.calls[0][0],
+      fetchMock.mock.calls[0][1]
+    )) as Record<string, unknown>;
+    expect(body.optimization_direction).toBe("MAXIMIZE");
   });
 });

--- a/js/packages/phoenix-cli/test/annotationConfigGetCreate.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigGetCreate.test.ts
@@ -1,0 +1,323 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createAnnotationConfigCommand } from "../src/commands/annotationConfig";
+import { ExitCode } from "../src/exitCodes";
+
+function makeFetchMock(
+  responses: Array<{ ok: boolean; status?: number; body?: unknown }>
+) {
+  let callIndex = 0;
+  return vi.fn().mockImplementation((requestOrUrl: Request | string) => {
+    const resp = responses[callIndex++] ?? responses[responses.length - 1];
+    const status = resp.status ?? (resp.ok ? 200 : 500);
+    const url =
+      requestOrUrl instanceof Request ? requestOrUrl.url : requestOrUrl;
+    const body = resp.body ?? {};
+    const text = JSON.stringify(body);
+    return Promise.resolve({
+      ok: resp.ok,
+      status,
+      statusText: resp.ok ? "OK" : "Error",
+      url,
+      headers: new Headers(),
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(text),
+    });
+  });
+}
+
+function getFetchUrl(arg: unknown): string {
+  if (arg instanceof Request) return arg.url;
+  return String(arg);
+}
+
+function getFetchMethod(arg: unknown, init?: RequestInit): string {
+  if (arg instanceof Request) return arg.method;
+  return init?.method ?? "GET";
+}
+
+async function getFetchBody(
+  arg: unknown,
+  init?: RequestInit
+): Promise<unknown> {
+  if (arg instanceof Request) {
+    const text = await arg.clone().text();
+    return text ? JSON.parse(text) : undefined;
+  }
+  const body = init?.body;
+  return typeof body === "string" ? JSON.parse(body) : body;
+}
+
+const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
+
+const CATEGORICAL = {
+  id: "cat-id-001",
+  name: "quality",
+  type: "CATEGORICAL",
+  description: "Quality rating",
+  optimization_direction: "MAXIMIZE",
+  values: [
+    { label: "good", score: 1 },
+    { label: "bad", score: 0 },
+  ],
+};
+
+function useIsolatedProfilesDir() {
+  let tmpDir: string;
+  let originalXdg: string | undefined;
+  beforeEach(() => {
+    originalXdg = process.env.XDG_CONFIG_HOME;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "phoenix-ac-getcreate-"));
+    process.env.XDG_CONFIG_HOME = tmpDir;
+  });
+  afterEach(() => {
+    if (originalXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdg;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+}
+
+describe("annotation-config get", () => {
+  useIsolatedProfilesDir();
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("GETs by identifier and prints the config as a single object (raw)", async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { data: CATEGORICAL } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createAnnotationConfigCommand().parseAsync(
+      ["get", "quality", "--format", "raw", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
+      "/v1/annotation_configs/quality"
+    );
+    expect(
+      getFetchMethod(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
+    ).toBe("GET");
+    expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(CATEGORICAL));
+  });
+
+  it("exits FAILURE when the identifier is not found", async () => {
+    // The client throws on a 404, which the handler's catch maps to FAILURE.
+    const fetchMock = makeFetchMock([{ ok: false, status: 404, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createAnnotationConfigCommand().parseAsync(
+        ["get", "missing", "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Error fetching annotation config")
+    );
+  });
+});
+
+describe("annotation-config create", () => {
+  useIsolatedProfilesDir();
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("POSTs a categorical config built from repeatable --value flags", async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { data: CATEGORICAL } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createAnnotationConfigCommand().parseAsync(
+      [
+        "create",
+        "--type",
+        "CATEGORICAL",
+        "--name",
+        "quality",
+        "--value",
+        "good=1",
+        "--value",
+        "bad=0",
+        "--optimization-direction",
+        "MAXIMIZE",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
+      "/v1/annotation_configs"
+    );
+    expect(
+      getFetchMethod(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
+    ).toBe("POST");
+
+    const body = (await getFetchBody(
+      fetchMock.mock.calls[0][0],
+      fetchMock.mock.calls[0][1]
+    )) as Record<string, unknown>;
+    expect(body.type).toBe("CATEGORICAL");
+    expect(body.name).toBe("quality");
+    expect(body.optimization_direction).toBe("MAXIMIZE");
+    expect(body.values).toEqual([
+      { label: "good", score: 1 },
+      { label: "bad", score: 0 },
+    ]);
+    expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(CATEGORICAL));
+  });
+
+  it("lowercases --type and defaults optimization_direction to NONE", async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { data: CATEGORICAL } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createAnnotationConfigCommand().parseAsync(
+      [
+        "create",
+        "--type",
+        "continuous",
+        "--name",
+        "score",
+        "--lower-bound",
+        "0",
+        "--upper-bound",
+        "1",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    const body = (await getFetchBody(
+      fetchMock.mock.calls[0][0],
+      fetchMock.mock.calls[0][1]
+    )) as Record<string, unknown>;
+    expect(body.type).toBe("CONTINUOUS");
+    expect(body.optimization_direction).toBe("NONE");
+    expect(body.lower_bound).toBe(0);
+    expect(body.upper_bound).toBe(1);
+  });
+
+  it("exits INVALID_ARGUMENT when --type is missing", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createAnnotationConfigCommand().parseAsync(
+        ["create", "--name", "quality", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("exits INVALID_ARGUMENT for an invalid --type", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createAnnotationConfigCommand().parseAsync(
+        ["create", "--type", "RATING", "--name", "quality", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("exits INVALID_ARGUMENT when a categorical config has no values", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createAnnotationConfigCommand().parseAsync(
+        ["create", "--type", "CATEGORICAL", "--name", "quality", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("exits FAILURE when a value flag is used on a non-categorical type", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createAnnotationConfigCommand().parseAsync(
+        [
+          "create",
+          "--type",
+          "CONTINUOUS",
+          "--name",
+          "score",
+          "--value",
+          "good=1",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+  });
+});

--- a/js/packages/phoenix-cli/test/annotationConfigUpdate.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigUpdate.test.ts
@@ -1,0 +1,344 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createAnnotationConfigCommand } from "../src/commands/annotationConfig";
+import { ExitCode } from "../src/exitCodes";
+
+/**
+ * Build a fetch mock that returns each queued response in order, falling back
+ * to the last response once exhausted.
+ */
+function makeFetchMock(
+  responses: Array<{ ok: boolean; status?: number; body?: unknown }>
+) {
+  let callIndex = 0;
+  return vi.fn().mockImplementation((requestOrUrl: Request | string) => {
+    const resp = responses[callIndex++] ?? responses[responses.length - 1];
+    const status = resp.status ?? (resp.ok ? 200 : 500);
+    const url =
+      requestOrUrl instanceof Request ? requestOrUrl.url : requestOrUrl;
+    const body = resp.body ?? {};
+    const text = JSON.stringify(body);
+    return Promise.resolve({
+      ok: resp.ok,
+      status,
+      statusText: resp.ok ? "OK" : "Error",
+      url,
+      headers: new Headers(),
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(text),
+    });
+  });
+}
+
+function getFetchUrl(arg: unknown): string {
+  if (arg instanceof Request) return arg.url;
+  return String(arg);
+}
+
+function getFetchMethod(arg: unknown, init?: RequestInit): string {
+  if (arg instanceof Request) return arg.method;
+  return init?.method ?? "GET";
+}
+
+async function getFetchBody(
+  arg: unknown,
+  init?: RequestInit
+): Promise<unknown> {
+  if (arg instanceof Request) {
+    const text = await arg.clone().text();
+    return text ? JSON.parse(text) : undefined;
+  }
+  const body = init?.body;
+  return typeof body === "string" ? JSON.parse(body) : body;
+}
+
+const BASE_ARGS = ["--endpoint", "http://localhost:6006"];
+
+const CATEGORICAL = {
+  id: "cat-id-001",
+  name: "quality",
+  type: "CATEGORICAL",
+  description: "Quality rating",
+  optimization_direction: "MAXIMIZE",
+  values: [
+    { label: "good", score: 1 },
+    { label: "bad", score: 0 },
+  ],
+};
+
+const CONTINUOUS = {
+  id: "cont-id-002",
+  name: "score",
+  type: "CONTINUOUS",
+  description: null,
+  optimization_direction: "MAXIMIZE",
+  lower_bound: 0,
+  upper_bound: 1,
+};
+
+/**
+ * Point XDG_CONFIG_HOME at a clean temp dir so the CLI's settings resolution
+ * doesn't pick up a developer's real `~/.px/settings.json`.
+ */
+function useIsolatedProfilesDir() {
+  let tmpDir: string;
+  let originalXdg: string | undefined;
+  beforeEach(() => {
+    originalXdg = process.env.XDG_CONFIG_HOME;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "phoenix-ac-update-test-"));
+    process.env.XDG_CONFIG_HOME = tmpDir;
+  });
+  afterEach(() => {
+    if (originalXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdg;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+}
+
+describe("annotation-config update", () => {
+  useIsolatedProfilesDir();
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches the config then PUTs a merged body changing only --name", async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { data: CATEGORICAL } },
+      {
+        ok: true,
+        body: { data: { ...CATEGORICAL, name: "renamed" } },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createAnnotationConfigCommand().parseAsync(
+      ["update", "quality", "--name", "renamed", ...BASE_ARGS, "--no-progress"],
+      { from: "user" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // First call: GET by identifier
+    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
+      "/v1/annotation_configs/quality"
+    );
+    // Second call: PUT using the resolved ID
+    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain(
+      "/v1/annotation_configs/cat-id-001"
+    );
+    expect(
+      getFetchMethod(fetchMock.mock.calls[1][0], fetchMock.mock.calls[1][1])
+    ).toBe("PUT");
+
+    const body = (await getFetchBody(
+      fetchMock.mock.calls[1][0],
+      fetchMock.mock.calls[1][1]
+    )) as Record<string, unknown>;
+    // Changed field
+    expect(body.name).toBe("renamed");
+    // Preserved fields
+    expect(body.type).toBe("CATEGORICAL");
+    expect(body.description).toBe("Quality rating");
+    expect(body.optimization_direction).toBe("MAXIMIZE");
+    expect(body.values).toEqual(CATEGORICAL.values);
+    // PUT body must not carry the read-only id
+    expect(body).not.toHaveProperty("id");
+  });
+
+  it("updates categorical values from --values JSON", async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { data: CATEGORICAL } },
+      { ok: true, body: { data: CATEGORICAL } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createAnnotationConfigCommand().parseAsync(
+      [
+        "update",
+        "quality",
+        "--values",
+        '[{"label":"excellent","score":2},{"label":"poor"}]',
+        ...BASE_ARGS,
+        "--no-progress",
+      ],
+      { from: "user" }
+    );
+
+    const body = (await getFetchBody(
+      fetchMock.mock.calls[1][0],
+      fetchMock.mock.calls[1][1]
+    )) as Record<string, unknown>;
+    expect(body.values).toEqual([
+      { label: "excellent", score: 2 },
+      { label: "poor" },
+    ]);
+  });
+
+  it("updates continuous bounds", async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { data: CONTINUOUS } },
+      { ok: true, body: { data: CONTINUOUS } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createAnnotationConfigCommand().parseAsync(
+      [
+        "update",
+        "score",
+        "--lower-bound",
+        "-1",
+        "--upper-bound",
+        "10",
+        ...BASE_ARGS,
+        "--no-progress",
+      ],
+      { from: "user" }
+    );
+
+    const body = (await getFetchBody(
+      fetchMock.mock.calls[1][0],
+      fetchMock.mock.calls[1][1]
+    )) as Record<string, unknown>;
+    expect(body.type).toBe("CONTINUOUS");
+    expect(body.lower_bound).toBe(-1);
+    expect(body.upper_bound).toBe(10);
+  });
+
+  it("outputs the updated config as a single object with --format raw", async () => {
+    const updated = { ...CATEGORICAL, name: "renamed" };
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { data: CATEGORICAL } },
+      { ok: true, body: { data: updated } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createAnnotationConfigCommand().parseAsync(
+      [
+        "update",
+        "quality",
+        "--name",
+        "renamed",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+        "--no-progress",
+      ],
+      { from: "user" }
+    );
+
+    expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(updated));
+  });
+
+  it("exits INVALID_ARGUMENT when no fields are provided", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createAnnotationConfigCommand().parseAsync(
+        ["update", "quality", ...BASE_ARGS, "--no-progress"],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    // No network call should happen — validation fails first.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("exits INVALID_ARGUMENT for an invalid --optimization-direction", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createAnnotationConfigCommand().parseAsync(
+        [
+          "update",
+          "quality",
+          "--optimization-direction",
+          "SIDEWAYS",
+          ...BASE_ARGS,
+          "--no-progress",
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("exits FAILURE when --values is used on a non-categorical config", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: { data: CONTINUOUS } }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createAnnotationConfigCommand().parseAsync(
+        [
+          "update",
+          "score",
+          "--values",
+          '[{"label":"good"}]',
+          ...BASE_ARGS,
+          "--no-progress",
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    // The GET happened, but the PUT never fired because the merge threw.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("exits FAILURE when the config is not found", async () => {
+    const fetchMock = makeFetchMock([{ ok: false, status: 404, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createAnnotationConfigCommand().parseAsync(
+        ["update", "missing", "--name", "x", ...BASE_ARGS, "--no-progress"],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+  });
+});

--- a/js/packages/phoenix-cli/test/annotationConfigUpdate.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigUpdate.test.ts
@@ -184,6 +184,70 @@ describe("annotation-config update", () => {
     ]);
   });
 
+  it("updates categorical values from repeatable --value flags", async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { data: CATEGORICAL } },
+      { ok: true, body: { data: CATEGORICAL } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createAnnotationConfigCommand().parseAsync(
+      [
+        "update",
+        "quality",
+        "--value",
+        "excellent=2",
+        "--value",
+        "poor",
+        ...BASE_ARGS,
+        "--no-progress",
+      ],
+      { from: "user" }
+    );
+
+    const body = (await getFetchBody(
+      fetchMock.mock.calls[1][0],
+      fetchMock.mock.calls[1][1]
+    )) as Record<string, unknown>;
+    expect(body.values).toEqual([
+      { label: "excellent", score: 2 },
+      { label: "poor" },
+    ]);
+  });
+
+  it("exits FAILURE when both --value and --values are supplied", async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { data: CATEGORICAL } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createAnnotationConfigCommand().parseAsync(
+        [
+          "update",
+          "quality",
+          "--value",
+          "good=1",
+          "--values",
+          '[{"label":"bad"}]',
+          ...BASE_ARGS,
+          "--no-progress",
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+  });
+
   it("updates continuous bounds", async () => {
     const fetchMock = makeFetchMock([
       { ok: true, body: { data: CONTINUOUS } },

--- a/js/packages/phoenix-cli/test/annotationConfigUpdate.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigUpdate.test.ts
@@ -217,7 +217,7 @@ describe("annotation-config update", () => {
     ]);
   });
 
-  it("exits FAILURE when both --value and --values are supplied", async () => {
+  it("exits INVALID_ARGUMENT when both --value and --values are supplied", async () => {
     const fetchMock = makeFetchMock([
       { ok: true, body: { data: CATEGORICAL } },
     ]);
@@ -243,9 +243,67 @@ describe("annotation-config update", () => {
         ],
         { from: "user" }
       )
-    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
-    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+  });
+
+  it("exits INVALID_ARGUMENT before any network call when a numeric flag is not a number", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: { data: CONTINUOUS } }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createAnnotationConfigCommand().parseAsync(
+        [
+          "update",
+          "score",
+          "--lower-bound",
+          "abc",
+          ...BASE_ARGS,
+          "--no-progress",
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    // A typo'd bound must never reach the API (it would silently clear the
+    // existing bound to null).
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts a lowercase --optimization-direction and sends it uppercased", async () => {
+    const fetchMock = makeFetchMock([
+      { ok: true, body: { data: CATEGORICAL } },
+      { ok: true, body: { data: CATEGORICAL } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createAnnotationConfigCommand().parseAsync(
+      [
+        "update",
+        "quality",
+        "--optimization-direction",
+        "minimize",
+        ...BASE_ARGS,
+        "--no-progress",
+      ],
+      { from: "user" }
+    );
+
+    const body = (await getFetchBody(
+      fetchMock.mock.calls[1][0],
+      fetchMock.mock.calls[1][1]
+    )) as Record<string, unknown>;
+    expect(body.optimization_direction).toBe("MINIMIZE");
   });
 
   it("updates continuous bounds", async () => {
@@ -357,7 +415,7 @@ describe("annotation-config update", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("exits FAILURE when --values is used on a non-categorical config", async () => {
+  it("exits INVALID_ARGUMENT when --values is used on a non-categorical config", async () => {
     const fetchMock = makeFetchMock([{ ok: true, body: { data: CONTINUOUS } }]);
     vi.stubGlobal("fetch", fetchMock);
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -379,9 +437,9 @@ describe("annotation-config update", () => {
         ],
         { from: "user" }
       )
-    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
-    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
     // The GET happened, but the PUT never fired because the merge threw.
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/js/packages/phoenix-cli/test/annotationConfigValues.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigValues.test.ts
@@ -1,19 +1,35 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  collectValueFlag,
   hasCategoricalValueInput,
   resolveCategoricalValues,
 } from "../src/commands/annotationConfigValues";
+import { InvalidArgumentError } from "../src/exitCodes";
+import { collectString, parseNumberOption } from "../src/optionParsers";
 
-describe("collectValueFlag", () => {
+describe("collectString", () => {
   it("appends without mutating the previous array", () => {
-    const first = collectValueFlag("good=1", []);
-    const second = collectValueFlag("bad=0", first);
+    const first = collectString("good=1", []);
+    const second = collectString("bad=0", first);
     expect(first).toEqual(["good=1"]);
     expect(second).toEqual(["good=1", "bad=0"]);
     // previous array is untouched
     expect(first).toEqual(["good=1"]);
+  });
+});
+
+describe("parseNumberOption", () => {
+  it("parses integers, decimals, and negatives", () => {
+    expect(parseNumberOption("1")).toBe(1);
+    expect(parseNumberOption("-1.5")).toBe(-1.5);
+    expect(parseNumberOption(" 0 ")).toBe(0);
+  });
+
+  it("yields NaN for garbage instead of truncating like parseFloat", () => {
+    expect(parseNumberOption("abc")).toBeNaN();
+    expect(parseNumberOption("1abc")).toBeNaN();
+    expect(parseNumberOption("")).toBeNaN();
+    expect(parseNumberOption("   ")).toBeNaN();
   });
 });
 
@@ -128,5 +144,17 @@ describe("resolveCategoricalValues - precedence and absence", () => {
         values: '[{"label":"good"}]',
       })
     ).toThrow(/not both/);
+  });
+
+  it("throws InvalidArgumentError so handlers exit with INVALID_ARGUMENT", () => {
+    expect(() => resolveCategoricalValues({ value: ["good=abc"] })).toThrow(
+      InvalidArgumentError
+    );
+    expect(() => resolveCategoricalValues({ values: "not json" })).toThrow(
+      InvalidArgumentError
+    );
+    expect(() =>
+      resolveCategoricalValues({ value: ["a=1"], values: "[]" })
+    ).toThrow(InvalidArgumentError);
   });
 });

--- a/js/packages/phoenix-cli/test/annotationConfigValues.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigValues.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  collectValueFlag,
+  hasCategoricalValueInput,
+  resolveCategoricalValues,
+} from "../src/commands/annotationConfigValues";
+
+describe("collectValueFlag", () => {
+  it("appends without mutating the previous array", () => {
+    const first = collectValueFlag("good=1", []);
+    const second = collectValueFlag("bad=0", first);
+    expect(first).toEqual(["good=1"]);
+    expect(second).toEqual(["good=1", "bad=0"]);
+    // previous array is untouched
+    expect(first).toEqual(["good=1"]);
+  });
+});
+
+describe("hasCategoricalValueInput", () => {
+  it("is false when neither form is provided", () => {
+    expect(hasCategoricalValueInput({})).toBe(false);
+    expect(hasCategoricalValueInput({ value: [] })).toBe(false);
+  });
+
+  it("is true when either form is provided", () => {
+    expect(hasCategoricalValueInput({ value: ["good=1"] })).toBe(true);
+    expect(hasCategoricalValueInput({ values: "[]" })).toBe(true);
+  });
+});
+
+describe("resolveCategoricalValues - repeatable --value", () => {
+  it("parses label=score pairs", () => {
+    expect(resolveCategoricalValues({ value: ["good=1", "bad=0"] })).toEqual([
+      { label: "good", score: 1 },
+      { label: "bad", score: 0 },
+    ]);
+  });
+
+  it("allows a label with no score", () => {
+    expect(resolveCategoricalValues({ value: ["needs-review"] })).toEqual([
+      { label: "needs-review" },
+    ]);
+  });
+
+  it("parses negative and decimal scores", () => {
+    expect(resolveCategoricalValues({ value: ["low=-1.5"] })).toEqual([
+      { label: "low", score: -1.5 },
+    ]);
+  });
+
+  it("splits on the first '=' so a non-numeric remainder is a score error, not a label", () => {
+    // 'a=b=1' -> label 'a', score text 'b=1' which is non-numeric -> throws
+    expect(() => resolveCategoricalValues({ value: ["a=b=1"] })).toThrow(
+      /non-numeric score/
+    );
+  });
+
+  it("rejects an empty label before '='", () => {
+    expect(() => resolveCategoricalValues({ value: ["=1"] })).toThrow(
+      /missing a label/
+    );
+  });
+
+  it("rejects an empty score after '='", () => {
+    expect(() => resolveCategoricalValues({ value: ["good="] })).toThrow(
+      /empty score/
+    );
+  });
+
+  it("rejects a non-numeric score", () => {
+    expect(() => resolveCategoricalValues({ value: ["good=high"] })).toThrow(
+      /non-numeric score/
+    );
+  });
+});
+
+describe("resolveCategoricalValues - --values JSON", () => {
+  it("parses a JSON array of label objects", () => {
+    expect(
+      resolveCategoricalValues({
+        values: '[{"label":"good","score":1},{"label":"bad"}]',
+      })
+    ).toEqual([{ label: "good", score: 1 }, { label: "bad" }]);
+  });
+
+  it("rejects invalid JSON", () => {
+    expect(() => resolveCategoricalValues({ values: "not json" })).toThrow(
+      /valid JSON array/
+    );
+  });
+
+  it("rejects a non-array payload", () => {
+    expect(() =>
+      resolveCategoricalValues({ values: '{"label":"good"}' })
+    ).toThrow(/non-empty JSON array/);
+  });
+
+  it("rejects an empty array", () => {
+    expect(() => resolveCategoricalValues({ values: "[]" })).toThrow(
+      /non-empty JSON array/
+    );
+  });
+
+  it("rejects entries missing a label", () => {
+    expect(() => resolveCategoricalValues({ values: '[{"score":1}]' })).toThrow(
+      /non-empty string "label"/
+    );
+  });
+
+  it("rejects a non-numeric score", () => {
+    expect(() =>
+      resolveCategoricalValues({ values: '[{"label":"good","score":"high"}]' })
+    ).toThrow(/must be a number/);
+  });
+});
+
+describe("resolveCategoricalValues - precedence and absence", () => {
+  it("returns undefined when neither form is provided", () => {
+    expect(resolveCategoricalValues({})).toBeUndefined();
+    expect(resolveCategoricalValues({ value: [] })).toBeUndefined();
+  });
+
+  it("rejects supplying both forms at once", () => {
+    expect(() =>
+      resolveCategoricalValues({
+        value: ["good=1"],
+        values: '[{"label":"good"}]',
+      })
+    ).toThrow(/not both/);
+  });
+});

--- a/js/packages/phoenix-cli/test/annotationConfigs.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigs.test.ts
@@ -1,7 +1,10 @@
 import type { componentsV1 } from "@arizeai/phoenix-client";
 import { describe, expect, it } from "vitest";
 
-import { formatAnnotationConfigsOutput } from "../src/commands/formatAnnotationConfigs";
+import {
+  formatAnnotationConfigOutput,
+  formatAnnotationConfigsOutput,
+} from "../src/commands/formatAnnotationConfigs";
 
 type CategoricalAnnotationConfig =
   componentsV1["schemas"]["CategoricalAnnotationConfig"];
@@ -151,6 +154,38 @@ describe("Annotation Config Formatting", () => {
 
       expect(output).toContain("name");
       expect(output).toContain("quality");
+    });
+  });
+
+  describe("formatAnnotationConfigOutput - single config", () => {
+    it("should emit the config object directly (not an array) for raw", () => {
+      const output = formatAnnotationConfigOutput({
+        config: mockCategorical,
+        format: "raw",
+      });
+
+      expect(output).toBe(JSON.stringify(mockCategorical));
+      expect(output.startsWith("[")).toBe(false);
+    });
+
+    it("should emit the config object directly (not an array) for json", () => {
+      const output = formatAnnotationConfigOutput({
+        config: mockCategorical,
+        format: "json",
+      });
+
+      expect(output).toBe(JSON.stringify(mockCategorical, null, 2));
+    });
+
+    it("should render a single-row table for pretty", () => {
+      const output = formatAnnotationConfigOutput({
+        config: mockContinuous,
+        format: "pretty",
+      });
+
+      expect(output).toContain("score");
+      expect(output).toContain("cont-id-002");
+      expect(output).toContain("CONTINUOUS");
     });
   });
 });


### PR DESCRIPTION
resolves #12029
refs #12023, #12025

## Summary

Rounds out the `px annotation-config` command surface so it makes cohesive sense. `list` (#12021) and `delete` already existed; this PR adds **`get`** (#12023), **`create`** (#12025), and **`update`** (#12029), giving annotation configs full CRUD.

A central design goal (per review feedback) was the categorical **values** input, which is the most brittle part. Instead of only a hand-quoted JSON string, `create` and `update` share one mechanism:

- **`--value label[=score]`** — repeatable, shell-friendly (`--value good=1 --value bad=0`; score optional: `--value needs-review`)
- **`--values '<json>'`** — retained as a bulk/agent-friendly alternative

The two forms are mutually exclusive. Parsing lives in a dedicated, unit-tested module (`annotationConfigValues.ts`) reused by both write commands, so the behavior can't drift between them.

## Commands

- **`get <identifier>`** — fetch one config by name or ID; outputs the config object.
- **`create`** — `POST /v1/annotation_configs`. Requires `--type` (CATEGORICAL/CONTINUOUS/FREEFORM, case-insensitive) and `--name`; a CATEGORICAL config requires at least one value. `--optimization-direction` is case-insensitive and defaults to `NONE`. Type-mismatched flags (e.g. `--threshold` on a categorical) are rejected.
- **`update <identifier>`** — `PUT /v1/annotation_configs/{id}`. Fetches the existing config, merges only the flags you pass, and writes the full body back (partial-update semantics on a full-replace endpoint). The `type` is immutable.

All three write the affected config to stdout in the selected `--format` (single object for `raw`/`json`, so agents can `jq -r '.id'`). All invalid input — missing/invalid flags, type-mismatched flags, and `--value`/`--values` parse failures — exits `INVALID_ARGUMENT` (3), with a `StructuredError` JSON envelope on stderr in `json`/`raw` mode. Non-finite numeric flags (e.g. `--lower-bound abc`) are rejected before any network call rather than silently becoming `null`.

## Examples

```bash
px annotation-config get quality --format raw | jq -r '.id'
px annotation-config create --type CATEGORICAL --name quality --value good=1 --value bad=0
px annotation-config create --type CONTINUOUS --name score --lower-bound 0 --upper-bound 1
px annotation-config update quality --name accuracy --optimization-direction MAXIMIZE
px annotation-config update quality --value good=1 --value bad=0
```

## Changes

- `src/commands/annotationConfigValues.ts` — shared, tested value-input parsing (`--value` + `--values`)
- `src/commands/annotationConfig.ts` — `get`, `create`, refactored `update`; shared per-type flag validation; command registration
- `src/optionParsers.ts` — shared `collectString` (consolidates four identical Commander collectors across annotation-config, `profile --header`, `dataset --split`, and `docs --workflow`) and strict `parseNumberOption`
- `src/commands/formatAnnotationConfigs.ts` — single-config formatter (object, not array, in raw/json)
- `test/` — value-parser unit tests, get/create handler tests, and expanded update tests (exit codes, NaN rejection, case-insensitivity)
- `README.md` and `.agents/skills/phoenix-cli/SKILL.md` — documentation for the full CRUD surface

## Testing

- `pnpm test` — 509 passed
- `pnpm typecheck`, `pnpm build`, and `oxfmt --check` — clean
- Manual: `--help` for each subcommand renders examples; error paths return structured errors with the documented exit codes (verified exit 3 + JSON envelope for NaN bounds, type mismatches, and invalid enum values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrM9PbMRoJMvD7ULTWTpDC