### PR TITLE
docs(skills): weekly audit — 2026-07-01

### DIFF
--- a/.agents/skills/phoenix-tracing/references/instrumentation-manual-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/instrumentation-manual-typescript.md
@@ -20,12 +20,22 @@ register({ projectName: "my-app" });
 | CHAIN | `traceChain` | Workflows, pipelines, orchestration |
 | AGENT | `traceAgent` | Multi-step reasoning, planning |
 | TOOL | `traceTool` | External APIs, function calls |
-| RETRIEVER | `withSpan` | Vector search, document retrieval |
-| LLM | `withSpan` | LLM API calls (prefer auto-instrumentation) |
-| EMBEDDING | `withSpan` | Embedding generation |
-| RERANKER | `withSpan` | Document re-ranking |
-| GUARDRAIL | `withSpan` | Safety checks, content moderation |
-| EVALUATOR | `withSpan` | LLM evaluation |
+| LLM | `traceLLM` | LLM API calls (prefer auto-instrumentation) |
+| RETRIEVER | `traceRetriever` | Vector search, document retrieval |
+| RERANKER | `traceReranker` | Document re-ranking |
+| EMBEDDING | `traceEmbedding` | Embedding generation |
+| GUARDRAIL | `traceGuardrail` | Safety checks, content moderation |
+| EVALUATOR | `traceEvaluator` | LLM evaluation |
+| PROMPT | `tracePrompt` | Prompt construction, rendering, templating |
+
+Every OpenInference span kind has a matching wrapper. Each `trace*` wrapper is a
+shorthand for `withSpan(fn, { ...options, kind })` with `kind` pre-set, so it takes
+the same options *except* `kind`. Reach for `withSpan` directly only when you want
+`processInput`/`processOutput` to build richer attributes than the default
+JSON-serialized `input.value`/`output.value`. All wrappers are re-exported from
+`@arizeai/phoenix-otel` as well as `@arizeai/openinference-core`. The kind-specific
+wrappers beyond `traceChain`/`traceAgent`/`traceTool` are marked `@experimental` in
+`@arizeai/openinference-core`.
 
 ## Convenience Wrappers
 
@@ -57,7 +67,37 @@ const getWeather = traceTool(
 );
 ```
 
-## withSpan for Other Kinds
+The remaining span kinds have dedicated wrappers too — same call shape, `kind`
+pre-set:
+
+```typescript
+import {
+  traceLLM,
+  traceRetriever,
+  traceReranker,
+  traceEmbedding,
+  traceGuardrail,
+  traceEvaluator,
+  tracePrompt,
+} from "@arizeai/openinference-core"; // also re-exported from @arizeai/phoenix-otel
+
+// RETRIEVER - fetch documents (RAG)
+const retrieveDocuments = traceRetriever(
+  async (query: string) => vectorStore.similaritySearch(query, 5),
+  { name: "vector-search" }
+);
+
+// EVALUATOR - score output quality (LLM-as-a-judge)
+const evaluateAnswer = traceEvaluator(
+  async (question: string, answer: string) => judge.score({ question, answer }),
+  { name: "answer-evaluation" }
+);
+```
+
+## withSpan for Custom Attributes
+
+When the default JSON-serialized I/O isn't enough, drop to `withSpan` (or pass
+`processInput`/`processOutput` to any `trace*` wrapper) to build richer attributes:
 
 ```typescript
 import { withSpan, getInputAttributes, getRetrieverAttributes } from "@arizeai/openinference-core";


### PR DESCRIPTION
# Phoenix Skills Audit — 2026-06-24 → 2026-07-01 (last 7 days)

**Audited against:** `origin/main` at `1151885bffdbec3a0d05342ff4625663bca56be1`
**Commits analyzed:** 71 (1 skill edit applied, 8 user-facing candidates verified as already-covered or non-public, 62 skipped)

## Edits applied

### phoenix-tracing
- `references/instrumentation-manual-typescript.md` — documented the seven new
  OpenInference span-kind wrappers (`traceLLM`, `traceRetriever`, `traceReranker`,
  `traceEmbedding`, `traceGuardrail`, `traceEvaluator`, `tracePrompt`) added in
  `@arizeai/openinference-core` 2.4.0 and re-exported by `@arizeai/phoenix-otel`
  (commit `506011536`).
  - **What was stale:** the Quick Reference table mapped RETRIEVER / LLM / EMBEDDING /
    RERANKER / GUARDRAIL / EVALUATOR to `withSpan` (the old workaround). Those kinds now
    have dedicated `trace*` wrappers, so the table taught the wrong idiom.
  - Updated the table to point each kind at its wrapper, added a PROMPT row, added an
    import + usage example block for the new wrappers, and reframed the `withSpan`
    section as "for Custom Attributes" (its actual remaining purpose).
  - **Grounding:** wrapper names and re-export verified against
    `js/packages/phoenix-otel/test/openinference.test.ts:4-21,58-78` (asserts all ten
    wrappers are exported from `../src`, i.e. `@arizeai/phoenix-otel`). Example call
    shapes mirror the verified example in `js/packages/phoenix-otel/README.md` and the
    committed `examples/tracing_wrappers_example.ts`. Marked `@experimental` per the
    commit body.

## Verified — user-facing, but already reflected or no skill impact (no edit)

- **`524471807` feat(js): add CI eval testing API to phoenix-client** — already covered
  by `phoenix-evals/references/integrations-vitest-jest.md` (added/refined in-window by
  `071aa66d7`, `d22579333`, `f9b5abcd5`, `5965566b6`, `1151885bf`). Spot-checked:
  `px.logAnnotation` signature and `PHOENIX_TEST_TRACKING` env var match the shipped code.
