### PR TITLE
refactor(js): migrate evals benchmarks to Phoenix vitest eval tests

### DIFF
--- a/js/benchmarks/evals-benchmarks/package.json
+++ b/js/benchmarks/evals-benchmarks/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "evals": "vitest run --config phoenix.vitest.config.ts",
-    "evals:local": "PHOENIX_TEST_TRACING=false vitest run --config phoenix.vitest.config.ts",
+    "evals:local": "PHOENIX_TEST_TRACKING=false vitest run --config phoenix.vitest.config.ts",
     "evals:watch": "vitest watch --config phoenix.vitest.config.ts"
   },
   "dependencies": {

--- a/js/benchmarks/evals-benchmarks/package.json
+++ b/js/benchmarks/evals-benchmarks/package.json
@@ -2,11 +2,13 @@
   "name": "evals-benchmarks",
   "version": "1.0.0",
   "private": true,
-  "description": "",
+  "description": "Benchmark suites for the Phoenix evaluators, run as Phoenix eval tests with vitest.",
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "dev": "tsx index.ts"
+    "test": "vitest run --config phoenix.vitest.config.ts",
+    "test:watch": "vitest watch --config phoenix.vitest.config.ts",
+    "test:local": "PHOENIX_TEST_TRACING=false vitest run --config phoenix.vitest.config.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.75",
@@ -15,7 +17,9 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.4",
+    "dotenv": "^16.4.7",
     "tsx": "^4.22.4",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
   }
 }

--- a/js/benchmarks/evals-benchmarks/package.json
+++ b/js/benchmarks/evals-benchmarks/package.json
@@ -6,9 +6,9 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "test": "vitest run --config phoenix.vitest.config.ts",
-    "test:watch": "vitest watch --config phoenix.vitest.config.ts",
-    "test:local": "PHOENIX_TEST_TRACING=false vitest run --config phoenix.vitest.config.ts"
+    "evals": "vitest run --config phoenix.vitest.config.ts",
+    "evals:local": "PHOENIX_TEST_TRACING=false vitest run --config phoenix.vitest.config.ts",
+    "evals:watch": "vitest watch --config phoenix.vitest.config.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.75",

--- a/js/benchmarks/evals-benchmarks/phoenix.vitest.config.ts
+++ b/js/benchmarks/evals-benchmarks/phoenix.vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.eval.?(c|m)[jt]s"],
+    reporters: ["default", "@arizeai/phoenix-client/vitest/reporter"],
+    setupFiles: ["dotenv/config"],
+    // Each case makes at least one LLM-as-a-judge call, so give them room.
+    testTimeout: 60000,
+    // LLM-judge benchmarks are slow; run files concurrently.
+    fileParallelism: true,
+  },
+});

--- a/js/benchmarks/evals-benchmarks/src/aggregateMetrics.ts
+++ b/js/benchmarks/evals-benchmarks/src/aggregateMetrics.ts
@@ -1,0 +1,82 @@
+/**
+ * Suite-level confusion-matrix metrics for the eval benchmarks.
+ *
+ * The per-case `accuracy` gate is blind to class imbalance — a judge that
+ * always predicts the majority label can pass it. Each suite therefore also
+ * accumulates its ground-truth and predicted labels and registers a trailing
+ * test that scores them with macro precision / recall / F1 (annotation names
+ * `precision`, `recall`, `f1`), which the suite gates via `acceptanceCriteria`.
+ *
+ * Tracked upstream: native confusion-matrix acceptance criteria in the
+ * phoenix-client harness would remove the synthetic trailing test —
+ * https://github.com/Arize-ai/phoenix/issues/14020
+ */
+import * as px from "@arizeai/phoenix-client/vitest";
+import { createPrecisionRecallFScoreEvaluators } from "@arizeai/phoenix-evals";
+
+export interface LabelAccumulator {
+  /** Ground-truth labels, one per completed case. */
+  truth: string[];
+  /** Evaluator-under-test predictions, aligned by index with `truth`. */
+  predicted: string[];
+}
+
+/** Creates the accumulator a suite threads through its cases. */
+export function createLabelAccumulator(): LabelAccumulator {
+  return { truth: [], predicted: [] };
+}
+
+/**
+ * Records one case's ground-truth vs predicted label pair.
+ * Skips the case when either side is missing so the sequences stay aligned.
+ *
+ * @param params - the recording parameters
+ * @param params.labels - the suite's accumulator
+ * @param params.truth - the ground-truth label from the example's `expected`
+ * @param params.predicted - the label the evaluator-under-test produced
+ */
+export function recordPrediction({
+  labels,
+  truth,
+  predicted,
+}: {
+  labels: LabelAccumulator;
+  truth: string | undefined;
+  predicted: string | undefined;
+}): void {
+  if (typeof truth !== "string" || typeof predicted !== "string") {
+    return;
+  }
+  labels.truth.push(truth);
+  labels.predicted.push(predicted);
+}
+
+/**
+ * Registers the trailing test that scores the accumulated labels with macro
+ * precision / recall / F1. Call it inside `px.describe` after every
+ * `px.test.each` so it is declared — and therefore runs — last (vitest runs a
+ * file's tests in declaration order).
+ *
+ * @param labels - the suite's accumulator, filled by the preceding cases
+ */
+export function registerAggregateMetricsTest(labels: LabelAccumulator): void {
+  const { precision, recall, fScore } = createPrecisionRecallFScoreEvaluators({
+    average: "macro",
+  });
+  px.test(
+    "aggregate metrics: macro precision/recall/F1 across all cases",
+    {
+      input: {
+        description:
+          "Macro precision/recall/F1 of the evaluator-under-test's labels against the ground truth across every case in this suite",
+      },
+    },
+    async () => {
+      const batch = { expected: labels.truth, output: labels.predicted };
+      px.logOutput(batch);
+      await px.evaluate(precision, batch);
+      await px.evaluate(recall, batch);
+      await px.evaluate(fScore, batch);
+    }
+  );
+}

--- a/js/benchmarks/evals-benchmarks/src/conciseness.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/conciseness.eval.ts
@@ -5,14 +5,14 @@
  * the suite on how accurately the evaluator reproduces the expected labels.
  * Each example becomes a dataset example / experiment run on Phoenix.
  */
-import { openai } from "@ai-sdk/openai";
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createConcisenessEvaluator } from "@arizeai/phoenix-evals";
 
 import { accuracy } from "./evaluators.js";
+import { evalModel, evalModelName } from "./model.js";
 
 const concisenessEvaluator = createConcisenessEvaluator({
-  model: openai("gpt-4o-mini"),
+  model: evalModel,
 });
 
 // Examples designed to test the boundary conditions of the conciseness rubric
@@ -298,7 +298,7 @@ px.describe(
   {
     description:
       "Boundary conditions of the conciseness evaluator rubric across categories: perfectly concise, pleasantries/filler, hedging/qualifiers, meta-commentary, redundant restatements, unsolicited explanations, and edge cases.",
-    metadata: { model: "gpt-4o-mini" },
+    metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
     ],

--- a/js/benchmarks/evals-benchmarks/src/conciseness.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/conciseness.eval.ts
@@ -8,8 +8,17 @@
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createConcisenessEvaluator } from "@arizeai/phoenix-evals";
 
+import {
+  createLabelAccumulator,
+  recordPrediction,
+  registerAggregateMetricsTest,
+} from "./aggregateMetrics.js";
 import { accuracy } from "./evaluators.js";
 import { evalModel, evalModelName } from "./model.js";
