### PR TITLE
fix(storybook): disable Rolldown's lazyBarrel experiment to fix the Chromatic build

### DIFF
--- a/app/.storybook/main.ts
+++ b/app/.storybook/main.ts
@@ -34,17 +34,17 @@ const config: StorybookConfig = {
       },
       build: {
         rolldownOptions: {
-          output: {
-            manualChunks(id) {
-              if (
-                id.includes("/node_modules/.pnpm/shiki@") ||
-                id.includes("/node_modules/.pnpm/@shikijs+") ||
-                id.includes("/node_modules/.pnpm/@streamdown+code@") ||
-                id.includes("/node_modules/.pnpm/streamdown@")
-              ) {
-                return "streamdown-shiki";
-              }
-            },
+          experimental: {
+            // Rolldown's `lazyBarrel` optimization (on by default in the
+            // rolldown 1.1.3 that vite 8.1.0 locks) miscompiles shiki's
+            // deeply-nested `export *` re-export chains: emitted chunks call
+            // the `__reExport` helper with no definition in scope, which
+            // crashes the published Storybook when Chromatic verifies it.
+            // Shiki is pulled in via @streamdown/code and @pierre/diffs.
+            // Remove once the lockfile resolves rolldown >= 1.1.4, which
+            // turns the experiment off by default; see
+            // https://github.com/rolldown/rolldown/issues/9806.
+            lazyBarrel: false,
           },
         },
       },

--- a/app/.storybook/preview-head.html
+++ b/app/.storybook/preview-head.html
@@ -8,41 +8,4 @@
   window.Config = {
     basename: "",
   };
-
-  // Vite 8/Rolldown can reference these helpers from generated Storybook
-  // chunks without binding them. Keep the workaround scoped to Storybook.
-  window.__exportAll =
-    window.__exportAll ||
-    ((all, noSymbols) => {
-      const target = {};
-      for (const name in all) {
-        Object.defineProperty(target, name, {
-          get: all[name],
-          enumerable: true,
-        });
-      }
-      if (!noSymbols) {
-        Object.defineProperty(target, Symbol.toStringTag, { value: "Module" });
-      }
-      return target;
-    });
-  window.__reExport =
-    window.__reExport ||
-    ((target, mod, except) => {
-      if (mod && (typeof mod === "object" || typeof mod === "function")) {
-        for (const key of Object.getOwnPropertyNames(mod)) {
-          if (
-            !Object.prototype.hasOwnProperty.call(target, key) &&
-            key !== except
-          ) {
-            const descriptor = Object.getOwnPropertyDescriptor(mod, key);
-            Object.defineProperty(target, key, {
-              get: () => mod[key],
-              enumerable: !descriptor || descriptor.enumerable,
-            });
-          }
-        }
-      }
-      return target;
-    });
 </script>


### PR DESCRIPTION
## Problem

The published Storybook crashed when Chromatic verified it: generated chunks called Rolldown's `__reExport` helper with no definition anywhere in scope (`ReferenceError` at runtime in `DiffAcceptRejectToolDetails-*.js`, which pulls in shiki via `@streamdown/code` and `@pierre/diffs`).

## Root cause

Rolldown's **experimental `lazyBarrel` optimization** (on by default in `rolldown@1.1.3`, which `vite@8.1.0` locks) miscompiles shiki's deeply-nested `export *` re-export chains — rolldown/rolldown#9806. Rolldown **1.1.4** turns the experiment off by default, so the override added here can be deleted once the lockfile resolves `rolldown >= 1.1.4`.

## Fix

One config line in `.storybook/main.ts`:

```ts
build: { rolldownOptions: { experimental: { lazyBarrel: false } } }
```

This fixes the crash at the source and lets us **remove the two workarounds that had stacked up** for the same bug:

- the `manualChunks` block from #13823 that forced shiki/streamdown into a single chunk
- the `window.__reExport` / `window.__exportAll` shims in `preview-head.html` from #13823, which would have silently papered over future miscompilations with approximate helper semantics

Earlier iterations of this branch stubbed out `@streamdown/code` / `@pierre/diffs` entirely; that worked but cost Chromatic its real syntax-highlighting and diff-rendering coverage, and required stub maintenance. The lazyBarrel fix keeps the real components in the build.

## Verification

- **Baseline repro**: building without any workaround reproduces orphaned `__reExport` calls in `DiffAcceptRejectToolDetails-*.js`
- With `lazyBarrel: false`: `build-storybook` succeeds and **no chunk contains an orphaned `__reExport`/`__exportAll` call**
- Runtime smoke test on the static build: MarkdownBlock stories render real shiki token highlighting; the previously-miscompiled lazy chunk dynamic-imports cleanly with the shims removed (`window.__reExport === undefined`)
- `tsc --noEmit` and `oxfmt --check` pass