### PR TITLE
fix(evals): gate 0/1 positive_label auto-detection on default macro average

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/metrics/precision_recall.py
+++ b/packages/phoenix-evals/src/phoenix/evals/metrics/precision_recall.py
@@ -74,8 +74,9 @@ class PrecisionRecallFScore(Evaluator):
           Defaults to 'macro'. Suffixes are only appended to metric names when a non-default
           average is used.
         - positive_label: When set, compute binary precision/recall/F exclusively for this label
-          (one-vs-rest). If None and labels are numeric with unique set {0,1}, the
-          positive label defaults to 1. Otherwise, multi-class averaging is used.
+          (one-vs-rest). If None, `average` is at its default 'macro', and labels are numeric
+          with unique set {0,1}, the positive label defaults to 1. Otherwise, multi-class
+          averaging is used.
         - zero_division: Value to use when a metric is undefined (e.g., 0/0). Defaults to 0.0.
 
     Args:
@@ -170,7 +171,7 @@ class PrecisionRecallFScore(Evaluator):
         counts_by_label = self._compute_counts(expected, output, labels)
 
         # Determine if we are in binary (positive_label) mode
-        pos_label = self._resolve_positive_label(self.positive_label, labels)
+        pos_label = self._resolve_positive_label(self.positive_label, labels, self.average)
 
         if pos_label is not None:
             class_counts = counts_by_label.get(pos_label)
@@ -386,23 +387,35 @@ class PrecisionRecallFScore(Evaluator):
         return self._safe_div(numerator, denominator)
 
     def _resolve_positive_label(
-        self, configured_positive: Optional[Hashable], labels: Sequence[Hashable]
+        self,
+        configured_positive: Optional[Hashable],
+        labels: Sequence[Hashable],
+        average: AverageType,
     ) -> Optional[Hashable]:
         """Decide whether to run in binary mode and which label is positive.
 
         - If a positive label is provided, use it.
-        - Else, if labels are a binary numeric set {0, 1}, use 1 as positive.
+        - Else, if `average` is at its default "macro" and labels are a binary
+          numeric set {0, 1}, use 1 as positive.
         - Otherwise, return None to indicate multi-class averaging mode.
+
+        Auto-detection is gated on the default "macro" average so an explicitly
+        configured "micro"/"weighted" average is never silently overridden by
+        the shape of the data.
 
         Args:
             configured_positive (Optional[Hashable]): The explicitly configured positive label.
             labels (Sequence[Hashable]): The set of all possible labels.
+            average (AverageType): The configured averaging strategy.
 
         Returns:
             Optional[Hashable]: The positive label to use, or None for multi-class mode.
         """
         if configured_positive is not None:
             return configured_positive
+
+        if average != "macro":
+            return None
 
         unique = set(labels)
         if unique.issubset({0, 1}) and len(unique) == 2:

--- a/packages/phoenix-evals/tests/phoenix/evals/metrics/test_precision_recall.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/metrics/test_precision_recall.py
@@ -135,6 +135,21 @@ def _scores_by_name(scores: List[Any]) -> Dict[str, float]:
             False,
             id="multiclass-macro-beta2-sklearn-parity",
         ),
+        pytest.param(
+            "0/1 labels with a non-macro average must not auto-detect a positive "
+            "label; average must be honored instead",
+            dict(beta=1.0, average="micro"),
+            [0, 1, 1, 0, 1],
+            [0, 1, 0, 0, 1],
+            ["precision_micro", "recall_micro", "f1_micro"],
+            # label0: TP=2,FP=1,FN=0; label1: TP=2,FP=0,FN=1. Pooled: TP=4,
+            # FP=1,FN=1 -> precision=recall=f1=4/5=0.8. If auto-detection were
+            # not gated on "macro", this would incorrectly use binary
+            # positive_label=1 scoring (precision=1.0, recall=2/3) instead.
+            dict(precision_micro=0.8, recall_micro=0.8, f1_micro=0.8),
+            False,
+            id="binary-labels-non-macro-average-not-auto-detected",
+        ),
     ],
 )
 def test_precision_recall_fscore_success(


### PR DESCRIPTION
## Summary

`PrecisionRecallFScore` auto-detected a binary `positive_label=1` for numeric `{0, 1}` labels **regardless of the configured `average`**, silently overriding an explicitly requested `"micro"`/`"weighted"` average with binary one-vs-rest scoring instead of honoring the requested multi-class aggregation.

This is the same class of bug fixed for macro/weighted F-score parity with sklearn in #13740, and was surfaced while reviewing #14004 (the TypeScript port), whose `resolvePositiveLabel` already gates this auto-detection on the default `"macro"` average. This PR brings the Python evaluator in line with that same rule.

- `_resolve_positive_label` now takes `average` and returns `None` (multi-class mode) whenever `average != "macro"`.
- Docstrings updated to describe the gating.
- Added a regression test: `average="micro"` on `[0, 1, ...]` labels with no `positive_label` now correctly returns `precision_micro`/`recall_micro`/`f1_micro` instead of silently switching to binary scoring.

## Test plan

- [x] `pytest tests/phoenix/evals/metrics/test_precision_recall.py -v` — 16/16 passed (15 existing + 1 new regression test)
- [x] Verified the new test would have failed against the old (ungated) implementation