### PR TITLE
feat: session stats side panel for the sessions table

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2737,24 +2737,24 @@ type Project implements Node {
   sessions(timeRange: TimeRange, first: Int = 30, after: String, sort: ProjectSessionSort, filterIoSubstring: String, sessionId: String): ProjectSessionConnection!
 
   """
-  Number of sessions in the project, optionally filtered by a time range and a substring of the session input/output.
+  Number of sessions in the project, optionally filtered by a time range and a substring of the session input/output. An exact session-ID match takes precedence over the other filters, mirroring the sessions table search.
   """
-  sessionCount(timeRange: TimeRange, filterIoSubstring: String): Int!
+  sessionCount(timeRange: TimeRange, filterIoSubstring: String, sessionId: String): Int!
 
   """
-  Average session duration in milliseconds, i.e. the mean of end time minus start time across sessions, optionally filtered by a time range and a substring of the session input/output.
+  Average session duration in milliseconds, i.e. the mean of end time minus start time across sessions, optionally filtered by a time range and a substring of the session input/output. An exact session-ID match takes precedence over the other filters, mirroring the sessions table search.
   """
-  averageSessionDurationMs(timeRange: TimeRange, filterIoSubstring: String): Float
+  averageSessionDurationMs(timeRange: TimeRange, filterIoSubstring: String, sessionId: String): Float
 
   """
-  Average number of traces (e.g. conversation turns) per session, optionally filtered by a time range and a substring of the session input/output.
+  Average number of traces (e.g. conversation turns) per session, optionally filtered by a time range and a substring of the session input/output. An exact session-ID match takes precedence over the other filters, mirroring the sessions table search.
   """
-  averageTracesPerSession(timeRange: TimeRange, filterIoSubstring: String): Float
+  averageTracesPerSession(timeRange: TimeRange, filterIoSubstring: String, sessionId: String): Float
 
   """
-  Quantile (e.g. p50, p99) of session duration in milliseconds, i.e. end time minus start time, optionally filtered by a time range and a substring of the session input/output.
+  Quantile (e.g. p50, p99) of session duration in milliseconds, i.e. end time minus start time, optionally filtered by a time range and a substring of the session input/output. An exact session-ID match takes precedence over the other filters, mirroring the sessions table search.
   """
-  sessionDurationMsQuantile(probability: Float!, timeRange: TimeRange, filterIoSubstring: String): Float
+  sessionDurationMsQuantile(probability: Float!, timeRange: TimeRange, filterIoSubstring: String, sessionId: String): Float
 
   """
   Names of all available annotations for traces. (The list contains no duplicates.)
@@ -2790,7 +2790,11 @@ type Project implements Node {
   documentEvaluationNames(spanId: ID): [String!]!
   traceAnnotationSummary(annotationName: String!, filterCondition: String, sessionFilterCondition: String, timeRange: TimeRange): AnnotationSummary
   spanAnnotationSummary(annotationName: String!, timeRange: TimeRange, filterCondition: String, sessionFilterCondition: String): AnnotationSummary
-  sessionAnnotationSummary(annotationName: String!, timeRange: TimeRange, filterIoSubstring: String): AnnotationSummary
+
+  """
+  Summary (score and label fractions) of a session annotation across the project's sessions, optionally filtered by a time range and a substring of the session input/output. An exact session-ID match takes precedence over the other filters, mirroring the sessions table search.
+  """
+  sessionAnnotationSummary(annotationName: String!, timeRange: TimeRange, filterIoSubstring: String, sessionId: String): AnnotationSummary
   documentEvaluationSummary(evaluationName: String!, timeRange: TimeRange, filterCondition: String): DocumentEvaluationSummary
   streamingLastUpdatedAt: DateTime
   validateSpanFilterCondition(condition: String!): ValidationResult!

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2737,6 +2737,26 @@ type Project implements Node {
   sessions(timeRange: TimeRange, first: Int = 30, after: String, sort: ProjectSessionSort, filterIoSubstring: String, sessionId: String): ProjectSessionConnection!
 
   """
+  Number of sessions in the project, optionally filtered by a time range and a substring of the session input/output.
+  """
+  sessionCount(timeRange: TimeRange, filterIoSubstring: String): Int!
+
+  """
+  Average session duration in milliseconds, i.e. the mean of end time minus start time across sessions, optionally filtered by a time range and a substring of the session input/output.
+  """
+  averageSessionDurationMs(timeRange: TimeRange, filterIoSubstring: String): Float
+
+  """
+  Average number of traces (e.g. conversation turns) per session, optionally filtered by a time range and a substring of the session input/output.
+  """
+  averageTracesPerSession(timeRange: TimeRange, filterIoSubstring: String): Float
+
+  """
+  Quantile (e.g. p50, p99) of session duration in milliseconds, i.e. end time minus start time, optionally filtered by a time range and a substring of the session input/output.
+  """
+  sessionDurationMsQuantile(probability: Float!, timeRange: TimeRange, filterIoSubstring: String): Float
+
+  """
   Names of all available annotations for traces. (The list contains no duplicates.)
   """
   traceAnnotationsNames: [String!]!
@@ -2770,6 +2790,7 @@ type Project implements Node {
   documentEvaluationNames(spanId: ID): [String!]!
   traceAnnotationSummary(annotationName: String!, filterCondition: String, sessionFilterCondition: String, timeRange: TimeRange): AnnotationSummary
   spanAnnotationSummary(annotationName: String!, timeRange: TimeRange, filterCondition: String, sessionFilterCondition: String): AnnotationSummary
+  sessionAnnotationSummary(annotationName: String!, timeRange: TimeRange, filterIoSubstring: String): AnnotationSummary
   documentEvaluationSummary(evaluationName: String!, timeRange: TimeRange, filterCondition: String): DocumentEvaluationSummary
   streamingLastUpdatedAt: DateTime
   validateSpanFilterCondition(condition: String!): ValidationResult!

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -268,7 +268,7 @@ export const appRouteObjects = createRoutesFromElements(
                   agentRoute: {
                     label: "Project Sessions",
                     description:
-                      "Browse user or application sessions and the session list for a project. Supports configurable metric charts shown above the table.",
+                      "Browse user or application sessions and the session list for a project. Supports configurable metric charts shown above the table, with a stats side panel showing session count, average session duration, and session annotation summaries.",
                   },
                 }}
               >

--- a/app/src/pages/project/SessionAnnotationSummary.tsx
+++ b/app/src/pages/project/SessionAnnotationSummary.tsx
@@ -15,11 +15,11 @@ import {
 type SessionAnnotationSummaryProps = {
   annotationName: string;
   /**
-   * Optional input/output substring filter. When set, the session annotation
-   * summary is restricted to sessions whose root span input/output contains
-   * the substring.
+   * The sessions table search text. Like the table, the summary treats it as
+   * both an input/output substring filter and an exact session-ID lookup,
+   * with an exact match taking precedence.
    */
-  filterIoSubstring?: string | null;
+  filterIoSubstringOrSessionId?: string | null;
 };
 
 /**
@@ -29,7 +29,7 @@ type SessionAnnotationSummaryProps = {
  */
 export function SessionAnnotationSummary({
   annotationName,
-  filterIoSubstring,
+  filterIoSubstringOrSessionId,
 }: SessionAnnotationSummaryProps) {
   const { projectId } = useParams();
   const { timeRange } = useTimeRange();
@@ -40,6 +40,7 @@ export function SessionAnnotationSummary({
         $annotationName: String!
         $timeRange: TimeRange!
         $filterIoSubstring: String
+        $sessionId: String
       ) {
         project: node(id: $id) {
           ...SessionAnnotationSummaryValueFragment
@@ -47,6 +48,7 @@ export function SessionAnnotationSummary({
               annotationName: $annotationName
               timeRange: $timeRange
               filterIoSubstring: $filterIoSubstring
+              sessionId: $sessionId
             )
         }
       }
@@ -58,14 +60,15 @@ export function SessionAnnotationSummary({
         start: timeRange?.start?.toISOString(),
         end: timeRange?.end?.toISOString(),
       },
-      filterIoSubstring: filterIoSubstring || null,
+      filterIoSubstring: filterIoSubstringOrSessionId || null,
+      sessionId: filterIoSubstringOrSessionId || null,
     }
   );
   return (
     <Summary name={annotationName}>
       <SessionAnnotationSummaryValue
         annotationName={annotationName}
-        filterIoSubstring={filterIoSubstring || null}
+        filterIoSubstringOrSessionId={filterIoSubstringOrSessionId || null}
         project={data.project}
       />
     </Summary>
@@ -74,10 +77,10 @@ export function SessionAnnotationSummary({
 
 function SessionAnnotationSummaryValue(props: {
   annotationName: string;
-  filterIoSubstring: string | null;
+  filterIoSubstringOrSessionId: string | null;
   project: SessionAnnotationSummaryValueFragment$key;
 }) {
-  const { project, annotationName, filterIoSubstring } = props;
+  const { project, annotationName, filterIoSubstringOrSessionId } = props;
   const [data, refetch] = useRefetchableFragment<
     SessionAnnotationSummaryQuery,
     SessionAnnotationSummaryValueFragment$key
@@ -89,6 +92,7 @@ function SessionAnnotationSummaryValue(props: {
         annotationName: { type: "String!" }
         timeRange: { type: "TimeRange!" }
         filterIoSubstring: { type: "String", defaultValue: null }
+        sessionId: { type: "String", defaultValue: null }
       ) {
         annotationConfigs {
           edges {
@@ -113,6 +117,7 @@ function SessionAnnotationSummaryValue(props: {
           annotationName: $annotationName
           timeRange: $timeRange
           filterIoSubstring: $filterIoSubstring
+          sessionId: $sessionId
         ) {
           name
           count
@@ -131,7 +136,13 @@ function SessionAnnotationSummaryValue(props: {
 
   useRefetchOnStreamAdvance(() => {
     startTransition(() => {
-      refetch({ filterIoSubstring }, { fetchPolicy: "store-and-network" });
+      refetch(
+        {
+          filterIoSubstring: filterIoSubstringOrSessionId,
+          sessionId: filterIoSubstringOrSessionId,
+        },
+        { fetchPolicy: "store-and-network" }
+      );
     });
   });
 

--- a/app/src/pages/project/SessionAnnotationSummary.tsx
+++ b/app/src/pages/project/SessionAnnotationSummary.tsx
@@ -1,0 +1,145 @@
+import { startTransition } from "react";
+import { graphql, useLazyLoadQuery, useRefetchableFragment } from "react-relay";
+import { useParams } from "react-router";
+
+import { useTimeRange } from "@phoenix/components/datetime";
+
+import type { SessionAnnotationSummaryQuery } from "./__generated__/SessionAnnotationSummaryQuery.graphql";
+import type { SessionAnnotationSummaryValueFragment$key } from "./__generated__/SessionAnnotationSummaryValueFragment.graphql";
+import {
+  AnnotationSummaryValueView,
+  Summary,
+  useRefetchOnStreamAdvance,
+} from "./AnnotationSummary";
+
+type SessionAnnotationSummaryProps = {
+  annotationName: string;
+  /**
+   * Optional input/output substring filter. When set, the session annotation
+   * summary is restricted to sessions whose root span input/output contains
+   * the substring.
+   */
+  filterIoSubstring?: string | null;
+};
+
+/**
+ * Project-level summary for a single session annotation. Mirrors
+ * {@link AnnotationSummary} (which summarizes span annotations) so
+ * session-level feedback can sit in the sessions table stats panel.
+ */
+export function SessionAnnotationSummary({
+  annotationName,
+  filterIoSubstring,
+}: SessionAnnotationSummaryProps) {
+  const { projectId } = useParams();
+  const { timeRange } = useTimeRange();
+  const data = useLazyLoadQuery<SessionAnnotationSummaryQuery>(
+    graphql`
+      query SessionAnnotationSummaryQuery(
+        $id: ID!
+        $annotationName: String!
+        $timeRange: TimeRange!
+        $filterIoSubstring: String
+      ) {
+        project: node(id: $id) {
+          ...SessionAnnotationSummaryValueFragment
+            @arguments(
+              annotationName: $annotationName
+              timeRange: $timeRange
+              filterIoSubstring: $filterIoSubstring
+            )
+        }
+      }
+    `,
+    {
+      annotationName,
+      id: projectId as string,
+      timeRange: {
+        start: timeRange?.start?.toISOString(),
+        end: timeRange?.end?.toISOString(),
+      },
+      filterIoSubstring: filterIoSubstring || null,
+    }
+  );
+  return (
+    <Summary name={annotationName}>
+      <SessionAnnotationSummaryValue
+        annotationName={annotationName}
+        filterIoSubstring={filterIoSubstring || null}
+        project={data.project}
+      />
+    </Summary>
+  );
+}
+
+function SessionAnnotationSummaryValue(props: {
+  annotationName: string;
+  filterIoSubstring: string | null;
+  project: SessionAnnotationSummaryValueFragment$key;
+}) {
+  const { project, annotationName, filterIoSubstring } = props;
+  const [data, refetch] = useRefetchableFragment<
+    SessionAnnotationSummaryQuery,
+    SessionAnnotationSummaryValueFragment$key
+  >(
+    graphql`
+      fragment SessionAnnotationSummaryValueFragment on Project
+      @refetchable(queryName: "SessionAnnotationSummaryValueQuery")
+      @argumentDefinitions(
+        annotationName: { type: "String!" }
+        timeRange: { type: "TimeRange!" }
+        filterIoSubstring: { type: "String", defaultValue: null }
+      ) {
+        annotationConfigs {
+          edges {
+            node {
+              ... on AnnotationConfigBase {
+                annotationType
+              }
+              ... on CategoricalAnnotationConfig {
+                annotationType
+                id
+                optimizationDirection
+                name
+                values {
+                  label
+                  score
+                }
+              }
+            }
+          }
+        }
+        sessionAnnotationSummary(
+          annotationName: $annotationName
+          timeRange: $timeRange
+          filterIoSubstring: $filterIoSubstring
+        ) {
+          name
+          count
+          scoreCount
+          labelCount
+          labelFractions {
+            label
+            fraction
+          }
+          meanScore
+        }
+      }
+    `,
+    project
+  );
+
+  useRefetchOnStreamAdvance(() => {
+    startTransition(() => {
+      refetch({ filterIoSubstring }, { fetchPolicy: "store-and-network" });
+    });
+  });
+
+  return (
+    <AnnotationSummaryValueView
+      name={annotationName}
+      summary={data?.sessionAnnotationSummary}
+      annotationConfigs={data?.annotationConfigs}
+    />
+  );
+}

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -14,27 +14,32 @@ import {
 } from "@tanstack/react-table";
 import React, {
   startTransition,
+  Suspense,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
+import { Group, Panel, Separator } from "react-resizable-panels";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 
 import {
   ContextualHelp,
   CopyToClipboardButton,
+  ErrorBoundary,
   Flex,
   Heading,
   Icon,
   Icons,
   Text,
+  TextErrorBoundaryFallback,
   View,
 } from "@phoenix/components";
 import { MeanScore } from "@phoenix/components/annotation/MeanScore";
 import { SessionAnnotationSummaryGroupTokens } from "@phoenix/components/annotation/SessionAnnotationSummaryGroup";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
+import { compactResizeHandleCSS } from "@phoenix/components/resize";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
@@ -57,10 +62,19 @@ import { DEFAULT_PAGE_SIZE } from "./constants";
 import { SessionColumnSelector } from "./SessionColumnSelector";
 import { useSessionSearchContext } from "./SessionSearchContext";
 import { SessionSearchField } from "./SessionSearchField";
+import { SessionsTableAside } from "./SessionsTableAside";
 import { SessionsTableEmpty } from "./SessionsTableEmpty";
 import { spansTableCSS } from "./styles";
 import { TableMetricsChartsPanelGroup } from "./TableMetricsCharts";
 import { TableMetricsChartSelector } from "./TableMetricsChartSelector";
+import {
+  ASIDE_PANEL_DEFAULT_SIZE_PIXELS,
+  ASIDE_PANEL_MAX_SIZE_PIXELS,
+  ASIDE_PANEL_MIN_SIZE_PIXELS,
+  TableAsideSkeleton,
+  TableAsideToggleButton,
+  useTableAsidePanel,
+} from "./TableAside";
 import {
   DEFAULT_SESSION_SORT,
   getGqlSessionSort,
@@ -139,6 +153,8 @@ export function SessionsTable(props: SessionsTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const { filterIoSubstringOrSessionId } = useSessionSearchContext();
   const { fetchKey } = useStreamState();
+  const { showTableAside, asidePanelRef, onAsidePanelResize } =
+    useTableAsidePanel();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<SessionsTableQuery, SessionsTable_sessions$key>(
       graphql`
@@ -530,114 +546,151 @@ export function SessionsTable(props: SessionsTableProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getFlatHeaders, columnSizingInfo, columnSizingState, colLength]);
   return (
-    <TableMetricsChartsPanelGroup view="sessions">
-      <div css={spansTableCSS}>
-        <View
-          paddingTop="size-100"
-          paddingBottom="size-100"
-          paddingStart="size-200"
-          paddingEnd="size-200"
-          borderBottomColor="default"
-          borderBottomWidth="thin"
-          flex="none"
-        >
-          <Flex direction="row" gap="size-100" width="100%" alignItems="center">
-            <View flex="1 1 auto">
-              <SessionSearchField />
+    <Group orientation="horizontal" id="sessions-table-layout">
+      <Panel>
+        <TableMetricsChartsPanelGroup view="sessions">
+          <div css={spansTableCSS}>
+            <View
+              paddingTop="size-100"
+              paddingBottom="size-100"
+              paddingStart="size-200"
+              paddingEnd="size-200"
+              borderBottomColor="default"
+              borderBottomWidth="thin"
+              flex="none"
+            >
+              <Flex
+                direction="row"
+                gap="size-100"
+                width="100%"
+                alignItems="center"
+              >
+                <View flex="1 1 auto">
+                  <SessionSearchField />
+                </View>
+                <TableMetricsChartSelector view="sessions" />
+                <SessionColumnSelector columns={computedColumns} query={data} />
+                <TableAsideToggleButton />
+              </Flex>
             </View>
-            <TableMetricsChartSelector view="sessions" />
-            <SessionColumnSelector columns={computedColumns} query={data} />
-          </Flex>
-        </View>
-        <div
-          css={css`
-            flex: 1 1 auto;
-            overflow: auto;
-          `}
-          onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
-          ref={tableContainerRef}
-        >
-          <table
-            css={selectableTableCSS}
-            style={{
-              ...columnSizeVars,
-              width: table.getTotalSize(),
-              minWidth: "100%",
-            }}
-          >
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => (
-                    <th
-                      colSpan={header.colSpan}
-                      style={{
-                        width: `calc(var(--header-${header.id}-size) * 1px)`,
-                      }}
-                      key={header.id}
-                    >
-                      {header.isPlaceholder ? null : (
-                        <>
-                          <div
-                            data-sortable={header.column.getCanSort()}
-                            {...{
-                              className: header.column.getCanSort()
-                                ? "sort"
-                                : "",
-                              onClick: header.column.getToggleSortingHandler(),
-                              style: {
-                                left: header.getStart(),
-                                width: header.getSize(),
-                              },
-                            }}
-                          >
-                            <Truncate maxWidth="100%">
-                              {flexRender(
-                                header.column.columnDef.header,
-                                header.getContext()
-                              )}
-                            </Truncate>
-                            {header.column.getIsSorted() ? (
-                              <Icon
-                                className="sort-icon"
-                                svg={
-                                  header.column.getIsSorted() === "asc" ? (
-                                    <Icons.CaretUpFilled />
-                                  ) : (
-                                    <Icons.CaretDownFilled />
-                                  )
-                                }
+            <div
+              css={css`
+                flex: 1 1 auto;
+                overflow: auto;
+              `}
+              onScroll={(e) =>
+                fetchMoreOnBottomReached(e.target as HTMLDivElement)
+              }
+              ref={tableContainerRef}
+            >
+              <table
+                css={selectableTableCSS}
+                style={{
+                  ...columnSizeVars,
+                  width: table.getTotalSize(),
+                  minWidth: "100%",
+                }}
+              >
+                <thead>
+                  {table.getHeaderGroups().map((headerGroup) => (
+                    <tr key={headerGroup.id}>
+                      {headerGroup.headers.map((header) => (
+                        <th
+                          colSpan={header.colSpan}
+                          style={{
+                            width: `calc(var(--header-${header.id}-size) * 1px)`,
+                          }}
+                          key={header.id}
+                        >
+                          {header.isPlaceholder ? null : (
+                            <>
+                              <div
+                                data-sortable={header.column.getCanSort()}
+                                {...{
+                                  className: header.column.getCanSort()
+                                    ? "sort"
+                                    : "",
+                                  onClick:
+                                    header.column.getToggleSortingHandler(),
+                                  style: {
+                                    left: header.getStart(),
+                                    width: header.getSize(),
+                                  },
+                                }}
+                              >
+                                <Truncate maxWidth="100%">
+                                  {flexRender(
+                                    header.column.columnDef.header,
+                                    header.getContext()
+                                  )}
+                                </Truncate>
+                                {header.column.getIsSorted() ? (
+                                  <Icon
+                                    className="sort-icon"
+                                    svg={
+                                      header.column.getIsSorted() === "asc" ? (
+                                        <Icons.CaretUpFilled />
+                                      ) : (
+                                        <Icons.CaretDownFilled />
+                                      )
+                                    }
+                                  />
+                                ) : null}
+                              </div>
+                              <div
+                                {...{
+                                  onMouseDown: header.getResizeHandler(),
+                                  onTouchStart: header.getResizeHandler(),
+                                  className: `resizer ${
+                                    header.column.getIsResizing()
+                                      ? "isResizing"
+                                      : ""
+                                  }`,
+                                }}
                               />
-                            ) : null}
-                          </div>
-                          <div
-                            {...{
-                              onMouseDown: header.getResizeHandler(),
-                              onTouchStart: header.getResizeHandler(),
-                              className: `resizer ${
-                                header.column.getIsResizing()
-                                  ? "isResizing"
-                                  : ""
-                              }`,
-                            }}
-                          />
-                        </>
-                      )}
-                    </th>
+                            </>
+                          )}
+                        </th>
+                      ))}
+                    </tr>
                   ))}
-                </tr>
-              ))}
-            </thead>
-            {isEmpty ? (
-              <SessionsTableEmpty />
-            ) : columnSizingInfo.isResizingColumn ? (
-              <MemoizedTableBody table={table} />
-            ) : (
-              <TableBody table={table} />
-            )}
-          </table>
-        </div>
-      </div>
-    </TableMetricsChartsPanelGroup>
+                </thead>
+                {isEmpty ? (
+                  <SessionsTableEmpty />
+                ) : columnSizingInfo.isResizingColumn ? (
+                  <MemoizedTableBody table={table} />
+                ) : (
+                  <TableBody table={table} />
+                )}
+              </table>
+            </div>
+          </div>
+        </TableMetricsChartsPanelGroup>
+      </Panel>
+      <Separator
+        css={compactResizeHandleCSS}
+        disabled={!showTableAside}
+        style={showTableAside ? undefined : { display: "none" }}
+      />
+      <Panel
+        panelRef={asidePanelRef}
+        defaultSize={ASIDE_PANEL_DEFAULT_SIZE_PIXELS}
+        collapsedSize={0}
+        minSize={ASIDE_PANEL_MIN_SIZE_PIXELS}
+        maxSize={ASIDE_PANEL_MAX_SIZE_PIXELS}
+        collapsible
+        onResize={onAsidePanelResize}
+      >
+        {showTableAside ? (
+          <ErrorBoundary fallback={TextErrorBoundaryFallback}>
+            <Suspense fallback={<TableAsideSkeleton />}>
+              <SessionsTableAside
+                filterIoSubstring={filterIoSubstringOrSessionId}
+              />
+            </Suspense>
+          </ErrorBoundary>
+        ) : null}
+      </Panel>
+    </Group>
   );
 }

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -14,32 +14,28 @@ import {
 } from "@tanstack/react-table";
 import React, {
   startTransition,
-  Suspense,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
-import { Group, Panel, Separator } from "react-resizable-panels";
+import { Group, Panel } from "react-resizable-panels";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 
 import {
   ContextualHelp,
   CopyToClipboardButton,
-  ErrorBoundary,
   Flex,
   Heading,
   Icon,
   Icons,
   Text,
-  TextErrorBoundaryFallback,
   View,
 } from "@phoenix/components";
 import { MeanScore } from "@phoenix/components/annotation/MeanScore";
 import { SessionAnnotationSummaryGroupTokens } from "@phoenix/components/annotation/SessionAnnotationSummaryGroup";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
-import { compactResizeHandleCSS } from "@phoenix/components/resize";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
@@ -67,14 +63,7 @@ import { SessionsTableEmpty } from "./SessionsTableEmpty";
 import { spansTableCSS } from "./styles";
 import { TableMetricsChartsPanelGroup } from "./TableMetricsCharts";
 import { TableMetricsChartSelector } from "./TableMetricsChartSelector";
-import {
-  ASIDE_PANEL_DEFAULT_SIZE_PIXELS,
-  ASIDE_PANEL_MAX_SIZE_PIXELS,
-  ASIDE_PANEL_MIN_SIZE_PIXELS,
-  TableAsideSkeleton,
-  TableAsideToggleButton,
-  useTableAsidePanel,
-} from "./TableAside";
+import { TableAsidePanel, TableAsideToggleButton } from "./TableAside";
 import {
   DEFAULT_SESSION_SORT,
   getGqlSessionSort,
@@ -153,8 +142,6 @@ export function SessionsTable(props: SessionsTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const { filterIoSubstringOrSessionId } = useSessionSearchContext();
   const { fetchKey } = useStreamState();
-  const { showTableAside, asidePanelRef, onAsidePanelResize } =
-    useTableAsidePanel();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<SessionsTableQuery, SessionsTable_sessions$key>(
       graphql`
@@ -667,30 +654,9 @@ export function SessionsTable(props: SessionsTableProps) {
           </div>
         </TableMetricsChartsPanelGroup>
       </Panel>
-      <Separator
-        css={compactResizeHandleCSS}
-        disabled={!showTableAside}
-        style={showTableAside ? undefined : { display: "none" }}
-      />
-      <Panel
-        panelRef={asidePanelRef}
-        defaultSize={ASIDE_PANEL_DEFAULT_SIZE_PIXELS}
-        collapsedSize={0}
-        minSize={ASIDE_PANEL_MIN_SIZE_PIXELS}
-        maxSize={ASIDE_PANEL_MAX_SIZE_PIXELS}
-        collapsible
-        onResize={onAsidePanelResize}
-      >
-        {showTableAside ? (
-          <ErrorBoundary fallback={TextErrorBoundaryFallback}>
-            <Suspense fallback={<TableAsideSkeleton />}>
-              <SessionsTableAside
-                filterIoSubstring={filterIoSubstringOrSessionId}
-              />
-            </Suspense>
-          </ErrorBoundary>
-        ) : null}
-      </Panel>
+      <TableAsidePanel>
+        <SessionsTableAside filterIoSubstring={filterIoSubstringOrSessionId} />
+      </TableAsidePanel>
     </Group>
   );
 }

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -61,9 +61,9 @@ import { SessionSearchField } from "./SessionSearchField";
 import { SessionsTableAside } from "./SessionsTableAside";
 import { SessionsTableEmpty } from "./SessionsTableEmpty";
 import { spansTableCSS } from "./styles";
+import { TableAsidePanel, TableAsideToggleButton } from "./TableAside";
 import { TableMetricsChartsPanelGroup } from "./TableMetricsCharts";
 import { TableMetricsChartSelector } from "./TableMetricsChartSelector";
-import { TableAsidePanel, TableAsideToggleButton } from "./TableAside";
 import {
   DEFAULT_SESSION_SORT,
   getGqlSessionSort,
@@ -655,7 +655,9 @@ export function SessionsTable(props: SessionsTableProps) {
         </TableMetricsChartsPanelGroup>
       </Panel>
       <TableAsidePanel>
-        <SessionsTableAside filterIoSubstring={filterIoSubstringOrSessionId} />
+        <SessionsTableAside
+          filterIoSubstringOrSessionId={filterIoSubstringOrSessionId}
+        />
       </TableAsidePanel>
     </Group>
   );

--- a/app/src/pages/project/SessionsTableAside.tsx
+++ b/app/src/pages/project/SessionsTableAside.tsx
@@ -1,0 +1,146 @@
+import { graphql, useLazyLoadQuery } from "react-relay";
+import { Group } from "react-resizable-panels";
+
+import {
+  ErrorBoundary,
+  Flex,
+  Text,
+  TextErrorBoundaryFallback,
+  View,
+} from "@phoenix/components";
+import { useTimeRange } from "@phoenix/components/datetime";
+import { TitledPanel } from "@phoenix/components/react-resizable-panels";
+import { useStreamState } from "@phoenix/contexts/StreamStateContext";
+import { useTracingContext } from "@phoenix/contexts/TracingContext";
+import { floatFormatter, intFormatter } from "@phoenix/utils/numberFormatUtils";
+
+import type { SessionsTableAsideQuery } from "./__generated__/SessionsTableAsideQuery.graphql";
+import { SessionAnnotationSummary } from "./SessionAnnotationSummary";
+import {
+  LatencyStatItem,
+  ProjectInfoTitledPanel,
+  StatItem,
+  StatsSection,
+} from "./TableAside";
+
+/**
+ * Top-level session stats for the sessions table — session count, average
+ * traces (turns) per session, session duration (average and P50/P99), and
+ * per-annotation summaries. Mirrors {@link SpansTableAside} so the sessions
+ * tab gets the same collapsible stats panel as the spans tab.
+ */
+export function SessionsTableAside(props: {
+  filterIoSubstring?: string | null;
+}) {
+  const filterIoSubstring = props.filterIoSubstring || null;
+  const projectId = useTracingContext((state) => state.projectId);
+  const { timeRange } = useTimeRange();
+  const { fetchKey } = useStreamState();
+  const data = useLazyLoadQuery<SessionsTableAsideQuery>(
+    graphql`
+      query SessionsTableAsideQuery(
+        $id: ID!
+        $timeRange: TimeRange!
+        $filterIoSubstring: String
+      ) {
+        project: node(id: $id) {
+          ... on Project {
+            name
+            description
+            sessionCount(
+              timeRange: $timeRange
+              filterIoSubstring: $filterIoSubstring
+            )
+            averageSessionDurationMs(
+              timeRange: $timeRange
+              filterIoSubstring: $filterIoSubstring
+            )
+            averageTracesPerSession(
+              timeRange: $timeRange
+              filterIoSubstring: $filterIoSubstring
+            )
+            sessionDurationMsP50: sessionDurationMsQuantile(
+              probability: 0.5
+              timeRange: $timeRange
+              filterIoSubstring: $filterIoSubstring
+            )
+            sessionDurationMsP99: sessionDurationMsQuantile(
+              probability: 0.99
+              timeRange: $timeRange
+              filterIoSubstring: $filterIoSubstring
+            )
+            sessionAnnotationNames
+          }
+        }
+      }
+    `,
+    {
+      id: projectId,
+      timeRange: {
+        start: timeRange?.start?.toISOString(),
+        end: timeRange?.end?.toISOString(),
+      },
+      filterIoSubstring,
+    },
+    { fetchKey, fetchPolicy: "store-and-network" }
+  );
+
+  const project = data?.project;
+  const sessionAnnotationNames =
+    project?.sessionAnnotationNames?.filter((name) => name !== "note") ?? [];
+
+  return (
+    <Group orientation="vertical">
+      <ProjectInfoTitledPanel
+        projectId={projectId}
+        name={project?.name}
+        description={project?.description}
+      />
+      <TitledPanel resizable title="Stats" panelProps={{ minSize: "10%" }}>
+        <View padding="size-200" overflow="auto" height="100%">
+          <Flex direction="column" gap="size-300" minWidth="size-3400">
+            <Flex direction="column" gap="size-200" alignItems="start">
+              <StatItem label="Total Sessions">
+                <Text size="L" fontFamily="mono">
+                  {intFormatter(project?.sessionCount)}
+                </Text>
+              </StatItem>
+              <StatItem label="Avg Traces per Session">
+                <Text size="L" fontFamily="mono">
+                  {floatFormatter(project?.averageTracesPerSession)}
+                </Text>
+              </StatItem>
+              <LatencyStatItem
+                label="Avg Session Duration"
+                latencyMs={project?.averageSessionDurationMs}
+              />
+              <LatencyStatItem
+                label="Duration P50"
+                latencyMs={project?.sessionDurationMsP50}
+              />
+              <LatencyStatItem
+                label="Duration P99"
+                latencyMs={project?.sessionDurationMsP99}
+              />
+            </Flex>
+            {sessionAnnotationNames.length > 0 ? (
+              <StatsSection title="Session Annotations">
+                {sessionAnnotationNames.map((name) => (
+                  <ErrorBoundary
+                    key={name}
+                    fallback={TextErrorBoundaryFallback}
+                  >
+                    <SessionAnnotationSummary
+                      annotationName={name}
+                      filterIoSubstring={filterIoSubstring}
+                    />
+                  </ErrorBoundary>
+                ))}
+              </StatsSection>
+            ) : null}
+          </Flex>
+        </View>
+      </TitledPanel>
+    </Group>
+  );
+}

--- a/app/src/pages/project/SessionsTableAside.tsx
+++ b/app/src/pages/project/SessionsTableAside.tsx
@@ -16,6 +16,7 @@ import { floatFormatter, intFormatter } from "@phoenix/utils/numberFormatUtils";
 
 import type { SessionsTableAsideQuery } from "./__generated__/SessionsTableAsideQuery.graphql";
 import { SessionAnnotationSummary } from "./SessionAnnotationSummary";
+import { getNonNoteAnnotationNames } from "./spanAnnotationUtils";
 import {
   LatencyStatItem,
   ProjectInfoTitledPanel,
@@ -86,8 +87,9 @@ export function SessionsTableAside(props: {
   );
 
   const project = data?.project;
-  const sessionAnnotationNames =
-    project?.sessionAnnotationNames?.filter((name) => name !== "note") ?? [];
+  const sessionAnnotationNames = getNonNoteAnnotationNames(
+    project?.sessionAnnotationNames ?? []
+  );
 
   return (
     <Group orientation="vertical">

--- a/app/src/pages/project/SessionsTableAside.tsx
+++ b/app/src/pages/project/SessionsTableAside.tsx
@@ -31,9 +31,15 @@ import {
  * tab gets the same collapsible stats panel as the spans tab.
  */
 export function SessionsTableAside(props: {
-  filterIoSubstring?: string | null;
+  /**
+   * The sessions table search text. Like the table, the stats treat it as
+   * both an input/output substring filter and an exact session-ID lookup,
+   * with an exact match taking precedence.
+   */
+  filterIoSubstringOrSessionId?: string | null;
 }) {
-  const filterIoSubstring = props.filterIoSubstring || null;
+  const filterIoSubstringOrSessionId =
+    props.filterIoSubstringOrSessionId || null;
   const projectId = useTracingContext((state) => state.projectId);
   const { timeRange } = useTimeRange();
   const { fetchKey } = useStreamState();
@@ -43,6 +49,7 @@ export function SessionsTableAside(props: {
         $id: ID!
         $timeRange: TimeRange!
         $filterIoSubstring: String
+        $sessionId: String
       ) {
         project: node(id: $id) {
           ... on Project {
@@ -51,24 +58,29 @@ export function SessionsTableAside(props: {
             sessionCount(
               timeRange: $timeRange
               filterIoSubstring: $filterIoSubstring
+              sessionId: $sessionId
             )
             averageSessionDurationMs(
               timeRange: $timeRange
               filterIoSubstring: $filterIoSubstring
+              sessionId: $sessionId
             )
             averageTracesPerSession(
               timeRange: $timeRange
               filterIoSubstring: $filterIoSubstring
+              sessionId: $sessionId
             )
             sessionDurationMsP50: sessionDurationMsQuantile(
               probability: 0.5
               timeRange: $timeRange
               filterIoSubstring: $filterIoSubstring
+              sessionId: $sessionId
             )
             sessionDurationMsP99: sessionDurationMsQuantile(
               probability: 0.99
               timeRange: $timeRange
               filterIoSubstring: $filterIoSubstring
+              sessionId: $sessionId
             )
             sessionAnnotationNames
           }
@@ -81,7 +93,8 @@ export function SessionsTableAside(props: {
         start: timeRange?.start?.toISOString(),
         end: timeRange?.end?.toISOString(),
       },
-      filterIoSubstring,
+      filterIoSubstring: filterIoSubstringOrSessionId,
+      sessionId: filterIoSubstringOrSessionId,
     },
     { fetchKey, fetchPolicy: "store-and-network" }
   );
@@ -134,7 +147,9 @@ export function SessionsTableAside(props: {
                   >
                     <SessionAnnotationSummary
                       annotationName={name}
-                      filterIoSubstring={filterIoSubstring}
+                      filterIoSubstringOrSessionId={
+                        filterIoSubstringOrSessionId
+                      }
                     />
                   </ErrorBoundary>
                 ))}

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -8,7 +8,6 @@ import {
 } from "@tanstack/react-table";
 import React, {
   startTransition,
-  Suspense,
   useCallback,
   useEffect,
   useMemo,
@@ -16,21 +15,19 @@ import React, {
   useState,
 } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
-import { Group, Panel, Separator } from "react-resizable-panels";
+import { Group, Panel } from "react-resizable-panels";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 
 import type { AgentContext } from "@phoenix/agent/context/agentContextTypes";
 import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
 import {
   CopyToClipboardButton,
-  ErrorBoundary,
   Flex,
   Heading,
   Icon,
   Icons,
   Link,
   Text,
-  TextErrorBoundaryFallback,
   ToggleButton,
   ToggleButtonGroup,
   View,
@@ -40,7 +37,6 @@ import { MeanScore } from "@phoenix/components/annotation/MeanScore";
 import { TraceAnnotationSummaryGroupTokens } from "@phoenix/components/annotation/TraceAnnotationSummaryGroup";
 import { ContextualHelp } from "@phoenix/components/core/tooltip/ContextualHelp";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
-import { compactResizeHandleCSS } from "@phoenix/components/resize";
 import {
   CellWithControlsWrap,
   createRowSelectionColumn,
@@ -91,14 +87,7 @@ import { SpansTableAside } from "./SpansTableAside";
 import { spansTableCSS } from "./styles";
 import { TableMetricsChartsPanelGroup } from "./TableMetricsCharts";
 import { TableMetricsChartSelector } from "./TableMetricsChartSelector";
-import {
-  ASIDE_PANEL_DEFAULT_SIZE_PIXELS,
-  ASIDE_PANEL_MAX_SIZE_PIXELS,
-  ASIDE_PANEL_MIN_SIZE_PIXELS,
-  TableAsideSkeleton,
-  TableAsideToggleButton,
-  useTableAsidePanel,
-} from "./TableAside";
+import { TableAsidePanel, TableAsideToggleButton } from "./TableAside";
 import {
   DEFAULT_SORT,
   getGqlSort,
@@ -230,8 +219,6 @@ export function SpansTable(props: SpansTableProps) {
   useAdvertiseAgentContext(advertisedRootSpansOnlyContext);
 
   const columnVisibility = useTracingContext((state) => state.columnVisibility);
-  const { showTableAside, asidePanelRef, onAsidePanelResize } =
-    useTableAsidePanel();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<SpansTableSpansQuery, SpansTable_spans$key>(
       graphql`
@@ -1045,28 +1032,9 @@ export function SpansTable(props: SpansTableProps) {
           </div>
         </TableMetricsChartsPanelGroup>
       </Panel>
-      <Separator
-        css={compactResizeHandleCSS}
-        disabled={!showTableAside}
-        style={showTableAside ? undefined : { display: "none" }}
-      />
-      <Panel
-        panelRef={asidePanelRef}
-        defaultSize={ASIDE_PANEL_DEFAULT_SIZE_PIXELS}
-        collapsedSize={0}
-        minSize={ASIDE_PANEL_MIN_SIZE_PIXELS}
-        maxSize={ASIDE_PANEL_MAX_SIZE_PIXELS}
-        collapsible
-        onResize={onAsidePanelResize}
-      >
-        {showTableAside ? (
-          <ErrorBoundary fallback={TextErrorBoundaryFallback}>
-            <Suspense fallback={<TableAsideSkeleton />}>
-              <SpansTableAside filterCondition={filterCondition} />
-            </Suspense>
-          </ErrorBoundary>
-        ) : null}
-      </Panel>
+      <TableAsidePanel>
+        <SpansTableAside filterCondition={filterCondition} />
+      </TableAsidePanel>
     </Group>
   );
 }

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -16,18 +16,12 @@ import React, {
   useState,
 } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
-import {
-  Group,
-  Panel,
-  type PanelImperativeHandle,
-  Separator,
-} from "react-resizable-panels";
+import { Group, Panel, Separator } from "react-resizable-panels";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 
 import type { AgentContext } from "@phoenix/agent/context/agentContextTypes";
 import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
 import {
-  Button,
   CopyToClipboardButton,
   ErrorBoundary,
   Flex,
@@ -35,7 +29,6 @@ import {
   Icon,
   Icons,
   Link,
-  Skeleton,
   Text,
   TextErrorBoundaryFallback,
   ToggleButton,
@@ -72,7 +65,6 @@ import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon
 import { SpanTokenCosts } from "@phoenix/components/trace/SpanTokenCosts";
 import { SpanTokenCount } from "@phoenix/components/trace/SpanTokenCount";
 import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
-import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { SummaryValueLabels } from "@phoenix/pages/project/AnnotationSummary";
@@ -99,6 +91,14 @@ import { SpansTableAside } from "./SpansTableAside";
 import { spansTableCSS } from "./styles";
 import { TableMetricsChartsPanelGroup } from "./TableMetricsCharts";
 import { TableMetricsChartSelector } from "./TableMetricsChartSelector";
+import {
+  ASIDE_PANEL_DEFAULT_SIZE_PIXELS,
+  ASIDE_PANEL_MAX_SIZE_PIXELS,
+  ASIDE_PANEL_MIN_SIZE_PIXELS,
+  TableAsideSkeleton,
+  TableAsideToggleButton,
+  useTableAsidePanel,
+} from "./TableAside";
 import {
   DEFAULT_SORT,
   getGqlSort,
@@ -203,23 +203,6 @@ export const MemoizedTableBody = React.memo(
   (prev, next) => prev.table.options.data === next.table.options.data
 ) as typeof TableBody;
 
-function SpansTableAsideSkeleton() {
-  return (
-    <View padding="size-200" overflow="hidden" height="100%" aria-hidden="true">
-      <Flex direction="column" gap="size-200" minWidth="size-3400">
-        <Skeleton width={96} height={20} animation="wave" />
-        <Skeleton width="100%" height={32} animation="wave" />
-        <Skeleton width={72} height={20} animation="wave" />
-        <Skeleton width={96} height={24} animation="wave" />
-        <Skeleton width={84} height={20} animation="wave" />
-        <Skeleton width={72} height={24} animation="wave" />
-        <Skeleton width={84} height={20} animation="wave" />
-        <Skeleton width={80} height={24} animation="wave" />
-      </Flex>
-    </View>
-  );
-}
-
 export function SpansTable(props: SpansTableProps) {
   const [searchParams] = useSearchParams();
   const { fetchKey } = useStreamState();
@@ -247,22 +230,8 @@ export function SpansTable(props: SpansTableProps) {
   useAdvertiseAgentContext(advertisedRootSpansOnlyContext);
 
   const columnVisibility = useTracingContext((state) => state.columnVisibility);
-  const showTableAside = useProjectContext((state) => state.showTableAside);
-  const setShowTableAside = useProjectContext(
-    (state) => state.setShowTableAside
-  );
-  const asidePanelRef = useRef<PanelImperativeHandle>(null);
-  const didSyncAsideFromStoreRef = useRef(false);
-  useEffect(() => {
-    const panel = asidePanelRef.current;
-    if (!panel) return;
-    if (showTableAside && panel.isCollapsed()) {
-      panel.expand();
-    } else if (!showTableAside && !panel.isCollapsed()) {
-      panel.collapse();
-    }
-    didSyncAsideFromStoreRef.current = true;
-  }, [showTableAside]);
+  const { showTableAside, asidePanelRef, onAsidePanelResize } =
+    useTableAsidePanel();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<SpansTableSpansQuery, SpansTable_spans$key>(
       graphql`
@@ -959,20 +928,7 @@ export function SpansTable(props: SpansTableProps) {
                 <TableMetricsChartSelector view="spans" />
                 <SpanColumnSelector columns={computedColumns} query={data} />
                 <ProjectFilterConfigButton />
-                <Button
-                  size="M"
-                  aria-label={
-                    showTableAside ? "Hide aside panel" : "Show aside panel"
-                  }
-                  leadingVisual={
-                    <Icon
-                      svg={
-                        showTableAside ? <Icons.SlideIn /> : <Icons.SlideOut />
-                      }
-                    />
-                  }
-                  onPress={() => setShowTableAside(!showTableAside)}
-                />
+                <TableAsideToggleButton />
               </Flex>
             </View>
             <div
@@ -1101,17 +1057,11 @@ export function SpansTable(props: SpansTableProps) {
         minSize={ASIDE_PANEL_MIN_SIZE_PIXELS}
         maxSize={ASIDE_PANEL_MAX_SIZE_PIXELS}
         collapsible
-        onResize={(panelSize) => {
-          if (!didSyncAsideFromStoreRef.current) return;
-          const shouldBeVisible = panelSize.asPercentage > 0;
-          if (shouldBeVisible !== showTableAside) {
-            setShowTableAside(shouldBeVisible);
-          }
-        }}
+        onResize={onAsidePanelResize}
       >
         {showTableAside ? (
           <ErrorBoundary fallback={TextErrorBoundaryFallback}>
-            <Suspense fallback={<SpansTableAsideSkeleton />}>
+            <Suspense fallback={<TableAsideSkeleton />}>
               <SpansTableAside filterCondition={filterCondition} />
             </Suspense>
           </ErrorBoundary>
@@ -1120,7 +1070,3 @@ export function SpansTable(props: SpansTableProps) {
     </Group>
   );
 }
-
-const ASIDE_PANEL_DEFAULT_SIZE_PIXELS = 360;
-const ASIDE_PANEL_MIN_SIZE_PIXELS = 320;
-const ASIDE_PANEL_MAX_SIZE_PIXELS = 600;

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -85,9 +85,9 @@ import { SpanNotesTableCell } from "./SpanNotesTableCell";
 import { SpanSelectionToolbar } from "./SpanSelectionToolbar";
 import { SpansTableAside } from "./SpansTableAside";
 import { spansTableCSS } from "./styles";
+import { TableAsidePanel, TableAsideToggleButton } from "./TableAside";
 import { TableMetricsChartsPanelGroup } from "./TableMetricsCharts";
 import { TableMetricsChartSelector } from "./TableMetricsChartSelector";
-import { TableAsidePanel, TableAsideToggleButton } from "./TableAside";
 import {
   DEFAULT_SORT,
   getGqlSort,

--- a/app/src/pages/project/SpansTableAside.tsx
+++ b/app/src/pages/project/SpansTableAside.tsx
@@ -23,6 +23,7 @@ import { costFormatter, intFormatter } from "@phoenix/utils/numberFormatUtils";
 import type { SpansTableAsideQuery } from "./__generated__/SpansTableAsideQuery.graphql";
 import { AnnotationSummary } from "./AnnotationSummary";
 import { DocumentEvaluationSummary } from "./DocumentEvaluationSummary";
+import { getNonNoteAnnotationNames } from "./spanAnnotationUtils";
 import {
   LatencyStatItem,
   ProjectInfoTitledPanel,
@@ -94,10 +95,12 @@ export function SpansTableAside(props: { filterCondition?: string | null }) {
   );
 
   const project = data?.project;
-  const spanAnnotationNames =
-    project?.spanAnnotationNames?.filter((name) => name !== "note") ?? [];
-  const traceAnnotationNames =
-    project?.traceAnnotationsNames?.filter((name) => name !== "note") ?? [];
+  const spanAnnotationNames = getNonNoteAnnotationNames(
+    project?.spanAnnotationNames ?? []
+  );
+  const traceAnnotationNames = getNonNoteAnnotationNames(
+    project?.traceAnnotationsNames ?? []
+  );
   const documentEvaluationNames = project?.documentEvaluationNames ?? [];
   const colors = useCategoryChartColors();
 

--- a/app/src/pages/project/SpansTableAside.tsx
+++ b/app/src/pages/project/SpansTableAside.tsx
@@ -1,15 +1,10 @@
-import { css } from "@emotion/react";
-import type { ReactNode } from "react";
 import { Focusable } from "react-aria";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { Group } from "react-resizable-panels";
 
 import {
-  CopyField,
-  CopyInput,
   ErrorBoundary,
   Flex,
-  Label,
   RichTooltip,
   Text,
   TextErrorBoundaryFallback,
@@ -21,7 +16,6 @@ import { useCategoryChartColors } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/components/datetime";
 import { TitledPanel } from "@phoenix/components/react-resizable-panels";
 import { RichTokenBreakdown } from "@phoenix/components/RichTokenCostBreakdown";
-import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { costFormatter, intFormatter } from "@phoenix/utils/numberFormatUtils";
@@ -29,44 +23,13 @@ import { costFormatter, intFormatter } from "@phoenix/utils/numberFormatUtils";
 import type { SpansTableAsideQuery } from "./__generated__/SpansTableAsideQuery.graphql";
 import { AnnotationSummary } from "./AnnotationSummary";
 import { DocumentEvaluationSummary } from "./DocumentEvaluationSummary";
+import {
+  LatencyStatItem,
+  ProjectInfoTitledPanel,
+  StatItem,
+  StatsSection,
+} from "./TableAside";
 import { TraceAnnotationSummary } from "./TraceAnnotationSummary";
-
-const sectionHeadingCSS = css`
-  font-size: var(--global-font-size-xs);
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--global-text-color-700);
-  margin: 0 0 var(--global-dimension-size-100) 0;
-  padding-bottom: var(--global-dimension-size-50);
-  border-bottom: 1px solid var(--global-border-color-default);
-`;
-
-/**
- * A titled group of stats. The heading doubles as a divider — an underlined,
- * uppercase label — so each level of feedback (span, document, trace) reads as
- * its own clearly delineated section rather than one undifferentiated list.
- */
-function StatsSection({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactNode;
-}) {
-  return (
-    <section
-      css={css`
-        width: 100%;
-      `}
-    >
-      <h3 css={sectionHeadingCSS}>{title}</h3>
-      <Flex direction="column" gap="size-200" alignItems="start">
-        {children}
-      </Flex>
-    </section>
-  );
-}
 
 export function SpansTableAside(props: { filterCondition?: string | null }) {
   const filterCondition = props.filterCondition || null;
@@ -131,8 +94,6 @@ export function SpansTableAside(props: { filterCondition?: string | null }) {
   );
 
   const project = data?.project;
-  const latencyMsP50 = project?.latencyMsP50;
-  const latencyMsP99 = project?.latencyMsP99;
   const spanAnnotationNames =
     project?.spanAnnotationNames?.filter((name) => name !== "note") ?? [];
   const traceAnnotationNames =
@@ -142,46 +103,21 @@ export function SpansTableAside(props: { filterCondition?: string | null }) {
 
   return (
     <Group orientation="vertical">
-      <TitledPanel
-        title="Project Info"
-        panelProps={{
-          defaultSize: "0%",
-          minSize: 240,
-        }}
-      >
-        <View padding="size-200" overflow="auto" height="100%">
-          <Flex direction="column" gap="size-100" minWidth="size-3400">
-            <CopyField value={project?.name ?? ""}>
-              <Label>Name</Label>
-              <CopyInput />
-            </CopyField>
-            <CopyField value={projectId}>
-              <Label>ID</Label>
-              <CopyInput />
-            </CopyField>
-            <CopyField value={project?.description ?? ""}>
-              <Label>Description</Label>
-              <CopyInput />
-            </CopyField>
-          </Flex>
-        </View>
-      </TitledPanel>
+      <ProjectInfoTitledPanel
+        projectId={projectId}
+        name={project?.name}
+        description={project?.description}
+      />
       <TitledPanel resizable title="Stats" panelProps={{ minSize: "10%" }}>
         <View padding="size-200" overflow="auto" height="100%">
           <Flex direction="column" gap="size-300" minWidth="size-3400">
             <Flex direction="column" gap="size-200" alignItems="start">
-              <Flex direction="column" flex="none">
-                <Text elementType="h3" size="S" color="text-700">
-                  Total Traces
-                </Text>
+              <StatItem label="Total Traces">
                 <Text size="L" fontFamily="mono">
                   {intFormatter(project?.timeRangeTraceCount)}
                 </Text>
-              </Flex>
-              <Flex direction="column" flex="none">
-                <Text elementType="h3" size="S" color="text-700">
-                  Total Cost
-                </Text>
+              </StatItem>
+              <StatItem label="Total Cost">
                 <TooltipTrigger delay={0}>
                   <Focusable>
                     <Text size="L" role="button" fontFamily="mono">
@@ -211,27 +147,15 @@ export function SpansTableAside(props: { filterCondition?: string | null }) {
                     </View>
                   </RichTooltip>
                 </TooltipTrigger>
-              </Flex>
-              <Flex direction="column" flex="none">
-                <Text elementType="h3" size="S" color="text-700">
-                  Latency P50
-                </Text>
-                {latencyMsP50 != null ? (
-                  <LatencyText latencyMs={latencyMsP50} size="L" />
-                ) : (
-                  <Text size="L">--</Text>
-                )}
-              </Flex>
-              <Flex direction="column" flex="none">
-                <Text elementType="h3" size="S" color="text-700">
-                  Latency P99
-                </Text>
-                {latencyMsP99 != null ? (
-                  <LatencyText latencyMs={latencyMsP99} size="L" />
-                ) : (
-                  <Text size="L">--</Text>
-                )}
-              </Flex>
+              </StatItem>
+              <LatencyStatItem
+                label="Latency P50"
+                latencyMs={project?.latencyMsP50}
+              />
+              <LatencyStatItem
+                label="Latency P99"
+                latencyMs={project?.latencyMsP99}
+              />
             </Flex>
             {spanAnnotationNames.length > 0 ? (
               <StatsSection title="Span Annotations">

--- a/app/src/pages/project/TableAside.tsx
+++ b/app/src/pages/project/TableAside.tsx
@@ -1,26 +1,30 @@
 import { css } from "@emotion/react";
-import { type ReactNode, useEffect, useRef } from "react";
+import { type ReactNode, Suspense, useEffect, useRef } from "react";
+import { Panel, Separator } from "react-resizable-panels";
 import type { PanelImperativeHandle } from "react-resizable-panels";
 
 import {
   Button,
   CopyField,
   CopyInput,
+  ErrorBoundary,
   Flex,
   Icon,
   Icons,
   Label,
   Skeleton,
   Text,
+  TextErrorBoundaryFallback,
   View,
 } from "@phoenix/components";
 import { TitledPanel } from "@phoenix/components/react-resizable-panels";
+import { compactResizeHandleCSS } from "@phoenix/components/resize";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 
-export const ASIDE_PANEL_DEFAULT_SIZE_PIXELS = 360;
-export const ASIDE_PANEL_MIN_SIZE_PIXELS = 320;
-export const ASIDE_PANEL_MAX_SIZE_PIXELS = 600;
+const ASIDE_PANEL_DEFAULT_SIZE_PIXELS = 360;
+const ASIDE_PANEL_MIN_SIZE_PIXELS = 320;
+const ASIDE_PANEL_MAX_SIZE_PIXELS = 600;
 
 /**
  * Wires a table's collapsible aside panel to the shared `showTableAside`
@@ -29,7 +33,7 @@ export const ASIDE_PANEL_MAX_SIZE_PIXELS = 600;
  * the panel's initial mount (before the store value has been applied) from
  * clobbering the store via onResize.
  */
-export function useTableAsidePanel() {
+function useTableAsidePanel() {
   const showTableAside = useProjectContext((state) => state.showTableAside);
   const setShowTableAside = useProjectContext(
     (state) => state.setShowTableAside
@@ -54,6 +58,41 @@ export function useTableAsidePanel() {
     }
   };
   return { showTableAside, asidePanelRef, onAsidePanelResize };
+}
+
+/**
+ * The resizable, collapsible aside panel of a table page: the drag separator,
+ * the panel itself (wired to the shared `showTableAside` store flag), and the
+ * error/suspense boundaries around the aside content. Render it as the last
+ * child of the table's resizable `Group`.
+ */
+export function TableAsidePanel({ children }: { children: ReactNode }) {
+  const { showTableAside, asidePanelRef, onAsidePanelResize } =
+    useTableAsidePanel();
+  return (
+    <>
+      <Separator
+        css={compactResizeHandleCSS}
+        disabled={!showTableAside}
+        style={showTableAside ? undefined : { display: "none" }}
+      />
+      <Panel
+        panelRef={asidePanelRef}
+        defaultSize={ASIDE_PANEL_DEFAULT_SIZE_PIXELS}
+        collapsedSize={0}
+        minSize={ASIDE_PANEL_MIN_SIZE_PIXELS}
+        maxSize={ASIDE_PANEL_MAX_SIZE_PIXELS}
+        collapsible
+        onResize={onAsidePanelResize}
+      >
+        {showTableAside ? (
+          <ErrorBoundary fallback={TextErrorBoundaryFallback}>
+            <Suspense fallback={<TableAsideSkeleton />}>{children}</Suspense>
+          </ErrorBoundary>
+        ) : null}
+      </Panel>
+    </>
+  );
 }
 
 /**
@@ -199,7 +238,7 @@ export function ProjectInfoTitledPanel({
 /**
  * Loading placeholder for a table aside while its stats query is in flight.
  */
-export function TableAsideSkeleton() {
+function TableAsideSkeleton() {
   return (
     <View padding="size-200" overflow="hidden" height="100%" aria-hidden="true">
       <Flex direction="column" gap="size-200" minWidth="size-3400">

--- a/app/src/pages/project/TableAside.tsx
+++ b/app/src/pages/project/TableAside.tsx
@@ -1,0 +1,217 @@
+import { css } from "@emotion/react";
+import { type ReactNode, useEffect, useRef } from "react";
+import type { PanelImperativeHandle } from "react-resizable-panels";
+
+import {
+  Button,
+  CopyField,
+  CopyInput,
+  Flex,
+  Icon,
+  Icons,
+  Label,
+  Skeleton,
+  Text,
+  View,
+} from "@phoenix/components";
+import { TitledPanel } from "@phoenix/components/react-resizable-panels";
+import { LatencyText } from "@phoenix/components/trace/LatencyText";
+import { useProjectContext } from "@phoenix/contexts/ProjectContext";
+
+export const ASIDE_PANEL_DEFAULT_SIZE_PIXELS = 360;
+export const ASIDE_PANEL_MIN_SIZE_PIXELS = 320;
+export const ASIDE_PANEL_MAX_SIZE_PIXELS = 600;
+
+/**
+ * Wires a table's collapsible aside panel to the shared `showTableAside`
+ * project-store flag: expands/collapses the panel when the store changes, and
+ * writes drag-driven expand/collapse back to the store. The didSync ref keeps
+ * the panel's initial mount (before the store value has been applied) from
+ * clobbering the store via onResize.
+ */
+export function useTableAsidePanel() {
+  const showTableAside = useProjectContext((state) => state.showTableAside);
+  const setShowTableAside = useProjectContext(
+    (state) => state.setShowTableAside
+  );
+  const asidePanelRef = useRef<PanelImperativeHandle>(null);
+  const didSyncAsideFromStoreRef = useRef(false);
+  useEffect(() => {
+    const panel = asidePanelRef.current;
+    if (!panel) return;
+    if (showTableAside && panel.isCollapsed()) {
+      panel.expand();
+    } else if (!showTableAside && !panel.isCollapsed()) {
+      panel.collapse();
+    }
+    didSyncAsideFromStoreRef.current = true;
+  }, [showTableAside]);
+  const onAsidePanelResize = (panelSize: { asPercentage: number }) => {
+    if (!didSyncAsideFromStoreRef.current) return;
+    const shouldBeVisible = panelSize.asPercentage > 0;
+    if (shouldBeVisible !== showTableAside) {
+      setShowTableAside(shouldBeVisible);
+    }
+  };
+  return { showTableAside, asidePanelRef, onAsidePanelResize };
+}
+
+/**
+ * Toolbar button that toggles a table's aside panel open or closed.
+ */
+export function TableAsideToggleButton() {
+  const showTableAside = useProjectContext((state) => state.showTableAside);
+  const setShowTableAside = useProjectContext(
+    (state) => state.setShowTableAside
+  );
+  return (
+    <Button
+      size="M"
+      aria-label={showTableAside ? "Hide aside panel" : "Show aside panel"}
+      leadingVisual={
+        <Icon svg={showTableAside ? <Icons.SlideIn /> : <Icons.SlideOut />} />
+      }
+      onPress={() => setShowTableAside(!showTableAside)}
+    />
+  );
+}
+
+/**
+ * A single labeled stat in an aside's Stats panel.
+ */
+export function StatItem({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <Flex direction="column" flex="none">
+      <Text elementType="h3" size="S" color="text-700">
+        {label}
+      </Text>
+      {children}
+    </Flex>
+  );
+}
+
+/**
+ * A latency/duration stat that renders "--" when the value is unavailable.
+ */
+export function LatencyStatItem({
+  label,
+  latencyMs,
+}: {
+  label: string;
+  latencyMs?: number | null;
+}) {
+  return (
+    <StatItem label={label}>
+      {latencyMs != null ? (
+        <LatencyText latencyMs={latencyMs} size="L" />
+      ) : (
+        <Text size="L">--</Text>
+      )}
+    </StatItem>
+  );
+}
+
+const sectionHeadingCSS = css`
+  font-size: var(--global-font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--global-text-color-700);
+  margin: 0 0 var(--global-dimension-size-100) 0;
+  padding-bottom: var(--global-dimension-size-50);
+  border-bottom: 1px solid var(--global-border-color-default);
+`;
+
+/**
+ * A titled group of stats. The heading doubles as a divider — an underlined,
+ * uppercase label — so each level of feedback (span, document, trace, session)
+ * reads as its own clearly delineated section rather than one undifferentiated
+ * list.
+ */
+export function StatsSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      css={css`
+        width: 100%;
+      `}
+    >
+      <h3 css={sectionHeadingCSS}>{title}</h3>
+      <Flex direction="column" gap="size-200" alignItems="start">
+        {children}
+      </Flex>
+    </section>
+  );
+}
+
+/**
+ * The "Project Info" section of a table aside — name, ID, and description as
+ * copyable fields. Shared by the spans and sessions asides.
+ */
+export function ProjectInfoTitledPanel({
+  projectId,
+  name,
+  description,
+}: {
+  projectId: string;
+  name?: string | null;
+  description?: string | null;
+}) {
+  return (
+    <TitledPanel
+      title="Project Info"
+      panelProps={{
+        defaultSize: "0%",
+        minSize: 240,
+      }}
+    >
+      <View padding="size-200" overflow="auto" height="100%">
+        <Flex direction="column" gap="size-100" minWidth="size-3400">
+          <CopyField value={name ?? ""}>
+            <Label>Name</Label>
+            <CopyInput />
+          </CopyField>
+          <CopyField value={projectId}>
+            <Label>ID</Label>
+            <CopyInput />
+          </CopyField>
+          <CopyField value={description ?? ""}>
+            <Label>Description</Label>
+            <CopyInput />
+          </CopyField>
+        </Flex>
+      </View>
+    </TitledPanel>
+  );
+}
+
+/**
+ * Loading placeholder for a table aside while its stats query is in flight.
+ */
+export function TableAsideSkeleton() {
+  return (
+    <View padding="size-200" overflow="hidden" height="100%" aria-hidden="true">
+      <Flex direction="column" gap="size-200" minWidth="size-3400">
+        <Skeleton width={96} height={20} animation="wave" />
+        <Skeleton width="100%" height={32} animation="wave" />
+        <Skeleton width={72} height={20} animation="wave" />
+        <Skeleton width={96} height={24} animation="wave" />
+        <Skeleton width={84} height={20} animation="wave" />
+        <Skeleton width={72} height={24} animation="wave" />
+        <Skeleton width={84} height={20} animation="wave" />
+        <Skeleton width={80} height={24} animation="wave" />
+      </Flex>
+    </View>
+  );
+}

--- a/app/src/pages/project/__generated__/SessionAnnotationSummaryQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionAnnotationSummaryQuery.graphql.ts
@@ -1,0 +1,336 @@
+/**
+ * @generated SignedSource<<27b482a7bde6d3a69007948c922c1daa>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type TimeRange = {
+  end?: string | null;
+  start?: string | null;
+};
+export type SessionAnnotationSummaryQuery$variables = {
+  annotationName: string;
+  filterIoSubstring?: string | null;
+  id: string;
+  timeRange: TimeRange;
+};
+export type SessionAnnotationSummaryQuery$data = {
+  readonly project: {
+    readonly " $fragmentSpreads": FragmentRefs<"SessionAnnotationSummaryValueFragment">;
+  };
+};
+export type SessionAnnotationSummaryQuery = {
+  response: SessionAnnotationSummaryQuery$data;
+  variables: SessionAnnotationSummaryQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "annotationName"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filterIoSubstring"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "id"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "timeRange"
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v5 = [
+  {
+    "kind": "Variable",
+    "name": "annotationName",
+    "variableName": "annotationName"
+  },
+  {
+    "kind": "Variable",
+    "name": "filterIoSubstring",
+    "variableName": "filterIoSubstring"
+  },
+  {
+    "kind": "Variable",
+    "name": "timeRange",
+    "variableName": "timeRange"
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "annotationType",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SessionAnnotationSummaryQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v5/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "SessionAnnotationSummaryValueFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v2/*: any*/),
+      (v0/*: any*/),
+      (v3/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "SessionAnnotationSummaryQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v6/*: any*/),
+          (v7/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v6/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*: any*/)
+                            ],
+                            "type": "AnnotationConfigBase",
+                            "abstractKey": "__isAnnotationConfigBase"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*: any*/),
+                              (v7/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "optimizationDirection",
+                                "storageKey": null
+                              },
+                              (v9/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": [
+                                  (v10/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "score",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v7/*: any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v5/*: any*/),
+                "concreteType": "AnnotationSummary",
+                "kind": "LinkedField",
+                "name": "sessionAnnotationSummary",
+                "plural": false,
+                "selections": [
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "count",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "scoreCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "labelCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "LabelFraction",
+                    "kind": "LinkedField",
+                    "name": "labelFractions",
+                    "plural": true,
+                    "selections": [
+                      (v10/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "fraction",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "meanScore",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "9eb7657abae349d627df9a480614ae04",
+    "id": null,
+    "metadata": {},
+    "name": "SessionAnnotationSummaryQuery",
+    "operationKind": "query",
+    "text": "query SessionAnnotationSummaryQuery(\n  $id: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $filterIoSubstring: String\n) {\n  project: node(id: $id) {\n    __typename\n    ...SessionAnnotationSummaryValueFragment_2saBdj\n    id\n  }\n}\n\nfragment SessionAnnotationSummaryValueFragment_2saBdj on Project {\n  annotationConfigs {\n    edges {\n      node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          annotationType\n          id\n          optimizationDirection\n          name\n          values {\n            label\n            score\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  sessionAnnotationSummary(annotationName: $annotationName, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring) {\n    name\n    count\n    scoreCount\n    labelCount\n    labelFractions {\n      label\n      fraction\n    }\n    meanScore\n  }\n  id\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "11058a43caffc2d27fdfe466fa956a4b";
+
+export default node;

--- a/app/src/pages/project/__generated__/SessionAnnotationSummaryQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionAnnotationSummaryQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<27b482a7bde6d3a69007948c922c1daa>>
+ * @generated SignedSource<<9a8cde80fd4f528a2c1bff6b0cdb4af6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,6 +18,7 @@ export type SessionAnnotationSummaryQuery$variables = {
   annotationName: string;
   filterIoSubstring?: string | null;
   id: string;
+  sessionId?: string | null;
   timeRange: TimeRange;
 };
 export type SessionAnnotationSummaryQuery$data = {
@@ -49,16 +50,21 @@ v2 = {
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "sessionId"
+},
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "timeRange"
 },
-v4 = [
+v5 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v5 = [
+v6 = [
   {
     "kind": "Variable",
     "name": "annotationName",
@@ -71,39 +77,44 @@ v5 = [
   },
   {
     "kind": "Variable",
+    "name": "sessionId",
+    "variableName": "sessionId"
+  },
+  {
+    "kind": "Variable",
     "name": "timeRange",
     "variableName": "timeRange"
   }
 ],
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "annotationType",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -116,7 +127,8 @@ return {
       (v0/*: any*/),
       (v1/*: any*/),
       (v2/*: any*/),
-      (v3/*: any*/)
+      (v3/*: any*/),
+      (v4/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -124,14 +136,14 @@ return {
     "selections": [
       {
         "alias": "project",
-        "args": (v4/*: any*/),
+        "args": (v5/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
           {
-            "args": (v5/*: any*/),
+            "args": (v6/*: any*/),
             "kind": "FragmentSpread",
             "name": "SessionAnnotationSummaryValueFragment"
           }
@@ -147,22 +159,23 @@ return {
     "argumentDefinitions": [
       (v2/*: any*/),
       (v0/*: any*/),
-      (v3/*: any*/),
-      (v1/*: any*/)
+      (v4/*: any*/),
+      (v1/*: any*/),
+      (v3/*: any*/)
     ],
     "kind": "Operation",
     "name": "SessionAnnotationSummaryQuery",
     "selections": [
       {
         "alias": "project",
-        "args": (v4/*: any*/),
+        "args": (v5/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v6/*: any*/),
           (v7/*: any*/),
+          (v8/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
@@ -190,11 +203,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v8/*: any*/)
+                              (v9/*: any*/)
                             ],
                             "type": "AnnotationConfigBase",
                             "abstractKey": "__isAnnotationConfigBase"
@@ -202,8 +215,8 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
+                              (v9/*: any*/),
                               (v8/*: any*/),
-                              (v7/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -211,7 +224,7 @@ return {
                                 "name": "optimizationDirection",
                                 "storageKey": null
                               },
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -220,7 +233,7 @@ return {
                                 "name": "values",
                                 "plural": true,
                                 "selections": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -238,7 +251,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v7/*: any*/)
+                              (v8/*: any*/)
                             ],
                             "type": "Node",
                             "abstractKey": "__isNode"
@@ -254,13 +267,13 @@ return {
               },
               {
                 "alias": null,
-                "args": (v5/*: any*/),
+                "args": (v6/*: any*/),
                 "concreteType": "AnnotationSummary",
                 "kind": "LinkedField",
                 "name": "sessionAnnotationSummary",
                 "plural": false,
                 "selections": [
-                  (v9/*: any*/),
+                  (v10/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -290,7 +303,7 @@ return {
                     "name": "labelFractions",
                     "plural": true,
                     "selections": [
-                      (v10/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -321,16 +334,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9eb7657abae349d627df9a480614ae04",
+    "cacheID": "628935098135187711509c8d5cf27810",
     "id": null,
     "metadata": {},
     "name": "SessionAnnotationSummaryQuery",
     "operationKind": "query",
-    "text": "query SessionAnnotationSummaryQuery(\n  $id: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $filterIoSubstring: String\n) {\n  project: node(id: $id) {\n    __typename\n    ...SessionAnnotationSummaryValueFragment_2saBdj\n    id\n  }\n}\n\nfragment SessionAnnotationSummaryValueFragment_2saBdj on Project {\n  annotationConfigs {\n    edges {\n      node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          annotationType\n          id\n          optimizationDirection\n          name\n          values {\n            label\n            score\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  sessionAnnotationSummary(annotationName: $annotationName, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring) {\n    name\n    count\n    scoreCount\n    labelCount\n    labelFractions {\n      label\n      fraction\n    }\n    meanScore\n  }\n  id\n}\n"
+    "text": "query SessionAnnotationSummaryQuery(\n  $id: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $filterIoSubstring: String\n  $sessionId: String\n) {\n  project: node(id: $id) {\n    __typename\n    ...SessionAnnotationSummaryValueFragment_1mBxVA\n    id\n  }\n}\n\nfragment SessionAnnotationSummaryValueFragment_1mBxVA on Project {\n  annotationConfigs {\n    edges {\n      node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          annotationType\n          id\n          optimizationDirection\n          name\n          values {\n            label\n            score\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  sessionAnnotationSummary(annotationName: $annotationName, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId) {\n    name\n    count\n    scoreCount\n    labelCount\n    labelFractions {\n      label\n      fraction\n    }\n    meanScore\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "11058a43caffc2d27fdfe466fa956a4b";
+(node as any).hash = "960bc4d76b26fb5e314c5ebb4bfe7c0e";
 
 export default node;

--- a/app/src/pages/project/__generated__/SessionAnnotationSummaryValueFragment.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionAnnotationSummaryValueFragment.graphql.ts
@@ -1,0 +1,275 @@
+/**
+ * @generated SignedSource<<aa877dea9ca3e60222f0d2ef08ff3e20>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type AnnotationType = "CATEGORICAL" | "CONTINUOUS" | "FREEFORM";
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
+import { FragmentRefs } from "relay-runtime";
+export type SessionAnnotationSummaryValueFragment$data = {
+  readonly annotationConfigs: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly annotationType?: AnnotationType;
+        readonly id?: string;
+        readonly name?: string;
+        readonly optimizationDirection?: OptimizationDirection;
+        readonly values?: ReadonlyArray<{
+          readonly label: string;
+          readonly score: number | null;
+        }>;
+      };
+    }>;
+  };
+  readonly id: string;
+  readonly sessionAnnotationSummary: {
+    readonly count: number;
+    readonly labelCount: number;
+    readonly labelFractions: ReadonlyArray<{
+      readonly fraction: number;
+      readonly label: string;
+    }>;
+    readonly meanScore: number | null;
+    readonly name: string;
+    readonly scoreCount: number;
+  } | null;
+  readonly " $fragmentType": "SessionAnnotationSummaryValueFragment";
+};
+export type SessionAnnotationSummaryValueFragment$key = {
+  readonly " $data"?: SessionAnnotationSummaryValueFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"SessionAnnotationSummaryValueFragment">;
+};
+
+import SessionAnnotationSummaryValueQuery_graphql from './SessionAnnotationSummaryValueQuery.graphql';
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "annotationType",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "annotationName"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "filterIoSubstring"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "timeRange"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": SessionAnnotationSummaryValueQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "SessionAnnotationSummaryValueFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AnnotationConfigConnection",
+      "kind": "LinkedField",
+      "name": "annotationConfigs",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AnnotationConfigEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": null,
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v0/*: any*/)
+                  ],
+                  "type": "AnnotationConfigBase",
+                  "abstractKey": "__isAnnotationConfigBase"
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v0/*: any*/),
+                    (v1/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "optimizationDirection",
+                      "storageKey": null
+                    },
+                    (v2/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "CategoricalAnnotationValue",
+                      "kind": "LinkedField",
+                      "name": "values",
+                      "plural": true,
+                      "selections": [
+                        (v3/*: any*/),
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "score",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "CategoricalAnnotationConfig",
+                  "abstractKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "annotationName",
+          "variableName": "annotationName"
+        },
+        {
+          "kind": "Variable",
+          "name": "filterIoSubstring",
+          "variableName": "filterIoSubstring"
+        },
+        {
+          "kind": "Variable",
+          "name": "timeRange",
+          "variableName": "timeRange"
+        }
+      ],
+      "concreteType": "AnnotationSummary",
+      "kind": "LinkedField",
+      "name": "sessionAnnotationSummary",
+      "plural": false,
+      "selections": [
+        (v2/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "scoreCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "labelCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "LabelFraction",
+          "kind": "LinkedField",
+          "name": "labelFractions",
+          "plural": true,
+          "selections": [
+            (v3/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "fraction",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "meanScore",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    (v1/*: any*/)
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "1bd031f6e3670ef12e20dac1398cf782";
+
+export default node;

--- a/app/src/pages/project/__generated__/SessionAnnotationSummaryValueFragment.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionAnnotationSummaryValueFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<aa877dea9ca3e60222f0d2ef08ff3e20>>
+ * @generated SignedSource<<f9396ed4446d0194ac9023d2f0629370>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -88,6 +88,11 @@ return {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "filterIoSubstring"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "sessionId"
     },
     {
       "defaultValue": null,
@@ -203,6 +208,11 @@ return {
         },
         {
           "kind": "Variable",
+          "name": "sessionId",
+          "variableName": "sessionId"
+        },
+        {
+          "kind": "Variable",
           "name": "timeRange",
           "variableName": "timeRange"
         }
@@ -270,6 +280,6 @@ return {
 };
 })();
 
-(node as any).hash = "1bd031f6e3670ef12e20dac1398cf782";
+(node as any).hash = "78d6985aa96cf32af722550d3db8bb65";
 
 export default node;

--- a/app/src/pages/project/__generated__/SessionAnnotationSummaryValueQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionAnnotationSummaryValueQuery.graphql.ts
@@ -1,0 +1,336 @@
+/**
+ * @generated SignedSource<<78e22e84555382ed452e33d2aceb603c>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type TimeRange = {
+  end?: string | null;
+  start?: string | null;
+};
+export type SessionAnnotationSummaryValueQuery$variables = {
+  annotationName: string;
+  filterIoSubstring?: string | null;
+  id: string;
+  timeRange: TimeRange;
+};
+export type SessionAnnotationSummaryValueQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"SessionAnnotationSummaryValueFragment">;
+  };
+};
+export type SessionAnnotationSummaryValueQuery = {
+  response: SessionAnnotationSummaryValueQuery$data;
+  variables: SessionAnnotationSummaryValueQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "annotationName"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filterIoSubstring"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "id"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "timeRange"
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v5 = [
+  {
+    "kind": "Variable",
+    "name": "annotationName",
+    "variableName": "annotationName"
+  },
+  {
+    "kind": "Variable",
+    "name": "filterIoSubstring",
+    "variableName": "filterIoSubstring"
+  },
+  {
+    "kind": "Variable",
+    "name": "timeRange",
+    "variableName": "timeRange"
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "annotationType",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SessionAnnotationSummaryValueQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v5/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "SessionAnnotationSummaryValueFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v3/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "SessionAnnotationSummaryValueQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v6/*: any*/),
+          (v7/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v6/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*: any*/)
+                            ],
+                            "type": "AnnotationConfigBase",
+                            "abstractKey": "__isAnnotationConfigBase"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*: any*/),
+                              (v7/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "optimizationDirection",
+                                "storageKey": null
+                              },
+                              (v9/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": [
+                                  (v10/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "score",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v7/*: any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v5/*: any*/),
+                "concreteType": "AnnotationSummary",
+                "kind": "LinkedField",
+                "name": "sessionAnnotationSummary",
+                "plural": false,
+                "selections": [
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "count",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "scoreCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "labelCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "LabelFraction",
+                    "kind": "LinkedField",
+                    "name": "labelFractions",
+                    "plural": true,
+                    "selections": [
+                      (v10/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "fraction",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "meanScore",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "074ff87b952b8259c67e4ad15f87c49b",
+    "id": null,
+    "metadata": {},
+    "name": "SessionAnnotationSummaryValueQuery",
+    "operationKind": "query",
+    "text": "query SessionAnnotationSummaryValueQuery(\n  $annotationName: String!\n  $filterIoSubstring: String = null\n  $timeRange: TimeRange!\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionAnnotationSummaryValueFragment_2saBdj\n    id\n  }\n}\n\nfragment SessionAnnotationSummaryValueFragment_2saBdj on Project {\n  annotationConfigs {\n    edges {\n      node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          annotationType\n          id\n          optimizationDirection\n          name\n          values {\n            label\n            score\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  sessionAnnotationSummary(annotationName: $annotationName, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring) {\n    name\n    count\n    scoreCount\n    labelCount\n    labelFractions {\n      label\n      fraction\n    }\n    meanScore\n  }\n  id\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1bd031f6e3670ef12e20dac1398cf782";
+
+export default node;

--- a/app/src/pages/project/__generated__/SessionAnnotationSummaryValueQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionAnnotationSummaryValueQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<78e22e84555382ed452e33d2aceb603c>>
+ * @generated SignedSource<<2b9a334144cd62aa8dba2d137b4bdabb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,6 +18,7 @@ export type SessionAnnotationSummaryValueQuery$variables = {
   annotationName: string;
   filterIoSubstring?: string | null;
   id: string;
+  sessionId?: string | null;
   timeRange: TimeRange;
 };
 export type SessionAnnotationSummaryValueQuery$data = {
@@ -49,16 +50,21 @@ v2 = {
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "sessionId"
+},
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "timeRange"
 },
-v4 = [
+v5 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v5 = [
+v6 = [
   {
     "kind": "Variable",
     "name": "annotationName",
@@ -71,39 +77,44 @@ v5 = [
   },
   {
     "kind": "Variable",
+    "name": "sessionId",
+    "variableName": "sessionId"
+  },
+  {
+    "kind": "Variable",
     "name": "timeRange",
     "variableName": "timeRange"
   }
 ],
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "annotationType",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -116,7 +127,8 @@ return {
       (v0/*: any*/),
       (v1/*: any*/),
       (v2/*: any*/),
-      (v3/*: any*/)
+      (v3/*: any*/),
+      (v4/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -124,14 +136,14 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v4/*: any*/),
+        "args": (v5/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
           {
-            "args": (v5/*: any*/),
+            "args": (v6/*: any*/),
             "kind": "FragmentSpread",
             "name": "SessionAnnotationSummaryValueFragment"
           }
@@ -148,6 +160,7 @@ return {
       (v0/*: any*/),
       (v1/*: any*/),
       (v3/*: any*/),
+      (v4/*: any*/),
       (v2/*: any*/)
     ],
     "kind": "Operation",
@@ -155,14 +168,14 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v4/*: any*/),
+        "args": (v5/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v6/*: any*/),
           (v7/*: any*/),
+          (v8/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
@@ -190,11 +203,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v8/*: any*/)
+                              (v9/*: any*/)
                             ],
                             "type": "AnnotationConfigBase",
                             "abstractKey": "__isAnnotationConfigBase"
@@ -202,8 +215,8 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
+                              (v9/*: any*/),
                               (v8/*: any*/),
-                              (v7/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -211,7 +224,7 @@ return {
                                 "name": "optimizationDirection",
                                 "storageKey": null
                               },
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -220,7 +233,7 @@ return {
                                 "name": "values",
                                 "plural": true,
                                 "selections": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -238,7 +251,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v7/*: any*/)
+                              (v8/*: any*/)
                             ],
                             "type": "Node",
                             "abstractKey": "__isNode"
@@ -254,13 +267,13 @@ return {
               },
               {
                 "alias": null,
-                "args": (v5/*: any*/),
+                "args": (v6/*: any*/),
                 "concreteType": "AnnotationSummary",
                 "kind": "LinkedField",
                 "name": "sessionAnnotationSummary",
                 "plural": false,
                 "selections": [
-                  (v9/*: any*/),
+                  (v10/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -290,7 +303,7 @@ return {
                     "name": "labelFractions",
                     "plural": true,
                     "selections": [
-                      (v10/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -321,16 +334,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "074ff87b952b8259c67e4ad15f87c49b",
+    "cacheID": "3709b4c500f165563c72b5e65c12613d",
     "id": null,
     "metadata": {},
     "name": "SessionAnnotationSummaryValueQuery",
     "operationKind": "query",
-    "text": "query SessionAnnotationSummaryValueQuery(\n  $annotationName: String!\n  $filterIoSubstring: String = null\n  $timeRange: TimeRange!\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionAnnotationSummaryValueFragment_2saBdj\n    id\n  }\n}\n\nfragment SessionAnnotationSummaryValueFragment_2saBdj on Project {\n  annotationConfigs {\n    edges {\n      node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          annotationType\n          id\n          optimizationDirection\n          name\n          values {\n            label\n            score\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  sessionAnnotationSummary(annotationName: $annotationName, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring) {\n    name\n    count\n    scoreCount\n    labelCount\n    labelFractions {\n      label\n      fraction\n    }\n    meanScore\n  }\n  id\n}\n"
+    "text": "query SessionAnnotationSummaryValueQuery(\n  $annotationName: String!\n  $filterIoSubstring: String = null\n  $sessionId: String = null\n  $timeRange: TimeRange!\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionAnnotationSummaryValueFragment_1mBxVA\n    id\n  }\n}\n\nfragment SessionAnnotationSummaryValueFragment_1mBxVA on Project {\n  annotationConfigs {\n    edges {\n      node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          annotationType\n          id\n          optimizationDirection\n          name\n          values {\n            label\n            score\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  sessionAnnotationSummary(annotationName: $annotationName, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId) {\n    name\n    count\n    scoreCount\n    labelCount\n    labelFractions {\n      label\n      fraction\n    }\n    meanScore\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1bd031f6e3670ef12e20dac1398cf782";
+(node as any).hash = "78d6985aa96cf32af722550d3db8bb65";
 
 export default node;

--- a/app/src/pages/project/__generated__/SessionsTableAsideQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionsTableAsideQuery.graphql.ts
@@ -1,0 +1,232 @@
+/**
+ * @generated SignedSource<<9b8ccbfc5b29e4f9880229b830b76361>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type TimeRange = {
+  end?: string | null;
+  start?: string | null;
+};
+export type SessionsTableAsideQuery$variables = {
+  filterIoSubstring?: string | null;
+  id: string;
+  timeRange: TimeRange;
+};
+export type SessionsTableAsideQuery$data = {
+  readonly project: {
+    readonly averageSessionDurationMs?: number | null;
+    readonly averageTracesPerSession?: number | null;
+    readonly description?: string | null;
+    readonly name?: string;
+    readonly sessionAnnotationNames?: ReadonlyArray<string>;
+    readonly sessionCount?: number;
+    readonly sessionDurationMsP50?: number | null;
+    readonly sessionDurationMsP99?: number | null;
+  };
+};
+export type SessionsTableAsideQuery = {
+  response: SessionsTableAsideQuery$data;
+  variables: SessionsTableAsideQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filterIoSubstring"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "id"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "timeRange"
+},
+v3 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v4 = {
+  "kind": "Variable",
+  "name": "filterIoSubstring",
+  "variableName": "filterIoSubstring"
+},
+v5 = {
+  "kind": "Variable",
+  "name": "timeRange",
+  "variableName": "timeRange"
+},
+v6 = [
+  (v4/*: any*/),
+  (v5/*: any*/)
+],
+v7 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": (v6/*: any*/),
+      "kind": "ScalarField",
+      "name": "sessionCount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": (v6/*: any*/),
+      "kind": "ScalarField",
+      "name": "averageSessionDurationMs",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": (v6/*: any*/),
+      "kind": "ScalarField",
+      "name": "averageTracesPerSession",
+      "storageKey": null
+    },
+    {
+      "alias": "sessionDurationMsP50",
+      "args": [
+        (v4/*: any*/),
+        {
+          "kind": "Literal",
+          "name": "probability",
+          "value": 0.5
+        },
+        (v5/*: any*/)
+      ],
+      "kind": "ScalarField",
+      "name": "sessionDurationMsQuantile",
+      "storageKey": null
+    },
+    {
+      "alias": "sessionDurationMsP99",
+      "args": [
+        (v4/*: any*/),
+        {
+          "kind": "Literal",
+          "name": "probability",
+          "value": 0.99
+        },
+        (v5/*: any*/)
+      ],
+      "kind": "ScalarField",
+      "name": "sessionDurationMsQuantile",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "sessionAnnotationNames",
+      "storageKey": null
+    }
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SessionsTableAsideQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v3/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v7/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "SessionsTableAsideQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v3/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v7/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "342f8e3cec6c060baee1de24c4e9a6b8",
+    "id": null,
+    "metadata": {},
+    "name": "SessionsTableAsideQuery",
+    "operationKind": "query",
+    "text": "query SessionsTableAsideQuery(\n  $id: ID!\n  $timeRange: TimeRange!\n  $filterIoSubstring: String\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      name\n      description\n      sessionCount(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)\n      averageSessionDurationMs(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)\n      averageTracesPerSession(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)\n      sessionDurationMsP50: sessionDurationMsQuantile(probability: 0.5, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)\n      sessionDurationMsP99: sessionDurationMsQuantile(probability: 0.99, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)\n      sessionAnnotationNames\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "2d143007946e7d7441222f8a4e82bedb";
+
+export default node;

--- a/app/src/pages/project/__generated__/SessionsTableAsideQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionsTableAsideQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9b8ccbfc5b29e4f9880229b830b76361>>
+ * @generated SignedSource<<ca061285c9f3adf69fd47d301c77d1f0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type TimeRange = {
 export type SessionsTableAsideQuery$variables = {
   filterIoSubstring?: string | null;
   id: string;
+  sessionId?: string | null;
   timeRange: TimeRange;
 };
 export type SessionsTableAsideQuery$data = {
@@ -49,30 +50,41 @@ v1 = {
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "sessionId"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "timeRange"
 },
-v3 = [
+v4 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v4 = {
+v5 = {
   "kind": "Variable",
   "name": "filterIoSubstring",
   "variableName": "filterIoSubstring"
 },
-v5 = {
+v6 = {
+  "kind": "Variable",
+  "name": "sessionId",
+  "variableName": "sessionId"
+},
+v7 = {
   "kind": "Variable",
   "name": "timeRange",
   "variableName": "timeRange"
 },
-v6 = [
-  (v4/*: any*/),
-  (v5/*: any*/)
+v8 = [
+  (v5/*: any*/),
+  (v6/*: any*/),
+  (v7/*: any*/)
 ],
-v7 = {
+v9 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -91,21 +103,21 @@ v7 = {
     },
     {
       "alias": null,
-      "args": (v6/*: any*/),
+      "args": (v8/*: any*/),
       "kind": "ScalarField",
       "name": "sessionCount",
       "storageKey": null
     },
     {
       "alias": null,
-      "args": (v6/*: any*/),
+      "args": (v8/*: any*/),
       "kind": "ScalarField",
       "name": "averageSessionDurationMs",
       "storageKey": null
     },
     {
       "alias": null,
-      "args": (v6/*: any*/),
+      "args": (v8/*: any*/),
       "kind": "ScalarField",
       "name": "averageTracesPerSession",
       "storageKey": null
@@ -113,13 +125,14 @@ v7 = {
     {
       "alias": "sessionDurationMsP50",
       "args": [
-        (v4/*: any*/),
+        (v5/*: any*/),
         {
           "kind": "Literal",
           "name": "probability",
           "value": 0.5
         },
-        (v5/*: any*/)
+        (v6/*: any*/),
+        (v7/*: any*/)
       ],
       "kind": "ScalarField",
       "name": "sessionDurationMsQuantile",
@@ -128,13 +141,14 @@ v7 = {
     {
       "alias": "sessionDurationMsP99",
       "args": [
-        (v4/*: any*/),
+        (v5/*: any*/),
         {
           "kind": "Literal",
           "name": "probability",
           "value": 0.99
         },
-        (v5/*: any*/)
+        (v6/*: any*/),
+        (v7/*: any*/)
       ],
       "kind": "ScalarField",
       "name": "sessionDurationMsQuantile",
@@ -156,7 +170,8 @@ return {
     "argumentDefinitions": [
       (v0/*: any*/),
       (v1/*: any*/),
-      (v2/*: any*/)
+      (v2/*: any*/),
+      (v3/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -164,13 +179,13 @@ return {
     "selections": [
       {
         "alias": "project",
-        "args": (v3/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v7/*: any*/)
+          (v9/*: any*/)
         ],
         "storageKey": null
       }
@@ -182,15 +197,16 @@ return {
   "operation": {
     "argumentDefinitions": [
       (v1/*: any*/),
-      (v2/*: any*/),
-      (v0/*: any*/)
+      (v3/*: any*/),
+      (v0/*: any*/),
+      (v2/*: any*/)
     ],
     "kind": "Operation",
     "name": "SessionsTableAsideQuery",
     "selections": [
       {
         "alias": "project",
-        "args": (v3/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -203,7 +219,7 @@ return {
             "name": "__typename",
             "storageKey": null
           },
-          (v7/*: any*/),
+          (v9/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -217,16 +233,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "342f8e3cec6c060baee1de24c4e9a6b8",
+    "cacheID": "271432fa765dad968dfacd96dad900d6",
     "id": null,
     "metadata": {},
     "name": "SessionsTableAsideQuery",
     "operationKind": "query",
-    "text": "query SessionsTableAsideQuery(\n  $id: ID!\n  $timeRange: TimeRange!\n  $filterIoSubstring: String\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      name\n      description\n      sessionCount(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)\n      averageSessionDurationMs(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)\n      averageTracesPerSession(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)\n      sessionDurationMsP50: sessionDurationMsQuantile(probability: 0.5, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)\n      sessionDurationMsP99: sessionDurationMsQuantile(probability: 0.99, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)\n      sessionAnnotationNames\n    }\n    id\n  }\n}\n"
+    "text": "query SessionsTableAsideQuery(\n  $id: ID!\n  $timeRange: TimeRange!\n  $filterIoSubstring: String\n  $sessionId: String\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      name\n      description\n      sessionCount(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId)\n      averageSessionDurationMs(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId)\n      averageTracesPerSession(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId)\n      sessionDurationMsP50: sessionDurationMsQuantile(probability: 0.5, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId)\n      sessionDurationMsP99: sessionDurationMsQuantile(probability: 0.99, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId)\n      sessionAnnotationNames\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2d143007946e7d7441222f8a4e82bedb";
+(node as any).hash = "67d25925d174621807b12661e70110e6";
 
 export default node;

--- a/app/src/pages/trace/SessionDetails.tsx
+++ b/app/src/pages/trace/SessionDetails.tsx
@@ -60,78 +60,67 @@ function SessionDetailsHeader({
       borderBottomWidth={"thin"}
       borderBottomColor="default"
     >
-      <Flex
-        direction="row"
-        gap="size-400"
-        alignItems="center"
-        justifyContent="space-between"
-      >
-        <Flex direction="row" gap="size-400" alignItems="center">
-          {tokenUsage != null ? (
-            <Flex direction={"column"}>
-              <Text elementType={"h3"} color={"text-700"}>
-                Total Tokens
-              </Text>
-              <SessionTokenCount
-                tokenCountTotal={tokenUsage.total}
-                nodeId={sessionId}
-                size="L"
-              />
-            </Flex>
-          ) : null}
-          {costSummary != null ? (
-            <Flex direction="column" flex="none">
-              <Text elementType="h3" size="S" color="text-700">
-                Total Cost
-              </Text>
-              <TooltipTrigger delay={0}>
-                <TriggerWrap>
-                  <Text size="L">
-                    {costFormatter(costSummary.total?.cost ?? 0)}
-                  </Text>
-                </TriggerWrap>
-                <RichTooltip placement="bottom">
-                  <View width="size-2400">
-                    <Flex direction="column">
-                      <Flex justifyContent="space-between">
-                        <Text>Prompt Cost</Text>
-                        <Text>
-                          {costFormatter(costSummary.prompt?.cost ?? 0)}
-                        </Text>
-                      </Flex>
-                      <Flex justifyContent="space-between">
-                        <Text>Completion Cost</Text>
-                        <Text>
-                          {costFormatter(costSummary.completion?.cost ?? 0)}
-                        </Text>
-                      </Flex>
-                      <Flex justifyContent="space-between">
-                        <Text>Total Cost</Text>
-                        <Text>
-                          {costFormatter(costSummary.total?.cost ?? 0)}
-                        </Text>
-                      </Flex>
+      <Flex direction="row" gap="size-400" alignItems="center">
+        {tokenUsage != null ? (
+          <Flex direction={"column"}>
+            <Text elementType={"h3"} color={"text-700"}>
+              Total Tokens
+            </Text>
+            <SessionTokenCount
+              tokenCountTotal={tokenUsage.total}
+              nodeId={sessionId}
+              size="L"
+            />
+          </Flex>
+        ) : null}
+        {costSummary != null ? (
+          <Flex direction="column" flex="none">
+            <Text elementType="h3" size="S" color="text-700">
+              Total Cost
+            </Text>
+            <TooltipTrigger delay={0}>
+              <TriggerWrap>
+                <Text size="L">
+                  {costFormatter(costSummary.total?.cost ?? 0)}
+                </Text>
+              </TriggerWrap>
+              <RichTooltip placement="bottom">
+                <View width="size-2400">
+                  <Flex direction="column">
+                    <Flex justifyContent="space-between">
+                      <Text>Prompt Cost</Text>
+                      <Text>
+                        {costFormatter(costSummary.prompt?.cost ?? 0)}
+                      </Text>
                     </Flex>
-                  </View>
-                </RichTooltip>
-              </TooltipTrigger>
-            </Flex>
-          ) : null}
-          {latencyP50 != null ? (
-            <Flex direction={"column"}>
-              <Text elementType={"h3"} color={"text-700"}>
-                Latency P50
-              </Text>
-              <LatencyText latencyMs={latencyP50} size="L" />
-            </Flex>
-          ) : null}
-        </Flex>
-        <Flex direction="row" justifyContent="end">
-          <SessionAnnotationSummaryGroupStacks
-            session={session}
-            renderEmptyState={() => null}
-          />
-        </Flex>
+                    <Flex justifyContent="space-between">
+                      <Text>Completion Cost</Text>
+                      <Text>
+                        {costFormatter(costSummary.completion?.cost ?? 0)}
+                      </Text>
+                    </Flex>
+                    <Flex justifyContent="space-between">
+                      <Text>Total Cost</Text>
+                      <Text>{costFormatter(costSummary.total?.cost ?? 0)}</Text>
+                    </Flex>
+                  </Flex>
+                </View>
+              </RichTooltip>
+            </TooltipTrigger>
+          </Flex>
+        ) : null}
+        {latencyP50 != null ? (
+          <Flex direction={"column"}>
+            <Text elementType={"h3"} color={"text-700"}>
+              Latency P50
+            </Text>
+            <LatencyText latencyMs={latencyP50} size="L" />
+          </Flex>
+        ) : null}
+        <SessionAnnotationSummaryGroupStacks
+          session={session}
+          renderEmptyState={() => null}
+        />
       </Flex>
     </View>
   );

--- a/src/phoenix/server/api/dataloaders/annotation_summaries.py
+++ b/src/phoenix/server/api/dataloaders/annotation_summaries.py
@@ -1,11 +1,12 @@
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Literal, Optional, Type, Union, cast
+from typing import Any, Literal, Optional, Type, Union
 
 import pandas as pd
 from aioitertools.itertools import groupby
 from cachetools import LFUCache, TTLCache
 from sqlalchemy import Select, and_, case, distinct, func, or_, select
+from sqlalchemy.orm import InstrumentedAttribute
 from strawberry.dataloader import AbstractCache, DataLoader
 from typing_extensions import TypeAlias, assert_never
 
@@ -22,6 +23,9 @@ ProjectRowId: TypeAlias = int
 TimeInterval: TypeAlias = tuple[Optional[datetime], Optional[datetime]]
 FilterCondition: TypeAlias = Optional[str]
 SessionFilterCondition: TypeAlias = Optional[str]
+# Rowid of a single session to scope the summary to, used when the sessions
+# table search resolves to an exact session-ID match.
+SessionRowId: TypeAlias = Optional[int]
 AnnotationName: TypeAlias = str
 
 Segment: TypeAlias = tuple[
@@ -30,6 +34,7 @@ Segment: TypeAlias = tuple[
     TimeInterval,
     FilterCondition,
     SessionFilterCondition,
+    SessionRowId,
 ]
 Param: TypeAlias = AnnotationName
 
@@ -39,6 +44,7 @@ Key: TypeAlias = tuple[
     Optional[TimeRange],
     FilterCondition,
     SessionFilterCondition,
+    SessionRowId,
     AnnotationName,
 ]
 Result: TypeAlias = Optional[AnnotationSummary]
@@ -47,15 +53,30 @@ DEFAULT_VALUE: Result = None
 
 
 def _cache_key_fn(key: Key) -> tuple[Segment, Param]:
-    kind, project_rowid, time_range, filter_condition, session_filter_condition, eval_name = key
+    (
+        kind,
+        project_rowid,
+        time_range,
+        filter_condition,
+        session_filter_condition,
+        session_rowid,
+        eval_name,
+    ) = key
     interval = (
         (time_range.start, time_range.end) if isinstance(time_range, TimeRange) else (None, None)
     )
-    return (kind, project_rowid, interval, filter_condition, session_filter_condition), eval_name
+    return (
+        kind,
+        project_rowid,
+        interval,
+        filter_condition,
+        session_filter_condition,
+        session_rowid,
+    ), eval_name
 
 
 _Section: TypeAlias = tuple[ProjectRowId, AnnotationName, Kind]
-_SubKey: TypeAlias = tuple[TimeInterval, FilterCondition, SessionFilterCondition]
+_SubKey: TypeAlias = tuple[TimeInterval, FilterCondition, SessionFilterCondition, SessionRowId]
 
 
 class AnnotationSummaryCache(
@@ -83,6 +104,7 @@ class AnnotationSummaryCache(
                 interval,
                 filter_condition,
                 session_filter_condition,
+                session_rowid,
             ),
             annotation_name,
         ) = _cache_key_fn(key)
@@ -90,6 +112,7 @@ class AnnotationSummaryCache(
             interval,
             filter_condition,
             session_filter_condition,
+            session_rowid,
         )
 
 
@@ -130,9 +153,14 @@ def _get_stmt(
     segment: Segment,
     *annotation_names: Param,
 ) -> Select[Any]:
-    kind, project_rowid, (start_time, end_time), filter_condition, session_filter_condition = (
-        segment
-    )
+    (
+        kind,
+        project_rowid,
+        (start_time, end_time),
+        filter_condition,
+        session_filter_condition,
+        session_rowid,
+    ) = segment
 
     annotation_model: Union[
         Type[models.SpanAnnotation],
@@ -145,6 +173,9 @@ def _get_stmt(
     # The column holding the session rowid, used when a session filter narrows
     # the summary to sessions whose root span input/output matches a substring.
     session_rowid_column: Any
+    # The column holding the project rowid, used to scope the (possibly
+    # joined) entity rows to a project.
+    project_rowid_column: InstrumentedAttribute[int]
 
     if kind == "span":
         annotation_model = models.SpanAnnotation
@@ -152,18 +183,21 @@ def _get_stmt(
         entity_join_model = models.Trace
         entity_id_column = models.Span.id.label("entity_id")
         session_rowid_column = models.Trace.project_session_rowid
+        project_rowid_column = models.Trace.project_rowid
     elif kind == "trace":
         annotation_model = models.TraceAnnotation
         entity_model = models.Trace
         entity_join_model = None
         entity_id_column = models.Trace.id.label("entity_id")
         session_rowid_column = models.Trace.project_session_rowid
+        project_rowid_column = models.Trace.project_rowid
     elif kind == "session":
         annotation_model = models.ProjectSessionAnnotation
         entity_model = models.ProjectSession
         entity_join_model = None
         entity_id_column = models.ProjectSession.id.label("entity_id")
         session_rowid_column = models.ProjectSession.id
+        project_rowid_column = models.ProjectSession.project_id
     else:
         assert_never(kind)
 
@@ -178,26 +212,10 @@ def _get_stmt(
         name_column, func.count(distinct(entity_id_column)).label("entity_count")
     )
 
-    if kind == "span":
-        entity_count_query = entity_count_query.join(cast(Type[models.Span], entity_model))
-        entity_count_query = entity_count_query.join_from(
-            cast(Type[models.Span], entity_model), cast(Type[models.Trace], entity_join_model)
-        )
-        entity_count_query = entity_count_query.where(models.Trace.project_rowid == project_rowid)
-    elif kind == "trace":
-        entity_count_query = entity_count_query.join(cast(Type[models.Trace], entity_model))
-        entity_count_query = entity_count_query.where(
-            cast(Type[models.Trace], entity_model).project_rowid == project_rowid
-        )
-    elif kind == "session":
-        entity_count_query = entity_count_query.join(
-            cast(Type[models.ProjectSession], entity_model)
-        )
-        entity_count_query = entity_count_query.where(
-            cast(Type[models.ProjectSession], entity_model).project_id == project_rowid
-        )
-    else:
-        assert_never(kind)
+    entity_count_query = entity_count_query.join(entity_model)
+    if entity_join_model is not None:
+        entity_count_query = entity_count_query.join_from(entity_model, entity_join_model)
+    entity_count_query = entity_count_query.where(project_rowid_column == project_rowid)
 
     if session_filter_condition:
         filtered_session_rowids = get_filtered_session_rowids_subquery(
@@ -209,6 +227,8 @@ def _get_stmt(
         entity_count_query = entity_count_query.where(
             session_rowid_column.in_(filtered_session_rowids)
         )
+    if session_rowid is not None:
+        entity_count_query = entity_count_query.where(session_rowid_column == session_rowid)
 
     entity_count_query = entity_count_query.where(
         or_(score_column.is_not(None), label_column.is_not(None))
@@ -234,27 +254,13 @@ def _get_stmt(
         func.sum(score_column).label("score_sum"),
     )
 
-    if kind == "span":
-        base_stmt = base_stmt.join(cast(Type[models.Span], entity_model))
-        base_stmt = base_stmt.join_from(
-            cast(Type[models.Span], entity_model), cast(Type[models.Trace], entity_join_model)
-        )
-        base_stmt = base_stmt.where(models.Trace.project_rowid == project_rowid)
-        if filter_condition:
-            sf = SpanFilter(filter_condition)
-            base_stmt = sf(base_stmt)
-    elif kind == "trace":
-        base_stmt = base_stmt.join(cast(Type[models.Trace], entity_model))
-        base_stmt = base_stmt.where(
-            cast(Type[models.Trace], entity_model).project_rowid == project_rowid
-        )
-    elif kind == "session":
-        base_stmt = base_stmt.join(cast(Type[models.ProjectSession], entity_model))
-        base_stmt = base_stmt.where(
-            cast(Type[models.ProjectSession], entity_model).project_id == project_rowid
-        )
-    else:
-        assert_never(kind)
+    base_stmt = base_stmt.join(entity_model)
+    if entity_join_model is not None:
+        base_stmt = base_stmt.join_from(entity_model, entity_join_model)
+    base_stmt = base_stmt.where(project_rowid_column == project_rowid)
+    if kind == "span" and filter_condition:
+        sf = SpanFilter(filter_condition)
+        base_stmt = sf(base_stmt)
 
     if session_filter_condition:
         filtered_session_rowids = get_filtered_session_rowids_subquery(
@@ -264,6 +270,8 @@ def _get_stmt(
             end_time=end_time,
         )
         base_stmt = base_stmt.where(session_rowid_column.in_(filtered_session_rowids))
+    if session_rowid is not None:
+        base_stmt = base_stmt.where(session_rowid_column == session_rowid)
 
     base_stmt = base_stmt.where(or_(score_column.is_not(None), label_column.is_not(None)))
     base_stmt = base_stmt.where(name_column.in_(annotation_names))

--- a/src/phoenix/server/api/dataloaders/annotation_summaries.py
+++ b/src/phoenix/server/api/dataloaders/annotation_summaries.py
@@ -17,7 +17,7 @@ from phoenix.server.session_filters import get_filtered_session_rowids_subquery
 from phoenix.server.types import DbSessionFactory
 from phoenix.trace.dsl import SpanFilter
 
-Kind: TypeAlias = Literal["span", "trace"]
+Kind: TypeAlias = Literal["span", "trace", "session"]
 ProjectRowId: TypeAlias = int
 TimeInterval: TypeAlias = tuple[Optional[datetime], Optional[datetime]]
 FilterCondition: TypeAlias = Optional[str]
@@ -134,21 +134,36 @@ def _get_stmt(
         segment
     )
 
-    annotation_model: Union[Type[models.SpanAnnotation], Type[models.TraceAnnotation]]
-    entity_model: Union[Type[models.Span], Type[models.Trace]]
+    annotation_model: Union[
+        Type[models.SpanAnnotation],
+        Type[models.TraceAnnotation],
+        Type[models.ProjectSessionAnnotation],
+    ]
+    entity_model: Union[Type[models.Span], Type[models.Trace], Type[models.ProjectSession]]
     entity_join_model: Optional[Type[models.Base]]
     entity_id_column: Any
+    # The column holding the session rowid, used when a session filter narrows
+    # the summary to sessions whose root span input/output matches a substring.
+    session_rowid_column: Any
 
     if kind == "span":
         annotation_model = models.SpanAnnotation
         entity_model = models.Span
         entity_join_model = models.Trace
         entity_id_column = models.Span.id.label("entity_id")
+        session_rowid_column = models.Trace.project_session_rowid
     elif kind == "trace":
         annotation_model = models.TraceAnnotation
         entity_model = models.Trace
         entity_join_model = None
         entity_id_column = models.Trace.id.label("entity_id")
+        session_rowid_column = models.Trace.project_session_rowid
+    elif kind == "session":
+        annotation_model = models.ProjectSessionAnnotation
+        entity_model = models.ProjectSession
+        entity_join_model = None
+        entity_id_column = models.ProjectSession.id.label("entity_id")
+        session_rowid_column = models.ProjectSession.id
     else:
         assert_never(kind)
 
@@ -174,6 +189,13 @@ def _get_stmt(
         entity_count_query = entity_count_query.where(
             cast(Type[models.Trace], entity_model).project_rowid == project_rowid
         )
+    elif kind == "session":
+        entity_count_query = entity_count_query.join(
+            cast(Type[models.ProjectSession], entity_model)
+        )
+        entity_count_query = entity_count_query.where(
+            cast(Type[models.ProjectSession], entity_model).project_id == project_rowid
+        )
     else:
         assert_never(kind)
 
@@ -185,7 +207,7 @@ def _get_stmt(
             end_time=end_time,
         )
         entity_count_query = entity_count_query.where(
-            models.Trace.project_session_rowid.in_(filtered_session_rowids)
+            session_rowid_column.in_(filtered_session_rowids)
         )
 
     entity_count_query = entity_count_query.where(
@@ -226,6 +248,11 @@ def _get_stmt(
         base_stmt = base_stmt.where(
             cast(Type[models.Trace], entity_model).project_rowid == project_rowid
         )
+    elif kind == "session":
+        base_stmt = base_stmt.join(cast(Type[models.ProjectSession], entity_model))
+        base_stmt = base_stmt.where(
+            cast(Type[models.ProjectSession], entity_model).project_id == project_rowid
+        )
     else:
         assert_never(kind)
 
@@ -236,7 +263,7 @@ def _get_stmt(
             start_time=start_time,
             end_time=end_time,
         )
-        base_stmt = base_stmt.where(models.Trace.project_session_rowid.in_(filtered_session_rowids))
+        base_stmt = base_stmt.where(session_rowid_column.in_(filtered_session_rowids))
 
     base_stmt = base_stmt.where(or_(score_column.is_not(None), label_column.is_not(None)))
     base_stmt = base_stmt.where(name_column.in_(annotation_names))

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, cast
 import strawberry
 from aioitertools.itertools import groupby, islice
 from openinference.semconv.trace import SpanAttributes
-from sqlalchemy import Select, and_, case, desc, distinct, exists, func, or_, select
+from sqlalchemy import Select, and_, case, desc, distinct, exists, false, func, or_, select
 from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.sql.expression import tuple_
@@ -146,16 +146,24 @@ def _apply_project_session_filters(
     project_rowid: int,
     time_range: Optional[TimeRange],
     filter_io_substring: Optional[str],
+    session_id: Optional[str] = None,
 ) -> Select[Any]:
     """Restrict a ``ProjectSession`` aggregation to the project, time range, and
-    input/output substring filter used by the sessions table."""
+    input/output substring filter used by the sessions table.
+
+    When ``session_id`` is provided, mirror the ``sessions`` resolver's search
+    semantics: an exact session-ID match wins (ignoring the time range and
+    substring filter); otherwise fall back to the substring/time-range filters,
+    or to no sessions at all when there is no substring to fall back to.
+    """
     table = models.ProjectSession
     stmt = stmt.where(table.project_id == project_rowid)
+    conditions = []
     if time_range:
         if time_range.start:
-            stmt = stmt.where(time_range.start <= table.start_time)
+            conditions.append(time_range.start <= table.start_time)
         if time_range.end:
-            stmt = stmt.where(table.start_time < time_range.end)
+            conditions.append(table.start_time < time_range.end)
     if filter_io_substring:
         filtered_session_rowids = get_filtered_session_rowids_subquery(
             session_filter_condition=filter_io_substring,
@@ -163,8 +171,22 @@ def _apply_project_session_filters(
             start_time=time_range.start if time_range else None,
             end_time=time_range.end if time_range else None,
         )
-        stmt = stmt.where(table.id.in_(filtered_session_rowids))
-    return stmt
+        conditions.append(table.id.in_(filtered_session_rowids))
+    if not session_id:
+        return stmt.where(*conditions)
+    exact_match = exists(
+        select(1).where(
+            table.project_id == project_rowid,
+            table.session_id == session_id,
+        )
+    )
+    fallback = and_(*conditions) if filter_io_substring else false()
+    return stmt.where(
+        or_(
+            and_(exact_match, table.session_id == session_id),
+            and_(~exact_match, fallback),
+        )
+    )
 
 
 @strawberry.type
@@ -645,19 +667,23 @@ class Project(Node):
 
     @strawberry.field(
         description="Number of sessions in the project, optionally filtered by "
-        "a time range and a substring of the session input/output."
+        "a time range and a substring of the session input/output. An exact "
+        "session-ID match takes precedence over the other filters, mirroring "
+        "the sessions table search."
     )  # type: ignore
     async def session_count(
         self,
         info: Info[Context, None],
         time_range: Optional[TimeRange] = UNSET,
         filter_io_substring: Optional[str] = UNSET,
+        session_id: Optional[str] = UNSET,
     ) -> int:
         stmt = _apply_project_session_filters(
             select(func.count(models.ProjectSession.id)),
             project_rowid=self.id,
             time_range=time_range or None,
             filter_io_substring=filter_io_substring or None,
+            session_id=session_id or None,
         )
         async with info.context.db.read() as session:
             return await session.scalar(stmt) or 0
@@ -665,13 +691,16 @@ class Project(Node):
     @strawberry.field(
         description="Average session duration in milliseconds, i.e. the mean of "
         "end time minus start time across sessions, optionally filtered by a "
-        "time range and a substring of the session input/output."
+        "time range and a substring of the session input/output. An exact "
+        "session-ID match takes precedence over the other filters, mirroring "
+        "the sessions table search."
     )  # type: ignore
     async def average_session_duration_ms(
         self,
         info: Info[Context, None],
         time_range: Optional[TimeRange] = UNSET,
         filter_io_substring: Optional[str] = UNSET,
+        session_id: Optional[str] = UNSET,
     ) -> Optional[float]:
         stmt = _apply_project_session_filters(
             select(
@@ -685,6 +714,7 @@ class Project(Node):
             project_rowid=self.id,
             time_range=time_range or None,
             filter_io_substring=filter_io_substring or None,
+            session_id=session_id or None,
         )
         async with info.context.db.read() as session:
             average_duration_ms = await session.scalar(stmt)
@@ -693,13 +723,15 @@ class Project(Node):
     @strawberry.field(
         description="Average number of traces (e.g. conversation turns) per "
         "session, optionally filtered by a time range and a substring of the "
-        "session input/output."
+        "session input/output. An exact session-ID match takes precedence "
+        "over the other filters, mirroring the sessions table search."
     )  # type: ignore
     async def average_traces_per_session(
         self,
         info: Info[Context, None],
         time_range: Optional[TimeRange] = UNSET,
         filter_io_substring: Optional[str] = UNSET,
+        session_id: Optional[str] = UNSET,
     ) -> Optional[float]:
         traces_per_session = _apply_project_session_filters(
             select(func.count(models.Trace.id).label("num_traces"))
@@ -712,6 +744,7 @@ class Project(Node):
             project_rowid=self.id,
             time_range=time_range or None,
             filter_io_substring=filter_io_substring or None,
+            session_id=session_id or None,
         ).subquery()
         stmt = select(func.avg(traces_per_session.c.num_traces))
         async with info.context.db.read() as session:
@@ -721,7 +754,9 @@ class Project(Node):
     @strawberry.field(
         description="Quantile (e.g. p50, p99) of session duration in "
         "milliseconds, i.e. end time minus start time, optionally filtered by "
-        "a time range and a substring of the session input/output."
+        "a time range and a substring of the session input/output. An exact "
+        "session-ID match takes precedence over the other filters, mirroring "
+        "the sessions table search."
     )  # type: ignore
     async def session_duration_ms_quantile(
         self,
@@ -729,6 +764,7 @@ class Project(Node):
         probability: float,
         time_range: Optional[TimeRange] = UNSET,
         filter_io_substring: Optional[str] = UNSET,
+        session_id: Optional[str] = UNSET,
     ) -> Optional[float]:
         if not 0 <= probability <= 1:
             raise BadRequest("Probability must be between 0 and 1 (inclusive)")
@@ -749,6 +785,7 @@ class Project(Node):
             project_rowid=self.id,
             time_range=time_range or None,
             filter_io_substring=filter_io_substring or None,
+            session_id=session_id or None,
         )
         async with info.context.db.read() as session:
             quantile_value = await session.scalar(stmt)
@@ -902,6 +939,7 @@ class Project(Node):
                 time_range or None,
                 filter_condition or None,
                 session_filter_condition or None,
+                None,
                 annotation_name,
             ),
         )