- **`6ebe82cb9` feat(phoenix-client): add pytest plugin for eval CI** — already covered
  by `phoenix-evals/references/integrations-pytest.md`. Verified verbatim against the
  plugin: `log_output` / `log_evaluation` / `evaluate` are the public exports of
  `phoenix.client.pytest` (`__init__.py:21-23`); env vars `PHOENIX_TEST_TRACKING`,
  `PHOENIX_TEST_REPETITIONS`, `PHOENIX_TEST_DATASET` and marker args
  (`dataset`/`evaluators`/`repetitions`) match `pytest/config.py` and `pytest/marker.py`.
- **`a027adae5` refactor(js): rename PHOENIX_TEST_TRACING → PHOENIX_TEST_TRACKING** —
  skills already use the new name; no stale `PHOENIX_TEST_TRACING` remains anywhere under
  `.agents/skills/`.
- **`7afa18317` fix(js): PHOENIX_TEST_TRACKING=false reliably disables recording** —
  behavior already documented correctly in both integration references (dry-run rows).
- **`f123759e8` docs(phoenix-client): correct create_evaluator 2-tuple scorer docs** —
  the corrected 2-tuple/3-tuple return convention
  (`experiments/evaluators.py:180-181`) is not surfaced anywhere in the evals skill
  (the skill's experiment evaluators return plain floats), so nothing to update.
- **`c629b70cd` fix: preserve generator inputs in create_dataset / add_examples_to_dataset**
  — a behavior fix; the skill only documents list/DataFrame inputs to `create_dataset`
  (`experiments-datasets-python.md`), so no documented surface changed.
- **`05582a132` feat(ui): add annotation summary to project settings** — the touched
  `packages/phoenix-client/.../experiments/__init__.py` change is comment cleanup only,
  no public method/param change. The new `deleteProjectAnnotations` GraphQL mutation is
  a UI/project-level bulk delete with no CLI wrapper, so out of scope for phoenix-cli.
- **`74ffd6680` fix: preserve empty JSON object attributes in load_json_strings** —
  `load_json_strings` is an internal server-side span helper (not exported from any
  public `__init__.py`); no SDK-facing surface.

## Skipped commits

- **Feature / behavior changes belonging to other surfaces (not the 3 skills):**
  - `75254027a` feat(playground): add Claude Sonnet 5 — playground server, not a
    client/CLI/tracing surface.
  - `9bacd3398`, `0ab1b71ac`, `64d914e40`, `41b92c3c0`, `6e93f93d0`, `d261c8f8d`,
    `a488b4046`, `52d8c171a`, `4de402a61`, `bc55be9d7`, `71bec3c07`, `cacbbd41c` —
    server-side agents / PXI agent endpoint / frontend agent-chat internals.
  - `fc0e5f8f7` (async-client timeout parity) and `c8ec4b54a` (ATIF field validation)
    — internal robustness fixes in phoenix-client with no documented-surface change.
  - `0f8a65aac` (retention SQL), `afcc867b3` / `f37e8dc57` (cost manifest data) — server
    internals / data.
- **PXI TUI commits (see Out-of-scope findings):** `70246e989`, `6e6844c23`, `5db8ae8a4`,
  `128277716`, `314e7c500`, `a843aa9c5`, `f3809ed4f`, `6240c1350`.
- **Docs-only** (already self-contained; the eval-integration ones also directly patched
  the evals skill in-window): `1151885bf`, `5965566b6`, `f9b5abcd5`, `d22579333`,
  `071aa66d7`, `5325e6e83`, `65fde3753`, `b118eba44`, `fa22eeef2`, `797abe637`,
  `a8bf8e656`, `1b28981b9`, `7efabf6f7`, `506011536` (docs half — skill half applied above).
- **Deps / release / CI / chore / sitemap:** `209d065b5`, `97937f1a8`, `b932e699c`,
  `01d8bf44f`, `0207b65a5`, `6afc11f65`, `a77194cef`, `5b05e6dfe`, `2034158e5`,
  `5bc7743b4`, `f74c36282`, `832af9d3b`, `cfddfa6da`, `2912f0627`, `fc1a3df76`,
  `d9a0c0d08`, `c6278975d`, `26132c56c`, `07d0d1659`, `c7ec00d9d`, `5479a671b`,
  `fdf82f179`.
- **PXI eval-harness internal:** `d094a1417`.

## Out-of-scope findings

- **`pxi` interactive TUI (`70246e989` and follow-ups).** `feat(cli): add pxi tui`
  ships a new `pxi` binary from `@arizeai/phoenix-cli` (`package.json` `bin.pxi →
  build/pxi/index.js`) — an interactive, human-facing agent chat TUI, fully documented
  in `docs/phoenix/pxi.mdx`. The `phoenix-cli` skill deliberately teaches
  *non-interactive* `px` resource commands for agent-driven trace debugging (open/axial
  coding); an agent consuming that skill would not drive an interactive TUI, and all the
  in-window `pxi` commits (slash commands, token-usage line, model-name display, prompt
  editing, glyphs, preflight errors) are interactive-UX polish with no scriptable
  JSON-output surface. Left out of the skill intentionally. Flagging so the maintainer
  can decide whether `pxi` deserves its own coverage.

## Python/TS mirror note

- The new span-kind wrappers are a JavaScript `@arizeai/openinference-core` feature
  (function wrappers re-exported by the TS `@arizeai/phoenix-otel`). There is **no
  Python mirror** in this window — Python OpenInference uses a different idiom
  (`tracer.*` decorators / span-kind context managers), so the tracing edit is
  correctly TS-only. No change to `instrumentation-manual-python.md`.
