### PR TITLE
fix(app): remove chevron icon from column selector buttons

### DIFF
--- a/app/src/pages/experiments/ExperimentColumnSelector.tsx
+++ b/app/src/pages/experiments/ExperimentColumnSelector.tsx
@@ -10,7 +10,6 @@ import {
   Icon,
   Icons,
   Popover,
-  SelectChevronUpDownIcon,
   View,
 } from "@phoenix/components";
 
@@ -29,7 +28,7 @@ export function ExperimentColumnSelector<T extends object>(
 ) {
   return (
     <DialogTrigger>
-      <Button trailingVisual={<SelectChevronUpDownIcon />}>
+      <Button>
         <Flex alignItems="center" gap="size-100">
           <Icon svg={<Icons.Column />} />
           Columns

--- a/app/src/pages/project/SessionColumnSelector.tsx
+++ b/app/src/pages/project/SessionColumnSelector.tsx
@@ -11,7 +11,6 @@ import {
   Icon,
   Icons,
   Popover,
-  SelectChevronUpDownIcon,
   View,
 } from "@phoenix/components";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
@@ -37,7 +36,7 @@ export function SessionColumnSelector<T extends object>(
 ) {
   return (
     <DialogTrigger>
-      <Button trailingVisual={<SelectChevronUpDownIcon />}>
+      <Button>
         <Flex alignItems="center" gap="size-100">
           <Icon svg={<Icons.Column />} />
           Columns

--- a/app/src/pages/project/SpanColumnSelector.tsx
+++ b/app/src/pages/project/SpanColumnSelector.tsx
@@ -11,7 +11,6 @@ import {
   Icon,
   Icons,
   Popover,
-  SelectChevronUpDownIcon,
   View,
 } from "@phoenix/components";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
@@ -51,7 +50,7 @@ type SpanColumnSelectorProps = {
 export function SpanColumnSelector(props: SpanColumnSelectorProps) {
   return (
     <DialogTrigger>
-      <Button trailingVisual={<SelectChevronUpDownIcon />}>
+      <Button>
         <Flex direction="row" alignItems="center" gap="size-100">
           <Icon svg={<Icons.Column />} />
           Columns


### PR DESCRIPTION
## Summary
- Removed the trailing up/down chevron icon (`SelectChevronUpDownIcon`) from the "Columns" button in `SpanColumnSelector`, `SessionColumnSelector`, and `ExperimentColumnSelector`.
- The button already conveys it's interactive via its column icon and "Columns" label, so the chevron was unnecessary.

## Test plan
- [x] `pnpm run typecheck` passes with no errors
- [x] Verified no other column-toggle buttons reference `SelectChevronUpDownIcon`


---
_Generated by [Claude Code](https://claude.ai/code/session_01NXASEmBKR2z34Ew4Xhnpfr)_