@@ -927,18 +965,42 @@ class Project(Node):
                 time_range or None,
                 filter_condition or None,
                 session_filter_condition or None,
+                None,
                 annotation_name,
             ),
         )
 
-    @strawberry.field
+    @strawberry.field(
+        description="Summary (score and label fractions) of a session "
+        "annotation across the project's sessions, optionally filtered by a "
+        "time range and a substring of the session input/output. An exact "
+        "session-ID match takes precedence over the other filters, mirroring "
+        "the sessions table search."
+    )  # type: ignore
     async def session_annotation_summary(
         self,
         info: Info[Context, None],
         annotation_name: str,
         time_range: Optional[TimeRange] = UNSET,
         filter_io_substring: Optional[str] = UNSET,
+        session_id: Optional[str] = UNSET,
     ) -> Optional[AnnotationSummary]:
+        if session_id:
+            async with info.context.db.read() as session:
+                session_rowid = await session.scalar(
+                    select(models.ProjectSession.id).where(
+                        models.ProjectSession.project_id == self.id,
+                        models.ProjectSession.session_id == session_id,
+                    )
+                )
+            if session_rowid is not None:
+                # Mirror the sessions table: the exact match wins and ignores
+                # the time range and substring filter.
+                return await info.context.data_loaders.annotation_summaries.load(
+                    ("session", self.id, None, None, None, session_rowid, annotation_name),
+                )
+            if not filter_io_substring:
+                return None
         return await info.context.data_loaders.annotation_summaries.load(
             (
                 "session",
@@ -946,6 +1008,7 @@ class Project(Node):
                 time_range or None,
                 None,
                 filter_io_substring or None,
+                None,
                 annotation_name,
             ),
         )

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -141,6 +141,32 @@ async def _annotation_name_counts(
     return [AnnotationNameCount(name=name, count=count) for name, count in result]
 
 
+def _apply_project_session_filters(
+    stmt: Select[Any],
+    project_rowid: int,
+    time_range: Optional[TimeRange],
+    filter_io_substring: Optional[str],
+) -> Select[Any]:
+    """Restrict a ``ProjectSession`` aggregation to the project, time range, and
+    input/output substring filter used by the sessions table."""
+    table = models.ProjectSession
+    stmt = stmt.where(table.project_id == project_rowid)
+    if time_range:
+        if time_range.start:
+            stmt = stmt.where(time_range.start <= table.start_time)
+        if time_range.end:
+            stmt = stmt.where(table.start_time < time_range.end)
+    if filter_io_substring:
+        filtered_session_rowids = get_filtered_session_rowids_subquery(
+            session_filter_condition=filter_io_substring,
+            project_rowids=[project_rowid],
+            start_time=time_range.start if time_range else None,
+            end_time=time_range.end if time_range else None,
+        )
+        stmt = stmt.where(table.id.in_(filtered_session_rowids))
+    return stmt
+
+
 @strawberry.type
 class Project(Node):
     id: NodeID[int]
@@ -556,20 +582,12 @@ class Project(Node):
                     data=[],
                     args=ConnectionArgs(),
                 )
