### PR TITLE
fix(client): include PHOENIX_HOST_ROOT_PATH in default get_base_url()

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/utils/config.py
+++ b/packages/phoenix-client/src/phoenix/client/utils/config.py
@@ -69,7 +69,9 @@ def get_base_url() -> httpx.URL:
     host: str = get_env_host()
     if host == "0.0.0.0":
         host = "127.0.0.1"
-    base_url: str = get_env_collector_endpoint() or f"http://{host}:{get_env_port()}"
+    base_url: str = get_env_collector_endpoint() or (
+        f"http://{host}:{get_env_port()}{get_env_host_root_path()}"
+    )
     return httpx.URL(base_url)
 
 

--- a/packages/phoenix-client/tests/client/utils/test_config.py
+++ b/packages/phoenix-client/tests/client/utils/test_config.py
@@ -25,3 +25,22 @@ from phoenix.client.utils.config import get_env_collector_endpoint
 def test_get_env_collector_endpoint(env: dict[str, str], expected: Optional[str]) -> None:
     with patch.dict(os.environ, env, clear=True):
         assert get_env_collector_endpoint() == expected
+
+
+from phoenix.client.utils.config import get_base_url
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    [
+        ({"PHOENIX_HOST": "example.com", "PHOENIX_PORT": "6006"}, "http://example.com:6006"),
+        (
+            {"PHOENIX_HOST": "example.com", "PHOENIX_PORT": "6006", "PHOENIX_HOST_ROOT_PATH": "/phoenix"},
+            "http://example.com:6006/phoenix",
+        ),
+        ({}, "http://127.0.0.1:6006"),  # HOST=0.0.0.0 is converted to 127.0.0.1
+    ],
+)
+def test_get_base_url_includes_root_path(env: dict[str, str], expected: str) -> None:
+    with patch.dict(os.environ, env, clear=True):
+        assert str(get_base_url()) == expected


### PR DESCRIPTION
## Summary

Fixes #13770.

When `PHOENIX_HOST_ROOT_PATH` is set (e.g. the server is mounted behind a reverse proxy at `/phoenix`), the default client `base_url` derived from `PHOENIX_HOST` + `PHOENIX_PORT` did not include the root path. All client requests then hit the origin root instead of the sub-path.

### Root cause

`get_base_url()` in `packages/phoenix-client/src/phoenix/client/utils/config.py` builds:
```python
base_url = get_env_collector_endpoint() or f"http://{host}:{get_env_port()}"
```
but never calls `get_env_host_root_path()`. The server-side helper `get_env_root_url()` in `src/phoenix/config.py` does append the root path, making the behaviour inconsistent.

### Fix

Append `get_env_host_root_path()` to the fallback host+port URL:
```python
base_url = get_env_collector_endpoint() or (
    f"http://{host}:{get_env_port()}{get_env_host_root_path()}"
)
```

`get_env_host_root_path()` already validates leading/trailing slashes and returns `""` when the env var is unset, so the change is backward-compatible.

### Tests

Added `test_get_base_url_includes_root_path` parametrized over:
- no root path (baseline unchanged)
- `PHOENIX_HOST_ROOT_PATH=/phoenix` (new case)
- default host/port (ensures 0.0.0.0 → 127.0.0.1 conversion still works)