### PR TITLE
fix(app): style run errors in the experiment compare table

### DIFF
--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -20,6 +20,7 @@ import { graphql, usePaginationFragment, usePreloadedQuery } from "react-relay";
 import { useSearchParams } from "react-router";
 
 import {
+  Alert,
   Empty,
   ExpandableContent,
   Flex,
@@ -28,7 +29,6 @@ import {
   Icons,
   Modal,
   ModalOverlay,
-  Text,
   Tooltip,
   TooltipArrow,
   TooltipTrigger,
@@ -846,7 +846,7 @@ function ExperimentRunOutput(
     props;
 
   if (error) {
-    return <RunError error={error} />;
+    return <RunError error={error} height={height} />;
   }
   const annotationsList = annotations?.edges.length
     ? annotations.edges.map((edge) => edge.annotation)
@@ -879,11 +879,14 @@ function ExperimentRunOutput(
   );
 }
 
-function RunError({ error }: { error: string }) {
+function RunError({ error, height }: { error: string; height: number }) {
   return (
-    <Flex direction="row" gap="size-50" alignItems="center">
-      <Icon svg={<Icons.AlertCircle />} color="danger" />
-      <Text color="danger">{error}</Text>
+    <Flex direction="column" height="100%">
+      <ExpandableContent height={height}>
+        <div css={outputContentCSS}>
+          <Alert variant="danger">{error}</Alert>
+        </div>
+      </ExpandableContent>
     </Flex>
   );
 }


### PR DESCRIPTION
## Summary
- Run errors in the experiment compare table (Grid view) previously rendered as plain red text with no padding, flush against the cell edge.
- `RunError` now renders errors with the shared `Alert variant="danger"` component (icon, padding, rounded border/background) wrapped in `ExpandableContent`, matching how normal run output is displayed and padded, and giving long error messages truncate/expand behavior instead of overflowing the cell.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `pnpm run lint` passes with no errors on the changed file
- [ ] Manually verify in the UI: open Datasets & Experiments → an experiment with failed runs → compare table (Grid view) and confirm errors render as a padded danger alert that truncates/expands for long messages


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ts2ipNZqw1rS6F5uykLZMV)_