-        stmt = select(table).filter_by(project_id=self.id)
-        if time_range:
-            if time_range.start:
-                stmt = stmt.where(time_range.start <= table.start_time)
-            if time_range.end:
-                stmt = stmt.where(table.start_time < time_range.end)
-        if filter_io_substring:
-            filtered_session_rowids = get_filtered_session_rowids_subquery(
-                session_filter_condition=filter_io_substring,
-                project_rowids=[self.id],
-                start_time=time_range.start if time_range else None,
-                end_time=time_range.end if time_range else None,
-            )
-            stmt = stmt.where(table.id.in_(filtered_session_rowids))
+        stmt = _apply_project_session_filters(
+            select(table),
+            project_rowid=self.id,
+            time_range=time_range or None,
+            filter_io_substring=filter_io_substring or None,
+        )
         sort_config: Optional[ProjectSessionSortConfig] = None
         cursor_rowid_column: Any = table.id
         if sort:
@@ -624,6 +642,117 @@ class Project(Node):
             has_previous_page=False,
             has_next_page=has_next_page,
         )
+
+    @strawberry.field(
+        description="Number of sessions in the project, optionally filtered by "
+        "a time range and a substring of the session input/output."
+    )  # type: ignore
+    async def session_count(
+        self,
+        info: Info[Context, None],
+        time_range: Optional[TimeRange] = UNSET,
+        filter_io_substring: Optional[str] = UNSET,
+    ) -> int:
+        stmt = _apply_project_session_filters(
+            select(func.count(models.ProjectSession.id)),
+            project_rowid=self.id,
+            time_range=time_range or None,
+            filter_io_substring=filter_io_substring or None,
+        )
+        async with info.context.db.read() as session:
+            return await session.scalar(stmt) or 0
+
+    @strawberry.field(
+        description="Average session duration in milliseconds, i.e. the mean of "
+        "end time minus start time across sessions, optionally filtered by a "
+        "time range and a substring of the session input/output."
+    )  # type: ignore
+    async def average_session_duration_ms(
+        self,
+        info: Info[Context, None],
+        time_range: Optional[TimeRange] = UNSET,
+        filter_io_substring: Optional[str] = UNSET,
+    ) -> Optional[float]:
+        stmt = _apply_project_session_filters(
+            select(
+                func.avg(
+                    models.LatencyMs(
+                        models.ProjectSession.start_time,
+                        models.ProjectSession.end_time,
+                    )
+                )
+            ),
+            project_rowid=self.id,
+            time_range=time_range or None,
+            filter_io_substring=filter_io_substring or None,
+        )
+        async with info.context.db.read() as session:
+            average_duration_ms = await session.scalar(stmt)
+        return None if average_duration_ms is None else float(average_duration_ms)
+
+    @strawberry.field(
+        description="Average number of traces (e.g. conversation turns) per "
+        "session, optionally filtered by a time range and a substring of the "
+        "session input/output."
+    )  # type: ignore
+    async def average_traces_per_session(
+        self,
+        info: Info[Context, None],
+        time_range: Optional[TimeRange] = UNSET,
+        filter_io_substring: Optional[str] = UNSET,
+    ) -> Optional[float]:
+        traces_per_session = _apply_project_session_filters(
+            select(func.count(models.Trace.id).label("num_traces"))
+            .select_from(models.ProjectSession)
+            .outerjoin(
+                models.Trace,
+                models.Trace.project_session_rowid == models.ProjectSession.id,
+            )
+            .group_by(models.ProjectSession.id),
+            project_rowid=self.id,
+            time_range=time_range or None,
+            filter_io_substring=filter_io_substring or None,
+        ).subquery()
+        stmt = select(func.avg(traces_per_session.c.num_traces))
+        async with info.context.db.read() as session:
+            average_num_traces = await session.scalar(stmt)
+        return None if average_num_traces is None else float(average_num_traces)
+
+    @strawberry.field(
+        description="Quantile (e.g. p50, p99) of session duration in "
+        "milliseconds, i.e. end time minus start time, optionally filtered by "
+        "a time range and a substring of the session input/output."
+    )  # type: ignore
+    async def session_duration_ms_quantile(
+        self,
+        info: Info[Context, None],
+        probability: float,
+        time_range: Optional[TimeRange] = UNSET,
+        filter_io_substring: Optional[str] = UNSET,
+    ) -> Optional[float]:
+        if not 0 <= probability <= 1:
+            raise BadRequest("Probability must be between 0 and 1 (inclusive)")
+        duration_ms = models.LatencyMs(
+            models.ProjectSession.start_time,
+            models.ProjectSession.end_time,
+        )
+        dialect = info.context.db.dialect
+        quantile: Any
+        if dialect is SupportedSQLDialect.POSTGRESQL:
+            quantile = percentile_cont(probability).within_group(duration_ms)
+        elif dialect is SupportedSQLDialect.SQLITE:
+            quantile = func.percentile(duration_ms, probability * 100)
+        else:
+            assert_never(dialect)
+        stmt = _apply_project_session_filters(
+            select(quantile),
+            project_rowid=self.id,
+            time_range=time_range or None,
+            filter_io_substring=filter_io_substring or None,
+        )
+        async with info.context.db.read() as session:
+            quantile_value = await session.scalar(stmt)
+        return None if quantile_value is None else float(quantile_value)
 
     @strawberry.field(
         description="Names of all available annotations for traces. "
@@ -798,6 +927,25 @@ class Project(Node):
                 time_range or None,
                 filter_condition or None,
                 session_filter_condition or None,
+                annotation_name,
+            ),
+        )
+
+    @strawberry.field
+    async def session_annotation_summary(
+        self,
+        info: Info[Context, None],
+        annotation_name: str,
+        time_range: Optional[TimeRange] = UNSET,
+        filter_io_substring: Optional[str] = UNSET,
+    ) -> Optional[AnnotationSummary]:
+        return await info.context.data_loaders.annotation_summaries.load(
+            (
+                "session",
+                self.id,
+                time_range or None,
+                None,
+                filter_io_substring or None,
                 annotation_name,
             ),
         )

