### PR TITLE
docs: fill documentation gaps from 2026-06-24→07-01 audit

### DIFF
--- a/docs/phoenix/pxi.mdx
+++ b/docs/phoenix/pxi.mdx
@@ -109,7 +109,36 @@ opens.
 | `--custom-provider-id <id>` | Use a custom provider configured under **Settings → Models** (requires `--model`). |
 | `--bypass-edits` | Apply edits without manual approval (see [You stay in control](#you-stay-in-control)). |
 | `--enable-web-access` | Allow PXI to consult the web for grounding. |
+| `--enable-subagents` | Allow the server to attach subagents (including the server-side bash tool). |
+| `--enable-graphql-mutations` | Allow PXI to run state-changing GraphQL mutations. |
+| `--ingest-traces` | Persist this session's PXI traces locally in Phoenix. |
+| `--export-remote-traces` | Export this session's PXI traces to a configured remote collector. |
+| `--attach-user-id` | Attach the authenticated Phoenix user to PXI traces (opt-in; see the **Privacy, safety & configuration** section below). |
 | `--skip-model-preflight` | Skip the model catalog and credential checks before launch. |
+
+Each capability flag is still subject to the server's own settings — for
+example, `--enable-subagents` has no effect when
+`PHOENIX_AGENTS_DISABLE_BASH=true`, and `--export-remote-traces` requires a
+configured collector and an administrator who has allowed export.
+
+## Slash commands
+
+Inside the terminal chat, lines beginning with `/` are handled locally by the
+client and never sent to the model.
+
+| Command | Effect |
+| --- | --- |
+| `/help` | List the available slash commands. |
+| `/clear` | Clear the conversation history and start a fresh session. |
+| `/exit` | Exit the terminal client. |
+
+## Status line
+
+While a turn streams, PXI shows a live **thinking indicator** and, once the
+response arrives, a bottom-right **token-usage line** — the total tokens for the
+turn, preceded by a cache-activity summary when the provider reports cache
+reads or writes. The active model name is shown next to the input prompt so you
+always know which provider and model the session is talking to.
 
 ## What it does
 
@@ -298,6 +327,13 @@ present, so it does not offer an action that cannot succeed on your current page
   with `PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME`). When recording is enabled, tool
   inputs and outputs are recorded on the corresponding spans, so you can audit
   what PXI did and evaluate it like any other agent in Phoenix.
+
+  **Attach your identity (opt-in).** Session traces are anonymous by default. If
+  you want to associate a session with the signed-in user — for example to
+  attribute recorded sessions to a specific person — enable **Attach your email
+  to session traces** under **Settings → Assistant → Personal settings**. From
+  the terminal client the same opt-in is the `--attach-user-id` flag. It is off
+  unless you turn it on.
   </Accordion>
 
   <Accordion title="Safety limits">

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/ci-evals.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/ci-evals.mdx
@@ -97,7 +97,7 @@ standard Phoenix env vars.
 | `PHOENIX_HOST` | Phoenix base URL |
 | `PHOENIX_API_KEY` | Bearer token for Phoenix |
 | `PHOENIX_CLIENT_HEADERS` | Optional JSON headers forwarded to the Phoenix client and tracer |
-| `PHOENIX_TEST_TRACKING=false` | Disable sync to Phoenix for the current run (tracing is on by default) |
+| `PHOENIX_TEST_TRACKING=false` | Disable sync to Phoenix for the current run (tracking is on by default) |
 | `PHOENIX_TEST_REPETITIONS` | Default number of times to run each test |
 | `PHOENIX_TEST_REPORTER=verbose` | Show every test row plus per-test `output:` detail (default is the compact view) |
 | `PHOENIX_TEST_REPORTER_MAX_ROWS` | Max test rows shown per suite in compact mode (default `10`; failures are never hidden) |

--- a/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations/annotating-in-the-ui.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations/annotating-in-the-ui.mdx
@@ -32,7 +32,7 @@ Once you have annotations configured, you can associate annotations to the data 
 
 You can also take notes as you go by either clicking on the `explain` link or by adding your notes to the bottom messages UI. 
 
-You can always come back and edit / and delete your annotations. Annotations can be deleted from the table view under the `Annotations` tab.
+You can always come back and edit / and delete your annotations. Individual annotations can be deleted from the table view under the `Annotations` tab. To remove every annotation with a given name across an entire project at once, an admin can use the bulk delete in [Project Settings](/docs/phoenix/tracing/llm-traces/projects#annotation-summary-and-bulk-delete).
 
 <Check>
 Once an annotation has been provided, you can also add a reason to explain why this particular label or score was provided. This is useful to add additional context to the annotation.

--- a/docs/phoenix/tracing/llm-traces/projects.mdx
+++ b/docs/phoenix/tracing/llm-traces/projects.mdx
@@ -23,9 +23,19 @@ With Projects, you can:
 
 Projects act as containers that keep related traces and conversations together while preventing them from interfering with unrelated work. This organization becomes increasingly valuable as you scale - allowing you to easily switch between contexts without losing your place or mixing data.
 
-You can customize each project with a **description** and **gradient colors** from the Project Settings tab, making it easier to identify and differentiate projects at a glance.
+You can customize each project with a **description** and **gradient colors** from the Project Settings tab, making it easier to identify and differentiate projects at a glance. Project Settings also surfaces an **annotation summary** for the project and lets an admin bulk-delete annotations by name (see [Annotation summary and bulk delete](#annotation-summary-and-bulk-delete) below).
 
 The Project structure also enables comparative analysis across different implementations, models, or time periods. You can run parallel versions of your application in separate projects, then analyze the differences to identify improvements or regressions.
+
+## Annotation summary and bulk delete
+
+The Project Settings tab includes an **annotation summary** that lists every annotation name in the project alongside how many span, trace, and session annotations carry that name. It gives you an at-a-glance view of which annotations exist and how heavily each is used.
+
+From the same summary, an admin can **bulk-delete every annotation with a given name** across the project in a single action — useful for cleaning up a mislabeled or deprecated annotation without deleting rows one at a time. The delete can optionally be scoped to a **time range** so you only remove annotations created within a specific window.
+
+<Warning>
+Bulk deletion is **destructive and cannot be undone**, and is restricted to admins (when authentication is enabled). For removing individual annotations instead, use the per-row delete in the table view under the `Annotations` tab.
+</Warning>
 
 <Tip>
 **Try it out!** Explore a live demo project to see how traces are organized in Phoenix.

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -105,6 +105,25 @@ For VS Code project-wide association add to `.vscode/settings.json`:
 
 ## Commands
 
+### `pxi`
+
+Open **PXI** (Phoenix Intelligence), an interactive terminal chat with the Phoenix
+agent. It connects to a running Phoenix instance and is the same server-side agent
+that powers the in-browser assistant — investigate failing traces, iterate on
+prompts, and drive Phoenix from your terminal.
+
+```bash
+pxi                                                          # uses PHOENIX_HOST / PHOENIX_API_KEY
+pxi --endpoint http://localhost:6006 --provider OPENAI --model gpt-5.4
+npx -y @arizeai/phoenix-cli pxi                              # run without installing
+```
+
+Inside the chat, `/help`, `/clear`, and `/exit` are handled locally. See the
+[PXI documentation](https://arize.com/docs/phoenix/pxi) for the full flag and
+slash-command reference, model setup, and privacy controls.
+
+---
+
 ### `px self update`
 
 Check the npm registry for the latest CLI release and update the installed

--- a/packages/phoenix-client/README.md
+++ b/packages/phoenix-client/README.md
@@ -28,6 +28,7 @@ Phoenix Client provides an interface for interacting with the Phoenix platform v
 - **Prompts** - Create, version, and invoke prompt templates
 - **Datasets** - Create and append to datasets from DataFrames, CSV files, or dictionaries
 - **Experiments** - Run evaluations and track experiment results
+- **Eval CI (pytest)** - Run LLM evals as ordinary pytest tests and record them as Phoenix experiments (`pip install "arize-phoenix-client[pytest]"`)
 - **Spans** - Query and analyze traces with powerful filtering
 - **Annotations** - Add human feedback and automated evaluations
 - **Evaluation Helpers** - Extract span data in formats optimized for RAG evaluation workflows
@@ -393,6 +394,64 @@ ran_experiment = client.experiments.get_experiment(experiment_id="my-experiment-
 for run in ran_experiment["task_runs"]:
     print(f"Output: {run['output']}, Error: {run['error']}")
 ```
+
+Beyond the batch `run_experiment` loop, you can post runs and evaluations one at a
+time with `log_run` and `log_evaluation`. These are the incremental primitives the
+pytest plugin builds on, and they are useful for any consumer that produces results
+progressively rather than all at once:
+
+```python
+from datetime import datetime, timezone
+
+# Record a single run against an existing experiment and example
+run = client.experiments.log_run(
+    experiment_id="my-experiment-id",
+    dataset_example_id="my-example-id",
+    output="the task output",
+    start_time=datetime.now(timezone.utc),
+    end_time=datetime.now(timezone.utc),
+)
+
+# Attach an evaluation (annotation) to that run
+client.experiments.log_evaluation(
+    experiment_run_id=run["id"],
+    name="exact_match",
+    annotator_kind="CODE",
+    score=1.0,
+    label="correct",
+)
+```
+
+Both methods are available on `AsyncClient` as awaitable coroutines with the same
+signatures.
+
+### Eval CI (pytest)
+
+Write LLM evals as ordinary pytest tests and record each marked test as a run in a
+Phoenix experiment, so the same suite that gates your pull requests also builds a
+history of results in Phoenix. Install the `pytest` extra and mark tests with
+`@pytest.mark.phoenix`:
+
+```bash
+pip install "arize-phoenix-client[pytest]" pytest
+```
+
+```python
+import pytest
+from phoenix.client.pytest import evaluate, log_evaluation, log_output
+
+
+@pytest.mark.phoenix(dataset="qa-suite")
+@pytest.mark.parametrize("question,expected", [("2+2?", "4")], ids=["arithmetic"])
+def test_answers(question, expected):
+    result = my_app(question)
+    log_output(result)
+    log_evaluation(name="exact_match", score=float(result == expected))
+    assert result == expected
+```
+
+See the [Eval CI with pytest guide](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/eval-ci-with-pytest)
+for marker options, environment variables, and a CI recipe.
 
 ### Projects
 


### PR DESCRIPTION
resolves #13988

Addresses the documentation gaps identified in the 2026-06-24 → 07-01 docs gap audit.

## Changes

**PXI terminal client (`docs/phoenix/pxi.mdx`)**
- Added the 5 CLI flags that were wired into the program but missing from the flag table: `--enable-subagents`, `--enable-graphql-mutations`, `--ingest-traces`, `--export-remote-traces`, `--attach-user-id`, with a note that each is still gated by the server's own settings.
- Added a **Slash commands** reference (`/help`, `/clear`, `/exit`).
- Documented the live token-usage status line and the active-model-name display.
- Documented the opt-in "Attach your email to session traces" privacy control (`--attach-user-id`).

**phoenix-cli README (`js/packages/phoenix-cli/README.md`)**
- Added a `pxi` command entry so the terminal client is discoverable from the npm landing page.

**phoenix-client README (`packages/phoenix-client/README.md`)**
- Added an "Eval CI (pytest)" feature bullet and a section pointing at the pytest guide.
- Documented the incremental `client.experiments.log_run` / `log_evaluation` primitives (sync + async).

**Project annotation summary + bulk delete (`docs/phoenix/tracing/llm-traces/projects.mdx`, `.../annotating-in-the-ui.mdx`)**
- Updated the Project Settings description and added an **Annotation summary and bulk delete** section covering per-name counts and the admin-only, destructive bulk-delete-by-name (with optional time-range scoping).
- Linked the new project-wide bulk-delete path from the annotating-in-the-UI page.

**Stale env-var wording (`docs/.../phoenix-client/ci-evals.mdx`)**
- Fixed "tracing is on by default" → "tracking is on by default" after the `PHOENIX_TEST_TRACING` → `PHOENIX_TEST_TRACKING` rename.

## Not addressed
Gap 5 (medium): whether the internal `/agents/*` paths should be excluded from or annotated as internal in the generated `schemas/openapi.json` is a schema-generation decision the audit explicitly defers to a maintainer, so it is left out of this docs-only PR. The associated user-facing privacy control (Gap 5, low) is documented in `pxi.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhhnDs1BzjsgbjkYAqSWr4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhhnDs1BzjsgbjkYAqSWr4)_