### PR TITLE
feat(js): add logSpans to phoenix-client spans API

### DIFF
--- a/js/.changeset/phoenix-client-log-spans.md
+++ b/js/.changeset/phoenix-client-log-spans.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Add `logSpans` to `@arizeai/phoenix-client/spans`, mirroring the Python client's `log_spans` API. It submits spans directly to a project using Phoenix's simplified span structure (the same shape returned by `getSpans`), without requiring OpenTelemetry. Throws a new `SpanCreationError` with `invalidSpans`/`duplicateSpans` details if any span in the request is invalid or a duplicate.

--- a/js/packages/phoenix-client/README.md
+++ b/js/packages/phoenix-client/README.md
@@ -544,6 +544,32 @@ const rootSpans = await getSpans({
 | `spanKind`   | `SpanKindFilter \| SpanKindFilter[]` | Filter by span kind (`LLM`, `CHAIN`, `TOOL`, `RETRIEVER`, etc.) |
 | `statusCode` | `SpanStatusCode \| SpanStatusCode[]` | Filter by status code (`OK`, `ERROR`, `UNSET`)                  |
 
+### Logging Spans
+
+Use `logSpans` to submit spans directly to a project using Phoenix's simplified span structure — the same shape returned by `getSpans`. This is useful for backfilling or migrating spans without going through OpenTelemetry. If your application is already instrumented with OpenTelemetry, export spans via `@arizeai/phoenix-otel` instead.
+
+```ts
+import { logSpans } from "@arizeai/phoenix-client/spans";
+
+const result = await logSpans({
+  project: { projectName: "my-project" },
+  spans: [
+    {
+      name: "chat_completion",
+      context: { trace_id: "abc123", span_id: "def456" },
+      span_kind: "LLM",
+      start_time: "2024-01-01T00:00:00Z",
+      end_time: "2024-01-01T00:00:01Z",
+      status_code: "OK",
+      attributes: { "llm.model_name": "gpt-4" },
+    },
+  ],
+});
+console.log(`Queued ${result.totalQueued} of ${result.totalReceived} spans`);
+```
+
+If any span in the request is invalid or a duplicate of a span that already exists, none of the spans are queued and `logSpans` throws a `SpanCreationError` with `invalidSpans` and `duplicateSpans` details.
+
 ## Span Annotations
 
 The `spans` export also provides functions for managing span annotations — adding evaluations, feedback, and labels to spans.

--- a/js/packages/phoenix-client/examples/log_spans.ts
+++ b/js/packages/phoenix-client/examples/log_spans.ts
@@ -165,8 +165,6 @@ async function main() {
         );
       }
     }
-
-    process.exit(1);
   }
 }
 