--- a/src/phoenix/server/dml_event_handler.py
+++ b/src/phoenix/server/dml_event_handler.py
@@ -14,6 +14,8 @@ from phoenix.db.models import (
     Base,
     DocumentAnnotation,
     Project,
+    ProjectSession,
+    ProjectSessionAnnotation,
     Span,
     SpanAnnotation,
     Trace,
@@ -23,6 +25,7 @@ from phoenix.server.api.dataloaders import CacheForDataLoaders
 from phoenix.server.dml_event import (
     DmlEvent,
     DocumentAnnotationDmlEvent,
+    ProjectSessionAnnotationDmlEvent,
     SpanAnnotationDmlEvent,
     SpanDeleteEvent,
     SpanDmlEvent,
@@ -140,6 +143,7 @@ _AnnotationTable: TypeAlias = Union[
     type[SpanAnnotation],
     type[TraceAnnotation],
     type[DocumentAnnotation],
+    type[ProjectSessionAnnotation],
 ]
 
 _AnnotationDmlEventT = TypeVar(
@@ -147,6 +151,7 @@ _AnnotationDmlEventT = TypeVar(
     SpanAnnotationDmlEvent,
     TraceAnnotationDmlEvent,
     DocumentAnnotationDmlEvent,
+    ProjectSessionAnnotationDmlEvent,
 )
 
 
@@ -218,6 +223,23 @@ class _DocumentAnnotationDmlEventHandler(_AnnotationDmlEventHandler[DocumentAnno
         cache.document_evaluation_summary.invalidate((project_id, name))
 
 
+class _ProjectSessionAnnotationDmlEventHandler(
+    _AnnotationDmlEventHandler[ProjectSessionAnnotationDmlEvent]
+):
+    _table = ProjectSessionAnnotation
+    # Session annotations hang off project sessions rather than traces, so the
+    # project lookup joins through ProjectSession instead of the default Trace.
+    _base_stmt = select(Project.id).join_from(Project, ProjectSession).distinct()
+
+    def __init__(self, **kwargs: Unpack[_HandlerParams]) -> None:
+        super().__init__(**kwargs)
+        self._stmt = self._stmt.join_from(ProjectSession, self._table)
+
+    @staticmethod
+    def _clear(cache: CacheForDataLoaders, project_id: int, name: str) -> None:
+        cache.annotation_summary.invalidate((project_id, name, "session"))
+
+
 class DmlEventHandler:
     def __init__(
         self,
@@ -240,6 +262,7 @@ class DmlEventHandler:
             SpanAnnotationDmlEvent: [_SpanAnnotationDmlEventHandler(**kwargs)],
             TraceAnnotationDmlEvent: [_TraceAnnotationDmlEventHandler(**kwargs)],
             DocumentAnnotationDmlEvent: [_DocumentAnnotationDmlEventHandler(**kwargs)],
+            ProjectSessionAnnotationDmlEvent: [_ProjectSessionAnnotationDmlEventHandler(**kwargs)],
         }
         self._all_handlers = frozenset(chain.from_iterable(self._handlers.values()))
 

--- a/tests/unit/_helpers.py
+++ b/tests/unit/_helpers.py
@@ -146,13 +146,14 @@ async def _add_project_session(
     project: models.Project,
     session_id: Optional[str] = None,
     start_time: Optional[datetime] = None,
+    end_time: Optional[datetime] = None,
 ) -> models.ProjectSession:
     start_time = start_time or datetime.now(timezone.utc)
     project_session = models.ProjectSession(
         session_id=session_id or token_hex(4),
         project_id=project.id,
         start_time=start_time,
-        end_time=start_time,
+        end_time=end_time or start_time,
     )
     session.add(project_session)
     await session.flush()

--- a/tests/unit/server/api/dataloaders/test_annotation_summaries.py
+++ b/tests/unit/server/api/dataloaders/test_annotation_summaries.py
@@ -56,6 +56,7 @@ async def test_evaluation_summaries(
     expected = trace_df.loc[:, "mean_score"].to_list() + span_df.loc[:, "mean_score"].to_list()
     kinds: list[Literal["span", "trace"]] = ["trace", "span"]
     session_filter_condition = None
+    session_rowid = None
     keys: list[Key] = [
         (
             kind,
@@ -63,6 +64,7 @@ async def test_evaluation_summaries(
             TimeRange(start=start_time, end=end_time),
             "'_trace4_' in name" if kind == "span" else None,
             session_filter_condition,
+            session_rowid,
             eval_name,
         )
         for kind in kinds
@@ -103,6 +105,7 @@ async def test_multiple_annotations_score_weighting(
     loader = AnnotationSummaryDataLoader(db)
     filter_condition = None
     session_filter_condition = None
+    session_rowid = None
     result = await loader.load(
         (
             "span",
@@ -110,6 +113,7 @@ async def test_multiple_annotations_score_weighting(
             TimeRange(start=start_time, end=end_time),
             filter_condition,
             session_filter_condition,
+            session_rowid,
             "quality",
         )
     )
@@ -148,6 +152,7 @@ async def test_missing_label_aggregation(
         assert isinstance(project_id, int)
     filter_condition = None
     session_filter_condition = None
+    session_rowid = None
     result = await loader.load(
         (
             "span",
@@ -155,6 +160,7 @@ async def test_missing_label_aggregation(
             TimeRange(start=start_time, end=end_time),
             filter_condition,
             session_filter_condition,
+            session_rowid,
             "distribution",
         )
     )
@@ -187,7 +193,15 @@ async def test_mixed_emit_coverage_counts(
         assert isinstance(project_id, int)
 
     result = await AnnotationSummaryDataLoader(db).load(
-        ("span", project_id, TimeRange(start=start_time, end=end_time), None, None, "coverage")
+        (
+            "span",
+            project_id,
+            TimeRange(start=start_time, end=end_time),
+            None,
+            None,
+            None,
+            "coverage",
+        )
     )
     assert result is not None
     assert result.score_count() == 60  # type: ignore[call-arg, comparison-overlap]
@@ -218,7 +232,15 @@ async def test_pure_score_only_coverage_counts(
         assert isinstance(project_id, int)
 
     result = await AnnotationSummaryDataLoader(db).load(
-        ("span", project_id, TimeRange(start=start_time, end=end_time), None, None, "unlabeled")
+        (
+            "span",
+            project_id,
+            TimeRange(start=start_time, end=end_time),
+            None,
+            None,
+            None,
+            "unlabeled",
+        )
     )
     assert result is not None
     assert result.label_count() == 0  # type: ignore[call-arg, comparison-overlap]
@@ -248,6 +270,7 @@ async def test_null_label_handling(
     loader = AnnotationSummaryDataLoader(db)
     filter_condition = None
     session_filter_condition = None
+    session_rowid = None
     result = await loader.load(
         (
             "span",
@@ -255,6 +278,7 @@ async def test_null_label_handling(
             TimeRange(start=start_time, end=end_time),
             filter_condition,
             session_filter_condition,
+            session_rowid,
             "unlabeled",
         )
     )

--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -5379,6 +5379,7 @@ async def test_session_stats(
         session1 = await _add_project_session(
             session,
             project,
+            session_id="session-1-exact-id",
             start_time=base_time,
             end_time=base_time + timedelta(seconds=10),
         )
@@ -5400,21 +5401,40 @@ async def test_session_stats(
         await _add_span(session, trace2, attributes={"input": {"value": "beta task"}})
 
     query = """
-      query ($projectId: ID!, $timeRange: TimeRange, $filterIoSubstring: String) {
+      query (
+        $projectId: ID!
+        $timeRange: TimeRange
+        $filterIoSubstring: String
+        $sessionId: String
+      ) {
         node(id: $projectId) {
           ... on Project {
-            sessionCount(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)
-            averageSessionDurationMs(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)
-            averageTracesPerSession(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)
+            sessionCount(
+              timeRange: $timeRange
+              filterIoSubstring: $filterIoSubstring
+              sessionId: $sessionId
+            )
+            averageSessionDurationMs(
+              timeRange: $timeRange
+              filterIoSubstring: $filterIoSubstring
+              sessionId: $sessionId
+            )
+            averageTracesPerSession(
+              timeRange: $timeRange
+              filterIoSubstring: $filterIoSubstring
+              sessionId: $sessionId
+            )
             sessionDurationMsP50: sessionDurationMsQuantile(
               probability: 0.5
               timeRange: $timeRange
               filterIoSubstring: $filterIoSubstring
+              sessionId: $sessionId
             )
             sessionDurationMsP99: sessionDurationMsQuantile(
               probability: 0.99
               timeRange: $timeRange
               filterIoSubstring: $filterIoSubstring
+              sessionId: $sessionId
             )
           }
         }
@@ -5478,6 +5498,60 @@ async def test_session_stats(
     assert response.data["node"]["sessionDurationMsP50"] is None
     assert response.data["node"]["sessionDurationMsP99"] is None
 
+    # The UI passes the search text as both the substring filter and an exact
+    # session-ID lookup; the exact match wins even though the ID appears
+    # nowhere in the input/output, mirroring the sessions table
+    response = await gql_client.execute(
+        query=query,
+        variables={
+            "projectId": project_gid,
+            "filterIoSubstring": "session-1-exact-id",
+            "sessionId": "session-1-exact-id",
+        },
+    )
+    assert not response.errors
+    assert response.data is not None
+    assert response.data["node"]["sessionCount"] == 1
+    assert response.data["node"]["averageSessionDurationMs"] == 10000.0
+    assert response.data["node"]["averageTracesPerSession"] == 2.0
+    assert response.data["node"]["sessionDurationMsP50"] == pytest.approx(10000.0)
+    assert response.data["node"]["sessionDurationMsP99"] == pytest.approx(10000.0)
+
+    # The exact session-ID match also ignores the time range, like the
+    # sessions table
+    response = await gql_client.execute(
+        query=query,
+        variables={
+            "projectId": project_gid,
+            "timeRange": {
+                "start": (base_time + timedelta(days=1)).isoformat(),
+                "end": (base_time + timedelta(days=2)).isoformat(),
+            },
+            "filterIoSubstring": "session-1-exact-id",
+            "sessionId": "session-1-exact-id",
+        },
+    )
+    assert not response.errors
+    assert response.data is not None
+    assert response.data["node"]["sessionCount"] == 1
+    assert response.data["node"]["averageSessionDurationMs"] == 10000.0
+
+    # When the search text matches no session ID exactly, the substring
+    # filter still applies
+    response = await gql_client.execute(
+        query=query,
+        variables={
+            "projectId": project_gid,
+            "filterIoSubstring": "alpha",
+            "sessionId": "alpha",
+        },
+    )
+    assert not response.errors
+    assert response.data is not None
+    assert response.data["node"]["sessionCount"] == 1
+    assert response.data["node"]["averageSessionDurationMs"] == 10000.0
+    assert response.data["node"]["averageTracesPerSession"] == 2.0
+
 
 async def test_session_annotation_summary_returns_expected_results(
     gql_client: AsyncGraphQLClient,
@@ -5485,7 +5559,9 @@ async def test_session_annotation_summary_returns_expected_results(
 ) -> None:
     async with db() as session:
         project = await _add_project(session, name="session-annotation-summary-test")
-        session1 = await _add_project_session(session, project)
+        session1 = await _add_project_session(
+            session, project, session_id="annotated-session-exact-id"
+        )
         trace1 = await _add_trace(session, project, session1)
         await _add_span(session, trace1, attributes={"input": {"value": "priority task"}})
         session.add(
@@ -5517,12 +5593,13 @@ async def test_session_annotation_summary_returns_expected_results(
         )
 
     query = """
-      query ($projectId: ID!, $filterIoSubstring: String) {
+      query ($projectId: ID!, $filterIoSubstring: String, $sessionId: String) {
         node(id: $projectId) {
           ... on Project {
             sessionAnnotationSummary(
               annotationName: "test-annotation"
               filterIoSubstring: $filterIoSubstring
+              sessionId: $sessionId
             ) {
               name
               count
@@ -5557,6 +5634,25 @@ async def test_session_annotation_summary_returns_expected_results(
 
     response = await gql_client.execute(
         query=query, variables={"projectId": project_gid, "filterIoSubstring": "priority"}
+    )
+    assert not response.errors
+    assert response.data is not None
+    summary = response.data["node"]["sessionAnnotationSummary"]
+    assert summary is not None
+    assert summary["count"] == 1
+    assert summary["meanScore"] == 1.0
+    assert summary["labelFractions"] == [{"label": "important", "fraction": 1.0}]
+
+    # The UI passes the search text as both the substring filter and an exact
+    # session-ID lookup; the exact match wins even though the ID appears
+    # nowhere in the input/output, mirroring the sessions table
+    response = await gql_client.execute(
+        query=query,
+        variables={
+            "projectId": project_gid,
+            "filterIoSubstring": "annotated-session-exact-id",
+            "sessionId": "annotated-session-exact-id",
+        },
     )
     assert not response.errors
     assert response.data is not None

--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -5365,3 +5365,203 @@ async def test_trace_with_unmatched_global_node_id_returns_null(
     assert not response.errors
     assert response.data is not None
     assert response.data["node"]["trace"] is None
+
+
+async def test_session_stats(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+) -> None:
+    # session1 has two traces (i.e. two turns) and lasts 10 seconds; session2
+    # has one trace and lasts 20 seconds
+    base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    async with db() as session:
+        project = await _add_project(session, name="session-stats-test")
+        session1 = await _add_project_session(
+            session,
+            project,
+            start_time=base_time,
+            end_time=base_time + timedelta(seconds=10),
+        )
+        trace1 = await _add_trace(session, project, session1, start_time=base_time)
+        await _add_span(session, trace1, attributes={"input": {"value": "alpha task"}})
+        trace1b = await _add_trace(
+            session, project, session1, start_time=base_time + timedelta(seconds=5)
+        )
+        await _add_span(session, trace1b, attributes={"input": {"value": "alpha follow-up"}})
+        session2 = await _add_project_session(
+            session,
+            project,
+            start_time=base_time + timedelta(minutes=5),
+            end_time=base_time + timedelta(minutes=5, seconds=20),
+        )
+        trace2 = await _add_trace(
+            session, project, session2, start_time=base_time + timedelta(minutes=5)
+        )
+        await _add_span(session, trace2, attributes={"input": {"value": "beta task"}})
+
+    query = """
+      query ($projectId: ID!, $timeRange: TimeRange, $filterIoSubstring: String) {
+        node(id: $projectId) {
+          ... on Project {
+            sessionCount(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)
+            averageSessionDurationMs(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)
+            averageTracesPerSession(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring)
+            sessionDurationMsP50: sessionDurationMsQuantile(
+              probability: 0.5
+              timeRange: $timeRange
+              filterIoSubstring: $filterIoSubstring
+            )
+            sessionDurationMsP99: sessionDurationMsQuantile(
+              probability: 0.99
+              timeRange: $timeRange
+              filterIoSubstring: $filterIoSubstring
+            )
+          }
+        }
+      }
+    """
+    project_gid = str(GlobalID(type_name="Project", node_id=str(project.id)))
+
+    response = await gql_client.execute(query=query, variables={"projectId": project_gid})
+    assert not response.errors
+    assert response.data is not None
+    assert response.data["node"]["sessionCount"] == 2
+    assert response.data["node"]["averageSessionDurationMs"] == 15000.0
+    assert response.data["node"]["averageTracesPerSession"] == 1.5
+    assert response.data["node"]["sessionDurationMsP50"] == pytest.approx(15000.0)
+    assert response.data["node"]["sessionDurationMsP99"] == pytest.approx(19900.0)
+
+    response = await gql_client.execute(
+        query=query, variables={"projectId": project_gid, "filterIoSubstring": "alpha"}
+    )
+    assert not response.errors
+    assert response.data is not None
+    assert response.data["node"]["sessionCount"] == 1
+    assert response.data["node"]["averageSessionDurationMs"] == 10000.0
+    assert response.data["node"]["averageTracesPerSession"] == 2.0
+    assert response.data["node"]["sessionDurationMsP50"] == pytest.approx(10000.0)
+    assert response.data["node"]["sessionDurationMsP99"] == pytest.approx(10000.0)
+
+    response = await gql_client.execute(
+        query=query,
+        variables={
+            "projectId": project_gid,
+            "timeRange": {
+                "start": base_time.isoformat(),
+                "end": (base_time + timedelta(minutes=1)).isoformat(),
+            },
+        },
+    )
+    assert not response.errors
+    assert response.data is not None
+    assert response.data["node"]["sessionCount"] == 1
+    assert response.data["node"]["averageSessionDurationMs"] == 10000.0
+    assert response.data["node"]["averageTracesPerSession"] == 2.0
+    assert response.data["node"]["sessionDurationMsP50"] == pytest.approx(10000.0)
+    assert response.data["node"]["sessionDurationMsP99"] == pytest.approx(10000.0)
+
+    response = await gql_client.execute(
+        query=query,
+        variables={
+            "projectId": project_gid,
+            "timeRange": {
+                "start": (base_time + timedelta(days=1)).isoformat(),
+                "end": (base_time + timedelta(days=2)).isoformat(),
+            },
+        },
+    )
+    assert not response.errors
+    assert response.data is not None
+    assert response.data["node"]["sessionCount"] == 0
+    assert response.data["node"]["averageSessionDurationMs"] is None
+    assert response.data["node"]["averageTracesPerSession"] is None
+    assert response.data["node"]["sessionDurationMsP50"] is None
+    assert response.data["node"]["sessionDurationMsP99"] is None
+
+
+async def test_session_annotation_summary_returns_expected_results(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session, name="session-annotation-summary-test")
+        session1 = await _add_project_session(session, project)
+        trace1 = await _add_trace(session, project, session1)
+        await _add_span(session, trace1, attributes={"input": {"value": "priority task"}})
+        session.add(
+            models.ProjectSessionAnnotation(
+                project_session_id=session1.id,
+                name="test-annotation",
+                label="important",
+                score=1.0,
+                explanation="Test annotation",
+                metadata_={},
+                annotator_kind="HUMAN",
+                source="APP",
+            )
+        )
+        session2 = await _add_project_session(session, project)
+        trace2 = await _add_trace(session, project, session2)
+        await _add_span(session, trace2, attributes={"input": {"value": "normal task"}})
+        session.add(
+            models.ProjectSessionAnnotation(
+                project_session_id=session2.id,
+                name="test-annotation",
+                label="normal",
+                score=0.5,
+                explanation="Test annotation",
+                metadata_={},
+                annotator_kind="HUMAN",
+                source="APP",
+            )
+        )
+
+    query = """
+      query ($projectId: ID!, $filterIoSubstring: String) {
+        node(id: $projectId) {
+          ... on Project {
+            sessionAnnotationSummary(
+              annotationName: "test-annotation"
+              filterIoSubstring: $filterIoSubstring
+            ) {
+              name
+              count
+              scoreCount
+              labelCount
+              meanScore
+              labelFractions {
+                label
+                fraction
+              }
+            }
+          }
+        }
+      }
+    """
+    project_gid = str(GlobalID(type_name="Project", node_id=str(project.id)))
+
+    response = await gql_client.execute(query=query, variables={"projectId": project_gid})
+    assert not response.errors
+    assert response.data is not None
+    summary = response.data["node"]["sessionAnnotationSummary"]
+    assert summary is not None
+    assert summary["name"] == "test-annotation"
+    assert summary["count"] == 2
+    assert summary["scoreCount"] == 2
+    assert summary["labelCount"] == 2
+    assert summary["meanScore"] == 0.75
+    assert summary["labelFractions"] == [
+        {"label": "important", "fraction": 0.5},
+        {"label": "normal", "fraction": 0.5},
+    ]
+
+    response = await gql_client.execute(
+        query=query, variables={"projectId": project_gid, "filterIoSubstring": "priority"}
+    )
+    assert not response.errors
+    assert response.data is not None
+    summary = response.data["node"]["sessionAnnotationSummary"]
+    assert summary is not None
+    assert summary["count"] == 1
+    assert summary["meanScore"] == 1.0
+    assert summary["labelFractions"] == [{"label": "important", "fraction": 1.0}]


### PR DESCRIPTION

<img width="2554" height="1261" alt="Screenshot 2026-07-02 at 9 43 59 AM" src="https://github.com/user-attachments/assets/fe6cc76c-c549-488f-80b9-6f4a48d273a4" />


Adds a collapsible stats aside to the project **sessions** table, mirroring the spans table aside:

- **Session stats**: total sessions, average traces (turns) per session, session duration (average, P50, P99), all respecting the page's time range and the message-substring search filter
- **Session annotation summaries**: per-name summaries (mean score / label fractions), reusing the `AnnotationSummary` value views