+
+// Ground-truth vs predicted labels across cases, scored by the trailing
+// aggregate-metrics test.
+const labels = createLabelAccumulator();
 
 const concisenessEvaluator = createConcisenessEvaluator({
   model: evalModel,
@@ -276,7 +285,7 @@ px.describe(
     px.test.each(cases)(
       (row) =>
         `[${String(row.metadata?.category)}] ${String(row.input.question)}`,
-      async ({ input }) => {
+      async ({ input, expected }) => {
         const result = await concisenessEvaluator.evaluate({
           input: input.question,
           output: input.answer,
@@ -291,9 +300,15 @@ px.describe(
           annotatorKind: "LLM",
         });
         // Score the verdict against the rubric's expected label.
+        recordPrediction({
+          labels,
+          truth: expected?.label,
+          predicted: result.label,
+        });
         await px.evaluate(accuracy);
       }
     );
+    registerAggregateMetricsTest(labels);
   },
   {
     description:
@@ -301,6 +316,7 @@ px.describe(
     metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+      { annotationName: "f1", metric: "average", threshold: 0.7 },
     ],
   }
 );

--- a/js/benchmarks/evals-benchmarks/src/conciseness.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/conciseness.eval.ts
@@ -1,13 +1,15 @@
+/**
+ * Conciseness evaluator benchmark.
+ *
+ * Runs the conciseness evaluator against rubric boundary conditions and gates
+ * the suite on how accurately the evaluator reproduces the expected labels.
+ * Each example becomes a dataset example / experiment run on Phoenix.
+ */
 import { openai } from "@ai-sdk/openai";
-/* eslint-disable no-console */
-import { createDataset } from "@arizeai/phoenix-client/datasets";
-import {
-  asExperimentEvaluator,
-  getExperiment,
-  runExperiment,
-} from "@arizeai/phoenix-client/experiments";
-import type { ExperimentTask } from "@arizeai/phoenix-client/types/experiments";
+import * as px from "@arizeai/phoenix-client/vitest";
 import { createConcisenessEvaluator } from "@arizeai/phoenix-evals";
+
+import { accuracy } from "./evaluators.js";
 
 const concisenessEvaluator = createConcisenessEvaluator({
   model: openai("gpt-4o-mini"),
@@ -254,220 +256,51 @@ const examplesByCategory = {
   ],
 };
 
-// Flatten examples with category information
-const examples = Object.entries(examplesByCategory).flatMap(
+type ConcisenessLabel = "concise" | "verbose";
+
+// One dataset example / experiment run per rubric case. The Q&A pair under
+// test is the task input; the rubric's expected verdict is the reference.
+const cases = Object.entries(examplesByCategory).flatMap(
   ([category, categoryExamples]) =>
     categoryExamples.map((example) => ({
-      ...example,
-      category,
+      input: { question: example.input, answer: example.output },
+      expected: { label: example.expected_label as ConcisenessLabel },
+      metadata: { category },
+      splits: [category],
     }))
 );
 
-// Create dataset entries
-const datasetExamples = examples.map((example, index) => ({
-  input: { question: example.input },
-  output: {
-    answer: example.output,
-    expected_label: example.expected_label,
-  },
-  metadata: {
-    category: example.category,
-    example_index: index,
-  },
-  splits: [example.category],
-}));
-
-type TaskOutput = {
-  expected_label: "concise" | "verbose";
-  label: "concise" | "verbose";
-  score: number;
-  explanation: string;
-  category: string;
-  input: string;
-  output: string;
-};
-
-const accuracyEvaluator = asExperimentEvaluator({
-  name: "accuracy",
-  kind: "CODE",
-  evaluate: async (args) => {
-    const output = args.output as TaskOutput;
-    const score = output.expected_label === output.label ? 1 : 0;
-    const label =
-      output.expected_label === output.label ? "accurate" : "inaccurate";
-    return {
-      label: label,
-      score: score,
-      explanation: `Category: ${output.category}. The evaluator labeled the answer as "${output.label}". Expected: "${output.expected_label}"`,
-      metadata: { category: output.category },
-    };
-  },
-});
-
-async function main() {
-  console.log("\n" + "=".repeat(60));
-  console.log("BENCHMARK CONFIGURATION");
-  console.log("=".repeat(60));
-  console.log(`Categories: ${Object.keys(examplesByCategory).length}`);
-  console.log(`Total examples: ${examples.length}`);
-  console.log("=".repeat(60) + "\n");
-
-  const dataset = await createDataset({
-    name: "conciseness-rubric-boundary-test-" + Date.now(),
-    description:
-      "Benchmark testing boundary conditions of the conciseness evaluator rubric across categories: perfectly concise, pleasantries/filler, hedging/qualifiers, meta-commentary, redundant restatements, unsolicited explanations, and edge cases",
-    examples: datasetExamples,
-  });
-
-  const task: ExperimentTask = async (example) => {
-    const answer = example.output?.answer as string;
-    const expectedLabel = example.output?.expected_label as
-      | "concise"
-      | "verbose";
-
-    const evalResult = await concisenessEvaluator.evaluate({
-      input: example.input.question as string,
-      output: answer,
-    });
-
-    return {
-      expected_label: expectedLabel,
-      category: example.metadata?.category as string,
-      input: example.input.question as string,
-      output: answer,
-      ...evalResult,
-    };
-  };
-
-  const experiment = await runExperiment({
-    experimentName: "conciseness-rubric-boundary-test",
-    experimentDescription:
-      "Testing the conciseness evaluator against rubric boundary conditions",
-    concurrency: 8,
-    dataset: dataset,
-    task,
-    evaluators: [accuracyEvaluator],
-  });
-
-  // Fetch full experiment details including runs
-  const experimentResult = await getExperiment({
-    experimentId: experiment.id,
-  });
-
-  // Print experiment summary
-  console.log("\n" + "=".repeat(80));
-  console.log("EXPERIMENT RESULTS SUMMARY");
-  console.log("=".repeat(80));
-  console.log(`Experiment ID: ${experimentResult.id}`);
-  console.log(`Dataset ID: ${experimentResult.datasetId}`);
-  console.log(`Total Examples: ${experimentResult.exampleCount}`);
-  console.log(`Successful Runs: ${experimentResult.successfulRunCount}`);
-  console.log(`Failed Runs: ${experimentResult.failedRunCount}`);
-  console.log(`Missing Runs: ${experimentResult.missingRunCount}`);
-
-  // Analyze runs by category and collect failed examples
-  const runsByCategory: Record<
-    string,
-    { correct: number; incorrect: number; errors: number }
-  > = {};
-
-  const failedExamples: {
-    category: string;
-    input: string;
-    output: string;
-    expected: string;
-    actual: string;
-    explanation: string;
-  }[] = [];
-
-  for (const run of Object.values(experimentResult.runs)) {
-    const output = run.output as TaskOutput | null;
-    const category = output?.category || "unknown";
-
-    if (!runsByCategory[category]) {
-      runsByCategory[category] = { correct: 0, incorrect: 0, errors: 0 };
-    }
-
-    if (run.error) {
-      runsByCategory[category].errors++;
-    } else if (output?.expected_label === output?.label) {
-      runsByCategory[category].correct++;
-    } else {
-      runsByCategory[category].incorrect++;
-      if (output) {
-        failedExamples.push({
-          category: output.category,
-          input: output.input,
-          output: output.output,
-          expected: output.expected_label,
-          actual: output.label,
-          explanation: output.explanation,
+px.describe(
+  "conciseness-rubric-boundary-test",
+  () => {
+    px.test.each(cases)(
+      (row) =>
+        `[${String(row.metadata?.category)}] ${String(row.input.question)}`,
+      async ({ input }) => {
+        const result = await concisenessEvaluator.evaluate({
+          input: input.question,
+          output: input.answer,
         });
+        // The evaluator-under-test's verdict is the run output.
+        px.logOutput(result);
+        px.logAnnotation({
+          name: "conciseness",
+          label: result.label,
+          score: result.score,
+          explanation: result.explanation,
+          annotatorKind: "LLM",
+        });
+        // Score the verdict against the rubric's expected label.
+        await px.evaluate(accuracy);
       }
-    }
-  }
-
-  console.log("\n" + "-".repeat(80));
-  console.log("ACCURACY BY CATEGORY");
-  console.log("-".repeat(80));
-  console.log(
-    `  ${"Category".padEnd(30)} | ${"Accuracy".padEnd(15)} | Details`
-  );
-  console.log("-".repeat(80));
-
-  let totalCorrect = 0;
-  let totalIncorrect = 0;
-  let totalErrors = 0;
-
-  for (const [category, stats] of Object.entries(runsByCategory).sort()) {
-    const total = stats.correct + stats.incorrect + stats.errors;
-    const acc = total > 0 ? ((stats.correct / total) * 100).toFixed(0) : "N/A";
-
-    console.log(
-      `  ${category.padEnd(30)} | ${`${acc}% (${stats.correct}/${total})`.padEnd(15)} | ${stats.errors > 0 ? `${stats.errors} errors` : ""}`
     );
-
-    totalCorrect += stats.correct;
-    totalIncorrect += stats.incorrect;
-    totalErrors += stats.errors;
+  },
+  {
+    description:
+      "Boundary conditions of the conciseness evaluator rubric across categories: perfectly concise, pleasantries/filler, hedging/qualifiers, meta-commentary, redundant restatements, unsolicited explanations, and edge cases.",
+    metadata: { model: "gpt-4o-mini" },
+    acceptanceCriteria: [
+      { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+    ],
   }
-
-  const overallTotal = totalCorrect + totalIncorrect + totalErrors;
-  const overallAccuracy =
-    overallTotal > 0 ? ((totalCorrect / overallTotal) * 100).toFixed(1) : "N/A";
-
-  console.log("-".repeat(80));
-  console.log(
-    `  ${"OVERALL".padEnd(30)} | ${`${overallAccuracy}% (${totalCorrect}/${overallTotal})`.padEnd(15)} | ${totalErrors > 0 ? `${totalErrors} errors` : ""}`
-  );
-  console.log("=".repeat(80));
-  console.log(`\nTotal Errors: ${totalErrors}`);
-
-  // Print failed examples
-  if (failedExamples.length > 0) {
-    console.log("\n" + "=".repeat(80));
-    console.log(`FAILED EXAMPLES (${failedExamples.length})`);
-    console.log("=".repeat(80));
-
-    for (const [i, ex] of failedExamples.entries()) {
-      const truncatedOutput =
-        ex.output.length > 120 ? ex.output.slice(0, 120) + "..." : ex.output;
-      const truncatedExplanation =
-        ex.explanation.length > 200
-          ? ex.explanation.slice(0, 200) + "..."
-          : ex.explanation;
-
-      console.log(`\n  ${i + 1}. [${ex.category}]`);
-      console.log(`     Input:    ${ex.input}`);
-      console.log(`     Output:   ${truncatedOutput}`);
-      console.log(`     Expected: ${ex.expected}  |  Got: ${ex.actual}`);
-      console.log(`     Reason:   ${truncatedExplanation}`);
-    }
-  } else if (totalIncorrect === 0 && totalErrors === 0) {
-    console.log("\nAll examples matched expected labels.");
-  }
-
-  console.log("\n" + "=".repeat(80) + "\n");
-}
-
-main();
+);

--- a/js/benchmarks/evals-benchmarks/src/correctness.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/correctness.eval.ts
@@ -8,8 +8,17 @@
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createCorrectnessEvaluator } from "@arizeai/phoenix-evals";
 
+import {
+  createLabelAccumulator,
+  recordPrediction,
+  registerAggregateMetricsTest,
+} from "./aggregateMetrics.js";
 import { accuracy } from "./evaluators.js";
 import { evalModel, evalModelName } from "./model.js";
+
+// Ground-truth vs predicted labels across cases, scored by the trailing
+// aggregate-metrics test.
+const labels = createLabelAccumulator();
 
 const correctnessEvaluator = createCorrectnessEvaluator({
   model: evalModel,
@@ -366,7 +375,7 @@ px.describe(
     px.test.each(cases)(
       (row) =>
         `[${String(row.metadata?.category)}/${String(row.metadata?.variant)}] ${String(row.input.question)}`,
-      async ({ input }) => {
+      async ({ input, expected }) => {
         const result = await correctnessEvaluator.evaluate({
           input: input.question,
           output: input.answer,
@@ -379,9 +388,15 @@ px.describe(
           explanation: result.explanation,
           annotatorKind: "LLM",
         });
+        recordPrediction({
+          labels,
+          truth: expected?.label,
+          predicted: result.label,
+        });
         await px.evaluate(accuracy);
       }
     );
+    registerAggregateMetricsTest(labels);
   },
   {
     description:
@@ -389,6 +404,7 @@ px.describe(
     metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+      { annotationName: "f1", metric: "average", threshold: 0.7 },
     ],
   }
 );

--- a/js/benchmarks/evals-benchmarks/src/correctness.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/correctness.eval.ts
@@ -1,13 +1,15 @@
+/**
+ * Correctness evaluator benchmark.
+ *
+ * Each base example yields two runs — one with the correct answer and one with
+ * the incorrect answer — and the suite is gated on how accurately the
+ * correctness evaluator labels them.
+ */
 import { openai } from "@ai-sdk/openai";
-/* eslint-disable no-console */
-import { createDataset } from "@arizeai/phoenix-client/datasets";
-import {
-  asExperimentEvaluator,
-  getExperiment,
-  runExperiment,
-} from "@arizeai/phoenix-client/experiments";
-import type { ExperimentTask } from "@arizeai/phoenix-client/types/experiments";
+import * as px from "@arizeai/phoenix-client/vitest";
 import { createCorrectnessEvaluator } from "@arizeai/phoenix-evals";
+
+import { accuracy } from "./evaluators.js";
 
 const correctnessEvaluator = createCorrectnessEvaluator({
   model: openai("gpt-4o-mini"),
@@ -335,257 +337,58 @@ const examplesByCategory = {
 };
 
 // Flatten examples with category information
-const examples = Object.entries(examplesByCategory).flatMap(
+
+type CorrectnessLabel = "correct" | "incorrect";
+
+// Deterministic 50/50 split: each base example becomes two runs, one labelled
+// "correct" (correct answer) and one "incorrect" (incorrect answer).
+const cases = Object.entries(examplesByCategory).flatMap(
   ([category, categoryExamples]) =>
-    categoryExamples.map((example) => ({
-      ...example,
-      category,
-    }))
+    categoryExamples.flatMap((example) => [
+      {
+        input: { question: example.input, answer: example.correct_answer },
+        expected: { label: "correct" as CorrectnessLabel },
+        metadata: { category, variant: "correct" },
+        splits: [category, "correct_answer"],
+      },
+      {
+        input: { question: example.input, answer: example.incorrect_answer },
+        expected: { label: "incorrect" as CorrectnessLabel },
+        metadata: { category, variant: "incorrect" },
+        splits: [category, "incorrect_answer"],
+      },
+    ])
 );
 
-// Create dataset entries with deterministic correct/incorrect split
-// For each example, we create TWO entries: one with correct answer, one with incorrect
-const datasetExamples = examples.flatMap((example, index) => [
-  {
-    input: { question: example.input },
-    output: {
-      answer: example.correct_answer,
-      expected_label: "correct" as const,
-    },
-    metadata: {
-      category: example.category,
-      variant: "correct",
-      example_index: index,
-    },
-    splits: [example.category, "correct_answer"],
-  },
-  {
-    input: { question: example.input },
-    output: {
-      answer: example.incorrect_answer,
-      expected_label: "incorrect" as const,
-    },
-    metadata: {
-      category: example.category,
-      variant: "incorrect",
-      example_index: index,
-    },
-    splits: [example.category, "incorrect_answer"],
-  },
-]);
-
-type TaskOutput = {
-  expected_label: "correct" | "incorrect";
-  label: "correct" | "incorrect";
-  score: number;
-  explanation: string;
-  category: string;
-  variant: string;
-};
-
-const accuracyEvaluator = asExperimentEvaluator({
-  name: "accuracy",
-  kind: "CODE",
-  evaluate: async (args) => {
-    const output = args.output as TaskOutput;
-    const score = output.expected_label === output.label ? 1 : 0;
-    const label =
-      output.expected_label === output.label ? "accurate" : "inaccurate";
-    return {
-      label: label,
-      score: score,
-      explanation: `Category: ${output.category}, Variant: ${output.variant}. The evaluator labeled the answer as "${output.label}". Expected: "${output.expected_label}"`,
-      metadata: { category: output.category, variant: output.variant },
-    };
-  },
-});
-
-async function main() {
-  console.log("\n" + "=".repeat(60));
-  console.log("BENCHMARK CONFIGURATION");
-  console.log("=".repeat(60));
-  console.log(`Categories: ${Object.keys(examplesByCategory).length}`);
-  console.log(
-    `Examples per category: ${Object.values(examplesByCategory)[0]?.length ?? 0}`
-  );
-  console.log(`Total base examples: ${examples.length}`);
-  console.log(
-    `Total dataset entries (2 per example): ${datasetExamples.length}`
-  );
-  console.log(
-    `Split: 50% correct answers, 50% incorrect answers (deterministic)`
-  );
-  console.log("=".repeat(60) + "\n");
-
-  const dataset = await createDataset({
-    name: "correctness-rubric-boundary-test-" + Date.now(),
-    description:
-      "Benchmark testing boundary conditions of the correctness evaluator rubric with deterministic 50/50 correct/incorrect split across 10 categories: factual accuracy, completeness, logical consistency, precise terminology, misleading statements, missing info, ambiguity, partial correctness, nuanced accuracy, and technical precision",
-    examples: datasetExamples,
-  });
-
-  const task: ExperimentTask = async (example) => {
-    const answer = example.output?.answer as string;
-    const expectedLabel = example.output?.expected_label as
-      | "correct"
-      | "incorrect";
-
-    const evalResult = await correctnessEvaluator.evaluate({
-      input: example.input.question as string,
-      output: answer,
-    });
-
-    return {
-      expected_label: expectedLabel,
-      category: example.metadata?.category as string,
-      variant: example.metadata?.variant as string,
-      ...evalResult,
-    };
-  };
-
-  const experiment = await runExperiment({
-    experimentName: "correctness-rubric-boundary-test",
-    experimentDescription:
-      "Testing the correctness evaluator against rubric boundary conditions with deterministic 50/50 split",
-    concurrency: 8,
-    dataset: dataset,
-    task,
-    evaluators: [accuracyEvaluator],
-  });
-
-  // Fetch full experiment details including runs
-  const experimentResult = await getExperiment({
-    experimentId: experiment.id,
-  });
-
-  // Print experiment summary
-  console.log("\n" + "=".repeat(80));
-  console.log("EXPERIMENT RESULTS SUMMARY");
-  console.log("=".repeat(80));
-  console.log(`Experiment ID: ${experimentResult.id}`);
-  console.log(`Dataset ID: ${experimentResult.datasetId}`);
-  console.log(`Total Examples: ${experimentResult.exampleCount}`);
-  console.log(`Successful Runs: ${experimentResult.successfulRunCount}`);
-  console.log(`Failed Runs: ${experimentResult.failedRunCount}`);
-  console.log(`Missing Runs: ${experimentResult.missingRunCount}`);
-
-  // Analyze runs by category and variant
-  const runsByCategory: Record<
-    string,
-    {
-      correct_variant: { correct: number; incorrect: number; errors: number };
-      incorrect_variant: { correct: number; incorrect: number; errors: number };
-    }
-  > = {};
-
-  for (const run of Object.values(experimentResult.runs)) {
-    const output = run.output as TaskOutput | null;
-    const category = output?.category || "unknown";
-    const variant = output?.variant || "unknown";
-
-    if (!runsByCategory[category]) {
-      runsByCategory[category] = {
-        correct_variant: { correct: 0, incorrect: 0, errors: 0 },
-        incorrect_variant: { correct: 0, incorrect: 0, errors: 0 },
-      };
-    }
-
-    const variantKey =
-      variant === "correct" ? "correct_variant" : "incorrect_variant";
-
-    if (run.error) {
-      runsByCategory[category][variantKey].errors++;
-    } else if (output?.expected_label === output?.label) {
-      runsByCategory[category][variantKey].correct++;
-    } else {
-      runsByCategory[category][variantKey].incorrect++;
-    }
-  }
-
-  console.log("\n" + "-".repeat(80));
-  console.log("ACCURACY BY CATEGORY AND VARIANT");
-  console.log("-".repeat(80));
-  console.log(
-    `  ${"Category".padEnd(25)} | ${"Correct Answers".padEnd(20)} | ${"Incorrect Answers".padEnd(20)} | Overall`
-  );
-  console.log("-".repeat(80));
-
-  let totalCorrect = 0;
-  let totalIncorrect = 0;
-  let totalErrors = 0;
-  let totalCorrectVariantCorrect = 0;
-  let totalCorrectVariantTotal = 0;
-  let totalIncorrectVariantCorrect = 0;
-  let totalIncorrectVariantTotal = 0;
-
-  for (const [category, stats] of Object.entries(runsByCategory).sort()) {
-    const correctTotal =
-      stats.correct_variant.correct +
-      stats.correct_variant.incorrect +
-      stats.correct_variant.errors;
-    const incorrectTotal =
-      stats.incorrect_variant.correct +
-      stats.incorrect_variant.incorrect +
-      stats.incorrect_variant.errors;
-    const overallTotal = correctTotal + incorrectTotal;
-
-    const correctAcc =
-      correctTotal > 0
-        ? ((stats.correct_variant.correct / correctTotal) * 100).toFixed(0)
-        : "N/A";
-    const incorrectAcc =
-      incorrectTotal > 0
-        ? ((stats.incorrect_variant.correct / incorrectTotal) * 100).toFixed(0)
-        : "N/A";
-    const overallAcc =
-      overallTotal > 0
-        ? (
-            ((stats.correct_variant.correct + stats.incorrect_variant.correct) /
-              overallTotal) *
-            100
-          ).toFixed(0)
-        : "N/A";
-
-    console.log(
-      `  ${category.padEnd(25)} | ${`${correctAcc}% (${stats.correct_variant.correct}/${correctTotal})`.padEnd(20)} | ${`${incorrectAcc}% (${stats.incorrect_variant.correct}/${incorrectTotal})`.padEnd(20)} | ${overallAcc}%`
+px.describe(
+  "correctness-rubric-boundary-test",
+  () => {
+    px.test.each(cases)(
+      (row) =>
+        `[${String(row.metadata?.category)}/${String(row.metadata?.variant)}] ${String(row.input.question)}`,
+      async ({ input }) => {
+        const result = await correctnessEvaluator.evaluate({
+          input: input.question,
+          output: input.answer,
+        });
+        px.logOutput(result);
+        px.logAnnotation({
+          name: "correctness",
+          label: result.label,
+          score: result.score,
+          explanation: result.explanation,
+          annotatorKind: "LLM",
+        });
+        await px.evaluate(accuracy);
+      }
     );
-
-    totalCorrect +=
-      stats.correct_variant.correct + stats.incorrect_variant.correct;
-    totalIncorrect +=
-      stats.correct_variant.incorrect + stats.incorrect_variant.incorrect;
-    totalErrors +=
-      stats.correct_variant.errors + stats.incorrect_variant.errors;
-    totalCorrectVariantCorrect += stats.correct_variant.correct;
-    totalCorrectVariantTotal += correctTotal;
-    totalIncorrectVariantCorrect += stats.incorrect_variant.correct;
-    totalIncorrectVariantTotal += incorrectTotal;
+  },
+  {
+    description:
+      "Boundary conditions of the correctness evaluator rubric with a deterministic 50/50 correct/incorrect split across categories: factual accuracy, completeness, logical consistency, precise terminology, misleading statements, missing info, ambiguity, partial correctness, nuanced accuracy, and technical precision.",
+    metadata: { model: "gpt-4o-mini" },
+    acceptanceCriteria: [
+      { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+    ],
   }
-
-  const overallTotal = totalCorrect + totalIncorrect + totalErrors;
-  const overallAccuracy =
-    overallTotal > 0 ? ((totalCorrect / overallTotal) * 100).toFixed(1) : "N/A";
-  const correctVariantAccuracy =
-    totalCorrectVariantTotal > 0
-      ? ((totalCorrectVariantCorrect / totalCorrectVariantTotal) * 100).toFixed(
-          0
-        )
-      : "N/A";
-  const incorrectVariantAccuracy =
-    totalIncorrectVariantTotal > 0
-      ? (
-          (totalIncorrectVariantCorrect / totalIncorrectVariantTotal) *
-          100
-        ).toFixed(0)
-      : "N/A";
-
-  console.log("-".repeat(80));
-  console.log(
-    `  ${"OVERALL".padEnd(25)} | ${`${correctVariantAccuracy}% (${totalCorrectVariantCorrect}/${totalCorrectVariantTotal})`.padEnd(20)} | ${`${incorrectVariantAccuracy}% (${totalIncorrectVariantCorrect}/${totalIncorrectVariantTotal})`.padEnd(20)} | ${overallAccuracy}%`
-  );
-  console.log("=".repeat(80));
-  console.log(`\nTotal Errors: ${totalErrors}`);
-  console.log("=".repeat(80) + "\n");
-}
-
-main();
+);

--- a/js/benchmarks/evals-benchmarks/src/correctness.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/correctness.eval.ts
@@ -5,14 +5,14 @@
  * the incorrect answer — and the suite is gated on how accurately the
  * correctness evaluator labels them.
  */
-import { openai } from "@ai-sdk/openai";
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createCorrectnessEvaluator } from "@arizeai/phoenix-evals";
 
 import { accuracy } from "./evaluators.js";
+import { evalModel, evalModelName } from "./model.js";
 
 const correctnessEvaluator = createCorrectnessEvaluator({
-  model: openai("gpt-4o-mini"),
+  model: evalModel,
 });
 
 // Examples designed to test the boundary conditions of the correctness rubric
@@ -386,7 +386,7 @@ px.describe(
   {
     description:
       "Boundary conditions of the correctness evaluator rubric with a deterministic 50/50 correct/incorrect split across categories: factual accuracy, completeness, logical consistency, precise terminology, misleading statements, missing info, ambiguity, partial correctness, nuanced accuracy, and technical precision.",
-    metadata: { model: "gpt-4o-mini" },
+    metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
     ],

--- a/js/benchmarks/evals-benchmarks/src/document_relevance.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/document_relevance.eval.ts
@@ -4,14 +4,14 @@
  * Runs the document-relevance evaluator over query/document pairs and gates the
  * suite on how accurately it labels each document as relevant vs unrelated.
  */
-import { openai } from "@ai-sdk/openai";
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createDocumentRelevanceEvaluator } from "@arizeai/phoenix-evals";
 
 import { accuracy } from "./evaluators.js";
+import { evalModel, evalModelName } from "./model.js";
 
 const relevanceEvaluator = createDocumentRelevanceEvaluator({
-  model: openai("gpt-4o-mini"),
+  model: evalModel,
 });
 
 const examples = [
@@ -235,7 +235,7 @@ px.describe(
   {
     description:
       "Document relevance evaluator accuracy at labelling documents as relevant vs unrelated to a query.",
-    metadata: { model: "gpt-4o-mini" },
+    metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
     ],

--- a/js/benchmarks/evals-benchmarks/src/document_relevance.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/document_relevance.eval.ts
@@ -1,11 +1,14 @@
+/**
+ * Document relevance evaluator benchmark.
+ *
+ * Runs the document-relevance evaluator over query/document pairs and gates the
+ * suite on how accurately it labels each document as relevant vs unrelated.
+ */
 import { openai } from "@ai-sdk/openai";
-import { createDataset } from "@arizeai/phoenix-client/datasets";
-import {
-  asExperimentEvaluator,
-  runExperiment,
-} from "@arizeai/phoenix-client/experiments";
-import type { ExperimentTask } from "@arizeai/phoenix-client/types/experiments";
+import * as px from "@arizeai/phoenix-client/vitest";
 import { createDocumentRelevanceEvaluator } from "@arizeai/phoenix-evals";
+
+import { accuracy } from "./evaluators.js";
 
 const relevanceEvaluator = createDocumentRelevanceEvaluator({
   model: openai("gpt-4o-mini"),
@@ -195,60 +198,46 @@ const examples = [
   },
 ];
 
-type TaskOutput = {
-  label: "relevant" | "unrelated";
-  score: number;
-  explanation: string;
-};
+type RelevanceLabel = "relevant" | "unrelated";
 
-const correctEvaluator = asExperimentEvaluator({
-  name: "correctness",
-  kind: "CODE",
-  evaluate: async (args) => {
-    const output = args.output as TaskOutput;
-    const expected = args.expected as TaskOutput;
-    const label = output.label === expected.label ? "correct" : "incorrect";
-    const score = output.label === expected.label ? 1 : 0;
-    return {
-      label: label,
-      score: score,
-      explanation: `The evaluator labeled the answer as ${label}. Expected: ${expected?.label}`,
-      metadata: {},
-    };
-  },
+const cases = examples.map((example) => {
+  const label: RelevanceLabel = example.relevant ? "relevant" : "unrelated";
+  return {
+    input: { question: example.input, documentText: example.documentText },
+    expected: { label },
+    metadata: {},
+    splits: [label],
+  };
 });
 
-async function main() {
-  const dataset = await createDataset({
-    name: "document-relevancy-eval" + Math.random(),
-    description: "Evaluate the relevancy of the model",
-    examples: examples.map((example) => ({
-      input: { question: example.input, documentText: example.documentText },
-      output: {
-        label: example.relevant ? "relevant" : "unrelated",
-      },
-      metadata: {},
-    })),
-  });
-
-  const task: ExperimentTask = async (example) => {
-    const evalResult = await relevanceEvaluator.evaluate({
-      input: example.input.question as string,
-      documentText: example.input.documentText as string,
-    });
-
-    return {
-      ...evalResult,
-    };
-  };
-  runExperiment({
-    experimentName: "document-relevancy-eval",
-    experimentDescription: "Evaluate the relevancy of the model",
-    concurrency: 8,
-    dataset: dataset,
-    task,
-    evaluators: [correctEvaluator],
-  });
-}
-
-main();
+px.describe(
+  "document-relevancy-eval",
+  () => {
+    px.test.each(cases)(
+      (row) => String(row.input.question),
+      async ({ input }) => {
+        const result = await relevanceEvaluator.evaluate({
+          input: input.question,
+          documentText: input.documentText,
+        });
+        px.logOutput(result);
+        px.logAnnotation({
+          name: "document_relevance",
+          label: result.label,
+          score: result.score,
+          explanation: result.explanation,
+          annotatorKind: "LLM",
+        });
+        await px.evaluate(accuracy);
+      }
+    );
+  },
+  {
+    description:
+      "Document relevance evaluator accuracy at labelling documents as relevant vs unrelated to a query.",
+    metadata: { model: "gpt-4o-mini" },
+    acceptanceCriteria: [
+      { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+    ],
+  }
+);

--- a/js/benchmarks/evals-benchmarks/src/document_relevance.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/document_relevance.eval.ts
@@ -7,8 +7,17 @@
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createDocumentRelevanceEvaluator } from "@arizeai/phoenix-evals";
 
+import {
+  createLabelAccumulator,
+  recordPrediction,
+  registerAggregateMetricsTest,
+} from "./aggregateMetrics.js";
 import { accuracy } from "./evaluators.js";
 import { evalModel, evalModelName } from "./model.js";
+
+// Ground-truth vs predicted labels across cases, scored by the trailing
+// aggregate-metrics test.
+const labels = createLabelAccumulator();
 
 const relevanceEvaluator = createDocumentRelevanceEvaluator({
   model: evalModel,
@@ -215,7 +224,7 @@ px.describe(
   () => {
     px.test.each(cases)(
       (row) => String(row.input.question),
-      async ({ input }) => {
+      async ({ input, expected }) => {
         const result = await relevanceEvaluator.evaluate({
           input: input.question,
           documentText: input.documentText,
@@ -228,9 +237,15 @@ px.describe(
           explanation: result.explanation,
           annotatorKind: "LLM",
         });
+        recordPrediction({
+          labels,
+          truth: expected?.label,
+          predicted: result.label,
+        });
         await px.evaluate(accuracy);
       }
     );
+    registerAggregateMetricsTest(labels);
   },
   {
     description:
@@ -238,6 +253,7 @@ px.describe(
     metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+      { annotationName: "f1", metric: "average", threshold: 0.7 },
     ],
   }
 );

--- a/js/benchmarks/evals-benchmarks/src/evaluators.ts
+++ b/js/benchmarks/evals-benchmarks/src/evaluators.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared evaluators for the eval benchmarks.
+ *
+ * Every benchmark runs a Phoenix evaluator-under-test as the task and records
+ * its result as the run output via `px.logOutput(result)` — a
+ * `{ label, score, explanation }` object. Each example's `expected` carries the
+ * ground-truth `{ label }`. The `accuracy` evaluator below scores whether the
+ * evaluator-under-test predicted the ground-truth label, so the suite measures
+ * the *evaluator's* accuracy rather than any model output.
+ */
+import type { Evaluator } from "@arizeai/phoenix-client/vitest";
+
+/** Boolean-as-1/0 agreement between the predicted label and the ground truth. */
+export const accuracy: Evaluator = {
+  name: "accuracy",
+  kind: "CODE",
+  evaluate: ({ output, expected }) => {
+    const predicted = (output as { label?: string } | null | undefined)?.label;
+    const truth = (expected as { label?: string } | undefined)?.label;
+    return predicted === truth ? 1 : 0;
+  },
+};

--- a/js/benchmarks/evals-benchmarks/src/faithfulness.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/faithfulness.eval.ts
@@ -8,8 +8,17 @@
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createFaithfulnessEvaluator } from "@arizeai/phoenix-evals";
 
+import {
+  createLabelAccumulator,
+  recordPrediction,
+  registerAggregateMetricsTest,
+} from "./aggregateMetrics.js";
 import { accuracy } from "./evaluators.js";
 import { evalModel, evalModelName } from "./model.js";
+
+// Ground-truth vs predicted labels across cases, scored by the trailing
+// aggregate-metrics test.
+const labels = createLabelAccumulator();
 
 const faithfulnessEvaluator = createFaithfulnessEvaluator({
   model: evalModel,
@@ -116,7 +125,7 @@ px.describe(
     px.test.each(cases)(
       (row) =>
         `[${String(row.metadata?.variant)}] ${String(row.input.question)}`,
-      async ({ input }) => {
+      async ({ input, expected }) => {
         const result = await faithfulnessEvaluator.evaluate({
           input: input.question,
           context: input.context,
@@ -130,9 +139,15 @@ px.describe(
           explanation: result.explanation,
           annotatorKind: "LLM",
         });
+        recordPrediction({
+          labels,
+          truth: expected?.label,
+          predicted: result.label,
+        });
         await px.evaluate(accuracy);
       }
     );
+    registerAggregateMetricsTest(labels);
   },
   {
     description:
@@ -140,6 +155,7 @@ px.describe(
     metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+      { annotationName: "f1", metric: "average", threshold: 0.7 },
     ],
   }
 );

--- a/js/benchmarks/evals-benchmarks/src/faithfulness.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/faithfulness.eval.ts
@@ -1,11 +1,16 @@
+/**
+ * Faithfulness evaluator benchmark.
+ *
+ * Each example becomes two deterministic runs — the faithful answer and the
+ * unfaithful answer — and the suite is gated on how accurately the
+ * faithfulness evaluator distinguishes them given the supporting knowledge.
+ */
 import { openai } from "@ai-sdk/openai";
-import { createDataset } from "@arizeai/phoenix-client/datasets";
-import {
-  asExperimentEvaluator,
-  runExperiment,
-} from "@arizeai/phoenix-client/experiments";
-import type { ExperimentTask } from "@arizeai/phoenix-client/types/experiments";
+import * as px from "@arizeai/phoenix-client/vitest";
 import { createFaithfulnessEvaluator } from "@arizeai/phoenix-evals";
+
+import { accuracy } from "./evaluators.js";
+
 const faithfulnessEvaluator = createFaithfulnessEvaluator({
   model: openai("gpt-4o-mini"),
 });
@@ -78,71 +83,63 @@ const examples = [
   },
 ];
 
-type TaskOutput = {
-  expected_label: "unfaithful" | "faithful";
-  label: "unfaithful" | "faithful";
-  score: number;
-  explanation: string;
-};
+type FaithfulnessLabel = "faithful" | "unfaithful";
 
-const correctEvaluator = asExperimentEvaluator({
-  name: "correctness",
-  kind: "CODE",
-  evaluate: async (args) => {
-    const output = args.output as TaskOutput;
-    const score = output.expected_label === output.label ? 1 : 0;
-    const label =
-      output.expected_label === "unfaithful" ? "unfaithful" : "faithful";
-    return {
-      label: label,
-      score: score,
-      explanation: `The evaluator labeled the answer as ${label}. Expected: ${(output as unknown as { expected_label: string }).expected_label}`,
-      metadata: {},
-    };
+// Deterministic split: each example contributes a faithful run (the correct
+// answer) and an unfaithful run (a contradicting answer) over the same context.
+const cases = examples.flatMap((example) => [
+  {
+    input: {
+      question: example.question,
+      context: example.knowledge,
+      answer: example.right_answer,
+    },
+    expected: { label: "faithful" as FaithfulnessLabel },
+    metadata: { variant: "faithful" },
+    splits: ["faithful"],
   },
-});
+  {
+    input: {
+      question: example.question,
+      context: example.knowledge,
+      answer: example.unfaithful_answer,
+    },
+    expected: { label: "unfaithful" as FaithfulnessLabel },
+    metadata: { variant: "unfaithful" },
+    splits: ["unfaithful"],
+  },
+]);
 
-async function main() {
-  const dataset = await createDataset({
-    name: "faithfulness-eval" + Math.random(),
-    description: "Evaluate the faithfulness of the model",
-    examples: examples.map((example) => ({
-      input: { question: example.question, context: example.knowledge },
-      output: {
-        answer: example.right_answer,
-        unfaithful_answer: example.unfaithful_answer,
-      },
-      metadata: {
-        knowledge: example.knowledge,
-      },
-    })),
-  });
-
-  const task: ExperimentTask = async (example) => {
-    const useUnfaithful = Math.random() < 0.2;
-    const answer = useUnfaithful
-      ? example.output?.unfaithful_answer
-      : example.output?.answer;
-
-    const evalResult = await faithfulnessEvaluator.evaluate({
-      input: example.input.question as string,
-      context: example.input.context as string,
-      output: answer as string,
-    });
-
-    return {
-      expected_label: useUnfaithful ? "unfaithful" : "faithful",
-      ...evalResult,
-    };
-  };
-  runExperiment({
-    experimentName: "faithfulness-eval",
-    experimentDescription: "Evaluate the faithfulness of the model",
-    concurrency: 8,
-    dataset: dataset,
-    task,
-    evaluators: [correctEvaluator],
-  });
-}
-
-main();
+px.describe(
+  "faithfulness-eval",
+  () => {
+    px.test.each(cases)(
+      (row) =>
+        `[${String(row.metadata?.variant)}] ${String(row.input.question)}`,
+      async ({ input }) => {
+        const result = await faithfulnessEvaluator.evaluate({
+          input: input.question,
+          context: input.context,
+          output: input.answer,
+        });
+        px.logOutput(result);
+        px.logAnnotation({
+          name: "faithfulness",
+          label: result.label,
+          score: result.score,
+          explanation: result.explanation,
+          annotatorKind: "LLM",
+        });
+        await px.evaluate(accuracy);
+      }
+    );
+  },
+  {
+    description:
+      "Faithfulness evaluator accuracy at distinguishing faithful from unfaithful answers given supporting knowledge.",
+    metadata: { model: "gpt-4o-mini" },
+    acceptanceCriteria: [
+      { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+    ],
+  }
+);

--- a/js/benchmarks/evals-benchmarks/src/faithfulness.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/faithfulness.eval.ts
@@ -5,14 +5,14 @@
  * unfaithful answer — and the suite is gated on how accurately the
  * faithfulness evaluator distinguishes them given the supporting knowledge.
  */
-import { openai } from "@ai-sdk/openai";
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createFaithfulnessEvaluator } from "@arizeai/phoenix-evals";
 
 import { accuracy } from "./evaluators.js";
+import { evalModel, evalModelName } from "./model.js";
 
 const faithfulnessEvaluator = createFaithfulnessEvaluator({
-  model: openai("gpt-4o-mini"),
+  model: evalModel,
 });
 
 const examples = [
@@ -137,7 +137,7 @@ px.describe(
   {
     description:
       "Faithfulness evaluator accuracy at distinguishing faithful from unfaithful answers given supporting knowledge.",
-    metadata: { model: "gpt-4o-mini" },
+    metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
     ],

--- a/js/benchmarks/evals-benchmarks/src/model.ts
+++ b/js/benchmarks/evals-benchmarks/src/model.ts
@@ -1,0 +1,13 @@
+/**
+ * The judge model shared by every benchmark suite.
+ *
+ * Override via the `EVAL_MODEL` env var to benchmark the evaluators on a
+ * different model, e.g. `EVAL_MODEL=gpt-4o pnpm run evals:local`.
+ */
+import { openai } from "@ai-sdk/openai";
+
+export const DEFAULT_EVAL_MODEL = "gpt-4o-mini";
+
+export const evalModelName = process.env.EVAL_MODEL ?? DEFAULT_EVAL_MODEL;
+
+export const evalModel = openai(evalModelName);

--- a/js/benchmarks/evals-benchmarks/src/refusal.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/refusal.eval.ts
@@ -7,8 +7,17 @@
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createRefusalEvaluator } from "@arizeai/phoenix-evals";
 
+import {
+  createLabelAccumulator,
+  recordPrediction,
+  registerAggregateMetricsTest,
+} from "./aggregateMetrics.js";
 import { accuracy } from "./evaluators.js";
 import { evalModel, evalModelName } from "./model.js";
+
+// Ground-truth vs predicted labels across cases, scored by the trailing
+// aggregate-metrics test.
+const labels = createLabelAccumulator();
 
 const refusalEvaluator = createRefusalEvaluator({
   model: evalModel,
@@ -319,7 +328,7 @@ px.describe(
     px.test.each(cases)(
       (row) =>
         `[${String(row.metadata?.category)}] ${String(row.input.question)}`,
-      async ({ input }) => {
+      async ({ input, expected }) => {
         const result = await refusalEvaluator.evaluate({
           input: input.question,
           output: input.answer,
@@ -332,9 +341,15 @@ px.describe(
           explanation: result.explanation,
           annotatorKind: "LLM",
         });
+        recordPrediction({
+          labels,
+          truth: expected?.label,
+          predicted: result.label,
+        });
         await px.evaluate(accuracy);
       }
     );
+    registerAggregateMetricsTest(labels);
   },
   {
     description:
@@ -342,6 +357,7 @@ px.describe(
     metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+      { annotationName: "f1", metric: "average", threshold: 0.7 },
     ],
   }
 );

--- a/js/benchmarks/evals-benchmarks/src/refusal.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/refusal.eval.ts
@@ -4,14 +4,14 @@
  * Runs the refusal evaluator across refusal / answer categories and gates the
  * suite on how accurately it labels each response as refused vs answered.
  */
-import { openai } from "@ai-sdk/openai";
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createRefusalEvaluator } from "@arizeai/phoenix-evals";
 
 import { accuracy } from "./evaluators.js";
+import { evalModel, evalModelName } from "./model.js";
 
 const refusalEvaluator = createRefusalEvaluator({
-  model: openai("gpt-4o-mini"),
+  model: evalModel,
 });
 
 const examplesByCategory = {
@@ -339,7 +339,7 @@ px.describe(
   {
     description:
       "Refusal evaluator across categories: explicit refusals, scope disclaimers, lack of information, safety refusals, redirections, partial refusals, clear answers, incorrect answers, hedged answers, answers with caveats, and edge cases.",
-    metadata: { model: "gpt-4o-mini" },
+    metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
     ],

--- a/js/benchmarks/evals-benchmarks/src/refusal.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/refusal.eval.ts
@@ -1,13 +1,14 @@
+/**
+ * Refusal evaluator benchmark.
+ *
+ * Runs the refusal evaluator across refusal / answer categories and gates the
+ * suite on how accurately it labels each response as refused vs answered.
+ */
 import { openai } from "@ai-sdk/openai";
-/* eslint-disable no-console */
-import { createDataset } from "@arizeai/phoenix-client/datasets";
-import {
-  asExperimentEvaluator,
-  getExperiment,
-  runExperiment,
-} from "@arizeai/phoenix-client/experiments";
-import type { ExperimentTask } from "@arizeai/phoenix-client/types/experiments";
+import * as px from "@arizeai/phoenix-client/vitest";
 import { createRefusalEvaluator } from "@arizeai/phoenix-evals";
+
+import { accuracy } from "./evaluators.js";
 
 const refusalEvaluator = createRefusalEvaluator({
   model: openai("gpt-4o-mini"),
@@ -300,214 +301,47 @@ const examplesByCategory = {
   ],
 };
 
-const examples = Object.entries(examplesByCategory).flatMap(
+type RefusalLabel = "refused" | "answered";
+
+const cases = Object.entries(examplesByCategory).flatMap(
   ([category, categoryExamples]) =>
     categoryExamples.map((example) => ({
-      ...example,
-      category,
+      input: { question: example.input, answer: example.output },
+      expected: { label: example.expected_label as RefusalLabel },
+      metadata: { category },
+      splits: [category],
     }))
 );
 
-const datasetExamples = examples.map((example, index) => ({
-  input: { question: example.input },
-  output: {
-    answer: example.output,
-    expected_label: example.expected_label,
-  },
-  metadata: {
-    category: example.category,
-    example_index: index,
-  },
-  splits: [example.category],
-}));
-
-type TaskOutput = {
-  expected_label: "refused" | "answered";
-  label: "refused" | "answered";
-  score: number;
-  explanation: string;
-  category: string;
-  input: string;
-  output: string;
-};
-
-const accuracyEvaluator = asExperimentEvaluator({
-  name: "accuracy",
-  kind: "CODE",
-  evaluate: async (args) => {
-    const output = args.output as TaskOutput;
-    const score = output.expected_label === output.label ? 1 : 0;
-    const label =
-      output.expected_label === output.label ? "accurate" : "inaccurate";
-    return {
-      label: label,
-      score: score,
-      explanation: `Category: ${output.category}. The evaluator labeled the answer as "${output.label}". Expected: "${output.expected_label}"`,
-      metadata: { category: output.category },
-    };
-  },
-});
-
-async function main() {
-  console.log("\n" + "=".repeat(60));
-  console.log("BENCHMARK CONFIGURATION");
-  console.log("=".repeat(60));
-  console.log(`Categories: ${Object.keys(examplesByCategory).length}`);
-  console.log(`Total examples: ${examples.length}`);
-  console.log("=".repeat(60) + "\n");
-
-  const dataset = await createDataset({
-    name: "refusal-benchmark-" + Date.now(),
-    description:
-      "Benchmark testing the refusal evaluator across categories: explicit refusals, scope disclaimers, lack of information, safety refusals, redirections, partial refusals, clear answers, incorrect answers, hedged answers, answers with caveats, and edge cases",
-    examples: datasetExamples,
-  });
-
-  const task: ExperimentTask = async (example) => {
-    const answer = example.output?.answer as string;
-    const expectedLabel = example.output?.expected_label as
-      | "refused"
-      | "answered";
-
-    const evalResult = await refusalEvaluator.evaluate({
-      input: example.input.question as string,
-      output: answer,
-    });
-
-    return {
-      expected_label: expectedLabel,
-      category: example.metadata?.category as string,
-      input: example.input.question as string,
-      output: answer,
-      ...evalResult,
-    };
-  };
-
-  const experiment = await runExperiment({
-    experimentName: "refusal-benchmark",
-    experimentDescription:
-      "Testing the refusal evaluator against diverse refusal and non-refusal scenarios",
-    concurrency: 8,
-    dataset: dataset,
-    task,
-    evaluators: [accuracyEvaluator],
-  });
-
-  const experimentResult = await getExperiment({
-    experimentId: experiment.id,
-  });
-
-  console.log("\n" + "=".repeat(80));
-  console.log("EXPERIMENT RESULTS SUMMARY");
-  console.log("=".repeat(80));
-  console.log(`Experiment ID: ${experimentResult.id}`);
-  console.log(`Dataset ID: ${experimentResult.datasetId}`);
-  console.log(`Total Examples: ${experimentResult.exampleCount}`);
-  console.log(`Successful Runs: ${experimentResult.successfulRunCount}`);
-  console.log(`Failed Runs: ${experimentResult.failedRunCount}`);
-  console.log(`Missing Runs: ${experimentResult.missingRunCount}`);
-
-  const runsByCategory: Record<
-    string,
-    { correct: number; incorrect: number; errors: number }
-  > = {};
-
-  const failedExamples: {
-    category: string;
-    input: string;
-    output: string;
-    expected: string;
-    actual: string;
-    explanation: string;
-  }[] = [];
-
-  for (const run of Object.values(experimentResult.runs)) {
-    const output = run.output as TaskOutput | null;
-    const category = output?.category || "unknown";
-
-    if (!runsByCategory[category]) {
-      runsByCategory[category] = { correct: 0, incorrect: 0, errors: 0 };
-    }
-
-    if (run.error) {
-      runsByCategory[category].errors++;
-    } else if (output?.expected_label === output?.label) {
-      runsByCategory[category].correct++;
-    } else {
-      runsByCategory[category].incorrect++;
-      if (output) {
-        failedExamples.push({
-          category: output.category,
-          input: output.input,
-          output: output.output,
-          expected: output.expected_label,
-          actual: output.label,
-          explanation: output.explanation,
+px.describe(
+  "refusal-benchmark",
+  () => {
+    px.test.each(cases)(
+      (row) =>
+        `[${String(row.metadata?.category)}] ${String(row.input.question)}`,
+      async ({ input }) => {
+        const result = await refusalEvaluator.evaluate({
+          input: input.question,
+          output: input.answer,
         });
+        px.logOutput(result);
+        px.logAnnotation({
+          name: "refusal",
+          label: result.label,
+          score: result.score,
+          explanation: result.explanation,
+          annotatorKind: "LLM",
+        });
+        await px.evaluate(accuracy);
       }
-    }
-  }
-
-  console.log("\n" + "-".repeat(80));
-  console.log("ACCURACY BY CATEGORY");
-  console.log("-".repeat(80));
-  console.log(
-    `  ${"Category".padEnd(30)} | ${"Accuracy".padEnd(15)} | Details`
-  );
-  console.log("-".repeat(80));
-
-  let totalCorrect = 0;
-  let totalIncorrect = 0;
-  let totalErrors = 0;
-
-  for (const [category, stats] of Object.entries(runsByCategory).sort()) {
-    const total = stats.correct + stats.incorrect + stats.errors;
-    const acc = total > 0 ? ((stats.correct / total) * 100).toFixed(0) : "N/A";
-
-    console.log(
-      `  ${category.padEnd(30)} | ${`${acc}% (${stats.correct}/${total})`.padEnd(15)} | ${stats.errors > 0 ? `${stats.errors} errors` : ""}`
     );
-
-    totalCorrect += stats.correct;
-    totalIncorrect += stats.incorrect;
-    totalErrors += stats.errors;
+  },
+  {
+    description:
+      "Refusal evaluator across categories: explicit refusals, scope disclaimers, lack of information, safety refusals, redirections, partial refusals, clear answers, incorrect answers, hedged answers, answers with caveats, and edge cases.",
+    metadata: { model: "gpt-4o-mini" },
+    acceptanceCriteria: [
+      { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+    ],
   }
-
-  const overallTotal = totalCorrect + totalIncorrect + totalErrors;
-  const overallAccuracy =
-    overallTotal > 0 ? ((totalCorrect / overallTotal) * 100).toFixed(1) : "N/A";
-
-  console.log("-".repeat(80));
-  console.log(
-    `  ${"OVERALL".padEnd(30)} | ${`${overallAccuracy}% (${totalCorrect}/${overallTotal})`.padEnd(15)} | ${totalErrors > 0 ? `${totalErrors} errors` : ""}`
-  );
-  console.log("=".repeat(80));
-  console.log(`\nTotal Errors: ${totalErrors}`);
-
-  if (failedExamples.length > 0) {
-    console.log("\n" + "=".repeat(80));
-    console.log(`FAILED EXAMPLES (${failedExamples.length})`);
-    console.log("=".repeat(80));
-
-    for (const [i, ex] of failedExamples.entries()) {
-      const truncatedOutput =
-        ex.output.length > 120 ? ex.output.slice(0, 120) + "..." : ex.output;
-      const truncatedExplanation =
-        ex.explanation.length > 200
-          ? ex.explanation.slice(0, 200) + "..."
-          : ex.explanation;
-
-      console.log(`\n  ${i + 1}. [${ex.category}]`);
-      console.log(`     Input:    ${ex.input}`);
-      console.log(`     Output:   ${truncatedOutput}`);
-      console.log(`     Expected: ${ex.expected}  |  Got: ${ex.actual}`);
-      console.log(`     Reason:   ${truncatedExplanation}`);
-    }
-  } else if (totalIncorrect === 0 && totalErrors === 0) {
-    console.log("\nAll examples matched expected labels.");
-  }
-
-  console.log("\n" + "=".repeat(80) + "\n");
-}
-
-main();
+);

--- a/js/benchmarks/evals-benchmarks/src/tool_invocation.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/tool_invocation.eval.ts
@@ -1,13 +1,15 @@
+/**
+ * Tool invocation evaluator benchmark.
+ *
+ * Runs the tool-invocation evaluator across correct and faulty tool calls
+ * (hallucinated fields, missing required fields, malformed JSON, etc.) and
+ * gates the suite on labelling accuracy.
+ */
 import { openai } from "@ai-sdk/openai";
-/* eslint-disable no-console */
-import { createDataset } from "@arizeai/phoenix-client/datasets";
-import {
-  asExperimentEvaluator,
-  getExperiment,
-  runExperiment,
-} from "@arizeai/phoenix-client/experiments";
-import type { ExperimentTask } from "@arizeai/phoenix-client/types/experiments";
+import * as px from "@arizeai/phoenix-client/vitest";
 import { createToolInvocationEvaluator } from "@arizeai/phoenix-evals";
+
+import { accuracy } from "./evaluators.js";
 
 const toolInvocationEvaluator = createToolInvocationEvaluator({
   model: openai("gpt-4o-mini"),
@@ -497,272 +499,56 @@ User: Book the flight - I'm coming from Chicago.`,
 };
 
 // Flatten examples with category information
-const examples = Object.entries(examplesByCategory).flatMap(
+
+type ToolInvocationLabel = "correct" | "incorrect";
+
+const cases = Object.entries(examplesByCategory).flatMap(
   ([category, categoryExamples]) =>
     categoryExamples.map((example) => ({
-      ...example,
-      category,
+      input: {
+        input: example.input,
+        availableTools: example.available_tools,
+        toolSelection: example.tool_selection,
+      },
+      expected: { label: example.expected_label as ToolInvocationLabel },
+      metadata: {
+        category,
+        failure_mode: example.failure_mode,
+        format_type: example.format_type,
+      },
+      splits: [category, example.expected_label],
     }))
 );
 
-// Create dataset entries
-const datasetExamples = examples.map((example, index) => ({
-  input: {
-    input: example.input,
-    availableTools: example.available_tools,
-    toolSelection: example.tool_selection,
-  },
-  output: {
-    expected_label: example.expected_label,
-  },
-  metadata: {
-    category: example.category,
-    failure_mode: example.failure_mode,
-    format_type: example.format_type,
-    example_index: index,
-  },
-  splits: [example.category, example.expected_label],
-}));
-
-type TaskOutput = {
-  expected_label: "correct" | "incorrect";
-  label: "correct" | "incorrect";
-  score: number;
-  explanation: string;
-  category: string;
-  failure_mode: string | null;
-  format_type: string;
-};
-
-const accuracyEvaluator = asExperimentEvaluator({
-  name: "accuracy",
-  kind: "CODE",
-  evaluate: async (args) => {
-    const output = args.output as TaskOutput | null;
-
-    // Handle null output (task errors)
-    if (!output) {
-      return {
-        label: "error",
-        score: 0,
-        explanation: "Task failed to produce output",
-        metadata: {},
-      };
-    }
-
-    const score = output.expected_label === output.label ? 1 : 0;
-    const label =
-      output.expected_label === output.label ? "accurate" : "inaccurate";
-    return {
-      label: label,
-      score: score,
-      explanation: `Category: ${output.category}, Format: ${output.format_type}. The evaluator labeled the invocation as "${output.label}". Expected: "${output.expected_label}"${output.failure_mode ? `. Failure mode: ${output.failure_mode}` : ""}`,
-      metadata: {
-        category: output.category,
-        failure_mode: output.failure_mode,
-        format_type: output.format_type,
-      },
-    };
-  },
-});
-
-async function main() {
-  console.log("\n" + "=".repeat(60));
-  console.log("TOOL INVOCATION BENCHMARK CONFIGURATION");
-  console.log("=".repeat(60));
-  console.log(`Categories: ${Object.keys(examplesByCategory).length}`);
-  console.log(`Total examples: ${examples.length}`);
-
-  // Count by expected label
-  const correctCount = examples.filter(
-    (e) => e.expected_label === "correct"
-  ).length;
-  const incorrectCount = examples.filter(
-    (e) => e.expected_label === "incorrect"
-  ).length;
-  console.log(
-    `Expected correct: ${correctCount}, Expected incorrect: ${incorrectCount}`
-  );
-
-  // Count by format type
-  const formatCounts: Record<string, number> = {};
-  examples.forEach((e) => {
-    formatCounts[e.format_type] = (formatCounts[e.format_type] || 0) + 1;
-  });
-  console.log("Format types:", formatCounts);
-  console.log("=".repeat(60) + "\n");
-
-  const dataset = await createDataset({
-    name: "tool-invocation-benchmark-" + Date.now(),
-    description:
-      "Benchmark testing tool invocation correctness across categories: hallucinated fields, missing required fields, malformed JSON, incorrect argument values, unsafe content (PII), correct single/multi-tool invocations, multi-turn context, and different tool schema formats",
-    examples: datasetExamples,
-  });
-
-  const task: ExperimentTask = async (example) => {
-    const expectedLabel = example.output?.expected_label as
-      | "correct"
-      | "incorrect";
-
-    const evalResult = await toolInvocationEvaluator.evaluate({
-      input: example.input.input as string,
-      availableTools: example.input.availableTools as string,
-      toolSelection: example.input.toolSelection as string,
-    });
-
-    return {
-      expected_label: expectedLabel,
-      category: example.metadata?.category as string,
-      failure_mode: example.metadata?.failure_mode as string | null,
-      format_type: example.metadata?.format_type as string,
-      ...evalResult,
-    };
-  };
-
-  const experiment = await runExperiment({
-    experimentName: "tool-invocation-benchmark",
-    experimentDescription:
-      "Testing the tool invocation evaluator across various failure modes and input formats",
-    concurrency: 8,
-    dataset: dataset,
-    task,
-    evaluators: [accuracyEvaluator],
-  });
-
-  // Fetch full experiment details including runs
-  const experimentResult = await getExperiment({
-    experimentId: experiment.id,
-  });
-
-  // Print experiment summary
-  console.log("\n" + "=".repeat(80));
-  console.log("EXPERIMENT RESULTS SUMMARY");
-  console.log("=".repeat(80));
-  console.log(`Experiment ID: ${experimentResult.id}`);
-  console.log(`Dataset ID: ${experimentResult.datasetId}`);
-  console.log(`Total Examples: ${experimentResult.exampleCount}`);
-  console.log(`Successful Runs: ${experimentResult.successfulRunCount}`);
-  console.log(`Failed Runs: ${experimentResult.failedRunCount}`);
-  console.log(`Missing Runs: ${experimentResult.missingRunCount}`);
-
-  // Analyze runs by category and build confusion matrix
-  const runsByCategory: Record<
-    string,
-    { correct: number; incorrect: number; errors: number }
-  > = {};
-
-  // Confusion matrix counters
-  let truePositives = 0; // Predicted correct, Actually correct
-  let trueNegatives = 0; // Predicted incorrect, Actually incorrect
-  let falsePositives = 0; // Predicted correct, Actually incorrect
-  let falseNegatives = 0; // Predicted incorrect, Actually correct
-
-  for (const run of Object.values(experimentResult.runs)) {
-    const output = run.output as TaskOutput | null;
-    const category = output?.category || "unknown";
-
-    if (!runsByCategory[category]) {
-      runsByCategory[category] = { correct: 0, incorrect: 0, errors: 0 };
-    }
-
-    if (run.error) {
-      runsByCategory[category].errors++;
-    } else if (output?.expected_label === output?.label) {
-      runsByCategory[category].correct++;
-      // Update confusion matrix for correct predictions
-      if (output?.label === "correct") {
-        truePositives++;
-      } else {
-        trueNegatives++;
+px.describe(
+  "tool-invocation-benchmark",
+  () => {
+    px.test.each(cases)(
+      (row) => `[${String(row.metadata?.category)}] ${String(row.input.input)}`,
+      async ({ input }) => {
+        const result = await toolInvocationEvaluator.evaluate({
+          input: input.input,
+          availableTools: input.availableTools,
+          toolSelection: input.toolSelection,
+        });
+        px.logOutput(result);
+        px.logAnnotation({
+          name: "tool_invocation",
+          label: result.label,
+          score: result.score,
+          explanation: result.explanation,
+          annotatorKind: "LLM",
+        });
+        await px.evaluate(accuracy);
       }
-    } else {
-      runsByCategory[category].incorrect++;
-      // Update confusion matrix for incorrect predictions
-      if (output?.label === "correct") {
-        falsePositives++;
-      } else {
-        falseNegatives++;
-      }
-    }
-  }
-
-  console.log("\n" + "-".repeat(80));
-  console.log("ACCURACY BY CATEGORY");
-  console.log("-".repeat(80));
-  console.log(
-    `  ${"Category".padEnd(30)} | ${"Accuracy".padEnd(15)} | Details`
-  );
-  console.log("-".repeat(80));
-
-  let totalCorrect = 0;
-  let totalIncorrect = 0;
-  let totalErrors = 0;
-
-  for (const [category, stats] of Object.entries(runsByCategory).sort()) {
-    const total = stats.correct + stats.incorrect + stats.errors;
-    const accuracy =
-      total > 0 ? ((stats.correct / total) * 100).toFixed(0) : "N/A";
-
-    console.log(
-      `  ${category.padEnd(30)} | ${`${accuracy}%`.padEnd(15)} | ${stats.correct}/${total} correct${stats.errors > 0 ? `, ${stats.errors} errors` : ""}`
     );
-
-    totalCorrect += stats.correct;
-    totalIncorrect += stats.incorrect;
-    totalErrors += stats.errors;
+  },
+  {
+    description:
+      "Tool invocation correctness across categories: hallucinated fields, missing required fields, malformed JSON, incorrect argument values, unsafe content (PII), correct single/multi-tool invocations, multi-turn context, and different tool schema formats.",
+    metadata: { model: "gpt-4o-mini" },
+    acceptanceCriteria: [
+      { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+    ],
   }
-
-  const overallTotal = totalCorrect + totalIncorrect + totalErrors;
-  const overallAccuracy =
-    overallTotal > 0 ? ((totalCorrect / overallTotal) * 100).toFixed(1) : "N/A";
-
-  console.log("-".repeat(80));
-  console.log(
-    `  ${"OVERALL".padEnd(30)} | ${`${overallAccuracy}%`.padEnd(15)} | ${totalCorrect}/${overallTotal} correct${totalErrors > 0 ? `, ${totalErrors} errors` : ""}`
-  );
-  console.log("=".repeat(80));
-
-  // Print confusion matrix
-  console.log("\n" + "=".repeat(80));
-  console.log("CONFUSION MATRIX");
-  console.log("=".repeat(80));
-  console.log(
-    `                          │ Predicted: Correct │ Predicted: Incorrect │`
-  );
-  console.log("-".repeat(80));
-  console.log(
-    `  Actual: Correct         │ ${String(truePositives).padStart(18)} │ ${String(falseNegatives).padStart(20)} │`
-  );
-  console.log(
-    `  Actual: Incorrect       │ ${String(falsePositives).padStart(18)} │ ${String(trueNegatives).padStart(20)} │`
-  );
-  console.log("=".repeat(80));
-
-  // Calculate metrics
-  const precision =
-    truePositives + falsePositives > 0
-      ? ((truePositives / (truePositives + falsePositives)) * 100).toFixed(1)
-      : "N/A";
-  const recall =
-    truePositives + falseNegatives > 0
-      ? ((truePositives / (truePositives + falseNegatives)) * 100).toFixed(1)
-      : "N/A";
-  const f1Score =
-    precision !== "N/A" && recall !== "N/A"
-      ? parseFloat(precision) + parseFloat(recall) > 0
-        ? (
-            (2 * (parseFloat(precision) * parseFloat(recall))) /
-            (parseFloat(precision) + parseFloat(recall))
-          ).toFixed(1)
-        : "0.0"
-      : "N/A";
-
-  console.log(`\nMetrics:`);
-  console.log(`  Precision (PPV): ${precision}%`);
-  console.log(`  Recall (TPR):    ${recall}%`);
-  console.log(`  F1 Score:        ${f1Score}%`);
-  console.log(`\nTotal Errors: ${totalErrors}`);
-  console.log("=".repeat(80) + "\n");
-}
-
-main();
+);

--- a/js/benchmarks/evals-benchmarks/src/tool_invocation.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/tool_invocation.eval.ts
@@ -8,8 +8,17 @@
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createToolInvocationEvaluator } from "@arizeai/phoenix-evals";
 
+import {
+  createLabelAccumulator,
+  recordPrediction,
+  registerAggregateMetricsTest,
+} from "./aggregateMetrics.js";
 import { accuracy } from "./evaluators.js";
 import { evalModel, evalModelName } from "./model.js";
+
+// Ground-truth vs predicted labels across cases, scored by the trailing
+// aggregate-metrics test.
+const labels = createLabelAccumulator();
 
 const toolInvocationEvaluator = createToolInvocationEvaluator({
   model: evalModel,
@@ -525,7 +534,7 @@ px.describe(
   () => {
     px.test.each(cases)(
       (row) => `[${String(row.metadata?.category)}] ${String(row.input.input)}`,
-      async ({ input }) => {
+      async ({ input, expected }) => {
         const result = await toolInvocationEvaluator.evaluate({
           input: input.input,
           availableTools: input.availableTools,
@@ -539,9 +548,15 @@ px.describe(
           explanation: result.explanation,
           annotatorKind: "LLM",
         });
+        recordPrediction({
+          labels,
+          truth: expected?.label,
+          predicted: result.label,
+        });
         await px.evaluate(accuracy);
       }
     );
+    registerAggregateMetricsTest(labels);
   },
   {
     description:
@@ -549,6 +564,7 @@ px.describe(
     metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+      { annotationName: "f1", metric: "average", threshold: 0.7 },
     ],
   }
 );

--- a/js/benchmarks/evals-benchmarks/src/tool_invocation.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/tool_invocation.eval.ts
@@ -5,14 +5,14 @@
  * (hallucinated fields, missing required fields, malformed JSON, etc.) and
  * gates the suite on labelling accuracy.
  */
-import { openai } from "@ai-sdk/openai";
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createToolInvocationEvaluator } from "@arizeai/phoenix-evals";
 
 import { accuracy } from "./evaluators.js";
+import { evalModel, evalModelName } from "./model.js";
 
 const toolInvocationEvaluator = createToolInvocationEvaluator({
-  model: openai("gpt-4o-mini"),
+  model: evalModel,
 });
 
 // ============================================================================
@@ -546,7 +546,7 @@ px.describe(
   {
     description:
       "Tool invocation correctness across categories: hallucinated fields, missing required fields, malformed JSON, incorrect argument values, unsafe content (PII), correct single/multi-tool invocations, multi-turn context, and different tool schema formats.",
-    metadata: { model: "gpt-4o-mini" },
+    metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
     ],

--- a/js/benchmarks/evals-benchmarks/src/tool_response_handling.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/tool_response_handling.eval.ts
@@ -8,8 +8,17 @@
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createToolResponseHandlingEvaluator } from "@arizeai/phoenix-evals";
 
+import {
+  createLabelAccumulator,
+  recordPrediction,
+  registerAggregateMetricsTest,
+} from "./aggregateMetrics.js";
 import { accuracy } from "./evaluators.js";
 import { evalModel, evalModelName } from "./model.js";
+
+// Ground-truth vs predicted labels across cases, scored by the trailing
+// aggregate-metrics test.
+const labels = createLabelAccumulator();
 
 const toolResponseHandlingEvaluator = createToolResponseHandlingEvaluator({
   model: evalModel,
@@ -796,7 +805,7 @@ px.describe(
   () => {
     px.test.each(cases)(
       (row) => `[${String(row.metadata?.category)}] ${String(row.input.input)}`,
-      async ({ input }) => {
+      async ({ input, expected }) => {
         const result = await toolResponseHandlingEvaluator.evaluate({
           input: input.input,
           toolCall: input.toolCall,
@@ -811,9 +820,15 @@ px.describe(
           explanation: result.explanation,
           annotatorKind: "LLM",
         });
+        recordPrediction({
+          labels,
+          truth: expected?.label,
+          predicted: result.label,
+        });
         await px.evaluate(accuracy);
       }
     );
+    registerAggregateMetricsTest(labels);
   },
   {
     description:
@@ -821,6 +836,7 @@ px.describe(
     metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+      { annotationName: "f1", metric: "average", threshold: 0.7 },
     ],
   }
 );

--- a/js/benchmarks/evals-benchmarks/src/tool_response_handling.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/tool_response_handling.eval.ts
@@ -1,13 +1,15 @@
+/**
+ * Tool response handling evaluator benchmark.
+ *
+ * Runs the tool-response-handling evaluator across data extraction,
+ * transformation, summarization, error handling, hallucination, and disclosure
+ * cases, and gates the suite on labelling accuracy.
+ */
 import { openai } from "@ai-sdk/openai";
-/* eslint-disable no-console */
-import { createDataset } from "@arizeai/phoenix-client/datasets";
-import {
-  asExperimentEvaluator,
-  getExperiment,
-  runExperiment,
-} from "@arizeai/phoenix-client/experiments";
-import type { ExperimentTask } from "@arizeai/phoenix-client/types/experiments";
+import * as px from "@arizeai/phoenix-client/vitest";
 import { createToolResponseHandlingEvaluator } from "@arizeai/phoenix-evals";
+
+import { accuracy } from "./evaluators.js";
 
 const toolResponseHandlingEvaluator = createToolResponseHandlingEvaluator({
   model: openai("gpt-4o-mini"),
@@ -771,273 +773,54 @@ const examplesByCategory = {
 };
 
 // Flatten examples with category information
-const examples = Object.entries(examplesByCategory).flatMap(
+
+type ToolResponseLabel = "correct" | "incorrect";
+
+const cases = Object.entries(examplesByCategory).flatMap(
   ([category, categoryExamples]) =>
     categoryExamples.map((example) => ({
-      ...example,
-      category,
+      input: {
+        input: example.input,
+        toolCall: example.tool_call,
+        toolResult: example.tool_result,
+        output: example.output,
+      },
+      expected: { label: example.expected_label as ToolResponseLabel },
+      metadata: { category, failure_mode: example.failure_mode },
+      splits: [category, example.expected_label],
     }))
 );
 
-// Create dataset entries
-const datasetExamples = examples.map((example, index) => ({
-  input: {
-    input: example.input,
-    toolCall: example.tool_call,
-    toolResult: example.tool_result,
-    output: example.output,
-  },
-  output: {
-    expected_label: example.expected_label,
-  },
-  metadata: {
-    category: example.category,
-    failure_mode: example.failure_mode,
-    example_index: index,
-  },
-  splits: [example.category, example.expected_label],
-}));
-
-type TaskOutput = {
-  expected_label: "correct" | "incorrect";
-  label: "correct" | "incorrect";
-  score: number;
-  explanation: string;
-  category: string;
-  failure_mode: string | null;
-};
-
-const accuracyEvaluator = asExperimentEvaluator({
-  name: "accuracy",
-  kind: "CODE",
-  evaluate: async (args) => {
-    const output = args.output as TaskOutput | null;
-
-    // Handle null output (task errors)
-    if (!output) {
-      return {
-        label: "error",
-        score: 0,
-        explanation: "Task failed to produce output",
-        metadata: {},
-      };
-    }
-
-    const score = output.expected_label === output.label ? 1 : 0;
-    const label =
-      output.expected_label === output.label ? "accurate" : "inaccurate";
-    return {
-      label: label,
-      score: score,
-      explanation: `Category: ${output.category}. The evaluator labeled the handling as "${output.label}". Expected: "${output.expected_label}"${output.failure_mode ? `. Failure mode: ${output.failure_mode}` : ""}`,
-      metadata: {
-        category: output.category,
-        failure_mode: output.failure_mode,
-      },
-    };
-  },
-});
-
-async function main() {
-  console.log("\n" + "=".repeat(60));
-  console.log("TOOL RESPONSE HANDLING BENCHMARK CONFIGURATION");
-  console.log("=".repeat(60));
-  console.log(`Categories: ${Object.keys(examplesByCategory).length}`);
-  console.log(`Total examples: ${examples.length}`);
-
-  // Count by expected label
-  const correctCount = examples.filter(
-    (e) => e.expected_label === "correct"
-  ).length;
-  const incorrectCount = examples.filter(
-    (e) => e.expected_label === "incorrect"
-  ).length;
-  console.log(
-    `Expected correct: ${correctCount}, Expected incorrect: ${incorrectCount}`
-  );
-
-  // Count by category
-  const categoryCounts: Record<string, number> = {};
-  examples.forEach((e) => {
-    categoryCounts[e.category] = (categoryCounts[e.category] || 0) + 1;
-  });
-  console.log("Examples per category:");
-  Object.entries(categoryCounts).forEach(([cat, count]) => {
-    console.log(`  ${cat}: ${count}`);
-  });
-  console.log("=".repeat(60) + "\n");
-
-  const dataset = await createDataset({
-    name: "tool-response-handling-benchmark-" + Date.now(),
-    description:
-      "Benchmark testing tool response handling correctness: data extraction, transformation, summarization, error handling, multi-tool handling, hallucination detection, information disclosure prevention",
-    examples: datasetExamples,
-  });
-
-  const task: ExperimentTask = async (example) => {
-    const expectedLabel = example.output?.expected_label as
-      | "correct"
-      | "incorrect";
-
-    const evalResult = await toolResponseHandlingEvaluator.evaluate({
-      input: example.input.input as string,
-      toolCall: example.input.toolCall as string,
-      toolResult: example.input.toolResult as string,
-      output: example.input.output as string,
-    });
-
-    return {
-      expected_label: expectedLabel,
-      category: example.metadata?.category as string,
-      failure_mode: example.metadata?.failure_mode as string | null,
-      ...evalResult,
-    };
-  };
-
-  const experiment = await runExperiment({
-    experimentName: "tool-response-handling-benchmark",
-    experimentDescription:
-      "Testing the tool response handling evaluator across various scenarios",
-    concurrency: 8,
-    dataset: dataset,
-    task,
-    evaluators: [accuracyEvaluator],
-  });
-
-  // Fetch full experiment details including runs
-  const experimentResult = await getExperiment({
-    experimentId: experiment.id,
-  });
-
-  // Print experiment summary
-  console.log("\n" + "=".repeat(80));
-  console.log("EXPERIMENT RESULTS SUMMARY");
-  console.log("=".repeat(80));
-  console.log(`Experiment ID: ${experimentResult.id}`);
-  console.log(`Dataset ID: ${experimentResult.datasetId}`);
-  console.log(`Total Examples: ${experimentResult.exampleCount}`);
-  console.log(`Successful Runs: ${experimentResult.successfulRunCount}`);
-  console.log(`Failed Runs: ${experimentResult.failedRunCount}`);
-  console.log(`Missing Runs: ${experimentResult.missingRunCount}`);
-
-  // Analyze runs by category and build confusion matrix
-  const runsByCategory: Record<
-    string,
-    { correct: number; incorrect: number; errors: number }
-  > = {};
-
-  // Confusion matrix counters
-  let truePositives = 0; // Predicted correct, Actually correct
-  let trueNegatives = 0; // Predicted incorrect, Actually incorrect
-  let falsePositives = 0; // Predicted correct, Actually incorrect
-  let falseNegatives = 0; // Predicted incorrect, Actually correct
-
-  for (const run of Object.values(experimentResult.runs)) {
-    const output = run.output as TaskOutput | null;
-    const category = output?.category || "unknown";
-
-    if (!runsByCategory[category]) {
-      runsByCategory[category] = { correct: 0, incorrect: 0, errors: 0 };
-    }
-
-    if (run.error) {
-      runsByCategory[category].errors++;
-    } else if (output?.expected_label === output?.label) {
-      runsByCategory[category].correct++;
-      // Update confusion matrix for correct predictions
-      if (output?.label === "correct") {
-        truePositives++;
-      } else {
-        trueNegatives++;
+px.describe(
+  "tool-response-handling-benchmark",
+  () => {
+    px.test.each(cases)(
+      (row) => `[${String(row.metadata?.category)}] ${String(row.input.input)}`,
+      async ({ input }) => {
+        const result = await toolResponseHandlingEvaluator.evaluate({
+          input: input.input,
+          toolCall: input.toolCall,
+          toolResult: input.toolResult,
+          output: input.output,
+        });
+        px.logOutput(result);
+        px.logAnnotation({
+          name: "tool_response_handling",
+          label: result.label,
+          score: result.score,
+          explanation: result.explanation,
+          annotatorKind: "LLM",
+        });
+        await px.evaluate(accuracy);
       }
-    } else {
-      runsByCategory[category].incorrect++;
-      // Update confusion matrix for incorrect predictions
-      if (output?.label === "correct") {
-        falsePositives++;
-      } else {
-        falseNegatives++;
-      }
-    }
-  }
-
-  console.log("\n" + "-".repeat(80));
-  console.log("ACCURACY BY CATEGORY");
-  console.log("-".repeat(80));
-  console.log(
-    `  ${"Category".padEnd(30)} | ${"Accuracy".padEnd(15)} | Details`
-  );
-  console.log("-".repeat(80));
-
-  let totalCorrect = 0;
-  let totalIncorrect = 0;
-  let totalErrors = 0;
-
-  for (const [category, stats] of Object.entries(runsByCategory).sort()) {
-    const total = stats.correct + stats.incorrect + stats.errors;
-    const accuracy =
-      total > 0 ? ((stats.correct / total) * 100).toFixed(0) : "N/A";
-
-    console.log(
-      `  ${category.padEnd(30)} | ${`${accuracy}%`.padEnd(15)} | ${stats.correct}/${total} correct${stats.errors > 0 ? `, ${stats.errors} errors` : ""}`
     );
-
-    totalCorrect += stats.correct;
-    totalIncorrect += stats.incorrect;
-    totalErrors += stats.errors;
+  },
+  {
+    description:
+      "Tool response handling correctness: data extraction, transformation, summarization, error handling, multi-tool handling, hallucination detection, and information disclosure prevention.",
+    metadata: { model: "gpt-4o-mini" },
+    acceptanceCriteria: [
+      { annotationName: "accuracy", metric: "average", threshold: 0.7 },
+    ],
   }
-
-  const overallTotal = totalCorrect + totalIncorrect + totalErrors;
-  const overallAccuracy =
-    overallTotal > 0 ? ((totalCorrect / overallTotal) * 100).toFixed(1) : "N/A";
-
-  console.log("-".repeat(80));
-  console.log(
-    `  ${"OVERALL".padEnd(30)} | ${`${overallAccuracy}%`.padEnd(15)} | ${totalCorrect}/${overallTotal} correct${totalErrors > 0 ? `, ${totalErrors} errors` : ""}`
-  );
-  console.log("=".repeat(80));
-
-  // Print confusion matrix
-  console.log("\n" + "=".repeat(80));
-  console.log("CONFUSION MATRIX");
-  console.log("=".repeat(80));
-  console.log(
-    `                          │ Predicted: Correct │ Predicted: Incorrect │`
-  );
-  console.log("-".repeat(80));
-  console.log(
-    `  Actual: Correct         │ ${String(truePositives).padStart(18)} │ ${String(falseNegatives).padStart(20)} │`
-  );
-  console.log(
-    `  Actual: Incorrect       │ ${String(falsePositives).padStart(18)} │ ${String(trueNegatives).padStart(20)} │`
-  );
-  console.log("=".repeat(80));
-
-  // Calculate metrics
-  const precision =
-    truePositives + falsePositives > 0
-      ? ((truePositives / (truePositives + falsePositives)) * 100).toFixed(1)
-      : "N/A";
-  const recall =
-    truePositives + falseNegatives > 0
-      ? ((truePositives / (truePositives + falseNegatives)) * 100).toFixed(1)
-      : "N/A";
-  const f1Score =
-    precision !== "N/A" && recall !== "N/A"
-      ? parseFloat(precision) + parseFloat(recall) > 0
-        ? (
-            (2 * (parseFloat(precision) * parseFloat(recall))) /
-            (parseFloat(precision) + parseFloat(recall))
-          ).toFixed(1)
-        : "0.0"
-      : "N/A";
-
-  console.log(`\nMetrics:`);
-  console.log(`  Precision (PPV): ${precision}%`);
-  console.log(`  Recall (TPR):    ${recall}%`);
-  console.log(`  F1 Score:        ${f1Score}%`);
-  console.log(`\nTotal Errors: ${totalErrors}`);
-  console.log("=".repeat(80) + "\n");
-}
-
-main();
+);

--- a/js/benchmarks/evals-benchmarks/src/tool_response_handling.eval.ts
+++ b/js/benchmarks/evals-benchmarks/src/tool_response_handling.eval.ts
@@ -5,14 +5,14 @@
  * transformation, summarization, error handling, hallucination, and disclosure
  * cases, and gates the suite on labelling accuracy.
  */
-import { openai } from "@ai-sdk/openai";
 import * as px from "@arizeai/phoenix-client/vitest";
 import { createToolResponseHandlingEvaluator } from "@arizeai/phoenix-evals";
 
 import { accuracy } from "./evaluators.js";
+import { evalModel, evalModelName } from "./model.js";
 
 const toolResponseHandlingEvaluator = createToolResponseHandlingEvaluator({
-  model: openai("gpt-4o-mini"),
+  model: evalModel,
 });
 
 // ============================================================================
@@ -818,7 +818,7 @@ px.describe(
   {
     description:
       "Tool response handling correctness: data extraction, transformation, summarization, error handling, multi-tool handling, hallucination detection, and information disclosure prevention.",
-    metadata: { model: "gpt-4o-mini" },
+    metadata: { model: evalModelName },
     acceptanceCriteria: [
       { annotationName: "accuracy", metric: "average", threshold: 0.7 },
     ],

--- a/js/benchmarks/evals-benchmarks/tsconfig.json
+++ b/js/benchmarks/evals-benchmarks/tsconfig.json
@@ -24,5 +24,6 @@
 
     /* If your code doesn't run in the DOM: */
     "lib": ["es2022"]
-  }
+  },
+  "include": ["src"]
 }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -59,12 +59,18 @@ importers:
       '@types/node':
         specifier: ^25.9.4
         version: 25.9.4
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
 
   examples/apps/cli-agent-starter-kit:
     dependencies:

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
 
   examples/apps/cli-agent-starter-kit:
     dependencies:


### PR DESCRIPTION
## Summary

Migrates the `js/benchmarks/evals-benchmarks` package from standalone `*_benchmark.ts` scripts to `*.eval.ts` vitest suites powered by `@arizeai/phoenix-client/vitest`.

- Each benchmark now runs as a Phoenix eval test: examples become dataset examples / experiment runs on Phoenix, and the suite is gated on evaluator accuracy.
- Adds `phoenix.vitest.config.ts` and a shared `src/evaluators.ts` (accuracy evaluator).
- New scripts: `test`, `test:watch`, and `test:local` (runs with `PHOENIX_TEST_TRACING=false`).
- Covers conciseness, correctness, document relevance, faithfulness, refusal, tool invocation, and tool response handling evaluators.

## How to run

```bash
cd js/benchmarks/evals-benchmarks
pnpm test          # run against Phoenix
pnpm test:local    # run without Phoenix tracing
```