--- a/js/packages/phoenix-client/examples/log_spans.ts
+++ b/js/packages/phoenix-client/examples/log_spans.ts
@@ -1,0 +1,173 @@
+/* eslint-disable no-console */
+import { createClient } from "../src/client";
+import { getSpans, logSpans, SpanCreationError } from "../src/spans";
+import type { Span } from "../src/spans";
+
+/**
+ * Example: Log spans of different OpenInference kinds to a project
+ *
+ * This example demonstrates how to:
+ * 1. Build a small trace made up of several span kinds (AGENT, RETRIEVER,
+ *    EMBEDDING, LLM, TOOL, CHAIN) using Phoenix's simplified span structure
+ * 2. Submit them all in a single `logSpans` call — no OpenTelemetry SDK
+ *    required
+ * 3. Handle a `SpanCreationError` if any span is invalid or a duplicate
+ * 4. Read the spans back with `getSpans` to confirm every kind was ingested
+ */
+
+function randomHexId(byteLength: number): string {
+  return Array.from({ length: byteLength }, () =>
+    Math.floor(Math.random() * 256)
+      .toString(16)
+      .padStart(2, "0")
+  ).join("");
+}
+
+async function main() {
+  const client = createClient({
+    options: {
+      baseUrl: "http://localhost:6006",
+    },
+  });
+
+  const projectName = "log-spans-example";
+  const traceId = randomHexId(16); // 32 hex chars, like an OTel trace ID
+  const startedAt = Date.now();
+  const at = (offsetMs: number) => new Date(startedAt + offsetMs).toISOString();
+
+  const rootSpanId = randomHexId(8);
+  const retrieverSpanId = randomHexId(8);
+  const llmSpanId = randomHexId(8);
+
+  // One small trace covering six different OpenInference span kinds
+  const spans: Span[] = [
+    {
+      name: "answer_question",
+      span_kind: "AGENT",
+      context: { trace_id: traceId, span_id: rootSpanId },
+      start_time: at(0),
+      end_time: at(500),
+      status_code: "OK",
+      attributes: { "input.value": "What is Phoenix?" },
+    },
+    {
+      name: "retrieve_documents",
+      span_kind: "RETRIEVER",
+      context: { trace_id: traceId, span_id: retrieverSpanId },
+      parent_id: rootSpanId,
+      start_time: at(10),
+      end_time: at(120),
+      status_code: "OK",
+      attributes: {
+        "retrieval.documents.0.document.content":
+          "Phoenix is an open-source observability library for LLM apps.",
+        "retrieval.documents.0.document.score": 0.92,
+      },
+    },
+    {
+      name: "embed_query",
+      span_kind: "EMBEDDING",
+      context: { trace_id: traceId, span_id: randomHexId(8) },
+      parent_id: retrieverSpanId,
+      start_time: at(15),
+      end_time: at(40),
+      status_code: "OK",
+      attributes: {
+        "embedding.model_name": "text-embedding-3-small",
+        "embedding.embeddings.0.embedding.text": "What is Phoenix?",
+      },
+    },
+    {
+      name: "chat_completion",
+      span_kind: "LLM",
+      context: { trace_id: traceId, span_id: llmSpanId },
+      parent_id: rootSpanId,
+      start_time: at(130),
+      end_time: at(430),
+      status_code: "OK",
+      attributes: {
+        "llm.model_name": "gpt-4o-mini",
+        "llm.token_count.prompt": 42,
+        "llm.token_count.completion": 18,
+      },
+    },
+    {
+      name: "search_docs",
+      span_kind: "TOOL",
+      context: { trace_id: traceId, span_id: randomHexId(8) },
+      parent_id: llmSpanId,
+      start_time: at(200),
+      end_time: at(260),
+      status_code: "OK",
+      attributes: {
+        "tool.name": "search_docs",
+        "tool.parameters": JSON.stringify({ query: "Phoenix" }),
+      },
+    },
+    {
+      name: "format_response",
+      span_kind: "CHAIN",
+      context: { trace_id: traceId, span_id: randomHexId(8) },
+      parent_id: rootSpanId,
+      start_time: at(440),
+      end_time: at(490),
+      status_code: "OK",
+      attributes: {
+        "output.value":
+          "Phoenix is an open-source observability library for LLM apps.",
+      },
+    },
+  ];
+
+  try {
+    const kinds = new Set(spans.map((span) => span.span_kind));
+    console.log(
+      `📝 Logging ${spans.length} spans across ${kinds.size} kinds (${[...kinds].join(", ")})...`
+    );
+
+    const result = await logSpans({
+      client,
+      project: { projectName },
+      spans,
+    });
+    console.log(
+      `✅ Queued ${result.totalQueued} of ${result.totalReceived} spans in project "${projectName}"`
+    );
+
+    // Spans are enqueued asynchronously server-side; give it a moment before reading them back.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    const { spans: ingested } = await getSpans({
+      client,
+      project: { projectName },
+      traceIds: [traceId],
+      limit: spans.length,
+    });
+
+    console.log(`\n🔍 Read back ${ingested.length} spans:`);
+    ingested.forEach((span) => {
+      console.log(`  - ${span.name} (${span.span_kind})`);
+    });
+
+    console.log("\n✅ Log spans example completed");
+  } catch (error) {
+    if (error instanceof SpanCreationError) {
+      console.error(`❌ Failed to log spans: ${error.message}`);
+      console.error(
+        `   invalid: ${error.totalInvalid}, duplicates: ${error.totalDuplicates}`
+      );
+    } else {
+      console.error("❌ Error:", error);
+
+      if (error instanceof Error && error.message.includes("ECONNREFUSED")) {
+        console.error(
+          "💡 Make sure Phoenix server is running on http://localhost:6006"
+        );
+      }
+    }
+
+    process.exit(1);
+  }
+}
+
+main();

--- a/js/packages/phoenix-client/src/spans/index.ts
+++ b/js/packages/phoenix-client/src/spans/index.ts
@@ -7,3 +7,4 @@ export * from "./getSpans";
 export type { SpanKindFilter, SpanStatusCode } from "../types/spans";
 export * from "./getSpanAnnotations";
 export * from "./deleteSpan";
+export * from "./logSpans";

--- a/js/packages/phoenix-client/src/spans/logSpans.ts
+++ b/js/packages/phoenix-client/src/spans/logSpans.ts
@@ -251,7 +251,9 @@ function parseLogSpansError(error: unknown, spans: Span[]): Error {
           invalidSpans,
           duplicateSpans: [],
           totalReceived: spans.length,
-          totalQueued: spans.length - invalidSpans.length,
+          // A FastAPI 422 rejects the entire request body, so no spans are
+          // queued — matching the all-or-nothing contract and the 400 path.
+          totalQueued: 0,
         });
       }
     } else if (isSpanCreationErrorPayload(error)) {

--- a/js/packages/phoenix-client/src/spans/logSpans.ts
+++ b/js/packages/phoenix-client/src/spans/logSpans.ts
@@ -1,0 +1,315 @@
+import type { paths } from "../__generated__/api/v1";
+import { createClient } from "../client";
+import type { ClientFn } from "../types/core";
+import type { ProjectIdentifier } from "../types/projects";
+import { resolveProjectIdentifier } from "../types/projects";
+import { formatApiError } from "../utils/apiErrorUtils";
+
+type CreateSpansRequestData =
+  paths["/v1/projects/{project_identifier}/spans"]["post"]["requestBody"]["content"]["application/json"]["data"];
+
+/**
+ * A span in Phoenix's simplified span structure, as accepted by {@link logSpans}.
+ * This is the same shape returned by `getSpans`, which makes it possible to read
+ * spans from one project and log them into another.
+ */
+export type Span = CreateSpansRequestData[number];
+
+/** Information about a span that failed validation and was not queued. */
+export interface InvalidSpanInfo {
+  spanId: string;
+  traceId: string;
+  error: string;
+}
+
+/** Information about a span that was rejected because it already exists. */
+export interface DuplicateSpanInfo {
+  spanId: string;
+  traceId: string;
+}
+
+/**
+ * Raised by {@link logSpans} when one or more spans in the request are invalid
+ * or duplicates. If any span in a request fails, none of the spans in that
+ * request are queued.
+ */
+export class SpanCreationError extends Error {
+  readonly invalidSpans: InvalidSpanInfo[];
+  readonly duplicateSpans: DuplicateSpanInfo[];
+  readonly totalReceived: number;
+  readonly totalQueued: number;
+  readonly totalInvalid: number;
+  readonly totalDuplicates: number;
+
+  constructor(params: {
+    message: string;
+    invalidSpans?: InvalidSpanInfo[];
+    duplicateSpans?: DuplicateSpanInfo[];
+    totalReceived?: number;
+    totalQueued?: number;
+    totalInvalid?: number;
+    totalDuplicates?: number;
+  }) {
+    super(params.message);
+    this.name = "SpanCreationError";
+    this.invalidSpans = params.invalidSpans ?? [];
+    this.duplicateSpans = params.duplicateSpans ?? [];
+    this.totalReceived = params.totalReceived ?? 0;
+    this.totalQueued = params.totalQueued ?? 0;
+    this.totalInvalid = params.totalInvalid ?? this.invalidSpans.length;
+    this.totalDuplicates = params.totalDuplicates ?? this.duplicateSpans.length;
+  }
+}
+
+/**
+ * Parameters to log spans to a project
+ */
+export interface LogSpansParams extends ClientFn {
+  /** The project to log spans into */
+  project: ProjectIdentifier;
+  /** The spans to log */
+  spans: Span[];
+}
+
+/**
+ * Statistics about a {@link logSpans} call. When successful, `totalQueued`
+ * equals `totalReceived`.
+ */
+export interface LogSpansResult {
+  totalReceived: number;
+  totalQueued: number;
+}
+
+const MAX_ERRORS_TO_SHOW = 5;
+
+function formatLogSpansErrorMessage({
+  invalidSpans,
+  duplicateSpans,
+}: {
+  invalidSpans: InvalidSpanInfo[];
+  duplicateSpans: DuplicateSpanInfo[];
+}): string {
+  const parts: string[] = [];
+
+  if (invalidSpans.length > 0) {
+    parts.push(`Failed to queue ${invalidSpans.length} invalid spans:`);
+    for (const span of invalidSpans.slice(0, MAX_ERRORS_TO_SHOW)) {
+      parts.push(`  - Span ${span.spanId}: ${span.error}`);
+    }
+    if (invalidSpans.length > MAX_ERRORS_TO_SHOW) {
+      parts.push(
+        `  ... and ${invalidSpans.length - MAX_ERRORS_TO_SHOW} more invalid spans`
+      );
+    }
+  }
+
+  if (duplicateSpans.length > 0) {
+    if (parts.length > 0) parts.push("");
+    parts.push(`Found ${duplicateSpans.length} duplicate spans:`);
+    for (const span of duplicateSpans.slice(0, MAX_ERRORS_TO_SHOW)) {
+      parts.push(`  - Span ${span.spanId}`);
+    }
+    if (duplicateSpans.length > MAX_ERRORS_TO_SHOW) {
+      parts.push(
+        `  ... and ${duplicateSpans.length - MAX_ERRORS_TO_SHOW} more duplicates`
+      );
+    }
+  }
+
+  return parts.join("\n");
+}
+
+function toInvalidSpanInfoList(value: unknown): InvalidSpanInfo[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => {
+    const record = (item ?? {}) as Record<string, unknown>;
+    return {
+      spanId: typeof record.span_id === "string" ? record.span_id : "unknown",
+      traceId:
+        typeof record.trace_id === "string" ? record.trace_id : "unknown",
+      error:
+        typeof record.error === "string" ? record.error : "Validation error",
+    };
+  });
+}
+
+function toDuplicateSpanInfoList(value: unknown): DuplicateSpanInfo[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => {
+    const record = (item ?? {}) as Record<string, unknown>;
+    return {
+      spanId: typeof record.span_id === "string" ? record.span_id : "unknown",
+      traceId:
+        typeof record.trace_id === "string" ? record.trace_id : "unknown",
+    };
+  });
+}
+
+/**
+ * Builds a {@link SpanCreationError} from a parsed error payload matching the
+ * shape returned by the server for invalid/duplicate spans:
+ * `{ total_received, total_queued, total_invalid, total_duplicates, invalid_spans, duplicate_spans }`.
+ */
+function buildSpanCreationError(
+  payload: Record<string, unknown>
+): SpanCreationError {
+  const invalidSpans = toInvalidSpanInfoList(payload.invalid_spans);
+  const duplicateSpans = toDuplicateSpanInfoList(payload.duplicate_spans);
+
+  return new SpanCreationError({
+    message: formatLogSpansErrorMessage({ invalidSpans, duplicateSpans }),
+    invalidSpans,
+    duplicateSpans,
+    totalReceived:
+      typeof payload.total_received === "number" ? payload.total_received : 0,
+    totalQueued:
+      typeof payload.total_queued === "number" ? payload.total_queued : 0,
+  });
+}
+
+function isSpanCreationErrorPayload(
+  value: unknown
+): value is Record<string, unknown> {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    ("invalid_spans" in value || "duplicate_spans" in value)
+  );
+}
+
+/**
+ * Extracts invalid span info from a FastAPI request-validation error array
+ * (returned with a 422 status when a span in the payload is malformed).
+ */
+function extractInvalidSpansFromValidationErrors(
+  errors: unknown[],
+  spans: Span[]
+): InvalidSpanInfo[] {
+  const invalidSpans: InvalidSpanInfo[] = [];
+
+  for (const rawError of errors) {
+    if (!rawError || typeof rawError !== "object") continue;
+    const loc = (rawError as { loc?: unknown }).loc;
+    if (
+      !Array.isArray(loc) ||
+      loc.length < 3 ||
+      loc[0] !== "body" ||
+      loc[1] !== "data" ||
+      typeof loc[2] !== "number"
+    ) {
+      continue;
+    }
+
+    const span = spans[loc[2]];
+    if (!span) continue;
+
+    const msg = (rawError as { msg?: unknown }).msg;
+    invalidSpans.push({
+      spanId: span.context?.span_id ?? "unknown",
+      traceId: span.context?.trace_id ?? "unknown",
+      error: typeof msg === "string" ? msg : "Validation error",
+    });
+  }
+
+  return invalidSpans;
+}
+
+function parseLogSpansError(error: unknown, spans: Span[]): Error {
+  if (error && typeof error === "object") {
+    const detail = (error as { detail?: unknown }).detail;
+
+    if (typeof detail === "string") {
+      try {
+        const parsed = JSON.parse(detail);
+        if (isSpanCreationErrorPayload(parsed)) {
+          return buildSpanCreationError(parsed);
+        }
+      } catch {
+        // detail wasn't JSON-encoded; fall through to the generic error below
+      }
+    } else if (Array.isArray(detail)) {
+      const invalidSpans = extractInvalidSpansFromValidationErrors(
+        detail,
+        spans
+      );
+      if (invalidSpans.length > 0) {
+        return new SpanCreationError({
+          message: formatLogSpansErrorMessage({
+            invalidSpans,
+            duplicateSpans: [],
+          }),
+          invalidSpans,
+          totalReceived: spans.length,
+          totalQueued: spans.length - invalidSpans.length,
+        });
+      }
+    } else if (isSpanCreationErrorPayload(error)) {
+      return buildSpanCreationError(error as Record<string, unknown>);
+    }
+  }
+
+  return new Error(`Failed to log spans: ${formatApiError(error)}`);
+}
+
+/**
+ * Log spans to a project using Phoenix's simplified span structure.
+ *
+ * If any span in the request is invalid or a duplicate of a span that already
+ * exists, none of the spans in the request are queued and a
+ * {@link SpanCreationError} is thrown with details about the failures.
+ *
+ * @experimental this function is experimental and may change in the future
+ *
+ * @param params - The parameters to log spans
+ * @returns Statistics about the operation. When successful, `totalQueued`
+ * equals `totalReceived`.
+ *
+ * @example
+ * ```ts
+ * const result = await logSpans({
+ *   project: { projectName: "my-project" },
+ *   spans: [
+ *     {
+ *       name: "test",
+ *       context: { trace_id: "123", span_id: "456" },
+ *       span_kind: "CHAIN",
+ *       start_time: "2024-01-01T00:00:00Z",
+ *       end_time: "2024-01-01T00:00:01Z",
+ *       status_code: "OK",
+ *     },
+ *   ],
+ * });
+ * console.log(`Queued ${result.totalQueued} spans`);
+ * ```
+ */
+export async function logSpans({
+  client: _client,
+  project,
+  spans,
+}: LogSpansParams): Promise<LogSpansResult> {
+  const client = _client ?? createClient();
+  const projectIdentifier = resolveProjectIdentifier(project);
+
+  const { data, error } = await client.POST(
+    "/v1/projects/{project_identifier}/spans",
+    {
+      params: {
+        path: {
+          project_identifier: projectIdentifier,
+        },
+      },
+      body: {
+        data: spans,
+      },
+    }
+  );
+
+  if (error) {
+    throw parseLogSpansError(error, spans);
+  }
+
+  return {
+    totalReceived: data?.total_received ?? spans.length,
+    totalQueued: data?.total_queued ?? 0,
+  };
+}

--- a/js/packages/phoenix-client/src/spans/logSpans.ts
+++ b/js/packages/phoenix-client/src/spans/logSpans.ts
@@ -4,6 +4,8 @@ import type { ClientFn } from "../types/core";
 import type { ProjectIdentifier } from "../types/projects";
 import { resolveProjectIdentifier } from "../types/projects";
 import { formatApiError } from "../utils/apiErrorUtils";
+import { isObject } from "../utils/isObject";
+import { safelyParseJSON } from "../utils/safelyParseJSON";
 
 type CreateSpansRequestData =
   paths["/v1/projects/{project_identifier}/spans"]["post"]["requestBody"]["content"]["application/json"]["data"];
@@ -38,8 +40,6 @@ export class SpanCreationError extends Error {
   readonly duplicateSpans: DuplicateSpanInfo[];
   readonly totalReceived: number;
   readonly totalQueued: number;
-  readonly totalInvalid: number;
-  readonly totalDuplicates: number;
 
   constructor(params: {
     message: string;
@@ -47,8 +47,6 @@ export class SpanCreationError extends Error {
     duplicateSpans?: DuplicateSpanInfo[];
     totalReceived?: number;
     totalQueued?: number;
-    totalInvalid?: number;
-    totalDuplicates?: number;
   }) {
     super(params.message);
     this.name = "SpanCreationError";
@@ -56,8 +54,16 @@ export class SpanCreationError extends Error {
     this.duplicateSpans = params.duplicateSpans ?? [];
     this.totalReceived = params.totalReceived ?? 0;
     this.totalQueued = params.totalQueued ?? 0;
-    this.totalInvalid = params.totalInvalid ?? this.invalidSpans.length;
-    this.totalDuplicates = params.totalDuplicates ?? this.duplicateSpans.length;
+  }
+
+  /** Number of spans rejected as invalid. */
+  get totalInvalid(): number {
+    return this.invalidSpans.length;
+  }
+
+  /** Number of spans rejected as duplicates. */
+  get totalDuplicates(): number {
+    return this.duplicateSpans.length;
   }
 }
 
@@ -119,14 +125,23 @@ function formatLogSpansErrorMessage({
   return parts.join("\n");
 }
 
+function toSpanIdAndTraceId(item: unknown): {
+  spanId: string;
+  traceId: string;
+} {
+  const record = isObject(item) ? (item as Record<string, unknown>) : {};
+  return {
+    spanId: typeof record.span_id === "string" ? record.span_id : "unknown",
+    traceId: typeof record.trace_id === "string" ? record.trace_id : "unknown",
+  };
+}
+
 function toInvalidSpanInfoList(value: unknown): InvalidSpanInfo[] {
   if (!Array.isArray(value)) return [];
   return value.map((item) => {
-    const record = (item ?? {}) as Record<string, unknown>;
+    const record = isObject(item) ? (item as Record<string, unknown>) : {};
     return {
-      spanId: typeof record.span_id === "string" ? record.span_id : "unknown",
-      traceId:
-        typeof record.trace_id === "string" ? record.trace_id : "unknown",
+      ...toSpanIdAndTraceId(item),
       error:
         typeof record.error === "string" ? record.error : "Validation error",
     };
@@ -135,13 +150,22 @@ function toInvalidSpanInfoList(value: unknown): InvalidSpanInfo[] {
 
 function toDuplicateSpanInfoList(value: unknown): DuplicateSpanInfo[] {
   if (!Array.isArray(value)) return [];
-  return value.map((item) => {
-    const record = (item ?? {}) as Record<string, unknown>;
-    return {
-      spanId: typeof record.span_id === "string" ? record.span_id : "unknown",
-      traceId:
-        typeof record.trace_id === "string" ? record.trace_id : "unknown",
-    };
+  return value.map(toSpanIdAndTraceId);
+}
+
+/**
+ * Builds a {@link SpanCreationError} from already-normalized invalid/duplicate
+ * span lists, computing the shared message once.
+ */
+function makeSpanCreationError(params: {
+  invalidSpans: InvalidSpanInfo[];
+  duplicateSpans: DuplicateSpanInfo[];
+  totalReceived: number;
+  totalQueued: number;
+}): SpanCreationError {
+  return new SpanCreationError({
+    message: formatLogSpansErrorMessage(params),
+    ...params,
   });
 }
 
@@ -153,13 +177,9 @@ function toDuplicateSpanInfoList(value: unknown): DuplicateSpanInfo[] {
 function buildSpanCreationError(
   payload: Record<string, unknown>
 ): SpanCreationError {
-  const invalidSpans = toInvalidSpanInfoList(payload.invalid_spans);
-  const duplicateSpans = toDuplicateSpanInfoList(payload.duplicate_spans);
-
-  return new SpanCreationError({
-    message: formatLogSpansErrorMessage({ invalidSpans, duplicateSpans }),
-    invalidSpans,
-    duplicateSpans,
+  return makeSpanCreationError({
+    invalidSpans: toInvalidSpanInfoList(payload.invalid_spans),
+    duplicateSpans: toDuplicateSpanInfoList(payload.duplicate_spans),
     totalReceived:
       typeof payload.total_received === "number" ? payload.total_received : 0,
     totalQueued:
@@ -171,9 +191,7 @@ function isSpanCreationErrorPayload(
   value: unknown
 ): value is Record<string, unknown> {
   return (
-    !!value &&
-    typeof value === "object" &&
-    ("invalid_spans" in value || "duplicate_spans" in value)
+    isObject(value) && ("invalid_spans" in value || "duplicate_spans" in value)
   );
 }
 
@@ -188,7 +206,7 @@ function extractInvalidSpansFromValidationErrors(
   const invalidSpans: InvalidSpanInfo[] = [];
 
   for (const rawError of errors) {
-    if (!rawError || typeof rawError !== "object") continue;
+    if (!isObject(rawError)) continue;
     const loc = (rawError as { loc?: unknown }).loc;
     if (
       !Array.isArray(loc) ||
@@ -215,17 +233,13 @@ function extractInvalidSpansFromValidationErrors(
 }
 
 function parseLogSpansError(error: unknown, spans: Span[]): Error {
-  if (error && typeof error === "object") {
+  if (isObject(error)) {
     const detail = (error as { detail?: unknown }).detail;
 
     if (typeof detail === "string") {
-      try {
-        const parsed = JSON.parse(detail);
-        if (isSpanCreationErrorPayload(parsed)) {
-          return buildSpanCreationError(parsed);
-        }
-      } catch {
-        // detail wasn't JSON-encoded; fall through to the generic error below
+      const { json: parsed } = safelyParseJSON(detail);
+      if (isSpanCreationErrorPayload(parsed)) {
+        return buildSpanCreationError(parsed);
       }
     } else if (Array.isArray(detail)) {
       const invalidSpans = extractInvalidSpansFromValidationErrors(
@@ -233,18 +247,15 @@ function parseLogSpansError(error: unknown, spans: Span[]): Error {
         spans
       );
       if (invalidSpans.length > 0) {
-        return new SpanCreationError({
-          message: formatLogSpansErrorMessage({
-            invalidSpans,
-            duplicateSpans: [],
-          }),
+        return makeSpanCreationError({
           invalidSpans,
+          duplicateSpans: [],
           totalReceived: spans.length,
           totalQueued: spans.length - invalidSpans.length,
         });
       }
     } else if (isSpanCreationErrorPayload(error)) {
-      return buildSpanCreationError(error as Record<string, unknown>);
+      return buildSpanCreationError(error);
     }
   }
 

--- a/js/packages/phoenix-client/test/spans/logSpans.test.ts
+++ b/js/packages/phoenix-client/test/spans/logSpans.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Span } from "../../src/spans/logSpans";
+import { logSpans, SpanCreationError } from "../../src/spans/logSpans";
+
+// Mock the fetch module with an inspectable mock
+const mockPost = vi.fn();
+vi.mock("openapi-fetch", () => ({
+  default: () => ({
+    POST: mockPost,
+    use: () => {},
+  }),
+}));
+
+const testSpan: Span = {
+  name: "test-span",
+  context: {
+    trace_id: "trace-123",
+    span_id: "span-456",
+  },
+  span_kind: "CHAIN",
+  start_time: "2024-01-01T00:00:00Z",
+  end_time: "2024-01-01T00:00:01Z",
+  status_code: "OK",
+};
+
+describe("logSpans", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("logs spans to a project by name", async () => {
+    mockPost.mockResolvedValue({
+      data: { total_received: 1, total_queued: 1 },
+      error: null,
+    });
+
+    const result = await logSpans({
+      project: { projectName: "my-project" },
+      spans: [testSpan],
+    });
+
+    expect(result).toEqual({ totalReceived: 1, totalQueued: 1 });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/v1/projects/{project_identifier}/spans",
+      {
+        params: { path: { project_identifier: "my-project" } },
+        body: { data: [testSpan] },
+      }
+    );
+  });
+
+  it("resolves a project identifier passed via `project`", async () => {
+    mockPost.mockResolvedValue({
+      data: { total_received: 1, total_queued: 1 },
+      error: null,
+    });
+
+    await logSpans({
+      project: { project: "some-id-or-name" },
+      spans: [testSpan],
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/v1/projects/{project_identifier}/spans",
+      expect.objectContaining({
+        params: { path: { project_identifier: "some-id-or-name" } },
+      })
+    );
+  });
+
+  it("throws a SpanCreationError with parsed details on a 400 response", async () => {
+    const errorDetail = {
+      error: "Request contains invalid or duplicate spans",
+      total_received: 2,
+      total_queued: 0,
+      total_duplicates: 1,
+      total_invalid: 1,
+      duplicate_spans: [{ span_id: "dup-1", trace_id: "trace-1" }],
+      invalid_spans: [
+        { span_id: "bad-1", trace_id: "trace-2", error: "bad span_kind" },
+      ],
+    };
+    mockPost.mockResolvedValue({
+      data: null,
+      error: { detail: JSON.stringify(errorDetail) },
+    });
+
+    let thrown: unknown;
+    try {
+      await logSpans({
+        project: { projectName: "my-project" },
+        spans: [testSpan, testSpan],
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(SpanCreationError);
+    const err = thrown as SpanCreationError;
+    expect(err.totalReceived).toBe(2);
+    expect(err.totalQueued).toBe(0);
+    expect(err.totalInvalid).toBe(1);
+    expect(err.totalDuplicates).toBe(1);
+    expect(err.invalidSpans).toEqual([
+      { spanId: "bad-1", traceId: "trace-2", error: "bad span_kind" },
+    ]);
+    expect(err.duplicateSpans).toEqual([
+      { spanId: "dup-1", traceId: "trace-1" },
+    ]);
+    expect(err.message).toContain("Failed to queue 1 invalid spans");
+    expect(err.message).toContain("Found 1 duplicate spans");
+  });
+
+  it("throws a SpanCreationError parsed from a 422 validation error array", async () => {
+    mockPost.mockResolvedValue({
+      data: null,
+      error: {
+        detail: [
+          {
+            loc: ["body", "data", 0],
+            msg: "field required",
+            type: "value_error.missing",
+          },
+        ],
+      },
+    });
+
+    let thrown: unknown;
+    try {
+      await logSpans({
+        project: { projectName: "my-project" },
+        spans: [testSpan],
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(SpanCreationError);
+    const err = thrown as SpanCreationError;
+    expect(err.totalReceived).toBe(1);
+    expect(err.totalQueued).toBe(0);
+    expect(err.invalidSpans).toEqual([
+      { spanId: "span-456", traceId: "trace-123", error: "field required" },
+    ]);
+  });
+
+  it("throws a generic error for unrecognized error shapes", async () => {
+    mockPost.mockResolvedValue({
+      data: null,
+      error: { status: 500, message: "Internal Server Error" },
+    });
+
+    await expect(
+      logSpans({
+        project: { projectName: "my-project" },
+        spans: [testSpan],
+      })
+    ).rejects.toThrow("Failed to log spans:");
+  });
+});

--- a/js/packages/phoenix-client/test/spans/logSpans.test.ts
+++ b/js/packages/phoenix-client/test/spans/logSpans.test.ts
@@ -113,12 +113,14 @@ describe("logSpans", () => {
   });
 
   it("throws a SpanCreationError parsed from a 422 validation error array", async () => {
+    // Only the span at index 1 is flagged, but a FastAPI 422 rejects the
+    // entire request body, so totalQueued must be 0 (all-or-nothing contract).
     mockPost.mockResolvedValue({
       data: null,
       error: {
         detail: [
           {
-            loc: ["body", "data", 0],
+            loc: ["body", "data", 1],
             msg: "field required",
             type: "value_error.missing",
           },
@@ -126,11 +128,17 @@ describe("logSpans", () => {
       },
     });
 
+    const spans: Span[] = [
+      { ...testSpan, context: { trace_id: "trace-1", span_id: "span-1" } },
+      { ...testSpan, context: { trace_id: "trace-2", span_id: "span-2" } },
+      { ...testSpan, context: { trace_id: "trace-3", span_id: "span-3" } },
+    ];
+
     let thrown: unknown;
     try {
       await logSpans({
         project: { projectName: "my-project" },
-        spans: [testSpan],
+        spans,
       });
     } catch (e) {
       thrown = e;
@@ -138,10 +146,10 @@ describe("logSpans", () => {
 
     expect(thrown).toBeInstanceOf(SpanCreationError);
     const err = thrown as SpanCreationError;
-    expect(err.totalReceived).toBe(1);
+    expect(err.totalReceived).toBe(3);
     expect(err.totalQueued).toBe(0);
     expect(err.invalidSpans).toEqual([
-      { spanId: "span-456", traceId: "trace-123", error: "field required" },
+      { spanId: "span-2", traceId: "trace-2", error: "field required" },
     ]);
   });
 


### PR DESCRIPTION
resolves #13970
- Adds `logSpans` to `@arizeai/phoenix-client/spans`, mirroring the Python client's `Spans.log_spans()` for submitting spans via Phoenix's simplified JSON span structure (`POST /v1/projects/{project_identifier}/spans`). The `spans` param accepts the same shape returned by the existing `getSpans`, so spans can be read from one project and logged into another.
- Adds a `SpanCreationError` (with `invalidSpans`/`duplicateSpans`/`totalReceived`/`totalQueued` details) thrown when the server rejects invalid or duplicate spans, parsed from both the 400 (invalid/duplicate) and 422 (request validation) error responses — mirroring the Python client's `SpanCreationError`.